### PR TITLE
Ignore shoots in deletion when removing versions from a cloud profile

### DIFF
--- a/plugin/pkg/global/resourcereferencemanager/admission.go
+++ b/plugin/pkg/global/resourcereferencemanager/admission.go
@@ -433,7 +433,7 @@ func (r *ReferenceManager) Admit(ctx context.Context, a admission.Attributes, o 
 				wg.Add(len(shootList))
 
 				for _, s := range shootList {
-					if s.Spec.CloudProfileName != cloudProfile.Name {
+					if s.Spec.CloudProfileName != cloudProfile.Name || s.DeletionTimestamp != nil {
 						wg.Done()
 						continue
 					}


### PR DESCRIPTION
**How to categorize this PR?**

/area ops-producitify
/kind enhancement

**What this PR does / why we need it**:
Ensures that shoots currently being deleted are ignored when removing Kubernetes or image versions from a cloud profile.

**Which issue(s) this PR fixes**:
Fixes #4142

**Special notes for your reviewer**:

**Release note**:

```other operator
When removing Kubernetes or image versions from a cloud profile, shoots currently being deleted are now ignored.
```
