### PR TITLE
[CPM Integration Tests] Adding support for hibernated shoots

### DIFF
--- a/test/framework/shootmigrationtest.go
+++ b/test/framework/shootmigrationtest.go
@@ -119,6 +119,10 @@ func (t *ShootMigrationTest) MigrateShoot(ctx context.Context) error {
 
 // GetNodeNames uses the shootClient to fetch all Node names from the Shoot
 func (t *ShootMigrationTest) GetNodeNames(ctx context.Context, shootClient kubernetes.Interface) (nodeNames []string, err error) {
+	if t.Shoot.Status.IsHibernated {
+		return make([]string, 0), nil // Initialize to empty slice in order pass 0 elements DeepEqual check
+	}
+
 	nodeList := corev1.NodeList{}
 	t.GardenerFramework.Logger.Infof("Getting node names...")
 	if err := shootClient.Client().List(ctx, &nodeList); err != nil {
@@ -166,6 +170,7 @@ func (t *ShootMigrationTest) PopulateBeforeMigrationComparisonElements(ctx conte
 		return
 	}
 	t.ComparisonElementsBeforeMigration.NodeNames, err = t.GetNodeNames(ctx, t.ShootClient)
+
 	return
 }
 
@@ -176,6 +181,7 @@ func (t *ShootMigrationTest) PopulateAfterMigrationComparisonElements(ctx contex
 		return
 	}
 	t.ComparisonElementsAfterMigration.NodeNames, err = t.GetNodeNames(ctx, t.ShootClient)
+
 	return
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind test

**What this PR does / why we need it**:
This PR skips the parts of the integration tests for control plane migration that are not applicable for shoots that are hibernated. This parts are:
1. Creating a client that connects to the shoot.
1. Creation / Deletion of `Secrets` and `ServiceAccount`.
1. `Nodes` comparison.
1. Deploying `Guest Book Application`.

The CPM IT will still check for successful migration and non - namespaced orphaned resources. It will also fetch the `Machines` that if everything is as expected should not exist.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
