### PR TITLE
[release-v1.23] [ci:component:github.com/gardener/etcd-druid:v0.5.0->v0.5.1]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -20,7 +20,7 @@ images:
 - name: etcd-druid
   sourceRepository: github.com/gardener/etcd-druid
   repository: eu.gcr.io/gardener-project/gardener/etcd-druid
-  tag: "v0.5.0"
+  tag: "v0.5.1"
 - name: gardener-resource-manager
   sourceRepository: github.com/gardener/gardener-resource-manager
   repository: eu.gcr.io/gardener-project/gardener/gardener-resource-manager


### PR DESCRIPTION
/kind bug
/kind regression

Cherry pick of #4086 on release-v1.23.

#4086: [ci:component:github.com/gardener/etcd-druid:v0.5.0->v0.5.1]

**Release Notes**:
``` other operator github.com/gardener/etcd-druid #176 @amshuman-kr
Removed synchronisation before updating ETCD status.
```