### PR TITLE
Add new ProjectValidator admission plugin

### DIFF
--- a/docs/concepts/apiserver_admission_plugins.md
+++ b/docs/concepts/apiserver_admission_plugins.md
@@ -62,6 +62,8 @@ _(enabled by default)_
 This admission controller reacts on `CREATE` operations for `Project`s.
 It prevents creating `Project`s with a non-empty `.spec.namespace` if the value in `.spec.namespace` does not start with `garden-`.
 
+⚠️ This admission plugin will be removed in a future release and its business logic will be incorporated into the static validation of the `gardener-apiserver`.
+
 ## `ResourceQuota`
 
 _(enabled by default)_

--- a/docs/concepts/apiserver_admission_plugins.md
+++ b/docs/concepts/apiserver_admission_plugins.md
@@ -55,6 +55,13 @@ This admission controller reacts on `CREATE` and `UPDATE` operations for `Plant`
 It sets the `gardener.cloud/created-by` annotation for newly created `Plant` resources.
 Also, it prevents creating new `Plant` resources in `Project`s that are already have a deletion timestamp.
 
+## `ProjectValidator`
+
+_(enabled by default)_
+
+This admission controller reacts on `CREATE` operations for `Project`s.
+It prevents creating `Project`s with a non-empty `.spec.namespace` if the value in `.spec.namespace` does not start with `garden-`.
+
 ## `ResourceQuota`
 
 _(enabled by default)_

--- a/pkg/apiserver/plugins.go
+++ b/pkg/apiserver/plugins.go
@@ -24,6 +24,7 @@ import (
 	managedseedshoot "github.com/gardener/gardener/plugin/pkg/managedseed/shoot"
 	managedseedvalidator "github.com/gardener/gardener/plugin/pkg/managedseed/validator"
 	plantvalidator "github.com/gardener/gardener/plugin/pkg/plant"
+	projectvalidator "github.com/gardener/gardener/plugin/pkg/project/validator"
 	seedvalidator "github.com/gardener/gardener/plugin/pkg/seed/validator"
 	shootdns "github.com/gardener/gardener/plugin/pkg/shoot/dns"
 	shootmanagedseed "github.com/gardener/gardener/plugin/pkg/shoot/managedseed"
@@ -56,6 +57,7 @@ var (
 		seedvalidator.PluginName,                   // SeedValidator
 		controllerregistrationresources.PluginName, // ControllerRegistrationResources
 		plantvalidator.PluginName,                  // PlantValidator
+		projectvalidator.PluginName,                // ProjectValidator
 		deletionconfirmation.PluginName,            // DeletionConfirmation
 		openidconnectpreset.PluginName,             // OpenIDConnectPreset
 		clusteropenidconnectpreset.PluginName,      // ClusterOpenIDConnectPreset
@@ -89,6 +91,7 @@ var (
 		seedvalidator.PluginName,                   // SeedValidator
 		controllerregistrationresources.PluginName, // ControllerRegistrationResources
 		plantvalidator.PluginName,                  // PlantValidator
+		projectvalidator.PluginName,                // ProjectValidator
 		deletionconfirmation.PluginName,            // DeletionConfirmation
 		openidconnectpreset.PluginName,             // OpenIDConnectPreset
 		clusteropenidconnectpreset.PluginName,      // ClusterOpenIDConnectPreset
@@ -118,6 +121,7 @@ func RegisterAllAdmissionPlugins(plugins *admission.Plugins) {
 	seedvalidator.Register(plugins)
 	controllerregistrationresources.Register(plugins)
 	plantvalidator.Register(plugins)
+	projectvalidator.Register(plugins)
 	openidconnectpreset.Register(plugins)
 	clusteropenidconnectpreset.Register(plugins)
 	customverbauthorizer.Register(plugins)

--- a/pkg/controllermanager/controller/project/project_control_reconcile.go
+++ b/pkg/controllermanager/controller/project/project_control_reconcile.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/projectrbac"
 	"github.com/gardener/gardener/pkg/utils"
+	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	retryutils "github.com/gardener/gardener/pkg/utils/retry"
 
@@ -40,9 +41,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
-
-// NamespacePrefix is the prefix of namespaces representing projects.
-const NamespacePrefix = "garden-"
 
 func (r *projectReconciler) reconcile(ctx context.Context, project *gardencorev1beta1.Project, gardenClient client.Client, gardenReader client.Reader) (reconcile.Result, error) {
 	var (
@@ -169,7 +167,7 @@ func (r *projectReconciler) reconcileNamespaceForProject(ctx context.Context, ga
 	if namespaceName == nil {
 		obj := &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				GenerateName:    fmt.Sprintf("%s%s-", NamespacePrefix, project.Name),
+				GenerateName:    fmt.Sprintf("%s%s-", gutil.ProjectNamespacePrefix, project.Name),
 				OwnerReferences: []metav1.OwnerReference{*ownerReference},
 				Labels:          projectLabels,
 				Annotations:     projectAnnotations,

--- a/pkg/utils/gardener/project.go
+++ b/pkg/utils/gardener/project.go
@@ -29,6 +29,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// ProjectNamespacePrefix is the prefix of namespaces representing projects.
+const ProjectNamespacePrefix = "garden-"
+
 // ProjectForNamespaceFromInternalLister returns the Project responsible for a given <namespace>. It lists all Projects
 // via the given lister, iterates over them and tries to identify the Project by looking for the namespace name
 // in the project spec.

--- a/plugin/pkg/project/validator/admission.go
+++ b/plugin/pkg/project/validator/admission.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	gardencore "github.com/gardener/gardener/pkg/apis/core"
+	gutil "github.com/gardener/gardener/pkg/utils/gardener"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apiserver/pkg/admission"
+)
+
+const (
+	// PluginName is the name of this admission plugin.
+	PluginName = "ProjectValidator"
+)
+
+// Register registers a plugin.
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
+		return New()
+	})
+}
+
+type handler struct {
+	*admission.Handler
+}
+
+// New creates a new handler admission plugin.
+func New() (*handler, error) {
+	return &handler{
+		Handler: admission.NewHandler(admission.Create),
+	}, nil
+}
+
+var _ admission.ValidationInterface = &handler{}
+
+func (v *handler) Validate(_ context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {
+	// Ignore all kinds other than Project
+	if a.GetKind().GroupKind() != gardencore.Kind("Project") {
+		return nil
+	}
+
+	// Ignore updates to status or other subresources
+	if a.GetSubresource() != "" {
+		return nil
+	}
+
+	// Convert object to Project
+	project, ok := a.GetObject().(*gardencore.Project)
+	if !ok {
+		return apierrors.NewBadRequest("could not convert object to Project")
+	}
+
+	if project.Spec.Namespace != nil && !strings.HasPrefix(*project.Spec.Namespace, gutil.ProjectNamespacePrefix) {
+		return admission.NewForbidden(a, fmt.Errorf(".spec.namespace must start with %s", gutil.ProjectNamespacePrefix))
+	}
+
+	return nil
+}

--- a/plugin/pkg/project/validator/admission.go
+++ b/plugin/pkg/project/validator/admission.go
@@ -69,6 +69,7 @@ func (v *handler) Validate(_ context.Context, a admission.Attributes, _ admissio
 		return apierrors.NewBadRequest("could not convert object to Project")
 	}
 
+	// TODO: Remove this admission plugin in favor of static validation in a future release, see https://github.com/gardener/gardener/pull/4228.
 	if project.Spec.Namespace != nil && !strings.HasPrefix(*project.Spec.Namespace, gutil.ProjectNamespacePrefix) {
 		return admission.NewForbidden(a, fmt.Errorf(".spec.namespace must start with %s", gutil.ProjectNamespacePrefix))
 	}

--- a/plugin/pkg/project/validator/admission_test.go
+++ b/plugin/pkg/project/validator/admission_test.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator_test
+
+import (
+	"context"
+
+	"github.com/gardener/gardener/pkg/apis/core"
+	. "github.com/gardener/gardener/plugin/pkg/project/validator"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/utils/pointer"
+)
+
+var _ = Describe("Admission", func() {
+	Describe("#Admit", func() {
+		var (
+			err              error
+			project          core.Project
+			admissionHandler admission.ValidationInterface
+
+			namespaceName = "garden-my-project"
+			projectName   = "my-project"
+			projectBase   = core.Project{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      projectName,
+					Namespace: namespaceName,
+				},
+				Spec: core.ProjectSpec{
+					Namespace: &namespaceName,
+				},
+			}
+		)
+
+		BeforeEach(func() {
+			admissionHandler, err = New()
+			Expect(err).NotTo(HaveOccurred())
+
+			project = projectBase
+		})
+
+		It("should allow creating the project", func() {
+			attrs := admission.NewAttributesRecord(&project, nil, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+
+			Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
+		})
+
+		It("should prevent creating the project because namespace prefix is missing", func() {
+			project.Spec.Namespace = pointer.StringPtr("foo")
+
+			attrs := admission.NewAttributesRecord(&project, nil, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+
+			Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(MatchError(ContainSubstring(".spec.namespace must start with garden-")))
+		})
+	})
+
+	Describe("#Register", func() {
+		It("should register the plugin", func() {
+			plugins := admission.NewPlugins()
+			Register(plugins)
+
+			registered := plugins.Registered()
+			Expect(registered).To(HaveLen(1))
+			Expect(registered).To(ContainElement(PluginName))
+		})
+	})
+
+	Describe("#New", func() {
+		It("should only handle CREATE or UPDATE operations", func() {
+			dr, err := New()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(dr.Handles(admission.Create)).To(BeTrue())
+			Expect(dr.Handles(admission.Update)).To(BeFalse())
+			Expect(dr.Handles(admission.Connect)).To(BeFalse())
+			Expect(dr.Handles(admission.Delete)).To(BeFalse())
+		})
+	})
+})

--- a/plugin/pkg/project/validator/admission_test.go
+++ b/plugin/pkg/project/validator/admission_test.go
@@ -41,9 +41,6 @@ var _ = Describe("Admission", func() {
 					Name:      projectName,
 					Namespace: namespaceName,
 				},
-				Spec: core.ProjectSpec{
-					Namespace: &namespaceName,
-				},
 			}
 		)
 
@@ -54,7 +51,15 @@ var _ = Describe("Admission", func() {
 			project = projectBase
 		})
 
-		It("should allow creating the project", func() {
+		It("should allow creating the project (namespace nil)", func() {
+			attrs := admission.NewAttributesRecord(&project, nil, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+
+			Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
+		})
+
+		It("should allow creating the project(namespace non-nil)", func() {
+			project.Spec.Namespace = &namespaceName
+
 			attrs := admission.NewAttributesRecord(&project, nil, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 
 			Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
@@ -81,7 +86,7 @@ var _ = Describe("Admission", func() {
 	})
 
 	Describe("#New", func() {
-		It("should only handle CREATE or UPDATE operations", func() {
+		It("should only handle CREATE operations", func() {
 			dr, err := New()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(dr.Handles(admission.Create)).To(BeTrue())

--- a/plugin/pkg/project/validator/validator_suite_test.go
+++ b/plugin/pkg/project/validator/validator_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validator_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestValidator(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Admission ProjectValidator Suite")
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:
Add new ProjectValidator admission plugin to prevent creating `Project`s whose namespaces don't start with `garden-`.

**Special notes for your reviewer**:
/invite @timebertt 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
A new `ProjectValidator` admission plugin has been added (enabled by default). It prevents creating `Project`s with non-empty `.spec.namespace` fields if the value in `.spec.namespace` does not start with `garden-`. Please note that this admission plugin will be removed in a future release again in favor of the static validation in the `gardener-apiserver`.
```
