### PR TITLE
Selectable Api Server endpoints aka ExposureClasses [Part 4]

### DIFF
--- a/docs/concepts/apiserver_admission_plugins.md
+++ b/docs/concepts/apiserver_admission_plugins.md
@@ -39,6 +39,13 @@ It validates that the respective resource is annotated with a deletion confirmat
 Only if this annotation is present it allows the `DELETE` operation to pass.
 This prevents users from accidental/undesired deletions.
 
+## `ExposureClass`
+
+_(enabled by default)_
+
+This admission controller reacts on `Create` operations for `Shoots`s.
+It mutates `Shoot` resources which has an `ExposureClass` referenced by merging their both `shootSelectors` and/or `tolerations` into the `Shoot` resource.
+
 ## `ExtensionValidator`
 
 _(enabled by default)_

--- a/pkg/apiserver/plugins.go
+++ b/pkg/apiserver/plugins.go
@@ -27,6 +27,7 @@ import (
 	projectvalidator "github.com/gardener/gardener/plugin/pkg/project/validator"
 	seedvalidator "github.com/gardener/gardener/plugin/pkg/seed/validator"
 	shootdns "github.com/gardener/gardener/plugin/pkg/shoot/dns"
+	shootexposureclass "github.com/gardener/gardener/plugin/pkg/shoot/exposureclass"
 	shootmanagedseed "github.com/gardener/gardener/plugin/pkg/shoot/managedseed"
 	"github.com/gardener/gardener/plugin/pkg/shoot/oidc/clusteropenidconnectpreset"
 	"github.com/gardener/gardener/plugin/pkg/shoot/oidc/openidconnectpreset"
@@ -50,6 +51,7 @@ var (
 		resourcereferencemanager.PluginName,        // ResourceReferenceManager
 		extensionvalidation.PluginName,             // ExtensionValidator
 		shoottolerationrestriction.PluginName,      // ShootTolerationRestriction
+		shootexposureclass.PluginName,              // ShootExposureClass
 		shootdns.PluginName,                        // ShootDNS
 		shootmanagedseed.PluginName,                // ShootManagedSeed
 		shootquotavalidator.PluginName,             // ShootQuotaValidator
@@ -84,6 +86,7 @@ var (
 		resourcereferencemanager.PluginName,        // ResourceReferenceManager
 		extensionvalidation.PluginName,             // ExtensionValidator
 		shoottolerationrestriction.PluginName,      // ShootTolerationRestriction
+		shootexposureclass.PluginName,              // ShootExposureClass
 		shootdns.PluginName,                        // ShootDNS
 		shootmanagedseed.PluginName,                // ShootManagedSeed
 		shootquotavalidator.PluginName,             // ShootQuotaValidator
@@ -114,6 +117,7 @@ func RegisterAllAdmissionPlugins(plugins *admission.Plugins) {
 	deletionconfirmation.Register(plugins)
 	extensionvalidation.Register(plugins)
 	shoottolerationrestriction.Register(plugins)
+	shootexposureclass.Register(plugins)
 	shootquotavalidator.Register(plugins)
 	shootdns.Register(plugins)
 	shootmanagedseed.Register(plugins)

--- a/plugin/pkg/shoot/exposureclass/admission.go
+++ b/plugin/pkg/shoot/exposureclass/admission.go
@@ -1,0 +1,211 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apacht.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exposureclass
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/gardener/gardener/pkg/apis/core"
+	"github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	admissioninitializer "github.com/gardener/gardener/pkg/apiserver/admission/initializer"
+	externalcoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
+	corev1alphalisters "github.com/gardener/gardener/pkg/client/core/listers/core/v1alpha1"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apiserver/pkg/admission"
+)
+
+const (
+	// PluginName is the name of this admission plugin.
+	PluginName = "ShootExposureClass"
+)
+
+// Register registers a plugin.
+func Register(plugins *admission.Plugins) {
+	plugins.Register(PluginName, func(config io.Reader) (admission.Interface, error) {
+		return New()
+	})
+}
+
+// ExposureClass contains listers and admission handler.
+type ExposureClass struct {
+	*admission.Handler
+
+	exposureClassLister corev1alphalisters.ExposureClassLister
+	readyFunc           admission.ReadyFunc
+}
+
+var (
+	_ = admissioninitializer.WantsExternalCoreInformerFactory(&ExposureClass{})
+
+	readyFuncs []admission.ReadyFunc
+)
+
+// New creates a new ExposureClass admission plugin.
+func New() (*ExposureClass, error) {
+	return &ExposureClass{
+		Handler: admission.NewHandler(admission.Create),
+	}, nil
+}
+
+// AssignReadyFunc assigns the ready function to the admission handler.
+func (e *ExposureClass) AssignReadyFunc(f admission.ReadyFunc) {
+	e.readyFunc = f
+	e.SetReadyFunc(f)
+}
+
+// SetExternalCoreInformerFactory sets the external garden core informer factory.
+func (e *ExposureClass) SetExternalCoreInformerFactory(f externalcoreinformers.SharedInformerFactory) {
+	exposureClassInformer := f.Core().V1alpha1().ExposureClasses()
+	e.exposureClassLister = exposureClassInformer.Lister()
+
+	readyFuncs = append(readyFuncs, exposureClassInformer.Informer().HasSynced)
+}
+
+func (e *ExposureClass) waitUntilReady(attrs admission.Attributes) error {
+	// Wait until the caches have been synced
+	if e.readyFunc == nil {
+		e.AssignReadyFunc(func() bool {
+			for _, readyFunc := range readyFuncs {
+				if !readyFunc() {
+					return false
+				}
+			}
+			return true
+		})
+	}
+
+	if !e.WaitForReady() {
+		return admission.NewForbidden(attrs, errors.New("not yet ready to handle request"))
+	}
+
+	return nil
+}
+
+// ValidateInitialization checks whether the plugin was correctly initialized.
+func (e *ExposureClass) ValidateInitialization() error {
+	if e.exposureClassLister == nil {
+		return errors.New("missing ExposureClass lister")
+	}
+	return nil
+}
+
+// Admit unite the seed selector and/or tolerations of a Shoot resource
+// with the ones from the referenced ExposureClass.
+func (e *ExposureClass) Admit(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) error {
+	if err := e.waitUntilReady(a); err != nil {
+		return fmt.Errorf("err while waiting for ready %v", err)
+	}
+
+	if a.GetKind().GroupKind() != core.Kind("Shoot") {
+		return nil
+	}
+
+	// Ignore any updates to shoot subresources.
+	if a.GetSubresource() != "" {
+		return nil
+	}
+
+	shoot, ok := a.GetObject().(*core.Shoot)
+	if !ok {
+		return apierrors.NewBadRequest("could not convert resource into Shoot object")
+	}
+
+	if err := e.admitShoot(shoot); err != nil {
+		return admission.NewForbidden(a, err)
+	}
+
+	return nil
+}
+
+func (e *ExposureClass) admitShoot(shoot *core.Shoot) error {
+	if shoot.Spec.ExposureClassName == nil {
+		return nil
+	}
+
+	exposureClass, err := e.exposureClassLister.Get(*shoot.Spec.ExposureClassName)
+	if err != nil {
+		return err
+	}
+
+	if exposureClass.Scheduling == nil {
+		return nil
+	}
+
+	targetSeedSelector, err := uniteSeedSelectors(shoot.Spec.SeedSelector, exposureClass.Scheduling.SeedSelector)
+	if err != nil {
+		return err
+	}
+	shoot.Spec.SeedSelector = targetSeedSelector
+
+	targetTolerations, err := uniteTolerations(shoot.Spec.Tolerations, exposureClass.Scheduling.Tolerations)
+	if err != nil {
+		return err
+	}
+	shoot.Spec.Tolerations = targetTolerations
+
+	return nil
+}
+
+func uniteSeedSelectors(shootSeedSelector *core.SeedSelector, exposureClassSeedSelector *v1alpha1.SeedSelector) (*core.SeedSelector, error) {
+	if exposureClassSeedSelector == nil {
+		return shootSeedSelector, nil
+	}
+
+	if shootSeedSelector == nil {
+		shootSeedSelector = &core.SeedSelector{}
+	}
+	if shootSeedSelector.LabelSelector == nil {
+		shootSeedSelector.LabelSelector = &v1.LabelSelector{}
+	}
+
+	// Unite matching labels.
+	if labels.Conflicts(shootSeedSelector.MatchLabels, exposureClassSeedSelector.MatchLabels) {
+		return nil, fmt.Errorf("matching labels of the seed selector conflicts with the ones of referenced exposureclass")
+	}
+	shootSeedSelector.MatchLabels = labels.Merge(shootSeedSelector.MatchLabels, exposureClassSeedSelector.MatchLabels)
+
+	// Unite matching expressions.
+	shootSeedSelector.MatchExpressions = append(shootSeedSelector.MatchExpressions, exposureClassSeedSelector.MatchExpressions...)
+
+	// Unite provider types.
+	shootProviderTypes := sets.NewString().Insert(shootSeedSelector.ProviderTypes...)
+	exposureclasssProviderTypes := sets.NewString().Insert(exposureClassSeedSelector.ProviderTypes...)
+	shootSeedSelector.ProviderTypes = shootProviderTypes.Union(exposureclasssProviderTypes).List()
+
+	return shootSeedSelector, nil
+}
+
+func uniteTolerations(shootTolerations []core.Toleration, exposureClassTolerations []v1alpha1.Toleration) ([]core.Toleration, error) {
+	shootTolerationsKeys := sets.NewString()
+	for _, toleration := range shootTolerations {
+		shootTolerationsKeys.Insert(toleration.Key)
+	}
+
+	for _, toleration := range exposureClassTolerations {
+		if shootTolerationsKeys.Has(toleration.Key) {
+			return nil, fmt.Errorf("toleration with key %q conflicts with the ones of referenced exposureclass", toleration.Key)
+		}
+		shootTolerations = append(shootTolerations, core.Toleration(toleration))
+	}
+
+	return shootTolerations, nil
+}

--- a/plugin/pkg/shoot/exposureclass/admission_test.go
+++ b/plugin/pkg/shoot/exposureclass/admission_test.go
@@ -1,0 +1,249 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exposureclass_test
+
+import (
+	"context"
+
+	"github.com/gardener/gardener/pkg/apis/core"
+	corev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	externalcoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
+	. "github.com/gardener/gardener/plugin/pkg/shoot/exposureclass"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/admission"
+	"k8s.io/utils/pointer"
+)
+
+var _ = Describe("exposureclass", func() {
+	Describe("#Admit", func() {
+		var (
+			exposureClassName = "test"
+
+			shoot         *core.Shoot
+			exposureClass *corev1alpha1.ExposureClass
+
+			attrs            admission.Attributes
+			admissionHandler *ExposureClass
+
+			gardenCoreInformerFactory externalcoreinformers.SharedInformerFactory
+		)
+
+		BeforeEach(func() {
+			gardenCoreInformerFactory = externalcoreinformers.NewSharedInformerFactory(nil, 0)
+
+			admissionHandler, _ = New()
+			admissionHandler.AssignReadyFunc(func() bool { return true })
+			admissionHandler.SetExternalCoreInformerFactory(gardenCoreInformerFactory)
+
+			shoot = &core.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "test",
+				},
+				Spec: core.ShootSpec{
+					ExposureClassName: &exposureClassName,
+				},
+			}
+
+			exposureClass = &corev1alpha1.ExposureClass{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: exposureClassName,
+				},
+				Scheduling: &corev1alpha1.ExposureClassScheduling{},
+			}
+		})
+
+		It("should do nothing because the resource is not Shoot", func() {
+			attrs = admission.NewAttributesRecord(nil, nil, core.Kind("Test").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("foos").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+			err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should do nothing as Shoot has no ExposureClass referenced", func() {
+			shoot.Spec.ExposureClassName = nil
+
+			attrs = admission.NewAttributesRecord(shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+			err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should fail as referenced ExposureClass was not found", func() {
+			attrs = admission.NewAttributesRecord(shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+			err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should do nothing as referenced ExposureClass has no scheduling settings", func() {
+			exposureClass.Scheduling = nil
+			Expect(gardenCoreInformerFactory.Core().V1alpha1().ExposureClasses().Informer().GetStore().Add(exposureClass)).To(Succeed())
+
+			attrs = admission.NewAttributesRecord(shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+			err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		Context("SeedSelector", func() {
+			BeforeEach(func() {
+				exposureClass.Scheduling.SeedSelector = &corev1alpha1.SeedSelector{
+					LabelSelector: &metav1.LabelSelector{},
+				}
+
+				shoot.Spec.SeedSelector = &core.SeedSelector{
+					LabelSelector: &metav1.LabelSelector{},
+				}
+			})
+
+			It("should do nothing as ExposureClass has no seed selector", func() {
+				exposureClass.Scheduling.SeedSelector = nil
+				Expect(gardenCoreInformerFactory.Core().V1alpha1().ExposureClasses().Informer().GetStore().Add(exposureClass)).To(Succeed())
+
+				attrs = admission.NewAttributesRecord(shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should unite the matching labels of seed selector from Shoot and ExposureClass", func() {
+				shoot.Spec.SeedSelector.MatchLabels = map[string]string{"abc": "abc"}
+				exposureClass.Scheduling.SeedSelector.LabelSelector.MatchLabels = map[string]string{"xyz": "xyz"}
+				Expect(gardenCoreInformerFactory.Core().V1alpha1().ExposureClasses().Informer().GetStore().Add(exposureClass)).To(Succeed())
+
+				attrs = admission.NewAttributesRecord(shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(shoot.Spec.SeedSelector.MatchLabels).To(Equal(map[string]string{
+					"abc": "abc",
+					"xyz": "xyz",
+				}))
+			})
+
+			It("should fail as seed selector from Shoot and ExposureClass have conflicting labels", func() {
+				shoot.Spec.SeedSelector.MatchLabels = map[string]string{"abc": "abc"}
+				exposureClass.Scheduling.SeedSelector.LabelSelector.MatchLabels = map[string]string{"abc": "xyz"}
+				Expect(gardenCoreInformerFactory.Core().V1alpha1().ExposureClasses().Informer().GetStore().Add(exposureClass)).To(Succeed())
+
+				attrs = admission.NewAttributesRecord(shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("should unite the seed selector expressions from Shoot and Exposureclass", func() {
+				shoot.Spec.SeedSelector.MatchExpressions = []metav1.LabelSelectorRequirement{{
+					Key:      "abc",
+					Operator: metav1.LabelSelectorOpIn,
+					Values:   []string{"abc", "def"},
+				}}
+				exposureClass.Scheduling.SeedSelector.LabelSelector.MatchExpressions = []metav1.LabelSelectorRequirement{{
+					Key:      "abc",
+					Operator: metav1.LabelSelectorOpIn,
+					Values:   []string{"xyz"},
+				}}
+				Expect(gardenCoreInformerFactory.Core().V1alpha1().ExposureClasses().Informer().GetStore().Add(exposureClass)).To(Succeed())
+
+				attrs = admission.NewAttributesRecord(shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(shoot.Spec.SeedSelector.MatchExpressions).To(Equal([]metav1.LabelSelectorRequirement{
+					{
+						Key:      "abc",
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{"abc", "def"},
+					},
+					{
+						Key:      "abc",
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{"xyz"},
+					},
+				}))
+			})
+
+			It("should unite the seedselector provider types from Shoot and ExposureClass", func() {
+				shoot.Spec.SeedSelector.ProviderTypes = []string{"aws", "gcp"}
+				exposureClass.Scheduling.SeedSelector.ProviderTypes = []string{"gcp"}
+				Expect(gardenCoreInformerFactory.Core().V1alpha1().ExposureClasses().Informer().GetStore().Add(exposureClass)).To(Succeed())
+
+				attrs = admission.NewAttributesRecord(shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(shoot.Spec.SeedSelector.ProviderTypes).To(Equal([]string{"aws", "gcp"}))
+			})
+		})
+
+		Context("Tolerations", func() {
+			BeforeEach(func() {
+				exposureClass.Scheduling.Tolerations = []corev1alpha1.Toleration{{
+					Key:   "abc",
+					Value: pointer.StringPtr("def"),
+				}}
+
+				shoot.Spec.Tolerations = []core.Toleration{{
+					Key: "xyz",
+				}}
+			})
+
+			It("should do nothing as ExposureClass has no tolerations", func() {
+				exposureClass.Scheduling.Tolerations = []corev1alpha1.Toleration{}
+				Expect(gardenCoreInformerFactory.Core().V1alpha1().ExposureClasses().Informer().GetStore().Add(exposureClass)).To(Succeed())
+
+				attrs = admission.NewAttributesRecord(shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(shoot.Spec.Tolerations).To(Equal([]core.Toleration{{
+					Key: "xyz",
+				}}))
+			})
+
+			It("should unite the tolerations from Shoot and ExposureClass", func() {
+				Expect(gardenCoreInformerFactory.Core().V1alpha1().ExposureClasses().Informer().GetStore().Add(exposureClass)).To(Succeed())
+
+				attrs = admission.NewAttributesRecord(shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(shoot.Spec.Tolerations).To(Equal([]core.Toleration{
+					{
+						Key: "xyz",
+					},
+					{
+						Key:   "abc",
+						Value: pointer.StringPtr("def"),
+					},
+				}))
+			})
+
+			It("should fail as Shoot and ExposureClass tolerations have conflicting keys", func() {
+				shoot.Spec.Tolerations[0].Key = "abc"
+				Expect(gardenCoreInformerFactory.Core().V1alpha1().ExposureClasses().Informer().GetStore().Add(exposureClass)).To(Succeed())
+
+				attrs = admission.NewAttributesRecord(shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+})

--- a/plugin/pkg/shoot/exposureclass/exposureclass_suite_test.go
+++ b/plugin/pkg/shoot/exposureclass/exposureclass_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exposureclass_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestExposureClass(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Admission ExposureClass Suite")
+}


### PR DESCRIPTION
**How to categorize this PR?**
/area control-plane open-source
/kind enhancement

**What this PR does / why we need it**:
This PR implements the step 4 of the Selectable Api Server endpoint story. This story will be implemented in several steps, see: #3505 (comment) The previous PR can be found here: #3951 and here https://github.com/gardener/gardener/pull/4117

This PR adds an Admission Plugin for Shoots which will unite the seed selector and tolerations of the Shoot with the referenced ExposureClass.

Please check the [implementation proposal](https://github.com/gardener/gardener/issues/3505#issuecomment-795656500) for more details.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I will open this PR as draft until my test completed but to gather already feedback.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```NONE
```

/invite @rfranzke @timuthy 