### PR TITLE
Preserve area/ and kind/ labels on cherry pick PRs

### DIFF
--- a/hack/cherry-pick-pull.sh
+++ b/hack/cherry-pick-pull.sh
@@ -137,6 +137,7 @@ trap return_to_kansas EXIT
 
 SUBJECTS=()
 RELEASE_NOTES=()
+LABELS=()
 function make-a-pr() {
   local rel
   rel="$(basename "${BRANCH}")"
@@ -151,8 +152,11 @@ function make-a-pr() {
   local numandtitle
   numandtitle=$(printf '%s\n' "${SUBJECTS[@]}")
   relnotes=$(printf "${RELEASE_NOTES[@]}")
+  labels=$(printf "${LABELS[@]}")
   cat >"${prtext}" <<EOF
 [${rel}] Automated cherry pick of ${numandtitle}
+
+${labels}
 
 Cherry pick of ${PULLSUBJ} on ${rel}.
 
@@ -206,6 +210,8 @@ for pull in "${PULLS[@]}"; do
   pr_info=$(curl "https://api.github.com/repos/${MAIN_REPO_ORG}/${MAIN_REPO_NAME}/pulls/${pull}" -sS)
   subject=$(echo ${pr_info} | jq -cr '.title')
   SUBJECTS+=("#${pull}: ${subject}")
+  labels=$(echo ${pr_info} | jq '.labels[].name' -cr | grep -P '^(area|kind)' | sed 's|^|/|g')
+  LABELS+=("${labels}")
 
   # remove the patch file from /tmp
   rm -f "/tmp/${pull}.patch"


### PR DESCRIPTION
**How to categorize this PR?**
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Preserve area/ and kind/ labels on cherry pick PRs

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
/invite @ialidzhikov 