### PR TITLE
Use alpine:3 in dev setup

### DIFF
--- a/hack/local-development/dev-setup
+++ b/hack/local-development/dev-setup
@@ -49,7 +49,7 @@ case "${kubernetes_env}" in
         if [[ "$(uname)" == "Darwin" ]]; then
           echo "After OSX sleep, minikube's time is off."
           echo "This results in x509 certificate auth to not work for shoot certificates"
-          minikube ssh -- docker run -i --rm --privileged --pid=host alpine:3.10.3 nsenter -t 1 -m -u -n -i date -u $(date -u +%m%d%H%M%Y)
+          minikube ssh -- docker run -i --rm --privileged --pid=host alpine:3 nsenter -t 1 -m -u -n -i date -u $(date -u +%m%d%H%M%Y)
         fi
         ;;
  esac


### PR DESCRIPTION
At this step, it is not important which exact version of
Alpine is used. To avoid old versions, the last version
of the Alpine 3 series can always be used at this point

Signed-off-by: Christian Berendt <berendt@23technologies.cloud>