### PR TITLE
Add missing field index for projects

### DIFF
--- a/pkg/controllermanager/controller/project/project_stale_control_test.go
+++ b/pkg/controllermanager/controller/project/project_stale_control_test.go
@@ -470,13 +470,12 @@ var _ = Describe("ProjectStaleControl", func() {
 							return time.Date(1, 1, minimumLifetimeDays+1, 1, 0, 0, 0, time.UTC)
 						}
 
-						k8sGardenRuntimeClient.EXPECT().Get(ctx, kutil.Key(projectName), project)
 						projectCopy := project.DeepCopy()
 						projectCopy.Annotations = map[string]string{
 							gutil.ConfirmationDeletion:         "true",
 							v1beta1constants.GardenerTimestamp: gutil.TimeNow().UTC().String(),
 						}
-						k8sGardenRuntimeClient.EXPECT().Update(ctx, projectCopy)
+						k8sGardenRuntimeClient.EXPECT().Patch(ctx, projectCopy, gomock.Any())
 						k8sGardenRuntimeClient.EXPECT().Delete(ctx, projectCopy)
 
 						_, result := reconciler.Reconcile(ctx, request)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind regression

**What this PR does / why we need it**:

Add missing field index for projects (`spec.namespace`) in the controller-runtime cache in gcm that is required since https://github.com/gardener/gardener/pull/3774 (if the `CachedRuntimeClients` feature gate is activated) here https://github.com/gardener/gardener/blob/453b70ed9a40c0eb72694452d55d54b9d074ea29/pkg/controllermanager/controller/project/rolebinding_control.go#L50

**Which issue(s) this PR fixes**:

```
time="2021-05-03T07:41:30+02:00" level=error msg="Couldn't get list keys for object &RoleBinding{ObjectMeta:{gardener.cloud:system:project-viewer  garden  fd50db07-848b-4517-a87b-599df18d2840 3039805 0 2021-04-01 09:54:35 +0200 CEST <nil> <nil> map[] map[] [{core.gardener.cloud/v1beta1 Project garden f3addf0d-17b5-438e-a6a7-5b7ab94fca1f 0xc001714d8e 0xc001714d8f}] []  [{gardener_controller_manager Update rbac.authorization.k8s.io/v1 2021-04-01 09:54:35 +0200 CEST FieldsV1 {\"f:metadata\":{\"f:ownerReferences\":{\".\":{},\"k:{\\\"uid\\\":\\\"f3addf0d-17b5-438e-a6a7-5b7ab94fca1f\\\"}\":{\".\":{},\"f:apiVersion\":{},\"f:blockOwnerDeletion\":{},\"f:controller\":{},\"f:kind\":{},\"f:name\":{},\"f:uid\":{}}}},\"f:roleRef\":{\"f:apiGroup\":{},\"f:kind\":{},\"f:name\":{}}}}]},Subjects:[]Subject{},RoleRef:RoleRef{APIGroup:rbac.authorization.k8s.io,Kind:ClusterRole,Name:gardener.cloud:system:project-viewer,},}: Index with name field:spec.namespace does not exist"
```

**Special notes for your reviewer**:

We will need to add any new field indexes we use in our controllers for reading from the c-r cache to the newly added func (and similarly in gardenlet).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue has been fixed which could cause Projects not to be reconciled immediately when corresponding `RoleBinding`s were changed.
```
