### PR TITLE
Cleanup special wait logic in DNS components

### DIFF
--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -121,7 +121,6 @@ func (b *Botanist) DefaultNginxIngressDNSEntry(seedClient client.Client) compone
 			Name: common.ShootDNSIngressName,
 			TTL:  *b.Config.Controllers.Shoot.DNSEntryTTLSeconds,
 		},
-		nil,
 	))
 }
 
@@ -160,7 +159,6 @@ func (b *Botanist) SetNginxIngressAddress(address string, seedClient client.Clie
 				OwnerID: ownerID,
 				TTL:     *b.Config.Controllers.Shoot.DNSEntryTTLSeconds,
 			},
-			nil,
 		)
 	}
 }

--- a/pkg/operation/botanist/component/extensions/dns/dns.go
+++ b/pkg/operation/botanist/component/extensions/dns/dns.go
@@ -14,7 +14,87 @@
 
 package dns
 
-import "time"
+import (
+	"fmt"
+	"time"
+
+	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
 
 // TimeNow returns the current time. Exposed for testing.
 var TimeNow = time.Now
+
+// Object is an interface for accessing common fields across DNS objects.
+// It is similar to extensionsv1alpha1.Object but special, as the DNS objects don't have the same
+// structure as all other extension objects and thus don't implement extensionsv1alpha1.Object.
+type Object interface {
+	client.Object
+
+	GetObservedGeneration() int64
+	SetObservedGeneration(observedGeneration int64)
+	GetState() string
+	SetState(state string)
+	GetMessage() *string
+	SetMessage(message *string)
+}
+
+// dnsProviderAccessor implements Object for a DNSProvider object.
+type dnsProviderAccessor struct {
+	*dnsv1alpha1.DNSProvider
+}
+
+func (d dnsProviderAccessor) GetObservedGeneration() int64  { return d.Status.ObservedGeneration }
+func (d dnsProviderAccessor) SetObservedGeneration(o int64) { d.Status.ObservedGeneration = o }
+func (d dnsProviderAccessor) GetState() string              { return d.Status.State }
+func (d dnsProviderAccessor) SetState(state string)         { d.Status.State = state }
+func (d dnsProviderAccessor) GetMessage() *string           { return d.Status.Message }
+func (d dnsProviderAccessor) SetMessage(message *string)    { d.Status.Message = message }
+
+// dnsEntryAccessor implements Object for a DNSEntry object.
+type dnsEntryAccessor struct {
+	*dnsv1alpha1.DNSEntry
+}
+
+func (d dnsEntryAccessor) GetObservedGeneration() int64  { return d.Status.ObservedGeneration }
+func (d dnsEntryAccessor) SetObservedGeneration(o int64) { d.Status.ObservedGeneration = o }
+func (d dnsEntryAccessor) GetState() string              { return d.Status.State }
+func (d dnsEntryAccessor) SetState(state string)         { d.Status.State = state }
+func (d dnsEntryAccessor) GetMessage() *string           { return d.Status.Message }
+func (d dnsEntryAccessor) SetMessage(message *string)    { d.Status.Message = message }
+
+// Accessor returns an Object implementation for the given obj.
+func Accessor(obj client.Object) (Object, error) {
+	switch v := obj.(type) {
+	case *dnsv1alpha1.DNSProvider:
+		return dnsProviderAccessor{v}, nil
+	case *dnsv1alpha1.DNSEntry:
+		return dnsEntryAccessor{v}, nil
+	default:
+		return nil, fmt.Errorf("expected either *dnsv1alpha1.DNSProvider or *dnsv1alpha1.DNSEntry but got %T", obj)
+	}
+}
+
+// CheckDNSObject is similar to health.CheckExtensionObject, but implements the special handling for DNS objects
+// as they don't implement extensionsv1alpha1.Object.
+func CheckDNSObject(obj client.Object) error {
+	dnsObj, err := Accessor(obj)
+	if err != nil {
+		return err
+	}
+
+	generation := dnsObj.GetGeneration()
+	observedGeneration := dnsObj.GetObservedGeneration()
+	if observedGeneration != generation {
+		return fmt.Errorf("observed generation outdated (%d/%d)", observedGeneration, generation)
+	}
+
+	if state := dnsObj.GetState(); state != dnsv1alpha1.STATE_READY {
+		if msg := dnsObj.GetMessage(); msg != nil {
+			return fmt.Errorf("state %s: %s", state, *msg)
+		}
+		return fmt.Errorf("state %s", state)
+	}
+
+	return nil
+}

--- a/pkg/operation/botanist/component/extensions/dns/dns_test.go
+++ b/pkg/operation/botanist/component/extensions/dns/dns_test.go
@@ -1,0 +1,95 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dns_test
+
+import (
+	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	. "github.com/gardener/gardener/pkg/operation/botanist/component/extensions/dns"
+)
+
+var _ = Describe("#CheckDNSObject", func() {
+	var (
+		obj client.Object
+		acc Object
+	)
+
+	It("should return error for non-dns object", func() {
+		Expect(CheckDNSObject(&corev1.ConfigMap{}))
+	})
+
+	test := func() {
+		It("should return error if observedGeneration is outdated", func() {
+			acc.SetGeneration(1)
+			acc.SetObservedGeneration(0)
+			Expect(CheckDNSObject(obj)).To(MatchError(ContainSubstring("observed generation")))
+		})
+
+		It("should return error if state is not ready", func() {
+			for _, state := range []string{
+				dnsv1alpha1.STATE_PENDING,
+				dnsv1alpha1.STATE_ERROR,
+				dnsv1alpha1.STATE_INVALID,
+				dnsv1alpha1.STATE_STALE,
+				dnsv1alpha1.STATE_DELETING,
+			} {
+				acc.SetState(state)
+				Expect(CheckDNSObject(obj)).To(MatchError(ContainSubstring(state)), "state: "+state)
+			}
+		})
+
+		It("should include status.message in error message", func() {
+			msg := "invalid credentials"
+			acc.SetState(dnsv1alpha1.STATE_ERROR)
+			acc.SetMessage(&msg)
+			Expect(CheckDNSObject(obj)).To(MatchError(ContainSubstring(msg)))
+		})
+
+		It("should not return error if object is ready", func() {
+			acc.SetGeneration(1)
+			acc.SetObservedGeneration(1)
+			acc.SetState(dnsv1alpha1.STATE_READY)
+			Expect(CheckDNSObject(obj)).To(Succeed())
+		})
+	}
+
+	Context("#DNSProvider", func() {
+		BeforeEach(func() {
+			obj = &dnsv1alpha1.DNSProvider{}
+
+			var err error
+			acc, err = Accessor(obj)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		test()
+	})
+
+	Context("#DNSEntry", func() {
+		BeforeEach(func() {
+			obj = &dnsv1alpha1.DNSEntry{}
+
+			var err error
+			acc, err = Accessor(obj)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		test()
+	})
+})

--- a/pkg/operation/botanist/component/extensions/dns/dnsentry_test.go
+++ b/pkg/operation/botanist/component/extensions/dns/dnsentry_test.go
@@ -17,13 +17,9 @@ package dns_test
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"time"
 
 	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	retryfake "github.com/gardener/gardener/pkg/utils/retry/fake"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -36,10 +32,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/logger"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	. "github.com/gardener/gardener/pkg/operation/botanist/component/extensions/dns"
+	"github.com/gardener/gardener/pkg/utils/retry"
+	retryfake "github.com/gardener/gardener/pkg/utils/retry/fake"
+	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
@@ -50,24 +51,30 @@ var _ = Describe("#DNSEntry", func() {
 	)
 
 	var (
-		ctrl             *gomock.Controller
-		ctx              context.Context
-		c                client.Client
-		scheme           *runtime.Scheme
-		fakeOps          *retryfake.Ops
+		ctrl      *gomock.Controller
+		ctx       context.Context
+		c         client.Client
+		scheme    *runtime.Scheme
+		fakeOps   *retryfake.Ops
+		now       time.Time
+		resetVars func()
+
 		expected         *dnsv1alpha1.DNSEntry
 		vals             *EntryValues
 		log              logrus.FieldLogger
 		defaultDepWaiter component.DeployWaiter
-		now              time.Time
 	)
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 
 		now = time.Now()
-		TimeNow = func() time.Time { return now }
-
+		fakeOps = &retryfake.Ops{MaxAttempts: 1}
+		resetVars = test.WithVars(
+			&retry.Until, fakeOps.Until,
+			&retry.UntilTimeout, fakeOps.UntilTimeout,
+			&TimeNow, func() time.Time { return now },
+		)
 		ctx = context.TODO()
 		log = logger.NewNopLogger()
 
@@ -98,12 +105,11 @@ var _ = Describe("#DNSEntry", func() {
 			},
 		}
 
-		fakeOps = &retryfake.Ops{MaxAttempts: 1}
-		defaultDepWaiter = NewEntry(log, c, deployNS, vals, fakeOps)
+		defaultDepWaiter = NewEntry(log, c, deployNS, vals)
 	})
 
 	AfterEach(func() {
-		TimeNow = time.Now
+		resetVars()
 		ctrl.Finish()
 	})
 
@@ -150,7 +156,7 @@ var _ = Describe("#DNSEntry", func() {
 			)
 
 			fakeOps.MaxAttempts = 2
-			defaultDepWaiter = NewEntry(log, mc, deployNS, vals, fakeOps)
+			defaultDepWaiter = NewEntry(log, mc, deployNS, vals)
 			Expect(defaultDepWaiter.Wait(ctx)).To(Succeed())
 		})
 
@@ -198,11 +204,6 @@ var _ = Describe("#DNSEntry", func() {
 			By("wait")
 			Expect(defaultDepWaiter.Wait(ctx)).To(Succeed(), "dnsentry is ready")
 		})
-
-		It("should set a default waiter", func() {
-			wrt := NewEntry(log, c, deployNS, vals, nil)
-			Expect(reflect.ValueOf(wrt).Elem().FieldByName("waiter").IsNil()).ToNot(BeTrue())
-		})
 	})
 
 	Describe("#Destroy", func() {
@@ -224,7 +225,7 @@ var _ = Describe("#DNSEntry", func() {
 					Namespace: deployNS,
 				}}).Times(1).Return(fmt.Errorf("some random error"))
 
-			defaultDepWaiter = NewEntry(log, mc, deployNS, vals, fakeOps)
+			defaultDepWaiter = NewEntry(log, mc, deployNS, vals)
 
 			Expect(defaultDepWaiter.Destroy(ctx)).To(HaveOccurred())
 		})

--- a/pkg/operation/botanist/component/extensions/dns/dnsowner_test.go
+++ b/pkg/operation/botanist/component/extensions/dns/dnsowner_test.go
@@ -132,6 +132,12 @@ var _ = Describe("#DNSOwner", func() {
 		})
 	})
 
+	Describe("#Wait", func() {
+		It("should succeed", func() {
+			Expect(defaultDepWaiter.Wait(ctx)).To(Succeed())
+		})
+	})
+
 	Describe("#WaitCleanup", func() {
 		It("should not return error when it's already removed", func() {
 			Expect(defaultDepWaiter.WaitCleanup(ctx)).ToNot(HaveOccurred())

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -881,7 +881,6 @@ func (b *Botanist) setAPIServerAddress(address string, seedClient client.Client)
 				OwnerID: ownerID,
 				TTL:     *b.Config.Controllers.Shoot.DNSEntryTTLSeconds,
 			},
-			nil,
 		)
 	}
 
@@ -907,7 +906,6 @@ func (b *Botanist) setAPIServerAddress(address string, seedClient client.Client)
 				OwnerID: ownerID,
 				TTL:     *b.Config.Controllers.Shoot.DNSEntryTTLSeconds,
 			},
-			nil,
 		)
 	}
 }

--- a/pkg/operation/botanist/dns.go
+++ b/pkg/operation/botanist/dns.go
@@ -123,7 +123,6 @@ func (b *Botanist) DefaultExternalDNSProvider(seedClient client.Client) componen
 				},
 				Annotations: b.enableDNSProviderForShootDNSEntries(),
 			},
-			nil,
 		)
 	}
 
@@ -135,7 +134,6 @@ func (b *Botanist) DefaultExternalDNSProvider(seedClient client.Client) componen
 			Name:    DNSExternalName,
 			Purpose: DNSExternalName,
 		},
-		nil,
 	))
 }
 
@@ -149,7 +147,6 @@ func (b *Botanist) DefaultExternalDNSEntry(seedClient client.Client) component.D
 			Name: DNSExternalName,
 			TTL:  *b.Config.Controllers.Shoot.DNSEntryTTLSeconds,
 		},
-		nil,
 	))
 }
 
@@ -185,7 +182,6 @@ func (b *Botanist) DefaultInternalDNSProvider(seedClient client.Client) componen
 					Exclude: b.Garden.InternalDomain.ExcludeZones,
 				},
 			},
-			nil,
 		)
 	}
 
@@ -197,7 +193,6 @@ func (b *Botanist) DefaultInternalDNSProvider(seedClient client.Client) componen
 			Name:    DNSInternalName,
 			Purpose: DNSInternalName,
 		},
-		nil,
 	))
 }
 
@@ -211,7 +206,6 @@ func (b *Botanist) DefaultInternalDNSEntry(seedClient client.Client) component.D
 			Name: DNSInternalName,
 			TTL:  *b.Config.Controllers.Shoot.DNSEntryTTLSeconds,
 		},
-		nil,
 	))
 }
 
@@ -295,7 +289,6 @@ func (b *Botanist) AdditionalDNSProviders(ctx context.Context, gardenClient, see
 					},
 					Annotations: b.enableDNSProviderForShootDNSEntries(),
 				},
-				nil,
 			)
 		}
 	}
@@ -322,7 +315,6 @@ func (b *Botanist) AdditionalDNSProviders(ctx context.Context, gardenClient, see
 					Purpose: p.Name,
 					Labels:  map[string]string{v1beta1constants.GardenRole: DNSProviderRoleAdditional},
 				},
-				nil,
 			))
 		}
 	}

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -1202,7 +1202,6 @@ func getManagedIngressDNSEntry(k8sSeedClient client.Client, seedFQDN string, loa
 		k8sSeedClient,
 		v1beta1constants.GardenNamespace,
 		values,
-		nil,
 	)
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:

As discussed in https://github.com/gardener/gardener/pull/4141#pullrequestreview-673009809, the DNS components didn't use the common extension helper funcs yet (e.g. `WaitUntilExtensionObjectReady`), as they don't implement the `extensionsv1alpha1.Object` interface.
This PR cleans up the specialized wait logic in favor of using the same generic helper funcs for less duplication, confusion and increased maintainability.

**Special notes for your reviewer**:

Compared to how the DNS components are currently implemented, there are some minimal behavioral changes in this PR.
I assume they are fine, but I still want to highlight them here to collect some explicit feedback:

1. before, the `DNSProvider` component didn't check for `generation == observedGeneration` in `Wait` ([ref](https://github.com/gardener/gardener/blob/0968f39752e046235ed1bdf4618781b6b57268c9/pkg/operation/botanist/component/extensions/dns/dnsprovider.go#L178)), now it does
1. before, `retry.MinorOrSevereError` was used in case of `state == {Error,Invalid}` to provide faster user feedback for e.g. invalid credentials (ref [here](https://github.com/gardener/gardener/blob/0968f39752e046235ed1bdf4618781b6b57268c9/pkg/operation/botanist/component/extensions/dns/dnsprovider.go#L191) and [here](https://github.com/gardener/gardener/blob/0968f39752e046235ed1bdf4618781b6b57268c9/pkg/operation/botanist/component/extensions/dns/dnsentry.go#L158)). ~Now, `WaitUntilObjectReadyWithHealthFunction` will only return after the given timeout, as the errors don't carry an error code. We could detect the error codes early on in `CheckDNSObject`, though I'm not sure if that's desirable.~ Now, the DNS components detect error codes early on and return `retry.MinorOrSevereError` if an error code is detected.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
