### PR TITLE
[release-v1.24] Automated cherry pick of #4156: Switch to GCR image to prevent Docker Hub rate limits

### DIFF
--- a/test/framework/k8s_utils.go
+++ b/test/framework/k8s_utils.go
@@ -458,7 +458,7 @@ func DeployRootPod(ctx context.Context, c client.Client, namespace string, noden
 			Containers: []corev1.Container{
 				{
 					Name:  "root-container",
-					Image: "busybox",
+					Image: "eu.gcr.io/gardener-project/3rd/busybox:1.29.2",
 					Command: []string{
 						"sleep",
 						"10000000",


### PR DESCRIPTION
/area/testing

Cherry pick of #4156 on release-v1.24.

#4156: Switch to GCR image to prevent Docker Hub rate limits

**Release Notes:**
```other operator
NONE
```