### PR TITLE
Kubeconfig generation supports multiple server hosts

### DIFF
--- a/extensions/pkg/util/shoot.go
+++ b/extensions/pkg/util/shoot.go
@@ -75,10 +75,10 @@ func GetOrCreateShootKubeconfig(ctx context.Context, c client.Client, certificat
 	config := secrets.ControlPlaneSecretConfig{
 		CertificateSecretConfig: &certificateConfig,
 
-		KubeConfigRequest: &secrets.KubeConfigRequest{
-			ClusterName:  namespace,
-			APIServerURL: kubeAPIServerServiceDNS(namespace),
-		},
+		KubeConfigRequests: []secrets.KubeConfigRequest{{
+			ClusterName:   namespace,
+			APIServerHost: kubeAPIServerServiceDNS(namespace),
+		}},
 	}
 
 	controlPlane, err := config.GenerateControlPlane()

--- a/hack/local-development/local-garden/garden-certificate-generator.go
+++ b/hack/local-development/local-garden/garden-certificate-generator.go
@@ -1,4 +1,4 @@
-//usr/bin/env go run $0 "$@"; exit
+// usr/bin/env go run $0 "$@"; exit
 
 package main
 
@@ -236,10 +236,10 @@ func createClusterCertificatesAndKeys(caCertificate *secrets.Certificate) (map[s
 				CertType:  secrets.ClientCert,
 				SigningCA: caCertificate,
 			},
-			KubeConfigRequest: &secrets.KubeConfigRequest{
-				ClusterName:  "local-garden",
-				APIServerURL: "localhost:2443",
-			},
+			KubeConfigRequests: []secrets.KubeConfigRequest{{
+				ClusterName:   "local-garden",
+				APIServerHost: "localhost:2443",
+			}},
 		},
 		// Secret definition for kube-controller-manager kubeconfig
 		&secrets.ControlPlaneSecretConfig{
@@ -252,10 +252,10 @@ func createClusterCertificatesAndKeys(caCertificate *secrets.Certificate) (map[s
 				CertType:  secrets.ClientCert,
 				SigningCA: caCertificate,
 			},
-			KubeConfigRequest: &secrets.KubeConfigRequest{
-				ClusterName:  "local-garden",
-				APIServerURL: "kube-apiserver:2443",
-			},
+			KubeConfigRequests: []secrets.KubeConfigRequest{{
+				ClusterName:   "local-garden",
+				APIServerHost: "kube-apiserver:2443",
+			}},
 		},
 		// Secret definition for service account (used for kube-apiserver and kube-controller-manager)
 		&secrets.RSASecretConfig{
@@ -271,10 +271,10 @@ func createClusterCertificatesAndKeys(caCertificate *secrets.Certificate) (map[s
 				CertType:   secrets.ClientCert,
 				SigningCA:  caCertificate,
 			},
-			KubeConfigRequest: &secrets.KubeConfigRequest{
-				ClusterName:  "local-garden",
-				APIServerURL: "localhost:2443",
-			},
+			KubeConfigRequests: []secrets.KubeConfigRequest{{
+				ClusterName:   "local-garden",
+				APIServerHost: "localhost:2443",
+			}},
 		},
 		&secrets.ControlPlaneSecretConfig{
 			CertificateSecretConfig: &secrets.CertificateSecretConfig{
@@ -283,10 +283,10 @@ func createClusterCertificatesAndKeys(caCertificate *secrets.Certificate) (map[s
 				CertType:   secrets.ClientCert,
 				SigningCA:  caCertificate,
 			},
-			KubeConfigRequest: &secrets.KubeConfigRequest{
-				ClusterName:  "local-garden",
-				APIServerURL: "localhost:2443",
-			},
+			KubeConfigRequests: []secrets.KubeConfigRequest{{
+				ClusterName:   "local-garden",
+				APIServerHost: "localhost:2443",
+			}},
 		},
 		&secrets.ControlPlaneSecretConfig{
 			CertificateSecretConfig: &secrets.CertificateSecretConfig{
@@ -295,10 +295,10 @@ func createClusterCertificatesAndKeys(caCertificate *secrets.Certificate) (map[s
 				CertType:   secrets.ClientCert,
 				SigningCA:  caCertificate,
 			},
-			KubeConfigRequest: &secrets.KubeConfigRequest{
-				ClusterName:  "local-garden",
-				APIServerURL: "localhost:2443",
-			},
+			KubeConfigRequests: []secrets.KubeConfigRequest{{
+				ClusterName:   "local-garden",
+				APIServerHost: "localhost:2443",
+			}},
 		},
 		&secrets.ControlPlaneSecretConfig{
 			CertificateSecretConfig: &secrets.CertificateSecretConfig{
@@ -307,10 +307,10 @@ func createClusterCertificatesAndKeys(caCertificate *secrets.Certificate) (map[s
 				CertType:   secrets.ClientCert,
 				SigningCA:  caCertificate,
 			},
-			KubeConfigRequest: &secrets.KubeConfigRequest{
-				ClusterName:  "local-garden",
-				APIServerURL: "localhost:2443",
-			},
+			KubeConfigRequests: []secrets.KubeConfigRequest{{
+				ClusterName:   "local-garden",
+				APIServerHost: "localhost:2443",
+			}},
 		},
 		&secrets.ControlPlaneSecretConfig{
 			CertificateSecretConfig: &secrets.CertificateSecretConfig{
@@ -320,14 +320,14 @@ func createClusterCertificatesAndKeys(caCertificate *secrets.Certificate) (map[s
 				CertType:     secrets.ClientCert,
 				SigningCA:    caCertificate,
 			},
-			KubeConfigRequest: &secrets.KubeConfigRequest{
-				ClusterName:  "local-garden",
-				APIServerURL: "localhost:2443",
-			},
+			KubeConfigRequests: []secrets.KubeConfigRequest{{
+				ClusterName:   "local-garden",
+				APIServerHost: "localhost:2443",
+			}},
 		},
 	}
 
-	var credentials = make(map[string]certsAndKeys)
+	credentials := make(map[string]certsAndKeys)
 	for _, s := range secretList {
 		obj, err := s.Generate()
 		if err != nil {

--- a/pkg/operation/botanist/wanted_secrets.go
+++ b/pkg/operation/botanist/wanted_secrets.go
@@ -227,10 +227,10 @@ func (b *Botanist) generateWantedSecretConfigs(basicAuthAPIServer *secrets.Basic
 				CertType:  secrets.ClientCert,
 				SigningCA: certificateAuthorities[v1beta1constants.SecretNameCACluster],
 			},
-			KubeConfigRequest: &secrets.KubeConfigRequest{
-				ClusterName:  b.Shoot.SeedNamespace,
-				APIServerURL: b.Shoot.ComputeInClusterAPIServerAddress(true),
-			},
+			KubeConfigRequests: []secrets.KubeConfigRequest{{
+				ClusterName:   b.Shoot.SeedNamespace,
+				APIServerHost: b.Shoot.ComputeInClusterAPIServerAddress(true),
+			}},
 		},
 
 		// Secret definition for kube-controller-manager server
@@ -262,10 +262,10 @@ func (b *Botanist) generateWantedSecretConfigs(basicAuthAPIServer *secrets.Basic
 				SigningCA: certificateAuthorities[v1beta1constants.SecretNameCACluster],
 			},
 
-			KubeConfigRequest: &secrets.KubeConfigRequest{
-				ClusterName:  b.Shoot.SeedNamespace,
-				APIServerURL: b.Shoot.ComputeInClusterAPIServerAddress(true),
-			},
+			KubeConfigRequests: []secrets.KubeConfigRequest{{
+				ClusterName:   b.Shoot.SeedNamespace,
+				APIServerHost: b.Shoot.ComputeInClusterAPIServerAddress(true),
+			}},
 		},
 
 		// Secret definition for kube-scheduler server
@@ -297,10 +297,10 @@ func (b *Botanist) generateWantedSecretConfigs(basicAuthAPIServer *secrets.Basic
 				SigningCA: certificateAuthorities[v1beta1constants.SecretNameCACluster],
 			},
 
-			KubeConfigRequest: &secrets.KubeConfigRequest{
-				ClusterName:  b.Shoot.SeedNamespace,
-				APIServerURL: b.Shoot.ComputeInClusterAPIServerAddress(true),
-			},
+			KubeConfigRequests: []secrets.KubeConfigRequest{{
+				ClusterName:   b.Shoot.SeedNamespace,
+				APIServerHost: b.Shoot.ComputeInClusterAPIServerAddress(true),
+			}},
 		},
 
 		// Secret definition for gardener-resource-manager
@@ -317,10 +317,10 @@ func (b *Botanist) generateWantedSecretConfigs(basicAuthAPIServer *secrets.Basic
 				SigningCA: certificateAuthorities[v1beta1constants.SecretNameCACluster],
 			},
 
-			KubeConfigRequest: &secrets.KubeConfigRequest{
-				ClusterName:  b.Shoot.SeedNamespace,
-				APIServerURL: b.Shoot.ComputeInClusterAPIServerAddress(true),
-			},
+			KubeConfigRequests: []secrets.KubeConfigRequest{{
+				ClusterName:   b.Shoot.SeedNamespace,
+				APIServerHost: b.Shoot.ComputeInClusterAPIServerAddress(true),
+			}},
 		},
 
 		// Secret definition for kube-proxy
@@ -337,10 +337,10 @@ func (b *Botanist) generateWantedSecretConfigs(basicAuthAPIServer *secrets.Basic
 				SigningCA: certificateAuthorities[v1beta1constants.SecretNameCACluster],
 			},
 
-			KubeConfigRequest: &secrets.KubeConfigRequest{
-				ClusterName:  b.Shoot.SeedNamespace,
-				APIServerURL: b.Shoot.ComputeOutOfClusterAPIServerAddress(b.APIServerAddress, true),
-			},
+			KubeConfigRequests: []secrets.KubeConfigRequest{{
+				ClusterName:   b.Shoot.SeedNamespace,
+				APIServerHost: b.Shoot.ComputeOutOfClusterAPIServerAddress(b.APIServerAddress, true),
+			}},
 		},
 
 		// Secret definition for kube-state-metrics
@@ -357,10 +357,10 @@ func (b *Botanist) generateWantedSecretConfigs(basicAuthAPIServer *secrets.Basic
 				SigningCA: certificateAuthorities[v1beta1constants.SecretNameCACluster],
 			},
 
-			KubeConfigRequest: &secrets.KubeConfigRequest{
-				ClusterName:  b.Shoot.SeedNamespace,
-				APIServerURL: b.Shoot.ComputeInClusterAPIServerAddress(true),
-			},
+			KubeConfigRequests: []secrets.KubeConfigRequest{{
+				ClusterName:   b.Shoot.SeedNamespace,
+				APIServerHost: b.Shoot.ComputeInClusterAPIServerAddress(true),
+			}},
 		},
 
 		// Secret definition for prometheus
@@ -377,10 +377,10 @@ func (b *Botanist) generateWantedSecretConfigs(basicAuthAPIServer *secrets.Basic
 				SigningCA: certificateAuthorities[v1beta1constants.SecretNameCACluster],
 			},
 
-			KubeConfigRequest: &secrets.KubeConfigRequest{
-				ClusterName:  b.Shoot.SeedNamespace,
-				APIServerURL: b.Shoot.ComputeInClusterAPIServerAddress(true),
-			},
+			KubeConfigRequests: []secrets.KubeConfigRequest{{
+				ClusterName:   b.Shoot.SeedNamespace,
+				APIServerHost: b.Shoot.ComputeInClusterAPIServerAddress(true),
+			}},
 		},
 
 		// Secret definition for prometheus to kubelets communication
@@ -412,10 +412,10 @@ func (b *Botanist) generateWantedSecretConfigs(basicAuthAPIServer *secrets.Basic
 				SigningCA: certificateAuthorities[v1beta1constants.SecretNameCACluster],
 			},
 
-			KubeConfigRequest: &secrets.KubeConfigRequest{
-				ClusterName:  b.Shoot.SeedNamespace,
-				APIServerURL: b.Shoot.ComputeOutOfClusterAPIServerAddress(b.APIServerAddress, true),
-			},
+			KubeConfigRequests: []secrets.KubeConfigRequest{{
+				ClusterName:   b.Shoot.SeedNamespace,
+				APIServerHost: b.Shoot.ComputeOutOfClusterAPIServerAddress(b.APIServerAddress, true),
+			}},
 		},
 		&secrets.ControlPlaneSecretConfig{
 			CertificateSecretConfig: &secrets.CertificateSecretConfig{
@@ -430,10 +430,10 @@ func (b *Botanist) generateWantedSecretConfigs(basicAuthAPIServer *secrets.Basic
 				SigningCA: certificateAuthorities[v1beta1constants.SecretNameCACluster],
 			},
 
-			KubeConfigRequest: &secrets.KubeConfigRequest{
-				ClusterName:  b.Shoot.SeedNamespace,
-				APIServerURL: b.Shoot.ComputeInClusterAPIServerAddress(false),
-			},
+			KubeConfigRequests: []secrets.KubeConfigRequest{{
+				ClusterName:   b.Shoot.SeedNamespace,
+				APIServerHost: b.Shoot.ComputeInClusterAPIServerAddress(false),
+			}},
 		},
 
 		// Secret definition for cloud-config-downloader
@@ -450,10 +450,10 @@ func (b *Botanist) generateWantedSecretConfigs(basicAuthAPIServer *secrets.Basic
 				SigningCA: certificateAuthorities[v1beta1constants.SecretNameCACluster],
 			},
 
-			KubeConfigRequest: &secrets.KubeConfigRequest{
-				ClusterName:  b.Shoot.SeedNamespace,
-				APIServerURL: b.Shoot.ComputeOutOfClusterAPIServerAddress(b.APIServerAddress, true),
-			},
+			KubeConfigRequests: []secrets.KubeConfigRequest{{
+				ClusterName:   b.Shoot.SeedNamespace,
+				APIServerHost: b.Shoot.ComputeOutOfClusterAPIServerAddress(b.APIServerAddress, true),
+			}},
 		},
 
 		// Secret definition for monitoring
@@ -589,10 +589,10 @@ func (b *Botanist) generateWantedSecretConfigs(basicAuthAPIServer *secrets.Basic
 		BasicAuth: basicAuthAPIServer,
 		Token:     kubecfgToken,
 
-		KubeConfigRequest: &secrets.KubeConfigRequest{
-			ClusterName:  b.Shoot.SeedNamespace,
-			APIServerURL: b.Shoot.ComputeOutOfClusterAPIServerAddress(b.APIServerAddress, false),
-		},
+		KubeConfigRequests: []secrets.KubeConfigRequest{{
+			ClusterName:   b.Shoot.SeedNamespace,
+			APIServerHost: b.Shoot.ComputeOutOfClusterAPIServerAddress(b.APIServerAddress, false),
+		}},
 	})
 
 	// Secret definitions for dependency-watchdog-internal and external probes
@@ -608,10 +608,10 @@ func (b *Botanist) generateWantedSecretConfigs(basicAuthAPIServer *secrets.Basic
 			CertType:  secrets.ClientCert,
 			SigningCA: certificateAuthorities[v1beta1constants.SecretNameCACluster],
 		},
-		KubeConfigRequest: &secrets.KubeConfigRequest{
-			ClusterName:  b.Shoot.SeedNamespace,
-			APIServerURL: b.Shoot.ComputeInClusterAPIServerAddress(false),
-		},
+		KubeConfigRequests: []secrets.KubeConfigRequest{{
+			ClusterName:   b.Shoot.SeedNamespace,
+			APIServerHost: b.Shoot.ComputeInClusterAPIServerAddress(false),
+		}},
 	}, &secrets.ControlPlaneSecretConfig{
 		CertificateSecretConfig: &secrets.CertificateSecretConfig{
 			Name: common.DependencyWatchdogExternalProbeSecretName,
@@ -624,10 +624,10 @@ func (b *Botanist) generateWantedSecretConfigs(basicAuthAPIServer *secrets.Basic
 			CertType:  secrets.ClientCert,
 			SigningCA: certificateAuthorities[v1beta1constants.SecretNameCACluster],
 		},
-		KubeConfigRequest: &secrets.KubeConfigRequest{
-			ClusterName:  b.Shoot.SeedNamespace,
-			APIServerURL: b.Shoot.ComputeOutOfClusterAPIServerAddress(b.APIServerAddress, true),
-		},
+		KubeConfigRequests: []secrets.KubeConfigRequest{{
+			ClusterName:   b.Shoot.SeedNamespace,
+			APIServerHost: b.Shoot.ComputeOutOfClusterAPIServerAddress(b.APIServerAddress, true),
+		}},
 	})
 
 	if b.Shoot.KonnectivityTunnelEnabled {
@@ -650,10 +650,10 @@ func (b *Botanist) generateWantedSecretConfigs(basicAuthAPIServer *secrets.Basic
 				BasicAuth: basicAuthAPIServer,
 				Token:     konnectivityServerToken,
 
-				KubeConfigRequest: &secrets.KubeConfigRequest{
-					ClusterName:  b.Shoot.SeedNamespace,
-					APIServerURL: fmt.Sprintf("%s.%s", v1beta1constants.DeploymentNameKubeAPIServer, b.Shoot.SeedNamespace),
-				},
+				KubeConfigRequests: []secrets.KubeConfigRequest{{
+					ClusterName:   b.Shoot.SeedNamespace,
+					APIServerHost: fmt.Sprintf("%s.%s", v1beta1constants.DeploymentNameKubeAPIServer, b.Shoot.SeedNamespace),
+				}},
 			},
 			&secrets.ControlPlaneSecretConfig{
 				CertificateSecretConfig: &secrets.CertificateSecretConfig{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:

Adds additional hosts that can be exposed on the same server.

Prerequisite for #3932 and based on #4011

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
