### PR TITLE
Use Addon Resizer for scaling the Metrics Server

### DIFF
--- a/charts/images.go
+++ b/charts/images.go
@@ -19,6 +19,8 @@ limitations under the License.
 package charts
 
 const (
+	// ImageNameAlertmanager is a constant for an image in the image vector with name 'addon-resizer'.
+	ImageNameAddonResizer = "addon-resizer"
 	// ImageNameAlertmanager is a constant for an image in the image vector with name 'alertmanager'.
 	ImageNameAlertmanager = "alertmanager"
 	// ImageNameAlpine is a constant for an image in the image vector with name 'alpine'.

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -124,6 +124,10 @@ images:
   sourceRepository: github.com/kubernetes-sigs/metrics-server
   repository: k8s.gcr.io/metrics-server/metrics-server
   tag: v0.4.3
+- name: addon-resizer
+  sourceRepository: github.com/kubernetes/autoscaler
+  repository: k8s.gcr.io/addon-resizer
+  tag: "1.8.11"
 
 # Shoot core addons
 - name: vpn-shoot

--- a/pkg/operation/botanist/component/metricsserver/metrics_server.go
+++ b/pkg/operation/botanist/component/metricsserver/metrics_server.go
@@ -73,15 +73,15 @@ func New(
 	client client.Client,
 	namespace string,
 	image string,
+	imageAddonResizer string,
 	kubeAPIServerHost *string,
-	addonResizerImage string,
 ) Interface {
 	return &metricsServer{
 		client:            client,
 		namespace:         namespace,
 		image:             image,
 		kubeAPIServerHost: kubeAPIServerHost,
-		addonResizerImage: addonResizerImage,
+		imageAddonResizer: imageAddonResizer,
 	}
 }
 
@@ -89,8 +89,8 @@ type metricsServer struct {
 	client            client.Client
 	namespace         string
 	image             string
+	imageAddonResizer string
 	kubeAPIServerHost *string
-	addonResizerImage string
 	secrets           Secrets
 }
 
@@ -266,7 +266,7 @@ func (m *metricsServer) computeResourcesData() (map[string][]byte, error) {
 					v1beta1constants.GardenRole:     v1beta1constants.GardenRoleSystemComponent,
 				}),
 				Annotations: map[string]string{
-					resourcesv1alpha1.PreserveResources: true,
+					resourcesv1alpha1.PreserveResources: "true",
 				},
 			},
 			Spec: appsv1.DeploymentSpec{
@@ -366,7 +366,7 @@ func (m *metricsServer) computeResourcesData() (map[string][]byte, error) {
 							}},
 						}, {
 							Name:            addonResizerName,
-							Image:           m.addonResizerImage,
+							Image:           m.imageAddonResizer,
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Command: []string{
 								"/pod_nanny",
@@ -375,8 +375,8 @@ func (m *metricsServer) computeResourcesData() (map[string][]byte, error) {
 								"--memory=15Mi",
 								"--extra-memory=2Mi",
 								"--threshold=5",
-								"--deployment=metrics-server",
-								"--container=metrics-server",
+								"--deployment=" + deploymentName,
+								"--container=" + containerName,
 								"--poll-period=300000",
 								"--minClusterSize=10",
 								"--use-metrics=false",

--- a/pkg/operation/botanist/component/metricsserver/metrics_server.go
+++ b/pkg/operation/botanist/component/metricsserver/metrics_server.go
@@ -369,7 +369,7 @@ func (m *metricsServer) computeResourcesData() (map[string][]byte, error) {
 							}},
 						}, {
 							Name:            sideCarName,
-							Image:           m.sideCar,
+							Image:           m.addonResizerImage,
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Command: []string{
 								"/pod_nanny",

--- a/pkg/operation/botanist/component/metricsserver/metrics_server.go
+++ b/pkg/operation/botanist/component/metricsserver/metrics_server.go
@@ -75,7 +75,7 @@ func New(
 	image string,
 	vpaEnabled bool,
 	kubeAPIServerHost *string,
-	sideCar string,
+	addonResizerImage string,
 ) Interface {
 	return &metricsServer{
 		client:            client,

--- a/pkg/operation/botanist/component/metricsserver/metrics_server.go
+++ b/pkg/operation/botanist/component/metricsserver/metrics_server.go
@@ -73,7 +73,6 @@ func New(
 	client client.Client,
 	namespace string,
 	image string,
-	vpaEnabled bool,
 	kubeAPIServerHost *string,
 	addonResizerImage string,
 ) Interface {
@@ -81,9 +80,8 @@ func New(
 		client:            client,
 		namespace:         namespace,
 		image:             image,
-		vpaEnabled:        vpaEnabled,
 		kubeAPIServerHost: kubeAPIServerHost,
-		sideCar:           sideCar,
+		addonResizerImage: addonResizerImage,
 	}
 }
 
@@ -91,9 +89,8 @@ type metricsServer struct {
 	client            client.Client
 	namespace         string
 	image             string
-	vpaEnabled        bool
 	kubeAPIServerHost *string
-	sideCar           string
+	addonResizerImage string
 	secrets           Secrets
 }
 
@@ -368,7 +365,7 @@ func (m *metricsServer) computeResourcesData() (map[string][]byte, error) {
 								MountPath: volumeMountPathServer,
 							}},
 						}, {
-							Name:            sideCarName,
+							Name:            addonResizerName,
 							Image:           m.addonResizerImage,
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Command: []string{

--- a/pkg/operation/botanist/component/metricsserver/metrics_server.go
+++ b/pkg/operation/botanist/component/metricsserver/metrics_server.go
@@ -50,7 +50,7 @@ const (
 	serviceName        = "metrics-server"
 	serviceAccountName = "metrics-server"
 	containerName      = "metrics-server"
-	sideCarName        = "metrics-server-nanny"
+	addonResizerName   = "metrics-server-nanny"
 
 	servicePort   int32 = 443
 	containerPort int32 = 8443

--- a/pkg/operation/botanist/component/metricsserver/metrics_server_test.go
+++ b/pkg/operation/botanist/component/metricsserver/metrics_server_test.go
@@ -433,7 +433,7 @@ status: {}
 		ctrl = gomock.NewController(GinkgoT())
 		c = mockclient.NewMockClient(ctrl)
 
-		metricsServer = New(c, namespace, image, false, nil, sideCar)
+		metricsServer = New(c, namespace, image, nil, sideCar)
 
 		managedResourceSecret = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -526,7 +526,7 @@ status: {}
 			})
 
 			It("should successfully deploy all resources (w/ VPA, w/ host env)", func() {
-				metricsServer = New(c, namespace, image, true, &kubeAPIServerHost, sideCar)
+				metricsServer = New(c, namespace, image, &kubeAPIServerHost, sideCar)
 				metricsServer.SetSecrets(secrets)
 
 				managedResourceSecret.Data["deployment__kube-system__metrics-server.yaml"] = []byte(deploymentYAMLWithHostEnv)

--- a/pkg/operation/botanist/component/metricsserver/metrics_server_test.go
+++ b/pkg/operation/botanist/component/metricsserver/metrics_server_test.go
@@ -44,8 +44,8 @@ var _ = Describe("MetricsServer", func() {
 		fakeErr           = fmt.Errorf("fake error")
 		namespace         = "shoot--foo--bar"
 		image             = "k8s.gcr.io/metrics-server:v4.5.6"
+		imageSidecar      = "k8s.gcr.io/addon-resizer:1.8.11"
 		kubeAPIServerHost = "foo.bar"
-		sideCar           = "k8s.gcr.io/addon-resizer:1.8.11"
 
 		secretNameCA         = "ca-metrics-server"
 		secretChecksumCA     = "1234"
@@ -120,6 +120,15 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - update
+  - watch
 `
 		clusterRoleBindingYAML = `apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -181,6 +190,8 @@ metadata:
 		deploymentYAMLWithoutHostEnv = `apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    resources.gardener.cloud/preserve-resources: "true"
   creationTimestamp: null
   labels:
     gardener.cloud/role: system-component
@@ -251,8 +262,30 @@ spec:
         volumeMounts:
         - mountPath: /srv/metrics-server/tls
           name: metrics-server
-      - name: metrics-server-nanny
-        image: ` + sideCar + `
+      - command:
+        - /pod_nanny
+        - --cpu=20m
+        - --extra-cpu=1m
+        - --memory=15Mi
+        - --extra-memory=2Mi
+        - --threshold=5
+        - --deployment=metrics-server
+        - --container=metrics-server
+        - --poll-period=300000
+        - --minClusterSize=10
+        - --use-metrics=false
+        env:
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: ` + imageSidecar + `
+        imagePullPolicy: IfNotPresent
+        name: metrics-server-nanny
         resources:
           limits:
             cpu: 40m
@@ -260,27 +293,6 @@ spec:
           requests:
             cpu: 40m
             memory: 25Mi
-        env:
-          - name: MY_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: MY_POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-        command:
-          - /pod_nanny
-          - --cpu=20m
-          - --extra-cpu=1m
-          - --memory=15Mi
-          - --extra-memory=2Mi
-          - --threshold=5
-          - --deployment=metrics-server
-          - --container=metrics-server
-          - --poll-period=300000
-          - --minClusterSize=10
-          - --use-metrics=false
       dnsPolicy: Default
       nodeSelector:
         worker.gardener.cloud/system-components: "true"
@@ -301,6 +313,8 @@ status: {}
 		deploymentYAMLWithHostEnv = `apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    resources.gardener.cloud/preserve-resources: "true"
   creationTimestamp: null
   labels:
     gardener.cloud/role: system-component
@@ -374,8 +388,30 @@ spec:
         volumeMounts:
         - mountPath: /srv/metrics-server/tls
           name: metrics-server
-      - name: metrics-server-nanny
-        image: ` + sideCar + `
+      - command:
+        - /pod_nanny
+        - --cpu=20m
+        - --extra-cpu=1m
+        - --memory=15Mi
+        - --extra-memory=2Mi
+        - --threshold=5
+        - --deployment=metrics-server
+        - --container=metrics-server
+        - --poll-period=300000
+        - --minClusterSize=10
+        - --use-metrics=false
+        env:
+        - name: MY_POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        image: ` + imageSidecar + `
+        imagePullPolicy: IfNotPresent
+        name: metrics-server-nanny
         resources:
           limits:
             cpu: 40m
@@ -383,27 +419,6 @@ spec:
           requests:
             cpu: 40m
             memory: 25Mi
-        env:
-          - name: MY_POD_NAME
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.name
-          - name: MY_POD_NAMESPACE
-            valueFrom:
-              fieldRef:
-                fieldPath: metadata.namespace
-        command:
-          - /pod_nanny
-          - --cpu=20m
-          - --extra-cpu=1m
-          - --memory=15Mi
-          - --extra-memory=2Mi
-          - --threshold=5
-          - --deployment=metrics-server
-          - --container=metrics-server
-          - --poll-period=300000
-          - --minClusterSize=10
-          - --use-metrics=false
       dnsPolicy: Default
       nodeSelector:
         worker.gardener.cloud/system-components: "true"
@@ -433,7 +448,7 @@ status: {}
 		ctrl = gomock.NewController(GinkgoT())
 		c = mockclient.NewMockClient(ctrl)
 
-		metricsServer = New(c, namespace, image, nil, sideCar)
+		metricsServer = New(c, namespace, image, imageSidecar, nil)
 
 		managedResourceSecret = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -526,7 +541,7 @@ status: {}
 			})
 
 			It("should successfully deploy all resources (w/ VPA, w/ host env)", func() {
-				metricsServer = New(c, namespace, image, &kubeAPIServerHost, sideCar)
+				metricsServer = New(c, namespace, image, imageSidecar, &kubeAPIServerHost)
 				metricsServer.SetSecrets(secrets)
 
 				managedResourceSecret.Data["deployment__kube-system__metrics-server.yaml"] = []byte(deploymentYAMLWithHostEnv)

--- a/pkg/operation/botanist/metricsserver.go
+++ b/pkg/operation/botanist/metricsserver.go
@@ -32,6 +32,11 @@ func (b *Botanist) DefaultMetricsServer() (metricsserver.Interface, error) {
 		return nil, err
 	}
 
+	sideCar, err := b.ImageVector.FindImage(charts.ImageNameAddonResizer, imagevector.RuntimeVersion(b.ShootVersion()), imagevector.TargetVersion(b.ShootVersion()))
+	if err != nil {
+		return nil, err
+	}
+
 	var kubeAPIServerHost *string
 	if b.APIServerSNIEnabled() {
 		kubeAPIServerHost = pointer.String(b.outOfClusterAPIServerFQDN())
@@ -43,6 +48,7 @@ func (b *Botanist) DefaultMetricsServer() (metricsserver.Interface, error) {
 		image.String(),
 		b.Shoot.WantsVerticalPodAutoscaler,
 		kubeAPIServerHost,
+		sideCar.String(),
 	), nil
 }
 

--- a/pkg/operation/botanist/metricsserver.go
+++ b/pkg/operation/botanist/metricsserver.go
@@ -32,7 +32,7 @@ func (b *Botanist) DefaultMetricsServer() (metricsserver.Interface, error) {
 		return nil, err
 	}
 
-	sideCar, err := b.ImageVector.FindImage(charts.ImageNameAddonResizer, imagevector.RuntimeVersion(b.ShootVersion()), imagevector.TargetVersion(b.ShootVersion()))
+	imageAddonResizer, err := b.ImageVector.FindImage(charts.ImageNameAddonResizer, imagevector.RuntimeVersion(b.ShootVersion()), imagevector.TargetVersion(b.ShootVersion()))
 	if err != nil {
 		return nil, err
 	}
@@ -46,8 +46,8 @@ func (b *Botanist) DefaultMetricsServer() (metricsserver.Interface, error) {
 		b.K8sSeedClient.Client(),
 		b.Shoot.SeedNamespace,
 		image.String(),
+		imageAddonResizer.String(),
 		kubeAPIServerHost,
-		sideCar.String(),
 	), nil
 }
 

--- a/pkg/operation/botanist/metricsserver.go
+++ b/pkg/operation/botanist/metricsserver.go
@@ -46,7 +46,6 @@ func (b *Botanist) DefaultMetricsServer() (metricsserver.Interface, error) {
 		b.K8sSeedClient.Client(),
 		b.Shoot.SeedNamespace,
 		image.String(),
-		b.Shoot.WantsVerticalPodAutoscaler,
 		kubeAPIServerHost,
 		sideCar.String(),
 	), nil

--- a/pkg/operation/botanist/metricsserver_test.go
+++ b/pkg/operation/botanist/metricsserver_test.go
@@ -69,15 +69,23 @@ var _ = Describe("MetricsServer", func() {
 			defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.APIServerSNI, true)()
 
 			kubernetesClient.EXPECT().Client()
-			botanist.ImageVector = imagevector.ImageVector{{Name: "metrics-server"}}
+			botanist.ImageVector = imagevector.ImageVector{{Name: "metrics-server"}, {Name: "addon-resizer"}}
 
 			metricsServer, err := botanist.DefaultMetricsServer()
 			Expect(metricsServer).NotTo(BeNil())
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("should return an error because the image cannot be found", func() {
-			botanist.ImageVector = imagevector.ImageVector{}
+		It("should return an error because the metric-server image cannot be found", func() {
+			botanist.ImageVector = imagevector.ImageVector{{Name: "addon-resizer"}}
+
+			metricsServer, err := botanist.DefaultMetricsServer()
+			Expect(metricsServer).To(BeNil())
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should return an error because the addon-resizer image cannot be found", func() {
+			botanist.ImageVector = imagevector.ImageVector{{Name: "metrics-server"}}
 
 			metricsServer, err := botanist.DefaultMetricsServer()
 			Expect(metricsServer).To(BeNil())


### PR DESCRIPTION
**What this PR does / why we need it**:
Instead of using VPA to scale the metrics server, addon resizer is used. This is necessary to remove the circular dependency that exists between the metrics server and the VPA.

**Which issue(s) this PR fixes**:
[This](https://github.com/gardener/gardener/issues/4018) is the issue addressed [Fixes #4018]

**Special notes for your reviewer**:
As the GRM was reverting the recommendations by the addon resizer, it has been enhanced to include annotations from the metrics server. So, this can be merged once the [GRM ](https://github.com/gardener/gardener-resource-manager/pull/122)is tested.

**Release note**:
NONE
