### PR TITLE
Send logs of deleted shoots to the central Loki instance

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -216,7 +216,7 @@ images:
 - name: fluent-bit-plugin-installer
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/fluent-bit-to-loki
-  tag: "v0.34.0"
+  tag: "v0.35.0"
 - name: loki
   sourceRepository: github.com/grafana/loki
   repository: grafana/loki
@@ -224,7 +224,7 @@ images:
 - name: loki-curator
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/loki-curator
-  tag: "v0.34.0"
+  tag: "v0.35.0"
 
 # VPA
 - name: vpa-admission-controller

--- a/charts/seed-bootstrap/charts/fluent-bit/templates/_fluent-bit-config.tpl
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/_fluent-bit-config.tpl
@@ -93,7 +93,7 @@
         Match kubernetes.*
         Url http://loki.garden.svc:3100/loki/api/v1/push
         LogLevel info
-        BatchWait 40
+        BatchWait 40s
         BatchSize 30720
         Labels {test="fluent-bit-go"}
         LineFormat json
@@ -108,8 +108,8 @@
         DynamicHostSuffix .svc:3100/loki/api/v1/push
         DynamicHostRegex ^shoot-
         MaxRetries 3
-        Timeout 10
-        MinBackoff 30
+        Timeout 10s
+        MinBackoff 30s
         Buffer true
         BufferType dque
         QueueDir  /fluent-bit/buffers/operator
@@ -119,7 +119,9 @@
         FallbackToTagWhenMetadataIsMissing true
         TagKey tag
         DropLogEntryWithoutK8sMetadata true
-        ControllerSyncTimeout 120
+        SendDeletedClustersLogsToDefaultClient true
+        CleanExpiredClientsPeriod 1h
+        ControllerSyncTimeout 120s
         NumberOfBatchIDs 5
         TenantID operator
     
@@ -128,7 +130,7 @@
         Match {{ .Values.exposedComponentsTagPrefix }}.kubernetes.*
         Url http://loki.garden.svc:3100/loki/api/v1/push
         LogLevel info
-        BatchWait 40
+        BatchWait 40s
         BatchSize 30720
         Labels {test="fluent-bit-go", lang="Golang"}
         LineFormat json
@@ -143,8 +145,8 @@
         DynamicHostSuffix .svc:3100/loki/api/v1/push
         DynamicHostRegex ^shoot-
         MaxRetries 3
-        Timeout 10
-        MinBackoff 30
+        Timeout 10s
+        MinBackoff 30s
         Buffer true
         BufferType dque
         QueueDir  /fluent-bit/buffers/user
@@ -154,7 +156,7 @@
         FallbackToTagWhenMetadataIsMissing true
         TagKey tag
         DropLogEntryWithoutK8sMetadata true
-        ControllerSyncTimeout 120
+        ControllerSyncTimeout 120s
         NumberOfBatchIDs 5
         TenantID user
 
@@ -163,7 +165,7 @@
         Match journald.*
         Url http://loki.garden.svc:3100/loki/api/v1/push
         LogLevel info
-        BatchWait 60
+        BatchWait 60s
         BatchSize 30720
         Labels {test="fluent-bit-go"}
         LineFormat json
@@ -172,8 +174,8 @@
         RemoveKeys kubernetes,stream,hostname,unit
         LabelMapPath /fluent-bit/etc/systemd_label_map.json
         MaxRetries 3
-        Timeout 10
-        MinBackoff 30
+        Timeout 10s
+        MinBackoff 30s
         Buffer true
         BufferType dque
         QueueDir  /fluent-bit/buffers


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
With this PR when a Shoot is marked for deletion the logs from its components will be sent to the garden/loki-0 instance.
Time period based settings like `Timeout`, `MinBackoff`, etc. now include the time measure unit(seconds, minutes ...).

**Which issue(s) this PR fixes**:
Fixes [#3552](https://github.com/gardener/gardener/issues/3552)

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Logs from Shoots in deletion phase are kept in the Loki instance in the garden namespace. 
```
```other operator
All time period based settings now include the measure unit
```