### PR TITLE
[release-v1.22] Upgrade cluster-autoscaler

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -75,7 +75,7 @@ images:
 - name: cluster-autoscaler
   sourceRepository: github.com/gardener/autoscaler
   repository: eu.gcr.io/gardener-project/gardener/autoscaler/cluster-autoscaler
-  tag: "v0.15.0"
+  tag: "v0.16.0"
   targetVersion: ">= 1.16"
 - name: cluster-autoscaler
   sourceRepository: github.com/gardener/autoscaler


### PR DESCRIPTION
from v0.15.0 to v0.16.0

Co-authored-by: gardener-robot-ci-3 <gardener.ci.user3@gmail.com>

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind bug

**What this PR does / why we need it**:
This fixes [this issue](https://github.com/gardener/autoscaler/issues/64) where a machine could be targetted for scale down, but for some reason the scale down fails. In such a case the node is left with the `ToBeDeletedByClusterAutoscaler` taint which blocks the scheduling of pods on this node. 

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/autoscaler/issues/64

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator github.com/gardener/autoscaler #75 @prashanth26 
Bug fix: Allow scaling down of machine with the already lowered priority and nodes with `ToBeDeletedByClusterAutoscaler` taints. This solves issues where pods are pending due to nodes with such taints. 
```
/invite @ialidzhikov 