### PR TITLE
Get rid of the debug logging of Shoots in the shootUpdate func

### DIFF
--- a/pkg/gardenlet/controller/seed/seed_control.go
+++ b/pkg/gardenlet/controller/seed/seed_control.go
@@ -16,7 +16,6 @@ package seed
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -165,11 +164,10 @@ type defaultControl struct {
 
 func (c *defaultControl) ReconcileSeed(obj *gardencorev1beta1.Seed, key string) error {
 	var (
-		ctx         = context.TODO()
-		seed        = obj.DeepCopy()
-		seedJSON, _ = json.Marshal(seed)
-		seedLogger  = logger.NewFieldLogger(logger.Logger, "seed", seed.Name)
-		err         error
+		ctx        = context.TODO()
+		seed       = obj.DeepCopy()
+		seedLogger = logger.NewFieldLogger(logger.Logger, "seed", seed.Name)
+		err        error
 	)
 
 	gardenClient, err := c.clientMap.GetClient(ctx, keys.ForGarden())
@@ -310,7 +308,6 @@ func (c *defaultControl) ReconcileSeed(obj *gardencorev1beta1.Seed, key string) 
 	}
 
 	seedLogger.Infof("[SEED RECONCILE] %s", key)
-	seedLogger.Debugf(string(seedJSON))
 
 	// need retry logic, because controllerregistration controller is acting on it at the same time and cached object might not be up to date
 	seed, err = kutil.TryUpdateSeed(ctx, gardenClient.GardenCore(), retry.DefaultBackoff, seed.ObjectMeta, func(curSeed *gardencorev1beta1.Seed) (*gardencorev1beta1.Seed, error) {

--- a/pkg/gardenlet/controller/shoot/shoot_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control.go
@@ -16,7 +16,6 @@ package shoot
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"sync"
@@ -71,14 +70,10 @@ func (c *Controller) shootAdd(obj interface{}, resetRateLimiting bool) {
 
 func (c *Controller) shootUpdate(oldObj, newObj interface{}) {
 	var (
-		oldShoot        = oldObj.(*gardencorev1beta1.Shoot)
-		newShoot        = newObj.(*gardencorev1beta1.Shoot)
-		oldShootJSON, _ = json.Marshal(oldShoot)
-		newShootJSON, _ = json.Marshal(newShoot)
-		shootLogger     = logger.NewShootLogger(logger.Logger, newShoot.ObjectMeta.Name, newShoot.ObjectMeta.Namespace)
+		oldShoot    = oldObj.(*gardencorev1beta1.Shoot)
+		newShoot    = newObj.(*gardencorev1beta1.Shoot)
+		shootLogger = logger.NewShootLogger(logger.Logger, newShoot.ObjectMeta.Name, newShoot.ObjectMeta.Namespace)
 	)
-	shootLogger.Debugf(string(oldShootJSON))
-	shootLogger.Debugf(string(newShootJSON))
 
 	// If the generation did not change for an update event (i.e., no changes to the .spec section have
 	// been made), we do not want to add the Shoot to the queue. The period reconciliation is handled


### PR DESCRIPTION
/area quality
/kind bug
/kind cleanup

We observe some interesting panics with gardenlet@v1.22.2 such as:

```
E0512 10:36:12.474585       1 runtime.go:78] Observed a panic: &reflect.ValueError{Method:"reflect.Value.Type", Kind:0x0} (reflect: call of reflect.Value.Type on zero Value)
goroutine 655 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic(0x1f5b220, 0xc01565d548)
	/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:74 +0x95
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:48 +0x86
panic(0x1f5b220, 0xc01565d548)
	/usr/local/go/src/runtime/panic.go:965 +0x1b9
encoding/json.(*encodeState).marshal.func1(0xc00ae37ba0)
	/usr/local/go/src/encoding/json/encode.go:328 +0x8d
panic(0x1f5b220, 0xc01565d548)
	/usr/local/go/src/runtime/panic.go:965 +0x1b9
reflect.Value.Type(0x0, 0x0, 0x0, 0xc00fa44c50, 0x0)
	/usr/local/go/src/reflect/value.go:1908 +0x189
encoding/json.stringEncoder(0xc00e68ce00, 0x0, 0x0, 0x0, 0xc00fa40100)
	/usr/local/go/src/encoding/json/encode.go:620 +0x4c
encoding/json.mapEncoder.encode(0x23417e8, 0xc00e68ce00, 0x1f6ddc0, 0xc0105100b8, 0x195, 0x100)
	/usr/local/go/src/encoding/json/encode.go:813 +0x366
encoding/json.structEncoder.encode(0xc00086e000, 0x10, 0x10, 0xc0008338f0, 0xc00e68ce00, 0x21d7020, 0xc010510020, 0x199, 0x100)
	/usr/local/go/src/encoding/json/encode.go:761 +0x2ab
encoding/json.structEncoder.encode(0xc00a69bb00, 0x5, 0x8, 0xc013a574d0, 0xc00e68ce00, 0x20c4c20, 0xc010510000, 0x199, 0x1f60100)
	/usr/local/go/src/encoding/json/encode.go:761 +0x2ab
encoding/json.ptrEncoder.encode(0xc013a57500, 0xc00e68ce00, 0x221c080, 0xc010510000, 0x16, 0x2210100)
	/usr/local/go/src/encoding/json/encode.go:944 +0x125
encoding/json.(*encodeState).reflectValue(0xc00e68ce00, 0x221c080, 0xc010510000, 0x16, 0xc00ae30100)
	/usr/local/go/src/encoding/json/encode.go:360 +0x82
encoding/json.(*encodeState).marshal(0xc00e68ce00, 0x221c080, 0xc010510000, 0xc015dc0100, 0x0, 0x0)
	/usr/local/go/src/encoding/json/encode.go:332 +0xf9
encoding/json.Marshal(0x221c080, 0xc010510000, 0xc00ae37c98, 0x1, 0x1, 0x0, 0x0)
	/usr/local/go/src/encoding/json/encode.go:161 +0x52
github.com/gardener/gardener/pkg/gardenlet/controller/shoot.(*Controller).shootUpdate(0xc005613080, 0x221c080, 0xc010510000, 0x221c080, 0xc0159d0700)
	/go/src/github.com/gardener/gardener/pkg/gardenlet/controller/shoot/shoot_control.go:76 +0x70
k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnUpdate(...)
	/go/src/github.com/gardener/gardener/vendor/k8s.io/client-go/tools/cache/controller.go:238
k8s.io/client-go/tools/cache.FilteringResourceEventHandler.OnUpdate(0xc005af9050, 0x2550380, 0xc0056f4858, 0x221c080, 0xc010510000, 0x221c080, 0xc0159d0700)
	/go/src/github.com/gardener/gardener/vendor/k8s.io/client-go/tools/cache/controller.go:273 +0x122
k8s.io/client-go/tools/cache.(*processorListener).run.func1()
	/go/src/github.com/gardener/gardener/vendor/k8s.io/client-go/tools/cache/shared_informer.go:775 +0x1c5
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0xc000846f60)
	/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155 +0x5f
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc00ae37f60, 0x2505440, 0xc00557a540, 0x1f47201, 0xc00923c8a0)
	/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156 +0x9b
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc000846f60, 0x3b9aca00, 0x0, 0x431b01, 0xc00923c8a0)
	/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133 +0x98
k8s.io/apimachinery/pkg/util/wait.Until(...)
	/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90
k8s.io/client-go/tools/cache.(*processorListener).run(0xc006072200)
	/go/src/github.com/gardener/gardener/vendor/k8s.io/client-go/tools/cache/shared_informer.go:771 +0x95
k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1(0xc000400680, 0xc0056c5f40)
	/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:73 +0x51
created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start
	/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:71 +0x65
time="2021-05-12T10:36:12Z" level=info msg="Found secrets in namespace \"seed-az-us1\": internal domain secret \"internal-domain-internal-canary-k8s-ondemand-com\" for domain \"internal.canary.k8s.ondemand.com\", default domain secret \"default-domain-shoot-canary-k8s-hana-ondemand-com\" for domain \"shoot.canary.k8s-hana.ondemand.com\", alerting secret \"alerting-0\", OpenVPN Diffie Hellman secret \"openvpn-diffie-hellman-key\", monitoring basic auth secret \"monitoring-ingress-credentials\""
panic: reflect: call of reflect.Value.Type on zero Value [recovered]
	panic: reflect: call of reflect.Value.Type on zero Value [recovered]
	panic: reflect: call of reflect.Value.Type on zero Value

goroutine 655 [running]:
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
	/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:55 +0x109
panic(0x1f5b220, 0xc01565d548)
	/usr/local/go/src/runtime/panic.go:965 +0x1b9
encoding/json.(*encodeState).marshal.func1(0xc00ae37ba0)
	/usr/local/go/src/encoding/json/encode.go:328 +0x8d
panic(0x1f5b220, 0xc01565d548)
	/usr/local/go/src/runtime/panic.go:965 +0x1b9
reflect.Value.Type(0x0, 0x0, 0x0, 0xc00fa44c50, 0x0)
	/usr/local/go/src/reflect/value.go:1908 +0x189
encoding/json.stringEncoder(0xc00e68ce00, 0x0, 0x0, 0x0, 0xc00fa40100)
	/usr/local/go/src/encoding/json/encode.go:620 +0x4c
encoding/json.mapEncoder.encode(0x23417e8, 0xc00e68ce00, 0x1f6ddc0, 0xc0105100b8, 0x195, 0x100)
	/usr/local/go/src/encoding/json/encode.go:813 +0x366
encoding/json.structEncoder.encode(0xc00086e000, 0x10, 0x10, 0xc0008338f0, 0xc00e68ce00, 0x21d7020, 0xc010510020, 0x199, 0x100)
	/usr/local/go/src/encoding/json/encode.go:761 +0x2ab
encoding/json.structEncoder.encode(0xc00a69bb00, 0x5, 0x8, 0xc013a574d0, 0xc00e68ce00, 0x20c4c20, 0xc010510000, 0x199, 0x1f60100)
	/usr/local/go/src/encoding/json/encode.go:761 +0x2ab
encoding/json.ptrEncoder.encode(0xc013a57500, 0xc00e68ce00, 0x221c080, 0xc010510000, 0x16, 0x2210100)
	/usr/local/go/src/encoding/json/encode.go:944 +0x125
encoding/json.(*encodeState).reflectValue(0xc00e68ce00, 0x221c080, 0xc010510000, 0x16, 0xc00ae30100)
	/usr/local/go/src/encoding/json/encode.go:360 +0x82
encoding/json.(*encodeState).marshal(0xc00e68ce00, 0x221c080, 0xc010510000, 0xc015dc0100, 0x0, 0x0)
	/usr/local/go/src/encoding/json/encode.go:332 +0xf9
encoding/json.Marshal(0x221c080, 0xc010510000, 0xc00ae37c98, 0x1, 0x1, 0x0, 0x0)
	/usr/local/go/src/encoding/json/encode.go:161 +0x52
github.com/gardener/gardener/pkg/gardenlet/controller/shoot.(*Controller).shootUpdate(0xc005613080, 0x221c080, 0xc010510000, 0x221c080, 0xc0159d0700)
	/go/src/github.com/gardener/gardener/pkg/gardenlet/controller/shoot/shoot_control.go:76 +0x70
k8s.io/client-go/tools/cache.ResourceEventHandlerFuncs.OnUpdate(...)
	/go/src/github.com/gardener/gardener/vendor/k8s.io/client-go/tools/cache/controller.go:238
k8s.io/client-go/tools/cache.FilteringResourceEventHandler.OnUpdate(0xc005af9050, 0x2550380, 0xc0056f4858, 0x221c080, 0xc010510000, 0x221c080, 0xc0159d0700)
	/go/src/github.com/gardener/gardener/vendor/k8s.io/client-go/tools/cache/controller.go:273 +0x122
k8s.io/client-go/tools/cache.(*processorListener).run.func1()
	/go/src/github.com/gardener/gardener/vendor/k8s.io/client-go/tools/cache/shared_informer.go:775 +0x1c5
k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1(0xc000846f60)
	/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155 +0x5f
k8s.io/apimachinery/pkg/util/wait.BackoffUntil(0xc00ae37f60, 0x2505440, 0xc00557a540, 0x1f47201, 0xc00923c8a0)
	/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156 +0x9b
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc000846f60, 0x3b9aca00, 0x0, 0x431b01, 0xc00923c8a0)
	/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133 +0x98
k8s.io/apimachinery/pkg/util/wait.Until(...)
	/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:90
k8s.io/client-go/tools/cache.(*processorListener).run(0xc006072200)
	/go/src/github.com/gardener/gardener/vendor/k8s.io/client-go/tools/cache/shared_informer.go:771 +0x95
k8s.io/apimachinery/pkg/util/wait.(*Group).Start.func1(0xc000400680, 0xc0056c5f40)
	/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:73 +0x51
created by k8s.io/apimachinery/pkg/util/wait.(*Group).Start
	/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:71 +0x65
```

As a short term mitigation we can remove the corresponding code that is causing the trouble. The logging was with debug level so it was not enabled by default and it was not quite useful in large landscape as it generates tons of debug logs.
As an alternative audit logging can be used or other means. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Apply a mitigation that will prevent gardenlet to panic under certain circumstances.
```
