### PR TITLE
Disable etcd scale down for shoot clusters with purpose "production".

### DIFF
--- a/docs/usage/shoot_purposes.md
+++ b/docs/usage/shoot_purposes.md
@@ -14,6 +14,7 @@ The following enlists the differences in the way the shoot clusters are set up b
 
 * `testing` shoot clusters **do not** get a monitoring or a logging stack as part of their control planes.
 * `production` shoot clusters get at least two replicas of the `kube-apiserver` for their control planes.
+Auto-scaling scale down of the main ETCD is disabled for such clusters.
 
 There are also differences with respect to how `testing` shoots are scheduled after creation, please consult the [Scheduler documentation](../concepts/scheduler.md).
 

--- a/pkg/operation/botanist/component/etcd/etcd.go
+++ b/pkg/operation/botanist/component/etcd/etcd.go
@@ -358,11 +358,10 @@ func (e *etcd) Deploy(ctx context.Context) error {
 
 	if e.hvpaConfig != nil && e.hvpaConfig.Enabled {
 		var (
-			hpaLabels                   = map[string]string{v1beta1constants.LabelRole: "etcd-hpa-" + e.role}
-			vpaLabels                   = map[string]string{v1beta1constants.LabelRole: "etcd-vpa-" + e.role}
-			updateModeAuto              = hvpav1alpha1.UpdateModeAuto
-			updateModeMaintenanceWindow = hvpav1alpha1.UpdateModeMaintenanceWindow
-			containerPolicyOff          = autoscalingv1beta2.ContainerScalingModeOff
+			hpaLabels          = map[string]string{v1beta1constants.LabelRole: "etcd-hpa-" + e.role}
+			vpaLabels          = map[string]string{v1beta1constants.LabelRole: "etcd-vpa-" + e.role}
+			updateModeAuto     = hvpav1alpha1.UpdateModeAuto
+			containerPolicyOff = autoscalingv1beta2.ContainerScalingModeOff
 		)
 
 		if _, err := controllerutil.CreateOrUpdate(ctx, e.client, hvpa, func() error {
@@ -424,7 +423,7 @@ func (e *etcd) Deploy(ctx context.Context) error {
 				},
 				ScaleDown: hvpav1alpha1.ScaleType{
 					UpdatePolicy: hvpav1alpha1.UpdatePolicy{
-						UpdateMode: &updateModeMaintenanceWindow,
+						UpdateMode: e.hvpaConfig.ScaleDownUpdateMode,
 					},
 					StabilizationDuration: pointer.StringPtr("15m"),
 					MinChange: hvpav1alpha1.ScaleParams{
@@ -696,4 +695,6 @@ type HVPAConfig struct {
 	// MaintenanceTimeWindow contains begin and end of a time window that allows down-scaling the etcd in case its
 	// resource requests/limits are unnecessarily high.
 	MaintenanceTimeWindow gardencorev1beta1.MaintenanceTimeWindow
+	// The update mode to use for etcd scale down.
+	ScaleDownUpdateMode *string
 }

--- a/pkg/operation/botanist/etcd.go
+++ b/pkg/operation/botanist/etcd.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -63,9 +64,16 @@ func (b *Botanist) DefaultEtcd(role string, class etcd.Class) (etcd.Etcd, error)
 	if b.ManagedSeed != nil {
 		hvpaEnabled = gardenletfeatures.FeatureGate.Enabled(features.HVPAForShootedSeed)
 	}
+
+	scaleDownUpdateMode := hvpav1alpha1.UpdateModeMaintenanceWindow
+	if class == etcd.ClassImportant && b.Shoot.Purpose == gardencorev1beta1.ShootPurposeProduction {
+		scaleDownUpdateMode = hvpav1alpha1.UpdateModeOff
+	}
+
 	e.SetHVPAConfig(&etcd.HVPAConfig{
 		Enabled:               hvpaEnabled,
 		MaintenanceTimeWindow: *b.Shoot.Info.Spec.Maintenance.TimeWindow,
+		ScaleDownUpdateMode:   &scaleDownUpdateMode,
 	})
 
 	return e, nil


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane cost
/kind post-mortem

**What this PR does / why we need it**:

Disable etcd scale down for shoot clusters with purpose "production". This avoids multiple etcd restarts during the shoot's maintenance time window if VPA recommendation for scale down is inappropriate.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

cc @vlerenc @rfranzke @dguendisch 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Disable etcd scale down for shoot clusters with purpose "production". This avoids multiple etcd restarts during the shoot's maintenance time window if VPA recommendation for scale down is inappropriate.
```
