### PR TITLE
Add FluentBitIdleInputPlugins alert

### DIFF
--- a/charts/seed-bootstrap/aggregate-prometheus-rules-tests/fluent-bit.rules.test.yaml
+++ b/charts/seed-bootstrap/aggregate-prometheus-rules-tests/fluent-bit.rules.test.yaml
@@ -31,6 +31,28 @@ tests:
   external_labels:
     seed: aws
   input_series:
+  # FluentBitDown
+  - series: 'fluentbit_input_bytes_total{pod="fluent-bit-test"}'
+    values: '1+1x3 4+0x370'
+  alert_rule_test:
+  - eval_time: 370m
+    alertname: FluentBitIdleInputPlugins
+    exp_alerts:
+    - exp_labels:
+        service: logging
+        severity: warning
+        type: seed
+        visibility: operator
+        pod: fluent-bit-test
+      exp_annotations:
+        description: >
+          The input plugins of Fluent-bit pod fluent-bit-test running on seed aws haven't collected any logs for the last 6 hours.
+        summary: Fluent-bit input plugins haven't process any data for the past 6 hours
+
+- interval: 1m
+  external_labels:
+    seed: aws
+  input_series:
   # FluentBitReceivesLogsWithoutMetadata
   - series: 'fluentbit_loki_gardener_logs_without_metadata_total{pod="fluent-bit-test"}'
     values: '0+0x3 0+1x30'

--- a/charts/seed-bootstrap/aggregate-prometheus-rules/fluent-bit.rules.yaml
+++ b/charts/seed-bootstrap/aggregate-prometheus-rules/fluent-bit.rules.yaml
@@ -19,7 +19,25 @@ groups:
         description: >
           There are no fluent-bit pods running on seed: {{$externalLabels.seed}}.
           No logs will be collected.
-  
+
+    - alert: FluentBitIdleInputPlugins
+      expr: |
+        sum by (pod) (
+          increase(
+            fluentbit_input_bytes_total{pod=~"fluent-bit.*"}[4m]
+          )
+        ) == 0
+      for: 6h
+      labels:
+        severity: warning
+        service: logging
+        type: seed
+        visibility: operator
+      annotations:
+        summary: Fluent-bit input plugins haven't process any data for the past 6 hours
+        description: >
+          The input plugins of Fluent-bit pod {{$labels.pod}} running on seed {{$externalLabels.seed}} haven't collected any logs for the last 6 hours.
+
     - alert: FluentBitReceivesLogsWithoutMetadata
       expr: |
         sum by (pod) (
@@ -37,7 +55,7 @@ groups:
         description: >
           {{$labels.pod}} receives logs without metadata on seed:
           {{$externalLabels.seed}}. These logs will be dropped.
-  
+
     - alert: FluentBitSendsOoOLogs
       expr: |
         sum by (pod) (
@@ -55,7 +73,7 @@ groups:
         description: >
           {{$labels.pod}} on seed: {{$externalLabels.seed}} sends OutOfOrder logs
           to the Loki. These logs will be dropped.
-  
+
     - alert: FluentBitGardenerLokiPluginErrors
       expr: |
         sum by (pod) (


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
Recently we found that sometimes flued-bit pods stuck. They stops to prosses logs.
It is difficult to catch when this happens because the pods are still using CPU and Memory and looks like other working fluent-bit pods. The only difference is in the metric `fluentbit_input_bytes_total` which doesn't increase.
The new alert `FluentBitIdleInputPlugins` warn us when this is happening.
 
**Which issue(s) this PR fixes**:
This new alert will help debugging  [#94](https://github.com/gardener/logging/issues/94)

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
New alert `FluentBitIdleInputPlugins` for idle fluent-bit pods.
```
