### PR TITLE
Add missing cloudprofile permission for scheduler

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/clusterrole-scheduler.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/clusterrole-scheduler.yaml
@@ -39,6 +39,7 @@ rules:
   - core.gardener.cloud
   resources:
   - seeds
+  - cloudprofiles
   verbs:
   - get
   - list

--- a/hack/local-development/start-admission-controller
+++ b/hack/local-development/start-admission-controller
@@ -16,6 +16,8 @@
 
 source $(dirname "${0}")/common/helpers
 
+kubeconfig="$KUBECONFIG"
+
 if [[ $(k8s_env) == "$NODELESS" ]]; then
   kubeconfig="$(dirname $0)/local-garden/kubeconfigs/gardener-admission-controller.conf"
 else
@@ -24,7 +26,7 @@ else
   trap cleanup_kubeconfig EXIT
 fi
 
-KUBECONFIG="${KUBECONFIG:-$kubeconfig}" GO111MODULE=on \
+KUBECONFIG="$kubeconfig" GO111MODULE=on \
     go run \
       -mod=vendor \
       -ldflags "$(./hack/get-build-ld-flags.sh)" \

--- a/hack/local-development/start-apiserver
+++ b/hack/local-development/start-apiserver
@@ -16,6 +16,8 @@
 
 source $(dirname "${0}")/common/helpers
 
+kubeconfig="$KUBECONFIG"
+
 if [[ $(k8s_env) == "$NODELESS" ]]; then
   kubeconfig="$(dirname $0)/local-garden/kubeconfigs/gardener-apiserver.conf"
 else

--- a/hack/local-development/start-controller-manager
+++ b/hack/local-development/start-controller-manager
@@ -16,6 +16,8 @@
 
 source $(dirname "${0}")/common/helpers
 
+kubeconfig="$KUBECONFIG"
+
 if [[ $(k8s_env) == "$NODELESS" ]]; then
   kubeconfig="$(dirname $0)/local-garden/kubeconfigs/gardener-controller-manager.conf"
 else
@@ -24,7 +26,7 @@ else
   trap cleanup_kubeconfig EXIT
 fi
 
-KUBECONFIG="${KUBECONFIG:-$kubeconfig}" GO111MODULE=on \
+KUBECONFIG="$kubeconfig" GO111MODULE=on \
     go run \
       -mod=vendor \
       -ldflags "$("$(dirname $0)"/../get-build-ld-flags.sh)" \

--- a/hack/local-development/start-gardenlet
+++ b/hack/local-development/start-gardenlet
@@ -19,6 +19,8 @@ source $(dirname "${0}")/common/local-imagevector-overwrite
 
 REPO_ROOT=$(dirname $0)/../..
 
+kubeconfig="$KUBECONFIG"
+
 if [[ $(k8s_env) == "$NODELESS" ]]; then
   kubeconfig="$(dirname $0)/local-garden/kubeconfigs/gardenlet.conf"
 else
@@ -33,7 +35,7 @@ if [ ! -f "$file_imagevector_overwrite" ]; then
 else
   trap cleanup_imagevector_overwrite EXIT
 
-  KUBECONFIG="${KUBECONFIG:-$kubeconfig}" \
+  KUBECONFIG="$kubeconfig" \
   GARDEN_KUBECONFIG="${GARDEN_KUBECONFIG:-$kubeconfig}" \
   IMAGEVECTOR_OVERWRITE="$file_imagevector_overwrite" \
   GO111MODULE=on \

--- a/hack/local-development/start-scheduler
+++ b/hack/local-development/start-scheduler
@@ -16,6 +16,8 @@
 
 source $(dirname "${0}")/common/helpers
 
+kubeconfig="$KUBECONFIG"
+
 if [[ $(k8s_env) == "$NODELESS" ]]; then
   kubeconfig="$(dirname $0)/local-garden/kubeconfigs/gardener-scheduler.conf"
 else
@@ -24,7 +26,7 @@ else
   trap cleanup_kubeconfig EXIT
 fi
 
-KUBECONFIG="${KUBECONFIG:-$kubeconfig}" GO111MODULE=on \
+KUBECONFIG="$kubeconfig" GO111MODULE=on \
     go run \
       -mod=vendor \
       -ldflags "$("$(dirname $0)"/../get-build-ld-flags.sh)" \


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:

- Add missing cloudprofile permission for scheduler (only relevant for local dev setup, as `ClusterRole/gardener.cloud:system:read-global-resources` also allows it)
- If the `KUBECONFIG` env var is set, when running `make start-*`, it doesn't overwrite the dedicated component kubeconfig (introduced by https://github.com/gardener/gardener/pull/3901) anymore

**Which issue(s) this PR fixes**:
```
E0503 08:04:25.629818   78473 reflector.go:138] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:229: Failed to watch *v1beta1.CloudProfile: failed to list *v1beta1.CloudProfile: cloudprofiles.core.gardener.cloud is forbidden: User "gardener.cloud:system:scheduler" cannot list resource "cloudprofiles" in API group "core.gardener.cloud" at the cluster scope
```

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
NONE
```
