### PR TITLE
Add docu for using the seed authorizer with the remote garden setup

### DIFF
--- a/hack/local-development/remote-garden/enable-seed-authorizer
+++ b/hack/local-development/remote-garden/enable-seed-authorizer
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source $(dirname "${0}")/../common/helpers
+
+SEED_KUBECONFIG=$1
+NAMESPACE=$2
+
+checkPrereqs() {
+  if [ "$(k8s_env)" != "$REMOTE" ]; then
+    echo "KUBECONFIG must point to a cluster with a garden namespace labeled with gardener.cloud/purpose=remote-garden"
+    return 1
+  fi
+}
+
+getQuicServerPodIP() {
+  kubectl -n garden get pod quic-server -o go-template="{{ .status.podIP }}"
+}
+
+applyAuthWebhookSecret() {
+  quic_server_pod_ip=$1
+  cat <<EOF | kubectl --kubeconfig "$SEED_KUBECONFIG" apply -f -
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: kube-apiserver-auth-webhook-config
+  namespace: $NAMESPACE
+data:
+  config.yaml: $(cat <<EOFX | base64 -w 0
+apiVersion: v1
+kind: Config
+current-context: seedauthorizer
+clusters:
+- name: gardener-admission-controller
+  cluster:
+    insecure-skip-tls-verify: true
+    server: https://$quic_server_pod_ip:10444/webhooks/auth/seed
+users:
+- name: kube-apiserver
+  user: {}
+contexts:
+- name: seedauthorizer
+  context:
+    cluster: gardener-admission-controller
+    user: kube-apiserver
+EOFX
+)
+EOF
+}
+
+deleteAuthWebhookSecret() {
+  kubectl --kubeconfig "$SEED_KUBECONFIG" -n "$NAMESPACE" delete secret kube-apiserver-auth-webhook-config --ignore-not-found
+}
+
+patchKubeApiserverAddAuthWebhook() {
+  command=$(kubectl --kubeconfig "$SEED_KUBECONFIG" -n "$NAMESPACE" get deployment kube-apiserver -o jsonpath='{.spec.template.spec.containers[?(@.name=="kube-apiserver")].command}' | \
+    jq '(.[] | select(. == "--authorization-mode=Node,RBAC")) |= "--authorization-mode=Node,RBAC,Webhook"' | \
+    jq '. += ["--authorization-webhook-config-file=/etc/kubernetes/auth-webhook/config.yaml"]' | \
+    jq '. += ["--authorization-webhook-cache-authorized-ttl=0"]' | \
+    jq '. += ["--authorization-webhook-cache-unauthorized-ttl=0"]')
+  cat <<EOF | kubectl --kubeconfig "$SEED_KUBECONFIG" -n "$NAMESPACE" patch deployment kube-apiserver -p "$(cat -)"
+{
+  "spec": {
+    "template": {
+      "spec": {
+        "containers": [
+          {
+            "name": "kube-apiserver",
+            "command": $command,
+            "volumeMounts": [
+              {
+                "mountPath": "/etc/kubernetes/auth-webhook",
+                "name": "kube-apiserver-auth-webhook-config"
+              }
+            ]
+          }
+        ],
+        "volumes": [
+          {
+            "name": "kube-apiserver-auth-webhook-config",
+            "secret": {
+              "defaultMode": 420,
+              "secretName": "kube-apiserver-auth-webhook-config"
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+EOF
+}
+
+patchKubeApiserverDeleteAuthWebhook() {
+  command=$(kubectl --kubeconfig "$SEED_KUBECONFIG" -n "$NAMESPACE" get deployment kube-apiserver -o jsonpath='{.spec.template.spec.containers[?(@.name=="kube-apiserver")].command}' | \
+    jq '(.[] | select(. == "--authorization-mode=Node,RBAC,Webhook")) |= "--authorization-mode=Node,RBAC"' | \
+    jq '. -= ["--authorization-webhook-config-file=/etc/kubernetes/auth-webhook/config.yaml"]' | \
+    jq '. -= ["--authorization-webhook-cache-authorized-ttl=0"]' | \
+    jq '. -= ["--authorization-webhook-cache-unauthorized-ttl=0"]')
+  cat <<EOF | kubectl --kubeconfig "$SEED_KUBECONFIG" -n "$NAMESPACE" patch deployment kube-apiserver -p "$(cat -)"
+{
+  "spec": {
+    "template": {
+      "spec": {
+        "containers": [
+          {
+            "name": "kube-apiserver",
+            "command": $command,
+            "volumeMounts": [
+              {
+                "\$patch": "delete",
+                "mountPath": "/etc/kubernetes/auth-webhook"
+              }
+            ]
+          }
+        ],
+        "volumes": [
+          {
+            "\$patch": "delete",
+            "name": "kube-apiserver-auth-webhook-config"
+          }
+        ]
+      }
+    }
+  }
+}
+EOF
+}
+
+applyGardenletAdminTemplates() {
+  helm template \
+    "$(dirname "$0")/../../../charts/gardener/controlplane/charts/application" \
+    -s templates/clusterrole-seeds.yaml \
+    -s templates/clusterrolebinding-seeds.yaml | \
+  kubectl apply -f -
+}
+
+deleteGardenletAdminTemplates() {
+  kubectl delete clusterrole gardener.cloud:system:seeds --ignore-not-found
+  kubectl delete clusterrolebinding gardener.cloud:system:seeds --ignore-not-found
+}
+
+usage() {
+  echo "Usage:"
+  echo "> enable-seed-authorizer [ -h ] seed_kubeconfig namespace [ -d ]"
+  echo
+  echo "Prerequisites:"
+  echo "* KUBECONFIG pointing to a cluster with a garden namespace labeled with gardener.cloud/purpose=remote-garden"
+
+  exit 0
+}
+
+if [ "$3" == "-d" ]; then
+  echo "Applying gardenlet admin templates..."
+  applyGardenletAdminTemplates
+
+  echo "Patching kube-apiserver deployment in seed cluster..."
+  patchKubeApiserverDeleteAuthWebhook
+
+  echo "Deleting auth webhook secret in seed cluster..."
+  deleteAuthWebhookSecret
+
+  exit 0
+elif [ "$1" == "-h" ]; then
+  usage
+fi
+
+echo "Checking prerequisites..."
+checkPrereqs
+
+echo "Getting quic server podIP..."
+quic_server_pod_ip=$(getQuicServerPodIP)
+if [[ "$quic_server_pod_ip" == "" ]]; then
+  echo "Quic server pod must be running, run 'make remote-garden-up' first"
+  return 1
+fi
+
+echo "Applying auth webhook secret in seed cluster..."
+applyAuthWebhookSecret "$quic_server_pod_ip"
+
+echo "Patching kube-apiserver deployment in seed cluster..."
+patchKubeApiserverAddAuthWebhook
+
+echo "Deleting gardenlet admin templates..."
+deleteGardenletAdminTemplates


### PR DESCRIPTION
**How to categorize this PR?**

/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
* Adds docu for using the `SeedAuthorization` feature with the remote garden setup to `docs/development/local_setup.md`
* Adds a script for automating the process on remote garden clusters that are Gardener shoots.

**Which issue(s) this PR fixes**:
Part of #1723

**Special notes for your reviewer**:
Due to the way `ReversedVPN` feature is implemented, shoot cluster IPs are no longer accessible by the `kube-apiserver` running in the seed cluster if this feature is enabled. This can perhaps be fixed in general (cc @mvladev), but is likely not worth it while the old VPN is still available. I have included a note in the documentation how to disable this feature on particular shoots.

**Release note**:

```other operator
NONE
```
