### PR TITLE
Selectable Api Server endpoints aka ExposureClasses [Part 3]

### DIFF
--- a/charts/istio/istio-ingress/templates/envoy-filter.yaml
+++ b/charts/istio/istio-ingress/templates/envoy-filter.yaml
@@ -207,8 +207,7 @@ metadata:
 spec:
   workloadSelector:
     labels:
-      app: istio-ingressgateway
-      istio: ingressgateway
+{{ .Values.labels | toYaml | indent 6 }}
   configPatches:
   - applyTo: NETWORK_FILTER
     match:

--- a/charts/istio/istio-ingress/values.yaml
+++ b/charts/istio/istio-ingress/values.yaml
@@ -1,6 +1,5 @@
 labels:
   app: istio-ingressgateway
-  istio: ingressgateway
 annotations: {}
 image: to-be-injected-by-imagevector
 trustDomain: cluster.local

--- a/charts/istio/istio-proxy-protocol/values.yaml
+++ b/charts/istio/istio-proxy-protocol/values.yaml
@@ -1,3 +1,2 @@
 labels:
   app: istio-ingressgateway
-  istio: ingressgateway

--- a/landscaper/pkg/gardenlet/chart/charttest/charttest.go
+++ b/landscaper/pkg/gardenlet/chart/charttest/charttest.go
@@ -727,7 +727,7 @@ func ComputeExpectedGardenletConfiguration(
 		SNI: &gardenletconfigv1alpha1.SNI{Ingress: &gardenletconfigv1alpha1.SNIIngress{
 			ServiceName: pointer.String(gardenletconfigv1alpha1.DefaultSNIIngresServiceName),
 			Namespace:   pointer.String(gardenletconfigv1alpha1.DefaultSNIIngresNamespace),
-			Labels:      map[string]string{"istio": "ingressgateway"},
+			Labels:      map[string]string{"app": "istio-ingressgateway", "istio": "ingressgateway"},
 		}},
 	}
 

--- a/pkg/apis/core/v1alpha1/constants/types_constants.go
+++ b/pkg/apis/core/v1alpha1/constants/types_constants.go
@@ -127,6 +127,8 @@ const (
 	GardenRoleMonitoring = "monitoring"
 	// GardenRoleOptionalAddon is the value of the GardenRole key indicating type 'optional-addon'.
 	GardenRoleOptionalAddon = "optional-addon"
+	// GardenRoleExposureClassHandler is the value of the GardenRole key indicating type 'exposureclass-handler'.
+	GardenRoleExposureClassHandler = "exposureclass-handler"
 
 	// ShootUID is an annotation key for the shoot namespace in the seed cluster,
 	// which value will be the value of `shoot.status.uid`
@@ -247,6 +249,9 @@ const (
 
 	// LabelControllerRegistrationName is the key of a label on extension namespaces that indicates the controller registration name.
 	LabelControllerRegistrationName = "controllerregistration.core.gardener.cloud/name"
+
+	// LabelExposureClassHandlerName is the label key for exposure class handler names.
+	LabelExposureClassHandlerName = "handler.exposureclass.gardener.cloud/name"
 
 	// EventResourceReferenced indicates that the resource deletion is in waiting mode because the resource is still
 	// being referenced by at least one other resource (e.g. a SecretBinding is still referenced by a Shoot)

--- a/pkg/apis/core/validation/exposureclass_test.go
+++ b/pkg/apis/core/validation/exposureclass_test.go
@@ -44,8 +44,28 @@ var _ = Describe("ExposureClass Validation Tests ", func() {
 			Expect(errorList).To(HaveLen(0))
 		})
 
-		It("should fail as exposure class handler is empty", func() {
+		It("should fail as exposure class handler is no DNS1123 label with zero length", func() {
 			exposureClass.Handler = ""
+			errorList := ValidateExposureClass(exposureClass)
+
+			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeInvalid),
+				"Field": Equal("handler"),
+			}))))
+		})
+
+		It("should fail as exposure class handler is no DNS1123 label", func() {
+			exposureClass.Handler = "TES:T"
+			errorList := ValidateExposureClass(exposureClass)
+
+			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeInvalid),
+				"Field": Equal("handler"),
+			}))))
+		})
+
+		It("should fail as exposure class handler contains more than 41 characters", func() {
+			exposureClass.Handler = "izqissuczonxfeq346ce5exr9rhkcmb398tlloo2tb"
 			errorList := ValidateExposureClass(exposureClass)
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{

--- a/pkg/gardenlet/apis/config/v1alpha1/defaults.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/defaults.go
@@ -15,7 +15,11 @@
 package v1alpha1
 
 import (
+	"fmt"
 	"time"
+
+	v1alpha1constants "github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -108,6 +112,29 @@ func SetDefaults_GardenletConfiguration(obj *GardenletConfiguration) {
 
 	if obj.SNI == nil {
 		obj.SNI = &SNI{}
+	}
+
+	var defaultSVCName = DefaultSNIIngresServiceName
+	for i, handler := range obj.ExposureClassHandlers {
+		if obj.ExposureClassHandlers[i].SNI == nil {
+			obj.ExposureClassHandlers[i].SNI = &SNI{Ingress: &SNIIngress{}}
+		}
+		if obj.ExposureClassHandlers[i].SNI.Ingress == nil {
+			obj.ExposureClassHandlers[i].SNI.Ingress = &SNIIngress{}
+		}
+		if obj.ExposureClassHandlers[i].SNI.Ingress.Namespace == nil {
+			namespaceName := fmt.Sprintf("istio-ingress-handler-%s", handler.Name)
+			obj.ExposureClassHandlers[i].SNI.Ingress.Namespace = &namespaceName
+		}
+		if obj.ExposureClassHandlers[i].SNI.Ingress.ServiceName == nil {
+			obj.ExposureClassHandlers[i].SNI.Ingress.ServiceName = &defaultSVCName
+		}
+		if len(obj.ExposureClassHandlers[i].SNI.Ingress.Labels) == 0 {
+			obj.ExposureClassHandlers[i].SNI.Ingress.Labels = map[string]string{
+				v1beta1constants.LabelApp:    DefaultIngressGatewayAppLabelValue,
+				v1alpha1constants.GardenRole: v1alpha1constants.GardenRoleExposureClassHandler,
+			}
+		}
 	}
 }
 
@@ -340,6 +367,9 @@ func SetDefaults_SNIIngress(obj *SNIIngress) {
 	}
 
 	if obj.Labels == nil {
-		obj.Labels = map[string]string{"istio": "ingressgateway"}
+		obj.Labels = map[string]string{
+			v1beta1constants.LabelApp: DefaultIngressGatewayAppLabelValue,
+			"istio":                   "ingressgateway",
+		}
 	}
 }

--- a/pkg/gardenlet/apis/config/v1alpha1/types.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/types.go
@@ -529,6 +529,9 @@ const (
 
 	// DefaultSNIIngresServiceName is the default sni ingress service name.
 	DefaultSNIIngresServiceName = "istio-ingressgateway"
+
+	// DefaultIngressGatewayAppLabelValue is the ingress gateway value for the app label.
+	DefaultIngressGatewayAppLabelValue = "istio-ingressgateway"
 )
 
 // DefaultControllerSyncPeriod is a default value for sync period for controllers.

--- a/pkg/gardenlet/apis/config/validation/validation.go
+++ b/pkg/gardenlet/apis/config/validation/validation.go
@@ -23,6 +23,7 @@ import (
 
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
@@ -80,8 +81,9 @@ func ValidateGardenletConfiguration(cfg *config.GardenletConfiguration, fldPath 
 	exposureClassHandlersPath := fldPath.Child("exposureClassHandlers")
 	for i, handler := range cfg.ExposureClassHandlers {
 		handlerPath := exposureClassHandlersPath.Index(i)
-		if len(handler.Name) == 0 {
-			allErrs = append(allErrs, field.Invalid(handlerPath.Child("name"), handler.Name, "handler name cannot be empty"))
+
+		for _, errorMessage := range validation.IsDNS1123Label(handler.Name) {
+			allErrs = append(allErrs, field.Invalid(handlerPath.Child("name"), handler.Name, errorMessage))
 		}
 	}
 

--- a/pkg/gardenlet/apis/config/validation/validation_test.go
+++ b/pkg/gardenlet/apis/config/validation/validation_test.go
@@ -353,7 +353,7 @@ var _ = Describe("GardenletConfiguration", func() {
 				Expect(errorList).To(BeEmpty())
 			})
 
-			It("should fail as exposureClassHandler name is empty", func() {
+			It("should fail as exposureClassHandler name is no DNS1123 label with zero length", func() {
 				cfg.ExposureClassHandlers[0].Name = ""
 
 				errorList := ValidateGardenletConfiguration(cfg, nil, false)
@@ -363,6 +363,18 @@ var _ = Describe("GardenletConfiguration", func() {
 					"Field": Equal("exposureClassHandlers[0].name"),
 				}))))
 			})
+
+			It("should fail as exposureClassHandler name is no DNS1123 label", func() {
+				cfg.ExposureClassHandlers[0].Name = "TE:ST"
+
+				errorList := ValidateGardenletConfiguration(cfg, nil, false)
+
+				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("exposureClassHandlers[0].name"),
+				}))))
+			})
+
 		})
 	})
 

--- a/pkg/operation/botanist/component/istio/proxy_protocol.go
+++ b/pkg/operation/botanist/component/istio/proxy_protocol.go
@@ -25,19 +25,27 @@ import (
 )
 
 type proxyProtocol struct {
+	values       *ProxyValues
 	namespace    string
 	chartApplier kubernetes.ChartApplier
 	chartPath    string
 }
 
+// ProxyValues holds values for the istio-proxy-protocol chart.
+type ProxyValues struct {
+	Labels map[string]string `json:"labels,omitempty"`
+}
+
 // NewProxyProtocolGateway creates a new DeployWaiter for istio which
 // adds a PROXY Protocol listener to the istio-ingressgateway.
 func NewProxyProtocolGateway(
+	values *ProxyValues,
 	namespace string,
 	chartApplier kubernetes.ChartApplier,
 	chartsRootPath string,
 ) component.DeployWaiter {
 	return &proxyProtocol{
+		values:       values,
 		namespace:    namespace,
 		chartApplier: chartApplier,
 		chartPath:    filepath.Join(chartsRootPath, istioReleaseName, "istio-proxy-protocol"),
@@ -45,7 +53,7 @@ func NewProxyProtocolGateway(
 }
 
 func (i *proxyProtocol) Deploy(ctx context.Context) error {
-	return i.chartApplier.Apply(ctx, i.chartPath, i.namespace, istioReleaseName)
+	return i.chartApplier.Apply(ctx, i.chartPath, i.namespace, istioReleaseName, kubernetes.Values(i.values))
 }
 
 func (i *proxyProtocol) Destroy(ctx context.Context) error {

--- a/pkg/operation/botanist/component/istio/proxy_protocol_test.go
+++ b/pkg/operation/botanist/component/istio/proxy_protocol_test.go
@@ -72,14 +72,12 @@ var _ = Describe("Proxy protocol", func() {
 		expectedGW = &networkingv1beta1.Gateway{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
-					"app":   "istio-ingressgateway",
-					"istio": "ingressgateway",
+					"app": "istio-ingressgateway",
 				},
 			},
 			Spec: v1beta1.Gateway{
 				Selector: map[string]string{
-					"app":   "istio-ingressgateway",
-					"istio": "ingressgateway",
+					"app": "istio-ingressgateway",
 				},
 				Servers: []*v1beta1.Server{{
 					Port: &v1beta1.Port{
@@ -95,8 +93,7 @@ var _ = Describe("Proxy protocol", func() {
 		expectedVS = &networkingv1beta1.VirtualService{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
-					"app":   "istio-ingressgateway",
-					"istio": "ingressgateway",
+					"app": "istio-ingressgateway",
 				},
 			},
 			Spec: v1beta1.VirtualService{
@@ -120,15 +117,13 @@ var _ = Describe("Proxy protocol", func() {
 		expectedEF = &networkingv1alpha3.EnvoyFilter{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
-					"app":   "istio-ingressgateway",
-					"istio": "ingressgateway",
+					"app": "istio-ingressgateway",
 				},
 			},
 			Spec: v1alpha3.EnvoyFilter{
 				WorkloadSelector: &v1alpha3.WorkloadSelector{
 					Labels: map[string]string{
-						"app":   "istio-ingressgateway",
-						"istio": "ingressgateway",
+						"app": "istio-ingressgateway",
 					},
 				},
 				ConfigPatches: []*v1alpha3.EnvoyFilter_EnvoyConfigObjectPatch{{
@@ -162,7 +157,7 @@ var _ = Describe("Proxy protocol", func() {
 		)
 		Expect(ca).NotTo(BeNil(), "should return chart applier")
 
-		proxy = NewProxyProtocolGateway(deployNS, ca, chartsRootPath)
+		proxy = NewProxyProtocolGateway(nil, deployNS, ca, chartsRootPath)
 	})
 
 	JustBeforeEach(func() {

--- a/pkg/operation/botanist/component/networkpolicies/global.go
+++ b/pkg/operation/botanist/component/networkpolicies/global.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -126,7 +127,7 @@ func getGlobalNetworkPolicyTransformers(values GlobalValues) []networkPolicyTran
 							NamespaceSelector: &metav1.LabelSelector{},
 							PodSelector: &metav1.LabelSelector{
 								MatchLabels: map[string]string{
-									v1beta1constants.LabelApp: "istio-ingressgateway",
+									v1beta1constants.LabelApp: gardenletconfigv1alpha1.DefaultIngressGatewayAppLabelValue,
 								},
 							},
 						})

--- a/pkg/operation/botanist/component/vpnseedserver/mock/mocks.go
+++ b/pkg/operation/botanist/component/vpnseedserver/mock/mocks.go
@@ -8,6 +8,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	config "github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	vpnseedserver "github.com/gardener/gardener/pkg/operation/botanist/component/vpnseedserver"
 	gomock "github.com/golang/mock/gomock"
 	types "k8s.io/apimachinery/pkg/types"
@@ -62,6 +63,30 @@ func (m *MockInterface) Destroy(arg0 context.Context) error {
 func (mr *MockInterfaceMockRecorder) Destroy(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Destroy", reflect.TypeOf((*MockInterface)(nil).Destroy), arg0)
+}
+
+// SetExposureClassHandlerName mocks base method.
+func (m *MockInterface) SetExposureClassHandlerName(arg0 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetExposureClassHandlerName", arg0)
+}
+
+// SetExposureClassHandlerName indicates an expected call of SetExposureClassHandlerName.
+func (mr *MockInterfaceMockRecorder) SetExposureClassHandlerName(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetExposureClassHandlerName", reflect.TypeOf((*MockInterface)(nil).SetExposureClassHandlerName), arg0)
+}
+
+// SetSNIConfig mocks base method.
+func (m *MockInterface) SetSNIConfig(arg0 *config.SNI) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetSNIConfig", arg0)
+}
+
+// SetSNIConfig indicates an expected call of SetSNIConfig.
+func (mr *MockInterfaceMockRecorder) SetSNIConfig(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSNIConfig", reflect.TypeOf((*MockInterface)(nil).SetSNIConfig), arg0)
 }
 
 // SetSecrets mocks base method.

--- a/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server_test.go
+++ b/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server_test.go
@@ -379,7 +379,7 @@ var _ = Describe("VpnSeedServer", func() {
 			ObjectMeta: metav1.ObjectMeta{Name: DeploymentName, Namespace: namespace},
 			Spec: v1beta1.Gateway{
 				Selector: map[string]string{
-					"istio": "ingressgateway",
+					"app": "istio-ingressgateway",
 				},
 				Servers: []*v1beta1.Server{
 					{

--- a/pkg/operation/botanist/vpnseedserver.go
+++ b/pkg/operation/botanist/vpnseedserver.go
@@ -100,6 +100,11 @@ func (b *Botanist) DeployVPNServer(ctx context.Context) error {
 	})
 
 	b.Shoot.Components.ControlPlane.VPNSeedServer.SetSeedNamespaceObjectUID(b.SeedNamespaceObject.UID)
+	b.Shoot.Components.ControlPlane.VPNSeedServer.SetSNIConfig(b.Config.SNI)
+	if b.ExposureClassHandler != nil {
+		b.Shoot.Components.ControlPlane.VPNSeedServer.SetExposureClassHandlerName(b.ExposureClassHandler.Name)
+		b.Shoot.Components.ControlPlane.VPNSeedServer.SetSNIConfig(b.ExposureClassHandler.SNI)
+	}
 
 	return b.Shoot.Components.ControlPlane.VPNSeedServer.Deploy(ctx)
 }

--- a/pkg/operation/botanist/vpnseedserver_test.go
+++ b/pkg/operation/botanist/vpnseedserver_test.go
@@ -175,9 +175,23 @@ var _ = Describe("VPNSeedServer", func() {
 				DiffieHellmanKey: component.Secret{Name: secretNameDH, Checksum: secretChecksumDH},
 			})
 			vpnSeedServer.EXPECT().SetSeedNamespaceObjectUID(namespaceUID)
+			vpnSeedServer.EXPECT().SetSNIConfig(botanist.Config.SNI)
 		})
 
-		It("should set the secrets and deploy", func() {
+		It("should set the secrets and SNI config and deploy", func() {
+			vpnSeedServer.EXPECT().Deploy(ctx)
+			Expect(botanist.DeployVPNServer(ctx)).To(Succeed())
+		})
+
+		It("should set the secrets and the ExposureClass handler config and deploy", func() {
+			botanist.ExposureClassHandler = &config.ExposureClassHandler{
+				Name: "test",
+				SNI:  &config.SNI{},
+			}
+
+			vpnSeedServer.EXPECT().SetExposureClassHandlerName(botanist.ExposureClassHandler.Name)
+			vpnSeedServer.EXPECT().SetSNIConfig(botanist.ExposureClassHandler.SNI)
+
 			vpnSeedServer.EXPECT().Deploy(ctx)
 			Expect(botanist.DeployVPNServer(ctx)).To(Succeed())
 		})

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/gardener/gardener/charts"
+	v1alpha1constants "github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
@@ -50,6 +51,7 @@ import (
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/flow"
+	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	secretsutils "github.com/gardener/gardener/pkg/utils/secrets"
@@ -58,6 +60,7 @@ import (
 	"github.com/Masterminds/semver"
 	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	"github.com/sirupsen/logrus"
+	istiov1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
@@ -693,7 +696,7 @@ func RunReconcileSeedFlow(
 		istioCRDs := istio.NewIstioCRD(chartApplier, charts.Path, k8sSeedClient.Client())
 		istiod := istio.NewIstiod(
 			&istio.IstiodValues{
-				TrustDomain: "cluster.local",
+				TrustDomain: gardencorev1beta1.DefaultDomain,
 				Image:       istiodImage.String(),
 			},
 			common.IstioNamespace,
@@ -701,49 +704,97 @@ func RunReconcileSeedFlow(
 			charts.Path,
 			k8sSeedClient.Client(),
 		)
+		istioDeployers := []component.DeployWaiter{istioCRDs, istiod}
 
-		igwConfig := &istio.IngressValues{
-			TrustDomain:     "cluster.local",
+		defaultIngressGatewayConfig := &istio.IngressValues{
+			TrustDomain:     gardencorev1beta1.DefaultDomain,
 			Image:           igwImage.String(),
 			IstiodNamespace: common.IstioNamespace,
 			Annotations:     seed.LoadBalancerServiceAnnotations,
 			Ports:           []corev1.ServicePort{},
+			Labels:          conf.SNI.Ingress.Labels,
 		}
 
 		// even if SNI is being disabled, the existing ports must stay the same
 		// until all APIServer SNI resources are removed.
 		if gardenletfeatures.FeatureGate.Enabled(features.APIServerSNI) || anySNI {
-			igwConfig.Ports = append(
-				igwConfig.Ports,
+			defaultIngressGatewayConfig.Ports = append(
+				defaultIngressGatewayConfig.Ports,
 				corev1.ServicePort{Name: "proxy", Port: 8443, TargetPort: intstr.FromInt(8443)},
 				corev1.ServicePort{Name: "tcp", Port: 443, TargetPort: intstr.FromInt(9443)},
 				corev1.ServicePort{Name: "tls-tunnel", Port: vpnseedserver.GatewayPort, TargetPort: intstr.FromInt(vpnseedserver.GatewayPort)},
 			)
 		}
 
-		igw := istio.NewIngressGateway(
-			igwConfig,
+		istioDeployers = append(istioDeployers, istio.NewIngressGateway(
+			defaultIngressGatewayConfig,
 			*conf.SNI.Ingress.Namespace,
 			chartApplier,
 			charts.Path,
 			k8sSeedClient.Client(),
-		)
+		))
 
-		if err := component.OpWaiter(istioCRDs, istiod, igw).Deploy(ctx); err != nil {
+		// Add for each ExposureClass handler in the config an own Ingress Gateway.
+		for _, handler := range conf.ExposureClassHandlers {
+			istioDeployers = append(istioDeployers, istio.NewIngressGateway(
+				&istio.IngressValues{
+					TrustDomain:     gardencorev1beta1.DefaultDomain,
+					Image:           igwImage.String(),
+					IstiodNamespace: common.IstioNamespace,
+					Annotations:     utils.MergeStringMaps(seed.LoadBalancerServiceAnnotations, handler.LoadBalancerService.Annotations),
+					Ports:           defaultIngressGatewayConfig.Ports,
+					Labels:          gutil.GetMandatoryExposureClassHandlerSNILabels(handler.SNI.Ingress.Labels, handler.Name),
+				},
+				*handler.SNI.Ingress.Namespace,
+				chartApplier,
+				charts.Path,
+				k8sSeedClient.Client(),
+			))
+		}
+
+		if err := component.OpWaiter(istioDeployers...).Deploy(ctx); err != nil {
 			return err
 		}
 	}
 
-	proxy := istio.NewProxyProtocolGateway(*conf.SNI.Ingress.Namespace, chartApplier, charts.Path)
+	var proxyGatewayDeployers = []component.DeployWaiter{
+		istio.NewProxyProtocolGateway(
+			&istio.ProxyValues{
+				Labels: conf.SNI.Ingress.Labels,
+			},
+			*conf.SNI.Ingress.Namespace,
+			chartApplier,
+			charts.Path,
+		),
+	}
+
+	for _, handler := range conf.ExposureClassHandlers {
+		proxyGatewayDeployers = append(proxyGatewayDeployers, istio.NewProxyProtocolGateway(
+			&istio.ProxyValues{
+				Labels: gutil.GetMandatoryExposureClassHandlerSNILabels(handler.SNI.Ingress.Labels, handler.Name),
+			},
+			*handler.SNI.Ingress.Namespace,
+			chartApplier,
+			charts.Path,
+		))
+	}
 
 	if gardenletfeatures.FeatureGate.Enabled(features.APIServerSNI) {
-		if err := proxy.Deploy(ctx); err != nil {
-			return err
+		for _, proxyDeployer := range proxyGatewayDeployers {
+			if err := proxyDeployer.Deploy(ctx); err != nil {
+				return err
+			}
 		}
 	} else {
-		if err := proxy.Destroy(ctx); err != nil {
-			return err
+		for _, proxyDeployer := range proxyGatewayDeployers {
+			if err := proxyDeployer.Destroy(ctx); err != nil {
+				return err
+			}
 		}
+	}
+
+	if err := cleanupOrphanExposureClassHandlerResources(ctx, k8sSeedClient.Client(), conf.ExposureClassHandlers, seedLogger); err != nil {
+		return err
 	}
 
 	if seed.Info.Status.ClusterIdentity == nil {
@@ -1428,4 +1479,63 @@ func deletePriorityClassIfValueNotTheSame(ctx context.Context, k8sClient client.
 	}
 
 	return client.IgnoreNotFound(k8sClient.Delete(ctx, pc))
+}
+
+func cleanupOrphanExposureClassHandlerResources(ctx context.Context, c client.Client, exposureClassHandlers []config.ExposureClassHandler, logger *logrus.Entry) error {
+	exposureClassHandlerNamespaces := &corev1.NamespaceList{}
+
+	if err := c.List(ctx, exposureClassHandlerNamespaces, client.MatchingLabels{v1alpha1constants.GardenRole: v1alpha1constants.GardenRoleExposureClassHandler}); err != nil {
+		return err
+	}
+
+	for _, namespace := range exposureClassHandlerNamespaces.Items {
+		var exposureClassHandlerExists bool
+		for _, handler := range exposureClassHandlers {
+			if *handler.SNI.Ingress.Namespace == namespace.Name {
+				exposureClassHandlerExists = true
+				break
+			}
+		}
+		if exposureClassHandlerExists {
+			continue
+		}
+		logger.Infof("Namespace %q is orphan as there is no ExposureClass handler in the gardenlet configuration anymore", namespace.Name)
+
+		// Determine the corresponding handler name to the ExposureClass handler resources.
+		handlerName, ok := namespace.Labels[v1alpha1constants.LabelExposureClassHandlerName]
+		if !ok {
+			logger.Info("Cannot delete ExposureClass handler resources as the corresponging handler is unknown and it is not save to remove them")
+			continue
+		}
+
+		gatewayList := istiov1beta1.GatewayList{}
+		if err := c.List(ctx, &gatewayList); err != nil {
+			return err
+		}
+
+		var exposureClassHandlerInUse bool
+		for _, gateway := range gatewayList.Items {
+			if gateway.Name != v1beta1constants.DeploymentNameKubeAPIServer && gateway.Name != v1beta1constants.DeploymentNameVPNSeedServer {
+				continue
+			}
+			// Check if the gateway still selects the ExposureClass handler ingress gateway.
+			if value, ok := gateway.Spec.Selector[v1alpha1constants.LabelExposureClassHandlerName]; ok && value == handlerName {
+				exposureClassHandlerInUse = true
+				break
+			}
+		}
+		if exposureClassHandlerInUse {
+			logger.Infof("Resources of ExposureClass handler %q in namespace %q cannot be deleted as they are still in use", handlerName, namespace.Name)
+			continue
+		}
+
+		// ExposureClass handler is orphan and not used by any Shoots anymore
+		// therefore it is save to clean it up.
+		logger.Infof("Delete orphan ExposureClass handler namespace %q", namespace.Name)
+		if err := c.Delete(ctx, &namespace); client.IgnoreNotFound(err) != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/pkg/utils/gardener/exposureclass.go
+++ b/pkg/utils/gardener/exposureclass.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gardener
+
+import (
+	v1alpha1constants "github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
+	"github.com/gardener/gardener/pkg/utils"
+)
+
+// GetMandatoryExposureClassHandlerSNILabels get the labels of an ExposureClass Handler plus its name
+// and will add the mandatory SNI labels for ExposureClass handlers to it.
+// Existing label keys will be overridden by the mandatory labels keys.
+func GetMandatoryExposureClassHandlerSNILabels(labels map[string]string, exposureClassName string) map[string]string {
+	return utils.MergeStringMaps(labels, map[string]string{
+		v1beta1constants.LabelApp:                       gardenletconfigv1alpha1.DefaultIngressGatewayAppLabelValue,
+		v1alpha1constants.GardenRole:                    v1alpha1constants.GardenRoleExposureClassHandler,
+		v1alpha1constants.LabelExposureClassHandlerName: exposureClassName,
+	})
+}

--- a/pkg/utils/gardener/exposureclass_test.go
+++ b/pkg/utils/gardener/exposureclass_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gardener_test
+
+import (
+	. "github.com/gardener/gardener/pkg/utils/gardener"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ExposureClass", func() {
+	DescribeTable("#GetMandatoryExposureClassHandlerSNILabels",
+		func(name string, labels, expectedLabels map[string]string) {
+			Expect(GetMandatoryExposureClassHandlerSNILabels(labels, name)).To(Equal(expectedLabels))
+		},
+
+		Entry("target labels contain only mandatory labels as source labels are empty", "test1", map[string]string{}, map[string]string{
+			"app":                 "istio-ingressgateway",
+			"gardener.cloud/role": "exposureclass-handler",
+			"handler.exposureclass.gardener.cloud/name": "test1",
+		}),
+		Entry("target labels contain source and mandatory labels", "test2", map[string]string{
+			"gardener": "test2",
+		}, map[string]string{
+			"gardener":            "test2",
+			"app":                 "istio-ingressgateway",
+			"gardener.cloud/role": "exposureclass-handler",
+			"handler.exposureclass.gardener.cloud/name": "test2",
+		}),
+		Entry("source label should be overriden by mandatory label", "test3", map[string]string{
+			"app": "test3",
+		}, map[string]string{
+			"app":                 "istio-ingressgateway",
+			"gardener.cloud/role": "exposureclass-handler",
+			"handler.exposureclass.gardener.cloud/name": "test3",
+		}),
+	)
+})


### PR DESCRIPTION
**How to categorize this PR?**
/area control-plane open-source
/kind api-change enhancement

**What this PR does / why we need it**:
This PR implements the  step 3 of the [Selectable Api Server endpoint story](https://github.com/gardener/gardener/issues/3505). This story will be implemented in several steps, see: https://github.com/gardener/gardener/issues/3505#issuecomment-821118819 The previous PR can be found here: https://github.com/gardener/gardener/pull/3951

This PR integrates the `ExposureClass` resource with the SNI feature.

Please check the [implementation proposal](https://github.com/gardener/gardener/issues/3505#issuecomment-795656500) for more details.

In detail this PR adds the following:
- During the Seed bootstrap there will be, for each ExposureClass handler specified in the Gardenlet configuration, a dedicated istio ingress gateway deployed to the managed Seeds of the respective Gardenlet
- The istio resources of a Shoot controlplane will select the ingress gateway of the ExposureClass handler if the Shoot has a matching ExposureClass assigned
- ExposureClass handler ingress gateway resources which are not in the Gardenlet configuration and not used by Shoots anymore will be removed

**Note:** Referencing an `ExposureClass` in Shoot resources  via `.spec.exposureClassName` is temporarily disabled via validation. This will be enabled again when the implementation of the story has been completed.

**Which issue(s) this PR fixes**:
Step 3 of https://github.com/gardener/gardener/issues/3505

**Special notes for your reviewer**:
I will open it as draft as I run some final tests.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```NONE

```
