### PR TITLE
fix DNS provider messages with "emptyProvider"

### DIFF
--- a/pkg/operation/botanist/component/extensions/dns/dnsprovider.go
+++ b/pkg/operation/botanist/component/extensions/dns/dnsprovider.go
@@ -49,7 +49,7 @@ type IncludeExclude struct {
 	Exclude []string
 }
 
-// NewProvider creates a new instance of DeployWaiter for a specific DNS emptyProvider.
+// NewProvider creates a new instance of DeployWaiter for a specific DNS provider.
 // <waiter> is optional and it's defaulted to github.com/gardener/gardener/pkg/utils/retry.DefaultOps()
 func NewProvider(
 	logger logrus.FieldLogger,
@@ -155,16 +155,16 @@ func (p *provider) Wait(ctx context.Context) error {
 		if msg := obj.Status.Message; msg != nil {
 			message = *msg
 		}
-		providerErr := fmt.Errorf("DNS emptyProvider %q is not ready (status=%s, message=%s)", p.values.Name, status, message)
+		providerErr := fmt.Errorf("DNS provider %q is not ready (status=%s, message=%s)", p.values.Name, status, message)
 
-		p.logger.Infof("Waiting for %q DNS emptyProvider to be ready... (status=%s, message=%s)", p.values.Name, status, message)
+		p.logger.Infof("Waiting for %q DNS provider to be ready... (status=%s, message=%s)", p.values.Name, status, message)
 		if status == dnsv1alpha1.STATE_ERROR || status == dnsv1alpha1.STATE_INVALID {
 			return retry.MinorOrSevereError(retryCountUntilSevere, int(severeThreshold.Nanoseconds()/interval.Nanoseconds()), providerErr)
 		}
 
 		return retry.MinorError(providerErr)
 	}); err != nil {
-		return fmt.Errorf("Failed to create DNS emptyProvider for %q DNS record: %q (status=%s, message=%s)", p.values.Name, err.Error(), status, message)
+		return fmt.Errorf("Failed to create DNS provider for %q DNS record: %q (status=%s, message=%s)", p.values.Name, err.Error(), status, message)
 	}
 
 	return nil


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind regression

**What this PR does / why we need it**:
Fix messages for DNS provider probably changed by mistake on code refactoring.
