### PR TITLE
Enh/stable worker hash

### DIFF
--- a/extensions/pkg/controller/worker/machines.go
+++ b/extensions/pkg/controller/worker/machines.go
@@ -22,6 +22,7 @@ import (
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	"github.com/gardener/gardener/extensions/pkg/util"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils"
 
@@ -146,6 +147,9 @@ func WorkerPoolHash(pool extensionsv1alpha1.WorkerPool, cluster *extensionscontr
 	for _, w := range cluster.Shoot.Spec.Provider.Workers {
 		if pool.Name == w.Name {
 			if w.CRI != nil {
+				if w.CRI.Name == gardencorev1beta1.CRINameDocker {
+					continue
+				}
 				data = append(data, string(w.CRI.Name))
 			}
 		}

--- a/extensions/pkg/controller/worker/machines.go
+++ b/extensions/pkg/controller/worker/machines.go
@@ -146,10 +146,7 @@ func WorkerPoolHash(pool extensionsv1alpha1.WorkerPool, cluster *extensionscontr
 
 	for _, w := range cluster.Shoot.Spec.Provider.Workers {
 		if pool.Name == w.Name {
-			if w.CRI != nil {
-				if w.CRI.Name == gardencorev1beta1.CRINameDocker {
-					continue
-				}
+			if w.CRI != nil && w.CRI.Name != gardencorev1beta1.CRINameDocker {
 				data = append(data, string(w.CRI.Name))
 			}
 		}

--- a/extensions/pkg/controller/worker/machines_test.go
+++ b/extensions/pkg/controller/worker/machines_test.go
@@ -184,6 +184,20 @@ var _ = Describe("Machines", func() {
 					},
 				})
 			})
+
+			It("when changing CRI configuration from `nil` to `docker`", func() {
+				v, err = WorkerPoolHash(*p, &extensionscontroller.Cluster{
+					Shoot: &gardencorev1beta1.Shoot{
+						Spec: gardencorev1beta1.ShootSpec{
+							Kubernetes: gardencorev1beta1.Kubernetes{
+								Version: "1.2.4",
+							},
+							Provider: gardencorev1beta1.Provider{Workers: []gardencorev1beta1.Worker{
+								{Name: "test-worker", CRI: &gardencorev1beta1.CRI{Name: gardencorev1beta1.CRINameDocker}}}},
+						},
+					},
+				})
+			})
 		})
 
 		Context("hash value should change", func() {


### PR DESCRIPTION
**How to categorize this PR?**
 /kind enhancement

**What this PR does / why we need it**:
Exclude cri.name `docker` from worker hash calculation

Worker pools with `CRI==nil` use `docker` as their container runtime. Changing to an explicit configuration of `docker` should not trigger a node rollout. Therefore, we need to keep the Worker hash stable by excluding the `cri.name` property from hash calculation in this case.

Part of #4110

**Special notes for your reviewer**:
Marked as draft as it depends on #4218 .

**Release note**:
```feature user
Do not trigger a node rollout when switching from `CRI.Name==nil` to `CRI.Name==docker`.
```

cc @BeckerMax 
