### PR TITLE
Fix filtering of owned seeds in managed seed controller

### DIFF
--- a/pkg/controllermanager/controller/managedseedset/managedseedset_reconciler_test.go
+++ b/pkg/controllermanager/controller/managedseedset/managedseedset_reconciler_test.go
@@ -162,14 +162,11 @@ var _ = Describe("Reconciler", func() {
 				Expect(result).To(Equal(reconcile.Result{RequeueAfter: syncPeriod}))
 			})
 
-			It("should reconcile the ManagedSeedSet deletion, remove the finalizer, and update the status", func() {
+			It("should reconcile the ManagedSeedSet deletion, remove the finalizer, and not update the status", func() {
 				expectGetManagedSeedSet()
 				actuator.EXPECT().Reconcile(ctx, set).Return(status, true, nil)
 				expectPatchManagedSeedSet(func(mss *seedmanagementv1alpha1.ManagedSeedSet) {
 					Expect(mss.Finalizers).To(BeEmpty())
-				})
-				expectPatchManagedSeedSetStatus(func(mss *seedmanagementv1alpha1.ManagedSeedSet) {
-					Expect(&mss.Status).To(Equal(status))
 				})
 
 				result, err := reconciler.Reconcile(ctx, request)

--- a/pkg/controllerutils/seedfilter.go
+++ b/pkg/controllerutils/seedfilter.go
@@ -124,7 +124,7 @@ func ControllerInstallationFilterFunc(seedName string, seedLister gardencorelist
 }
 
 // BackupBucketFilterFunc returns a filtering func for the seeds and the given label selector.
-func BackupBucketFilterFunc(ctx context.Context, c client.Client, seedName string, labelSelector *metav1.LabelSelector) func(obj interface{}) bool {
+func BackupBucketFilterFunc(ctx context.Context, c client.Reader, seedName string, labelSelector *metav1.LabelSelector) func(obj interface{}) bool {
 	return func(obj interface{}) bool {
 		backupBucket, ok := obj.(*gardencorev1beta1.BackupBucket)
 		if !ok {
@@ -141,7 +141,7 @@ func BackupBucketFilterFunc(ctx context.Context, c client.Client, seedName strin
 }
 
 // BackupEntryFilterFunc returns a filtering func for the seeds and the given label selector.
-func BackupEntryFilterFunc(ctx context.Context, c client.Client, seedName string, labelSelector *metav1.LabelSelector) func(obj interface{}) bool {
+func BackupEntryFilterFunc(ctx context.Context, c client.Reader, seedName string, labelSelector *metav1.LabelSelector) func(obj interface{}) bool {
 	return func(obj interface{}) bool {
 		backupEntry, ok := obj.(*gardencorev1beta1.BackupEntry)
 		if !ok {
@@ -165,7 +165,7 @@ func BackupEntryFilterFunc(ctx context.Context, c client.Client, seedName string
 
 // BackupEntryIsManagedByThisGardenlet checks if the given BackupEntry is managed by this gardenlet by comparing it with the seed name from the GardenletConfiguration
 // or by checking whether the seed labels match the seed selector from the GardenletConfiguration.
-func BackupEntryIsManagedByThisGardenlet(ctx context.Context, c client.Client, backupEntry *gardencorev1beta1.BackupEntry, gc *config.GardenletConfiguration) bool {
+func BackupEntryIsManagedByThisGardenlet(ctx context.Context, c client.Reader, backupEntry *gardencorev1beta1.BackupEntry, gc *config.GardenletConfiguration) bool {
 	seedName := confighelper.SeedNameFromSeedConfig(gc.SeedConfig)
 	if len(seedName) > 0 {
 		return backupEntry.Spec.SeedName != nil && *backupEntry.Spec.SeedName == seedName
@@ -174,7 +174,7 @@ func BackupEntryIsManagedByThisGardenlet(ctx context.Context, c client.Client, b
 }
 
 // BastionFilterFunc returns a filtering func for the seeds and the given label selector.
-func BastionFilterFunc(ctx context.Context, c client.Client, seedName string, labelSelector *metav1.LabelSelector) func(obj interface{}) bool {
+func BastionFilterFunc(ctx context.Context, c client.Reader, seedName string, labelSelector *metav1.LabelSelector) func(obj interface{}) bool {
 	return func(obj interface{}) bool {
 		bastion, ok := obj.(*operationsv1alpha1.Bastion)
 		if !ok {
@@ -192,7 +192,7 @@ func BastionFilterFunc(ctx context.Context, c client.Client, seedName string, la
 
 // BastionIsManagedByThisGardenlet checks if the given Bastion is managed by this gardenlet by comparing it with the seed name from the GardenletConfiguration
 // or by checking whether the seed labels match the seed selector from the GardenletConfiguration.
-func BastionIsManagedByThisGardenlet(ctx context.Context, c client.Client, bastion *operationsv1alpha1.Bastion, gc *config.GardenletConfiguration) bool {
+func BastionIsManagedByThisGardenlet(ctx context.Context, c client.Reader, bastion *operationsv1alpha1.Bastion, gc *config.GardenletConfiguration) bool {
 	seedName := confighelper.SeedNameFromSeedConfig(gc.SeedConfig)
 	if len(seedName) > 0 {
 		return bastion.Spec.SeedName != nil && *bastion.Spec.SeedName == seedName
@@ -201,7 +201,7 @@ func BastionIsManagedByThisGardenlet(ctx context.Context, c client.Client, basti
 }
 
 // ManagedSeedFilterFunc returns a filtering func for ManagedSeeds that checks if the ManagedSeed references a Shoot scheduled on a Seed, for which the gardenlet is responsible..
-func ManagedSeedFilterFunc(ctx context.Context, c client.Client, seedName string, labelSelector *metav1.LabelSelector) func(obj interface{}) bool {
+func ManagedSeedFilterFunc(ctx context.Context, c client.Reader, seedName string, labelSelector *metav1.LabelSelector) func(obj interface{}) bool {
 	return func(obj interface{}) bool {
 		managedSeed, ok := obj.(*seedmanagementv1alpha1.ManagedSeed)
 		if !ok {
@@ -232,7 +232,7 @@ func ManagedSeedFilterFunc(ctx context.Context, c client.Client, seedName string
 
 // SeedOfManagedSeedFilterFunc returns a filtering func for Seeds that checks if the Seed is owned by a ManagedSeed
 // that references a Shoot scheduled on a Seed, for which the gardenlet is responsible.
-func SeedOfManagedSeedFilterFunc(ctx context.Context, c client.Client, seedName string, labelSelector *metav1.LabelSelector) func(obj interface{}) bool {
+func SeedOfManagedSeedFilterFunc(ctx context.Context, c client.Reader, seedName string, labelSelector *metav1.LabelSelector) func(obj interface{}) bool {
 	return func(obj interface{}) bool {
 		seed, ok := obj.(*gardencorev1beta1.Seed)
 		if !ok {

--- a/pkg/controllerutils/seedfilter_test.go
+++ b/pkg/controllerutils/seedfilter_test.go
@@ -46,7 +46,7 @@ const (
 var _ = Describe("seedfilter", func() {
 	var (
 		ctrl *gomock.Controller
-		c    *mockclient.MockClient
+		c    *mockclient.MockReader
 
 		ctx context.Context
 
@@ -58,7 +58,7 @@ var _ = Describe("seedfilter", func() {
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
-		c = mockclient.NewMockClient(ctrl)
+		c = mockclient.NewMockReader(ctrl)
 
 		ctx = context.TODO()
 

--- a/pkg/gardenlet/controller/managedseed/managedseed.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed.go
@@ -110,7 +110,7 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 	var waitGroup sync.WaitGroup
 
 	c.managedSeedInformer.AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controllerutils.ManagedSeedFilterFunc(ctx, c.gardenClient.Client(), confighelper.SeedNameFromSeedConfig(c.config.SeedConfig), c.config.SeedSelector),
+		FilterFunc: controllerutils.ManagedSeedFilterFunc(ctx, c.gardenClient.Cache(), confighelper.SeedNameFromSeedConfig(c.config.SeedConfig), c.config.SeedSelector),
 		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc:    c.managedSeedAdd,
 			UpdateFunc: c.managedSeedUpdate,
@@ -120,7 +120,7 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 
 	// Add event handler for controlled seeds
 	c.seedInformer.AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controllerutils.SeedOfManagedSeedFilterFunc(ctx, c.gardenClient.Client(), confighelper.SeedNameFromSeedConfig(c.config.SeedConfig), c.config.SeedSelector),
+		FilterFunc: controllerutils.SeedOfManagedSeedFilterFunc(ctx, c.gardenClient.Cache(), confighelper.SeedNameFromSeedConfig(c.config.SeedConfig), c.config.SeedSelector),
 		Handler: &kutils.ControlledResourceEventHandler{
 			ControllerTypes: []kutils.ControllerType{
 				{

--- a/pkg/gardenlet/controller/managedseed/managedseed_predicates.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_predicates.go
@@ -32,8 +32,6 @@ func (c *Controller) filterSeed(obj, _, controller client.Object, deleted bool) 
 		return false
 	}
 
-	// TODO Return true if the seed was deleted or updated and metadata / spec don't match its checksum
-
 	if ms.DeletionTimestamp != nil && deleted {
 		c.logger.Debugf("Managed seed %s is deleting and seed %s no longer exists", kutil.ObjectName(ms), kutil.ObjectName(seed))
 		return true

--- a/pkg/gardenlet/controller/managedseed/managedseed_reconciler_test.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_reconciler_test.go
@@ -198,14 +198,11 @@ var _ = Describe("Reconciler", func() {
 				Expect(result).To(Equal(reconcile.Result{RequeueAfter: waitSyncPeriod}))
 			})
 
-			It("should reconcile the ManagedSeed deletion, remove the finalizer, and update the status", func() {
+			It("should reconcile the ManagedSeed deletion, remove the finalizer, and not update the status", func() {
 				expectGetManagedSeed()
 				actuator.EXPECT().Delete(ctx, managedSeed).Return(status, false, true, nil)
 				expectPatchManagedSeed(func(ms *seedmanagementv1alpha1.ManagedSeed) {
 					Expect(ms.Finalizers).To(BeEmpty())
-				})
-				expectPatchManagedSeedStatus(func(ms *seedmanagementv1alpha1.ManagedSeed) {
-					Expect(&ms.Status).To(Equal(status))
 				})
 
 				result, err := reconciler.Reconcile(ctx, request)


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind bug

**What this PR does / why we need it**:
Fixes the filtering of owned seeds in the managed seed controller to avoid gardenlets not responsible for the shoot that has been registered as seed attempting to reconcile the managed seed at the seed deletion event. With seed authorizer enabled, this leads to errors such as:
```
{"level":"info","ts":"2021-06-02T08:06:56.712Z","logger":"seedauthorizer","msg":"SEED DENY: 'alicloud' authorizer.AttributesRecord{User:(*user.DefaultInfo)(0xc001fe9040), Verb:\"patch\", Namespace:\"garden\", APIGroup:\"seedmanagement.gardener.cloud\", APIVersion:\"v1alpha1\", Resource:\"managedseeds\", Subresource:\"status\", Name:\"rfranzke\", ResourceRequest:true, Path:\"\"}"}
```

Also fixes a different issue leading to errors at the end of the managed seed deletion, due to an attempt to update the status of a managed seed that is already gone (because its finalizer was just removed). This leads to errors such as:
```
time="2021-06-02T08:07:21Z" level=info msg="Error syncing ManagedSeed garden/rfranzke: could not update status: managedseeds.seedmanagement.gardener.cloud \"rfranzke\" not found"
time="2021-06-02T08:07:21Z" level=info msg="Error syncing ManagedSeed garden/rfranzke: could not remove gardener finalizer: managedseeds.seedmanagement.gardener.cloud \"rfranzke\" not found"
```

With seed authorizer enabled, there is also one additional error:
```
time="2021-06-02T08:07:21Z" level=error msg="could not get seed rfranzke secrets: secrets \"seed-rfranzke\" is forbidden: User \"gardener.cloud:system:seed:aws\" cannot get resource \"secrets\" in API group \"\" in the namespace \"garden\": no relationship found between seed 'aws' and this object" managedSeed=garden/rfranzke
```

Fixes also the same issue for managed seed sets.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```other operator
NONE
```
