### PR TITLE
Use CreateOrGetAndStrategicMergePatch when gardenlet creates bucket secret

### DIFF
--- a/pkg/gardenlet/controller/backupbucket/backup_bucket_actuator.go
+++ b/pkg/gardenlet/controller/backupbucket/backup_bucket_actuator.go
@@ -243,7 +243,7 @@ func (a *actuator) waitUntilBackupBucketExtensionReconciled(ctx context.Context)
 				}
 				ownerRef := metav1.NewControllerRef(a.extensionBackupBucket, gardencorev1beta1.SchemeGroupVersion.WithKind("BackupBucket"))
 
-				if _, err := controllerutil.CreateOrUpdate(ctx, a.gardenClient.Client(), coreGeneratedSecret, func() error {
+				if _, err := controllerutils.CreateOrGetAndStrategicMergePatch(ctx, a.gardenClient.Client(), coreGeneratedSecret, func() error {
 					coreGeneratedSecret.OwnerReferences = []metav1.OwnerReference{*ownerRef}
 					controllerutil.AddFinalizer(coreGeneratedSecret, finalizerName)
 					coreGeneratedSecret.Data = generatedSecret.DeepCopy().Data


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement
/milestone v1.25

**What this PR does / why we need it**:
Use `CreateOrGetAndStrategicMergePatch` when gardenlet creates bucket secret, otherwise the SeedAuthorizer will deny the initial `GET`.

**Which issue(s) this PR fixes**:
Part of #1723

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
