### PR TITLE
Fix ./hack/.ci/prepare_release

### DIFF
--- a/hack/.ci/prepare_release
+++ b/hack/.ci/prepare_release
@@ -50,6 +50,10 @@ cd /usr/local/go/src
 echo "Executing make on go $GOLANG_VERSION"
 ./make.bash > /dev/null 2>&1
 
+# Make the newly "installed from source" go the default one
+export PATH="/usr/local/go/bin:$PATH"
+export GOROOT="/usr/local/go"
+
 export GOPATH="$(mktemp -d)"
 export GOBIN="$GOPATH/bin"
 export PATH="$GOBIN:$PATH"
@@ -73,4 +77,3 @@ if ! make generate; then
 fi
 cd "$cur_dir"
 cp -RT "$REPO_PATH/" "$repo_root_dir/"
-


### PR DESCRIPTION
/kind bug

Fixes #4055

The fix was verified with the provider-azure release. This PR is a backport of https://github.com/gardener/gardener-extension-provider-azure/pull/300.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
