### PR TITLE
Make Bastion controller and BackupEntry component ready for cached client

### DIFF
--- a/pkg/extensions/customresources.go
+++ b/pkg/extensions/customresources.go
@@ -20,6 +20,13 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/sirupsen/logrus"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	gardencorev1alpha1helper "github.com/gardener/gardener/pkg/apis/core/v1alpha1/helper"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -32,13 +39,6 @@ import (
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 	"github.com/gardener/gardener/pkg/utils/retry"
-
-	"github.com/sirupsen/logrus"
-	autoscalingv1 "k8s.io/api/autoscaling/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // TimeNow returns the current time. Exposed for testing.
@@ -352,7 +352,7 @@ func RestoreExtensionObjectState(
 				if err != nil {
 					return err
 				}
-				if err := utils.CreateOrUpdateObjectByRef(ctx, c, &resourceRef, extensionObj.GetNamespace(), obj); err != nil {
+				if err := utils.CreateOrPatchObjectByRef(ctx, c, &resourceRef, extensionObj.GetNamespace(), obj); err != nil {
 					return err
 				}
 			}

--- a/pkg/extensions/customresources.go
+++ b/pkg/extensions/customresources.go
@@ -33,11 +33,11 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
+	unstructuredutils "github.com/gardener/gardener/pkg/utils/kubernetes/unstructured"
 	"github.com/gardener/gardener/pkg/utils/retry"
 )
 
@@ -352,7 +352,7 @@ func RestoreExtensionObjectState(
 				if err != nil {
 					return err
 				}
-				if err := utils.CreateOrPatchObjectByRef(ctx, c, &resourceRef, extensionObj.GetNamespace(), obj); err != nil {
+				if err := unstructuredutils.CreateOrPatchObjectByRef(ctx, c, &resourceRef, extensionObj.GetNamespace(), obj); err != nil {
 					return err
 				}
 			}

--- a/pkg/gardenlet/controller/backupentry/backup_entry_actuator.go
+++ b/pkg/gardenlet/controller/backupentry/backup_entry_actuator.go
@@ -23,7 +23,6 @@ import (
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/extensions"
@@ -240,7 +239,7 @@ func (a *actuator) waitUntilBackupBucketReconciled(ctx context.Context) error {
 		a.logger,
 		health.CheckBackupBucket,
 		a.backupBucket,
-		extensionsv1alpha1.BackupBucketResource,
+		"BackupBucket",
 		defaultInterval,
 		defaultSevereThreshold,
 		defaultTimeout,

--- a/pkg/gardenlet/controller/federatedseed/extensions/shootstate_control.go
+++ b/pkg/gardenlet/controller/federatedseed/extensions/shootstate_control.go
@@ -37,9 +37,9 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/extensions"
-	"github.com/gardener/gardener/pkg/utils"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	unstructuredutils "github.com/gardener/gardener/pkg/utils/kubernetes/unstructured"
 )
 
 // ShootStateControl is used to update data about extensions and any resources required by them in the ShootState.
@@ -141,7 +141,7 @@ func (s *ShootStateControl) getResourcesToUpdate(ctx context.Context, shootState
 	var resourcesToAddUpdate gardencorev1alpha1helper.ResourceDataList
 
 	for _, newResource := range newResources {
-		obj, err := utils.GetObjectByRef(ctx, s.seedClient.Client(), &newResource.ResourceRef, namespace)
+		obj, err := unstructuredutils.GetObjectByRef(ctx, s.seedClient.Client(), &newResource.ResourceRef, namespace)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -112,10 +112,10 @@ func (b *Botanist) MigrateIngressDNSRecord(ctx context.Context) error {
 }
 
 // DefaultNginxIngressDNSEntry returns a Deployer which removes existing nginx ingress DNSEntry.
-func (b *Botanist) DefaultNginxIngressDNSEntry(seedClient client.Client) component.DeployWaiter {
+func (b *Botanist) DefaultNginxIngressDNSEntry() component.DeployWaiter {
 	return component.OpDestroy(dns.NewEntry(
 		b.Logger,
-		seedClient,
+		b.K8sSeedClient.Client(),
 		b.Shoot.SeedNamespace,
 		&dns.EntryValues{
 			Name: common.ShootDNSIngressName,
@@ -125,9 +125,9 @@ func (b *Botanist) DefaultNginxIngressDNSEntry(seedClient client.Client) compone
 }
 
 // DefaultNginxIngressDNSOwner returns DeployWaiter which removes the nginx ingress DNSOwner.
-func (b *Botanist) DefaultNginxIngressDNSOwner(seedClient client.Client) component.DeployWaiter {
+func (b *Botanist) DefaultNginxIngressDNSOwner() component.DeployWaiter {
 	return component.OpDestroy(dns.NewOwner(
-		seedClient,
+		b.K8sSeedClient.Client(),
 		b.Shoot.SeedNamespace,
 		&dns.OwnerValues{
 			Name: common.ShootDNSIngressName,

--- a/pkg/operation/botanist/addons_test.go
+++ b/pkg/operation/botanist/addons_test.go
@@ -103,6 +103,7 @@ var _ = Describe("dns", func() {
 		Expect(chartApplier).NotTo(BeNil(), "should return chart applier")
 
 		fakeClientSet := fakeclientset.NewClientSetBuilder().
+			WithClient(seedClient).
 			WithChartApplier(chartApplier).
 			Build()
 
@@ -115,7 +116,7 @@ var _ = Describe("dns", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: "ingress", Namespace: seedNS},
 			})).ToNot(HaveOccurred())
 
-			Expect(b.DefaultNginxIngressDNSEntry(seedClient).Deploy(ctx)).ToNot(HaveOccurred())
+			Expect(b.DefaultNginxIngressDNSEntry().Deploy(ctx)).ToNot(HaveOccurred())
 
 			found := &dnsv1alpha1.DNSEntry{}
 			err := seedClient.Get(ctx, types.NamespacedName{Name: "ingress", Namespace: seedNS}, found)
@@ -129,7 +130,7 @@ var _ = Describe("dns", func() {
 				ObjectMeta: metav1.ObjectMeta{Name: seedNS + "-ingress"},
 			})).ToNot(HaveOccurred())
 
-			Expect(b.DefaultNginxIngressDNSOwner(seedClient).Deploy(ctx)).ToNot(HaveOccurred())
+			Expect(b.DefaultNginxIngressDNSOwner().Deploy(ctx)).ToNot(HaveOccurred())
 
 			found := &dnsv1alpha1.DNSOwner{}
 			err := seedClient.Get(ctx, types.NamespacedName{Name: seedNS + "-ingress"}, found)

--- a/pkg/operation/botanist/backupentry.go
+++ b/pkg/operation/botanist/backupentry.go
@@ -24,17 +24,16 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // DefaultCoreBackupEntry creates the default deployer for the core.gardener.cloud/v1beta1.BackupEntry resource.
-func (b *Botanist) DefaultCoreBackupEntry(gardenClient client.Client) component.DeployMigrateWaiter {
+func (b *Botanist) DefaultCoreBackupEntry() component.DeployMigrateWaiter {
 	ownerRef := metav1.NewControllerRef(b.Shoot.Info, gardencorev1beta1.SchemeGroupVersion.WithKind("Shoot"))
 	ownerRef.BlockOwnerDeletion = pointer.BoolPtr(false)
 
 	return corebackupentry.New(
 		b.Logger,
-		gardenClient,
+		b.K8sGardenClient.Client(),
 		&corebackupentry.Values{
 			Namespace:      b.Shoot.Info.Namespace,
 			Name:           gutil.GenerateBackupEntryName(b.Shoot.Info.Status.TechnicalID, b.Shoot.Info.Status.UID),

--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -68,33 +68,32 @@ func New(ctx context.Context, o *operation.Operation) (*Botanist, error) {
 	}
 
 	// extension components
-	// TODO(timebertt): remove client param from Default* funcs
-	o.Shoot.Components.Extensions.ContainerRuntime = b.DefaultContainerRuntime(b.K8sSeedClient.Client())
-	o.Shoot.Components.Extensions.ControlPlane = b.DefaultControlPlane(b.K8sSeedClient.Client(), extensionsv1alpha1.Normal)
-	o.Shoot.Components.Extensions.ControlPlaneExposure = b.DefaultControlPlane(b.K8sSeedClient.Client(), extensionsv1alpha1.Exposure)
-	o.Shoot.Components.Extensions.DNS.ExternalProvider = b.DefaultExternalDNSProvider(b.K8sSeedClient.Client())
-	o.Shoot.Components.Extensions.DNS.ExternalOwner = b.DefaultExternalDNSOwner(b.K8sSeedClient.Client())
-	o.Shoot.Components.Extensions.DNS.ExternalEntry = b.DefaultExternalDNSEntry(b.K8sSeedClient.Client())
-	o.Shoot.Components.Extensions.DNS.InternalProvider = b.DefaultInternalDNSProvider(b.K8sSeedClient.Client())
-	o.Shoot.Components.Extensions.DNS.InternalOwner = b.DefaultInternalDNSOwner(b.K8sSeedClient.Client())
-	o.Shoot.Components.Extensions.DNS.InternalEntry = b.DefaultInternalDNSEntry(b.K8sSeedClient.Client())
-	o.Shoot.Components.Extensions.DNS.NginxOwner = b.DefaultNginxIngressDNSOwner(b.K8sSeedClient.Client())
-	o.Shoot.Components.Extensions.DNS.NginxEntry = b.DefaultNginxIngressDNSEntry(b.K8sSeedClient.Client())
-	o.Shoot.Components.Extensions.DNS.AdditionalProviders, err = b.AdditionalDNSProviders(ctx, b.K8sGardenClient.Client(), b.K8sSeedClient.Client())
+	o.Shoot.Components.Extensions.ContainerRuntime = b.DefaultContainerRuntime()
+	o.Shoot.Components.Extensions.ControlPlane = b.DefaultControlPlane(extensionsv1alpha1.Normal)
+	o.Shoot.Components.Extensions.ControlPlaneExposure = b.DefaultControlPlane(extensionsv1alpha1.Exposure)
+	o.Shoot.Components.Extensions.DNS.ExternalProvider = b.DefaultExternalDNSProvider()
+	o.Shoot.Components.Extensions.DNS.ExternalOwner = b.DefaultExternalDNSOwner()
+	o.Shoot.Components.Extensions.DNS.ExternalEntry = b.DefaultExternalDNSEntry()
+	o.Shoot.Components.Extensions.DNS.InternalProvider = b.DefaultInternalDNSProvider()
+	o.Shoot.Components.Extensions.DNS.InternalOwner = b.DefaultInternalDNSOwner()
+	o.Shoot.Components.Extensions.DNS.InternalEntry = b.DefaultInternalDNSEntry()
+	o.Shoot.Components.Extensions.DNS.NginxOwner = b.DefaultNginxIngressDNSOwner()
+	o.Shoot.Components.Extensions.DNS.NginxEntry = b.DefaultNginxIngressDNSEntry()
+	o.Shoot.Components.Extensions.DNS.AdditionalProviders, err = b.AdditionalDNSProviders(ctx)
 	if err != nil {
 		return nil, err
 	}
-	o.Shoot.Components.Extensions.Extension, err = b.DefaultExtension(ctx, b.K8sSeedClient.Client())
+	o.Shoot.Components.Extensions.Extension, err = b.DefaultExtension(ctx)
 	if err != nil {
 		return nil, err
 	}
-	o.Shoot.Components.Extensions.Infrastructure = b.DefaultInfrastructure(b.K8sSeedClient.Client())
-	o.Shoot.Components.Extensions.Network = b.DefaultNetwork(b.K8sSeedClient.Client())
-	o.Shoot.Components.Extensions.OperatingSystemConfig, err = b.DefaultOperatingSystemConfig(b.K8sSeedClient.Client())
+	o.Shoot.Components.Extensions.Infrastructure = b.DefaultInfrastructure()
+	o.Shoot.Components.Extensions.Network = b.DefaultNetwork()
+	o.Shoot.Components.Extensions.OperatingSystemConfig, err = b.DefaultOperatingSystemConfig()
 	if err != nil {
 		return nil, err
 	}
-	o.Shoot.Components.Extensions.Worker = b.DefaultWorker(b.K8sSeedClient.Client())
+	o.Shoot.Components.Extensions.Worker = b.DefaultWorker()
 
 	sniPhase, err := b.SNIPhase(ctx)
 	if err != nil {
@@ -147,7 +146,7 @@ func New(ctx context.Context, o *operation.Operation) (*Botanist, error) {
 	}
 
 	// other components
-	o.Shoot.Components.BackupEntry = b.DefaultCoreBackupEntry(b.K8sGardenClient.Client())
+	o.Shoot.Components.BackupEntry = b.DefaultCoreBackupEntry()
 	o.Shoot.Components.NetworkPolicies, err = b.DefaultNetworkPolicies(sniPhase)
 	if err != nil {
 		return nil, err

--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -147,7 +147,7 @@ func New(ctx context.Context, o *operation.Operation) (*Botanist, error) {
 	}
 
 	// other components
-	o.Shoot.Components.BackupEntry = b.DefaultCoreBackupEntry(b.K8sGardenClient.DirectClient())
+	o.Shoot.Components.BackupEntry = b.DefaultCoreBackupEntry(b.K8sGardenClient.Client())
 	o.Shoot.Components.NetworkPolicies, err = b.DefaultNetworkPolicies(sniPhase)
 	if err != nil {
 		return nil, err

--- a/pkg/operation/botanist/component/backupentry/backupentry_test.go
+++ b/pkg/operation/botanist/component/backupentry/backupentry_test.go
@@ -98,7 +98,6 @@ var _ = Describe("BackupEntry", func() {
 					v1beta1constants.GardenerTimestamp: now.UTC().String(),
 					v1beta1constants.ShootPurpose:      string(shootPurpose),
 				},
-				Finalizers:      []string{"gardener"},
 				OwnerReferences: []metav1.OwnerReference{*ownerRef},
 			},
 			Spec: gardencorev1beta1.BackupEntrySpec{
@@ -167,7 +166,7 @@ var _ = Describe("BackupEntry", func() {
 			}
 
 			Expect(c.Create(ctx, expected)).To(Succeed(), "creating BackupEntry succeeds")
-			Expect(defaultDepWaiter.Wait(ctx)).To(MatchError(ContainSubstring("has not yet been reconciled")), "BackupEntry indicates error")
+			Expect(defaultDepWaiter.Wait(ctx)).To(MatchError(ContainSubstring("error during reconciliation: Some error")), "BackupEntry indicates error")
 		})
 
 		It("should return no error when is ready", func() {

--- a/pkg/operation/botanist/component/extensions/extension/extension_test.go
+++ b/pkg/operation/botanist/component/extensions/extension/extension_test.go
@@ -19,6 +19,19 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/go-multierror"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
@@ -31,19 +44,6 @@ import (
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-
-	"github.com/golang/mock/gomock"
-	"github.com/hashicorp/go-multierror"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-	"github.com/sirupsen/logrus"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/utils/pointer"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var _ = Describe("Extension", func() {
@@ -157,7 +157,7 @@ var _ = Describe("Extension", func() {
 				Expect(c.Create(ctx, expected[i])).To(Succeed(), "creating extensions succeeds")
 			}
 
-			Expect(defaultDepWaiter.Wait(ctx)).To(MatchError(ContainSubstring("encountered error during reconciliation: "+errDescription)), "extensions indicates error")
+			Expect(defaultDepWaiter.Wait(ctx)).To(MatchError(ContainSubstring("error during reconciliation: "+errDescription)), "extensions indicates error")
 		})
 
 		It("should return error if we haven't observed the latest timestamp annotation", func() {

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"time"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
@@ -35,7 +37,6 @@ import (
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/Masterminds/semver"
 	"github.com/golang/mock/gomock"
@@ -403,7 +404,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 					Expect(c.Create(ctx, expected[i])).To(Succeed())
 				}
 
-				Expect(defaultDepWaiter.Wait(ctx)).To(MatchError(ContainSubstring("encountered error during reconciliation: " + errDescription)))
+				Expect(defaultDepWaiter.Wait(ctx)).To(MatchError(ContainSubstring("error during reconciliation: " + errDescription)))
 			})
 
 			It("should return error when status does not contain cloud config information", func() {

--- a/pkg/operation/botanist/containerruntime.go
+++ b/pkg/operation/botanist/containerruntime.go
@@ -17,16 +17,14 @@ package botanist
 import (
 	"context"
 
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/containerruntime"
 )
 
 // DefaultContainerRuntime creates the default deployer for the ContainerRuntime custom resource.
-func (b *Botanist) DefaultContainerRuntime(seedClient client.Client) containerruntime.Interface {
+func (b *Botanist) DefaultContainerRuntime() containerruntime.Interface {
 	return containerruntime.New(
 		b.Logger,
-		seedClient,
+		b.K8sSeedClient.Client(),
 		&containerruntime.Values{
 			Namespace: b.Shoot.SeedNamespace,
 			Workers:   b.Shoot.Info.Spec.Provider.Workers,

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -291,7 +291,7 @@ func (b *Botanist) PrepareKubeAPIServerForMigration(ctx context.Context) error {
 }
 
 // DefaultControlPlane creates the default deployer for the ControlPlane custom resource with the given purpose.
-func (b *Botanist) DefaultControlPlane(seedClient client.Client, purpose extensionsv1alpha1.Purpose) extensionscontrolplane.Interface {
+func (b *Botanist) DefaultControlPlane(purpose extensionsv1alpha1.Purpose) extensionscontrolplane.Interface {
 	values := &extensionscontrolplane.Values{
 		Name:      b.Shoot.Info.Name,
 		Namespace: b.Shoot.SeedNamespace,
@@ -311,7 +311,7 @@ func (b *Botanist) DefaultControlPlane(seedClient client.Client, purpose extensi
 
 	return extensionscontrolplane.New(
 		b.Logger,
-		seedClient,
+		b.K8sSeedClient.Client(),
 		values,
 		extensionscontrolplane.DefaultInterval,
 		extensionscontrolplane.DefaultSevereThreshold,

--- a/pkg/operation/botanist/dns.go
+++ b/pkg/operation/botanist/dns.go
@@ -102,11 +102,11 @@ func (b *Botanist) enableDNSProviderForShootDNSEntries() map[string]string {
 
 // DefaultExternalDNSProvider returns the external DNSProvider if external DNS is
 // enabled and if not DeployWaiter which removes the external DNSProvider.
-func (b *Botanist) DefaultExternalDNSProvider(seedClient client.Client) component.DeployWaiter {
+func (b *Botanist) DefaultExternalDNSProvider() component.DeployWaiter {
 	if b.NeedsExternalDNS() {
 		return dns.NewProvider(
 			b.Logger,
-			seedClient,
+			b.K8sSeedClient.Client(),
 			b.Shoot.SeedNamespace,
 			&dns.ProviderValues{
 				Name:       DNSExternalName,
@@ -128,7 +128,7 @@ func (b *Botanist) DefaultExternalDNSProvider(seedClient client.Client) componen
 
 	return component.OpDestroy(dns.NewProvider(
 		b.Logger,
-		seedClient,
+		b.K8sSeedClient.Client(),
 		b.Shoot.SeedNamespace,
 		&dns.ProviderValues{
 			Name:    DNSExternalName,
@@ -138,10 +138,10 @@ func (b *Botanist) DefaultExternalDNSProvider(seedClient client.Client) componen
 }
 
 // DefaultExternalDNSEntry returns DeployWaiter which removes the external DNSEntry.
-func (b *Botanist) DefaultExternalDNSEntry(seedClient client.Client) component.DeployWaiter {
+func (b *Botanist) DefaultExternalDNSEntry() component.DeployWaiter {
 	return component.OpDestroy(dns.NewEntry(
 		b.Logger,
-		seedClient,
+		b.K8sSeedClient.Client(),
 		b.Shoot.SeedNamespace,
 		&dns.EntryValues{
 			Name: DNSExternalName,
@@ -151,9 +151,9 @@ func (b *Botanist) DefaultExternalDNSEntry(seedClient client.Client) component.D
 }
 
 // DefaultExternalDNSOwner returns DeployWaiter which removes the external DNSOwner.
-func (b *Botanist) DefaultExternalDNSOwner(seedClient client.Client) component.DeployWaiter {
+func (b *Botanist) DefaultExternalDNSOwner() component.DeployWaiter {
 	return component.OpDestroy(dns.NewOwner(
-		seedClient,
+		b.K8sSeedClient.Client(),
 		b.Shoot.SeedNamespace,
 		&dns.OwnerValues{
 			Name: DNSExternalName,
@@ -163,11 +163,11 @@ func (b *Botanist) DefaultExternalDNSOwner(seedClient client.Client) component.D
 
 // DefaultInternalDNSProvider returns the internal DNSProvider if internal DNS is
 // enabled and if not, DeployWaiter which removes the internal DNSProvider.
-func (b *Botanist) DefaultInternalDNSProvider(seedClient client.Client) component.DeployWaiter {
+func (b *Botanist) DefaultInternalDNSProvider() component.DeployWaiter {
 	if b.NeedsInternalDNS() {
 		return dns.NewProvider(
 			b.Logger,
-			seedClient,
+			b.K8sSeedClient.Client(),
 			b.Shoot.SeedNamespace,
 			&dns.ProviderValues{
 				Name:       DNSInternalName,
@@ -187,7 +187,7 @@ func (b *Botanist) DefaultInternalDNSProvider(seedClient client.Client) componen
 
 	return component.OpDestroy(dns.NewProvider(
 		b.Logger,
-		seedClient,
+		b.K8sSeedClient.Client(),
 		b.Shoot.SeedNamespace,
 		&dns.ProviderValues{
 			Name:    DNSInternalName,
@@ -197,10 +197,10 @@ func (b *Botanist) DefaultInternalDNSProvider(seedClient client.Client) componen
 }
 
 // DefaultInternalDNSEntry returns DeployWaiter which removes the internal DNSEntry.
-func (b *Botanist) DefaultInternalDNSEntry(seedClient client.Client) component.DeployWaiter {
+func (b *Botanist) DefaultInternalDNSEntry() component.DeployWaiter {
 	return component.OpDestroy(dns.NewEntry(
 		b.Logger,
-		seedClient,
+		b.K8sSeedClient.Client(),
 		b.Shoot.SeedNamespace,
 		&dns.EntryValues{
 			Name: DNSInternalName,
@@ -210,9 +210,9 @@ func (b *Botanist) DefaultInternalDNSEntry(seedClient client.Client) component.D
 }
 
 // DefaultInternalDNSOwner returns a DeployWaiter which removes the internal DNSOwner.
-func (b *Botanist) DefaultInternalDNSOwner(seedClient client.Client) component.DeployWaiter {
+func (b *Botanist) DefaultInternalDNSOwner() component.DeployWaiter {
 	return component.OpDestroy(dns.NewOwner(
-		seedClient,
+		b.K8sSeedClient.Client(),
 		b.Shoot.SeedNamespace,
 		&dns.OwnerValues{
 			Name: DNSInternalName,
@@ -223,7 +223,8 @@ func (b *Botanist) DefaultInternalDNSOwner(seedClient client.Client) component.D
 // AdditionalDNSProviders returns a map containing DNSProviders where the key is the provider name.
 // Providers and DNSEntries which are no longer needed / or in use, contain a DeployWaiter which removes
 // said DNSEntry / DNSProvider.
-func (b *Botanist) AdditionalDNSProviders(ctx context.Context, gardenClient, seedClient client.Client) (map[string]component.DeployWaiter, error) {
+func (b *Botanist) AdditionalDNSProviders(ctx context.Context) (map[string]component.DeployWaiter, error) {
+	seedClient := b.K8sSeedClient.Client()
 	additionalProviders := map[string]component.DeployWaiter{}
 
 	if b.NeedsAdditionalDNSProviders() {
@@ -260,7 +261,7 @@ func (b *Botanist) AdditionalDNSProviders(ctx context.Context, gardenClient, see
 			}
 
 			secret := &corev1.Secret{}
-			if err := gardenClient.Get(
+			if err := b.K8sGardenClient.Client().Get(
 				ctx,
 				kutil.Key(b.Shoot.Info.Namespace, *secretName),
 				secret,

--- a/pkg/operation/botanist/extension.go
+++ b/pkg/operation/botanist/extension.go
@@ -24,11 +24,10 @@ import (
 	"github.com/gardener/gardener/pkg/utils"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // DefaultExtension creates the default deployer for the Extension custom resources.
-func (b *Botanist) DefaultExtension(ctx context.Context, seedClient client.Client) (extension.Interface, error) {
+func (b *Botanist) DefaultExtension(ctx context.Context) (extension.Interface, error) {
 	controllerRegistrations := &gardencorev1beta1.ControllerRegistrationList{}
 	if err := b.K8sGardenClient.Client().List(ctx, controllerRegistrations); err != nil {
 		return nil, err
@@ -41,7 +40,7 @@ func (b *Botanist) DefaultExtension(ctx context.Context, seedClient client.Clien
 
 	return extension.New(
 		b.Logger,
-		seedClient,
+		b.K8sSeedClient.Client(),
 		&extension.Values{
 			Namespace:  b.Shoot.SeedNamespace,
 			Extensions: extensions,

--- a/pkg/operation/botanist/extension_test.go
+++ b/pkg/operation/botanist/extension_test.go
@@ -22,6 +22,7 @@ import (
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	fakeclientset "github.com/gardener/gardener/pkg/client/kubernetes/fake"
 	mockkubernetes "github.com/gardener/gardener/pkg/client/kubernetes/mock"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	"github.com/gardener/gardener/pkg/operation"
@@ -63,6 +64,7 @@ var _ = Describe("Extensions", func() {
 		gardenClient = mockclient.NewMockClient(ctrl)
 		botanist = &Botanist{Operation: &operation.Operation{
 			K8sGardenClient: gardenClientInterface,
+			K8sSeedClient:   fakeclientset.NewClientSet(),
 			Shoot: &shootpkg.Shoot{
 				Components: &shootpkg.Components{
 					Extensions: &shootpkg.Extensions{
@@ -133,7 +135,7 @@ var _ = Describe("Extensions", func() {
 		It("should return the error because listing failed", func() {
 			gardenClient.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerRegistrationList{})).Return(fakeErr)
 
-			ext, err := botanist.DefaultExtension(ctx, nil)
+			ext, err := botanist.DefaultExtension(ctx)
 			Expect(ext).To(BeNil())
 			Expect(err).To(MatchError(fakeErr))
 		})
@@ -146,7 +148,7 @@ var _ = Describe("Extensions", func() {
 					return nil
 				})
 
-				ext, err := botanist.DefaultExtension(ctx, nil)
+				ext, err := botanist.DefaultExtension(ctx)
 				Expect(err).To(BeNil())
 				Expect(ext.Extensions()).To(conditionMatcher)
 			},

--- a/pkg/operation/botanist/infrastructure.go
+++ b/pkg/operation/botanist/infrastructure.go
@@ -21,15 +21,13 @@ import (
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/infrastructure"
 	"github.com/gardener/gardener/pkg/utils/secrets"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // DefaultInfrastructure creates the default deployer for the Infrastructure custom resource.
-func (b *Botanist) DefaultInfrastructure(seedClient client.Client) infrastructure.Interface {
+func (b *Botanist) DefaultInfrastructure() infrastructure.Interface {
 	return infrastructure.New(
 		b.Logger,
-		seedClient,
+		b.K8sSeedClient.Client(),
 		&infrastructure.Values{
 			Namespace:         b.Shoot.SeedNamespace,
 			Name:              b.Shoot.Info.Name,

--- a/pkg/operation/botanist/network.go
+++ b/pkg/operation/botanist/network.go
@@ -19,15 +19,13 @@ import (
 
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/network"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // DefaultNetwork creates the default deployer for the Network custom resource.
-func (b *Botanist) DefaultNetwork(seedClient client.Client) component.DeployMigrateWaiter {
+func (b *Botanist) DefaultNetwork() component.DeployMigrateWaiter {
 	return network.New(
 		b.Logger,
-		seedClient,
+		b.K8sSeedClient.Client(),
 		&network.Values{
 			Namespace:      b.Shoot.SeedNamespace,
 			Name:           b.Shoot.Info.Name,

--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -43,7 +43,7 @@ import (
 )
 
 // DefaultOperatingSystemConfig creates the default deployer for the OperatingSystemConfig custom resource.
-func (b *Botanist) DefaultOperatingSystemConfig(seedClient client.Client) (operatingsystemconfig.Interface, error) {
+func (b *Botanist) DefaultOperatingSystemConfig() (operatingsystemconfig.Interface, error) {
 	images, err := imagevector.FindImages(b.ImageVector, []string{charts.ImageNameHyperkube, charts.ImageNamePauseContainer}, imagevector.RuntimeVersion(b.ShootVersion()), imagevector.TargetVersion(b.ShootVersion()))
 	if err != nil {
 		return nil, err
@@ -59,7 +59,7 @@ func (b *Botanist) DefaultOperatingSystemConfig(seedClient client.Client) (opera
 
 	return operatingsystemconfig.New(
 		b.Logger,
-		seedClient,
+		b.K8sSeedClient.Client(),
 		&operatingsystemconfig.Values{
 			Namespace:         b.Shoot.SeedNamespace,
 			KubernetesVersion: b.Shoot.KubernetesVersion,

--- a/pkg/operation/botanist/resources.go
+++ b/pkg/operation/botanist/resources.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	"github.com/gardener/gardener/pkg/utils"
+	unstructuredutils "github.com/gardener/gardener/pkg/utils/kubernetes/unstructured"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -37,7 +37,7 @@ func (b *Botanist) DeployReferencedResources(ctx context.Context) error {
 	var unstructuredObjs []*unstructured.Unstructured
 	for _, resource := range b.Shoot.Info.Spec.Resources {
 		// Read the resource from the Garden cluster
-		obj, err := utils.GetObjectByRef(ctx, b.K8sGardenClient.Client(), &resource.ResourceRef, b.Shoot.Info.Namespace)
+		obj, err := unstructuredutils.GetObjectByRef(ctx, b.K8sGardenClient.Client(), &resource.ResourceRef, b.Shoot.Info.Namespace)
 		if err != nil {
 			return err
 		}

--- a/pkg/operation/botanist/worker.go
+++ b/pkg/operation/botanist/worker.go
@@ -35,10 +35,10 @@ import (
 )
 
 // DefaultWorker creates the default deployer for the Worker custom resource.
-func (b *Botanist) DefaultWorker(seedClient client.Client) worker.Interface {
+func (b *Botanist) DefaultWorker() worker.Interface {
 	return worker.New(
 		b.Logger,
-		seedClient,
+		b.K8sSeedClient.Client(),
 		&worker.Values{
 			Namespace:         b.Shoot.SeedNamespace,
 			Name:              b.Shoot.Info.Name,

--- a/pkg/utils/kubernetes/health/health.go
+++ b/pkg/utils/kubernetes/health/health.go
@@ -372,19 +372,28 @@ func ExtensionOperationHasBeenUpdatedSince(lastUpdateTime metav1.Time) Func {
 	}
 }
 
-// CheckBackupBucket checks if an backup bucket Object is healthy or not.
-func CheckBackupBucket(bb client.Object) error {
-	obj, ok := bb.(*gardencorev1beta1.BackupBucket)
+// CheckBackupBucket checks if an backup bucket object is healthy or not.
+func CheckBackupBucket(obj client.Object) error {
+	bb, ok := obj.(*gardencorev1beta1.BackupBucket)
 	if !ok {
-		return fmt.Errorf("expected gardencorev1beta1.BackupBucket but got %T", bb)
+		return fmt.Errorf("expected *gardencorev1beta1.BackupBucket but got %T", obj)
 	}
-	return checkExtensionObject(obj.Generation, obj.Status.ObservedGeneration, obj.Annotations, obj.Status.LastError, obj.Status.LastOperation)
+	return checkExtensionObject(bb.Generation, bb.Status.ObservedGeneration, bb.Annotations, bb.Status.LastError, bb.Status.LastOperation)
+}
+
+// CheckBackupEntry checks if an backup entry object is healthy or not.
+func CheckBackupEntry(obj client.Object) error {
+	be, ok := obj.(*gardencorev1beta1.BackupEntry)
+	if !ok {
+		return fmt.Errorf("expected *gardencorev1beta1.BackupEntry but got %T", obj)
+	}
+	return checkExtensionObject(be.Generation, be.Status.ObservedGeneration, be.Annotations, be.Status.LastError, be.Status.LastOperation)
 }
 
 // checkExtensionObject checks if an extension Object is healthy or not.
 func checkExtensionObject(generation int64, observedGeneration int64, annotations map[string]string, lastError *gardencorev1beta1.LastError, lastOperation *gardencorev1beta1.LastOperation) error {
 	if lastError != nil {
-		return gardencorev1beta1helper.NewErrorWithCodes(fmt.Sprintf("extension encountered error during reconciliation: %s", lastError.Description), lastError.Codes...)
+		return gardencorev1beta1helper.NewErrorWithCodes(fmt.Sprintf("error during reconciliation: %s", lastError.Description), lastError.Codes...)
 	}
 
 	if observedGeneration != generation {

--- a/pkg/utils/kubernetes/unstructured/object.go
+++ b/pkg/utils/kubernetes/unstructured/object.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package utils
+package unstructured
 
 import (
 	"context"
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener/pkg/controllerutils"
+	"github.com/gardener/gardener/pkg/utils"
 )
 
 var systemMetadataFields = []string{"ownerReferences", "uid", "resourceVersion", "generation", "selfLink", "creationTimestamp", "deletionTimestamp", "deletionGracePeriodSeconds", "managedFields"}
@@ -136,7 +137,7 @@ func mergeObjectContents(dest, src map[string]interface{}) map[string]interface{
 	if srcMetadataOK {
 		destMetadata, destMetadataOK := dest["metadata"].(map[string]interface{})
 		if destMetadataOK {
-			dest["metadata"] = MergeMaps(destMetadata, srcMetadata)
+			dest["metadata"] = utils.MergeMaps(destMetadata, srcMetadata)
 		} else {
 			dest["metadata"] = srcMetadata
 		}

--- a/pkg/utils/object.go
+++ b/pkg/utils/object.go
@@ -21,9 +21,9 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/gardener/gardener/pkg/controllerutils"
 )
 
 var systemMetadataFields = []string{"ownerReferences", "uid", "resourceVersion", "generation", "selfLink", "creationTimestamp", "deletionTimestamp", "deletionGracePeriodSeconds", "managedFields"}
@@ -40,7 +40,7 @@ func GetObjectByRef(ctx context.Context, c client.Client, ref *autoscalingv1.Cro
 	return GetObject(ctx, c, gvk, ref.Name, namespace)
 }
 
-// GetObjectByRef returns the object with the given GVK, name, and namespace as a map using the given client.
+// GetObject returns the object with the given GVK, name, and namespace as a map using the given client.
 // The full content of the object is returned as map[string]interface{}, except for system metadata fields.
 // This function can be combined with runtime.DefaultUnstructuredConverter.FromUnstructured to get the object content
 // as runtime.RawExtension.
@@ -62,42 +62,39 @@ func GetObject(ctx context.Context, c client.Client, gvk schema.GroupVersionKind
 	return filterMetadata(obj.UnstructuredContent(), systemMetadataFields...), nil
 }
 
-// CreateOrUpdateObjectByRef creates or updates the object with the given reference and namespace using the given client.
-// The object is created or updated with the given content, except for system metadata fields.
+// CreateOrPatchObjectByRef creates or patches the object with the given reference and namespace using the given client.
+// The object is created or patched with the given content, except for system metadata fields.
 // This function can be combined with runtime.DefaultUnstructuredConverter.ToUnstructured to create or update an object
 // from runtime.RawExtension.
-func CreateOrUpdateObjectByRef(ctx context.Context, c client.Client, ref *autoscalingv1.CrossVersionObjectReference, namespace string, content map[string]interface{}) error {
+func CreateOrPatchObjectByRef(ctx context.Context, c client.Client, ref *autoscalingv1.CrossVersionObjectReference, namespace string, content map[string]interface{}) error {
 	gvk, err := gvkFromCrossVersionObjectReference(ref)
 	if err != nil {
 		return err
 	}
-	return CreateOrUpdateObject(ctx, c, gvk, ref.Name, namespace, content)
+	return CreateOrPatchObject(ctx, c, gvk, ref.Name, namespace, content)
 }
 
-// CreateOrUpdateObject creates or updates the object with the given GVK, name, and namespace using the given client.
-// The object is created or updated with the given content, except for system metadata fields, namespace, and name.
+// CreateOrPatchObject creates or patches the object with the given GVK, name, and namespace using the given client.
+// The object is created or patched with the given content, except for system metadata fields, namespace, and name.
 // This function can be combined with runtime.DefaultUnstructuredConverter.ToUnstructured to create or update an object
 // from runtime.RawExtension.
-func CreateOrUpdateObject(ctx context.Context, c client.Client, gvk schema.GroupVersionKind, name, namespace string, content map[string]interface{}) error {
+func CreateOrPatchObject(ctx context.Context, c client.Client, gvk schema.GroupVersionKind, name, namespace string, content map[string]interface{}) error {
 	// Initialize the object
 	obj := &unstructured.Unstructured{}
 	obj.SetGroupVersionKind(gvk)
 	obj.SetName(name)
 	obj.SetNamespace(namespace)
 
-	// Create or update the object
-	// TODO(timebertt): replace RetryOnConflict+CreateOrUpdate with PatchOrCreate
-	return retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		_, err := controllerutil.CreateOrUpdate(ctx, c, obj, func() error {
-			// Set object content
-			if content != nil {
-				obj.SetUnstructuredContent(mergeObjectContents(obj.UnstructuredContent(),
-					filterMetadata(content, add(systemMetadataFields, "namespace", "name")...)))
-			}
-			return nil
-		})
-		return err
+	// Create or patch the object
+	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, c, obj, func() error {
+		// Set object content
+		if content != nil {
+			obj.SetUnstructuredContent(mergeObjectContents(obj.UnstructuredContent(),
+				filterMetadata(content, add(systemMetadataFields, "namespace", "name")...)))
+		}
+		return nil
 	})
+	return err
 }
 
 // DeleteObjectByRef deletes the object with the given reference and namespace using the given client.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity scalability
/kind cleanup

**What this PR does / why we need it**:

Similar to previous PRs, this PR works towards getting rid of the `DirectClient`.
This one tackles usages in the `Bastion` controller and `core.BackupEntry` component and makes them ready for cached clients.

**Which issue(s) this PR fixes**:
Part of #2822

**Special notes for your reviewer**:

/squash

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
