### PR TITLE
Fixed vpn-seed-server envoy filter configuration not being deleted when feature is disabled.

### DIFF
--- a/charts/seed-controlplane/charts/kube-apiserver-sni/templates/kube-apiserver-envoyfilter.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver-sni/templates/kube-apiserver-envoyfilter.yaml
@@ -35,6 +35,7 @@ spec:
           prefix_ranges:
           - address_prefix: {{ .Values.apiserverClusterIP }}
             prefix_len: 32
+  {{- if .Values.reversedVPN.enabled }}
   - applyTo: NETWORK_FILTER
     match:
       context: GATEWAY
@@ -63,3 +64,4 @@ spec:
                   upgrade_configs:
                   - upgrade_type: CONNECT
                     connect_config: {}
+  {{- end }}

--- a/charts/seed-controlplane/charts/kube-apiserver-sni/values.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver-sni/values.yaml
@@ -9,3 +9,5 @@ istioIngressGateway:
   labels:
     istio: ingressgateway
 internalDNSNameApiserver: api.internal
+reversedVPN:
+  enabled: false

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -890,6 +890,9 @@ func (b *Botanist) DefaultKubeAPIServerSNI() component.DeployWaiter {
 				Labels:    b.Config.SNI.Ingress.Labels,
 			},
 			InternalDNSNameApiserver: b.outOfClusterAPIServerFQDN(),
+			ReversedVPN: controlplane.ReversedVPN{
+				Enabled: b.Shoot.ReversedVPNEnabled,
+			},
 		},
 		b.Shoot.SeedNamespace,
 		b.K8sSeedClient.ChartApplier(),
@@ -918,6 +921,9 @@ func (b *Botanist) setAPIServerServiceClusterIP(clusterIP string) {
 				Labels:    b.Config.SNI.Ingress.Labels,
 			},
 			InternalDNSNameApiserver: b.outOfClusterAPIServerFQDN(),
+			ReversedVPN: controlplane.ReversedVPN{
+				Enabled: b.Shoot.ReversedVPNEnabled,
+			},
 		},
 		b.Shoot.SeedNamespace,
 		b.K8sSeedClient.ChartApplier(),

--- a/pkg/operation/botanist/controlplane/kube_apiserver_sni.go
+++ b/pkg/operation/botanist/controlplane/kube_apiserver_sni.go
@@ -35,12 +35,18 @@ type KubeAPIServerSNIValues struct {
 	ApiserverClusterIP       string              `json:"apiserverClusterIP,omitempty"`
 	IstioIngressGateway      IstioIngressGateway `json:"istioIngressGateway,omitempty"`
 	InternalDNSNameApiserver string              `json:"internalDNSNameApiserver,omitempty"`
+	ReversedVPN              ReversedVPN         `json:"reversedVPN,omitempty"`
 }
 
 // IstioIngressGateway contains the values for istio ingress gateway configuration.
 type IstioIngressGateway struct {
 	Namespace string            `json:"namespace,omitempty"`
 	Labels    map[string]string `json:"labels,omitempty"`
+}
+
+// ReversedVPN contains whether the reversed vpn is enabled or not.
+type ReversedVPN struct {
+	Enabled bool `json:"enabled,omitempty"`
 }
 
 // NewKubeAPIServerSNI creates a new instance of DeployWaiter which deploys Istio resources for


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
In case the reverse vpn is not enabled the envoy filter is still applied causing the istio configuration to become inconsistent. This change ensures that the envoy filter for the reverse vpn is only created in case it is enabled.

**Which issue(s) this PR fixes**:
Fixes the istio configuration in case reverse vpn is not enabled.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
