### PR TITLE
[release-v1.22] Automated cherry pick of #4046: Get rid of the debug logging of Shoots in the shootUpdate func

### DIFF
--- a/pkg/gardenlet/controller/seed/seed_control.go
+++ b/pkg/gardenlet/controller/seed/seed_control.go
@@ -16,7 +16,6 @@ package seed
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"time"
@@ -165,11 +164,10 @@ type defaultControl struct {
 
 func (c *defaultControl) ReconcileSeed(obj *gardencorev1beta1.Seed, key string) error {
 	var (
-		ctx         = context.TODO()
-		seed        = obj.DeepCopy()
-		seedJSON, _ = json.Marshal(seed)
-		seedLogger  = logger.NewFieldLogger(logger.Logger, "seed", seed.Name)
-		err         error
+		ctx        = context.TODO()
+		seed       = obj.DeepCopy()
+		seedLogger = logger.NewFieldLogger(logger.Logger, "seed", seed.Name)
+		err        error
 	)
 
 	gardenClient, err := c.clientMap.GetClient(ctx, keys.ForGarden())
@@ -310,7 +308,6 @@ func (c *defaultControl) ReconcileSeed(obj *gardencorev1beta1.Seed, key string) 
 	}
 
 	seedLogger.Infof("[SEED RECONCILE] %s", key)
-	seedLogger.Debugf(string(seedJSON))
 
 	// need retry logic, because controllerregistration controller is acting on it at the same time and cached object might not be up to date
 	seed, err = kutil.TryUpdateSeed(ctx, gardenClient.GardenCore(), retry.DefaultBackoff, seed.ObjectMeta, func(curSeed *gardencorev1beta1.Seed) (*gardencorev1beta1.Seed, error) {

--- a/pkg/gardenlet/controller/shoot/shoot_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control.go
@@ -16,7 +16,6 @@ package shoot
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"sync"
@@ -71,14 +70,10 @@ func (c *Controller) shootAdd(obj interface{}, resetRateLimiting bool) {
 
 func (c *Controller) shootUpdate(oldObj, newObj interface{}) {
 	var (
-		oldShoot        = oldObj.(*gardencorev1beta1.Shoot)
-		newShoot        = newObj.(*gardencorev1beta1.Shoot)
-		oldShootJSON, _ = json.Marshal(oldShoot)
-		newShootJSON, _ = json.Marshal(newShoot)
-		shootLogger     = logger.NewShootLogger(logger.Logger, newShoot.ObjectMeta.Name, newShoot.ObjectMeta.Namespace)
+		oldShoot    = oldObj.(*gardencorev1beta1.Shoot)
+		newShoot    = newObj.(*gardencorev1beta1.Shoot)
+		shootLogger = logger.NewShootLogger(logger.Logger, newShoot.ObjectMeta.Name, newShoot.ObjectMeta.Namespace)
 	)
-	shootLogger.Debugf(string(oldShootJSON))
-	shootLogger.Debugf(string(newShootJSON))
 
 	// If the generation did not change for an update event (i.e., no changes to the .spec section have
 	// been made), we do not want to add the Shoot to the queue. The period reconciliation is handled


### PR DESCRIPTION
Cherry pick of #4046 on release-v1.22.

#4046: Get rid of the debug logging of Shoots in the shootUpdate func

**Release Notes:**
```other operator
Apply a mitigation that will prevent gardenlet to panic under certain circumstances.
```