### PR TITLE
Isto is upgraded to 1.9.5

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -254,11 +254,11 @@ images:
 - name: istio-proxy
   sourceRepository: github.com/istio/istio
   repository: gcr.io/istio-release/proxyv2
-  tag: "1.8.0"
+  tag: "1.9.5"
 - name: istio-istiod
   sourceRepository: github.com/istio/istio
   repository: gcr.io/istio-release/pilot
-  tag: "1.8.0"
+  tag: "1.9.5"
 
 # API Server SNI
 - name: apiserver-proxy

--- a/charts/istio/istio-crds/templates/crd-all.gen.yaml
+++ b/charts/istio/istio-crds/templates/crd-all.gen.yaml
@@ -1287,6 +1287,10 @@ spec:
                                 description: Applies only to sidecars.
                                 format: string
                                 type: string
+                              destinationPort:
+                                description: The destination_port value used by a
+                                  filter chain's match condition.
+                                type: integer
                               filter:
                                 description: The name of a specific filter to apply
                                   the patch to.
@@ -2469,7 +2473,8 @@ spec:
                         format: int32
                         type: integer
                       perTryTimeout:
-                        description: Timeout per retry attempt for a given request.
+                        description: Timeout per attempt for a given request, including
+                          the initial call and any retries.
                         type: string
                       retryOn:
                         description: Specifies the conditions under which retry takes
@@ -2817,6 +2822,11 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
+  labels:
+    app: istio-pilot
+    chart: istio
+    heritage: Tiller
+    release: istio
   name: workloadgroups.networking.istio.io
 spec:
   additionalPrinterColumns:
@@ -2884,11 +2894,11 @@ spec:
                 - exec
               properties:
                 exec:
-                  description: health is determined by how the command that is executed
+                  description: Health is determined by how the command that is executed
                     exited.
                   properties:
                     command:
-                      description: command to run.
+                      description: Command to run.
                       items:
                         format: string
                         type: string
@@ -2906,7 +2916,7 @@ spec:
                       format: string
                       type: string
                     httpHeaders:
-                      description: headers the proxy will pass on to make the request.
+                      description: Headers the proxy will pass on to make the request.
                       items:
                         properties:
                           name:
@@ -2922,7 +2932,7 @@ spec:
                       format: string
                       type: string
                     port:
-                      description: port on which the endpoint lives.
+                      description: Port on which the endpoint lives.
                       type: integer
                     scheme:
                       format: string
@@ -2943,7 +2953,7 @@ spec:
                   format: int32
                   type: integer
                 tcpSocket:
-                  description: health is determined by if the proxy is able to connect.
+                  description: Health is determined by if the proxy is able to connect.
                   properties:
                     host:
                       format: string
@@ -3244,6 +3254,19 @@ metadata:
     release: istio
   name: peerauthentications.security.istio.io
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.mtls.mode
+    description: Defines the mTLS mode used for peer authentication.
+    name: Mode
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: 'CreationTimestamp is a timestamp representing the server time when
+      this object was created. It is not guaranteed to be set in happens-before order
+      across separate operations. Clients may not set this value. It is represented
+      in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
+      lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+    name: Age
+    type: date
   group: security.istio.io
   names:
     categories:

--- a/charts/istio/istio-ingress/templates/envoy-filter.yaml
+++ b/charts/istio/istio-ingress/templates/envoy-filter.yaml
@@ -134,7 +134,7 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
-  name: tcp-stats-filter-1.7
+  name: tcp-stats-filter-1.9
   namespace: {{ .Release.Namespace }}
 spec:
   configPatches:
@@ -146,7 +146,7 @@ spec:
           filter:
             name: envoy.filters.network.tcp_proxy
       proxy:
-        proxyVersion: ^1\.7.*
+        proxyVersion: ^1\.9.*
     patch:
       operation: INSERT_BEFORE
       value:
@@ -176,7 +176,7 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
-  name: tcp-metadata-exchange-1.7
+  name: tcp-metadata-exchange-1.9
   namespace: {{ .Release.Namespace }}
 spec:
   configPatches:
@@ -184,7 +184,7 @@ spec:
     match:
       context: GATEWAY
       proxy:
-        proxyVersion: '^1\.7.*'
+        proxyVersion: '^1\.9.*'
       cluster: {}
     patch:
       operation: MERGE
@@ -222,7 +222,7 @@ spec:
     patch:
       operation: MERGE
       value:
-        name: "envoy.filters.network.http_connection_manager"
+        name: envoy.filters.network.http_connection_manager
         typed_config:
           "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager"
           http_protocol_options:

--- a/pkg/operation/botanist/component/istio/crds.go
+++ b/pkg/operation/botanist/component/istio/crds.go
@@ -21,16 +21,13 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 type crds struct {
 	kubernetes.ChartApplier
-	chartPath      string
-	client         crclient.Client
-	deprecatedCRDs []apiextensionsv1.CustomResourceDefinition
+	chartPath string
+	client    crclient.Client
 }
 
 // NewIstioCRD can be used to deploy istio CRDs.
@@ -44,32 +41,10 @@ func NewIstioCRD(
 		ChartApplier: applier,
 		chartPath:    filepath.Join(chartsRootPath, "istio", "istio-crds"),
 		client:       client,
-		deprecatedCRDs: []apiextensionsv1.CustomResourceDefinition{
-			{ObjectMeta: metav1.ObjectMeta{Name: "attributemanifests.config.istio.io"}},
-			{ObjectMeta: metav1.ObjectMeta{Name: "clusterrbacconfigs.rbac.istio.io"}},
-			{ObjectMeta: metav1.ObjectMeta{Name: "handlers.config.istio.io"}},
-			{ObjectMeta: metav1.ObjectMeta{Name: "httpapispecbindings.config.istio.io"}},
-			{ObjectMeta: metav1.ObjectMeta{Name: "httpapispecs.config.istio.io"}},
-			{ObjectMeta: metav1.ObjectMeta{Name: "instances.config.istio.io"}},
-			{ObjectMeta: metav1.ObjectMeta{Name: "meshpolicies.authentication.istio.io"}},
-			{ObjectMeta: metav1.ObjectMeta{Name: "policies.authentication.istio.io"}},
-			{ObjectMeta: metav1.ObjectMeta{Name: "quotaspecbindings.config.istio.io"}},
-			{ObjectMeta: metav1.ObjectMeta{Name: "quotaspecs.config.istio.io"}},
-			{ObjectMeta: metav1.ObjectMeta{Name: "rbacconfigs.rbac.istio.io"}},
-			{ObjectMeta: metav1.ObjectMeta{Name: "rules.config.istio.io"}},
-			{ObjectMeta: metav1.ObjectMeta{Name: "servicerolebindings.rbac.istio.io"}},
-			{ObjectMeta: metav1.ObjectMeta{Name: "serviceroles.rbac.istio.io"}},
-		},
 	}
 }
 
 func (c *crds) Deploy(ctx context.Context) error {
-	for _, deprecatedCRD := range c.deprecatedCRDs {
-		if err := crclient.IgnoreNotFound(c.client.Delete(ctx, &deprecatedCRD)); err != nil {
-			return err
-		}
-	}
-
 	return c.Apply(ctx, c.chartPath, "", "istio")
 }
 

--- a/pkg/operation/botanist/component/istio/ingress_gateway_test.go
+++ b/pkg/operation/botanist/component/istio/ingress_gateway_test.go
@@ -30,6 +30,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	networkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
@@ -65,6 +66,7 @@ var _ = Describe("ingress", func() {
 		s := runtime.NewScheme()
 		Expect(corev1.AddToScheme(s)).ToNot(HaveOccurred())
 		Expect(appsv1.AddToScheme(s)).ToNot(HaveOccurred())
+		Expect(networkingv1alpha3.AddToScheme(s)).ToNot(HaveOccurred())
 		Expect(policyv1beta1.AddToScheme(s)).ToNot(HaveOccurred())
 		c = fake.NewFakeClientWithScheme(s)
 		renderer := cr.NewWithServerVersion(&version.Info{})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:

There are multiple CVEs (not affecting us) that were fixed in this version. Envoy is also updated.

**Which issue(s) this PR fixes**:
Fixes # n/a

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
<!---->
```other operator
Istio, used by the `ManagedIstio` feature gate, is upgraded from `1.8.0` to `1.9.5` 
```

