### PR TITLE
Allow admission-controller to list/watch bastions

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/clusterrole-admission-controller.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/clusterrole-admission-controller.yaml
@@ -35,6 +35,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - operations.gardener.cloud
+  resources:
+  - bastions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - configmaps


### PR DESCRIPTION
/kind bug

After https://github.com/gardener/gardener/pull/3974, the gardener-admission-controller fails to start with:

```
E0510 11:43:20.039408       1 reflector.go:138] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:137: Failed to watch *v1alpha1.Bastion: failed to list *v1alpha1.Bastion: bastions.operations.gardener.cloud is forbidden: User "system:serviceaccount:garden:gardener-admission-controller" cannot list resource "bastions" in API group "operations.gardener.cloud" at the cluster scope
E0510 11:43:23.902647       1 reflector.go:138] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:137: Failed to watch *v1alpha1.Bastion: failed to list *v1alpha1.Bastion: bastions.operations.gardener.cloud is forbidden: User "system:serviceaccount:garden:gardener-admission-controller" cannot list resource "bastions" in API group "operations.gardener.cloud" at the cluster scope
E0510 11:43:35.844298       1 reflector.go:138] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:137: Failed to watch *v1alpha1.Bastion: failed to list *v1alpha1.Bastion: bastions.operations.gardener.cloud is forbidden: User "system:serviceaccount:garden:gardener-admission-controller" cannot list resource "bastions" in API group "operations.gardener.cloud" at the cluster scope
E0510 11:43:57.566003       1 reflector.go:138] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:137: Failed to watch *v1alpha1.Bastion: failed to list *v1alpha1.Bastion: bastions.operations.gardener.cloud is forbidden: User "system:serviceaccount:garden:gardener-admission-controller" cannot list resource "bastions" in API group "operations.gardener.cloud" at the cluster scope
E0510 11:44:36.578674       1 reflector.go:138] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:137: Failed to watch *v1alpha1.Bastion: failed to list *v1alpha1.Bastion: bastions.operations.gardener.cloud is forbidden: User "system:serviceaccount:garden:gardener-admission-controller" cannot list resource "bastions" in API group "operations.gardener.cloud" at the cluster scope
```

Apparently the gardener-admission-controller needs these permissions to setup a watch on bastions 

https://github.com/gardener/gardener/blob/c7b165485ee58d935ba31c1e0a7c61d3e0d5f52e/pkg/admissioncontroller/webhooks/auth/seed/graph/graph.go#L74

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
