### PR TITLE
Use cache in .ci/verify

### DIFF
--- a/.ci/verify
+++ b/.ci/verify
@@ -1,14 +1,19 @@
-#!/bin/bash
+#!/bin/bash -x
 
 set -o errexit
 set -o nounset
 set -o pipefail
+
+concourse_cache_dir="$PWD/.cache_concourse"
+use_cache=no
+[ -d "$concourse_cache_dir" ] && use_cache=yes
 
 cd "$(dirname $0)/.."
 
 git config --global user.email "gardener@sap.com"
 git config --global user.name "Gardener CI/CD"
 
+# TODO: use pre-built image instead of installing in every pipeline run
 apt-get update
 apt-get install -y unzip jq parallel
 
@@ -16,4 +21,33 @@ mkdir -p /go/src/github.com/gardener/gardener
 cp -r . /go/src/github.com/gardener/gardener
 cd /go/src/github.com/gardener/gardener
 
-make verify-extended
+if [ $use_cache = yes ] ; then
+  make install-requirements
+
+  # list of all to-be-cached directories
+  cache_dirs=(
+    "$(go env GOCACHE)"
+    "$(golangci-lint cache status | grep -i 'dir:' | awk '{print $2}')"
+    # TODO: cache tools (golangci-lint, mockgen, envtest bins, promtool, protoc, ...)
+  )
+
+  echo "> retrieving all cached dirs from concourse cache dir"
+  for cache in "${cache_dirs[@]}" ; do
+    mkdir -p "$cache"
+    cache_name=$(echo "$cache" | tr ' /' '_')
+    if [ -d "$concourse_cache_dir/$cache_name" ] ; then
+      cp -TR "$concourse_cache_dir/$cache_name" "$cache"
+    fi
+  done
+
+  # run test instead of test-cov to speed-up PR verification as `-cover` flag is not "cacheable"
+  make check-generate verify
+
+  echo "> moving all cached dirs back to concourse cache dir"
+  for cache in "${cache_dirs[@]}" ; do
+    cache_name=$(echo "$cache" | tr ' /' '_')
+    cp -TR "$cache" "$concourse_cache_dir/$cache_name"
+  done
+else
+  make verify-extended
+fi

--- a/.ci/verify
+++ b/.ci/verify
@@ -34,7 +34,7 @@ if [ $use_cache = yes ] ; then
   echo "> retrieving all cached dirs from concourse cache dir"
   for cache in "${cache_dirs[@]}" ; do
     mkdir -p "$cache"
-    cache_name=$(echo "$cache" | tr ' /' '_')
+    cache_name=$(echo "$cache" | tr ' /' '_' | cut -c 2-)
     if [ -d "$concourse_cache_dir/$cache_name" ] ; then
       rm -rf "$cache"
       mv "$concourse_cache_dir/$cache_name" "$cache"
@@ -46,7 +46,7 @@ if [ $use_cache = yes ] ; then
 
   echo "> moving all cached dirs back to concourse cache dir"
   for cache in "${cache_dirs[@]}" ; do
-    cache_name=$(echo "$cache" | tr ' /' '_')
+    cache_name=$(echo "$cache" | tr ' /' '_' | cut -c 2-)
     rm -rf "$concourse_cache_dir/$cache_name"
     mv "$cache" "$concourse_cache_dir/$cache_name"
   done

--- a/.ci/verify
+++ b/.ci/verify
@@ -36,7 +36,8 @@ if [ $use_cache = yes ] ; then
     mkdir -p "$cache"
     cache_name=$(echo "$cache" | tr ' /' '_')
     if [ -d "$concourse_cache_dir/$cache_name" ] ; then
-      cp -TR "$concourse_cache_dir/$cache_name" "$cache"
+      rm -rf "$cache"
+      mv "$concourse_cache_dir/$cache_name" "$cache"
     fi
   done
 
@@ -46,7 +47,8 @@ if [ $use_cache = yes ] ; then
   echo "> moving all cached dirs back to concourse cache dir"
   for cache in "${cache_dirs[@]}" ; do
     cache_name=$(echo "$cache" | tr ' /' '_')
-    cp -TR "$cache" "$concourse_cache_dir/$cache_name"
+    rm -rf "$concourse_cache_dir/$cache_name"
+    mv "$cache" "$concourse_cache_dir/$cache_name"
   done
 else
   make verify-extended

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 .DS_Store
 *~
 
+.cache_concourse
 ./gardener-apiserver
 ./gardener-controller-manager
 TODO


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

This PR uses concourse's cache for keeping the go build/test cache and golangci-lint cache between verify runs.
It relies on the experimental `cache_paths` attribute to be setup for `.cache_concourse` in the pipeline definition (see [cc-utils docs](https://gardener.github.io/cc-utils/pipeline_step.html#pipeline-step)).
For now, the pipeline definition only specifies the cache for the PR `verify` step.

In order for the go test results to be cached, it uses `make test` instead of `make test-cov` during PR verfication, as the `-cover` flag is not "cacheable" (see [go docs](https://golang.org/pkg/cmd/go/internal/test/)):

> The rule for a match in the cache is that the run involves the same
test binary and the flags on the command line come entirely from a
restricted set of 'cacheable' test flags, defined as -cpu, -list,
-parallel, -run, -short, and -v. If a run of go test has any test
or non-test flags outside this set, the result is not cached.

Although concourse's caching mechanism is quite primitive and worker-local, it should still help in speeding up PR verification times significantly (also, unit tests without coverage enabled run a lot faster already).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

