### PR TITLE
Centralize error code extraction

### DIFF
--- a/pkg/apis/core/v1beta1/helper/errors.go
+++ b/pkg/apis/core/v1beta1/helper/errors.go
@@ -86,16 +86,16 @@ func DetermineErrorCodes(err error) []gardencorev1beta1.ErrorCode {
 		message = err.Error()
 		codes   = sets.NewString()
 
-		knownCodes = map[string]func(string) bool{
-			string(gardencorev1beta1.ErrorInfraUnauthorized):             unauthorizedRegexp.MatchString,
-			string(gardencorev1beta1.ErrorInfraQuotaExceeded):            quotaExceededRegexp.MatchString,
-			string(gardencorev1beta1.ErrorInfraRateLimitsExceeded):       rateLimitsExceededRegexp.MatchString,
-			string(gardencorev1beta1.ErrorInfraInsufficientPrivileges):   insufficientPrivilegesRegexp.MatchString,
-			string(gardencorev1beta1.ErrorInfraDependencies):             dependenciesRegexp.MatchString,
-			string(gardencorev1beta1.ErrorRetryableInfraDependencies):    retryableDependenciesRegexp.MatchString,
-			string(gardencorev1beta1.ErrorInfraResourcesDepleted):        resourcesDepletedRegexp.MatchString,
-			string(gardencorev1beta1.ErrorConfigurationProblem):          configurationProblemRegexp.MatchString,
-			string(gardencorev1beta1.ErrorRetryableConfigurationProblem): retryableConfigurationProblemRegexp.MatchString,
+		knownCodes = map[gardencorev1beta1.ErrorCode]func(string) bool{
+			gardencorev1beta1.ErrorInfraUnauthorized:             unauthorizedRegexp.MatchString,
+			gardencorev1beta1.ErrorInfraQuotaExceeded:            quotaExceededRegexp.MatchString,
+			gardencorev1beta1.ErrorInfraRateLimitsExceeded:       rateLimitsExceededRegexp.MatchString,
+			gardencorev1beta1.ErrorInfraInsufficientPrivileges:   insufficientPrivilegesRegexp.MatchString,
+			gardencorev1beta1.ErrorInfraDependencies:             dependenciesRegexp.MatchString,
+			gardencorev1beta1.ErrorRetryableInfraDependencies:    retryableDependenciesRegexp.MatchString,
+			gardencorev1beta1.ErrorInfraResourcesDepleted:        resourcesDepletedRegexp.MatchString,
+			gardencorev1beta1.ErrorConfigurationProblem:          configurationProblemRegexp.MatchString,
+			gardencorev1beta1.ErrorRetryableConfigurationProblem: retryableConfigurationProblemRegexp.MatchString,
 		}
 	)
 
@@ -104,14 +104,14 @@ func DetermineErrorCodes(err error) []gardencorev1beta1.ErrorCode {
 		for _, code := range coder.Codes() {
 			codes.Insert(string(code))
 			// found codes don't need to be checked any more
-			delete(knownCodes, string(code))
+			delete(knownCodes, code)
 		}
 	}
 
 	// determine error codes
 	for code, matchFn := range knownCodes {
-		if !codes.Has(code) && matchFn(message) {
-			codes.Insert(code)
+		if !codes.Has(string(code)) && matchFn(message) {
+			codes.Insert(string(code))
 		}
 	}
 

--- a/pkg/operation/botanist/component/extensions/dns/dnsentry.go
+++ b/pkg/operation/botanist/component/extensions/dns/dnsentry.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"time"
 
-	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/retry"
@@ -138,7 +137,7 @@ func (e *entry) Wait(ctx context.Context) error {
 
 		return retry.MinorError(entryErr)
 	}); err != nil {
-		return gardencorev1beta1helper.DetermineError(err, fmt.Sprintf("Failed to create %q DNS record: %q (status=%s, message=%s)", e.values.Name, err.Error(), status, message))
+		return fmt.Errorf("Failed to create %q DNS record: %q (status=%s, message=%s)", e.values.Name, err.Error(), status, message)
 	}
 
 	return nil

--- a/pkg/operation/botanist/component/extensions/dns/dnsprovider.go
+++ b/pkg/operation/botanist/component/extensions/dns/dnsprovider.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"time"
 
-	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/retry"
@@ -165,7 +164,7 @@ func (p *provider) Wait(ctx context.Context) error {
 
 		return retry.MinorError(providerErr)
 	}); err != nil {
-		return gardencorev1beta1helper.DetermineError(err, fmt.Sprintf("Failed to create DNS emptyProvider for %q DNS record: %q (status=%s, message=%s)", p.values.Name, err.Error(), status, message))
+		return fmt.Errorf("Failed to create DNS emptyProvider for %q DNS record: %q (status=%s, message=%s)", p.values.Name, err.Error(), status, message)
 	}
 
 	return nil

--- a/pkg/operation/botanist/waiter.go
+++ b/pkg/operation/botanist/waiter.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/konnectivity"
 	"github.com/gardener/gardener/pkg/operation/common"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -124,7 +123,7 @@ func (b *Botanist) WaitUntilKubeAPIServerReady(ctx context.Context) error {
 		}
 
 		errWithLogs := fmt.Errorf("%s, logs of newest pod:\n%s", err.Error(), logs)
-		return gardencorev1beta1helper.DetermineError(errWithLogs, errWithLogs.Error())
+		return errWithLogs
 	}
 
 	return nil

--- a/pkg/utils/flow/flow.go
+++ b/pkg/utils/flow/flow.go
@@ -98,11 +98,16 @@ func (n *node) addTargets(taskIDs ...TaskID) {
 // Opts are options for a Flow execution. If they are not set, they
 // are left blank and don't affect the Flow.
 type Opts struct {
-	Logger           logrus.FieldLogger
+	// Logger is used to log any output during flow execution.
+	Logger logrus.FieldLogger
+	// ProgressReporter is used to report the progress during flow execution.
 	ProgressReporter ProgressReporter
-	ErrorCleaner     func(ctx context.Context, taskID string)
-	ErrorContext     *utilerrors.ErrorContext
-	Context          context.Context
+	// ErrorCleaner is used to clean up a previously failed task.
+	ErrorCleaner func(ctx context.Context, taskID string)
+	// ErrorContext is used to store any error related context.
+	ErrorContext *utilerrors.ErrorContext
+	// Context is the context used during flow execution.
+	Context context.Context
 }
 
 // Run starts an execution of a Flow.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/area dev-productivity
/area usability
/kind enhancement

**What this PR does / why we need it**:
Earlier, each step in the shoot flow had to extract error codes separately to propagate them to the shoot `status`. This PR moves the extraction to a more central point, so that other steps in the flow automatically benefit from error code detection, e.g., `Waiting until nginx ingress LoadBalancer is ready`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Error code detection has been improved and is now enabled for more steps in the shoot `reconciliation`, `deletion` and `migration`.
```
