### PR TITLE
CreateAnd*Patch now GETs the object if it already exists

### DIFF
--- a/pkg/controllerutils/patch.go
+++ b/pkg/controllerutils/patch.go
@@ -30,9 +30,7 @@ import (
 //
 // It returns the executed operation and an error.
 func GetAndCreateOrMergePatch(ctx context.Context, c client.Client, obj client.Object, f controllerutil.MutateFn) (controllerutil.OperationResult, error) {
-	return getAndCreateOrPatch(ctx, c, obj, func(obj client.Object) client.Patch {
-		return client.MergeFrom(obj)
-	}, f)
+	return getAndCreateOrPatch(ctx, c, obj, func(obj client.Object) client.Patch { return client.MergeFrom(obj) }, f)
 }
 
 // GetAndCreateOrStrategicMergePatch is similar to controllerutil.CreateOrPatch, but does not care about the object's status section.
@@ -43,9 +41,7 @@ func GetAndCreateOrMergePatch(ctx context.Context, c client.Client, obj client.O
 //
 // It returns the executed operation and an error.
 func GetAndCreateOrStrategicMergePatch(ctx context.Context, c client.Client, obj client.Object, f controllerutil.MutateFn) (controllerutil.OperationResult, error) {
-	return getAndCreateOrPatch(ctx, c, obj, func(obj client.Object) client.Patch {
-		return client.StrategicMergeFrom(obj)
-	}, f)
+	return getAndCreateOrPatch(ctx, c, obj, func(obj client.Object) client.Patch { return client.StrategicMergeFrom(obj) }, f)
 }
 
 func getAndCreateOrPatch(ctx context.Context, c client.Client, obj client.Object, patchFunc func(client.Object) client.Patch, f controllerutil.MutateFn) (controllerutil.OperationResult, error) {
@@ -74,33 +70,25 @@ func getAndCreateOrPatch(ctx context.Context, c client.Client, obj client.Object
 	return controllerutil.OperationResultUpdated, nil
 }
 
-// CreateOrMergePatch creates or patches (using a merge patch) the given object in the Kubernetes cluster.
-// The object's desired state is only reconciled with the existing state inside the passed in callback MutateFn,
-// however, the object is not read from the client. This means the object should already be filled with the
-// last-known state if operating on more complex structures (e.g. if the patch is supposed to remove an optional field
-// or section).
+// CreateOrGetAndMergePatch creates or gets and patches (using a merge patch) the given object in the Kubernetes cluster.
 //
 // The MutateFn is called regardless of creating or patching an object.
 //
 // It returns the executed operation and an error.
-func CreateOrMergePatch(ctx context.Context, c client.Writer, obj client.Object, f controllerutil.MutateFn) (controllerutil.OperationResult, error) {
-	return createOrPatch(ctx, c, obj, func(obj client.Object) client.Patch { return client.MergeFrom(obj) }, f)
+func CreateOrGetAndMergePatch(ctx context.Context, c client.Client, obj client.Object, f controllerutil.MutateFn) (controllerutil.OperationResult, error) {
+	return createOrGetAndPatch(ctx, c, obj, func(obj client.Object) client.Patch { return client.MergeFrom(obj) }, f)
 }
 
-// CreateOrStrategicMergePatch creates or patches (using a strategic merge patch) the given object in the Kubernetes cluster.
-// The object's desired state is only reconciled with the existing state inside the passed in callback MutateFn,
-// however, the object is not read from the client. This means the object should already be filled with the
-// last-known state if operating on more complex structures (e.g. if the patch is supposed to remove an optional field
-// or section).
+// CreateOrGetAndStrategicMergePatch creates or gets and patches (using a strategic merge patch) the given object in the Kubernetes cluster.
 //
 // The MutateFn is called regardless of creating or patching an object.
 //
 // It returns the executed operation and an error.
-func CreateOrStrategicMergePatch(ctx context.Context, c client.Writer, obj client.Object, f controllerutil.MutateFn) (controllerutil.OperationResult, error) {
-	return createOrPatch(ctx, c, obj, func(obj client.Object) client.Patch { return client.StrategicMergeFrom(obj) }, f)
+func CreateOrGetAndStrategicMergePatch(ctx context.Context, c client.Client, obj client.Object, f controllerutil.MutateFn) (controllerutil.OperationResult, error) {
+	return createOrGetAndPatch(ctx, c, obj, func(obj client.Object) client.Patch { return client.StrategicMergeFrom(obj) }, f)
 }
 
-func createOrPatch(ctx context.Context, c client.Writer, obj client.Object, patchFunc func(client.Object) client.Patch, f controllerutil.MutateFn) (controllerutil.OperationResult, error) {
+func createOrGetAndPatch(ctx context.Context, c client.Client, obj client.Object, patchFunc func(client.Object) client.Patch, f controllerutil.MutateFn) (controllerutil.OperationResult, error) {
 	patch := patchFunc(obj.DeepCopyObject().(client.Object))
 
 	if err := f(); err != nil {
@@ -110,6 +98,14 @@ func createOrPatch(ctx context.Context, c client.Writer, obj client.Object, patc
 	if err := c.Create(ctx, obj); err != nil {
 		if !apierrors.IsAlreadyExists(err) {
 			return controllerutil.OperationResultNone, err
+		}
+
+		if err2 := c.Get(ctx, client.ObjectKeyFromObject(obj), obj); err2 != nil {
+			return controllerutil.OperationResultNone, err2
+		}
+
+		if err2 := f(); err2 != nil {
+			return controllerutil.OperationResultNone, err2
 		}
 
 		if err2 := c.Patch(ctx, obj, patch); err2 != nil {

--- a/pkg/controllerutils/patch.go
+++ b/pkg/controllerutils/patch.go
@@ -17,6 +17,8 @@ package controllerutils
 import (
 	"context"
 
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -89,7 +91,15 @@ func CreateOrGetAndStrategicMergePatch(ctx context.Context, c client.Client, obj
 }
 
 func createOrGetAndPatch(ctx context.Context, c client.Client, obj client.Object, patchFunc func(client.Object) client.Patch, f controllerutil.MutateFn) (controllerutil.OperationResult, error) {
-	patch := patchFunc(obj.DeepCopyObject().(client.Object))
+	var (
+		namespace = obj.GetNamespace()
+		name      = obj.GetName()
+	)
+
+	resetObj, err := kutil.CreateResetObjectFunc(obj, c.Scheme())
+	if err != nil {
+		return controllerutil.OperationResultNone, err
+	}
 
 	if err := f(); err != nil {
 		return controllerutil.OperationResultNone, err
@@ -100,9 +110,15 @@ func createOrGetAndPatch(ctx context.Context, c client.Client, obj client.Object
 			return controllerutil.OperationResultNone, err
 		}
 
+		resetObj()
+		obj.SetNamespace(namespace)
+		obj.SetName(name)
+
 		if err2 := c.Get(ctx, client.ObjectKeyFromObject(obj), obj); err2 != nil {
 			return controllerutil.OperationResultNone, err2
 		}
+
+		patch := patchFunc(obj.DeepCopyObject().(client.Object))
 
 		if err2 := f(); err2 != nil {
 			return controllerutil.OperationResultNone, err2

--- a/pkg/controllerutils/patch_test.go
+++ b/pkg/controllerutils/patch_test.go
@@ -209,6 +209,8 @@ var _ = Describe("Patch", func() {
 				gomock.InOrder(
 					c.EXPECT().Create(ctx, obj).Return(apierrors.NewAlreadyExists(schema.GroupResource{}, "")),
 					c.EXPECT().Get(ctx, client.ObjectKeyFromObject(obj), obj).DoAndReturn(func(_ context.Context, _ client.ObjectKey, objToReturn *corev1.ServiceAccount) error {
+						Expect(obj.GetLabels()).To(BeEmpty(), "object should be reset before getting it again")
+
 						obj.DeepCopyInto(objToReturn)
 						return nil
 					}),

--- a/pkg/controllerutils/patch_test.go
+++ b/pkg/controllerutils/patch_test.go
@@ -24,8 +24,10 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	corescheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -39,15 +41,21 @@ var _ = Describe("Patch", func() {
 		ctx     = context.TODO()
 		fakeErr = fmt.Errorf("fake err")
 
-		ctrl *gomock.Controller
-		c    *mockclient.MockClient
-		obj  *corev1.ServiceAccount
+		ctrl   *gomock.Controller
+		c      *mockclient.MockClient
+		scheme *runtime.Scheme
+		obj    *corev1.ServiceAccount
 	)
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		c = mockclient.NewMockClient(ctrl)
 		obj = &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "foo", Namespace: "bar"}}
+
+		scheme = runtime.NewScheme()
+		Expect(corescheme.AddToScheme(scheme)).NotTo(HaveOccurred())
+
+		c.EXPECT().Scheme().Return(scheme).AnyTimes()
 	})
 
 	AfterEach(func() {

--- a/pkg/gardenlet/bootstrap/util/util.go
+++ b/pkg/gardenlet/bootstrap/util/util.go
@@ -227,7 +227,7 @@ func ComputeGardenletKubeconfigWithServiceAccountToken(ctx context.Context, gard
 			Namespace: serviceAccountNamespace,
 		},
 	}
-	if _, err := controllerutils.CreateOrStrategicMergePatch(ctx, gardenClient, sa, func() error { return nil }); err != nil {
+	if _, err := controllerutils.CreateOrGetAndStrategicMergePatch(ctx, gardenClient, sa, func() error { return nil }); err != nil {
 		return nil, err
 	}
 
@@ -246,7 +246,7 @@ func ComputeGardenletKubeconfigWithServiceAccountToken(ctx context.Context, gard
 			Name: ClusterRoleBindingName(sa.Namespace, sa.Name),
 		},
 	}
-	if _, err := controllerutils.CreateOrStrategicMergePatch(ctx, gardenClient, clusterRoleBinding, func() error {
+	if _, err := controllerutils.CreateOrGetAndStrategicMergePatch(ctx, gardenClient, clusterRoleBinding, func() error {
 		clusterRoleBinding.RoleRef = rbacv1.RoleRef{
 			APIGroup: rbacv1.GroupName,
 			Kind:     "ClusterRole",

--- a/pkg/gardenlet/bootstrap/util/util_test.go
+++ b/pkg/gardenlet/bootstrap/util/util_test.go
@@ -86,6 +86,8 @@ var _ = Describe("Util", func() {
 		BeforeEach(func() {
 			ctrl = gomock.NewController(GinkgoT())
 			c = mockclient.NewMockClient(ctrl)
+
+			c.EXPECT().Scheme().Return(kubernetes.GardenScheme).AnyTimes()
 		})
 
 		AfterEach(func() {

--- a/pkg/gardenlet/controller/managedseed/managedseed_actuator.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_actuator.go
@@ -302,7 +302,7 @@ func (a *actuator) createOrUpdateSeed(ctx context.Context, managedSeed *seedmana
 			Name: managedSeed.Name,
 		},
 	}
-	_, err := controllerutils.CreateOrStrategicMergePatch(ctx, a.gardenClient.Client(), seed, func() error {
+	_, err := controllerutils.CreateOrGetAndStrategicMergePatch(ctx, a.gardenClient.Client(), seed, func() error {
 		seed.OwnerReferences = []metav1.OwnerReference{
 			*metav1.NewControllerRef(managedSeed, seedmanagementv1alpha1.SchemeGroupVersion.WithKind("ManagedSeed")),
 		}
@@ -451,7 +451,7 @@ func (a *actuator) createOrUpdateSeedSecrets(ctx context.Context, spec *gardenco
 			secret := &corev1.Secret{
 				ObjectMeta: kutil.ObjectMeta(spec.Backup.SecretRef.Namespace, spec.Backup.SecretRef.Name),
 			}
-			if _, err := controllerutils.CreateOrStrategicMergePatch(ctx, a.gardenClient.Client(), secret, func() error {
+			if _, err := controllerutils.CreateOrGetAndStrategicMergePatch(ctx, a.gardenClient.Client(), secret, func() error {
 				secret.OwnerReferences = []metav1.OwnerReference{
 					*metav1.NewControllerRef(managedSeed, seedmanagementv1alpha1.SchemeGroupVersion.WithKind("ManagedSeed")),
 				}
@@ -480,7 +480,7 @@ func (a *actuator) createOrUpdateSeedSecrets(ctx context.Context, spec *gardenco
 		secret := &corev1.Secret{
 			ObjectMeta: kutil.ObjectMeta(spec.SecretRef.Namespace, spec.SecretRef.Name),
 		}
-		if _, err := controllerutils.CreateOrStrategicMergePatch(ctx, a.gardenClient.Client(), secret, func() error {
+		if _, err := controllerutils.CreateOrGetAndStrategicMergePatch(ctx, a.gardenClient.Client(), secret, func() error {
 			secret.OwnerReferences = []metav1.OwnerReference{
 				*metav1.NewControllerRef(managedSeed, seedmanagementv1alpha1.SchemeGroupVersion.WithKind("ManagedSeed")),
 			}

--- a/pkg/gardenlet/controller/managedseed/managedseed_actuator_test.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_actuator_test.go
@@ -583,6 +583,7 @@ var _ = Describe("Actuator", func() {
 		BeforeEach(func() {
 			clientMap.EXPECT().GetClient(ctx, keys.ForShoot(shoot)).Return(shootClient, nil).AnyTimes()
 			clientMap.EXPECT().GetClient(ctx, keys.ForSeedWithName(seedName)).Return(seedClient, nil).AnyTimes()
+			gc.EXPECT().Scheme().Return(kubernetes.GardenScheme).AnyTimes()
 		})
 
 		It("should wait if the Shoot is still reconciling", func() {

--- a/pkg/gardenlet/controller/seed/seed_control.go
+++ b/pkg/gardenlet/controller/seed/seed_control.go
@@ -420,7 +420,7 @@ func deployBackupBucketInGarden(ctx context.Context, k8sGardenClient client.Clie
 
 	ownerRef := metav1.NewControllerRef(seed, gardencorev1beta1.SchemeGroupVersion.WithKind("Seed"))
 
-	_, err := controllerutils.CreateOrStrategicMergePatch(ctx, k8sGardenClient, backupBucket, func() error {
+	_, err := controllerutils.CreateOrGetAndStrategicMergePatch(ctx, k8sGardenClient, backupBucket, func() error {
 		backupBucket.OwnerReferences = []metav1.OwnerReference{*ownerRef}
 		backupBucket.Spec = gardencorev1beta1.BackupBucketSpec{
 			Provider: gardencorev1beta1.BackupBucketProvider{

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -345,7 +345,7 @@ func (b *Botanist) SyncShootCredentialsToGarden(ctx context.Context) error {
 				},
 			}
 
-			_, err := controllerutils.CreateOrStrategicMergePatch(ctx, b.K8sGardenClient.Client(), secretObj, func() error {
+			_, err := controllerutils.CreateOrGetAndStrategicMergePatch(ctx, b.K8sGardenClient.Client(), secretObj, func() error {
 				secretObj.OwnerReferences = []metav1.OwnerReference{
 					*metav1.NewControllerRef(b.Shoot.Info, gardencorev1beta1.SchemeGroupVersion.WithKind("Shoot")),
 				}

--- a/pkg/utils/kubernetes/object.go
+++ b/pkg/utils/kubernetes/object.go
@@ -16,12 +16,14 @@ package kubernetes
 
 import (
 	"context"
+	"reflect"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
 	"github.com/gardener/gardener/pkg/utils/flow"
 )
@@ -81,4 +83,29 @@ func IsNamespaceInUse(ctx context.Context, reader client.Reader, namespace strin
 	}
 
 	return len(objects.Items) > 0, nil
+}
+
+// CreateResetObjectFunc creates a func that will reset the given object to a new empty object every time the func is called.
+// This is useful for resetting an in-memory object before re-getting it from the API server / cache
+// to avoid executing checks on stale/removed object data e.g. annotations/lastError
+// (json decoder does not unset fields in the in-memory object that are unset in the API server's response)
+func CreateResetObjectFunc(obj runtime.Object, scheme *runtime.Scheme) (func(), error) {
+	gvk, err := apiutil.GVKForObject(obj, scheme)
+	if err != nil {
+		return nil, err
+	}
+	emptyObj, err := scheme.New(gvk)
+	if err != nil {
+		return nil, err
+	}
+	return func() {
+		deepCopyIntoObject(obj, emptyObj)
+	}, nil
+}
+
+// deepCopyIntoObject deep copies src into dest.
+// This is a workaround for runtime.Object's lack of a DeepCopyInto method, similar to what the c-r cache does:
+// https://github.com/kubernetes-sigs/controller-runtime/blob/55a329c15d6b4f91a9ff072fed6f6f05ff3339e7/pkg/cache/internal/cache_reader.go#L85-L90
+func deepCopyIntoObject(dest, src runtime.Object) {
+	reflect.ValueOf(dest).Elem().Set(reflect.ValueOf(src.DeepCopyObject()).Elem())
 }

--- a/pkg/utils/kubernetes/object_test.go
+++ b/pkg/utils/kubernetes/object_test.go
@@ -177,4 +177,34 @@ var _ = Describe("Object", func() {
 			Expect(inUse).To(BeFalse())
 		})
 	})
+
+	Describe("#CreateResetObjectFunc", func() {
+		var (
+			obj = &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "non-empty-sa",
+				},
+			}
+			objCopy = obj.DeepCopy()
+		)
+
+		It("should fail because the GVK for the object cannot be determined", func() {
+			f, err := CreateResetObjectFunc(obj, runtime.NewScheme())
+			Expect(f).To(BeNil())
+			Expect(runtime.IsNotRegisteredError(err)).To(BeTrue())
+			Expect(obj).To(Equal(objCopy))
+		})
+
+		It("should return a function that allows resets an object", func() {
+			scheme := runtime.NewScheme()
+			Expect(corev1.AddToScheme(scheme)).To(Succeed())
+
+			f, err := CreateResetObjectFunc(obj, scheme)
+			Expect(f).NotTo(BeNil())
+			Expect(err).NotTo(HaveOccurred())
+
+			f()
+			Expect(obj).To(Equal(&corev1.ServiceAccount{}))
+		})
+	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind task

**What this PR does / why we need it**:
As discussed in https://github.com/gardener/gardener/pull/4027#issuecomment-851942595 and ff.

/invite @timebertt 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
