### PR TITLE
Add alert for snapshotter failure in etcd-backup-restore

### DIFF
--- a/pkg/operation/botanist/component/etcd/testdata/monitoring_alertingrules_normal_with_backup.yaml
+++ b/pkg/operation/botanist/component/etcd/testdata/monitoring_alertingrules_normal_with_backup.yaml
@@ -7,8 +7,9 @@ tests:
 - interval: 30s
   input_series:
   # KubeEtcdTestDown
+  # KubeEtcdBackupRestoreTestDown
   - series: 'up{job="kube-etcd3-test"}'
-    values: '0+0x30'
+    values: '0+0x30 1+0x40'
   # KubeEtcd3TestNoLeader
   - series: 'etcd_server_has_leader{job="kube-etcd3-test"}'
     values: '0+0x30'
@@ -32,6 +33,11 @@ tests:
   # KubeEtcdRestorationFailed
   - series: 'etcdbr_restoration_duration_seconds_count{job="kube-etcd3-backup-restore-test",succeeded="false"}'
     values: '0+0x7 1 2 2'
+  # KubeEtcdBackupRestoreTestDown
+  - series: 'up{job="kube-etcd3-backup-restore-test"}'
+    values: '0+0x60 1+0x10'
+  - series: 'etcdbr_snapshotter_failure{job="kube-etcd3-backup-restore-test"}'
+    values: '1+1x30 1+0x40'
   alert_rule_test:
   - eval_time: 15m
     alertname: KubeEtcdTestDown
@@ -131,3 +137,29 @@ tests:
       exp_annotations:
         description: Etcd data restoration was triggered, but has failed.
         summary: Etcd data restoration failure.
+  - eval_time: 16m
+    alertname: KubeEtcdBackupRestoreTestDown
+    exp_alerts:
+    - exp_labels:
+        job: kube-etcd3-backup-restore-test
+        service: etcd
+        severity: critical
+        type: seed
+        visibility: operator
+      exp_annotations:
+        description: Etcd backup restore test process down or snapshotter failed with error. Backups will not be triggered unless backup restore is brought back up. This is unsafe behaviour and may cause data loss.
+        summary: Etcd backup restore test process down or snapshotter failed with error
+  - eval_time: 30m
+    alertname: KubeEtcdBackupRestoreTestDown
+    exp_alerts:
+    - exp_labels:
+        service: etcd
+        severity: critical
+        type: seed
+        visibility: operator
+      exp_annotations:
+        description: Etcd backup restore test process down or snapshotter failed with error. Backups will not be triggered unless backup restore is brought back up. This is unsafe behaviour and may cause data loss.
+        summary: Etcd backup restore test process down or snapshotter failed with error
+  - eval_time: 35m
+    alertname: KubeEtcdBackupRestoreTestDown
+    exp_alerts:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/area backup
/area high-availability
/kind enhancement

**What this PR does / why we need it**:
Adds an alert to monitor for any snapshotter failure in etcd-backup-restore that would affect the backup snapshots being taken or deleted.

**Which issue(s) this PR fixes**:
Fixes partially gardener/etcd-backup-restore#325

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Added alert to monitor for any snapshotter failure in etcd-backup-restore
```
