### PR TITLE
Read vpn-shoot service events if tunnel check fails

### DIFF
--- a/pkg/operation/botanist/tunnel.go
+++ b/pkg/operation/botanist/tunnel.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package botanist
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/retry"
+
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// CheckTunnelConnection checks if the tunnel connection between the control plane and the shoot networks
+// is established.
+func CheckTunnelConnection(ctx context.Context, shootClient kubernetes.Interface, logger logrus.FieldLogger, tunnelName string) (bool, error) {
+	podList := &corev1.PodList{}
+	if err := shootClient.Client().List(ctx, podList, client.InNamespace(metav1.NamespaceSystem), client.MatchingLabels{"app": tunnelName}); err != nil {
+		return retry.SevereError(err)
+	}
+
+	var tunnelPod *corev1.Pod
+	for _, pod := range podList.Items {
+		if pod.Status.Phase == corev1.PodRunning {
+			tunnelPod = &pod
+			break
+		}
+	}
+
+	if tunnelPod == nil {
+		logger.Infof("Waiting until a running %s pod exists in the Shoot cluster...", tunnelName)
+		return retry.MinorError(fmt.Errorf("no running %s pod found yet in the shoot cluster", tunnelName))
+	}
+	if err := shootClient.CheckForwardPodPort(tunnelPod.Namespace, tunnelPod.Name, 0, 22); err != nil {
+		logger.Info("Waiting until the tunnel connection has been established...")
+		return retry.MinorError(fmt.Errorf("could not forward to %s pod: %v", tunnelName, err))
+	}
+
+	logger.Info("Tunnel connection has been established.")
+	return retry.Ok()
+}

--- a/pkg/operation/botanist/tunnel_test.go
+++ b/pkg/operation/botanist/tunnel_test.go
@@ -1,0 +1,137 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package botanist_test
+
+import (
+	"context"
+	"errors"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes/fake"
+	"github.com/gardener/gardener/pkg/logger"
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	"github.com/gardener/gardener/pkg/operation/botanist"
+	"github.com/gardener/gardener/pkg/operation/common"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Tunnel", func() {
+	Describe("CheckTunnelConnection", func() {
+		var (
+			ctrl *gomock.Controller
+
+			ctx        context.Context
+			checkFn    fake.CheckForwardPodPortFn
+			cl         *mockclient.MockClient
+			clientset  *fake.ClientSet
+			logEntry   logrus.FieldLogger
+			tunnelName string
+			tunnelPod  corev1.Pod
+		)
+
+		BeforeEach(func() {
+			ctrl = gomock.NewController(GinkgoT())
+
+			ctx = context.Background()
+			cl = mockclient.NewMockClient(ctrl)
+			logEntry = logger.NewNopLogger()
+			tunnelName = common.VPNTunnel
+			tunnelPod = corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: metav1.NamespaceSystem,
+					Name:      tunnelName,
+				},
+			}
+		})
+
+		AfterEach(func() {
+			ctrl.Finish()
+		})
+
+		JustBeforeEach(func() {
+			clientset = fake.NewClientSetBuilder().
+				WithClient(cl).
+				WithCheckForwardPodPortFn(checkFn).
+				Build()
+		})
+
+		Context("unavailable tunnel pod", func() {
+			It("should fail because pod does not exist", func() {
+				cl.EXPECT().List(ctx, gomock.AssignableToTypeOf(&corev1.PodList{}), client.InNamespace(metav1.NamespaceSystem), client.MatchingLabels{"app": tunnelName}).Return(nil)
+				done, err := botanist.CheckTunnelConnection(context.Background(), clientset, logEntry, tunnelName)
+				Expect(done).To(BeFalse())
+				Expect(err).To(HaveOccurred())
+			})
+			It("should fail because pod list returns error", func() {
+				cl.EXPECT().List(ctx, gomock.AssignableToTypeOf(&corev1.PodList{}), client.InNamespace(metav1.NamespaceSystem), client.MatchingLabels{"app": tunnelName}).Return(errors.New("foo"))
+				done, err := botanist.CheckTunnelConnection(context.Background(), clientset, logEntry, tunnelName)
+				Expect(done).To(BeTrue())
+				Expect(err).To(HaveOccurred())
+			})
+			It("should fail because pod is not running", func() {
+				cl.EXPECT().List(ctx, gomock.AssignableToTypeOf(&corev1.PodList{}), client.InNamespace(metav1.NamespaceSystem), client.MatchingLabels{"app": tunnelName}).DoAndReturn(
+					func(_ context.Context, podList *corev1.PodList, _ ...client.ListOption) error {
+						podList.Items = append(podList.Items, tunnelPod)
+						return nil
+					})
+				done, err := botanist.CheckTunnelConnection(context.Background(), clientset, logEntry, tunnelName)
+				Expect(done).To(BeFalse())
+				Expect(err).To(HaveOccurred())
+			})
+		})
+		Context("available tunnel pod", func() {
+			BeforeEach(func() {
+				tunnelPod.Status = corev1.PodStatus{
+					Phase: corev1.PodRunning,
+				}
+				cl.EXPECT().List(ctx, gomock.AssignableToTypeOf(&corev1.PodList{}), client.InNamespace(metav1.NamespaceSystem), client.MatchingLabels{"app": tunnelName}).DoAndReturn(
+					func(_ context.Context, podList *corev1.PodList, _ ...client.ListOption) error {
+						podList.Items = append(podList.Items, tunnelPod)
+						return nil
+					})
+			})
+			Context("established connection", func() {
+				BeforeEach(func() {
+					checkFn = func(_, _ string, _, _ int) error {
+						return nil
+					}
+				})
+				It("should succeed because pod is running and connection successful", func() {
+					done, err := botanist.CheckTunnelConnection(context.Background(), clientset, logEntry, tunnelName)
+					Expect(done).To(BeTrue())
+					Expect(err).ToNot(HaveOccurred())
+				})
+			})
+			Context("broken connection", func() {
+				BeforeEach(func() {
+					checkFn = func(_, _ string, _, _ int) error {
+						return errors.New("foo")
+					}
+				})
+				It("should fail because pod is running and but connection is not established", func() {
+					done, err := botanist.CheckTunnelConnection(context.Background(), clientset, logEntry, tunnelName)
+					Expect(done).To(BeFalse())
+					Expect(err).To(HaveOccurred())
+				})
+			})
+		})
+	})
+})

--- a/pkg/operation/botanist/waiter.go
+++ b/pkg/operation/botanist/waiter.go
@@ -187,11 +187,11 @@ func (b *Botanist) WaitUntilTunnelConnectionExists(ctx context.Context) error {
 			eventsErrorMessage, err2 := kutil.FetchEventMessages(ctx, b.K8sShootClient.Client().Scheme(), b.K8sShootClient.Client(), service, corev1.EventTypeWarning, 2)
 			if err2 != nil {
 				b.Logger.Errorf("error %q occured while fetching events for error %q", err2, err)
-				return true, fmt.Errorf("'%w' occurred but could not fetch events for more information", err)
+				return retry.SevereError(fmt.Errorf("'%w' occurred but could not fetch events for more information", err))
 			}
 
 			if eventsErrorMessage != "" {
-				return true, fmt.Errorf("%s\n\n%s", err.Error(), eventsErrorMessage)
+				return retry.SevereError(fmt.Errorf("%s\n\n%s", err.Error(), eventsErrorMessage))
 			}
 		}
 

--- a/pkg/operation/botanist/waiter.go
+++ b/pkg/operation/botanist/waiter.go
@@ -25,7 +25,6 @@ import (
 	"github.com/gardener/gardener/pkg/operation/botanist/component/konnectivity"
 	"github.com/gardener/gardener/pkg/operation/common"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
-	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 	"github.com/gardener/gardener/pkg/utils/retry"
 
 	"github.com/Masterminds/semver"
@@ -161,7 +160,7 @@ func (b *Botanist) WaitUntilTunnelConnectionExists(ctx context.Context) error {
 			tunnelName = konnectivity.AgentName
 		}
 
-		return health.CheckTunnelConnection(ctx, b.K8sShootClient, b.Logger, tunnelName)
+		return CheckTunnelConnection(ctx, b.K8sShootClient, b.Logger, tunnelName)
 	})
 }
 

--- a/pkg/operation/botanist/waiter.go
+++ b/pkg/operation/botanist/waiter.go
@@ -173,6 +173,8 @@ func (b *Botanist) WaitUntilTunnelConnectionExists(ctx context.Context) error {
 			!b.Shoot.KonnectivityTunnelEnabled &&
 			!b.Shoot.ReversedVPNEnabled {
 
+			b.Logger.Errorf("error %v occurred while checking the tunnel connection", err)
+
 			service := &corev1.Service{
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: corev1.SchemeGroupVersion.String(),
@@ -186,7 +188,7 @@ func (b *Botanist) WaitUntilTunnelConnectionExists(ctx context.Context) error {
 
 			eventsErrorMessage, err2 := kutil.FetchEventMessages(ctx, b.K8sShootClient.Client().Scheme(), b.K8sShootClient.Client(), service, corev1.EventTypeWarning, 2)
 			if err2 != nil {
-				b.Logger.Errorf("error %q occured while fetching events for error %q", err2, err)
+				b.Logger.Errorf("error %v occurred while fetching events for VPN load balancer service", err2)
 				return retry.SevereError(fmt.Errorf("'%w' occurred but could not fetch events for more information", err))
 			}
 

--- a/pkg/operation/botanist/waiter.go
+++ b/pkg/operation/botanist/waiter.go
@@ -154,13 +154,48 @@ func (b *Botanist) WaitUntilKubeAPIServerReady(ctx context.Context) error {
 // WaitUntilTunnelConnectionExists waits until a port forward connection to the tunnel pod (vpn-shoot or konnectivity-agent) in the kube-system
 // namespace of the Shoot cluster can be established.
 func (b *Botanist) WaitUntilTunnelConnectionExists(ctx context.Context) error {
-	return retry.UntilTimeout(ctx, 5*time.Second, 900*time.Second, func(ctx context.Context) (done bool, err error) {
-		tunnelName := common.VPNTunnel
-		if b.Shoot.KonnectivityTunnelEnabled {
-			tunnelName = konnectivity.AgentName
+	tunnelName := common.VPNTunnel
+	if b.Shoot.KonnectivityTunnelEnabled {
+		tunnelName = konnectivity.AgentName
+	}
+
+	timeoutCtx, cancel := context.WithTimeout(ctx, 15*time.Minute)
+	defer cancel()
+
+	return retry.Until(timeoutCtx, 5*time.Second, func(ctx context.Context) (bool, error) {
+		done, err := CheckTunnelConnection(ctx, b.K8sShootClient, b.Logger, tunnelName)
+
+		// If the tunnel connection check failed but is not yet "done" (i.e., will be retried, hence, it didn't fail
+		// with a severe error), and if the classic VPN solution is used for the shoot cluster then let's try to fetch
+		// the last events of the vpn-shoot service (potentially indicating an error with the load balancer service).
+		if err != nil &&
+			!done &&
+			!b.Shoot.KonnectivityTunnelEnabled &&
+			!b.Shoot.ReversedVPNEnabled {
+
+			service := &corev1.Service{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: corev1.SchemeGroupVersion.String(),
+					Kind:       "Service",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "vpn-shoot",
+					Namespace: metav1.NamespaceSystem,
+				},
+			}
+
+			eventsErrorMessage, err2 := kutil.FetchEventMessages(ctx, b.K8sShootClient.Client().Scheme(), b.K8sShootClient.Client(), service, corev1.EventTypeWarning, 2)
+			if err2 != nil {
+				b.Logger.Errorf("error %q occured while fetching events for error %q", err2, err)
+				return true, fmt.Errorf("'%w' occurred but could not fetch events for more information", err)
+			}
+
+			if eventsErrorMessage != "" {
+				return true, fmt.Errorf("%s\n\n%s", err.Error(), eventsErrorMessage)
+			}
 		}
 
-		return CheckTunnelConnection(ctx, b.K8sShootClient, b.Logger, tunnelName)
+		return done, err
 	})
 }
 

--- a/pkg/operation/care/health.go
+++ b/pkg/operation/care/health.go
@@ -28,6 +28,7 @@ import (
 	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/operation"
+	"github.com/gardener/gardener/pkg/operation/botanist"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/konnectivity"
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/operation/shoot"
@@ -35,7 +36,6 @@ import (
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
-	kuberneteshealth "github.com/gardener/gardener/pkg/utils/kubernetes/health"
 
 	resourcesv1alpha1 "github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1"
 	"github.com/sirupsen/logrus"
@@ -324,7 +324,7 @@ func (h *Health) checkSystemComponents(
 		tunnelName = konnectivity.AgentName
 	}
 
-	if established, err := kuberneteshealth.CheckTunnelConnection(ctx, h.shootClient, logrus.NewEntry(logger.NewNopLogger()), tunnelName); err != nil || !established {
+	if established, err := botanist.CheckTunnelConnection(ctx, h.shootClient, logrus.NewEntry(logger.NewNopLogger()), tunnelName); err != nil || !established {
 		msg := "Tunnel connection has not been established"
 		if err != nil {
 			msg += fmt.Sprintf(" (%+v)", err)

--- a/pkg/utils/kubernetes/health/health.go
+++ b/pkg/utils/kubernetes/health/health.go
@@ -38,9 +38,7 @@ import (
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
-	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/utils"
-	"github.com/gardener/gardener/pkg/utils/retry"
 )
 
 func requiredConditionMissing(conditionType string) error {
@@ -479,33 +477,4 @@ func getManagedResourceCondition(conditions []resourcesv1alpha1.ManagedResourceC
 		}
 	}
 	return nil
-}
-
-// CheckTunnelConnection checks if the tunnel connection between the control plane and the shoot networks
-// is established.
-func CheckTunnelConnection(ctx context.Context, shootClient kubernetes.Interface, logger logrus.FieldLogger, tunnelName string) (bool, error) {
-	podList := &corev1.PodList{}
-	if err := shootClient.Client().List(ctx, podList, client.InNamespace(metav1.NamespaceSystem), client.MatchingLabels{"app": tunnelName}); err != nil {
-		return retry.SevereError(err)
-	}
-
-	var tunnelPod *corev1.Pod
-	for _, pod := range podList.Items {
-		if pod.Status.Phase == corev1.PodRunning {
-			tunnelPod = &pod
-			break
-		}
-	}
-
-	if tunnelPod == nil {
-		logger.Infof("Waiting until a running %s pod exists in the Shoot cluster...", tunnelName)
-		return retry.MinorError(fmt.Errorf("no running %s pod found yet in the shoot cluster", tunnelName))
-	}
-	if err := shootClient.CheckForwardPodPort(tunnelPod.Namespace, tunnelPod.Name, 0, 22); err != nil {
-		logger.Info("Waiting until the tunnel connection has been established...")
-		return retry.MinorError(fmt.Errorf("could not forward to %s pod: %v", tunnelName, err))
-	}
-
-	logger.Info("Tunnel connection has been established.")
-	return retry.Ok()
 }

--- a/pkg/utils/kubernetes/health/health_test.go
+++ b/pkg/utils/kubernetes/health/health_test.go
@@ -15,17 +15,13 @@
 package health_test
 
 import (
-	"context"
-	"errors"
 	"time"
 
 	resourcesv1alpha1 "github.com/gardener/gardener-resource-manager/pkg/apis/resources/v1alpha1"
-	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
-	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,10 +32,6 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	"github.com/gardener/gardener/pkg/client/kubernetes/fake"
-	"github.com/gardener/gardener/pkg/logger"
-	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
-	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 )
 
@@ -520,105 +512,4 @@ var _ = Describe("health", func() {
 			ObjectMeta: metav1.ObjectMeta{Generation: 1},
 		}, HaveOccurred()),
 	)
-
-	Describe("CheckTunnelConnection", func() {
-		var (
-			ctrl *gomock.Controller
-
-			ctx        context.Context
-			checkFn    fake.CheckForwardPodPortFn
-			cl         *mockclient.MockClient
-			clientset  *fake.ClientSet
-			logEntry   logrus.FieldLogger
-			tunnelName string
-			tunnelPod  corev1.Pod
-		)
-
-		BeforeEach(func() {
-			ctrl = gomock.NewController(GinkgoT())
-
-			ctx = context.Background()
-			cl = mockclient.NewMockClient(ctrl)
-			logEntry = logger.NewNopLogger()
-			tunnelName = common.VPNTunnel
-			tunnelPod = corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: metav1.NamespaceSystem,
-					Name:      tunnelName,
-				},
-			}
-		})
-
-		AfterEach(func() {
-			ctrl.Finish()
-		})
-
-		JustBeforeEach(func() {
-			clientset = fake.NewClientSetBuilder().
-				WithClient(cl).
-				WithCheckForwardPodPortFn(checkFn).
-				Build()
-		})
-
-		Context("unavailable tunnel pod", func() {
-			It("should fail because pod does not exist", func() {
-				cl.EXPECT().List(ctx, gomock.AssignableToTypeOf(&corev1.PodList{}), client.InNamespace(metav1.NamespaceSystem), client.MatchingLabels{"app": tunnelName}).Return(nil)
-				done, err := health.CheckTunnelConnection(context.Background(), clientset, logEntry, tunnelName)
-				Expect(done).To(BeFalse())
-				Expect(err).To(HaveOccurred())
-			})
-			It("should fail because pod list returns error", func() {
-				cl.EXPECT().List(ctx, gomock.AssignableToTypeOf(&corev1.PodList{}), client.InNamespace(metav1.NamespaceSystem), client.MatchingLabels{"app": tunnelName}).Return(errors.New("foo"))
-				done, err := health.CheckTunnelConnection(context.Background(), clientset, logEntry, tunnelName)
-				Expect(done).To(BeTrue())
-				Expect(err).To(HaveOccurred())
-			})
-			It("should fail because pod is not running", func() {
-				cl.EXPECT().List(ctx, gomock.AssignableToTypeOf(&corev1.PodList{}), client.InNamespace(metav1.NamespaceSystem), client.MatchingLabels{"app": tunnelName}).DoAndReturn(
-					func(_ context.Context, podList *corev1.PodList, _ ...client.ListOption) error {
-						podList.Items = append(podList.Items, tunnelPod)
-						return nil
-					})
-				done, err := health.CheckTunnelConnection(context.Background(), clientset, logEntry, tunnelName)
-				Expect(done).To(BeFalse())
-				Expect(err).To(HaveOccurred())
-			})
-		})
-		Context("available tunnel pod", func() {
-			BeforeEach(func() {
-				tunnelPod.Status = corev1.PodStatus{
-					Phase: corev1.PodRunning,
-				}
-				cl.EXPECT().List(ctx, gomock.AssignableToTypeOf(&corev1.PodList{}), client.InNamespace(metav1.NamespaceSystem), client.MatchingLabels{"app": tunnelName}).DoAndReturn(
-					func(_ context.Context, podList *corev1.PodList, _ ...client.ListOption) error {
-						podList.Items = append(podList.Items, tunnelPod)
-						return nil
-					})
-			})
-			Context("established connection", func() {
-				BeforeEach(func() {
-					checkFn = func(_, _ string, _, _ int) error {
-						return nil
-					}
-				})
-				It("should succeed because pod is running and connection successful", func() {
-					done, err := health.CheckTunnelConnection(context.Background(), clientset, logEntry, tunnelName)
-					Expect(done).To(BeTrue())
-					Expect(err).ToNot(HaveOccurred())
-				})
-			})
-			Context("broken connection", func() {
-				BeforeEach(func() {
-					checkFn = func(_, _ string, _, _ int) error {
-						return errors.New("foo")
-					}
-				})
-				It("should fail because pod is running and but connection is not established", func() {
-					done, err := health.CheckTunnelConnection(context.Background(), clientset, logEntry, tunnelName)
-					Expect(done).To(BeFalse())
-					Expect(err).To(HaveOccurred())
-				})
-			})
-		})
-	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
Read `vpn-shoot` service events if tunnel check fails.

ℹ️ The first commit is just relocation code, the second commit is the actual change.
/squash

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
In case the shoot VPN tunnel connection does not work and the classic VPN solution is used, the latest 'warning' events for the `vpn-shoot` service are now read and returned to the user.
```
