### PR TITLE
Add the `certificatesigningrequests/seedclient` RBAC rule to the seed-bootstrapper ClusterRole

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/clusterrole-seed-bootstrapper.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/clusterrole-seed-bootstrapper.yaml
@@ -11,3 +11,9 @@ rules:
   verbs:
   - create
   - get
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests/seedclient
+  verbs:
+  - create

--- a/docs/deployment/deploy_gardenlet_manually.md
+++ b/docs/deployment/deploy_gardenlet_manually.md
@@ -213,6 +213,12 @@ rules:
     verbs:
       - create
       - get
+  - apiGroups:
+      - certificates.k8s.io
+    resources:
+      - certificatesigningrequests/seedclient
+    verbs:
+      - create
 ---
 # A kubelet/gardenlet authenticating using bootstrap tokens is authenticated as a user in the group system:bootstrappers
 # Allows the Gardenlet to create a CSR


### PR DESCRIPTION
/kind bug
/kind regression

I suspect that https://github.com/gardener/gardener/pull/3992 wrongly removes the  `certificatesigningrequests/seedclient` RBAC rule from seed-bootstrapper ClusterRole. The GCM is performing SubjectAccessReview to `certificatesigningrequests/seedclient` using the user from the CSR - see https://github.com/gardener/gardener/blob/7231a2077279d9ebb612ee59960070b3a8a4b6c7/pkg/controllermanager/controller/certificatesigningrequest/csr_autoapprove_control.go#L131_L139.
I think the assumption in https://github.com/gardener/gardener/pull/3992/files#r627191821 is wrong as the SubjectAccessReview is not performed with the GCM user, but with the user from the CSR.

Fixes #4054

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
