### PR TITLE
Move kube-apiserver exposure related functions into dedicated file

### DIFF
--- a/pkg/apis/seedmanagement/validation/managedseedset.go
+++ b/pkg/apis/seedmanagement/validation/managedseedset.go
@@ -72,7 +72,7 @@ func ValidateManagedSeedSetStatusUpdate(newManagedSeedSet, oldManagedSeedSet *se
 		allErrs = append(allErrs, field.Invalid(statusPath.Child("nextReplicaNumber"), newManagedSeedSet.Status.NextReplicaNumber, "cannot be decremented"))
 	}
 	if isDecremented(newManagedSeedSet.Status.CollisionCount, oldManagedSeedSet.Status.CollisionCount) {
-		value := pointer.Int32PtrDerefOr(newManagedSeedSet.Status.CollisionCount, 0)
+		value := pointer.Int32Deref(newManagedSeedSet.Status.CollisionCount, 0)
 		allErrs = append(allErrs, field.Invalid(statusPath.Child("collisionCount"), value, "cannot be decremented"))
 	}
 

--- a/pkg/gardenlet/controller/shoot/shoot_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control.go
@@ -100,11 +100,11 @@ func (c *Controller) shootDelete(obj interface{}) {
 }
 
 func (c *Controller) reconcileInMaintenanceOnly() bool {
-	return pointer.BoolPtrDerefOr(c.config.Controllers.Shoot.ReconcileInMaintenanceOnly, false)
+	return pointer.BoolDeref(c.config.Controllers.Shoot.ReconcileInMaintenanceOnly, false)
 }
 
 func (c *Controller) respectSyncPeriodOverwrite() bool {
-	return pointer.BoolPtrDerefOr(c.config.Controllers.Shoot.RespectSyncPeriodOverwrite, false)
+	return pointer.BoolDeref(c.config.Controllers.Shoot.RespectSyncPeriodOverwrite, false)
 }
 
 func confineSpecUpdateRollout(maintenance *gardencorev1beta1.Maintenance) bool {

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -717,11 +717,6 @@ func (b *Botanist) getAuditPolicy(ctx context.Context, name, namespace string) (
 	return auditPolicy, nil
 }
 
-// DefaultKubeAPIServerService returns a deployer for kube-apiserver service.
-func (b *Botanist) DefaultKubeAPIServerService(sniPhase component.Phase) component.DeployWaiter {
-	return b.kubeAPIServiceService(sniPhase)
-}
-
 func (b *Botanist) getKubeApiServerServiceAnnotations(sniPhase component.Phase) map[string]string {
 	if b.ExposureClassHandler != nil && sniPhase != component.PhaseEnabled {
 		return utils.MergeStringMaps(b.Seed.LoadBalancerServiceAnnotations, b.ExposureClassHandler.LoadBalancerService.Annotations)

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -749,11 +749,6 @@ func (b *Botanist) SNIPhase(ctx context.Context) (component.Phase, error) {
 	}
 }
 
-// DeployKubeAPIService deploys for kube-apiserver service.
-func (b *Botanist) DeployKubeAPIService(ctx context.Context, sniPhase component.Phase) error {
-	return b.newKubeAPIServiceServiceComponent(sniPhase).Deploy(ctx)
-}
-
 // DeployKubeAPIServerSNI deploys the kube-apiserver-sni chart.
 func (b *Botanist) DeployKubeAPIServerSNI(ctx context.Context) error {
 	return b.Shoot.Components.ControlPlane.KubeAPIServerSNI.Deploy(ctx)

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -30,11 +30,9 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
 	"github.com/gardener/gardener/pkg/features"
 	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
-	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/etcd"
 	extensionscontrolplane "github.com/gardener/gardener/pkg/operation/botanist/component/extensions/controlplane"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/dns"
-	"github.com/gardener/gardener/pkg/operation/botanist/component/kubeapiserverexposure"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/vpnseedserver"
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils"
@@ -715,30 +713,6 @@ func (b *Botanist) getAuditPolicy(ctx context.Context, name, namespace string) (
 		return "", fmt.Errorf("missing '.data.policy' in audit policy configmap %v/%v", namespace, name)
 	}
 	return auditPolicy, nil
-}
-
-func (b *Botanist) setAPIServerServiceClusterIP(clusterIP string) {
-	if b.Shoot.Components.ControlPlane.KubeAPIServerSNIPhase == component.PhaseDisabled {
-		return
-	}
-
-	b.APIServerClusterIP = clusterIP
-
-	b.Shoot.Components.ControlPlane.KubeAPIServerSNI = kubeapiserverexposure.NewSNI(
-		b.K8sSeedClient.Client(),
-		b.K8sSeedClient.Applier(),
-		b.Shoot.SeedNamespace,
-		&kubeapiserverexposure.SNIValues{
-			APIServerClusterIP: clusterIP,
-			NamespaceUID:       b.SeedNamespaceObject.UID,
-			Hosts: []string{
-				gutil.GetAPIServerDomain(*b.Shoot.ExternalClusterDomain),
-				gutil.GetAPIServerDomain(b.Shoot.InternalClusterDomain),
-			},
-			IstioIngressGateway:      b.getIngressGatewayConfig(),
-			APIServerInternalDNSName: b.outOfClusterAPIServerFQDN(),
-		},
-	)
 }
 
 // setAPIServerAddress sets the IP address of the API server's LoadBalancer.

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -749,11 +749,6 @@ func (b *Botanist) SNIPhase(ctx context.Context) (component.Phase, error) {
 	}
 }
 
-// DeployKubeAPIServerSNI deploys the kube-apiserver-sni chart.
-func (b *Botanist) DeployKubeAPIServerSNI(ctx context.Context) error {
-	return b.Shoot.Components.ControlPlane.KubeAPIServerSNI.Deploy(ctx)
-}
-
 func (b *Botanist) setAPIServerServiceClusterIP(clusterIP string) {
 	if b.Shoot.Components.ControlPlane.KubeAPIServerSNIPhase == component.PhaseDisabled {
 		return

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -717,28 +717,6 @@ func (b *Botanist) getAuditPolicy(ctx context.Context, name, namespace string) (
 	return auditPolicy, nil
 }
 
-func (b *Botanist) kubeAPIServiceService(sniPhase component.Phase) component.DeployWaiter {
-	var sniServiceKey = client.ObjectKey{Name: *b.Config.SNI.Ingress.ServiceName, Namespace: *b.Config.SNI.Ingress.Namespace}
-	if b.ExposureClassHandler != nil {
-		sniServiceKey.Name = *b.ExposureClassHandler.SNI.Ingress.ServiceName
-		sniServiceKey.Namespace = *b.ExposureClassHandler.SNI.Ingress.Namespace
-	}
-
-	return kubeapiserverexposure.NewService(
-		b.Logger,
-		b.K8sSeedClient.Client(),
-		&kubeapiserverexposure.ServiceValues{
-			Annotations: b.getKubeApiServerServiceAnnotations(sniPhase),
-			SNIPhase:    sniPhase,
-		},
-		client.ObjectKey{Name: v1beta1constants.DeploymentNameKubeAPIServer, Namespace: b.Shoot.SeedNamespace},
-		sniServiceKey,
-		nil,
-		b.setAPIServerServiceClusterIP,
-		func(address string) { b.setAPIServerAddress(address, b.K8sSeedClient.Client()) },
-	)
-}
-
 // SNIPhase returns the current phase of the SNI enablement of kube-apiserver's service.
 func (b *Botanist) SNIPhase(ctx context.Context) (component.Phase, error) {
 	var (
@@ -773,7 +751,7 @@ func (b *Botanist) SNIPhase(ctx context.Context) (component.Phase, error) {
 
 // DeployKubeAPIService deploys for kube-apiserver service.
 func (b *Botanist) DeployKubeAPIService(ctx context.Context, sniPhase component.Phase) error {
-	return b.kubeAPIServiceService(sniPhase).Deploy(ctx)
+	return b.newKubeAPIServiceServiceComponent(sniPhase).Deploy(ctx)
 }
 
 // DeployKubeAPIServerSNI deploys the kube-apiserver-sni chart.

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -717,13 +717,6 @@ func (b *Botanist) getAuditPolicy(ctx context.Context, name, namespace string) (
 	return auditPolicy, nil
 }
 
-func (b *Botanist) getKubeApiServerServiceAnnotations(sniPhase component.Phase) map[string]string {
-	if b.ExposureClassHandler != nil && sniPhase != component.PhaseEnabled {
-		return utils.MergeStringMaps(b.Seed.LoadBalancerServiceAnnotations, b.ExposureClassHandler.LoadBalancerService.Annotations)
-	}
-	return b.Seed.LoadBalancerServiceAnnotations
-}
-
 func (b *Botanist) kubeAPIServiceService(sniPhase component.Phase) component.DeployWaiter {
 	var sniServiceKey = client.ObjectKey{Name: *b.Config.SNI.Ingress.ServiceName, Namespace: *b.Config.SNI.Ingress.Namespace}
 	if b.ExposureClassHandler != nil {

--- a/pkg/operation/botanist/controlplane_test.go
+++ b/pkg/operation/botanist/controlplane_test.go
@@ -20,48 +20,22 @@ import (
 
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	cr "github.com/gardener/gardener/pkg/chartrenderer"
-	"github.com/gardener/gardener/pkg/client/kubernetes"
-	fakeclientset "github.com/gardener/gardener/pkg/client/kubernetes/fake"
-	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
-	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/operation"
 	mockcontrolplane "github.com/gardener/gardener/pkg/operation/botanist/component/extensions/controlplane/mock"
 	mockdnsrecord "github.com/gardener/gardener/pkg/operation/botanist/component/extensions/dnsrecord/mock"
 	mockinfrastructure "github.com/gardener/gardener/pkg/operation/botanist/component/extensions/infrastructure/mock"
-	"github.com/gardener/gardener/pkg/operation/garden"
 	"github.com/gardener/gardener/pkg/operation/shoot"
-	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 
-	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
-	"github.com/sirupsen/logrus"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/version"
-	"k8s.io/utils/pointer"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var _ = Describe("controlplane", func() {
-	const (
-		seedNS  = "test-ns"
-		shootNS = "shoot-ns"
-	)
-
 	var (
-		ctrl   *gomock.Controller
-		scheme *runtime.Scheme
-		client client.Client
+		ctrl *gomock.Controller
 
 		infrastructure       *mockinfrastructure.MockInterface
 		controlPlane         *mockcontrolplane.MockInterface
@@ -70,18 +44,12 @@ var _ = Describe("controlplane", func() {
 		internalDNSRecord    *mockdnsrecord.MockInterface
 		botanist             *Botanist
 
-		ctx               = context.TODO()
-		fakeErr           = fmt.Errorf("fake err")
-		dnsEntryTTL int64 = 1234
+		ctx     = context.TODO()
+		fakeErr = fmt.Errorf("fake err")
 	)
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
-
-		scheme = runtime.NewScheme()
-		Expect(dnsv1alpha1.AddToScheme(scheme)).NotTo(HaveOccurred())
-		Expect(corev1.AddToScheme(scheme)).NotTo(HaveOccurred())
-		client = fake.NewClientBuilder().WithScheme(scheme).Build()
 
 		infrastructure = mockinfrastructure.NewMockInterface(ctrl)
 		controlPlane = mockcontrolplane.NewMockInterface(ctrl)
@@ -91,21 +59,9 @@ var _ = Describe("controlplane", func() {
 
 		botanist = &Botanist{
 			Operation: &operation.Operation{
-				Config: &config.GardenletConfiguration{
-					Controllers: &config.GardenletControllerConfiguration{
-						Shoot: &config.ShootControllerConfiguration{
-							DNSEntryTTLSeconds: &dnsEntryTTL,
-						},
-					},
-				},
 				Shoot: &shoot.Shoot{
-					Info: &gardencorev1beta1.Shoot{
-						ObjectMeta: metav1.ObjectMeta{Namespace: shootNS},
-					},
-					SeedNamespace: seedNS,
 					Components: &shoot.Components{
 						Extensions: &shoot.Extensions{
-							DNS:                  &shoot.DNS{},
 							ControlPlane:         controlPlane,
 							ControlPlaneExposure: controlPlaneExposure,
 							ExternalDNSRecord:    externalDNSRecord,
@@ -114,23 +70,8 @@ var _ = Describe("controlplane", func() {
 						},
 					},
 				},
-				Garden: &garden.Garden{},
-				Logger: logrus.NewEntry(logger.NewNopLogger()),
 			},
 		}
-
-		renderer := cr.NewWithServerVersion(&version.Info{})
-		mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{corev1.SchemeGroupVersion, dnsv1alpha1.SchemeGroupVersion})
-		mapper.Add(dnsv1alpha1.SchemeGroupVersion.WithKind("DNSOwner"), meta.RESTScopeRoot)
-		chartApplier := kubernetes.NewChartApplier(renderer, kubernetes.NewApplier(client, mapper))
-		Expect(chartApplier).NotTo(BeNil(), "should return chart applier")
-
-		fakeClientSet := fakeclientset.NewClientSetBuilder().
-			WithChartApplier(chartApplier).
-			WithAPIReader(client).
-			Build()
-
-		botanist.K8sSeedClient = fakeClientSet
 	})
 
 	AfterEach(func() {
@@ -168,119 +109,6 @@ var _ = Describe("controlplane", func() {
 		Entry("nodes <= 10, scaling class xlarge", 10, "xlarge", "2500m", "5200Mi", "3000m", "5900Mi"),
 		Entry("nodes <= 2, scaling class 2xlarge", 2, "2xlarge", "3000m", "5200Mi", "4000m", "7800Mi"),
 	)
-
-	Context("setAPIServerAddress", func() {
-		It("does nothing when DNS is disabled", func() {
-			botanist.Shoot.DisableDNS = true
-
-			botanist.setAPIServerAddress("1.2.3.4", client)
-
-			Expect(botanist.Shoot.Components.Extensions.DNS.InternalOwner).To(BeNil())
-			Expect(botanist.Shoot.Components.Extensions.DNS.InternalEntry).To(BeNil())
-			Expect(botanist.Shoot.Components.Extensions.DNS.ExternalOwner).To(BeNil())
-			Expect(botanist.Shoot.Components.Extensions.DNS.ExternalEntry).To(BeNil())
-		})
-
-		It("sets owners and entries which create DNSOwner and DNSEntry", func() {
-			botanist.Shoot.Info.Status.ClusterIdentity = pointer.String("shoot-cluster-identity")
-			botanist.Shoot.DisableDNS = false
-			botanist.Shoot.Info.Spec.DNS = &gardencorev1beta1.DNS{Domain: pointer.String("foo")}
-			botanist.Shoot.InternalClusterDomain = "bar"
-			botanist.Shoot.ExternalClusterDomain = pointer.String("baz")
-			botanist.Shoot.ExternalDomain = &garden.Domain{Provider: "valid-provider"}
-			botanist.Garden.InternalDomain = &garden.Domain{Provider: "valid-provider"}
-
-			externalDNSRecord.EXPECT().SetRecordType(extensionsv1alpha1.DNSRecordTypeA)
-			externalDNSRecord.EXPECT().SetValues([]string{"1.2.3.4"})
-			internalDNSRecord.EXPECT().SetRecordType(extensionsv1alpha1.DNSRecordTypeA)
-			internalDNSRecord.EXPECT().SetValues([]string{"1.2.3.4"})
-
-			botanist.setAPIServerAddress("1.2.3.4", client)
-
-			Expect(botanist.Shoot.Components.Extensions.DNS.InternalOwner).ToNot(BeNil())
-			Expect(botanist.Shoot.Components.Extensions.DNS.InternalOwner.Deploy(ctx)).ToNot(HaveOccurred())
-			Expect(botanist.Shoot.Components.Extensions.DNS.InternalEntry).ToNot(BeNil())
-			Expect(botanist.Shoot.Components.Extensions.DNS.InternalEntry.Deploy(ctx)).ToNot(HaveOccurred())
-			Expect(botanist.Shoot.Components.Extensions.DNS.ExternalOwner).ToNot(BeNil())
-			Expect(botanist.Shoot.Components.Extensions.DNS.ExternalOwner.Deploy(ctx)).ToNot(HaveOccurred())
-			Expect(botanist.Shoot.Components.Extensions.DNS.ExternalEntry).ToNot(BeNil())
-			Expect(botanist.Shoot.Components.Extensions.DNS.ExternalEntry.Deploy(ctx)).ToNot(HaveOccurred())
-
-			internalOwner := &dnsv1alpha1.DNSOwner{}
-			Expect(client.Get(ctx, types.NamespacedName{Name: seedNS + "-internal"}, internalOwner)).ToNot(HaveOccurred())
-
-			internalEntry := &dnsv1alpha1.DNSEntry{}
-			Expect(client.Get(ctx, types.NamespacedName{Name: "internal", Namespace: seedNS}, internalEntry)).ToNot(HaveOccurred())
-
-			externalOwner := &dnsv1alpha1.DNSOwner{}
-			Expect(client.Get(ctx, types.NamespacedName{Name: seedNS + "-external"}, externalOwner)).ToNot(HaveOccurred())
-
-			externalEntry := &dnsv1alpha1.DNSEntry{}
-			Expect(client.Get(ctx, types.NamespacedName{Name: "external", Namespace: seedNS}, externalEntry)).ToNot(HaveOccurred())
-
-			Expect(internalOwner).To(DeepDerivativeEqual(&dnsv1alpha1.DNSOwner{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:            "test-ns-internal",
-					ResourceVersion: "1",
-				},
-				Spec: dnsv1alpha1.DNSOwnerSpec{
-					OwnerId: "shoot-cluster-identity-internal",
-					Active:  pointer.Bool(true),
-				},
-			}))
-			Expect(internalEntry).To(DeepDerivativeEqual(&dnsv1alpha1.DNSEntry{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:            "internal",
-					Namespace:       "test-ns",
-					ResourceVersion: "1",
-				},
-				Spec: dnsv1alpha1.DNSEntrySpec{
-					DNSName: "api.bar",
-					TTL:     &dnsEntryTTL,
-					Targets: []string{"1.2.3.4"},
-				},
-			}))
-			Expect(externalOwner).To(DeepDerivativeEqual(&dnsv1alpha1.DNSOwner{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:            "test-ns-external",
-					ResourceVersion: "1",
-				},
-				Spec: dnsv1alpha1.DNSOwnerSpec{
-					OwnerId: "shoot-cluster-identity-external",
-					Active:  pointer.Bool(true),
-				},
-			}))
-			Expect(externalEntry).To(DeepDerivativeEqual(&dnsv1alpha1.DNSEntry{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:            "external",
-					Namespace:       "test-ns",
-					ResourceVersion: "1",
-				},
-				Spec: dnsv1alpha1.DNSEntrySpec{
-					DNSName: "api.baz",
-					TTL:     &dnsEntryTTL,
-					Targets: []string{"1.2.3.4"},
-				},
-			}))
-
-			Expect(botanist.Shoot.Components.Extensions.DNS.InternalOwner.Destroy(ctx)).ToNot(HaveOccurred())
-			Expect(botanist.Shoot.Components.Extensions.DNS.InternalEntry.Destroy(ctx)).ToNot(HaveOccurred())
-			Expect(botanist.Shoot.Components.Extensions.DNS.ExternalOwner.Destroy(ctx)).ToNot(HaveOccurred())
-			Expect(botanist.Shoot.Components.Extensions.DNS.ExternalEntry.Destroy(ctx)).ToNot(HaveOccurred())
-
-			internalOwner = &dnsv1alpha1.DNSOwner{}
-			Expect(client.Get(ctx, types.NamespacedName{Name: seedNS + "-internal"}, internalOwner)).To(BeNotFoundError())
-
-			internalEntry = &dnsv1alpha1.DNSEntry{}
-			Expect(client.Get(ctx, types.NamespacedName{Name: "internal", Namespace: seedNS}, internalEntry)).To(BeNotFoundError())
-
-			externalOwner = &dnsv1alpha1.DNSOwner{}
-			Expect(client.Get(ctx, types.NamespacedName{Name: seedNS + "-external"}, externalOwner)).To(BeNotFoundError())
-
-			externalEntry = &dnsv1alpha1.DNSEntry{}
-			Expect(client.Get(ctx, types.NamespacedName{Name: "external", Namespace: seedNS}, externalEntry)).To(BeNotFoundError())
-		})
-	})
 
 	Describe("#DeployControlPlane", func() {
 		var infrastructureStatus = &runtime.RawExtension{Raw: []byte("infra-status")}

--- a/pkg/operation/botanist/dns.go
+++ b/pkg/operation/botanist/dns.go
@@ -23,8 +23,6 @@ import (
 
 	"github.com/gardener/gardener/pkg/apis/core"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	"github.com/gardener/gardener/pkg/features"
-	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/dns"
 	"github.com/gardener/gardener/pkg/utils/flow"
@@ -349,12 +347,6 @@ func (b *Botanist) NeedsAdditionalDNSProviders() bool {
 	return !b.Shoot.DisableDNS &&
 		b.Shoot.Info.Spec.DNS != nil &&
 		len(b.Shoot.Info.Spec.DNS.Providers) > 0
-}
-
-// APIServerSNIEnabled returns true if APIServerSNI feature gate is enabled and
-// the shoot uses internal and external DNS.
-func (b *Botanist) APIServerSNIEnabled() bool {
-	return gardenletfeatures.FeatureGate.Enabled(features.APIServerSNI) && b.NeedsInternalDNS() && b.NeedsExternalDNS()
 }
 
 // APIServerSNIPodMutatorEnabled returns false if the value of the Shoot annotation

--- a/pkg/operation/botanist/dns.go
+++ b/pkg/operation/botanist/dns.go
@@ -21,8 +21,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/gardener/gardener/pkg/apis/core"
+	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1helper "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1/helper"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/dns"
 	"github.com/gardener/gardener/pkg/utils/flow"
@@ -32,6 +33,7 @@ import (
 	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -250,8 +252,8 @@ func (b *Botanist) AdditionalDNSProviders(ctx context.Context) (map[string]compo
 				return nil, fmt.Errorf("dns provider[%d] doesn't specify a type", i)
 			}
 
-			if *providerType == core.DNSUnmanaged {
-				b.Logger.Infof("Skipping deployment of DNS provider[%d] since it specifies type %q", i, core.DNSUnmanaged)
+			if *providerType == gardencore.DNSUnmanaged {
+				b.Logger.Infof("Skipping deployment of DNS provider[%d] since it specifies type %q", i, gardencore.DNSUnmanaged)
 				continue
 			}
 
@@ -500,6 +502,64 @@ func (d dnsRestoreDeployer) Deploy(ctx context.Context) error {
 	return nil
 }
 
-func (d dnsRestoreDeployer) Destroy(ctx context.Context) error {
-	return nil
+func (d dnsRestoreDeployer) Destroy(_ context.Context) error { return nil }
+
+func (b *Botanist) newDNSComponentsTargetingAPIServerAddress() {
+	if b.NeedsInternalDNS() {
+		ownerID := *b.Shoot.Info.Status.ClusterIdentity + "-" + DNSInternalName
+
+		b.Shoot.Components.Extensions.DNS.InternalOwner = dns.NewOwner(
+			b.K8sSeedClient.Client(),
+			b.Shoot.SeedNamespace,
+			&dns.OwnerValues{
+				Name:    DNSInternalName,
+				Active:  pointer.Bool(true),
+				OwnerID: ownerID,
+			},
+		)
+		b.Shoot.Components.Extensions.DNS.InternalEntry = dns.NewEntry(
+			b.Logger,
+			b.K8sSeedClient.Client(),
+			b.Shoot.SeedNamespace,
+			&dns.EntryValues{
+				Name:    DNSInternalName,
+				DNSName: gutil.GetAPIServerDomain(b.Shoot.InternalClusterDomain),
+				Targets: []string{b.APIServerAddress},
+				OwnerID: ownerID,
+				TTL:     *b.Config.Controllers.Shoot.DNSEntryTTLSeconds,
+			},
+		)
+
+		b.Shoot.Components.Extensions.InternalDNSRecord.SetRecordType(extensionsv1alpha1helper.GetDNSRecordType(b.APIServerAddress))
+		b.Shoot.Components.Extensions.InternalDNSRecord.SetValues([]string{b.APIServerAddress})
+	}
+
+	if b.NeedsExternalDNS() {
+		ownerID := *b.Shoot.Info.Status.ClusterIdentity + "-" + DNSExternalName
+
+		b.Shoot.Components.Extensions.DNS.ExternalOwner = dns.NewOwner(
+			b.K8sSeedClient.Client(),
+			b.Shoot.SeedNamespace,
+			&dns.OwnerValues{
+				Name:    DNSExternalName,
+				Active:  pointer.Bool(true),
+				OwnerID: ownerID,
+			},
+		)
+		b.Shoot.Components.Extensions.DNS.ExternalEntry = dns.NewEntry(
+			b.Logger,
+			b.K8sSeedClient.Client(),
+			b.Shoot.SeedNamespace,
+			&dns.EntryValues{
+				Name:    DNSExternalName,
+				DNSName: gutil.GetAPIServerDomain(*b.Shoot.ExternalClusterDomain),
+				Targets: []string{b.APIServerAddress},
+				OwnerID: ownerID,
+				TTL:     *b.Config.Controllers.Shoot.DNSEntryTTLSeconds,
+			},
+		)
+
+		b.Shoot.Components.Extensions.ExternalDNSRecord.SetRecordType(extensionsv1alpha1helper.GetDNSRecordType(b.APIServerAddress))
+		b.Shoot.Components.Extensions.ExternalDNSRecord.SetValues([]string{b.APIServerAddress})
+	}
 }

--- a/pkg/operation/botanist/dns_test.go
+++ b/pkg/operation/botanist/dns_test.go
@@ -35,7 +35,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
@@ -55,7 +54,7 @@ import (
 var _ = Describe("dns", func() {
 	const (
 		seedNS  = "test-ns"
-		shootNS = "shootpkg-ns"
+		shootNS = "shoot-ns"
 	)
 
 	var (
@@ -79,7 +78,7 @@ var _ = Describe("dns", func() {
 					},
 				},
 				Shoot: &shootpkg.Shoot{
-					Info: &v1beta1.Shoot{
+					Info: &gardencorev1beta1.Shoot{
 						ObjectMeta: metav1.ObjectMeta{Namespace: shootNS},
 					},
 					Components: &shootpkg.Components{
@@ -117,7 +116,7 @@ var _ = Describe("dns", func() {
 	Context("DefaultExternalDNSProvider", func() {
 		It("should create when calling Deploy and dns is enabled", func() {
 			b.Shoot.DisableDNS = false
-			b.Shoot.Info.Spec.DNS = &v1beta1.DNS{Domain: pointer.String("foo")}
+			b.Shoot.Info.Spec.DNS = &gardencorev1beta1.DNS{Domain: pointer.String("foo")}
 			b.Shoot.ExternalClusterDomain = pointer.String("baz")
 			b.Shoot.ExternalDomain = &garden.Domain{Provider: "valid-provider"}
 
@@ -315,8 +314,8 @@ var _ = Describe("dns", func() {
 
 		It("should return error when provider is without Type", func() {
 			b.Shoot.DisableDNS = false
-			b.Shoot.Info.Spec.DNS = &v1beta1.DNS{
-				Providers: []v1beta1.DNSProvider{{}},
+			b.Shoot.Info.Spec.DNS = &gardencorev1beta1.DNS{
+				Providers: []gardencorev1beta1.DNSProvider{{}},
 			}
 
 			ap, err := b.AdditionalDNSProviders(ctx)
@@ -326,8 +325,8 @@ var _ = Describe("dns", func() {
 
 		It("should return error when provider is without secretName", func() {
 			b.Shoot.DisableDNS = false
-			b.Shoot.Info.Spec.DNS = &v1beta1.DNS{
-				Providers: []v1beta1.DNSProvider{{
+			b.Shoot.Info.Spec.DNS = &gardencorev1beta1.DNS{
+				Providers: []gardencorev1beta1.DNSProvider{{
 					Type: pointer.String("foo"),
 				}},
 			}
@@ -339,8 +338,8 @@ var _ = Describe("dns", func() {
 
 		It("should return error when provider is without secret", func() {
 			b.Shoot.DisableDNS = false
-			b.Shoot.Info.Spec.DNS = &v1beta1.DNS{
-				Providers: []v1beta1.DNSProvider{{
+			b.Shoot.Info.Spec.DNS = &gardencorev1beta1.DNS{
+				Providers: []gardencorev1beta1.DNSProvider{{
 					Type:       pointer.String("foo"),
 					SecretName: pointer.String("not-existing-secret"),
 				}},
@@ -353,8 +352,8 @@ var _ = Describe("dns", func() {
 
 		It("should add providers", func() {
 			b.Shoot.DisableDNS = false
-			b.Shoot.Info.Spec.DNS = &v1beta1.DNS{
-				Providers: []v1beta1.DNSProvider{
+			b.Shoot.Info.Spec.DNS = &gardencorev1beta1.DNS{
+				Providers: []gardencorev1beta1.DNSProvider{
 					{
 						Type:    pointer.String("primary-skip"),
 						Primary: pointer.Bool(true),
@@ -365,11 +364,11 @@ var _ = Describe("dns", func() {
 					{
 						Type:       pointer.String("provider-one"),
 						SecretName: pointer.String("secret-one"),
-						Domains: &v1beta1.DNSIncludeExclude{
+						Domains: &gardencorev1beta1.DNSIncludeExclude{
 							Include: []string{"domain-1-include"},
 							Exclude: []string{"domain-2-exclude"},
 						},
-						Zones: &v1beta1.DNSIncludeExclude{
+						Zones: &gardencorev1beta1.DNSIncludeExclude{
 							Include: []string{"zone-1-include"},
 							Exclude: []string{"zone-1-exclude"},
 						},
@@ -459,27 +458,27 @@ var _ = Describe("dns", func() {
 
 		It("should be false when Shoot DNS's domain is nil", func() {
 			b.Shoot.DisableDNS = false
-			b.Shoot.Info.Spec.DNS = &v1beta1.DNS{Domain: nil}
+			b.Shoot.Info.Spec.DNS = &gardencorev1beta1.DNS{Domain: nil}
 			Expect(b.NeedsExternalDNS()).To(BeFalse())
 		})
 
 		It("should be false when Shoot ExternalClusterDomain is nil", func() {
 			b.Shoot.DisableDNS = false
-			b.Shoot.Info.Spec.DNS = &v1beta1.DNS{Domain: pointer.String("foo")}
+			b.Shoot.Info.Spec.DNS = &gardencorev1beta1.DNS{Domain: pointer.String("foo")}
 			b.Shoot.ExternalClusterDomain = nil
 			Expect(b.NeedsExternalDNS()).To(BeFalse())
 		})
 
 		It("should be false when Shoot ExternalClusterDomain is in nip.io", func() {
 			b.Shoot.DisableDNS = false
-			b.Shoot.Info.Spec.DNS = &v1beta1.DNS{Domain: pointer.String("foo")}
+			b.Shoot.Info.Spec.DNS = &gardencorev1beta1.DNS{Domain: pointer.String("foo")}
 			b.Shoot.ExternalClusterDomain = pointer.String("foo.nip.io")
 			Expect(b.NeedsExternalDNS()).To(BeFalse())
 		})
 
 		It("should be false when Shoot ExternalDomain is nil", func() {
 			b.Shoot.DisableDNS = false
-			b.Shoot.Info.Spec.DNS = &v1beta1.DNS{Domain: pointer.String("foo")}
+			b.Shoot.Info.Spec.DNS = &gardencorev1beta1.DNS{Domain: pointer.String("foo")}
 			b.Shoot.ExternalClusterDomain = pointer.String("baz")
 			b.Shoot.ExternalDomain = nil
 
@@ -488,7 +487,7 @@ var _ = Describe("dns", func() {
 
 		It("should be false when Shoot ExternalDomain provider is unamanaged", func() {
 			b.Shoot.DisableDNS = false
-			b.Shoot.Info.Spec.DNS = &v1beta1.DNS{Domain: pointer.String("foo")}
+			b.Shoot.Info.Spec.DNS = &gardencorev1beta1.DNS{Domain: pointer.String("foo")}
 			b.Shoot.ExternalClusterDomain = pointer.String("baz")
 			b.Shoot.ExternalDomain = &garden.Domain{Provider: "unmanaged"}
 
@@ -497,7 +496,7 @@ var _ = Describe("dns", func() {
 
 		It("should be true when Shoot ExternalDomain provider is valid", func() {
 			b.Shoot.DisableDNS = false
-			b.Shoot.Info.Spec.DNS = &v1beta1.DNS{Domain: pointer.String("foo")}
+			b.Shoot.Info.Spec.DNS = &gardencorev1beta1.DNS{Domain: pointer.String("foo")}
 			b.Shoot.ExternalClusterDomain = pointer.String("baz")
 			b.Shoot.ExternalDomain = &garden.Domain{Provider: "valid-provider"}
 
@@ -544,14 +543,14 @@ var _ = Describe("dns", func() {
 
 		It("should be false when there are no Shoot DNS Providers", func() {
 			b.Shoot.DisableDNS = false
-			b.Shoot.Info.Spec.DNS = &v1beta1.DNS{}
+			b.Shoot.Info.Spec.DNS = &gardencorev1beta1.DNS{}
 			Expect(b.NeedsAdditionalDNSProviders()).To(BeFalse())
 		})
 
 		It("should be true when there are Shoot DNS Providers", func() {
 			b.Shoot.DisableDNS = false
-			b.Shoot.Info.Spec.DNS = &v1beta1.DNS{
-				Providers: []v1beta1.DNSProvider{
+			b.Shoot.Info.Spec.DNS = &gardencorev1beta1.DNS{
+				Providers: []gardencorev1beta1.DNSProvider{
 					{Type: pointer.String("foo")},
 					{Type: pointer.String("bar")},
 				},
@@ -574,7 +573,7 @@ var _ = Describe("dns", func() {
 		It("returns true when feature gate is enabled", func() {
 			Expect(gardenletfeatures.FeatureGate.Set("APIServerSNI=true")).ToNot(HaveOccurred())
 			b.Garden.InternalDomain = &garden.Domain{Provider: "some-provider"}
-			b.Shoot.Info.Spec.DNS = &v1beta1.DNS{Domain: pointer.String("foo")}
+			b.Shoot.Info.Spec.DNS = &gardencorev1beta1.DNS{Domain: pointer.String("foo")}
 			b.Shoot.ExternalClusterDomain = pointer.String("baz")
 			b.Shoot.ExternalDomain = &garden.Domain{Provider: "valid-provider"}
 
@@ -597,7 +596,7 @@ var _ = Describe("dns", func() {
 			BeforeEach(func() {
 				Expect(gardenletfeatures.FeatureGate.Set("APIServerSNI=true")).ToNot(HaveOccurred())
 				b.Garden.InternalDomain = &garden.Domain{Provider: "some-provider"}
-				b.Shoot.Info.Spec.DNS = &v1beta1.DNS{Domain: pointer.String("foo")}
+				b.Shoot.Info.Spec.DNS = &gardencorev1beta1.DNS{Domain: pointer.String("foo")}
 				b.Shoot.ExternalClusterDomain = pointer.String("baz")
 				b.Shoot.ExternalDomain = &garden.Domain{Provider: "valid-provider"}
 			})
@@ -665,7 +664,7 @@ var _ = Describe("dns", func() {
 		})
 
 		It("sets owners and entries which create DNSOwner and DNSEntry", func() {
-			b.Shoot.Info.Status.ClusterIdentity = pointer.String("shootpkg-cluster-identity")
+			b.Shoot.Info.Status.ClusterIdentity = pointer.String("shoot-cluster-identity")
 			b.Shoot.DisableDNS = false
 			b.Shoot.Info.Spec.DNS = &gardencorev1beta1.DNS{Domain: pointer.String("foo")}
 			b.Shoot.InternalClusterDomain = "bar"
@@ -707,7 +706,7 @@ var _ = Describe("dns", func() {
 					ResourceVersion: "1",
 				},
 				Spec: dnsv1alpha1.DNSOwnerSpec{
-					OwnerId: "shootpkg-cluster-identity-internal",
+					OwnerId: "shoot-cluster-identity-internal",
 					Active:  pointer.Bool(true),
 				},
 			}))
@@ -729,7 +728,7 @@ var _ = Describe("dns", func() {
 					ResourceVersion: "1",
 				},
 				Spec: dnsv1alpha1.DNSOwnerSpec{
-					OwnerId: "shootpkg-cluster-identity-external",
+					OwnerId: "shoot-cluster-identity-external",
 					Active:  pointer.Bool(true),
 				},
 			}))

--- a/pkg/operation/botanist/kubeapiserverexposure.go
+++ b/pkg/operation/botanist/kubeapiserverexposure.go
@@ -16,6 +16,7 @@ package botanist
 
 import (
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
+	"github.com/gardener/gardener/pkg/utils"
 )
 
 // DefaultKubeAPIServerService returns a deployer for kube-apiserver service.
@@ -23,3 +24,9 @@ func (b *Botanist) DefaultKubeAPIServerService(sniPhase component.Phase) compone
 	return b.kubeAPIServiceService(sniPhase)
 }
 
+func (b *Botanist) getKubeAPIServerServiceAnnotations(sniPhase component.Phase) map[string]string {
+	if b.ExposureClassHandler != nil && sniPhase != component.PhaseEnabled {
+		return utils.MergeStringMaps(b.Seed.LoadBalancerServiceAnnotations, b.ExposureClassHandler.LoadBalancerService.Annotations)
+	}
+	return b.Seed.LoadBalancerServiceAnnotations
+}

--- a/pkg/operation/botanist/kubeapiserverexposure.go
+++ b/pkg/operation/botanist/kubeapiserverexposure.go
@@ -23,6 +23,7 @@ import (
 	"github.com/gardener/gardener/pkg/utils"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -95,4 +96,36 @@ func (b *Botanist) getIngressGatewayConfig() kubeapiserverexposure.IstioIngressG
 	}
 
 	return ingressGatewayConfig
+}
+
+// SNIPhase returns the current phase of the SNI enablement of kube-apiserver's service.
+func (b *Botanist) SNIPhase(ctx context.Context) (component.Phase, error) {
+	var (
+		svc        = &corev1.Service{}
+		sniEnabled = b.APIServerSNIEnabled()
+	)
+
+	if err := b.K8sSeedClient.APIReader().Get(
+		ctx,
+		client.ObjectKey{Name: v1beta1constants.DeploymentNameKubeAPIServer, Namespace: b.Shoot.SeedNamespace},
+		svc,
+	); client.IgnoreNotFound(err) != nil {
+		return component.PhaseUnknown, err
+	}
+
+	switch {
+	case svc.Spec.Type == corev1.ServiceTypeLoadBalancer && sniEnabled:
+		return component.PhaseEnabling, nil
+	case svc.Spec.Type == corev1.ServiceTypeClusterIP && sniEnabled:
+		return component.PhaseEnabled, nil
+	case svc.Spec.Type == corev1.ServiceTypeClusterIP && !sniEnabled:
+		return component.PhaseDisabling, nil
+	default:
+		if sniEnabled {
+			// initial cluster creation with SNI enabled (enabling only relevant for migration).
+			return component.PhaseEnabled, nil
+		}
+		// initial cluster creation with SNI disabled.
+		return component.PhaseDisabled, nil
+	}
 }

--- a/pkg/operation/botanist/kubeapiserverexposure.go
+++ b/pkg/operation/botanist/kubeapiserverexposure.go
@@ -47,7 +47,10 @@ func (b *Botanist) newKubeAPIServiceServiceComponent(sniPhase component.Phase) c
 		sniServiceKey,
 		nil,
 		b.setAPIServerServiceClusterIP,
-		func(address string) { b.setAPIServerAddress(address, b.K8sSeedClient.Client()) },
+		func(address string) {
+			b.APIServerAddress = address
+			b.newDNSComponentsTargetingAPIServerAddress()
+		},
 	)
 }
 

--- a/pkg/operation/botanist/kubeapiserverexposure.go
+++ b/pkg/operation/botanist/kubeapiserverexposure.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package botanist
+
+import (
+	"github.com/gardener/gardener/pkg/operation/botanist/component"
+)
+
+// DefaultKubeAPIServerService returns a deployer for kube-apiserver service.
+func (b *Botanist) DefaultKubeAPIServerService(sniPhase component.Phase) component.DeployWaiter {
+	return b.kubeAPIServiceService(sniPhase)
+}
+

--- a/pkg/operation/botanist/kubeapiserverexposure.go
+++ b/pkg/operation/botanist/kubeapiserverexposure.go
@@ -15,6 +15,8 @@
 package botanist
 
 import (
+	"context"
+
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/kubeapiserverexposure"
@@ -34,7 +36,7 @@ func (b *Botanist) newKubeAPIServiceServiceComponent(sniPhase component.Phase) c
 		b.Logger,
 		b.K8sSeedClient.Client(),
 		&kubeapiserverexposure.ServiceValues{
-			Annotations: b.getKubeApiServerServiceAnnotations(sniPhase),
+			Annotations: b.getKubeAPIServerServiceAnnotations(sniPhase),
 			SNIPhase:    sniPhase,
 		},
 		client.ObjectKey{Name: v1beta1constants.DeploymentNameKubeAPIServer, Namespace: b.Shoot.SeedNamespace},
@@ -48,6 +50,11 @@ func (b *Botanist) newKubeAPIServiceServiceComponent(sniPhase component.Phase) c
 // DefaultKubeAPIServerService returns a deployer for kube-apiserver service.
 func (b *Botanist) DefaultKubeAPIServerService(sniPhase component.Phase) component.DeployWaiter {
 	return b.newKubeAPIServiceServiceComponent(sniPhase)
+}
+
+// DeployKubeAPIService deploys for kube-apiserver service.
+func (b *Botanist) DeployKubeAPIService(ctx context.Context, sniPhase component.Phase) error {
+	return b.newKubeAPIServiceServiceComponent(sniPhase).Deploy(ctx)
 }
 
 func (b *Botanist) getKubeAPIServerServiceAnnotations(sniPhase component.Phase) map[string]string {

--- a/pkg/operation/botanist/kubeapiserverexposure.go
+++ b/pkg/operation/botanist/kubeapiserverexposure.go
@@ -71,6 +71,11 @@ func (b *Botanist) DefaultKubeAPIServerSNI() component.DeployWaiter {
 	))
 }
 
+// DeployKubeAPIServerSNI deploys the kube-apiserver-sni chart.
+func (b *Botanist) DeployKubeAPIServerSNI(ctx context.Context) error {
+	return b.Shoot.Components.ControlPlane.KubeAPIServerSNI.Deploy(ctx)
+}
+
 func (b *Botanist) getKubeAPIServerServiceAnnotations(sniPhase component.Phase) map[string]string {
 	if b.ExposureClassHandler != nil && sniPhase != component.PhaseEnabled {
 		return utils.MergeStringMaps(b.Seed.LoadBalancerServiceAnnotations, b.ExposureClassHandler.LoadBalancerService.Annotations)

--- a/pkg/operation/botanist/kubeapiserverexposure.go
+++ b/pkg/operation/botanist/kubeapiserverexposure.go
@@ -18,6 +18,8 @@ import (
 	"context"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/features"
+	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/kubeapiserverexposure"
 	"github.com/gardener/gardener/pkg/utils"
@@ -96,6 +98,12 @@ func (b *Botanist) getIngressGatewayConfig() kubeapiserverexposure.IstioIngressG
 	}
 
 	return ingressGatewayConfig
+}
+
+// APIServerSNIEnabled returns true if APIServerSNI feature gate is enabled and the shoot uses internal and external
+// DNS.
+func (b *Botanist) APIServerSNIEnabled() bool {
+	return gardenletfeatures.FeatureGate.Enabled(features.APIServerSNI) && b.NeedsInternalDNS() && b.NeedsExternalDNS()
 }
 
 // SNIPhase returns the current phase of the SNI enablement of kube-apiserver's service.

--- a/pkg/operation/botanist/kubeapiserverexposure_test.go
+++ b/pkg/operation/botanist/kubeapiserverexposure_test.go
@@ -1,0 +1,182 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package botanist
+
+import (
+	"context"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	fakeclientset "github.com/gardener/gardener/pkg/client/kubernetes/fake"
+	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
+	"github.com/gardener/gardener/pkg/logger"
+	"github.com/gardener/gardener/pkg/operation"
+	"github.com/gardener/gardener/pkg/operation/botanist/component"
+	"github.com/gardener/gardener/pkg/operation/garden"
+	"github.com/gardener/gardener/pkg/operation/shoot"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("KubeAPIServerExposure", func() {
+	var (
+		ctrl   *gomock.Controller
+		scheme *runtime.Scheme
+		client client.Client
+
+		botanist *Botanist
+
+		ctx       = context.TODO()
+		namespace = "shoot--foo--bar"
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+
+		scheme = runtime.NewScheme()
+		Expect(corev1.AddToScheme(scheme)).NotTo(HaveOccurred())
+		client = fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		fakeClientSet := fakeclientset.NewClientSetBuilder().
+			WithAPIReader(client).
+			Build()
+
+		botanist = &Botanist{
+			Operation: &operation.Operation{
+				K8sSeedClient: fakeClientSet,
+				Shoot: &shoot.Shoot{
+					Info:          &gardencorev1beta1.Shoot{},
+					SeedNamespace: namespace,
+				},
+				Garden: &garden.Garden{},
+				Logger: logrus.NewEntry(logger.NewNopLogger()),
+			},
+		}
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Describe("#SNIPhase", func() {
+		var svc *corev1.Service
+
+		BeforeEach(func() {
+			gardenletfeatures.RegisterFeatureGates()
+
+			svc = &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "kube-apiserver",
+					Namespace: namespace,
+				},
+			}
+		})
+
+		Context("sni enabled", func() {
+			BeforeEach(func() {
+				Expect(gardenletfeatures.FeatureGate.Set("APIServerSNI=true")).ToNot(HaveOccurred())
+				botanist.Garden.InternalDomain = &garden.Domain{Provider: "some-provider"}
+				botanist.Shoot.Info.Spec.DNS = &gardencorev1beta1.DNS{Domain: pointer.StringPtr("foo")}
+				botanist.Shoot.ExternalClusterDomain = pointer.StringPtr("baz")
+				botanist.Shoot.ExternalDomain = &garden.Domain{Provider: "valid-provider"}
+			})
+
+			It("returns Enabled for not existing services", func() {
+				phase, err := botanist.SNIPhase(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(phase).To(Equal(component.PhaseEnabled))
+			})
+
+			It("returns Enabling for service of type LoadBalancer", func() {
+				svc.Spec.Type = corev1.ServiceTypeLoadBalancer
+				Expect(client.Create(ctx, svc)).NotTo(HaveOccurred())
+
+				phase, err := botanist.SNIPhase(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(phase).To(Equal(component.PhaseEnabling))
+			})
+
+			It("returns Enabled for service of type ClusterIP", func() {
+				svc.Spec.Type = corev1.ServiceTypeClusterIP
+				Expect(client.Create(ctx, svc)).NotTo(HaveOccurred())
+
+				phase, err := botanist.SNIPhase(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(phase).To(Equal(component.PhaseEnabled))
+			})
+
+			DescribeTable(
+				"return Enabled for service of type",
+				func(svcType corev1.ServiceType) {
+					svc.Spec.Type = svcType
+					Expect(client.Create(ctx, svc)).NotTo(HaveOccurred())
+
+					phase, err := botanist.SNIPhase(ctx)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(phase).To(Equal(component.PhaseEnabled))
+				},
+
+				Entry("ExternalName", corev1.ServiceTypeExternalName),
+				Entry("NodePort", corev1.ServiceTypeNodePort),
+			)
+		})
+
+		Context("sni disabled", func() {
+			BeforeEach(func() {
+				Expect(gardenletfeatures.FeatureGate.Set("APIServerSNI=false")).ToNot(HaveOccurred())
+			})
+
+			It("returns Disabled for not existing services", func() {
+				phase, err := botanist.SNIPhase(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(phase).To(Equal(component.PhaseDisabled))
+			})
+
+			It("returns Disabling for service of type ClusterIP", func() {
+				svc.Spec.Type = corev1.ServiceTypeClusterIP
+				Expect(client.Create(ctx, svc)).NotTo(HaveOccurred())
+
+				phase, err := botanist.SNIPhase(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(phase).To(Equal(component.PhaseDisabling))
+			})
+
+			DescribeTable(
+				"return Disabled for service of type",
+				func(svcType corev1.ServiceType) {
+					svc.Spec.Type = svcType
+					Expect(client.Create(ctx, svc)).NotTo(HaveOccurred())
+
+					phase, err := botanist.SNIPhase(ctx)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(phase).To(Equal(component.PhaseDisabled))
+				},
+
+				Entry("ExternalName", corev1.ServiceTypeExternalName),
+				Entry("LoadBalancer", corev1.ServiceTypeLoadBalancer),
+				Entry("NodePort", corev1.ServiceTypeNodePort),
+			)
+		})
+	})
+})

--- a/pkg/operation/botanist/kubeapiserverexposure_test.go
+++ b/pkg/operation/botanist/kubeapiserverexposure_test.go
@@ -97,8 +97,8 @@ var _ = Describe("KubeAPIServerExposure", func() {
 			BeforeEach(func() {
 				Expect(gardenletfeatures.FeatureGate.Set("APIServerSNI=true")).ToNot(HaveOccurred())
 				botanist.Garden.InternalDomain = &garden.Domain{Provider: "some-provider"}
-				botanist.Shoot.Info.Spec.DNS = &gardencorev1beta1.DNS{Domain: pointer.StringPtr("foo")}
-				botanist.Shoot.ExternalClusterDomain = pointer.StringPtr("baz")
+				botanist.Shoot.Info.Spec.DNS = &gardencorev1beta1.DNS{Domain: pointer.String("foo")}
+				botanist.Shoot.ExternalClusterDomain = pointer.String("baz")
 				botanist.Shoot.ExternalDomain = &garden.Domain{Provider: "valid-provider"}
 			})
 

--- a/pkg/registry/seedmanagement/managedseedset/storage/storage.go
+++ b/pkg/registry/seedmanagement/managedseedset/storage/storage.go
@@ -214,7 +214,7 @@ func scaleFromManagedSeedSet(mss *seedmanagement.ManagedSeedSet) (*autoscalingv1
 			CreationTimestamp: mss.CreationTimestamp,
 		},
 		Spec: autoscalingv1.ScaleSpec{
-			Replicas: pointer.Int32PtrDerefOr(mss.Spec.Replicas, 0),
+			Replicas: pointer.Int32Deref(mss.Spec.Replicas, 0),
 		},
 		Status: autoscalingv1.ScaleStatus{
 			Replicas: mss.Status.Replicas,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup technical-debt

**What this PR does / why we need it**:
This PR moves functions related to the exposure of shoot kube-apiservers into a dedicated `kubeapiserverexposure.go` file in the `botanist` package. Earlier, they were in the `controlplane.go` file which was too overloaded and not well-scoped.

/squash

Follow-up of #3983 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
