### PR TITLE
Fix minor nit in `make remote-garden-up`

### DIFF
--- a/hack/local-development/remote-garden/open-gardener-tunnels
+++ b/hack/local-development/remote-garden/open-gardener-tunnels
@@ -256,6 +256,7 @@ echo "Checking prerequisites..."
 checkPrereqs
 
 echo "Generating tunnel certificates..."
+mkdir -p "$CERTS_DIR"
 $(dirname "${0}")/generate-certs $CA_NAME $SERVER_NAME $CLIENT_NAME "$CERTS_DIR"
 
 echo "Applying quic LB service..."


### PR DESCRIPTION
/area dev-productivity
/kind enhancement

Currently on a fresh new local setup, `make remote-garden-up` fails with:

```
$ make remote-garden-up
# Remove old containers and create the docker user network
36987f99f18c5a90aaff4026cb5010ec1c9e34d3259a30602f3dc54b7b04de79
# Start gardener etcd used to store gardener resources (e.g., seeds, shoots)
Starting gardener-dev-remote gardener-etcd cluster!
c923858a571dd733a7799975ece6d9e2b9c7f372d1a18ac564dcd64c8c060cd2
# Open tunnels for accessing local gardener components from the remote cluster
Checking prerequisites...
Generating tunnel certificates...
./hack/local-development/remote-garden/generate-certs: line 24: /go/src/github.com/gardener/gardener/hack/local-development/remote-garden/../../../dev/tls/quic-tunnel-server.conf: No such file or directory
make: *** [remote-garden-up] Error 1
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
