### PR TITLE
add missing clusterrole permissions

### DIFF
--- a/charts/shoot-core/components/charts/coredns/templates/coredns-rbac.yaml
+++ b/charts/shoot-core/components/charts/coredns/templates/coredns-rbac.yaml
@@ -19,6 +19,13 @@ rules:
   - nodes
   verbs:
   - get
+- apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - list
+  - watch
 ---
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRoleBinding


### PR DESCRIPTION
**How to categorize this PR?**

/area networking
/kind bug

**What this PR does / why we need it**:
Add missing permissions for coredns servicediscovery to clusterrole.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
none
```
