### PR TITLE
Switch to GCR image to prevent Docker Hub rate limits

### DIFF
--- a/test/framework/k8s_utils.go
+++ b/test/framework/k8s_utils.go
@@ -458,7 +458,7 @@ func DeployRootPod(ctx context.Context, c client.Client, namespace string, noden
 			Containers: []corev1.Container{
 				{
 					Name:  "root-container",
-					Image: "busybox",
+					Image: "eu.gcr.io/gardener-project/3rd/busybox:1.29.2",
 					Command: []string{
 						"sleep",
 						"10000000",


### PR DESCRIPTION
/area testing

While investigating for integration test failures, I see that some of integration tests (that use `rootPodExecutor`) fail to wait until the rootpod Pod is Running.

```
    /src/test/integration/shoots/operatingsystem/os.go:79

    occurred
        retry failed with context deadline exceeded, last error: pod "gardener-e2e-pqccr/rootpod-h4o" is not ready: <nil>
        }
            },
                s: "pod \"gardener-e2e-pqccr/rootpod-h4o\" is not ready: <nil>",
            err: {
            ctxError: {},
        <*retry.Error | 0xc0014d4080>: {
    Unexpected error:

    /src/test/framework/gingko_utils.go:26
    [DEFAULT] [SERIAL] [SHOOT] should not segfault [It]
  /src/test/integration/shoots/operatingsystem/os.go:46
  OperatingSystem load
/src/test/integration/shoots/operatingsystem/os.go:40
Operating system testing
```

```
time="2021-06-02T10:56:10Z" level=info msg="At 2021-06-02 10:26:27 +0000 UTC - event for rootpod-h4o: {kubelet shoot--it--tm7xt-i8o-worker-1-z1-694cb-lstqj} Failed: Failed to pull image \"busybox\": rpc error: code = Unknown desc = Error response from daemon: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit"
```

Similar to https://github.com/gardener/gardener/pull/3785

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
