### PR TITLE
fix labels on grafana netpol to match nginx-ingress

### DIFF
--- a/charts/seed-monitoring/charts/grafana/templates/grafana-network-policy.yaml
+++ b/charts/seed-monitoring/charts/grafana/templates/grafana-network-policy.yaml
@@ -35,8 +35,8 @@ spec:
           role: kube-system
       podSelector:
         matchLabels:
-          app: nginx-ingress
-          component: controller
+          app.kubernetes.io/name: ingress-nginx
+          app.kubernetes.io/component: controller
     ports:
     - protocol: TCP
       port: {{ required ".ports.grafana is required" .Values.ports.grafana }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:

adjusts the labels for the allow-grafana network policy so that it matches the nginx controller deployed to kube-system

**Which issue(s) this PR fixes**:
Fixes #4108 


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fix the Shoot Grafana Network Policies to match the Nginx-Ingress controller in kube-system
```
