### PR TITLE
Allow Gardener admins to access csrs

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
@@ -59,6 +59,12 @@ rules:
   - leases
   verbs:
   - '*'
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  verbs:
+  - '*'
 
 # Aggregated cluster role specifying garden administrators.
 # IMPORTANT: You need to define a corresponding ClusterRoleBinding binding specific users


### PR DESCRIPTION
/area security ops-productivity
/kind enhancement

```
$ k get csr -A
Error from server (Forbidden): certificatesigningrequests.certificates.k8s.io is forbidden: User "some.admin@gardener.cloud" cannot list resource "certificatesigningrequests" in API group "certificates.k8s.io" at the cluster scope
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Gardener administrators are now allowed to access certificatesigningrequests.
```
