### PR TITLE
Made check script to also work for api modules

### DIFF
--- a/hack/check.sh
+++ b/hack/check.sh
@@ -32,13 +32,19 @@ echo "> Check"
 echo "Executing golangci-lint"
 golangci-lint run $GOLANGCI_LINT_CONFIG_FILE --timeout 10m $@
 
+if [ -d "./vendor" ]; then
+  VET_MOD_OPTS=-mod=vendor
+else
+  VET_MOD_OPTS=-mod=readonly
+fi
+
 echo "Executing go vet"
-go vet -mod=vendor $@
+go vet ${VET_MOD_OPTS} $@
 
 echo "Executing gofmt/goimports"
 folders=()
 for f in $@; do
-  folders+=( "$(echo $f | sed 's/\.\/\(.*\)\/\.\.\./\1/')" )
+  folders+=( "$(echo $f | sed 's/\.\.\.//')" )
 done
 unformatted_files="$(goimports -l ${folders[*]})"
 if [[ "$unformatted_files" ]]; then


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:

Made check script to also work for api modules.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

To be used as in https://github.com/gardener/etcd-druid/pull/169, [here](https://github.com/gardener/etcd-druid/pull/169/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R79-R80).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
