### PR TITLE
Cleanup context.TODO(), migrate from DeprecatedCreateWorker to CreateWorker (3)

### DIFF
--- a/pkg/controllermanager/controller/controllerregistration/controllerregistration.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerregistration.go
@@ -75,6 +75,11 @@ func NewController(
 		return nil, fmt.Errorf("failed to get BackupBucket Informer: %w", err)
 	}
 
+	backupEntryInformer, err := gardenClient.Cache().GetInformer(ctx, &gardencorev1beta1.BackupEntry{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get BackupEntry Informer: %w", err)
+	}
+
 	controllerRegistrationInformer, err := gardenClient.Cache().GetInformer(ctx, &gardencorev1beta1.ControllerRegistration{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get ControllerRegistration Informer: %w", err)
@@ -83,8 +88,6 @@ func NewController(
 	var (
 		gardenCoreInformer = gardenCoreInformerFactory.Core().V1beta1()
 		k8sCoreInformer    = kubeInformerFactory.Core().V1()
-
-		backupEntryInformer = gardenCoreInformer.BackupEntries()
 
 		controllerInstallationInformer = gardenCoreInformer.ControllerInstallations()
 		controllerInstallationLister   = controllerInstallationInformer.Lister()
@@ -122,7 +125,7 @@ func NewController(
 		DeleteFunc: controller.backupBucketDelete,
 	})
 
-	backupEntryInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+	backupEntryInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    controller.backupEntryAdd,
 		UpdateFunc: controller.backupEntryUpdate,
 		DeleteFunc: controller.backupEntryDelete,
@@ -153,7 +156,7 @@ func NewController(
 
 	controller.hasSyncedFuncs = append(controller.hasSyncedFuncs,
 		backupBucketInformer.HasSynced,
-		backupEntryInformer.Informer().HasSynced,
+		backupEntryInformer.HasSynced,
 		controllerRegistrationInformer.HasSynced,
 		controllerInstallationInformer.Informer().HasSynced,
 		seedInformer.Informer().HasSynced,

--- a/pkg/controllermanager/controller/controllerregistration/controllerregistration_control.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerregistration_control.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -36,7 +37,8 @@ func (c *Controller) controllerRegistrationAdd(ctx context.Context, obj interfac
 	}
 	c.controllerRegistrationQueue.Add(key)
 
-	seedList := &gardencorev1beta1.SeedList{}
+	seedList := &metav1.PartialObjectMetadataList{}
+	seedList.SetGroupVersionKind(gardencorev1beta1.SchemeGroupVersion.WithKind("SeedList"))
 	if err := c.gardenClient.List(ctx, seedList); err != nil {
 		return
 	}

--- a/pkg/controllermanager/controller/controllerregistration/controllerregistration_control_test.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerregistration_control_test.go
@@ -90,7 +90,7 @@ var _ = Describe("Controller", func() {
 					},
 				}
 
-				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.SeedList{}))
+				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&metav1.PartialObjectMetadataList{}))
 
 				controller.controllerRegistrationAdd(ctx, obj)
 
@@ -105,7 +105,7 @@ var _ = Describe("Controller", func() {
 					},
 				}
 
-				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.SeedList{})).Return(fakeErr)
+				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&metav1.PartialObjectMetadataList{})).Return(fakeErr)
 
 				controller.controllerRegistrationAdd(ctx, obj)
 
@@ -123,14 +123,14 @@ var _ = Describe("Controller", func() {
 				var (
 					seed1    = "seed1"
 					seed2    = "seed2"
-					seedList = []gardencorev1beta1.Seed{
+					seedList = []metav1.PartialObjectMetadata{
 						{ObjectMeta: metav1.ObjectMeta{Name: seed1}},
 						{ObjectMeta: metav1.ObjectMeta{Name: seed2}},
 					}
 				)
 
-				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.SeedList{})).DoAndReturn(func(_ context.Context, obj *gardencorev1beta1.SeedList, _ ...client.ListOption) error {
-					(&gardencorev1beta1.SeedList{Items: seedList}).DeepCopyInto(obj)
+				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&metav1.PartialObjectMetadataList{})).DoAndReturn(func(_ context.Context, obj *metav1.PartialObjectMetadataList, _ ...client.ListOption) error {
+					(&metav1.PartialObjectMetadataList{Items: seedList}).DeepCopyInto(obj)
 					return nil
 				})
 
@@ -160,7 +160,7 @@ var _ = Describe("Controller", func() {
 					},
 				}
 
-				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.SeedList{}))
+				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&metav1.PartialObjectMetadataList{}))
 
 				controller.controllerRegistrationUpdate(ctx, nil, obj)
 

--- a/pkg/controllermanager/controller/controllerregistration/controllerregistration_control_test.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerregistration_control_test.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -26,24 +27,21 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
-	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
-	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
-	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/fake"
-	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
-	fakeclientset "github.com/gardener/gardener/pkg/client/kubernetes/fake"
 	"github.com/gardener/gardener/pkg/logger"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 )
 
 var _ = Describe("Controller", func() {
-	logger.Logger = logger.NewNopLogger()
-
 	var (
+		log = logger.NewNopLogger()
+
 		gardenCoreInformerFactory gardencoreinformers.SharedInformerFactory
 
 		queue                           *fakeQueue
@@ -55,8 +53,6 @@ var _ = Describe("Controller", func() {
 
 	BeforeEach(func() {
 		gardenCoreInformerFactory = gardencoreinformers.NewSharedInformerFactory(nil, 0)
-		controllerRegistrationInformer := gardenCoreInformerFactory.Core().V1beta1().ControllerRegistrations()
-		controllerRegistrationLister := controllerRegistrationInformer.Lister()
 		seedInformer := gardenCoreInformerFactory.Core().V1beta1().Seeds()
 		seedLister := seedInformer.Lister()
 
@@ -65,7 +61,6 @@ var _ = Describe("Controller", func() {
 
 		c = &Controller{
 			controllerRegistrationQueue:     queue,
-			controllerRegistrationLister:    controllerRegistrationLister,
 			controllerRegistrationSeedQueue: controllerRegistrationSeedQueue,
 			seedLister:                      seedLister,
 		}
@@ -191,213 +186,163 @@ var _ = Describe("Controller", func() {
 		})
 	})
 
-	Describe("#reconcileControllerRegistrationKey", func() {
-		It("should return an error because the key cannot be split", func() {
-			Expect(c.reconcileControllerRegistrationKey("a/b/c")).To(HaveOccurred())
+	Describe("#Reconcile", func() {
+		const finalizerName = "core.gardener.cloud/controllerregistration"
+
+		var (
+			ctx     = context.TODO()
+			fakeErr = fmt.Errorf("fake err")
+
+			ctrl *gomock.Controller
+			c    *mockclient.MockClient
+
+			reconciler             reconcile.Reconciler
+			controllerRegistration *gardencorev1beta1.ControllerRegistration
+		)
+
+		BeforeEach(func() {
+			ctrl = gomock.NewController(GinkgoT())
+			c = mockclient.NewMockClient(ctrl)
+
+			reconciler = NewControllerRegistrationReconciler(log, c)
+			controllerRegistration = &gardencorev1beta1.ControllerRegistration{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            controllerRegistrationName,
+					ResourceVersion: "42",
+				},
+			}
+		})
+
+		AfterEach(func() {
+			ctrl.Finish()
 		})
 
 		It("should return nil because object not found", func() {
-			c.controllerRegistrationLister = newFakeControllerRegistrationLister(c.controllerRegistrationLister, nil, apierrors.NewNotFound(schema.GroupResource{}, controllerRegistrationName))
+			c.EXPECT().Get(ctx, kutil.Key(controllerRegistrationName), gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerRegistration{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
 
-			Expect(c.reconcileControllerRegistrationKey(controllerRegistrationName)).NotTo(HaveOccurred())
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: controllerRegistrationName}})
+			Expect(result).To(Equal(reconcile.Result{}))
+			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("should return err because object not found", func() {
-			err := errors.New("error")
+		It("should return err because object reading failed", func() {
+			c.EXPECT().Get(ctx, kutil.Key(controllerRegistrationName), gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerRegistration{})).Return(fakeErr)
 
-			c.controllerRegistrationLister = newFakeControllerRegistrationLister(c.controllerRegistrationLister, nil, err)
-
-			Expect(c.reconcileControllerRegistrationKey(controllerRegistrationName)).To(Equal(err))
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: controllerRegistrationName}})
+			Expect(result).To(Equal(reconcile.Result{}))
+			Expect(err).To(MatchError(fakeErr))
 		})
 
-		It("should return the result of the reconciliation (nil)", func() {
-			obj := &gardencorev1beta1.ControllerRegistration{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: controllerRegistrationName,
-				},
-			}
-
-			c.controllerRegistrationControl = &fakeControllerRegistrationControl{}
-			c.controllerRegistrationLister = newFakeControllerRegistrationLister(c.controllerRegistrationLister, obj, nil)
-
-			Expect(c.reconcileControllerRegistrationKey(controllerRegistrationName)).To(BeNil())
-		})
-
-		It("should return the result of the reconciliation (error)", func() {
-			obj := &gardencorev1beta1.ControllerRegistration{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: controllerRegistrationName,
-				},
-			}
-
-			c.controllerRegistrationControl = &fakeControllerRegistrationControl{result: errors.New("")}
-			c.controllerRegistrationLister = newFakeControllerRegistrationLister(c.controllerRegistrationLister, obj, nil)
-
-			Expect(c.reconcileControllerRegistrationKey(controllerRegistrationName)).To(HaveOccurred())
-		})
-	})
-})
-
-type fakeControllerRegistrationControl struct {
-	result error
-}
-
-func (f *fakeControllerRegistrationControl) Reconcile(obj *gardencorev1beta1.ControllerRegistration) error {
-	return f.result
-}
-
-type fakeControllerRegistrationLister struct {
-	gardencorelisters.ControllerRegistrationLister
-
-	getResult *gardencorev1beta1.ControllerRegistration
-	getErr    error
-}
-
-func newFakeControllerRegistrationLister(controllerRegistrationLister gardencorelisters.ControllerRegistrationLister, getResult *gardencorev1beta1.ControllerRegistration, getErr error) *fakeControllerRegistrationLister {
-	return &fakeControllerRegistrationLister{
-		ControllerRegistrationLister: controllerRegistrationLister,
-
-		getResult: getResult,
-		getErr:    getErr,
-	}
-}
-
-func (c *fakeControllerRegistrationLister) Get(string) (*gardencorev1beta1.ControllerRegistration, error) {
-	if c.getErr != nil {
-		return nil, c.getErr
-	}
-	return c.getResult, nil
-}
-
-var _ = Describe("ControllerRegistrationControl", func() {
-	const (
-		finalizerName = "core.gardener.cloud/controllerregistration"
-	)
-
-	var (
-		ctrl                   *gomock.Controller
-		clientMap              clientmap.ClientMap
-		k8sGardenRuntimeClient *mockclient.MockClient
-
-		gardenCoreInformerFactory gardencoreinformers.SharedInformerFactory
-
-		d *defaultControllerRegistrationControl
-
-		ctx                        = context.TODO()
-		controllerRegistrationName = "controllerRegistration"
-		obj                        *gardencorev1beta1.ControllerRegistration
-	)
-
-	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
-		k8sGardenRuntimeClient = mockclient.NewMockClient(ctrl)
-		k8sGardenClient := fakeclientset.NewClientSetBuilder().WithClient(k8sGardenRuntimeClient).Build()
-
-		clientMap = fake.NewClientMap().AddClient(keys.ForGarden(), k8sGardenClient)
-
-		gardenCoreInformerFactory = gardencoreinformers.NewSharedInformerFactory(nil, 0)
-		controllerInstallationInformer := gardenCoreInformerFactory.Core().V1beta1().ControllerInstallations()
-		controllerInstallationLister := controllerInstallationInformer.Lister()
-
-		d = &defaultControllerRegistrationControl{clientMap, controllerInstallationLister}
-		obj = &gardencorev1beta1.ControllerRegistration{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:            controllerRegistrationName,
-				ResourceVersion: "42",
-			},
-		}
-	})
-
-	AfterEach(func() {
-		ctrl.Finish()
-	})
-
-	Describe("#Reconcile", func() {
 		Context("deletion timestamp not set", func() {
+			BeforeEach(func() {
+				c.EXPECT().Get(ctx, kutil.Key(controllerRegistrationName), gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerRegistration{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.ControllerRegistration) error {
+					*obj = *controllerRegistration
+					return nil
+				})
+			})
+
 			It("should ensure the finalizer (error)", func() {
-				err := apierrors.NewNotFound(schema.GroupResource{}, controllerRegistrationName)
+				errToReturn := apierrors.NewNotFound(schema.GroupResource{}, controllerRegistrationName)
 
-				k8sGardenRuntimeClient.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerRegistration{}), gomock.Any()).
-					DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
-						Expect(patch.Data(o)).To(BeEquivalentTo(fmt.Sprintf(`{"metadata":{"finalizers":["%s"],"resourceVersion":"42"}}`, finalizerName)))
-						return err
-					})
+				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerRegistration{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
+					Expect(patch.Data(o)).To(BeEquivalentTo(fmt.Sprintf(`{"metadata":{"finalizers":["%s"],"resourceVersion":"42"}}`, finalizerName)))
+					return errToReturn
+				})
 
-				Expect(d.Reconcile(obj)).To(HaveOccurred())
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: controllerRegistrationName}})
+				Expect(result).To(Equal(reconcile.Result{}))
+				Expect(err).To(MatchError(err))
 			})
 
 			It("should ensure the finalizer (no error)", func() {
-				k8sGardenRuntimeClient.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerRegistration{}), gomock.Any()).
-					DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
-						Expect(patch.Data(o)).To(BeEquivalentTo(fmt.Sprintf(`{"metadata":{"finalizers":["%s"],"resourceVersion":"42"}}`, finalizerName)))
-						return nil
-					})
+				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerRegistration{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
+					Expect(patch.Data(o)).To(BeEquivalentTo(fmt.Sprintf(`{"metadata":{"finalizers":["%s"],"resourceVersion":"42"}}`, finalizerName)))
+					return nil
+				})
 
-				Expect(d.Reconcile(obj)).NotTo(HaveOccurred())
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: controllerRegistrationName}})
+				Expect(result).To(Equal(reconcile.Result{}))
+				Expect(err).NotTo(HaveOccurred())
 			})
 		})
 
 		Context("deletion timestamp set", func() {
 			BeforeEach(func() {
 				now := metav1.Now()
-				obj.DeletionTimestamp = &now
-				obj.Finalizers = []string{FinalizerName}
+				controllerRegistration.DeletionTimestamp = &now
+				controllerRegistration.Finalizers = []string{FinalizerName}
+
+				c.EXPECT().Get(ctx, kutil.Key(controllerRegistrationName), gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerRegistration{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.ControllerRegistration) error {
+					*obj = *controllerRegistration
+					return nil
+				})
 			})
 
 			It("should do nothing because finalizer is not present", func() {
-				obj.Finalizers = nil
+				controllerRegistration.Finalizers = nil
 
-				Expect(d.Reconcile(obj)).NotTo(HaveOccurred())
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: controllerRegistrationName}})
+				Expect(result).To(Equal(reconcile.Result{}))
+				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("should return an error because installation list failed", func() {
-				err := errors.New("err")
+				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallationList{})).Return(fakeErr)
 
-				d.controllerInstallationLister = newFakeControllerInstallationLister(d.controllerInstallationLister, nil, err)
-
-				Expect(d.Reconcile(obj)).To(Equal(err))
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: controllerRegistrationName}})
+				Expect(result).To(Equal(reconcile.Result{}))
+				Expect(err).To(MatchError(fakeErr))
 			})
 
 			It("should return an error because installation referencing controllerRegistration exists", func() {
-				controllerInstallationList := []*gardencorev1beta1.ControllerInstallation{
-					{
-						Spec: gardencorev1beta1.ControllerInstallationSpec{
-							RegistrationRef: corev1.ObjectReference{
-								Name: controllerRegistrationName,
+				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallationList{})).DoAndReturn(func(_ context.Context, obj *gardencorev1beta1.ControllerInstallationList, _ ...client.ListOption) error {
+					(&gardencorev1beta1.ControllerInstallationList{Items: []gardencorev1beta1.ControllerInstallation{
+						{
+							Spec: gardencorev1beta1.ControllerInstallationSpec{
+								RegistrationRef: corev1.ObjectReference{
+									Name: controllerRegistrationName,
+								},
 							},
 						},
-					},
-				}
+					}}).DeepCopyInto(obj)
+					return nil
+				})
 
-				d.controllerInstallationLister = newFakeControllerInstallationLister(d.controllerInstallationLister, controllerInstallationList, nil)
-
-				err := d.Reconcile(obj)
-				Expect(err.Error()).To(ContainSubstring("cannot remove finalizer"))
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: controllerRegistrationName}})
+				Expect(result).To(Equal(reconcile.Result{}))
+				Expect(err).To(MatchError(ContainSubstring("cannot remove finalizer")))
 			})
 
 			It("should remove the finalizer (error)", func() {
-				err := errors.New("some err")
-				d.controllerInstallationLister = newFakeControllerInstallationLister(d.controllerInstallationLister, nil, nil)
+				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallationList{})).DoAndReturn(func(_ context.Context, obj *gardencorev1beta1.ControllerInstallationList, _ ...client.ListOption) error {
+					(&gardencorev1beta1.ControllerInstallationList{}).DeepCopyInto(obj)
+					return nil
+				})
 
-				k8sGardenRuntimeClient.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerRegistration{}), gomock.Any()).
-					DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
-						Expect(patch.Data(o)).To(BeEquivalentTo(`{"metadata":{"finalizers":null,"resourceVersion":"42"}}`))
-						return err
-					})
+				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerRegistration{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
+					Expect(patch.Data(o)).To(BeEquivalentTo(`{"metadata":{"finalizers":null,"resourceVersion":"42"}}`))
+					return fakeErr
+				})
 
-				Expect(d.Reconcile(obj)).To(HaveOccurred())
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: controllerRegistrationName}})
+				Expect(result).To(Equal(reconcile.Result{}))
+				Expect(err).To(MatchError(fakeErr))
 			})
 
 			It("should remove the finalizer (no error)", func() {
-				d.controllerInstallationLister = newFakeControllerInstallationLister(d.controllerInstallationLister, nil, nil)
+				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallationList{})).DoAndReturn(func(_ context.Context, obj *gardencorev1beta1.ControllerInstallationList, _ ...client.ListOption) error {
+					(&gardencorev1beta1.ControllerInstallationList{}).DeepCopyInto(obj)
+					return nil
+				})
 
-				k8sGardenRuntimeClient.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerRegistration{}), gomock.Any()).
-					DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
-						Expect(patch.Data(o)).To(BeEquivalentTo(`{"metadata":{"finalizers":null,"resourceVersion":"42"}}`))
-						return nil
-					})
+				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerRegistration{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
+					Expect(patch.Data(o)).To(BeEquivalentTo(`{"metadata":{"finalizers":null,"resourceVersion":"42"}}`))
+					return nil
+				})
 
-				Expect(d.Reconcile(obj)).NotTo(HaveOccurred())
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: controllerRegistrationName}})
+				Expect(result).To(Equal(reconcile.Result{}))
+				Expect(err).NotTo(HaveOccurred())
 			})
 		})
 	})

--- a/pkg/controllermanager/controller/controllerregistration/controllerregistration_seed_control.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerregistration_seed_control.go
@@ -24,7 +24,6 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/pkg/logger"
@@ -79,15 +78,13 @@ type RegistrationSeedControlInterface interface {
 func NewDefaultControllerRegistrationSeedControl(
 	gardenClient kubernetes.Interface,
 	secretLister corev1listers.SecretLister,
-	seedLister gardencorelisters.SeedLister,
 ) RegistrationSeedControlInterface {
-	return &defaultControllerRegistrationSeedControl{gardenClient, secretLister, seedLister}
+	return &defaultControllerRegistrationSeedControl{gardenClient, secretLister}
 }
 
 type defaultControllerRegistrationSeedControl struct {
 	gardenClient kubernetes.Interface
 	secretLister corev1listers.SecretLister
-	seedLister   gardencorelisters.SeedLister
 }
 
 // Reconcile reconciles the ControllerInstallations for given Seed object. It computes the desired list of
@@ -128,7 +125,7 @@ func (c *defaultControllerRegistrationSeedControl) Reconcile(obj *gardencorev1be
 		return err
 	}
 
-	secrets, err := gardenpkg.ReadGardenSecretsFromLister(ctx, c.secretLister, c.seedLister, gardenerutils.ComputeGardenNamespace(seed.Name))
+	secrets, err := gardenpkg.ReadGardenSecretsFromLister(ctx, c.secretLister, c.gardenClient.Client(), gardenerutils.ComputeGardenNamespace(seed.Name))
 	if err != nil {
 		return err
 	}

--- a/pkg/controllermanager/controller/controllerregistration/controllerregistration_seed_control.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerregistration_seed_control.go
@@ -41,7 +41,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/sets"
-	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -77,14 +76,12 @@ type RegistrationSeedControlInterface interface {
 // for any scenario other than testing.
 func NewDefaultControllerRegistrationSeedControl(
 	gardenClient kubernetes.Interface,
-	secretLister corev1listers.SecretLister,
 ) RegistrationSeedControlInterface {
-	return &defaultControllerRegistrationSeedControl{gardenClient, secretLister}
+	return &defaultControllerRegistrationSeedControl{gardenClient}
 }
 
 type defaultControllerRegistrationSeedControl struct {
 	gardenClient kubernetes.Interface
-	secretLister corev1listers.SecretLister
 }
 
 // Reconcile reconciles the ControllerInstallations for given Seed object. It computes the desired list of
@@ -125,7 +122,7 @@ func (c *defaultControllerRegistrationSeedControl) Reconcile(obj *gardencorev1be
 		return err
 	}
 
-	secrets, err := gardenpkg.ReadGardenSecretsFromLister(ctx, c.secretLister, c.gardenClient.Client(), gardenerutils.ComputeGardenNamespace(seed.Name))
+	secrets, err := gardenpkg.ReadGardenSecretsFromReader(ctx, c.gardenClient.Client(), gardenerutils.ComputeGardenNamespace(seed.Name))
 	if err != nil {
 		return err
 	}

--- a/pkg/controllermanager/controller/controllerregistration/controllerregistration_seed_control.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerregistration_seed_control.go
@@ -72,7 +72,7 @@ func (r *controllerRegistrationSeedReconciler) Reconcile(ctx context.Context, re
 	}
 
 	logger := logger.NewFieldLogger(r.logger, "controllerregistration-seed", seed.Name)
-	logger.Infof("[CONTROLLERINSTALLATION SEED] Reconciling %s", seed.Name)
+	logger.Info("[CONTROLLERINSTALLATION SEED] Reconciling")
 
 	controllerRegistrationList := &gardencorev1beta1.ControllerRegistrationList{}
 	if err := r.gardenClient.Client().List(ctx, controllerRegistrationList); err != nil {

--- a/pkg/controllermanager/controller/controllerregistration/controllerregistration_seed_control_test.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerregistration_seed_control_test.go
@@ -185,15 +185,17 @@ var _ = Describe("ControllerRegistrationSeedControl", func() {
 				},
 			},
 		}
-		backupBucketList = []*gardencorev1beta1.BackupBucket{
-			backupBucket1,
-			backupBucket2,
-			backupBucket3,
+		backupBucketList = &gardencorev1beta1.BackupBucketList{
+			Items: []gardencorev1beta1.BackupBucket{
+				*backupBucket1,
+				*backupBucket2,
+				*backupBucket3,
+			},
 		}
-		buckets = map[string]*gardencorev1beta1.BackupBucket{
-			backupBucket1.Name: backupBucket1,
-			backupBucket2.Name: backupBucket2,
-			backupBucket3.Name: backupBucket3,
+		buckets = map[string]gardencorev1beta1.BackupBucket{
+			backupBucket1.Name: *backupBucket1,
+			backupBucket2.Name: *backupBucket2,
+			backupBucket3.Name: *backupBucket3,
 		}
 
 		backupEntry1 = &gardencorev1beta1.BackupEntry{
@@ -567,7 +569,7 @@ var _ = Describe("ControllerRegistrationSeedControl", func() {
 
 	Describe("#computeKindTypesForBackupBuckets", func() {
 		It("should return empty results for empty input", func() {
-			kindTypes, bs := computeKindTypesForBackupBuckets(nil, seedName)
+			kindTypes, bs := computeKindTypesForBackupBuckets(&gardencorev1beta1.BackupBucketList{}, seedName)
 
 			Expect(kindTypes.Len()).To(BeZero())
 			Expect(bs).To(BeEmpty())

--- a/pkg/controllermanager/controller/controllerregistration/controllerregistration_seed_control_test.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerregistration_seed_control_test.go
@@ -55,8 +55,6 @@ var _ = Describe("Controller", func() {
 
 	BeforeEach(func() {
 		gardenCoreInformerFactory = gardencoreinformers.NewSharedInformerFactory(nil, 0)
-		controllerRegistrationInformer := gardenCoreInformerFactory.Core().V1beta1().ControllerRegistrations()
-		controllerRegistrationLister := controllerRegistrationInformer.Lister()
 		seedInformer := gardenCoreInformerFactory.Core().V1beta1().Seeds()
 		seedLister := seedInformer.Lister()
 
@@ -65,7 +63,6 @@ var _ = Describe("Controller", func() {
 
 		c = &Controller{
 			controllerRegistrationQueue:     queue,
-			controllerRegistrationLister:    controllerRegistrationLister,
 			controllerRegistrationSeedQueue: controllerRegistrationSeedQueue,
 			seedLister:                      seedLister,
 		}
@@ -461,15 +458,17 @@ var _ = Describe("ControllerRegistrationSeedControl", func() {
 				},
 			},
 		}
-		controllerRegistrationList = []*gardencorev1beta1.ControllerRegistration{
-			controllerRegistration1,
-			controllerRegistration2,
-			controllerRegistration3,
-			controllerRegistration4,
-			controllerRegistration5,
-			controllerRegistration6,
-			controllerRegistration7,
-			controllerRegistration8,
+		controllerRegistrationList = &gardencorev1beta1.ControllerRegistrationList{
+			Items: []gardencorev1beta1.ControllerRegistration{
+				*controllerRegistration1,
+				*controllerRegistration2,
+				*controllerRegistration3,
+				*controllerRegistration4,
+				*controllerRegistration5,
+				*controllerRegistration6,
+				*controllerRegistration7,
+				*controllerRegistration8,
+			},
 		}
 		controllerRegistrations = map[string]controllerRegistration{
 			controllerRegistration1.Name: {obj: controllerRegistration1},

--- a/pkg/controllermanager/controller/controllerregistration/controllerregistration_suite_test.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerregistration_suite_test.go
@@ -44,29 +44,6 @@ func (f *fakeQueue) Len() int {
 	return len(f.items)
 }
 
-type fakeControllerInstallationLister struct {
-	gardencorelisters.ControllerInstallationLister
-
-	listResult []*gardencorev1beta1.ControllerInstallation
-	listErr    error
-}
-
-func newFakeControllerInstallationLister(controllerInstallationLister gardencorelisters.ControllerInstallationLister, listResult []*gardencorev1beta1.ControllerInstallation, listErr error) *fakeControllerInstallationLister {
-	return &fakeControllerInstallationLister{
-		ControllerInstallationLister: controllerInstallationLister,
-
-		listResult: listResult,
-		listErr:    listErr,
-	}
-}
-
-func (c *fakeControllerInstallationLister) List(labels.Selector) ([]*gardencorev1beta1.ControllerInstallation, error) {
-	if c.listErr != nil {
-		return nil, c.listErr
-	}
-	return c.listResult, nil
-}
-
 type fakeSeedLister struct {
 	gardencorelisters.SeedLister
 

--- a/pkg/controllermanager/controller/controllerregistration/controllerregistration_suite_test.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerregistration_suite_test.go
@@ -17,12 +17,8 @@ package controllerregistration
 import (
 	"testing"
 
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/util/workqueue"
 )
 
@@ -42,36 +38,4 @@ func (f *fakeQueue) Add(item interface{}) {
 
 func (f *fakeQueue) Len() int {
 	return len(f.items)
-}
-
-type fakeSeedLister struct {
-	gardencorelisters.SeedLister
-
-	getResult  *gardencorev1beta1.Seed
-	listResult []*gardencorev1beta1.Seed
-	err        error
-}
-
-func newFakeSeedLister(seedLister gardencorelisters.SeedLister, getResult *gardencorev1beta1.Seed, listResult []*gardencorev1beta1.Seed, err error) *fakeSeedLister {
-	return &fakeSeedLister{
-		SeedLister: seedLister,
-
-		getResult:  getResult,
-		listResult: listResult,
-		err:        err,
-	}
-}
-
-func (c *fakeSeedLister) Get(string) (*gardencorev1beta1.Seed, error) {
-	if c.err != nil {
-		return nil, c.err
-	}
-	return c.getResult, nil
-}
-
-func (c *fakeSeedLister) List(labels.Selector) ([]*gardencorev1beta1.Seed, error) {
-	if c.err != nil {
-		return nil, c.err
-	}
-	return c.listResult, nil
 }

--- a/pkg/controllermanager/controller/controllerregistration/seed_control_test.go
+++ b/pkg/controllermanager/controller/controllerregistration/seed_control_test.go
@@ -16,9 +16,9 @@ package controllerregistration
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -26,21 +26,18 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
 	"github.com/gardener/gardener/pkg/logger"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 )
 
 var _ = Describe("Controller", func() {
-	logger.Logger = logger.NewNopLogger()
-
 	var (
-		gardenCoreInformerFactory gardencoreinformers.SharedInformerFactory
-
 		seedQueue          *fakeQueue
 		controllerRegQueue *fakeQueue
 		c                  *Controller
@@ -50,16 +47,11 @@ var _ = Describe("Controller", func() {
 	)
 
 	BeforeEach(func() {
-		gardenCoreInformerFactory = gardencoreinformers.NewSharedInformerFactory(nil, 0)
-		seedInformer := gardenCoreInformerFactory.Core().V1beta1().Seeds()
-		seedLister := seedInformer.Lister()
-
 		seedQueue = &fakeQueue{}
 		controllerRegQueue = &fakeQueue{}
 		c = &Controller{
 			seedQueue:                       seedQueue,
 			controllerRegistrationSeedQueue: controllerRegQueue,
-			seedLister:                      seedLister,
 		}
 
 		obj = &gardencorev1beta1.Seed{
@@ -167,73 +159,29 @@ var _ = Describe("Controller", func() {
 			Expect(controllerRegQueue.items[0]).To(Equal(seedName))
 		})
 	})
-
-	Describe("#reconcileSeedKey", func() {
-		It("should return an error because the key cannot be split", func() {
-			Expect(c.reconcileSeedKey("a/b/c")).To(HaveOccurred())
-		})
-
-		It("should return nil because object not found", func() {
-			c.seedLister = newFakeSeedLister(c.seedLister, nil, nil, apierrors.NewNotFound(schema.GroupResource{}, seedName))
-
-			Expect(c.reconcileSeedKey(seedName)).NotTo(HaveOccurred())
-		})
-
-		It("should return err because object not found", func() {
-			err := errors.New("error")
-
-			c.seedLister = newFakeSeedLister(c.seedLister, nil, nil, err)
-
-			Expect(c.reconcileSeedKey(seedName)).To(Equal(err))
-		})
-
-		It("should return the result of the reconciliation (nil)", func() {
-			c.seedControl = &fakeSeedControl{}
-			c.seedLister = newFakeSeedLister(c.seedLister, obj, nil, nil)
-
-			Expect(c.reconcileSeedKey(seedName)).To(BeNil())
-		})
-
-		It("should return the result of the reconciliation (error)", func() {
-			c.seedControl = &fakeSeedControl{result: errors.New("")}
-			c.seedLister = newFakeSeedLister(c.seedLister, obj, nil, nil)
-
-			Expect(c.reconcileSeedKey(seedName)).To(HaveOccurred())
-		})
-	})
 })
 
-type fakeSeedControl struct {
-	result error
-}
-
-func (f *fakeSeedControl) Reconcile(obj *gardencorev1beta1.Seed) error {
-	return f.result
-}
-
-var _ = Describe("SeedControl", func() {
-	const (
-		finalizerName = "core.gardener.cloud/controllerregistration"
-	)
+var _ = Describe("seedReconciler", func() {
+	const finalizerName = "core.gardener.cloud/controllerregistration"
 
 	var (
 		ctrl *gomock.Controller
 		c    *mockclient.MockClient
 
-		d *defaultSeedControl
+		reconciler reconcile.Reconciler
 
 		ctx      = context.TODO()
 		fakeErr  = fmt.Errorf("fake err")
 		seedName = "seed"
-		obj      *gardencorev1beta1.Seed
+		seed     *gardencorev1beta1.Seed
 	)
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		c = mockclient.NewMockClient(ctrl)
 
-		d = &defaultSeedControl{c}
-		obj = &gardencorev1beta1.Seed{
+		reconciler = NewSeedReconciler(logger.NewNopLogger(), c)
+		seed = &gardencorev1beta1.Seed{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            seedName,
 				ResourceVersion: "42",
@@ -246,16 +194,41 @@ var _ = Describe("SeedControl", func() {
 	})
 
 	Describe("#Reconcile", func() {
+		It("should return nil because object not found", func() {
+			c.EXPECT().Get(ctx, kutil.Key(seedName), gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
+
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: seedName}})
+			Expect(result).To(Equal(reconcile.Result{}))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should return err because object reading failed", func() {
+			c.EXPECT().Get(ctx, kutil.Key(seedName), gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).Return(fakeErr)
+
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: seedName}})
+			Expect(result).To(Equal(reconcile.Result{}))
+			Expect(err).To(MatchError(fakeErr))
+		})
+
 		Context("deletion timestamp not set", func() {
+			BeforeEach(func() {
+				c.EXPECT().Get(ctx, kutil.Key(seedName), gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Seed) error {
+					*obj = *seed
+					return nil
+				})
+			})
+
 			It("should ensure the finalizer (error)", func() {
-				err := apierrors.NewNotFound(schema.GroupResource{}, seedName)
+				errToReturn := apierrors.NewNotFound(schema.GroupResource{}, seedName)
 
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
 					Expect(patch.Data(o)).To(BeEquivalentTo(fmt.Sprintf(`{"metadata":{"finalizers":["%s"],"resourceVersion":"42"}}`, finalizerName)))
-					return err
+					return errToReturn
 				})
 
-				Expect(d.Reconcile(obj)).To(HaveOccurred())
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: seedName}})
+				Expect(result).To(Equal(reconcile.Result{}))
+				Expect(err).To(MatchError(errToReturn))
 			})
 
 			It("should ensure the finalizer (no error)", func() {
@@ -264,27 +237,38 @@ var _ = Describe("SeedControl", func() {
 					return nil
 				})
 
-				Expect(d.Reconcile(obj)).NotTo(HaveOccurred())
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: seedName}})
+				Expect(result).To(Equal(reconcile.Result{}))
+				Expect(err).NotTo(HaveOccurred())
 			})
 		})
 
 		Context("deletion timestamp set", func() {
 			BeforeEach(func() {
 				now := metav1.Now()
-				obj.DeletionTimestamp = &now
-				obj.Finalizers = []string{FinalizerName}
+				seed.DeletionTimestamp = &now
+				seed.Finalizers = []string{FinalizerName}
+
+				c.EXPECT().Get(ctx, kutil.Key(seedName), gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Seed) error {
+					*obj = *seed
+					return nil
+				})
 			})
 
 			It("should do nothing because finalizer is not present", func() {
-				obj.Finalizers = nil
+				seed.Finalizers = nil
 
-				Expect(d.Reconcile(obj)).NotTo(HaveOccurred())
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: seedName}})
+				Expect(result).To(Equal(reconcile.Result{}))
+				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("should return an error because installation list failed", func() {
 				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallationList{})).Return(fakeErr)
 
-				Expect(d.Reconcile(obj)).To(MatchError(fakeErr))
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: seedName}})
+				Expect(result).To(Equal(reconcile.Result{}))
+				Expect(err).To(MatchError(fakeErr))
 			})
 
 			It("should return an error because installation referencing seed exists", func() {
@@ -301,8 +285,9 @@ var _ = Describe("SeedControl", func() {
 					return nil
 				})
 
-				err := d.Reconcile(obj)
-				Expect(err.Error()).To(ContainSubstring("cannot remove finalizer"))
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: seedName}})
+				Expect(result).To(Equal(reconcile.Result{}))
+				Expect(err).To(MatchError(ContainSubstring("cannot remove finalizer")))
 			})
 
 			It("should remove the finalizer (error)", func() {
@@ -316,7 +301,9 @@ var _ = Describe("SeedControl", func() {
 					return fakeErr
 				})
 
-				Expect(d.Reconcile(obj)).To(HaveOccurred())
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: seedName}})
+				Expect(result).To(Equal(reconcile.Result{}))
+				Expect(err).To(MatchError(fakeErr))
 			})
 
 			It("should remove the finalizer (no error)", func() {
@@ -330,7 +317,9 @@ var _ = Describe("SeedControl", func() {
 					return nil
 				})
 
-				Expect(d.Reconcile(obj)).NotTo(HaveOccurred())
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: seedName}})
+				Expect(result).To(Equal(reconcile.Result{}))
+				Expect(err).NotTo(HaveOccurred())
 			})
 		})
 	})

--- a/pkg/controllermanager/controller/factory.go
+++ b/pkg/controllermanager/controller/factory.go
@@ -157,7 +157,7 @@ func (f *GardenControllerFactory) Run(ctx context.Context) error {
 		return fmt.Errorf("failed initializing CloudProfile controller: %w", err)
 	}
 
-	controllerRegistrationController, err := controllerregistrationcontroller.NewController(ctx, f.clientMap, f.k8sGardenCoreInformers, f.k8sInformers)
+	controllerRegistrationController, err := controllerregistrationcontroller.NewController(ctx, f.clientMap, f.k8sInformers)
 	if err != nil {
 		return fmt.Errorf("failed initializing ControllerRegistration controller: %w", err)
 	}

--- a/pkg/controllermanager/controller/factory.go
+++ b/pkg/controllermanager/controller/factory.go
@@ -157,6 +157,11 @@ func (f *GardenControllerFactory) Run(ctx context.Context) error {
 		return fmt.Errorf("failed initializing CloudProfile controller: %w", err)
 	}
 
+	controllerRegistrationController, err := controllerregistrationcontroller.NewController(ctx, f.clientMap, f.k8sGardenCoreInformers, f.k8sInformers)
+	if err != nil {
+		return fmt.Errorf("failed initializing ControllerRegistration controller: %w", err)
+	}
+
 	csrController, err := csrcontroller.NewCSRController(ctx, f.clientMap)
 	if err != nil {
 		return fmt.Errorf("failed initializing CSR controller: %w", err)
@@ -183,9 +188,8 @@ func (f *GardenControllerFactory) Run(ctx context.Context) error {
 	}
 
 	var (
-		controllerRegistrationController = controllerregistrationcontroller.NewController(f.clientMap, f.k8sGardenCoreInformers, f.k8sInformers)
-		seedController                   = seedcontroller.NewSeedController(f.clientMap, f.k8sGardenCoreInformers, f.k8sInformers, f.cfg, f.recorder)
-		eventController                  = eventcontroller.NewController(f.clientMap, f.cfg.Controllers.Event)
+		seedController  = seedcontroller.NewSeedController(f.clientMap, f.k8sGardenCoreInformers, f.k8sInformers, f.cfg, f.recorder)
+		eventController = eventcontroller.NewController(f.clientMap, f.cfg.Controllers.Event)
 	)
 
 	shootController, err := shootcontroller.NewShootController(ctx, f.clientMap, f.k8sGardenCoreInformers, f.k8sInformers, f.cfg, f.recorder)
@@ -202,8 +206,8 @@ func (f *GardenControllerFactory) Run(ctx context.Context) error {
 	gardenmetrics.RegisterControllerMetrics(
 		controllermanager.ControllerWorkerSum,
 		controllermanager.ScrapeFailures,
-		controllerRegistrationController,
 		cloudProfileController,
+		controllerRegistrationController,
 		csrController,
 		quotaController,
 		plantController,

--- a/pkg/controllermanager/controller/factory.go
+++ b/pkg/controllermanager/controller/factory.go
@@ -157,7 +157,7 @@ func (f *GardenControllerFactory) Run(ctx context.Context) error {
 		return fmt.Errorf("failed initializing CloudProfile controller: %w", err)
 	}
 
-	controllerRegistrationController, err := controllerregistrationcontroller.NewController(ctx, f.clientMap, f.k8sInformers)
+	controllerRegistrationController, err := controllerregistrationcontroller.NewController(ctx, f.clientMap)
 	if err != nil {
 		return fmt.Errorf("failed initializing ControllerRegistration controller: %w", err)
 	}

--- a/pkg/controllermanager/controller/project/project.go
+++ b/pkg/controllermanager/controller/project/project.go
@@ -73,7 +73,7 @@ func NewProjectController(
 
 	projectInformer, err := gardenClient.Cache().GetInformer(ctx, &gardencorev1beta1.Project{})
 	if err != nil {
-		return nil, fmt.Errorf("failed to get Shoot Informer: %w", err)
+		return nil, fmt.Errorf("failed to get Project Informer: %w", err)
 	}
 
 	var (

--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -171,12 +171,7 @@ func (b *Botanist) RequiredExtensionsReady(ctx context.Context) error {
 		return err
 	}
 
-	var controllerRegistrations []*gardencorev1beta1.ControllerRegistration
-	for _, controllerRegistration := range controllerRegistrationList.Items {
-		controllerRegistrations = append(controllerRegistrations, controllerRegistration.DeepCopy())
-	}
-
-	requiredExtensions := shootpkg.ComputeRequiredExtensions(b.Shoot.Info, b.Seed.Info, controllerRegistrations, b.Garden.InternalDomain, b.Shoot.ExternalDomain)
+	requiredExtensions := shootpkg.ComputeRequiredExtensions(b.Shoot.Info, b.Seed.Info, controllerRegistrationList, b.Garden.InternalDomain, b.Shoot.ExternalDomain)
 
 	for _, controllerInstallation := range controllerInstallationList.Items {
 		if controllerInstallation.Spec.SeedRef.Name != b.Seed.Info.Name {

--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -510,7 +510,7 @@ func ToNetworks(s *gardencorev1beta1.Shoot) (*Networks, error) {
 
 // ComputeRequiredExtensions compute the extension kind/type combinations that are required for the
 // reconciliation flow.
-func ComputeRequiredExtensions(shoot *gardencorev1beta1.Shoot, seed *gardencorev1beta1.Seed, controllerRegistrationList []*gardencorev1beta1.ControllerRegistration, internalDomain, externalDomain *garden.Domain) sets.String {
+func ComputeRequiredExtensions(shoot *gardencorev1beta1.Shoot, seed *gardencorev1beta1.Seed, controllerRegistrationList *gardencorev1beta1.ControllerRegistrationList, internalDomain, externalDomain *garden.Domain) sets.String {
 	requiredExtensions := sets.NewString()
 
 	if seed.Spec.Backup != nil {
@@ -567,7 +567,7 @@ func ComputeRequiredExtensions(shoot *gardencorev1beta1.Shoot, seed *gardencorev
 		}
 	}
 
-	for _, controllerRegistration := range controllerRegistrationList {
+	for _, controllerRegistration := range controllerRegistrationList.Items {
 		for _, resource := range controllerRegistration.Spec.Resources {
 			id := gardenerextensions.Id(extensionsv1alpha1.ExtensionResource, resource.Type)
 			if resource.Kind == extensionsv1alpha1.ExtensionResource && resource.GloballyEnabled != nil && *resource.GloballyEnabled && !disabledExtensions.Has(id) {

--- a/pkg/operation/shoot/shoot_test.go
+++ b/pkg/operation/shoot/shoot_test.go
@@ -387,40 +387,42 @@ var _ = Describe("shoot", func() {
 		var (
 			shoot                      *gardencorev1beta1.Shoot
 			seed                       *gardencorev1beta1.Seed
-			controllerRegistrationList []*gardencorev1beta1.ControllerRegistration
+			controllerRegistrationList *gardencorev1beta1.ControllerRegistrationList
 			internalDomain             *garden.Domain
 			externalDomain             *garden.Domain
 		)
 
 		BeforeEach(func() {
-			controllerRegistrationList = []*gardencorev1beta1.ControllerRegistration{
-				{
-					Spec: gardencorev1beta1.ControllerRegistrationSpec{
-						Resources: []gardencorev1beta1.ControllerResource{
-							{
-								Kind: extensionsv1alpha1.ContainerRuntimeResource,
-								Type: extensionType3,
+			controllerRegistrationList = &gardencorev1beta1.ControllerRegistrationList{
+				Items: []gardencorev1beta1.ControllerRegistration{
+					{
+						Spec: gardencorev1beta1.ControllerRegistrationSpec{
+							Resources: []gardencorev1beta1.ControllerResource{
+								{
+									Kind: extensionsv1alpha1.ContainerRuntimeResource,
+									Type: extensionType3,
+								},
 							},
 						},
 					},
-				},
-				{
-					Spec: gardencorev1beta1.ControllerRegistrationSpec{
-						Resources: []gardencorev1beta1.ControllerResource{
-							{
-								Kind: extensionsv1alpha1.ExtensionResource,
-								Type: extensionType1,
+					{
+						Spec: gardencorev1beta1.ControllerRegistrationSpec{
+							Resources: []gardencorev1beta1.ControllerResource{
+								{
+									Kind: extensionsv1alpha1.ExtensionResource,
+									Type: extensionType1,
+								},
 							},
 						},
 					},
-				},
-				{
-					Spec: gardencorev1beta1.ControllerRegistrationSpec{
-						Resources: []gardencorev1beta1.ControllerResource{
-							{
-								Kind:            extensionsv1alpha1.ExtensionResource,
-								Type:            extensionType2,
-								GloballyEnabled: pointer.BoolPtr(true),
+					{
+						Spec: gardencorev1beta1.ControllerRegistrationSpec{
+							Resources: []gardencorev1beta1.ControllerResource{
+								{
+									Kind:            extensionsv1alpha1.ExtensionResource,
+									Type:            extensionType2,
+									GloballyEnabled: pointer.BoolPtr(true),
+								},
 							},
 						},
 					},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:
Similar to #3658 and #3681, this PR continues with migration a couple of our controllers from `controllerutils.DeprecatedCreateWorker` (deprecated since #1094) to `controllerutils.CreateWorker`. This helps to get rid of some remaining usages of `context.TODO()`. Also, it replace client-go informers/listers with informers from the controller-runtime.

**Which issue(s) this PR fixes**:
Part of #1648 

**Special notes for your reviewer**:
ℹ️ Once this PR is merged, I'll follow-up with more PRs that also cover the remaining/not-yet migrated controllers.
/squash

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
