### PR TITLE
Promote ReversedVPN feature gate to beta

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -25,11 +25,12 @@ The following tables are a summary of the feature gates that you can set on diff
 | HVPAForShootedSeed | `false` | `Alpha` | `0.32` | |
 | ManagedIstio | `true` | `Beta` | `1.19` | |
 | APIServerSNI | `true` | `Beta` | `1.19` | |
-| MountHostCADirectories | `false` | `Alpha` | `1.11.0` | `1.25.0` |
-| MountHostCADirectories | `true` | `Beta` | `1.26.0` | |
-| SeedChange | `false` | `Alpha` | `1.12.0` | |
-| SeedKubeScheduler | `false` | `Alpha` | `1.15.0` | |
-| ReversedVPN | `false` | `Alpha` | `1.22.0` | |
+| MountHostCADirectories | `false` | `Alpha` | `1.11` | `1.25` |
+| MountHostCADirectories | `true` | `Beta` | `1.26` | |
+| SeedChange | `false` | `Alpha` | `1.12` | |
+| SeedKubeScheduler | `false` | `Alpha` | `1.15` | |
+| ReversedVPN | `false` | `Alpha` | `1.22` | `v1.25`|
+| ReversedVPN | `true` | `Beta` | `1.26` | |
 
 ## Using a feature
 

--- a/example/20-componentconfig-gardenlet.yaml
+++ b/example/20-componentconfig-gardenlet.yaml
@@ -98,7 +98,7 @@ featureGates:
   NodeLocalDNS: true
   MountHostCADirectories: true
   SeedKubeScheduler: false
-  ReversedVPN: false
+  ReversedVPN: true
 seedSelector: {} # selects all seeds, only use for development purposes
 # seedConfig:
 #   metadata:

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -95,6 +95,7 @@ const (
 	// ReversedVPN moves the openvpn server to the seed.
 	// owner: @scheererj @docktofuture
 	// alpha: v1.22.0
+	// beta: v1.26.0
 	ReversedVPN featuregate.Feature = "ReversedVPN"
 
 	// AdminKubeconfigRequest enables the AdminKubeconfigRequest endpoint on shoot resources.

--- a/pkg/gardenlet/features/features.go
+++ b/pkg/gardenlet/features/features.go
@@ -35,7 +35,7 @@ var (
 		features.NodeLocalDNS:           {Default: false, PreRelease: featuregate.Alpha},
 		features.MountHostCADirectories: {Default: true, PreRelease: featuregate.Beta},
 		features.SeedKubeScheduler:      {Default: false, PreRelease: featuregate.Alpha},
-		features.ReversedVPN:            {Default: false, PreRelease: featuregate.Alpha},
+		features.ReversedVPN:            {Default: true, PreRelease: featuregate.Beta},
 	}
 )
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Promote ReversedVPN feature gate to beta.

**Special notes for your reviewer**:
/invite @DockToFuture @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
The `ReversedVPN` feature gate in the `gardenlet` has been promoted to beta and is now enabled by default.
```
