### PR TITLE
Promote MountHostCADirectories feature gate to beta

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -25,7 +25,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | HVPAForShootedSeed | `false` | `Alpha` | `0.32` | |
 | ManagedIstio | `true` | `Beta` | `1.19` | |
 | APIServerSNI | `true` | `Beta` | `1.19` | |
-| MountHostCADirectories | `false` | `Alpha` | `1.11.0` | |
+| MountHostCADirectories | `false` | `Alpha` | `1.11.0` | `1.25.0` |
+| MountHostCADirectories | `true` | `Beta` | `1.26.0` | |
 | SeedChange | `false` | `Alpha` | `1.12.0` | |
 | SeedKubeScheduler | `false` | `Alpha` | `1.15.0` | |
 | ReversedVPN | `false` | `Alpha` | `1.22.0` | |

--- a/example/20-componentconfig-gardenlet.yaml
+++ b/example/20-componentconfig-gardenlet.yaml
@@ -96,7 +96,7 @@ featureGates:
   APIServerSNI: true
   CachedRuntimeClients: true
   NodeLocalDNS: true
-  MountHostCADirectories: false
+  MountHostCADirectories: true
   SeedKubeScheduler: false
   ReversedVPN: false
 seedSelector: {} # selects all seeds, only use for development purposes

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -78,6 +78,7 @@ const (
 	// MountHostCADirectories enables mounting common CA certificate directories in the Shoot API server pod that might be required for webhooks or OIDC.
 	// owner @danielfoehrKn
 	// alpha: v1.11.0
+	// beta: v1.26.0
 	MountHostCADirectories featuregate.Feature = "MountHostCADirectories"
 
 	// SeedChange enables updating the `spec.seedName` field during shoot validation from a non-empty value

--- a/pkg/gardenlet/features/features.go
+++ b/pkg/gardenlet/features/features.go
@@ -33,7 +33,7 @@ var (
 		features.APIServerSNI:           {Default: true, PreRelease: featuregate.Beta},
 		features.CachedRuntimeClients:   {Default: false, PreRelease: featuregate.Alpha},
 		features.NodeLocalDNS:           {Default: false, PreRelease: featuregate.Alpha},
-		features.MountHostCADirectories: {Default: false, PreRelease: featuregate.Alpha},
+		features.MountHostCADirectories: {Default: true, PreRelease: featuregate.Beta},
 		features.SeedKubeScheduler:      {Default: false, PreRelease: featuregate.Alpha},
 		features.ReversedVPN:            {Default: false, PreRelease: featuregate.Alpha},
 	}


### PR DESCRIPTION
/kind enhancement

Part of https://github.com/gardener/gardener/issues/4147

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
The `MountHostCADirectories` feature gate in the `gardenlet` has been promoted to beta and is now enabled by default.
```
