### PR TITLE
Pull the istio images from the official mirror to GCR

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -253,11 +253,11 @@ images:
 # Istio
 - name: istio-proxy
   sourceRepository: github.com/istio/istio
-  repository: docker.io/istio/proxyv2
+  repository: gcr.io/istio-release/proxyv2
   tag: "1.8.0"
 - name: istio-istiod
   sourceRepository: github.com/istio/istio
-  repository: docker.io/istio/pilot
+  repository: gcr.io/istio-release/pilot
   tag: "1.8.0"
 
 # API Server SNI


### PR DESCRIPTION
/kind enhancement

We face dockerhub rate limit issues for istio images in environments where we don't use imagevector overwrite:

```
  Warning  Failed            6m48s (x4 over 10m)  kubelet             Failed to pull image "docker.io/istio/pilot:1.8.0": rpc error: code = Unknown desc = Error response from daemon: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit
```

It seems to tackle exactly this problem the istio community also provides official mirrors to [Google Container Registry](https://gcr.io/istio-release).

Ref https://istio.io/latest/blog/2020/docker-rate-limit/

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
istio images are now pulled from the official mirrors to [Google Container Registry](https://gcr.io/istio-release) to prevent any potential dockerhub rate limit issues in environments that use the default images (don't specify any imagevector overwrite).
```
