### PR TITLE
Add DeployMachineClasses step in the worker restore flow

### DIFF
--- a/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
@@ -72,6 +72,11 @@ func (a *genericActuator) Restore(ctx context.Context, worker *extensionsv1alpha
 		return errors.Wrap(err, "failed scale down machine-controller-manager")
 	}
 
+	// Deploy generated machine classes.
+	if err := workerDelegate.DeployMachineClasses(ctx); err != nil {
+		return errors.Wrapf(err, "failed to deploy the machine classes")
+	}
+
 	if err := kubernetes.WaitUntilDeploymentScaledToDesiredReplicas(ctx, a.client, kutil.Key(worker.Namespace, McmDeploymentName), 0); err != nil && !apierrors.IsNotFound(err) {
 		return errors.Wrap(err, "deadline exceeded while scaling down machine-controller-manager")
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind bug

**What this PR does / why we need it**:
When control plane migration is started on a shoot, the restore phase is stuck for 5-6 minutes and the following message can be seen in the extension provider logs.
```
{"level":"info","ts":"<date>","logger":"<provider>-worker-actuator.worker-actuator","msg":"Machine deployment is performing a rolling update","worker":"<worker name>","operation":"reconcile","machineDeployment":{"apiVersion":"machine.sapcloud.io/v1alpha1","kind":"MachineDeployment","namespace":"<NS>","name":"<name>"}}
{"level":"info","ts":"<date>","logger":"<provider>-worker-actuator.worker-actuator","msg":"waiting for the MachineControllerManager to create the machine sets for the machine deployment (<machine deployment>)","worker":"<worker>","operation":"reconcile"}
```
This is caused because the restore process enters the "Rolling update" logic here: https://github.com/gardener/gardener/blob/77e09dd522d7bfb682cc35d0be437201b606061b/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go#L393-L401
Since we are performing CPM and not rolling update there will never be more than one machine set. There should be exactly one machine set.  This behaviour is observed because the the `existingMachineClassNames` are listed before the the machine class is deployed here: https://github.com/gardener/gardener/blob/77e09dd522d7bfb682cc35d0be437201b606061b/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go#L101-L111
The CPM continues normally after the retry below finish with timeout and then in the second run when the `existingMachineClassNames` are listed the already deployed machine class is taken into account. https://github.com/gardener/gardener/blob/77e09dd522d7bfb682cc35d0be437201b606061b/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go#L345

So, to fix that issue I have added the machine class deployment in the restore phase, as I suspect that the logic above was implemented with a purpose, so I did not want to shuffle the reconcile flow.
**Which issue(s) this PR fixes**:
Fixes #
https://github.com/gardener/machine-controller-manager/issues/602
**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The restoration flow for the Worker resource no longer  enters a “rolling update” loop which was causing the restoration flow to take too much time.
```
