### PR TITLE
Selectable Api Server endpoints aka ExposureClasses [Part 5]

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,7 @@
 * [Cleanup of Shoot clusters in deletion](usage/shoot_cleanup.md)
 * [Custom `CoreDNS` configuration](usage/custom-dns.md)
 * [(Custom) CSI components](usage/csi_components.md)
+* [ExposureClasses](usage/exposureclasses.md)
 * [Gardener configuration and usage](usage/configuration.md)
 * [`ManagedIstio` feature](usage/istio.md)
 * [Network Policies in the Shoot Cluster](usage/shoot_network_policies.md)

--- a/docs/usage/exposureclasses.md
+++ b/docs/usage/exposureclasses.md
@@ -1,0 +1,147 @@
+# ExposureClasses
+
+The Gardener API server provides a cluster-scoped `ExposureClass` resource.
+This resource is used to allow exposing the control plane of a Shoot cluster in various network enviroments like restricted corporate networks, dmzs etc.
+
+## Background
+
+The `ExposureClass` resource is based on the concept for the `RuntimeClass` resource in Kubernetes.
+
+A `RuntimeClass` abstracts the installation of a certain container runtime (e.g. gVisor, kata containers) on all nodes or a subset of the nodes in a Kubernetes cluster.
+See [here](https://kubernetes.io/docs/concepts/containers/runtime-class/).
+
+In contrast, an `ExposureClass` abstracts the ability to expose a Shoot clusters control plane in certain network environments (e.g. corporate networks, dmz, internet) on all Seeds or a subset of the Seeds.
+
+Example: `RuntimeClass` and `ExposureClass`
+
+```yaml
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: gvisor
+handler: gvisorconfig
+# scheduling:
+#   nodeSelector:
+#     env: prod
+---
+kind: ExposureClass
+metadata:
+  name: internet
+handler: internetconfig
+# scheduling:
+#   seedSelector:
+#     matchLabels:
+#       network/env: internet
+```
+
+Similar to `RuntimeClasses`, `ExposureClasses` also define a `.handler` field reflecting the name reference for the corresponding CRI configuration of the `RuntimeClass` and the control plane exposure configuration for the `ExposureClass`.
+
+The CRI handler for `RuntimeClasses` is usually installed by an administrator (e.g. via a `DaemonSet` which installs the corresponding container runtime on the nodes).
+The control plane exposure configuration for `ExposureClasses` will be also provided by an administrator.
+This exposure configuration is part of the Gardenlet configuration as this component is responsible to configure the control plane accordingly.
+See [here](#Gardenlet-Configuration-ExposureClass-handlers).
+
+The `RuntimeClass` also supports the selection of a node subset (which have the respective controller runtime binaries installed) for pod scheduling via its `.scheduling` section.
+The `ExposureClass` also supports the selection of a subset of available Seed clusters whose Gardenlet is capable of applying the exposure configuration for the Shoot control plane accordingly via its `.scheduling` section.
+
+## Usage by a `Shoot`
+
+A `Shoot` can reference an `ExposureClass` via the `.spec.exposureClassName` field.
+
+:warning: When creating a `Shoot` resource, the Gardener scheduler will try to assign the `Shoot` to a `Seed` which will host its control plane.
+The scheduling behaviour can be influenced via the `.spec.seedSelectors` and/or `.spec.tolerations` fields in the `Shoot`.
+`ExposureClass`es can contain also scheduling instructions.
+If a `Shoot` is referencing an `ExposureClass` then the scheduling instructions of both will be merged into the `Shoot`.
+Those unions of scheduling instructions might lead to a selection of a `Seed` which is not able to deal with the `handler` of the `ExposureClass` and the `Shoot` creation might end up in an error.
+In such case, the `Shoot` scheduling instructions should be revisited to check that they are not interfere with the ones from the `ExposureClass`.
+If this is not feasible then the combination with the `ExposureClass` is might not possible and you need to contact your Gardener administrator.
+
+<details>
+<summary>Example: Shoot and ExposureClass scheduling instructions merge flow</summary>
+
+1. Assuming there is the following `Shoot` which is referencing the `ExposureClass` below:
+
+```yaml
+apiVersion: core.gardener.cloud/v1beta1
+kind: Shoot
+metadata:
+  name: abc
+  namespace: garden-dev
+spec:
+  exposureClassName: abc
+  seedSelectors:
+    matchLabels:
+      env: prod
+---
+apiVersion: core.gardener.cloud/v1alpha1
+kind: ExposureClass
+metadata:
+  name: abc
+handler: abc
+scheduling:
+  seedSelector:
+    matchLabels:
+      network: internal
+```
+
+2. Both `seedSelectors` would be merged into the `Shoot`. The result would be the following:
+```yaml
+apiVersion: core.gardener.cloud/v1alpha1
+kind: Shoot
+metadata:
+  name: abc
+  namespace: garden-dev
+spec:
+  exposureClassName: abc
+  seedSelectors:
+    matchLabels:
+      env: prod
+      network: internal
+```
+
+3. Now the Gardener Scheduler would try to find a `Seed` with those labels.
+  - If there are **no** Seeds with matching labels for the seed selector then the `Shoot` will be unschedulable
+  - If there are Seeds with matching labels for the seed selector then the Shoot will be assigned to the best candidate after the scheduling strategy is applied, see [here](https://github.com/gardener/gardener/blob/master/docs/concepts/scheduler.md#algorithm-overview)
+    - If the `Seed` is **not** able to serve the `ExposureClass` handler `abc` then the Shoot will end up in error state
+    - If the `Seed` is able to serve the `ExposureClass` handler `abc` then the `Shoot` will be created
+
+</details>
+
+## Gardenlet Configuration `ExposureClass` handlers
+
+The Gardenlet is responsible to realize the control plane exposure strategy defined in the referenced `ExposureClass` of a `Shoot`.
+
+Therefore, the `GardenletConfiguration` can contain an `.exposureClassHandlers` list with the respective configuration.
+
+Example of the `GardenletConfiguration`:
+
+```yaml
+exposureClassHandlers:
+- name: internetconfig
+  loadBalancerService:
+    annotations:
+      loadbalancer/nework: internet
+- name: internalconfig
+  loadBalancerService:
+    annotations:
+      loadbalancer/nework: internal
+  sni:
+    ingress:
+      namespace: ingress-internal
+      labels:
+        network: internal
+```
+
+Each Gardenlet can define how the handler of a certain `ExposureClass` needs to be implemented for the Seed(s) where it is responsible for.
+
+The `.name` is the name of the handler config and it must match to the `.handler` in the `ExposureClass`.
+
+All control planes on a `Seed` are exposed via a load balancer.
+Either a dedicated one or a central shared one.
+The load balancer service needs to be configured in a way that it is reachable from the target network environment.
+Therefore, the configuration of load balancer service need to be specified which can be done via the `.loadBalancerService` section.
+The common way to influence load balancer service behaviour is via annotations where the respective cloud-controller-manager will react on and configure the infrastucture load balancer accordingly.
+
+In case the Gardenlet runs with activated `APIServerSNI` feature flag (default), the control planes on a `Seed` will be exposed via a central load balancer and with Envoy via TLS SNI passthrough.
+In this case, the Gardenlet will install a dedicated ingress gateway (Envoy + load balancer + respective configuration) for each handler on the `Seed`.
+The configuration of the ingress gateways can be controlled via the `.sni` section in the same way like for the default ingress gateways.

--- a/example/20-componentconfig-gardener-controller-manager.yaml
+++ b/example/20-componentconfig-gardener-controller-manager.yaml
@@ -58,6 +58,8 @@ controllers:
     concurrentSyncs: 5
   controllerRegistration:
     concurrentSyncs: 5
+  exposureClass:
+    concurrentSyncs: 5
 leaderElection:
   leaderElect: true
   leaseDuration: 15s

--- a/example/20-componentconfig-gardenlet.yaml
+++ b/example/20-componentconfig-gardenlet.yaml
@@ -113,3 +113,17 @@ featureGates:
 #     namespace: istio-ingress
 #     labels:
 #       istio: ingressgateway
+# exposureClassHandlers:
+# - name: internetconfig
+#   loadBalancerService:
+#     annotations:
+#       loadbalancer/nework: internet
+# - name: internalconfig
+#   loadBalancerService:
+#     annotations:
+#       loadbalancer/nework: internal
+#   sni:
+#     ingress:
+#       namespace: ingress-internal
+#       labels:
+#         network: internal

--- a/example/81_exposureclass.yaml
+++ b/example/81_exposureclass.yaml
@@ -1,0 +1,13 @@
+# ExposureClass allow to expose a Shoot clusters control plane in a certain network enviroment e.g. a restricted corporate network.
+---
+apiVersion: core.gardener.cloud/v1alpha1
+kind: ExposureClass
+metadata:
+  name: internet
+handler: internetconfig # Gardenlet need to have configuration for a handler in its configuration.
+scheduling:
+  seedSelector:
+    matchLabels:
+      foo: bar
+  # tolerations:
+  # - key: <some-key>

--- a/example/90-shoot.yaml
+++ b/example/90-shoot.yaml
@@ -323,3 +323,4 @@ spec:
 #     apiVersion: v1
 #     kind: Secret
 #     name: my-foobar-secret
+# exposureClassName: <exposure-class-name>

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -173,11 +173,6 @@ func ValidateShootSpec(meta metav1.ObjectMeta, spec *core.ShootSpec, fldPath *fi
 	}
 	allErrs = append(allErrs, ValidateTolerations(spec.Tolerations, fldPath.Child("tolerations"))...)
 
-	// TODO(dkister) This can be removed once the exposureclass implementation has been completed.
-	if spec.ExposureClassName != nil {
-		allErrs = append(allErrs, field.Forbidden(fldPath.Child("exposureClassName"), "exposure class can currently not be referenced"))
-	}
-
 	return allErrs
 }
 

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -357,13 +357,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 
 				errorList := ValidateShootUpdate(newShoot, shoot)
 
-				// TODO(dkistner) The test condition can be removed once the exposureclass implementation has been completed.
-				// The errorList should then have len() == 0
-				Expect(errorList).To(HaveLen(1))
-				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeForbidden),
-					"Field": Equal("spec.exposureClassName"),
-				}))))
+				Expect(errorList).To(HaveLen(0))
 			})
 
 			It("should forbid to change the exposure class", func() {
@@ -378,23 +372,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 						"Type":  Equal(field.ErrorTypeInvalid),
 						"Field": Equal("spec.exposureClassName"),
 					})),
-					// TODO(dkistner) This test condition can be removed once the exposureclass implementation has been completed.
-					PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":  Equal(field.ErrorTypeForbidden),
-						"Field": Equal("spec.exposureClassName"),
-					})),
 				))
-			})
-
-			// TODO(dkistner) This can be removed once the exposureclass implementation has been completed.
-			It("should forbid referencing an exposure class", func() {
-				shoot.Spec.ExposureClassName = pointer.String("some-exposure-class")
-
-				errorList := ValidateShoot(shoot)
-				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeForbidden),
-					"Field": Equal("spec.exposureClassName"),
-				}))))
 			})
 		})
 


### PR DESCRIPTION
**How to categorize this PR?**
/area control-plane open-source
/kind enhancement

**What this PR does / why we need it**:
This PR implements the final step of the Selectable Api Server endpoint story. This story will be implemented in several steps, see: #3505 (comment) The previous PR can be found here: #3951,  #4117 and here #4243

This PR adds examples and documentation for ExposureClass resource usage and configuration.
Furthermore it removes the validation which prevents Shoot clusters to reference an ExposureClass. 
This will actually activate the feature.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
~~This PR need to stay in draft until all previous steps are integrated.~~
All the required prior steps are now integrated.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Shoot clusters can now reference an ExposureClass to expose their control plane in various network environments via the `.spec.exposureClassName`. Find more information in [this document](https://github.com/gardener/gardener/blob/master/docs/usage/exposureclasses.md).
```
```feature operator
Shoot clusters can now use ExposureClasses to expose the control plane in various network environments. The Gardenlet needs to realize the exposure strategy and is therefore required to have the ExposureClass handler configuration in its own config. This can be maintained in the `.exposureClassHandlers` list of the Gardenlet configuration. Find more information in [this document](https://github.com/gardener/gardener/blob/master/docs/usage/exposureclasses.md).
```

