### PR TITLE
Comment out testgrid table due to kubernetes/test-infra/issues/22140

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Please find more information regarding the concepts and a detailed description o
 
 Gardener takes part in the [Certified Kubernetes Conformance Program](https://www.cncf.io/certification/software-conformance/) to attest its compatibility with the K8s conformance testsuite. Currently Gardener is certified for K8s versions up to v1.20, see [the conformance spreadsheet](https://docs.google.com/spreadsheets/d/1LxSqBzjOxfGx3cmtZ4EbB_BGCxT_wlxW_xgHVVa23es/edit#gid=0&range=113:114).
 
-
+<!--
 Continuous conformance test results of the latest stable Gardener release are uploaded regularly to the CNCF test grid:
 
 | Provider/K8s | v1.21 | v1.20 | v1.19 | v1.18 | v1.17 | v1.16 | v1.15 |
@@ -50,6 +50,7 @@ Continuous conformance test results of the latest stable Gardener release are up
 | **vSphere** | N/A | N/A | N/A | N/A | N/A | N/A | N/A |
 
 [1] Conformance tests are still executed and validated, unfortunately [no longer shown in TestGrid](https://github.com/kubernetes/test-infra/pull/18509#issuecomment-668204180).
+-->
 
 Besides the conformance tests, over 400 additional e2e tests are executed on a daily basis. Get an overview of the test results at [testgrid](https://testgrid.k8s.io/gardener-all).
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind cleanup

**What this PR does / why we need it**:
This PR comments out the whole testgrid section due to testgrid currently showing failed overall test status although all tests succeed, see https://github.com/kubernetes/test-infra/issues/22140
