### PR TITLE
Improve dashboards

### DIFF
--- a/charts/seed-bootstrap/dashboards/extensions-dashboard.json
+++ b/charts/seed-bootstrap/dashboards/extensions-dashboard.json
@@ -218,7 +218,6 @@
       "type": "logs"
     }
   ],
-  "refresh": "30s",
   "schemaVersion": 25,
   "style": "dark",
   "tags": [

--- a/charts/seed-bootstrap/dashboards/istio/istio-control-plane-dashboard.json
+++ b/charts/seed-bootstrap/dashboards/istio/istio-control-plane-dashboard.json
@@ -1905,7 +1905,7 @@
       "14d"
     ]
   },
-  "timezone": "browser",
+  "timezone": "utc",
   "title": "Istio Control Plane Dashboard",
   "uid": "istio-control-plane-dashboard",
   "version": 1

--- a/charts/seed-bootstrap/dashboards/istio/istio-control-plane-dashboard.json
+++ b/charts/seed-bootstrap/dashboards/istio/istio-control-plane-dashboard.json
@@ -1808,7 +1808,6 @@
       }
     }
   ],
-  "refresh": "30s",
   "schemaVersion": 26,
   "style": "dark",
   "tags": [

--- a/charts/seed-bootstrap/dashboards/istio/istio-ingress-gateway-dashboard.json
+++ b/charts/seed-bootstrap/dashboards/istio/istio-ingress-gateway-dashboard.json
@@ -222,7 +222,6 @@
       }
     }
   ],
-  "refresh": "30s",
   "schemaVersion": 26,
   "style": "dark",
   "tags": [

--- a/charts/seed-bootstrap/dashboards/istio/istio-mesh-dashboard.json
+++ b/charts/seed-bootstrap/dashboards/istio/istio-mesh-dashboard.json
@@ -1562,7 +1562,7 @@
       "14d"
     ]
   },
-  "timezone": "browser",
+  "timezone": "utc",
   "title": "Istio Mesh Dashboard",
   "uid": "istio-mesh-dashboard",
   "version": 1

--- a/charts/seed-bootstrap/dashboards/istio/istio-mesh-dashboard.json
+++ b/charts/seed-bootstrap/dashboards/istio/istio-mesh-dashboard.json
@@ -1496,7 +1496,6 @@
       }
     }
   ],
-  "refresh": "30s",
   "schemaVersion": 26,
   "style": "dark",
   "tags": [

--- a/charts/seed-bootstrap/dashboards/seed-resource-usage.json
+++ b/charts/seed-bootstrap/dashboards/seed-resource-usage.json
@@ -394,7 +394,6 @@
       }
     }
   ],
-  "refresh": "30s",
   "schemaVersion": 19,
   "style": "dark",
   "tags": [

--- a/charts/seed-bootstrap/dashboards/vpa-dashboard.json
+++ b/charts/seed-bootstrap/dashboards/vpa-dashboard.json
@@ -269,7 +269,7 @@
       "14d"
     ]
   },
-  "timezone": "browser",
+  "timezone": "utc",
   "title": "VPA Recommendations",
   "uid": "vpa-recommendations",
   "version": 1

--- a/charts/seed-bootstrap/dashboards/vpa-dashboard.json
+++ b/charts/seed-bootstrap/dashboards/vpa-dashboard.json
@@ -189,7 +189,6 @@
       }
     }
   ],
-  "refresh": "30s",
   "schemaVersion": 19,
   "style": "dark",
   "tags": [

--- a/charts/seed-monitoring/charts/grafana/dashboards/dns/node-local-dns-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/dns/node-local-dns-dashboard.json
@@ -1357,7 +1357,6 @@
       }
     }
   ],
-  "refresh": "30s",
   "schemaVersion": 27,
   "style": "dark",
   "tags": [

--- a/charts/seed-monitoring/charts/grafana/dashboards/dns/node-local-dns-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/dns/node-local-dns-dashboard.json
@@ -1430,7 +1430,7 @@
       "14d"
     ]
   },
-  "timezone": "browser",
+  "timezone": "utc",
   "title": "NodeLocalDNS",
   "uid": "node-local-dns",
   "version": 1

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/cluster-overview-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/cluster-overview-dashboard.json
@@ -1898,7 +1898,7 @@
       "14d"
     ]
   },
-  "timezone": "browser",
+  "timezone": "utc",
   "title": "Cluster Overview",
   "uid": "cluster-overview",
   "version": 1

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/cluster-overview-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/cluster-overview-dashboard.json
@@ -1859,7 +1859,6 @@
       }
     }
   ],
-  "refresh": "30s",
   "schemaVersion": 18,
   "style": "dark",
   "tags": [

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/etcd-backup-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/etcd-backup-dashboard.json
@@ -1272,7 +1272,6 @@
       }
     }
   ],
-  "refresh": "30s",
   "schemaVersion": 21,
   "style": "dark",
   "tags": [

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/etcd-backup-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/etcd-backup-dashboard.json
@@ -1310,7 +1310,7 @@
       "14d"
     ]
   },
-  "timezone": "browser",
+  "timezone": "utc",
   "title": "ETCD Backup and Restore",
   "uid": "etcd-backup-restore",
   "version": 1

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/etcd-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/etcd-dashboard.json
@@ -1350,7 +1350,6 @@
       "type": "row"
     }
   ],
-  "refresh": "30s",
   "schemaVersion": 16,
   "style": "dark",
   "tags": [

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/etcd-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/etcd-dashboard.json
@@ -1422,7 +1422,7 @@
       "14d"
     ]
   },
-  "timezone": "browser",
+  "timezone": "utc",
   "title": "ETCD",
   "uid": "etcd",
   "version": 1

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-daemonsets-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-daemonsets-dashboard.json
@@ -714,7 +714,6 @@
       "type": "table"
     }
   ],
-  "refresh": "30s",
   "schemaVersion": 16,
   "style": "dark",
   "tags": [

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-daemonsets-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-daemonsets-dashboard.json
@@ -805,7 +805,7 @@
       "14d"
     ]
   },
-  "timezone": "browser",
+  "timezone": "utc",
   "title": "Kubernetes DaemonSets",
   "uid": "kube-daemonset",
   "version": 1

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-deployments-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-deployments-dashboard.json
@@ -949,7 +949,7 @@
       "14d"
     ]
   },
-  "timezone": "browser",
+  "timezone": "utc",
   "title": "Kubernetes Deployments",
   "uid": "kube-deployments",
   "version": 1

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-deployments-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-deployments-dashboard.json
@@ -849,7 +849,6 @@
       "type": "table-old"
     }
   ],
-  "refresh": "30s",
   "schemaVersion": 25,
   "style": "dark",
   "tags": [

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-pods-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-pods-dashboard.json
@@ -688,7 +688,7 @@
       "14d"
     ]
   },
-  "timezone": "browser",
+  "timezone": "utc",
   "title": "Kubernetes Pods",
   "uid": "kube-pods",
   "version": 1

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-pods-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-pods-dashboard.json
@@ -548,7 +548,6 @@
       "type": "logs"
     }
   ],
-  "refresh": "30s",
   "schemaVersion": 26,
   "style": "dark",
   "tags": [

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-statefulsets-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-statefulsets-dashboard.json
@@ -941,7 +941,7 @@
       "14d"
     ]
   },
-  "timezone": "browser",
+  "timezone": "utc",
   "title": "Kubernetes StatefulSets",
   "uid": "kube-statefulsets",
   "version": 1

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-statefulsets-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-statefulsets-dashboard.json
@@ -843,7 +843,6 @@
       "type": "table-old"
     }
   ],
-  "refresh": "30s",
   "schemaVersion": 25,
   "style": "dark",
   "tags": [

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/prometheus-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/prometheus-dashboard.json
@@ -1157,7 +1157,7 @@
       "14d"
     ]
   },
-  "timezone": "browser",
+  "timezone": "utc",
   "title": "Prometheus",
   "uid": "prometheus",
   "version": 19

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/vpa-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/vpa-dashboard.json
@@ -596,7 +596,7 @@
       "14d"
     ]
   },
-  "timezone": "browser",
+  "timezone": "utc",
   "title": "VPA Recommendations",
   "uid": "vpa-recommendations",
   "version": 1

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/vpa-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/vpa-dashboard.json
@@ -391,7 +391,6 @@
       }
     }
   ],
-  "refresh": "30s",
   "schemaVersion": 18,
   "style": "dark",
   "tags": [

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/vpn-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/vpn-dashboard.json
@@ -912,7 +912,6 @@
       "type": "row"
     }
   ],
-  "refresh": "30s",
   "schemaVersion": 19,
   "style": "dark",
   "tags": [

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/vpn-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/vpn-dashboard.json
@@ -952,7 +952,7 @@
       "14d"
     ]
   },
-  "timezone": "browser",
+  "timezone": "utc",
   "title": "VPN",
   "uid": "vpn",
   "version": 1

--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/apiserver-overview.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/apiserver-overview.json
@@ -3515,7 +3515,7 @@
       "14d"
     ]
   },
-  "timezone": "browser",
+  "timezone": "utc",
   "title": "API Server",
   "uid": "apiserver-overview"
 }

--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/apiserver-overview.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/apiserver-overview.json
@@ -3320,7 +3320,6 @@
       }
     }
   ],
-  "refresh": "30s",
   "schemaVersion": 26,
   "style": "dark",
   "tags": [

--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/coredns-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/coredns-dashboard.json
@@ -1357,7 +1357,6 @@
       }
     }
   ],
-  "refresh": "30s",
   "schemaVersion": 27,
   "style": "dark",
   "tags": [

--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/coredns-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/coredns-dashboard.json
@@ -1430,7 +1430,7 @@
       "14d"
     ]
   },
-  "timezone": "browser",
+  "timezone": "utc",
   "title": "CoreDNS",
   "uid": "core-dns",
   "version": 1

--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/kubernetes-api-server-details.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/kubernetes-api-server-details.json
@@ -1321,7 +1321,7 @@
       "14d"
     ]
   },
-  "timezone": "browser",
+  "timezone": "utc",
   "title": "Kubernetes API Server Details",
   "uid": "kube-apiserver-details",
   "version": 1

--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/kubernetes-api-server-details.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/kubernetes-api-server-details.json
@@ -1170,7 +1170,6 @@
       }
     }
   ],
-  "refresh": "30s",
   "schemaVersion": 26,
   "style": "dark",
   "tags": [

--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/kubernetes-control-plane-status-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/kubernetes-control-plane-status-dashboard.json
@@ -2010,7 +2010,7 @@
       "14d"
     ]
   },
-  "timezone": "browser",
+  "timezone": "utc",
   "title": "Kubernetes Control Plane Status",
   "uid": "kubernetes-control-plane-status",
   "version": 1

--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/node-details-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/node-details-dashboard.json
@@ -1289,7 +1289,7 @@
       "14d"
     ]
   },
-  "timezone": "browser",
+  "timezone": "utc",
   "title": "Node Details",
   "uid": "node-details",
   "version": 1

--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/node-pool-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/node-pool-dashboard.json
@@ -677,7 +677,7 @@
       "14d"
     ]
   },
-  "timezone": "browser",
+  "timezone": "utc",
   "title": "Node/Worker Pool Overview",
   "uid": "node-worker-pool-overview",
   "version": 1

--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/shoot-vpa-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/shoot-vpa-dashboard.json
@@ -328,7 +328,7 @@
       "14d"
     ]
   },
-  "timezone": "browser",
+  "timezone": "utc",
   "title": "Shoot VPA Recommendations",
   "uid": "shoot-vpa",
   "version": 1

--- a/charts/seed-monitoring/charts/grafana/templates/logging-dashboard.tpl
+++ b/charts/seed-monitoring/charts/grafana/templates/logging-dashboard.tpl
@@ -510,7 +510,7 @@
         "14d"
       ]
     },
-    "timezone": "browser",
+    "timezone": "utc",
     "title": "Controlplane Logs Dashboard",
     "version": 1
   }

--- a/docs/development/monitoring-stack.md
+++ b/docs/development/monitoring-stack.md
@@ -228,7 +228,7 @@ Example dashboard configuration
 ```json
 {
   "title": "example-component",
-  "timezone": "browser",
+  "timezone": "utc",
   "tags": [
     "seed",
     "control-plane"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

Dashboards use UTC instead of browser time by default and dashboards will no longer auto refresh by default.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/cc @dguendisch 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Dashboards use UTC instead of browser time by default
```
