### PR TITLE
Do not wait forever for Terraform pod creation if it's stuck

### DIFF
--- a/extensions/pkg/terraformer/config.go
+++ b/extensions/pkg/terraformer/config.go
@@ -63,6 +63,12 @@ func (t *terraformer) SetDeadlinePod(d time.Duration) Terraformer {
 	return t
 }
 
+// SetDeadlinePodCreation configures the deadline while waiting for the creation of the Terraformer apply/destroy pod.
+func (t *terraformer) SetDeadlinePodCreation(d time.Duration) Terraformer {
+	t.deadlinePodCreation = d
+	return t
+}
+
 // SetOwnerRef configures the resource that will be used as owner of the secrets and configmaps
 func (t *terraformer) SetOwnerRef(owner *metav1.OwnerReference) Terraformer {
 	t.ownerRef = owner

--- a/extensions/pkg/terraformer/mock/mocks.go
+++ b/extensions/pkg/terraformer/mock/mocks.go
@@ -248,6 +248,20 @@ func (mr *MockTerraformerMockRecorder) SetDeadlinePod(arg0 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDeadlinePod", reflect.TypeOf((*MockTerraformer)(nil).SetDeadlinePod), arg0)
 }
 
+// SetDeadlinePodCreation mocks base method.
+func (m *MockTerraformer) SetDeadlinePodCreation(arg0 time.Duration) terraformer.Terraformer {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetDeadlinePodCreation", arg0)
+	ret0, _ := ret[0].(terraformer.Terraformer)
+	return ret0
+}
+
+// SetDeadlinePodCreation indicates an expected call of SetDeadlinePodCreation.
+func (mr *MockTerraformerMockRecorder) SetDeadlinePodCreation(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDeadlinePodCreation", reflect.TypeOf((*MockTerraformer)(nil).SetDeadlinePodCreation), arg0)
+}
+
 // SetEnvVars mocks base method.
 func (m *MockTerraformer) SetEnvVars(arg0 ...v1.EnvVar) terraformer.Terraformer {
 	m.ctrl.T.Helper()

--- a/extensions/pkg/terraformer/terraformer.go
+++ b/extensions/pkg/terraformer/terraformer.go
@@ -121,8 +121,9 @@ func New(
 		logLevel:                      "info",
 		terminationGracePeriodSeconds: int64(3600),
 
-		deadlineCleaning: 20 * time.Minute,
-		deadlinePod:      20 * time.Minute,
+		deadlineCleaning:    20 * time.Minute,
+		deadlinePod:         20 * time.Minute,
+		deadlinePodCreation: 2 * time.Minute,
 	}
 }
 
@@ -243,7 +244,7 @@ func (t *terraformer) execute(ctx context.Context, command string) error {
 		}
 
 		// Wait for the Terraform apply/destroy Pod to be completed
-		status, terminationMessage := t.waitForPod(ctx, logger, pod, t.deadlinePod)
+		status, terminationMessage := t.waitForPod(ctx, logger, pod)
 		if status == podStatusSucceeded {
 			podLogger.Info("Terraformer pod finished successfully")
 		} else if status == podStatusCreationTimeout {

--- a/extensions/pkg/terraformer/terraformer.go
+++ b/extensions/pkg/terraformer/terraformer.go
@@ -246,6 +246,8 @@ func (t *terraformer) execute(ctx context.Context, command string) error {
 		status, terminationMessage := t.waitForPod(ctx, logger, pod, t.deadlinePod)
 		if status == podStatusSucceeded {
 			podLogger.Info("Terraformer pod finished successfully")
+		} else if status == podStatusCreationTimeout {
+			podLogger.Info("Terraformer pod creation timed out")
 		} else {
 			podLogger.Info("Terraformer pod finished with error")
 

--- a/extensions/pkg/terraformer/terraformer.go
+++ b/extensions/pkg/terraformer/terraformer.go
@@ -243,12 +243,11 @@ func (t *terraformer) execute(ctx context.Context, command string) error {
 		}
 
 		// Wait for the Terraform apply/destroy Pod to be completed
-		exitCode, terminationMessage := t.waitForPod(ctx, logger, pod, t.deadlinePod)
-		succeeded := exitCode == 0
-		if succeeded {
+		status, terminationMessage := t.waitForPod(ctx, logger, pod, t.deadlinePod)
+		if status == podStatusSucceeded {
 			podLogger.Info("Terraformer pod finished successfully")
 		} else {
-			podLogger.Info("Terraformer pod finished with error", "exitCode", exitCode)
+			podLogger.Info("Terraformer pod finished with error")
 
 			if terminationMessage != "" {
 				podLogger.V(1).Info("Termination message of Terraformer pod: " + terminationMessage)
@@ -269,7 +268,7 @@ func (t *terraformer) execute(ctx context.Context, command string) error {
 			return err
 		}
 
-		if !succeeded {
+		if status != podStatusSucceeded {
 			errorMessage := fmt.Sprintf("Terraform execution for command '%s' could not be completed", command)
 			if terraformErrors := findTerraformErrors(terminationMessage); terraformErrors != "" {
 				errorMessage += fmt.Sprintf(":\n\n%s", terraformErrors)

--- a/extensions/pkg/terraformer/terraformer.go
+++ b/extensions/pkg/terraformer/terraformer.go
@@ -123,7 +123,7 @@ func New(
 
 		deadlineCleaning:    20 * time.Minute,
 		deadlinePod:         20 * time.Minute,
-		deadlinePodCreation: 2 * time.Minute,
+		deadlinePodCreation: 5 * time.Minute,
 	}
 }
 

--- a/extensions/pkg/terraformer/types.go
+++ b/extensions/pkg/terraformer/types.go
@@ -70,8 +70,9 @@ type terraformer struct {
 	logLevel                      string
 	terminationGracePeriodSeconds int64
 
-	deadlineCleaning time.Duration
-	deadlinePod      time.Duration
+	deadlineCleaning    time.Duration
+	deadlinePod         time.Duration
+	deadlinePodCreation time.Duration
 }
 
 // RawState represent the terraformer state's raw data
@@ -107,6 +108,7 @@ type Terraformer interface {
 	SetTerminationGracePeriodSeconds(int64) Terraformer
 	SetDeadlineCleaning(time.Duration) Terraformer
 	SetDeadlinePod(time.Duration) Terraformer
+	SetDeadlinePodCreation(time.Duration) Terraformer
 	SetOwnerRef(*metav1.OwnerReference) Terraformer
 	InitializeWith(ctx context.Context, initializer Initializer) Terraformer
 	Apply(ctx context.Context) error

--- a/extensions/pkg/terraformer/waiter.go
+++ b/extensions/pkg/terraformer/waiter.go
@@ -48,31 +48,34 @@ func (t *terraformer) WaitForCleanEnvironment(ctx context.Context) error {
 	})
 }
 
+type podStatus byte
+
+const (
+	podStatusSucceeded podStatus = iota
+	podStatusFailure
+)
+
 // waitForPod waits for the Terraform Pod to be completed (either successful or failed).
 // It checks the Pod status field to identify the state.
-func (t *terraformer) waitForPod(ctx context.Context, logger logr.Logger, pod *corev1.Pod, deadline time.Duration) (int32, string) {
+func (t *terraformer) waitForPod(ctx context.Context, logger logr.Logger, pod *corev1.Pod, deadline time.Duration) (podStatus, string) {
 	var (
-		// 'terraform plan' returns exit code 2 if the plan succeeded and there is a diff
-		// If we can't read the terminated state of the container we simply force that the Terraform
-		// job gets created.
-		exitCode           int32 = 2
-		terminationMessage       = ""
+		status             = podStatusFailure
+		terminationMessage = ""
+		log                = logger.WithValues("pod", client.ObjectKeyFromObject(pod))
 	)
 
-	ctx, cancel := context.WithTimeout(ctx, deadline)
+	timeoutCtx, cancel := context.WithTimeout(ctx, deadline)
 	defer cancel()
 
-	logger = logger.WithValues("pod", client.ObjectKeyFromObject(pod))
+	log.Info("Waiting for Terraformer pod to be completed...")
+	_ = retry.Until(timeoutCtx, 5*time.Second, func(ctx context.Context) (bool, error) {
+		if err := t.client.Get(ctx, client.ObjectKeyFromObject(pod), pod); err != nil {
+			if apierrors.IsNotFound(err) {
+				log.Info("Terraformer pod disappeared unexpectedly, somebody must have manually deleted it")
+				return retry.Ok()
+			}
 
-	logger.Info("Waiting for Terraformer pod to be completed...")
-	if err := retry.Until(ctx, 5*time.Second, func(ctx context.Context) (done bool, err error) {
-		err = t.client.Get(ctx, client.ObjectKeyFromObject(pod), pod)
-		if apierrors.IsNotFound(err) {
-			logger.Info("Terraformer pod disappeared unexpectedly, somebody must have manually deleted it")
-			return retry.Ok()
-		}
-		if err != nil {
-			logger.Error(err, "Error retrieving pod")
+			log.Error(err, "Error retrieving pod")
 			return retry.SevereError(err)
 		}
 
@@ -84,17 +87,17 @@ func (t *terraformer) waitForPod(ctx context.Context, logger logr.Logger, pod *c
 
 		if (phase == corev1.PodSucceeded || phase == corev1.PodFailed) && len(containerStatuses) > 0 {
 			if containerStateTerminated := containerStatuses[0].State.Terminated; containerStateTerminated != nil {
-				exitCode = containerStateTerminated.ExitCode
+				if containerStateTerminated.ExitCode == 0 {
+					status = podStatusSucceeded
+				}
 				terminationMessage = containerStateTerminated.Message
 			}
 			return retry.Ok()
 		}
 
-		logger.Info("Waiting for Terraformer pod to be completed, pod hasn't finished yet", "phase", phase, "len-of-containerstatuses", len(containerStatuses))
+		log.Info("Waiting for Terraformer pod to be completed, pod hasn't finished yet", "phase", phase, "len-of-containerstatuses", len(containerStatuses))
 		return retry.MinorError(fmt.Errorf("pod was not successful: phase=%s, len-of-containerstatuses=%d", phase, len(containerStatuses)))
-	}); err != nil {
-		exitCode = 1
-	}
+	})
 
-	return exitCode, terminationMessage
+	return status, terminationMessage
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
Earlier, when a Terraform pod was stuck in creation (for whatever reason), the `terraformer` package still waited for the configured deadline period for the pod to complete.
Now, if the pod doesn't start after `5m` (overrideable), the wait procedure will be aborted such that the pod can be deleted and re-created.

/squash

**Special notes for your reviewer**:
/cc @vpnachev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Terraform pods stuck in creation are now deleted after `5m` instead of being waited for the configured deadline period (usually > `20m`/`30m`). 
```
