### PR TITLE
Add tests for the vpn tunnel

### DIFF
--- a/test/framework/resources/templates/templates.go
+++ b/test/framework/resources/templates/templates.go
@@ -27,6 +27,12 @@ const (
 	// LoggerAppName is the name of the logger app deployment template
 	LoggerAppName = "logger-app.yaml.tpl"
 
+	// VPNTunnelDeploymentName is the name of the vpn deployment template
+	VPNTunnelDeploymentName = "vpntunnel.yaml.tpl"
+
+	// VPNTunnelCopyDeploymentName is the name of the vpn copy deployment template
+	VPNTunnelCopyDeploymentName = "vpntunnel-copy.yaml.tpl"
+
 	// PodAntiAffinityDeploymentName is the name of the pod anti affinity deployment template
 	PodAntiAffinityDeploymentName = "pod-anti-affinity-deployment.yaml.tpl"
 

--- a/test/framework/resources/templates/vpntunnel-copy.yaml.tpl
+++ b/test/framework/resources/templates/vpntunnel-copy.yaml.tpl
@@ -1,0 +1,64 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Name }}
+  namespace: {{ .Namespace }}
+  labels:
+    app: {{ .AppLabel }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .AppLabel }}
+  template:
+    metadata:
+      labels:
+        app: {{ .AppLabel }}
+    spec:
+      initContainers:
+      - image: eu.gcr.io/gardener-project/3rd/alpine:3.13.5
+        name: data-generator
+        command:
+        - dd
+        - if=/dev/urandom
+        - of=/data/data
+        - bs=1M
+        - count={{ .SizeInMB }}
+        volumeMounts:
+        - name: source-data
+          mountPath: /data
+      containers:
+      - image: bitnami/kubectl:{{ .KubeVersion }}
+        name: hyperkube
+        command:
+        - sleep
+        - "3600"
+        env:
+        - name: KUBECONFIG
+          value: /secret/kubeconfig
+        volumeMounts:
+        - name: source-data
+          mountPath: /data
+        - name: kubecfg
+          mountPath: /secret
+      - image: bitnami/kubectl:{{ .KubeVersion }}
+        name: target-container
+        command:
+        - sleep
+        - "3600"
+        volumeMounts:
+        - name: target-data
+          mountPath: /data
+      securityContext:
+        fsGroup: 65532
+        runAsUser: 65532
+        runAsNonRoot: true
+      volumes:
+      - name: target-data
+        emptyDir: {}
+      - name: source-data
+        emptyDir: {}
+      - name: kubecfg
+        secret:
+          secretName: {{ .Name }}

--- a/test/framework/resources/templates/vpntunnel.yaml.tpl
+++ b/test/framework/resources/templates/vpntunnel.yaml.tpl
@@ -1,0 +1,48 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .LoggerName }}
+  namespace: {{ .HelmDeployNamespace }}
+  labels:
+    app: {{ .AppLabel }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: {{ .AppLabel }}
+  template:
+    metadata:
+      labels:
+        app: {{ .AppLabel }}
+    spec:
+      containers:
+      - image: eu.gcr.io/gardener-project/3rd/curlimages/curl:7.67.0
+        name: net-curl
+        args:
+          - /bin/sh
+          - -c
+          - |-
+            while true; do
+              sleep 3600;
+            done
+      - name: logger
+        image: eu.gcr.io/gardener-project/3rd/k8s_gcr_io/logs-generator:v0.1.1
+        args:
+          - /bin/sh
+          - -c
+          - |-
+            /logs-generator --logtostderr --log-lines-total=${LOGS_GENERATOR_LINES_TOTAL} --run-duration=${LOGS_GENERATOR_DURATION}
+            # Sleep forever to prevent restarts
+            while true; do
+              sleep 3600;
+            done
+        env:
+        - name: LOGS_GENERATOR_LINES_TOTAL
+          value: "{{ .LogsCount }}"
+        - name: LOGS_GENERATOR_DURATION
+          value: "{{ .LogsDuration }}"
+      securityContext:
+        fsGroup: 65532
+        runAsUser: 65532
+        runAsNonRoot: true

--- a/test/framework/shootframework.go
+++ b/test/framework/shootframework.go
@@ -56,7 +56,7 @@ type ShootConfig struct {
 }
 
 // ShootFramework represents the shoot test framework that includes
-// test functions that can be executed ona specific shoot
+// test functions that can be executed on a specific shoot
 type ShootFramework struct {
 	*GardenerFramework
 	TestDescription

--- a/test/integration/shoots/vpntunnel/vpntunnel.go
+++ b/test/integration/shoots/vpntunnel/vpntunnel.go
@@ -1,0 +1,207 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vpntunnel
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"strings"
+	"time"
+
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/gardener/gardener/test/framework"
+	"github.com/gardener/gardener/test/framework/resources/templates"
+
+	"github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	deploymentName = "logging-pod"
+	namespace      = "default"
+	logsCount      = 100000
+	logsDuration   = "1s"
+	loggerAppLabel = "vpnTunnelTesting"
+	testTimeout    = 5 * time.Minute
+	cleanupTimeout = 5 * time.Minute
+	maxIterations  = 300
+	copyDeployment = "copy-pod"
+	copyLabel      = "vpnTunnelCopyTesting"
+)
+
+var _ = ginkgo.Describe("Shoot vpn tunnel testing", func() {
+
+	f := framework.NewShootFramework(nil)
+
+	f.Beta().CIt("should get container logs from logging-pod", func(ctx context.Context) {
+
+		ginkgo.By("Deploy the logging-pod")
+		loggerParams := map[string]interface{}{
+			"LoggerName":          deploymentName,
+			"HelmDeployNamespace": namespace,
+			"AppLabel":            loggerAppLabel,
+			"LogsCount":           logsCount,
+			"LogsDuration":        logsDuration,
+		}
+
+		err := f.RenderAndDeployTemplate(ctx, f.ShootClient, templates.VPNTunnelDeploymentName, loggerParams)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Wait until logging-pod application is ready")
+		loggerLabels := labels.SelectorFromSet(labels.Set(map[string]string{
+			"app": loggerAppLabel,
+		}))
+
+		err = f.WaitUntilDeploymentsWithLabelsIsReady(ctx, loggerLabels, namespace, f.ShootClient)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Get kubeconfig and extract token")
+		data, err := framework.GetObjectFromSecret(ctx, f.SeedClient, f.ShootSeedNamespace(), "kubecfg", framework.KubeconfigSecretKeyName)
+		framework.ExpectNoError(err)
+		lines := strings.Split(string(data), "\n")
+		var token string
+		for _, line := range lines {
+			index := strings.Index(line, "token:")
+			if index >= 0 {
+				token = strings.TrimSpace(line[index+len("token:"):])
+			}
+		}
+
+		ginkgo.By("Get the pods matching the logging-pod label")
+		pods := &corev1.PodList{}
+		err = f.ShootClient.Client().List(ctx, pods, client.InNamespace(namespace), client.MatchingLabels{"app": loggerAppLabel})
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Check until we get all logs from logging-pod")
+		podExecutor := framework.NewPodExecutor(f.ShootClient)
+		for _, pod := range pods.Items {
+			i := 0
+			for ; i < maxIterations; i++ {
+				f.Logger.Infof("Using %s address for %d. iteration", f.Shoot.Status.AdvertisedAddresses[0].Name, i+1)
+				reader, err := podExecutor.Execute(ctx, pod.Namespace, pod.Name, "net-curl", fmt.Sprintf("curl -k -v -XGET  -H \"Accept: application/json, */*\" -H \"Authorization: Bearer %s\" \"%s/api/v1/namespaces/%s/pods/%s/log?container=logger\"", token, f.Shoot.Status.AdvertisedAddresses[0].URL, pod.Namespace, pod.Name))
+				if apierrors.IsNotFound(err) {
+					f.Logger.Infof("Aborting as pod %s was not found anymore: %s", pod.Name, err)
+					break
+				}
+				framework.ExpectNoError(err)
+				scanner := bufio.NewScanner(reader)
+				counter := 0
+				for scanner.Scan() {
+					counter++
+				}
+				err = scanner.Err()
+				framework.ExpectNoError(err)
+				f.Logger.Infof("Got %d lines from pod %s in %d. iteration", counter, pod.Name, i+1)
+				if counter >= logsCount {
+					break
+				}
+				time.Sleep(1 * time.Second)
+			}
+			Expect(i < maxIterations).To(Equal(true))
+		}
+
+	}, testTimeout, framework.WithCAfterTest(func(ctx context.Context) {
+		ginkgo.By("Cleaning up logging-pod resources")
+		loggerDeploymentToDelete := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      deploymentName,
+				Namespace: namespace,
+			},
+		}
+		err := kutil.DeleteObject(ctx, f.ShootClient.Client(), loggerDeploymentToDelete)
+		framework.ExpectNoError(err)
+	}, cleanupTimeout))
+
+	f.Beta().CIt("should copy data to pod", func(ctx context.Context) {
+
+		ginkgo.By("Get kubeconfig from shoot controlplane")
+		kubeCfgSecret := &corev1.Secret{}
+		err := f.SeedClient.Client().Get(ctx, types.NamespacedName{Namespace: f.ShootSeedNamespace(), Name: "kubecfg"}, kubeCfgSecret)
+		framework.ExpectNoError(err)
+
+		testSecret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: copyDeployment, Namespace: namespace}}
+		_, err = controllerutil.CreateOrUpdate(ctx, f.ShootClient.Client(), testSecret, func() error {
+			testSecret.Type = corev1.SecretTypeOpaque
+			testSecret.Data = kubeCfgSecret.Data
+			return nil
+		})
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Deploy the source and target pod")
+		params := map[string]interface{}{
+			"Name":        copyDeployment,
+			"Namespace":   namespace,
+			"AppLabel":    copyLabel,
+			"SizeInMB":    500,
+			"KubeVersion": f.Shoot.Spec.Kubernetes.Version,
+		}
+
+		err = f.RenderAndDeployTemplate(ctx, f.ShootClient, templates.VPNTunnelCopyDeploymentName, params)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Wait until pod is ready")
+		labels := labels.SelectorFromSet(labels.Set(map[string]string{
+			"app": copyLabel,
+		}))
+
+		err = f.WaitUntilDeploymentsWithLabelsIsReady(ctx, labels, namespace, f.ShootClient)
+		framework.ExpectNoError(err)
+
+		ginkgo.By("Get the pods matching the label")
+		pods := &corev1.PodList{}
+		err = f.ShootClient.Client().List(ctx, pods, client.InNamespace(namespace), client.MatchingLabels{"app": copyLabel})
+		framework.ExpectNoError(err)
+
+		podExecutor := framework.NewPodExecutor(f.ShootClient)
+		for _, pod := range pods.Items {
+			ginkgo.By(fmt.Sprintf("Copy data to target-container in pod %s", pod.Name))
+			reader, err := podExecutor.Execute(ctx, pod.Namespace, pod.Name, "hyperkube", fmt.Sprintf("kubectl cp /data/data %s/%s:/data/data -c target-container", pod.Namespace, pod.Name))
+			if apierrors.IsNotFound(err) {
+				f.Logger.Infof("Aborting as pod %s was not found anymore: %s", pod.Name, err)
+				break
+			}
+			framework.ExpectNoError(err)
+			output, err := ioutil.ReadAll(reader)
+			framework.ExpectNoError(err)
+			f.Logger.Infof("Got output from 'kubectl cp': %s", string(output))
+		}
+	}, testTimeout, framework.WithCAfterTest(func(ctx context.Context) {
+		ginkgo.By("Cleaning up copy resources")
+		deploymentToDelete := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      copyDeployment,
+				Namespace: namespace,
+			},
+		}
+		secretToDelete := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      copyDeployment,
+				Namespace: namespace,
+			},
+		}
+		err := kutil.DeleteObjects(ctx, f.ShootClient.Client(), deploymentToDelete, secretToDelete)
+		framework.ExpectNoError(err)
+	}, cleanupTimeout))
+})

--- a/test/suites/shoot/run_suite_test.go
+++ b/test/suites/shoot/run_suite_test.go
@@ -32,6 +32,7 @@ import (
 	_ "github.com/gardener/gardener/test/integration/shoots/logging"
 	_ "github.com/gardener/gardener/test/integration/shoots/operatingsystem"
 	_ "github.com/gardener/gardener/test/integration/shoots/operations"
+	_ "github.com/gardener/gardener/test/integration/shoots/vpntunnel"
 )
 
 var (


### PR DESCRIPTION
Co-authored-by: Johannes Scheerer <johannes.scheerer@sap.com>

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:

This PR adds two tests to the shoot test suite to test the vpn tunnel connection.
The first test tries to fetch the logs from a pod and the second one tries to copy data from one container to another via `kubectl cp`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
none
```
