### PR TITLE
Allow disabling scaling and having static resource requirements for some control-plane components

### DIFF
--- a/charts/seed-controlplane/charts/kube-apiserver/templates/hvpa.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/hvpa.yaml
@@ -48,13 +48,13 @@ spec:
     deploy: true
     scaleUp:
       updatePolicy:
-        updateMode: "Auto"
+        updateMode: {{ .Values.scaleUpUpdateMode | quote }}
 {{- if .Values.scaleUpStabilization }}
 {{ toYaml .Values.scaleUpStabilization | indent 6 }}
 {{- end }}
     scaleDown:
       updatePolicy:
-        updateMode: "Auto"
+        updateMode: {{ .Values.scaleDownUpdateMode | quote }}
 {{- if .Values.scaleDownStabilization }}
 {{ toYaml .Values.scaleDownStabilization | indent 6 }}
 {{- end }}

--- a/charts/seed-controlplane/charts/kube-apiserver/values.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/values.yaml
@@ -142,6 +142,7 @@ scaleUpStabilization:
     memory:
       value: 200M
       percentage: 80
+scaleUpUpdateMode: "Auto"
 
 scaleDownStabilization:
   stabilizationDuration: "15m"
@@ -152,6 +153,7 @@ scaleDownStabilization:
     memory:
       value: 200M
       percentage: 80
+scaleDownUpdateMode: "Auto"
 
 limitsRequestsGapScaleParams:
   cpu:

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -204,7 +204,7 @@ const (
 	// resource when cleaning a shoot during the deletion flow.
 	ShootNoCleanup = "shoot.gardener.cloud/no-cleanup"
 	// ShootAlphaScalingClass is a constant for an annotation on the shoot stating the initial scaling class.
-	// It influences the size of the initial resource requests/limits for the kube-apiserver.
+	// It influences the size of the initial resource requests/limits for the kube-apiserver and kube-controller-manager.
 	// Possible values are [small, medium, large, xlarge, 2xlarge].
 	// Note that this annotation is alpha and can be removed anytime without further notice. Only use it if you know
 	// what you do.

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -203,12 +203,12 @@ const (
 	// ShootNoCleanup is a constant for a label on a resource indicating that the Gardener cleaner should not delete this
 	// resource when cleaning a shoot during the deletion flow.
 	ShootNoCleanup = "shoot.gardener.cloud/no-cleanup"
-	// ShootAlphaScalingAPIServerClass is a constant for an annotation on the shoot stating the initial API server class.
-	// It influences the size of the initial resource requests/limits.
+	// ShootAlphaScalingClass is a constant for an annotation on the shoot stating the initial scaling class.
+	// It influences the size of the initial resource requests/limits for the kube-apiserver.
 	// Possible values are [small, medium, large, xlarge, 2xlarge].
 	// Note that this annotation is alpha and can be removed anytime without further notice. Only use it if you know
 	// what you do.
-	ShootAlphaScalingAPIServerClass = "alpha.kube-apiserver.scaling.shoot.gardener.cloud/class"
+	ShootAlphaScalingClass = "alpha.control-plane.scaling.shoot.gardener.cloud/class"
 	// ShootExpirationTimestamp is an annotation on a Shoot resource whose value represents the time when the Shoot lifetime
 	// is expired. The lifetime can be extended, but at most by the minimal value of the 'clusterLifetimeDays' property
 	// of referenced quotas.
@@ -433,9 +433,13 @@ const (
 	DefaultVpnRange = "192.168.123.0/24"
 )
 
-// ControlPlaneSecretRoles contains all role values used for control plane secrets synced to the Garden cluster.
-var ControlPlaneSecretRoles = []string{
-	GardenRoleKubeconfig,
-	GardenRoleSSHKeyPair,
-	GardenRoleMonitoring,
-}
+var (
+	// ControlPlaneSecretRoles contains all role values used for control plane secrets synced to the Garden cluster.
+	ControlPlaneSecretRoles = []string{
+		GardenRoleKubeconfig,
+		GardenRoleSSHKeyPair,
+		GardenRoleMonitoring,
+	}
+	// ScalingClasses is the list of valid values for the ShootAlphaScalingClass annotation.
+	ScalingClasses = []string{"small", "medium", "large", "xlarge", "2xlarge"}
+)

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -210,7 +210,7 @@ const (
 	// what you do.
 	ShootAlphaScalingClass = "alpha.control-plane.scaling.shoot.gardener.cloud/class"
 	// ShootAlphaScalingDisabled is a constant for an annotation on the shoot stating that the auto-scaling shall be
-	// disabled for the kube-apiserver and kube-controller-manager.
+	// disabled for the etcd, kube-apiserver, and kube-controller-manager.
 	// Note that this annotation is alpha and can be removed anytime without further notice. Only use it if you know
 	// what you do.
 	ShootAlphaScalingDisabled = "alpha.control-plane.scaling.shoot.gardener.cloud/disabled"

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -210,7 +210,7 @@ const (
 	// what you do.
 	ShootAlphaScalingClass = "alpha.control-plane.scaling.shoot.gardener.cloud/class"
 	// ShootAlphaScalingDisabled is a constant for an annotation on the shoot stating that the auto-scaling shall be
-	// disabled for the kube-controller-manager.
+	// disabled for the kube-apiserver and kube-controller-manager.
 	// Note that this annotation is alpha and can be removed anytime without further notice. Only use it if you know
 	// what you do.
 	ShootAlphaScalingDisabled = "alpha.control-plane.scaling.shoot.gardener.cloud/disabled"

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -209,6 +209,11 @@ const (
 	// Note that this annotation is alpha and can be removed anytime without further notice. Only use it if you know
 	// what you do.
 	ShootAlphaScalingClass = "alpha.control-plane.scaling.shoot.gardener.cloud/class"
+	// ShootAlphaScalingDisabled is a constant for an annotation on the shoot stating that the auto-scaling shall be
+	// disabled for the kube-controller-manager.
+	// Note that this annotation is alpha and can be removed anytime without further notice. Only use it if you know
+	// what you do.
+	ShootAlphaScalingDisabled = "alpha.control-plane.scaling.shoot.gardener.cloud/disabled"
 	// ShootExpirationTimestamp is an annotation on a Shoot resource whose value represents the time when the Shoot lifetime
 	// is expired. The lifetime can be extended, but at most by the minimal value of the 'clusterLifetimeDays' property
 	// of referenced quotas.

--- a/pkg/operation/botanist/component/etcd/monitoring_test.go
+++ b/pkg/operation/botanist/component/etcd/monitoring_test.go
@@ -27,7 +27,7 @@ import (
 var _ = Describe("Monitoring", func() {
 	Describe("#ScrapeConfig", func() {
 		It("should successfully test the scrape configuration", func() {
-			etcd := New(nil, testNamespace, testRole, ClassNormal, true, "", nil)
+			etcd := New(nil, testNamespace, testRole, ClassNormal, true, "", nil, false)
 			test.ScrapeConfigs(etcd, expectedScrapeConfigEtcd, expectedScrapeConfigBackupRestore)
 		})
 	})
@@ -35,7 +35,7 @@ var _ = Describe("Monitoring", func() {
 	Describe("#AlertingRules", func() {
 		Context("w/o backup", func() {
 			It("should successfully test the alerting rules (normal)", func() {
-				etcd := New(nil, testNamespace, testRole, ClassNormal, true, "", nil)
+				etcd := New(nil, testNamespace, testRole, ClassNormal, true, "", nil, false)
 				test.AlertingRulesWithPromtool(
 					etcd,
 					map[string]string{fmt.Sprintf("kube-etcd3-%s.rules.yaml", testRole): expectedAlertingRulesNormalWithoutBackup},
@@ -44,7 +44,7 @@ var _ = Describe("Monitoring", func() {
 			})
 
 			It("should successfully test the alerting rules (important)", func() {
-				etcd := New(nil, testNamespace, testRole, ClassImportant, true, "", nil)
+				etcd := New(nil, testNamespace, testRole, ClassImportant, true, "", nil, false)
 				test.AlertingRulesWithPromtool(
 					etcd,
 					map[string]string{fmt.Sprintf("kube-etcd3-%s.rules.yaml", testRole): expectedAlertingRulesImportantWithoutBackup},
@@ -55,7 +55,7 @@ var _ = Describe("Monitoring", func() {
 
 		Context("w/ backup", func() {
 			It("should successfully test the alerting rules (normal)", func() {
-				etcd := New(nil, testNamespace, testRole, ClassNormal, true, "", nil)
+				etcd := New(nil, testNamespace, testRole, ClassNormal, true, "", nil, false)
 				etcd.SetBackupConfig(&BackupConfig{})
 				test.AlertingRulesWithPromtool(
 					etcd,
@@ -65,7 +65,7 @@ var _ = Describe("Monitoring", func() {
 			})
 
 			It("should successfully test the alerting rules (important)", func() {
-				etcd := New(nil, testNamespace, testRole, ClassImportant, true, "", nil)
+				etcd := New(nil, testNamespace, testRole, ClassImportant, true, "", nil, false)
 				etcd.SetBackupConfig(&BackupConfig{})
 				test.AlertingRulesWithPromtool(
 					etcd,

--- a/pkg/operation/botanist/component/kubecontrollermanager/monitoring_test.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/monitoring_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Monitoring", func() {
 		func(version, expectedScrapeConfig string) {
 			semverVersion, err := semver.NewVersion(version)
 			Expect(err).NotTo(HaveOccurred())
-			kubeControllerManager := New(nil, nil, "", semverVersion, "", nil, nil, nil)
+			kubeControllerManager := New(nil, nil, "", semverVersion, "", nil, nil, nil, nil)
 			test.ScrapeConfigs(kubeControllerManager, expectedScrapeConfig)
 		},
 
@@ -45,7 +45,7 @@ var _ = Describe("Monitoring", func() {
 	It("should successfully test the alerting rules", func() {
 		semverVersion, err := semver.NewVersion("1.18.4")
 		Expect(err).NotTo(HaveOccurred())
-		kubeControllerManager := New(nil, nil, "", semverVersion, "", nil, nil, nil)
+		kubeControllerManager := New(nil, nil, "", semverVersion, "", nil, nil, nil, nil)
 
 		test.AlertingRulesWithPromtool(
 			kubeControllerManager,

--- a/pkg/operation/botanist/component/kubecontrollermanager/monitoring_test.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/monitoring_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Monitoring", func() {
 		func(version, expectedScrapeConfig string) {
 			semverVersion, err := semver.NewVersion(version)
 			Expect(err).NotTo(HaveOccurred())
-			kubeControllerManager := New(nil, nil, "", semverVersion, "", nil, nil, nil, nil)
+			kubeControllerManager := New(nil, nil, "", semverVersion, "", nil, nil, nil, nil, false)
 			test.ScrapeConfigs(kubeControllerManager, expectedScrapeConfig)
 		},
 
@@ -45,7 +45,7 @@ var _ = Describe("Monitoring", func() {
 	It("should successfully test the alerting rules", func() {
 		semverVersion, err := semver.NewVersion("1.18.4")
 		Expect(err).NotTo(HaveOccurred())
-		kubeControllerManager := New(nil, nil, "", semverVersion, "", nil, nil, nil, nil)
+		kubeControllerManager := New(nil, nil, "", semverVersion, "", nil, nil, nil, nil, false)
 
 		test.AlertingRulesWithPromtool(
 			kubeControllerManager,

--- a/pkg/operation/botanist/component/kubecontrollermanager/waiter_test.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/waiter_test.go
@@ -90,6 +90,7 @@ var _ = Describe("WaiterTest", func() {
 				nil,
 				nil,
 				nil,
+				nil,
 			)
 
 			kubeControllerManager.SetShootClient(shootClient)
@@ -251,6 +252,7 @@ var _ = Describe("WaiterTest", func() {
 				namespace,
 				semver.MustParse("v1.20.1"),
 				"",
+				nil,
 				nil,
 				nil,
 				nil,

--- a/pkg/operation/botanist/component/kubecontrollermanager/waiter_test.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/waiter_test.go
@@ -91,6 +91,7 @@ var _ = Describe("WaiterTest", func() {
 				nil,
 				nil,
 				nil,
+				false,
 			)
 
 			kubeControllerManager.SetShootClient(shootClient)
@@ -256,6 +257,7 @@ var _ = Describe("WaiterTest", func() {
 				nil,
 				nil,
 				nil,
+				false,
 			)
 			kubeControllerManager.SetShootClient(shootClient)
 

--- a/pkg/operation/botanist/etcd.go
+++ b/pkg/operation/botanist/etcd.go
@@ -35,6 +35,7 @@ import (
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -57,6 +58,7 @@ func (b *Botanist) DefaultEtcd(role string, class etcd.Class) (etcd.Etcd, error)
 		b.Shoot.HibernationEnabled,
 		b.Seed.GetValidVolumeSize("10Gi"),
 		&defragmentationSchedule,
+		metav1.HasAnnotation(b.Shoot.Info.ObjectMeta, v1beta1constants.ShootAlphaScalingDisabled),
 	)
 
 	hvpaEnabled := gardenletfeatures.FeatureGate.Enabled(features.HVPA)

--- a/pkg/operation/botanist/kubecontrollermanager.go
+++ b/pkg/operation/botanist/kubecontrollermanager.go
@@ -29,6 +29,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // DefaultKubeControllerManager returns a deployer for the kube-controller-manager.
@@ -48,6 +49,7 @@ func (b *Botanist) DefaultKubeControllerManager() (kubecontrollermanager.KubeCon
 		b.Shoot.Networks.Pods,
 		b.Shoot.Networks.Services,
 		getResourcesForKubeControllerManager(b.Shoot.Info.Annotations[v1beta1constants.ShootAlphaScalingClass]),
+		metav1.HasAnnotation(b.Shoot.Info.ObjectMeta, v1beta1constants.ShootAlphaScalingDisabled),
 	), nil
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability 
/kind enhancement

**What this PR does / why we need it**:
With this PR it is possible to
- use static initial resource requirements for `kube-apiserver` and `kube-controller-manager` by using the `alpha.control-plane.scaling.shoot.gardener.cloud/class` annotation
- disable auto-scaling for `etcd`, `kube-apiserver`, and `kube-controller-manager` by using the `alpha.control-plane.scaling.shoot.gardener.cloud/disabled` annotation

/squash
/cc @dguendisch @vlerenc 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
