### PR TITLE
Fix handling of aggregate-prometheus resources with hvpa

### DIFF
--- a/charts/seed-bootstrap/templates/aggregate-prometheus/statefulset.yaml
+++ b/charts/seed-bootstrap/templates/aggregate-prometheus/statefulset.yaml
@@ -58,7 +58,7 @@ spec:
           successThreshold: 1
           timeoutSeconds: 3
         resources:
-          {{- toYaml .Values.prometheus.resources.prometheus | nindent 10 }}
+          {{- toYaml .Values.aggregatePrometheus.resources.prometheus | nindent 10 }}
         volumeMounts:
         - mountPath: /etc/prometheus/config
           name: config

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -563,9 +563,9 @@ func RunReconcileSeedFlow(
 			if err != nil {
 				return err
 			}
-			if len(currentResources) != 0 && currentResources[resource] != nil {
+			if len(currentResources) != 0 && currentResources["prometheus"] != nil {
 				monitoringResources[resource] = map[string]interface{}{
-					resource: currentResources[resource],
+					"prometheus": currentResources["prometheus"],
 				}
 			}
 		}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:
Fix an issue where the gardenlet overwrites changes from `hvpa` for the `aggregate-prometheus`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @amshuman-kr 
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix an issue where the gardenlet overwrites changes from `hvpa` for the `aggregate-prometheus`.
```
