### PR TITLE
Use grm's default leader election settings

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -24,7 +24,7 @@ images:
 - name: gardener-resource-manager
   sourceRepository: github.com/gardener/gardener-resource-manager
   repository: eu.gcr.io/gardener-project/gardener/gardener-resource-manager
-  tag: "v0.23.0"
+  tag: "v0.24.0"
 - name: dependency-watchdog
   sourceRepository: github.com/gardener/dependency-watchdog
   repository: eu.gcr.io/gardener-project/gardener/dependency-watchdog

--- a/hack/local-development/local-garden/configure-rbac
+++ b/hack/local-development/local-garden/configure-rbac
@@ -40,15 +40,15 @@ helm template \
   --set global.scheduler.enabled=true | \
 KUBECONFIG=$KUBECONFIGPATH kubectl apply -f -
 
-if ! KUBECONFIG=$KUBECONFIGPATH kubectl get clusterrolebinding "gardener.cloud:system:admission-controller" > /dev/null; then
+if ! KUBECONFIG=$KUBECONFIGPATH kubectl get clusterrolebinding "gardener.cloud:system:admission-controller" >/dev/null 2>&1; then
   KUBECONFIG=$KUBECONFIGPATH kubectl create clusterrolebinding "gardener.cloud:system:admission-controller" --clusterrole="gardener.cloud:system:admission-controller" --user="gardener.cloud:system:admission-controller"
 fi
-if ! KUBECONFIG=$KUBECONFIGPATH kubectl get clusterrolebinding "gardener.cloud:system:apiserver" > /dev/null; then
+if ! KUBECONFIG=$KUBECONFIGPATH kubectl get clusterrolebinding "gardener.cloud:system:apiserver" >/dev/null 2>&1; then
   KUBECONFIG=$KUBECONFIGPATH kubectl create clusterrolebinding "gardener.cloud:system:apiserver" --clusterrole="gardener.cloud:system:gardener-apiserver" --user="gardener.cloud:system:apiserver"
 fi
-if ! KUBECONFIG=$KUBECONFIGPATH kubectl get clusterrolebinding "gardener.cloud:system:controller-manager" > /dev/null; then
+if ! KUBECONFIG=$KUBECONFIGPATH kubectl get clusterrolebinding "gardener.cloud:system:controller-manager" >/dev/null 2>&1; then
   KUBECONFIG=$KUBECONFIGPATH kubectl create clusterrolebinding "gardener.cloud:system:controller-manager" --clusterrole="gardener.cloud:system:gardener-controller-manager" --user="gardener.cloud:system:controller-manager"
 fi
-if ! KUBECONFIG=$KUBECONFIGPATH kubectl get clusterrolebinding "gardener.cloud:system:scheduler" > /dev/null; then
+if ! KUBECONFIG=$KUBECONFIGPATH kubectl get clusterrolebinding "gardener.cloud:system:scheduler" >/dev/null 2>&1; then
   KUBECONFIG=$KUBECONFIGPATH kubectl create clusterrolebinding "gardener.cloud:system:scheduler" --clusterrole="gardener.cloud:system:gardener-scheduler" --user="gardener.cloud:system:scheduler"
 fi

--- a/pkg/operation/botanist/resource_manager.go
+++ b/pkg/operation/botanist/resource_manager.go
@@ -48,14 +48,6 @@ func (b *Botanist) DefaultResourceManager() (resourcemanager.ResourceManager, er
 		SyncPeriod:                 utils.DurationPtr(time.Minute),
 		TargetDisableCache:         pointer.BoolPtr(true),
 		WatchedNamespace:           pointer.StringPtr(b.Shoot.SeedNamespace),
-		// We run one GRM per shoot control plane, and the GRM is doing its leader election via configmaps in the seed -
-		// by default every 2s. This can lead to a lot of PUT /v1/configmaps requests on the API server, and given that
-		// a seed is very busy anyways, we should not unnecessarily stress the API server with this leader election.
-		// The GRM's sync period is 1m anyways, so it doesn't matter too much if the leadership determination may take up
-		// to one minute.
-		LeaseDuration: utils.DurationPtr(time.Second * 40),
-		RenewDeadline: utils.DurationPtr(time.Second * 15),
-		RetryPeriod:   utils.DurationPtr(time.Second * 10),
 	}
 
 	// ensure grm is present during hibernation (if the cluster is not hibernated yet) to reconcile any changes to


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind cleanup

**What this PR does / why we need it**:

This PR cleans up the decreased leader election frequency of grm introduced by https://github.com/gardener/gardener/pull/2667, which is no longer necessary with https://github.com/gardener/gardener-resource-manager/pull/119.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener-resource-manager/issues/77.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`gardener-resource-manager` now uses the default leader election settings again (retries leader election every `2s`).
```

``` breaking operator github.com/gardener/gardener-resource-manager #119 @timebertt
The default leader election resource lock of `gardener-resource-manager` has been changed from `configmapsleases` to `leases`.
Please make sure, that you had at least `gardener-resource-manager@v0.22` running before upgrading to `v0.24`, so that it has successfully required leadership with the hybrid resource lock (`configmapsleases`) at least once.
```