### PR TITLE
Eliminate unnecessary Seed decoding in SeedRestriction

### DIFF
--- a/pkg/admissioncontroller/webhooks/admission/seedrestriction/admission.go
+++ b/pkg/admissioncontroller/webhooks/admission/seedrestriction/admission.go
@@ -207,12 +207,7 @@ func (h *handler) admitSeed(ctx context.Context, seedName string, request admiss
 		return admission.Errored(http.StatusBadRequest, fmt.Errorf("unexpected operation: %q", request.Operation))
 	}
 
-	seed := &gardencorev1beta1.Seed{}
-	if err := h.decoder.Decode(request, seed); err != nil {
-		return admission.Errored(http.StatusBadRequest, err)
-	}
-
-	response := h.admit(seedName, &seed.Name)
+	response := h.admit(seedName, &request.Name)
 	if response.Allowed {
 		return response
 	}
@@ -221,7 +216,7 @@ func (h *handler) admitSeed(ctx context.Context, seedName string, request admiss
 	// reconciliation. In this case, the another gardenlet (the "parent gardenlet") which is usually responsible for a
 	// different seed is doing the request.
 	managedSeed := &seedmanagementv1alpha1.ManagedSeed{}
-	if err := h.cacheReader.Get(ctx, kutil.Key(v1beta1constants.GardenNamespace, seed.Name), managedSeed); err != nil {
+	if err := h.cacheReader.Get(ctx, kutil.Key(v1beta1constants.GardenNamespace, request.Name), managedSeed); err != nil {
 		if apierrors.IsNotFound(err) {
 			return response
 		}

--- a/pkg/admissioncontroller/webhooks/admission/seedrestriction/admission_test.go
+++ b/pkg/admissioncontroller/webhooks/admission/seedrestriction/admission_test.go
@@ -668,42 +668,15 @@ var _ = Describe("handler", func() {
 						request.Operation = operation
 					})
 
-					It("should return an error because decoding the object failed", func() {
-						request.Object.Raw = []byte(`{]`)
-
-						Expect(handler.Handle(ctx, request)).To(Equal(admission.Response{
-							AdmissionResponse: admissionv1.AdmissionResponse{
-								Allowed: false,
-								Result: &metav1.Status{
-									Code:    int32(http.StatusBadRequest),
-									Message: "couldn't get version/kind; json parse error: invalid character ']' looking for beginning of object key string",
-								},
-							},
-						}))
-					})
-
 					It("should allow the request because seed name matches", func() {
-						objData, err := runtime.Encode(encoder, &gardencorev1beta1.Seed{
-							ObjectMeta: metav1.ObjectMeta{
-								Name: seedName,
-							},
-						})
-						Expect(err).NotTo(HaveOccurred())
-						request.Object.Raw = objData
+						request.Name = seedName
 
 						Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
 					})
 
 					It("should allow the request because seed name is ambiguous", func() {
 						request.UserInfo = ambiguousUser
-
-						objData, err := runtime.Encode(encoder, &gardencorev1beta1.Seed{
-							ObjectMeta: metav1.ObjectMeta{
-								Name: "some-different-seed",
-							},
-						})
-						Expect(err).NotTo(HaveOccurred())
-						request.Object.Raw = objData
+						request.Name = "some-different-seed"
 
 						Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
 					})
@@ -716,13 +689,7 @@ var _ = Describe("handler", func() {
 						)
 
 						BeforeEach(func() {
-							objData, err := runtime.Encode(encoder, &gardencorev1beta1.Seed{
-								ObjectMeta: metav1.ObjectMeta{
-									Name: differentSeedName,
-								},
-							})
-							Expect(err).NotTo(HaveOccurred())
-							request.Object.Raw = objData
+							request.Name = differentSeedName
 						})
 
 						It("should forbid the request because seed does not belong to a managedseed", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bug

**What this PR does / why we need it**:
For `DELETE` operations, the `request.Object` is `nil` ([ref](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#request)), only the `request.OldObject` is set.
However, decoding the entire `Seed` is not necessary as the SeedRestriction only requires the name which is already provided with `request.Name`.

**Which issue(s) this PR fixes**:
Fixes #4042

**Special notes for your reviewer**:
/cc @stoyanr @kris94 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug generally preventing `ManagedSeed` deletion has been fixed.
```
