### PR TITLE
Get rid of DirectClient

### DIFF
--- a/pkg/client/kubernetes/applier.go
+++ b/pkg/client/kubernetes/applier.go
@@ -54,7 +54,7 @@ func NewApplierForConfig(config *rest.Config) (Applier, error) {
 		return nil, err
 	}
 
-	c, err := NewDirectClient(config, opts)
+	c, err := client.New(config, opts)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/client/kubernetes/client.go
+++ b/pkg/client/kubernetes/client.go
@@ -46,8 +46,8 @@ import (
 
 var (
 	// UseCachedRuntimeClients is a flag for enabling cached controller-runtime clients (defaults to false).
-	// If enabled, the client returned by Interface.Client() will be backed by a cache, otherwise it will be the same
-	// client that will be returned by Interface.DirectClient().
+	// If enabled, the client returned by Interface.Client() will be backed by a cache, otherwise it will talk directly
+	// to the API server.
 	UseCachedRuntimeClients = false
 )
 
@@ -272,7 +272,7 @@ func newClientSet(conf *Config) (Interface, error) {
 		return nil, err
 	}
 
-	directClient, err := client.New(conf.restConfig, conf.clientOptions)
+	c, err := client.New(conf.restConfig, conf.clientOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -281,7 +281,7 @@ func newClientSet(conf *Config) (Interface, error) {
 	if UseCachedRuntimeClients && !conf.disableCache {
 		delegatingClient, err := client.NewDelegatingClient(client.NewDelegatingClientInput{
 			CacheReader:     runtimeCache,
-			Client:          directClient,
+			Client:          c,
 			UncachedObjects: conf.uncachedObjects,
 		})
 		if err != nil {
@@ -290,10 +290,10 @@ func newClientSet(conf *Config) (Interface, error) {
 
 		runtimeClient = &fallbackClient{
 			Client: delegatingClient,
-			reader: directClient,
+			reader: c,
 		}
 	} else {
-		runtimeClient = directClient
+		runtimeClient = c
 	}
 
 	// prepare rest config with contentType defaulted to protobuf for client-go style clients that either talk to
@@ -336,9 +336,9 @@ func newClientSet(conf *Config) (Interface, error) {
 
 		applier: NewApplier(runtimeClient, conf.clientOptions.Mapper),
 
-		client:       runtimeClient,
-		directClient: directClient,
-		cache:        runtimeCache,
+		client:    runtimeClient,
+		apiReader: c,
+		cache:     runtimeCache,
 
 		kubernetes:           kubernetes,
 		gardenCore:           gardenCore,

--- a/pkg/client/kubernetes/clientset.go
+++ b/pkg/client/kubernetes/clientset.go
@@ -50,9 +50,9 @@ type clientSet struct {
 
 	// client is the default controller-runtime client which uses SharedIndexInformers to keep its cache in sync
 	client client.Client
-	// directClient is a client which can be used to make requests directly to the API server instead of reading from
-	// the client's cache
-	directClient client.Client
+	// apiReader is a reader that can be used to read directly from the API server instead of reading from
+	// the client's cache.
+	apiReader client.Reader
 	// cache is the client's cache
 	cache cache.Cache
 
@@ -96,14 +96,7 @@ func (c *clientSet) Client() client.Client {
 
 // APIReader returns a client.Reader that directly reads from the API server.
 func (c *clientSet) APIReader() client.Reader {
-	return c.directClient
-}
-
-// DirectClient returns a controller-runtime client, which can be used to talk to the API server directly
-// (without using a cache).
-// Deprecated: used APIReader instead, if the controller can't tolerate stale reads.
-func (c *clientSet) DirectClient() client.Client {
-	return c.directClient
+	return c.apiReader
 }
 
 // Cache returns the ClientSet's controller-runtime cache. It can be used to get Informers for arbitrary objects.

--- a/pkg/client/kubernetes/fake/builder.go
+++ b/pkg/client/kubernetes/fake/builder.go
@@ -37,7 +37,6 @@ type ClientSetBuilder struct {
 	restConfig            *rest.Config
 	client                client.Client
 	apiReader             client.Reader
-	directClient          client.Client
 	cache                 cache.Cache
 	kubernetes            kubernetesclientset.Interface
 	gardenCore            gardencoreclientset.Interface
@@ -88,13 +87,6 @@ func (b *ClientSetBuilder) WithClient(client client.Client) *ClientSetBuilder {
 // WithAPIReader sets the apiReader attribute of the builder.
 func (b *ClientSetBuilder) WithAPIReader(apiReader client.Reader) *ClientSetBuilder {
 	b.apiReader = apiReader
-	return b
-}
-
-// WithDirectClient sets the directClient attribute of the builder.
-// Deprecated: kubernetes.Interface.DirectClient is also deprecated.
-func (b *ClientSetBuilder) WithDirectClient(directClient client.Client) *ClientSetBuilder {
-	b.directClient = directClient
 	return b
 }
 
@@ -174,7 +166,6 @@ func (b *ClientSetBuilder) Build() *ClientSet {
 		restConfig:            b.restConfig,
 		client:                b.client,
 		apiReader:             b.apiReader,
-		directClient:          b.directClient,
 		cache:                 b.cache,
 		kubernetes:            b.kubernetes,
 		gardenCore:            b.gardenCore,

--- a/pkg/client/kubernetes/fake/clientset.go
+++ b/pkg/client/kubernetes/fake/clientset.go
@@ -44,7 +44,6 @@ type ClientSet struct {
 	restConfig           *rest.Config
 	client               client.Client
 	apiReader            client.Reader
-	directClient         client.Client
 	cache                cache.Cache
 	kubernetes           kubernetesclientset.Interface
 	gardenCore           gardencoreclientset.Interface
@@ -89,13 +88,6 @@ func (c *ClientSet) Client() client.Client {
 // APIReader returns a client.Reader that directly reads from the API server.
 func (c *ClientSet) APIReader() client.Reader {
 	return c.apiReader
-}
-
-// DirectClient returns a controller-runtime client, which can be used to talk to the API server directly
-// (without using a cache).
-// Deprecated: used APIReader instead, if the controller can't tolerate stale reads.
-func (c *ClientSet) DirectClient() client.Client {
-	return c.directClient
 }
 
 // Cache returns the clientset's controller-runtime cache. It can be used to get Informers for arbitrary objects.

--- a/pkg/client/kubernetes/fake/fake_test.go
+++ b/pkg/client/kubernetes/fake/fake_test.go
@@ -97,13 +97,6 @@ var _ = Describe("Fake ClientSet", func() {
 		Expect(cs.APIReader()).To(BeIdenticalTo(apiReader))
 	})
 
-	It("should correctly set directClient attribute", func() {
-		directClient := mockclient.NewMockClient(ctrl)
-		cs := builder.WithDirectClient(directClient).Build()
-
-		Expect(cs.DirectClient()).To(BeIdenticalTo(directClient))
-	})
-
 	It("should correctly set cache attribute", func() {
 		cache := mockcache.NewMockCache(ctrl)
 		cs := builder.WithCache(cache).Build()

--- a/pkg/client/kubernetes/mock/mocks.go
+++ b/pkg/client/kubernetes/mock/mocks.go
@@ -172,20 +172,6 @@ func (mr *MockInterfaceMockRecorder) Client() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Client", reflect.TypeOf((*MockInterface)(nil).Client))
 }
 
-// DirectClient mocks base method.
-func (m *MockInterface) DirectClient() client.Client {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DirectClient")
-	ret0, _ := ret[0].(client.Client)
-	return ret0
-}
-
-// DirectClient indicates an expected call of DirectClient.
-func (mr *MockInterfaceMockRecorder) DirectClient() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DirectClient", reflect.TypeOf((*MockInterface)(nil).DirectClient))
-}
-
 // DiscoverVersion mocks base method.
 func (m *MockInterface) DiscoverVersion() (*version.Info, error) {
 	m.ctrl.T.Helper()

--- a/pkg/client/kubernetes/options.go
+++ b/pkg/client/kubernetes/options.go
@@ -85,8 +85,8 @@ func WithCacheResyncPeriod(resync time.Duration) ConfigFunc {
 	}
 }
 
-// WithDisabledCachedClient disables the cache in the controller-runtime client, so Client() will be equivalent to
-// DirectClient().
+// WithDisabledCachedClient disables the cache in the controller-runtime client, so Client() will talk directly to the
+// API server.
 func WithDisabledCachedClient() ConfigFunc {
 	return func(config *Config) error {
 		config.disableCache = true

--- a/pkg/client/kubernetes/types.go
+++ b/pkg/client/kubernetes/types.go
@@ -154,11 +154,12 @@ type Interface interface {
 	// a cache, which uses SharedIndexInformers to keep up-to-date.
 	Client() client.Client
 	// APIReader returns a client.Reader that directly reads from the API server.
+	// Wherever possible, try to avoid reading directly from the API server and instead rely on the cache. Some ideas:
+	// If you want to avoid conflicts, try using patch requests that don't require optimistic locking instead of reading
+	// from the APIReader. If you need to make sure, that you're not reading stale data (e.g. a previous update is
+	// observed), use some mechanism that can detect/tolerate stale reads (e.g. add a timestamp annotation during the
+	// write operation and wait until you see it in the cache).
 	APIReader() client.Reader
-	// DirectClient returns a controller-runtime client, which can be used to talk to the API server directly
-	// (without using a cache).
-	// Deprecated: used APIReader instead, if the controller can't tolerate stale reads.
-	DirectClient() client.Client
 	// Cache returns the ClientSet's controller-runtime cache. It can be used to get Informers for arbitrary objects.
 	Cache() cache.Cache
 

--- a/pkg/gardenlet/bootstrap/certificate/certificate_rotation_test.go
+++ b/pkg/gardenlet/bootstrap/certificate/certificate_rotation_test.go
@@ -417,8 +417,6 @@ users:
 					secret.Data = map[string][]byte{kubernetes.KubeConfig: []byte(testKubeconfig)}
 					return nil
 				})
-
-				mockSeedInterface.EXPECT().DirectClient().Return(mockSeedClient).AnyTimes()
 			})
 
 			It("should not return an error", func() {

--- a/pkg/gardenlet/controller/federatedseed/extensions/shootstate_control_test.go
+++ b/pkg/gardenlet/controller/federatedseed/extensions/shootstate_control_test.go
@@ -285,7 +285,7 @@ var _ = Describe("ShootState Control", func() {
 		It("should not try to patch the ShootState if there are no changes to the extension state", func() {
 			ctrl := gomock.NewController(GinkgoT())
 			mc := mockclient.NewMockClient(ctrl)
-			fakeClientSet := fakeclientset.NewClientSetBuilder().WithDirectClient(mc).WithClient(mc).Build()
+			fakeClientSet := fakeclientset.NewClientSetBuilder().WithClient(mc).Build()
 			recorder := record.NewFakeRecorder(64)
 			shootStateControl = extensions.NewShootStateControl(fakeClientSet, fakeClientSet, log.WithField("seed", "test-seed"), recorder)
 			gomock.InOrder(

--- a/pkg/operation/botanist/component/gardenerkubescheduler/gardener_kube_scheduler.go
+++ b/pkg/operation/botanist/component/gardenerkubescheduler/gardener_kube_scheduler.go
@@ -35,10 +35,10 @@ import (
 	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/gardenerkubescheduler/configurator"
 	"github.com/gardener/gardener/pkg/utils"
@@ -394,7 +394,7 @@ func (k *kubeScheduler) Deploy(ctx context.Context) error {
 		registry = managedresources.NewRegistry(kubernetes.SeedScheme, kubernetes.SeedCodec, kubernetes.SeedSerializer)
 	)
 
-	if _, err := controllerutil.CreateOrUpdate(ctx, k.client, namespace, func() error {
+	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, k.client, namespace, func() error {
 		namespace.Labels = utils.MergeStringMaps(namespace.Labels, getLabels())
 		return nil
 	}); err != nil {

--- a/pkg/operation/botanist/component/gardenerkubescheduler/gardener_kube_scheduler_bootstrap.go
+++ b/pkg/operation/botanist/component/gardenerkubescheduler/gardener_kube_scheduler_bootstrap.go
@@ -46,10 +46,6 @@ func Bootstrap(
 	component.DeployWaiter,
 	error,
 ) {
-	if c == nil {
-		return nil, errors.New("client is required")
-	}
-
 	if len(seedAdmissionControllerNamespace) == 0 {
 		return nil, errors.New("seedAdmissionControllerNamespace is required")
 	}

--- a/pkg/operation/botanist/component/gardenerkubescheduler/gardener_kube_scheduler_bootstrap_test.go
+++ b/pkg/operation/botanist/component/gardenerkubescheduler/gardener_kube_scheduler_bootstrap_test.go
@@ -67,10 +67,6 @@ var _ = Describe("Bootstrap", func() {
 	Context("fails", func() {
 		var err error
 
-		It("when client is nil", func() {
-			sched, err = Bootstrap(nil, "foo", image, &semver.Version{})
-		})
-
 		It("when namespace is empty", func() {
 			sched, err = Bootstrap(c, "", image, &semver.Version{})
 		})

--- a/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller.go
+++ b/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller.go
@@ -413,7 +413,7 @@ func (g *gardenerSeedAdmissionController) getReplicas(ctx context.Context) (int3
 	nodeList := &metav1.PartialObjectMetadataList{}
 	nodeList.SetGroupVersionKind(corev1.SchemeGroupVersion.WithKind("NodeList"))
 
-	err := g.client.List(ctx, nodeList)
+	err := g.client.List(ctx, nodeList, client.Limit(defaultReplicas))
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller_test.go
+++ b/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller_test.go
@@ -373,7 +373,7 @@ status: {}
 	Describe("#Deploy", func() {
 		It("should fail because the managed resource secret cannot be updated", func() {
 			gomock.InOrder(
-				c.EXPECT().List(ctx, gomock.Any()).DoAndReturn(
+				c.EXPECT().List(ctx, gomock.Any(), client.Limit(3)).DoAndReturn(
 					func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
 						Expect(list).To(BeAssignableToTypeOf(&metav1.PartialObjectMetadataList{}))
 						list.(*metav1.PartialObjectMetadataList).Items = make([]metav1.PartialObjectMetadata, 3)
@@ -388,7 +388,7 @@ status: {}
 
 		It("should fail because the managed resource cannot be updated", func() {
 			gomock.InOrder(
-				c.EXPECT().List(ctx, gomock.Any()).DoAndReturn(
+				c.EXPECT().List(ctx, gomock.Any(), client.Limit(3)).DoAndReturn(
 					func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
 						Expect(list).To(BeAssignableToTypeOf(&metav1.PartialObjectMetadataList{}))
 						list.(*metav1.PartialObjectMetadataList).Items = make([]metav1.PartialObjectMetadata, 3)
@@ -405,7 +405,7 @@ status: {}
 
 		It("should successfully deploy all resources", func() {
 			gomock.InOrder(
-				c.EXPECT().List(ctx, gomock.Any()).DoAndReturn(
+				c.EXPECT().List(ctx, gomock.Any(), client.Limit(3)).DoAndReturn(
 					func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
 						Expect(list).To(BeAssignableToTypeOf(&metav1.PartialObjectMetadataList{}))
 						list.(*metav1.PartialObjectMetadataList).Items = make([]metav1.PartialObjectMetadata, 3)
@@ -428,7 +428,7 @@ status: {}
 			managedResourceSecret.Data["deployment__shoot--foo--bar__gardener-seed-admission-controller.yaml"] = []byte(strings.Replace(deploymentYAML, "replicas: 3", "replicas: 1", -1))
 
 			gomock.InOrder(
-				c.EXPECT().List(ctx, gomock.Any()).DoAndReturn(
+				c.EXPECT().List(ctx, gomock.Any(), client.Limit(3)).DoAndReturn(
 					func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
 						Expect(list).To(BeAssignableToTypeOf(&metav1.PartialObjectMetadataList{}))
 						list.(*metav1.PartialObjectMetadataList).Items = make([]metav1.PartialObjectMetadata, 1)

--- a/pkg/operation/operation_test.go
+++ b/pkg/operation/operation_test.go
@@ -231,7 +231,7 @@ var _ = Describe("operation", func() {
 			ctrl = gomock.NewController(GinkgoT())
 			k8sGardenRuntimeClient = mockclient.NewMockClient(ctrl)
 			o = &Operation{
-				K8sGardenClient: fakeclientset.NewClientSetBuilder().WithClient(k8sGardenRuntimeClient).WithDirectClient(k8sGardenRuntimeClient).Build(),
+				K8sGardenClient: fakeclientset.NewClientSetBuilder().WithClient(k8sGardenRuntimeClient).Build(),
 				ShootState:      &gardencorev1alpha1.ShootState{},
 			}
 		})

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -949,7 +949,7 @@ func runCreateSeedFlow(
 	if err != nil {
 		return err
 	}
-	scheduler, err := gardenerkubescheduler.Bootstrap(sc.DirectClient(), v1beta1constants.GardenNamespace, schedulerImage, kubernetesVersion)
+	scheduler, err := gardenerkubescheduler.Bootstrap(sc.Client(), v1beta1constants.GardenNamespace, schedulerImage, kubernetesVersion)
 	if err != nil {
 		return err
 	}
@@ -1037,7 +1037,7 @@ func RunDeleteSeedFlow(ctx context.Context, sc, gc kubernetes.Interface, seed *S
 		networkPolicies = networkpolicies.NewBootstrapper(sc.Client(), v1beta1constants.GardenNamespace, networkpolicies.GlobalValues{})
 		clusterIdentity = clusteridentity.NewForSeed(sc.Client(), v1beta1constants.GardenNamespace, "")
 	)
-	scheduler, err := gardenerkubescheduler.Bootstrap(sc.DirectClient(), v1beta1constants.GardenNamespace, nil, kubernetesVersion)
+	scheduler, err := gardenerkubescheduler.Bootstrap(sc.Client(), v1beta1constants.GardenNamespace, nil, kubernetesVersion)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity scalability
/kind cleanup

**What this PR does / why we need it**:

This PR is the last one of a longer PR series for removing the `DirectClient` from our clientsets/codebase.
It removes the last remaining usages and finally gets rid of the `DirectClient` entirely 🎉 

**Which issue(s) this PR fixes**:
Part of #2822

**Special notes for your reviewer**:

/squash

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking developer
The already deprecated `DirectClient` has been removed from the codebase entirely.
```
