### PR TITLE
Add missing test suite

### DIFF
--- a/pkg/extensions/extensions_suite_test.go
+++ b/pkg/extensions/extensions_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extensions_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestExtensions(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Extensions Suite")
+}


### PR DESCRIPTION
/kind bug

Currently on `make test-cov` there is the following warning in the ouput:

```
[...]
testing: warning: no tests to run
coverage: 0.9% of statements
Found no test suites, did you forget to run "ginkgo bootstrap"?
[...]
```

The warning is coming from `pkg/extensions` as it defines tests but does not have a test suite. ginkgo requires each package to have a RunSpec function to be able run the tests - ref onsi/ginkgo#344.


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
