### PR TITLE
Cleanup context.TODO(), migrate from DeprecatedCreateWorker to CreateWorker (6)

### DIFF
--- a/cmd/gardener-controller-manager/app/gardener_controller_manager.go
+++ b/cmd/gardener-controller-manager/app/gardener_controller_manager.go
@@ -43,8 +43,6 @@ import (
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
-	"k8s.io/client-go/informers"
-	kubeinformers "k8s.io/client-go/informers"
 	kubernetesclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/record"
@@ -190,12 +188,11 @@ These so-called control plane components are hosted in Kubernetes clusters thems
 // Gardener represents all the parameters required to start the
 // Gardener controller manager.
 type Gardener struct {
-	Config              *config.ControllerManagerConfiguration
-	ClientMap           clientmap.ClientMap
-	KubeInformerFactory informers.SharedInformerFactory
-	Logger              *logrus.Logger
-	Recorder            record.EventRecorder
-	LeaderElection      *leaderelection.LeaderElectionConfig
+	Config         *config.ControllerManagerConfiguration
+	ClientMap      clientmap.ClientMap
+	Logger         *logrus.Logger
+	Recorder       record.EventRecorder
+	LeaderElection *leaderelection.LeaderElectionConfig
 }
 
 // NewGardener is the main entry point of instantiating a new Gardener controller manager.
@@ -264,12 +261,11 @@ func NewGardener(ctx context.Context, cfg *config.ControllerManagerConfiguration
 	}
 
 	return &Gardener{
-		Config:              cfg,
-		Logger:              logger,
-		Recorder:            recorder,
-		ClientMap:           clientMap,
-		KubeInformerFactory: kubeinformers.NewSharedInformerFactory(k8sGardenClient.Kubernetes(), 0),
-		LeaderElection:      leaderElectionConfig,
+		Config:         cfg,
+		Logger:         logger,
+		Recorder:       recorder,
+		ClientMap:      clientMap,
+		LeaderElection: leaderElectionConfig,
 	}, nil
 }
 
@@ -334,7 +330,6 @@ func (g *Gardener) Run(ctx context.Context) error {
 func (g *Gardener) startControllers(ctx context.Context) error {
 	return controller.NewGardenControllerFactory(
 		g.ClientMap,
-		g.KubeInformerFactory,
 		g.Config,
 		g.Recorder,
 	).Run(ctx)

--- a/cmd/gardener-controller-manager/app/gardener_controller_manager.go
+++ b/cmd/gardener-controller-manager/app/gardener_controller_manager.go
@@ -23,7 +23,6 @@ import (
 	"os"
 
 	"github.com/gardener/gardener/cmd/utils"
-	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
 	clientmapbuilder "github.com/gardener/gardener/pkg/client/kubernetes/clientmap/builder"
@@ -191,13 +190,12 @@ These so-called control plane components are hosted in Kubernetes clusters thems
 // Gardener represents all the parameters required to start the
 // Gardener controller manager.
 type Gardener struct {
-	Config                 *config.ControllerManagerConfiguration
-	ClientMap              clientmap.ClientMap
-	K8sGardenCoreInformers gardencoreinformers.SharedInformerFactory
-	KubeInformerFactory    informers.SharedInformerFactory
-	Logger                 *logrus.Logger
-	Recorder               record.EventRecorder
-	LeaderElection         *leaderelection.LeaderElectionConfig
+	Config              *config.ControllerManagerConfiguration
+	ClientMap           clientmap.ClientMap
+	KubeInformerFactory informers.SharedInformerFactory
+	Logger              *logrus.Logger
+	Recorder            record.EventRecorder
+	LeaderElection      *leaderelection.LeaderElectionConfig
 }
 
 // NewGardener is the main entry point of instantiating a new Gardener controller manager.
@@ -266,13 +264,12 @@ func NewGardener(ctx context.Context, cfg *config.ControllerManagerConfiguration
 	}
 
 	return &Gardener{
-		Config:                 cfg,
-		Logger:                 logger,
-		Recorder:               recorder,
-		ClientMap:              clientMap,
-		K8sGardenCoreInformers: gardencoreinformers.NewSharedInformerFactory(k8sGardenClient.GardenCore(), 0),
-		KubeInformerFactory:    kubeinformers.NewSharedInformerFactory(k8sGardenClient.Kubernetes(), 0),
-		LeaderElection:         leaderElectionConfig,
+		Config:              cfg,
+		Logger:              logger,
+		Recorder:            recorder,
+		ClientMap:           clientMap,
+		KubeInformerFactory: kubeinformers.NewSharedInformerFactory(k8sGardenClient.Kubernetes(), 0),
+		LeaderElection:      leaderElectionConfig,
 	}, nil
 }
 
@@ -337,7 +334,6 @@ func (g *Gardener) Run(ctx context.Context) error {
 func (g *Gardener) startControllers(ctx context.Context) error {
 	return controller.NewGardenControllerFactory(
 		g.ClientMap,
-		g.K8sGardenCoreInformers,
 		g.KubeInformerFactory,
 		g.Config,
 		g.Recorder,

--- a/pkg/controllermanager/controller/event/event.go
+++ b/pkg/controllermanager/controller/event/event.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -62,7 +63,9 @@ func NewController(
 		return nil, err
 	}
 
-	eventInformer, err := gardenClient.Cache().GetInformer(ctx, &corev1.Event{})
+	events := &metav1.PartialObjectMetadata{}
+	events.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("Event"))
+	eventInformer, err := gardenClient.Cache().GetInformer(ctx, events)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Event Informer: %w", err)
 	}

--- a/pkg/controllermanager/controller/factory.go
+++ b/pkg/controllermanager/controller/factory.go
@@ -202,7 +202,7 @@ func (f *GardenControllerFactory) Run(ctx context.Context) error {
 	}
 	metricsCollectors = append(metricsCollectors, secretBindingController)
 
-	seedController, err := seedcontroller.NewSeedController(ctx, f.clientMap, f.k8sInformers, f.cfg, f.recorder)
+	seedController, err := seedcontroller.NewSeedController(ctx, f.clientMap, f.cfg)
 	if err != nil {
 		return fmt.Errorf("failed initializing Seed controller: %w", err)
 	}

--- a/pkg/controllermanager/controller/factory.go
+++ b/pkg/controllermanager/controller/factory.go
@@ -152,7 +152,7 @@ func (f *GardenControllerFactory) Run(ctx context.Context) error {
 		return errors.New("Timed out waiting for Kube caches to sync")
 	}
 
-	runtime.Must(garden.BootstrapCluster(ctx, k8sGardenClient, v1beta1constants.GardenNamespace, f.k8sInformers.Core().V1().Secrets().Lister()))
+	runtime.Must(garden.BootstrapCluster(ctx, k8sGardenClient))
 	logger.Logger.Info("Successfully bootstrapped the Garden cluster.")
 
 	// Initialize the workqueue metrics collection.

--- a/pkg/controllermanager/controller/factory.go
+++ b/pkg/controllermanager/controller/factory.go
@@ -202,7 +202,10 @@ func (f *GardenControllerFactory) Run(ctx context.Context) error {
 	}
 	metricsCollectors = append(metricsCollectors, secretBindingController)
 
-	seedController := seedcontroller.NewSeedController(f.clientMap, f.k8sGardenCoreInformers, f.k8sInformers, f.cfg, f.recorder)
+	seedController, err := seedcontroller.NewSeedController(ctx, f.clientMap, f.k8sGardenCoreInformers, f.k8sInformers, f.cfg, f.recorder)
+	if err != nil {
+		return fmt.Errorf("failed initializing Seed controller: %w", err)
+	}
 	metricsCollectors = append(metricsCollectors, seedController)
 
 	shootController, err := shootcontroller.NewShootController(ctx, f.clientMap, f.k8sInformers, f.cfg, f.recorder)

--- a/pkg/controllermanager/controller/factory.go
+++ b/pkg/controllermanager/controller/factory.go
@@ -202,7 +202,7 @@ func (f *GardenControllerFactory) Run(ctx context.Context) error {
 	}
 	metricsCollectors = append(metricsCollectors, secretBindingController)
 
-	seedController, err := seedcontroller.NewSeedController(ctx, f.clientMap, f.k8sGardenCoreInformers, f.k8sInformers, f.cfg, f.recorder)
+	seedController, err := seedcontroller.NewSeedController(ctx, f.clientMap, f.k8sInformers, f.cfg, f.recorder)
 	if err != nil {
 		return fmt.Errorf("failed initializing Seed controller: %w", err)
 	}

--- a/pkg/controllermanager/controller/project/project_stale_control.go
+++ b/pkg/controllermanager/controller/project/project_stale_control.go
@@ -22,7 +22,6 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
-	"github.com/gardener/gardener/pkg/utils"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
@@ -30,8 +29,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -169,17 +166,8 @@ func (r *projectStaleReconciler) projectInUseDueToBackupEntries(ctx context.Cont
 }
 
 func (r *projectStaleReconciler) projectInUseDueToSecrets(ctx context.Context, namespace string) (bool, error) {
-	var (
-		noControlPlaneSecretsReq = utils.MustNewRequirement(
-			v1beta1constants.GardenRole,
-			selection.NotIn,
-			v1beta1constants.ControlPlaneSecretRoles...,
-		)
-		uncontrolledSecretSelector = client.MatchingLabelsSelector{Selector: labels.NewSelector().Add(noControlPlaneSecretsReq)}
-	)
-
 	secretList := &corev1.SecretList{}
-	if err := r.gardenClient.List(ctx, secretList, client.InNamespace(namespace), uncontrolledSecretSelector); err != nil {
+	if err := r.gardenClient.List(ctx, secretList, client.InNamespace(namespace), gutil.UncontrolledSecretSelector); err != nil {
 		return false, err
 	}
 

--- a/pkg/controllermanager/controller/seed/seed.go
+++ b/pkg/controllermanager/controller/seed/seed.go
@@ -84,9 +84,6 @@ func NewSeedController(
 	}
 
 	var (
-		leaseInformer = kubeInformerFactory.Coordination().V1().Leases()
-		leaseLister   = leaseInformer.Lister()
-
 		secretInformer = kubeInformerFactory.Core().V1().Secrets()
 		secretLister   = kubeInformerFactory.Core().V1().Secrets().Lister()
 	)
@@ -94,7 +91,7 @@ func NewSeedController(
 	seedController := &Controller{
 		config:                config,
 		seedReconciler:        NewDefaultControl(logger.Logger, gardenClient, secretLister),
-		lifeCycleReconciler:   NewLifecycleDefaultControl(logger.Logger, gardenClient, leaseLister, config),
+		lifeCycleReconciler:   NewLifecycleDefaultControl(logger.Logger, gardenClient, config),
 		recorder:              recorder,
 		seedBackupReconciler:  NewDefaultBackupBucketControl(logger.Logger, gardenClient),
 		seedBackupBucketQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Backup Bucket"),
@@ -128,7 +125,6 @@ func NewSeedController(
 	seedController.hasSyncedFuncs = []cache.InformerSynced{
 		backupBucketInformer.HasSynced,
 		seedInformer.HasSynced,
-		leaseInformer.Informer().HasSynced,
 		secretInformer.Informer().HasSynced,
 	}
 

--- a/pkg/controllermanager/controller/seed/seed.go
+++ b/pkg/controllermanager/controller/seed/seed.go
@@ -87,7 +87,7 @@ func NewSeedController(
 		gardenClient: gardenClient.Client(),
 		config:       config,
 
-		seedReconciler:       NewDefaultControl(logger.Logger, gardenClient),
+		seedReconciler:       NewDefaultControl(logger.Logger, gardenClient.Client()),
 		lifeCycleReconciler:  NewLifecycleDefaultControl(logger.Logger, gardenClient, config),
 		seedBackupReconciler: NewDefaultBackupBucketControl(logger.Logger, gardenClient),
 

--- a/pkg/controllermanager/controller/seed/seed_backup_bucket_reconcile_test.go
+++ b/pkg/controllermanager/controller/seed/seed_backup_bucket_reconcile_test.go
@@ -20,9 +20,7 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	coreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
-	fakeclientmap "github.com/gardener/gardener/pkg/client/kubernetes/clientmap/fake"
-	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
-	fakeclientset "github.com/gardener/gardener/pkg/client/kubernetes/fake"
+	mockkubernetes "github.com/gardener/gardener/pkg/client/kubernetes/mock"
 	. "github.com/gardener/gardener/pkg/controllermanager/controller/seed"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 
@@ -37,7 +35,10 @@ import (
 )
 
 var _ = Describe("BackupBucketReconciler", func() {
-	var ctrl *gomock.Controller
+	var (
+		ctx  = context.TODO()
+		ctrl *gomock.Controller
+	)
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
@@ -49,18 +50,19 @@ var _ = Describe("BackupBucketReconciler", func() {
 
 	Describe("#Reconcile", func() {
 		var (
-			cm *fakeclientmap.ClientMap
-			c  *mockclient.MockClient
-			sw *mockclient.MockStatusWriter
+			k8sGardenClient *mockkubernetes.MockInterface
+			c               *mockclient.MockClient
+			sw              *mockclient.MockStatusWriter
 
 			seed, seedPatch *gardencorev1beta1.Seed
-			bbs             []*gardencorev1beta1.BackupBucket
+			bbs             []gardencorev1beta1.BackupBucket
 
 			control             reconcile.Reconciler
 			coreInformerFactory coreinformers.SharedInformerFactory
 		)
 
 		BeforeEach(func() {
+			k8sGardenClient = mockkubernetes.NewMockInterface(ctrl)
 			c = mockclient.NewMockClient(ctrl)
 			sw = mockclient.NewMockStatusWriter(ctrl)
 			c.EXPECT().Status().Return(sw).AnyTimes()
@@ -70,10 +72,9 @@ var _ = Describe("BackupBucketReconciler", func() {
 				},
 			}
 
-			fakeGardenClientSet := fakeclientset.NewClientSetBuilder().WithClient(c).Build()
-			cm = fakeclientmap.NewClientMapBuilder().WithClientSetForKey(keys.ForGarden(), fakeGardenClientSet).Build()
-
 			seedPatch = &gardencorev1beta1.Seed{}
+
+			k8sGardenClient.EXPECT().Client().Return(c).AnyTimes()
 		})
 
 		JustBeforeEach(func() {
@@ -87,27 +88,28 @@ var _ = Describe("BackupBucketReconciler", func() {
 
 			coreInformerFactory = coreinformers.NewSharedInformerFactory(nil, 0)
 			Expect(coreInformerFactory.Core().V1beta1().Seeds().Informer().GetStore().Add(seed)).To(Succeed())
-			for _, bb := range bbs {
-				backupBucket := bb
-				Expect(coreInformerFactory.Core().V1beta1().BackupBuckets().Informer().GetStore().Add(backupBucket)).To(Succeed())
-			}
 
-			control = NewDefaultBackupBucketControl(cm, coreInformerFactory.Core().V1beta1().BackupBuckets().Lister(), coreInformerFactory.Core().V1beta1().Seeds().Lister())
+			control = NewDefaultBackupBucketControl(k8sGardenClient, coreInformerFactory.Core().V1beta1().Seeds().Lister())
 		})
 
 		Context("when Seed has healthy backup buckets", func() {
 			BeforeEach(func() {
-				bbs = []*gardencorev1beta1.BackupBucket{
+				bbs = []gardencorev1beta1.BackupBucket{
 					createBackupBucket("1", seed.Name, nil),
 					createBackupBucket("2", "fooSeed", nil),
 					createBackupBucket("3", "barSeed", nil),
 					createBackupBucket("4", seed.Name, nil),
 				}
+
+				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.BackupBucketList{})).DoAndReturn(func(ctx context.Context, list *gardencorev1beta1.BackupBucketList, opts ...client.ListOption) error {
+					(&gardencorev1beta1.BackupBucketList{Items: bbs}).DeepCopyInto(list)
+					return nil
+				})
 			})
 
 			It("should set condition to `True` when none was given", func() {
-				result, err := control.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKeyFromObject(seed)})
-				Expect(err).To(Not(HaveOccurred()))
+				result, err := control.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(seed)})
+				Expect(err).NotTo(HaveOccurred())
 				Expect(result).To(Equal(reconcile.Result{}))
 				Expect(seedPatch.Status.Conditions).To(ConsistOf(
 					MatchFields(IgnoreExtras, Fields{
@@ -134,8 +136,9 @@ var _ = Describe("BackupBucketReconciler", func() {
 						Type:    gardencorev1beta1.SeedBackupBucketsReady,
 					},
 				}
-				result, err := control.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKeyFromObject(seed)})
-				Expect(err).To(Not(HaveOccurred()))
+
+				result, err := control.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(seed)})
+				Expect(err).NotTo(HaveOccurred())
 				Expect(result).To(Equal(reconcile.Result{}))
 				Expect(seedPatch.Status.Conditions).To(ConsistOf(
 					MatchFields(IgnoreExtras, Fields{
@@ -150,17 +153,22 @@ var _ = Describe("BackupBucketReconciler", func() {
 
 		Context("when Seed has unhealthy backup buckets", func() {
 			BeforeEach(func() {
-				bbs = []*gardencorev1beta1.BackupBucket{
+				bbs = []gardencorev1beta1.BackupBucket{
 					createBackupBucket("1", seed.Name, &gardencorev1beta1.LastError{Description: "foo error"}),
 					createBackupBucket("2", "fooSeed", nil),
 					createBackupBucket("3", seed.Name, &gardencorev1beta1.LastError{Description: "bar error"}),
 					createBackupBucket("4", "barSeed", nil),
 				}
+
+				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.BackupBucketList{})).DoAndReturn(func(ctx context.Context, list *gardencorev1beta1.BackupBucketList, opts ...client.ListOption) error {
+					(&gardencorev1beta1.BackupBucketList{Items: bbs}).DeepCopyInto(list)
+					return nil
+				})
 			})
 
 			It("should set condition to `False`", func() {
-				result, err := control.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKeyFromObject(seed)})
-				Expect(err).To(Not(HaveOccurred()))
+				result, err := control.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(seed)})
+				Expect(err).NotTo(HaveOccurred())
 				Expect(result).To(Equal(reconcile.Result{}))
 				Expect(seedPatch.Status.Conditions).To(ConsistOf(
 					MatchFields(IgnoreExtras, Fields{
@@ -175,10 +183,14 @@ var _ = Describe("BackupBucketReconciler", func() {
 
 		Context("when a Seed's unhealthy backup bucket switches", func() {
 			BeforeEach(func() {
-				bbs = []*gardencorev1beta1.BackupBucket{
+				bbs = []gardencorev1beta1.BackupBucket{
 					createBackupBucket("1", seed.Name, &gardencorev1beta1.LastError{Description: "foo error"}),
 					createBackupBucket("2", seed.Name, nil),
 				}
+				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.BackupBucketList{})).DoAndReturn(func(ctx context.Context, list *gardencorev1beta1.BackupBucketList, opts ...client.ListOption) error {
+					(&gardencorev1beta1.BackupBucketList{Items: bbs}).DeepCopyInto(list)
+					return nil
+				})
 			})
 
 			It("should set condition to `False` and remove successful bucket from message", func() {
@@ -190,8 +202,8 @@ var _ = Describe("BackupBucketReconciler", func() {
 						Type:    gardencorev1beta1.SeedBackupBucketsReady,
 					},
 				}
-				result, err := control.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKeyFromObject(seed)})
-				Expect(err).To(Not(HaveOccurred()))
+				result, err := control.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(seed)})
+				Expect(err).NotTo(HaveOccurred())
 				Expect(result).To(Equal(reconcile.Result{}))
 				Expect(seedPatch.Status.Conditions).To(ConsistOf(
 					MatchFields(IgnoreExtras, Fields{
@@ -204,10 +216,14 @@ var _ = Describe("BackupBucketReconciler", func() {
 
 		Context("when a Seed's backup buckets are gone", func() {
 			BeforeEach(func() {
-				bbs = []*gardencorev1beta1.BackupBucket{
+				bbs = []gardencorev1beta1.BackupBucket{
 					createBackupBucket("1", "fooSeed", &gardencorev1beta1.LastError{Description: "foo error"}),
 					createBackupBucket("2", "barSeed", nil),
 				}
+				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.BackupBucketList{})).DoAndReturn(func(ctx context.Context, list *gardencorev1beta1.BackupBucketList, opts ...client.ListOption) error {
+					(&gardencorev1beta1.BackupBucketList{Items: bbs}).DeepCopyInto(list)
+					return nil
+				})
 			})
 
 			It("should set condition to `False` and remove successful bucket from message", func() {
@@ -219,8 +235,8 @@ var _ = Describe("BackupBucketReconciler", func() {
 						Type:    gardencorev1beta1.SeedBackupBucketsReady,
 					},
 				}
-				result, err := control.Reconcile(context.Background(), reconcile.Request{NamespacedName: client.ObjectKeyFromObject(seed)})
-				Expect(err).To(Not(HaveOccurred()))
+				result, err := control.Reconcile(ctx, reconcile.Request{NamespacedName: client.ObjectKeyFromObject(seed)})
+				Expect(err).NotTo(HaveOccurred())
 				Expect(result).To(Equal(reconcile.Result{}))
 				Expect(seedPatch.Status.Conditions).To(ConsistOf(
 					MatchFields(IgnoreExtras, Fields{
@@ -235,8 +251,8 @@ var _ = Describe("BackupBucketReconciler", func() {
 	})
 })
 
-func createBackupBucket(name, seedName string, lastErr *gardencorev1beta1.LastError) *gardencorev1beta1.BackupBucket {
-	return &gardencorev1beta1.BackupBucket{
+func createBackupBucket(name, seedName string, lastErr *gardencorev1beta1.LastError) gardencorev1beta1.BackupBucket {
+	return gardencorev1beta1.BackupBucket{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},

--- a/pkg/controllermanager/controller/seed/seed_reconcile.go
+++ b/pkg/controllermanager/controller/seed/seed_reconcile.go
@@ -109,13 +109,8 @@ func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 }
 
 var (
-	gardenRoleReq            = utils.MustNewRequirement(v1beta1constants.GardenRole, selection.Exists)
-	noControlPlaneSecretsReq = utils.MustNewRequirement(
-		v1beta1constants.GardenRole,
-		selection.NotIn,
-		v1beta1constants.ControlPlaneSecretRoles...,
-	)
-	gardenRoleSelector = labels.NewSelector().Add(gardenRoleReq).Add(noControlPlaneSecretsReq)
+	gardenRoleReq      = utils.MustNewRequirement(v1beta1constants.GardenRole, selection.Exists)
+	gardenRoleSelector = labels.NewSelector().Add(gardenRoleReq).Add(gardenerutils.NoControlPlaneSecretsReq)
 )
 
 func (r *reconciler) cleanupStaleSecrets(ctx context.Context, gardenClient kubernetes.Interface, existingSecrets []string, namespace string) error {

--- a/pkg/controllermanager/controller/seed/seed_reconcile_test.go
+++ b/pkg/controllermanager/controller/seed/seed_reconcile_test.go
@@ -20,7 +20,6 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
-	mockkubernetes "github.com/gardener/gardener/pkg/client/kubernetes/mock"
 	. "github.com/gardener/gardener/pkg/controllermanager/controller/seed"
 	"github.com/gardener/gardener/pkg/logger"
 	mockcorev1 "github.com/gardener/gardener/pkg/mock/client-go/core/v1"
@@ -64,12 +63,11 @@ var _ = Describe("SeedReconciler", func() {
 
 	Describe("#Reconcile", func() {
 		var (
-			k8sGardenClient *mockkubernetes.MockInterface
-			cl              *mockclient.MockClient
-			k               *mockclientgo.MockInterface
-			corev1If        *mockcorev1.MockCoreV1Interface
-			namespaceIf     *mockcorev1.MockNamespaceInterface
-			secretIf        *mockcorev1.MockSecretInterface
+			cl          *mockclient.MockClient
+			k           *mockclientgo.MockInterface
+			corev1If    *mockcorev1.MockCoreV1Interface
+			namespaceIf *mockcorev1.MockNamespaceInterface
+			secretIf    *mockcorev1.MockSecretInterface
 
 			control reconcile.Reconciler
 
@@ -79,7 +77,6 @@ var _ = Describe("SeedReconciler", func() {
 		)
 
 		BeforeEach(func() {
-			k8sGardenClient = mockkubernetes.NewMockInterface(ctrl)
 			cl = mockclient.NewMockClient(ctrl)
 			seed = &gardencorev1beta1.Seed{
 				ObjectMeta: metav1.ObjectMeta{
@@ -106,9 +103,7 @@ var _ = Describe("SeedReconciler", func() {
 				Expect(coreInformerFactory.Core().V1().Secrets().Informer().GetStore().Add(secret)).To(Succeed())
 			}
 
-			control = NewDefaultControl(logger.NewNopLogger(), k8sGardenClient)
-
-			k8sGardenClient.EXPECT().Client().Return(cl).AnyTimes()
+			control = NewDefaultControl(logger.NewNopLogger(), cl)
 		})
 
 		Context("when seed exists", func() {

--- a/pkg/controllermanager/controller/seed/seed_reconcile_test.go
+++ b/pkg/controllermanager/controller/seed/seed_reconcile_test.go
@@ -50,13 +50,8 @@ var _ = Describe("SeedReconciler", func() {
 		ctx  = context.TODO()
 		ctrl *gomock.Controller
 
-		gardenRoleReq            = utils.MustNewRequirement(v1beta1constants.GardenRole, selection.Exists)
-		noControlPlaneSecretsReq = utils.MustNewRequirement(
-			v1beta1constants.GardenRole,
-			selection.NotIn,
-			v1beta1constants.ControlPlaneSecretRoles...,
-		)
-		labelSelector = client.MatchingLabelsSelector{Selector: labels.NewSelector().Add(gardenRoleReq).Add(noControlPlaneSecretsReq)}
+		gardenRoleReq = utils.MustNewRequirement(v1beta1constants.GardenRole, selection.Exists)
+		labelSelector = client.MatchingLabelsSelector{Selector: labels.NewSelector().Add(gardenRoleReq).Add(gardenerutils.NoControlPlaneSecretsReq)}
 	)
 
 	BeforeEach(func() {

--- a/pkg/operation/garden/garden.go
+++ b/pkg/operation/garden/garden.go
@@ -33,7 +33,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
-	kubecorev1listers "k8s.io/client-go/listers/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -340,10 +339,8 @@ func readGardenSecretsFromCache(ctx context.Context, secretLister listSecretsFun
 	return secretsMap, nil
 }
 
-var monitoringRoleReq = utils.MustNewRequirement(v1beta1constants.GardenRole, selection.In, v1beta1constants.GardenRoleGlobalMonitoring)
-
 // BootstrapCluster bootstraps the Garden cluster and deploys various required manifests.
-func BootstrapCluster(ctx context.Context, k8sGardenClient kubernetes.Interface, gardenNamespace string, secretLister kubecorev1listers.SecretLister) error {
+func BootstrapCluster(ctx context.Context, k8sGardenClient kubernetes.Interface) error {
 	// Check whether the Kubernetes version of the Garden cluster is at least 1.16 (least supported K8s version of Gardener).
 	minGardenVersion := "1.16"
 	gardenVersionOK, err := version.CompareVersions(k8sGardenClient.Version(), ">=", minGardenVersion)
@@ -354,13 +351,18 @@ func BootstrapCluster(ctx context.Context, k8sGardenClient kubernetes.Interface,
 		return fmt.Errorf("the Kubernetes version of the Garden cluster must be at least %s", minGardenVersion)
 	}
 
-	secrets, err := secretLister.Secrets(v1beta1constants.GardenNamespace).List(labels.NewSelector().Add(monitoringRoleReq))
-	if err != nil {
+	secretList := &corev1.SecretList{}
+	if err := k8sGardenClient.Client().List(
+		ctx,
+		secretList,
+		client.InNamespace(v1beta1constants.GardenNamespace),
+		client.MatchingLabels{v1beta1constants.GardenRole: v1beta1constants.GardenRoleGlobalMonitoring},
+	); err != nil {
 		return err
 	}
 
-	if len(secrets) < 1 {
-		if _, err = generateMonitoringSecret(ctx, k8sGardenClient, gardenNamespace); err != nil {
+	if len(secretList.Items) < 1 {
+		if _, err = generateMonitoringSecret(ctx, k8sGardenClient); err != nil {
 			return err
 		}
 	}
@@ -368,7 +370,7 @@ func BootstrapCluster(ctx context.Context, k8sGardenClient kubernetes.Interface,
 	return nil
 }
 
-func generateMonitoringSecret(ctx context.Context, k8sGardenClient kubernetes.Interface, gardenNamespace string) (*corev1.Secret, error) {
+func generateMonitoringSecret(ctx context.Context, k8sGardenClient kubernetes.Interface) (*corev1.Secret, error) {
 	basicAuthSecret := &secretutils.BasicAuthSecretConfig{
 		Name:   "monitoring-ingress-credentials",
 		Format: secretutils.BasicAuthFormatNormal,
@@ -384,7 +386,7 @@ func generateMonitoringSecret(ctx context.Context, k8sGardenClient kubernetes.In
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      basicAuthSecret.Name,
-			Namespace: gardenNamespace,
+			Namespace: v1beta1constants.GardenNamespace,
 		},
 	}
 	if _, err := controllerutil.CreateOrUpdate(ctx, k8sGardenClient.Client(), secret, func() error {

--- a/pkg/utils/gardener/secrets.go
+++ b/pkg/utils/gardener/secrets.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gardener
+
+import (
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/utils"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	// NoControlPlaneSecretsReq is a label selector requirement to select non-control plane secrets.
+	NoControlPlaneSecretsReq = utils.MustNewRequirement(constants.GardenRole, selection.NotIn, constants.ControlPlaneSecretRoles...)
+	// UncontrolledSecretSelector is a selector for objects which are managed by operators/users and not created
+	// Gardener controllers.
+	UncontrolledSecretSelector = client.MatchingLabelsSelector{Selector: labels.NewSelector().Add(NoControlPlaneSecretsReq)}
+)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:
Similar to #3658, #3681, #3954, #3955, #3956 this is my final PR (for now) continuing with the migration of a couple of our controllers from `controllerutils.DeprecatedCreateWorker` (deprecated since #1094) to `controllerutils.CreateWorker`. This helps to get rid of some remaining usages of `context.TODO()`. Also, it replaces client-go informers/listers with informers from the controller-runtime.

**Which issue(s) this PR fixes**:
Part of #1648 

**Special notes for your reviewer**:
/squash

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
