### PR TITLE
Fix for splitting of envoy filters into separate resources for reverse vpn and sni.

### DIFF
--- a/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server.go
+++ b/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server.go
@@ -584,18 +584,16 @@ func (v *vpnSeedServer) Deploy(ctx context.Context) error {
 	}
 
 	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, v.client, envoyFilter, func() error {
-		envoyFilter.ObjectMeta = metav1.ObjectMeta{
-			Name:      envoyFilter.Name,
-			Namespace: envoyFilter.Namespace,
-			OwnerReferences: []metav1.OwnerReference{
-				metav1.OwnerReference{
-					APIVersion:         "v1",
-					Kind:               "Namespace",
-					Name:               v.namespace,
-					UID:                v.namespaceUID,
-					Controller:         pointer.BoolPtr(false),
-					BlockOwnerDeletion: pointer.BoolPtr(false),
-				},
+		envoyFilter.ObjectMeta.Name = envoyFilter.Name
+		envoyFilter.ObjectMeta.Namespace = envoyFilter.Namespace
+		envoyFilter.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
+			{
+				APIVersion:         "v1",
+				Kind:               "Namespace",
+				Name:               v.namespace,
+				UID:                v.namespaceUID,
+				Controller:         pointer.BoolPtr(false),
+				BlockOwnerDeletion: pointer.BoolPtr(false),
 			},
 		}
 		envoyFilter.Spec.WorkloadSelector = &istionetworkingv1alpha3.WorkloadSelector{
@@ -608,7 +606,7 @@ func (v *vpnSeedServer) Deploy(ctx context.Context) error {
 					Context: istionetworkingv1alpha3.EnvoyFilter_GATEWAY,
 					ObjectTypes: &istionetworkingv1alpha3.EnvoyFilter_EnvoyConfigObjectMatch_Listener{
 						Listener: &istionetworkingv1alpha3.EnvoyFilter_ListenerMatch{
-							Name:       "0.0.0.0_" + string(rune(istio.GatewayPort)),
+							Name:       fmt.Sprintf("0.0.0.0_%d", istio.GatewayPort),
 							PortNumber: istio.GatewayPort,
 							FilterChain: &istionetworkingv1alpha3.EnvoyFilter_ListenerMatch_FilterChainMatch{
 								Filter: &istionetworkingv1alpha3.EnvoyFilter_ListenerMatch_FilterMatch{
@@ -659,7 +657,7 @@ func (v *vpnSeedServer) Deploy(ctx context.Context) error {
 																										Values: []*protobuftypes.Value{
 																											{
 																												Kind: &protobuftypes.Value_StringValue{
-																													StringValue: *v.kubeAPIServerHost + ":" + string(rune(istio.GatewayPort)),
+																													StringValue: fmt.Sprintf("%s:%d", *v.kubeAPIServerHost, istio.GatewayPort),
 																												},
 																											},
 																										},

--- a/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server_test.go
+++ b/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server_test.go
@@ -585,7 +585,7 @@ var _ = Describe("VpnSeedServer", func() {
 							Context: istionetworkingv1alpha3.EnvoyFilter_GATEWAY,
 							ObjectTypes: &istionetworkingv1alpha3.EnvoyFilter_EnvoyConfigObjectMatch_Listener{
 								Listener: &istionetworkingv1alpha3.EnvoyFilter_ListenerMatch{
-									Name:       "0.0.0.0_" + string(rune(istio.GatewayPort)),
+									Name:       fmt.Sprintf("0.0.0.0_%d", istio.GatewayPort),
 									PortNumber: istio.GatewayPort,
 									FilterChain: &istionetworkingv1alpha3.EnvoyFilter_ListenerMatch_FilterChainMatch{
 										Filter: &istionetworkingv1alpha3.EnvoyFilter_ListenerMatch_FilterMatch{
@@ -636,7 +636,7 @@ var _ = Describe("VpnSeedServer", func() {
 																												Values: []*protobuftypes.Value{
 																													{
 																														Kind: &protobuftypes.Value_StringValue{
-																															StringValue: kubeAPIServerHost + ":" + string(rune(istio.GatewayPort)),
+																															StringValue: fmt.Sprintf("%s:%d", kubeAPIServerHost, istio.GatewayPort),
 																														},
 																													},
 																												},


### PR DESCRIPTION
The port was not correctly set into the envoy filter and the meta data, in particular the resource version, was always overwritten causing updates to fail.

Co-authored-by: Sebastian Stauch <sebastian.stauch@sap.com>

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
While splitting the envoy filters into separate entities for reverse vpn and sni some errors were introduced. The port was not correctly set into the envoy filter and the meta data, in particular the resource version, was always overwritten causing updates to fail.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
None
```
