### PR TITLE
Parse the webhook URL to detect and remove port given for SAN

### DIFF
--- a/extensions/pkg/webhook/certificates.go
+++ b/extensions/pkg/webhook/certificates.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/secrets"
@@ -124,6 +125,13 @@ func generateNewCAAndServerCert(mode, namespace, name, url string) (*secrets.Cer
 		ipAddresses []net.IP
 	)
 
+	serverName := url
+	serverNameData := strings.SplitN(url, ":", 3)
+
+	if len(serverNameData) == 2 {
+		serverName = serverNameData[0]
+	}
+
 	switch mode {
 	case ModeURL:
 		if addr := net.ParseIP(url); addr != nil {
@@ -132,7 +140,7 @@ func generateNewCAAndServerCert(mode, namespace, name, url string) (*secrets.Cer
 			}
 		} else {
 			dnsNames = []string{
-				url,
+				serverName,
 			}
 		}
 

--- a/extensions/pkg/webhook/certificates_test.go
+++ b/extensions/pkg/webhook/certificates_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhook
+
+import (
+	"net"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Certificates", func() {
+	const (
+		modeUrl   = "url"
+		name      = "provider-test"
+		namespace = "test-namespace"
+	)
+
+	var emptyStringArray []string
+
+	Describe("#generateNewCAAndServerCert", func() {
+		It("should return an valid certificate for '127.0.1.1'", func() {
+			_, serverCert, err := generateNewCAAndServerCert(modeUrl, namespace, name, "127.0.1.1")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(serverCert.Certificate.IPAddresses).To(Equal([]net.IP{net.ParseIP("127.0.1.1")}))
+			Expect(serverCert.Certificate.DNSNames).To(Equal(emptyStringArray))
+		})
+		It("should return an valid certificate for '::1'", func() {
+			_, serverCert, err := generateNewCAAndServerCert(modeUrl, namespace, name, "::1")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(serverCert.Certificate.IPAddresses).To(Equal([]net.IP{net.ParseIP("::1")}))
+			Expect(serverCert.Certificate.DNSNames).To(Equal(emptyStringArray))
+		})
+		It("should return an valid certificate for 'test.invalid'", func() {
+			_, serverCert, err := generateNewCAAndServerCert(modeUrl, namespace, name, "test.invalid")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(serverCert.Certificate.DNSNames).To(Equal([]string{"test.invalid"}))
+		})
+		It("should return an valid certificate for 'test.invalid:8443'", func() {
+			_, serverCert, err := generateNewCAAndServerCert(modeUrl, namespace, name, "test.invalid:8443")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(serverCert.Certificate.DNSNames).To(Equal([]string{"test.invalid"}))
+		})
+		It("should return the original url value for an invalid formatted value of 'test.invalid:8443:invalid'", func() {
+			_, serverCert, err := generateNewCAAndServerCert(modeUrl, namespace, name, "test.invalid:8443:invalid")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(serverCert.Certificate.DNSNames).To(Equal([]string{"test.invalid:8443:invalid"}))
+		})
+	})
+})


### PR DESCRIPTION
**How to categorize this PR?**
/area control-plane
/kind bug

**What this PR does / why we need it**:
In a local test environment running an extension provider created a certificate with SAN composed of server name and port. Reason was the `webhook-url=localhost:8444` being used in the code as the SAN server name without any further parsing. This PR ensures that the URL given is not a server name and port or if it is the case only considers the server name part for certificate creation.