### PR TITLE
Fix Bastion CRDs

### DIFF
--- a/hack/api-reference/extensions.md
+++ b/hack/api-reference/extensions.md
@@ -331,7 +331,7 @@ Kubernetes meta/v1.ObjectMeta
 </em>
 </td>
 <td>
-<p>Standard object metadata.</p>
+<em>(Optional)</em>
 Refer to the Kubernetes API documentation for the fields of the
 <code>metadata</code> field.
 </td>

--- a/pkg/apis/extensions/v1alpha1/types_bastion.go
+++ b/pkg/apis/extensions/v1alpha1/types_bastion.go
@@ -37,7 +37,7 @@ const BastionResource = "Bastion"
 // to provide SSH access to shoot nodes.
 type Bastion struct {
 	metav1.TypeMeta `json:",inline"`
-	// Standard object metadata.
+	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// Spec is the specification of this Bastion.
 	Spec BastionSpec `json:"spec"`


### PR DESCRIPTION
**How to categorize this PR?**
/area ops-productivity
/kind bug

**What this PR does / why we need it**:
Metadata is a field which must not be documented. This is not a release-note worthy change, as the CRD in the bootstrap Helm chart was functioning.

**Which issue(s) this PR fixes**:
Fixes #4114

**Special notes for your reviewer**:

**Release note**:
```other operator
NONE
```
