### PR TITLE
[release-v1.23] Upgrade etcd-druid from v0.5.1 to v0.5.2

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -20,7 +20,7 @@ images:
 - name: etcd-druid
   sourceRepository: github.com/gardener/etcd-druid
   repository: eu.gcr.io/gardener-project/gardener/etcd-druid
-  tag: "v0.5.1"
+  tag: "v0.5.2"
 - name: gardener-resource-manager
   sourceRepository: github.com/gardener/gardener-resource-manager
   repository: eu.gcr.io/gardener-project/gardener/gardener-resource-manager


### PR DESCRIPTION
**How to categorize this PR?**

**What this PR does / why we need it**:
Cherry-pick #4112 on release-v1.23 branch.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
``` other operator github.com/gardener/etcd-druid #183 @amshuman-kr
Updated number of chunks while uploading to never exceed the cloud provider limits.
```
