### PR TITLE
Ensure that reversed vpn and konnectivity tunnel are not set at the same time.

### DIFF
--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -244,9 +244,13 @@ func (b *Builder) Build(ctx context.Context, c client.Client) (*Shoot, error) {
 	kubernetesVersionGeq116 := versionConstraintK8sGreaterEqual116.Check(kubernetesVersion)
 	shoot.ReversedVPNEnabled = gardenletfeatures.FeatureGate.Enabled(features.ReversedVPN) && kubernetesVersionGeq116
 	if reversedVPNEnabled, err := strconv.ParseBool(shoot.Info.Annotations[v1beta1constants.AnnotationReversedVPN]); err == nil && kubernetesVersionGeq116 {
-		if gardenletfeatures.FeatureGate.Enabled(features.APIServerSNI) && !shoot.KonnectivityTunnelEnabled {
+		if gardenletfeatures.FeatureGate.Enabled(features.APIServerSNI) {
 			shoot.ReversedVPNEnabled = reversedVPNEnabled
 		}
+	}
+
+	if shoot.ReversedVPNEnabled {
+		shoot.KonnectivityTunnelEnabled = false
 	}
 
 	needsClusterAutoscaler, err := gardencorev1beta1helper.ShootWantsClusterAutoscaler(shootObject)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Ensure that at most one of reversed vpn and konnectivity tunnel is enabled per shoot.

**Which issue(s) this PR fixes**:
Fixes rare conditions were reverse vpn and konnectivity tunnel could be enabled at the same time leading to nil dereferences crashing the gardenlet.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
