### PR TITLE
Support helm3 in configure-rbac

### DIFF
--- a/hack/generate-controller-registration.sh
+++ b/hack/generate-controller-registration.sh
@@ -45,9 +45,9 @@ VERSION_FILE="$3"
 DEST="$4"
 KIND_AND_TYPE="$5"
 
-VERSION="$(cat "$VERSION_FILE")"
-
 ( [[ -z "$NAME" ]] || [[ -z "$CHART_DIR" ]] || [[ -z "$DEST" ]] || [[ -z "$KIND_AND_TYPE" ]]) && usage
+
+VERSION="$(cat "$VERSION_FILE")"
 
 KINDS_AND_TYPES=("$KIND_AND_TYPE" "${@:6}")
 

--- a/hack/install-requirements.sh
+++ b/hack/install-requirements.sh
@@ -22,7 +22,7 @@ GO111MODULE=off go get -u golang.org/x/tools/cmd/goimports
 
 export GO111MODULE=on
 curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0
-curl -s "https://raw.githubusercontent.com/helm/helm/v2.17.0/scripts/get" | bash -s -- --version 'v2.17.0'
+curl -s "https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3" | bash -s -- --version 'v3.5.4'
 
 platform=$(uname -s)
 if [[ ${platform} == "Linux" ]]; then

--- a/hack/local-development/local-garden/configure-rbac
+++ b/hack/local-development/local-garden/configure-rbac
@@ -20,26 +20,19 @@ KUBECONFIGPATH=${1:-"$(dirname $0)/kubeconfigs/default-admin.conf"}
 
 gardenlet_admin_templates=""
 
-HELM2=$(helm version 2>&1 | grep 'SemVer:"v2' || true)
-if [ -n "$HELM2" ]; then
-  HT="-x"
-else
-  HT="-s"
-fi
-
 if is_seedauthorizer_enabled; then
   KUBECONFIG=$KUBECONFIGPATH kubectl delete clusterrole/gardener.cloud:system:seeds        --ignore-not-found
   KUBECONFIG=$KUBECONFIGPATH kubectl delete clusterrolebinding/gardener.cloud:system:seeds --ignore-not-found
 else
-  gardenlet_admin_templates="$HT templates/clusterrole-seeds.yaml $HT templates/clusterrolebinding-seeds.yaml"
+  gardenlet_admin_templates="-s templates/clusterrole-seeds.yaml -s templates/clusterrolebinding-seeds.yaml"
 fi
 
 helm template \
   "$(dirname "$0")/../../../charts/gardener/controlplane/charts/application" \
-  $HT templates/clusterrole-admission-controller.yaml \
-  $HT templates/clusterrole-apiserver.yaml \
-  $HT templates/clusterrole-controller-manager.yaml \
-  $HT templates/clusterrole-scheduler.yaml $gardenlet_admin_templates \
+  -s templates/clusterrole-admission-controller.yaml \
+  -s templates/clusterrole-apiserver.yaml \
+  -s templates/clusterrole-controller-manager.yaml \
+  -s templates/clusterrole-scheduler.yaml $gardenlet_admin_templates \
   --set global.admission.enabled=true \
   --set global.apiserver.enabled=true \
   --set global.controller.enabled=true \

--- a/hack/local-development/local-garden/configure-rbac
+++ b/hack/local-development/local-garden/configure-rbac
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
 #
 # Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
 #
@@ -20,20 +20,26 @@ KUBECONFIGPATH=${1:-"$(dirname $0)/kubeconfigs/default-admin.conf"}
 
 gardenlet_admin_templates=""
 
+HELM2=$(helm version 2>&1 | grep 'SemVer:"v2' || true)
+if [ -n "$HELM2" ]; then
+  HT="-x"
+else
+  HT="-s"
+fi
+
 if is_seedauthorizer_enabled; then
   KUBECONFIG=$KUBECONFIGPATH kubectl delete clusterrole/gardener.cloud:system:seeds        --ignore-not-found
   KUBECONFIG=$KUBECONFIGPATH kubectl delete clusterrolebinding/gardener.cloud:system:seeds --ignore-not-found
 else
-  gardenlet_admin_templates="-x templates/clusterrole-seeds.yaml -x templates/clusterrolebinding-seeds.yaml"
+  gardenlet_admin_templates="$HT templates/clusterrole-seeds.yaml $HT templates/clusterrolebinding-seeds.yaml"
 fi
-
 
 helm template \
   "$(dirname "$0")/../../../charts/gardener/controlplane/charts/application" \
-  -x templates/clusterrole-admission-controller.yaml \
-  -x templates/clusterrole-apiserver.yaml \
-  -x templates/clusterrole-controller-manager.yaml \
-  -x templates/clusterrole-scheduler.yaml $gardenlet_admin_templates \
+  $HT templates/clusterrole-admission-controller.yaml \
+  $HT templates/clusterrole-apiserver.yaml \
+  $HT templates/clusterrole-controller-manager.yaml \
+  $HT templates/clusterrole-scheduler.yaml $gardenlet_admin_templates \
   --set global.admission.enabled=true \
   --set global.apiserver.enabled=true \
   --set global.controller.enabled=true \


### PR DESCRIPTION
helm3 has different calling syntax then helm2 for rendering templates
only. Detect if running under helm2 or 3 and use the proper syntax

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

support for helm3

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
