### PR TITLE
Smaller improvements in preparation for SeedAuthorizer

### DIFF
--- a/pkg/admissioncontroller/webhooks/auth/seed/authorizer.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/authorizer.go
@@ -195,7 +195,7 @@ func (a *authorizer) authorizeConfigMap(seedName string, attrs auth.Attributes) 
 }
 
 func (a *authorizer) authorizeEvent(seedName string, attrs auth.Attributes) (auth.Decision, string, error) {
-	if ok, reason := a.checkVerb(seedName, attrs, "create"); !ok {
+	if ok, reason := a.checkVerb(seedName, attrs, "create", "patch"); !ok {
 		return auth.DecisionNoOpinion, reason, nil
 	}
 

--- a/pkg/admissioncontroller/webhooks/auth/seed/authorizer_test.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/authorizer_test.go
@@ -1132,6 +1132,7 @@ var _ = Describe("Seed", func() {
 				},
 
 				Entry("create", "create"),
+				Entry("patch", "patch"),
 			)
 
 			DescribeTable("should have no opinion because verb is not allowed",
@@ -1141,7 +1142,7 @@ var _ = Describe("Seed", func() {
 					decision, reason, err := authorizer.Authorize(ctx, attrs)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(decision).To(Equal(auth.DecisionNoOpinion))
-					Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [create]"))
+					Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [create patch]"))
 
 				},
 
@@ -1149,7 +1150,6 @@ var _ = Describe("Seed", func() {
 				Entry("list", "list"),
 				Entry("watch", "watch"),
 				Entry("update", "update"),
-				Entry("patch", "patch"),
 				Entry("delete", "delete"),
 				Entry("deletecollection", "deletecollection"),
 			)
@@ -1195,6 +1195,7 @@ var _ = Describe("Seed", func() {
 				},
 
 				Entry("create", "create"),
+				Entry("patch", "patch"),
 			)
 
 			DescribeTable("should have no opinion because verb is not allowed",
@@ -1204,7 +1205,7 @@ var _ = Describe("Seed", func() {
 					decision, reason, err := authorizer.Authorize(ctx, attrs)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(decision).To(Equal(auth.DecisionNoOpinion))
-					Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [create]"))
+					Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [create patch]"))
 
 				},
 
@@ -1212,7 +1213,6 @@ var _ = Describe("Seed", func() {
 				Entry("list", "list"),
 				Entry("watch", "watch"),
 				Entry("update", "update"),
-				Entry("patch", "patch"),
 				Entry("delete", "delete"),
 				Entry("deletecollection", "deletecollection"),
 			)

--- a/pkg/admissioncontroller/webhooks/auth/seed/graph/eventhandler_backupbucket.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/graph/eventhandler_backupbucket.go
@@ -46,7 +46,8 @@ func (g *graph) setupBackupBucketWatch(informer cache.Informer) {
 			}
 
 			if !apiequality.Semantic.DeepEqual(oldBackupBucket.Spec.SeedName, newBackupBucket.Spec.SeedName) ||
-				!apiequality.Semantic.DeepEqual(oldBackupBucket.Spec.SecretRef, newBackupBucket.Spec.SecretRef) {
+				!apiequality.Semantic.DeepEqual(oldBackupBucket.Spec.SecretRef, newBackupBucket.Spec.SecretRef) ||
+				!apiequality.Semantic.DeepEqual(oldBackupBucket.Status.GeneratedSecretRef, newBackupBucket.Status.GeneratedSecretRef) {
 				g.handleBackupBucketCreateOrUpdate(newBackupBucket)
 			}
 		},
@@ -85,6 +86,11 @@ func (g *graph) handleBackupBucketCreateOrUpdate(backupBucket *gardencorev1beta1
 	if backupBucket.Spec.SeedName != nil {
 		seedVertex := g.getOrCreateVertex(VertexTypeSeed, "", *backupBucket.Spec.SeedName)
 		g.addEdge(backupBucketVertex, seedVertex)
+	}
+
+	if backupBucket.Status.GeneratedSecretRef != nil {
+		generatedSecretVertex := g.getOrCreateVertex(VertexTypeSecret, backupBucket.Status.GeneratedSecretRef.Namespace, backupBucket.Status.GeneratedSecretRef.Name)
+		g.addEdge(generatedSecretVertex, backupBucketVertex)
 	}
 }
 

--- a/pkg/gardenlet/controller/factory.go
+++ b/pkg/gardenlet/controller/factory.go
@@ -98,9 +98,6 @@ func NewGardenletControllerFactory(
 // Run starts all the controllers for the Garden API group. It also performs bootstrapping tasks.
 func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 	var (
-		// Garden core informers
-		backupBucketInformer           = f.k8sGardenCoreInformers.Core().V1beta1().BackupBuckets().Informer()
-		backupEntryInformer            = f.k8sGardenCoreInformers.Core().V1beta1().BackupEntries().Informer()
 		controllerRegistrationInformer = f.k8sGardenCoreInformers.Core().V1beta1().ControllerRegistrations().Informer()
 		controllerInstallationInformer = f.k8sGardenCoreInformers.Core().V1beta1().ControllerInstallations().Informer()
 		seedInformer                   = f.k8sGardenCoreInformers.Core().V1beta1().Seeds().Informer()
@@ -119,7 +116,7 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 	}
 
 	f.k8sGardenCoreInformers.Start(ctx.Done())
-	if !cache.WaitForCacheSync(ctx.Done(), backupBucketInformer.HasSynced, backupEntryInformer.HasSynced, controllerRegistrationInformer.HasSynced, controllerInstallationInformer.HasSynced, seedInformer.HasSynced, shootInformer.HasSynced) {
+	if !cache.WaitForCacheSync(ctx.Done(), controllerRegistrationInformer.HasSynced, controllerInstallationInformer.HasSynced, seedInformer.HasSynced, shootInformer.HasSynced) {
 		return fmt.Errorf("timed out waiting for Garden core caches to sync")
 	}
 

--- a/pkg/gardenlet/controller/shoot/shoot_care_control_types.go
+++ b/pkg/gardenlet/controller/shoot/shoot_care_control_types.go
@@ -115,7 +115,7 @@ var defaultNewOperationFunc = func(
 		WithGardenClusterIdentity(gardenClusterIdentity).
 		WithSecrets(secrets).
 		WithImageVector(imageVector).
-		WithGardenFrom(gardenClient.Client(), shoot.Namespace).
+		WithGardenFrom(gardenClient.APIReader(), shoot.Namespace).
 		WithSeedFrom(k8sGardenCoreInformers, *shoot.Spec.SeedName).
 		WithShootFromCluster(gardenClient, seedClient, shoot).
 		Build(ctx, clientMap)

--- a/pkg/operation/botanist/monitoring.go
+++ b/pkg/operation/botanist/monitoring.go
@@ -52,8 +52,8 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 	}
 
 	var (
-		credentials         = b.Secrets["monitoring-ingress-credentials"]
-		credentialsUsers    = b.Secrets["monitoring-ingress-credentials-users"]
+		credentials         = b.Secrets[common.MonitoringIngressCredentials]
+		credentialsUsers    = b.Secrets[common.MonitoringIngressCredentialsUsers]
 		basicAuth           = utils.CreateSHA1Secret(credentials.Data[secrets.DataKeyUserName], credentials.Data[secrets.DataKeyPassword])
 		basicAuthUsers      = utils.CreateSHA1Secret(credentialsUsers.Data[secrets.DataKeyUserName], credentialsUsers.Data[secrets.DataKeyPassword])
 		alertingRules       = strings.Builder{}

--- a/pkg/operation/botanist/wanted_secrets.go
+++ b/pkg/operation/botanist/wanted_secrets.go
@@ -458,7 +458,7 @@ func (b *Botanist) generateWantedSecretConfigs(basicAuthAPIServer *secrets.Basic
 
 		// Secret definition for monitoring
 		&secrets.BasicAuthSecretConfig{
-			Name:   "monitoring-ingress-credentials",
+			Name:   common.MonitoringIngressCredentials,
 			Format: secrets.BasicAuthFormatNormal,
 
 			Username:       "admin",
@@ -467,7 +467,7 @@ func (b *Botanist) generateWantedSecretConfigs(basicAuthAPIServer *secrets.Basic
 
 		// Secret definition for monitoring for shoot owners
 		&secrets.BasicAuthSecretConfig{
-			Name:   "monitoring-ingress-credentials-users",
+			Name:   common.MonitoringIngressCredentialsUsers,
 			Format: secrets.BasicAuthFormatNormal,
 
 			Username:       "admin",

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -145,4 +145,11 @@ const (
 
 	// GardenLokiPriorityClassName is the name of the PriorityClass for the Loki in the garden namespace
 	GardenLokiPriorityClassName = "garden-loki"
+
+	// MonitoringIngressCredentials is a constant for the name of a secret containing the monitoring credentials for
+	// operators monitoring for shoots.
+	MonitoringIngressCredentials = "monitoring-ingress-credentials"
+	// MonitoringIngressCredentialsUsers is a constant for the name of a secret containing the monitoring credentials
+	// for users monitoring for shoots.
+	MonitoringIngressCredentialsUsers = "monitoring-ingress-credentials-users"
 )

--- a/pkg/operation/garden/garden.go
+++ b/pkg/operation/garden/garden.go
@@ -24,6 +24,7 @@ import (
 	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/logger"
+	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	secretutils "github.com/gardener/gardener/pkg/utils/secrets"
@@ -372,7 +373,7 @@ func BootstrapCluster(ctx context.Context, k8sGardenClient kubernetes.Interface)
 
 func generateMonitoringSecret(ctx context.Context, k8sGardenClient kubernetes.Interface) (*corev1.Secret, error) {
 	basicAuthSecret := &secretutils.BasicAuthSecretConfig{
-		Name:   "monitoring-ingress-credentials",
+		Name:   common.MonitoringIngressCredentials,
 		Format: secretutils.BasicAuthFormatNormal,
 
 		Username:       "admin",

--- a/pkg/operation/garden/garden.go
+++ b/pkg/operation/garden/garden.go
@@ -57,7 +57,8 @@ func (b *Builder) WithProject(project *gardencorev1beta1.Project) *Builder {
 // WithProjectFromReader sets the projectFunc attribute after fetching it from the lister.
 func (b *Builder) WithProjectFromReader(reader client.Reader, namespace string) *Builder {
 	b.projectFunc = func(ctx context.Context) (*gardencorev1beta1.Project, error) {
-		return gutil.ProjectForNamespaceFromReader(ctx, reader, namespace)
+		project, _, err := gutil.ProjectAndNamespaceFromReader(ctx, reader, namespace)
+		return project, err
 	}
 	return b
 }

--- a/pkg/utils/gardener/project.go
+++ b/pkg/utils/gardener/project.go
@@ -21,7 +21,6 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencoreinternallisters "github.com/gardener/gardener/pkg/client/core/listers/core/internalversion"
-	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
 	corev1 "k8s.io/api/core/v1"
@@ -29,24 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-// ProjectForNamespaceFromLister returns the Project responsible for a given <namespace>. It lists all Projects
-// via the given lister, iterates over them and tries to identify the Project by looking for the namespace name
-// in the project spec.
-func ProjectForNamespaceFromLister(projectLister gardencorelisters.ProjectLister, namespaceName string) (*gardencorev1beta1.Project, error) {
-	projectList, err := projectLister.List(labels.Everything())
-	if err != nil {
-		return nil, err
-	}
-
-	for _, project := range projectList {
-		if project.Spec.Namespace != nil && *project.Spec.Namespace == namespaceName {
-			return project, nil
-		}
-	}
-
-	return nil, apierrors.NewNotFound(gardencorev1beta1.Resource("Project"), namespaceName)
-}
 
 // ProjectForNamespaceFromInternalLister returns the Project responsible for a given <namespace>. It lists all Projects
 // via the given lister, iterates over them and tries to identify the Project by looking for the namespace name

--- a/pkg/utils/gardener/project_test.go
+++ b/pkg/utils/gardener/project_test.go
@@ -80,36 +80,6 @@ var _ = Describe("Project", func() {
 		ctrl.Finish()
 	})
 
-	Describe("#ProjectForNamespaceFromLister", func() {
-		var lister *fakeLister
-
-		BeforeEach(func() {
-			lister = &fakeLister{}
-		})
-
-		It("should return an error because listing failed", func() {
-			lister.err = fakeErr
-
-			result, err := ProjectForNamespaceFromLister(lister, namespaceName)
-			Expect(err).To(MatchError(fakeErr))
-			Expect(result).To(BeNil())
-		})
-
-		It("should return the found project", func() {
-			lister.projects = []*gardencorev1beta1.Project{project}
-
-			result, err := ProjectForNamespaceFromLister(lister, namespaceName)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result).To(Equal(project))
-		})
-
-		It("should return a 'not found' error", func() {
-			result, err := ProjectForNamespaceFromLister(lister, namespaceName)
-			Expect(err).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: "core.gardener.cloud", Resource: "Project"}, namespaceName)))
-			Expect(result).To(BeNil())
-		})
-	})
-
 	Describe("#ProjectForNamespaceFromInternalLister", func() {
 		var lister *fakeInternalLister
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement cleanup
/squash

**What this PR does / why we need it**:
In preparation for usage of the SeedAuthorizer, this PR cleans up a few minor nits and implements a few leftovers.

**Which issue(s) this PR fixes**:
Part of #1723 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
