### PR TITLE
Cleanup context.TODO(), migrate from DeprecatedCreateWorker to CreateWorker (4)

### DIFF
--- a/pkg/controllermanager/controller/factory.go
+++ b/pkg/controllermanager/controller/factory.go
@@ -188,7 +188,7 @@ func (f *GardenControllerFactory) Run(ctx context.Context) error {
 		eventController                  = eventcontroller.NewController(f.clientMap, f.cfg.Controllers.Event)
 	)
 
-	shootController, err := shootcontroller.NewShootController(ctx, f.clientMap, f.k8sGardenCoreInformers, f.k8sInformers, f.cfg, f.recorder)
+	shootController, err := shootcontroller.NewShootController(ctx, f.clientMap, f.k8sInformers, f.cfg, f.recorder)
 	if err != nil {
 		return fmt.Errorf("failed initializing Shoot controller: %w", err)
 	}

--- a/pkg/controllermanager/controller/factory.go
+++ b/pkg/controllermanager/controller/factory.go
@@ -162,7 +162,7 @@ func (f *GardenControllerFactory) Run(ctx context.Context) error {
 		return fmt.Errorf("failed initializing CSR controller: %w", err)
 	}
 
-	plantController, err := plantcontroller.NewController(ctx, f.clientMap, f.k8sInformers, f.cfg)
+	plantController, err := plantcontroller.NewController(ctx, f.clientMap, f.cfg)
 	if err != nil {
 		return fmt.Errorf("failed initializing Plant controller: %w", err)
 	}

--- a/pkg/controllermanager/controller/factory.go
+++ b/pkg/controllermanager/controller/factory.go
@@ -172,7 +172,7 @@ func (f *GardenControllerFactory) Run(ctx context.Context) error {
 		return fmt.Errorf("failed initializing Project controller: %w", err)
 	}
 
-	quotaController, err := quotacontroller.NewQuotaController(ctx, f.clientMap, f.k8sGardenCoreInformers, f.recorder)
+	quotaController, err := quotacontroller.NewQuotaController(ctx, f.clientMap, f.recorder)
 	if err != nil {
 		return fmt.Errorf("failed initializing Quota controller: %w", err)
 	}

--- a/pkg/controllermanager/controller/factory.go
+++ b/pkg/controllermanager/controller/factory.go
@@ -177,7 +177,7 @@ func (f *GardenControllerFactory) Run(ctx context.Context) error {
 		return fmt.Errorf("failed initializing Quota controller: %w", err)
 	}
 
-	secretBindingController, err := secretbindingcontroller.NewSecretBindingController(ctx, f.clientMap, f.k8sGardenCoreInformers, f.k8sInformers, f.recorder)
+	secretBindingController, err := secretbindingcontroller.NewSecretBindingController(ctx, f.clientMap, f.recorder)
 	if err != nil {
 		return fmt.Errorf("failed initializing SecretBinding controller: %w", err)
 	}

--- a/pkg/controllermanager/controller/quota/quota.go
+++ b/pkg/controllermanager/controller/quota/quota.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
 	"github.com/gardener/gardener/pkg/controllermanager"
@@ -51,7 +50,6 @@ type Controller struct {
 func NewQuotaController(
 	ctx context.Context,
 	clientMap clientmap.ClientMap,
-	gardenCoreInformerFactory gardencoreinformers.SharedInformerFactory,
 	recorder record.EventRecorder,
 ) (
 	*Controller,
@@ -67,10 +65,8 @@ func NewQuotaController(
 		return nil, fmt.Errorf("failed to get Quota Informer: %w", err)
 	}
 
-	var secretBindingLister = gardenCoreInformerFactory.Core().V1beta1().SecretBindings().Lister()
-
 	quotaController := &Controller{
-		reconciler: NewQuotaReconciler(logger.Logger, gardenClient.Client(), recorder, secretBindingLister),
+		reconciler: NewQuotaReconciler(logger.Logger, gardenClient.Client(), recorder),
 		quotaQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Quota"),
 		workerCh:   make(chan int),
 	}

--- a/pkg/controllermanager/controller/quota/quota_control.go
+++ b/pkg/controllermanager/controller/quota/quota_control.go
@@ -21,7 +21,6 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/logger"
 
@@ -58,20 +57,18 @@ func (c *Controller) quotaDelete(obj interface{}) {
 }
 
 // NewQuotaReconciler creates a new instance of a reconciler which reconciles Quotas.
-func NewQuotaReconciler(l logrus.FieldLogger, gardenClient client.Client, recorder record.EventRecorder, secretBindingLister gardencorelisters.SecretBindingLister) reconcile.Reconciler {
+func NewQuotaReconciler(l logrus.FieldLogger, gardenClient client.Client, recorder record.EventRecorder) reconcile.Reconciler {
 	return &quotaReconciler{
-		logger:              l,
-		gardenClient:        gardenClient,
-		recorder:            recorder,
-		secretBindingLister: secretBindingLister,
+		logger:       l,
+		gardenClient: gardenClient,
+		recorder:     recorder,
 	}
 }
 
 type quotaReconciler struct {
-	logger              logrus.FieldLogger
-	gardenClient        client.Client
-	recorder            record.EventRecorder
-	secretBindingLister gardencorelisters.SecretBindingLister
+	logger       logrus.FieldLogger
+	gardenClient client.Client
+	recorder     record.EventRecorder
 }
 
 func (r *quotaReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
@@ -95,7 +92,7 @@ func (r *quotaReconciler) Reconcile(ctx context.Context, request reconcile.Reque
 			return reconcile.Result{}, nil
 		}
 
-		associatedSecretBindings, err := controllerutils.DetermineSecretBindingAssociations(quota, r.secretBindingLister)
+		associatedSecretBindings, err := controllerutils.DetermineSecretBindingAssociations(ctx, r.gardenClient, quota)
 		if err != nil {
 			quotaLogger.Error(err.Error())
 			return reconcile.Result{}, err

--- a/pkg/controllermanager/controller/secretbinding/secretbinding.go
+++ b/pkg/controllermanager/controller/secretbinding/secretbinding.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
 	"github.com/gardener/gardener/pkg/controllermanager"
@@ -29,7 +28,6 @@ import (
 	"github.com/gardener/gardener/pkg/logger"
 
 	"github.com/prometheus/client_golang/prometheus"
-	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
@@ -52,8 +50,6 @@ type Controller struct {
 func NewSecretBindingController(
 	ctx context.Context,
 	clientMap clientmap.ClientMap,
-	gardenInformerFactory gardencoreinformers.SharedInformerFactory,
-	kubeInformerFactory kubeinformers.SharedInformerFactory,
 	recorder record.EventRecorder,
 ) (
 	*Controller,
@@ -69,13 +65,8 @@ func NewSecretBindingController(
 		return nil, fmt.Errorf("failed to get SecretBinding Informer: %w", err)
 	}
 
-	var (
-		secretLister = kubeInformerFactory.Core().V1().Secrets().Lister()
-		shootLister  = gardenInformerFactory.Core().V1beta1().Shoots().Lister()
-	)
-
 	secretBindingController := &Controller{
-		reconciler:         NewSecretBindingReconciler(logger.Logger, gardenClient.Client(), recorder, secretLister, shootLister),
+		reconciler:         NewSecretBindingReconciler(logger.Logger, gardenClient.Client(), recorder),
 		secretBindingQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "SecretBinding"),
 		workerCh:           make(chan int),
 	}

--- a/pkg/controllermanager/controller/secretbinding/secretbinding_control.go
+++ b/pkg/controllermanager/controller/secretbinding/secretbinding_control.go
@@ -21,14 +21,13 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/logger"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	kubecorev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -59,19 +58,11 @@ func (c *Controller) secretBindingDelete(obj interface{}) {
 }
 
 // NewSecretBindingReconciler creates a new instance of a reconciler which reconciles SecretBindings.
-func NewSecretBindingReconciler(
-	l logrus.FieldLogger,
-	gardenClient client.Client,
-	recorder record.EventRecorder,
-	secretLister kubecorev1listers.SecretLister,
-	shootLister gardencorelisters.ShootLister,
-) reconcile.Reconciler {
+func NewSecretBindingReconciler(l logrus.FieldLogger, gardenClient client.Client, recorder record.EventRecorder) reconcile.Reconciler {
 	return &secretBindingReconciler{
 		logger:       l,
 		gardenClient: gardenClient,
 		recorder:     recorder,
-		secretLister: secretLister,
-		shootLister:  shootLister,
 	}
 }
 
@@ -79,8 +70,6 @@ type secretBindingReconciler struct {
 	logger       logrus.FieldLogger
 	gardenClient client.Client
 	recorder     record.EventRecorder
-	secretLister kubecorev1listers.SecretLister
-	shootLister  gardencorelisters.ShootLister
 }
 
 func (r *secretBindingReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
@@ -121,8 +110,8 @@ func (r *secretBindingReconciler) Reconcile(ctx context.Context, request reconci
 
 			if mayReleaseSecret {
 				// Remove finalizer from referenced secret
-				secret, err := r.secretLister.Secrets(secretBinding.SecretRef.Namespace).Get(secretBinding.SecretRef.Name)
-				if err == nil {
+				secret := &corev1.Secret{}
+				if err := r.gardenClient.Get(ctx, kutil.Key(secretBinding.SecretRef.Namespace, secretBinding.SecretRef.Name), secret); err == nil {
 					if err2 := controllerutils.PatchRemoveFinalizers(ctx, r.gardenClient, secret.DeepCopy(), gardencorev1beta1.ExternalGardenerName); err2 != nil {
 						secretBindingLogger.Error(err2.Error())
 						return reconcile.Result{}, err2
@@ -155,8 +144,8 @@ func (r *secretBindingReconciler) Reconcile(ctx context.Context, request reconci
 
 	// Add the Gardener finalizer to the referenced SecretBinding secret to protect it from deletion as long as
 	// the SecretBinding resource does exist.
-	secret, err := r.secretLister.Secrets(secretBinding.SecretRef.Namespace).Get(secretBinding.SecretRef.Name)
-	if err != nil {
+	secret := &corev1.Secret{}
+	if err := r.gardenClient.Get(ctx, kutil.Key(secretBinding.SecretRef.Namespace, secretBinding.SecretRef.Name), secret); err != nil {
 		secretBindingLogger.Error(err.Error())
 		return reconcile.Result{}, err
 	}

--- a/pkg/controllermanager/controller/shoot/shoot.go
+++ b/pkg/controllermanager/controller/shoot/shoot.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
 	"github.com/gardener/gardener/pkg/controllermanager"
@@ -66,7 +65,6 @@ type Controller struct {
 func NewShootController(
 	ctx context.Context,
 	clientMap clientmap.ClientMap,
-	k8sGardenCoreInformers gardencoreinformers.SharedInformerFactory,
 	kubeInformerFactory kubeinformers.SharedInformerFactory,
 	config *config.ControllerManagerConfiguration,
 	recorder record.EventRecorder,
@@ -89,12 +87,7 @@ func NewShootController(
 	}
 
 	var (
-		gardenCoreV1beta1Informer = k8sGardenCoreInformers.Core().V1beta1()
-		corev1Informer            = kubeInformerFactory.Core().V1()
-
-		cloudProfileInformer = gardenCoreV1beta1Informer.CloudProfiles()
-		cloudProfileLister   = cloudProfileInformer.Lister()
-
+		corev1Informer = kubeInformerFactory.Core().V1()
 		secretInformer = corev1Informer.Secrets()
 		secretLister   = secretInformer.Lister()
 	)
@@ -103,8 +96,8 @@ func NewShootController(
 		config: config,
 
 		shootHibernationReconciler: NewShootHibernationReconciler(logger.Logger, gardenClient, NewHibernationScheduleRegistry(), recorder),
-		shootMaintenanceReconciler: NewShootMaintenanceReconciler(logger.Logger, gardenClient, config.Controllers.ShootMaintenance, cloudProfileLister, recorder),
-		shootQuotaReconciler:       NewShootQuotaReconciler(logger.Logger, gardenClient.Client(), config.Controllers.ShootQuota, gardenCoreV1beta1Informer),
+		shootMaintenanceReconciler: NewShootMaintenanceReconciler(logger.Logger, gardenClient, config.Controllers.ShootMaintenance, recorder),
+		shootQuotaReconciler:       NewShootQuotaReconciler(logger.Logger, gardenClient.Client(), config.Controllers.ShootQuota),
 		configMapReconciler:        NewConfigMapReconciler(logger.Logger, gardenClient.Client()),
 
 		shootMaintenanceQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "shoot-maintenance"),
@@ -145,7 +138,6 @@ func NewShootController(
 
 	shootController.hasSyncedFuncs = []cache.InformerSynced{
 		shootInformer.HasSynced,
-		gardenCoreV1beta1Informer.Quotas().Informer().HasSynced,
 		configMapInformer.HasSynced,
 	}
 

--- a/pkg/controllermanager/controller/shoot/shoot_maintenance_control.go
+++ b/pkg/controllermanager/controller/shoot/shoot_maintenance_control.go
@@ -23,7 +23,6 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
-	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
 	"github.com/gardener/gardener/pkg/controllerutils"
@@ -77,22 +76,20 @@ func (c *Controller) shootMaintenanceDelete(obj interface{}) {
 }
 
 // NewShootMaintenanceReconciler creates a new instance of a reconciler which maintains Shoots.
-func NewShootMaintenanceReconciler(l logrus.FieldLogger, gardenClient kubernetes.Interface, config config.ShootMaintenanceControllerConfiguration, cloudProfileLister gardencorelisters.CloudProfileLister, recorder record.EventRecorder) reconcile.Reconciler {
+func NewShootMaintenanceReconciler(l logrus.FieldLogger, gardenClient kubernetes.Interface, config config.ShootMaintenanceControllerConfiguration, recorder record.EventRecorder) reconcile.Reconciler {
 	return &shootMaintenanceReconciler{
-		logger:             l,
-		gardenClient:       gardenClient,
-		config:             config,
-		cloudProfileLister: cloudProfileLister,
-		recorder:           recorder,
+		logger:       l,
+		gardenClient: gardenClient,
+		config:       config,
+		recorder:     recorder,
 	}
 }
 
 type shootMaintenanceReconciler struct {
-	logger             logrus.FieldLogger
-	gardenClient       kubernetes.Interface
-	config             config.ShootMaintenanceControllerConfiguration
-	cloudProfileLister gardencorelisters.CloudProfileLister
-	recorder           record.EventRecorder
+	logger       logrus.FieldLogger
+	gardenClient kubernetes.Interface
+	config       config.ShootMaintenanceControllerConfiguration
+	recorder     record.EventRecorder
 }
 
 func (r *shootMaintenanceReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
@@ -139,8 +136,8 @@ func (r *shootMaintenanceReconciler) reconcile(ctx context.Context, shoot *garde
 	shootLogger := r.logger.WithField("shoot", key)
 	shootLogger.Infof("[SHOOT MAINTENANCE] %s", key)
 
-	cloudProfile, err := r.cloudProfileLister.Get(shoot.Spec.CloudProfileName)
-	if err != nil {
+	cloudProfile := &gardencorev1beta1.CloudProfile{}
+	if err := r.gardenClient.Client().Get(ctx, kutil.Key(shoot.Spec.CloudProfileName), cloudProfile); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:
Similar to #3658, #3681, #3954, this PR continues with migration a couple of our controllers from `controllerutils.DeprecatedCreateWorker` (deprecated since #1094) to `controllerutils.CreateWorker`. This helps to get rid of some remaining usages of `context.TODO()`. Also, it replace client-go informers/listers with informers from the controller-runtime.

**Which issue(s) this PR fixes**:
Part of #1648 

**Special notes for your reviewer**:
ℹ️ Once this PR is merged, I'll follow-up with more PRs that also cover the remaining/not-yet migrated controllers.
/squash

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
