### PR TITLE
Allow CREATE requests for ShootStates,BackupEntries during control plane migration

### DIFF
--- a/pkg/admissioncontroller/webhooks/admission/seedrestriction/admission.go
+++ b/pkg/admissioncontroller/webhooks/admission/seedrestriction/admission.go
@@ -179,7 +179,7 @@ func (h *handler) admitBackupEntry(ctx context.Context, seedName string, request
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
-	if resp := h.admit(seedName, backupEntry.Spec.SeedName, backupEntry.Status.SeedName); !resp.Allowed {
+	if resp := h.admit(seedName, backupEntry.Spec.SeedName); !resp.Allowed {
 		return resp
 	}
 

--- a/pkg/admissioncontroller/webhooks/admission/seedrestriction/admission_test.go
+++ b/pkg/admissioncontroller/webhooks/admission/seedrestriction/admission_test.go
@@ -208,7 +208,7 @@ var _ = Describe("handler", func() {
 					Entry("seed name is different", pointer.StringPtr("some-different-seed")),
 				)
 
-				It("should allow the request because seed name matches", func() {
+				It("should allow the request because seed name in spec matches", func() {
 					mockCache.EXPECT().Get(ctx, kutil.Key(namespace, name), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot) error {
 						(&gardencorev1beta1.Shoot{Spec: gardencorev1beta1.ShootSpec{SeedName: &seedName}}).DeepCopyInto(obj)
 						return nil
@@ -217,11 +217,31 @@ var _ = Describe("handler", func() {
 					Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
 				})
 
-				It("should allow the request because seed name is ambiguous", func() {
+				It("should allow the request because seed name in status matches", func() {
+					mockCache.EXPECT().Get(ctx, kutil.Key(namespace, name), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot) error {
+						(&gardencorev1beta1.Shoot{Status: gardencorev1beta1.ShootStatus{SeedName: &seedName}}).DeepCopyInto(obj)
+						return nil
+					})
+
+					Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
+				})
+
+				It("should allow the request because seed name is ambiguous (spec)", func() {
 					request.UserInfo = ambiguousUser
 
 					mockCache.EXPECT().Get(ctx, kutil.Key(namespace, name), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot) error {
 						(&gardencorev1beta1.Shoot{Spec: gardencorev1beta1.ShootSpec{SeedName: pointer.StringPtr("some-different-seed")}}).DeepCopyInto(obj)
+						return nil
+					})
+
+					Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
+				})
+
+				It("should allow the request because seed name is ambiguous (status)", func() {
+					request.UserInfo = ambiguousUser
+
+					mockCache.EXPECT().Get(ctx, kutil.Key(namespace, name), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot) error {
+						(&gardencorev1beta1.Shoot{Status: gardencorev1beta1.ShootStatus{SeedName: pointer.StringPtr("some-different-seed")}}).DeepCopyInto(obj)
 						return nil
 					})
 
@@ -486,7 +506,7 @@ var _ = Describe("handler", func() {
 					Entry("seed name is equal but bucket's seed name is different", &seedName, pointer.StringPtr("some-different-seed")),
 				)
 
-				It("should allow the request because seed name matches for both entry and bucket", func() {
+				It("should allow the request because seed name matches for both entry (spec) and bucket", func() {
 					objData, err := runtime.Encode(encoder, &gardencorev1beta1.BackupEntry{
 						Spec: gardencorev1beta1.BackupEntrySpec{
 							BucketName: bucketName,
@@ -504,14 +524,38 @@ var _ = Describe("handler", func() {
 					Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
 				})
 
+				It("should allow the request because seed name matches for both entry (status) and bucket", func() {
+					objData, err := runtime.Encode(encoder, &gardencorev1beta1.BackupEntry{
+						Spec: gardencorev1beta1.BackupEntrySpec{
+							BucketName: bucketName,
+							SeedName:   pointer.StringPtr("some-other-seed"),
+						},
+						Status: gardencorev1beta1.BackupEntryStatus{
+							SeedName: &seedName,
+						},
+					})
+					Expect(err).NotTo(HaveOccurred())
+					request.Object.Raw = objData
+
+					mockCache.EXPECT().Get(ctx, kutil.Key(bucketName), gomock.AssignableToTypeOf(&gardencorev1beta1.BackupBucket{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.BackupBucket) error {
+						(&gardencorev1beta1.BackupBucket{Spec: gardencorev1beta1.BackupBucketSpec{SeedName: &seedName}}).DeepCopyInto(obj)
+						return nil
+					})
+
+					Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
+				})
+
 				DescribeTable("should allow the request because seed name is ambiguous",
-					func(seedNameInBackupEntry, seedNameInBackupBucket *string) {
+					func(seedNameInBackupEntrySpec, seedNameInBackupEntryStatus, seedNameInBackupBucket *string) {
 						request.UserInfo = ambiguousUser
 
 						objData, err := runtime.Encode(encoder, &gardencorev1beta1.BackupEntry{
 							Spec: gardencorev1beta1.BackupEntrySpec{
 								BucketName: bucketName,
-								SeedName:   seedNameInBackupEntry,
+								SeedName:   seedNameInBackupEntrySpec,
+							},
+							Status: gardencorev1beta1.BackupEntryStatus{
+								SeedName: seedNameInBackupEntryStatus,
 							},
 						})
 						Expect(err).NotTo(HaveOccurred())
@@ -525,10 +569,13 @@ var _ = Describe("handler", func() {
 						Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
 					},
 
-					Entry("seed name nil", nil, nil),
-					Entry("seed name is different", pointer.StringPtr("some-different-seed"), nil),
-					Entry("seed name is equal but bucket's seed name is nil", &seedName, nil),
-					Entry("seed name is equal but bucket's seed name is different", &seedName, pointer.StringPtr("some-different-seed")),
+					Entry("seed name nil", nil, nil, nil),
+					Entry("seed name in spec is different", pointer.StringPtr("some-different-seed"), nil, nil),
+					Entry("seed name in spec is equal but bucket's seed name is nil", &seedName, nil, nil),
+					Entry("seed name in spec is equal but bucket's seed name is different", &seedName, nil, pointer.StringPtr("some-different-seed")),
+					Entry("seed name in status is different", nil, pointer.StringPtr("some-different-seed"), nil),
+					Entry("seed name in status is equal but bucket's seed name is nil", nil, &seedName, nil),
+					Entry("seed name in status is equal but bucket's seed name is different", nil, &seedName, pointer.StringPtr("some-different-seed")),
 				)
 			})
 		})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security control-plane-migration
/kind enhancement

**What this PR does / why we need it**:
The `SeedRestriction` admission handler needs to be aware of the control plane migration use-case and allow the gardenlets of the source seeds to properly perform their migration flow:

```
task "Ensuring that ShootState exists" failed: retry failed with context deadline exceeded, last error: admission webhook "seed-restriction.gardener.cloud" denied the request: object does not belong to seed "aws"
```

**Special notes for your reviewer**:
/invite @timuthy @plkokanov @kris94 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
