### PR TITLE
Fixed bug in node local dns implementation.

### DIFF
--- a/pkg/operation/botanist/networkpolicies_test.go
+++ b/pkg/operation/botanist/networkpolicies_test.go
@@ -120,7 +120,7 @@ var _ = Describe("Networkpolicies", func() {
 				Expect(values.PrivateNetworkPeers).To(ConsistOf(defaultExpectedShootNetworkPeers...))
 				Expect(values.NodeLocalDNSEnabled).To(BeFalse())
 				Expect(values.NodeLocalIPVSAddress).To(PointTo(Equal("169.254.20.10")))
-				Expect(values.DNSServerAddress).To(PointTo(Equal("20.0.0.10")))
+				Expect(values.DNSServerAddress).To(PointTo(Equal("192.168.0.10")))
 			},
 		),
 
@@ -159,7 +159,7 @@ var _ = Describe("Networkpolicies", func() {
 				))
 				Expect(values.NodeLocalDNSEnabled).To(BeFalse())
 				Expect(values.NodeLocalIPVSAddress).To(PointTo(Equal("169.254.20.10")))
-				Expect(values.DNSServerAddress).To(PointTo(Equal("20.0.0.10")))
+				Expect(values.DNSServerAddress).To(PointTo(Equal("192.168.0.10")))
 			},
 		),
 
@@ -177,7 +177,7 @@ var _ = Describe("Networkpolicies", func() {
 				Expect(values.PrivateNetworkPeers).To(ConsistOf(defaultExpectedShootNetworkPeers...))
 				Expect(values.NodeLocalDNSEnabled).To(BeFalse())
 				Expect(values.NodeLocalIPVSAddress).To(PointTo(Equal("169.254.20.10")))
-				Expect(values.DNSServerAddress).To(PointTo(Equal("20.0.0.10")))
+				Expect(values.DNSServerAddress).To(PointTo(Equal("192.168.0.10")))
 			},
 		),
 
@@ -195,7 +195,7 @@ var _ = Describe("Networkpolicies", func() {
 				Expect(values.PrivateNetworkPeers).To(ConsistOf(defaultExpectedShootNetworkPeers...))
 				Expect(values.NodeLocalDNSEnabled).To(BeFalse())
 				Expect(values.NodeLocalIPVSAddress).To(PointTo(Equal("169.254.20.10")))
-				Expect(values.DNSServerAddress).To(PointTo(Equal("20.0.0.10")))
+				Expect(values.DNSServerAddress).To(PointTo(Equal("192.168.0.10")))
 			},
 		),
 
@@ -213,7 +213,7 @@ var _ = Describe("Networkpolicies", func() {
 				Expect(values.PrivateNetworkPeers).To(ConsistOf(defaultExpectedShootNetworkPeers...))
 				Expect(values.NodeLocalDNSEnabled).To(BeFalse())
 				Expect(values.NodeLocalIPVSAddress).To(PointTo(Equal("169.254.20.10")))
-				Expect(values.DNSServerAddress).To(PointTo(Equal("20.0.0.10")))
+				Expect(values.DNSServerAddress).To(PointTo(Equal("192.168.0.10")))
 			},
 		),
 
@@ -231,7 +231,7 @@ var _ = Describe("Networkpolicies", func() {
 				Expect(values.PrivateNetworkPeers).To(ConsistOf(defaultExpectedShootNetworkPeers...))
 				Expect(values.NodeLocalDNSEnabled).To(BeFalse())
 				Expect(values.NodeLocalIPVSAddress).To(PointTo(Equal("169.254.20.10")))
-				Expect(values.DNSServerAddress).To(PointTo(Equal("20.0.0.10")))
+				Expect(values.DNSServerAddress).To(PointTo(Equal("192.168.0.10")))
 			},
 		),
 
@@ -251,7 +251,7 @@ var _ = Describe("Networkpolicies", func() {
 				Expect(values.PrivateNetworkPeers).To(ConsistOf(defaultExpectedShootNetworkPeers...))
 				Expect(values.NodeLocalDNSEnabled).To(BeTrue())
 				Expect(values.NodeLocalIPVSAddress).To(PointTo(Equal("169.254.20.10")))
-				Expect(values.DNSServerAddress).To(PointTo(Equal("20.0.0.10")))
+				Expect(values.DNSServerAddress).To(PointTo(Equal("192.168.0.10")))
 			},
 		),
 	)


### PR DESCRIPTION
The networking policy in the seed need to refer to the dns server of the seed.

Co-authored-by: Sebastian Stauch <sebastian.stauch@sap.com>

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
This is one step to getting node local dns ready for actual use.

**Which issue(s) this PR fixes**:
The networking policy in the seed need to refer to the dns server of the seed instead of the dns server of the shoot.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed incorrect usage of shoot dns server in network policy inside the control plane where the seed dns server should have been used. This is only relevant if node local dns is activated.
```
