### PR TITLE
Added --external-hostname flag to the default kapi server config

### DIFF
--- a/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
@@ -156,6 +156,9 @@ spec:
         {{- if semverCompare ">= 1.16" .Values.kubernetesVersion }}
         - --shutdown-delay-duration=15s
         {{- end }}
+        {{- if .Values.externalHostname }}
+        - --external-hostname={{ .Values.externalHostname }}
+        {{- end }}
         - --token-auth-file=/srv/kubernetes/token/static_tokens.csv
         - --tls-cert-file=/srv/kubernetes/apiserver/kube-apiserver.crt
         - --tls-private-key-file=/srv/kubernetes/apiserver/kube-apiserver.key

--- a/charts/seed-controlplane/charts/kube-apiserver/values.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/values.yaml
@@ -185,3 +185,5 @@ mountHostCADirectories:
 
 reversedVPN:
   enabled: false
+
+externalHostname: ""

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -603,7 +603,8 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 	var (
 		apiServerConfig              = b.Shoot.Info.Spec.Kubernetes.KubeAPIServer
 		admissionPlugins             = kubernetes.GetAdmissionPluginsForVersion(b.Shoot.Info.Spec.Kubernetes.Version)
-		serviceAccountTokenIssuerURL = fmt.Sprintf("https://%s", b.Shoot.ComputeOutOfClusterAPIServerAddress(b.APIServerAddress, true))
+		externalHostname             = b.Shoot.ComputeOutOfClusterAPIServerAddress(b.APIServerAddress, true)
+		serviceAccountTokenIssuerURL = fmt.Sprintf("https://%s", externalHostname)
 		serviceAccountConfigVals     = map[string]interface{}{}
 	)
 
@@ -681,6 +682,8 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 				defaultValues["maxMutatingRequestsInflight"] = *v
 			}
 		}
+
+		defaultValues["externalHostname"] = externalHostname
 	}
 
 	serviceAccountConfigVals["issuer"] = serviceAccountTokenIssuerURL


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
This PR adds the `--external-hostname` flag to the kube-api server configuration. Since kube-apiserver relies on this flag to generate externalized URLs for OpenID Connect and the [test](https://github.com/kubernetes/kubernetes/blob/v1.21.0/test/e2e/auth/service_accounts.go#L683) is part of the Kubernetes certification program the responsibility for setting it should fall on the gardenlet and not different extension providers. This means that extension providers should refrain from setting the flag by themselves.


**Which issue(s) this PR fixes**:
Fixes #4023

**Special notes for your reviewer**:
Logs from test execution:
```
May 18 09:12:42.108: INFO: Pod logs:
2021/05/18 06:12:09 OK: Got token
2021/05/18 06:12:09 validating with in-cluster discovery
2021/05/18 06:12:09 OK: got issuer https://api.shoot-gcp-1.someinumber.internal.dev.k8s.ondemand.com
2021/05/18 06:12:09 Full, not-validated claims:
openidmetadata.claims{Claims:jwt.Claims{Issuer:"https://api.shoot-gcp-1.someinumber.internal.dev.k8s.ondemand.com", Subject:"system:serviceaccount:svcaccounts-5547:default", Audience:jwt.Audience{"oidc-discovery-test"}, Expiry:1621318928, NotBefore:1621318328, IssuedAt:1621318328, ID:""}, Kubernetes:openidmetadata.kubeClaims{Namespace:"svcaccounts-5547", ServiceAccount:openidmetadata.kubeName{Name:"default", UID:"87a0cced-8ce4-4ee6-870b-1aac6974d5fe"}}}
2021/05/18 06:12:09 OK: Constructed OIDC provider for issuer https://api.shoot-gcp-1.someinumber.internal.dev.k8s.ondemand.com
2021/05/18 06:12:09 OK: Validated signature on JWT
2021/05/18 06:12:09 OK: Got valid claims from token!
2021/05/18 06:12:09 Full, validated claims:
&openidmetadata.claims{Claims:jwt.Claims{Issuer:"https://api.shoot-gcp-1.someinumber.internal.dev.k8s.ondemand.com", Subject:"system:serviceaccount:svcaccounts-5547:default", Audience:jwt.Audience{"oidc-discovery-test"}, Expiry:1621318928, NotBefore:1621318328, IssuedAt:1621318328, ID:""}, Kubernetes:openidmetadata.kubeClaims{Namespace:"svcaccounts-5547", ServiceAccount:openidmetadata.kubeName{Name:"default", UID:"87a0cced-8ce4-4ee6-870b-1aac6974d5fe"}}}

May 18 09:12:42.108: INFO: completed pod
```
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
