### PR TITLE
Make etcd component ready for cached client

### DIFF
--- a/pkg/apis/core/v1beta1/helper/errors.go
+++ b/pkg/apis/core/v1beta1/helper/errors.go
@@ -34,6 +34,9 @@ type ErrorWithCodes struct {
 	codes   []gardencorev1beta1.ErrorCode
 }
 
+// Retriable marks ErrorWithCodes as retriable.
+func (e *ErrorWithCodes) Retriable() {}
+
 // NewErrorWithCodes creates a new error that additionally exposes the given codes via the Coder interface.
 func NewErrorWithCodes(message string, codes ...gardencorev1beta1.ErrorCode) error {
 	return &ErrorWithCodes{message, codes}

--- a/pkg/apis/core/v1beta1/helper/errors_test.go
+++ b/pkg/apis/core/v1beta1/helper/errors_test.go
@@ -20,6 +20,7 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	. "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	"github.com/gardener/gardener/pkg/utils/retry"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
@@ -28,6 +29,12 @@ import (
 )
 
 var _ = Describe("errors", func() {
+	Describe("#ErrorWithCodes", func() {
+		It("should be marked as a retriable error", func() {
+			Expect(retry.IsRetriable(&ErrorWithCodes{})).To(BeTrue())
+		})
+	})
+
 	DescribeTable("#DetermineError",
 		func(err error, msg string, expectedErr error) {
 			Expect(DetermineError(err, msg)).To(Equal(expectedErr))

--- a/pkg/extensions/customresources.go
+++ b/pkg/extensions/customresources.go
@@ -16,7 +16,6 @@ package extensions
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -89,7 +88,6 @@ func WaitUntilObjectReadyWithHealthFunction(
 	postReadyFunc func() error,
 ) error {
 	var (
-		errorWithCode         *gardencorev1beta1helper.ErrorWithCodes
 		lastObservedError     error
 		retryCountUntilSevere int
 
@@ -127,7 +125,7 @@ func WaitUntilObjectReadyWithHealthFunction(
 		if err := healthFunc(obj); err != nil {
 			lastObservedError = err
 			logger.WithError(err).Errorf("%s did not get ready yet", extensionKey(kind, namespace, name))
-			if errors.As(err, &errorWithCode) {
+			if retry.IsRetriable(err) {
 				return retry.MinorOrSevereError(retryCountUntilSevere, int(severeThreshold.Nanoseconds()/interval.Nanoseconds()), err)
 			}
 			return retry.MinorError(err)

--- a/pkg/operation/botanist/component/etcd/etcd.go
+++ b/pkg/operation/botanist/component/etcd/etcd.go
@@ -33,11 +33,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
 	"k8s.io/utils/pointer"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/utils"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -88,11 +88,6 @@ var (
 	PortBackupRestore = int32(8080)
 )
 
-// Name returns the name of the Etcd object for the given role.
-func Name(role string) string {
-	return "etcd-" + role
-}
-
 // ServiceName returns the service name for an etcd for the given role.
 func ServiceName(role string) string {
 	return fmt.Sprintf("etcd-%s-client", role)
@@ -132,6 +127,13 @@ func New(
 		retainReplicas:          retainReplicas,
 		storageCapacity:         storageCapacity,
 		defragmentationSchedule: defragmentationSchedule,
+
+		etcd: &druidv1alpha1.Etcd{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "etcd-" + role,
+				Namespace: namespace,
+			},
+		},
 	}
 }
 
@@ -143,6 +145,8 @@ type etcd struct {
 	retainReplicas          bool
 	storageCapacity         string
 	defragmentationSchedule *string
+
+	etcd *druidv1alpha1.Etcd
 
 	secrets      Secrets
 	backupConfig *BackupConfig
@@ -162,23 +166,33 @@ func (e *etcd) Deploy(ctx context.Context) error {
 
 	var (
 		networkPolicy = e.emptyNetworkPolicy()
-		etcd          = e.emptyEtcd()
 		hvpa          = e.emptyHVPA()
+
+		existingEtcd        *druidv1alpha1.Etcd
+		existingSts         = &appsv1.StatefulSet{}
+		foundEtcd, foundSts bool
 	)
 
-	existingEtcd, foundEtcd, err := e.getExistingEtcd(ctx, Name(e.role))
-	if err != nil {
-		return err
+	if err := e.client.Get(ctx, client.ObjectKeyFromObject(e.etcd), e.etcd); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+	} else {
+		foundEtcd = true
+		existingEtcd = e.etcd.DeepCopy()
 	}
 
-	stsName := Name(e.role)
+	stsName := e.etcd.Name
 	if foundEtcd && existingEtcd.Status.Etcd.Name != "" {
 		stsName = existingEtcd.Status.Etcd.Name
 	}
 
-	existingSts, foundSts, err := e.getExistingStatefulSet(ctx, stsName)
-	if err != nil {
-		return err
+	if err := e.client.Get(ctx, client.ObjectKey{Namespace: e.namespace, Name: stsName}, existingSts); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return err
+		}
+	} else {
+		foundSts = true
 	}
 
 	var (
@@ -205,7 +219,7 @@ func (e *etcd) Deploy(ctx context.Context) error {
 			"checksum/secret-etcd-client-tls":  e.secrets.Client.Checksum,
 		}
 		metrics             = druidv1alpha1.Basic
-		volumeClaimTemplate = Name(e.role)
+		volumeClaimTemplate = e.etcd.Name
 		minAllowed          = corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("50m"),
 			corev1.ResourceMemory: resource.MustParse("200M"),
@@ -222,7 +236,7 @@ func (e *etcd) Deploy(ctx context.Context) error {
 		}
 	}
 
-	if _, err := controllerutil.CreateOrUpdate(ctx, e.client, networkPolicy, func() error {
+	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, e.client, networkPolicy, func() error {
 		networkPolicy.Annotations = map[string]string{
 			v1beta1constants.GardenerDescription: "Allows Ingress to etcd pods from the Shoot's Kubernetes API Server.",
 		}
@@ -278,30 +292,30 @@ func (e *etcd) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	if _, err := controllerutil.CreateOrUpdate(ctx, e.client, etcd, func() error {
-		etcd.Annotations = map[string]string{
+	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, e.client, e.etcd, func() error {
+		e.etcd.Annotations = map[string]string{
 			v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
 			v1beta1constants.GardenerTimestamp: TimeNow().UTC().String(),
 		}
-		etcd.Labels = map[string]string{
+		e.etcd.Labels = map[string]string{
 			v1beta1constants.LabelRole:  e.role,
 			v1beta1constants.GardenRole: v1beta1constants.GardenRoleControlPlane,
 		}
-		etcd.Spec.Replicas = replicas
-		etcd.Spec.PriorityClassName = pointer.StringPtr(v1beta1constants.PriorityClassNameShootControlPlane)
-		etcd.Spec.Annotations = annotations
-		etcd.Spec.Labels = utils.MergeStringMaps(e.getLabels(), map[string]string{
+		e.etcd.Spec.Replicas = replicas
+		e.etcd.Spec.PriorityClassName = pointer.StringPtr(v1beta1constants.PriorityClassNameShootControlPlane)
+		e.etcd.Spec.Annotations = annotations
+		e.etcd.Spec.Labels = utils.MergeStringMaps(e.getLabels(), map[string]string{
 			v1beta1constants.LabelApp:                            LabelAppValue,
 			v1beta1constants.LabelNetworkPolicyToDNS:             v1beta1constants.LabelNetworkPolicyAllowed,
 			v1beta1constants.LabelNetworkPolicyToPublicNetworks:  v1beta1constants.LabelNetworkPolicyAllowed,
 			v1beta1constants.LabelNetworkPolicyToPrivateNetworks: v1beta1constants.LabelNetworkPolicyAllowed,
 		})
-		etcd.Spec.Selector = &metav1.LabelSelector{
+		e.etcd.Spec.Selector = &metav1.LabelSelector{
 			MatchLabels: utils.MergeStringMaps(e.getLabels(), map[string]string{
 				v1beta1constants.LabelApp: LabelAppValue,
 			}),
 		}
-		etcd.Spec.Etcd = druidv1alpha1.EtcdConfig{
+		e.etcd.Spec.Etcd = druidv1alpha1.EtcdConfig{
 			Resources: resourcesEtcd,
 			TLS: &druidv1alpha1.TLSConfig{
 				TLSCASecretRef: corev1.SecretReference{
@@ -323,7 +337,7 @@ func (e *etcd) Deploy(ctx context.Context) error {
 			DefragmentationSchedule: e.computeDefragmentationSchedule(foundEtcd, existingEtcd),
 			Quota:                   &quota,
 		}
-		etcd.Spec.Backup = druidv1alpha1.BackupSpec{
+		e.etcd.Spec.Backup = druidv1alpha1.BackupSpec{
 			Port:                    &PortBackupRestore,
 			Resources:               resourcesBackupRestore,
 			GarbageCollectionPolicy: &garbageCollectionPolicy,
@@ -338,19 +352,19 @@ func (e *etcd) Deploy(ctx context.Context) error {
 				deltaSnapshotMemoryLimit = resource.MustParse("100Mi")
 			)
 
-			etcd.Spec.Backup.Store = &druidv1alpha1.StoreSpec{
+			e.etcd.Spec.Backup.Store = &druidv1alpha1.StoreSpec{
 				SecretRef: &corev1.SecretReference{Name: e.backupConfig.SecretRefName},
 				Container: &e.backupConfig.Container,
 				Provider:  &provider,
 				Prefix:    fmt.Sprintf("%s/etcd-%s", e.backupConfig.Prefix, e.role),
 			}
-			etcd.Spec.Backup.FullSnapshotSchedule = e.computeFullSnapshotSchedule(foundEtcd, existingEtcd)
-			etcd.Spec.Backup.DeltaSnapshotPeriod = &deltaSnapshotPeriod
-			etcd.Spec.Backup.DeltaSnapshotMemoryLimit = &deltaSnapshotMemoryLimit
+			e.etcd.Spec.Backup.FullSnapshotSchedule = e.computeFullSnapshotSchedule(foundEtcd, existingEtcd)
+			e.etcd.Spec.Backup.DeltaSnapshotPeriod = &deltaSnapshotPeriod
+			e.etcd.Spec.Backup.DeltaSnapshotMemoryLimit = &deltaSnapshotMemoryLimit
 		}
 
-		etcd.Spec.StorageCapacity = &storageCapacity
-		etcd.Spec.VolumeClaimTemplate = &volumeClaimTemplate
+		e.etcd.Spec.StorageCapacity = &storageCapacity
+		e.etcd.Spec.VolumeClaimTemplate = &volumeClaimTemplate
 		return nil
 	}); err != nil {
 		return err
@@ -369,7 +383,7 @@ func (e *etcd) Deploy(ctx context.Context) error {
 			scaleDownUpdateMode = pointer.StringPtr(hvpav1alpha1.UpdateModeMaintenanceWindow)
 		}
 
-		if _, err := controllerutil.CreateOrUpdate(ctx, e.client, hvpa, func() error {
+		if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, e.client, hvpa, func() error {
 			hvpa.Labels = utils.MergeStringMaps(e.getLabels(), map[string]string{
 				v1beta1constants.LabelApp: LabelAppValue,
 			})
@@ -493,7 +507,7 @@ func (e *etcd) Deploy(ctx context.Context) error {
 			return err
 		}
 	} else {
-		if err := kutil.DeleteObjects(ctx, e.client, e.emptyHVPA()); err != nil {
+		if err := kutil.DeleteObjects(ctx, e.client, hvpa); err != nil {
 			return err
 		}
 	}
@@ -506,7 +520,7 @@ func (e *etcd) Destroy(ctx context.Context) error {
 		ctx,
 		e.client,
 		e.emptyHVPA(),
-		e.emptyEtcd(),
+		e.etcd,
 		e.emptyNetworkPolicy(),
 	)
 }
@@ -518,42 +532,12 @@ func (e *etcd) getLabels() map[string]string {
 	}
 }
 
-func (e *etcd) getExistingEtcd(ctx context.Context, name string) (*druidv1alpha1.Etcd, bool, error) {
-	obj, found, err := e.getExistingResource(ctx, name, &druidv1alpha1.Etcd{})
-	if obj != nil {
-		return obj.(*druidv1alpha1.Etcd), found, err
-	}
-	return nil, found, err
-}
-
-func (e *etcd) getExistingStatefulSet(ctx context.Context, name string) (*appsv1.StatefulSet, bool, error) {
-	obj, found, err := e.getExistingResource(ctx, name, &appsv1.StatefulSet{})
-	if obj != nil {
-		return obj.(*appsv1.StatefulSet), found, err
-	}
-	return nil, found, err
-}
-
-func (e *etcd) getExistingResource(ctx context.Context, name string, obj client.Object) (client.Object, bool, error) {
-	if err := e.client.Get(ctx, kutil.Key(e.namespace, name), obj); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return nil, false, err
-		}
-		return nil, false, nil
-	}
-	return obj, true, nil
-}
-
 func (e *etcd) emptyNetworkPolicy() *networkingv1.NetworkPolicy {
 	return &networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: NetworkPolicyName, Namespace: e.namespace}}
 }
 
-func (e *etcd) emptyEtcd() *druidv1alpha1.Etcd {
-	return &druidv1alpha1.Etcd{ObjectMeta: metav1.ObjectMeta{Name: Name(e.role), Namespace: e.namespace}}
-}
-
 func (e *etcd) emptyHVPA() *hvpav1alpha1.Hvpa {
-	return &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: Name(e.role), Namespace: e.namespace}}
+	return &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: e.etcd.Name, Namespace: e.namespace}}
 }
 
 func (e *etcd) Snapshot(ctx context.Context, podExecutor kubernetes.PodExecutor) error {

--- a/pkg/operation/botanist/component/etcd/etcd_test.go
+++ b/pkg/operation/botanist/component/etcd/etcd_test.go
@@ -21,6 +21,7 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	mockkubernetes "github.com/gardener/gardener/pkg/client/kubernetes/mock"
+	"github.com/gardener/gardener/pkg/logger"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	. "github.com/gardener/gardener/pkg/operation/botanist/component/etcd"
@@ -32,6 +33,7 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2beta1 "k8s.io/api/autoscaling/v2beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -58,6 +60,7 @@ var _ = Describe("Etcd", func() {
 		ctrl *gomock.Controller
 		c    *mockclient.MockClient
 		etcd Interface
+		log  logrus.FieldLogger
 
 		ctx                     = context.TODO()
 		fakeErr                 = fmt.Errorf("fake err")
@@ -463,7 +466,8 @@ var _ = Describe("Etcd", func() {
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		c = mockclient.NewMockClient(ctrl)
-		etcd = New(c, testNamespace, testRole, class, retainReplicas, storageCapacity, &defragmentationSchedule)
+		log = logger.NewNopLogger()
+		etcd = New(c, log, testNamespace, testRole, class, retainReplicas, storageCapacity, &defragmentationSchedule)
 	})
 
 	AfterEach(func() {
@@ -639,7 +643,7 @@ var _ = Describe("Etcd", func() {
 					retainReplicas         = true
 				)
 
-				etcd = New(c, testNamespace, testRole, class, retainReplicas, storageCapacity, &defragmentationSchedule)
+				etcd = New(c, log, testNamespace, testRole, class, retainReplicas, storageCapacity, &defragmentationSchedule)
 				setSecretsAndHVPAConfig()
 
 				gomock.InOrder(
@@ -842,7 +846,7 @@ var _ = Describe("Etcd", func() {
 						updateMode = hvpav1alpha1.UpdateModeOff
 					}
 
-					etcd = New(c, testNamespace, testRole, class, retainReplicas, storageCapacity, &defragmentationSchedule)
+					etcd = New(c, log, testNamespace, testRole, class, retainReplicas, storageCapacity, &defragmentationSchedule)
 					getSetSecretsAndHVPAConfigFunc(updateMode)()
 
 					gomock.InOrder(

--- a/pkg/operation/botanist/component/etcd/etcd_test.go
+++ b/pkg/operation/botanist/component/etcd/etcd_test.go
@@ -48,12 +48,6 @@ import (
 )
 
 var _ = Describe("Etcd", func() {
-	Describe("#Name", func() {
-		It("should return the expected name", func() {
-			Expect(Name(testRole)).To(Equal("etcd-" + testRole))
-		})
-	})
-
 	Describe("#ServiceName", func() {
 		It("should return the expected service name", func() {
 			Expect(ServiceName(testRole)).To(Equal("etcd-" + testRole + "-client"))
@@ -548,7 +542,7 @@ var _ = Describe("Etcd", func() {
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, networkPolicyName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})).Return(fakeErr),
+					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()).Return(fakeErr),
 				)
 
 				Expect(etcd.Deploy(ctx)).To(MatchError(fakeErr))
@@ -560,9 +554,9 @@ var _ = Describe("Etcd", func() {
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, networkPolicyName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
+					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()),
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(fakeErr),
+					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Return(fakeErr),
 				)
 
 				Expect(etcd.Deploy(ctx)).To(MatchError(fakeErr))
@@ -574,11 +568,11 @@ var _ = Describe("Etcd", func() {
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, networkPolicyName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
+					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()),
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
+					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()),
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})).Return(fakeErr),
+					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Return(fakeErr),
 				)
 
 				Expect(etcd.Deploy(ctx)).To(MatchError(fakeErr))
@@ -592,9 +586,9 @@ var _ = Describe("Etcd", func() {
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, networkPolicyName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
+					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()),
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
+					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()),
 					c.EXPECT().Delete(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})).Return(fakeErr),
 				)
 
@@ -611,11 +605,11 @@ var _ = Describe("Etcd", func() {
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, networkPolicyName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
+					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(networkPolicy))
 					}),
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
+					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(etcdObjFor(
 							class,
 							1,
@@ -627,7 +621,7 @@ var _ = Describe("Etcd", func() {
 						)))
 					}),
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
+					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(hvpaFor(class, 1, scaleDownUpdateMode)))
 					}),
 				)
@@ -669,11 +663,14 @@ var _ = Describe("Etcd", func() {
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, networkPolicyName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
+					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(networkPolicy))
 					}),
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
+					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(ctx context.Context, obj *druidv1alpha1.Etcd, _ client.Patch, _ ...client.PatchOption) {
+						// ignore status when comparing
+						obj.Status = druidv1alpha1.EtcdStatus{}
+
 						Expect(obj).To(DeepEqual(etcdObjFor(
 							class,
 							int(existingReplicas),
@@ -685,7 +682,7 @@ var _ = Describe("Etcd", func() {
 						)))
 					}),
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
+					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(hvpaFor(class, existingReplicas, scaleDownUpdateMode)))
 					}),
 				)
@@ -723,11 +720,14 @@ var _ = Describe("Etcd", func() {
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, networkPolicyName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
+					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(networkPolicy))
 					}),
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
+					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(ctx context.Context, obj *druidv1alpha1.Etcd, _ client.Patch, _ ...client.PatchOption) {
+						// ignore status when comparing
+						obj.Status = druidv1alpha1.EtcdStatus{}
+
 						Expect(obj).To(DeepEqual(etcdObjFor(
 							class,
 							1,
@@ -739,7 +739,7 @@ var _ = Describe("Etcd", func() {
 						)))
 					}),
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
+					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(hvpaFor(class, 1, scaleDownUpdateMode)))
 					}),
 				)
@@ -804,11 +804,11 @@ var _ = Describe("Etcd", func() {
 					}),
 
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, networkPolicyName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
+					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(networkPolicy))
 					}),
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
+					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(etcdObjFor(
 							class,
 							1,
@@ -820,7 +820,7 @@ var _ = Describe("Etcd", func() {
 						)))
 					}),
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
-					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
+					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(hvpaFor(class, 1, scaleDownUpdateMode)))
 					}),
 				)
@@ -850,11 +850,11 @@ var _ = Describe("Etcd", func() {
 						c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 
 						c.EXPECT().Get(ctx, kutil.Key(testNamespace, networkPolicyName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
-						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
+						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(networkPolicy))
 						}),
 						c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
-						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
+						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(etcdObjFor(
 								class,
 								1,
@@ -866,7 +866,7 @@ var _ = Describe("Etcd", func() {
 							)))
 						}),
 						c.EXPECT().Get(ctx, kutil.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
-						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
+						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(hvpaFor(class, 1, updateMode)))
 						}),
 					)
@@ -898,11 +898,11 @@ var _ = Describe("Etcd", func() {
 						c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 
 						c.EXPECT().Get(ctx, kutil.Key(testNamespace, networkPolicyName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
-						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
+						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(networkPolicy))
 						}),
 						c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
-						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
+						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(etcdObjFor(
 								class,
 								1,
@@ -914,7 +914,7 @@ var _ = Describe("Etcd", func() {
 							)))
 						}),
 						c.EXPECT().Get(ctx, kutil.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
-						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
+						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(hvpaFor(class, 1, scaleDownUpdateMode)))
 						}),
 					)
@@ -952,11 +952,11 @@ var _ = Describe("Etcd", func() {
 						c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 
 						c.EXPECT().Get(ctx, kutil.Key(testNamespace, networkPolicyName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
-						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
+						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(networkPolicy))
 						}),
 						c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
-						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
+						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(etcdObjFor(
 								class,
 								1,
@@ -968,7 +968,7 @@ var _ = Describe("Etcd", func() {
 							)))
 						}),
 						c.EXPECT().Get(ctx, kutil.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
-						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
+						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(hvpaFor(class, 1, scaleDownUpdateMode)))
 						}),
 					)

--- a/pkg/operation/botanist/component/etcd/monitoring_test.go
+++ b/pkg/operation/botanist/component/etcd/monitoring_test.go
@@ -27,7 +27,7 @@ import (
 var _ = Describe("Monitoring", func() {
 	Describe("#ScrapeConfig", func() {
 		It("should successfully test the scrape configuration", func() {
-			etcd := New(nil, testNamespace, testRole, ClassNormal, true, "", nil)
+			etcd := New(nil, nil, testNamespace, testRole, ClassNormal, true, "", nil)
 			test.ScrapeConfigs(etcd, expectedScrapeConfigEtcd, expectedScrapeConfigBackupRestore)
 		})
 	})
@@ -35,7 +35,7 @@ var _ = Describe("Monitoring", func() {
 	Describe("#AlertingRules", func() {
 		Context("w/o backup", func() {
 			It("should successfully test the alerting rules (normal)", func() {
-				etcd := New(nil, testNamespace, testRole, ClassNormal, true, "", nil)
+				etcd := New(nil, nil, testNamespace, testRole, ClassNormal, true, "", nil)
 				test.AlertingRulesWithPromtool(
 					etcd,
 					map[string]string{fmt.Sprintf("kube-etcd3-%s.rules.yaml", testRole): expectedAlertingRulesNormalWithoutBackup},
@@ -44,7 +44,7 @@ var _ = Describe("Monitoring", func() {
 			})
 
 			It("should successfully test the alerting rules (important)", func() {
-				etcd := New(nil, testNamespace, testRole, ClassImportant, true, "", nil)
+				etcd := New(nil, nil, testNamespace, testRole, ClassImportant, true, "", nil)
 				test.AlertingRulesWithPromtool(
 					etcd,
 					map[string]string{fmt.Sprintf("kube-etcd3-%s.rules.yaml", testRole): expectedAlertingRulesImportantWithoutBackup},
@@ -55,7 +55,7 @@ var _ = Describe("Monitoring", func() {
 
 		Context("w/ backup", func() {
 			It("should successfully test the alerting rules (normal)", func() {
-				etcd := New(nil, testNamespace, testRole, ClassNormal, true, "", nil)
+				etcd := New(nil, nil, testNamespace, testRole, ClassNormal, true, "", nil)
 				etcd.SetBackupConfig(&BackupConfig{})
 				test.AlertingRulesWithPromtool(
 					etcd,
@@ -65,7 +65,7 @@ var _ = Describe("Monitoring", func() {
 			})
 
 			It("should successfully test the alerting rules (important)", func() {
-				etcd := New(nil, testNamespace, testRole, ClassImportant, true, "", nil)
+				etcd := New(nil, nil, testNamespace, testRole, ClassImportant, true, "", nil)
 				etcd.SetBackupConfig(&BackupConfig{})
 				test.AlertingRulesWithPromtool(
 					etcd,

--- a/pkg/operation/botanist/component/etcd/waiter_test.go
+++ b/pkg/operation/botanist/component/etcd/waiter_test.go
@@ -16,150 +16,235 @@ package etcd_test
 
 import (
 	"context"
-	"fmt"
 	"time"
 
-	"github.com/gardener/gardener/pkg/logger"
-	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
-	. "github.com/gardener/gardener/pkg/operation/botanist/component/etcd"
-
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
+	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/logger"
+	mocktime "github.com/gardener/gardener/pkg/mock/go/time"
+	"github.com/gardener/gardener/pkg/operation/botanist/component"
+	. "github.com/gardener/gardener/pkg/operation/botanist/component/etcd"
+	"github.com/gardener/gardener/pkg/utils/retry"
+	retryfake "github.com/gardener/gardener/pkg/utils/retry/fake"
+	"github.com/gardener/gardener/pkg/utils/test"
 )
 
-var _ = Describe("Waiter", func() {
+var _ = Describe("#Wait", func() {
 	var (
-		ctrl *gomock.Controller
-		c    *mockclient.MockClient
+		ctrl    *gomock.Controller
+		c       client.Client
+		log     logrus.FieldLogger
+		mockNow *mocktime.MockNow
+		now     time.Time
 
-		ctx       = context.TODO()
-		fakeErr   = fmt.Errorf("fake error")
-		namespace = "shoot--foo--bar"
+		waiter      *retryfake.Ops
+		cleanupFunc func()
 
-		interval        = time.Second / 20
-		severeThreshold = time.Second / 10
-		timeout         = time.Second / 5
+		ctx  = context.TODO()
+		name = "etcd-" + testRole
+
+		etcd     Interface
+		expected *druidv1alpha1.Etcd
 	)
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
-		c = mockclient.NewMockClient(ctrl)
+		mockNow = mocktime.NewMockNow(ctrl)
+		now = time.Now()
+
+		s := runtime.NewScheme()
+		Expect(appsv1.AddToScheme(s)).To(Succeed())
+		Expect(networkingv1.AddToScheme(s)).To(Succeed())
+		Expect(hvpav1alpha1.AddToScheme(s)).To(Succeed())
+		Expect(druidv1alpha1.AddToScheme(s)).To(Succeed())
+		c = fake.NewClientBuilder().WithScheme(s).Build()
+
+		log = logger.NewNopLogger()
+
+		waiter = &retryfake.Ops{MaxAttempts: 1}
+		cleanupFunc = test.WithVars(
+			&retry.Until, waiter.Until,
+			&retry.UntilTimeout, waiter.UntilTimeout,
+		)
+
+		etcd = New(c, log, testNamespace, testRole, ClassNormal, false, "12Gi", pointer.StringPtr("abcd"))
+		etcd.SetSecrets(Secrets{
+			CA:     component.Secret{Name: "ca", Checksum: "abcdef"},
+			Server: component.Secret{Name: "server", Checksum: "abcdef"},
+			Client: component.Secret{Name: "client", Checksum: "abcdef"},
+		})
+		etcd.SetHVPAConfig(&HVPAConfig{
+			Enabled: true,
+			MaintenanceTimeWindow: gardencorev1beta1.MaintenanceTimeWindow{
+				Begin: "1234",
+				End:   "5678",
+			},
+			ScaleDownUpdateMode: pointer.StringPtr(hvpav1alpha1.UpdateModeMaintenanceWindow),
+		})
+
+		expected = &druidv1alpha1.Etcd{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: druidv1alpha1.GroupVersion.String(),
+				Kind:       "Etcd",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: testNamespace,
+				Annotations: map[string]string{
+					v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
+					v1beta1constants.GardenerTimestamp: now.UTC().String(),
+				},
+			},
+			Spec: druidv1alpha1.EtcdSpec{},
+		}
 	})
 
 	AfterEach(func() {
 		ctrl.Finish()
+		cleanupFunc()
 	})
 
-	Describe("#WaitUntilEtcdsReady", func() {
-		It("should return an error when the listing fail", func() {
-			c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&druidv1alpha1.EtcdList{}), gomock.AssignableToTypeOf(client.InNamespace(namespace)), client.MatchingLabels{"gardener.cloud/role": "controlplane"}).Return(fakeErr)
+	It("should return error when it's not found", func() {
+		Expect(etcd.Wait(ctx)).To(MatchError(ContainSubstring("not found")))
+	})
 
-			Expect(WaitUntilEtcdsReady(ctx, c, logger.NewFieldLogger(logger.NewNopLogger(), "", ""), namespace, 0, interval, severeThreshold, timeout)).To(MatchError(fakeErr))
-		})
+	It("should return error when it's not ready", func() {
+		defer test.WithVars(
+			&TimeNow, mockNow.Do,
+		)()
+		mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
+		expected.Status.LastError = pointer.StringPtr("some error")
 
-		It("should return an error when not all required etcds are created", func() {
-			etcdList := &druidv1alpha1.EtcdList{}
+		Expect(c.Create(ctx, expected)).To(Succeed(), "creating etcd succeeds")
+		Expect(etcd.Wait(ctx)).To(MatchError(ContainSubstring("some error")))
+	})
 
-			c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&druidv1alpha1.EtcdList{}), gomock.AssignableToTypeOf(client.InNamespace(namespace)), client.MatchingLabels{"gardener.cloud/role": "controlplane"}).DoAndReturn(func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
-				etcdList.DeepCopyInto(list.(*druidv1alpha1.EtcdList))
-				return nil
-			}).AnyTimes()
+	It("should return error if we haven't observed the latest timestamp annotation", func() {
+		defer test.WithVars(
+			&TimeNow, mockNow.Do,
+		)()
+		mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
 
-			Expect(WaitUntilEtcdsReady(ctx, c, logger.NewFieldLogger(logger.NewNopLogger(), "", ""), namespace, 1, interval, severeThreshold, timeout)).To(MatchError(ContainSubstring("etcd resources found")))
-		})
+		By("deploy")
+		// Deploy should fill internal state with the added timestamp annotation
+		Expect(etcd.Deploy(ctx)).To(Succeed())
 
-		It("should wait until all etcds are ready", func() {
-			etcdList := &druidv1alpha1.EtcdList{
-				Items: []druidv1alpha1.Etcd{
-					{
-						Status: druidv1alpha1.EtcdStatus{
-							ObservedGeneration: pointer.Int64Ptr(0),
-							Ready:              pointer.BoolPtr(true),
-						},
-					},
-					{
-						Status: druidv1alpha1.EtcdStatus{
-							ObservedGeneration: pointer.Int64Ptr(0),
-							Ready:              pointer.BoolPtr(true),
-						},
-					},
-				},
-			}
+		By("patch object")
+		patch := client.MergeFrom(expected.DeepCopy())
+		expected.Status.LastError = nil
+		// remove operation annotation, add old timestamp annotation
+		expected.ObjectMeta.Annotations = map[string]string{
+			v1beta1constants.GardenerTimestamp: now.Add(-time.Millisecond).UTC().String(),
+		}
+		expected.Status.Ready = pointer.BoolPtr(true)
+		Expect(c.Patch(ctx, expected, patch)).To(Succeed(), "patching etcd succeeds")
 
-			c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&druidv1alpha1.EtcdList{}), gomock.AssignableToTypeOf(client.InNamespace(namespace)), client.MatchingLabels{"gardener.cloud/role": "controlplane"}).DoAndReturn(func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
-				etcdList.DeepCopyInto(list.(*druidv1alpha1.EtcdList))
-				return nil
-			}).AnyTimes()
+		By("wait")
+		Expect(etcd.Wait(ctx)).NotTo(Succeed(), "etcd indicates error")
+	})
 
-			Expect(WaitUntilEtcdsReady(ctx, c, logger.NewFieldLogger(logger.NewNopLogger(), "", ""), namespace, len(etcdList.Items), interval, severeThreshold, timeout)).To(Succeed())
-		})
+	It("should return no error when is ready", func() {
+		defer test.WithVars(
+			&TimeNow, mockNow.Do,
+		)()
+		mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
 
-		It("should fail when an etcd has a last error", func() {
-			var (
-				errorMsg = "foo"
-				etcdList = &druidv1alpha1.EtcdList{
-					Items: []druidv1alpha1.Etcd{
-						{
-							Status: druidv1alpha1.EtcdStatus{
-								LastError: pointer.StringPtr(errorMsg),
-							},
-						},
-					},
-				}
-			)
+		By("deploy")
+		// Deploy should fill internal state with the added timestamp annotation
+		Expect(etcd.Deploy(ctx)).To(Succeed())
 
-			c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&druidv1alpha1.EtcdList{}), gomock.AssignableToTypeOf(client.InNamespace(namespace)), client.MatchingLabels{"gardener.cloud/role": "controlplane"}).DoAndReturn(func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
-				etcdList.DeepCopyInto(list.(*druidv1alpha1.EtcdList))
-				return nil
-			}).AnyTimes()
+		By("patch object")
+		delete(expected.Annotations, v1beta1constants.GardenerTimestamp)
+		patch := client.MergeFrom(expected.DeepCopy())
+		expected.Status.ObservedGeneration = pointer.Int64Ptr(0)
+		expected.Status.LastError = nil
+		// remove operation annotation, add up-to-date timestamp annotation
+		expected.ObjectMeta.Annotations = map[string]string{
+			v1beta1constants.GardenerTimestamp: now.UTC().String(),
+		}
+		expected.Status.Ready = pointer.BoolPtr(true)
+		Expect(c.Patch(ctx, expected, patch)).To(Succeed(), "patching etcd succeeds")
 
-			Expect(WaitUntilEtcdsReady(ctx, c, logger.NewFieldLogger(logger.NewNopLogger(), "", ""), namespace, len(etcdList.Items), interval, severeThreshold, timeout)).To(MatchError(ContainSubstring("reconciliation errored: " + errorMsg)))
-		})
+		By("wait")
+		Expect(etcd.Wait(ctx)).To(Succeed(), "etcd is ready")
+	})
+})
 
-		It("should fail when etcds have unexpected properties", func() {
-			etcdList := &druidv1alpha1.EtcdList{
-				Items: []druidv1alpha1.Etcd{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							DeletionTimestamp: &metav1.Time{},
-						},
-					},
-					{},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Annotations: map[string]string{
-								"gardener.cloud/operation": "reconcile",
-							},
-						},
-						Status: druidv1alpha1.EtcdStatus{
-							ObservedGeneration: pointer.Int64Ptr(0),
-						},
-					},
-					{
-						Status: druidv1alpha1.EtcdStatus{
-							ObservedGeneration: pointer.Int64Ptr(0),
-							Ready:              pointer.BoolPtr(false),
-						},
-					},
-				},
-			}
+var _ = Describe("#CheckEtcdObject", func() {
+	var (
+		obj *druidv1alpha1.Etcd
+	)
 
-			c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&druidv1alpha1.EtcdList{}), gomock.AssignableToTypeOf(client.InNamespace(namespace)), client.MatchingLabels{"gardener.cloud/role": "controlplane"}).DoAndReturn(func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
-				etcdList.DeepCopyInto(list.(*druidv1alpha1.EtcdList))
-				return nil
-			}).AnyTimes()
+	BeforeEach(func() {
+		obj = &druidv1alpha1.Etcd{}
+	})
 
-			Expect(WaitUntilEtcdsReady(ctx, c, logger.NewFieldLogger(logger.NewNopLogger(), "", ""), namespace, len(etcdList.Items), interval, severeThreshold, timeout)).To(MatchError(SatisfyAll(
-				ContainSubstring("unexpectedly has a deletion timestamp"),
-				ContainSubstring("reconciliation pending"),
-				ContainSubstring("reconciliation in process"),
-				ContainSubstring("not ready yet"),
-			)))
-		})
+	It("should return error for non-dns object", func() {
+		Expect(CheckEtcdObject(&corev1.ConfigMap{}))
+	})
+
+	It("should return error if reconciliation failed", func() {
+		obj.Status.LastError = pointer.StringPtr("foo")
+		err := CheckEtcdObject(obj)
+		Expect(err).To(MatchError("foo"))
+		Expect(retry.IsRetriable(err)).To(BeTrue())
+	})
+
+	It("should return error if etcd is marked for deletion", func() {
+		now := metav1.Now()
+		obj.SetDeletionTimestamp(&now)
+		Expect(CheckEtcdObject(obj)).To(MatchError("unexpectedly has a deletion timestamp"))
+	})
+
+	It("should return error if observedGeneration is not set", func() {
+		Expect(CheckEtcdObject(obj)).To(MatchError("observed generation not recorded"))
+	})
+
+	It("should return error if observedGeneration is outdated", func() {
+		obj.SetGeneration(1)
+		obj.Status.ObservedGeneration = pointer.Int64Ptr(0)
+		Expect(CheckEtcdObject(obj)).To(MatchError("observed generation outdated (0/1)"))
+	})
+
+	It("should return error if operation annotation is not removed yet", func() {
+		obj.SetGeneration(1)
+		obj.Status.ObservedGeneration = pointer.Int64Ptr(1)
+		metav1.SetMetaDataAnnotation(&obj.ObjectMeta, v1beta1constants.GardenerOperation, "reconcile")
+		Expect(CheckEtcdObject(obj)).To(MatchError("gardener operation \"reconcile\" is not yet picked up by etcd-druid"))
+	})
+
+	It("should return error if status.ready==nil", func() {
+		obj.SetGeneration(1)
+		obj.Status.ObservedGeneration = pointer.Int64Ptr(1)
+		Expect(CheckEtcdObject(obj)).To(MatchError("is not ready yet"))
+	})
+
+	It("should return error if status.ready==false", func() {
+		obj.SetGeneration(1)
+		obj.Status.ObservedGeneration = pointer.Int64Ptr(1)
+		obj.Status.Ready = pointer.BoolPtr(false)
+		Expect(CheckEtcdObject(obj)).To(MatchError("is not ready yet"))
+	})
+
+	It("should not return error if object is ready", func() {
+		obj.SetGeneration(1)
+		obj.Status.ObservedGeneration = pointer.Int64Ptr(1)
+		obj.Status.Ready = pointer.BoolPtr(true)
+		Expect(CheckEtcdObject(obj)).To(Succeed())
 	})
 })

--- a/pkg/operation/botanist/etcd_test.go
+++ b/pkg/operation/botanist/etcd_test.go
@@ -42,6 +42,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
+	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -128,6 +129,7 @@ var _ = Describe("Etcd", func() {
 
 						validator := &newEtcdValidator{
 							expectedClient:                  Equal(c),
+							expectedLogger:                  BeNil(),
 							expectedNamespace:               Equal(namespace),
 							expectedRole:                    Equal(role),
 							expectedClass:                   Equal(class),
@@ -165,6 +167,7 @@ var _ = Describe("Etcd", func() {
 
 				validator := &newEtcdValidator{
 					expectedClient:                  Equal(c),
+					expectedLogger:                  BeNil(),
 					expectedNamespace:               Equal(namespace),
 					expectedRole:                    Equal(role),
 					expectedClass:                   Equal(class),
@@ -194,6 +197,7 @@ var _ = Describe("Etcd", func() {
 
 				validator := &newEtcdValidator{
 					expectedClient:                  Equal(c),
+					expectedLogger:                  BeNil(),
 					expectedNamespace:               Equal(namespace),
 					expectedRole:                    Equal(role),
 					expectedClass:                   Equal(class),
@@ -451,6 +455,7 @@ type newEtcdValidator struct {
 	etcd.Interface
 
 	expectedClient                  gomegatypes.GomegaMatcher
+	expectedLogger                  gomegatypes.GomegaMatcher
 	expectedNamespace               gomegatypes.GomegaMatcher
 	expectedRole                    gomegatypes.GomegaMatcher
 	expectedClass                   gomegatypes.GomegaMatcher
@@ -462,6 +467,7 @@ type newEtcdValidator struct {
 
 func (v *newEtcdValidator) NewEtcd(
 	client client.Client,
+	logger logrus.FieldLogger,
 	namespace string,
 	role string,
 	class etcd.Class,
@@ -470,6 +476,7 @@ func (v *newEtcdValidator) NewEtcd(
 	defragmentationSchedule *string,
 ) etcd.Interface {
 	Expect(client).To(v.expectedClient)
+	Expect(logger).To(v.expectedLogger)
 	Expect(namespace).To(v.expectedNamespace)
 	Expect(role).To(v.expectedRole)
 	Expect(class).To(v.expectedClass)

--- a/pkg/utils/retry/error.go
+++ b/pkg/utils/retry/error.go
@@ -1,0 +1,59 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package retry
+
+import (
+	"errors"
+)
+
+// retriableError is a marker interface indicating that an error occurred in a different component occurred (e.g. during
+// reconciliation of an extension resource, the extension controller sets status.lastError), but the error should not be
+// treated as "severe" immediately. Instead, the wait func is supposed to continue retrying waiting for the health
+// condition to be met and only treat the error as severe, if it persists.
+type retriableError interface {
+	error
+	// Retriable distinguishes an retriableError from other errors.
+	Retriable()
+}
+
+// IsRetriable checks if any error in err's chain is marked as an retriableError.
+func IsRetriable(err error) bool {
+	var r retriableError
+	return errors.As(err, &r)
+}
+
+// RetriableError marks a given error as retriable.
+func RetriableError(err error) error {
+	return retriableErrorImpl{underlying: err}
+}
+
+var _ retriableError = retriableErrorImpl{}
+
+type retriableErrorImpl struct {
+	underlying error
+}
+
+// Error return the error message of the underlying (wrapped) error.
+func (r retriableErrorImpl) Error() string {
+	return r.underlying.Error()
+}
+
+// Retriable marks retriableErrorImpl as retriable.
+func (r retriableErrorImpl) Retriable() {}
+
+// Unwrap returns the underlying (wrapped) error.
+func (r retriableErrorImpl) Unwrap() error {
+	return r.underlying
+}

--- a/pkg/utils/retry/error_test.go
+++ b/pkg/utils/retry/error_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/utils/retry/error_test.go
+++ b/pkg/utils/retry/error_test.go
@@ -1,0 +1,74 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package retry_test
+
+import (
+	"errors"
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "github.com/gardener/gardener/pkg/utils/retry"
+)
+
+var _ = Describe("Retriable Errors", func() {
+	Describe("#RetriableError", func() {
+		It("should mark an error as retriable", func() {
+			err := fmt.Errorf("foo")
+			r := RetriableError(err)
+			Expect(r).To(MatchError("foo"))
+
+			var re interface{ Retriable() }
+			Expect(errors.As(r, &re)).To(BeTrue())
+		})
+		It("should allow unwrapping the given error", func() {
+			err := &specialError{}
+
+			r := RetriableError(err)
+			Expect(r).To(MatchError("special"))
+
+			var re interface{ Retriable() }
+			Expect(errors.As(r, &re)).To(BeTrue())
+
+			var special interface{ Special() }
+			Expect(errors.As(r, &special)).To(BeTrue())
+		})
+	})
+
+	Describe("#IsRetriable", func() {
+		It("should return false for non-retriable error", func() {
+			Expect(IsRetriable(fmt.Errorf("foo"))).To(BeFalse())
+		})
+		It("should return true for retriable error", func() {
+			Expect(IsRetriable(dummyRetriableError{})).To(BeTrue())
+			Expect(IsRetriable(&dummyRetriableError{})).To(BeTrue())
+		})
+		It("should return true for error created by RetriableError", func() {
+			Expect(IsRetriable(RetriableError(fmt.Errorf("foo")))).To(BeTrue())
+			Expect(IsRetriable(RetriableError(&specialError{}))).To(BeTrue())
+		})
+	})
+})
+
+type specialError struct{}
+
+func (s *specialError) Error() string { return "special" }
+func (s *specialError) Special()      {}
+
+type dummyRetriableError struct{}
+
+func (s dummyRetriableError) Error() string { return "dummy" }
+func (s dummyRetriableError) Retriable()    {}

--- a/pkg/utils/retry/retry_suite_test.go
+++ b/pkg/utils/retry/retry_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/utils/retry/retry_suite_test.go
+++ b/pkg/utils/retry/retry_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package retry_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestRetry(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Utils Retry Suite")
+}

--- a/pkg/utils/retry/retry_test.go
+++ b/pkg/utils/retry/retry_test.go
@@ -17,7 +17,6 @@ package retry_test
 import (
 	"errors"
 	"fmt"
-	"testing"
 	"time"
 
 	"github.com/golang/mock/gomock"
@@ -31,11 +30,6 @@ import (
 	. "github.com/gardener/gardener/pkg/utils/retry"
 	mockretry "github.com/gardener/gardener/pkg/utils/retry/mock"
 )
-
-func TestRetry(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Retry Suite")
-}
 
 var _ = Describe("Retry", func() {
 	var (


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity scalability
/kind cleanup

**What this PR does / why we need it**:

Similar to previous PRs, this PR works towards getting rid of the `DirectClient`.
This one tackles usages in the `etcd` component and makes it ready for cached clients.

It also
- cleans up the special handling for `ErrorWithCodes` in `WaitUntilObjectReadyWithHealthFunction` and introduces a new concept of "retriable errors" (the naming is not quite perfect, couldn't come up with something better, so better ideas are welcome!)
- refactors the `WaitUntilEtcdsReady` func that waits for both `Etcd`s into `etcd.Wait` (ties it to the component), which is important for preventing unwanted consequences of stale cache reads

**Which issue(s) this PR fixes**:
Part of #2822

**Special notes for your reviewer**:

/squash

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
