### PR TITLE
[release-v1.20] Automated cherry pick of #3927: Make sure Seed and ManagedSeed names are DNS-1123 label compliant names

### DIFF
--- a/pkg/apis/core/validation/controllerinstallation_test.go
+++ b/pkg/apis/core/validation/controllerinstallation_test.go
@@ -22,8 +22,10 @@ import (
 
 	. "github.com/gardener/gardener/pkg/apis/core/validation"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
+	gomegatypes "github.com/onsi/gomega/types"
 )
 
 var _ = Describe("validation", func() {
@@ -48,6 +50,45 @@ var _ = Describe("validation", func() {
 	})
 
 	Describe("#ValidateControllerInstallation", func() {
+		DescribeTable("ControllerInstallation metadata",
+			func(objectMeta metav1.ObjectMeta, matcher gomegatypes.GomegaMatcher) {
+				controllerInstallation.ObjectMeta = objectMeta
+
+				errorList := ValidateControllerInstallation(controllerInstallation)
+
+				Expect(errorList).To(matcher)
+			},
+
+			Entry("should forbid ControllerInstallation with empty metadata",
+				metav1.ObjectMeta{},
+				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("metadata.name"),
+				}))),
+			),
+			Entry("should forbid ControllerInstallation with empty name",
+				metav1.ObjectMeta{Name: ""},
+				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("metadata.name"),
+				}))),
+			),
+			Entry("should forbid ControllerInstallation with '.' in the name (not a DNS-1123 label compliant name)",
+				metav1.ObjectMeta{Name: "extension-abc.test"},
+				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("metadata.name"),
+				}))),
+			),
+			Entry("should forbid ControllerInstallation with '_' in the name (not a DNS-1123 subdomain)",
+				metav1.ObjectMeta{Name: "extension-abc_test"},
+				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("metadata.name"),
+				}))),
+			),
+		)
+
 		It("should forbid empty ControllerInstallation resources", func() {
 			errorList := ValidateControllerInstallation(&core.ControllerInstallation{})
 

--- a/pkg/apis/core/validation/seed.go
+++ b/pkg/apis/core/validation/seed.go
@@ -37,7 +37,7 @@ var (
 func ValidateSeed(seed *core.Seed) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	allErrs = append(allErrs, apivalidation.ValidateObjectMeta(&seed.ObjectMeta, false, ValidateName, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, apivalidation.ValidateObjectMeta(&seed.ObjectMeta, false, apivalidation.NameIsDNSLabel, field.NewPath("metadata"))...)
 	allErrs = append(allErrs, ValidateSeedSpec(&seed.Spec, field.NewPath("spec"), false)...)
 
 	return allErrs

--- a/pkg/apis/core/validation/shootstate_test.go
+++ b/pkg/apis/core/validation/shootstate_test.go
@@ -16,13 +16,15 @@ package validation_test
 
 import (
 	"github.com/gardener/gardener/pkg/apis/core"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-
 	. "github.com/gardener/gardener/pkg/apis/core/validation"
+
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
+	gomegatypes "github.com/onsi/gomega/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
@@ -41,6 +43,51 @@ var _ = Describe("validation", func() {
 				},
 			}
 		})
+
+		DescribeTable("ShootState metadata",
+			func(objectMeta metav1.ObjectMeta, matcher gomegatypes.GomegaMatcher) {
+				shootState.ObjectMeta = objectMeta
+
+				errorList := ValidateShootState(shootState)
+
+				Expect(errorList).To(matcher)
+			},
+
+			Entry("should forbid ShootState with empty metadata",
+				metav1.ObjectMeta{},
+				ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeRequired),
+						"Field": Equal("metadata.name"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeRequired),
+						"Field": Equal("metadata.namespace"),
+					})),
+				),
+			),
+			Entry("should forbid ShootState with empty name",
+				metav1.ObjectMeta{Name: "", Namespace: "project-foo"},
+				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("metadata.name"),
+				}))),
+			),
+			Entry("should forbid ShootState with '.' in the name (not a DNS-1123 label compliant name)",
+				metav1.ObjectMeta{Name: "shoot.test", Namespace: "project-foo"},
+				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("metadata.name"),
+				}))),
+			),
+			Entry("should forbid ShootState with '_' in the name (not a DNS-1123 subdomain)",
+				metav1.ObjectMeta{Name: "shoot_test", Namespace: "project-foo"},
+				ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("metadata.name"),
+				}))),
+			),
+		)
 
 		It("should forbid shootState containing data required for gardener resource generation with empty name", func() {
 			shootState.Spec.Gardener = []core.GardenerResourceData{

--- a/pkg/apis/seedmanagement/validation/managedseed.go
+++ b/pkg/apis/seedmanagement/validation/managedseed.go
@@ -42,7 +42,7 @@ func ValidateManagedSeed(managedSeed *seedmanagement.ManagedSeed) field.ErrorLis
 		allErrs = append(allErrs, field.Invalid(field.NewPath("metadata", "namespace"), managedSeed.Namespace, "namespace must be garden"))
 	}
 
-	allErrs = append(allErrs, apivalidation.ValidateObjectMeta(&managedSeed.ObjectMeta, true, corevalidation.ValidateName, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, apivalidation.ValidateObjectMeta(&managedSeed.ObjectMeta, true, apivalidation.NameIsDNSLabel, field.NewPath("metadata"))...)
 	allErrs = append(allErrs, ValidateManagedSeedSpec(&managedSeed.Spec, field.NewPath("spec"), false)...)
 
 	return allErrs


### PR DESCRIPTION
/kind bug

Cherry pick of #3927 on release-v1.20.

#3927: Make sure Seed and ManagedSeed names are DNS-1123 label compliant names

**Release Notes:**
```breaking operator
Gardener API server does no longer allow creating a Seed and ManagedSeed with `.` (dot) in the name. Before upgrading to this version of Gardener, make sure that you don't have Seed or ManagedSeed with `.` (dot) in the system.
```