### PR TITLE
Add release milestone check

### DIFF
--- a/.github/workflows/release-milestone.yaml
+++ b/.github/workflows/release-milestone.yaml
@@ -1,0 +1,66 @@
+name: 'Release Milestone Check'
+on:
+  pull_request_target:
+    types:
+    - opened
+    - reopened
+    - synchronize
+    - labeled
+    - unlabeled
+
+jobs:
+  check-release-milestone:
+    name: Check Release Milestone
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        path: './'
+
+    - id: version
+      run: |
+        echo "::set-output name=version::$(cat ./VERSION)"
+
+    - name: Block merge if release milestone is missing
+      uses: actions/github-script@v4
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const nextMinorRegex = /^(v[0-9]+\.[0-9]+)\.0-dev/gmi;
+
+          let match = nextMinorRegex.exec('${{ steps.version.outputs.version }}');
+          if (match == null) {
+            core.info('VERSION does not indicate that the next version is a new minor release - skipping check');
+            return;
+          }
+          const nextMinorVersion = match[1];
+
+          const milestones = await github.issues.listMilestones({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            state: 'open',
+            sort: 'due_on',
+            direction: 'desc'
+          });
+
+          let milestoneForNextMinorReleaseFound = false;
+
+          for (const milestone of milestones.data) {
+            if (milestone.title != nextMinorVersion) {
+              continue;
+            }
+
+            // milestone found, check if PR is associated
+            milestoneForNextMinorReleaseFound = true;
+
+            if (context.payload.pull_request.milestone == null) {
+              core.setFailed('Milestone for next minor release ' + nextMinorVersion + ' found, however, PR is not milestoned for it. Merge is not allowed.');
+              return
+            }
+          }
+
+          if (milestoneForNextMinorReleaseFound) {
+            core.info('Milestone for next minor release ' + nextMinorVersion + ' found and PR is milestoned for it. Merge is allowed.');
+          } else {
+            core.info('Milestone for next minor release ' + nextMinorVersion + ' not found. Merge is allowed.');
+          }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
With this PR, when a milestone for the next minor version exists, PRs are only mergeable if they are assigned to this milestone. Otherwise, the merge will be blocked.
This will help the developers who are currently in the release validation phase to prevent unexpected PR merges to `master`.

**Special notes for your reviewer**:
/cc @ialidzhikov @timebertt 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy developer
If a milestone for the next minor version exists then PRs to the `master` branch are only mergeable if they are assigned to this milestone.
```
