### PR TITLE
Added watch and get permissions for PVCs to Druid.

### DIFF
--- a/pkg/operation/botanist/component/etcd/bootstrap.go
+++ b/pkg/operation/botanist/component/etcd/bootstrap.go
@@ -148,7 +148,7 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 				{
 					APIGroups: []string{corev1.GroupName},
 					Resources: []string{"persistentvolumeclaims"},
-					Verbs:     []string{"list"},
+					Verbs:     []string{"get", "list", "watch"},
 				},
 			},
 		}

--- a/pkg/operation/botanist/component/etcd/bootstrap_test.go
+++ b/pkg/operation/botanist/component/etcd/bootstrap_test.go
@@ -175,7 +175,9 @@ rules:
   resources:
   - persistentvolumeclaims
   verbs:
+  - get
   - list
+  - watch
 `
 			clusterRoleBindingYAML = `apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
**Which issue(s) this PR fixes**:
There are some issues coming in ETCD druid pods as it was not able to watch PVC. Watching over PVC is necessary for druids to help it determine any PVC failure and change the status of ETCD resource as per that.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
