### PR TITLE
[release-v1.23] Automated cherry pick of #4090: Allow ControllerRegistration `.spec.resources[].type` to be `Bastion`

### DIFF
--- a/pkg/apis/extensions/v1alpha1/types.go
+++ b/pkg/apis/extensions/v1alpha1/types.go
@@ -81,6 +81,7 @@ type Object interface {
 var ExtensionKinds = sets.NewString(
 	BackupBucketResource,
 	BackupEntryResource,
+	BastionResource,
 	ContainerRuntimeResource,
 	ControlPlaneResource,
 	dnsv1alpha1.DNSProviderKind,


### PR DESCRIPTION
/kind/api-change
/kind/bug

Cherry pick of #4090 on release-v1.23.

#4090: Allow ControllerRegistration `.spec.resources[].type` to be `Bastion`

**Release Notes:**
```bugfix operator
The Gardener API server now allows `Bastion` to be specified for ControllerRegistration `.spec.resources[].type`.
```