### PR TITLE
Add 23 Technologies to the ADOPTERS file

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -39,5 +39,11 @@ and CI/CD systems internally.
 products across cloud providers and manage its clusters for different environments.
 - [PingCAP](https://pingcap.com/) uses Gardener to build its managed database service known as [TiDB Cloud](https://pingcap.com/tidb-cloud/) on mainstream cloud providers.
 
+Service provider adopters
+
+- [23 Technologies](https://23technologies.cloud/) uses Gardener to offer
+an enterprise-class Kubernetes engine for industrial use cases as well as
+cloud service providers and offers managed and professional services for it.
+
 If you’re using Gardener and aren’t on this list, feel free to
 [submit a pull request](https://github.com/gardener/gardener/pulls)!


### PR DESCRIPTION
23 Technologies is already listed on the website as an adopter and is still missing here. Was not sure about the category. We are not a cloud provider. I think we are a Service Provider.
