### PR TITLE
Fix the containerd integration test

### DIFF
--- a/test/integration/shoots/operations/containerruntime.go
+++ b/test/integration/shoots/operations/containerruntime.go
@@ -107,12 +107,12 @@ var _ = Describe("Shoot container runtime testing", func() {
 		containerdServiceCommand := fmt.Sprintf("systemctl is-active %s", "containerd")
 		executeCommand(ctx, rootPodExecutor, containerdServiceCommand, "active")
 
-		// check that confitoml is configured
-		checkConfigurationCommand := "cat /etc/systemd/system/containerd.service.d/11-exec_conficonf | grep 'usr/bin/containerd --config=/etc/containerd/confitoml' |  echo $?"
+		// check that config.toml is configured
+		checkConfigurationCommand := "cat /etc/systemd/system/containerd.service.d/11-exec_config.conf | grep 'usr/bin/containerd --config=/etc/containerd/config.toml' |  echo $?"
 		executeCommand(ctx, rootPodExecutor, checkConfigurationCommand, "0")
 
-		// check that confitoml exists
-		checkConfigCommand := "[ -f /etc/containerd/confitoml ] && echo 'found' || echo 'Not found'"
+		// check that config.toml exists
+		checkConfigCommand := "[ -f /etc/containerd/config.toml ] && echo 'found' || echo 'Not found'"
 		executeCommand(ctx, rootPodExecutor, checkConfigCommand, "found")
 	}, scaleWorkerTimeout)
 })


### PR DESCRIPTION
/area testing
/kind bug
/kind regression

https://github.com/gardener/gardener/pull/4098 does some unwanted things with the containerd integration test.

Fixes https://github.com/gardener/gardener/issues/4135

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
