### PR TITLE
Allow edit/explore in Grafana without login

### DIFF
--- a/charts/seed-bootstrap/templates/grafana/grafana-deployment.yaml
+++ b/charts/seed-bootstrap/templates/grafana/grafana-deployment.yaml
@@ -37,6 +37,8 @@ spec:
           value: "false"
         - name: GF_AUTH_ANONYMOUS_ENABLED
           value: "true"
+        - name: GF_USERS_VIEWERS_CAN_EDIT
+          value: "true"
         - name: GF_SNAPSHOTS_EXTERNAL_ENABLED
           value: "false"
         - name: GF_ALERTING_ENABLED

--- a/charts/seed-monitoring/charts/grafana/templates/grafana-deployment.yaml
+++ b/charts/seed-monitoring/charts/grafana/templates/grafana-deployment.yaml
@@ -43,6 +43,8 @@ spec:
           value: "true"
         - name: GF_AUTH_DISABLE_LOGIN_FORM
           value: "false"
+        - name: GF_USERS_VIEWERS_CAN_EDIT
+          value: "true"
 {{- else }}
         - name: GF_AUTH_BASIC_ENABLED
           value: "false"

--- a/docs/usage/logging.md
+++ b/docs/usage/logging.md
@@ -11,9 +11,11 @@ Kubernetes uses the underlying container runtime logging, which does not persist
 * One Grafana Deployment in `garden` namespace and two Deployments per shoot namespace (one exposed to the end users and one for the operators). Grafana is the UI component used in the logging stack.
 
 ### How to access the logs
-The first step is to authenticate in front of the Grafana ingress. The secret with the credentials can be found in garden-<project> namespace under <shoot-name>.monitoring.
-Logs are accessible via Grafana UI. Its URL can be found in the `Logging and Monitoring` section of a cluster in the Gardener Dashboard. There are two methods to explore logs: 
-* The first one is to log in in the admin panel located in bottom left corner. The default username and password are `admin`, `admin`. After successful log in, you will be asked to change the default password. **These credentials are shared by all operators. If you change the password this will affect their access.** After that, a new `Explore` menu will be available at the left side of the screen. It is used for creating log queries using the predefined filters in Loki. For example: 
+The first step is to authenticate in front of the Grafana ingress. The secret with the credentials can be found in `garden-<project>` namespace under `<shoot-name>.monitoring`.
+Logs are accessible via Grafana UI. Its URL can be found in the `Logging and Monitoring` section of a cluster in the Gardener Dashboard.
+
+There are two methods to explore logs:
+* The first option is to use the `Explore` view (available at the left side of the screen). It is used for creating log queries using the predefined filters in Loki. For example: 
 `{pod_name='prometheus-0'}`
 or with regex:
 `{pod_name=~'prometheus.+'}`


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity monitoring logging
/kind enhancement

**What this PR does / why we need it**:

This PR sets Grafana's `viewers_can_edit` configuration option to `true` in the `grafana-operators` deployment to allow operators to temporarily edit dashboards and use the explore feature more easily. This allows to freely browse any available metrics and logs without having to click through the login dialog and entering the default credentials (basic auth via Ingress is still enabled).

From the [Grafana docs](https://grafana.com/docs/grafana/latest/administration/configuration/#viewers_can_edit):

> **viewers_can_edit**
Viewers can access and use Explore and perform temporary edits on panels in dashboards they have access to. They cannot save their changes. Default is false.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/invite @wyb1 @istvanballok @Kristian-ZH @vlvasilev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Operators can now easily browse all available metrics and logs via Grafana's Explore view without logging into Grafana explicitly (basic auth via Ingress is still enabled).
```