### PR TITLE
Allow disabling scale-down of some control-plane components

### DIFF
--- a/charts/seed-controlplane/charts/kube-apiserver/templates/hvpa.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/hvpa.yaml
@@ -22,7 +22,7 @@ spec:
         updateMode: "Auto"
     scaleDown:
       updatePolicy:
-        updateMode: "Auto"
+        updateMode: {{ .Values.scaleDownUpdateMode | quote }}
     template:
       metadata:
         labels:
@@ -54,7 +54,7 @@ spec:
 {{- end }}
     scaleDown:
       updatePolicy:
-        updateMode: "Auto"
+        updateMode: {{ .Values.scaleDownUpdateMode | quote }}
 {{- if .Values.scaleDownStabilization }}
 {{ toYaml .Values.scaleDownStabilization | indent 6 }}
 {{- end }}

--- a/charts/seed-controlplane/charts/kube-apiserver/values.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/values.yaml
@@ -152,6 +152,7 @@ scaleDownStabilization:
     memory:
       value: 200M
       percentage: 80
+scaleDownUpdateMode: "Auto"
 
 limitsRequestsGapScaleParams:
   cpu:

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -213,7 +213,7 @@ const (
 	// what you do.
 	ShootAlphaScalingAPIServerClass = "alpha.kube-apiserver.scaling.shoot.gardener.cloud/class"
 	// ShootAlphaControlPlaneScaleDownDisabled is a constant for an annotation on the Shoot resource staiting that the
-	// automatic scale-down shall be disabled for the etcd, kube-controller-manager.
+	// automatic scale-down shall be disabled for the etcd, kube-apiserver, kube-controller-manager.
 	// Note that this annotation is alpha and can be removed anytime without further notice. Only use it if you know
 	// what you do.
 	ShootAlphaControlPlaneScaleDownDisabled = "alpha.control-plane.scaling.shoot.gardener.cloud/scale-down-disabled"

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -213,7 +213,7 @@ const (
 	// what you do.
 	ShootAlphaScalingAPIServerClass = "alpha.kube-apiserver.scaling.shoot.gardener.cloud/class"
 	// ShootAlphaControlPlaneScaleDownDisabled is a constant for an annotation on the Shoot resource staiting that the
-	// automatic scale-down shall be disabled for the etcd.
+	// automatic scale-down shall be disabled for the etcd, kube-controller-manager.
 	// Note that this annotation is alpha and can be removed anytime without further notice. Only use it if you know
 	// what you do.
 	ShootAlphaControlPlaneScaleDownDisabled = "alpha.control-plane.scaling.shoot.gardener.cloud/scale-down-disabled"

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -212,6 +212,11 @@ const (
 	// Note that this annotation is alpha and can be removed anytime without further notice. Only use it if you know
 	// what you do.
 	ShootAlphaScalingAPIServerClass = "alpha.kube-apiserver.scaling.shoot.gardener.cloud/class"
+	// ShootAlphaControlPlaneScaleDownDisabled is a constant for an annotation on the Shoot resource staiting that the
+	// automatic scale-down shall be disabled for the etcd.
+	// Note that this annotation is alpha and can be removed anytime without further notice. Only use it if you know
+	// what you do.
+	ShootAlphaControlPlaneScaleDownDisabled = "alpha.control-plane.scaling.shoot.gardener.cloud/scale-down-disabled"
 	// ShootExpirationTimestamp is an annotation on a Shoot resource whose value represents the time when the Shoot lifetime
 	// is expired. The lifetime can be extended, but at most by the minimal value of the 'clusterLifetimeDays' property
 	// of referenced quotas.

--- a/pkg/operation/botanist/component/etcd/etcd.go
+++ b/pkg/operation/botanist/component/etcd/etcd.go
@@ -364,6 +364,11 @@ func (e *etcd) Deploy(ctx context.Context) error {
 			containerPolicyOff = autoscalingv1beta2.ContainerScalingModeOff
 		)
 
+		scaleDownUpdateMode := e.hvpaConfig.ScaleDownUpdateMode
+		if scaleDownUpdateMode == nil {
+			scaleDownUpdateMode = pointer.StringPtr(hvpav1alpha1.UpdateModeMaintenanceWindow)
+		}
+
 		if _, err := controllerutil.CreateOrUpdate(ctx, e.client, hvpa, func() error {
 			hvpa.Labels = utils.MergeStringMaps(e.getLabels(), map[string]string{
 				v1beta1constants.LabelApp: LabelAppValue,
@@ -423,7 +428,7 @@ func (e *etcd) Deploy(ctx context.Context) error {
 				},
 				ScaleDown: hvpav1alpha1.ScaleType{
 					UpdatePolicy: hvpav1alpha1.UpdatePolicy{
-						UpdateMode: e.hvpaConfig.ScaleDownUpdateMode,
+						UpdateMode: scaleDownUpdateMode,
 					},
 					StabilizationDuration: pointer.StringPtr("15m"),
 					MinChange: hvpav1alpha1.ScaleParams{
@@ -695,6 +700,6 @@ type HVPAConfig struct {
 	// MaintenanceTimeWindow contains begin and end of a time window that allows down-scaling the etcd in case its
 	// resource requests/limits are unnecessarily high.
 	MaintenanceTimeWindow gardencorev1beta1.MaintenanceTimeWindow
-	// The update mode to use for etcd scale down.
+	// The update mode to use for scale down.
 	ScaleDownUpdateMode *string
 }

--- a/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager.go
@@ -361,6 +361,13 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 					},
 				},
 			}
+			hvpa.Spec.WeightBasedScalingIntervals = []hvpav1alpha1.WeightBasedScalingInterval{
+				{
+					VpaWeight:         hvpav1alpha1.VpaOnly,
+					StartReplicaCount: 1,
+					LastReplicaCount:  1,
+				},
+			}
 			hvpa.Spec.TargetRef = &autoscalingv2beta1.CrossVersionObjectReference{
 				APIVersion: appsv1.SchemeGroupVersion.String(),
 				Kind:       "Deployment",

--- a/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager.go
@@ -20,8 +20,6 @@ import (
 	"net"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
@@ -29,12 +27,16 @@ import (
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 	"github.com/gardener/gardener/pkg/utils/secrets"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 
 	"github.com/Masterminds/semver"
 	resourcesv1alpha1 "github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1"
+	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
+	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	autoscalingv2beta1 "k8s.io/api/autoscaling/v2beta1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -88,6 +90,12 @@ type KubeControllerManager interface {
 	SetShootClient(c client.Client)
 }
 
+// HVPAConfig contains information for configuring the HVPA object for the etcd.
+type HVPAConfig struct {
+	// Enabled states whether an HVPA object shall be deployed.
+	Enabled bool
+}
+
 // New creates a new instance of DeployWaiter for the kube-controller-manager.
 func New(
 	logger logrus.FieldLogger,
@@ -98,6 +106,7 @@ func New(
 	config *gardencorev1beta1.KubeControllerManagerConfig,
 	podNetwork *net.IPNet,
 	serviceNetwork *net.IPNet,
+	hvpaConfig *HVPAConfig,
 ) KubeControllerManager {
 	return &kubeControllerManager{
 		log:            logger,
@@ -108,6 +117,7 @@ func New(
 		config:         config,
 		podNetwork:     podNetwork,
 		serviceNetwork: serviceNetwork,
+		hvpaConfig:     hvpaConfig,
 	}
 }
 
@@ -123,6 +133,7 @@ type kubeControllerManager struct {
 	secrets        Secrets
 	podNetwork     *net.IPNet
 	serviceNetwork *net.IPNet
+	hvpaConfig     *HVPAConfig
 }
 
 func (k *kubeControllerManager) Deploy(ctx context.Context) error {
@@ -140,15 +151,29 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 	}
 
 	var (
-		vpa           = k.emptyVPA()
-		service       = k.emptyService()
-		deployment    = k.emptyDeployment()
-		vpaUpdateMode = autoscalingv1beta2.UpdateModeAuto
+		vpa        = k.emptyVPA()
+		hvpa       = k.emptyHVPA()
+		service    = k.emptyService()
+		deployment = k.emptyDeployment()
 
-		port           int32 = 10257
-		probeURIScheme       = corev1.URISchemeHTTPS
-		command              = k.computeCommand(port)
+		port              int32 = 10257
+		probeURIScheme          = corev1.URISchemeHTTPS
+		command                 = k.computeCommand(port)
+		vpaResourcePolicy       = &autoscalingv1beta2.PodResourcePolicy{
+			ContainerPolicies: []autoscalingv1beta2.ContainerResourcePolicy{{
+				ContainerName: containerName,
+				MinAllowed: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("100m"),
+					corev1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+			}},
+		}
 	)
+
+	resourceRequirements, err := k.computeResourceRequirements(ctx)
+	if err != nil {
+		return err
+	}
 
 	if _, err := controllerutil.CreateOrUpdate(ctx, k.seedClient, service, func() error {
 		service.Labels = getLabels()
@@ -219,16 +244,7 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 								Protocol:      corev1.ProtocolTCP,
 							},
 						},
-						Resources: corev1.ResourceRequirements{
-							Requests: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("100m"),
-								corev1.ResourceMemory: resource.MustParse("128Mi"),
-							},
-							Limits: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("400m"),
-								corev1.ResourceMemory: resource.MustParse("512Mi"),
-							},
-						},
+						Resources: resourceRequirements,
 						VolumeMounts: []corev1.VolumeMount{
 							{
 								Name:      k.secrets.CA.Name,
@@ -290,27 +306,84 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	if _, err := controllerutil.CreateOrUpdate(ctx, k.seedClient, vpa, func() error {
-		vpa.Spec.TargetRef = &autoscalingv1.CrossVersionObjectReference{
-			APIVersion: appsv1.SchemeGroupVersion.String(),
-			Kind:       "Deployment",
-			Name:       v1beta1constants.DeploymentNameKubeControllerManager,
+	if k.hvpaConfig != nil && k.hvpaConfig.Enabled {
+		if err := kutil.DeleteObject(ctx, k.seedClient, vpa); err != nil {
+			return err
 		}
-		vpa.Spec.UpdatePolicy = &autoscalingv1beta2.PodUpdatePolicy{
-			UpdateMode: &vpaUpdateMode,
-		}
-		vpa.Spec.ResourcePolicy = &autoscalingv1beta2.PodResourcePolicy{
-			ContainerPolicies: []autoscalingv1beta2.ContainerResourcePolicy{{
-				ContainerName: containerName,
-				MinAllowed: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("100m"),
-					corev1.ResourceMemory: resource.MustParse("100Mi"),
+
+		var (
+			updateModeAuto = hvpav1alpha1.UpdateModeAuto
+			vpaLabels      = map[string]string{v1beta1constants.LabelRole: "kube-controller-manager-vpa"}
+		)
+
+		if _, err := controllerutil.CreateOrUpdate(ctx, k.seedClient, hvpa, func() error {
+			hvpa.Labels = getLabels()
+			hvpa.Spec.Replicas = pointer.Int32Ptr(1)
+			hvpa.Spec.Hpa = hvpav1alpha1.HpaSpec{
+				Deploy:   false,
+				Selector: &metav1.LabelSelector{MatchLabels: getLabels()},
+				Template: hvpav1alpha1.HpaTemplate{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: getLabels(),
+					},
+					Spec: hvpav1alpha1.HpaTemplateSpec{
+						MinReplicas: pointer.Int32Ptr(int32(1)),
+						MaxReplicas: int32(1),
+					},
 				},
-			}},
+			}
+			hvpa.Spec.Vpa = hvpav1alpha1.VpaSpec{
+				Selector: &metav1.LabelSelector{MatchLabels: vpaLabels},
+				Deploy:   true,
+				ScaleUp: hvpav1alpha1.ScaleType{
+					UpdatePolicy: hvpav1alpha1.UpdatePolicy{
+						UpdateMode: &updateModeAuto,
+					},
+				},
+				ScaleDown: hvpav1alpha1.ScaleType{
+					UpdatePolicy: hvpav1alpha1.UpdatePolicy{
+						UpdateMode: &updateModeAuto,
+					},
+				},
+				Template: hvpav1alpha1.VpaTemplate{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: vpaLabels,
+					},
+					Spec: hvpav1alpha1.VpaTemplateSpec{
+						ResourcePolicy: vpaResourcePolicy,
+					},
+				},
+			}
+			hvpa.Spec.TargetRef = &autoscalingv2beta1.CrossVersionObjectReference{
+				APIVersion: appsv1.SchemeGroupVersion.String(),
+				Kind:       "Deployment",
+				Name:       v1beta1constants.DeploymentNameKubeControllerManager,
+			}
+			return nil
+		}); err != nil {
+			return err
 		}
-		return nil
-	}); err != nil {
-		return err
+	} else {
+		if err := kutil.DeleteObject(ctx, k.seedClient, hvpa); err != nil {
+			return err
+		}
+
+		vpaUpdateMode := autoscalingv1beta2.UpdateModeAuto
+
+		if _, err := controllerutil.CreateOrUpdate(ctx, k.seedClient, vpa, func() error {
+			vpa.Spec.TargetRef = &autoscalingv1.CrossVersionObjectReference{
+				APIVersion: appsv1.SchemeGroupVersion.String(),
+				Kind:       "Deployment",
+				Name:       v1beta1constants.DeploymentNameKubeControllerManager,
+			}
+			vpa.Spec.UpdatePolicy = &autoscalingv1beta2.PodUpdatePolicy{
+				UpdateMode: &vpaUpdateMode,
+			}
+			vpa.Spec.ResourcePolicy = vpaResourcePolicy
+			return nil
+		}); err != nil {
+			return err
+		}
 	}
 
 	// create managed resource that deploys resources to the Shoot API Server
@@ -326,6 +399,10 @@ func (k *kubeControllerManager) Destroy(_ context.Context) error { return nil }
 
 func (k *kubeControllerManager) emptyVPA() *autoscalingv1beta2.VerticalPodAutoscaler {
 	return &autoscalingv1beta2.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "kube-controller-manager-vpa", Namespace: k.namespace}}
+}
+
+func (k *kubeControllerManager) emptyHVPA() *hvpav1alpha1.Hvpa {
+	return &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameKubeControllerManager, Namespace: k.namespace}}
 }
 
 func (k *kubeControllerManager) emptyService() *corev1.Service {
@@ -463,6 +540,37 @@ func (k *kubeControllerManager) getHorizontalPodAutoscalerConfig() gardencorev1b
 		}
 	}
 	return horizontalPodAutoscalerConfig
+}
+
+func (k *kubeControllerManager) computeResourceRequirements(ctx context.Context) (corev1.ResourceRequirements, error) {
+	defaultResources := corev1.ResourceRequirements{
+		Requests: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("100m"),
+			corev1.ResourceMemory: resource.MustParse("128Mi"),
+		},
+		Limits: corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("400m"),
+			corev1.ResourceMemory: resource.MustParse("512Mi"),
+		},
+	}
+
+	if k.hvpaConfig == nil || !k.hvpaConfig.Enabled {
+		return defaultResources, nil
+	}
+
+	existingDeployment := k.emptyDeployment()
+	if err := k.seedClient.Get(ctx, client.ObjectKeyFromObject(existingDeployment), existingDeployment); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return corev1.ResourceRequirements{}, err
+		}
+		return defaultResources, nil // Deployment was not found, hence, use the default resources
+	}
+
+	if len(existingDeployment.Spec.Template.Spec.Containers) > 0 {
+		return existingDeployment.Spec.Template.Spec.Containers[0].Resources, nil
+	}
+
+	return defaultResources, nil
 }
 
 var (

--- a/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager_test.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager_test.go
@@ -342,6 +342,13 @@ var _ = Describe("KubeControllerManager", func() {
 									},
 								},
 							},
+							WeightBasedScalingIntervals: []hvpav1alpha1.WeightBasedScalingInterval{
+								{
+									VpaWeight:         hvpav1alpha1.VpaOnly,
+									StartReplicaCount: 1,
+									LastReplicaCount:  1,
+								},
+							},
 							TargetRef: &autoscalingv2beta1.CrossVersionObjectReference{
 								APIVersion: appsv1.SchemeGroupVersion.String(),
 								Kind:       "Deployment",

--- a/pkg/operation/botanist/component/kubecontrollermanager/monitoring_test.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/monitoring_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Monitoring", func() {
 		func(version, expectedScrapeConfig string) {
 			semverVersion, err := semver.NewVersion(version)
 			Expect(err).NotTo(HaveOccurred())
-			kubeControllerManager := New(nil, nil, "", semverVersion, "", nil, nil, nil)
+			kubeControllerManager := New(nil, nil, "", semverVersion, "", nil, nil, nil, nil)
 			test.ScrapeConfigs(kubeControllerManager, expectedScrapeConfig)
 		},
 
@@ -45,7 +45,7 @@ var _ = Describe("Monitoring", func() {
 	It("should successfully test the alerting rules", func() {
 		semverVersion, err := semver.NewVersion("1.18.4")
 		Expect(err).NotTo(HaveOccurred())
-		kubeControllerManager := New(nil, nil, "", semverVersion, "", nil, nil, nil)
+		kubeControllerManager := New(nil, nil, "", semverVersion, "", nil, nil, nil, nil)
 
 		test.AlertingRulesWithPromtool(
 			kubeControllerManager,

--- a/pkg/operation/botanist/component/kubecontrollermanager/waiter_test.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/waiter_test.go
@@ -90,6 +90,7 @@ var _ = Describe("WaiterTest", func() {
 				nil,
 				nil,
 				nil,
+				nil,
 			)
 
 			kubeControllerManager.SetShootClient(shootClient)
@@ -251,6 +252,7 @@ var _ = Describe("WaiterTest", func() {
 				namespace,
 				semver.MustParse("v1.20.1"),
 				"",
+				nil,
 				nil,
 				nil,
 				nil,

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -439,6 +439,11 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 		memoryMetricForHpaEnabled = true
 	}
 
+	scaleDownUpdateMode := hvpav1alpha1.UpdateModeAuto
+	if metav1.HasAnnotation(b.Shoot.Info.ObjectMeta, v1beta1constants.ShootAlphaControlPlaneScaleDownDisabled) {
+		scaleDownUpdateMode = hvpav1alpha1.UpdateModeOff
+	}
+
 	var (
 		podAnnotations = map[string]interface{}{
 			"checksum/secret-ca":                     b.CheckSums[v1beta1constants.SecretNameCACluster],
@@ -473,6 +478,7 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 			"hvpa": map[string]interface{}{
 				"enabled": hvpaEnabled,
 			},
+			"scaleDownUpdateMode": scaleDownUpdateMode,
 			"hpa": map[string]interface{}{
 				"memoryMetricForHpaEnabled": memoryMetricForHpaEnabled,
 			},

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -437,6 +437,15 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 		maxReplicas         int32 = 4
 	)
 
+	if b.Shoot.Purpose == gardencorev1beta1.ShootPurposeProduction {
+		minReplicas = 2
+	}
+
+	if metav1.HasAnnotation(b.Shoot.Info.ObjectMeta, v1beta1constants.ShootAlphaControlPlaneScaleDownDisabled) {
+		minReplicas = 4
+		scaleDownUpdateMode = hvpav1alpha1.UpdateModeOff
+	}
+
 	if b.ManagedSeed != nil {
 		// Override for shooted seeds
 		hvpaEnabled = gardenletfeatures.FeatureGate.Enabled(features.HVPAForShootedSeed)
@@ -447,15 +456,6 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 			minReplicas = *autoscaler.MinReplicas
 			maxReplicas = autoscaler.MaxReplicas
 		}
-	}
-
-	if b.Shoot.Purpose == gardencorev1beta1.ShootPurposeProduction {
-		minReplicas = 2
-	}
-
-	if metav1.HasAnnotation(b.Shoot.Info.ObjectMeta, v1beta1constants.ShootAlphaControlPlaneScaleDownDisabled) {
-		minReplicas = 4
-		scaleDownUpdateMode = hvpav1alpha1.UpdateModeOff
 	}
 
 	var (

--- a/pkg/operation/botanist/etcd.go
+++ b/pkg/operation/botanist/etcd.go
@@ -33,9 +33,10 @@ import (
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
-	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
 
+	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -66,7 +67,8 @@ func (b *Botanist) DefaultEtcd(role string, class etcd.Class) (etcd.Etcd, error)
 	}
 
 	scaleDownUpdateMode := hvpav1alpha1.UpdateModeMaintenanceWindow
-	if class == etcd.ClassImportant && b.Shoot.Purpose == gardencorev1beta1.ShootPurposeProduction {
+	if (class == etcd.ClassImportant && b.Shoot.Purpose == gardencorev1beta1.ShootPurposeProduction) ||
+		(metav1.HasAnnotation(b.Shoot.Info.ObjectMeta, v1beta1constants.ShootAlphaControlPlaneScaleDownDisabled)) {
 		scaleDownUpdateMode = hvpav1alpha1.UpdateModeOff
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability 
/kind enhancement

**What this PR does / why we need it**:
With this PR it is possible to disable automatic scale-down for `etcd`, `kube-apiserver`, and `kube-controller-manager` by using the `alpha.control-plane.scaling.shoot.gardener.cloud/scale-down-disabled=true` annotation on `Shoot`s.

/squash
/cc @dguendisch @vlerenc @amshuman-kr 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
