### PR TITLE
Cleanup nits for SeedAuthorizer preparation

### DIFF
--- a/pkg/admissioncontroller/webhooks/auth/seed/authorizer.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/authorizer.go
@@ -130,7 +130,14 @@ func (a *authorizer) authorize(seedName string, fromType graph.VertexType, attrs
 		return auth.DecisionAllow, "", nil
 	}
 
-	if !a.graph.HasPathFrom(fromType, attrs.GetNamespace(), attrs.GetName(), graph.VertexTypeSeed, "", seedName) {
+	// If the request is made for a namespace then the attributes.Namespace field is not empty. It contains the name of
+	// the namespace.
+	namespace := attrs.GetNamespace()
+	if fromType == graph.VertexTypeNamespace {
+		namespace = ""
+	}
+
+	if !a.graph.HasPathFrom(fromType, namespace, attrs.GetName(), graph.VertexTypeSeed, "", seedName) {
 		a.logger.Info(fmt.Sprintf("SEED DENY: '%s' %#v", seedName, attrs))
 		return auth.DecisionNoOpinion, fmt.Sprintf("no relationship found between seed '%s' and this object", seedName), nil
 	}

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation.go
@@ -29,7 +29,6 @@ import (
 	"github.com/gardener/gardener/pkg/logger"
 
 	"github.com/prometheus/client_golang/prometheus"
-	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
@@ -64,7 +63,7 @@ type Controller struct {
 }
 
 // NewController instantiates a new ControllerInstallation controller.
-func NewController(clientMap clientmap.ClientMap, gardenCoreInformerFactory gardencoreinformers.SharedInformerFactory, config *config.GardenletConfiguration, recorder record.EventRecorder, gardenNamespace *corev1.Namespace, gardenClusterIdentity string) *Controller {
+func NewController(clientMap clientmap.ClientMap, gardenCoreInformerFactory gardencoreinformers.SharedInformerFactory, config *config.GardenletConfiguration, recorder record.EventRecorder, gardenClusterIdentity string) *Controller {
 	var (
 		gardenCoreInformer = gardenCoreInformerFactory.Core().V1beta1()
 
@@ -83,7 +82,7 @@ func NewController(clientMap clientmap.ClientMap, gardenCoreInformerFactory gard
 	)
 
 	controller := &Controller{
-		controllerInstallationControl: NewDefaultControllerInstallationControl(clientMap, gardenCoreInformerFactory, recorder, config, seedLister, controllerRegistrationLister, controllerInstallationLister, gardenNamespace, gardenClusterIdentity),
+		controllerInstallationControl: NewDefaultControllerInstallationControl(clientMap, gardenCoreInformerFactory, recorder, config, seedLister, controllerRegistrationLister, controllerInstallationLister, gardenClusterIdentity),
 		careControl:                   NewDefaultCareControl(clientMap, config),
 
 		config:   config,

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation_control.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation_control.go
@@ -110,8 +110,8 @@ type ControlInterface interface {
 // NewDefaultControllerInstallationControl returns a new instance of the default implementation ControlInterface that
 // implements the documented semantics for ControllerInstallations. You should use an instance returned from
 // NewDefaultControllerInstallationControl() for any scenario other than testing.
-func NewDefaultControllerInstallationControl(clientMap clientmap.ClientMap, k8sGardenCoreInformers gardencoreinformers.SharedInformerFactory, recorder record.EventRecorder, config *config.GardenletConfiguration, seedLister gardencorelisters.SeedLister, controllerRegistrationLister gardencorelisters.ControllerRegistrationLister, controllerInstallationLister gardencorelisters.ControllerInstallationLister, gardenNamespace *corev1.Namespace, gardenClusterIdentity string) ControlInterface {
-	return &defaultControllerInstallationControl{clientMap, k8sGardenCoreInformers, recorder, config, seedLister, controllerRegistrationLister, controllerInstallationLister, gardenNamespace, gardenClusterIdentity}
+func NewDefaultControllerInstallationControl(clientMap clientmap.ClientMap, k8sGardenCoreInformers gardencoreinformers.SharedInformerFactory, recorder record.EventRecorder, config *config.GardenletConfiguration, seedLister gardencorelisters.SeedLister, controllerRegistrationLister gardencorelisters.ControllerRegistrationLister, controllerInstallationLister gardencorelisters.ControllerInstallationLister, gardenClusterIdentity string) ControlInterface {
+	return &defaultControllerInstallationControl{clientMap, k8sGardenCoreInformers, recorder, config, seedLister, controllerRegistrationLister, controllerInstallationLister, gardenClusterIdentity}
 }
 
 type defaultControllerInstallationControl struct {
@@ -122,7 +122,6 @@ type defaultControllerInstallationControl struct {
 	seedLister                   gardencorelisters.SeedLister
 	controllerRegistrationLister gardencorelisters.ControllerRegistrationLister
 	controllerInstallationLister gardencorelisters.ControllerInstallationLister
-	gardenNamespace              *corev1.Namespace
 	gardenClusterIdentity        string
 }
 
@@ -231,7 +230,6 @@ func (c *defaultControllerInstallationControl) reconcile(controllerInstallation 
 	gardenerValues := map[string]interface{}{
 		"gardener": map[string]interface{}{
 			"garden": map[string]interface{}{
-				"identity":        c.gardenNamespace.UID, // 'identity' value is deprecated to be replaced by 'clusterIdentity'. Should be removed in a future version.
 				"clusterIdentity": c.gardenClusterIdentity,
 			},
 			"seed": map[string]interface{}{

--- a/pkg/gardenlet/controller/factory.go
+++ b/pkg/gardenlet/controller/factory.go
@@ -66,7 +66,6 @@ type GardenletControllerFactory struct {
 	cfg                    *config.GardenletConfiguration
 	gardenClusterIdentity  string
 	identity               *gardencorev1beta1.Gardener
-	gardenNamespace        string
 	clientMap              clientmap.ClientMap
 	k8sGardenCoreInformers gardencoreinformers.SharedInformerFactory
 	k8sInformers           kubeinformers.SharedInformerFactory
@@ -80,7 +79,7 @@ func NewGardenletControllerFactory(
 	gardenCoreInformerFactory gardencoreinformers.SharedInformerFactory,
 	kubeInformerFactory kubeinformers.SharedInformerFactory,
 	cfg *config.GardenletConfiguration, identity *gardencorev1beta1.Gardener,
-	gardenClusterIdentity, gardenNamespace string,
+	gardenClusterIdentity string,
 	recorder record.EventRecorder,
 	healthManager healthz.Manager,
 ) *GardenletControllerFactory {
@@ -88,7 +87,6 @@ func NewGardenletControllerFactory(
 		cfg:                    cfg,
 		identity:               identity,
 		gardenClusterIdentity:  gardenClusterIdentity,
-		gardenNamespace:        gardenNamespace,
 		clientMap:              clientMap,
 		k8sGardenCoreInformers: gardenCoreInformerFactory,
 		k8sInformers:           kubeInformerFactory,

--- a/pkg/gardenlet/controller/factory.go
+++ b/pkg/gardenlet/controller/factory.go
@@ -146,15 +146,11 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 		runtime.Must(err)
 	}
 
-	gardenNamespace := &corev1.Namespace{}
-	// Use api reader here since we don't want to cache all namespaces of the Garden cluster.
-	runtime.Must(k8sGardenClient.APIReader().Get(ctx, kutil.Key(v1beta1constants.GardenNamespace), gardenNamespace))
-
 	// Initialize the workqueue metrics collection.
 	gardenmetrics.RegisterWorkqueMetrics()
 
 	var (
-		controllerInstallationController = controllerinstallationcontroller.NewController(f.clientMap, f.k8sGardenCoreInformers, f.cfg, f.recorder, gardenNamespace, f.gardenClusterIdentity)
+		controllerInstallationController = controllerinstallationcontroller.NewController(f.clientMap, f.k8sGardenCoreInformers, f.cfg, f.recorder, f.gardenClusterIdentity)
 		seedController                   = seedcontroller.NewSeedController(f.clientMap, f.k8sGardenCoreInformers, f.k8sInformers, f.healthManager, imageVector, componentImageVectors, f.identity, f.cfg, f.recorder)
 		shootController                  = shootcontroller.NewShootController(f.clientMap, f.k8sGardenCoreInformers, f.cfg, f.identity, f.gardenClusterIdentity, imageVector, f.recorder)
 	)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind cleanup
/squash

**What this PR does / why we need it**:
This PR cleans up a few nites I discovered during validation of the seed authorizer feature:

- The deprecated `.gardener.garden.identity` value is no longer passed to the Helm chart values of `ControllerInstallation`s (ref #2851)
- The gardenlet identity's namespace was unused and is removed
- The authorization attributes require special handling for `Namespace`s

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```action operator
The `.gardener.garden.identity` value (deprecated with v1.11.0) is removed and no longer passed to the Helm chart values of `ControllerInstallation`s. Gardener operators have to make sure to update affected provider extensions accordingly.
```
