### PR TITLE
Merge all logging dashboards into one

### DIFF
--- a/charts/seed-monitoring/charts/grafana/templates/grafana-dashboards-configmap.yaml
+++ b/charts/seed-monitoring/charts/grafana/templates/grafana-dashboards-configmap.yaml
@@ -36,9 +36,5 @@ data:
 {{- if .Values.extensions.dashboards }}
 {{- toString .Values.extensions.dashboards | indent 2 }}
 {{ end }}
-{{ range $component := .Values.exposedComponents }}
-  {{ if or (ne $component.fileName "vpa-logging.json") ($.Values.vpaEnabled)}}
-  {{ $component.fileName }}: |-
-{{ include "logging-dashboard" $component | indent 4 }}
-  {{ end }}
-{{- end }}
+  controlplane-logs-dashboard.json: |-
+{{ include "logging-dashboard" .Values.extensions.observedPods | indent 4 }}

--- a/charts/seed-monitoring/charts/grafana/templates/logging-dashboard.tpl
+++ b/charts/seed-monitoring/charts/grafana/templates/logging-dashboard.tpl
@@ -352,8 +352,8 @@
           "allValue": "",
           "current": {
             "selected": true,
-            "text": "{{ (index $.pods 0).podPrefix }}",
-            "value": "{{ (index $.pods 0).podPrefix }}"
+            "text": "{{ (index . 0).PodPrefix }}",
+            "value": "{{ (index . 0).PodPrefix }}"
           },
           "hide": 0,
           "includeAll": false,
@@ -363,17 +363,17 @@
           "options": [
             {
               "selected": true
-            }{{ range $i, $c := $.pods }},
+            }{{ range $i, $c := . }},
             {
               "selected": false,
-              "text": "{{ $c.podPrefix }}",
-              "value": "{{ $c.podPrefix }}"
+              "text": "{{ $c.PodPrefix }}",
+              "value": "{{ $c.PodPrefix }}"
             }
               {{- end }}
           ],
           "query": "",
           "queryValue": "",
-          "skipUrlSync": true,
+          "skipUrlSync": false,
           "type": "custom"
         },
         {
@@ -457,7 +457,7 @@
           ],
           "query": "INFO,WARN,ERR,DBG,NOTICE,FATAL",
           "queryValue": "",
-          "skipUrlSync": true,
+          "skipUrlSync": false,
           "type": "custom"
         },
         {
@@ -511,7 +511,7 @@
       ]
     },
     "timezone": "browser",
-    "title": "{{ $.dashboardName }}",
+    "title": "Controlplane Logs Dashboard",
     "version": 1
   }
 {{- end -}}

--- a/charts/seed-monitoring/charts/grafana/values.yaml
+++ b/charts/seed-monitoring/charts/grafana/values.yaml
@@ -18,33 +18,12 @@ vpaEnabled: false
 role: operators
 extensions:
   dashboards: ""
+  observedPods:
+  - PodPrefix: example-pod
+    IsExposedToUser: true
 
 konnectivityTunnel:
   enabled: false
 
 sni:
   enabled: false
-
-exposedComponents:
-- dashboardName: "Kube Apiserver"
-  fileName: "kube-apiserver-logging.json"
-  pods:
-  - podPrefix: "kube-apiserver"
-- dashboardName: "Kube Controller Manager"
-  fileName: "kube-controller-manager-logging.json"
-  pods:
-  - podPrefix: "kube-controller-manager"
-- dashboardName: "Kube Scheduler"
-  fileName: "kube-scheduler-logging.json"
-  pods:
-  - podPrefix: "kube-scheduler"
-- dashboardName: "Cluster Autoscaler"
-  fileName: "cluster-autoscaler-logging.json"
-  pods:
-  - podPrefix: "cluster-autoscaler"
-- dashboardName: "Vertical Pod Autoscaler"
-  fileName: "vpa-logging.json"
-  pods:
-  - podPrefix: "vpa-admission-controller"
-  - podPrefix: "vpa-recommender"
-  - podPrefix: "vpa-updater"

--- a/docs/usage/logging.md
+++ b/docs/usage/logging.md
@@ -34,13 +34,10 @@ or with regex:
     * Kubernetes Pods
 
 ### Expose logs for component to User Grafana
-Exposing logs for a new component to the User's Grafana happens with adding a new component section into: charts/seed-monitoring/charts/grafana/values.yaml
+Exposing logs for a new component to the User's Grafana happens with adding a new `extensions.observedPods` section into: charts/seed-monitoring/charts/grafana/values.yaml
 
-* dashboardName: The name of the dashboard. Use prefix `Logging` to make it recognizable for the users.
-* jobName: The job name of the component defined in the prometheus.
-* podPrefix: The prefix of the pod e.g. `kube-apiserver`
-* fileName: File which will be created in the container's disk with the dashboard configuration.
-
+* PodPrefix: The prefix of the pod e.g. `kube-apiserver`
+* IsExposedToUser: It is true when the component should be exposed to the end user
 
 ### Configuration
 #### Fluent-bit

--- a/pkg/operation/botanist/monitoring.go
+++ b/pkg/operation/botanist/monitoring.go
@@ -33,6 +33,7 @@ import (
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/secrets"
 
+	"gopkg.in/yaml.v2"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
@@ -52,14 +53,16 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 	}
 
 	var (
-		credentials         = b.Secrets[common.MonitoringIngressCredentials]
-		credentialsUsers    = b.Secrets[common.MonitoringIngressCredentialsUsers]
-		basicAuth           = utils.CreateSHA1Secret(credentials.Data[secrets.DataKeyUserName], credentials.Data[secrets.DataKeyPassword])
-		basicAuthUsers      = utils.CreateSHA1Secret(credentialsUsers.Data[secrets.DataKeyUserName], credentialsUsers.Data[secrets.DataKeyPassword])
-		alertingRules       = strings.Builder{}
-		scrapeConfigs       = strings.Builder{}
-		operatorsDashboards = strings.Builder{}
-		usersDashboards     = strings.Builder{}
+		credentials           = b.Secrets[common.MonitoringIngressCredentials]
+		credentialsUsers      = b.Secrets[common.MonitoringIngressCredentialsUsers]
+		basicAuth             = utils.CreateSHA1Secret(credentials.Data[secrets.DataKeyUserName], credentials.Data[secrets.DataKeyPassword])
+		basicAuthUsers        = utils.CreateSHA1Secret(credentialsUsers.Data[secrets.DataKeyUserName], credentialsUsers.Data[secrets.DataKeyPassword])
+		alertingRules         = strings.Builder{}
+		scrapeConfigs         = strings.Builder{}
+		operatorsDashboards   = strings.Builder{}
+		usersDashboards       = strings.Builder{}
+		usersObservedPods     = make([]ObservedPod, 0)
+		operatorsObservedPods = make([]ObservedPod, 0)
 	)
 
 	// Fetch component-specific monitoring configuration
@@ -103,12 +106,49 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 	// Need stable order before passing the dashboards to Grafana config to avoid unnecessary changes
 	kutil.ByName().Sort(existingConfigMaps)
 
+	// Apply controlplane user exposed pods
+	cpObservedPods := []ObservedPod{
+		{PodPrefix: "kube-apiserver", IsExposedToUser: true},
+		{PodPrefix: "kube-controller-manager", IsExposedToUser: true},
+		{PodPrefix: "kube-scheduler", IsExposedToUser: true},
+		{PodPrefix: "cluster-autoscaler", IsExposedToUser: true},
+	}
+
+	if b.Shoot.WantsVerticalPodAutoscaler {
+		vpaObservedPods := []ObservedPod{
+			{PodPrefix: "vpa-admission-controller", IsExposedToUser: true},
+			{PodPrefix: "vpa-recommender", IsExposedToUser: true},
+			{PodPrefix: "vpa-updater", IsExposedToUser: true},
+		}
+
+		cpObservedPods = append(cpObservedPods, vpaObservedPods...)
+	}
+
+	usersObservedPods = append(usersObservedPods, cpObservedPods...)
+	operatorsObservedPods = append(operatorsObservedPods, cpObservedPods...)
+
 	// Read extension monitoring configurations
 	for _, cm := range existingConfigMaps.Items {
 		alertingRules.WriteString(fmt.Sprintln(cm.Data[v1beta1constants.PrometheusConfigMapAlertingRules]))
 		scrapeConfigs.WriteString(fmt.Sprintln(cm.Data[v1beta1constants.PrometheusConfigMapScrapeConfig]))
 		operatorsDashboards.WriteString(fmt.Sprintln(cm.Data[v1beta1constants.GrafanaConfigMapOperatorDashboard]))
 		usersDashboards.WriteString(fmt.Sprintln(cm.Data[v1beta1constants.GrafanaConfigMapUserDashboard]))
+
+		components := cm.Data["observedComponents"]
+
+		var observedComponents ObservedComponents
+
+		err := yaml.Unmarshal([]byte(components), &observedComponents)
+		if err != nil {
+			return err
+		}
+		for _, pod := range observedComponents.ObservedPods {
+			if pod.IsExposedToUser {
+				usersObservedPods = append(usersObservedPods, pod)
+			}
+
+			operatorsObservedPods = append(operatorsObservedPods, pod)
+		}
 	}
 
 	alerting, err := b.getCustomAlertingConfigs(ctx, b.GetSecretKeysOfRole(v1beta1constants.GardenRoleAlerting))
@@ -228,11 +268,11 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 		return err
 	}
 
-	if err := b.deployGrafanaCharts(ctx, common.GrafanaOperatorsRole, operatorsDashboards.String(), basicAuth, common.GrafanaOperatorsPrefix); err != nil {
+	if err := b.deployGrafanaCharts(ctx, common.GrafanaOperatorsRole, operatorsDashboards.String(), basicAuth, common.GrafanaOperatorsPrefix, operatorsObservedPods); err != nil {
 		return err
 	}
 
-	if err := b.deployGrafanaCharts(ctx, common.GrafanaUsersRole, usersDashboards.String(), basicAuthUsers, common.GrafanaUsersPrefix); err != nil {
+	if err := b.deployGrafanaCharts(ctx, common.GrafanaUsersRole, usersDashboards.String(), basicAuthUsers, common.GrafanaUsersPrefix, usersObservedPods); err != nil {
 		return err
 	}
 
@@ -384,7 +424,7 @@ func (b *Botanist) getCustomAlertingConfigs(ctx context.Context, alertingSecretK
 	return configs, nil
 }
 
-func (b *Botanist) deployGrafanaCharts(ctx context.Context, role, dashboards, basicAuth, subDomain string) error {
+func (b *Botanist) deployGrafanaCharts(ctx context.Context, role, dashboards, basicAuth, subDomain string, observedPods []ObservedPod) error {
 	grafanaTLSOverride := common.GrafanaTLS
 	if b.ControlPlaneWildcardCert != nil {
 		grafanaTLSOverride = b.ControlPlaneWildcardCert.GetName()
@@ -406,7 +446,8 @@ func (b *Botanist) deployGrafanaCharts(ctx context.Context, role, dashboards, ba
 		"replicas": b.Shoot.GetReplicas(1),
 		"role":     role,
 		"extensions": map[string]interface{}{
-			"dashboards": dashboards,
+			"dashboards":   dashboards,
+			"observedPods": observedPods,
 		},
 		"vpaEnabled": b.Shoot.WantsVerticalPodAutoscaler,
 		"konnectivityTunnel": map[string]interface{}{
@@ -540,4 +581,17 @@ func (b *Botanist) DeleteSeedMonitoring(ctx context.Context) error {
 	}
 
 	return kutil.DeleteObjects(ctx, b.K8sSeedClient.Client(), objects...)
+}
+
+// ObservedComponents is a struct from all observed pods
+type ObservedComponents struct {
+	ObservedPods []ObservedPod `yaml:"observedPods"`
+}
+
+// ObservedPod holds Pod configuration monitored by Grafana
+type ObservedPod struct {
+	// PodPrefix contains the prefix (deployment name) for a specific pod
+	PodPrefix string `yaml:"podPrefix"`
+	// IsExposedToUser is a flag which represents if the Pod logs should be exposed to the end users
+	IsExposedToUser bool `yaml:"isExposedToUser"`
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
Currently we provide multiple dashboards where the end users can monitor their controlplane logs.
They all look the same way.

This PR merges all of the dashboards into one, which supports `Pod` and `Container` selectors.
In this way, the navigation between different components will be easier.

<img width="1728" alt="Screenshot 2021-05-17 at 14 51 36" src="https://user-images.githubusercontent.com/58623197/118484279-b8f70e00-b71f-11eb-9537-ae50cbd63cd7.png">

The PR will merge only the dashboards exposed by the gardener/gardener.
The approach for the components exposed by the extensions will be to reuse the existing Configmap with label `extensions.gardener.cloud/configuration: monitoring` there and to add the following section in it:

```
data:
  observedComponents: |
    observedPods:
    - podPrefix: component1
      isExposedToUser: true
    - podPrefix: component2
      isExposedToUser: true
```

**Which issue(s) this PR fixes**:
https://github.com/gardener/gardener/issues/3554

**Special notes for your reviewer**:
@vlvasilev 
@wyb1 
@istvanballok 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```user
All dashboards containing controlplane logs are combined into one `Controlplane Logs Dashboard`
```
