### PR TITLE
Enable overriding the grace periods for cleanup steps in shoot deletion

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@
 * [API Server Network Proxy Reverse Tunneling](usage/reverse-tunnel.md)
 * [Audit a Kubernetes cluster](usage/shoot_auditpolicy.md)
 * [Auto-Scaling for shoot clusters](usage/shoot_autoscaling.md)
+* [Cleanup of Shoot clusters in deletion](usage/shoot_cleanup.md)
 * [Custom `CoreDNS` configuration](usage/custom-dns.md)
 * [(Custom) CSI components](usage/csi_components.md)
 * [Gardener configuration and usage](usage/configuration.md)

--- a/docs/usage/shoot_cleanup.md
+++ b/docs/usage/shoot_cleanup.md
@@ -1,0 +1,28 @@
+# Cleanup of Shoot clusters in deletion
+
+When a shoot cluster is deleted then Gardener tries to gracefully remove most of the Kubernetes resources inside the cluster.
+This is to prevent that any infrastructure or other artefacts remain after the shoot deletion.
+
+The cleanup is performed in four steps.
+Some resources are deleted with a grace period, and all resources are forcefully deleted (by removing blocking finalizers) after some time to not block the cluster deletion entirely.
+
+**Cleanup steps:**
+
+1. All `ValidatingWebhookConfiguration`s and `MutatingWebhookConfiguration`s are deleted with a `5m` grace period. Forceful finalization happens after `5m`.
+1. All `APIService`s and `CustomResourceDefinition`s are deleted with a `5m` grace period. Forceful finalization happens after `1h`.
+1. All `CronJob`s, `DaemonSet`s, `Deployment`s, `Ingress`s, `Job`s, `Pod`s, `ReplicaSet`s, `ReplicationController`s, `Service`s, `StatefulSet`s, `PersistentVolumeClaim`s are deleted with a `5m` grace period. Forceful finalization happens after `5m`.
+   > If the `Shoot` is annotated with `shoot.gardener.cloud/skip-cleanup=true` then only `Service`s and `PersistentVolumeClaim`s are considered.
+1. All `Namespace`s  are deleted without any grace period. Forceful finalization happens after `5m`.
+
+It is possible to override the finalization grace periods via annotations on the `Shoot`:
+
+- `shoot.gardener.cloud/cleanup-webhooks-finalize-grace-period-seconds` (for the resources handled in step 1)
+- `shoot.gardener.cloud/cleanup-extended-apis-finalize-grace-period-seconds` (for the resources handled in step 2)
+- `shoot.gardener.cloud/cleanup-kubernetes-resources-finalize-grace-period-seconds` (for the resources handled in step 3)
+- `shoot.gardener.cloud/cleanup-namespaces-finalize-grace-period-seconds` (for the resources handled in step 4)
+
+If `"0"` is provided then all resources are finalized immediately without waiting for any graceful deletion.
+
+⚠️ Please be aware that this might lead to orphaned infrastructure artefacts.
+
+ 

--- a/docs/usage/shoot_cleanup.md
+++ b/docs/usage/shoot_cleanup.md
@@ -21,8 +21,7 @@ It is possible to override the finalization grace periods via annotations on the
 - `shoot.gardener.cloud/cleanup-kubernetes-resources-finalize-grace-period-seconds` (for the resources handled in step 3)
 - `shoot.gardener.cloud/cleanup-namespaces-finalize-grace-period-seconds` (for the resources handled in step 4)
 
-If `"0"` is provided then all resources are finalized immediately without waiting for any graceful deletion.
+⚠️ If `"0"` is provided then all resources are finalized immediately without waiting for any graceful deletion.
+Please be aware that this might lead to orphaned infrastructure artefacts.
 
-⚠️ Please be aware that this might lead to orphaned infrastructure artefacts.
-
- 
+ℹ️️ All grace period values larger than the above mentioned defaults are ignored.

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -350,6 +350,24 @@ const (
 	// AnnotationShootSkipCleanup is a key for an annotation on a Shoot resource that declares that the clean up steps should be skipped when the
 	// cluster is deleted. Concretely, this will skip everything except the deletion of (load balancer) services and persistent volume resources.
 	AnnotationShootSkipCleanup = "shoot.gardener.cloud/skip-cleanup"
+	// AnnotationShootCleanupWebhooksFinalizeGracePeriodSeconds is a key for an annotation on a Shoot resource that
+	// declares the grace period in seconds for finalizing the resources handled in the 'cleanup webhooks' step.
+	// Concretely, after the specified seconds, all the finalizers of the affected resources are forcefully removed.
+	AnnotationShootCleanupWebhooksFinalizeGracePeriodSeconds = "shoot.gardener.cloud/cleanup-webhooks-finalize-grace-period-seconds"
+	// AnnotationShootCleanupExtendedAPIsFinalizeGracePeriodSeconds is a key for an annotation on a Shoot resource that
+	// declares the grace period in seconds for finalizing the resources handled in the 'cleanup extended APIs' step.
+	// Concretely, after the specified seconds, all the finalizers of the affected resources are forcefully removed.
+	AnnotationShootCleanupExtendedAPIsFinalizeGracePeriodSeconds = "shoot.gardener.cloud/cleanup-extended-apis-finalize-grace-period-seconds"
+	// AnnotationShootCleanupKubernetesResourcesFinalizeGracePeriodSeconds is a key for an annotation on a Shoot
+	// resource that declares the grace period in seconds for finalizing the resources handled in the 'cleanup
+	// Kubernetes resources' step. Concretely, after the specified seconds, all the finalizers of the affected resources
+	// are forcefully removed.
+	AnnotationShootCleanupKubernetesResourcesFinalizeGracePeriodSeconds = "shoot.gardener.cloud/cleanup-kubernetes-resources-finalize-grace-period-seconds"
+	// AnnotationShootCleanupNamespaceResourcesFinalizeGracePeriodSeconds is a key for an annotation on a Shoot
+	// resource that declares the grace period in seconds for finalizing the resources handled in the 'cleanup shoot
+	// namespaces' step. Concretely, after the specified seconds, all the finalizers of the affected resources are
+	// forcefully removed.
+	AnnotationShootCleanupNamespaceResourcesFinalizeGracePeriodSeconds = "shoot.gardener.cloud/cleanup-namespaces-finalize-grace-period-seconds"
 	// AnnotationShootKonnectivityTunnel is the key for an annotation of a Shoot cluster whose value indicates
 	// if a konnectivity-tunnel should be deployed into the shoot cluster or not.
 	AnnotationShootKonnectivityTunnel = "alpha.featuregates.shoot.gardener.cloud/konnectivity-tunnel"

--- a/pkg/operation/botanist/cleanup.go
+++ b/pkg/operation/botanist/cleanup.go
@@ -64,10 +64,10 @@ var (
 	// FinalizeAfterOneHour is an option to finalize resources after one hour.
 	FinalizeAfterOneHour = utilclient.FinalizeGracePeriodSeconds(60 * 60)
 
-	// ZeroGracePeriod is an option to delete resources with no grace period.
-	ZeroGracePeriod = utilclient.DeleteWith{client.GracePeriodSeconds(0)}
-	// GracePeriodFiveMinutes is an option to delete resources with a grace period of five minutes.
-	GracePeriodFiveMinutes = utilclient.DeleteWith{client.GracePeriodSeconds(5 * 60)}
+	// ZeroGracePeriod can be used for deleting resources with no grace period.
+	ZeroGracePeriod = client.GracePeriodSeconds(0)
+	// GracePeriodFiveMinutes can be used for deleting resources with a grace period of five minutes.
+	GracePeriodFiveMinutes = client.GracePeriodSeconds(5 * 60)
 
 	// NotSystemComponent is a requirement that something doesn't have the GardenRole GardenRoleSystemComponent.
 	NotSystemComponent = utils.MustNewRequirement(v1beta1constants.GardenRole, selection.NotEquals, v1beta1constants.GardenRoleSystemComponent)
@@ -178,14 +178,14 @@ func (b *Botanist) CleanWebhooks(ctx context.Context) error {
 		ops     = utilclient.NewCleanOps(utilclient.DefaultCleaner(), ensurer)
 	)
 
-	deleteWith, finalizeAfter, err := b.getCleanOptions(GracePeriodFiveMinutes, FinalizeAfterFiveMinutes, v1beta1constants.AnnotationShootCleanupWebhooksFinalizeGracePeriodSeconds, 1)
+	cleanOptions, err := b.getCleanOptions(GracePeriodFiveMinutes, FinalizeAfterFiveMinutes, v1beta1constants.AnnotationShootCleanupWebhooksFinalizeGracePeriodSeconds, 1)
 	if err != nil {
 		return err
 	}
 
 	return flow.Parallel(
-		cleanResourceFn(ops, c, &admissionregistrationv1beta1.MutatingWebhookConfigurationList{}, MutatingWebhookConfigurationCleanOption, deleteWith, finalizeAfter),
-		cleanResourceFn(ops, c, &admissionregistrationv1beta1.ValidatingWebhookConfigurationList{}, ValidatingWebhookConfigurationCleanOption, deleteWith, finalizeAfter),
+		cleanResourceFn(ops, c, &admissionregistrationv1beta1.MutatingWebhookConfigurationList{}, MutatingWebhookConfigurationCleanOption, cleanOptions),
+		cleanResourceFn(ops, c, &admissionregistrationv1beta1.ValidatingWebhookConfigurationList{}, ValidatingWebhookConfigurationCleanOption, cleanOptions),
 	)(ctx)
 }
 
@@ -198,14 +198,14 @@ func (b *Botanist) CleanExtendedAPIs(ctx context.Context) error {
 		crdCleanOps = utilclient.NewCleanOps(utilclient.DefaultCleaner(), ensurer)
 	)
 
-	deleteWith, finalizeAfter, err := b.getCleanOptions(GracePeriodFiveMinutes, FinalizeAfterOneHour, v1beta1constants.AnnotationShootCleanupExtendedAPIsFinalizeGracePeriodSeconds, 0.1)
+	cleanOptions, err := b.getCleanOptions(GracePeriodFiveMinutes, FinalizeAfterOneHour, v1beta1constants.AnnotationShootCleanupExtendedAPIsFinalizeGracePeriodSeconds, 0.1)
 	if err != nil {
 		return err
 	}
 
 	return flow.Parallel(
-		cleanResourceFn(defaultOps, c, &apiregistrationv1.APIServiceList{}, APIServiceCleanOption, deleteWith, finalizeAfter),
-		cleanResourceFn(crdCleanOps, c, &apiextensionsv1beta1.CustomResourceDefinitionList{}, CustomResourceDefinitionCleanOption, deleteWith, finalizeAfter),
+		cleanResourceFn(defaultOps, c, &apiregistrationv1.APIServiceList{}, APIServiceCleanOption, cleanOptions),
+		cleanResourceFn(crdCleanOps, c, &apiextensionsv1beta1.CustomResourceDefinitionList{}, CustomResourceDefinitionCleanOption, cleanOptions),
 	)(ctx)
 }
 
@@ -220,30 +220,30 @@ func (b *Botanist) CleanKubernetesResources(ctx context.Context) error {
 		ops     = utilclient.NewCleanOps(utilclient.DefaultCleaner(), ensurer)
 	)
 
-	deleteWith, finalizeAfter, err := b.getCleanOptions(GracePeriodFiveMinutes, FinalizeAfterFiveMinutes, v1beta1constants.AnnotationShootCleanupKubernetesResourcesFinalizeGracePeriodSeconds, 1)
+	cleanOptions, err := b.getCleanOptions(GracePeriodFiveMinutes, FinalizeAfterFiveMinutes, v1beta1constants.AnnotationShootCleanupKubernetesResourcesFinalizeGracePeriodSeconds, 1)
 	if err != nil {
 		return err
 	}
 
 	if metav1.HasAnnotation(b.Shoot.Info.ObjectMeta, v1beta1constants.AnnotationShootSkipCleanup) {
 		return flow.Parallel(
-			cleanResourceFn(ops, c, &corev1.ServiceList{}, ServiceCleanOption, deleteWith, finalizeAfter),
-			cleanResourceFn(ops, c, &corev1.PersistentVolumeClaimList{}, PersistentVolumeClaimCleanOption, deleteWith, finalizeAfter),
+			cleanResourceFn(ops, c, &corev1.ServiceList{}, ServiceCleanOption, cleanOptions),
+			cleanResourceFn(ops, c, &corev1.PersistentVolumeClaimList{}, PersistentVolumeClaimCleanOption, cleanOptions),
 		)(ctx)
 	}
 
 	return flow.Parallel(
-		cleanResourceFn(ops, c, &batchv1beta1.CronJobList{}, CronJobCleanOption, deleteWith, finalizeAfter),
-		cleanResourceFn(ops, c, &appsv1.DaemonSetList{}, DaemonSetCleanOption, deleteWith, finalizeAfter),
-		cleanResourceFn(ops, c, &appsv1.DeploymentList{}, DeploymentCleanOption, deleteWith, finalizeAfter),
-		cleanResourceFn(ops, c, &extensionsv1beta1.IngressList{}, IngressCleanOption, deleteWith, finalizeAfter),
-		cleanResourceFn(ops, c, &batchv1.JobList{}, JobCleanOption, deleteWith, finalizeAfter),
-		cleanResourceFn(ops, c, &corev1.PodList{}, PodCleanOption, deleteWith, finalizeAfter),
-		cleanResourceFn(ops, c, &appsv1.ReplicaSetList{}, ReplicaSetCleanOption, deleteWith, finalizeAfter),
-		cleanResourceFn(ops, c, &corev1.ReplicationControllerList{}, ReplicationControllerCleanOption, deleteWith, finalizeAfter),
-		cleanResourceFn(ops, c, &corev1.ServiceList{}, ServiceCleanOption, deleteWith, finalizeAfter),
-		cleanResourceFn(ops, c, &appsv1.StatefulSetList{}, StatefulSetCleanOption, deleteWith, finalizeAfter),
-		cleanResourceFn(ops, c, &corev1.PersistentVolumeClaimList{}, PersistentVolumeClaimCleanOption, deleteWith, finalizeAfter),
+		cleanResourceFn(ops, c, &batchv1beta1.CronJobList{}, CronJobCleanOption, cleanOptions),
+		cleanResourceFn(ops, c, &appsv1.DaemonSetList{}, DaemonSetCleanOption, cleanOptions),
+		cleanResourceFn(ops, c, &appsv1.DeploymentList{}, DeploymentCleanOption, cleanOptions),
+		cleanResourceFn(ops, c, &extensionsv1beta1.IngressList{}, IngressCleanOption, cleanOptions),
+		cleanResourceFn(ops, c, &batchv1.JobList{}, JobCleanOption, cleanOptions),
+		cleanResourceFn(ops, c, &corev1.PodList{}, PodCleanOption, cleanOptions),
+		cleanResourceFn(ops, c, &appsv1.ReplicaSetList{}, ReplicaSetCleanOption, cleanOptions),
+		cleanResourceFn(ops, c, &corev1.ReplicationControllerList{}, ReplicationControllerCleanOption, cleanOptions),
+		cleanResourceFn(ops, c, &corev1.ServiceList{}, ServiceCleanOption, cleanOptions),
+		cleanResourceFn(ops, c, &appsv1.StatefulSetList{}, StatefulSetCleanOption, cleanOptions),
+		cleanResourceFn(ops, c, &corev1.PersistentVolumeClaimList{}, PersistentVolumeClaimCleanOption, cleanOptions),
 	)(ctx)
 }
 
@@ -256,44 +256,47 @@ func (b *Botanist) CleanShootNamespaces(ctx context.Context) error {
 		namespaceCleanOps = utilclient.NewCleanOps(namespaceCleaner, utilclient.DefaultGoneEnsurer())
 	)
 
-	deleteWith, finalizeAfter, err := b.getCleanOptions(ZeroGracePeriod, FinalizeAfterFiveMinutes, v1beta1constants.AnnotationShootCleanupNamespaceResourcesFinalizeGracePeriodSeconds, 0)
+	cleanOptions, err := b.getCleanOptions(ZeroGracePeriod, FinalizeAfterFiveMinutes, v1beta1constants.AnnotationShootCleanupNamespaceResourcesFinalizeGracePeriodSeconds, 0)
 	if err != nil {
 		return err
 	}
 
-	return cleanResourceFn(namespaceCleanOps, c, &corev1.NamespaceList{}, NamespaceMatchingLabelsSelector, NamespaceMatchingFieldsSelector, deleteWith, finalizeAfter, NamespaceErrorToleration)(ctx)
+	return cleanResourceFn(namespaceCleanOps, c, &corev1.NamespaceList{}, cleanOptions, NamespaceMatchingLabelsSelector, NamespaceMatchingFieldsSelector, NamespaceErrorToleration)(ctx)
 }
 
 // CleanVolumeAttachments cleans up all VolumeAttachments in the cluster, waits for them to be gone and finalizes any
 // remaining ones after five minutes.
 func CleanVolumeAttachments(ctx context.Context, c client.Client) error {
-	return cleanResourceFn(utilclient.DefaultCleanOps(), c, &storagev1.VolumeAttachmentList{}, ZeroGracePeriod, FinalizeAfterFiveMinutes)(ctx)
+	return cleanResourceFn(utilclient.DefaultCleanOps(), c, &storagev1.VolumeAttachmentList{}, utilclient.DeleteWith{ZeroGracePeriod}, FinalizeAfterFiveMinutes)(ctx)
 }
 
 func (b *Botanist) getCleanOptions(
-	defaultDeleteWith utilclient.DeleteWith,
+	defaultGracePeriodSeconds client.GracePeriodSeconds,
 	defaultFinalizeAfter utilclient.FinalizeGracePeriodSeconds,
 	annotationKey string,
 	gracePeriodSecondsFactor float64,
 ) (
-	utilclient.DeleteWith,
-	utilclient.FinalizeGracePeriodSeconds,
+	*utilclient.CleanOptions,
 	error,
 ) {
 	var (
-		deleteWith    = defaultDeleteWith
-		finalizeAfter = defaultFinalizeAfter
+		gracePeriodSeconds = defaultGracePeriodSeconds
+		finalizeAfter      = defaultFinalizeAfter
 	)
 
 	if v, ok := b.Shoot.Info.Annotations[annotationKey]; ok {
 		seconds, err := strconv.Atoi(v)
 		if err != nil {
-			return nil, -1, err
+			return nil, err
 		}
 
-		deleteWith = utilclient.DeleteWith{client.GracePeriodSeconds(int(float64(seconds) * gracePeriodSecondsFactor))}
+		gracePeriodSeconds = client.GracePeriodSeconds(int(float64(seconds) * gracePeriodSecondsFactor))
 		finalizeAfter = utilclient.FinalizeGracePeriodSeconds(seconds)
 	}
 
-	return deleteWith, finalizeAfter, nil
+	cleanOpts := &utilclient.CleanOptions{}
+	utilclient.DeleteWith{gracePeriodSeconds}.ApplyToClean(cleanOpts)
+	finalizeAfter.ApplyToClean(cleanOpts)
+
+	return cleanOpts, nil
 }

--- a/pkg/operation/botanist/cleanup.go
+++ b/pkg/operation/botanist/cleanup.go
@@ -290,8 +290,10 @@ func (b *Botanist) getCleanOptions(
 			return nil, err
 		}
 
-		gracePeriodSeconds = client.GracePeriodSeconds(int(float64(seconds) * gracePeriodSecondsFactor))
-		finalizeAfter = utilclient.FinalizeGracePeriodSeconds(seconds)
+		if int64(seconds) < int64(defaultFinalizeAfter) {
+			gracePeriodSeconds = client.GracePeriodSeconds(int(float64(seconds) * gracePeriodSecondsFactor))
+			finalizeAfter = utilclient.FinalizeGracePeriodSeconds(seconds)
+		}
 	}
 
 	cleanOpts := &utilclient.CleanOptions{}

--- a/pkg/utils/kubernetes/client/options.go
+++ b/pkg/utils/kubernetes/client/options.go
@@ -36,6 +36,24 @@ type CleanOptions struct {
 	ErrorToleration            []TolerateErrorFunc
 }
 
+var _ CleanOption = &CleanOptions{}
+
+// ApplyToClean implements CleanOption for CleanOptions.
+func (o *CleanOptions) ApplyToClean(co *CleanOptions) {
+	if o.ListOptions != nil {
+		co.ListOptions = o.ListOptions
+	}
+	if o.DeleteOptions != nil {
+		co.DeleteOptions = o.DeleteOptions
+	}
+	if o.FinalizeGracePeriodSeconds != nil {
+		co.FinalizeGracePeriodSeconds = o.FinalizeGracePeriodSeconds
+	}
+	if o.ErrorToleration != nil {
+		co.ErrorToleration = o.ErrorToleration
+	}
+}
+
 // ApplyOptions applies the OptFuncs to the CleanOptions.
 func (o *CleanOptions) ApplyOptions(opts []CleanOption) *CleanOptions {
 	for _, opt := range opts {

--- a/pkg/utils/kubernetes/client/options_test.go
+++ b/pkg/utils/kubernetes/client/options_test.go
@@ -15,46 +15,62 @@
 package client_test
 
 import (
-	utilclient "github.com/gardener/gardener/pkg/utils/kubernetes/client"
+	. "github.com/gardener/gardener/pkg/utils/kubernetes/client"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("CleanOptions", func() {
 	It("should allow setting ListWith", func() {
-		co := &utilclient.CleanOptions{}
-		utilclient.ListWith{client.InNamespace("ns"), client.MatchingLabels{"key": "value"}}.ApplyToClean(co)
+		co := &CleanOptions{}
+		ListWith{client.InNamespace("ns"), client.MatchingLabels{"key": "value"}}.ApplyToClean(co)
 		Expect(co.ListOptions).To(Equal([]client.ListOption{client.InNamespace("ns"), client.MatchingLabels{"key": "value"}}))
 	})
 
 	It("should allow setting DeleteWith", func() {
-		co := &utilclient.CleanOptions{}
-		utilclient.DeleteWith{client.GracePeriodSeconds(42), client.DryRunAll}.ApplyToClean(co)
+		co := &CleanOptions{}
+		DeleteWith{client.GracePeriodSeconds(42), client.DryRunAll}.ApplyToClean(co)
 		Expect(co.DeleteOptions).To(Equal([]client.DeleteOption{client.GracePeriodSeconds(42), client.DryRunAll}))
 	})
 
 	It("should allow setting FinalizeGracePeriodSeconds", func() {
-		co := &utilclient.CleanOptions{}
-		utilclient.FinalizeGracePeriodSeconds(42).ApplyToClean(co)
+		co := &CleanOptions{}
+		FinalizeGracePeriodSeconds(42).ApplyToClean(co)
 		gp := int64(42)
 		Expect(co.FinalizeGracePeriodSeconds).To(Equal(&gp))
 	})
 
 	It("should allow setting ErrorToleration", func() {
-		co := &utilclient.CleanOptions{}
-		utilclient.TolerateErrors{apierrors.IsConflict}.ApplyToClean(co)
+		co := &CleanOptions{}
+		TolerateErrors{apierrors.IsConflict}.ApplyToClean(co)
+		Expect(len(co.ErrorToleration)).To(Equal(1))
+	})
+
+	It("should allow setting CleanOptions", func() {
+		co := &CleanOptions{}
+		(&CleanOptions{
+			ListOptions:                []client.ListOption{client.InNamespace("ns"), client.MatchingLabels{"key": "value"}},
+			DeleteOptions:              []client.DeleteOption{client.GracePeriodSeconds(42), client.DryRunAll},
+			FinalizeGracePeriodSeconds: pointer.Int64Ptr(42),
+			ErrorToleration:            []TolerateErrorFunc{apierrors.IsConflict},
+		}).ApplyToClean(co)
+		Expect(co.ListOptions).To(Equal([]client.ListOption{client.InNamespace("ns"), client.MatchingLabels{"key": "value"}}))
+		Expect(co.DeleteOptions).To(Equal([]client.DeleteOption{client.GracePeriodSeconds(42), client.DryRunAll}))
+		gp := int64(42)
+		Expect(co.FinalizeGracePeriodSeconds).To(Equal(&gp))
 		Expect(len(co.ErrorToleration)).To(Equal(1))
 	})
 
 	It("should merge multiple options together", func() {
 		gp := int64(7)
-		co := &utilclient.CleanOptions{}
-		co.ApplyOptions([]utilclient.CleanOption{
-			utilclient.ListWith{client.InNamespace("ns")},
-			utilclient.FinalizeGracePeriodSeconds(gp),
+		co := &CleanOptions{}
+		co.ApplyOptions([]CleanOption{
+			ListWith{client.InNamespace("ns")},
+			FinalizeGracePeriodSeconds(gp),
 		})
 		Expect(co.ListOptions).To(Equal([]client.ListOption{client.InNamespace("ns")}))
 		Expect(co.FinalizeGracePeriodSeconds).To(Equal(&gp))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability ops-productivity
/kind enhancement

**What this PR does / why we need it**:
It's now possible to override the grace periods for the cleanup steps in the shoot deletion by specifying the following annotations on the `Shoot`:

- `shoot.gardener.cloud/cleanup-webhooks-finalize-grace-period-seconds` (default behaviour: `"300"`)
- `shoot.gardener.cloud/cleanup-extended-apis-finalize-grace-period-seconds` (default behaviour: `"3600"`)
- `shoot.gardener.cloud/cleanup-kubernetes-resources-finalize-grace-period-seconds` (default behaviour: `"300"`)
- `shoot.gardener.cloud/cleanup-namespaces-finalize-grace-period-seconds` (default behaviour: `"300"`)

If `"0"` is provided then all resources are finalized immediately without waiting for any graceful deletion. Please be aware that this might lead to orphaned infrastructure artefacts.

**Which issue(s) this PR fixes**:
Part 2 of https://github.com/gardener/gardener/issues/3110#issuecomment-738745082

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
It's now possible to override the grace periods for the cleanup steps in the shoot deletion by specifying the following annotations on the `Shoot`:

- `shoot.gardener.cloud/cleanup-webhooks-finalize-grace-period-seconds` (default behaviour: `"300"`)
- `shoot.gardener.cloud/cleanup-extended-apis-finalize-grace-period-seconds` (default behaviour: `"3600"`)
- `shoot.gardener.cloud/cleanup-kubernetes-resources-finalize-grace-period-seconds` (default behaviour: `"300"`)
- `shoot.gardener.cloud/cleanup-namespaces-finalize-grace-period-seconds` (default behaviour: `"300"`)

If `"0"` is provided then all resources are finalized immediately without waiting for any graceful deletion. Please be aware that this might lead to orphaned infrastructure artefacts.
```
