### PR TITLE
Fix `make install`

### DIFF
--- a/pkg/apis/operations/v1alpha1/conversions.go
+++ b/pkg/apis/operations/v1alpha1/conversions.go
@@ -15,7 +15,7 @@
 package v1alpha1
 
 import (
-	fmt "fmt"
+	"fmt"
 
 	"github.com/gardener/gardener/pkg/apis/operations"
 

--- a/pkg/gardenlet/controller/bastion/bastion_reconciler.go
+++ b/pkg/gardenlet/controller/bastion/bastion_reconciler.go
@@ -165,14 +165,12 @@ func (r *reconciler) reconcileBastion(
 	}
 
 	// wait for the extension controller to reconcile possible changes
-	if err := extensions.WaitUntilExtensionCRReady(
+	if err := extensions.WaitUntilExtensionObjectReady(
 		ctx,
 		seedClient,
 		logger,
-		func() client.Object { return &extensionsv1alpha1.Bastion{} },
+		extBastion,
 		extensionsv1alpha1.BastionResource,
-		extBastion.Namespace,
-		extBastion.Name,
 		defaultInterval,
 		defaultSevereThreshold,
 		defaultTimeout,


### PR DESCRIPTION
/kind bug

```
$ make install
# github.com/gardener/gardener/pkg/gardenlet/controller/bastion
pkg/gardenlet/controller/bastion/bastion_reconciler.go:168:12: undefined: extensions.WaitUntilExtensionCRReady
make: *** [install] Error 2
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
