### PR TITLE
Fix allow-to-dns networkpoliciy in garden namespace with node local dns

### DIFF
--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -283,7 +283,7 @@ func (b *Botanist) generateCoreAddonsChart(ctx context.Context) (*chartrenderer.
 	)
 
 	if b.Shoot.IPVSEnabled() {
-		networkPolicyConfig.NodeLocalDNS.KubeDNSClusterIP = NodeLocalIPVSAddress
+		networkPolicyConfig.NodeLocalDNS.KubeDNSClusterIP = common.NodeLocalIPVSAddress
 	}
 
 	if b.APIServerSNIEnabled() {

--- a/pkg/operation/botanist/networkpolicies.go
+++ b/pkg/operation/botanist/networkpolicies.go
@@ -83,7 +83,7 @@ func (b *Botanist) DefaultNetworkPolicies(sniPhase component.Phase) (component.D
 				PrivateNetworkPeers:  privateNetworkPeers,
 				DenyAllTraffic:       true,
 				NodeLocalDNSEnabled:  b.Shoot.NodeLocalDNSEnabled,
-				NodeLocalIPVSAddress: pointer.StringPtr(NodeLocalIPVSAddress),
+				NodeLocalIPVSAddress: pointer.StringPtr(common.NodeLocalIPVSAddress),
 				DNSServerAddress:     pointer.StringPtr(seedDNSServerAddress.String()),
 			},
 		},

--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig/downloader"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components"
+	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
@@ -54,7 +55,7 @@ func (b *Botanist) DefaultOperatingSystemConfig() (operatingsystemconfig.Interfa
 		// If IPVS is enabled then instruct the kubelet to create pods resolving DNS to the `nodelocaldns` network
 		// interface link-local ip address. For more information checkout the usage documentation under
 		// https://kubernetes.io/docs/tasks/administer-cluster/nodelocaldns/.
-		clusterDNSAddress = NodeLocalIPVSAddress
+		clusterDNSAddress = common.NodeLocalIPVSAddress
 	}
 
 	return operatingsystemconfig.New(

--- a/pkg/operation/botanist/types.go
+++ b/pkg/operation/botanist/types.go
@@ -28,6 +28,3 @@ type Botanist struct {
 	DefaultDomainSecret *corev1.Secret
 	mutex               sync.RWMutex
 }
-
-// NodeLocalIPVSAddress is the IPv4 address used by node local dns when IPVS is used.
-const NodeLocalIPVSAddress = "169.254.20.10"

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -152,4 +152,7 @@ const (
 	// MonitoringIngressCredentialsUsers is a constant for the name of a secret containing the monitoring credentials
 	// for users monitoring for shoots.
 	MonitoringIngressCredentialsUsers = "monitoring-ingress-credentials-users"
+
+	// NodeLocalIPVSAddress is the IPv4 address used by node local dns when IPVS is used.
+	NodeLocalIPVSAddress = "169.254.20.10"
 )


### PR DESCRIPTION
Fix allow-to-dns networkpoliciy in garden namespace with node local dns


Co-authored-by: johannes scheerer <johannes.scheerer@sap.com>


**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
none
```
