### PR TITLE
[release-v1.22] Automated cherry pick of #4070: Fix ManagedSeed update / deletion issue on soil clusters

### DIFF
--- a/pkg/gardenlet/controller/managedseed/managedseed_valueshelper.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_valueshelper.go
@@ -106,7 +106,11 @@ func (vp *valuesHelper) MergeGardenletConfiguration(config *configv1alpha1.Garde
 		return nil, err
 	}
 
-	// Delete seedClientConnection.kubeconfig and seedConfig in parent config values
+	// Delete gardenClientConnection.bootstrapKubeconfig, seedClientConnection.kubeconfig, and seedConfig in parent config values
+	parentConfigValues, err = utils.DeleteFromValuesMap(parentConfigValues, "gardenClientConnection", "bootstrapKubeconfig")
+	if err != nil {
+		return nil, err
+	}
 	parentConfigValues, err = utils.DeleteFromValuesMap(parentConfigValues, "seedClientConnection", "kubeconfig")
 	if err != nil {
 		return nil, err

--- a/pkg/gardenlet/controller/managedseed/managedseed_valueshelper_test.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_valueshelper_test.go
@@ -83,6 +83,10 @@ var _ = Describe("ValuesHelper", func() {
 					QPS:                100,
 					Burst:              130,
 				},
+				BootstrapKubeconfig: &corev1.SecretReference{
+					Name:      "gardenlet-kubeconfig-bootstrap",
+					Namespace: v1beta1constants.GardenNamespace,
+				},
 			},
 			SeedClientConnection: &config.SeedClientConnection{
 				ClientConnectionConfiguration: componentbaseconfig.ClientConnectionConfiguration{


### PR DESCRIPTION
/area/control-plane
/kind/bug

Cherry pick of #4070 on release-v1.22.

#4070: Fix ManagedSeed update / deletion issue on soil clusters

**Release Notes:**
```other operator
Fixed an issue that prevented the update and deletion of managed seeds on soil clusters.
```