### PR TITLE
feat: add helm chart releasing

### DIFF
--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -1,0 +1,32 @@
+name: Helm Chart Releaser
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.5.4
+
+      - name: Release charts (charts/gardener)
+        uses: helm/chart-releaser-action@v1.2.1
+        with:
+          charts_dir: charts/gardener
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/docs/README.md
+++ b/docs/README.md
@@ -127,6 +127,7 @@
 
 ## Deployment
 
+* [Helm charts](deployment/helm_charts.md)
 * [Setup Gardener on a Kubernetes cluster](deployment/setup_gardener.md)
 * [Deploying Gardenlets](deployment/deploy_gardenlet.md)
     * [Automatic Deployment of Gardenlets](deployment/deploy_gardenlet_automatically.md)

--- a/docs/deployment/helm_charts.md
+++ b/docs/deployment/helm_charts.md
@@ -1,0 +1,18 @@
+# Helm charts
+
+Helm charts are maintained in the `charts` directory.
+
+To enable deployment directly via helm without depending on addons or a cloned git repository,
+some charts are also published to GitHub pages.
+
+You can add them with
+
+```sh
+helm repo add gardener https://gardener.github.io/gardener/
+helm repo update
+```
+
+Currently, only the following charts are part of the chart repository:
+
+* controlplane
+* gardenlet

--- a/docs/development/process.md
+++ b/docs/development/process.md
@@ -37,6 +37,16 @@ v1.33   | Week 39-40  | September 27, 2021     | October 10, 2021   | [@voelzmo]
 Apart from the release of the next version, the release responsible is also taking care of potential hotfix releases of the last three minor versions.
 The release responsible is the main contact person for coordinating new feature PRs for the next minor versions or cherry-pick PRs for the last three minor versions.
 
+### Release of helm charts
+
+The helm charts are released in lockstep with gardener releases. Check [the discussion in #4123](https://github.com/gardener/gardener/issues/4123) for more information about this decision.
+
+Therefore, the helm chart versions for the [controlplane](../../charts/gardener/controlplane/Chart.yaml) and [gardenlet](../../charts/gardener/gardenlet/Chart.yaml) charts have to be bumped during the release process.
+
+Set the version to the same as the gardener version that is to be released, but remove the `v` in front of the version number for a valid semver version.
+
+Once the changes are commited/merged to master, the [Chart releaser action](../../.github/workflows/release-charts.yaml) will release the new version and publish it to the repository at https://gardener.github.io/gardener/.
+
 ### Release Validation
 
 The release phase for a new minor version lasts two weeks.


### PR DESCRIPTION
**How to categorize this PR?**
/area usability
/kind enhancement

**What this PR does / why we need it**:
This implements the chart releasing and documentation for it as discussed in #4123.

**Which issue(s) this PR fixes**:
Parts of #4123 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
helm charts are now released in a repository. 
```
