### PR TITLE
Fix regression in Shoot reconciliation

### DIFF
--- a/pkg/client/kubernetes/types.go
+++ b/pkg/client/kubernetes/types.go
@@ -30,6 +30,7 @@ import (
 	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	resourcesscheme "github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1"
 	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
+	istionetworkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	istionetworkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	apiextensionsclientset "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	apiextensionsscheme "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
@@ -112,6 +113,7 @@ func init() {
 		druidv1alpha1.AddToScheme,
 		apiextensionsscheme.AddToScheme,
 		istionetworkingv1beta1.AddToScheme,
+		istionetworkingv1alpha3.AddToScheme,
 	)
 	utilruntime.Must(seedSchemeBuilder.AddToScheme(SeedScheme))
 


### PR DESCRIPTION
/kind bug
/kind regression

After https://github.com/gardener/gardener/pull/3983, the Shoot creation fails with:

```yaml
status:
  lastErrors:
  - description: 'task "Deploying Kubernetes API server service SNI settings in the
      Seed cluster" failed: retry failed with context deadline exceeded, last error:
      no kind is registered for the type v1alpha3.EnvoyFilter in scheme "github.com/gardener/gardener/pkg/client/kubernetes/types.go:57"'
    lastUpdateTime: "2021-05-23T20:28:10Z"
    taskID: Deploying Kubernetes API server service SNI settings in the Seed cluster
  - description: 'task "Deleting SNI resources if SNI is disabled" failed: retry failed
      with context deadline exceeded, last error: no kind is registered for the type
      v1alpha3.EnvoyFilter in scheme "github.com/gardener/gardener/pkg/client/kubernetes/types.go:57"'
    lastUpdateTime: "2021-05-23T20:28:10Z"
    taskID: Deleting SNI resources if SNI is disabled
  lastOperation:
    description: Deleting SNI resources if SNI is disabled
    lastUpdateTime: "2021-05-23T20:28:41Z"
    progress: 97
    state: Processing
    type: Create
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
