### PR TITLE
clean up io/ioutil deprecation

### DIFF
--- a/cmd/gardener-admission-controller/app/gardener_admission_controller.go
+++ b/cmd/gardener-admission-controller/app/gardener_admission_controller.go
@@ -17,7 +17,6 @@ package app
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -90,7 +89,7 @@ func (o *options) complete() error {
 		return fmt.Errorf("missing config file")
 	}
 
-	data, err := ioutil.ReadFile(o.configFile)
+	data, err := os.ReadFile(o.configFile)
 	if err != nil {
 		return fmt.Errorf("error reading config file: %w", err)
 	}

--- a/cmd/gardener-controller-manager/app/gardener_controller_manager.go
+++ b/cmd/gardener-controller-manager/app/gardener_controller_manager.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/gardener/gardener/cmd/utils"
@@ -85,7 +84,7 @@ func NewOptions() (*Options, error) {
 // loadConfigFromFile loads the contents of file and decodes it as a
 // ControllerManagerConfiguration object.
 func (o *Options) loadConfigFromFile(file string) (*config.ControllerManagerConfiguration, error) {
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/gardenlet/app/gardenlet.go
+++ b/cmd/gardenlet/app/gardenlet.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -112,7 +111,7 @@ func NewOptions() (*Options, error) {
 // loadConfigFromFile loads the content of file and decodes it as a
 // GardenletConfiguration object.
 func (o *Options) loadConfigFromFile(file string) (*config.GardenletConfiguration, error) {
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}

--- a/extensions/pkg/controller/operatingsystemconfig/oscommon/cloudinit/cloudinit.go
+++ b/extensions/pkg/controller/operatingsystemconfig/oscommon/cloudinit/cloudinit.go
@@ -19,7 +19,7 @@ import (
 	"compress/gzip"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 )
 
 // FileCodecID is the id of a FileCodec for cloud-init scripts.
@@ -89,7 +89,7 @@ func (gzipFileCodec) Decode(data []byte) ([]byte, error) {
 		return nil, err
 	}
 	defer func() { _ = r.Close() }()
-	return ioutil.ReadAll(r)
+	return io.ReadAll(r)
 }
 
 // ParseFileCodecID tries to parse a string into a FileCodecID.

--- a/extensions/pkg/webhook/certificates.go
+++ b/extensions/pkg/webhook/certificates.go
@@ -17,7 +17,6 @@ package webhook
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -207,10 +206,10 @@ func writeCertificates(certDir string, caCert, serverCert *secrets.Certificate) 
 	if err := os.MkdirAll(certDir, 0755); err != nil {
 		return nil, err
 	}
-	if err := ioutil.WriteFile(serverKeyPath, serverCert.PrivateKeyPEM, 0666); err != nil {
+	if err := os.WriteFile(serverKeyPath, serverCert.PrivateKeyPEM, 0666); err != nil {
 		return nil, err
 	}
-	if err := ioutil.WriteFile(serverCertPath, serverCert.CertificatePEM, 0666); err != nil {
+	if err := os.WriteFile(serverCertPath, serverCert.CertificatePEM, 0666); err != nil {
 		return nil, err
 	}
 

--- a/extensions/test/tm/generator/helper.go
+++ b/extensions/test/tm/generator/helper.go
@@ -17,7 +17,7 @@
 package generator
 
 import (
-	"io/ioutil"
+
 	"os"
 	"path"
 
@@ -35,7 +35,7 @@ func MarshalAndWriteConfig(filepath string, config interface{}) error {
 	if err := os.MkdirAll(path.Dir(filepath), os.ModePerm); err != nil {
 		return errors.Wrapf(err, "unable to create path %s", path.Dir(filepath))
 	}
-	if err := ioutil.WriteFile(filepath, raw, os.ModePerm); err != nil {
+	if err := os.WriteFile(filepath, raw, os.ModePerm); err != nil {
 		return errors.Wrapf(err, "unable to write config to %s", filepath)
 	}
 

--- a/extensions/test/tm/generator/helper.go
+++ b/extensions/test/tm/generator/helper.go
@@ -17,7 +17,6 @@
 package generator
 
 import (
-
 	"os"
 	"path"
 

--- a/landscaper/cmd/landscaper-gardenlet/app/landscaper-gardenlet.go
+++ b/landscaper/cmd/landscaper-gardenlet/app/landscaper-gardenlet.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/gardener/gardener/landscaper/pkg/gardenlet/apis/imports"
@@ -115,7 +114,7 @@ func getLandscaperEnvironmentVariables() (string, string, string, error) {
 // loadImportsFromFile loads the content of file and decodes it as a
 // imports object.
 func loadImportsFromFile(file string) (*imports.Imports, error) {
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		return nil, err
 	}

--- a/landscaper/pkg/gardenlet/controller/gardenlet.go
+++ b/landscaper/pkg/gardenlet/controller/gardenlet.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"time"
 
 	v2 "github.com/gardener/component-spec/bindings-go/apis/v2"
@@ -107,7 +106,7 @@ func NewGardenletLandscaper(imports *imports.Imports, landscaperOperation, compo
 		rolloutSleepDuration:   10 * time.Second,
 	}
 
-	componentDescriptorData, err := ioutil.ReadFile(componentDescriptorPath)
+	componentDescriptorData, err := os.ReadFile(componentDescriptorPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse the Gardenlet component descriptor: %w", err)
 	}

--- a/landscaper/pkg/gardenlet/controller/gardenlet.go
+++ b/landscaper/pkg/gardenlet/controller/gardenlet.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"time"
 
 	v2 "github.com/gardener/component-spec/bindings-go/apis/v2"

--- a/pkg/admissioncontroller/webhooks/auth/seed/handler.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/handler.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"time"
 
@@ -79,7 +78,7 @@ func (h *handler) Handle(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Read body
-	if body, err = ioutil.ReadAll(r.Body); err != nil {
+	if body, err = io.ReadAll(r.Body); err != nil {
 		h.logger.Error(err, "unable to read the body from the incoming request")
 		h.writeResponse(w, nil, Errored(http.StatusBadRequest, err))
 		return

--- a/pkg/client/kubernetes/pods.go
+++ b/pkg/client/kubernetes/pods.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"time"
@@ -101,7 +100,7 @@ func GetPodLogs(ctx context.Context, podInterface corev1client.PodInterface, nam
 	}
 	defer func() { utilruntime.HandleError(stream.Close()) }()
 
-	return ioutil.ReadAll(stream)
+	return io.ReadAll(stream)
 }
 
 // ForwardPodPort tries to forward the <remote> port of the pod with name <name> in namespace <namespace> to
@@ -144,7 +143,7 @@ func (c *clientSet) setupForwardPodPort(namespace, name string, local, remote in
 	var (
 		stopChan  = make(chan struct{}, 1)
 		readyChan = make(chan struct{}, 1)
-		out       = ioutil.Discard
+		out       = io.Discard
 		localPort int
 	)
 

--- a/pkg/envtest/apiserver.go
+++ b/pkg/envtest/apiserver.go
@@ -21,7 +21,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -172,7 +171,7 @@ func (g *GardenerAPIServer) runAPIServerInProcess() error {
 	// Err is explicitly set.
 	if g.Err == nil {
 		// a nil writer causes klog to panic
-		g.Err = ioutil.Discard
+		g.Err = io.Discard
 	}
 	// --logtostderr defaults to true, which will cause klog to log to stderr even if we set a different output writer
 	g.Args = append(g.Args, "--logtostderr=false")
@@ -275,7 +274,7 @@ func (g *GardenerAPIServer) prepareKubeconfigFile() (string, error) {
 	}
 	kubeconfigFile := filepath.Join(g.CertDir, "kubeconfig.yaml")
 
-	return kubeconfigFile, ioutil.WriteFile(kubeconfigFile, kubeconfigBytes, 0600)
+	return kubeconfigFile, os.WriteFile(kubeconfigFile, kubeconfigBytes, 0600)
 }
 
 // waitUntilHealthy waits for the HealthCheckEndpoint to return 200.

--- a/pkg/gardenlet/controller/managedseed/managedseed_valueshelper.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_valueshelper.go
@@ -15,7 +15,6 @@
 package managedseed
 
 import (
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -222,7 +221,7 @@ func (vp *valuesHelper) getGardenletConfigurationValues(config *configv1alpha1.G
 			return nil, err
 		}
 		if kubeconfigPath != nil && kubeconfigPath.(string) != "" {
-			kubeconfig, err := ioutil.ReadFile(kubeconfigPath.(string))
+			kubeconfig, err := os.ReadFile(kubeconfigPath.(string))
 			if err != nil {
 				return nil, err
 			}
@@ -239,7 +238,7 @@ func (vp *valuesHelper) getGardenletConfigurationValues(config *configv1alpha1.G
 		return nil, err
 	}
 	if kubeconfigPath != nil && kubeconfigPath.(string) != "" {
-		kubeconfig, err := ioutil.ReadFile(kubeconfigPath.(string))
+		kubeconfig, err := os.ReadFile(kubeconfigPath.(string))
 		if err != nil {
 			return nil, err
 		}
@@ -255,7 +254,7 @@ func (vp *valuesHelper) getGardenletConfigurationValues(config *configv1alpha1.G
 		return nil, err
 	}
 	if certPath != nil && certPath.(string) != "" && !strings.Contains(certPath.(string), secrets.TemporaryDirectoryForSelfGeneratedTLSCertificatesPattern) {
-		cert, err := ioutil.ReadFile(certPath.(string))
+		cert, err := os.ReadFile(certPath.(string))
 		if err != nil {
 			return nil, err
 		}
@@ -271,7 +270,7 @@ func (vp *valuesHelper) getGardenletConfigurationValues(config *configv1alpha1.G
 		return nil, err
 	}
 	if keyPath != nil && keyPath.(string) != "" && !strings.Contains(keyPath.(string), secrets.TemporaryDirectoryForSelfGeneratedTLSCertificatesPattern) {
-		key, err := ioutil.ReadFile(keyPath.(string))
+		key, err := os.ReadFile(keyPath.(string))
 		if err != nil {
 			return nil, err
 		}
@@ -321,7 +320,7 @@ func getParentGardenletDeployment(imageVector imagevector.ImageVector, shoot *ga
 func getParentImageVectorOverwrite() (*string, error) {
 	var imageVectorOverwrite *string
 	if overWritePath := os.Getenv(imagevector.OverrideEnv); len(overWritePath) > 0 {
-		data, err := ioutil.ReadFile(overWritePath)
+		data, err := os.ReadFile(overWritePath)
 		if err != nil {
 			return nil, err
 		}
@@ -333,7 +332,7 @@ func getParentImageVectorOverwrite() (*string, error) {
 func getParentComponentImageVectorOverwrites() (*string, error) {
 	var componentImageVectorOverwrites *string
 	if overWritePath := os.Getenv(imagevector.ComponentOverrideEnv); len(overWritePath) > 0 {
-		data, err := ioutil.ReadFile(overWritePath)
+		data, err := os.ReadFile(overWritePath)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -17,7 +17,6 @@ package logger
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"github.com/gardener/gardener/pkg/utils"
@@ -62,7 +61,7 @@ func NewLogger(logLevel string) *logrus.Logger {
 // NewNopLogger instantiates a new logger that logs to ioutil.Discard.
 func NewNopLogger() *logrus.Logger {
 	logger := logrus.New()
-	logger.Out = ioutil.Discard
+	logger.Out = io.Discard
 	return logger
 }
 

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/utils/unitserializer.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/utils/unitserializer.go
@@ -15,7 +15,7 @@
 package utils
 
 import (
-	"io/ioutil"
+	"io"
 	"strings"
 
 	"github.com/coreos/go-systemd/v22/unit"
@@ -38,7 +38,7 @@ type unitSerializer struct{}
 
 // Serialize serializes the given slice of systemd unit options to a string.
 func (us *unitSerializer) Serialize(opts []*unit.UnitOption) (string, error) {
-	bytes, err := ioutil.ReadAll(unit.Serialize(opts))
+	bytes, err := io.ReadAll(unit.Serialize(opts))
 	if err != nil {
 		return "", err
 	}

--- a/pkg/operation/botanist/component/test/monitoringcomponent.go
+++ b/pkg/operation/botanist/component/test/monitoringcomponent.go
@@ -16,7 +16,6 @@ package test
 
 import (
 	"bytes"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -59,7 +58,7 @@ func ExecutePromtool(c component.MonitoringComponent, filenameRulesTest string) 
 	for filename, rule := range alertingRules {
 		filepath := filepath.Join("testdata", filename)
 
-		Expect(ioutil.WriteFile(filepath, []byte(rule), 0644)).To(Succeed())
+		Expect(os.WriteFile(filepath, []byte(rule), 0644)).To(Succeed())
 
 		var errBuf bytes.Buffer
 		cmd := exec.Command("promtool", "test", "rules", filenameRulesTest)

--- a/pkg/scheduler/apis/config/loader/loader.go
+++ b/pkg/scheduler/apis/config/loader/loader.go
@@ -16,7 +16,7 @@ package loader
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/gardener/gardener/pkg/scheduler/apis/config"
 	"github.com/gardener/gardener/pkg/scheduler/apis/config/install"
@@ -34,7 +34,7 @@ func init() {
 
 // LoadFromFile takes a filename and de-serializes the contents into SchedulerConfiguration object.
 func LoadFromFile(filename string) (*config.SchedulerConfiguration, error) {
-	bytes, err := ioutil.ReadFile(filename)
+	bytes, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/utils/imagevector/imagevector_test.go
+++ b/pkg/utils/imagevector/imagevector_test.go
@@ -16,7 +16,6 @@ package imagevector_test
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 
@@ -447,9 +446,9 @@ images:
 })
 
 func withTempFile(pattern string, data []byte) (*os.File, func()) {
-	tmpFile, err := ioutil.TempFile("", pattern)
+	tmpFile, err := os.CreateTemp("", pattern)
 	Expect(err).NotTo(HaveOccurred())
-	Expect(ioutil.WriteFile(tmpFile.Name(), data, os.ModePerm)).To(Succeed())
+	Expect(os.WriteFile(tmpFile.Name(), data, os.ModePerm)).To(Succeed())
 
 	return tmpFile, func() {
 		if err := tmpFile.Close(); err != nil {

--- a/pkg/utils/secrets/certificates.go
+++ b/pkg/utils/secrets/certificates.go
@@ -21,9 +21,9 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"net"
+	"os"
 	"path/filepath"
 	"sync"
 	"time"
@@ -432,7 +432,7 @@ const TemporaryDirectoryForSelfGeneratedTLSCertificatesPattern = "self-generated
 // The function will return the *Certificate object as well as the path of the temporary directory where the
 // certificates are stored.
 func SelfGenerateTLSServerCertificate(name string, dnsNames []string, ips []net.IP) (cert *Certificate, ca *Certificate, dir string, rErr error) {
-	tempDir, err := ioutil.TempDir("", TemporaryDirectoryForSelfGeneratedTLSCertificatesPattern)
+	tempDir, err := os.MkdirTemp("", TemporaryDirectoryForSelfGeneratedTLSCertificatesPattern)
 	if err != nil {
 		return nil, nil, "", err
 	}
@@ -446,10 +446,10 @@ func SelfGenerateTLSServerCertificate(name string, dnsNames []string, ips []net.
 	if err != nil {
 		return nil, nil, "", err
 	}
-	if err := ioutil.WriteFile(filepath.Join(tempDir, DataKeyCertificateCA), caCertificate.CertificatePEM, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tempDir, DataKeyCertificateCA), caCertificate.CertificatePEM, 0644); err != nil {
 		return nil, nil, "", err
 	}
-	if err := ioutil.WriteFile(filepath.Join(tempDir, DataKeyPrivateKeyCA), caCertificate.PrivateKeyPEM, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tempDir, DataKeyPrivateKeyCA), caCertificate.PrivateKeyPEM, 0644); err != nil {
 		return nil, nil, "", err
 	}
 
@@ -465,10 +465,10 @@ func SelfGenerateTLSServerCertificate(name string, dnsNames []string, ips []net.
 	if err != nil {
 		return nil, nil, "", err
 	}
-	if err := ioutil.WriteFile(filepath.Join(tempDir, DataKeyCertificate), certificate.CertificatePEM, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tempDir, DataKeyCertificate), certificate.CertificatePEM, 0644); err != nil {
 		return nil, nil, "", err
 	}
-	if err := ioutil.WriteFile(filepath.Join(tempDir, DataKeyPrivateKey), certificate.PrivateKeyPEM, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(tempDir, DataKeyPrivateKey), certificate.PrivateKeyPEM, 0644); err != nil {
 		return nil, nil, "", err
 	}
 

--- a/pkg/utils/test/test.go
+++ b/pkg/utils/test/test.go
@@ -17,7 +17,6 @@ package test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 
@@ -161,7 +160,7 @@ func WithFeatureGate(gate featuregate.FeatureGate, f featuregate.Feature, value 
 //  var fileName string
 //  defer WithTempFile("", "test", []byte("test file content"), &fileName)()
 func WithTempFile(dir, pattern string, content []byte, fileName *string) func() {
-	file, err := ioutil.TempFile(dir, pattern)
+	file, err := os.CreateTemp(dir, pattern)
 	if err != nil {
 		ginkgo.Fail(fmt.Sprintf("could not create temp file in directory %s: %v", dir, err))
 	}

--- a/pkg/utils/test/test_resources.go
+++ b/pkg/utils/test/test_resources.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -68,6 +67,7 @@ func ReadTestResources(scheme *runtime.Scheme, path string) ([]client.Object, er
 	decoder := serializer.NewCodecFactory(scheme).UniversalDeserializer()
 
 	var files []os.FileInfo
+	//var files []os.DirEntry
 	var err error
 	info, err := os.Stat(path)
 	if err != nil {
@@ -76,7 +76,7 @@ func ReadTestResources(scheme *runtime.Scheme, path string) ([]client.Object, er
 	if !info.IsDir() {
 		path, files = filepath.Dir(path), []os.FileInfo{info}
 	} else {
-		if files, err = ioutil.ReadDir(path); err != nil {
+		if files, err = os.ReadDir(path); err != nil {
 			return nil, err
 		}
 	}
@@ -116,7 +116,7 @@ func ReadTestResources(scheme *runtime.Scheme, path string) ([]client.Object, er
 
 // readDocuments reads documents from file
 func readDocuments(fp string) ([][]byte, error) {
-	b, err := ioutil.ReadFile(fp)
+	b, err := os.ReadFile(fp)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/utils/test/test_resources.go
+++ b/pkg/utils/test/test_resources.go
@@ -66,19 +66,9 @@ func EnsureTestResources(ctx context.Context, c client.Client, path string) ([]c
 func ReadTestResources(scheme *runtime.Scheme, path string) ([]client.Object, error) {
 	decoder := serializer.NewCodecFactory(scheme).UniversalDeserializer()
 
-	var files []os.FileInfo
-	//var files []os.DirEntry
-	var err error
-	info, err := os.Stat(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		return nil, err
-	}
-	if !info.IsDir() {
-		path, files = filepath.Dir(path), []os.FileInfo{info}
-	} else {
-		if files, err = os.ReadDir(path); err != nil {
-			return nil, err
-		}
 	}
 
 	// file extensions that may contain Webhooks
@@ -86,6 +76,10 @@ func ReadTestResources(scheme *runtime.Scheme, path string) ([]client.Object, er
 
 	var objects []client.Object
 	for _, file := range files {
+
+		if file.IsDir() {
+			continue
+		}
 		// Only parse allowlisted file types
 		if !resourceExtensions.Has(filepath.Ext(file.Name())) {
 			continue

--- a/plugin/pkg/shoot/tolerationrestriction/config.go
+++ b/plugin/pkg/shoot/tolerationrestriction/config.go
@@ -16,12 +16,10 @@ package tolerationrestriction
 
 import (
 	"fmt"
-	"io"
-	"io/ioutil"
-
 	"github.com/gardener/gardener/plugin/pkg/shoot/tolerationrestriction/apis/shoottolerationrestriction"
 	"github.com/gardener/gardener/plugin/pkg/shoot/tolerationrestriction/apis/shoottolerationrestriction/install"
 	"github.com/gardener/gardener/plugin/pkg/shoot/tolerationrestriction/apis/shoottolerationrestriction/v1alpha1"
+	"io"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -49,7 +47,7 @@ func LoadConfiguration(config io.Reader) (*shoottolerationrestriction.Configurat
 		return internalConfig, nil
 	}
 
-	data, err := ioutil.ReadAll(config)
+	data, err := io.ReadAll(config)
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/pkg/shoot/tolerationrestriction/config.go
+++ b/plugin/pkg/shoot/tolerationrestriction/config.go
@@ -16,10 +16,11 @@ package tolerationrestriction
 
 import (
 	"fmt"
+	"io"
+
 	"github.com/gardener/gardener/plugin/pkg/shoot/tolerationrestriction/apis/shoottolerationrestriction"
 	"github.com/gardener/gardener/plugin/pkg/shoot/tolerationrestriction/apis/shoottolerationrestriction/install"
 	"github.com/gardener/gardener/plugin/pkg/shoot/tolerationrestriction/apis/shoottolerationrestriction/v1alpha1"
-	"io"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"

--- a/test/framework/applications/guestbooktest.go
+++ b/test/framework/applications/guestbooktest.go
@@ -17,7 +17,7 @@ package applications
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -100,7 +100,7 @@ func (t *GuestBookTest) WaitUntilGuestbookURLsRespondOK(ctx context.Context, gue
 				return retry.MinorError(fmt.Errorf("guestbook app url %q returned status %s", guestbookAppURL, response.Status))
 			}
 
-			responseBytes, err := ioutil.ReadAll(response.Body)
+			responseBytes, err := io.ReadAll(response.Body)
 			if err != nil {
 				return retry.SevereError(err)
 			}
@@ -196,7 +196,7 @@ func (t *GuestBookTest) Test(ctx context.Context) {
 	framework.ExpectNoError(err)
 	gomega.Expect(pullResponse.StatusCode).To(gomega.Equal(http.StatusOK))
 
-	responseBytes, err := ioutil.ReadAll(pullResponse.Body)
+	responseBytes, err := io.ReadAll(pullResponse.Body)
 	framework.ExpectNoError(err)
 
 	// test if foobar-<shoot-name> was pulled successfully

--- a/test/framework/config/config_test.go
+++ b/test/framework/config/config_test.go
@@ -16,7 +16,6 @@ package config_test
 
 import (
 	"flag"
-	"io/ioutil"
 	"os"
 
 	"github.com/gardener/gardener/test/framework/config"
@@ -60,7 +59,7 @@ int: 5
 		fs.BoolVar(&data.Bool, "bool", false, "")
 		fs.IntVar(&data.Int, "int", 1, "")
 
-		tmpfile, err = ioutil.TempFile("", "configtest-*.yaml")
+		tmpfile, err = os.CreateTemp("", "configtest-*.yaml")
 		Expect(err).ToNot(HaveOccurred())
 		_, err = tmpfile.WriteString(configContent)
 		Expect(err).ToNot(HaveOccurred())

--- a/test/framework/k8s_utils.go
+++ b/test/framework/k8s_utils.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -340,7 +340,7 @@ func DownloadKubeconfig(ctx context.Context, client kubernetes.Interface, namesp
 		return err
 	}
 	if downloadPath != "" {
-		err = ioutil.WriteFile(downloadPath, []byte(kubeconfig), 0755)
+		err = os.WriteFile(downloadPath, []byte(kubeconfig), 0755)
 		if err != nil {
 			return err
 		}

--- a/test/framework/landscaper/commonframework.go
+++ b/test/framework/landscaper/commonframework.go
@@ -19,7 +19,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"time"
 
 	cdv2 "github.com/gardener/component-spec/bindings-go/apis/v2"
@@ -351,7 +351,7 @@ func (f *CommonFrameworkLandscaper) DeleteConfigMap(ctx context.Context, name st
 
 // CreateTargetWithKubeconfig creates the landscaper target from a given name and kubeconfig path on the local filesystem
 func (f *CommonFrameworkLandscaper) CreateTargetWithKubeconfig(ctx context.Context, name, kubeconfigPath string) error {
-	seedKubeconfigBytes, err := ioutil.ReadFile(kubeconfigPath)
+	seedKubeconfigBytes, err := os.ReadFile(kubeconfigPath)
 	ExpectNoError(err)
 
 	toJSON, err := yaml.ToJSON(seedKubeconfigBytes)

--- a/test/framework/rootpod_executor.go
+++ b/test/framework/rootpod_executor.go
@@ -17,7 +17,7 @@ package framework
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"time"
 
 	"github.com/gardener/gardener/pkg/client/kubernetes"
@@ -86,7 +86,7 @@ func (e *rootPodExecutor) Execute(ctx context.Context, command string) ([]byte, 
 	if err != nil {
 		return nil, err
 	}
-	response, err := ioutil.ReadAll(reader)
+	response, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, err
 	}

--- a/test/framework/utils.go
+++ b/test/framework/utils.go
@@ -16,7 +16,6 @@ package framework
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"reflect"
 	"regexp"
@@ -119,7 +118,7 @@ func FileExists(kc string) bool {
 
 // ReadObject loads the contents of file and decodes it as an object.
 func ReadObject(file string, into apimachineryRuntime.Object) error {
-	data, err := ioutil.ReadFile(file)
+	data, err := os.ReadFile(file)
 	if err != nil {
 		return err
 	}
@@ -130,7 +129,7 @@ func ReadObject(file string, into apimachineryRuntime.Object) error {
 
 // ParseFileAsProviderConfig parses a file as a ProviderConfig
 func ParseFileAsProviderConfig(filepath string) (*apimachineryRuntime.RawExtension, error) {
-	data, err := ioutil.ReadFile(filepath)
+	data, err := os.ReadFile(filepath)
 	if err != nil {
 		return nil, err
 	}
@@ -145,7 +144,7 @@ func ParseFileAsProviderConfig(filepath string) (*apimachineryRuntime.RawExtensi
 
 // ParseFileAsWorkers parses a file as a Worker configuration
 func ParseFileAsWorkers(filepath string) ([]gardencorev1beta1.Worker, error) {
-	data, err := ioutil.ReadFile(filepath)
+	data, err := os.ReadFile(filepath)
 	if err != nil {
 		return nil, err
 	}

--- a/test/framework/utils_test.go
+++ b/test/framework/utils_test.go
@@ -15,7 +15,6 @@
 package framework_test
 
 import (
-	"io/ioutil"
 	"os"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -27,7 +26,7 @@ import (
 var _ = Describe("Utils tests", func() {
 
 	It("should not fail if a path exists", func() {
-		tmpdir, err := ioutil.TempDir("", "e2e-")
+		tmpdir, err := os.MkdirTemp("", "e2e-")
 		Expect(err).ToNot(HaveOccurred())
 		defer os.RemoveAll(tmpdir)
 		framework.FileExists(tmpdir)

--- a/test/integration/shoots/applications/networking.go
+++ b/test/integration/shoots/applications/networking.go
@@ -29,7 +29,7 @@ package applications
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"time"
 
 	"github.com/gardener/gardener/test/framework"
@@ -89,7 +89,7 @@ var _ = ginkgo.Describe("Shoot network testing", func() {
 					res = multierror.Append(res, errors.Wrapf(err, "%s to %s", from.GetName(), to.GetName()))
 					continue
 				}
-				data, err := ioutil.ReadAll(reader)
+				data, err := io.ReadAll(reader)
 				if err != nil {
 					f.Logger.Error(err)
 					continue

--- a/test/integration/shoots/operations/operations.go
+++ b/test/integration/shoots/operations/operations.go
@@ -42,7 +42,6 @@ package operations
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"time"
@@ -138,7 +137,7 @@ var _ = ginkgo.Describe("Shoot operation testing", func() {
 				return
 			}
 			shootKubeconfigPath := filepath.Join(kubeconfigsPath, "shoot.config")
-			framework.ExpectNoError(ioutil.WriteFile(shootKubeconfigPath, []byte(newKubeconfig), os.ModePerm))
+			framework.ExpectNoError(os.WriteFile(shootKubeconfigPath, []byte(newKubeconfig), os.ModePerm))
 		}()
 
 		newClient, err := kubernetes.NewClientFromBytes([]byte(newKubeconfig))

--- a/test/integration/shoots/vpntunnel/vpntunnel.go
+++ b/test/integration/shoots/vpntunnel/vpntunnel.go
@@ -18,7 +18,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"strings"
 	"time"
 
@@ -183,7 +183,7 @@ var _ = ginkgo.Describe("Shoot vpn tunnel testing", func() {
 				break
 			}
 			framework.ExpectNoError(err)
-			output, err := ioutil.ReadAll(reader)
+			output, err := io.ReadAll(reader)
 			framework.ExpectNoError(err)
 			f.Logger.Infof("Got output from 'kubectl cp': %s", string(output))
 		}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/kind cleanup 

**What this PR does / why we need it**:
clean up io/ioutil deprecation

**Which issue(s) this PR fixes**:
Fixes #4020 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
