### PR TITLE
Enrich  component descriptor with Gardener landscaper blueprints

### DIFF
--- a/.ci/component_descriptor
+++ b/.ci/component_descriptor
@@ -1,3 +1,36 @@
 #!/usr/bin/env bash
 
-"$(dirname $0)"/../hack/.ci/component_descriptor "$(dirname $0)"/..
+repo_root_dir="$(dirname $0)"/..
+# Env variables provided by pipeline:
+# - BASE_DEFINITION_PATH: path to the basis component descriptor provided by the CI (contains only OCI images build by CI).
+# - CTF_PATH: pipeline will check for existing CTF archive and if exists, push the archive to a private repository.
+# - COMPONENT_DESCRIPTOR_PATH:
+#   - Filepath where the CI expects only the component-descriptor.yaml.
+#   - Cannot be used if with referenced resources in the component descriptor (like the Gardenlet blueprint).
+
+# call common hack script to enrich the base component descriptor
+"${repo_root_dir}"/hack/.ci/component_descriptor "${repo_root_dir}"
+
+echo "Enriching component descriptor with blueprints of Gardener landscaper components"
+
+COMPONENT_ARCHIVE_PATH="$(mktemp -d)"
+
+# Common hack script has copied the enriched component descriptor to COMPONENT_DESCRIPTOR_PATH for backwards-compatibility.
+# If the descriptor exists at this filepath, it will be uploaded to a private registry.
+# However, this mechanism does not work if there are resource references in the component descriptor (like a local blueprint).
+# Instead, we have to build a CTF.
+# Therefore, move the existing component-descriptor.yaml to the component archive directory.
+mv "${COMPONENT_DESCRIPTOR_PATH}" "${COMPONENT_ARCHIVE_PATH}/component-descriptor.yaml"
+
+# further enrich the component descriptor with the blueprints of landscaper components
+component-cli component-archive resources add \
+"${COMPONENT_ARCHIVE_PATH}" \
+"$repo_root_dir/landscaper/resources.yaml"
+
+# Create CTF tar archive at CTF_PATH based on directory in component archive layout (packed automatically)
+# Pushed by CI to private registry if CTF is found at CTF_PATH.
+component-cli ctf add "${CTF_PATH}" -f "${COMPONENT_ARCHIVE_PATH}"
+
+# Also upload the ctf to an open source repo
+# todo: remove as soon as the default component repository is public
+component-cli ctf push --repo-ctx="eu.gcr.io/gardener-project/development" "${CTF_PATH}"

--- a/hack/.ci/component_descriptor
+++ b/hack/.ci/component_descriptor
@@ -6,7 +6,7 @@ repo_root_dir="$1"
 repo_name="${2:-github.com/gardener/gardener}"
 descriptor_out_file="${COMPONENT_DESCRIPTOR_PATH}"
 
-echo "enriching creating component descriptor from ${BASE_DEFINITION_PATH}"
+echo "Enriching component descriptor from ${BASE_DEFINITION_PATH}"
 
 if [[ -f "$repo_root_dir/charts/images.yaml" ]]; then
   # translates all images defined the images.yaml into component descriptor resources.
@@ -26,7 +26,7 @@ if [[ -d "$repo_root_dir/charts/" ]]; then
     fi
 
     outputFile=$(sed 's/{{-//' $image_tpl_path | sed 's/}}//' | sed 's/define//' | sed 's/-//' | sed 's/end//' | sed 's/"//' | sed 's/"//' |sed 's/image.//' |  sed -e 's/^[ \t]*//' | awk -v RS= '{for (i=1; i<=NF; i++) printf "%s%s", $i, (i==NF?"\n":" ")}')
-    echo "enriching creating component descriptor from ${image_tpl_path}"
+    echo "enriching component descriptor from ${image_tpl_path}"
 
     while read p; do
       line="$(echo -e "$p")"

--- a/landscaper/resources.yaml
+++ b/landscaper/resources.yaml
@@ -1,0 +1,9 @@
+---
+type: landscaper.gardener.cloud/blueprint
+name: gardenlet-blueprint
+relation: local
+input:
+  type: "dir"
+  path: "./pkg/gardenlet"
+  compress: true
+  mediaType: "application/vnd.gardener.landscaper.blueprint.v1+tar+gzip"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:

Add Gardener landscaper blueprints to base component descriptor.
Will also upload the CTF archive to a public repository so that it can be used for development & open source users.

CTF contains the component-descriptor + referenced resources (blueprints).


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
