### PR TITLE
Remove watch on secrets from ManagedSeed controller

### DIFF
--- a/pkg/gardenlet/controller/managedseed/managedseed_actuator.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_actuator.go
@@ -267,7 +267,7 @@ func (a *actuator) Delete(ctx context.Context, ms *seedmanagementv1alpha1.Manage
 		} else {
 			a.deletingInfoEventf(ms, "Waiting for seed %s secrets to be deleted", ms.Name)
 		}
-		return status, false, false, nil
+		return status, true, false, nil
 	}
 
 	// Delete garden namespace from the shoot if it still exists and is not already deleting

--- a/pkg/gardenlet/controller/managedseed/managedseed_actuator_test.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_actuator_test.go
@@ -758,7 +758,7 @@ var _ = Describe("Actuator", func() {
 						"Reason": Equal(gardencorev1beta1.EventDeleting),
 					}),
 				))
-				Expect(wait).To(Equal(false))
+				Expect(wait).To(Equal(true))
 				Expect(removeFinalizer).To(Equal(false))
 			})
 
@@ -867,7 +867,7 @@ var _ = Describe("Actuator", func() {
 						"Reason": Equal(gardencorev1beta1.EventDeleting),
 					}),
 				))
-				Expect(wait).To(Equal(false))
+				Expect(wait).To(Equal(true))
 				Expect(removeFinalizer).To(Equal(false))
 			})
 

--- a/pkg/gardenlet/controller/managedseed/managedseed_predicates.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_predicates.go
@@ -15,7 +15,6 @@
 package managedseed
 
 import (
-	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -37,25 +36,6 @@ func (c *Controller) filterSeed(obj, _, controller client.Object, deleted bool) 
 
 	if ms.DeletionTimestamp != nil && deleted {
 		c.logger.Debugf("Managed seed %s is deleting and seed %s no longer exists", kutil.ObjectName(ms), kutil.ObjectName(seed))
-		return true
-	}
-	return false
-}
-
-func (c *Controller) filterSecret(obj, _, controller client.Object, deleted bool) bool {
-	secret, ok := obj.(*corev1.Secret)
-	if !ok {
-		return false
-	}
-	ms, ok := controller.(*seedmanagementv1alpha1.ManagedSeed)
-	if !ok {
-		return false
-	}
-
-	// TODO Return true if the secret was deleted or updated and metadata / data don't match its checksum
-
-	if ms.DeletionTimestamp != nil && deleted {
-		c.logger.Debugf("Managed seed %s is deleting and secret %s no longer exists", kutil.ObjectName(ms), kutil.ObjectName(secret))
 		return true
 	}
 	return false


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind bug

**What this PR does / why we need it**:
Removes watching of secrets in the garden cluster from the ManagedSeed controller. During deletion, the controller will requeue with `WaitSyncPeriod` when waiting for the seed secrets to be deleted instead of relying on events, similarly to the way it does it for resources that are not in the garden cluster.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
In the future, `gardenlet `may no longer be allowed to list/watch secrets - it will only be allowed to get secrets that somehow belong to its seed. Therefore, the watching of secrets by ManagedSeed controller in the garden cluster should be removed.

**Release note**:

```bugfix operator
The ManagedSeed controller no longer watches secrets in the garden cluster.
```
