### PR TITLE
Set `containerd` as default container runtime for k8s>=1.22

### DIFF
--- a/hack/api-reference/core.md
+++ b/hack/api-reference/core.md
@@ -9577,7 +9577,8 @@ CRI
 </td>
 <td>
 <em>(Optional)</em>
-<p>CRI contains configurations of CRI support of every machine in the worker pool</p>
+<p>CRI contains configurations of CRI support of every machine in the worker pool.
+Defaults to a CRI with name <code>containerd</code> when the Kubernetes version of the <code>Shoot</code> is &gt;= 1.22.</p>
 </td>
 </tr>
 <tr>

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -777,7 +777,8 @@ type Worker struct {
 	Annotations map[string]string
 	// CABundle is a certificate bundle which will be installed onto every machine of this worker pool.
 	CABundle *string
-	// CRI contains configurations of CRI support of every machine in the worker pool
+	// CRI contains configurations of CRI support of every machine in the worker pool.
+	// Defaults to a CRI with name `containerd` when the Kubernetes version of the `Shoot` is >= 1.22.
 	CRI *CRI
 	// Kubernetes contains configuration for Kubernetes components related to this worker pool.
 	Kubernetes *WorkerKubernetes

--- a/pkg/apis/core/v1alpha1/defaults.go
+++ b/pkg/apis/core/v1alpha1/defaults.go
@@ -124,8 +124,9 @@ func SetDefaults_Seed(obj *Seed) {
 // SetDefaults_Shoot sets default values for Shoot objects.
 func SetDefaults_Shoot(obj *Shoot) {
 	k8sVersionLessThan116, _ := versionutils.CompareVersions(obj.Spec.Kubernetes.Version, "<", "1.16")
+	k8sVersionGreaterOrEqualThan122, _ := versionutils.CompareVersions(obj.Spec.Kubernetes.Version, ">=", "1.22")
 	// Error is ignored here because we cannot do anything meaningful with it.
-	// k8sVersionLessThan116 will default to `false`.
+	// k8sVersionLessThan116 and k8sVersionGreaterOrEqualThan122 will default to `false`.
 
 	if obj.Spec.Kubernetes.AllowPrivilegedContainers == nil {
 		obj.Spec.Kubernetes.AllowPrivilegedContainers = pointer.BoolPtr(true)
@@ -234,6 +235,15 @@ func SetDefaults_Shoot(obj *Shoot) {
 
 	if obj.Spec.Kubernetes.KubeAPIServer.EnableAnonymousAuthentication == nil {
 		obj.Spec.Kubernetes.KubeAPIServer.EnableAnonymousAuthentication = pointer.BoolPtr(false)
+	}
+
+	if k8sVersionGreaterOrEqualThan122 {
+		for i := 0; i < len(obj.Spec.Provider.Workers); i++ {
+			if obj.Spec.Provider.Workers[i].CRI != nil {
+				continue
+			}
+			obj.Spec.Provider.Workers[i].CRI = &CRI{Name: CRINameContainerD}
+		}
 	}
 }
 

--- a/pkg/apis/core/v1alpha1/defaults.go
+++ b/pkg/apis/core/v1alpha1/defaults.go
@@ -238,7 +238,7 @@ func SetDefaults_Shoot(obj *Shoot) {
 	}
 
 	if k8sVersionGreaterOrEqualThan122 {
-		for i := 0; i < len(obj.Spec.Provider.Workers); i++ {
+		for i := range obj.Spec.Provider.Workers {
 			if obj.Spec.Provider.Workers[i].CRI != nil {
 				continue
 			}

--- a/pkg/apis/core/v1alpha1/defaults_test.go
+++ b/pkg/apis/core/v1alpha1/defaults_test.go
@@ -15,7 +15,6 @@
 package v1alpha1_test
 
 import (
-	"fmt"
 	"time"
 
 	. "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
@@ -454,8 +453,9 @@ var _ = Describe("Defaults", func() {
 					CRI: &CRI{Name: CRIName("some configured value")}},
 			}
 			SetDefaults_Shoot(obj)
-			assertCRIName(obj.Spec.Provider.Workers[0], CRINameContainerD)
-			assertCRIName(obj.Spec.Provider.Workers[1], CRIName("some configured value"))
+			Expect(obj.Spec.Provider.Workers[0].CRI).ToNot(BeNil())
+			Expect(obj.Spec.Provider.Workers[0].CRI.Name).To(Equal(CRINameContainerD))
+			Expect(obj.Spec.Provider.Workers[1].CRI.Name).To(BeEquivalentTo("some configured value"))
 		})
 
 		It("should not default cri.name for k8s versions <1.22", func() {
@@ -467,7 +467,7 @@ var _ = Describe("Defaults", func() {
 			}
 			SetDefaults_Shoot(obj)
 			Expect(obj.Spec.Provider.Workers[0].CRI).To(BeNil())
-			assertCRIName(obj.Spec.Provider.Workers[1], CRIName("some configured value"))
+			Expect(obj.Spec.Provider.Workers[1].CRI.Name).To(BeEquivalentTo("some configured value"))
 		})
 	})
 
@@ -530,10 +530,3 @@ var _ = Describe("Defaults", func() {
 		})
 	})
 })
-
-func assertCRIName(worker Worker, expectedCRIName CRIName) {
-	if worker.CRI == nil || worker.CRI.Name == "" {
-		Fail(fmt.Sprintf("expected `worker.cri.name` to be not empty, got %+v", worker))
-	}
-	ExpectWithOffset(1, worker.CRI.Name).To(Equal(expectedCRIName))
-}

--- a/pkg/apis/core/v1alpha1/generated.proto
+++ b/pkg/apis/core/v1alpha1/generated.proto
@@ -2410,7 +2410,8 @@ message Worker {
   // +optional
   optional string caBundle = 2;
 
-  // CRI contains configurations of CRI support of every machine in the worker pool
+  // CRI contains configurations of CRI support of every machine in the worker pool.
+  // Defaults to a CRI with name `containerd` when the Kubernetes version of the `Shoot` is >= 1.22.
   // +optional
   optional CRI cri = 3;
 

--- a/pkg/apis/core/v1alpha1/types_shoot.go
+++ b/pkg/apis/core/v1alpha1/types_shoot.go
@@ -973,7 +973,8 @@ type Worker struct {
 	// CABundle is a certificate bundle which will be installed onto every machine of this worker pool.
 	// +optional
 	CABundle *string `json:"caBundle,omitempty" protobuf:"bytes,2,opt,name=caBundle"`
-	// CRI contains configurations of CRI support of every machine in the worker pool
+	// CRI contains configurations of CRI support of every machine in the worker pool.
+	// Defaults to a CRI with name `containerd` when the Kubernetes version of the `Shoot` is >= 1.22.
 	// +optional
 	CRI *CRI `json:"cri,omitempty" protobuf:"bytes,3,opt,name=cri"`
 	// Kubernetes contains configuration for Kubernetes components related to this worker pool.

--- a/pkg/apis/core/v1beta1/defaults.go
+++ b/pkg/apis/core/v1beta1/defaults.go
@@ -238,7 +238,7 @@ func SetDefaults_Shoot(obj *Shoot) {
 	}
 
 	if k8sVersionGreaterOrEqualThan122 {
-		for i, _ := range obj.Spec.Provider.Workers {
+		for i := 0; i < len(obj.Spec.Provider.Workers); i++ {
 			if obj.Spec.Provider.Workers[i].CRI != nil {
 				continue
 			}

--- a/pkg/apis/core/v1beta1/defaults.go
+++ b/pkg/apis/core/v1beta1/defaults.go
@@ -238,7 +238,7 @@ func SetDefaults_Shoot(obj *Shoot) {
 	}
 
 	if k8sVersionGreaterOrEqualThan122 {
-		for i := 0; i < len(obj.Spec.Provider.Workers); i++ {
+		for i := range obj.Spec.Provider.Workers {
 			if obj.Spec.Provider.Workers[i].CRI != nil {
 				continue
 			}

--- a/pkg/apis/core/v1beta1/defaults.go
+++ b/pkg/apis/core/v1beta1/defaults.go
@@ -124,8 +124,9 @@ func SetDefaults_Seed(obj *Seed) {
 // SetDefaults_Shoot sets default values for Shoot objects.
 func SetDefaults_Shoot(obj *Shoot) {
 	k8sVersionLessThan116, _ := versionutils.CompareVersions(obj.Spec.Kubernetes.Version, "<", "1.16")
+	k8sVersionGreaterOrEqualThan122, _ := versionutils.CompareVersions(obj.Spec.Kubernetes.Version, ">=", "1.22")
 	// Error is ignored here because we cannot do anything meaningful with it.
-	// k8sVersionLessThan116 will default to `false`.
+	// k8sVersionLessThan116 and k8sVersionGreaterOrEqualThan122 will default to `false`.
 
 	if obj.Spec.Kubernetes.AllowPrivilegedContainers == nil {
 		obj.Spec.Kubernetes.AllowPrivilegedContainers = pointer.BoolPtr(true)
@@ -234,6 +235,15 @@ func SetDefaults_Shoot(obj *Shoot) {
 
 	if obj.Spec.Kubernetes.KubeAPIServer.EnableAnonymousAuthentication == nil {
 		obj.Spec.Kubernetes.KubeAPIServer.EnableAnonymousAuthentication = pointer.BoolPtr(false)
+	}
+
+	if k8sVersionGreaterOrEqualThan122 {
+		for i, _ := range obj.Spec.Provider.Workers {
+			if obj.Spec.Provider.Workers[i].CRI != nil {
+				continue
+			}
+			obj.Spec.Provider.Workers[i].CRI = &CRI{Name: CRINameContainerD}
+		}
 	}
 }
 

--- a/pkg/apis/core/v1beta1/defaults_test.go
+++ b/pkg/apis/core/v1beta1/defaults_test.go
@@ -15,6 +15,7 @@
 package v1beta1_test
 
 import (
+	"fmt"
 	"time"
 
 	. "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -444,6 +445,30 @@ var _ = Describe("Defaults", func() {
 			SetDefaults_Shoot(obj)
 			Expect(obj.Spec.Kubernetes.KubeAPIServer.EnableAnonymousAuthentication).To(PointTo(BeTrue()))
 		})
+
+		It("should default cri.name for k8s versions >=1.22 to containerd", func() {
+			obj.Spec.Kubernetes.Version = "1.22"
+			obj.Spec.Provider.Workers = []Worker{
+				{Name: "DefaultWorker"},
+				{Name: "Worker with CRI configuration",
+					CRI: &CRI{Name: CRIName("some configured value")}},
+			}
+			SetDefaults_Shoot(obj)
+			assertCRIName(obj.Spec.Provider.Workers[0], CRINameContainerD)
+			assertCRIName(obj.Spec.Provider.Workers[1], CRIName("some configured value"))
+		})
+
+		It("should not default cri.name for k8s versions <1.22", func() {
+			obj.Spec.Kubernetes.Version = "1.21"
+			obj.Spec.Provider.Workers = []Worker{
+				{Name: "DefaultWorker"},
+				{Name: "Worker with CRI configuration",
+					CRI: &CRI{Name: CRIName("some configured value")}},
+			}
+			SetDefaults_Shoot(obj)
+			Expect(obj.Spec.Provider.Workers[0].CRI).To(BeNil())
+			assertCRIName(obj.Spec.Provider.Workers[1], CRIName("some configured value"))
+		})
 	})
 
 	Describe("#SetDefaults_Maintenance", func() {
@@ -505,3 +530,10 @@ var _ = Describe("Defaults", func() {
 		})
 	})
 })
+
+func assertCRIName(worker Worker, expectedCRIName CRIName) {
+	if worker.CRI == nil || worker.CRI.Name == "" {
+		Fail(fmt.Sprintf("expected `worker.cri.name` to be not empty, got %+v", worker))
+	}
+	ExpectWithOffset(1, worker.CRI.Name).To(Equal(expectedCRIName))
+}

--- a/pkg/apis/core/v1beta1/defaults_test.go
+++ b/pkg/apis/core/v1beta1/defaults_test.go
@@ -15,7 +15,6 @@
 package v1beta1_test
 
 import (
-	"fmt"
 	"time"
 
 	. "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -454,8 +453,9 @@ var _ = Describe("Defaults", func() {
 					CRI: &CRI{Name: CRIName("some configured value")}},
 			}
 			SetDefaults_Shoot(obj)
-			assertCRIName(obj.Spec.Provider.Workers[0], CRINameContainerD)
-			assertCRIName(obj.Spec.Provider.Workers[1], CRIName("some configured value"))
+			Expect(obj.Spec.Provider.Workers[0].CRI).ToNot(BeNil())
+			Expect(obj.Spec.Provider.Workers[0].CRI.Name).To(Equal(CRINameContainerD))
+			Expect(obj.Spec.Provider.Workers[1].CRI.Name).To(BeEquivalentTo("some configured value"))
 		})
 
 		It("should not default cri.name for k8s versions <1.22", func() {
@@ -467,7 +467,7 @@ var _ = Describe("Defaults", func() {
 			}
 			SetDefaults_Shoot(obj)
 			Expect(obj.Spec.Provider.Workers[0].CRI).To(BeNil())
-			assertCRIName(obj.Spec.Provider.Workers[1], CRIName("some configured value"))
+			Expect(obj.Spec.Provider.Workers[1].CRI.Name).To(BeEquivalentTo("some configured value"))
 		})
 	})
 
@@ -530,10 +530,3 @@ var _ = Describe("Defaults", func() {
 		})
 	})
 })
-
-func assertCRIName(worker Worker, expectedCRIName CRIName) {
-	if worker.CRI == nil || worker.CRI.Name == "" {
-		Fail(fmt.Sprintf("expected `worker.cri.name` to be not empty, got %+v", worker))
-	}
-	ExpectWithOffset(1, worker.CRI.Name).To(Equal(expectedCRIName))
-}

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -2278,7 +2278,8 @@ message Worker {
   // +optional
   optional string caBundle = 2;
 
-  // CRI contains configurations of CRI support of every machine in the worker pool
+  // CRI contains configurations of CRI support of every machine in the worker pool.
+  // Defaults to a CRI with name `containerd` when the Kubernetes version of the `Shoot` is >= 1.22.
   // +optional
   optional CRI cri = 3;
 

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -980,7 +980,8 @@ type Worker struct {
 	// CABundle is a certificate bundle which will be installed onto every machine of this worker pool.
 	// +optional
 	CABundle *string `json:"caBundle,omitempty" protobuf:"bytes,2,opt,name=caBundle"`
-	// CRI contains configurations of CRI support of every machine in the worker pool
+	// CRI contains configurations of CRI support of every machine in the worker pool.
+	// Defaults to a CRI with name `containerd` when the Kubernetes version of the `Shoot` is >= 1.22.
 	// +optional
 	CRI *CRI `json:"cri,omitempty" protobuf:"bytes,3,opt,name=cri"`
 	// Kubernetes contains configuration for Kubernetes components related to this worker pool.

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -7530,7 +7530,7 @@ func schema_pkg_apis_core_v1alpha1_Worker(ref common.ReferenceCallback) common.O
 					},
 					"cri": {
 						SchemaProps: spec.SchemaProps{
-							Description: "CRI contains configurations of CRI support of every machine in the worker pool",
+							Description: "CRI contains configurations of CRI support of every machine in the worker pool. Defaults to a CRI with name `containerd` when the Kubernetes version of the `Shoot` is >= 1.22.",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1alpha1.CRI"),
 						},
 					},
@@ -13978,7 +13978,7 @@ func schema_pkg_apis_core_v1beta1_Worker(ref common.ReferenceCallback) common.Op
 					},
 					"cri": {
 						SchemaProps: spec.SchemaProps{
-							Description: "CRI contains configurations of CRI support of every machine in the worker pool",
+							Description: "CRI contains configurations of CRI support of every machine in the worker pool. Defaults to a CRI with name `containerd` when the Kubernetes version of the `Shoot` is >= 1.22.",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1beta1.CRI"),
 						},
 					},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind api-change

**What this PR does / why we need it**:
An empty `cri.name` field for a worker pool means all nodes are configured with `docker` as the container runtime. When users upgrade their shoots to k8s>=1.22 (or create new ones) the default is changed to `containerd`. This also means that starting with k8s 1.22 the shoot object will always contain an explicit configuration of the container runtime.

**Which issue(s) this PR fixes**:
related #4110 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Shoots created with or updated to Kubernetes version >= 1.22 will get `containerd` as default container runtime. If you upgrade an existing shoot which doesn't specify a `cri.name` property in its worker pools, this will trigger a graceful node rollout and the container runtime is switched from `docker` to `containerd`.
```

/cc @BeckerMax 