### PR TITLE
Enable martian packets

### DIFF
--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kernelconfig/component.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kernelconfig/component.go
@@ -64,6 +64,8 @@ net.core.netdev_max_backlog = 5000
 net.core.rmem_max = 16777216
 # Default Socket Send Buffer
 net.core.wmem_max = 16777216
+# enable martian packets
+net.ipv4.conf.default.log_martians = 1
 # Increase the maximum total buffer-space allocatable
 net.ipv4.tcp_wmem = 4096 12582912 16777216
 net.ipv4.tcp_rmem = 4096 12582912 16777216

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kernelconfig/component_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kernelconfig/component_test.go
@@ -73,6 +73,8 @@ net.core.netdev_max_backlog = 5000
 net.core.rmem_max = 16777216
 # Default Socket Send Buffer
 net.core.wmem_max = 16777216
+# enable martian packets
+net.ipv4.conf.default.log_martians = 1
 # Increase the maximum total buffer-space allocatable
 net.ipv4.tcp_wmem = 4096 12582912 16777216
 net.ipv4.tcp_rmem = 4096 12582912 16777216


### PR DESCRIPTION
**How to categorize this PR?**

/area networking
/kind enhancement

**What this PR does / why we need it**:
We want to [enable martian packets](https://en.wikipedia.org/wiki/Martian_packet) to be able to see in the kernel logs when packets are dropped. This is an important indicator for networking problems. We saw it in the past on one cilium cluster on gcp and want to enable it now for all infrastructures (https://github.com/gardener/gardener-extension-networking-cilium/issues/51).


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Martian packets are now explicitly enabled in the kernel settings of the shoot clusters nodes.
```
