### PR TITLE
Allow changing container runtime on existing workers

### DIFF
--- a/docs/usage/shoot_updates.md
+++ b/docs/usage/shoot_updates.md
@@ -75,7 +75,7 @@ Additionally, you might customize how the machine-controller-manager (abbrev.: M
 Apart from the above mentioned triggers, a rolling update of the shoot worker nodes is also triggered for some changes to your worker pool specification (`.spec.provider.workers[]`, even if you don't change the Kubernetes or machine image version).
 The complete list of fields that trigger a rolling update:
 
-* `.spec.kubernetes.version`
+* `.spec.kubernetes.version` (except for patch version changes)
 * `.spec.provider.workers[].machine.image.name`
 * `.spec.provider.workers[].machine.image.version`
 * `.spec.provider.workers[].machine.type`

--- a/docs/usage/shoot_updates.md
+++ b/docs/usage/shoot_updates.md
@@ -82,6 +82,7 @@ The complete list of fields that trigger a rolling update:
 * `.spec.provider.workers[].volume.type`
 * `.spec.provider.workers[].volume.size`
 * `.spec.provider.workers[].providerConfig`
+* `.spec.provider.workers[].cri.name`
 
 Generally, the provider extension controllers might have additional constraints for changes leading to rolling updates, so please consult the respective documentation as well.
 

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -207,45 +207,7 @@ func ValidateShootSpecUpdate(newSpec, oldSpec *core.ShootSpec, newObjectMeta met
 
 // ValidateProviderUpdate validates the specification of a Provider object.
 func ValidateProviderUpdate(newProvider, oldProvider *core.Provider, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newProvider.Type, oldProvider.Type, fldPath.Child("type"))...)
-	allErrs = append(allErrs, ValidateWorkersUpdate(newProvider.Workers, oldProvider.Workers, fldPath.Child("workers"))...)
-
-	return allErrs
-}
-
-// ValidateWorkersUpdate validates the specification of a Provider object.
-func ValidateWorkersUpdate(newWorkers, oldWorkers []core.Worker, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-	oldWorkersMap := make(map[string]core.Worker)
-	for _, w := range oldWorkers {
-		oldWorkersMap[w.Name] = w
-	}
-	for i, w := range newWorkers {
-		if _, ok := oldWorkersMap[w.Name]; ok {
-			oldWorker := oldWorkersMap[w.Name]
-			allErrs = append(allErrs, ValidateWorkerUpdate(&w, &oldWorker, fldPath.Index(i))...)
-		}
-	}
-	return allErrs
-}
-
-// ValidateWorkerUpdate validates the specification of a Provider object.
-func ValidateWorkerUpdate(newWorker, oldWorker *core.Worker, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-	allErrs = append(allErrs, validateCRIUpdate(newWorker.CRI, oldWorker.CRI, fldPath.Child("cri"))...)
-
-	return allErrs
-}
-
-func validateCRIUpdate(newCri *core.CRI, oldCri *core.CRI, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-
-	if (newCri == nil && oldCri != nil) || (newCri != nil && oldCri == nil) || (newCri != nil && oldCri != nil && newCri.Name != oldCri.Name) {
-		allErrs = append(allErrs, field.Invalid(fldPath, newCri, "can't update cri configurations"))
-	}
-	return allErrs
+	return apivalidation.ValidateImmutableField(newProvider.Type, oldProvider.Type, fldPath.Child("type"))
 }
 
 // ValidateShootStatusUpdate validates the status field of a Shoot object.

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -1044,33 +1044,6 @@ var _ = Describe("Shoot Validation Tests", func() {
 
 				Expect(errorList).To(HaveLen(0))
 			})
-
-			It("should not allow update cri configurations enablement", func() {
-				newShoot := prepareShootForUpdate(shoot)
-				newWorker := *shoot.Spec.Provider.Workers[0].DeepCopy()
-				newWorker.Name = "second-worker"
-				newWorker.CRI = &core.CRI{Name: core.CRINameContainerD}
-				shoot.Spec.Provider.Workers = append(shoot.Spec.Provider.Workers, newWorker)
-
-				newShoot.Spec.Provider.Workers = []core.Worker{newWorker, shoot.Spec.Provider.Workers[0]}
-				newShoot.Spec.Provider.Workers[0].CRI = nil
-				newShoot.Spec.Provider.Workers[1].CRI = &core.CRI{Name: core.CRINameContainerD}
-
-				errorList := ValidateShootUpdate(newShoot, shoot)
-
-				Expect(errorList).To(HaveLen(2))
-			})
-
-			It("should not allow update cri name", func() {
-				shoot.Spec.Provider.Workers[0].CRI = &core.CRI{Name: "test-cri"}
-				newShoot := prepareShootForUpdate(shoot)
-
-				newShoot.Spec.Provider.Workers[0].CRI = &core.CRI{Name: core.CRINameContainerD}
-
-				errorList := ValidateShootUpdate(newShoot, shoot)
-
-				Expect(errorList).To(HaveLen(1))
-			})
 		})
 
 		Context("dns section", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
Allow changing container runtime on existing workers.

Changing the container runtime on an existing worker will result in a node rollout and is therefore unproblematic and a use-case we want to support. We're not sure why this was specifically forbidden before.

**Which issue(s) this PR fixes**:
Related to #4110 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Allow changing container runtime on existing workers. This triggers a graceful recreation of the workers.
```

/cc @BeckerMax 
