### PR TITLE
[release-v1.24] Automated cherry pick of #4200: Upgrade cluster-autoscaler from v0.16.1 to v0.16.2

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -75,7 +75,7 @@ images:
 - name: cluster-autoscaler
   sourceRepository: github.com/gardener/autoscaler
   repository: eu.gcr.io/gardener-project/gardener/autoscaler/cluster-autoscaler
-  tag: "v0.16.1"
+  tag: "v0.16.2"
   targetVersion: ">= 1.16"
 - name: cluster-autoscaler
   sourceRepository: github.com/gardener/autoscaler


### PR DESCRIPTION
/area/auto-scaling
/kind/bug

Cherry pick of #4200 on release-v1.24.

#4200: Upgrade cluster-autoscaler from v0.16.1 to v0.16.2

**Release Notes:**
``` bugfix user github.com/gardener/autoscaler #86 @AxiomSamarth
Added support for 12 new AWS instance types and 1 Azure instance type to support scale up from zero.
```