### PR TITLE
Changed priority class of vpn-seed-server deployment to shoot controlplane.

### DIFF
--- a/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server.go
+++ b/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server.go
@@ -280,7 +280,7 @@ func (v *vpnSeedServer) Deploy(ctx context.Context) error {
 				},
 				Spec: corev1.PodSpec{
 					AutomountServiceAccountToken: pointer.BoolPtr(false),
-					PriorityClassName:            "system-cluster-critical",
+					PriorityClassName:            v1beta1constants.PriorityClassNameShootControlPlane,
 					DNSPolicy:                    corev1.DNSDefault, // make sure to not use the coredns for DNS resolution.
 					Containers: []corev1.Container{
 						{

--- a/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server_test.go
+++ b/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server_test.go
@@ -193,7 +193,7 @@ var _ = Describe("VpnSeedServer", func() {
 						},
 						Spec: corev1.PodSpec{
 							AutomountServiceAccountToken: pointer.BoolPtr(false),
-							PriorityClassName:            "system-cluster-critical",
+							PriorityClassName:            v1beta1constants.PriorityClassNameShootControlPlane,
 							DNSPolicy:                    corev1.DNSDefault, // make sure to not use the coredns for DNS resolution.
 							Containers: []corev1.Container{
 								{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
This pull request changes the priority class of the vpn-seed-server deployment to shoot controlplane.

**Which issue(s) this PR fixes**:
Fixes issues where insufficient quota is assigned to priority class system-cluster-critical.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
