### PR TITLE
Increase limits for metrics-server.

### DIFF
--- a/pkg/operation/botanist/component/metricsserver/metrics_server.go
+++ b/pkg/operation/botanist/component/metricsserver/metrics_server.go
@@ -350,7 +350,7 @@ func (m *metricsServer) computeResourcesData() (map[string][]byte, error) {
 									corev1.ResourceMemory: resource.MustParse("150Mi"),
 								},
 								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("100m"),
+									corev1.ResourceCPU:    resource.MustParse("500m"),
 									corev1.ResourceMemory: resource.MustParse("1Gi"),
 								},
 							},
@@ -383,11 +383,6 @@ func (m *metricsServer) computeResourcesData() (map[string][]byte, error) {
 	}
 
 	if m.vpaEnabled {
-		deployment.Spec.Template.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("80m"),
-			corev1.ResourceMemory: resource.MustParse("400Mi"),
-		}
-
 		vpaUpdateMode := autoscalingv1beta2.UpdateModeAuto
 		vpa = &autoscalingv1beta2.VerticalPodAutoscaler{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operation/botanist/component/metricsserver/metrics_server_test.go
+++ b/pkg/operation/botanist/component/metricsserver/metrics_server_test.go
@@ -198,7 +198,7 @@ metadata:
   namespace: kube-system
 `
 
-		deploymentYAMLWithoutVPAWithoutHostEnv = `apiVersion: apps/v1
+		deploymentYAMLWithoutHostEnv = `apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
@@ -263,7 +263,7 @@ spec:
           periodSeconds: 10
         resources:
           limits:
-            cpu: 100m
+            cpu: 500m
             memory: 1Gi
           requests:
             cpu: 50m
@@ -288,7 +288,7 @@ spec:
           secretName: metrics-server
 status: {}
 `
-		deploymentYAMLWithVPAWithHostEnv = `apiVersion: apps/v1
+		deploymentYAMLWithHostEnv = `apiVersion: apps/v1
 kind: Deployment
 metadata:
   creationTimestamp: null
@@ -356,8 +356,8 @@ spec:
           periodSeconds: 10
         resources:
           limits:
-            cpu: 80m
-            memory: 400Mi
+            cpu: 500m
+            memory: 1Gi
           requests:
             cpu: 50m
             memory: 150Mi
@@ -406,7 +406,7 @@ status: {}
 				"clusterrole____system_metrics-server.yaml":                       []byte(clusterRoleYAML),
 				"clusterrolebinding____system_metrics-server.yaml":                []byte(clusterRoleBindingYAML),
 				"clusterrolebinding____metrics-server_system_auth-delegator.yaml": []byte(clusterRoleBindingAuthDelegatorYAML),
-				"deployment__kube-system__metrics-server.yaml":                    []byte(deploymentYAMLWithoutVPAWithoutHostEnv),
+				"deployment__kube-system__metrics-server.yaml":                    []byte(deploymentYAMLWithoutHostEnv),
 				"rolebinding__kube-system__metrics-server-auth-reader.yaml":       []byte(roleBindingYAML),
 				"secret__kube-system__metrics-server.yaml":                        []byte(secretYAML),
 				"service__kube-system__metrics-server.yaml":                       []byte(serviceYAML),
@@ -489,7 +489,7 @@ status: {}
 				metricsServer = New(c, namespace, image, true, &kubeAPIServerHost)
 				metricsServer.SetSecrets(secrets)
 
-				managedResourceSecret.Data["deployment__kube-system__metrics-server.yaml"] = []byte(deploymentYAMLWithVPAWithHostEnv)
+				managedResourceSecret.Data["deployment__kube-system__metrics-server.yaml"] = []byte(deploymentYAMLWithHostEnv)
 				managedResourceSecret.Data["verticalpodautoscaler__kube-system__metrics-server.yaml"] = []byte(vpaYAML)
 
 				gomock.InOrder(


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane auto-scaling 
/kind post-mortem

**What this PR does / why we need it**:

Increase limits for metrics-server. This is a temporary fix until we have non-circular auto-scaling for metrics-server.

**Which issue(s) this PR fixes**:
Fixes #

https://github.tools.sap/kubernetes-live/issues-live/issues/453#issuecomment-213566

**Special notes for your reviewer**:

Follow up issue after this PR goes in -> https://github.com/gardener/gardener/issues/4018

cc @timuthy @schrodit @tedteng @dguendisch @vlerenc 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Increase limits for metrics-server. This is a temporary fix until we have non-circular auto-scaling for metrics-server.
```
