### PR TITLE
Add alert for etcd high memory usage

### DIFF
--- a/pkg/operation/botanist/component/etcd/monitoring.go
+++ b/pkg/operation/botanist/component/etcd/monitoring.go
@@ -115,6 +115,18 @@ const (
         within the last hour.
       summary: High number of failed etcd proposals
 
+  - alert: KubeEtcd3HighMemoryConsumption
+    expr: sum(container_memory_working_set_bytes{pod="etcd-main-0",container="etcd"}) / sum(vpa_spec_container_resource_policy_allowed{allowed="max",container="etcd", targetName="etcd-main", resource="memory"}) > .4
+    for: 15m
+    labels:
+      service: etcd
+      severity: warning
+      type: seed
+      visibility: operator
+    annotations:
+      description: Etcd is consuming over 50% of the max allowed value specified by VPA.
+      summary: Etcd is consuming too much memory
+
   # etcd DB size alerts
   - alert: KubeEtcd3DbSizeLimitApproaching
     expr: (` + monitoringMetricEtcdMvccDBTotalSizeInBytes + `{job="` + monitoringPrometheusJobEtcdNamePrefix + `-{{ .role }}"} > bool 7516193000) + (` + monitoringMetricEtcdMvccDBTotalSizeInBytes + `{job="` + monitoringPrometheusJobEtcdNamePrefix + `-{{ .role }}"} <= bool 8589935000) == 2 # between 7GB and 8GB

--- a/pkg/operation/botanist/component/etcd/monitoring_test.go
+++ b/pkg/operation/botanist/component/etcd/monitoring_test.go
@@ -215,6 +215,18 @@ metric_relabel_configs:
         within the last hour.
       summary: High number of failed etcd proposals
 
+  - alert: KubeEtcd3HighMemoryConsumption
+    expr: sum(container_memory_working_set_bytes{pod="etcd-main-0",container="etcd"}) / sum(vpa_spec_container_resource_policy_allowed{allowed="max",container="etcd", targetName="etcd-main", resource="memory"}) > .4
+    for: 15m
+    labels:
+      service: etcd
+      severity: warning
+      type: seed
+      visibility: operator
+    annotations:
+      description: Etcd is consuming over 50% of the max allowed value specified by VPA.
+      summary: Etcd is consuming too much memory
+
   # etcd DB size alerts
   - alert: KubeEtcd3DbSizeLimitApproaching
     expr: (etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3-` + testRole + `"} > bool 7516193000) + (etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3-` + testRole + `"} <= bool 8589935000) == 2 # between 7GB and 8GB


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
Add an alert if etcd is using more than 50% of the max allowed specified by vpa.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @amshuman-kr 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
