### PR TITLE
Make extension components ready for cached client

### DIFF
--- a/extensions/pkg/controller/utils_test.go
+++ b/extensions/pkg/controller/utils_test.go
@@ -165,7 +165,7 @@ var _ = Describe("Utils", func() {
 					Annotations: annotations,
 				},
 			}
-			workerWithAnnotation := worker.DeepCopyObject()
+			workerWithAnnotation := worker.DeepCopy()
 			expectedWorker := worker.DeepCopy()
 			delete(expectedWorker.Annotations, annotation)
 

--- a/pkg/controllerutils/patch.go
+++ b/pkg/controllerutils/patch.go
@@ -22,54 +22,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-// MergePatchOrCreate patches (using a merge patch) or creates the given object in the Kubernetes cluster.
-// The object's desired state is only reconciled with the existing state inside the passed in callback MutateFn,
-// however, the object is not read from the client. This means the object should already be filled with the
-// last-known state if operating on more complex structures (e.g. if the patch is supposed to remove an optional field
-// or section). If you don't have the current state of an object, use GetAndCreateOrMergePatch instead.
-//
-// The MutateFn is called regardless of creating or patching an object.
-//
-// It returns the executed operation and an error.
-func MergePatchOrCreate(ctx context.Context, c client.Writer, obj client.Object, f controllerutil.MutateFn) (controllerutil.OperationResult, error) {
-	return patchOrCreate(ctx, c, obj, func(obj client.Object) client.Patch { return client.MergeFrom(obj) }, f)
-}
-
-// StrategicMergePatchOrCreate patches (using a strategic merge patch) or creates the given object in the Kubernetes cluster.
-// The object's desired state is only reconciled with the existing state inside the passed in callback MutateFn,
-// however, the object is not read from the client. This means the object should already be filled with the
-// last-known state if operating on more complex structures (e.g. if the patch is supposed to remove an optional field
-// or section). If you don't have the current state of an object, use GetAndCreateOrStrategicMergePatch instead.
-//
-// The MutateFn is called regardless of creating or patching an object.
-//
-// It returns the executed operation and an error.
-func StrategicMergePatchOrCreate(ctx context.Context, c client.Writer, obj client.Object, f controllerutil.MutateFn) (controllerutil.OperationResult, error) {
-	return patchOrCreate(ctx, c, obj, func(obj client.Object) client.Patch { return client.StrategicMergeFrom(obj) }, f)
-}
-
-func patchOrCreate(ctx context.Context, c client.Writer, obj client.Object, patchFunc func(client.Object) client.Patch, f controllerutil.MutateFn) (controllerutil.OperationResult, error) {
-	patch := patchFunc(obj.DeepCopyObject().(client.Object))
-
-	if err := f(); err != nil {
-		return controllerutil.OperationResultNone, err
-	}
-
-	if err := c.Patch(ctx, obj, patch); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return controllerutil.OperationResultNone, err
-		}
-
-		if err2 := c.Create(ctx, obj); err2 != nil {
-			return controllerutil.OperationResultNone, err2
-		}
-
-		return controllerutil.OperationResultCreated, nil
-	}
-
-	return controllerutil.OperationResultUpdated, nil
-}
-
 // GetAndCreateOrMergePatch is similar to controllerutil.CreateOrPatch, but does not care about the object's status section.
 // It reads the object from the client, reconciles the desired state with the existing state using the given MutateFn
 // and creates or patches the object (using a merge patch) accordingly.

--- a/pkg/controllerutils/seedfilter.go
+++ b/pkg/controllerutils/seedfilter.go
@@ -99,7 +99,7 @@ func SeedLabelsMatch(seedLister gardencorelisters.SeedLister, seedName string, l
 
 // seedLabelsMatchWithClient fetches the given seed by its name from the client and then checks whether the given
 // label selector matches the seed labels.
-func seedLabelsMatchWithClient(ctx context.Context, c client.Client, seedName string, labelSelector *metav1.LabelSelector) bool {
+func seedLabelsMatchWithClient(ctx context.Context, c client.Reader, seedName string, labelSelector *metav1.LabelSelector) bool {
 	seed := &gardencorev1beta1.Seed{}
 	if err := c.Get(ctx, client.ObjectKey{Name: seedName}, seed); err != nil {
 		return false

--- a/pkg/extensions/customresources_test.go
+++ b/pkg/extensions/customresources_test.go
@@ -199,8 +199,7 @@ var _ = Describe("extensions", func() {
 			passedObj := expected.DeepCopy()
 			passedObj.SetAnnotations(map[string]string{"gardener.cloud/operation": "reconcile"})
 			expected.Status.LastOperation = &gardencorev1beta1.LastOperation{
-				State:          gardencorev1beta1.LastOperationStateSucceeded,
-				LastUpdateTime: metav1.Now().Rfc3339Copy(), // time.Now returns millisecond precision which is not marshalled
+				State: gardencorev1beta1.LastOperationStateSucceeded,
 			}
 
 			Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "creating worker succeeds")

--- a/pkg/extensions/customresources_test.go
+++ b/pkg/extensions/customresources_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/gardener/gardener/pkg/logger"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	mocktime "github.com/gardener/gardener/pkg/mock/go/time"
-	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/test"
 
 	"github.com/golang/mock/gomock"
@@ -97,66 +96,122 @@ var _ = Describe("extensions", func() {
 		ctrl.Finish()
 	})
 
-	Describe("#WaitUntilExtensionCRReady", func() {
-		It("should return error if extension CR does not exist", func() {
-			err := WaitUntilExtensionCRReady(
+	Describe("#WaitUntilExtensionObjectReady", func() {
+		It("should return error if extension object does not exist", func() {
+			err := WaitUntilExtensionObjectReady(
 				ctx, c, log,
-				func() client.Object { return &extensionsv1alpha1.Worker{} }, extensionsv1alpha1.WorkerResource,
-				namespace, name,
+				expected, extensionsv1alpha1.WorkerResource,
 				defaultInterval, defaultTimeout, defaultTimeout, nil,
 			)
 			Expect(err).To(HaveOccurred())
 		})
 
-		It("should return error if extension CR is not ready", func() {
+		It("should return error if extension object is not ready", func() {
 			expected.Status.LastError = &gardencorev1beta1.LastError{
 				Description: "Some error",
 			}
 
 			Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "creating worker succeeds")
-			err := WaitUntilExtensionCRReady(
+			err := WaitUntilExtensionObjectReady(
 				ctx, c, log,
-				func() client.Object { return &extensionsv1alpha1.Worker{} }, extensionsv1alpha1.WorkerResource,
-				namespace, name,
+				expected, extensionsv1alpha1.WorkerResource,
 				defaultInterval, defaultThreshold, defaultTimeout, nil,
 			)
 			Expect(err).To(HaveOccurred(), "worker readiness error")
 		})
 
-		It("should return success if extension CR is ready", func() {
+		It("should return success if extension object got ready the first time", func() {
+			passedObj := expected.DeepCopy()
 			expected.Status.LastOperation = &gardencorev1beta1.LastOperation{
-				State: gardencorev1beta1.LastOperationStateSucceeded,
+				State:          gardencorev1beta1.LastOperationStateSucceeded,
+				LastUpdateTime: metav1.Now(),
 			}
 
 			Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "creating worker succeeds")
-			err := WaitUntilExtensionCRReady(
+			err := WaitUntilExtensionObjectReady(
 				ctx, c, log,
-				func() client.Object { return &extensionsv1alpha1.Worker{} }, extensionsv1alpha1.WorkerResource,
-				namespace, name,
+				passedObj, extensionsv1alpha1.WorkerResource,
 				defaultInterval, defaultThreshold, defaultTimeout, nil,
 			)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("should call postReadyFunc if extension CR is ready", func() {
+		It("should return error if client has not observed latest timestamp annotation", func() {
 			expected.Status.LastOperation = &gardencorev1beta1.LastOperation{
-				State: gardencorev1beta1.LastOperationStateSucceeded,
+				State:          gardencorev1beta1.LastOperationStateSucceeded,
+				LastUpdateTime: metav1.Now(),
+			}
+			now = time.Now()
+			metav1.SetMetaDataAnnotation(&expected.ObjectMeta, v1beta1constants.GardenerTimestamp, now.UTC().String())
+			passedObj := expected.DeepCopy()
+			metav1.SetMetaDataAnnotation(&passedObj.ObjectMeta, v1beta1constants.GardenerTimestamp, now.Add(time.Millisecond).UTC().String())
+
+			Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "creating worker succeeds")
+			err := WaitUntilExtensionObjectReady(
+				ctx, c, log,
+				passedObj, extensionsv1alpha1.WorkerResource,
+				defaultInterval, defaultThreshold, defaultTimeout, nil,
+			)
+			Expect(err).To(MatchError(ContainSubstring("annotation is not")), "worker readiness error")
+		})
+
+		It("should return success if extension object got ready again and we observed latest timestamp annotation", func() {
+			expected.Status.LastOperation = &gardencorev1beta1.LastOperation{
+				State:          gardencorev1beta1.LastOperationStateSucceeded,
+				LastUpdateTime: metav1.Now(),
+			}
+			now = time.Now()
+			metav1.SetMetaDataAnnotation(&expected.ObjectMeta, v1beta1constants.GardenerTimestamp, now.UTC().String())
+			passedObj := expected.DeepCopy()
+
+			Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "creating worker succeeds")
+			err := WaitUntilExtensionObjectReady(
+				ctx, c, log,
+				passedObj, extensionsv1alpha1.WorkerResource,
+				defaultInterval, defaultThreshold, defaultTimeout, nil,
+			)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should call postReadyFunc if extension object is ready", func() {
+			passedObj := expected.DeepCopy()
+			expected.Status.LastOperation = &gardencorev1beta1.LastOperation{
+				State:          gardencorev1beta1.LastOperationStateSucceeded,
+				LastUpdateTime: metav1.Now(),
 			}
 
 			Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "creating worker succeeds")
 
 			val := 0
-			err := WaitUntilExtensionCRReady(
+			err := WaitUntilExtensionObjectReady(
 				ctx, c, log,
-				func() client.Object { return &extensionsv1alpha1.Worker{} }, extensionsv1alpha1.WorkerResource,
-				namespace, name,
-				defaultInterval, defaultThreshold, defaultTimeout, func(client.Object) error {
+				passedObj, extensionsv1alpha1.WorkerResource,
+				defaultInterval, defaultThreshold, defaultTimeout, func() error {
 					val++
 					return nil
 				},
 			)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(val).To(Equal(1))
+		})
+
+		It("should set passed object to latest state once ready", func() {
+			passedObj := expected.DeepCopy()
+			passedObj.SetAnnotations(map[string]string{"gardener.cloud/operation": "reconcile"})
+			expected.Status.LastOperation = &gardencorev1beta1.LastOperation{
+				State:          gardencorev1beta1.LastOperationStateSucceeded,
+				LastUpdateTime: metav1.Now().Rfc3339Copy(), // time.Now returns millisecond precision which is not marshalled
+			}
+
+			Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "creating worker succeeds")
+
+			err := WaitUntilExtensionObjectReady(
+				ctx, c, log,
+				passedObj, extensionsv1alpha1.WorkerResource,
+				defaultInterval, defaultThreshold, defaultTimeout, nil,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(passedObj).To(Equal(expected))
 		})
 	})
 
@@ -167,8 +222,7 @@ var _ = Describe("extensions", func() {
 				func(obj client.Object) error {
 					return nil
 				},
-				func() client.Object { return &extensionsv1alpha1.Worker{} }, extensionsv1alpha1.WorkerResource,
-				namespace, name,
+				expected, extensionsv1alpha1.WorkerResource,
 				defaultInterval, defaultThreshold, defaultTimeout,
 				nil,
 			)
@@ -182,8 +236,7 @@ var _ = Describe("extensions", func() {
 				func(obj client.Object) error {
 					return errors.New("error")
 				},
-				func() client.Object { return &extensionsv1alpha1.Worker{} }, extensionsv1alpha1.WorkerResource,
-				namespace, name,
+				expected, extensionsv1alpha1.WorkerResource,
 				defaultInterval, defaultThreshold, defaultTimeout,
 				nil,
 			)
@@ -197,8 +250,7 @@ var _ = Describe("extensions", func() {
 				func(obj client.Object) error {
 					return nil
 				},
-				func() client.Object { return &extensionsv1alpha1.Worker{} }, extensionsv1alpha1.WorkerResource,
-				namespace, name,
+				expected, extensionsv1alpha1.WorkerResource,
 				defaultInterval, defaultThreshold, defaultTimeout,
 				nil,
 			)
@@ -206,6 +258,8 @@ var _ = Describe("extensions", func() {
 		})
 
 		It("should pass correct object to health func", func() {
+			passedObj := expected.DeepCopy()
+			metav1.SetMetaDataAnnotation(&passedObj.ObjectMeta, "foo", "bar")
 			Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "creating worker succeeds")
 			err := WaitUntilObjectReadyWithHealthFunction(
 				ctx, c, log,
@@ -213,8 +267,7 @@ var _ = Describe("extensions", func() {
 					Expect(obj).To(Equal(expected))
 					return nil
 				},
-				func() client.Object { return &extensionsv1alpha1.Worker{} }, extensionsv1alpha1.WorkerResource,
-				namespace, name,
+				passedObj, extensionsv1alpha1.WorkerResource,
 				defaultInterval, defaultThreshold, defaultTimeout,
 				nil,
 			)
@@ -234,9 +287,8 @@ var _ = Describe("extensions", func() {
 				func(obj client.Object) error {
 					return nil
 				},
-				func() client.Object { return &extensionsv1alpha1.Worker{} }, extensionsv1alpha1.WorkerResource,
-				namespace, name,
-				defaultInterval, defaultThreshold, defaultTimeout, func(client.Object) error {
+				expected, extensionsv1alpha1.WorkerResource,
+				defaultInterval, defaultThreshold, defaultTimeout, func() error {
 					val++
 					return nil
 				},
@@ -246,17 +298,17 @@ var _ = Describe("extensions", func() {
 		})
 	})
 
-	Describe("#DeleteExtensionCR", func() {
-		It("should not return error if extension CR does not exist", func() {
-			Expect(DeleteExtensionCR(ctx, c, func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Worker{} }, namespace, name)).To(Succeed())
+	Describe("#DeleteExtensionObject", func() {
+		It("should not return error if extension object does not exist", func() {
+			Expect(DeleteExtensionObject(ctx, c, expected)).To(Succeed())
 		})
 
 		It("should not return error if deleted successfully", func() {
 			Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "adding pre-existing worker succeeds")
-			Expect(DeleteExtensionCR(ctx, c, func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Worker{} }, namespace, name)).To(Succeed())
+			Expect(DeleteExtensionObject(ctx, c, expected)).To(Succeed())
 		})
 
-		It("should delete extension CR", func() {
+		It("should delete extension object", func() {
 			defer test.WithVars(
 				&TimeNow, mockNow.Do,
 			)()
@@ -272,12 +324,12 @@ var _ = Describe("extensions", func() {
 			mc.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&extensionsv1alpha1.Worker{}), gomock.Any()).SetArg(1, *expected).Return(nil)
 			mc.EXPECT().Delete(ctx, expected).Times(1).Return(fmt.Errorf("some random error"))
 
-			Expect(DeleteExtensionCR(ctx, mc, func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Worker{} }, namespace, name)).To(HaveOccurred())
+			Expect(DeleteExtensionObject(ctx, mc, expected)).To(HaveOccurred())
 		})
 	})
 
-	Describe("#DeleteExtensionCRs", func() {
-		It("should delete all extension CRs", func() {
+	Describe("#DeleteExtensionObjects", func() {
+		It("should delete all extension objects", func() {
 			deletionTimestamp := metav1.Now()
 			expected.ObjectMeta.DeletionTimestamp = &deletionTimestamp
 
@@ -289,11 +341,10 @@ var _ = Describe("extensions", func() {
 			Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "adding pre-existing worker succeeds")
 			Expect(c.Create(ctx, expected2)).ToNot(HaveOccurred(), "adding pre-existing worker succeeds")
 
-			err := DeleteExtensionCRs(
+			err := DeleteExtensionObjects(
 				ctx,
 				c,
 				list,
-				func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Worker{} },
 				namespace,
 				func(obj extensionsv1alpha1.Object) bool { return true },
 			)
@@ -302,8 +353,8 @@ var _ = Describe("extensions", func() {
 		})
 	})
 
-	Describe("#WaitUntilExtensionCRsDeleted", func() {
-		It("should return error if atleast one extension CR is not deleted", func() {
+	Describe("#WaitUntilExtensionObjectsDeleted", func() {
+		It("should return error if atleast one extension object is not deleted", func() {
 			list := &extensionsv1alpha1.WorkerList{}
 
 			deletionTimestamp := metav1.Now()
@@ -311,12 +362,12 @@ var _ = Describe("extensions", func() {
 
 			Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "adding pre-existing worker succeeds")
 
-			err := WaitUntilExtensionCRsDeleted(
+			err := WaitUntilExtensionObjectsDeleted(
 				ctx,
 				c,
 				log,
 				list,
-				func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Worker{} }, extensionsv1alpha1.WorkerResource,
+				extensionsv1alpha1.WorkerResource,
 				namespace, defaultInterval, defaultTimeout,
 				func(object extensionsv1alpha1.Object) bool { return true })
 
@@ -325,12 +376,12 @@ var _ = Describe("extensions", func() {
 
 		It("should return success if all extensions CRs are deleted", func() {
 			list := &extensionsv1alpha1.WorkerList{}
-			err := WaitUntilExtensionCRsDeleted(
+			err := WaitUntilExtensionObjectsDeleted(
 				ctx,
 				c,
 				log,
 				list,
-				func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Worker{} }, extensionsv1alpha1.WorkerResource,
+				extensionsv1alpha1.WorkerResource,
 				namespace, defaultInterval, defaultTimeout,
 				func(object extensionsv1alpha1.Object) bool { return true })
 			Expect(err).NotTo(HaveOccurred())
@@ -338,30 +389,28 @@ var _ = Describe("extensions", func() {
 
 	})
 
-	Describe("#WaitUntilExtensionCRDeleted", func() {
-		It("should return error if extension CR is not deleted", func() {
+	Describe("#WaitUntilExtensionObjectDeleted", func() {
+		It("should return error if extension object is not deleted", func() {
 			deletionTimestamp := metav1.Now()
 			expected.ObjectMeta.DeletionTimestamp = &deletionTimestamp
 
 			Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "adding pre-existing worker succeeds")
-			err := WaitUntilExtensionCRDeleted(ctx, c, log,
-				func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Worker{} }, extensionsv1alpha1.WorkerResource,
-				namespace, name,
+			err := WaitUntilExtensionObjectDeleted(ctx, c, log,
+				expected, extensionsv1alpha1.WorkerResource,
 				defaultInterval, defaultTimeout)
 
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("should return success if extensions CRs gets deleted", func() {
-			err := WaitUntilExtensionCRDeleted(ctx, c, log,
-				func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Worker{} }, extensionsv1alpha1.WorkerResource,
-				namespace, name,
+			err := WaitUntilExtensionObjectDeleted(ctx, c, log,
+				expected, extensionsv1alpha1.WorkerResource,
 				defaultInterval, defaultTimeout)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 
-	Context("restoring extension CR state", func() {
+	Context("restoring extension object state", func() {
 		var (
 			expectedState *runtime.RawExtension
 			shootState    *gardencorev1alpha1.ShootState
@@ -384,7 +433,7 @@ var _ = Describe("extensions", func() {
 		})
 
 		Describe("#RestoreExtensionWithDeployFunction", func() {
-			It("should restore the extension CR state with the provided deploy fuction and annotate it for restoration", func() {
+			It("should restore the extension object state with the provided deploy fuction and annotate it for restoration", func() {
 				defer test.WithVars(
 					&TimeNow, mockNow.Do,
 				)()
@@ -395,7 +444,6 @@ var _ = Describe("extensions", func() {
 					c,
 					shootState,
 					extensionsv1alpha1.WorkerResource,
-					namespace,
 					func(ctx context.Context, operationAnnotation string) (extensionsv1alpha1.Object, error) {
 						Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "adding pre-existing worker succeeds")
 						return expected, nil
@@ -422,7 +470,6 @@ var _ = Describe("extensions", func() {
 					c,
 					shootState,
 					extensionsv1alpha1.WorkerResource,
-					namespace,
 					func(ctx context.Context, operationAnnotation string) (extensionsv1alpha1.Object, error) {
 						Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "adding pre-existing worker succeeds")
 						return expected, nil
@@ -439,19 +486,18 @@ var _ = Describe("extensions", func() {
 		})
 
 		Describe("#RestoreExtensionObjectState", func() {
-			It("should return error if the extension CR does not exist", func() {
+			It("should return error if the extension object does not exist", func() {
 				err := RestoreExtensionObjectState(
 					ctx,
 					c,
 					shootState,
-					namespace,
 					expected,
 					extensionsv1alpha1.WorkerResource,
 				)
 				Expect(err).To(HaveOccurred())
 			})
 
-			It("should update the state if the extension CR exists", func() {
+			It("should update the state if the extension object exists", func() {
 				defer test.WithVars(
 					&TimeNow, mockNow.Do,
 				)()
@@ -462,7 +508,6 @@ var _ = Describe("extensions", func() {
 					ctx,
 					c,
 					shootState,
-					namespace,
 					expected,
 					extensionsv1alpha1.WorkerResource,
 				)
@@ -472,12 +517,12 @@ var _ = Describe("extensions", func() {
 		})
 	})
 
-	Describe("#MigrateExtensionCR", func() {
-		It("should not return error if extension CR does not exist", func() {
-			Expect(MigrateExtensionCR(ctx, c, func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Worker{} }, namespace, name)).To(Succeed())
+	Describe("#MigrateExtensionObject", func() {
+		It("should not return error if extension object does not exist", func() {
+			Expect(MigrateExtensionObject(ctx, c, expected)).To(Succeed())
 		})
 
-		It("should properly annotate extension CR for migration", func() {
+		It("should properly annotate extension object for migration", func() {
 			defer test.WithVars(
 				&TimeNow, mockNow.Do,
 			)()
@@ -491,22 +536,21 @@ var _ = Describe("extensions", func() {
 			}
 
 			mc := mockclient.NewMockClient(ctrl)
-			mc.EXPECT().Get(ctx, kutil.Key(namespace, name), gomock.AssignableToTypeOf(&extensionsv1alpha1.Worker{})).SetArg(2, *expected).Return(nil)
 			mc.EXPECT().Patch(ctx, expectedWithAnnotations, gomock.AssignableToTypeOf(client.MergeFrom(expected))).Return(nil)
 
-			err := MigrateExtensionCR(ctx, mc, func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Worker{} }, namespace, name)
+			err := MigrateExtensionObject(ctx, mc, expected)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 
-	Describe("#MigrateExtensionCRs", func() {
+	Describe("#MigrateExtensionObjects", func() {
 		It("should not return error if there are no extension resources", func() {
 			Expect(
-				MigrateExtensionCRs(ctx, c, &extensionsv1alpha1.BackupBucketList{}, func() extensionsv1alpha1.Object { return &extensionsv1alpha1.BackupBucket{} }, namespace),
+				MigrateExtensionObjects(ctx, c, &extensionsv1alpha1.BackupBucketList{}, namespace),
 			).To(Succeed())
 		})
 
-		It("should properly annotate all extension CRs for migration", func() {
+		It("should properly annotate all extension objects for migration", func() {
 			for i := 0; i < 4; i++ {
 				containerRuntimeExtension := &extensionsv1alpha1.ContainerRuntime{
 					ObjectMeta: metav1.ObjectMeta{
@@ -518,7 +562,7 @@ var _ = Describe("extensions", func() {
 			}
 
 			Expect(
-				MigrateExtensionCRs(ctx, c, &extensionsv1alpha1.ContainerRuntimeList{}, func() extensionsv1alpha1.Object { return &extensionsv1alpha1.ContainerRuntime{} }, namespace),
+				MigrateExtensionObjects(ctx, c, &extensionsv1alpha1.ContainerRuntimeList{}, namespace),
 			).To(Succeed())
 
 			containerRuntimeList := &extensionsv1alpha1.ContainerRuntimeList{}
@@ -530,13 +574,12 @@ var _ = Describe("extensions", func() {
 		})
 	})
 
-	Describe("#WaitUntilExtensionCRMigrated", func() {
+	Describe("#WaitUntilExtensionObjectMigrated", func() {
 		It("should not return error if resource does not exist", func() {
-			err := WaitUntilExtensionCRMigrated(
+			err := WaitUntilExtensionObjectMigrated(
 				ctx,
 				c,
-				func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Worker{} },
-				namespace, name,
+				expected,
 				defaultInterval, defaultTimeout,
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -546,11 +589,10 @@ var _ = Describe("extensions", func() {
 			func(lastOperation *gardencorev1beta1.LastOperation, match func() GomegaMatcher) {
 				expected.Status.LastOperation = lastOperation
 				Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "adding pre-existing worker succeeds")
-				err := WaitUntilExtensionCRMigrated(
+				err := WaitUntilExtensionObjectMigrated(
 					ctx,
 					c,
-					func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Worker{} },
-					namespace, name,
+					expected,
 					defaultInterval, defaultTimeout,
 				)
 				Expect(err).To(match())
@@ -570,13 +612,13 @@ var _ = Describe("extensions", func() {
 		)
 	})
 
-	Describe("#WaitUntilExtensionCRsMigrated", func() {
-		It("should not return error if there are no extension CRs", func() {
-			Expect(WaitUntilExtensionCRsMigrated(
+	Describe("#WaitUntilExtensionObjectsMigrated", func() {
+		It("should not return error if there are no extension objects", func() {
+			Expect(WaitUntilExtensionObjectsMigrated(
 				ctx,
 				c,
 				&extensionsv1alpha1.WorkerList{},
-				func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Worker{} },
+
 				namespace,
 				defaultInterval,
 				defaultTimeout)).To(Succeed())
@@ -590,11 +632,10 @@ var _ = Describe("extensions", func() {
 					existing.Name = fmt.Sprintf("worker-%d", i)
 					Expect(c.Create(ctx, existing)).ToNot(HaveOccurred(), "adding pre-existing worker succeeds")
 				}
-				err := WaitUntilExtensionCRsMigrated(
+				err := WaitUntilExtensionObjectsMigrated(
 					ctx,
 					c,
 					&extensionsv1alpha1.WorkerList{},
-					func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Worker{} },
 					namespace,
 					defaultInterval,
 					defaultTimeout)
@@ -648,9 +689,9 @@ var _ = Describe("extensions", func() {
 		)
 	})
 
-	Describe("#AnnotateExtensionObjectWithOperation", func() {
+	Describe("#AnnotateObjectWithOperation", func() {
 		It("should return error if object does not exist", func() {
-			Expect(AnnotateExtensionObjectWithOperation(ctx, c, expected, v1beta1constants.GardenerOperationMigrate)).NotTo(Succeed())
+			Expect(AnnotateObjectWithOperation(ctx, c, expected, v1beta1constants.GardenerOperationMigrate)).NotTo(Succeed())
 		})
 
 		It("should annotate extension object with operation", func() {
@@ -669,7 +710,7 @@ var _ = Describe("extensions", func() {
 			mc := mockclient.NewMockClient(ctrl)
 			mc.EXPECT().Patch(ctx, expectedWithAnnotations, gomock.AssignableToTypeOf(client.MergeFrom(expected))).Return(nil)
 
-			err := AnnotateExtensionObjectWithOperation(ctx, mc, expected, v1beta1constants.GardenerOperationMigrate)
+			err := AnnotateObjectWithOperation(ctx, mc, expected, v1beta1constants.GardenerOperationMigrate)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})

--- a/pkg/gardenlet/controller/backupbucket/backup_bucket_actuator.go
+++ b/pkg/gardenlet/controller/backupbucket/backup_bucket_actuator.go
@@ -182,7 +182,7 @@ func (a *actuator) deployBackupBucketExtensionSecret(ctx context.Context) error 
 	}
 
 	extensionSecret := a.emptyExtensionSecret()
-	_, err = controllerutils.MergePatchOrCreate(ctx, a.seedClient.Client(), extensionSecret, func() error {
+	_, err = controllerutils.GetAndCreateOrMergePatch(ctx, a.seedClient.Client(), extensionSecret, func() error {
 		extensionSecret.Data = coreSecret.DeepCopy().Data
 		return nil
 	})
@@ -194,7 +194,7 @@ func (a *actuator) deployBackupBucketExtension(ctx context.Context) error {
 	extensionSecret := a.emptyExtensionSecret()
 
 	// reconcile extension backup bucket resource in seed
-	_, err := controllerutils.MergePatchOrCreate(ctx, a.seedClient.Client(), a.extensionBackupBucket, func() error {
+	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, a.seedClient.Client(), a.extensionBackupBucket, func() error {
 		metav1.SetMetaDataAnnotation(&a.extensionBackupBucket.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
 		metav1.SetMetaDataAnnotation(&a.extensionBackupBucket.ObjectMeta, v1beta1constants.GardenerTimestamp, time.Now().UTC().String())
 

--- a/pkg/gardenlet/controller/backupentry/backup_entry_actuator.go
+++ b/pkg/gardenlet/controller/backupentry/backup_entry_actuator.go
@@ -275,7 +275,7 @@ func (a *actuator) deployBackupEntryExtensionSecret(ctx context.Context) error {
 
 	// create secret for extension BackupEntry in seed
 	extensionSecret := emptyExtensionSecret(a.backupEntry)
-	if _, err := controllerutils.MergePatchOrCreate(ctx, a.seedClient.Client(), extensionSecret, func() error {
+	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, a.seedClient.Client(), extensionSecret, func() error {
 		extensionSecret.Data = coreSecret.DeepCopy().Data
 		return nil
 	}); err != nil {

--- a/pkg/gardenlet/controller/backupentry/backup_entry_reconciler.go
+++ b/pkg/gardenlet/controller/backupentry/backup_entry_reconciler.go
@@ -51,7 +51,7 @@ type reconciler struct {
 	config    *config.GardenletConfiguration
 }
 
-// newReconciler returns the new backupBucker reconciler.
+// newReconciler returns the new backupEntry reconciler.
 func newReconciler(clientMap clientmap.ClientMap, recorder record.EventRecorder, config *config.GardenletConfiguration) reconcile.Reconciler {
 	return &reconciler{
 		clientMap: clientMap,

--- a/pkg/operation/botanist/backupentry.go
+++ b/pkg/operation/botanist/backupentry.go
@@ -20,7 +20,6 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	corebackupentry "github.com/gardener/gardener/pkg/operation/botanist/component/backupentry"
-	extensionsbackupentry "github.com/gardener/gardener/pkg/operation/botanist/component/extensions/backupentry"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,21 +45,6 @@ func (b *Botanist) DefaultCoreBackupEntry(gardenClient client.Client) component.
 		},
 		corebackupentry.DefaultInterval,
 		corebackupentry.DefaultTimeout,
-	)
-}
-
-// DefaultExtensionsBackupEntry creates the default deployer for the extensions.gardener.cloud/v1alpha1.BackupEntry
-// custom resource.
-func (b *Botanist) DefaultExtensionsBackupEntry(seedClient client.Client) extensionsbackupentry.Interface {
-	return extensionsbackupentry.New(
-		b.Logger,
-		seedClient,
-		&extensionsbackupentry.Values{
-			Name: gutil.GenerateBackupEntryName(b.Shoot.Info.Status.TechnicalID, b.Shoot.Info.Status.UID),
-		},
-		extensionsbackupentry.DefaultInterval,
-		extensionsbackupentry.DefaultSevereThreshold,
-		extensionsbackupentry.DefaultTimeout,
 	)
 }
 

--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -89,7 +89,7 @@ func New(ctx context.Context, o *operation.Operation) (*Botanist, error) {
 	}
 	o.Shoot.Components.Extensions.Infrastructure = b.DefaultInfrastructure(b.K8sSeedClient.Client())
 	o.Shoot.Components.Extensions.Network = b.DefaultNetwork(b.K8sSeedClient.Client())
-	o.Shoot.Components.Extensions.OperatingSystemConfig, err = b.DefaultOperatingSystemConfig(b.K8sSeedClient.DirectClient())
+	o.Shoot.Components.Extensions.OperatingSystemConfig, err = b.DefaultOperatingSystemConfig(b.K8sSeedClient.Client())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -87,7 +87,7 @@ func New(ctx context.Context, o *operation.Operation) (*Botanist, error) {
 	if err != nil {
 		return nil, err
 	}
-	o.Shoot.Components.Extensions.Infrastructure = b.DefaultInfrastructure(b.K8sSeedClient.DirectClient())
+	o.Shoot.Components.Extensions.Infrastructure = b.DefaultInfrastructure(b.K8sSeedClient.Client())
 	o.Shoot.Components.Extensions.Network = b.DefaultNetwork(b.K8sSeedClient.DirectClient())
 	o.Shoot.Components.Extensions.OperatingSystemConfig, err = b.DefaultOperatingSystemConfig(b.K8sSeedClient.DirectClient())
 	if err != nil {

--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -83,7 +83,7 @@ func New(ctx context.Context, o *operation.Operation) (*Botanist, error) {
 	if err != nil {
 		return nil, err
 	}
-	o.Shoot.Components.Extensions.Extension, err = b.DefaultExtension(ctx, b.K8sSeedClient.DirectClient())
+	o.Shoot.Components.Extensions.Extension, err = b.DefaultExtension(ctx, b.K8sSeedClient.Client())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -88,7 +88,7 @@ func New(ctx context.Context, o *operation.Operation) (*Botanist, error) {
 		return nil, err
 	}
 	o.Shoot.Components.Extensions.Infrastructure = b.DefaultInfrastructure(b.K8sSeedClient.Client())
-	o.Shoot.Components.Extensions.Network = b.DefaultNetwork(b.K8sSeedClient.DirectClient())
+	o.Shoot.Components.Extensions.Network = b.DefaultNetwork(b.K8sSeedClient.Client())
 	o.Shoot.Components.Extensions.OperatingSystemConfig, err = b.DefaultOperatingSystemConfig(b.K8sSeedClient.DirectClient())
 	if err != nil {
 		return nil, err

--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -93,7 +93,7 @@ func New(ctx context.Context, o *operation.Operation) (*Botanist, error) {
 	if err != nil {
 		return nil, err
 	}
-	o.Shoot.Components.Extensions.Worker = b.DefaultWorker(b.K8sSeedClient.DirectClient())
+	o.Shoot.Components.Extensions.Worker = b.DefaultWorker(b.K8sSeedClient.Client())
 
 	sniPhase, err := b.SNIPhase(ctx)
 	if err != nil {

--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -68,7 +68,7 @@ func New(ctx context.Context, o *operation.Operation) (*Botanist, error) {
 	}
 
 	// extension components
-	o.Shoot.Components.Extensions.ContainerRuntime = b.DefaultContainerRuntime(b.K8sSeedClient.DirectClient())
+	o.Shoot.Components.Extensions.ContainerRuntime = b.DefaultContainerRuntime(b.K8sSeedClient.Client())
 	o.Shoot.Components.Extensions.ControlPlane = b.DefaultControlPlane(b.K8sSeedClient.DirectClient(), extensionsv1alpha1.Normal)
 	o.Shoot.Components.Extensions.ControlPlaneExposure = b.DefaultControlPlane(b.K8sSeedClient.DirectClient(), extensionsv1alpha1.Exposure)
 	o.Shoot.Components.Extensions.DNS.ExternalProvider = b.DefaultExternalDNSProvider(b.K8sSeedClient.DirectClient())

--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -68,7 +68,6 @@ func New(ctx context.Context, o *operation.Operation) (*Botanist, error) {
 	}
 
 	// extension components
-	o.Shoot.Components.Extensions.BackupEntry = b.DefaultExtensionsBackupEntry(b.K8sSeedClient.DirectClient())
 	o.Shoot.Components.Extensions.ContainerRuntime = b.DefaultContainerRuntime(b.K8sSeedClient.DirectClient())
 	o.Shoot.Components.Extensions.ControlPlane = b.DefaultControlPlane(b.K8sSeedClient.DirectClient(), extensionsv1alpha1.Normal)
 	o.Shoot.Components.Extensions.ControlPlaneExposure = b.DefaultControlPlane(b.K8sSeedClient.DirectClient(), extensionsv1alpha1.Exposure)

--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -69,8 +69,8 @@ func New(ctx context.Context, o *operation.Operation) (*Botanist, error) {
 
 	// extension components
 	o.Shoot.Components.Extensions.ContainerRuntime = b.DefaultContainerRuntime(b.K8sSeedClient.Client())
-	o.Shoot.Components.Extensions.ControlPlane = b.DefaultControlPlane(b.K8sSeedClient.DirectClient(), extensionsv1alpha1.Normal)
-	o.Shoot.Components.Extensions.ControlPlaneExposure = b.DefaultControlPlane(b.K8sSeedClient.DirectClient(), extensionsv1alpha1.Exposure)
+	o.Shoot.Components.Extensions.ControlPlane = b.DefaultControlPlane(b.K8sSeedClient.Client(), extensionsv1alpha1.Normal)
+	o.Shoot.Components.Extensions.ControlPlaneExposure = b.DefaultControlPlane(b.K8sSeedClient.Client(), extensionsv1alpha1.Exposure)
 	o.Shoot.Components.Extensions.DNS.ExternalProvider = b.DefaultExternalDNSProvider(b.K8sSeedClient.DirectClient())
 	o.Shoot.Components.Extensions.DNS.ExternalOwner = b.DefaultExternalDNSOwner(b.K8sSeedClient.DirectClient())
 	o.Shoot.Components.Extensions.DNS.ExternalEntry = b.DefaultExternalDNSEntry(b.K8sSeedClient.DirectClient())

--- a/pkg/operation/botanist/component/extensions/backupentry/backupentry.go
+++ b/pkg/operation/botanist/component/extensions/backupentry/backupentry.go
@@ -115,7 +115,7 @@ func (b *backupEntry) Deploy(ctx context.Context) error {
 }
 
 func (b *backupEntry) deploy(ctx context.Context, operation string) (extensionsv1alpha1.Object, error) {
-	_, err := controllerutils.MergePatchOrCreate(ctx, b.client, b.backupEntry, func() error {
+	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, b.client, b.backupEntry, func() error {
 		metav1.SetMetaDataAnnotation(&b.backupEntry.ObjectMeta, v1beta1constants.GardenerOperation, operation)
 		metav1.SetMetaDataAnnotation(&b.backupEntry.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
 

--- a/pkg/operation/botanist/component/extensions/backupentry/backupentry.go
+++ b/pkg/operation/botanist/component/extensions/backupentry/backupentry.go
@@ -21,6 +21,7 @@ import (
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 
@@ -29,7 +30,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 const (
@@ -88,6 +88,12 @@ func New(
 		waitInterval:        waitInterval,
 		waitSevereThreshold: waitSevereThreshold,
 		waitTimeout:         waitTimeout,
+
+		backupEntry: &extensionsv1alpha1.BackupEntry{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: values.Name,
+			},
+		},
 	}
 }
 
@@ -98,6 +104,8 @@ type backupEntry struct {
 	waitInterval        time.Duration
 	waitSevereThreshold time.Duration
 	waitTimeout         time.Duration
+
+	backupEntry *extensionsv1alpha1.BackupEntry
 }
 
 // Deploy uses the seed client to create or update the BackupEntry custom resource in the Seed.
@@ -107,17 +115,11 @@ func (b *backupEntry) Deploy(ctx context.Context) error {
 }
 
 func (b *backupEntry) deploy(ctx context.Context, operation string) (extensionsv1alpha1.Object, error) {
-	backupEntry := &extensionsv1alpha1.BackupEntry{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: b.values.Name,
-		},
-	}
+	_, err := controllerutils.MergePatchOrCreate(ctx, b.client, b.backupEntry, func() error {
+		metav1.SetMetaDataAnnotation(&b.backupEntry.ObjectMeta, v1beta1constants.GardenerOperation, operation)
+		metav1.SetMetaDataAnnotation(&b.backupEntry.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
 
-	_, err := controllerutil.CreateOrUpdate(ctx, b.client, backupEntry, func() error {
-		metav1.SetMetaDataAnnotation(&backupEntry.ObjectMeta, v1beta1constants.GardenerOperation, operation)
-		metav1.SetMetaDataAnnotation(&backupEntry.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
-
-		backupEntry.Spec = extensionsv1alpha1.BackupEntrySpec{
+		b.backupEntry.Spec = extensionsv1alpha1.BackupEntrySpec{
 			DefaultSpec: extensionsv1alpha1.DefaultSpec{
 				Type:           b.values.Type,
 				ProviderConfig: b.values.ProviderConfig,
@@ -131,7 +133,7 @@ func (b *backupEntry) deploy(ctx context.Context, operation string) (extensionsv
 		return nil
 	})
 
-	return backupEntry, err
+	return b.backupEntry, err
 }
 
 // Restore uses the seed client and the ShootState to create the BackupEntry custom resource in the Seed and restore its
@@ -142,30 +144,25 @@ func (b *backupEntry) Restore(ctx context.Context, shootState *gardencorev1alpha
 		b.client,
 		shootState,
 		extensionsv1alpha1.BackupEntryResource,
-		"",
 		b.deploy,
 	)
 }
 
 // Migrate migrates the BackupEntry custom resource
 func (b *backupEntry) Migrate(ctx context.Context) error {
-	return extensions.MigrateExtensionCR(
+	return extensions.MigrateExtensionObject(
 		ctx,
 		b.client,
-		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.BackupEntry{} },
-		"",
-		b.values.Name,
+		b.backupEntry,
 	)
 }
 
 // WaitMigrate waits until the BackupEntry custom resource has been successfully migrated.
 func (b *backupEntry) WaitMigrate(ctx context.Context) error {
-	return extensions.WaitUntilExtensionCRMigrated(
+	return extensions.WaitUntilExtensionObjectMigrated(
 		ctx,
 		b.client,
-		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.BackupEntry{} },
-		"",
-		b.values.Name,
+		b.backupEntry,
 		b.waitInterval,
 		b.waitTimeout,
 	)
@@ -173,25 +170,21 @@ func (b *backupEntry) WaitMigrate(ctx context.Context) error {
 
 // Destroy deletes the BackupEntry CRD
 func (b *backupEntry) Destroy(ctx context.Context) error {
-	return extensions.DeleteExtensionCR(
+	return extensions.DeleteExtensionObject(
 		ctx,
 		b.client,
-		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.BackupEntry{} },
-		"",
-		b.values.Name,
+		b.backupEntry,
 	)
 }
 
 // Wait waits until the BackupEntry CRD is ready (deployed or restored)
 func (b *backupEntry) Wait(ctx context.Context) error {
-	return extensions.WaitUntilExtensionCRReady(
+	return extensions.WaitUntilExtensionObjectReady(
 		ctx,
 		b.client,
 		b.logger,
-		func() client.Object { return &extensionsv1alpha1.BackupEntry{} },
+		b.backupEntry,
 		extensionsv1alpha1.BackupEntryResource,
-		"",
-		b.values.Name,
 		b.waitInterval,
 		b.waitSevereThreshold,
 		b.waitTimeout,
@@ -201,14 +194,12 @@ func (b *backupEntry) Wait(ctx context.Context) error {
 
 // WaitCleanup waits until the BackupEntry CRD is deleted
 func (b *backupEntry) WaitCleanup(ctx context.Context) error {
-	return extensions.WaitUntilExtensionCRDeleted(
+	return extensions.WaitUntilExtensionObjectDeleted(
 		ctx,
 		b.client,
 		b.logger,
-		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.BackupEntry{} },
+		b.backupEntry,
 		extensionsv1alpha1.BackupEntryResource,
-		"",
-		b.values.Name,
 		b.waitInterval,
 		b.waitTimeout,
 	)

--- a/pkg/operation/botanist/component/extensions/backupentry/backupentry_test.go
+++ b/pkg/operation/botanist/component/extensions/backupentry/backupentry_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/backupentry"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
-	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 
@@ -39,7 +38,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -53,6 +51,7 @@ var _ = Describe("#BackupEntry", func() {
 
 		ctx              context.Context
 		c                client.Client
+		empty            *extensionsv1alpha1.BackupEntry
 		expected         *extensionsv1alpha1.BackupEntry
 		values           *backupentry.Values
 		log              logrus.FieldLogger
@@ -78,6 +77,7 @@ var _ = Describe("#BackupEntry", func() {
 		ctrl = gomock.NewController(GinkgoT())
 
 		mockNow = mocktime.NewMockNow(ctrl)
+		now = time.Now()
 
 		ctx = context.TODO()
 		log = logger.NewNopLogger()
@@ -96,6 +96,12 @@ var _ = Describe("#BackupEntry", func() {
 			SecretRef:                  secretRef,
 			BucketName:                 bucketName,
 			BackupBucketProviderStatus: backupBucketProviderStatus,
+		}
+
+		empty = &extensionsv1alpha1.BackupEntry{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: name,
+			},
 		}
 
 		expected = &extensionsv1alpha1.BackupEntry{
@@ -161,15 +167,56 @@ var _ = Describe("#BackupEntry", func() {
 			Expect(defaultDepWaiter.Wait(ctx)).To(MatchError(ContainSubstring("error during reconciliation: Some error")), "backupentry indicates error")
 		})
 
-		It("should return no error when is ready", func() {
+		It("should return error if we haven't observed the latest timestamp annotation", func() {
+			defer test.WithVars(
+				&backupentry.TimeNow, mockNow.Do,
+			)()
+			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+
+			By("deploy")
+			// Deploy should fill internal state with the added timestamp annotation
+			Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
+
+			By("patch object")
+			patch := client.MergeFrom(expected.DeepCopy())
 			expected.Status.LastError = nil
-			expected.ObjectMeta.Annotations = map[string]string{}
+			// remove operation annotation, add old timestamp annotation
+			expected.ObjectMeta.Annotations = map[string]string{
+				v1beta1constants.GardenerTimestamp: now.Add(-time.Millisecond).UTC().String(),
+			}
 			expected.Status.LastOperation = &gardencorev1beta1.LastOperation{
 				State: gardencorev1beta1.LastOperationStateSucceeded,
 			}
+			Expect(c.Patch(ctx, expected, patch)).To(Succeed(), "patching backupentry succeeds")
 
-			Expect(c.Create(ctx, expected)).To(Succeed(), "creating backupentry succeeds")
-			Expect(defaultDepWaiter.Wait(ctx)).To(Succeed(), "backupentry is ready, should not return an error")
+			By("wait")
+			Expect(defaultDepWaiter.Wait(ctx)).NotTo(Succeed(), "backupentry indicates error")
+		})
+
+		It("should return no error when it's ready", func() {
+			defer test.WithVars(
+				&backupentry.TimeNow, mockNow.Do,
+			)()
+			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+
+			By("deploy")
+			// Deploy should fill internal state with the added timestamp annotation
+			Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
+
+			By("patch object")
+			patch := client.MergeFrom(expected.DeepCopy())
+			expected.Status.LastError = nil
+			// remove operation annotation, add up-to-date timestamp annotation
+			expected.ObjectMeta.Annotations = map[string]string{
+				v1beta1constants.GardenerTimestamp: now.UTC().String(),
+			}
+			expected.Status.LastOperation = &gardencorev1beta1.LastOperation{
+				State: gardencorev1beta1.LastOperationStateSucceeded,
+			}
+			Expect(c.Patch(ctx, expected, patch)).To(Succeed(), "patching backupentry succeeds")
+
+			By("wait")
+			Expect(defaultDepWaiter.Wait(ctx)).To(Succeed(), "backupentry is ready")
 		})
 	})
 
@@ -190,21 +237,17 @@ var _ = Describe("#BackupEntry", func() {
 			)()
 
 			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
-
-			expected := extensionsv1alpha1.BackupEntry{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: name,
-					Annotations: map[string]string{
-						gutil.ConfirmationDeletion:         "true",
-						v1beta1constants.GardenerTimestamp: now.UTC().String(),
-					},
-				}}
-
 			mc := mockclient.NewMockClient(ctrl)
+
+			expected = empty.DeepCopy()
+			expected.SetAnnotations(map[string]string{
+				gutil.ConfirmationDeletion:         "true",
+				v1beta1constants.GardenerTimestamp: now.UTC().String(),
+			})
 
 			// add deletion confirmation and timestamp annotation
 			mc.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&extensionsv1alpha1.BackupEntry{}), gomock.Any()).Return(nil)
-			mc.EXPECT().Delete(ctx, &expected).Times(1).Return(fakeErr)
+			mc.EXPECT().Delete(ctx, expected).Times(1).Return(fakeErr)
 
 			defaultDepWaiter = backupentry.New(log, mc, &backupentry.Values{Name: name}, time.Millisecond, 250*time.Millisecond, 500*time.Millisecond)
 			Expect(defaultDepWaiter.Destroy(ctx)).To(MatchError(fakeErr))
@@ -214,6 +257,15 @@ var _ = Describe("#BackupEntry", func() {
 	Describe("#WaitCleanup", func() {
 		It("should not return error when it's already removed", func() {
 			Expect(defaultDepWaiter.WaitCleanup(ctx)).To(Succeed())
+		})
+
+		It("should return error when it's not deleted successfully", func() {
+			expected.Status.LastError = &gardencorev1beta1.LastError{
+				Description: "Some error",
+			}
+
+			Expect(c.Create(ctx, expected)).To(Succeed(), "creating backupentry succeeds")
+			Expect(defaultDepWaiter.WaitCleanup(ctx)).To(MatchError(ContainSubstring("Some error")))
 		})
 	})
 
@@ -238,26 +290,36 @@ var _ = Describe("#BackupEntry", func() {
 		})
 
 		It("should properly restore the BackupEntry state if it exists", func() {
+			// NB(timebertt): such tests with mocks are ridiculously hard to adapt to refactoring changes.
+			// Let's **please** just stop writing such tests with mocks and use a fake client or envtest instead.
+			// Testing with mocks does not only assert that the tested unit fulfills its task but also
+			// asserts that specific calls are made in order to fulfill its task. However, we/the caller don't
+			// care about what helper funcs are used internally or whether it uses update or patch to fullfill
+			// the task, as long as the result is what we expect (which is what should be asserted instead).
 			defer test.WithVars(
 				&backupentry.TimeNow, mockNow.Do,
 				&extensions.TimeNow, mockNow.Do,
 			)()
 			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
 
+			mc := mockclient.NewMockClient(ctrl)
+			mc.EXPECT().Status().Return(mc)
+
+			// deploy with wait-for-state annotation
 			obj := expected.DeepCopy()
 			metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "gardener.cloud/operation", "wait-for-state")
 			metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "gardener.cloud/timestamp", now.UTC().String())
 			obj.TypeMeta = metav1.TypeMeta{}
+			test.EXPECTPatch(ctx, mc, obj, empty, types.MergePatchType)
+
+			// restore state
 			expectedWithState := obj.DeepCopy()
 			expectedWithState.Status.State = state
-			expectedWithRestore := expectedWithState.DeepCopy()
-			expectedWithRestore.Annotations["gardener.cloud/operation"] = "restore"
+			test.EXPECTPatch(ctx, mc, expectedWithState, obj, types.MergePatchType)
 
-			mc := mockclient.NewMockClient(ctrl)
-			mc.EXPECT().Get(ctx, kutil.Key(expected.Namespace, expected.Name), gomock.AssignableToTypeOf(&extensionsv1alpha1.BackupEntry{})).Return(apierrors.NewNotFound(extensionsv1alpha1.Resource("BackupEntry"), expected.Name))
-			mc.EXPECT().Create(ctx, obj)
-			mc.EXPECT().Status().Return(mc)
-			mc.EXPECT().Update(ctx, expectedWithState)
+			// annotate with restore annotation
+			expectedWithRestore := expectedWithState.DeepCopy()
+			metav1.SetMetaDataAnnotation(&expectedWithRestore.ObjectMeta, "gardener.cloud/operation", "restore")
 			test.EXPECTPatch(ctx, mc, expectedWithRestore, expectedWithState, types.MergePatchType)
 
 			Expect(backupentry.New(log, mc, values, time.Millisecond, 250*time.Millisecond, 500*time.Millisecond).Restore(ctx, shootState)).To(Succeed())
@@ -271,21 +333,29 @@ var _ = Describe("#BackupEntry", func() {
 				&extensions.TimeNow, mockNow.Do,
 			)()
 			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
-
-			expectedCopy := expected.DeepCopy()
-			expectedCopy.Annotations[v1beta1constants.GardenerOperation] = v1beta1constants.GardenerOperationMigrate
-
 			mc := mockclient.NewMockClient(ctrl)
-			mc.EXPECT().Get(ctx, kutil.Key(name), gomock.AssignableToTypeOf(&extensionsv1alpha1.BackupEntry{})).SetArg(2, *expected)
-			test.EXPECTPatch(ctx, mc, expectedCopy, expected, types.MergePatchType)
+
+			expectedCopy := empty.DeepCopy()
+			metav1.SetMetaDataAnnotation(&expectedCopy.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationMigrate)
+			metav1.SetMetaDataAnnotation(&expectedCopy.ObjectMeta, v1beta1constants.GardenerTimestamp, now.UTC().String())
+			test.EXPECTPatch(ctx, mc, expectedCopy, empty, types.MergePatchType)
 
 			defaultDepWaiter = backupentry.New(log, mc, values, time.Millisecond, 250*time.Millisecond, 500*time.Millisecond)
 			Expect(defaultDepWaiter.Migrate(ctx)).To(Succeed())
 		})
 
 		It("should not return error if resource does not exist", func() {
+			defer test.WithVars(
+				&backupentry.TimeNow, mockNow.Do,
+				&extensions.TimeNow, mockNow.Do,
+			)()
+			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
 			mc := mockclient.NewMockClient(ctrl)
-			mc.EXPECT().Get(ctx, kutil.Key(name), gomock.AssignableToTypeOf(&extensionsv1alpha1.BackupEntry{})).Return(apierrors.NewNotFound(extensionsv1alpha1.Resource("BackupEntry"), expected.Name))
+
+			expectedCopy := empty.DeepCopy()
+			metav1.SetMetaDataAnnotation(&expectedCopy.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationMigrate)
+			metav1.SetMetaDataAnnotation(&expectedCopy.ObjectMeta, v1beta1constants.GardenerTimestamp, now.UTC().String())
+			test.EXPECTPatch(ctx, mc, expectedCopy, empty, types.MergePatchType)
 
 			defaultDepWaiter = backupentry.New(log, mc, values, time.Millisecond, 250*time.Millisecond, 500*time.Millisecond)
 			Expect(defaultDepWaiter.Migrate(ctx)).To(Succeed())

--- a/pkg/operation/botanist/component/extensions/containerruntime/containerruntime.go
+++ b/pkg/operation/botanist/component/extensions/containerruntime/containerruntime.go
@@ -23,6 +23,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/utils/flow"
@@ -31,7 +32,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 const (
@@ -68,6 +68,8 @@ type containerRuntime struct {
 	waitInterval        time.Duration
 	waitSevereThreshold time.Duration
 	waitTimeout         time.Duration
+
+	containerRuntimes map[string]*extensionsv1alpha1.ContainerRuntime
 }
 
 // New creates a new instance of Interface.
@@ -86,18 +88,33 @@ func New(
 		waitInterval:        waitInterval,
 		waitSevereThreshold: waitSevereThreshold,
 		waitTimeout:         waitTimeout,
+
+		containerRuntimes: make(map[string]*extensionsv1alpha1.ContainerRuntime),
 	}
 }
 
 // Deploy uses the seed client to create or update the ContainerRuntime resources.
 func (c *containerRuntime) Deploy(ctx context.Context) error {
-	fns := c.forEachContainerRuntime(func(ctx context.Context, workerName string, cr gardencorev1beta1.ContainerRuntime) error {
-		rd := resourceDeployer{c.values.Namespace, workerName, cr, c.client}
-		_, err := rd.deploy(ctx, v1beta1constants.GardenerOperationReconcile)
+	fns := c.forEachContainerRuntime(func(ctx context.Context, cr *extensionsv1alpha1.ContainerRuntime, coreCR gardencorev1beta1.ContainerRuntime, workerName string) error {
+		_, err := c.deploy(ctx, cr, coreCR, workerName, v1beta1constants.GardenerOperationReconcile)
 		return err
 	})
 
 	return flow.Parallel(fns...)(ctx)
+}
+
+func (c *containerRuntime) deploy(ctx context.Context, cr *extensionsv1alpha1.ContainerRuntime, coreCR gardencorev1beta1.ContainerRuntime, workerName, operation string) (extensionsv1alpha1.Object, error) {
+	_, err := controllerutils.MergePatchOrCreate(ctx, c.client, cr, func() error {
+		metav1.SetMetaDataAnnotation(&cr.ObjectMeta, v1beta1constants.GardenerOperation, operation)
+		metav1.SetMetaDataAnnotation(&cr.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
+		cr.Spec.BinaryPath = extensionsv1alpha1.ContainerDRuntimeContainersBinFolder
+		cr.Spec.Type = coreCR.Type
+		cr.Spec.ProviderConfig = coreCR.ProviderConfig
+		cr.Spec.WorkerPool.Name = workerName
+		cr.Spec.WorkerPool.Selector.MatchLabels = map[string]string{v1beta1constants.LabelWorkerPool: workerName, v1beta1constants.LabelWorkerPoolDeprecated: workerName}
+		return nil
+	})
+	return cr, err
 }
 
 // Destroy deletes the ContainerRuntime resources.
@@ -107,15 +124,13 @@ func (c *containerRuntime) Destroy(ctx context.Context) error {
 
 // Wait waits until the ContainerRuntime resources are ready.
 func (c *containerRuntime) Wait(ctx context.Context) error {
-	fns := c.forEachContainerRuntime(func(ctx context.Context, workerName string, cr gardencorev1beta1.ContainerRuntime) error {
-		return extensions.WaitUntilExtensionCRReady(
+	fns := c.forEachContainerRuntime(func(ctx context.Context, cr *extensionsv1alpha1.ContainerRuntime, _ gardencorev1beta1.ContainerRuntime, _ string) error {
+		return extensions.WaitUntilExtensionObjectReady(
 			ctx,
 			c.client,
 			c.logger,
-			func() client.Object { return &extensionsv1alpha1.ContainerRuntime{} },
+			cr,
 			extensionsv1alpha1.ContainerRuntimeResource,
-			c.values.Namespace,
-			getContainerRuntimeKey(cr.Type, workerName),
 			c.waitInterval,
 			c.waitSevereThreshold,
 			c.waitTimeout,
@@ -128,12 +143,11 @@ func (c *containerRuntime) Wait(ctx context.Context) error {
 
 // WaitCleanup waits until the ContainerRuntime resources are cleaned up.
 func (c *containerRuntime) WaitCleanup(ctx context.Context) error {
-	return extensions.WaitUntilExtensionCRsDeleted(
+	return extensions.WaitUntilExtensionObjectsDeleted(
 		ctx,
 		c.client,
 		c.logger,
 		&extensionsv1alpha1.ContainerRuntimeList{},
-		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.ContainerRuntime{} },
 		extensionsv1alpha1.ContainerRuntimeResource,
 		c.values.Namespace,
 		c.waitInterval,
@@ -144,9 +158,10 @@ func (c *containerRuntime) WaitCleanup(ctx context.Context) error {
 
 // Restore uses the seed client and the ShootState to create the ContainerRuntime resources and restore their state.
 func (c *containerRuntime) Restore(ctx context.Context, shootState *gardencorev1alpha1.ShootState) error {
-	fns := c.forEachContainerRuntime(func(ctx context.Context, workerName string, cr gardencorev1beta1.ContainerRuntime) error {
-		rd := resourceDeployer{c.values.Namespace, workerName, cr, c.client}
-		return extensions.RestoreExtensionWithDeployFunction(ctx, c.client, shootState, extensionsv1alpha1.ContainerRuntimeResource, c.values.Namespace, rd.deploy)
+	fns := c.forEachContainerRuntime(func(ctx context.Context, cr *extensionsv1alpha1.ContainerRuntime, coreCR gardencorev1beta1.ContainerRuntime, workerName string) error {
+		return extensions.RestoreExtensionWithDeployFunction(ctx, c.client, shootState, extensionsv1alpha1.ContainerRuntimeResource, func(ctx context.Context, operationAnnotation string) (extensionsv1alpha1.Object, error) {
+			return c.deploy(ctx, cr, coreCR, workerName, operationAnnotation)
+		})
 	})
 
 	return flow.Parallel(fns...)(ctx)
@@ -154,22 +169,20 @@ func (c *containerRuntime) Restore(ctx context.Context, shootState *gardencorev1
 
 // Migrate migrates the ContainerRuntime resources.
 func (c *containerRuntime) Migrate(ctx context.Context) error {
-	return extensions.MigrateExtensionCRs(
+	return extensions.MigrateExtensionObjects(
 		ctx,
 		c.client,
 		&extensionsv1alpha1.ContainerRuntimeList{},
-		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.ContainerRuntime{} },
 		c.values.Namespace,
 	)
 }
 
 // WaitMigrate waits until the ContainerRuntime resources are migrated successfully.
 func (c *containerRuntime) WaitMigrate(ctx context.Context) error {
-	return extensions.WaitUntilExtensionCRsMigrated(
+	return extensions.WaitUntilExtensionObjectsMigrated(
 		ctx,
 		c.client,
 		&extensionsv1alpha1.ContainerRuntimeList{},
-		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.ContainerRuntime{} },
 		c.values.Namespace,
 		c.waitInterval,
 		c.waitTimeout,
@@ -181,9 +194,8 @@ func (c *containerRuntime) DeleteStaleResources(ctx context.Context) error {
 	wantedContainerRuntimeTypes := sets.NewString()
 	for _, worker := range c.values.Workers {
 		if worker.CRI != nil {
-			for _, containerRuntime := range worker.CRI.ContainerRuntimes {
-				key := getContainerRuntimeKey(containerRuntime.Type, worker.Name)
-				wantedContainerRuntimeTypes.Insert(key)
+			for _, cr := range worker.CRI.ContainerRuntimes {
+				wantedContainerRuntimeTypes.Insert(getContainerRuntimeName(cr.Type, worker.Name))
 			}
 		}
 	}
@@ -191,33 +203,39 @@ func (c *containerRuntime) DeleteStaleResources(ctx context.Context) error {
 }
 
 func (c *containerRuntime) deleteContainerRuntimeResources(ctx context.Context, wantedContainerRuntimeTypes sets.String) error {
-	return extensions.DeleteExtensionCRs(
+	return extensions.DeleteExtensionObjects(
 		ctx,
 		c.client,
 		&extensionsv1alpha1.ContainerRuntimeList{},
-		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.ContainerRuntime{} },
 		c.values.Namespace,
 		func(obj extensionsv1alpha1.Object) bool {
-			cr, ok := obj.(*extensionsv1alpha1.ContainerRuntime)
-			if !ok {
-				return false
-			}
-			return !wantedContainerRuntimeTypes.Has(getContainerRuntimeKey(cr.Spec.Type, cr.Spec.WorkerPool.Name))
+			return !wantedContainerRuntimeTypes.Has(obj.GetName())
 		},
 	)
 }
 
-func (c *containerRuntime) forEachContainerRuntime(fn func(ctx context.Context, workerName string, cr gardencorev1beta1.ContainerRuntime) error) []flow.TaskFn {
+func (c *containerRuntime) forEachContainerRuntime(fn func(ctx context.Context, cr *extensionsv1alpha1.ContainerRuntime, coreCR gardencorev1beta1.ContainerRuntime, workerName string) error) []flow.TaskFn {
 	var fns []flow.TaskFn
 	for _, worker := range c.values.Workers {
 		if worker.CRI == nil {
 			continue
 		}
-		for _, containerRuntime := range worker.CRI.ContainerRuntimes {
-			cr := containerRuntime
-			workerName := worker.Name
+		for _, cr := range worker.CRI.ContainerRuntimes {
+			var (
+				workerName = worker.Name
+				coreCR     = cr
+				crName     = getContainerRuntimeName(coreCR.Type, workerName)
+			)
+
+			extensionCR, ok := c.containerRuntimes[crName]
+			if !ok {
+				extensionCR = c.emptyContainerRuntimeExtension(crName)
+				// store object for later usage (we want to pass a filled object to WaitUntil*)
+				c.containerRuntimes[crName] = extensionCR
+			}
+
 			fns = append(fns, func(ctx context.Context) error {
-				return fn(ctx, workerName, cr)
+				return fn(ctx, extensionCR, coreCR, workerName)
 			})
 		}
 	}
@@ -225,34 +243,15 @@ func (c *containerRuntime) forEachContainerRuntime(fn func(ctx context.Context, 
 	return fns
 }
 
-func getContainerRuntimeKey(criType, workerName string) string {
-	return fmt.Sprintf("%s-%s", criType, workerName)
-}
-
-type resourceDeployer struct {
-	namespace        string
-	workerName       string
-	containerRuntime gardencorev1beta1.ContainerRuntime
-	client           client.Client
-}
-
-func (d *resourceDeployer) deploy(ctx context.Context, operation string) (extensionsv1alpha1.Object, error) {
-	toApply := extensionsv1alpha1.ContainerRuntime{
+func (c *containerRuntime) emptyContainerRuntimeExtension(name string) *extensionsv1alpha1.ContainerRuntime {
+	return &extensionsv1alpha1.ContainerRuntime{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      getContainerRuntimeKey(d.containerRuntime.Type, d.workerName),
-			Namespace: d.namespace,
+			Name:      name,
+			Namespace: c.values.Namespace,
 		},
 	}
+}
 
-	_, err := controllerutil.CreateOrUpdate(ctx, d.client, &toApply, func() error {
-		metav1.SetMetaDataAnnotation(&toApply.ObjectMeta, v1beta1constants.GardenerOperation, operation)
-		metav1.SetMetaDataAnnotation(&toApply.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
-		toApply.Spec.BinaryPath = extensionsv1alpha1.ContainerDRuntimeContainersBinFolder
-		toApply.Spec.Type = d.containerRuntime.Type
-		toApply.Spec.ProviderConfig = d.containerRuntime.ProviderConfig
-		toApply.Spec.WorkerPool.Name = d.workerName
-		toApply.Spec.WorkerPool.Selector.MatchLabels = map[string]string{v1beta1constants.LabelWorkerPool: d.workerName, v1beta1constants.LabelWorkerPoolDeprecated: d.workerName}
-		return nil
-	})
-	return &toApply, err
+func getContainerRuntimeName(criType, workerName string) string {
+	return fmt.Sprintf("%s-%s", criType, workerName)
 }

--- a/pkg/operation/botanist/component/extensions/containerruntime/containerruntime.go
+++ b/pkg/operation/botanist/component/extensions/containerruntime/containerruntime.go
@@ -104,9 +104,10 @@ func (c *containerRuntime) Deploy(ctx context.Context) error {
 }
 
 func (c *containerRuntime) deploy(ctx context.Context, cr *extensionsv1alpha1.ContainerRuntime, coreCR gardencorev1beta1.ContainerRuntime, workerName, operation string) (extensionsv1alpha1.Object, error) {
-	_, err := controllerutils.MergePatchOrCreate(ctx, c.client, cr, func() error {
+	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, c.client, cr, func() error {
 		metav1.SetMetaDataAnnotation(&cr.ObjectMeta, v1beta1constants.GardenerOperation, operation)
 		metav1.SetMetaDataAnnotation(&cr.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
+
 		cr.Spec.BinaryPath = extensionsv1alpha1.ContainerDRuntimeContainersBinFolder
 		cr.Spec.Type = coreCR.Type
 		cr.Spec.ProviderConfig = coreCR.ProviderConfig

--- a/pkg/operation/botanist/component/extensions/containerruntime/containerruntime_test.go
+++ b/pkg/operation/botanist/component/extensions/containerruntime/containerruntime_test.go
@@ -21,9 +21,9 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/sirupsen/logrus"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -38,7 +38,6 @@ import (
 	mocktime "github.com/gardener/gardener/pkg/mock/go/time"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/containerruntime"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
-	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 
@@ -46,7 +45,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("#ContainerRuntimee", func() {
+var _ = Describe("#ContainerRuntime", func() {
 	const (
 		namespace = "test-namespace"
 	)
@@ -59,6 +58,7 @@ var _ = Describe("#ContainerRuntimee", func() {
 
 		ctx      context.Context
 		c        client.Client
+		empty    *extensionsv1alpha1.ContainerRuntime
 		expected []*extensionsv1alpha1.ContainerRuntime
 		values   *containerruntime.Values
 		log      logrus.FieldLogger
@@ -73,6 +73,7 @@ var _ = Describe("#ContainerRuntimee", func() {
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockNow = mocktime.NewMockNow(ctrl)
+		now = time.Now()
 
 		ctx = context.TODO()
 		log = logger.NewNopLogger()
@@ -98,6 +99,12 @@ var _ = Describe("#ContainerRuntimee", func() {
 					ContainerRuntimes: containerRuntimes,
 				},
 			})
+		}
+
+		empty = &extensionsv1alpha1.ContainerRuntime{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+			},
 		}
 
 		expected = []*extensionsv1alpha1.ContainerRuntime{}
@@ -153,6 +160,11 @@ var _ = Describe("#ContainerRuntimee", func() {
 			for _, e := range expected {
 				actual := &extensionsv1alpha1.ContainerRuntime{}
 				err := c.Get(ctx, client.ObjectKey{Name: e.Name, Namespace: e.Namespace}, actual)
+
+				// ignore changes to TypeMeta and resourceVersion
+				actual.SetGroupVersionKind(schema.GroupVersionKind{})
+				actual.SetResourceVersion("")
+
 				Expect(err).NotTo(HaveOccurred())
 				Expect(actual).To(DeepDerivativeEqual(e))
 			}
@@ -175,18 +187,60 @@ var _ = Describe("#ContainerRuntimee", func() {
 			Expect(defaultDepWaiter.Wait(ctx)).To(HaveOccurred(), "containerruntime indicates error")
 		})
 
-		It("should return no error when it's ready", func() {
+		It("should return error if we haven't observed the latest timestamp annotation", func() {
+			defer test.WithVars(
+				&containerruntime.TimeNow, mockNow.Do,
+			)()
+			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+
+			By("deploy")
+			// Deploy should fill internal state with the added timestamp annotation
+			Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
+
+			By("patch object")
 			for i := range expected {
-				// remove operation annotation
-				expected[i].ObjectMeta.Annotations = map[string]string{}
+				patch := client.MergeFrom(expected[i].DeepCopy())
+				// remove operation annotation, add old timestamp annotation
+				expected[i].ObjectMeta.Annotations = map[string]string{
+					v1beta1constants.GardenerTimestamp: now.Add(-time.Millisecond).UTC().String(),
+				}
 				// set last operation
 				expected[i].Status.LastOperation = &gardencorev1beta1.LastOperation{
 					State: gardencorev1beta1.LastOperationStateSucceeded,
 				}
-				Expect(c.Create(ctx, expected[i])).ToNot(HaveOccurred(), "creating containerruntime succeeds")
+				Expect(c.Patch(ctx, expected[i], patch)).ToNot(HaveOccurred(), "patching containerruntime succeeds")
 			}
 
-			Expect(defaultDepWaiter.Wait(ctx)).ToNot(HaveOccurred(), "containerruntime is ready, should not return an error")
+			By("wait")
+			Expect(defaultDepWaiter.Wait(ctx)).NotTo(Succeed(), "containerruntime indicates error")
+		})
+
+		It("should return no error when it's ready", func() {
+			defer test.WithVars(
+				&containerruntime.TimeNow, mockNow.Do,
+			)()
+			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+
+			By("deploy")
+			// Deploy should fill internal state with the added timestamp annotation
+			Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
+
+			By("patch object")
+			for i := range expected {
+				patch := client.MergeFrom(expected[i].DeepCopy())
+				// remove operation annotation, add up-to-date timestamp annotation
+				expected[i].ObjectMeta.Annotations = map[string]string{
+					v1beta1constants.GardenerTimestamp: now.UTC().String(),
+				}
+				// set last operation
+				expected[i].Status.LastOperation = &gardencorev1beta1.LastOperation{
+					State: gardencorev1beta1.LastOperationStateSucceeded,
+				}
+				Expect(c.Patch(ctx, expected[i], patch)).ToNot(HaveOccurred(), "patching containerruntime succeeds")
+			}
+
+			By("wait")
+			Expect(defaultDepWaiter.Wait(ctx)).To(Succeed(), "containerruntime is ready, should not return an error")
 		})
 	})
 
@@ -300,6 +354,8 @@ var _ = Describe("#ContainerRuntimee", func() {
 			)()
 
 			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+			mc := mockclient.NewMockClient(ctrl)
+			mc.EXPECT().Status().Return(mc)
 
 			worker := gardencorev1beta1.Worker{
 				Name: workerNames[0],
@@ -314,31 +370,30 @@ var _ = Describe("#ContainerRuntimee", func() {
 				},
 			}
 
+			// deploy with wait-for-state annotation
+			empty.SetName(expected[0].GetName())
 			expected[0].Annotations[v1beta1constants.GardenerOperation] = v1beta1constants.GardenerOperationWaitForState
+			expected[0].Annotations[v1beta1constants.GardenerTimestamp] = now.UTC().String()
+			test.EXPECTPatch(ctx, mc, expected[0], empty, types.MergePatchType)
+
+			// restore state
 			expectedWithState := expected[0].DeepCopy()
 			expectedWithState.Status = extensionsv1alpha1.ContainerRuntimeStatus{
 				DefaultStatus: extensionsv1alpha1.DefaultStatus{State: &runtime.RawExtension{Raw: []byte(`{"dummy":"state"}`)}},
 			}
+			test.EXPECTPatch(ctx, mc, expectedWithState, expected[0], types.MergePatchType)
+
+			// annotate with restore annotation
 			expectedWithRestore := expectedWithState.DeepCopy()
 			expectedWithRestore.Annotations[v1beta1constants.GardenerOperation] = v1beta1constants.GardenerOperationRestore
-
-			mc := mockclient.NewMockClient(ctrl)
-			mc.EXPECT().Get(ctx, kutil.Key(namespace, expected[0].Name), gomock.AssignableToTypeOf(&extensionsv1alpha1.ContainerRuntime{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, n *extensionsv1alpha1.ContainerRuntime) error {
-				return apierrors.NewNotFound(extensionsv1alpha1.Resource("ContainerRuntime"), expected[0].Name)
-			})
-			mc.EXPECT().Create(ctx, expected[0]).Return(nil).Times(1)
-			mc.EXPECT().Status().DoAndReturn(func() *mockclient.MockClient {
-				return mc
-			})
-			mc.EXPECT().Update(ctx, expectedWithState).Return(nil)
 			test.EXPECTPatch(ctx, mc, expectedWithRestore, expectedWithState, types.MergePatchType)
 
 			defaultDepWaiter = containerruntime.New(
 				log,
 				mc,
 				&containerruntime.Values{
-					namespace,
-					[]gardencorev1beta1.Worker{worker},
+					Namespace: namespace,
+					Workers:   []gardencorev1beta1.Worker{worker},
 				}, time.Millisecond, 250*time.Millisecond, 500*time.Millisecond)
 
 			Expect(defaultDepWaiter.Restore(ctx, shootState)).To(Succeed())

--- a/pkg/operation/botanist/component/extensions/controlplane/controlplane.go
+++ b/pkg/operation/botanist/component/extensions/controlplane/controlplane.go
@@ -81,23 +81,26 @@ func New(
 	waitSevereThreshold time.Duration,
 	waitTimeout time.Duration,
 ) Interface {
-	c := &controlPlane{
+	name := values.Name
+	if values.Purpose == extensionsv1alpha1.Exposure {
+		name += "-exposure"
+	}
+
+	return &controlPlane{
 		client:              client,
 		logger:              logger,
 		values:              values,
 		waitInterval:        waitInterval,
 		waitSevereThreshold: waitSevereThreshold,
 		waitTimeout:         waitTimeout,
-	}
 
-	c.controlPlane = &extensionsv1alpha1.ControlPlane{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      c.name(),
-			Namespace: c.values.Namespace,
+		controlPlane: &extensionsv1alpha1.ControlPlane{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: values.Namespace,
+			},
 		},
 	}
-
-	return c
 }
 
 type controlPlane struct {
@@ -110,13 +113,6 @@ type controlPlane struct {
 
 	controlPlane   *extensionsv1alpha1.ControlPlane
 	providerStatus *runtime.RawExtension
-}
-
-func (c *controlPlane) name() string {
-	if c.values.Purpose == extensionsv1alpha1.Exposure {
-		return c.values.Name + "-exposure"
-	}
-	return c.values.Name
 }
 
 // Deploy uses the seed client to create or update the ControlPlane resource.

--- a/pkg/operation/botanist/component/extensions/controlplane/controlplane.go
+++ b/pkg/operation/botanist/component/extensions/controlplane/controlplane.go
@@ -127,7 +127,7 @@ func (c *controlPlane) deploy(ctx context.Context, operation string) (extensions
 		providerConfig = &runtime.RawExtension{Raw: cfg.Raw}
 	}
 
-	_, err := controllerutils.MergePatchOrCreate(ctx, c.client, c.controlPlane, func() error {
+	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, c.client, c.controlPlane, func() error {
 		metav1.SetMetaDataAnnotation(&c.controlPlane.ObjectMeta, v1beta1constants.GardenerOperation, operation)
 		metav1.SetMetaDataAnnotation(&c.controlPlane.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
 

--- a/pkg/operation/botanist/component/extensions/controlplane/controlplane_test.go
+++ b/pkg/operation/botanist/component/extensions/controlplane/controlplane_test.go
@@ -21,6 +21,7 @@ import (
 
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/pkg/logger"
@@ -28,7 +29,6 @@ import (
 	mocktime "github.com/gardener/gardener/pkg/mock/go/time"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/controlplane"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
-	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 
@@ -36,7 +36,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -64,13 +63,8 @@ var _ = Describe("ControlPlane", func() {
 		providerConfig               = &runtime.RawExtension{Raw: []byte(`{"bar":"baz"}`)}
 		infrastructureProviderStatus = &runtime.RawExtension{Raw: []byte(`{"baz":"foo"}`)}
 
-		cp = &extensionsv1alpha1.ControlPlane{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: namespace,
-			},
-		}
-		cpSpec extensionsv1alpha1.ControlPlaneSpec
+		cp, empty *extensionsv1alpha1.ControlPlane
+		cpSpec    extensionsv1alpha1.ControlPlaneSpec
 
 		defaultDepWaiter controlplane.Interface
 		values           *controlplane.Values
@@ -79,10 +73,23 @@ var _ = Describe("ControlPlane", func() {
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockNow = mocktime.NewMockNow(ctrl)
+		now = time.Now()
 
 		s := runtime.NewScheme()
 		Expect(extensionsv1alpha1.AddToScheme(s)).NotTo(HaveOccurred())
 		c = fake.NewFakeClientWithScheme(s)
+
+		empty = &extensionsv1alpha1.ControlPlane{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+		}
+		cp = empty.DeepCopy()
+		cp.SetAnnotations(map[string]string{
+			v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
+			v1beta1constants.GardenerTimestamp: now.UTC().String(),
+		})
 
 		cpSpec = extensionsv1alpha1.ControlPlaneSpec{
 			DefaultSpec: extensionsv1alpha1.DefaultSpec{
@@ -191,30 +198,104 @@ var _ = Describe("ControlPlane", func() {
 			Expect(defaultDepWaiter.Wait(ctx)).To(HaveOccurred(), "controlplane indicates error")
 		})
 
-		It("should return no error when it's ready (purpose != exposure)", func() {
-			obj := cp.DeepCopy()
-			obj.Annotations = nil
-			obj.Status.LastOperation = &gardencorev1beta1.LastOperation{
+		It("should return error if we haven't observed the latest timestamp annotation (purpose != exposure)", func() {
+			defer test.WithVars(&controlplane.TimeNow, mockNow.Do)()
+			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+
+			By("deploy")
+			// Deploy should fill internal state with the added timestamp annotation
+			Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
+
+			By("patch object")
+			patch := client.MergeFrom(cp.DeepCopy())
+			// remove operation annotation, add old timestamp annotation
+			cp.ObjectMeta.Annotations = map[string]string{
+				v1beta1constants.GardenerTimestamp: now.Add(-time.Millisecond).UTC().String(),
+			}
+			cp.Status.LastOperation = &gardencorev1beta1.LastOperation{
 				State: gardencorev1beta1.LastOperationStateSucceeded,
 			}
-			Expect(c.Create(ctx, obj)).To(Succeed(), "creating controlplane succeeds")
+			Expect(c.Patch(ctx, cp, patch)).To(Succeed(), "patching controlplane succeeds")
 
-			Expect(defaultDepWaiter.Wait(ctx)).To(Succeed(), "controlplane is ready, should not return an error")
+			By("wait")
+			Expect(defaultDepWaiter.Wait(ctx)).NotTo(Succeed(), "controlplane indicates error")
+		})
+
+		It("should return no error when it's ready (purpose != exposure)", func() {
+			defer test.WithVars(&controlplane.TimeNow, mockNow.Do)()
+			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+
+			By("deploy")
+			// Deploy should fill internal state with the added timestamp annotation
+			Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
+
+			By("patch object")
+			patch := client.MergeFrom(cp.DeepCopy())
+			// remove operation annotation, add up-to-date timestamp annotation
+			cp.ObjectMeta.Annotations = map[string]string{
+				v1beta1constants.GardenerTimestamp: now.UTC().String(),
+			}
+			cp.Status.LastOperation = &gardencorev1beta1.LastOperation{
+				State: gardencorev1beta1.LastOperationStateSucceeded,
+			}
+			Expect(c.Patch(ctx, cp, patch)).To(Succeed(), "patching controlplane succeeds")
+
+			By("wait")
+			Expect(defaultDepWaiter.Wait(ctx)).To(Succeed(), "controlplane is ready")
+		})
+
+		It("should return error if we haven't observed the latest timestamp annotation (purpose == exposure)", func() {
+			defer test.WithVars(&controlplane.TimeNow, mockNow.Do)()
+			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+
+			values.Purpose = extensionsv1alpha1.Exposure
+			defaultDepWaiter = controlplane.New(log, c, values, time.Millisecond, 250*time.Millisecond, 500*time.Millisecond)
+			cp.Name += "-exposure"
+
+			By("deploy")
+			// Deploy should fill internal state with the added timestamp annotation
+			Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
+
+			By("patch object")
+			patch := client.MergeFrom(cp.DeepCopy())
+			// remove operation annotation, add old timestamp annotation
+			cp.ObjectMeta.Annotations = map[string]string{
+				v1beta1constants.GardenerTimestamp: now.Add(-time.Millisecond).UTC().String(),
+			}
+			cp.Status.LastOperation = &gardencorev1beta1.LastOperation{
+				State: gardencorev1beta1.LastOperationStateSucceeded,
+			}
+			Expect(c.Patch(ctx, cp, patch)).To(Succeed(), "patching controlplane succeeds")
+
+			By("wait")
+			Expect(defaultDepWaiter.Wait(ctx)).NotTo(Succeed(), "controlplane indicates error")
 		})
 
 		It("should return no error when it's ready (purpose == exposure)", func() {
+			defer test.WithVars(&controlplane.TimeNow, mockNow.Do)()
+			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+
 			values.Purpose = extensionsv1alpha1.Exposure
 			defaultDepWaiter = controlplane.New(log, c, values, time.Millisecond, 250*time.Millisecond, 500*time.Millisecond)
+			cp.Name += "-exposure"
 
-			obj := cp.DeepCopy()
-			obj.Name += "-exposure"
-			obj.Annotations = nil
-			obj.Status.LastOperation = &gardencorev1beta1.LastOperation{
+			By("deploy")
+			// Deploy should fill internal state with the added timestamp annotation
+			Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
+
+			By("patch object")
+			patch := client.MergeFrom(cp.DeepCopy())
+			// remove operation annotation, add up-to-date timestamp annotation
+			cp.ObjectMeta.Annotations = map[string]string{
+				v1beta1constants.GardenerTimestamp: now.UTC().String(),
+			}
+			cp.Status.LastOperation = &gardencorev1beta1.LastOperation{
 				State: gardencorev1beta1.LastOperationStateSucceeded,
 			}
-			Expect(c.Create(ctx, obj)).To(Succeed(), "creating controlplane succeeds")
+			Expect(c.Patch(ctx, cp, patch)).To(Succeed(), "patching controlplane succeeds")
 
-			Expect(defaultDepWaiter.Wait(ctx)).To(Succeed(), "controlplane is ready, should not return an error")
+			By("wait")
+			Expect(defaultDepWaiter.Wait(ctx)).To(Succeed(), "controlplane is ready")
 		})
 	})
 
@@ -330,20 +411,24 @@ var _ = Describe("ControlPlane", func() {
 			)()
 			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
 
+			mc := mockclient.NewMockClient(ctrl)
+			mc.EXPECT().Status().Return(mc)
+
+			// deploy with wait-for-state annotation
 			obj := cp.DeepCopy()
 			obj.Spec = cpSpec
 			metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "gardener.cloud/operation", "wait-for-state")
 			metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "gardener.cloud/timestamp", now.UTC().String())
+			test.EXPECTPatch(ctx, mc, obj, empty, types.MergePatchType)
+
+			// restore state
 			expectedWithState := obj.DeepCopy()
 			expectedWithState.Status.State = state
-			expectedWithRestore := expectedWithState.DeepCopy()
-			expectedWithRestore.Annotations["gardener.cloud/operation"] = "restore"
+			test.EXPECTPatch(ctx, mc, expectedWithState, obj, types.MergePatchType)
 
-			mc := mockclient.NewMockClient(ctrl)
-			mc.EXPECT().Get(ctx, kutil.Key(namespace, name), gomock.AssignableToTypeOf(&extensionsv1alpha1.ControlPlane{})).Return(apierrors.NewNotFound(extensionsv1alpha1.Resource("ControlPlane"), name))
-			mc.EXPECT().Create(ctx, obj)
-			mc.EXPECT().Status().Return(mc)
-			mc.EXPECT().Update(ctx, expectedWithState)
+			// annotate with restore annotation
+			expectedWithRestore := expectedWithState.DeepCopy()
+			metav1.SetMetaDataAnnotation(&expectedWithRestore.ObjectMeta, "gardener.cloud/operation", "restore")
 			test.EXPECTPatch(ctx, mc, expectedWithRestore, expectedWithState, types.MergePatchType)
 
 			Expect(controlplane.New(log, mc, values, time.Millisecond, 250*time.Millisecond, 500*time.Millisecond).Restore(ctx, shootState)).To(Succeed())
@@ -356,29 +441,33 @@ var _ = Describe("ControlPlane", func() {
 			)()
 			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
 
+			mc := mockclient.NewMockClient(ctrl)
+			mc.EXPECT().Status().Return(mc)
+
+			// deploy with wait-for-state annotation
 			values.Purpose = extensionsv1alpha1.Exposure
+			empty.Name += "-exposure"
+			cp.Name += "-exposure"
 			obj := cp.DeepCopy()
-			obj.Name += "-exposure"
 			obj.Spec = cpSpec
 			obj.Spec.Purpose = &values.Purpose
-			shootState.Spec.Extensions[0].Name = &obj.Name
-			shootState.Spec.Extensions[0].Purpose = pointer.StringPtr(string(values.Purpose))
 			metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "gardener.cloud/operation", "wait-for-state")
 			metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "gardener.cloud/timestamp", now.UTC().String())
+			test.EXPECTPatch(ctx, mc, obj, empty, types.MergePatchType)
+
+			// restore state
+			shootState.Spec.Extensions[0].Name = &obj.Name
+			shootState.Spec.Extensions[0].Purpose = pointer.StringPtr(string(values.Purpose))
 			expectedWithState := obj.DeepCopy()
 			expectedWithState.Status.State = state
+			test.EXPECTPatch(ctx, mc, expectedWithState, obj, types.MergePatchType)
+
+			// annotate with restore annotation
 			expectedWithRestore := expectedWithState.DeepCopy()
 			expectedWithRestore.Annotations["gardener.cloud/operation"] = "restore"
-
-			mc := mockclient.NewMockClient(ctrl)
-			mc.EXPECT().Get(ctx, kutil.Key(obj.Namespace, obj.Name), gomock.AssignableToTypeOf(&extensionsv1alpha1.ControlPlane{})).Return(apierrors.NewNotFound(extensionsv1alpha1.Resource("ControlPlane"), obj.Name))
-			mc.EXPECT().Create(ctx, obj)
-			mc.EXPECT().Status().Return(mc)
-			mc.EXPECT().Update(ctx, expectedWithState)
 			test.EXPECTPatch(ctx, mc, expectedWithRestore, expectedWithState, types.MergePatchType)
 
-			defaultDepWaiter = controlplane.New(log, mc, values, time.Millisecond, 250*time.Millisecond, 500*time.Millisecond)
-			Expect(defaultDepWaiter.Restore(ctx, shootState)).To(Succeed())
+			Expect(controlplane.New(log, mc, values, time.Millisecond, 250*time.Millisecond, 500*time.Millisecond).Restore(ctx, shootState)).To(Succeed())
 		})
 	})
 

--- a/pkg/operation/botanist/component/extensions/extension/extension.go
+++ b/pkg/operation/botanist/component/extensions/extension/extension.go
@@ -113,7 +113,7 @@ func (e *extension) Deploy(ctx context.Context) error {
 }
 
 func (e *extension) deploy(ctx context.Context, ext *extensionsv1alpha1.Extension, extType string, providerConfig *runtime.RawExtension, operation string) (extensionsv1alpha1.Object, error) {
-	_, err := controllerutils.MergePatchOrCreate(ctx, e.client, ext, func() error {
+	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, e.client, ext, func() error {
 		metav1.SetMetaDataAnnotation(&ext.ObjectMeta, v1beta1constants.GardenerOperation, operation)
 		metav1.SetMetaDataAnnotation(&ext.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
 		ext.Spec.Type = extType

--- a/pkg/operation/botanist/component/extensions/extension/extension.go
+++ b/pkg/operation/botanist/component/extensions/extension/extension.go
@@ -21,15 +21,16 @@ import (
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/utils/flow"
 
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 const (
@@ -76,6 +77,8 @@ type extension struct {
 	waitInterval        time.Duration
 	waitSevereThreshold time.Duration
 	waitTimeout         time.Duration
+
+	extensions map[string]*extensionsv1alpha1.Extension
 }
 
 // New creates a new instance of Extension deployer.
@@ -94,19 +97,30 @@ func New(
 		waitInterval:        waitInterval,
 		waitSevereThreshold: waitSevereThreshold,
 		waitTimeout:         waitTimeout,
+
+		extensions: make(map[string]*extensionsv1alpha1.Extension),
 	}
 }
 
 // Deploy uses the seed client to create or update the Extension resources.
 func (e *extension) Deploy(ctx context.Context) error {
-	fns := e.forEach(func(ctx context.Context, extension extensionsv1alpha1.Extension, _ time.Duration) error {
-		deployer := &deployer{e.client, extension}
-
-		_, err := deployer.deploy(ctx, v1beta1constants.GardenerOperationReconcile)
+	fns := e.forEach(func(ctx context.Context, ext *extensionsv1alpha1.Extension, extType string, providerConfig *runtime.RawExtension, _ time.Duration) error {
+		_, err := e.deploy(ctx, ext, extType, providerConfig, v1beta1constants.GardenerOperationReconcile)
 		return err
 	})
 
 	return flow.Parallel(fns...)(ctx)
+}
+
+func (e *extension) deploy(ctx context.Context, ext *extensionsv1alpha1.Extension, extType string, providerConfig *runtime.RawExtension, operation string) (extensionsv1alpha1.Object, error) {
+	_, err := controllerutils.MergePatchOrCreate(ctx, e.client, ext, func() error {
+		metav1.SetMetaDataAnnotation(&ext.ObjectMeta, v1beta1constants.GardenerOperation, operation)
+		metav1.SetMetaDataAnnotation(&ext.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
+		ext.Spec.Type = extType
+		ext.Spec.ProviderConfig = providerConfig
+		return nil
+	})
+	return ext, err
 }
 
 // Destroy deletes all the Extension resources.
@@ -116,15 +130,13 @@ func (e *extension) Destroy(ctx context.Context) error {
 
 // Wait waits until the Extension resources are ready.
 func (e *extension) Wait(ctx context.Context) error {
-	fns := e.forEach(func(ctx context.Context, extension extensionsv1alpha1.Extension, timeout time.Duration) error {
-		return extensions.WaitUntilExtensionCRReady(
+	fns := e.forEach(func(ctx context.Context, ext *extensionsv1alpha1.Extension, _ string, _ *runtime.RawExtension, timeout time.Duration) error {
+		return extensions.WaitUntilExtensionObjectReady(
 			ctx,
 			e.client,
 			e.logger,
-			func() client.Object { return &extensionsv1alpha1.Extension{} },
+			ext,
 			extensionsv1alpha1.ExtensionResource,
-			extension.Namespace,
-			extension.Name,
 			e.waitInterval,
 			e.waitSevereThreshold,
 			timeout,
@@ -137,12 +149,11 @@ func (e *extension) Wait(ctx context.Context) error {
 
 // WaitCleanup waits until the Extension resources are cleaned up.
 func (e *extension) WaitCleanup(ctx context.Context) error {
-	return extensions.WaitUntilExtensionCRsDeleted(
+	return extensions.WaitUntilExtensionObjectsDeleted(
 		ctx,
 		e.client,
 		e.logger,
 		&extensionsv1alpha1.ExtensionList{},
-		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Extension{} },
 		extensionsv1alpha1.ExtensionResource,
 		e.values.Namespace,
 		e.waitInterval,
@@ -153,16 +164,15 @@ func (e *extension) WaitCleanup(ctx context.Context) error {
 
 // Restore uses the seed client and the ShootState to create the Extension resources and restore their state.
 func (e *extension) Restore(ctx context.Context, shootState *gardencorev1alpha1.ShootState) error {
-	fns := e.forEach(func(ctx context.Context, extension extensionsv1alpha1.Extension, _ time.Duration) error {
-		deployer := &deployer{e.client, extension}
-
+	fns := e.forEach(func(ctx context.Context, ext *extensionsv1alpha1.Extension, extType string, providerConfig *runtime.RawExtension, _ time.Duration) error {
 		return extensions.RestoreExtensionWithDeployFunction(
 			ctx,
 			e.client,
 			shootState,
 			extensionsv1alpha1.ExtensionResource,
-			e.values.Namespace,
-			deployer.deploy,
+			func(ctx context.Context, operationAnnotation string) (extensionsv1alpha1.Object, error) {
+				return e.deploy(ctx, ext, extType, providerConfig, operationAnnotation)
+			},
 		)
 	})
 
@@ -171,22 +181,20 @@ func (e *extension) Restore(ctx context.Context, shootState *gardencorev1alpha1.
 
 // Migrate migrates the Extension resources.
 func (e *extension) Migrate(ctx context.Context) error {
-	return extensions.MigrateExtensionCRs(
+	return extensions.MigrateExtensionObjects(
 		ctx,
 		e.client,
 		&extensionsv1alpha1.ExtensionList{},
-		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Extension{} },
 		e.values.Namespace,
 	)
 }
 
 // WaitMigrate waits until the Extension resources are migrated successfully.
 func (e *extension) WaitMigrate(ctx context.Context) error {
-	return extensions.WaitUntilExtensionCRsMigrated(
+	return extensions.WaitUntilExtensionObjectsMigrated(
 		ctx,
 		e.client,
 		&extensionsv1alpha1.ExtensionList{},
-		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Extension{} },
 		e.values.Namespace,
 		e.waitInterval,
 		e.waitTimeout,
@@ -203,11 +211,10 @@ func (e *extension) DeleteStaleResources(ctx context.Context) error {
 }
 
 func (e *extension) deleteExtensionResources(ctx context.Context, wantedExtensionTypes sets.String) error {
-	return extensions.DeleteExtensionCRs(
+	return extensions.DeleteExtensionObjects(
 		ctx,
 		e.client,
 		&extensionsv1alpha1.ExtensionList{},
-		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Extension{} },
 		e.values.Namespace,
 		func(obj extensionsv1alpha1.Object) bool {
 			return !wantedExtensionTypes.Has(obj.GetExtensionSpec().GetExtensionType())
@@ -215,15 +222,26 @@ func (e *extension) deleteExtensionResources(ctx context.Context, wantedExtensio
 	)
 }
 
-func (e *extension) forEach(fn func(context.Context, extensionsv1alpha1.Extension, time.Duration) error) []flow.TaskFn {
+func (e *extension) forEach(fn func(ctx context.Context, ext *extensionsv1alpha1.Extension, extType string, providerConfig *runtime.RawExtension, timeout time.Duration) error) []flow.TaskFn {
 	fns := make([]flow.TaskFn, 0, len(e.values.Extensions))
 
 	for _, ext := range e.values.Extensions {
-		obj := ext.Extension
-		timeout := ext.Timeout
+		extensionTemplate := ext
+
+		extensionObj, ok := e.extensions[extensionTemplate.Name]
+		if !ok {
+			extensionObj = &extensionsv1alpha1.Extension{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      extensionTemplate.Name,
+					Namespace: e.values.Namespace,
+				},
+			}
+			// store object for later usage (we want to pass a filled object to WaitUntil*)
+			e.extensions[extensionTemplate.Name] = extensionObj
+		}
 
 		fns = append(fns, func(ctx context.Context) error {
-			return fn(ctx, obj, timeout)
+			return fn(ctx, extensionObj, extensionTemplate.Spec.Type, extensionTemplate.Spec.ProviderConfig, extensionTemplate.Timeout)
 		})
 	}
 
@@ -233,28 +251,4 @@ func (e *extension) forEach(fn func(context.Context, extensionsv1alpha1.Extensio
 // Extensions returns the map of extensions where the key is the type and the value is an Extension structure.
 func (e *extension) Extensions() map[string]Extension {
 	return e.values.Extensions
-}
-
-type deployer struct {
-	client client.Client
-	obj    extensionsv1alpha1.Extension
-}
-
-func (d *deployer) deploy(ctx context.Context, operation string) (extensionsv1alpha1.Object, error) {
-	obj := &extensionsv1alpha1.Extension{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      d.obj.Name,
-			Namespace: d.obj.Namespace,
-		},
-	}
-
-	_, err := controllerutil.CreateOrUpdate(ctx, d.client, obj, func() error {
-		metav1.SetMetaDataAnnotation(&obj.ObjectMeta, v1beta1constants.GardenerOperation, operation)
-		metav1.SetMetaDataAnnotation(&obj.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
-		obj.Spec.Type = d.obj.Spec.Type
-		obj.Spec.ProviderConfig = d.obj.Spec.ProviderConfig
-		return nil
-	})
-
-	return obj, err
 }

--- a/pkg/operation/botanist/component/extensions/extension/extension_test.go
+++ b/pkg/operation/botanist/component/extensions/extension/extension_test.go
@@ -31,6 +31,7 @@ import (
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/golang/mock/gomock"
 	"github.com/hashicorp/go-multierror"
@@ -310,11 +311,18 @@ var _ = Describe("Extension", func() {
 			mc := mockclient.NewMockClient(ctrl)
 			mc.EXPECT().Status().Return(mc)
 
-			// deploy with wait-for-state annotation
 			empty.SetName(expected[0].GetName())
+			mc.EXPECT().Get(ctx, client.ObjectKeyFromObject(empty), gomock.AssignableToTypeOf(empty)).
+				Return(apierrors.NewNotFound(extensionsv1alpha1.Resource("extensions"), empty.GetName()))
+
+			// deploy with wait-for-state annotation
 			expected[0].Annotations[v1beta1constants.GardenerOperation] = v1beta1constants.GardenerOperationWaitForState
 			expected[0].Annotations[v1beta1constants.GardenerTimestamp] = now.UTC().String()
-			test.EXPECTPatch(ctx, mc, expected[0], empty, types.MergePatchType)
+			mc.EXPECT().Create(ctx, test.HasObjectKeyOf(expected[0])).
+				DoAndReturn(func(ctx context.Context, actual client.Object, opts ...client.CreateOption) error {
+					Expect(actual).To(DeepEqual(expected[0]))
+					return nil
+				})
 
 			// restore state
 			expectedWithState := expected[0].DeepCopy()

--- a/pkg/operation/botanist/component/extensions/infrastructure/infrastructure.go
+++ b/pkg/operation/botanist/component/extensions/infrastructure/infrastructure.go
@@ -16,22 +16,20 @@ package infrastructure
 
 import (
 	"context"
-	"fmt"
 	"time"
+
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/controllerutils"
+	"github.com/gardener/gardener/pkg/extensions"
+	"github.com/gardener/gardener/pkg/operation/botanist/component"
 
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-
-	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	"github.com/gardener/gardener/pkg/extensions"
-	"github.com/gardener/gardener/pkg/operation/botanist/component"
-	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 const (
@@ -97,6 +95,13 @@ func New(
 		waitInterval:        waitInterval,
 		waitSevereThreshold: waitSevereThreshold,
 		waitTimeout:         waitTimeout,
+
+		infrastructure: &extensionsv1alpha1.Infrastructure{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      values.Name,
+				Namespace: values.Namespace,
+			},
+		},
 	}
 }
 
@@ -108,6 +113,7 @@ type infrastructure struct {
 	waitSevereThreshold time.Duration
 	waitTimeout         time.Duration
 
+	infrastructure *extensionsv1alpha1.Infrastructure
 	providerStatus *runtime.RawExtension
 	nodesCIDR      *string
 }
@@ -119,29 +125,20 @@ func (i *infrastructure) Deploy(ctx context.Context) error {
 }
 
 func (i *infrastructure) deploy(ctx context.Context, operation string) (extensionsv1alpha1.Object, error) {
-	var (
-		infra = &extensionsv1alpha1.Infrastructure{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      i.values.Name,
-				Namespace: i.values.Namespace,
-			},
-		}
-		providerConfig *runtime.RawExtension
-	)
-
+	var providerConfig *runtime.RawExtension
 	if cfg := i.values.ProviderConfig; cfg != nil {
 		providerConfig = &runtime.RawExtension{
 			Raw: cfg.Raw,
 		}
 	}
 
-	_, err := controllerutil.CreateOrUpdate(ctx, i.client, infra, func() error {
+	_, err := controllerutils.MergePatchOrCreate(ctx, i.client, i.infrastructure, func() error {
 		if i.values.AnnotateOperation {
-			metav1.SetMetaDataAnnotation(&infra.ObjectMeta, v1beta1constants.GardenerOperation, operation)
-			metav1.SetMetaDataAnnotation(&infra.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
+			metav1.SetMetaDataAnnotation(&i.infrastructure.ObjectMeta, v1beta1constants.GardenerOperation, operation)
+			metav1.SetMetaDataAnnotation(&i.infrastructure.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
 		}
 
-		infra.Spec = extensionsv1alpha1.InfrastructureSpec{
+		i.infrastructure.Spec = extensionsv1alpha1.InfrastructureSpec{
 			DefaultSpec: extensionsv1alpha1.DefaultSpec{
 				Type:           i.values.Type,
 				ProviderConfig: providerConfig,
@@ -150,13 +147,13 @@ func (i *infrastructure) deploy(ctx context.Context, operation string) (extensio
 			SSHPublicKey: i.values.SSHPublicKey,
 			SecretRef: corev1.SecretReference{
 				Name:      v1beta1constants.SecretNameCloudProvider,
-				Namespace: infra.Namespace,
+				Namespace: i.infrastructure.Namespace,
 			},
 		}
 		return nil
 	})
 
-	return infra, err
+	return i.infrastructure, err
 }
 
 // Restore uses the seed client and the ShootState to create the Infrastructure resources and restore their state.
@@ -166,66 +163,51 @@ func (i *infrastructure) Restore(ctx context.Context, shootState *gardencorev1al
 		i.client,
 		shootState,
 		extensionsv1alpha1.InfrastructureResource,
-		i.values.Namespace,
 		i.deploy,
 	)
 }
 
 // Migrate migrates the Infrastructure resources.
 func (i *infrastructure) Migrate(ctx context.Context) error {
-	return extensions.MigrateExtensionCR(
+	return extensions.MigrateExtensionObject(
 		ctx,
 		i.client,
-		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Infrastructure{} },
-		i.values.Namespace,
-		i.values.Name,
+		i.infrastructure,
 	)
 }
 
 // Destroy deletes the Infrastructure resource.
 func (i *infrastructure) Destroy(ctx context.Context) error {
-	return extensions.DeleteExtensionCR(
+	return extensions.DeleteExtensionObject(
 		ctx,
 		i.client,
-		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Infrastructure{} },
-		i.values.Namespace,
-		i.values.Name,
+		i.infrastructure,
 	)
 }
 
 // Wait waits until the Infrastructure resource is ready.
 func (i *infrastructure) Wait(ctx context.Context) error {
-	return extensions.WaitUntilExtensionCRReady(
+	return extensions.WaitUntilExtensionObjectReady(
 		ctx,
 		i.client,
 		i.logger,
-		func() client.Object { return &extensionsv1alpha1.Infrastructure{} },
+		i.infrastructure,
 		extensionsv1alpha1.InfrastructureResource,
-		i.values.Namespace,
-		i.values.Name,
 		i.waitInterval,
 		i.waitSevereThreshold,
 		i.waitTimeout,
-		func(obj client.Object) error {
-			infrastructure, ok := obj.(*extensionsv1alpha1.Infrastructure)
-			if !ok {
-				return fmt.Errorf("expected extensionsv1alpha1.Infrastructure but got %T", infrastructure)
-			}
-
-			i.extractStatus(infrastructure.Status)
+		func() error {
+			i.extractStatus(i.infrastructure.Status)
 			return nil
-		},
-	)
+		})
 }
 
 // WaitMigrate waits until the Infrastructure resources are migrated successfully.
 func (i *infrastructure) WaitMigrate(ctx context.Context) error {
-	return extensions.WaitUntilExtensionCRMigrated(
+	return extensions.WaitUntilExtensionObjectMigrated(
 		ctx,
 		i.client,
-		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Infrastructure{} },
-		i.values.Namespace,
-		i.values.Name,
+		i.infrastructure,
 		i.waitInterval,
 		i.waitTimeout,
 	)
@@ -233,14 +215,12 @@ func (i *infrastructure) WaitMigrate(ctx context.Context) error {
 
 // WaitCleanup waits until the Infrastructure resource is deleted.
 func (i *infrastructure) WaitCleanup(ctx context.Context) error {
-	return extensions.WaitUntilExtensionCRDeleted(
+	return extensions.WaitUntilExtensionObjectDeleted(
 		ctx,
 		i.client,
 		i.logger,
-		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Infrastructure{} },
+		i.infrastructure,
 		extensionsv1alpha1.InfrastructureResource,
-		i.values.Namespace,
-		i.values.Name,
 		i.waitInterval,
 		i.waitTimeout,
 	)
@@ -248,13 +228,12 @@ func (i *infrastructure) WaitCleanup(ctx context.Context) error {
 
 // Get retrieves and returns the Infrastructure resources based on the configured values.
 func (i *infrastructure) Get(ctx context.Context) (*extensionsv1alpha1.Infrastructure, error) {
-	obj := &extensionsv1alpha1.Infrastructure{}
-	if err := i.client.Get(ctx, kutil.Key(i.values.Namespace, i.values.Name), obj); err != nil {
+	if err := i.client.Get(ctx, client.ObjectKeyFromObject(i.infrastructure), i.infrastructure); err != nil {
 		return nil, err
 	}
 
-	i.extractStatus(obj.Status)
-	return obj, nil
+	i.extractStatus(i.infrastructure.Status)
+	return i.infrastructure, nil
 }
 
 // SetSSHPublicKey sets the SSH public key in the values.

--- a/pkg/operation/botanist/component/extensions/infrastructure/infrastructure.go
+++ b/pkg/operation/botanist/component/extensions/infrastructure/infrastructure.go
@@ -132,7 +132,7 @@ func (i *infrastructure) deploy(ctx context.Context, operation string) (extensio
 		}
 	}
 
-	_, err := controllerutils.MergePatchOrCreate(ctx, i.client, i.infrastructure, func() error {
+	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, i.client, i.infrastructure, func() error {
 		if i.values.AnnotateOperation {
 			metav1.SetMetaDataAnnotation(&i.infrastructure.ObjectMeta, v1beta1constants.GardenerOperation, operation)
 			metav1.SetMetaDataAnnotation(&i.infrastructure.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())

--- a/pkg/operation/botanist/component/extensions/infrastructure/infrastructure_test.go
+++ b/pkg/operation/botanist/component/extensions/infrastructure/infrastructure_test.go
@@ -29,22 +29,21 @@ import (
 	mocktime "github.com/gardener/gardener/pkg/mock/go/time"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/infrastructure"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
-	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/retry"
 	retryfake "github.com/gardener/gardener/pkg/utils/retry/fake"
 	"github.com/gardener/gardener/pkg/utils/test"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -62,7 +61,7 @@ var _ = Describe("#Interface", func() {
 		fakeErr = errors.New("fake")
 
 		ctrl    *gomock.Controller
-		c       *mockclient.MockClient
+		c       client.Client
 		mockNow *mocktime.MockNow
 		now     time.Time
 
@@ -72,11 +71,10 @@ var _ = Describe("#Interface", func() {
 		providerStatus *runtime.RawExtension
 		nodesCIDR      *string
 
-		infra        *extensionsv1alpha1.Infrastructure
-		infraSpec    extensionsv1alpha1.InfrastructureSpec
-		values       *infrastructure.Values
-		deployWaiter infrastructure.Interface
-		waiter       *retryfake.Ops
+		empty, expected *extensionsv1alpha1.Infrastructure
+		values          *infrastructure.Values
+		deployWaiter    infrastructure.Interface
+		waiter          *retryfake.Ops
 
 		cleanupFunc func()
 	)
@@ -86,8 +84,12 @@ var _ = Describe("#Interface", func() {
 		log = logger.NewNopLogger()
 
 		ctrl = gomock.NewController(GinkgoT())
-		c = mockclient.NewMockClient(ctrl)
 		mockNow = mocktime.NewMockNow(ctrl)
+		now = time.Now()
+
+		s := runtime.NewScheme()
+		Expect(extensionsv1alpha1.AddToScheme(s)).To(Succeed())
+		c = fake.NewFakeClientWithScheme(s)
 
 		region = "europe"
 		sshPublicKey = []byte("secure")
@@ -102,22 +104,38 @@ var _ = Describe("#Interface", func() {
 			ProviderConfig: providerConfig,
 			Region:         region,
 		}
-		infra = &extensionsv1alpha1.Infrastructure{
+
+		empty = &extensionsv1alpha1.Infrastructure{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
 				Namespace: namespace,
 			},
 		}
-		infraSpec = extensionsv1alpha1.InfrastructureSpec{
-			DefaultSpec: extensionsv1alpha1.DefaultSpec{
-				Type:           providerType,
-				ProviderConfig: providerConfig,
+
+		expected = &extensionsv1alpha1.Infrastructure{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: extensionsv1alpha1.SchemeGroupVersion.String(),
+				Kind:       extensionsv1alpha1.InfrastructureResource,
 			},
-			Region:       region,
-			SSHPublicKey: sshPublicKey,
-			SecretRef: corev1.SecretReference{
-				Name:      v1beta1constants.SecretNameCloudProvider,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
 				Namespace: namespace,
+				Annotations: map[string]string{
+					v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
+					v1beta1constants.GardenerTimestamp: now.UTC().String(),
+				},
+			},
+			Spec: extensionsv1alpha1.InfrastructureSpec{
+				DefaultSpec: extensionsv1alpha1.DefaultSpec{
+					Type:           providerType,
+					ProviderConfig: providerConfig,
+				},
+				Region:       region,
+				SSHPublicKey: sshPublicKey,
+				SecretRef: corev1.SecretReference{
+					Name:      v1beta1constants.SecretNameCloudProvider,
+					Namespace: namespace,
+				},
 			},
 		}
 
@@ -136,178 +154,140 @@ var _ = Describe("#Interface", func() {
 	})
 
 	Describe("#Deploy", func() {
-		DescribeTable("correct Infrastructure is created", func(mutator func()) {
+		BeforeEach(func() {
+			expected.ResourceVersion = "1"
+		})
+
+		It("correct Infrastructure is created (AnnotateOperation=false)", func() {
 			defer test.WithVars(
 				&infrastructure.TimeNow, mockNow.Do,
 			)()
 			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
 
-			c.
-				EXPECT().
-				Get(ctx, kutil.Key(namespace, name), infra.DeepCopy()).
-				Return(apierrors.NewNotFound(schema.GroupResource{}, name))
-
 			deployWaiter.SetSSHPublicKey(sshPublicKey)
-			infra.Spec = infraSpec
-			mutator()
-
-			c.
-				EXPECT().
-				Create(ctx, infra)
-
 			Expect(deployWaiter.Deploy(ctx)).To(Succeed())
-		},
-			Entry("with no modification", func() {}),
-			Entry("without provider config", func() {
-				values.ProviderConfig = nil
-				infra.Spec.ProviderConfig = nil
-			}),
-			Entry("annotate operation", func() {
-				values.AnnotateOperation = true
-				infra.Annotations = map[string]string{
-					v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
-					v1beta1constants.GardenerTimestamp: now.UTC().String(),
-				}
-			}),
-		)
+
+			actual := &extensionsv1alpha1.Infrastructure{}
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(expected), actual)).To(Succeed())
+			expected.SetAnnotations(nil)
+			Expect(actual).To(DeepEqual(expected))
+		})
+
+		It("correct Infrastructure is created (AnnotateOperation=true)", func() {
+			defer test.WithVars(
+				&infrastructure.TimeNow, mockNow.Do,
+			)()
+			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+
+			values.AnnotateOperation = true
+			deployWaiter.SetSSHPublicKey(sshPublicKey)
+			Expect(deployWaiter.Deploy(ctx)).To(Succeed())
+
+			actual := &extensionsv1alpha1.Infrastructure{}
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(expected), actual)).To(Succeed())
+			Expect(actual).To(DeepEqual(expected))
+		})
 	})
 
 	Describe("#Wait", func() {
 		It("should return error when it's not found", func() {
-			c.
-				EXPECT().
-				Get(gomock.Any(), kutil.Key(namespace, name), &extensionsv1alpha1.Infrastructure{}).
-				Return(apierrors.NewNotFound(schema.GroupResource{}, name)).
-				AnyTimes()
-
-			Expect(deployWaiter.Wait(ctx)).To(HaveOccurred())
-		})
-
-		It("should return unexpected errors", func() {
-			c.
-				EXPECT().
-				Get(gomock.Any(), kutil.Key(namespace, name), gomock.AssignableToTypeOf(&extensionsv1alpha1.Infrastructure{})).
-				Return(fakeErr)
-
-			Expect(deployWaiter.Wait(ctx)).To(MatchError(ContainSubstring(fakeErr.Error())))
+			Expect(deployWaiter.Wait(ctx)).To(MatchError(ContainSubstring("not found")))
 		})
 
 		It("should return error when it's not ready", func() {
-			c.
-				EXPECT().
-				Get(gomock.Any(), kutil.Key(namespace, name), &extensionsv1alpha1.Infrastructure{}).
-				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *extensionsv1alpha1.Infrastructure) error {
-					obj.Status.LastError = &gardencorev1beta1.LastError{
-						Description: fakeErr.Error(),
-					}
-					return nil
-				}).
-				AnyTimes()
+			expected.Status.LastError = &gardencorev1beta1.LastError{
+				Description: "Some error",
+			}
 
-			Expect(deployWaiter.Wait(ctx)).To(MatchError(ContainSubstring(fakeErr.Error())))
+			Expect(c.Create(ctx, expected)).To(Succeed(), "creating infrastructure succeeds")
+			Expect(deployWaiter.Wait(ctx)).To(MatchError(ContainSubstring("error during reconciliation: Some error")))
+		})
+
+		It("should return error if we haven't observed the latest timestamp annotation", func() {
+			defer test.WithVars(
+				&infrastructure.TimeNow, mockNow.Do,
+			)()
+			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+
+			By("deploy")
+			// Deploy should fill internal state with the added timestamp annotation
+			values.AnnotateOperation = true
+			deployWaiter.SetSSHPublicKey(sshPublicKey)
+			Expect(deployWaiter.Deploy(ctx)).To(Succeed())
+
+			By("patch object")
+			patch := client.MergeFrom(expected.DeepCopy())
+			expected.Status.LastError = nil
+			// remove operation annotation, add old timestamp annotation
+			expected.ObjectMeta.Annotations = map[string]string{
+				v1beta1constants.GardenerTimestamp: now.Add(-time.Millisecond).UTC().String(),
+			}
+			expected.Status.LastOperation = &gardencorev1beta1.LastOperation{
+				State: gardencorev1beta1.LastOperationStateSucceeded,
+			}
+			Expect(c.Patch(ctx, expected, patch)).To(Succeed(), "patching infrastructure succeeds")
+
+			By("wait")
+			Expect(deployWaiter.Wait(ctx)).NotTo(Succeed(), "infrastructure indicates error")
 		})
 
 		It("should return no error when is ready", func() {
+			defer test.WithVars(
+				&infrastructure.TimeNow, mockNow.Do,
+			)()
+			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
 
-			c.
-				EXPECT().
-				Get(gomock.Any(), kutil.Key(namespace, name), &extensionsv1alpha1.Infrastructure{}).
-				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *extensionsv1alpha1.Infrastructure) error {
-					obj.Status.LastError = nil
-					obj.ObjectMeta.Annotations = map[string]string{}
-					obj.Status.LastOperation = &gardencorev1beta1.LastOperation{
-						State: gardencorev1beta1.LastOperationStateSucceeded,
-					}
-					obj.Status.NodesCIDR = nodesCIDR
-					obj.Status.ProviderStatus = providerStatus
-					return nil
-				})
+			By("deploy")
+			// Deploy should fill internal state with the added timestamp annotation
+			values.AnnotateOperation = true
+			deployWaiter.SetSSHPublicKey(sshPublicKey)
+			Expect(deployWaiter.Deploy(ctx)).To(Succeed())
 
-			Expect(deployWaiter.Wait(ctx)).To(Succeed())
+			By("patch object")
+			patch := client.MergeFrom(expected.DeepCopy())
+			expected.Status.LastError = nil
+			// remove operation annotation, add up-to-date timestamp annotation
+			expected.ObjectMeta.Annotations = map[string]string{
+				v1beta1constants.GardenerTimestamp: now.UTC().String(),
+			}
+			expected.Status.LastOperation = &gardencorev1beta1.LastOperation{
+				State: gardencorev1beta1.LastOperationStateSucceeded,
+			}
+			expected.Status.NodesCIDR = nodesCIDR
+			expected.Status.ProviderStatus = providerStatus
+			Expect(c.Patch(ctx, expected, patch)).To(Succeed(), "patching infrastructure succeeds")
+
+			By("wait")
+			Expect(deployWaiter.Wait(ctx)).To(Succeed(), "infrastructure is ready")
+
+			By("verify status")
 			Expect(deployWaiter.ProviderStatus()).To(Equal(providerStatus))
 			Expect(deployWaiter.NodesCIDR()).To(Equal(nodesCIDR))
 		})
 
-		It("should poll until it's ready", func() {
-			waiter.MaxAttempts = 2
+		It("should return no error when is ready (AnnotateOperation == false)", func() {
+			expected.Status.LastError = nil
+			expected.ObjectMeta.Annotations = map[string]string{}
+			expected.Status.LastOperation = &gardencorev1beta1.LastOperation{
+				State: gardencorev1beta1.LastOperationStateSucceeded,
+			}
+			expected.Status.NodesCIDR = nodesCIDR
+			expected.Status.ProviderStatus = providerStatus
 
-			c.
-				EXPECT().
-				Get(gomock.Any(), kutil.Key(namespace, name), &extensionsv1alpha1.Infrastructure{}).
-				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *extensionsv1alpha1.Infrastructure) error {
-					obj.Status.LastError = &gardencorev1beta1.LastError{
-						Description: fakeErr.Error(),
-					}
-					return nil
-				})
-
-			c.
-				EXPECT().
-				Get(gomock.Any(), kutil.Key(namespace, name), &extensionsv1alpha1.Infrastructure{}).
-				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *extensionsv1alpha1.Infrastructure) error {
-					obj.Status.LastError = nil
-					obj.ObjectMeta.Annotations = map[string]string{}
-					obj.Status.LastOperation = &gardencorev1beta1.LastOperation{
-						State: gardencorev1beta1.LastOperationStateSucceeded,
-					}
-					obj.Status.NodesCIDR = nodesCIDR
-					obj.Status.ProviderStatus = providerStatus
-					return nil
-				})
-
+			Expect(c.Create(ctx, expected)).To(Succeed(), "creating infrastructure succeeds")
 			Expect(deployWaiter.Wait(ctx)).To(Succeed())
 			Expect(deployWaiter.ProviderStatus()).To(Equal(providerStatus))
 			Expect(deployWaiter.NodesCIDR()).To(Equal(nodesCIDR))
-		})
-
-		It("should poll until it times out", func() {
-			waiter.MaxAttempts = 3
-
-			c.
-				EXPECT().
-				Get(gomock.Any(), kutil.Key(namespace, name), &extensionsv1alpha1.Infrastructure{}).
-				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *extensionsv1alpha1.Infrastructure) error {
-					obj.Status.LastError = &gardencorev1beta1.LastError{
-						Description: fakeErr.Error(),
-					}
-					return nil
-				}).
-				AnyTimes()
-
-			Expect(deployWaiter.Wait(ctx)).To(MatchError(ContainSubstring(fakeErr.Error())))
 		})
 	})
 
 	Describe("#Destroy", func() {
 		It("should not return error when it's not found", func() {
-			c.
-				EXPECT().
-				Patch(gomock.Any(), gomock.AssignableToTypeOf(infra), gomock.Any()).
-				Return(apierrors.NewNotFound(schema.GroupResource{}, name))
-
 			Expect(deployWaiter.Destroy(ctx)).To(Succeed())
 		})
 
 		It("should not return error when it's deleted successfully", func() {
-			defer test.WithVars(
-				&extensions.TimeNow, mockNow.Do,
-				&gutil.TimeNow, mockNow.Do,
-			)()
-			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
-
-			infraCopy := infra.DeepCopy()
-			infraCopy.Annotations = map[string]string{
-				gutil.ConfirmationDeletion:         "true",
-				v1beta1constants.GardenerTimestamp: now.UTC().String(),
-			}
-
-			c.
-				EXPECT().
-				Patch(ctx, infraCopy, gomock.Any())
-			c.
-				EXPECT().
-				Delete(ctx, infraCopy)
-
+			Expect(c.Create(ctx, expected)).To(Succeed(), "creating infrastructure succeeds")
 			Expect(deployWaiter.Destroy(ctx)).To(Succeed())
 		})
 
@@ -316,100 +296,37 @@ var _ = Describe("#Interface", func() {
 				&extensions.TimeNow, mockNow.Do,
 				&gutil.TimeNow, mockNow.Do,
 			)()
-			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
 
-			infraCopy := infra.DeepCopy()
-			infraCopy.Annotations = map[string]string{
+			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+			mc := mockclient.NewMockClient(ctrl)
+
+			expected = empty.DeepCopy()
+			expected.SetAnnotations(map[string]string{
 				gutil.ConfirmationDeletion:         "true",
 				v1beta1constants.GardenerTimestamp: now.UTC().String(),
-			}
+			})
 
-			c.
-				EXPECT().
-				Patch(ctx, infraCopy, gomock.Any())
-			c.
-				EXPECT().
-				Delete(ctx, infraCopy).
-				Return(fakeErr)
+			// add deletion confirmation and timestamp annotation
+			mc.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&extensionsv1alpha1.Infrastructure{}), gomock.Any()).Return(nil)
+			mc.EXPECT().Delete(ctx, expected).Times(1).Return(fakeErr)
 
-			Expect(deployWaiter.Destroy(ctx)).To(MatchError(ContainSubstring(fakeErr.Error())))
+			deployWaiter = infrastructure.New(log, mc, values, time.Millisecond, 250*time.Millisecond, 500*time.Millisecond)
+			Expect(deployWaiter.Destroy(ctx)).To(MatchError(fakeErr))
 		})
 	})
 
 	Describe("#WaitCleanup", func() {
 		It("should not return error when it's already removed", func() {
-			c.
-				EXPECT().
-				Get(gomock.Any(), kutil.Key(namespace, name), gomock.AssignableToTypeOf(&extensionsv1alpha1.Infrastructure{})).
-				Return(apierrors.NewNotFound(schema.GroupResource{}, name))
-
 			Expect(deployWaiter.WaitCleanup(ctx)).To(Succeed())
 		})
 
 		It("should return error when it's not deleted successfully", func() {
-			description := "some error"
+			expected.Status.LastError = &gardencorev1beta1.LastError{
+				Description: "Some error",
+			}
 
-			c.
-				EXPECT().
-				Get(gomock.Any(), kutil.Key(namespace, name), &extensionsv1alpha1.Infrastructure{}).
-				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *extensionsv1alpha1.Infrastructure) error {
-					obj.Status.LastError = &gardencorev1beta1.LastError{
-						Description: description,
-					}
-					return nil
-				})
-
-			Expect(deployWaiter.WaitCleanup(ctx)).To(MatchError(ContainSubstring(description)))
-		})
-
-		It("should poll until it's removed", func() {
-			waiter.MaxAttempts = 2
-			description := "some error"
-
-			c.
-				EXPECT().
-				Get(gomock.Any(), kutil.Key(namespace, name), &extensionsv1alpha1.Infrastructure{}).
-				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *extensionsv1alpha1.Infrastructure) error {
-					obj.Status.LastError = &gardencorev1beta1.LastError{
-						Description: description,
-					}
-					return nil
-				})
-			c.
-				EXPECT().
-				Get(gomock.Any(), kutil.Key(namespace, name), gomock.AssignableToTypeOf(&extensionsv1alpha1.Infrastructure{})).
-				Return(apierrors.NewNotFound(schema.GroupResource{}, name))
-
-			Expect(deployWaiter.WaitCleanup(ctx)).To(Succeed())
-		})
-
-		It("should poll until it times out", func() {
-			waiter.MaxAttempts = 3
-			description := "some error"
-
-			c.
-				EXPECT().
-				Get(gomock.Any(), kutil.Key(namespace, name), &extensionsv1alpha1.Infrastructure{}).
-				DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *extensionsv1alpha1.Infrastructure) error {
-					obj.Status.LastError = &gardencorev1beta1.LastError{
-						Description: description,
-					}
-					return nil
-				}).
-				AnyTimes()
-
-			Expect(deployWaiter.WaitCleanup(ctx)).To(MatchError(ContainSubstring(description)))
-		})
-
-		It("should return unexpected errors", func() {
-			waiter.MaxAttempts = 2
-
-			c.
-				EXPECT().
-				Get(gomock.Any(), kutil.Key(namespace, name), gomock.AssignableToTypeOf(&extensionsv1alpha1.Infrastructure{})).
-				Return(fakeErr)
-
-			Expect(deployWaiter.WaitCleanup(ctx)).To(MatchError(ContainSubstring(fakeErr.Error())))
+			Expect(c.Create(ctx, expected)).To(Succeed(), "creating infrastructure succeeds")
+			Expect(deployWaiter.WaitCleanup(ctx)).To(MatchError(ContainSubstring("Some error")))
 		})
 	})
 
@@ -436,23 +353,27 @@ var _ = Describe("#Interface", func() {
 			)()
 			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
 
+			mc := mockclient.NewMockClient(ctrl)
+			mc.EXPECT().Status().Return(mc)
+
 			values.SSHPublicKey = sshPublicKey
 			values.AnnotateOperation = true
 
-			obj := infra.DeepCopy()
-			obj.Spec = infraSpec
+			// deploy with wait-for-state annotation
+			obj := expected.DeepCopy()
 			metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "gardener.cloud/operation", "wait-for-state")
 			metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "gardener.cloud/timestamp", now.UTC().String())
+			obj.TypeMeta = metav1.TypeMeta{}
+			test.EXPECTPatch(ctx, mc, obj, empty, types.MergePatchType)
+
+			// restore state
 			expectedWithState := obj.DeepCopy()
 			expectedWithState.Status.State = state
-			expectedWithRestore := expectedWithState.DeepCopy()
-			expectedWithRestore.Annotations["gardener.cloud/operation"] = "restore"
+			test.EXPECTPatch(ctx, mc, expectedWithState, obj, types.MergePatchType)
 
-			mc := mockclient.NewMockClient(ctrl)
-			mc.EXPECT().Get(ctx, kutil.Key(namespace, name), gomock.AssignableToTypeOf(&extensionsv1alpha1.Infrastructure{})).Return(apierrors.NewNotFound(extensionsv1alpha1.Resource("Infrastructure"), name))
-			mc.EXPECT().Create(ctx, obj)
-			mc.EXPECT().Status().Return(mc)
-			mc.EXPECT().Update(ctx, expectedWithState)
+			// annotate with restore annotation
+			expectedWithRestore := expectedWithState.DeepCopy()
+			metav1.SetMetaDataAnnotation(&expectedWithRestore.ObjectMeta, "gardener.cloud/operation", "restore")
 			test.EXPECTPatch(ctx, mc, expectedWithRestore, expectedWithState, types.MergePatchType)
 
 			Expect(infrastructure.New(log, mc, values, time.Millisecond, 250*time.Millisecond, 500*time.Millisecond).Restore(ctx, shootState)).To(Succeed())
@@ -462,102 +383,65 @@ var _ = Describe("#Interface", func() {
 	Describe("#Migrate", func() {
 		It("should migrate the resources", func() {
 			defer test.WithVars(
+				&infrastructure.TimeNow, mockNow.Do,
 				&extensions.TimeNow, mockNow.Do,
 			)()
 			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
 
-			obj := infra.DeepCopy()
-			obj.Annotations = map[string]string{
-				"gardener.cloud/operation": "migrate",
-				"gardener.cloud/timestamp": now.UTC().String(),
-			}
+			Expect(c.Create(ctx, expected)).To(Succeed(), "creating infrastructure succeeds")
 
-			gomock.InOrder(
-				c.
-					EXPECT().
-					Get(ctx, kutil.Key(infra.Namespace, infra.Name), gomock.AssignableToTypeOf(&extensionsv1alpha1.Infrastructure{})).
-					DoAndReturn(func(_ context.Context, _ client.ObjectKey, o *extensionsv1alpha1.Infrastructure) error {
-						infra.DeepCopyInto(o)
-						return nil
-					}),
-				test.
-					EXPECTPatch(ctx, c, obj, infra, types.MergePatchType),
-			)
-
+			deployWaiter.SetSSHPublicKey(sshPublicKey)
 			Expect(deployWaiter.Migrate(ctx)).To(Succeed())
+
+			actual := &extensionsv1alpha1.Infrastructure{}
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(expected), actual)).To(Succeed())
+			expected.SetResourceVersion("2")
+			metav1.SetMetaDataAnnotation(&expected.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationMigrate)
+			metav1.SetMetaDataAnnotation(&expected.ObjectMeta, v1beta1constants.GardenerTimestamp, now.UTC().String())
+			Expect(actual).To(DeepEqual(expected))
 		})
 
 		It("should not return error if resource does not exist", func() {
-			c.
-				EXPECT().
-				Get(ctx, kutil.Key(infra.Namespace, infra.Name), gomock.AssignableToTypeOf(&extensionsv1alpha1.Infrastructure{})).
-				Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
-
 			Expect(deployWaiter.Migrate(ctx)).To(Succeed())
 		})
 	})
 
 	Describe("#WaitMigrate", func() {
 		It("should not return error when resource is missing", func() {
-			c.
-				EXPECT().
-				Get(ctx, kutil.Key(infra.Namespace, infra.Name), gomock.AssignableToTypeOf(&extensionsv1alpha1.Infrastructure{})).
-				Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
-
 			Expect(deployWaiter.WaitMigrate(ctx)).To(Succeed())
 		})
 
 		It("should return error if resource is not yet migrated successfully", func() {
-			obj := infra.DeepCopy()
-			obj.Status.LastError = &gardencorev1beta1.LastError{
+			expected.Status.LastError = &gardencorev1beta1.LastError{
 				Description: "Some error",
 			}
-			obj.Status.LastOperation = &gardencorev1beta1.LastOperation{
+
+			expected.Status.LastOperation = &gardencorev1beta1.LastOperation{
 				State: gardencorev1beta1.LastOperationStateError,
 				Type:  gardencorev1beta1.LastOperationTypeMigrate,
 			}
 
-			c.
-				EXPECT().
-				Get(ctx, kutil.Key(obj.Namespace, obj.Name), gomock.AssignableToTypeOf(&extensionsv1alpha1.Infrastructure{})).
-				DoAndReturn(func(_ context.Context, _ client.ObjectKey, o *extensionsv1alpha1.Infrastructure) error {
-					obj.DeepCopyInto(o)
-					return nil
-				})
-
-			Expect(deployWaiter.WaitMigrate(ctx)).To(HaveOccurred())
+			Expect(c.Create(ctx, expected)).To(Succeed(), "creating infrastructure succeeds")
+			Expect(deployWaiter.WaitMigrate(ctx)).To(MatchError(ContainSubstring("is not Migrate=Succeeded")))
 		})
 
 		It("should not return error if resource gets migrated successfully", func() {
-			obj := infra.DeepCopy()
-			obj.Status.LastError = nil
-			obj.Status.LastOperation = &gardencorev1beta1.LastOperation{
+			expected.Status.LastError = nil
+			expected.Status.LastOperation = &gardencorev1beta1.LastOperation{
 				State: gardencorev1beta1.LastOperationStateSucceeded,
 				Type:  gardencorev1beta1.LastOperationTypeMigrate,
 			}
 
-			c.
-				EXPECT().
-				Get(ctx, kutil.Key(obj.Namespace, obj.Name), gomock.AssignableToTypeOf(&extensionsv1alpha1.Infrastructure{})).
-				DoAndReturn(func(_ context.Context, _ client.ObjectKey, o *extensionsv1alpha1.Infrastructure) error {
-					obj.DeepCopyInto(o)
-					return nil
-				})
-
+			Expect(c.Create(ctx, expected)).To(Succeed(), "creating infrastructure succeeds")
 			Expect(deployWaiter.WaitMigrate(ctx)).To(Succeed(), "infrastructure is ready, should not return an error")
 		})
 	})
 
 	Describe("#Get", func() {
 		It("should return an error when the retrieval fails", func() {
-			c.
-				EXPECT().
-				Get(ctx, kutil.Key(infra.Namespace, infra.Name), gomock.AssignableToTypeOf(&extensionsv1alpha1.Infrastructure{})).
-				Return(fakeErr)
-
 			res, err := deployWaiter.Get(ctx)
 			Expect(res).To(BeNil())
-			Expect(err).To(MatchError(fakeErr))
+			Expect(err).To(MatchError(ContainSubstring("not found")))
 		})
 
 		It("should retrieve the object and extract the status", func() {
@@ -569,21 +453,16 @@ var _ = Describe("#Interface", func() {
 				nodesCIDR      = pointer.StringPtr("1.2.3.4")
 			)
 
-			obj := infra.DeepCopy()
-			obj.Status.ProviderStatus = providerStatus
-			obj.Status.NodesCIDR = nodesCIDR
+			infra := empty.DeepCopy()
+			infra.Status.ProviderStatus = providerStatus
+			infra.Status.NodesCIDR = nodesCIDR
+			Expect(c.Create(ctx, infra)).To(Succeed())
 
-			c.
-				EXPECT().
-				Get(ctx, kutil.Key(obj.Namespace, obj.Name), gomock.AssignableToTypeOf(&extensionsv1alpha1.Infrastructure{})).
-				DoAndReturn(func(_ context.Context, _ client.ObjectKey, o *extensionsv1alpha1.Infrastructure) error {
-					obj.DeepCopyInto(o)
-					return nil
-				})
-
-			res, err := deployWaiter.Get(ctx)
+			expected = infra.DeepCopy()
+			actual, err := deployWaiter.Get(ctx)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(res).To(Equal(obj))
+			actual.SetGroupVersionKind(schema.GroupVersionKind{})
+			Expect(actual).To(DeepEqual(expected))
 
 			Expect(deployWaiter.ProviderStatus()).To(Equal(providerStatus))
 			Expect(deployWaiter.NodesCIDR()).To(Equal(nodesCIDR))

--- a/pkg/operation/botanist/component/extensions/network/network.go
+++ b/pkg/operation/botanist/component/extensions/network/network.go
@@ -173,7 +173,7 @@ func (n *network) WaitCleanup(ctx context.Context) error {
 }
 
 func (n *network) deploy(ctx context.Context, operation string) (extensionsv1alpha1.Object, error) {
-	_, err := controllerutils.MergePatchOrCreate(ctx, n.client, n.network, func() error {
+	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, n.client, n.network, func() error {
 		metav1.SetMetaDataAnnotation(&n.network.ObjectMeta, v1beta1constants.GardenerOperation, operation)
 		metav1.SetMetaDataAnnotation(&n.network.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
 

--- a/pkg/operation/botanist/component/extensions/network/network.go
+++ b/pkg/operation/botanist/component/extensions/network/network.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 
@@ -29,7 +30,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 const (
@@ -77,6 +77,13 @@ func New(
 		waitInterval:        waitInterval,
 		waitSevereThreshold: waitSevereThreshold,
 		waitTimeout:         waitTimeout,
+
+		network: &extensionsv1alpha1.Network{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      values.Name,
+				Namespace: values.Namespace,
+			},
+		},
 	}
 }
 
@@ -87,11 +94,13 @@ type network struct {
 	waitInterval        time.Duration
 	waitSevereThreshold time.Duration
 	waitTimeout         time.Duration
+
+	network *extensionsv1alpha1.Network
 }
 
 // Deploy uses the seed client to create or update the Network custom resource in the Shoot namespace in the Seed
 func (n *network) Deploy(ctx context.Context) error {
-	_, err := n.internalDeploy(ctx, v1beta1constants.GardenerOperationReconcile)
+	_, err := n.deploy(ctx, v1beta1constants.GardenerOperationReconcile)
 	return err
 }
 
@@ -102,30 +111,25 @@ func (n *network) Restore(ctx context.Context, shootState *v1alpha1.ShootState) 
 		n.client,
 		shootState,
 		extensionsv1alpha1.NetworkResource,
-		n.values.Namespace,
-		n.internalDeploy,
+		n.deploy,
 	)
 }
 
 // Migrate migrates the Network custom resource
 func (n *network) Migrate(ctx context.Context) error {
-	return extensions.MigrateExtensionCR(
+	return extensions.MigrateExtensionObject(
 		ctx,
 		n.client,
-		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Network{} },
-		n.values.Namespace,
-		n.values.Name,
+		n.network,
 	)
 }
 
 // WaitMigrate waits until the Network custom resource has been successfully migrated.
 func (n *network) WaitMigrate(ctx context.Context) error {
-	return extensions.WaitUntilExtensionCRMigrated(
+	return extensions.WaitUntilExtensionObjectMigrated(
 		ctx,
 		n.client,
-		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Network{} },
-		n.values.Namespace,
-		n.values.Name,
+		n.network,
 		n.waitInterval,
 		n.waitTimeout,
 	)
@@ -133,25 +137,21 @@ func (n *network) WaitMigrate(ctx context.Context) error {
 
 // Destroy deletes the Network CRD
 func (n *network) Destroy(ctx context.Context) error {
-	return extensions.DeleteExtensionCR(
+	return extensions.DeleteExtensionObject(
 		ctx,
 		n.client,
-		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Network{} },
-		n.values.Namespace,
-		n.values.Name,
+		n.network,
 	)
 }
 
 // Wait waits until the Network CRD is ready (deployed or restored)
 func (n *network) Wait(ctx context.Context) error {
-	return extensions.WaitUntilExtensionCRReady(
+	return extensions.WaitUntilExtensionObjectReady(
 		ctx,
 		n.client,
 		n.logger,
-		func() client.Object { return &extensionsv1alpha1.Network{} },
+		n.network,
 		extensionsv1alpha1.NetworkResource,
-		n.values.Namespace,
-		n.values.Name,
 		n.waitInterval,
 		n.waitSevereThreshold,
 		n.waitTimeout,
@@ -161,34 +161,23 @@ func (n *network) Wait(ctx context.Context) error {
 
 // WaitCleanup waits until the Network CRD is deleted
 func (n *network) WaitCleanup(ctx context.Context) error {
-	return extensions.WaitUntilExtensionCRDeleted(
+	return extensions.WaitUntilExtensionObjectDeleted(
 		ctx,
 		n.client,
 		n.logger,
-		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Network{} },
+		n.network,
 		extensionsv1alpha1.NetworkResource,
-		n.values.Namespace,
-		n.values.Name,
 		n.waitInterval,
 		n.waitTimeout,
 	)
 }
 
-func (n *network) internalDeploy(ctx context.Context, operation string) (extensionsv1alpha1.Object, error) {
-	var (
-		network = &extensionsv1alpha1.Network{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      n.values.Name,
-				Namespace: n.values.Namespace,
-			},
-		}
-	)
+func (n *network) deploy(ctx context.Context, operation string) (extensionsv1alpha1.Object, error) {
+	_, err := controllerutils.MergePatchOrCreate(ctx, n.client, n.network, func() error {
+		metav1.SetMetaDataAnnotation(&n.network.ObjectMeta, v1beta1constants.GardenerOperation, operation)
+		metav1.SetMetaDataAnnotation(&n.network.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
 
-	_, err := controllerutil.CreateOrUpdate(ctx, n.client, network, func() error {
-		metav1.SetMetaDataAnnotation(&network.ObjectMeta, v1beta1constants.GardenerOperation, operation)
-		metav1.SetMetaDataAnnotation(&network.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
-
-		network.Spec = extensionsv1alpha1.NetworkSpec{
+		n.network.Spec = extensionsv1alpha1.NetworkSpec{
 			DefaultSpec: extensionsv1alpha1.DefaultSpec{
 				Type:           n.values.Type,
 				ProviderConfig: n.values.ProviderConfig,
@@ -200,5 +189,5 @@ func (n *network) internalDeploy(ctx context.Context, operation string) (extensi
 		return nil
 	})
 
-	return network, err
+	return n.network, err
 }

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -24,6 +24,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig/downloader"
@@ -42,7 +43,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 const (
@@ -143,6 +143,7 @@ func New(
 	for _, worker := range values.Workers {
 		osc.workerNameToOSCs[worker.Name] = &OperatingSystemConfigs{}
 	}
+	osc.oscs = make(map[string]*extensionsv1alpha1.OperatingSystemConfig, len(osc.workerNameToOSCs)*2)
 
 	return osc
 }
@@ -157,6 +158,7 @@ type operatingSystemConfig struct {
 
 	lock             sync.Mutex
 	workerNameToOSCs map[string]*OperatingSystemConfigs
+	oscs             map[string]*extensionsv1alpha1.OperatingSystemConfig
 }
 
 // OperatingSystemConfigs contains operating system configs for the downloader script as well as for the original cloud
@@ -180,8 +182,8 @@ type Data struct {
 
 // Deploy uses the client to create or update the OperatingSystemConfig custom resources.
 func (o *operatingSystemConfig) Deploy(ctx context.Context) error {
-	fns := o.forEachWorkerPoolAndPurposeTaskFn(func(ctx context.Context, worker gardencorev1beta1.Worker, purpose extensionsv1alpha1.OperatingSystemConfigPurpose) error {
-		d := o.newDeployer(worker, purpose)
+	fns := o.forEachWorkerPoolAndPurposeTaskFn(func(ctx context.Context, osc *extensionsv1alpha1.OperatingSystemConfig, worker gardencorev1beta1.Worker, purpose extensionsv1alpha1.OperatingSystemConfigPurpose) error {
+		d := o.newDeployer(osc, worker, purpose)
 		_, err := d.deploy(ctx, v1beta1constants.GardenerOperationReconcile)
 		return err
 	})
@@ -192,9 +194,9 @@ func (o *operatingSystemConfig) Deploy(ctx context.Context) error {
 // Restore uses the seed client and the ShootState to create the OperatingSystemConfig custom resources in the Shoot
 // namespace in the Seed and restore its state.
 func (o *operatingSystemConfig) Restore(ctx context.Context, shootState *v1alpha1.ShootState) error {
-	fns := o.forEachWorkerPoolAndPurposeTaskFn(func(ctx context.Context, worker gardencorev1beta1.Worker, purpose extensionsv1alpha1.OperatingSystemConfigPurpose) error {
-		d := o.newDeployer(worker, purpose)
-		return extensions.RestoreExtensionWithDeployFunction(ctx, o.client, shootState, extensionsv1alpha1.OperatingSystemConfigResource, o.values.Namespace, d.deploy)
+	fns := o.forEachWorkerPoolAndPurposeTaskFn(func(ctx context.Context, osc *extensionsv1alpha1.OperatingSystemConfig, worker gardencorev1beta1.Worker, purpose extensionsv1alpha1.OperatingSystemConfigPurpose) error {
+		d := o.newDeployer(osc, worker, purpose)
+		return extensions.RestoreExtensionWithDeployFunction(ctx, o.client, shootState, extensionsv1alpha1.OperatingSystemConfigResource, d.deploy)
 	})
 
 	return flow.Parallel(fns...)(ctx)
@@ -204,23 +206,16 @@ func (o *operatingSystemConfig) Restore(ctx context.Context, shootState *v1alpha
 // containing the cloud-config and stores its data which can later be retrieved with the WorkerNameToOperatingSystemConfigsMap
 // method.
 func (o *operatingSystemConfig) Wait(ctx context.Context) error {
-	fns := o.forEachWorkerPoolAndPurposeTaskFn(func(ctx context.Context, worker gardencorev1beta1.Worker, purpose extensionsv1alpha1.OperatingSystemConfigPurpose) error {
-		return extensions.WaitUntilExtensionCRReady(
-			ctx,
+	fns := o.forEachWorkerPoolAndPurposeTaskFn(func(ctx context.Context, osc *extensionsv1alpha1.OperatingSystemConfig, worker gardencorev1beta1.Worker, purpose extensionsv1alpha1.OperatingSystemConfigPurpose) error {
+		return extensions.WaitUntilExtensionObjectReady(ctx,
 			o.client,
 			o.logger,
-			func() client.Object { return &extensionsv1alpha1.OperatingSystemConfig{} },
+			osc,
 			extensionsv1alpha1.OperatingSystemConfigResource,
-			o.values.Namespace,
-			Key(worker.Name, o.values.KubernetesVersion)+purposeToKeySuffix(purpose),
 			o.waitInterval,
 			o.waitSevereThreshold,
 			o.waitTimeout,
-			func(obj client.Object) error {
-				osc, ok := obj.(*extensionsv1alpha1.OperatingSystemConfig)
-				if !ok {
-					return fmt.Errorf("expected extensionsv1alpha1.OperatingSystemConfig but got %T", obj)
-				}
+			func() error {
 				if osc.Status.CloudConfig == nil {
 					return fmt.Errorf("no cloud config information provided in status")
 				}
@@ -258,22 +253,20 @@ func (o *operatingSystemConfig) Wait(ctx context.Context) error {
 
 // Migrate migrates the OperatingSystemConfig custom resources.
 func (o *operatingSystemConfig) Migrate(ctx context.Context) error {
-	return extensions.MigrateExtensionCRs(
+	return extensions.MigrateExtensionObjects(
 		ctx,
 		o.client,
 		&extensionsv1alpha1.OperatingSystemConfigList{},
-		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.OperatingSystemConfig{} },
 		o.values.Namespace,
 	)
 }
 
 // WaitMigrate waits until the OperatingSystemConfig custom resource have been successfully migrated.
 func (o *operatingSystemConfig) WaitMigrate(ctx context.Context) error {
-	return extensions.WaitUntilExtensionCRsMigrated(
+	return extensions.WaitUntilExtensionObjectsMigrated(
 		ctx,
 		o.client,
 		&extensionsv1alpha1.OperatingSystemConfigList{},
-		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.OperatingSystemConfig{} },
 		o.values.Namespace,
 		o.waitInterval,
 		o.waitTimeout,
@@ -286,11 +279,10 @@ func (o *operatingSystemConfig) Destroy(ctx context.Context) error {
 }
 
 func (o *operatingSystemConfig) deleteOperatingSystemConfigResources(ctx context.Context, wantedOSCNames sets.String) error {
-	return extensions.DeleteExtensionCRs(
+	return extensions.DeleteExtensionObjects(
 		ctx,
 		o.client,
 		&extensionsv1alpha1.OperatingSystemConfigList{},
-		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.OperatingSystemConfig{} },
 		o.values.Namespace,
 		func(obj extensionsv1alpha1.Object) bool {
 			return !wantedOSCNames.Has(obj.GetName())
@@ -300,12 +292,11 @@ func (o *operatingSystemConfig) deleteOperatingSystemConfigResources(ctx context
 
 // WaitCleanup waits until the OperatingSystemConfig CRD is deleted
 func (o *operatingSystemConfig) WaitCleanup(ctx context.Context) error {
-	return extensions.WaitUntilExtensionCRsDeleted(
+	return extensions.WaitUntilExtensionObjectsDeleted(
 		ctx,
 		o.client,
 		o.logger,
 		&extensionsv1alpha1.OperatingSystemConfigList{},
-		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.OperatingSystemConfig{} },
 		extensionsv1alpha1.OperatingSystemConfigResource,
 		o.values.Namespace,
 		o.waitInterval,
@@ -318,15 +309,15 @@ func (o *operatingSystemConfig) WaitCleanup(ctx context.Context) error {
 func (o *operatingSystemConfig) DeleteStaleResources(ctx context.Context) error {
 	wantedOSCNames := sets.NewString()
 
-	_ = o.forEachWorkerPoolAndPurpose(ctx, func(_ context.Context, worker gardencorev1beta1.Worker, purpose extensionsv1alpha1.OperatingSystemConfigPurpose) error {
-		wantedOSCNames.Insert(Key(worker.Name, o.values.KubernetesVersion) + purposeToKeySuffix(purpose))
+	_ = o.forEachWorkerPoolAndPurpose(func(osc *extensionsv1alpha1.OperatingSystemConfig, _ gardencorev1beta1.Worker, _ extensionsv1alpha1.OperatingSystemConfigPurpose) error {
+		wantedOSCNames.Insert(osc.GetName())
 		return nil
 	})
 
 	return o.deleteOperatingSystemConfigResources(ctx, wantedOSCNames)
 }
 
-func (o *operatingSystemConfig) forEachWorkerPoolAndPurpose(ctx context.Context, fn func(context.Context, gardencorev1beta1.Worker, extensionsv1alpha1.OperatingSystemConfigPurpose) error) error {
+func (o *operatingSystemConfig) forEachWorkerPoolAndPurpose(fn func(*extensionsv1alpha1.OperatingSystemConfig, gardencorev1beta1.Worker, extensionsv1alpha1.OperatingSystemConfigPurpose) error) error {
 	for _, worker := range o.values.Workers {
 		if worker.Machine.Image == nil {
 			continue
@@ -336,7 +327,21 @@ func (o *operatingSystemConfig) forEachWorkerPoolAndPurpose(ctx context.Context,
 			extensionsv1alpha1.OperatingSystemConfigPurposeProvision,
 			extensionsv1alpha1.OperatingSystemConfigPurposeReconcile,
 		} {
-			if err := fn(ctx, worker, purpose); err != nil {
+			oscName := Key(worker.Name, o.values.KubernetesVersion) + purposeToKeySuffix(purpose)
+
+			osc, ok := o.oscs[oscName]
+			if !ok {
+				osc = &extensionsv1alpha1.OperatingSystemConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      oscName,
+						Namespace: o.values.Namespace,
+					},
+				}
+				// store object for later usage (we want to pass a filled object to WaitUntil*)
+				o.oscs[oscName] = osc
+			}
+
+			if err := fn(osc, worker, purpose); err != nil {
 				return err
 			}
 		}
@@ -345,12 +350,12 @@ func (o *operatingSystemConfig) forEachWorkerPoolAndPurpose(ctx context.Context,
 	return nil
 }
 
-func (o *operatingSystemConfig) forEachWorkerPoolAndPurposeTaskFn(fn func(context.Context, gardencorev1beta1.Worker, extensionsv1alpha1.OperatingSystemConfigPurpose) error) []flow.TaskFn {
+func (o *operatingSystemConfig) forEachWorkerPoolAndPurposeTaskFn(fn func(context.Context, *extensionsv1alpha1.OperatingSystemConfig, gardencorev1beta1.Worker, extensionsv1alpha1.OperatingSystemConfigPurpose) error) []flow.TaskFn {
 	var fns []flow.TaskFn
 
-	_ = o.forEachWorkerPoolAndPurpose(context.Background(), func(_ context.Context, worker gardencorev1beta1.Worker, purpose extensionsv1alpha1.OperatingSystemConfigPurpose) error {
+	_ = o.forEachWorkerPoolAndPurpose(func(osc *extensionsv1alpha1.OperatingSystemConfig, worker gardencorev1beta1.Worker, purpose extensionsv1alpha1.OperatingSystemConfigPurpose) error {
 		fns = append(fns, func(ctx context.Context) error {
-			return fn(ctx, worker, purpose)
+			return fn(ctx, osc, worker, purpose)
 		})
 		return nil
 	})
@@ -358,7 +363,7 @@ func (o *operatingSystemConfig) forEachWorkerPoolAndPurposeTaskFn(fn func(contex
 	return fns
 }
 
-// AppendCABundle sets the CABundle value.
+// SetCABundle sets the CABundle value.
 func (o *operatingSystemConfig) SetCABundle(val *string) {
 	o.values.CABundle = val
 }
@@ -379,7 +384,7 @@ func (o *operatingSystemConfig) WorkerNameToOperatingSystemConfigsMap() map[stri
 	return o.workerNameToOSCs
 }
 
-func (o *operatingSystemConfig) newDeployer(worker gardencorev1beta1.Worker, purpose extensionsv1alpha1.OperatingSystemConfigPurpose) deployer {
+func (o *operatingSystemConfig) newDeployer(osc *extensionsv1alpha1.OperatingSystemConfig, worker gardencorev1beta1.Worker, purpose extensionsv1alpha1.OperatingSystemConfigPurpose) deployer {
 	criName := extensionsv1alpha1.CRINameDocker
 	if worker.CRI != nil {
 		criName = extensionsv1alpha1.CRIName(worker.CRI.Name)
@@ -404,10 +409,10 @@ func (o *operatingSystemConfig) newDeployer(worker gardencorev1beta1.Worker, pur
 
 	return deployer{
 		client:                  o.client,
+		osc:                     osc,
 		worker:                  worker,
 		purpose:                 purpose,
 		key:                     Key(worker.Name, o.values.KubernetesVersion),
-		namespace:               o.values.Namespace,
 		apiServerURL:            o.values.APIServerURL,
 		caBundle:                caBundle,
 		clusterDNSAddress:       o.values.ClusterDNSAddress,
@@ -454,11 +459,12 @@ func setDefaultEvictionMemoryAvailable(evictionHard, evictionSoft map[string]str
 }
 
 type deployer struct {
-	client    client.Client
-	worker    gardencorev1beta1.Worker
-	purpose   extensionsv1alpha1.OperatingSystemConfigPurpose
-	key       string
-	namespace string
+	client client.Client
+	osc    *extensionsv1alpha1.OperatingSystemConfig
+
+	key     string
+	worker  gardencorev1beta1.Worker
+	purpose extensionsv1alpha1.OperatingSystemConfigPurpose
 
 	// downloader values
 	apiServerURL string
@@ -490,8 +496,6 @@ func (d *deployer) deploy(ctx context.Context, operation string) (extensionsv1al
 		units []extensionsv1alpha1.Unit
 		files []extensionsv1alpha1.File
 		err   error
-
-		name = d.key + purposeToKeySuffix(d.purpose)
 	)
 
 	// The cloud-config-downloader unit is added regardless of the purpose of the OperatingSystemConfig:
@@ -558,36 +562,33 @@ func (d *deployer) deploy(ctx context.Context, operation string) (extensionsv1al
 		return nil, fmt.Errorf("unknown purpose: %q", d.purpose)
 	}
 
-	osc := &extensionsv1alpha1.OperatingSystemConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: d.namespace,
-		},
-	}
+	// We operate on arrays (units, files) with merge patch without optimistic locking here, meaning this will replace
+	// the arrays as a whole.
+	// However, this is not a problem, as no other client should write to these arrays as the OSC spec is supposed
+	// to be owned by gardenlet exclusively.
+	_, err = controllerutils.MergePatchOrCreate(ctx, d.client, d.osc, func() error {
+		metav1.SetMetaDataAnnotation(&d.osc.ObjectMeta, v1beta1constants.GardenerOperation, operation)
+		metav1.SetMetaDataAnnotation(&d.osc.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
 
-	_, err = controllerutil.CreateOrUpdate(ctx, d.client, osc, func() error {
-		metav1.SetMetaDataAnnotation(&osc.ObjectMeta, v1beta1constants.GardenerOperation, operation)
-		metav1.SetMetaDataAnnotation(&osc.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
-
-		osc.Spec.Type = d.worker.Machine.Image.Name
-		osc.Spec.ProviderConfig = d.worker.Machine.Image.ProviderConfig
-		osc.Spec.Purpose = d.purpose
-		osc.Spec.Units = units
-		osc.Spec.Files = files
+		d.osc.Spec.Type = d.worker.Machine.Image.Name
+		d.osc.Spec.ProviderConfig = d.worker.Machine.Image.ProviderConfig
+		d.osc.Spec.Purpose = d.purpose
+		d.osc.Spec.Units = units
+		d.osc.Spec.Files = files
 
 		if d.worker.CRI != nil {
-			osc.Spec.CRIConfig = &extensionsv1alpha1.CRIConfig{
+			d.osc.Spec.CRIConfig = &extensionsv1alpha1.CRIConfig{
 				Name: extensionsv1alpha1.CRIName(d.worker.CRI.Name),
 			}
 		}
 
 		if d.purpose == extensionsv1alpha1.OperatingSystemConfigPurposeReconcile {
-			osc.Spec.ReloadConfigFilePath = pointer.StringPtr(downloader.PathDownloadedCloudConfig)
+			d.osc.Spec.ReloadConfigFilePath = pointer.StringPtr(downloader.PathDownloadedCloudConfig)
 		}
 
 		return nil
 	})
-	return osc, err
+	return d.osc, err
 }
 
 // Key returns the key that can be used as secret name based on the provided worker name and Kubernetes version.

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -566,7 +566,7 @@ func (d *deployer) deploy(ctx context.Context, operation string) (extensionsv1al
 	// the arrays as a whole.
 	// However, this is not a problem, as no other client should write to these arrays as the OSC spec is supposed
 	// to be owned by gardenlet exclusively.
-	_, err = controllerutils.MergePatchOrCreate(ctx, d.client, d.osc, func() error {
+	_, err = controllerutils.GetAndCreateOrMergePatch(ctx, d.client, d.osc, func() error {
 		metav1.SetMetaDataAnnotation(&d.osc.ObjectMeta, v1beta1constants.GardenerOperation, operation)
 		metav1.SetMetaDataAnnotation(&d.osc.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
 

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/gardener/gardener/pkg/utils"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
-	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/test"
 
 	"github.com/Masterminds/semver"
@@ -43,10 +42,8 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	kubernetesfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/utils/pointer"
@@ -143,12 +140,14 @@ var _ = Describe("OperatingSystemConfig", func() {
 					KubeletDataVolumeName: &kubeletDataVolumeName,
 				},
 			}
+			empty    *extensionsv1alpha1.OperatingSystemConfig
 			expected []*extensionsv1alpha1.OperatingSystemConfig
 		)
 
 		BeforeEach(func() {
 			ctrl = gomock.NewController(GinkgoT())
 			mockNow = mocktime.NewMockNow(ctrl)
+			now = time.Now()
 
 			ctx = context.TODO()
 			log = logger.NewNopLogger()
@@ -175,6 +174,12 @@ var _ = Describe("OperatingSystemConfig", func() {
 					KubeletCLIFlags:         kubeletCLIFlags,
 					MachineTypes:            machineTypes,
 					SSHPublicKey:            sshPublicKey,
+				},
+			}
+
+			empty = &extensionsv1alpha1.OperatingSystemConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: namespace,
 				},
 			}
 
@@ -273,7 +278,6 @@ var _ = Describe("OperatingSystemConfig", func() {
 
 		Describe("#Deploy", func() {
 			It("should successfully deploy all extensions resources", func() {
-
 				defer test.WithVars(
 					&TimeNow, mockNow.Do,
 					&DownloaderConfigFn, downloaderConfigFn,
@@ -337,9 +341,10 @@ var _ = Describe("OperatingSystemConfig", func() {
 					&TimeNow, mockNow.Do,
 					&extensions.TimeNow, mockNow.Do,
 				)()
-
 				mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+
 				mc := mockclient.NewMockClient(ctrl)
+				mc.EXPECT().Status().Return(mc).AnyTimes()
 
 				for i := range expected {
 					var state []byte
@@ -349,18 +354,23 @@ var _ = Describe("OperatingSystemConfig", func() {
 						state = stateOriginal
 					}
 
-					expected[i].Annotations[v1beta1constants.GardenerOperation] = v1beta1constants.GardenerOperationWaitForState
-					expectedWithState := expected[i].DeepCopy()
-					expectedWithState.Status = extensionsv1alpha1.OperatingSystemConfigStatus{
-						DefaultStatus: extensionsv1alpha1.DefaultStatus{State: &runtime.RawExtension{Raw: state}},
-					}
-					expectedWithRestore := expectedWithState.DeepCopy()
-					expectedWithRestore.Annotations[v1beta1constants.GardenerOperation] = v1beta1constants.GardenerOperationRestore
+					// deploy with wait-for-state annotation
+					emptyWithName := empty.DeepCopy()
+					emptyWithName.SetName(expected[i].GetName())
+					obj := expected[i].DeepCopy()
+					metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "gardener.cloud/operation", "wait-for-state")
+					metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "gardener.cloud/timestamp", now.UTC().String())
+					obj.TypeMeta = metav1.TypeMeta{}
+					test.EXPECTPatch(ctx, mc, obj, emptyWithName, types.MergePatchType)
 
-					mc.EXPECT().Get(ctx, kutil.Key(namespace, expected[i].Name), gomock.AssignableToTypeOf(&extensionsv1alpha1.OperatingSystemConfig{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
-					mc.EXPECT().Create(ctx, expected[i])
-					mc.EXPECT().Status().Return(mc)
-					mc.EXPECT().Update(ctx, expectedWithState)
+					// restore state
+					expectedWithState := obj.DeepCopy()
+					expectedWithState.Status.State = &runtime.RawExtension{Raw: state}
+					test.EXPECTPatch(ctx, mc, expectedWithState, obj, types.MergePatchType)
+
+					// annotate with restore annotation
+					expectedWithRestore := expectedWithState.DeepCopy()
+					metav1.SetMetaDataAnnotation(&expectedWithRestore.ObjectMeta, "gardener.cloud/operation", "restore")
 					test.EXPECTPatch(ctx, mc, expectedWithRestore, expectedWithState, types.MergePatchType)
 				}
 
@@ -369,7 +379,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 			})
 		})
 
-		Describe("#Wait, #WorkerNameToOperatingSystemConfigsMap", func() {
+		Describe("#Wait", func() {
 			It("should return error when no resources are found", func() {
 				Expect(defaultDepWaiter.Wait(ctx)).To(MatchError(ContainSubstring("not found")))
 			})
@@ -401,7 +411,113 @@ var _ = Describe("OperatingSystemConfig", func() {
 				Expect(defaultDepWaiter.Wait(ctx)).To(MatchError(ContainSubstring("no cloud config information provided in status")))
 			})
 
+			It("should return error if we haven't observed the latest timestamp annotation", func() {
+				defer test.WithVars(
+					&TimeNow, mockNow.Do,
+					&DownloaderConfigFn, downloaderConfigFn,
+					&OriginalConfigFn, originalConfigFn,
+				)()
+				mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+
+				By("deploy")
+				// Deploy should fill internal state with the added timestamp annotation
+				Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
+
+				By("patch object")
+				for i := range expected {
+					patch := client.MergeFrom(expected[i].DeepCopy())
+					// remove operation annotation, add old timestamp annotation
+					expected[i].ObjectMeta.Annotations = map[string]string{
+						v1beta1constants.GardenerTimestamp: now.Add(-time.Millisecond).UTC().String(),
+					}
+					// set last operation
+					expected[i].Status.LastOperation = &gardencorev1beta1.LastOperation{
+						State: gardencorev1beta1.LastOperationStateSucceeded,
+					}
+					// set cloud-config secret information
+					expected[i].Status.CloudConfig = &extensionsv1alpha1.CloudConfig{
+						SecretRef: corev1.SecretReference{
+							Name:      "cc-" + expected[i].Name,
+							Namespace: expected[i].Name,
+						},
+					}
+					// set other status fields
+					expected[i].Status.Command = pointer.StringPtr("foo-" + expected[i].Name)
+					expected[i].Status.Units = []string{"bar-" + expected[i].Name, "baz-" + expected[i].Name}
+					Expect(c.Patch(ctx, expected[i], patch)).ToNot(HaveOccurred(), "patching operatingsystemconfig succeeds")
+
+					// create cloud-config secret
+					ccSecret := &corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "cc-" + expected[i].Name,
+							Namespace: expected[i].Name,
+						},
+						Data: map[string][]byte{
+							"cloud_config": []byte("foobar-" + expected[i].Name),
+						},
+					}
+					Expect(c.Create(ctx, ccSecret)).To(Succeed())
+				}
+
+				By("wait")
+				Expect(defaultDepWaiter.Wait(ctx)).NotTo(Succeed(), "operatingsystemconfig indicates error")
+			})
+
 			It("should return no error when it's ready", func() {
+				defer test.WithVars(
+					&TimeNow, mockNow.Do,
+					&DownloaderConfigFn, downloaderConfigFn,
+					&OriginalConfigFn, originalConfigFn,
+				)()
+				mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+
+				By("deploy")
+				// Deploy should fill internal state with the added timestamp annotation
+				Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
+
+				By("patch object")
+				for i := range expected {
+					patch := client.MergeFrom(expected[i].DeepCopy())
+					// remove operation annotation, add up-to-date timestamp annotation
+					expected[i].ObjectMeta.Annotations = map[string]string{
+						v1beta1constants.GardenerTimestamp: now.UTC().String(),
+					}
+					// set last operation
+					expected[i].Status.LastOperation = &gardencorev1beta1.LastOperation{
+						State: gardencorev1beta1.LastOperationStateSucceeded,
+					}
+					// set cloud-config secret information
+					expected[i].Status.CloudConfig = &extensionsv1alpha1.CloudConfig{
+						SecretRef: corev1.SecretReference{
+							Name:      "cc-" + expected[i].Name,
+							Namespace: expected[i].Name,
+						},
+					}
+					// set other status fields
+					expected[i].Status.Command = pointer.StringPtr("foo-" + expected[i].Name)
+					expected[i].Status.Units = []string{"bar-" + expected[i].Name, "baz-" + expected[i].Name}
+					Expect(c.Patch(ctx, expected[i], patch)).ToNot(HaveOccurred(), "patching operatingsystemconfig succeeds")
+
+					// create cloud-config secret
+					ccSecret := &corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "cc-" + expected[i].Name,
+							Namespace: expected[i].Name,
+						},
+						Data: map[string][]byte{
+							"cloud_config": []byte("foobar-" + expected[i].Name),
+						},
+					}
+					Expect(c.Create(ctx, ccSecret)).To(Succeed())
+				}
+
+				By("wait")
+				Expect(defaultDepWaiter.Wait(ctx)).To(Succeed(), "operatingsystemconfig is ready")
+			})
+		})
+
+		Describe("WorkerNameToOperatingSystemConfigsMap", func() {
+			It("should return the correct result from the Wait operation", func() {
 				for i := range expected {
 					// remove operation annotation
 					expected[i].ObjectMeta.Annotations = map[string]string{}

--- a/pkg/operation/botanist/component/extensions/worker/worker.go
+++ b/pkg/operation/botanist/component/extensions/worker/worker.go
@@ -24,6 +24,7 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig"
@@ -35,7 +36,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 const (
@@ -100,6 +100,13 @@ func New(
 		waitInterval:        waitInterval,
 		waitSevereThreshold: waitSevereThreshold,
 		waitTimeout:         waitTimeout,
+
+		worker: &extensionsv1alpha1.Worker{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      values.Name,
+				Namespace: values.Namespace,
+			},
+		},
 	}
 }
 
@@ -111,6 +118,7 @@ type worker struct {
 	waitSevereThreshold time.Duration
 	waitTimeout         time.Duration
 
+	worker             *extensionsv1alpha1.Worker
 	machineDeployments []extensionsv1alpha1.MachineDeployment
 }
 
@@ -121,15 +129,7 @@ func (w *worker) Deploy(ctx context.Context) error {
 }
 
 func (w *worker) deploy(ctx context.Context, operation string) (extensionsv1alpha1.Object, error) {
-	var (
-		worker = &extensionsv1alpha1.Worker{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      w.values.Name,
-				Namespace: w.values.Namespace,
-			},
-		}
-		pools []extensionsv1alpha1.WorkerPool
-	)
+	var pools []extensionsv1alpha1.WorkerPool
 
 	for _, workerPool := range w.values.Workers {
 		var volume *extensionsv1alpha1.Volume
@@ -216,18 +216,22 @@ func (w *worker) deploy(ctx context.Context, operation string) (extensionsv1alph
 		})
 	}
 
-	_, err := controllerutil.CreateOrUpdate(ctx, w.client, worker, func() error {
-		metav1.SetMetaDataAnnotation(&worker.ObjectMeta, v1beta1constants.GardenerOperation, operation)
-		metav1.SetMetaDataAnnotation(&worker.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
+	// We operate on arrays (pools) with merge patch without optimistic locking here, meaning this will replace
+	// the arrays as a whole.
+	// However, this is not a problem, as no other client should write to these arrays as the Worker spec is supposed
+	// to be owned by gardenlet exclusively.
+	_, err := controllerutils.MergePatchOrCreate(ctx, w.client, w.worker, func() error {
+		metav1.SetMetaDataAnnotation(&w.worker.ObjectMeta, v1beta1constants.GardenerOperation, operation)
+		metav1.SetMetaDataAnnotation(&w.worker.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
 
-		worker.Spec = extensionsv1alpha1.WorkerSpec{
+		w.worker.Spec = extensionsv1alpha1.WorkerSpec{
 			DefaultSpec: extensionsv1alpha1.DefaultSpec{
 				Type: w.values.Type,
 			},
 			Region: w.values.Region,
 			SecretRef: corev1.SecretReference{
 				Name:      v1beta1constants.SecretNameCloudProvider,
-				Namespace: worker.Namespace,
+				Namespace: w.worker.Namespace,
 			},
 			SSHPublicKey:                 w.values.SSHPublicKey,
 			InfrastructureProviderStatus: w.values.InfrastructureProviderStatus,
@@ -237,7 +241,7 @@ func (w *worker) deploy(ctx context.Context, operation string) (extensionsv1alph
 		return nil
 	})
 
-	return worker, err
+	return w.worker, err
 }
 
 // Restore uses the seed client and the ShootState to create the Worker resources and restore their state.
@@ -247,53 +251,41 @@ func (w *worker) Restore(ctx context.Context, shootState *gardencorev1alpha1.Sho
 		w.client,
 		shootState,
 		extensionsv1alpha1.WorkerResource,
-		w.values.Namespace,
 		w.deploy,
 	)
 }
 
 // Migrate migrates the Worker resource.
 func (w *worker) Migrate(ctx context.Context) error {
-	return extensions.MigrateExtensionCR(
+	return extensions.MigrateExtensionObject(
 		ctx,
 		w.client,
-		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Worker{} },
-		w.values.Namespace,
-		w.values.Name,
+		w.worker,
 	)
 }
 
 // Destroy deletes the Worker resource.
 func (w *worker) Destroy(ctx context.Context) error {
-	return extensions.DeleteExtensionCR(
+	return extensions.DeleteExtensionObject(
 		ctx,
 		w.client,
-		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Worker{} },
-		w.values.Namespace,
-		w.values.Name,
+		w.worker,
 	)
 }
 
 // Wait waits until the Worker resource is ready.
 func (w *worker) Wait(ctx context.Context) error {
-	return extensions.WaitUntilExtensionCRReady(
+	return extensions.WaitUntilExtensionObjectReady(
 		ctx,
 		w.client,
 		w.logger,
-		func() client.Object { return &extensionsv1alpha1.Worker{} },
+		w.worker,
 		extensionsv1alpha1.WorkerResource,
-		w.values.Namespace,
-		w.values.Name,
 		w.waitInterval,
 		w.waitSevereThreshold,
 		w.waitTimeout,
-		func(obj client.Object) error {
-			worker, ok := obj.(*extensionsv1alpha1.Worker)
-			if !ok {
-				return fmt.Errorf("expected extensionsv1alpha1.Worker but got %T", worker)
-			}
-
-			w.machineDeployments = worker.Status.MachineDeployments
+		func() error {
+			w.machineDeployments = w.worker.Status.MachineDeployments
 			return nil
 		},
 	)
@@ -301,12 +293,10 @@ func (w *worker) Wait(ctx context.Context) error {
 
 // WaitMigrate waits until the Worker resources are migrated successfully.
 func (w *worker) WaitMigrate(ctx context.Context) error {
-	return extensions.WaitUntilExtensionCRMigrated(
+	return extensions.WaitUntilExtensionObjectMigrated(
 		ctx,
 		w.client,
-		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Worker{} },
-		w.values.Namespace,
-		w.values.Name,
+		w.worker,
 		w.waitInterval,
 		w.waitTimeout,
 	)
@@ -314,20 +304,18 @@ func (w *worker) WaitMigrate(ctx context.Context) error {
 
 // WaitCleanup waits until the Worker resource is deleted.
 func (w *worker) WaitCleanup(ctx context.Context) error {
-	return extensions.WaitUntilExtensionCRDeleted(
+	return extensions.WaitUntilExtensionObjectDeleted(
 		ctx,
 		w.client,
 		w.logger,
-		func() extensionsv1alpha1.Object { return &extensionsv1alpha1.Worker{} },
+		w.worker,
 		extensionsv1alpha1.WorkerResource,
-		w.values.Namespace,
-		w.values.Name,
 		w.waitInterval,
 		w.waitTimeout,
 	)
 }
 
-// SetPublicSSHKey sets the public SSH key in the values.
+// SetSSHPublicKey sets the public SSH key in the values.
 func (w *worker) SetSSHPublicKey(key []byte) {
 	w.values.SSHPublicKey = key
 }
@@ -337,7 +325,7 @@ func (w *worker) SetInfrastructureProviderStatus(status *runtime.RawExtension) {
 	w.values.InfrastructureProviderStatus = status
 }
 
-// SetOperatingSystemConfigMaps sets the operating system config maps in the values.
+// SetWorkerNameToOperatingSystemConfigsMap sets the operating system config maps in the values.
 func (w *worker) SetWorkerNameToOperatingSystemConfigsMap(maps map[string]*operatingsystemconfig.OperatingSystemConfigs) {
 	w.values.WorkerNameToOperatingSystemConfigsMap = maps
 }

--- a/pkg/operation/botanist/component/extensions/worker/worker.go
+++ b/pkg/operation/botanist/component/extensions/worker/worker.go
@@ -220,7 +220,7 @@ func (w *worker) deploy(ctx context.Context, operation string) (extensionsv1alph
 	// the arrays as a whole.
 	// However, this is not a problem, as no other client should write to these arrays as the Worker spec is supposed
 	// to be owned by gardenlet exclusively.
-	_, err := controllerutils.MergePatchOrCreate(ctx, w.client, w.worker, func() error {
+	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, w.client, w.worker, func() error {
 		metav1.SetMetaDataAnnotation(&w.worker.ObjectMeta, v1beta1constants.GardenerOperation, operation)
 		metav1.SetMetaDataAnnotation(&w.worker.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
 

--- a/pkg/operation/botanist/component/extensions/worker/worker_test.go
+++ b/pkg/operation/botanist/component/extensions/worker/worker_test.go
@@ -21,6 +21,7 @@ import (
 
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/pkg/logger"
@@ -30,7 +31,6 @@ import (
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/worker"
 	"github.com/gardener/gardener/pkg/utils"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
-	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 
@@ -39,7 +39,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -105,13 +104,8 @@ var _ = Describe("Worker", func() {
 		worker2MachineImageVersion       = "worker2machineimagev1"
 		worker2UserData                  = []byte("bootstrap-me-now")
 
-		w = &extensionsv1alpha1.Worker{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: namespace,
-			},
-		}
-		wSpec extensionsv1alpha1.WorkerSpec
+		w, empty *extensionsv1alpha1.Worker
+		wSpec    extensionsv1alpha1.WorkerSpec
 
 		defaultDepWaiter worker.Interface
 		values           *worker.Values
@@ -120,6 +114,7 @@ var _ = Describe("Worker", func() {
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		mockNow = mocktime.NewMockNow(ctrl)
+		now = time.Now()
 
 		s := runtime.NewScheme()
 		Expect(extensionsv1alpha1.AddToScheme(s)).NotTo(HaveOccurred())
@@ -202,6 +197,18 @@ var _ = Describe("Worker", func() {
 				},
 			},
 		}
+
+		empty = &extensionsv1alpha1.Worker{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+		}
+		w = empty.DeepCopy()
+		w.SetAnnotations(map[string]string{
+			v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
+			v1beta1constants.GardenerTimestamp: now.UTC().String(),
+		})
 
 		wSpec = extensionsv1alpha1.WorkerSpec{
 			DefaultSpec: extensionsv1alpha1.DefaultSpec{
@@ -330,15 +337,56 @@ var _ = Describe("Worker", func() {
 			Expect(defaultDepWaiter.Wait(ctx)).To(HaveOccurred(), "worker indicates error")
 		})
 
-		It("should return no error when it's ready", func() {
-			obj := w.DeepCopy()
-			obj.Annotations = nil
-			obj.Status.LastOperation = &gardencorev1beta1.LastOperation{
+		It("should return error if we haven't observed the latest timestamp annotation", func() {
+			defer test.WithVars(
+				&worker.TimeNow, mockNow.Do,
+			)()
+			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+
+			By("deploy")
+			// Deploy should fill internal state with the added timestamp annotation
+			Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
+
+			By("patch object")
+			patch := client.MergeFrom(w.DeepCopy())
+			w.Status.LastError = nil
+			// remove operation annotation, add old timestamp annotation
+			w.ObjectMeta.Annotations = map[string]string{
+				v1beta1constants.GardenerTimestamp: now.Add(-time.Millisecond).UTC().String(),
+			}
+			w.Status.LastOperation = &gardencorev1beta1.LastOperation{
 				State: gardencorev1beta1.LastOperationStateSucceeded,
 			}
-			Expect(c.Create(ctx, obj)).To(Succeed(), "creating worker succeeds")
+			Expect(c.Patch(ctx, w, patch)).To(Succeed(), "patching worker succeeds")
 
-			Expect(defaultDepWaiter.Wait(ctx)).To(Succeed(), "worker is ready, should not return an error")
+			By("wait")
+			Expect(defaultDepWaiter.Wait(ctx)).NotTo(Succeed(), "worker indicates error")
+		})
+
+		It("should return no error when it's ready", func() {
+			defer test.WithVars(
+				&worker.TimeNow, mockNow.Do,
+			)()
+			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+
+			By("deploy")
+			// Deploy should fill internal state with the added timestamp annotation
+			Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
+
+			By("patch object")
+			patch := client.MergeFrom(w.DeepCopy())
+			w.Status.LastError = nil
+			// remove operation annotation, add up-to-date timestamp annotation
+			w.ObjectMeta.Annotations = map[string]string{
+				v1beta1constants.GardenerTimestamp: now.UTC().String(),
+			}
+			w.Status.LastOperation = &gardencorev1beta1.LastOperation{
+				State: gardencorev1beta1.LastOperationStateSucceeded,
+			}
+			Expect(c.Patch(ctx, w, patch)).To(Succeed(), "patching worker succeeds")
+
+			By("wait")
+			Expect(defaultDepWaiter.Wait(ctx)).To(Succeed(), "worker is ready")
 		})
 	})
 
@@ -413,20 +461,25 @@ var _ = Describe("Worker", func() {
 			)()
 			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
 
+			mc := mockclient.NewMockClient(ctrl)
+			mc.EXPECT().Status().Return(mc)
+
+			// deploy with wait-for-state annotation
 			obj := w.DeepCopy()
 			obj.Spec = wSpec
 			metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "gardener.cloud/operation", "wait-for-state")
 			metav1.SetMetaDataAnnotation(&obj.ObjectMeta, "gardener.cloud/timestamp", now.UTC().String())
+			obj.TypeMeta = metav1.TypeMeta{}
+			test.EXPECTPatch(ctx, mc, obj, empty, types.MergePatchType)
+
+			// restore state
 			expectedWithState := obj.DeepCopy()
 			expectedWithState.Status.State = state
+			test.EXPECTPatch(ctx, mc, expectedWithState, obj, types.MergePatchType)
+
+			// annotate with restore annotation
 			expectedWithRestore := expectedWithState.DeepCopy()
 			expectedWithRestore.Annotations["gardener.cloud/operation"] = "restore"
-
-			mc := mockclient.NewMockClient(ctrl)
-			mc.EXPECT().Get(ctx, kutil.Key(namespace, name), gomock.AssignableToTypeOf(&extensionsv1alpha1.Worker{})).Return(apierrors.NewNotFound(extensionsv1alpha1.Resource("Worker"), name))
-			mc.EXPECT().Create(ctx, obj)
-			mc.EXPECT().Status().Return(mc)
-			mc.EXPECT().Update(ctx, expectedWithState)
 			test.EXPECTPatch(ctx, mc, expectedWithRestore, expectedWithState, types.MergePatchType)
 
 			Expect(worker.New(log, mc, values, time.Millisecond, 250*time.Millisecond, 500*time.Millisecond).Restore(ctx, shootState)).To(Succeed())

--- a/pkg/operation/shoot/types.go
+++ b/pkg/operation/shoot/types.go
@@ -24,7 +24,6 @@ import (
 	"github.com/gardener/gardener/pkg/operation/botanist/component/clusterautoscaler"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/clusteridentity"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/etcd"
-	extensionsbackupentry "github.com/gardener/gardener/pkg/operation/botanist/component/extensions/backupentry"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/containerruntime"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/controlplane"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/extension"
@@ -113,7 +112,6 @@ type ControlPlane struct {
 
 // Extensions contains references to extension resources.
 type Extensions struct {
-	BackupEntry           extensionsbackupentry.Interface
 	ContainerRuntime      containerruntime.Interface
 	ControlPlane          controlplane.Interface
 	ControlPlaneExposure  controlplane.Interface

--- a/pkg/utils/kubernetes/health/health.go
+++ b/pkg/utils/kubernetes/health/health.go
@@ -324,6 +324,21 @@ func CheckManagedSeed(managedSeed *seedmanagementv1alpha1.ManagedSeed) error {
 	return nil
 }
 
+// ObjectHasAnnotationWithValue returns a health check function that checks if a given Object has an annotation with
+// a specified value.
+func ObjectHasAnnotationWithValue(key, value string) Func {
+	return func(o client.Object) error {
+		actual, ok := o.GetAnnotations()[key]
+		if !ok {
+			return fmt.Errorf("object does not have %q annotation", key)
+		}
+		if actual != value {
+			return fmt.Errorf("object's %q annotation is not %q but %q", key, value, actual)
+		}
+		return nil
+	}
+}
+
 // CheckExtensionObject checks if an extension Object is healthy or not.
 // An extension object is healthy if
 // * Its observed generation is up-to-date
@@ -351,7 +366,7 @@ func ExtensionOperationHasBeenUpdatedSince(lastUpdateTime metav1.Time) Func {
 
 		lastOperation := obj.GetExtensionStatus().GetLastOperation()
 		if lastOperation == nil || !lastOperation.LastUpdateTime.After(lastUpdateTime.Time) {
-			return fmt.Errorf("extension operation was not updated yet")
+			return fmt.Errorf("extension operation has not been updated yet")
 		}
 		return nil
 	}

--- a/pkg/utils/kubernetes/health/health_test.go
+++ b/pkg/utils/kubernetes/health/health_test.go
@@ -306,6 +306,41 @@ var _ = Describe("health", func() {
 		)
 	})
 
+	Describe("ObjectHasAnnotationWithValue", func() {
+		var (
+			healthFunc health.Func
+			key, value string
+		)
+
+		BeforeEach(func() {
+			key = "foo"
+			value = "bar"
+			healthFunc = health.ObjectHasAnnotationWithValue(key, value)
+		})
+
+		It("should fail if object does not have the annotation", func() {
+			Expect(healthFunc(&extensionsv1alpha1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"other": "bla"},
+				},
+			})).NotTo(Succeed())
+		})
+		It("should fail if object's annotation have a different value", func() {
+			Expect(healthFunc(&extensionsv1alpha1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{key: "nope"},
+				},
+			})).NotTo(Succeed())
+		})
+		It("should succeed if object's annotation has the expected value", func() {
+			Expect(healthFunc(&extensionsv1alpha1.Infrastructure{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{key: value},
+				},
+			})).To(Succeed())
+		})
+	})
+
 	Describe("CheckExtensionObject", func() {
 		DescribeTable("extension objects",
 			func(obj client.Object, match types.GomegaMatcher) {

--- a/pkg/utils/object.go
+++ b/pkg/utils/object.go
@@ -86,6 +86,7 @@ func CreateOrUpdateObject(ctx context.Context, c client.Client, gvk schema.Group
 	obj.SetNamespace(namespace)
 
 	// Create or update the object
+	// TODO(timebertt): replace RetryOnConflict+CreateOrUpdate with PatchOrCreate
 	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
 		_, err := controllerutil.CreateOrUpdate(ctx, c, obj, func() error {
 			// Set object content

--- a/pkg/utils/test/gomock.go
+++ b/pkg/utils/test/gomock.go
@@ -1,0 +1,49 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"fmt"
+
+	"github.com/golang/mock/gomock"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// HasObjectKeyOf returns a gomock.Matcher that matches if actual is a client.Object that has the same
+// ObjectKey as expected.
+func HasObjectKeyOf(expected client.Object) gomock.Matcher {
+	return &objectKeyMatcher{key: client.ObjectKeyFromObject(expected)}
+}
+
+type objectKeyMatcher struct {
+	key client.ObjectKey
+}
+
+func (o *objectKeyMatcher) Matches(actual interface{}) bool {
+	if actual == nil {
+		return false
+	}
+
+	obj, ok := actual.(client.Object)
+	if !ok {
+		return false
+	}
+
+	return o.key == client.ObjectKeyFromObject(obj)
+}
+
+func (o *objectKeyMatcher) String() string {
+	return fmt.Sprintf("has object key %q", o.key)
+}

--- a/pkg/utils/test/gomock_test.go
+++ b/pkg/utils/test/gomock_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test_test
+
+import (
+	"github.com/gardener/gardener/pkg/utils/test"
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("gomock Matchers", func() {
+	Describe("#HasObjectKeyOf", func() {
+		var (
+			matcher  gomock.Matcher
+			expected client.Object
+		)
+
+		BeforeEach(func() {
+			expected = &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+				},
+			}
+			matcher = test.HasObjectKeyOf(expected)
+		})
+
+		Describe("#Matches", func() {
+			It("return true for same key", func() {
+				Expect(matcher.Matches(expected.DeepCopyObject())).To(BeTrue())
+			})
+			It("return false for different key", func() {
+				otherObject := expected.DeepCopyObject().(client.Object)
+				otherObject.SetName("other")
+				Expect(matcher.Matches(otherObject)).To(BeFalse())
+			})
+			It("return false for non-objects", func() {
+				notAnObject := corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "foo",
+						Namespace: "bar",
+					},
+				}
+				Expect(matcher.Matches(notAnObject)).To(BeFalse())
+			})
+		})
+
+		Describe("#String", func() {
+			It("should return key in description", func() {
+				Expect(matcher.String()).To(ContainSubstring(client.ObjectKeyFromObject(expected).String()))
+			})
+		})
+	})
+})

--- a/pkg/utils/test/matchers/matchers.go
+++ b/pkg/utils/test/matchers/matchers.go
@@ -25,15 +25,19 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
-// DeepEqual returns a Gomega matcher which checks whether the expected object is deeply equal with the object it is
-// being compared against.
-func DeepEqual(expected interface{}) types.GomegaMatcher {
+func init() {
 	// if CharactersAroundMismatchToInclude is too small, then format.MessageWithDiff will be unable to output our
 	// mismatch message
+	// set the variable in init func, otherwise the race detector will complain when matchers are used concurrently in
+	// multiple goroutines
 	if format.CharactersAroundMismatchToInclude < 50 {
 		format.CharactersAroundMismatchToInclude = 50
 	}
+}
 
+// DeepEqual returns a Gomega matcher which checks whether the expected object is deeply equal with the object it is
+// being compared against.
+func DeepEqual(expected interface{}) types.GomegaMatcher {
 	return newDeepEqualMatcher(expected)
 }
 
@@ -41,12 +45,6 @@ func DeepEqual(expected interface{}) types.GomegaMatcher {
 // ignored (not compared). This allows us to focus on the fields that matter to
 // the semantic comparison.
 func DeepDerivativeEqual(expected interface{}) types.GomegaMatcher {
-	// if CharactersAroundMismatchToInclude is too small, then format.MessageWithDiff will be unable to output our
-	// mismatch message
-	if format.CharactersAroundMismatchToInclude < 50 {
-		format.CharactersAroundMismatchToInclude = 50
-	}
-
 	return newDeepDerivativeMatcher(expected)
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity scalability
/kind cleanup

**What this PR does / why we need it**:

Similar to previous PRs, this PR works towards getting rid of the `DirectClient`.
This one tackles usages in the extension components and makes them ready for cached clients.

**Which issue(s) this PR fixes**:
Part of #2822

**Special notes for your reviewer**:

c7bd0175eadbf34e8c4ac44eb4640c183d39fda3 is a prefactoring of the extension helper funcs, that is necessary for making the components ready for a cached client (see commit message for more details/reasoning).
The other commits perform the actual refactoring/adaption per component.

/squash

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
