### PR TITLE
Refactored support for node local dns.

### DIFF
--- a/docs/usage/node-local-dns.md
+++ b/docs/usage/node-local-dns.md
@@ -21,12 +21,11 @@ To workaround the issues described above, `node-local-dns` was introduced. The a
 
 ## Configuring NodeLocalDNS
 
-All that needs to be done to enable the usage of the `node-local-dns` feature is to set the corresponding feature-gate to true for the
-`Gardenlet`:
+All that needs to be done to enable the usage of the `node-local-dns` feature is to annotate the `Shoot` resource with the annotation `alpha.featuregates.shoot.gardener.cloud/node-local-dns` set to `"true"`:
 
 ```yaml
- featureGates:
-   NodeLocalDNS: true
+ annotations:
+   alpha.featuregates.shoot.gardener.cloud/node-local-dns: "true"
 ```
 
 It is worth noting that: 

--- a/example/20-componentconfig-gardenlet.yaml
+++ b/example/20-componentconfig-gardenlet.yaml
@@ -95,7 +95,6 @@ featureGates:
   KonnectivityTunnel: false
   APIServerSNI: true
   CachedRuntimeClients: true
-  NodeLocalDNS: true
   MountHostCADirectories: true
   SeedKubeScheduler: false
   ReversedVPN: false

--- a/pkg/apis/core/v1alpha1/constants/types_constants.go
+++ b/pkg/apis/core/v1alpha1/constants/types_constants.go
@@ -223,6 +223,8 @@ const (
 	AnnotationShootKonnectivityTunnel = "alpha.featuregates.shoot.gardener.cloud/konnectivity-tunnel"
 	// AnnotationReversedVPN moves the vpn-server to the seed.
 	AnnotationReversedVPN = "alpha.featuregates.shoot.gardener.cloud/reversed-vpn"
+	// AnnotationNodeLocalDNS enables a per node dns cache on the shoot cluster.
+	AnnotationNodeLocalDNS = "alpha.featuregates.shoot.gardener.cloud/node-local-dns"
 
 	// OperatingSystemConfigUnitNameKubeletService is a constant for a unit in the operating system config that contains the kubelet service.
 	OperatingSystemConfigUnitNameKubeletService = "kubelet.service"

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -373,6 +373,8 @@ const (
 	AnnotationShootKonnectivityTunnel = "alpha.featuregates.shoot.gardener.cloud/konnectivity-tunnel"
 	// AnnotationReversedVPN moves the vpn-server to the seed.
 	AnnotationReversedVPN = "alpha.featuregates.shoot.gardener.cloud/reversed-vpn"
+	// AnnotationNodeLocalDNS enables a per node dns cache on the shoot cluster.
+	AnnotationNodeLocalDNS = "alpha.featuregates.shoot.gardener.cloud/node-local-dns"
 
 	// AnnotationShootAPIServerSNIPodInjector is the key for an annotation of a Shoot cluster whose value indicates
 	// if pod injection of 'KUBERNETES_SERVICE_HOST' environment variable should happen for clusters where APIServerSNI

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -70,11 +70,6 @@ const (
 	// alpha: v1.7.0
 	CachedRuntimeClients featuregate.Feature = "CachedRuntimeClients"
 
-	// NodeLocalDNS enables node-local-dns cache feature.
-	// owner @DockToFuture
-	// alpha: v1.7.0
-	NodeLocalDNS featuregate.Feature = "NodeLocalDNS"
-
 	// MountHostCADirectories enables mounting common CA certificate directories in the Shoot API server pod that might be required for webhooks or OIDC.
 	// owner @danielfoehrKn
 	// alpha: v1.11.0

--- a/pkg/gardenlet/features/features.go
+++ b/pkg/gardenlet/features/features.go
@@ -32,7 +32,6 @@ var (
 		features.KonnectivityTunnel:     {Default: false, PreRelease: featuregate.Alpha},
 		features.APIServerSNI:           {Default: true, PreRelease: featuregate.Beta},
 		features.CachedRuntimeClients:   {Default: false, PreRelease: featuregate.Alpha},
-		features.NodeLocalDNS:           {Default: false, PreRelease: featuregate.Alpha},
 		features.MountHostCADirectories: {Default: true, PreRelease: featuregate.Beta},
 		features.SeedKubeScheduler:      {Default: false, PreRelease: featuregate.Alpha},
 		features.ReversedVPN:            {Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/operation/botanist/component/networkpolicies/bootstrap_test.go
+++ b/pkg/operation/botanist/component/networkpolicies/bootstrap_test.go
@@ -119,7 +119,7 @@ var _ = Describe("Bootstrap", func() {
 			Expect(registry.Add(constructNPAllowToAggregatePrometheus(namespace))).To(Succeed())
 			Expect(registry.Add(constructNPAllowToAllShootAPIServers(namespace, values.SNIEnabled))).To(Succeed())
 			Expect(registry.Add(constructNPAllowToBlockedCIDRs(namespace, values.BlockedAddresses))).To(Succeed())
-			Expect(registry.Add(constructNPAllowToDNS(namespace, values.NodeLocalDNSEnabled, values.DNSServerAddress, values.NodeLocalIPVSAddress))).To(Succeed())
+			Expect(registry.Add(constructNPAllowToDNS(namespace, values.DNSServerAddress, values.NodeLocalIPVSAddress))).To(Succeed())
 			Expect(registry.Add(constructNPDenyAll(namespace, values.DenyAllTraffic))).To(Succeed())
 			Expect(registry.Add(constructNPAllowToPrivateNetworks(namespace, values.PrivateNetworkPeers))).To(Succeed())
 			Expect(registry.Add(constructNPAllowToPublicNetworks(namespace, values.BlockedAddresses))).To(Succeed())
@@ -139,7 +139,7 @@ var _ = Describe("Bootstrap", func() {
 			Expect(deployer.Deploy(ctx)).To(Succeed())
 		})
 
-		It("should successfully deploy all the resources (w/ SNI enabled, w/ blocked addresses, w/ node-local DNS, w/ deny all, w/ private network peers, w/ shoot network peers)", func() {
+		It("should successfully deploy all the resources (w/ SNI enabled, w/ blocked addresses, w/ deny all, w/ private network peers, w/ shoot network peers)", func() {
 			values = GlobalValues{
 				SNIEnabled:       true,
 				BlockedAddresses: []string{"foo", "bar"},
@@ -148,7 +148,6 @@ var _ = Describe("Bootstrap", func() {
 					{IPBlock: &networkingv1.IPBlock{CIDR: "6.7.8.9/10"}},
 				},
 				DenyAllTraffic:       true,
-				NodeLocalDNSEnabled:  true,
 				NodeLocalIPVSAddress: pointer.StringPtr("node-local-ipvs-address"),
 				DNSServerAddress:     pointer.StringPtr("dns-server-address"),
 			}
@@ -158,7 +157,7 @@ var _ = Describe("Bootstrap", func() {
 			Expect(registry.Add(constructNPAllowToAggregatePrometheus(namespace))).To(Succeed())
 			Expect(registry.Add(constructNPAllowToAllShootAPIServers(namespace, values.SNIEnabled))).To(Succeed())
 			Expect(registry.Add(constructNPAllowToBlockedCIDRs(namespace, values.BlockedAddresses))).To(Succeed())
-			Expect(registry.Add(constructNPAllowToDNS(namespace, values.NodeLocalDNSEnabled, values.DNSServerAddress, values.NodeLocalIPVSAddress))).To(Succeed())
+			Expect(registry.Add(constructNPAllowToDNS(namespace, values.DNSServerAddress, values.NodeLocalIPVSAddress))).To(Succeed())
 			Expect(registry.Add(constructNPDenyAll(namespace, values.DenyAllTraffic))).To(Succeed())
 			Expect(registry.Add(constructNPAllowToPrivateNetworks(namespace, values.PrivateNetworkPeers))).To(Succeed())
 			Expect(registry.Add(constructNPAllowToPublicNetworks(namespace, values.BlockedAddresses))).To(Succeed())

--- a/pkg/operation/botanist/component/networkpolicies/global.go
+++ b/pkg/operation/botanist/component/networkpolicies/global.go
@@ -36,11 +36,9 @@ type GlobalValues struct {
 	// DenyAllTraffic states whether all traffic should be denied by default and must be explicitly allowed by dedicated
 	// network policy rules.
 	DenyAllTraffic bool
-	// NodeLocalDNSEnabled states whether the node-local DNS feature for shoot clusters is enabled.
-	NodeLocalDNSEnabled bool
-	// NodeLocalIPVSAddress is the CIDR of the node-local IPVS address. Only meaningful when NodeLocalDNSEnabled=true.
+	// NodeLocalIPVSAddress is the CIDR of the node-local IPVS address.
 	NodeLocalIPVSAddress *string
-	// DNSServerAddress is the CIDR of the usual DNS server address. Only meaningful when NodeLocalDNSEnabled=true.
+	// DNSServerAddress is the CIDR of the usual DNS server address.
 	DNSServerAddress *string
 }
 
@@ -213,24 +211,22 @@ func getGlobalNetworkPolicyTransformers(values GlobalValues) []networkPolicyTran
 						PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
 					}
 
-					if values.NodeLocalDNSEnabled {
-						if values.DNSServerAddress != nil {
-							obj.Spec.Egress[0].To = append(obj.Spec.Egress[0].To, networkingv1.NetworkPolicyPeer{
-								IPBlock: &networkingv1.IPBlock{
-									// required for node local dns feature, allows egress traffic to kube-dns
-									CIDR: fmt.Sprintf("%s/32", *values.DNSServerAddress),
-								},
-							})
-						}
+					if values.DNSServerAddress != nil {
+						obj.Spec.Egress[0].To = append(obj.Spec.Egress[0].To, networkingv1.NetworkPolicyPeer{
+							IPBlock: &networkingv1.IPBlock{
+								// required for node local dns feature, allows egress traffic to kube-dns
+								CIDR: fmt.Sprintf("%s/32", *values.DNSServerAddress),
+							},
+						})
+					}
 
-						if values.NodeLocalIPVSAddress != nil {
-							obj.Spec.Egress[0].To = append(obj.Spec.Egress[0].To, networkingv1.NetworkPolicyPeer{
-								IPBlock: &networkingv1.IPBlock{
-									// required for node local dns feature, allows egress traffic to node local dns cache
-									CIDR: fmt.Sprintf("%s/32", *values.NodeLocalIPVSAddress),
-								},
-							})
-						}
+					if values.NodeLocalIPVSAddress != nil {
+						obj.Spec.Egress[0].To = append(obj.Spec.Egress[0].To, networkingv1.NetworkPolicyPeer{
+							IPBlock: &networkingv1.IPBlock{
+								// required for node local dns feature, allows egress traffic to node local dns cache
+								CIDR: fmt.Sprintf("%s/32", *values.NodeLocalIPVSAddress),
+							},
+						})
 					}
 
 					return nil

--- a/pkg/operation/botanist/component/networkpolicies/global_test.go
+++ b/pkg/operation/botanist/component/networkpolicies/global_test.go
@@ -127,7 +127,7 @@ func constructNPAllowToBlockedCIDRs(namespace string, blockedAddresses []string)
 	return obj
 }
 
-func constructNPAllowToDNS(namespace string, nodeLocalDNSEnabled bool, dnsServerAddress, nodeLocalIPVSAddress *string) *networkingv1.NetworkPolicy {
+func constructNPAllowToDNS(namespace string, dnsServerAddress, nodeLocalIPVSAddress *string) *networkingv1.NetworkPolicy {
 	var (
 		protocolUDP = corev1.ProtocolUDP
 		protocolTCP = corev1.ProtocolTCP
@@ -171,22 +171,20 @@ func constructNPAllowToDNS(namespace string, nodeLocalDNSEnabled bool, dnsServer
 		}
 	)
 
-	if nodeLocalDNSEnabled {
-		if dnsServerAddress != nil {
-			obj.Spec.Egress[0].To = append(obj.Spec.Egress[0].To, networkingv1.NetworkPolicyPeer{
-				IPBlock: &networkingv1.IPBlock{
-					CIDR: fmt.Sprintf("%s/32", *dnsServerAddress),
-				},
-			})
-		}
+	if dnsServerAddress != nil {
+		obj.Spec.Egress[0].To = append(obj.Spec.Egress[0].To, networkingv1.NetworkPolicyPeer{
+			IPBlock: &networkingv1.IPBlock{
+				CIDR: fmt.Sprintf("%s/32", *dnsServerAddress),
+			},
+		})
+	}
 
-		if nodeLocalIPVSAddress != nil {
-			obj.Spec.Egress[0].To = append(obj.Spec.Egress[0].To, networkingv1.NetworkPolicyPeer{
-				IPBlock: &networkingv1.IPBlock{
-					CIDR: fmt.Sprintf("%s/32", *nodeLocalIPVSAddress),
-				},
-			})
-		}
+	if nodeLocalIPVSAddress != nil {
+		obj.Spec.Egress[0].To = append(obj.Spec.Egress[0].To, networkingv1.NetworkPolicyPeer{
+			IPBlock: &networkingv1.IPBlock{
+				CIDR: fmt.Sprintf("%s/32", *nodeLocalIPVSAddress),
+			},
+		})
 	}
 
 	return obj

--- a/pkg/operation/botanist/component/networkpolicies/networkpolicies_test.go
+++ b/pkg/operation/botanist/component/networkpolicies/networkpolicies_test.go
@@ -68,7 +68,7 @@ var _ = Describe("Networkpolicies", func() {
 			expectGetUpdate(ctx, c, constructNPAllowToAggregatePrometheus(namespace))
 			expectGetUpdate(ctx, c, constructNPAllowToAllShootAPIServers(namespace, values.SNIEnabled))
 			expectGetUpdate(ctx, c, constructNPAllowToBlockedCIDRs(namespace, values.BlockedAddresses))
-			expectGetUpdate(ctx, c, constructNPAllowToDNS(namespace, values.NodeLocalDNSEnabled, values.DNSServerAddress, values.NodeLocalIPVSAddress))
+			expectGetUpdate(ctx, c, constructNPAllowToDNS(namespace, values.DNSServerAddress, values.NodeLocalIPVSAddress))
 			expectGetUpdate(ctx, c, constructNPDenyAll(namespace, values.DenyAllTraffic))
 			expectGetUpdate(ctx, c, constructNPAllowToPrivateNetworks(namespace, values.PrivateNetworkPeers))
 			expectGetUpdate(ctx, c, constructNPAllowToPublicNetworks(namespace, values.BlockedAddresses))
@@ -77,7 +77,7 @@ var _ = Describe("Networkpolicies", func() {
 			Expect(deployer.Deploy(ctx)).To(Succeed())
 		})
 
-		It("w/ SNI enabled, w/ blocked addresses, w/ node-local DNS, w/ deny all, w/ private network peers, w/ shoot network peers", func() {
+		It("w/ SNI enabled, w/ blocked addresses, w/ deny all, w/ private network peers, w/ shoot network peers", func() {
 			values = Values{
 				ShootNetworkPeers: []networkingv1.NetworkPolicyPeer{
 					{IPBlock: &networkingv1.IPBlock{CIDR: "1.2.3.4/5"}},
@@ -91,7 +91,6 @@ var _ = Describe("Networkpolicies", func() {
 						{IPBlock: &networkingv1.IPBlock{CIDR: "6.7.8.9/10"}},
 					},
 					DenyAllTraffic:       true,
-					NodeLocalDNSEnabled:  true,
 					NodeLocalIPVSAddress: pointer.StringPtr("node-local-ipvs-address"),
 					DNSServerAddress:     pointer.StringPtr("dns-server-address"),
 				},
@@ -101,7 +100,7 @@ var _ = Describe("Networkpolicies", func() {
 			expectGetUpdate(ctx, c, constructNPAllowToAggregatePrometheus(namespace))
 			expectGetUpdate(ctx, c, constructNPAllowToAllShootAPIServers(namespace, values.SNIEnabled))
 			expectGetUpdate(ctx, c, constructNPAllowToBlockedCIDRs(namespace, values.BlockedAddresses))
-			expectGetUpdate(ctx, c, constructNPAllowToDNS(namespace, values.NodeLocalDNSEnabled, values.DNSServerAddress, values.NodeLocalIPVSAddress))
+			expectGetUpdate(ctx, c, constructNPAllowToDNS(namespace, values.DNSServerAddress, values.NodeLocalIPVSAddress))
 			expectGetUpdate(ctx, c, constructNPDenyAll(namespace, values.DenyAllTraffic))
 			expectGetUpdate(ctx, c, constructNPAllowToPrivateNetworks(namespace, values.PrivateNetworkPeers))
 			expectGetUpdate(ctx, c, constructNPAllowToPublicNetworks(namespace, values.BlockedAddresses))

--- a/pkg/operation/botanist/networkpolicies.go
+++ b/pkg/operation/botanist/networkpolicies.go
@@ -82,7 +82,6 @@ func (b *Botanist) DefaultNetworkPolicies(sniPhase component.Phase) (component.D
 				BlockedAddresses:     b.Seed.Info.Spec.Networks.BlockCIDRs,
 				PrivateNetworkPeers:  privateNetworkPeers,
 				DenyAllTraffic:       true,
-				NodeLocalDNSEnabled:  b.Shoot.NodeLocalDNSEnabled,
 				NodeLocalIPVSAddress: pointer.StringPtr(common.NodeLocalIPVSAddress),
 				DNSServerAddress:     pointer.StringPtr(seedDNSServerAddress.String()),
 			},

--- a/pkg/operation/botanist/networkpolicies_test.go
+++ b/pkg/operation/botanist/networkpolicies_test.go
@@ -118,7 +118,6 @@ var _ = Describe("Networkpolicies", func() {
 				Expect(values.DenyAllTraffic).To(BeTrue())
 				Expect(values.ShootNetworkPeers).To(BeEmpty())
 				Expect(values.PrivateNetworkPeers).To(ConsistOf(defaultExpectedShootNetworkPeers...))
-				Expect(values.NodeLocalDNSEnabled).To(BeFalse())
 				Expect(values.NodeLocalIPVSAddress).To(PointTo(Equal("169.254.20.10")))
 				Expect(values.DNSServerAddress).To(PointTo(Equal("192.168.0.10")))
 			},
@@ -157,7 +156,6 @@ var _ = Describe("Networkpolicies", func() {
 						Except: []string{podCIDRShoot},
 					}},
 				))
-				Expect(values.NodeLocalDNSEnabled).To(BeFalse())
 				Expect(values.NodeLocalIPVSAddress).To(PointTo(Equal("169.254.20.10")))
 				Expect(values.DNSServerAddress).To(PointTo(Equal("192.168.0.10")))
 			},
@@ -175,7 +173,6 @@ var _ = Describe("Networkpolicies", func() {
 				Expect(values.DenyAllTraffic).To(BeTrue())
 				Expect(values.ShootNetworkPeers).To(BeEmpty())
 				Expect(values.PrivateNetworkPeers).To(ConsistOf(defaultExpectedShootNetworkPeers...))
-				Expect(values.NodeLocalDNSEnabled).To(BeFalse())
 				Expect(values.NodeLocalIPVSAddress).To(PointTo(Equal("169.254.20.10")))
 				Expect(values.DNSServerAddress).To(PointTo(Equal("192.168.0.10")))
 			},
@@ -193,7 +190,6 @@ var _ = Describe("Networkpolicies", func() {
 				Expect(values.DenyAllTraffic).To(BeTrue())
 				Expect(values.ShootNetworkPeers).To(BeEmpty())
 				Expect(values.PrivateNetworkPeers).To(ConsistOf(defaultExpectedShootNetworkPeers...))
-				Expect(values.NodeLocalDNSEnabled).To(BeFalse())
 				Expect(values.NodeLocalIPVSAddress).To(PointTo(Equal("169.254.20.10")))
 				Expect(values.DNSServerAddress).To(PointTo(Equal("192.168.0.10")))
 			},
@@ -211,7 +207,6 @@ var _ = Describe("Networkpolicies", func() {
 				Expect(values.DenyAllTraffic).To(BeTrue())
 				Expect(values.ShootNetworkPeers).To(BeEmpty())
 				Expect(values.PrivateNetworkPeers).To(ConsistOf(defaultExpectedShootNetworkPeers...))
-				Expect(values.NodeLocalDNSEnabled).To(BeFalse())
 				Expect(values.NodeLocalIPVSAddress).To(PointTo(Equal("169.254.20.10")))
 				Expect(values.DNSServerAddress).To(PointTo(Equal("192.168.0.10")))
 			},
@@ -229,27 +224,6 @@ var _ = Describe("Networkpolicies", func() {
 				Expect(values.DenyAllTraffic).To(BeTrue())
 				Expect(values.ShootNetworkPeers).To(BeEmpty())
 				Expect(values.PrivateNetworkPeers).To(ConsistOf(defaultExpectedShootNetworkPeers...))
-				Expect(values.NodeLocalDNSEnabled).To(BeFalse())
-				Expect(values.NodeLocalIPVSAddress).To(PointTo(Equal("169.254.20.10")))
-				Expect(values.DNSServerAddress).To(PointTo(Equal("192.168.0.10")))
-			},
-		),
-
-		Entry(
-			"node local DNS enabled",
-			component.PhaseDisabled,
-			func() {
-				botanist.Shoot.NodeLocalDNSEnabled = true
-			},
-			func(client client.Client, namespace string, values networkpolicies.Values) {
-				Expect(client).To(Equal(c))
-				Expect(namespace).To(Equal(seedNamespace))
-				Expect(values.SNIEnabled).To(BeFalse())
-				Expect(values.BlockedAddresses).To(BeEmpty())
-				Expect(values.DenyAllTraffic).To(BeTrue())
-				Expect(values.ShootNetworkPeers).To(BeEmpty())
-				Expect(values.PrivateNetworkPeers).To(ConsistOf(defaultExpectedShootNetworkPeers...))
-				Expect(values.NodeLocalDNSEnabled).To(BeTrue())
 				Expect(values.NodeLocalIPVSAddress).To(PointTo(Equal("169.254.20.10")))
 				Expect(values.DNSServerAddress).To(PointTo(Equal("192.168.0.10")))
 			},

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -901,7 +901,6 @@ func runCreateSeedFlow(
 		SNIEnabled:           gardenletfeatures.FeatureGate.Enabled(features.APIServerSNI) || anySNI,
 		DenyAllTraffic:       false,
 		PrivateNetworkPeers:  privateNetworkPeers,
-		NodeLocalDNSEnabled:  gardenletfeatures.FeatureGate.Enabled(features.NodeLocalDNS),
 		NodeLocalIPVSAddress: pointer.StringPtr(common.NodeLocalIPVSAddress),
 		DNSServerAddress:     pointer.StringPtr(seedDNSServerAddress.String()),
 	})

--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -284,7 +284,11 @@ func (b *Builder) Build(ctx context.Context, c client.Client) (*Shoot, error) {
 	}
 	shoot.Networks = networks
 
-	shoot.NodeLocalDNSEnabled = gardenletfeatures.FeatureGate.Enabled(features.NodeLocalDNS)
+	shoot.NodeLocalDNSEnabled = false
+	if nodeLocalDNSEnabled, err := strconv.ParseBool(shoot.Info.Annotations[v1beta1constants.AnnotationNodeLocalDNS]); err == nil {
+		shoot.NodeLocalDNSEnabled = nodeLocalDNSEnabled
+	}
+
 	shoot.Purpose = gardencorev1beta1helper.GetPurpose(shootObject)
 
 	return shoot, nil


### PR DESCRIPTION
Removed feature flag and introduced a shoot specific annotation instead.
All (dns related) network policies now always allow the traffic to the node local dns endpoints.
Node local dns should no longer have a cascading effect requiring shoots to enable it if it is enabled on the seed.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind api-change

**What this PR does / why we need it**:
Removed feature flag and introduced a shoot specific annotation instead.
All (dns related) network policies now always allow the traffic to the node local dns endpoints.
Node local dns should no longer have a cascading effect requiring shoots to enable it if it is enabled on the seed.

**Which issue(s) this PR fixes**:
None in particular, but it removes the somewhat broken feature gate NodeLocalDNS, which could not be easily (without downtime and additional effort) be switched.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
Gardenlet feature gate NodeLocalDNS was removed and replaced by a shoot specific annotation.
```
