### PR TITLE
Update VPA components

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -230,15 +230,15 @@ images:
 - name: vpa-admission-controller
   sourceRepository: github.com/kubernetes/autoscaler
   repository: k8s.gcr.io/autoscaling/vpa-admission-controller
-  tag: "0.9.0"
+  tag: "0.9.2"
 - name: vpa-recommender
   sourceRepository: github.com/kubernetes/autoscaler
   repository: k8s.gcr.io/autoscaling/vpa-recommender
-  tag: "0.9.0"
+  tag: "0.9.2"
 - name: vpa-updater
   sourceRepository: github.com/kubernetes/autoscaler
   repository: k8s.gcr.io/autoscaling/vpa-updater
-  tag: "0.9.0"
+  tag: "0.9.2"
 - name: vpa-exporter
   sourceRepository: github.com/gardener/vpa-exporter
   repository: eu.gcr.io/gardener-project/gardener/vpa-exporter


### PR DESCRIPTION
Ref https://github.com/kubernetes/autoscaler/releases/tag/vertical-pod-autoscaler-0.9.2

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The following images are updated:
- k8s.gcr.io/autoscaling/vpa-admission-controller: 0.9.0 -> 0.9.2
- k8s.gcr.io/autoscaling/vpa-recommender: 0.9.0 -> 0.9.2
- k8s.gcr.io/autoscaling/vpa-updater: 0.9.0 -> 0.9.2
```
