### PR TITLE
Even more DirectClient cleanup

### DIFF
--- a/pkg/extensions/cluster.go
+++ b/pkg/extensions/cluster.go
@@ -21,13 +21,13 @@ import (
 	gardencoreinstall "github.com/gardener/gardener/pkg/apis/core/install"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 var gardenScheme *runtime.Scheme
@@ -41,7 +41,7 @@ func init() {
 // cluster by adding the shoot, seed, and cloudprofile specification.
 func SyncClusterResourceToSeed(
 	ctx context.Context,
-	client client.Client,
+	client client.Writer,
 	clusterName string,
 	shoot *gardencorev1beta1.Shoot,
 	cloudProfile *gardencorev1beta1.CloudProfile,
@@ -90,7 +90,7 @@ func SyncClusterResourceToSeed(
 		shootObj.ManagedFields = nil
 	}
 
-	_, err := controllerutil.CreateOrUpdate(ctx, client, cluster, func() error {
+	_, err := controllerutils.MergePatchOrCreate(ctx, client, cluster, func() error {
 		if cloudProfileObj != nil {
 			cluster.Spec.CloudProfile = runtime.RawExtension{Object: cloudProfileObj}
 		}

--- a/pkg/operation/botanist/cleanup.go
+++ b/pkg/operation/botanist/cleanup.go
@@ -204,7 +204,7 @@ func (b *Botanist) CleanExtendedAPIs(ctx context.Context) error {
 // It will return an error in case it has not finished yet, and nil if all resources are gone.
 func (b *Botanist) CleanKubernetesResources(ctx context.Context) error {
 	var (
-		c       = b.K8sShootClient.DirectClient()
+		c       = b.K8sShootClient.Client()
 		ensurer = utilclient.GoneBeforeEnsurer(b.Shoot.Info.GetDeletionTimestamp().Time)
 		ops     = utilclient.NewCleanOps(utilclient.DefaultCleaner(), ensurer)
 	)
@@ -235,9 +235,7 @@ func (b *Botanist) CleanKubernetesResources(ctx context.Context) error {
 // It assumes that all workload resources are cleaned up in previous step(s).
 func (b *Botanist) CleanShootNamespaces(ctx context.Context) error {
 	var (
-		// use direct client here, as cached client does not support field selector with multiple requirements
-		// see https://github.com/kubernetes-sigs/controller-runtime/blob/ca25c1f1014d6db6eba745e04f180d272a854e9a/pkg/cache/internal/cache_reader.go#L98-L103
-		c                 = b.K8sShootClient.DirectClient()
+		c                 = b.K8sShootClient.Client()
 		namespaceCleaner  = utilclient.NewNamespaceCleaner(b.K8sShootClient.Kubernetes().CoreV1().Namespaces())
 		namespaceCleanOps = utilclient.NewCleanOps(namespaceCleaner, utilclient.DefaultGoneEnsurer())
 	)

--- a/pkg/operation/botanist/infrastructure_test.go
+++ b/pkg/operation/botanist/infrastructure_test.go
@@ -26,13 +26,13 @@ import (
 	. "github.com/gardener/gardener/pkg/operation/botanist"
 	mockinfrastructure "github.com/gardener/gardener/pkg/operation/botanist/component/extensions/infrastructure/mock"
 	shootpkg "github.com/gardener/gardener/pkg/operation/shoot"
-	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
-
+	"github.com/gardener/gardener/pkg/utils/test"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
 )
 
@@ -143,11 +143,10 @@ var _ = Describe("Infrastructure", func() {
 			infrastructure.EXPECT().Wait(ctx)
 			infrastructure.EXPECT().NodesCIDR().Return(nodesCIDR)
 
-			kubernetesGardenInterface.EXPECT().DirectClient().Return(kubernetesGardenClient)
+			kubernetesGardenInterface.EXPECT().Client().Return(kubernetesGardenClient)
 			updatedShoot := shoot.DeepCopy()
 			updatedShoot.Spec.Networking.Nodes = nodesCIDR
-			kubernetesGardenClient.EXPECT().Get(ctx, kutil.Key(namespace, name), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{}))
-			kubernetesGardenClient.EXPECT().Update(ctx, updatedShoot)
+			test.EXPECTPatch(ctx, kubernetesGardenClient, updatedShoot, shoot, types.StrategicMergePatchType)
 
 			kubernetesSeedInterface.EXPECT().Client().Return(kubernetesSeedClient)
 
@@ -174,11 +173,10 @@ var _ = Describe("Infrastructure", func() {
 			infrastructure.EXPECT().Wait(ctx)
 			infrastructure.EXPECT().NodesCIDR().Return(nodesCIDR)
 
-			kubernetesGardenInterface.EXPECT().DirectClient().Return(kubernetesGardenClient)
+			kubernetesGardenInterface.EXPECT().Client().Return(kubernetesGardenClient)
 			updatedShoot := shoot.DeepCopy()
 			updatedShoot.Spec.Networking.Nodes = nodesCIDR
-			kubernetesGardenClient.EXPECT().Get(ctx, kutil.Key(namespace, name), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{}))
-			kubernetesGardenClient.EXPECT().Update(ctx, updatedShoot).Return(fakeErr)
+			test.EXPECTPatch(ctx, kubernetesGardenClient, updatedShoot, shoot, types.StrategicMergePatchType, fakeErr)
 
 			Expect(botanist.WaitForInfrastructure(ctx)).To(MatchError(fakeErr))
 			Expect(botanist.Shoot.Info).To(Equal(shoot))

--- a/pkg/operation/botanist/managedresources.go
+++ b/pkg/operation/botanist/managedresources.go
@@ -77,7 +77,7 @@ func (b *Botanist) KeepObjectsForAllManagedResources(ctx context.Context) error 
 	}
 
 	for _, resource := range managedResources.Items {
-		if err := managedresources.SetKeepObjects(ctx, b.K8sSeedClient.DirectClient(), resource.Namespace, resource.Name, true); err != nil {
+		if err := managedresources.SetKeepObjects(ctx, b.K8sSeedClient.Client(), resource.Namespace, resource.Name, true); err != nil {
 			return err
 		}
 	}

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -500,7 +500,7 @@ func (o *Operation) EnsureShootStateExists(ctx context.Context) error {
 	ownerReference := metav1.NewControllerRef(o.Shoot.Info, gardencorev1beta1.SchemeGroupVersion.WithKind("Shoot"))
 	ownerReference.BlockOwnerDeletion = pointer.BoolPtr(false)
 
-	_, err := controllerutils.PatchOrCreate(ctx, o.K8sGardenClient.Client(), shootState, func() error {
+	_, err := controllerutils.StrategicMergePatchOrCreate(ctx, o.K8sGardenClient.Client(), shootState, func() error {
 		shootState.OwnerReferences = []metav1.OwnerReference{*ownerReference}
 		return nil
 	})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity scalability
/kind cleanup

**What this PR does / why we need it**:

Similar to previous PRs, this PR works towards getting rid of the DirectClient.
Commit messages should be self-explanatory.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2822

**Special notes for your reviewer**:
/squash

The remaining usages of the `DirectClient` are all in the shoot/seed components. I will clean them up in the next PR.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
