### PR TITLE
Make docker nodeless setup the recommended way

### DIFF
--- a/docs/development/local_setup.md
+++ b/docs/development/local_setup.md
@@ -11,8 +11,6 @@ Further details could be found in
 1. [Kubernetes Development Guide](https://github.com/kubernetes/community/tree/master/contributors/devel)
 1. [Architecture of Gardener](https://github.com/gardener/documentation/wiki/Architecture)
 
-This setup is based on [minikube](https://github.com/kubernetes/minikube), a Kubernetes cluster running on a single node. Docker for Desktop and [kind](https://github.com/kubernetes-sigs/kind) are also supported.
-
 ## Installing Golang environment
 
 Install latest version of Golang. For MacOS you could use [Homebrew](https://brew.sh/):
@@ -72,26 +70,9 @@ export PATH=$(brew --prefix openvpn)/sbin:$PATH
 
 On other OS, please check the [OpenVPN downloads page](https://openvpn.net/index.php/open-source/downloads.html).
 
-## Installing Minikube
+## Installing Docker
 
-You'll need to have [minikube](https://github.com/kubernetes/minikube#installation) installed and running.
-
-On MacOS run
-
-```bash
-brew install minikube
-```
-
-> Note: Gardener is working only with self-contained kubeconfig files because of [security issue](https://banzaicloud.com/blog/kubeconfig-security/). You can configure your minikube to create self-contained kubeconfig files via:
-> ```bash
-> minikube config set embed-certs true
-> ```
-
-Alternatively, you can also install Docker for Desktop and [kind](https://github.com/kubernetes-sigs/kind).
-
-In case you want to use the "Docker for Mac Kubernetes" or if you want to build Docker images for the Gardener you have to install Docker itself. On MacOS, please use [Docker for MacOS](https://docs.docker.com/docker-for-mac/) which can be downloaded [here](https://download.docker.com/mac/stable/Docker.dmg).
-
-On other OS, please check the [Docker installation documentation](https://docs.docker.com/install/).
+You'll need to have [docker](https://docs.docker.com/get-docker/) installed and running.
 
 ## Installing iproute2
 
@@ -175,17 +156,14 @@ cd gardener
 
 For the development of Gardener you need some kind of Kubernetes cluster, which can be used as a "garden" cluster.
 I.e. you need a Kubernetes API server on which you can register a `APIService` Gardener's own Extension API Server.  
-For this you can use a standard tool from the community to setup a local cluster like minikube, kind or the Kubernetes Cluster feature in Docker for Desktop.
 
-However, if you develop and run Gardener's components locally, you don't actually need a fully fledged Kubernetes Cluster,
-i.e. you don't actually need to run Pods on it. If you want to use a more lightweight approach for development purposes,
-you can use the "nodeless Garden cluster setup" residing in `hack/local-garden`. This is the easiest way to get your
+If you develop and run Gardener's components locally, you don't need a fully fledged Kubernetes Cluster,
+i.e. you don't need to run Pods on it. Therefore, you can use the "nodeless Garden cluster setup" residing in `hack/local-garden`. This is the easiest way to get your
 Gardener development setup up and running.
 
 **Using the nodeless cluster setup**
 
-Setting up a local nodeless Garden cluster is quite simple. The only prerequisite is a running docker daemon.
-Just use the provided Makefile rules to start your local Garden:
+Use the provided Makefile rules to start your local Garden:
 ```bash
 make local-garden-up
 [...]
@@ -209,58 +187,15 @@ To tear down the local Garden cluster and remove the Docker containers, simply r
 make local-garden-down
 ```
 
-**Using minikube**
-
-Alternatively, spin up a cluster with minikube with this command:
-
-```bash
-minikube start --embed-certs #  `--embed-certs` can be omitted if minikube has already been set to create self-contained kubeconfig files.
-😄  minikube v1.8.2 on Darwin 10.15.3
-🔥  Creating virtualbox VM (CPUs=2, Memory=2048MB, Disk=20000MB) ...
-[...]
-🏄  Done! Thank you for using minikube!
-```
-
-**Using a remote cluster as Garden cluster**
-
-For some testing scenarios, you may want to use a remote cluster instead of a local one as your Garden cluster. 
-To do this, you can use the "remote Garden cluster setup" residing in `hack/remote-garden`. 
-To avoid mistakes, the remote cluster must have a `garden` namespace labeled with `gardener.cloud/purpose=remote-garden`. 
-You must create the `garden` namespace and label it manually before running `make remote-garden-up` as described below.
-
-Use the provided `Makefile` rules to bootstrap your remote Garden:
-
-```bash
-export KUBECONFIG=<path to kubeconfig>
-make remote-garden-up
-[...]
-# Start gardener etcd used to store gardener resources (e.g., seeds, shoots)
-Starting gardener-dev-remote gardener-etcd cluster!
-[...]
-# Open tunnels for accessing local gardener components from the remote cluster
-[...]
-```
-
-This will start an `etcd` instance for the `gardener-apiserver` as a Docker container, and open tunnels for accessing local gardener components from the remote cluster.
-
-To close the tunnels and remove the locally-running Docker containers, run:
-
-```bash
-make remote-garden-down
-```
-
-> Note: The minimum K8S version of the remote cluster that can be used as Garden cluster is `1.19.x`.
-
-> ⚠️ Please be aware that in the remote garden setup all Gardener components run with administrative permissions, i.e., there is no fine-grained access control via RBAC (as opposed to productive installations of Gardener).
-
 #### Prepare the Gardener
 
 Now, that you have started your local cluster, we can go ahead and register the Gardener API Server.
 Just point your `KUBECONFIG` environment variable to the local cluster you created in the previous step and run:
 
 ```bash
+export KUBECONFIG=hack/local-development/local-garden/kubeconfigs/default-admin.conf
 make dev-setup
-Found Minikube ...
+[...]
 namespace/garden created
 namespace/garden-dev created
 deployment.apps/etcd created
@@ -297,7 +232,7 @@ Next, run the Gardener API Server, the Gardener Controller Manager (optionally),
 
 ```bash
 make start-apiserver
-Found Minikube ...
+[...]
 I0306 15:23:51.044421   74536 plugins.go:84] Registered admission plugin "ResourceReferenceManager"
 I0306 15:23:51.044523   74536 plugins.go:84] Registered admission plugin "DeletionConfirmation"
 [...]
@@ -367,7 +302,7 @@ No resources found.
 
 to operate against your local running Gardener API Server.
 
-> Note: It may take several seconds until the `minikube` cluster recognizes that the Gardener API server has been started and is available. `No resources found` is the expected result of our initial development setup.
+> Note: It may take several seconds until the Gardener API server has been started and is available. `No resources found` is the expected result of our initial development setup.
 
 ### Create a Shoot
 

--- a/docs/development/local_setup.md
+++ b/docs/development/local_setup.md
@@ -185,6 +185,7 @@ make local-garden-down
   <summary><b>Alternative: Using a local kubernetes cluster</b></summary>
 
   Instead of starting a kubernetes API server and etcd as docker containers, you can also opt for running a local kubernetes cluster, provided by e.g. [minikube](https://minikube.sigs.k8s.io/docs/start/), [kind](https://kind.sigs.k8s.io/docs/user/quick-start/) or docker desktop.
+
   > Note: Gardener requires self-contained kubeconfig files because of a [security issue](https://banzaicloud.com/blog/kubeconfig-security/). You can configure your minikube to create self-contained kubeconfig files via:
   > ```bash
   > minikube config set embed-certs true
@@ -193,6 +194,7 @@ make local-garden-down
   > ```bash
   > minikube start --embed-certs
   > ```
+
 </details>
 
 <details>

--- a/docs/development/local_setup.md
+++ b/docs/development/local_setup.md
@@ -154,7 +154,7 @@ cd gardener
 
 #### Start a local kubernetes cluster
 
-For the development of Gardener you need a Kubernetes API server on which you can register Gardener's own Extension API Server as `APIService`. This cluster doesn't need any worker nodes to run pods, though, therefore, you can use the "nodeless Garden cluster setup" residing in `hack/local-garden`.This will start all minimally required components of a Kubernetes cluster (`etcd`, `kube-apiserver`, `kube-controller-manager`)
+For the development of Gardener you need a Kubernetes API server on which you can register Gardener's own Extension API Server as `APIService`. This cluster doesn't need any worker nodes to run pods, though, therefore, you can use the "nodeless Garden cluster setup" residing in `hack/local-garden`. This will start all minimally required components of a Kubernetes cluster (`etcd`, `kube-apiserver`, `kube-controller-manager`)
 and an `etcd` Instance for the `gardener-apiserver` as Docker containers. This is the easiest way to get your
 Gardener development setup up and running.
 

--- a/docs/development/local_setup.md
+++ b/docs/development/local_setup.md
@@ -182,7 +182,7 @@ make local-garden-down
 ```
 
 <details>
-  <summary>Alternative: Using a local kubernetes cluster</summary>
+  <summary><b>Alternative: Using a local kubernetes cluster</b></summary>
 
   Instead of starting a kubernetes API server and etcd as docker containers, you can also opt for running a local kubernetes cluster, provided by e.g. [minikube](https://minikube.sigs.k8s.io/docs/start/), [kind](https://kind.sigs.k8s.io/docs/user/quick-start/) or docker desktop.
   > Note: Gardener requires self-contained kubeconfig files because of a [security issue](https://banzaicloud.com/blog/kubeconfig-security/). You can configure your minikube to create self-contained kubeconfig files via:
@@ -190,13 +190,13 @@ make local-garden-down
   > minikube config set embed-certs true
   > ``` 
   > or when starting the local cluster
-> ```bash
-> minikube start --embed-certs
-> ```
+  > ```bash
+  > minikube start --embed-certs
+  > ```
 </details>
 
 <details>
-  <summary>Alternative: Using a remote kubernetes cluster</summary>
+  <summary><b>Alternative: Using a remote kubernetes cluster</b></summary>
 
 For some testing scenarios, you may want to use a remote cluster instead of a local one as your Garden cluster.
 To do this, you can use the "remote Garden cluster setup" residing in `hack/remote-garden`. This will start an `etcd` instance for the `gardener-apiserver` as a Docker container, and open tunnels for accessing local gardener components from the remote cluster.
@@ -235,7 +235,6 @@ Now, that you have started your local cluster, we can go ahead and register the 
 Just point your `KUBECONFIG` environment variable to the cluster you created in the previous step and run:
 
 ```bash
-export KUBECONFIG=hack/local-development/local-garden/kubeconfigs/default-admin.conf # this export is different when using the local cluster or remote cluster alternatives
 make dev-setup
 [...]
 namespace/garden created

--- a/docs/development/local_setup.md
+++ b/docs/development/local_setup.md
@@ -227,7 +227,6 @@ make remote-garden-down
 
 > ⚠️ Please be aware that in the remote garden setup all Gardener components run with administrative permissions, i.e., there is no fine-grained access control via RBAC (as opposed to productive installations of Gardener).
 
-
 </details>
 
 #### Prepare the Gardener


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
Let's focus on an easy, streamlined setup first and (re-)introduce options once we're done with that. This means, for the time being this change removes other local options like Minikube and the option to use a remote cluster.

```other operator
NONE
```
