### PR TITLE
External Alert Manager secret type certificate fix

### DIFF
--- a/charts/gardener/controlplane/charts/utils-common/templates/_secret-alerting.yaml
+++ b/charts/gardener/controlplane/charts/utils-common/templates/_secret-alerting.yaml
@@ -36,6 +36,7 @@ data:
   ca.crt: {{ ( required ".alerting[].ca_crt is required" $config.ca_crt ) | b64enc }}
   tls.crt: {{ ( required ".alerting[].tls_crt is required" $config.tls_cert ) | b64enc }}
   tls.key: {{ ( required ".alerting[].tls_key is required" $config.tls_key ) | b64enc }}
+  insecure_skip_verify: {{ ( required ".alerting[].insecure_skip_verify is required" $config.insecure_skip_verify ) | b64enc }}
 {{- end }}
 {{- end }}
 {{- end -}}

--- a/example/10-secret-alerting.yaml
+++ b/example/10-secret-alerting.yaml
@@ -25,7 +25,8 @@ data:
   ca.crt: base64(ca)
   tls.crt: base64(certificate)
   tls.key: base64(key)
-
+  insecure_skip_verify: base64(false)
+  
   # Email Alerts (internal alertmanager)
   auth_type: base64(smtp)
   auth_identity: base64(internal.alertmanager.auth_identity)


### PR DESCRIPTION
**How to categorize this PR?**

/area monitoring
/kind bug

**What this PR does / why we need it**:
If insecure_skip_verify key is not explicitly set in secret for external Alert Manager config, gardener won't use the secret for configuring the prometheus
-> https://github.com/gardener/gardener/blob/master/pkg/operation/botanist/monitoring.go#L398

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
