### PR TITLE
[release-v1.21] Automated cherry pick of #3990 & #4029: [ci:component:github.com/gardener/autoscaler:v0.15.0->v0.16.1]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -75,7 +75,7 @@ images:
 - name: cluster-autoscaler
   sourceRepository: github.com/gardener/autoscaler
   repository: eu.gcr.io/gardener-project/gardener/autoscaler/cluster-autoscaler
-  tag: "v0.16.0"
+  tag: "v0.16.1"
   targetVersion: ">= 1.16"
 - name: cluster-autoscaler
   sourceRepository: github.com/gardener/autoscaler

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -75,7 +75,7 @@ images:
 - name: cluster-autoscaler
   sourceRepository: github.com/gardener/autoscaler
   repository: eu.gcr.io/gardener-project/gardener/autoscaler/cluster-autoscaler
-  tag: "v0.15.0"
+  tag: "v0.16.0"
   targetVersion: ">= 1.16"
 - name: cluster-autoscaler
   sourceRepository: github.com/gardener/autoscaler


### PR DESCRIPTION
Cherry pick of #3990 on release-v1.21.
Cherry pick of #4029 on release-v1.21.

#3990: [ci:component:github.com/gardener/autoscaler:v0.15.0->v0.16.0]
#4029: [ci:component:github.com/gardener/autoscaler:v0.16.0->v0.16.1]

**Release Notes:**
``` bugfix operator github.com/gardener/autoscaler #75 @prashanth26
Allow scaling down of machine with already lowered priority
```
``` bugfix developer github.com/gardener/autoscaler #78 @prashanth26
Avoids panics when VM type isn't found during scale from zero
```
``` bugfix developer github.com/gardener/autoscaler #78 @prashanth26
Fetches the VM from the correct map for MCM provider Azure and hence doesn't panic anymore
```

/kind bug