### PR TITLE
Fix bugs in CPM introduced by latest refactorings

### DIFF
--- a/pkg/apis/core/v1beta1/helper/errors.go
+++ b/pkg/apis/core/v1beta1/helper/errors.go
@@ -62,6 +62,9 @@ var (
 )
 
 // DetermineError determines the Garden error code for the given error and creates a new error with the given message.
+// TODO(timebertt): this is should be improved: clean up the usages to not pass the error twice (once as an error and
+// once as a string) and properly wrap the given error instead of creating a new one from the given error message,
+// so we can use errors.As up the call stack.
 func DetermineError(err error, message string) error {
 	if err == nil {
 		return errors.New(message)

--- a/pkg/extensions/customresources.go
+++ b/pkg/extensions/customresources.go
@@ -115,7 +115,9 @@ func WaitUntilObjectReadyWithHealthFunction(
 		retryCountUntilSevere++
 
 		resetObj()
-		if err := c.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, obj); err != nil {
+		obj.SetName(name)
+		obj.SetNamespace(namespace)
+		if err := c.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
 			if apierrors.IsNotFound(err) {
 				return retry.MinorError(err)
 			}
@@ -266,7 +268,9 @@ func WaitUntilExtensionObjectDeleted(
 
 	if err := retry.UntilTimeout(ctx, interval, timeout, func(ctx context.Context) (bool, error) {
 		resetObj()
-		if err := c.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, obj); err != nil {
+		obj.SetName(name)
+		obj.SetNamespace(namespace)
+		if err := c.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
 			if apierrors.IsNotFound(err) {
 				return retry.Ok()
 			}
@@ -411,7 +415,9 @@ func WaitUntilExtensionObjectMigrated(
 
 	return retry.UntilTimeout(ctx, interval, timeout, func(ctx context.Context) (done bool, err error) {
 		resetObj()
-		if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, obj); err != nil {
+		obj.SetName(name)
+		obj.SetNamespace(namespace)
+		if err := c.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
 			if client.IgnoreNotFound(err) == nil {
 				return retry.Ok()
 			}

--- a/pkg/extensions/customresources.go
+++ b/pkg/extensions/customresources.go
@@ -143,9 +143,9 @@ func WaitUntilObjectReadyWithHealthFunction(
 	}); err != nil {
 		message := fmt.Sprintf("Error while waiting for %s to become ready", extensionKey(kind, namespace, name))
 		if lastObservedError != nil {
-			return gardencorev1beta1helper.NewErrorWithCodes(formatErrorMessage(message, lastObservedError.Error()), gardencorev1beta1helper.ExtractErrorCodes(lastObservedError)...)
+			return fmt.Errorf("%s: %w", message, lastObservedError)
 		}
-		return errors.New(formatErrorMessage(message, err.Error()))
+		return fmt.Errorf("%s: %w", message, err)
 	}
 
 	return nil
@@ -290,9 +290,9 @@ func WaitUntilExtensionObjectDeleted(
 	}); err != nil {
 		message := fmt.Sprintf("Failed to delete %s", extensionKey(kind, namespace, name))
 		if lastObservedError != nil {
-			return gardencorev1beta1helper.NewErrorWithCodes(formatErrorMessage(message, lastObservedError.Error()), gardencorev1beta1helper.ExtractErrorCodes(lastObservedError)...)
+			return fmt.Errorf("%s: %w", message, lastObservedError)
 		}
-		return errors.New(formatErrorMessage(message, err.Error()))
+		return fmt.Errorf("%s: %w", message, err)
 	}
 
 	return nil
@@ -511,8 +511,4 @@ func applyFuncToExtensionObjects(
 
 func extensionKey(kind, namespace, name string) string {
 	return fmt.Sprintf("%s %s/%s", kind, namespace, name)
-}
-
-func formatErrorMessage(message, description string) string {
-	return fmt.Sprintf("%s: %s", message, description)
 }

--- a/pkg/extensions/customresources_test.go
+++ b/pkg/extensions/customresources_test.go
@@ -98,6 +98,10 @@ var _ = Describe("extensions", func() {
 	})
 
 	Describe("#WaitUntilExtensionObjectReady", func() {
+		AfterEach(func() {
+			Expect(client.ObjectKeyFromObject(expected)).To(Equal(client.ObjectKey{Namespace: namespace, Name: name}), "should not reset object's key")
+		})
+
 		It("should return error if extension object does not exist", func() {
 			err := WaitUntilExtensionObjectReady(
 				ctx, c, log,
@@ -179,6 +183,10 @@ var _ = Describe("extensions", func() {
 	})
 
 	Describe("#WaitUntilObjectReadyWithHealthFunction", func() {
+		AfterEach(func() {
+			Expect(client.ObjectKeyFromObject(expected)).To(Equal(client.ObjectKey{Namespace: namespace, Name: name}), "should not reset object's key")
+		})
+
 		It("should return error if object does not exist", func() {
 			err := WaitUntilObjectReadyWithHealthFunction(
 				ctx, c, log,
@@ -408,6 +416,10 @@ var _ = Describe("extensions", func() {
 	})
 
 	Describe("#WaitUntilExtensionObjectDeleted", func() {
+		AfterEach(func() {
+			Expect(client.ObjectKeyFromObject(expected)).To(Equal(client.ObjectKey{Namespace: namespace, Name: name}), "should not reset object's key")
+		})
+
 		It("should return error if extension object is not deleted", func() {
 			deletionTimestamp := metav1.Now()
 			expected.ObjectMeta.DeletionTimestamp = &deletionTimestamp
@@ -593,6 +605,10 @@ var _ = Describe("extensions", func() {
 	})
 
 	Describe("#WaitUntilExtensionObjectMigrated", func() {
+		AfterEach(func() {
+			Expect(client.ObjectKeyFromObject(expected)).To(Equal(client.ObjectKey{Namespace: namespace, Name: name}), "should not reset object's key")
+		})
+
 		It("should not return error if resource does not exist", func() {
 			err := WaitUntilExtensionObjectMigrated(
 				ctx,

--- a/pkg/extensions/customresources_test.go
+++ b/pkg/extensions/customresources_test.go
@@ -23,6 +23,7 @@ import (
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	. "github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/pkg/logger"
@@ -227,17 +228,28 @@ var _ = Describe("extensions", func() {
 		})
 
 		It("should return error if ready func returns error", func() {
+			fakeError := &specialWrappingError{
+				error: gardencorev1beta1helper.NewErrorWithCodes("foo", gardencorev1beta1.ErrorInfraUnauthorized),
+			}
+
 			Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "creating worker succeeds")
 			err := WaitUntilObjectReadyWithHealthFunction(
 				ctx, c, log,
 				func(obj client.Object) error {
-					return errors.New("error")
+					return fakeError
 				},
 				expected, extensionsv1alpha1.WorkerResource,
 				defaultInterval, defaultThreshold, defaultTimeout,
 				nil,
 			)
 			Expect(err).To(HaveOccurred())
+
+			// ensure, that errors are properly wrapped
+			var specialError interface {
+				Special()
+			}
+			Expect(errors.As(err, &specialError)).To(BeTrue(), "should properly wrap the error returned by the health func")
+			Expect(gardencorev1beta1helper.ExtractErrorCodes(err)).To(ConsistOf(gardencorev1beta1.ErrorInfraUnauthorized), "should be able to extract error codes from wrapped error")
 		})
 
 		It("should return error if client has not observed latest timestamp annotation", func() {
@@ -430,6 +442,25 @@ var _ = Describe("extensions", func() {
 				defaultInterval, defaultTimeout)
 
 			Expect(err).To(HaveOccurred())
+		})
+
+		It("should return error with codes if extension object has status.lastError.codes", func() {
+			deletionTimestamp := metav1.Now()
+			expected.ObjectMeta.DeletionTimestamp = &deletionTimestamp
+			expected.Status.LastError = &gardencorev1beta1.LastError{
+				Description: "invalid credentials",
+				Codes:       []gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorInfraUnauthorized},
+			}
+
+			Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "adding pre-existing worker succeeds")
+			err := WaitUntilExtensionObjectDeleted(ctx, c, log,
+				expected, extensionsv1alpha1.WorkerResource,
+				defaultInterval, defaultTimeout)
+
+			Expect(err).To(HaveOccurred())
+
+			// ensure, that errors are properly wrapped
+			Expect(gardencorev1beta1helper.ExtractErrorCodes(err)).To(ConsistOf(gardencorev1beta1.ErrorInfraUnauthorized), "should be able to extract error codes from wrapped error")
 		})
 
 		It("should return success if extensions CRs gets deleted", func() {
@@ -749,3 +780,13 @@ var _ = Describe("extensions", func() {
 		})
 	})
 })
+
+type specialWrappingError struct {
+	error
+}
+
+func (s *specialWrappingError) Unwrap() error {
+	return s.error
+}
+
+func (s *specialWrappingError) Special() {}

--- a/pkg/operation/botanist/component/extensions/dns/dns_test.go
+++ b/pkg/operation/botanist/component/extensions/dns/dns_test.go
@@ -88,6 +88,22 @@ var _ = Describe("#CheckDNSObject", func() {
 			}
 		})
 
+		It("should return ErrorWithCodes, if status is Error or Invalid, even if no code is determined", func() {
+			for _, state := range []string{
+				dnsv1alpha1.STATE_ERROR,
+				dnsv1alpha1.STATE_INVALID,
+			} {
+				msg := "unknown owner id 'foo--bar'"
+				acc.SetState(state)
+				acc.SetMessage(&msg)
+				err := CheckDNSObject(obj)
+
+				var errorWithCodes *helper.ErrorWithCodes
+				Expect(errors.As(err, &errorWithCodes)).To(BeTrue(), "state: "+state)
+				Expect(errorWithCodes.Codes()).To(BeEmpty(), "state: "+state)
+			}
+		})
+
 		It("should not return error if object is ready", func() {
 			acc.SetGeneration(1)
 			acc.SetObservedGeneration(1)

--- a/pkg/operation/botanist/component/extensions/dns/dns_test.go
+++ b/pkg/operation/botanist/component/extensions/dns/dns_test.go
@@ -104,6 +104,22 @@ var _ = Describe("#CheckDNSObject", func() {
 			}
 		})
 
+		It("should annotate error with state of dns object", func() {
+			for _, state := range []string{
+				dnsv1alpha1.STATE_ERROR,
+				dnsv1alpha1.STATE_INVALID,
+			} {
+				msg := "unknown owner id 'foo--bar'"
+				acc.SetState(state)
+				acc.SetMessage(&msg)
+				err := CheckDNSObject(obj)
+
+				var errorWithState ErrorWithDNSState
+				Expect(errors.As(err, &errorWithState)).To(BeTrue(), "state: "+state)
+				Expect(errorWithState.DNSState()).To(Equal(state), "state: "+state)
+			}
+		})
+
 		It("should not return error if object is ready", func() {
 			acc.SetGeneration(1)
 			acc.SetObservedGeneration(1)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug

**What this PR does / why we need it**:

This PR fixes three bugs in the Control Plane Migration flow introduced by latests refactorings:

- Don't reset ObjectKey in `extensions.WaitUntil*` funcs. Callers might want to reuse the passed in object afterwards, even if it was not found. Thus, we have to ensure, that the ObjectKey is not reset in the helper funcs (described in #4180, introduced by #4027)
- Return faster when waiting for `DNS{Provider,Entry}` (behavior was changed in #4161, brings back old behavior) to detect the `Invalid` state of `DNSEntries` faster when restoring them. The behavioral change added an extra ~minute to the restoration flow, because it waited longer until the overall timeout has elapsed (cc @timuthy).
- Fix detecting the `Invalid` state of `DNSEntries` when restoring them (error message was changed in #4161, which broke the string matching)

You can find more details in the respective commit messages.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/4180

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
