### PR TITLE
Do not use hostport for konnectivity-server

### DIFF
--- a/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
@@ -368,7 +368,6 @@ spec:
         livenessProbe:
           httpGet:
             scheme: HTTP
-            host: 127.0.0.1
             port: {{ .Values.konnectivityTunnel.healthPort }}
             path: /healthz
           initialDelaySeconds: 30
@@ -378,10 +377,8 @@ spec:
           containerPort: {{ .Values.konnectivityTunnel.agentPort }}
         - name: adminport
           containerPort: {{ .Values.konnectivityTunnel.adminPort }}
-          hostPort: {{ .Values.konnectivityTunnel.adminPort }}
         - name: healthport
           containerPort: {{ .Values.konnectivityTunnel.healthPort }}
-          hostPort: {{ .Values.konnectivityTunnel.healthPort }}
         volumeMounts:
         - name: konnectivity-server-certs
           mountPath: /certs/konnectivity-server

--- a/pkg/operation/botanist/component/konnectivity/konnectivity_server.go
+++ b/pkg/operation/botanist/component/konnectivity/konnectivity_server.go
@@ -260,7 +260,6 @@ func (k *konnectivityServer) Deploy(ctx context.Context) error {
 									HTTPGet: &corev1.HTTPGetAction{
 										Path:   "/healthz",
 										Port:   intstr.IntOrString{Type: intstr.Int, IntVal: healthPort},
-										Host:   "127.0.0.1",
 										Scheme: corev1.URISchemeHTTP,
 									},
 								},
@@ -278,19 +277,15 @@ func (k *konnectivityServer) Deploy(ctx context.Context) error {
 							Ports: []corev1.ContainerPort{{
 								Name:          "server",
 								ContainerPort: ServerHTTPSPort,
-								HostPort:      ServerHTTPSPort,
 							}, {
 								Name:          "agent",
 								ContainerPort: ServerAgentPort,
-								HostPort:      ServerAgentPort,
 							}, {
 								Name:          "admin",
 								ContainerPort: adminPort,
-								HostPort:      adminPort,
 							}, {
 								Name:          "health",
 								ContainerPort: healthPort,
-								HostPort:      healthPort,
 							}},
 							VolumeMounts: []corev1.VolumeMount{
 								{

--- a/pkg/operation/botanist/component/konnectivity/konnectivity_server_test.go
+++ b/pkg/operation/botanist/component/konnectivity/konnectivity_server_test.go
@@ -366,7 +366,6 @@ var _ = Describe("NewServer", func() {
 													Path:   "/healthz",
 													Scheme: corev1.URISchemeHTTP,
 													Port:   intstr.FromInt(8134),
-													Host:   "127.0.0.1",
 												},
 											},
 										},
@@ -383,19 +382,15 @@ var _ = Describe("NewServer", func() {
 										Ports: []corev1.ContainerPort{{
 											Name:          "server",
 											ContainerPort: 9443,
-											HostPort:      9443,
 										}, {
 											Name:          "agent",
 											ContainerPort: 8132,
-											HostPort:      8132,
 										}, {
 											Name:          "admin",
 											ContainerPort: 8133,
-											HostPort:      8133,
 										}, {
 											Name:          "health",
 											ContainerPort: 8134,
-											HostPort:      8134,
 										}},
 										VolumeMounts: []corev1.VolumeMount{
 											{


### PR DESCRIPTION
/area control-plane
/kind  bug

**What this PR does / why we need it**:
If APIServerSNI is not enabled, but a shoot has konnectivity-tunnel feature flag set, the kube-api-server in the shoot namespace can not start anymore with:

```
shoot--pz9cjf--...            15m         Warning   FailedScheduling               pod/kube-apiserver-6f5cb7d4f-7h8rh                                            0/3 nodes are available: 1 Insufficient cpu, 3 node(s) didn't have free ports for the requested pod ports

```
This is the case since g/g 1.16.x and was introduced with https://github.com/gardener/gardener/pull/3267

The Reason is that the konnectivity-server sidecar is started with hostport for admin and health endpoint, which only allows one kube-api-server to be started on one seed worker node.

