### PR TITLE
Use new vpn2 container image to include firewall rules for vpn-seed-server

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -89,7 +89,7 @@ images:
 - name: vpn-seed-server
   sourceRepository: github.com/gardener/vpn2
   repository: eu.gcr.io/gardener-project/gardener/vpn-seed-server
-  tag: "0.3.0"
+  tag: "0.4.0"
 - name: konnectivity-server
   sourceRepository: github.com/gardener/replica-reloader
   repository: eu.gcr.io/gardener-project/gardener/replica-reloader
@@ -137,7 +137,7 @@ images:
 - name: vpn-shoot-client
   sourceRepository: github.com/gardener/vpn2
   repository: eu.gcr.io/gardener-project/gardener/vpn-shoot-client
-  tag: "0.3.0"
+  tag: "0.4.0"
 - name: konnectivity-agent
   sourceRepository: github.com/kubernetes-sigs/apiserver-network-proxy
   repository: k8s.gcr.io/kas-network-proxy/proxy-agent


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
This pull request uses the new vpn2 container images, which add firewall rules to the vpn-seed-server pod ensuring that it is not possible for the shoot to connect to seed resources.

**Which issue(s) this PR fixes**:
Fixes potential security vulnerability. Adds another layer of security.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->

``` noteworthy operator github.com/gardener/vpn2 #2 @marwinski
This PR prevents any direct traffic from the shoot cluster towards the `vpn-seed-server` pod via the OpenVPN connection. Connectivity from the shoot cluster to the seed cluster via the VPN connection is not needed and blocked with this PR for security reasons.
```