### PR TITLE
Use terraformer termination message

### DIFF
--- a/extensions/pkg/terraformer/errors.go
+++ b/extensions/pkg/terraformer/errors.go
@@ -15,37 +15,10 @@
 package terraformer
 
 import (
-	"fmt"
 	"regexp"
 	"sort"
 	"strings"
 )
-
-// retrieveTerraformErrors gets a map <logList> whose keys are pod names and whose values are the corresponding logs,
-// and it parses the logs for Terraform errors. If none are found, it will return nil, and otherwise the list of
-// found errors as string slice.
-func retrieveTerraformErrors(podName, logs string) []string {
-	var (
-		foundErrors = map[string]struct{}{}
-		errorList   []string
-	)
-
-	errorMessage := findTerraformErrors(logs)
-
-	// Add the errorMessage to the list of found errors (only if it does not already exist).
-	if _, ok := foundErrors[errorMessage]; !ok && errorMessage != "" {
-		foundErrors[errorMessage] = struct{}{}
-	}
-
-	for message := range foundErrors {
-		errorList = append(errorList, fmt.Sprintf("-> Pod '%s' reported:\n%s", podName, message))
-	}
-
-	if len(errorList) == 0 {
-		return nil
-	}
-	return errorList
-}
 
 // findTerraformErrors gets the <output> of a Terraform run and parses it to find the occurred
 // errors (which will be returned). If no errors occurred, an empty string will be returned.

--- a/extensions/pkg/terraformer/errors_test.go
+++ b/extensions/pkg/terraformer/errors_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 var _ = Describe("Errors", func() {
-	Describe("#retrieveTerraformErrors", func() {
+	Describe("#findTerraformErrors", func() {
 		var (
 			errorLog1error1 = `Error waiting to create Router: Error waiting for Creating Router: Quota 'ROUTERS' exceeded.  Limit: 20.0 globally.
 
@@ -141,15 +141,15 @@ Error: ` + errorLog5error2
 		)
 
 		DescribeTable("detects correct errors",
-			func(podName, logs, expectedMessage string) {
-				Expect(retrieveTerraformErrors(podName, logs)).To(ConsistOf(expectedMessage))
+			func(logs, expectedMessage string) {
+				Expect(findTerraformErrors(logs)).To(Equal(expectedMessage))
 			},
 
-			Entry("pod1", "pod1", errorLog1, "-> Pod 'pod1' reported:\n* "+regexUUID.ReplaceAllString(regexMultiNewline.ReplaceAllString(errorLog1error1, "\n"), "<omitted>")),
-			Entry("pod2", "pod2", errorLog2, "-> Pod 'pod2' reported:\n* "+regexUUID.ReplaceAllString(regexMultiNewline.ReplaceAllString(errorLog2error2, "\n")+"\n* "+regexMultiNewline.ReplaceAllString(errorLog2error1, "\n"), "<omitted>")),
-			Entry("pod3", "pod3", errorLog3, "-> Pod 'pod3' reported:\n* "+regexUUID.ReplaceAllString(regexMultiNewline.ReplaceAllString(errorLog3error1, "\n")+"\n* "+regexMultiNewline.ReplaceAllString(errorLog3error2, "\n")+"\n* "+regexMultiNewline.ReplaceAllString(errorLog3error3, "\n"), "<omitted>")),
-			Entry("pod4", "pod4", errorLog4, "-> Pod 'pod4' reported:\n* "+regexUUID.ReplaceAllString(regexMultiNewline.ReplaceAllString(errorLog4error1, "\n")+"\n* "+regexMultiNewline.ReplaceAllString(errorLog4error1, "\n"), "<omitted>")),
-			Entry("pod5", "pod5", errorLog5, "-> Pod 'pod5' reported:\n* "+regexUUID.ReplaceAllString(regexMultiNewline.ReplaceAllString(errorLog5error2, "\n")+"\n* "+regexMultiNewline.ReplaceAllString(errorLog5error1, "\n"), "<omitted>")),
+			Entry("pod1", errorLog1, "* "+regexUUID.ReplaceAllString(regexMultiNewline.ReplaceAllString(errorLog1error1, "\n"), "<omitted>")),
+			Entry("pod2", errorLog2, "* "+regexUUID.ReplaceAllString(regexMultiNewline.ReplaceAllString(errorLog2error2, "\n")+"\n* "+regexMultiNewline.ReplaceAllString(errorLog2error1, "\n"), "<omitted>")),
+			Entry("pod3", errorLog3, "* "+regexUUID.ReplaceAllString(regexMultiNewline.ReplaceAllString(errorLog3error1, "\n")+"\n* "+regexMultiNewline.ReplaceAllString(errorLog3error2, "\n")+"\n* "+regexMultiNewline.ReplaceAllString(errorLog3error3, "\n"), "<omitted>")),
+			Entry("pod4", errorLog4, "* "+regexUUID.ReplaceAllString(regexMultiNewline.ReplaceAllString(errorLog4error1, "\n")+"\n* "+regexMultiNewline.ReplaceAllString(errorLog4error1, "\n"), "<omitted>")),
+			Entry("pod5", errorLog5, "* "+regexUUID.ReplaceAllString(regexMultiNewline.ReplaceAllString(errorLog5error2, "\n")+"\n* "+regexMultiNewline.ReplaceAllString(errorLog5error1, "\n"), "<omitted>")),
 		)
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:

Use the terraformer termination message introduced by https://github.com/gardener/terraformer/pull/93 in the terraformer library to detect error codes instead of pod logs.
If the terraformer pod fails and no termination message is present, fallback to logs (forwards-compatible).

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/terraformer/issues/67 (<- see this issue for more details and background)

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other dependency
The Terraformer library now conducts the Pod's termination message for improved readability of error messages.
```
