### PR TITLE
Add check for Stale objects during DNS deployment

### DIFF
--- a/pkg/operation/botanist/dns.go
+++ b/pkg/operation/botanist/dns.go
@@ -457,7 +457,7 @@ func (d dnsRestoreDeployer) Deploy(ctx context.Context) error {
 	if err := d.entry.Wait(ctx); err != nil {
 		var errWithState dns.ErrorWithDNSState
 		if errors.As(err, &errWithState) {
-			if errWithState.DNSState() != dnsv1alpha1.STATE_ERROR && errWithState.DNSState() != dnsv1alpha1.STATE_INVALID {
+			if errWithState.DNSState() != dnsv1alpha1.STATE_ERROR && errWithState.DNSState() != dnsv1alpha1.STATE_INVALID && errWithState.DNSState() != dnsv1alpha1.STATE_STALE {
 				return err
 			}
 		} else {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
This PR adds one additional check for "Stale" DNS objects. If this check is missing the task `Deploying internal domain DNS record` is failing with the following error:
```
time="Some Timestamp" level=error msg="DNSEntry shoot--NS--NAME/ingress did not get ready yet" error="state Invalid: unknown owner id 'shoot--NS--SOME-ID'" operation=reconcile shoot=NS/SHOOT
```
This can be reproduced every time during the restore phase of the CPM.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
It appears that this issue occurring due to a combination of [this commit](https://github.com/gardener/gardener/commit/14a5f61874d3f6af678608d8d15c1345126b7f6d#diff-fce0018cddf987e8304db37eea5f51ea9d258851b1f2c607f28841ffaac17b49) and changes introduced in the `dns-external` extension after version `0.8.0`
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
