### PR TITLE
Fix make local-garden-up

### DIFF
--- a/hack/local-development/local-garden/configure-rbac
+++ b/hack/local-development/local-garden/configure-rbac
@@ -16,11 +16,13 @@
 
 source $(dirname "${0}")/../common/helpers
 
+KUBECONFIGPATH=${1:-"$(dirname $0)/kubeconfigs/default-admin.conf"}
+
 gardenlet_admin_templates=""
 
 if is_seedauthorizer_enabled; then
-  kubectl delete clusterrole/gardener.cloud:system:seeds        --ignore-not-found
-  kubectl delete clusterrolebinding/gardener.cloud:system:seeds --ignore-not-found
+  KUBECONFIG=$KUBECONFIGPATH kubectl delete clusterrole/gardener.cloud:system:seeds        --ignore-not-found
+  KUBECONFIG=$KUBECONFIGPATH kubectl delete clusterrolebinding/gardener.cloud:system:seeds --ignore-not-found
 else
   gardenlet_admin_templates="-x templates/clusterrole-seeds.yaml -x templates/clusterrolebinding-seeds.yaml"
 fi
@@ -36,17 +38,17 @@ helm template \
   --set global.apiserver.enabled=true \
   --set global.controller.enabled=true \
   --set global.scheduler.enabled=true | \
-kubectl apply -f -
+KUBECONFIG=$KUBECONFIGPATH kubectl apply -f -
 
-if ! kubectl get clusterrolebinding "gardener.cloud:system:admission-controller" > /dev/null; then
-  kubectl create clusterrolebinding "gardener.cloud:system:admission-controller" --clusterrole="gardener.cloud:system:admission-controller" --user="gardener.cloud:system:admission-controller"
+if ! KUBECONFIG=$KUBECONFIGPATH kubectl get clusterrolebinding "gardener.cloud:system:admission-controller" > /dev/null; then
+  KUBECONFIG=$KUBECONFIGPATH kubectl create clusterrolebinding "gardener.cloud:system:admission-controller" --clusterrole="gardener.cloud:system:admission-controller" --user="gardener.cloud:system:admission-controller"
 fi
-if ! kubectl get clusterrolebinding "gardener.cloud:system:apiserver" > /dev/null; then
-  kubectl create clusterrolebinding "gardener.cloud:system:apiserver" --clusterrole="gardener.cloud:system:gardener-apiserver" --user="gardener.cloud:system:apiserver"
+if ! KUBECONFIG=$KUBECONFIGPATH kubectl get clusterrolebinding "gardener.cloud:system:apiserver" > /dev/null; then
+  KUBECONFIG=$KUBECONFIGPATH kubectl create clusterrolebinding "gardener.cloud:system:apiserver" --clusterrole="gardener.cloud:system:gardener-apiserver" --user="gardener.cloud:system:apiserver"
 fi
-if ! kubectl get clusterrolebinding "gardener.cloud:system:controller-manager" > /dev/null; then
-  kubectl create clusterrolebinding "gardener.cloud:system:controller-manager" --clusterrole="gardener.cloud:system:gardener-controller-manager" --user="gardener.cloud:system:controller-manager"
+if ! KUBECONFIG=$KUBECONFIGPATH kubectl get clusterrolebinding "gardener.cloud:system:controller-manager" > /dev/null; then
+  KUBECONFIG=$KUBECONFIGPATH kubectl create clusterrolebinding "gardener.cloud:system:controller-manager" --clusterrole="gardener.cloud:system:gardener-controller-manager" --user="gardener.cloud:system:controller-manager"
 fi
-if ! kubectl get clusterrolebinding "gardener.cloud:system:scheduler" > /dev/null; then
-  kubectl create clusterrolebinding "gardener.cloud:system:scheduler" --clusterrole="gardener.cloud:system:gardener-scheduler" --user="gardener.cloud:system:scheduler"
+if ! KUBECONFIG=$KUBECONFIGPATH kubectl get clusterrolebinding "gardener.cloud:system:scheduler" > /dev/null; then
+  KUBECONFIG=$KUBECONFIGPATH kubectl create clusterrolebinding "gardener.cloud:system:scheduler" --clusterrole="gardener.cloud:system:gardener-scheduler" --user="gardener.cloud:system:scheduler"
 fi


### PR DESCRIPTION
/kind regression

Currently `make local-garden-up` fails with:

```
$ make local-garden-up
# Remove old containers and create the docker user network
e6217f172c2893a0f41c18a0e13159d23313ec8592db4e5cb7eb127696766c8d
# Start the nodeless kubernetes environment
Starting gardener-dev kube-etcd cluster!
7ec7868d06d32153ec53b53557ccbd1b5445efcc198452469670cefb0d27d0f1
Starting gardener-dev kube-apiserver!
ba800f1b521fd8f1cb4c01328f1b84f3269b3b2699c6347697d1c5bcd5313975
Starting gardener-dev kube-controller-manager!
5805d9cfe1cef25b03d2995398b4d69a5afea0b30969c948a505421f781e92f7
# This etcd will be used to storge gardener resources (e.g., seeds, shoots)
Starting gardener-dev gardener-etcd cluster!
ea04b6fd58b5120bed168055922ce0f0b0e93d0b94d0aca5e0c4205c18b385b4
# Configuring RBAC resources for Gardener components
The connection to the server localhost:8080 was refused - did you specify the right host or port?
2021/04/28 14:00:55 found symbolic link in path: /go/src/github.com/gardener/gardener/charts/gardener/controlplane/charts/application/charts/utils-common resolves to /go/src/github.com/gardener/gardener/charts/gardener/controlplane/charts/utils-common
2021/04/28 14:00:55 found symbolic link in path: /go/src/github.com/gardener/gardener/charts/gardener/controlplane/charts/application/charts/utils-common/charts/utils-templates resolves to /go/src/github.com/gardener/gardener/charts/utils-templates
2021/04/28 14:00:55 found symbolic link in path: /go/src/github.com/gardener/gardener/charts/gardener/controlplane/charts/application/charts/utils-common/values.yaml resolves to /go/src/github.com/gardener/gardener/charts/gardener/controlplane/values.yaml
2021/04/28 14:00:55 found symbolic link in path: /go/src/github.com/gardener/gardener/charts/gardener/controlplane/charts/application/charts/utils-templates resolves to /go/src/github.com/gardener/gardener/charts/utils-templates
2021/04/28 14:00:55 found symbolic link in path: /go/src/github.com/gardener/gardener/charts/gardener/controlplane/charts/application/values.yaml resolves to /go/src/github.com/gardener/gardener/charts/gardener/controlplane/values.yaml
make: *** [local-garden-up] Error 1
```

`hack/local-development/local-garden/configure-rbac` should not rely that KUBECONFIG env var is already pointing to `hack/local-development/local-garden/kubeconfigs/default-admin.conf`. The usual flow is that you run `make local-garden-up` and the output suggest you to set the KUBECONFIG env var:

```
# Now you can start using the cluster at with `export KUBECONFIG=hack/local-development/local-garden/kubeconfigs/default-admin.conf`
```

Also in `./docs/development/local_setup.md` there are no prerequisites about the KUBECONFIG env var before running `make local-garden-up`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
