### PR TITLE
fixed external alertmanager mtls doc example - added missing required…

### DIFF
--- a/docs/monitoring/alerting.md
+++ b/docs/monitoring/alerting.md
@@ -69,6 +69,7 @@ data:
   ca.crt: base64(ca)
   tls.crt: base64(certificate)
   tls.key: base64(key)
+  insecure_skip_verify: base64(false)
 
   # Email Alerts (internal alertmanager)
   auth_type: base64(smtp)


### PR DESCRIPTION
… field to example

**How to categorize this PR?**
/area documentation bug fix

/kind bug
**What this PR does / why we need it**:
Adds missing required field into documentation example of external alert manager with mTLS. Without this field it is skipped and external AM with mTLS doesn't work at all.
**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
Its just documentation fix.
**Release note**:
NONE

