### PR TITLE
Fix SeedSettingExcessCapacityReservation in seed example

### DIFF
--- a/example/50-seed.yaml
+++ b/example/50-seed.yaml
@@ -58,7 +58,7 @@ spec:
     blockCIDRs:
     - 169.254.169.254/32
   settings:
-    excessCapacity:
+    excessCapacityReservation:
       enabled: true # this seed will deploy excess-capacity-reservation pods
     scheduling:
       visible: true # the gardener-scheduler will consider this seed for shoots


### PR DESCRIPTION
**How to categorize this PR?**
/area documentation
/kind bug

**What this PR does / why we need it**:
SeedSettings doesn't have a key excessCapacity:
https://gardener.cloud/documentation/references/core/#core.gardener.cloud/v1beta1.SeedSettings

Therefore, using the example currently fails with 
```
error validating data: ValidationError(Seed.spec.settings): unknown field "excessCapacity" in com.github.gardener.gardener.pkg.apis.core.v1beta1.SeedSettings; if you choose to ignore these errors, turn validation off with --validate=false
```

**Release note**:
```other operator
NONE
```
