### PR TITLE
Allow to disable ClusterRole{Binding} for global gardenlet access

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/clusterrole-seeds.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/clusterrole-seeds.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.global.rbac.seedAuthorizer.enabled }}
 ---
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
@@ -10,3 +11,4 @@ rules:
   - '*'
   verbs:
   - '*'
+{{- end }}

--- a/charts/gardener/controlplane/charts/application/templates/clusterrolebinding-seeds.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/clusterrolebinding-seeds.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.global.rbac.seedAuthorizer.enabled }}
 ---
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRoleBinding
@@ -11,3 +12,4 @@ subjects:
 - kind: Group
   name: gardener.cloud:system:seeds
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/gardener/controlplane/values.yaml
+++ b/charts/gardener/controlplane/values.yaml
@@ -254,6 +254,7 @@ global:
  #      truncateMaxEventSize: 102400
  #      version: audit.k8s.io/v1
  #  clusterIdentity: garden-cluster-identity
+
   # Gardener admission controller configuration values
   admission:
     enabled: true
@@ -421,6 +422,8 @@ global:
               ...
               -----END RSA PRIVATE KEY-----
       featureGates: {}
+
+  # Gardener scheduler configuration values
   scheduler:
     enabled: true
     replicaCount: 1
@@ -465,6 +468,8 @@ global:
 #         concurrentSyncs: 5
 #         candidateDeterminationStrategy: SameRegion # either {SameRegion,MinimalDistance}
       featureGates: {}
+
+  # System secrets
   internalDomain:
     provider: aws-route53 # depends on the DNS extension of your choice
     domain: example.com
@@ -491,3 +496,8 @@ global:
       enabled: false
       clusterIP: 1.2.3.4
       createNamespace: true
+
+  # RBAC related configuration
+  rbac:
+    seedAuthorizer:
+      enabled: false


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:
Allow to disable ClusterRole{Binding} for global gardenlet access (when seed authorizer is enabled).

**Which issue(s) this PR fixes**:
Part of #1723

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
NONE
```
