### PR TITLE
Allow selecting docker as cri.name

### DIFF
--- a/docs/extensions/operatingsystemconfig.md
+++ b/docs/extensions/operatingsystemconfig.md
@@ -186,7 +186,7 @@ status:
 Once the `.status` indicates that the extension controller finished reconciling Gardener will continue with the next step of the shoot reconciliation flow.
 
 ## CRI Support
-Gardener supports specifying Container Runtime Interface (CRI) configuration in the `OperatingSystemConfig` resource. The only CRI supported at the moment is: "containerd".
+Gardener supports specifying Container Runtime Interface (CRI) configuration in the `OperatingSystemConfig` resource. If the `.spec.cri` section exists then the `name` property is mandatory. The only supported values for `cri.name` at the moment are: `containerd` and `docker`, which uses the in-tree dockershim.
 For example:
 ```yaml
 ---
@@ -203,13 +203,11 @@ spec:
     name: containerd
 ...
 ```
-If the `.spec.cri` section exists then the `name` property is mandatory. The only valid value at the moment is `containerd`.
-When the `.spec.cri` field is declared the kubelet will be configured by Gardener to work with ContainerD. Gardener expects that ContainerD service is running on the OS with the default socket path: `unix:///run/containerd/containerd.sock`. 
 
-Each OS extension must support the CRI configurations by:
+To support ContainerD, an OS extension must :
 1. The operating system must have built-in  [ContainerD](https://containerd.io/) and the  [Client CLI](https://github.com/projectatomic/containerd/blob/master/docs/cli.md/)
-2. ContainerD service should be configure to work with the default configuration file in: /etc/containerd.config.toml (Created by Gardener).
-
+1. ContainerD must listen on its default socket path: `unix:///run/containerd/containerd.sock`
+1. ContainerD must be configured to work with the default configuration file in: `/etc/containerd.config.toml` (Created by Gardener).
 
 If CRI configurations are not supported it is recommended create a validating webhook running in the garden cluster that prevents specifying the `.spec.providers.workers[].cri` section in the `Shoot` objects.
 

--- a/example/30-cloudprofile.yaml
+++ b/example/30-cloudprofile.yaml
@@ -31,6 +31,7 @@ spec:
     versions:
     - version: 18.04.201906170
     # cri:
+    # - name: docker
     # - name: containerd
     #   containerRuntimes:
     #   - type: gvisor

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -899,6 +899,7 @@ type CRIName string
 
 const (
 	CRINameContainerD CRIName = "containerd"
+	CRINameDocker     CRIName = "docker"
 )
 
 // ContainerRuntime contains information about worker's available container runtime

--- a/pkg/apis/core/v1alpha1/types_shoot.go
+++ b/pkg/apis/core/v1alpha1/types_shoot.go
@@ -1123,6 +1123,7 @@ type CRIName string
 
 const (
 	CRINameContainerD CRIName = "containerd"
+	CRINameDocker     CRIName = "docker"
 )
 
 // ContainerRuntime contains information about worker's available container runtime

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -1130,6 +1130,7 @@ type CRIName string
 
 const (
 	CRINameContainerD CRIName = "containerd"
+	CRINameDocker     CRIName = "docker"
 )
 
 // ContainerRuntime contains information about worker's available container runtime

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -69,6 +69,7 @@ var (
 	)
 	availableWorkerCRINames = sets.NewString(
 		string(core.CRINameContainerD),
+		string(core.CRINameDocker),
 	)
 	// https://datatracker.ietf.org/doc/html/rfc7518#section-3.1
 	availableOIDCSigningAlgs = sets.NewString(

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -2778,7 +2778,8 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Expect(errList).To(matcher)
 			},
 
-			Entry("valid CRI name", core.CRINameContainerD, HaveLen(0)),
+			Entry("containerd as CRI name", core.CRINameContainerD, HaveLen(0)),
+			Entry("docker as CRI name", core.CRINameDocker, HaveLen(0)),
 			Entry("not valid CRI name", core.CRIName("other"), ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeNotSupported),
 				"Field": Equal("cri.name"),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
Allow selecting `docker` as `cri.name`, such that users can explicitly choose `docker` once we switched the default to `containerd`. This decouples the choice of the container runtime from the next k8s update and allows for switching back to `docker` without downgrading your k8s version.

**Which issue(s) this PR fixes**:
related #4110

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Allow explicit configuration of `docker` as a container runtime (`.spec.provider.workers[].cri.name` field in `Shoot`s) for backwards compatibility. Select this only if your workload doesn't run nicely with `containerd`. This configuration option will be removed in the future!
```

/cc @BeckerMax 