### PR TITLE
Deny mentions in commit messages

### DIFF
--- a/.github/workflows/commit-message.yaml
+++ b/.github/workflows/commit-message.yaml
@@ -1,0 +1,63 @@
+name: 'Commit Message Check'
+on:
+  pull_request:
+    types:
+    - opened
+    - reopened
+    - synchronize
+
+jobs:
+  check-commit-messages:
+    name: Check Commit Messages
+    runs-on: ubuntu-latest
+    steps:
+    - name: Block mentions
+      uses: actions/github-script@v4
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const commits = await github.pulls.listCommits({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            pull_number: context.issue.number
+          });
+
+          const mentionRegex = /(^| )@([a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38})/gmi;
+          let mentioningCommitShas = [];
+
+          for (const commit of commits.data) {
+            while (match = mentionRegex.exec(commit.commit.message)) {
+              const mention = match[2];
+
+              // check if detected mention is actually a github username
+              try {
+                const user = await github.users.getByUsername({
+                  username: mention,
+                });
+                if (user.data.login == mention) {
+                  mentioningCommitShas.push(commit.sha);
+                }
+              } catch (err) {
+                if (err.status != 404) {
+                  throw err;
+                }
+              }
+            }
+          }
+
+          if (mentioningCommitShas.length == 0) {
+            core.info("no commit messages with mentions detected");
+            return;
+          }
+
+          errMsg = `This PR contains commits including \`@mentions\` in the commit message: ${mentioningCommitShas.join(", ")}\n`+
+            `Please remove the mentions from the commit messages to prevent notifying the mentioned users every time the commit is pushed to some fork of this repository.`;
+
+          await github.issues.createComment({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: `@${context.payload.pull_request.user.login} ` + errMsg
+          });
+
+          core.setFailed(errMsg);


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:

This PR adds a GitHub action workflow, that blocks PRs with commits that include `@mentions`.
Commits including mentions will notify the mentioned users every time the commit is pushed to some fork of the repo, which is very annoying.

You can find example test runs in https://github.com/timebertt/gardener/pull/2 and https://github.com/timebertt/gardener/pull/3