### PR TITLE
Cleanup context.TODO(), migrate from DeprecatedCreateWorker to CreateWorker (5)

### DIFF
--- a/pkg/controllermanager/controller/factory.go
+++ b/pkg/controllermanager/controller/factory.go
@@ -167,7 +167,7 @@ func (f *GardenControllerFactory) Run(ctx context.Context) error {
 		return fmt.Errorf("failed initializing Plant controller: %w", err)
 	}
 
-	projectController, err := projectcontroller.NewProjectController(ctx, f.clientMap, f.k8sInformers, f.cfg, f.recorder)
+	projectController, err := projectcontroller.NewProjectController(ctx, f.clientMap, f.cfg, f.recorder)
 	if err != nil {
 		return fmt.Errorf("failed initializing Project controller: %w", err)
 	}

--- a/pkg/controllermanager/controller/factory.go
+++ b/pkg/controllermanager/controller/factory.go
@@ -167,7 +167,7 @@ func (f *GardenControllerFactory) Run(ctx context.Context) error {
 		return fmt.Errorf("failed initializing Plant controller: %w", err)
 	}
 
-	projectController, err := projectcontroller.NewProjectController(ctx, f.clientMap, f.k8sGardenCoreInformers, f.k8sInformers, f.cfg, f.recorder)
+	projectController, err := projectcontroller.NewProjectController(ctx, f.clientMap, f.k8sInformers, f.cfg, f.recorder)
 	if err != nil {
 		return fmt.Errorf("failed initializing Project controller: %w", err)
 	}

--- a/pkg/controllermanager/controller/project/project.go
+++ b/pkg/controllermanager/controller/project/project.go
@@ -88,9 +88,6 @@ func NewProjectController(
 		shootInformer = gardenCoreV1beta1Informer.Shoots()
 		shootLister   = shootInformer.Lister()
 
-		plantInformer = gardenCoreV1beta1Informer.Plants()
-		plantLister   = plantInformer.Lister()
-
 		secretInformer = corev1Informer.Secrets()
 		secretLister   = secretInformer.Lister()
 	)
@@ -98,7 +95,7 @@ func NewProjectController(
 	projectController := &Controller{
 		gardenClient:           gardenClient.Client(),
 		projectReconciler:      NewProjectReconciler(logger.Logger, config.Controllers.Project, gardenClient, recorder),
-		projectStaleReconciler: NewProjectStaleReconciler(logger.Logger, config.Controllers.Project, gardenClient.Client(), shootLister, plantLister, secretLister),
+		projectStaleReconciler: NewProjectStaleReconciler(logger.Logger, config.Controllers.Project, gardenClient.Client(), shootLister, secretLister),
 		projectQueue:           workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Project"),
 		projectStaleQueue:      workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Project Stale"),
 		workerCh:               make(chan int),

--- a/pkg/controllermanager/controller/project/project.go
+++ b/pkg/controllermanager/controller/project/project.go
@@ -96,9 +96,6 @@ func NewProjectController(
 		quotaInformer = gardenCoreV1beta1Informer.Quotas()
 		quotaLister   = quotaInformer.Lister()
 
-		namespaceInformer = corev1Informer.Namespaces()
-		namespaceLister   = namespaceInformer.Lister()
-
 		secretInformer = corev1Informer.Secrets()
 		secretLister   = secretInformer.Lister()
 
@@ -107,8 +104,8 @@ func NewProjectController(
 
 	projectController := &Controller{
 		gardenClient:           gardenClient.Client(),
-		projectReconciler:      NewProjectReconciler(logger.Logger, config.Controllers.Project, gardenClient, recorder, namespaceLister),
-		projectStaleReconciler: NewProjectStaleReconciler(logger.Logger, config.Controllers.Project, gardenClient.Client(), shootLister, plantLister, backupEntryLister, secretBindingLister, quotaLister, namespaceLister, secretLister),
+		projectReconciler:      NewProjectReconciler(logger.Logger, config.Controllers.Project, gardenClient, recorder),
+		projectStaleReconciler: NewProjectStaleReconciler(logger.Logger, config.Controllers.Project, gardenClient.Client(), shootLister, plantLister, backupEntryLister, secretBindingLister, quotaLister, secretLister),
 		projectQueue:           workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Project"),
 		projectStaleQueue:      workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Project Stale"),
 		workerCh:               make(chan int),
@@ -127,7 +124,6 @@ func NewProjectController(
 
 	projectController.hasSyncedFuncs = append(projectController.hasSyncedFuncs,
 		projectInformer.HasSynced,
-		namespaceInformer.Informer().HasSynced,
 		roleBindingInformer.Informer().HasSynced,
 	)
 

--- a/pkg/controllermanager/controller/project/project.go
+++ b/pkg/controllermanager/controller/project/project.go
@@ -91,9 +91,6 @@ func NewProjectController(
 		plantInformer = gardenCoreV1beta1Informer.Plants()
 		plantLister   = plantInformer.Lister()
 
-		backupEntryInformer = gardenCoreV1beta1Informer.BackupEntries()
-		backupEntryLister   = backupEntryInformer.Lister()
-
 		secretInformer = corev1Informer.Secrets()
 		secretLister   = secretInformer.Lister()
 	)
@@ -101,7 +98,7 @@ func NewProjectController(
 	projectController := &Controller{
 		gardenClient:           gardenClient.Client(),
 		projectReconciler:      NewProjectReconciler(logger.Logger, config.Controllers.Project, gardenClient, recorder),
-		projectStaleReconciler: NewProjectStaleReconciler(logger.Logger, config.Controllers.Project, gardenClient.Client(), shootLister, plantLister, backupEntryLister, secretLister),
+		projectStaleReconciler: NewProjectStaleReconciler(logger.Logger, config.Controllers.Project, gardenClient.Client(), shootLister, plantLister, secretLister),
 		projectQueue:           workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Project"),
 		projectStaleQueue:      workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Project Stale"),
 		workerCh:               make(chan int),

--- a/pkg/controllermanager/controller/project/project.go
+++ b/pkg/controllermanager/controller/project/project.go
@@ -94,9 +94,6 @@ func NewProjectController(
 		backupEntryInformer = gardenCoreV1beta1Informer.BackupEntries()
 		backupEntryLister   = backupEntryInformer.Lister()
 
-		secretBindingInformer = gardenCoreV1beta1Informer.SecretBindings()
-		secretBindingLister   = secretBindingInformer.Lister()
-
 		secretInformer = corev1Informer.Secrets()
 		secretLister   = secretInformer.Lister()
 	)
@@ -104,7 +101,7 @@ func NewProjectController(
 	projectController := &Controller{
 		gardenClient:           gardenClient.Client(),
 		projectReconciler:      NewProjectReconciler(logger.Logger, config.Controllers.Project, gardenClient, recorder),
-		projectStaleReconciler: NewProjectStaleReconciler(logger.Logger, config.Controllers.Project, gardenClient.Client(), shootLister, plantLister, backupEntryLister, secretBindingLister, secretLister),
+		projectStaleReconciler: NewProjectStaleReconciler(logger.Logger, config.Controllers.Project, gardenClient.Client(), shootLister, plantLister, backupEntryLister, secretLister),
 		projectQueue:           workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Project"),
 		projectStaleQueue:      workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Project Stale"),
 		workerCh:               make(chan int),

--- a/pkg/controllermanager/controller/project/project.go
+++ b/pkg/controllermanager/controller/project/project.go
@@ -97,9 +97,6 @@ func NewProjectController(
 		secretBindingInformer = gardenCoreV1beta1Informer.SecretBindings()
 		secretBindingLister   = secretBindingInformer.Lister()
 
-		quotaInformer = gardenCoreV1beta1Informer.Quotas()
-		quotaLister   = quotaInformer.Lister()
-
 		secretInformer = corev1Informer.Secrets()
 		secretLister   = secretInformer.Lister()
 	)
@@ -107,7 +104,7 @@ func NewProjectController(
 	projectController := &Controller{
 		gardenClient:           gardenClient.Client(),
 		projectReconciler:      NewProjectReconciler(logger.Logger, config.Controllers.Project, gardenClient, recorder),
-		projectStaleReconciler: NewProjectStaleReconciler(logger.Logger, config.Controllers.Project, gardenClient.Client(), shootLister, plantLister, backupEntryLister, secretBindingLister, quotaLister, secretLister),
+		projectStaleReconciler: NewProjectStaleReconciler(logger.Logger, config.Controllers.Project, gardenClient.Client(), shootLister, plantLister, backupEntryLister, secretBindingLister, secretLister),
 		projectQueue:           workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Project"),
 		projectStaleQueue:      workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Project Stale"),
 		workerCh:               make(chan int),

--- a/pkg/controllermanager/controller/project/project_control.go
+++ b/pkg/controllermanager/controller/project/project_control.go
@@ -25,7 +25,6 @@ import (
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	kubecorev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -65,22 +64,20 @@ func (c *Controller) projectDelete(obj interface{}) {
 }
 
 // NewProjectReconciler creates a new instance of a reconciler which reconciles Projects.
-func NewProjectReconciler(l logrus.FieldLogger, config *config.ProjectControllerConfiguration, gardenClient kubernetes.Interface, recorder record.EventRecorder, namespaceLister kubecorev1listers.NamespaceLister) reconcile.Reconciler {
+func NewProjectReconciler(l logrus.FieldLogger, config *config.ProjectControllerConfiguration, gardenClient kubernetes.Interface, recorder record.EventRecorder) reconcile.Reconciler {
 	return &projectReconciler{
-		logger:          l,
-		config:          config,
-		gardenClient:    gardenClient,
-		recorder:        recorder,
-		namespaceLister: namespaceLister,
+		logger:       l,
+		config:       config,
+		gardenClient: gardenClient,
+		recorder:     recorder,
 	}
 }
 
 type projectReconciler struct {
-	logger          logrus.FieldLogger
-	config          *config.ProjectControllerConfiguration
-	gardenClient    kubernetes.Interface
-	recorder        record.EventRecorder
-	namespaceLister kubecorev1listers.NamespaceLister
+	logger       logrus.FieldLogger
+	config       *config.ProjectControllerConfiguration
+	gardenClient kubernetes.Interface
+	recorder     record.EventRecorder
 }
 
 func (r *projectReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {

--- a/pkg/controllermanager/controller/project/project_stale_control.go
+++ b/pkg/controllermanager/controller/project/project_stale_control.go
@@ -22,6 +22,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
+	"github.com/gardener/gardener/pkg/utils"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
@@ -29,6 +30,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -162,8 +165,17 @@ func (r *projectStaleReconciler) projectInUseDueToBackupEntries(ctx context.Cont
 }
 
 func (r *projectStaleReconciler) projectInUseDueToSecrets(ctx context.Context, namespace string) (bool, error) {
+	var (
+		noControlPlaneSecretsReq = utils.MustNewRequirement(
+			v1beta1constants.GardenRole,
+			selection.NotIn,
+			v1beta1constants.ControlPlaneSecretRoles...,
+		)
+		uncontrolledSecretSelector = client.MatchingLabelsSelector{Selector: labels.NewSelector().Add(noControlPlaneSecretsReq)}
+	)
+
 	secretList := &corev1.SecretList{}
-	if err := r.gardenClient.List(ctx, secretList, client.InNamespace(namespace)); err != nil {
+	if err := r.gardenClient.List(ctx, secretList, client.InNamespace(namespace), uncontrolledSecretSelector); err != nil {
 		return false, err
 	}
 

--- a/pkg/controllermanager/controller/project/project_stale_control_test.go
+++ b/pkg/controllermanager/controller/project/project_stale_control_test.go
@@ -139,7 +139,6 @@ var _ = Describe("ProjectStaleControl", func() {
 				gardenCoreInformerFactory.Core().V1beta1().Shoots().Lister(),
 				gardenCoreInformerFactory.Core().V1beta1().Plants().Lister(),
 				gardenCoreInformerFactory.Core().V1beta1().BackupEntries().Lister(),
-				gardenCoreInformerFactory.Core().V1beta1().SecretBindings().Lister(),
 				kubeCoreInformerFactory.Core().V1().Secrets().Lister(),
 			)
 

--- a/pkg/controllermanager/controller/project/project_stale_control_test.go
+++ b/pkg/controllermanager/controller/project/project_stale_control_test.go
@@ -136,7 +136,6 @@ var _ = Describe("ProjectStaleControl", func() {
 				logger.NewNopLogger(),
 				cfg,
 				k8sGardenRuntimeClient,
-				gardenCoreInformerFactory.Core().V1beta1().Shoots().Lister(),
 				kubeCoreInformerFactory.Core().V1().Secrets().Lister(),
 			)
 

--- a/pkg/controllermanager/controller/project/project_stale_control_test.go
+++ b/pkg/controllermanager/controller/project/project_stale_control_test.go
@@ -141,7 +141,6 @@ var _ = Describe("ProjectStaleControl", func() {
 				gardenCoreInformerFactory.Core().V1beta1().BackupEntries().Lister(),
 				gardenCoreInformerFactory.Core().V1beta1().SecretBindings().Lister(),
 				gardenCoreInformerFactory.Core().V1beta1().Quotas().Lister(),
-				kubeCoreInformerFactory.Core().V1().Namespaces().Lister(),
 				kubeCoreInformerFactory.Core().V1().Secrets().Lister(),
 			)
 

--- a/pkg/controllermanager/controller/project/project_stale_control_test.go
+++ b/pkg/controllermanager/controller/project/project_stale_control_test.go
@@ -138,7 +138,6 @@ var _ = Describe("ProjectStaleControl", func() {
 				k8sGardenRuntimeClient,
 				gardenCoreInformerFactory.Core().V1beta1().Shoots().Lister(),
 				gardenCoreInformerFactory.Core().V1beta1().Plants().Lister(),
-				gardenCoreInformerFactory.Core().V1beta1().BackupEntries().Lister(),
 				kubeCoreInformerFactory.Core().V1().Secrets().Lister(),
 			)
 

--- a/pkg/controllermanager/controller/project/project_stale_control_test.go
+++ b/pkg/controllermanager/controller/project/project_stale_control_test.go
@@ -140,7 +140,6 @@ var _ = Describe("ProjectStaleControl", func() {
 				gardenCoreInformerFactory.Core().V1beta1().Plants().Lister(),
 				gardenCoreInformerFactory.Core().V1beta1().BackupEntries().Lister(),
 				gardenCoreInformerFactory.Core().V1beta1().SecretBindings().Lister(),
-				gardenCoreInformerFactory.Core().V1beta1().Quotas().Lister(),
 				kubeCoreInformerFactory.Core().V1().Secrets().Lister(),
 			)
 

--- a/pkg/controllermanager/controller/project/project_stale_control_test.go
+++ b/pkg/controllermanager/controller/project/project_stale_control_test.go
@@ -132,12 +132,7 @@ var _ = Describe("ProjectStaleControl", func() {
 			}
 			request = reconcile.Request{NamespacedName: types.NamespacedName{Name: project.Name}}
 
-			reconciler = NewProjectStaleReconciler(
-				logger.NewNopLogger(),
-				cfg,
-				k8sGardenRuntimeClient,
-				kubeCoreInformerFactory.Core().V1().Secrets().Lister(),
-			)
+			reconciler = NewProjectStaleReconciler(logger.NewNopLogger(), cfg, k8sGardenRuntimeClient)
 
 			k8sGardenRuntimeClient.EXPECT().Get(ctx, kutil.Key(project.Name), gomock.AssignableToTypeOf(&gardencorev1beta1.Project{}))
 			Expect(kubeCoreInformerFactory.Core().V1().Namespaces().Informer().GetStore().Add(namespace)).To(Succeed())

--- a/pkg/controllermanager/controller/project/project_stale_control_test.go
+++ b/pkg/controllermanager/controller/project/project_stale_control_test.go
@@ -137,7 +137,6 @@ var _ = Describe("ProjectStaleControl", func() {
 				cfg,
 				k8sGardenRuntimeClient,
 				gardenCoreInformerFactory.Core().V1beta1().Shoots().Lister(),
-				gardenCoreInformerFactory.Core().V1beta1().Plants().Lister(),
 				kubeCoreInformerFactory.Core().V1().Secrets().Lister(),
 			)
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:
Similar to #3658, #3681, #3954, #3955, this PR continues with migration a couple of our controllers from `controllerutils.DeprecatedCreateWorker` (deprecated since #1094) to `controllerutils.CreateWorker`. This helps to get rid of some remaining usages of `context.TODO()`. Also, it replace client-go informers/listers with informers from the controller-runtime.

**Which issue(s) this PR fixes**:
Part of #1648 

**Special notes for your reviewer**:
ℹ️ Once this PR is merged, I'll follow-up with more PRs that also cover the remaining/not-yet migrated controllers.
/squash

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
