### PR TITLE
Fix wrong MergePatchOrCreate usage

### DIFF
--- a/pkg/controllerutils/patch_test.go
+++ b/pkg/controllerutils/patch_test.go
@@ -54,65 +54,155 @@ var _ = Describe("Patch", func() {
 		ctrl.Finish()
 	})
 
-	testSuite := func(f func(ctx context.Context, c client.Writer, obj client.Object, f controllerutil.MutateFn) (controllerutil.OperationResult, error), patchType types.PatchType) {
-		It("should return an error because the mutate function returned an error", func() {
-			result, err := f(ctx, c, obj, func() error { return fakeErr })
-			Expect(result).To(Equal(controllerutil.OperationResultNone))
-			Expect(err).To(MatchError(fakeErr))
-		})
+	Describe("*PatchOrCreate", func() {
+		testSuite := func(f func(ctx context.Context, c client.Writer, obj client.Object, f controllerutil.MutateFn) (controllerutil.OperationResult, error), patchType types.PatchType) {
+			It("should return an error because the mutate function returned an error", func() {
+				result, err := f(ctx, c, obj, func() error { return fakeErr })
+				Expect(result).To(Equal(controllerutil.OperationResultNone))
+				Expect(err).To(MatchError(fakeErr))
+			})
 
-		It("should return an error because the patch failed", func() {
-			test.EXPECTPatch(ctx, c, obj, obj, patchType, fakeErr)
+			It("should return an error because the patch failed", func() {
+				test.EXPECTPatch(ctx, c, obj, obj, patchType, fakeErr)
 
-			result, err := f(ctx, c, obj, func() error { return nil })
-			Expect(result).To(Equal(controllerutil.OperationResultNone))
-			Expect(err).To(MatchError(fakeErr))
-		})
+				result, err := f(ctx, c, obj, func() error { return nil })
+				Expect(result).To(Equal(controllerutil.OperationResultNone))
+				Expect(err).To(MatchError(fakeErr))
+			})
 
-		It("should return an error because the create failed", func() {
-			gomock.InOrder(
-				test.EXPECTPatch(ctx, c, obj, obj, patchType, apierrors.NewNotFound(schema.GroupResource{}, "")),
-				c.EXPECT().Create(ctx, obj).Return(fakeErr),
-			)
+			It("should return an error because the create failed", func() {
+				gomock.InOrder(
+					test.EXPECTPatch(ctx, c, obj, obj, patchType, apierrors.NewNotFound(schema.GroupResource{}, "")),
+					c.EXPECT().Create(ctx, obj).Return(fakeErr),
+				)
 
-			result, err := f(ctx, c, obj, func() error { return nil })
-			Expect(result).To(Equal(controllerutil.OperationResultNone))
-			Expect(err).To(MatchError(fakeErr))
-		})
+				result, err := f(ctx, c, obj, func() error { return nil })
+				Expect(result).To(Equal(controllerutil.OperationResultNone))
+				Expect(err).To(MatchError(fakeErr))
+			})
 
-		It("should successfully create the object", func() {
-			gomock.InOrder(
-				test.EXPECTPatch(ctx, c, obj, obj, patchType, apierrors.NewNotFound(schema.GroupResource{}, "")),
-				c.EXPECT().Create(ctx, obj),
-			)
+			It("should successfully create the object", func() {
+				gomock.InOrder(
+					test.EXPECTPatch(ctx, c, obj, obj, patchType, apierrors.NewNotFound(schema.GroupResource{}, "")),
+					c.EXPECT().Create(ctx, obj),
+				)
 
-			result, err := f(ctx, c, obj, func() error { return nil })
-			Expect(result).To(Equal(controllerutil.OperationResultCreated))
-			Expect(err).NotTo(HaveOccurred())
-		})
+				result, err := f(ctx, c, obj, func() error { return nil })
+				Expect(result).To(Equal(controllerutil.OperationResultCreated))
+				Expect(err).NotTo(HaveOccurred())
+			})
 
-		It("should successfully patch the object", func() {
-			objCopy := obj.DeepCopy()
-			mutateFn := func(o *corev1.ServiceAccount) func() error {
-				return func() error {
-					o.Labels = map[string]string{"foo": "bar"}
-					return nil
+			It("should successfully patch the object", func() {
+				objCopy := obj.DeepCopy()
+				mutateFn := func(o *corev1.ServiceAccount) func() error {
+					return func() error {
+						o.Labels = map[string]string{"foo": "bar"}
+						return nil
+					}
 				}
-			}
-			_ = mutateFn(objCopy)()
+				_ = mutateFn(objCopy)()
 
-			test.EXPECTPatch(ctx, c, objCopy, obj, patchType)
+				test.EXPECTPatch(ctx, c, objCopy, obj, patchType)
 
-			result, err := f(ctx, c, obj, mutateFn(obj))
-			Expect(result).To(Equal(controllerutil.OperationResultUpdated))
-			Expect(err).NotTo(HaveOccurred())
+				result, err := f(ctx, c, obj, mutateFn(obj))
+				Expect(result).To(Equal(controllerutil.OperationResultUpdated))
+				Expect(err).NotTo(HaveOccurred())
+			})
+		}
+
+		Describe("#MergePatchOrCreate", func() {
+			testSuite(MergePatchOrCreate, types.MergePatchType)
 		})
-	}
-
-	Describe("#MergePatchOrCreate", func() {
-		testSuite(MergePatchOrCreate, types.MergePatchType)
+		Describe("#StrategicMergePatchOrCreate", func() {
+			testSuite(StrategicMergePatchOrCreate, types.StrategicMergePatchType)
+		})
 	})
-	Describe("#StrategicMergePatchOrCreate", func() {
-		testSuite(StrategicMergePatchOrCreate, types.StrategicMergePatchType)
+
+	Describe("GetAndCreateOr*Patch", func() {
+		testSuite := func(f func(ctx context.Context, c client.Client, obj client.Object, f controllerutil.MutateFn) (controllerutil.OperationResult, error), patchType types.PatchType) {
+			It("should return an error because reading the object fails", func() {
+				c.EXPECT().Get(ctx, client.ObjectKeyFromObject(obj), obj).Return(fakeErr)
+
+				result, err := f(ctx, c, obj, func() error { return nil })
+				Expect(result).To(Equal(controllerutil.OperationResultNone))
+				Expect(err).To(MatchError(fakeErr))
+			})
+
+			It("should return an error because the mutate function returned an error (object found)", func() {
+				c.EXPECT().Get(ctx, client.ObjectKeyFromObject(obj), obj)
+
+				result, err := f(ctx, c, obj, func() error { return fakeErr })
+				Expect(result).To(Equal(controllerutil.OperationResultNone))
+				Expect(err).To(MatchError(fakeErr))
+			})
+
+			It("should return an error because the mutate function returned an error (object not found)", func() {
+				c.EXPECT().Get(ctx, client.ObjectKeyFromObject(obj), obj).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
+
+				result, err := f(ctx, c, obj, func() error { return fakeErr })
+				Expect(result).To(Equal(controllerutil.OperationResultNone))
+				Expect(err).To(MatchError(fakeErr))
+			})
+
+			It("should return an error because the create failed", func() {
+				gomock.InOrder(
+					c.EXPECT().Get(ctx, client.ObjectKeyFromObject(obj), obj).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+					c.EXPECT().Create(ctx, obj).Return(fakeErr),
+				)
+
+				result, err := f(ctx, c, obj, func() error { return nil })
+				Expect(result).To(Equal(controllerutil.OperationResultNone))
+				Expect(err).To(MatchError(fakeErr))
+			})
+
+			It("should successfully create the object", func() {
+				gomock.InOrder(
+					c.EXPECT().Get(ctx, client.ObjectKeyFromObject(obj), obj).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+					c.EXPECT().Create(ctx, obj),
+				)
+
+				result, err := f(ctx, c, obj, func() error { return nil })
+				Expect(result).To(Equal(controllerutil.OperationResultCreated))
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should return an error because the patch failed", func() {
+				gomock.InOrder(
+					c.EXPECT().Get(ctx, client.ObjectKeyFromObject(obj), obj),
+					test.EXPECTPatch(ctx, c, obj, obj, patchType).Return(fakeErr),
+				)
+
+				result, err := f(ctx, c, obj, func() error { return nil })
+				Expect(result).To(Equal(controllerutil.OperationResultNone))
+				Expect(err).To(MatchError(fakeErr))
+			})
+
+			It("should successfully patch the object", func() {
+				objCopy := obj.DeepCopy()
+				mutateFn := func(o *corev1.ServiceAccount) func() error {
+					return func() error {
+						o.Labels = map[string]string{"foo": "bar"}
+						return nil
+					}
+				}
+				_ = mutateFn(objCopy)()
+
+				gomock.InOrder(
+					c.EXPECT().Get(ctx, client.ObjectKeyFromObject(obj), obj),
+					test.EXPECTPatch(ctx, c, objCopy, obj, patchType),
+				)
+
+				result, err := f(ctx, c, obj, mutateFn(obj))
+				Expect(result).To(Equal(controllerutil.OperationResultUpdated))
+				Expect(err).NotTo(HaveOccurred())
+			})
+		}
+
+		Describe("#GetAndCreateOrMergePatch", func() {
+			testSuite(GetAndCreateOrMergePatch, types.MergePatchType)
+		})
+		Describe("#GetAndCreateOrStrategicMergePatch", func() {
+			testSuite(GetAndCreateOrStrategicMergePatch, types.StrategicMergePatchType)
+		})
 	})
 })

--- a/pkg/extensions/cluster.go
+++ b/pkg/extensions/cluster.go
@@ -41,7 +41,7 @@ func init() {
 // cluster by adding the shoot, seed, and cloudprofile specification.
 func SyncClusterResourceToSeed(
 	ctx context.Context,
-	client client.Writer,
+	c client.Client,
 	clusterName string,
 	shoot *gardencorev1beta1.Shoot,
 	cloudProfile *gardencorev1beta1.CloudProfile,
@@ -90,7 +90,7 @@ func SyncClusterResourceToSeed(
 		shootObj.ManagedFields = nil
 	}
 
-	_, err := controllerutils.MergePatchOrCreate(ctx, client, cluster, func() error {
+	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, c, cluster, func() error {
 		if cloudProfileObj != nil {
 			cluster.Spec.CloudProfile = runtime.RawExtension{Object: cloudProfileObj}
 		}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug

## :warning: TL;DR

When using `client.MergeFrom` (e.g. in `MergePatchOrCreate`), the object should already be filled with the last-known/last applied state, so that `client.MergeFrom` will compute the correct patch including removal of optional fields, that shall be unset  with the patch.
For this, I added a helper func `GetAndCreateOrMergePatch`, which can be used analogously to `CreateOrUpdate`, but is safe to use with a cached client (won't run into conflicts), as long as operating on fields that are exclusively owned by the controller.


## What this PR does / why we need it

In one of my recent refactorings I switched to `MergePatchOrCreate` for syncing the cluster resource to the Seed [here](https://github.com/gardener/gardener/blob/5589fcc84dfc76e8763cfa3ee44be5db57950e74/pkg/extensions/cluster.go#L93-L104).

However I missed an import detail wrt using `client.MergeFrom`:
When computing a patch with `client.MergeFrom` from an empty object (like in the usage on `master` linked above), the patch won't remove optional fields/sections (marked with `omitempty`) that are now unset in comparison to the current state on the cluster, because the patch does not marshal empty optional fields.

For example:
When a Shoot was previously hibernated and the `Cluster` object looked like this:
```yaml
apiVersion: extensions.gardener.cloud/v1alpha1
kind: Cluster
# ...
spec:
  # ...
  shoot:
    apiVersion: core.gardener.cloud/v1beta1
    kind: Shoot
    spec:
      hibernation:
        enabled: true
# ...
```

and the `hibernation` section is removed in the `Shoot` object to wake it up, the patch will just look similar to this:
```json
{"spec":{"shoot":{"apiVersion":"core.gardener.cloud/v1beta1","kind":"Shoot","metadata":{"creationTimestamp":null},"spec":{"cloudProfileName":"","kubernetes":{"version":""},"networking":{"type":""},"provider":{"type":"","workers":null},"region":"","secretBindingName":""},"status":{"gardener":{"id":"","name":"","version":""},"hibernated":false,"technicalID":"","uid":""}}}}
```
Note, that there is no `hibernation` section in the patch, which means that the `hibernation` section in the `Cluster` resource will not be changed/removed.

In an ideal world, we would just use SSA (server-side-apply) and don't care about anything of this at all (just send the desired state of the fields we care about and let the API server take care of applying the changes) but unfortunately, we still have to support older k8s versions for Seeds, that don't support SSA.