### PR TITLE
Make sure Seed and ManagedSeed names are DNS-1123 label compliant names

### DIFF
--- a/pkg/apis/core/validation/controllerinstallation_test.go
+++ b/pkg/apis/core/validation/controllerinstallation_test.go
@@ -22,8 +22,10 @@ import (
 
 	. "github.com/gardener/gardener/pkg/apis/core/validation"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
+	gomegatypes "github.com/onsi/gomega/types"
 )
 
 var _ = Describe("validation", func() {
@@ -48,6 +50,45 @@ var _ = Describe("validation", func() {
 	})
 
 	Describe("#ValidateControllerInstallation", func() {
+		DescribeTable("ControllerInstallation metadata",
+			func(objectMeta metav1.ObjectMeta, matcher gomegatypes.GomegaMatcher) {
+				controllerInstallation.ObjectMeta = objectMeta
+
+				errorList := ValidateControllerInstallation(controllerInstallation)
+
+				Expect(errorList).To(matcher)
+			},
+
+			Entry("should forbid ControllerInstallation with empty metadata",
+				metav1.ObjectMeta{},
+				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("metadata.name"),
+				}))),
+			),
+			Entry("should forbid ControllerInstallation with empty name",
+				metav1.ObjectMeta{Name: ""},
+				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("metadata.name"),
+				}))),
+			),
+			Entry("should forbid ControllerInstallation with '.' in the name (not a DNS-1123 label compliant name)",
+				metav1.ObjectMeta{Name: "extension-abc.test"},
+				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("metadata.name"),
+				}))),
+			),
+			Entry("should forbid ControllerInstallation with '_' in the name (not a DNS-1123 subdomain)",
+				metav1.ObjectMeta{Name: "extension-abc_test"},
+				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("metadata.name"),
+				}))),
+			),
+		)
+
 		It("should forbid empty ControllerInstallation resources", func() {
 			errorList := ValidateControllerInstallation(&core.ControllerInstallation{})
 

--- a/pkg/apis/core/validation/seed.go
+++ b/pkg/apis/core/validation/seed.go
@@ -37,7 +37,7 @@ var (
 func ValidateSeed(seed *core.Seed) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	allErrs = append(allErrs, apivalidation.ValidateObjectMeta(&seed.ObjectMeta, false, ValidateName, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, apivalidation.ValidateObjectMeta(&seed.ObjectMeta, false, apivalidation.NameIsDNSLabel, field.NewPath("metadata"))...)
 	allErrs = append(allErrs, ValidateSeedSpec(&seed.Spec, field.NewPath("spec"), false)...)
 
 	return allErrs

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -246,29 +246,57 @@ var _ = Describe("Shoot Validation Tests", func() {
 			}
 		})
 
-		It("should forbid shoots containing two consecutive hyphens", func() {
-			shoot.ObjectMeta.Name = "sho--ot"
+		DescribeTable("Shoot metadata",
+			func(objectMeta metav1.ObjectMeta, matcher gomegatypes.GomegaMatcher) {
+				shoot.ObjectMeta = objectMeta
 
-			errorList := ValidateShoot(shoot)
+				errorList := ValidateShoot(shoot)
 
-			Expect(errorList).To(HaveLen(1))
-			Expect(*errorList[0]).To(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeInvalid),
-				"Field": Equal("metadata.name"),
-			}))
-		})
+				Expect(errorList).To(matcher)
+			},
 
-		It("should forbid shoots with a not DNS-1123 label compliant name", func() {
-			shoot.ObjectMeta.Name = "shoot.test"
-
-			errorList := ValidateShoot(shoot)
-
-			Expect(errorList).To(HaveLen(1))
-			Expect(*errorList[0]).To(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeInvalid),
-				"Field": Equal("metadata.name"),
-			}))
-		})
+			Entry("should forbid Shoot with empty metadata",
+				metav1.ObjectMeta{},
+				ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeRequired),
+						"Field": Equal("metadata.name"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeRequired),
+						"Field": Equal("metadata.namespace"),
+					})),
+				),
+			),
+			Entry("should forbid Shoot with empty name",
+				metav1.ObjectMeta{Name: "", Namespace: "my-namespace"},
+				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("metadata.name"),
+				}))),
+			),
+			Entry("should forbid Shoot with '.' in the name (not a DNS-1123 label compliant name)",
+				metav1.ObjectMeta{Name: "shoot.test", Namespace: "my-namespace"},
+				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("metadata.name"),
+				}))),
+			),
+			Entry("should forbid Shoot with '_' in the name (not a DNS-1123 subdomain)",
+				metav1.ObjectMeta{Name: "shoot_test", Namespace: "my-namespace"},
+				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("metadata.name"),
+				}))),
+			),
+			Entry("should forbid Shoot with name containing two consecutive hyphens",
+				metav1.ObjectMeta{Name: "sho--ot", Namespace: "my-namespace"},
+				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("metadata.name"),
+				}))),
+			),
+		)
 
 		It("should forbid empty Shoot resources", func() {
 			shoot := &core.Shoot{

--- a/pkg/apis/core/validation/shootstate_test.go
+++ b/pkg/apis/core/validation/shootstate_test.go
@@ -16,13 +16,15 @@ package validation_test
 
 import (
 	"github.com/gardener/gardener/pkg/apis/core"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	. "github.com/gardener/gardener/pkg/apis/core/validation"
+
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
+	gomegatypes "github.com/onsi/gomega/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
@@ -41,6 +43,51 @@ var _ = Describe("validation", func() {
 				},
 			}
 		})
+
+		DescribeTable("ShootState metadata",
+			func(objectMeta metav1.ObjectMeta, matcher gomegatypes.GomegaMatcher) {
+				shootState.ObjectMeta = objectMeta
+
+				errorList := ValidateShootState(shootState)
+
+				Expect(errorList).To(matcher)
+			},
+
+			Entry("should forbid ShootState with empty metadata",
+				metav1.ObjectMeta{},
+				ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeRequired),
+						"Field": Equal("metadata.name"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeRequired),
+						"Field": Equal("metadata.namespace"),
+					})),
+				),
+			),
+			Entry("should forbid ShootState with empty name",
+				metav1.ObjectMeta{Name: "", Namespace: "project-foo"},
+				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("metadata.name"),
+				}))),
+			),
+			Entry("should forbid ShootState with '.' in the name (not a DNS-1123 label compliant name)",
+				metav1.ObjectMeta{Name: "shoot.test", Namespace: "project-foo"},
+				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("metadata.name"),
+				}))),
+			),
+			Entry("should forbid ShootState with '_' in the name (not a DNS-1123 subdomain)",
+				metav1.ObjectMeta{Name: "shoot_test", Namespace: "project-foo"},
+				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("metadata.name"),
+				}))),
+			),
+		)
 
 		It("should forbid shootState containing data required for gardener resource generation with empty name", func() {
 			shootState.Spec.Gardener = []core.GardenerResourceData{

--- a/pkg/apis/seedmanagement/validation/managedseed.go
+++ b/pkg/apis/seedmanagement/validation/managedseed.go
@@ -42,7 +42,7 @@ func ValidateManagedSeed(managedSeed *seedmanagement.ManagedSeed) field.ErrorLis
 		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata", "namespace"), managedSeed.Namespace, "namespace must be garden"))
 	}
 
-	allErrs = append(allErrs, apivalidation.ValidateObjectMeta(&managedSeed.ObjectMeta, true, corevalidation.ValidateName, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, apivalidation.ValidateObjectMeta(&managedSeed.ObjectMeta, true, apivalidation.NameIsDNSLabel, field.NewPath("metadata"))...)
 	allErrs = append(allErrs, ValidateManagedSeedSpec(&managedSeed.Spec, field.NewPath("spec"), false)...)
 
 	return allErrs

--- a/pkg/apis/seedmanagement/validation/managedseedset_test.go
+++ b/pkg/apis/seedmanagement/validation/managedseedset_test.go
@@ -16,8 +16,10 @@ package validation_test
 
 import (
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
+	gomegatypes "github.com/onsi/gomega/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -128,39 +130,58 @@ var _ = Describe("ManagedSeedSet Validation Tests", func() {
 			Expect(errorList).To(HaveLen(0))
 		})
 
-		It("should forbid empty metadata", func() {
-			managedSeedSet.ObjectMeta = metav1.ObjectMeta{}
+		DescribeTable("ManagedSeedSet metadata",
+			func(objectMeta metav1.ObjectMeta, matcher gomegatypes.GomegaMatcher) {
+				managedSeedSet.ObjectMeta = objectMeta
 
-			errorList := ValidateManagedSeedSet(managedSeedSet)
+				errorList := ValidateManagedSeedSet(managedSeedSet)
 
-			Expect(errorList).To(ConsistOf(
-				PointTo(MatchFields(IgnoreExtras, Fields{
+				Expect(errorList).To(matcher)
+			},
+
+			Entry("should forbid ManagedSeedSet with empty metadata",
+				metav1.ObjectMeta{},
+				ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeRequired),
+						"Field": Equal("metadata.name"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeRequired),
+						"Field": Equal("metadata.namespace"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal("metadata.namespace"),
+					})),
+				),
+			),
+			Entry("should forbid ManagedSeedSet with empty name",
+				metav1.ObjectMeta{Name: "", Namespace: namespace},
+				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeRequired),
 					"Field": Equal("metadata.name"),
-				})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("metadata.namespace"),
-				})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
+				}))),
+			),
+			Entry("should allow ManagedSeedSet with '.' in the name",
+				metav1.ObjectMeta{Name: "managedseedset.test", Namespace: namespace},
+				BeEmpty(),
+			),
+			Entry("should forbid ManagedSeedSet with '_' in the name (not a DNS-1123 label compliant name)",
+				metav1.ObjectMeta{Name: "managedseedset_test", Namespace: namespace},
+				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("metadata.name"),
+				}))),
+			),
+			Entry("should forbid ManagedSeedSet with namespace different from garden",
+				metav1.ObjectMeta{Name: name, Namespace: "foo"},
+				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeInvalid),
 					"Field": Equal("metadata.namespace"),
-				})),
-			))
-		})
-
-		It("should forbid namespace different from garden", func() {
-			managedSeedSet.Namespace = "foo"
-
-			errorList := ValidateManagedSeedSet(managedSeedSet)
-
-			Expect(errorList).To(ConsistOf(
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("metadata.namespace"),
-				})),
-			))
-		})
+				}))),
+			),
+		)
 
 		It("should forbid negative replicas, updateStrategy.rollingUpdate.partition, and revisionHistoryLimit", func() {
 			managedSeedSet.Spec.Replicas = pointer.Int32Ptr(-1)


### PR DESCRIPTION
/area quality
/kind bug

Reopen of https://github.com/gardener/gardener/pull/3877

Fixes #3872

In the Slack thread that I initiated (ref https://kubernetes.slack.com/archives/CB57N0BFG/p1618849898292100) no one of the adopters confirmed about usage of Seed names with `.` (dot) and no one requested the backwards-compatibility to be preserved in this corner case.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
Gardener API server does no longer allow creating a Seed and ManagedSeed with `.` (dot) in the name. Before upgrading to this version of Gardener, make sure that you don't have Seed or ManagedSeed with `.` (dot) in the system.
```
