### PR TITLE
Allow gardenlet to list and watch priorityclasses.scheduling.k8s.io in the seeed cluster

### DIFF
--- a/charts/gardener/gardenlet/charts/runtime/templates/clusterrole-gardenlet.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/clusterrole-gardenlet.yaml
@@ -299,6 +299,8 @@ rules:
   - create
   - delete
   - get
+  - list
+  - watch
   - patch
   - update
 - nonResourceURLs:

--- a/landscaper/pkg/gardenlet/chart/charttest/charttest.go
+++ b/landscaper/pkg/gardenlet/chart/charttest/charttest.go
@@ -306,7 +306,7 @@ func getGardenletClusterRole(labels map[string]string) *rbacv1.ClusterRole {
 			{
 				APIGroups: []string{"scheduling.k8s.io"},
 				Resources: []string{"priorityclasses"},
-				Verbs:     []string{"create", "delete", "get", "patch", "update"},
+				Verbs:     []string{"create", "delete", "get", "list", "watch", "patch", "update"},
 			},
 			{
 				NonResourceURLs: []string{"/healthz", "/version"},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug

**What this PR does / why we need it**:
Fix errors in the gardenlet like 
```
E0624 14:51:52.028638       1 reflector.go:138] sigs.k8s.io/controller-runtime/pkg/cache/internal/informers_map.go:241: Failed to watch *v1.PriorityClass: failed to list *v1.PriorityClass: priorityclasses.scheduling.k8s.io is forbidden: User "system:serviceaccount:garden:gardenlet" cannot list resource "priorityclasses" in API group "scheduling.k8s.io" at the cluster scope
```


**Which issue(s) this PR fixes**:
Follow up after #4129

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
