### PR TITLE
[release-v1.23] Automated cherry pick of #4088: Remove from ControllerDeployment in generate script

### DIFF
--- a/hack/generate-controller-registration.sh
+++ b/hack/generate-controller-registration.sh
@@ -79,13 +79,12 @@ apiVersion: core.gardener.cloud/v1beta1
 kind: ControllerDeployment
 metadata:
   name: $NAME
-spec:
-  type: helm
-  providerConfig:
-    chart: $chart
-    values:
-      image:
-        tag: $VERSION
+type: helm
+providerConfig:
+  chart: $chart
+  values:
+    image:
+      tag: $VERSION
 ---
 apiVersion: core.gardener.cloud/v1beta1
 kind: ControllerRegistration


### PR DESCRIPTION
/area/usability
/kind/bug

Cherry pick of #4088 on release-v1.23.

#4088: Remove from ControllerDeployment in generate script

**Release Notes:**
```bugfix dependency
The `hack/generate-controller-registration.sh` script does now produce valid `ControllerDeployment` resources.
```