### PR TITLE
Several corrections in preparation for the activation of SeedAuthorizer

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/validatingwebhook-admission-controller.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/validatingwebhook-admission-controller.yaml
@@ -128,9 +128,17 @@ webhooks:
     operations:
     - CREATE
     resources:
-    - backupbuckets
     - backupentries
     - shootstates
+  - apiGroups:
+    - core.gardener.cloud
+    apiVersions:
+    - "*"
+    operations:
+    - CREATE
+    - DELETE
+    resources:
+    - backupbuckets
   - apiGroups:
     - operations.gardener.cloud
     apiVersions:

--- a/hack/local-development/dev-setup-register-gardener
+++ b/hack/local-development/dev-setup-register-gardener
@@ -407,9 +407,17 @@ $ADMISSION_CONTROLLER_PORT_STRING
     operations:
     - CREATE
     resources:
-    - backupbuckets
     - backupentries
     - shootstates
+  - apiGroups:
+    - core.gardener.cloud
+    apiVersions:
+    - "*"
+    operations:
+    - CREATE
+    - DELETE
+    resources:
+    - backupbuckets
   - apiGroups:
     - operations.gardener.cloud
     apiVersions:

--- a/pkg/admissioncontroller/webhooks/auth/seed/authorizer.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/authorizer.go
@@ -97,8 +97,8 @@ func (a *authorizer) Authorize(_ context.Context, attrs auth.Attributes) (auth.D
 		switch requestResource {
 		case backupBucketResource:
 			return a.authorize(seedName, graph.VertexTypeBackupBucket, attrs,
-				[]string{"update", "patch", "delete"},
-				[]string{"create", "get", "list", "watch"},
+				[]string{"update", "patch"},
+				[]string{"create", "delete", "get", "list", "watch"},
 				[]string{"status"},
 			)
 		case backupEntryResource:

--- a/pkg/admissioncontroller/webhooks/auth/seed/authorizer.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/authorizer.go
@@ -240,8 +240,9 @@ func (a *authorizer) authorizeNamespace(seedName string, attrs auth.Attributes) 
 }
 
 func (a *authorizer) authorizeSecret(seedName string, attrs auth.Attributes) (auth.Decision, string, error) {
-	if attrs.GetNamespace() == gutil.ComputeGardenNamespace(seedName) &&
-		utils.ValueExists(attrs.GetVerb(), []string{"get", "list", "watch"}) {
+	if seedName == "" ||
+		(attrs.GetNamespace() == gutil.ComputeGardenNamespace(seedName) &&
+			utils.ValueExists(attrs.GetVerb(), []string{"get", "list", "watch"})) {
 
 		return auth.DecisionAllow, "", nil
 	}

--- a/pkg/admissioncontroller/webhooks/auth/seed/authorizer_test.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/authorizer_test.go
@@ -1833,6 +1833,23 @@ var _ = Describe("Seed", func() {
 				Entry("watch", "watch"),
 			)
 
+			DescribeTable("should allow without consulting the graph because verb is get, list, or watch in the seed's namespace when user is ambiguous",
+				func(verb string) {
+					attrs.User = ambiguousUser
+					attrs.Namespace = "seed-" + seedName
+					attrs.Verb = verb
+
+					decision, reason, err := authorizer.Authorize(ctx, attrs)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(decision).To(Equal(auth.DecisionAllow))
+					Expect(reason).To(BeEmpty())
+				},
+
+				Entry("get", "get"),
+				Entry("list", "list"),
+				Entry("watch", "watch"),
+			)
+
 			DescribeTable("should allow without consulting the graph because verb is create",
 				func(verb string) {
 					attrs.Verb = verb

--- a/pkg/admissioncontroller/webhooks/auth/seed/authorizer_test.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/authorizer_test.go
@@ -670,6 +670,7 @@ var _ = Describe("Seed", func() {
 				Entry("list", "list"),
 				Entry("watch", "watch"),
 				Entry("create", "create"),
+				Entry("delete", "delete"),
 			)
 
 			It("should have no opinion because no allowed verb", func() {
@@ -678,7 +679,7 @@ var _ = Describe("Seed", func() {
 				decision, reason, err := authorizer.Authorize(ctx, attrs)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(decision).To(Equal(auth.DecisionNoOpinion))
-				Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [create get list watch update patch delete]"))
+				Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [create delete get list watch update patch]"))
 			})
 
 			It("should have no opinion because no allowed subresource", func() {
@@ -712,8 +713,6 @@ var _ = Describe("Seed", func() {
 				Entry("patch w/ subresource", "patch", "status"),
 				Entry("update w/o subresource", "update", ""),
 				Entry("update w/ subresource", "update", "status"),
-				Entry("delete w/o subresource", "delete", ""),
-				Entry("delete w/ subresource", "delete", "status"),
 			)
 
 			It("should allow because seed name is ambiguous", func() {
@@ -727,7 +726,7 @@ var _ = Describe("Seed", func() {
 			})
 		})
 
-		Context("when requested for BackupEntrys", func() {
+		Context("when requested for BackupEntries", func() {
 			var (
 				name, namespace string
 				attrs           *auth.AttributesRecord

--- a/pkg/admissioncontroller/webhooks/auth/seed/graph/eventhandler_seed.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/graph/eventhandler_seed.go
@@ -19,7 +19,7 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
-	gardenerutils "github.com/gardener/gardener/pkg/utils/gardener"
+	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	toolscache "k8s.io/client-go/tools/cache"
@@ -79,7 +79,7 @@ func (g *graph) handleSeedCreateOrUpdate(seed *gardencorev1beta1.Seed) {
 	g.deleteAllIncomingEdges(VertexTypeNamespace, VertexTypeSeed, "", seed.Name)
 
 	seedVertex := g.getOrCreateVertex(VertexTypeSeed, "", seed.Name)
-	namespaceVertex := g.getOrCreateVertex(VertexTypeNamespace, "", gardenerutils.ComputeGardenNamespace(seed.Name))
+	namespaceVertex := g.getOrCreateVertex(VertexTypeNamespace, "", gutil.ComputeGardenNamespace(seed.Name))
 	g.addEdge(namespaceVertex, seedVertex)
 
 	if seed.Spec.SecretRef != nil {

--- a/pkg/controllermanager/controller/project/project_control.go
+++ b/pkg/controllermanager/controller/project/project_control.go
@@ -95,10 +95,10 @@ func (r *projectReconciler) Reconcile(ctx context.Context, request reconcile.Req
 	projectLogger.Infof("[PROJECT RECONCILE] %s", project.Name)
 
 	if project.DeletionTimestamp != nil {
-		return r.delete(ctx, project, r.gardenClient.Client(), r.gardenClient.APIReader())
+		return r.delete(ctx, project, r.gardenClient.Client(), r.gardenClient.Client())
 	}
 
-	return r.reconcile(ctx, project, r.gardenClient.Client(), r.gardenClient.APIReader())
+	return r.reconcile(ctx, project, r.gardenClient.Client(), r.gardenClient.Client())
 }
 
 func newProjectLogger(project *gardencorev1beta1.Project) logrus.FieldLogger {

--- a/pkg/controllermanager/controller/project/project_control_delete.go
+++ b/pkg/controllermanager/controller/project/project_control_delete.go
@@ -33,9 +33,9 @@ import (
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
-func (r *projectReconciler) delete(ctx context.Context, project *gardencorev1beta1.Project, gardenClient client.Client, gardenAPIReader client.Reader) (reconcile.Result, error) {
+func (r *projectReconciler) delete(ctx context.Context, project *gardencorev1beta1.Project, gardenClient client.Client, gardenReader client.Reader) (reconcile.Result, error) {
 	if namespace := project.Spec.Namespace; namespace != nil {
-		inUse, err := kutil.IsNamespaceInUse(ctx, gardenAPIReader, *namespace, gardencorev1beta1.SchemeGroupVersion.WithKind("ShootList"))
+		inUse, err := kutil.IsNamespaceInUse(ctx, gardenReader, *namespace, gardencorev1beta1.SchemeGroupVersion.WithKind("ShootList"))
 		if err != nil {
 			return reconcile.Result{}, fmt.Errorf("failed to check if namespace is empty: %w", err)
 		}

--- a/pkg/controllermanager/controller/project/project_control_reconcile.go
+++ b/pkg/controllermanager/controller/project/project_control_reconcile.go
@@ -44,7 +44,7 @@ import (
 // NamespacePrefix is the prefix of namespaces representing projects.
 const NamespacePrefix = "garden-"
 
-func (r *projectReconciler) reconcile(ctx context.Context, project *gardencorev1beta1.Project, gardenClient client.Client, gardenAPIReader client.Reader) (reconcile.Result, error) {
+func (r *projectReconciler) reconcile(ctx context.Context, project *gardencorev1beta1.Project, gardenClient client.Client, gardenReader client.Reader) (reconcile.Result, error) {
 	var (
 		generation = project.Generation
 		err        error
@@ -56,7 +56,7 @@ func (r *projectReconciler) reconcile(ctx context.Context, project *gardencorev1
 
 	// Ensure that we really get the latest version of the project to prevent working with an outdated version that has
 	// an unset .spec.namespace field (which would result in trying to create another namespace again).
-	if err := gardenAPIReader.Get(ctx, kutil.Key(project.Name), project); err != nil {
+	if err := gardenReader.Get(ctx, kutil.Key(project.Name), project); err != nil {
 		if apierrors.IsNotFound(err) {
 			return reconcile.Result{}, nil
 		}

--- a/pkg/controllerutils/patch.go
+++ b/pkg/controllerutils/patch.go
@@ -122,7 +122,7 @@ func getAndCreateOrPatch(ctx context.Context, c client.Client, obj client.Object
 	return controllerutil.OperationResultUpdated, nil
 }
 
-// MergeCreateOrPatch creates or patches (using a merge patch) the given object in the Kubernetes cluster.
+// CreateOrMergePatch creates or patches (using a merge patch) the given object in the Kubernetes cluster.
 // The object's desired state is only reconciled with the existing state inside the passed in callback MutateFn,
 // however, the object is not read from the client. This means the object should already be filled with the
 // last-known state if operating on more complex structures (e.g. if the patch is supposed to remove an optional field
@@ -131,11 +131,11 @@ func getAndCreateOrPatch(ctx context.Context, c client.Client, obj client.Object
 // The MutateFn is called regardless of creating or patching an object.
 //
 // It returns the executed operation and an error.
-func MergeCreateOrPatch(ctx context.Context, c client.Writer, obj client.Object, f controllerutil.MutateFn) (controllerutil.OperationResult, error) {
+func CreateOrMergePatch(ctx context.Context, c client.Writer, obj client.Object, f controllerutil.MutateFn) (controllerutil.OperationResult, error) {
 	return createOrPatch(ctx, c, obj, func(obj client.Object) client.Patch { return client.MergeFrom(obj) }, f)
 }
 
-// StrategicMergeCreateOrPatch creates or patches (using a strategic merge patch) the given object in the Kubernetes cluster.
+// CreateOrStrategicMergePatch creates or patches (using a strategic merge patch) the given object in the Kubernetes cluster.
 // The object's desired state is only reconciled with the existing state inside the passed in callback MutateFn,
 // however, the object is not read from the client. This means the object should already be filled with the
 // last-known state if operating on more complex structures (e.g. if the patch is supposed to remove an optional field
@@ -144,7 +144,7 @@ func MergeCreateOrPatch(ctx context.Context, c client.Writer, obj client.Object,
 // The MutateFn is called regardless of creating or patching an object.
 //
 // It returns the executed operation and an error.
-func StrategicMergeCreateOrPatch(ctx context.Context, c client.Writer, obj client.Object, f controllerutil.MutateFn) (controllerutil.OperationResult, error) {
+func CreateOrStrategicMergePatch(ctx context.Context, c client.Writer, obj client.Object, f controllerutil.MutateFn) (controllerutil.OperationResult, error) {
 	return createOrPatch(ctx, c, obj, func(obj client.Object) client.Patch { return client.StrategicMergeFrom(obj) }, f)
 }
 

--- a/pkg/controllerutils/patch_test.go
+++ b/pkg/controllerutils/patch_test.go
@@ -254,7 +254,7 @@ var _ = Describe("Patch", func() {
 			})
 		}
 
-		Describe("#MergeCreateOrPatch", func() { testSuite(MergeCreateOrPatch, types.MergePatchType) })
-		Describe("#StrategicMergePatchOrCreate", func() { testSuite(StrategicMergeCreateOrPatch, types.StrategicMergePatchType) })
+		Describe("#CreateOrMergePatch", func() { testSuite(CreateOrMergePatch, types.MergePatchType) })
+		Describe("#CreateOrStrategicMergePatch", func() { testSuite(CreateOrStrategicMergePatch, types.StrategicMergePatchType) })
 	})
 })

--- a/pkg/gardenlet/controller/backupbucket/backup_bucket_reconciler.go
+++ b/pkg/gardenlet/controller/backupbucket/backup_bucket_reconciler.go
@@ -157,7 +157,7 @@ func (r *reconciler) deleteBackupBucket(ctx context.Context, gardenClient kubern
 	}
 
 	backupEntryList := &gardencorev1beta1.BackupEntryList{}
-	if err := gardenClient.APIReader().List(ctx, backupEntryList); err != nil {
+	if err := gardenClient.Client().List(ctx, backupEntryList); err != nil {
 		backupBucketLogger.Errorf("Could not list the backup entries associated with backupbucket: %s", err)
 		return reconcile.Result{}, err
 	}

--- a/pkg/gardenlet/controller/factory.go
+++ b/pkg/gardenlet/controller/factory.go
@@ -132,8 +132,7 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 	}
 
 	gardenNamespace := &corev1.Namespace{}
-	// Use api reader here since we don't want to cache all namespaces of the Garden cluster.
-	runtime.Must(k8sGardenClient.APIReader().Get(ctx, kutil.Key(v1beta1constants.GardenNamespace), gardenNamespace))
+	runtime.Must(k8sGardenClient.Client().Get(ctx, kutil.Key(v1beta1constants.GardenNamespace), gardenNamespace))
 
 	// Initialize the workqueue metrics collection.
 	gardenmetrics.RegisterWorkqueMetrics()
@@ -226,7 +225,7 @@ func (f *GardenletControllerFactory) registerSeed(ctx context.Context, gardenCli
 
 	// wait seed namespace to be created by GCM
 	return retryutils.UntilTimeout(ctx, 5*time.Second, 2*time.Minute, func(context.Context) (done bool, err error) {
-		if err := gardenClient.APIReader().Get(ctx, kutil.Key(seedNamespaceName), seedNamespace); err != nil {
+		if err := gardenClient.Client().Get(ctx, kutil.Key(seedNamespaceName), seedNamespace); err != nil {
 			if apierrors.IsNotFound(err) {
 				logger.Logger.Infof("Waiting until namespace %q is created.", seedNamespaceName)
 				return retryutils.MinorError(fmt.Errorf("namespace %q still not created", seedNamespaceName))

--- a/pkg/gardenlet/controller/seed/seed_control.go
+++ b/pkg/gardenlet/controller/seed/seed_control.go
@@ -261,7 +261,8 @@ func (c *defaultControl) ReconcileSeed(obj *gardencorev1beta1.Seed, key string) 
 						Namespace: seed.Spec.SecretRef.Namespace,
 					},
 				}
-				if err := gardenClient.APIReader().Get(ctx, client.ObjectKeyFromObject(secret), secret); err == nil {
+				err = gardenClient.Client().Get(ctx, client.ObjectKeyFromObject(secret), secret)
+				if err == nil {
 					if err2 := controllerutils.PatchRemoveFinalizers(ctx, gardenClient.Client(), secret, gardencorev1beta1.ExternalGardenerName); err2 != nil {
 						return fmt.Errorf("failed to remove finalizer from Seed secret '%s/%s': %w", secret.Namespace, secret.Name, err2)
 					}
@@ -322,7 +323,7 @@ func (c *defaultControl) ReconcileSeed(obj *gardencorev1beta1.Seed, key string) 
 	// Add the Gardener finalizer to the referenced Seed secret to protect it from deletion as long as the Seed resource
 	// does exist.
 	if seed.Spec.SecretRef != nil {
-		secret, err := kutil.GetSecretByReference(ctx, gardenClient.APIReader(), seed.Spec.SecretRef)
+		secret, err := kutil.GetSecretByReference(ctx, gardenClient.Client(), seed.Spec.SecretRef)
 		if err != nil {
 			seedLogger.Error(err.Error())
 			return err

--- a/pkg/gardenlet/controller/seed/seed_control.go
+++ b/pkg/gardenlet/controller/seed/seed_control.go
@@ -174,7 +174,7 @@ func (c *defaultControl) ReconcileSeed(obj *gardencorev1beta1.Seed, key string) 
 	}
 
 	// Check if seed namespace is already available.
-	if err := gardenClient.APIReader().Get(ctx, client.ObjectKeyFromObject(seedNamespace), seedNamespace); err != nil {
+	if err := gardenClient.Client().Get(ctx, client.ObjectKeyFromObject(seedNamespace), seedNamespace); err != nil {
 		return fmt.Errorf("failed to get seed namespace in garden cluster: %w", err)
 	}
 

--- a/pkg/gardenlet/controller/seed/seed_control.go
+++ b/pkg/gardenlet/controller/seed/seed_control.go
@@ -262,8 +262,7 @@ func (c *defaultControl) ReconcileSeed(obj *gardencorev1beta1.Seed, key string) 
 						Namespace: seed.Spec.SecretRef.Namespace,
 					},
 				}
-				err = gardenClient.Client().Get(ctx, client.ObjectKeyFromObject(secret), secret)
-				if err == nil {
+				if err := gardenClient.APIReader().Get(ctx, client.ObjectKeyFromObject(secret), secret); err == nil {
 					if err2 := controllerutils.PatchRemoveFinalizers(ctx, gardenClient.Client(), secret, gardencorev1beta1.ExternalGardenerName); err2 != nil {
 						return fmt.Errorf("failed to remove finalizer from Seed secret '%s/%s': %w", secret.Namespace, secret.Name, err2)
 					}
@@ -324,7 +323,7 @@ func (c *defaultControl) ReconcileSeed(obj *gardencorev1beta1.Seed, key string) 
 	// Add the Gardener finalizer to the referenced Seed secret to protect it from deletion as long as the Seed resource
 	// does exist.
 	if seed.Spec.SecretRef != nil {
-		secret, err := kutil.GetSecretByReference(ctx, gardenClient.Client(), seed.Spec.SecretRef)
+		secret, err := kutil.GetSecretByReference(ctx, gardenClient.APIReader(), seed.Spec.SecretRef)
 		if err != nil {
 			seedLogger.Error(err.Error())
 			return err

--- a/pkg/gardenlet/controller/seed/seed_control.go
+++ b/pkg/gardenlet/controller/seed/seed_control.go
@@ -45,7 +45,6 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 func (c *Controller) seedAdd(obj interface{}) {
@@ -420,7 +419,7 @@ func deployBackupBucketInGarden(ctx context.Context, k8sGardenClient client.Clie
 
 	ownerRef := metav1.NewControllerRef(seed, gardencorev1beta1.SchemeGroupVersion.WithKind("Seed"))
 
-	_, err := controllerutil.CreateOrUpdate(ctx, k8sGardenClient, backupBucket, func() error {
+	_, err := controllerutils.CreateOrStrategicMergePatch(ctx, k8sGardenClient, backupBucket, func() error {
 		backupBucket.OwnerReferences = []metav1.OwnerReference{*ownerRef}
 		backupBucket.Spec = gardencorev1beta1.BackupBucketSpec{
 			Provider: gardencorev1beta1.BackupBucketProvider{

--- a/pkg/gardenlet/controller/shoot/shoot_care_control_types.go
+++ b/pkg/gardenlet/controller/shoot/shoot_care_control_types.go
@@ -115,7 +115,7 @@ var defaultNewOperationFunc = func(
 		WithGardenClusterIdentity(gardenClusterIdentity).
 		WithSecrets(secrets).
 		WithImageVector(imageVector).
-		WithGardenFrom(gardenClient.APIReader(), shoot.Namespace).
+		WithGardenFrom(gardenClient.Client(), shoot.Namespace).
 		WithSeedFrom(k8sGardenCoreInformers, *shoot.Spec.SeedName).
 		WithShootFromCluster(gardenClient, seedClient, shoot).
 		Build(ctx, clientMap)

--- a/pkg/gardenlet/controller/shoot/shoot_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control.go
@@ -189,13 +189,13 @@ func (c *Controller) reconcileShootRequest(ctx context.Context, req reconcile.Re
 	}
 
 	// fetch related objects required for shoot operation
-	project, _, err := gutil.ProjectAndNamespaceFromReader(ctx, gardenClient.APIReader(), shoot.Namespace)
+	project, _, err := gutil.ProjectAndNamespaceFromReader(ctx, gardenClient.Client(), shoot.Namespace)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
 
 	cloudProfile := &gardencorev1beta1.CloudProfile{}
-	if err := gardenClient.APIReader().Get(ctx, kutil.Key(shoot.Spec.CloudProfileName), cloudProfile); err != nil {
+	if err := gardenClient.Client().Get(ctx, kutil.Key(shoot.Spec.CloudProfileName), cloudProfile); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -279,9 +279,9 @@ func (c *Controller) initializeOperation(ctx context.Context, logger *logrus.Ent
 		NewBuilder().
 		WithShootObject(shoot).
 		WithCloudProfileObject(cloudProfile).
-		WithShootSecretFromReader(gardenClient.APIReader()).
+		WithShootSecretFromReader(gardenClient.Client()).
 		WithProjectName(project.Name).
-		WithExposureClassFromReader(gardenClient.APIReader()).
+		WithExposureClassFromReader(gardenClient.Client()).
 		WithDisableDNS(!seedObj.Info.Spec.Settings.ShootDNS.Enabled).
 		WithInternalDomain(gardenObj.InternalDomain).
 		WithDefaultDomains(gardenObj.DefaultDomains).

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -732,7 +732,7 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 
 func (b *Botanist) getAuditPolicy(ctx context.Context, name, namespace string) (string, error) {
 	auditPolicyCm := &corev1.ConfigMap{}
-	if err := b.K8sGardenClient.APIReader().Get(ctx, kutil.Key(namespace, name), auditPolicyCm); err != nil {
+	if err := b.K8sGardenClient.Client().Get(ctx, kutil.Key(namespace, name), auditPolicyCm); err != nil {
 		return "", err
 	}
 	auditPolicy, ok := auditPolicyCm.Data[auditPolicyConfigMapDataKey]

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -345,7 +345,7 @@ func (b *Botanist) SyncShootCredentialsToGarden(ctx context.Context) error {
 				},
 			}
 
-			_, err := controllerutils.StrategicMergeCreateOrPatch(ctx, b.K8sGardenClient.Client(), secretObj, func() error {
+			_, err := controllerutils.CreateOrStrategicMergePatch(ctx, b.K8sGardenClient.Client(), secretObj, func() error {
 				secretObj.OwnerReferences = []metav1.OwnerReference{
 					*metav1.NewControllerRef(b.Shoot.Info, gardencorev1beta1.SchemeGroupVersion.WithKind("Shoot")),
 				}

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -174,10 +174,10 @@ func (b *Builder) WithShootFrom(k8sGardenCoreInformers gardencoreinformers.Inter
 		return shoot.
 			NewBuilder().
 			WithShootObject(s).
-			WithCloudProfileObjectFromReader(gardenClient.APIReader()).
-			WithShootSecretFromReader(gardenClient.APIReader()).
+			WithCloudProfileObjectFromReader(gardenClient.Client()).
+			WithShootSecretFromReader(gardenClient.Client()).
 			WithProjectName(gardenObj.Project.Name).
-			WithExposureClassFromReader(gardenClient.APIReader()).
+			WithExposureClassFromReader(gardenClient.Client()).
 			WithDisableDNS(!seedObj.Info.Spec.Settings.ShootDNS.Enabled).
 			WithInternalDomain(gardenObj.InternalDomain).
 			WithDefaultDomains(gardenObj.DefaultDomains).
@@ -196,9 +196,9 @@ func (b *Builder) WithShootFromCluster(gardenClient, seedClient kubernetes.Inter
 			NewBuilder().
 			WithShootObjectFromCluster(seedClient, shootNamespace).
 			WithCloudProfileObjectFromCluster(seedClient, shootNamespace).
-			WithShootSecretFromReader(gardenClient.APIReader()).
+			WithShootSecretFromReader(gardenClient.Client()).
 			WithProjectName(gardenObj.Project.Name).
-			WithExposureClassFromReader(gardenClient.APIReader()).
+			WithExposureClassFromReader(gardenClient.Client()).
 			WithDisableDNS(!seedObj.Info.Spec.Settings.ShootDNS.Enabled).
 			WithInternalDomain(gardenObj.InternalDomain).
 			WithDefaultDomains(gardenObj.DefaultDomains).

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -514,7 +514,7 @@ func (o *Operation) EnsureShootStateExists(ctx context.Context) error {
 	ownerReference := metav1.NewControllerRef(o.Shoot.Info, gardencorev1beta1.SchemeGroupVersion.WithKind("Shoot"))
 	ownerReference.BlockOwnerDeletion = pointer.BoolPtr(false)
 
-	_, err := controllerutils.StrategicMergeCreateOrPatch(ctx, o.K8sGardenClient.Client(), shootState, func() error {
+	_, err := controllerutils.CreateOrStrategicMergePatch(ctx, o.K8sGardenClient.Client(), shootState, func() error {
 		shootState.OwnerReferences = []metav1.OwnerReference{*ownerReference}
 		return nil
 	})

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -1090,9 +1090,9 @@ func RunDeleteSeedFlow(ctx context.Context, sc, gc kubernetes.Interface, seed *S
 	return nil
 }
 
-func copySecretToSeed(ctx context.Context, gardenReader client.Reader, seedClient client.Client, sourceSecret types.NamespacedName, targetSecret *corev1.Secret) error {
+func copySecretToSeed(ctx context.Context, gardenClient, seedClient client.Client, sourceSecret types.NamespacedName, targetSecret *corev1.Secret) error {
 	gardenSecret := &corev1.Secret{}
-	if err := gardenReader.Get(ctx, sourceSecret, gardenSecret); err != nil {
+	if err := gardenClient.Get(ctx, sourceSecret, gardenSecret); err != nil {
 		return err
 	}
 
@@ -1119,7 +1119,7 @@ func ensureNoControllerInstallations(gc kubernetes.Interface, seedName string) f
 
 func updateDNSProviderSecret(ctx context.Context, sc kubernetes.Interface, gc kubernetes.Interface, seed *Seed) error {
 	if dnsConfig := seed.Info.Spec.DNS; dnsConfig.Provider != nil {
-		return copySecretToSeed(ctx, gc.APIReader(), sc.Client(), kutil.Key(dnsConfig.Provider.SecretRef.Namespace, dnsConfig.Provider.SecretRef.Name), emptyDNSProviderSecret())
+		return copySecretToSeed(ctx, gc.Client(), sc.Client(), kutil.Key(dnsConfig.Provider.SecretRef.Namespace, dnsConfig.Provider.SecretRef.Name), emptyDNSProviderSecret())
 	}
 	return nil
 }

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -1090,9 +1090,9 @@ func RunDeleteSeedFlow(ctx context.Context, sc, gc kubernetes.Interface, seed *S
 	return nil
 }
 
-func copySecretToSeed(ctx context.Context, gardenClient, seedClient client.Client, sourceSecret types.NamespacedName, targetSecret *corev1.Secret) error {
+func copySecretToSeed(ctx context.Context, gardenReader client.Reader, seedClient client.Client, sourceSecret types.NamespacedName, targetSecret *corev1.Secret) error {
 	gardenSecret := &corev1.Secret{}
-	if err := gardenClient.Get(ctx, sourceSecret, gardenSecret); err != nil {
+	if err := gardenReader.Get(ctx, sourceSecret, gardenSecret); err != nil {
 		return err
 	}
 
@@ -1119,7 +1119,7 @@ func ensureNoControllerInstallations(gc kubernetes.Interface, seedName string) f
 
 func updateDNSProviderSecret(ctx context.Context, sc kubernetes.Interface, gc kubernetes.Interface, seed *Seed) error {
 	if dnsConfig := seed.Info.Spec.DNS; dnsConfig.Provider != nil {
-		return copySecretToSeed(ctx, gc.Client(), sc.Client(), kutil.Key(dnsConfig.Provider.SecretRef.Namespace, dnsConfig.Provider.SecretRef.Name), emptyDNSProviderSecret())
+		return copySecretToSeed(ctx, gc.APIReader(), sc.Client(), kutil.Key(dnsConfig.Provider.SecretRef.Namespace, dnsConfig.Provider.SecretRef.Name), emptyDNSProviderSecret())
 	}
 	return nil
 }

--- a/pkg/utils/kubernetes/kubernetes.go
+++ b/pkg/utils/kubernetes/kubernetes.go
@@ -196,7 +196,7 @@ func WaitUntilLoadBalancerIsReady(ctx context.Context, kubeClient kubernetes.Int
 		const eventsLimit = 2
 
 		// use API reader here, we don't want to cache all events
-		eventsErrorMessage, err2 := FetchEventMessages(ctx, kubeClient.Client().Scheme(), kubeClient.APIReader(), service, corev1.EventTypeWarning, eventsLimit)
+		eventsErrorMessage, err2 := FetchEventMessages(ctx, kubeClient.Client().Scheme(), kubeClient.Client(), service, corev1.EventTypeWarning, eventsLimit)
 		if err2 != nil {
 			logger.Errorf("error %q occured while fetching events for error %q", err2, err)
 			return "", fmt.Errorf("'%w' occurred but could not fetch events for more information", err)

--- a/pkg/utils/kubernetes/kubernetes_test.go
+++ b/pkg/utils/kubernetes/kubernetes_test.go
@@ -809,7 +809,6 @@ var _ = Describe("kubernetes", func() {
 	Describe("#WaitUntilLoadBalancerIsReady", func() {
 		var (
 			k8sShootClient kubernetes.Interface
-			reader         *mockclient.MockReader
 			key            = client.ObjectKey{Namespace: metav1.NamespaceSystem, Name: "load-balancer"}
 			logger         = logrus.NewEntry(logger.NewNopLogger())
 			scheme         *runtime.Scheme
@@ -818,11 +817,9 @@ var _ = Describe("kubernetes", func() {
 		BeforeEach(func() {
 			scheme = runtime.NewScheme()
 			Expect(corev1.AddToScheme(scheme)).To(Succeed())
-			reader = mockclient.NewMockReader(ctrl)
 			c.EXPECT().Scheme().Return(scheme).AnyTimes()
 			k8sShootClient = fakeclientset.NewClientSetBuilder().
 				WithClient(c).
-				WithAPIReader(reader).
 				Build()
 		})
 
@@ -887,7 +884,7 @@ var _ = Describe("kubernetes", func() {
 						*obj = *svc
 						return nil
 					}),
-				reader.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.EventList{}), gomock.Any()).DoAndReturn(
+				c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.EventList{}), gomock.Any()).DoAndReturn(
 					func(_ context.Context, list *corev1.EventList, _ ...client.ListOption) error {
 						list.Items = append(list.Items, event)
 						return nil

--- a/pkg/utils/kubernetes/secretref.go
+++ b/pkg/utils/kubernetes/secretref.go
@@ -24,7 +24,7 @@ import (
 )
 
 // GetSecretByReference returns the secret referenced by the given secret reference.
-func GetSecretByReference(ctx context.Context, c client.Client, ref *corev1.SecretReference) (*corev1.Secret, error) {
+func GetSecretByReference(ctx context.Context, c client.Reader, ref *corev1.SecretReference) (*corev1.Secret, error) {
 	secret := &corev1.Secret{}
 	if err := c.Get(ctx, Key(ref.Namespace, ref.Name), secret); err != nil {
 		return nil, err


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
In preparation for the seed authorizer activation, this PR corrects several usages of the garden client when the gardenlet communicates with the garden cluster.

**Which issue(s) this PR fixes**:
Part of #1723

**Special notes for your reviewer**:
/cc @timuthy 
/squash

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
