### PR TITLE
Allow ControllerRegistration `.spec.resources[].type` to be `Bastion`

### DIFF
--- a/pkg/apis/extensions/v1alpha1/types.go
+++ b/pkg/apis/extensions/v1alpha1/types.go
@@ -81,6 +81,7 @@ type Object interface {
 var ExtensionKinds = sets.NewString(
 	BackupBucketResource,
 	BackupEntryResource,
+	BastionResource,
 	ContainerRuntimeResource,
 	ControlPlaneResource,
 	dnsv1alpha1.DNSProviderKind,


### PR DESCRIPTION
/kind bug

Currently trying to apply provider-aws ControllerRegistration with Bastion fails with:

```
$ k apply -f https://raw.githubusercontent.com/gardener/gardener-extension-provider-aws/67201b176e1460d5a51f44ada0e58011bd120536/example/controller-registration.yaml
The ControllerRegistration "provider-aws" is invalid: spec.resources[2].kind: Unsupported value: "Bastion": supported values: "BackupEntry", "DNSProvider", "Extension", "Infrastructure", "Network", "OperatingSystemConfig", "Worker", "BackupBucket", "ContainerRuntime", "ControlPlane"
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The Gardener API server now allows `Bastion` to be specified for ControllerRegistration `.spec.resources[].type`.
```
