### PR TITLE
Add ManagedSeedShoot admission plugin

### DIFF
--- a/docs/concepts/apiserver_admission_plugins.md
+++ b/docs/concepts/apiserver_admission_plugins.md
@@ -125,3 +125,26 @@ This admission controller reacts on `CREATE` and `UPDATE` operations for `Shoot`
 It validates certain configurations in the specification against the referred `CloudProfile` (e.g., machine images, machine types, used Kubernetes version, ...).
 Generally, it performs validations that cannot be handled by the static API validation due to their dynamic nature (e.g., when something needs to be checked against referred resources).
 Additionally, it takes over certain defaulting tasks (e.g., default machine image for worker pools).
+
+## `ShootManagedSeed`
+
+_(enabled by default)_
+
+This admission controller reacts on `DELETE` operations for `Shoot`s.
+It rejects the deletion if the `Shoot` is referred to by a `ManagedSeed`.
+
+## `ManagedSeedValidator`
+
+_(enabled by default)_
+
+This admission controller reacts on `CREATE` and `UPDATE` operations for `ManagedSeeds`s.
+It validates certain configuration values in the specification against the referred `Shoot`, for example Seed provider, network ranges, DNS domain, etc.
+Similarly to `ShootValidator`, it performs validations that cannot be handled by the static API validation due to their dynamic nature.
+Additionally, it performs certain defaulting tasks, making sure that configuration values that are not specified are defaulted to the values of the referred `Shoot`, for example Seed provider, network ranges, DNS domain, etc.
+
+## `ManagedSeedShoot`
+
+_(enabled by default)_
+
+This admission controller reacts on `DELETE` operations for `ManagedSeed`s.
+It rejects the deletion if there are `Shoot`s that are scheduled onto the `Seed` that is registered by the `ManagedSeed`.

--- a/pkg/apiserver/plugins.go
+++ b/pkg/apiserver/plugins.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gardener/gardener/plugin/pkg/global/deletionconfirmation"
 	"github.com/gardener/gardener/plugin/pkg/global/extensionvalidation"
 	"github.com/gardener/gardener/plugin/pkg/global/resourcereferencemanager"
+	managedseedshoot "github.com/gardener/gardener/plugin/pkg/managedseed/shoot"
 	managedseedvalidator "github.com/gardener/gardener/plugin/pkg/managedseed/validator"
 	plantvalidator "github.com/gardener/gardener/plugin/pkg/plant"
 	seedvalidator "github.com/gardener/gardener/plugin/pkg/seed/validator"
@@ -32,6 +33,7 @@ import (
 	shoottolerationrestriction "github.com/gardener/gardener/plugin/pkg/shoot/tolerationrestriction"
 	shootvalidator "github.com/gardener/gardener/plugin/pkg/shoot/validator"
 	shootvpa "github.com/gardener/gardener/plugin/pkg/shoot/vpa"
+
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apiserver/pkg/admission"
 	"k8s.io/apiserver/pkg/admission/plugin/namespace/lifecycle"
@@ -60,6 +62,7 @@ var (
 		customverbauthorizer.PluginName,            // CustomVerbAuthorizer
 		shootvpa.PluginName,                        // ShootVPAEnabledByDefault
 		managedseedvalidator.PluginName,            // ManagedSeed
+		managedseedshoot.PluginName,                // ManagedSeedShoot
 		bastionvalidator.PluginName,                // Bastion
 
 		// new admission plugins should generally be inserted above here
@@ -91,6 +94,7 @@ var (
 		clusteropenidconnectpreset.PluginName,      // ClusterOpenIDConnectPreset
 		customverbauthorizer.PluginName,            // CustomVerbAuthorizer
 		managedseedvalidator.PluginName,            // ManagedSeed
+		managedseedshoot.PluginName,                // ManagedSeedShoot
 		bastionvalidator.PluginName,                // Bastion
 		mutatingwebhook.PluginName,                 // MutatingAdmissionWebhook
 		validatingwebhook.PluginName,               // ValidatingAdmissionWebhook
@@ -118,6 +122,7 @@ func RegisterAllAdmissionPlugins(plugins *admission.Plugins) {
 	clusteropenidconnectpreset.Register(plugins)
 	customverbauthorizer.Register(plugins)
 	managedseedvalidator.Register(plugins)
+	managedseedshoot.Register(plugins)
 	bastionvalidator.Register(plugins)
 	resourcequota.Register(plugins)
 	shootvpa.Register(plugins)

--- a/plugin/pkg/managedseed/shoot/admission.go
+++ b/plugin/pkg/managedseed/shoot/admission.go
@@ -1,0 +1,198 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shoot
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/gardener/gardener/pkg/apis/core"
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
+	admissioninitializer "github.com/gardener/gardener/pkg/apiserver/admission/initializer"
+	coreclientset "github.com/gardener/gardener/pkg/client/core/clientset/internalversion"
+	seedmanagementclientset "github.com/gardener/gardener/pkg/client/seedmanagement/clientset/versioned"
+	admissionutils "github.com/gardener/gardener/plugin/pkg/utils"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apiserver/pkg/admission"
+)
+
+const (
+	// PluginName is the name of this admission plugin.
+	PluginName = "ManagedSeedShoot"
+)
+
+// Register registers a plugin.
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
+		return New()
+	})
+}
+
+// Shoot contains listers and and admission handler.
+type Shoot struct {
+	*admission.Handler
+	coreClient           coreclientset.Interface
+	seedManagementClient seedmanagementclientset.Interface
+	readyFunc            admission.ReadyFunc
+}
+
+var (
+	_ = admissioninitializer.WantsInternalCoreClientset(&Shoot{})
+	_ = admissioninitializer.WantsSeedManagementClientset(&Shoot{})
+
+	readyFuncs = []admission.ReadyFunc{}
+)
+
+// New creates a new Shoot admission plugin.
+func New() (*Shoot, error) {
+	return &Shoot{
+		Handler: admission.NewHandler(admission.Delete),
+	}, nil
+}
+
+// AssignReadyFunc assigns the ready function to the admission handler.
+func (v *Shoot) AssignReadyFunc(f admission.ReadyFunc) {
+	v.readyFunc = f
+	v.SetReadyFunc(f)
+}
+
+// SetInternalCoreClientset sets the garden core clientset.
+func (v *Shoot) SetInternalCoreClientset(c coreclientset.Interface) {
+	v.coreClient = c
+}
+
+// SetSeedManagementClientset sets the garden seedmanagement clientset.
+func (v *Shoot) SetSeedManagementClientset(c seedmanagementclientset.Interface) {
+	v.seedManagementClient = c
+}
+
+// ValidateInitialization checks whether the plugin was correctly initialized.
+func (v *Shoot) ValidateInitialization() error {
+	if v.coreClient == nil {
+		return errors.New("missing garden core client")
+	}
+	if v.seedManagementClient == nil {
+		return errors.New("missing garden seedmanagement client")
+	}
+	return nil
+}
+
+var _ admission.ValidationInterface = &Shoot{}
+
+// Validate validates if the Shoot can be deleted. If the
+func (v *Shoot) Validate(ctx context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {
+	// Wait until the caches have been synced
+	if v.readyFunc == nil {
+		v.AssignReadyFunc(func() bool {
+			for _, readyFunc := range readyFuncs {
+				if !readyFunc() {
+					return false
+				}
+			}
+			return true
+		})
+	}
+	if !v.WaitForReady() {
+		return admission.NewForbidden(a, errors.New("not yet ready to handle request"))
+	}
+
+	// Ignore all kinds other than ManagedSeed
+	if a.GetKind().GroupKind() != seedmanagementv1alpha1.Kind("ManagedSeed") {
+		return nil
+	}
+
+	// Ignore updates to status or other subresources
+	if a.GetSubresource() != "" {
+		return nil
+	}
+
+	switch {
+	case a.GetName() == "":
+		return v.validateDeleteCollection(ctx, a)
+	default:
+		return v.validateDelete(ctx, a)
+	}
+}
+
+func (v *Shoot) validateDeleteCollection(ctx context.Context, a admission.Attributes) error {
+	managedSeeds, err := v.getManagedSeeds(ctx, labels.Everything())
+	if err != nil {
+		return err
+	}
+	for _, managedSeed := range managedSeeds {
+		if err := v.validateDelete(ctx, newAttributesWithName(a, managedSeed.Name)); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (v *Shoot) validateDelete(ctx context.Context, a admission.Attributes) error {
+	seedName := a.GetName()
+
+	shoots, err := v.getShoots(ctx, labels.Everything())
+	if err != nil {
+		return err
+	}
+
+	if admissionutils.IsSeedUsedByShoot(seedName, getShootPointersFromShoots(shoots)) {
+		return admission.NewForbidden(a, fmt.Errorf("cannot delete managed seed %s/%s since its seed %s is still used by shoot(s)", a.GetNamespace(), a.GetName(), a.GetName()))
+	}
+
+	return nil
+}
+
+func newAttributesWithName(a admission.Attributes, name string) admission.Attributes {
+	return admission.NewAttributesRecord(a.GetObject(),
+		a.GetOldObject(),
+		a.GetKind(),
+		a.GetNamespace(),
+		name,
+		a.GetResource(),
+		a.GetSubresource(),
+		a.GetOperation(),
+		a.GetOperationOptions(),
+		a.IsDryRun(),
+		a.GetUserInfo())
+}
+
+func (v *Shoot) getManagedSeeds(ctx context.Context, selector labels.Selector) ([]seedmanagementv1alpha1.ManagedSeed, error) {
+	managedSeedList, err := v.seedManagementClient.SeedmanagementV1alpha1().ManagedSeeds("").List(ctx, metav1.ListOptions{LabelSelector: selector.String()})
+	if err != nil {
+		return nil, err
+	}
+	return managedSeedList.Items, nil
+}
+
+func (v *Shoot) getShoots(ctx context.Context, selector labels.Selector) ([]core.Shoot, error) {
+	shootList, err := v.coreClient.Core().Shoots("").List(ctx, metav1.ListOptions{LabelSelector: selector.String()})
+	if err != nil {
+		return nil, err
+	}
+	return shootList.Items, nil
+}
+
+func getShootPointersFromShoots(shoots []core.Shoot) []*core.Shoot {
+	var shootPointers []*core.Shoot
+	for i := range shoots {
+		shootPointers = append(shootPointers, &shoots[i])
+	}
+	return shootPointers
+}

--- a/plugin/pkg/managedseed/shoot/admission_test.go
+++ b/plugin/pkg/managedseed/shoot/admission_test.go
@@ -1,0 +1,206 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shoot_test
+
+import (
+	"context"
+	"errors"
+
+	"github.com/gardener/gardener/pkg/apis/core"
+	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
+	corefake "github.com/gardener/gardener/pkg/client/core/clientset/internalversion/fake"
+	seedmanagementfake "github.com/gardener/gardener/pkg/client/seedmanagement/clientset/versioned/fake"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	. "github.com/gardener/gardener/plugin/pkg/managedseed/shoot"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/client-go/testing"
+	"k8s.io/utils/pointer"
+)
+
+const (
+	name      = "foo"
+	shootName = "test"
+	namespace = "garden"
+)
+
+var _ = Describe("Shoot", func() {
+	Describe("#Validate", func() {
+		var (
+			managedSeed          *seedmanagementv1alpha1.ManagedSeed
+			shoot                *core.Shoot
+			coreClient           *corefake.Clientset
+			seedManagementClient *seedmanagementfake.Clientset
+			admissionHandler     *Shoot
+		)
+
+		BeforeEach(func() {
+			managedSeed = &seedmanagementv1alpha1.ManagedSeed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      name,
+					Namespace: namespace,
+				},
+			}
+
+			shoot = &core.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      shootName,
+					Namespace: namespace,
+				},
+				Spec: core.ShootSpec{
+					SeedName: pointer.StringPtr(name),
+				},
+			}
+
+			admissionHandler, _ = New()
+			admissionHandler.AssignReadyFunc(func() bool { return true })
+
+			coreClient = &corefake.Clientset{}
+			admissionHandler.SetInternalCoreClientset(coreClient)
+
+			seedManagementClient = &seedmanagementfake.Clientset{}
+			admissionHandler.SetSeedManagementClientset(seedManagementClient)
+		})
+
+		Context("delete", func() {
+			It("should do nothing if the resource is not a ManagedSeed", func() {
+				attrs := admission.NewAttributesRecord(nil, nil, core.Kind("Foo").WithVersion("version"), managedSeed.Namespace, managedSeed.Name, core.Resource("foos").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil)
+
+				err := admissionHandler.Validate(context.TODO(), attrs, nil)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should forbid the ManagedSeed deletion if a Shoot scheduled on its Seed exists", func() {
+				coreClient.AddReactor("list", "shoots", func(action testing.Action) (bool, runtime.Object, error) {
+					return true, &core.ShootList{Items: []core.Shoot{*shoot}}, nil
+				})
+
+				err := admissionHandler.Validate(context.TODO(), getManagedSeedAttributes(managedSeed), nil)
+				Expect(err).To(BeForbiddenError())
+			})
+
+			It("should allow the ManagedSeed deletion if a Shoot scheduled on its Seed does not exists", func() {
+				coreClient.AddReactor("list", "shoots", func(action testing.Action) (bool, runtime.Object, error) {
+					return true, &core.ShootList{Items: []core.Shoot{}}, nil
+				})
+
+				err := admissionHandler.Validate(context.TODO(), getManagedSeedAttributes(managedSeed), nil)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should fail with an error different from Forbidden if listing the Shoots fails with an error", func() {
+				coreClient.AddReactor("list", "shoots", func(action testing.Action) (bool, runtime.Object, error) {
+					return true, nil, apierrors.NewInternalError(errors.New("Internal Server Error"))
+				})
+
+				err := admissionHandler.Validate(context.TODO(), getManagedSeedAttributes(managedSeed), nil)
+				Expect(err).To(HaveOccurred())
+				Expect(err).ToNot(BeForbiddenError())
+			})
+		})
+
+		Context("delete collection", func() {
+			var (
+				anotherManagedSeed *seedmanagementv1alpha1.ManagedSeed
+			)
+
+			BeforeEach(func() {
+				anotherManagedSeed = &seedmanagementv1alpha1.ManagedSeed{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "bar",
+						Namespace: namespace,
+					},
+				}
+			})
+
+			It("should forbid multiple ManagedSeed deletion if a Shoots scheduled on any of their Seeds exists", func() {
+				seedManagementClient.AddReactor("list", "managedseeds", func(action testing.Action) (bool, runtime.Object, error) {
+					return true, &seedmanagementv1alpha1.ManagedSeedList{Items: []seedmanagementv1alpha1.ManagedSeed{*managedSeed, *anotherManagedSeed}}, nil
+				})
+				coreClient.AddReactor("list", "shoots", func(action testing.Action) (bool, runtime.Object, error) {
+					return true, &core.ShootList{Items: []core.Shoot{*shoot}}, nil
+				})
+
+				err := admissionHandler.Validate(context.TODO(), getAllManagedSeedAttributes(managedSeed.Namespace), nil)
+				Expect(err).To(BeForbiddenError())
+			})
+
+			It("should allow multiple ManagedSeed deletion if no Shoots scheduled on any of their Seeds exist", func() {
+				seedManagementClient.AddReactor("list", "managedseeds", func(action testing.Action) (bool, runtime.Object, error) {
+					return true, &seedmanagementv1alpha1.ManagedSeedList{Items: []seedmanagementv1alpha1.ManagedSeed{*managedSeed, *anotherManagedSeed}}, nil
+				})
+				coreClient.AddReactor("list", "shoots", func(action testing.Action) (bool, runtime.Object, error) {
+					return true, &core.ShootList{Items: []core.Shoot{}}, nil
+				})
+
+				err := admissionHandler.Validate(context.TODO(), getAllManagedSeedAttributes(managedSeed.Namespace), nil)
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+	})
+
+	Describe("#Register", func() {
+		It("should register the plugin", func() {
+			plugins := admission.NewPlugins()
+			Register(plugins)
+
+			registered := plugins.Registered()
+			Expect(registered).To(HaveLen(1))
+			Expect(registered).To(ContainElement(PluginName))
+		})
+	})
+
+	Describe("#New", func() {
+		It("should only handle DELETE operations", func() {
+			admissionHandler, err := New()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(admissionHandler.Handles(admission.Create)).NotTo(BeTrue())
+			Expect(admissionHandler.Handles(admission.Update)).NotTo(BeTrue())
+			Expect(admissionHandler.Handles(admission.Connect)).NotTo(BeTrue())
+			Expect(admissionHandler.Handles(admission.Delete)).To(BeTrue())
+		})
+	})
+
+	Describe("#ValidateInitialization", func() {
+		It("should fail if the required clients are not set", func() {
+			admissionHandler, _ := New()
+
+			err := admissionHandler.ValidateInitialization()
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should not fail if the required clients are set", func() {
+			admissionHandler, _ := New()
+			admissionHandler.SetInternalCoreClientset(&corefake.Clientset{})
+			admissionHandler.SetSeedManagementClientset(&seedmanagementfake.Clientset{})
+
+			err := admissionHandler.ValidateInitialization()
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+})
+
+func getManagedSeedAttributes(managedSeed *seedmanagementv1alpha1.ManagedSeed) admission.Attributes {
+	return admission.NewAttributesRecord(managedSeed, nil, seedmanagementv1alpha1.Kind("ManagedSeed").WithVersion("v1alpha1"), managedSeed.Namespace, managedSeed.Name, seedmanagementv1alpha1.Resource("managedseeds").WithVersion("v1alpha1"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil)
+}
+
+func getAllManagedSeedAttributes(namespace string) admission.Attributes {
+	return admission.NewAttributesRecord(nil, nil, seedmanagementv1alpha1.Kind("ManagedSeed").WithVersion("v1alpha1"), namespace, "", seedmanagementv1alpha1.Resource("managedseeds").WithVersion("v1alpha1"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil)
+}

--- a/plugin/pkg/managedseed/shoot/shoot_suite_test.go
+++ b/plugin/pkg/managedseed/shoot/shoot_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shoot_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestManagedSeed(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Admission ManagedSeedShoot Suite")
+}

--- a/plugin/pkg/seed/validator/admission.go
+++ b/plugin/pkg/seed/validator/admission.go
@@ -131,7 +131,7 @@ func (v *ValidateSeed) Validate(ctx context.Context, a admission.Attributes, o a
 	}
 
 	if admissionutils.IsSeedUsedByShoot(seedName, shoots) {
-		return admission.NewForbidden(a, fmt.Errorf("cannot delete seed '%s' which is still used by shoot(s)", seedName))
+		return admission.NewForbidden(a, fmt.Errorf("cannot delete seed %s since it is still used by shoot(s)", seedName))
 	}
 
 	return nil


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Adds the `ManagedSeedShoot` admission plugin to prevent the deletion of a `ManagedSeed` if there are shoots scheduled  on its seed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```noteworthy operator
It's no longer allowed to delete a `ManagedSeed` if there are shoots scheduled on its seed.
```
