### PR TITLE
Add default shoots capacity for ManagedSeeds

### DIFF
--- a/pkg/apis/seedmanagement/v1alpha1/defaults_managedseed.go
+++ b/pkg/apis/seedmanagement/v1alpha1/defaults_managedseed.go
@@ -17,6 +17,8 @@ package v1alpha1
 import (
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/api/resource"
+
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement/helper"
 	configv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
@@ -122,6 +124,14 @@ func setDefaultsGardenlet(obj *Gardenlet, name, namespace string) {
 }
 
 func setDefaultsGardenletConfiguration(obj *configv1alpha1.GardenletConfiguration, name, namespace string) {
+	// Initialize resources
+	if obj.Resources == nil {
+		obj.Resources = &configv1alpha1.ResourcesConfiguration{}
+	}
+
+	// Set resources defaults
+	setDefaultsResources(obj.Resources)
+
 	// Initialize seed config
 	if obj.SeedConfig == nil {
 		obj.SeedConfig = &configv1alpha1.SeedConfig{}
@@ -129,6 +139,15 @@ func setDefaultsGardenletConfiguration(obj *configv1alpha1.GardenletConfiguratio
 
 	// Set seed spec defaults
 	setDefaultsSeedSpec(&obj.SeedConfig.SeedTemplate.Spec, name, namespace, false)
+}
+
+func setDefaultsResources(obj *configv1alpha1.ResourcesConfiguration) {
+	if _, ok := obj.Capacity[gardencorev1beta1.ResourceShoots]; !ok {
+		if obj.Capacity == nil {
+			obj.Capacity = make(corev1.ResourceList)
+		}
+		obj.Capacity[gardencorev1beta1.ResourceShoots] = resource.MustParse("250")
+	}
 }
 
 func setDefaultsSeedSpec(spec *gardencorev1beta1.SeedSpec, name, namespace string, withSecretRef bool) {

--- a/pkg/apis/seedmanagement/v1alpha1/defaults_managedseed_test.go
+++ b/pkg/apis/seedmanagement/v1alpha1/defaults_managedseed_test.go
@@ -18,6 +18,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/api/resource"
+
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	. "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	configv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
@@ -123,6 +125,11 @@ var _ = Describe("Defaults", func() {
 									APIVersion: configv1alpha1.SchemeGroupVersion.String(),
 									Kind:       "GardenletConfiguration",
 								},
+								Resources: &configv1alpha1.ResourcesConfiguration{
+									Capacity: corev1.ResourceList{
+										gardencorev1beta1.ResourceShoots: resource.MustParse("250"),
+									},
+								},
 								SeedConfig: &configv1alpha1.SeedConfig{},
 							},
 						},
@@ -167,6 +174,11 @@ var _ = Describe("Defaults", func() {
 								TypeMeta: metav1.TypeMeta{
 									APIVersion: configv1alpha1.SchemeGroupVersion.String(),
 									Kind:       "GardenletConfiguration",
+								},
+								Resources: &configv1alpha1.ResourcesConfiguration{
+									Capacity: corev1.ResourceList{
+										gardencorev1beta1.ResourceShoots: resource.MustParse("250"),
+									},
 								},
 								SeedConfig: &configv1alpha1.SeedConfig{
 									SeedTemplate: gardencorev1beta1.SeedTemplate{


### PR DESCRIPTION
**How to categorize this PR?**

/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
Adds a default shoot capacity of 250 for ManagedSeeds. This is the same default added when using the `use-as-seed` annotation. It is needed in order to have an equivalent behavior to the annotation if a ManagedSeed with no resources specified is created.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This is needed in order to properly get rid of the `use-as-seed` annotation in our landscape setup without adding an arbitrary default in the landscape setup scripts.

**Release note**:

```other operator
NONE
```
