### PR TITLE
Reconcile annotations and labels of ResourceQuota

### DIFF
--- a/docs/concepts/controller-manager.md
+++ b/docs/concepts/controller-manager.md
@@ -49,7 +49,8 @@ controllers:
 ```
 
 The Project controller takes the shown `config` and creates a `ResourceQuota` with the name `gardener` in the project namespace.
-If a `ResourceQuota` resource with the name `gardener` already exists, the controller will only update fields in `spec.hard` which are **unavailable** at that time.
+If a `ResourceQuota` resource with the name `gardener` already exists, the controller will only update fields in `spec.hard` which are **unavailable** at that time. 
+Labels and annotations on the `ResourceQuota` `config` get merged with the respective fields on existing `ResourceQuota`s.
 An optional `projectSelector` narrows down the amount of projects that are equipped with the given `config`.
 If multiple configs match for a project, then only the first match in the list is applied to the project namespace.
 

--- a/pkg/controllermanager/controller/project/project_control_reconcile.go
+++ b/pkg/controllermanager/controller/project/project_control_reconcile.go
@@ -261,6 +261,8 @@ func createOrUpdateResourceQuota(ctx context.Context, c client.Client, projectNa
 
 	if _, err := controllerutils.GetAndCreateOrStrategicMergePatch(ctx, c, projectResourceQuota, func() error {
 		projectResourceQuota.SetOwnerReferences(kutil.MergeOwnerReferences(projectResourceQuota.GetOwnerReferences(), *ownerReference))
+		projectResourceQuota.Labels = utils.MergeStringMaps(projectResourceQuota.Labels, resourceQuota.Labels)
+		projectResourceQuota.Annotations = utils.MergeStringMaps(projectResourceQuota.Annotations, resourceQuota.Annotations)
 		quotas := make(map[corev1.ResourceName]resource.Quantity)
 		for resourceName, quantity := range resourceQuota.Spec.Hard {
 			if val, ok := projectResourceQuota.Spec.Hard[resourceName]; ok {

--- a/pkg/controllermanager/controller/project/project_control_reconcile_test.go
+++ b/pkg/controllermanager/controller/project/project_control_reconcile_test.go
@@ -187,6 +187,14 @@ var _ = Describe("ProjectControlReconcile", func() {
 			secrets = "secrets"
 			quantity = resource.MustParse("10")
 			resourceQuota = &corev1.ResourceQuota{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"foo": "bar",
+					},
+					Labels: map[string]string{
+						"bar": "baz",
+					},
+				},
 				Spec: corev1.ResourceQuotaSpec{
 					Hard: map[corev1.ResourceName]resource.Quantity{
 						shoots:  quantity,
@@ -206,6 +214,8 @@ var _ = Describe("ProjectControlReconcile", func() {
 
 			expectedResourceQuota := resourceQuota.DeepCopy()
 			expectedResourceQuota.SetOwnerReferences([]metav1.OwnerReference{*ownerRef})
+			expectedResourceQuota.ObjectMeta.Labels = map[string]string{"bar":"baz"}
+			expectedResourceQuota.ObjectMeta.Annotations = map[string]string{"foo":"bar"}
 			expectedResourceQuota.SetName(ResourceQuotaName)
 			expectedResourceQuota.SetNamespace(namespace)
 
@@ -241,6 +251,8 @@ var _ = Describe("ProjectControlReconcile", func() {
 
 			expectedResourceQuota := existingResourceQuota.DeepCopy()
 			expectedResourceQuota.SetOwnerReferences([]metav1.OwnerReference{existingOwnerRef, *ownerRef})
+			expectedResourceQuota.ObjectMeta.Labels = map[string]string{"bar":"baz"}
+			expectedResourceQuota.ObjectMeta.Annotations = map[string]string{"foo":"bar"}
 			expectedResourceQuota.Spec.Hard[secrets] = quantity
 
 			c.EXPECT().Patch(ctx, expectedResourceQuota, gomock.Any()).Return(nil)

--- a/pkg/controllermanager/controller/project/project_control_reconcile_test.go
+++ b/pkg/controllermanager/controller/project/project_control_reconcile_test.go
@@ -214,8 +214,8 @@ var _ = Describe("ProjectControlReconcile", func() {
 
 			expectedResourceQuota := resourceQuota.DeepCopy()
 			expectedResourceQuota.SetOwnerReferences([]metav1.OwnerReference{*ownerRef})
-			expectedResourceQuota.ObjectMeta.Labels = map[string]string{"bar":"baz"}
-			expectedResourceQuota.ObjectMeta.Annotations = map[string]string{"foo":"bar"}
+			expectedResourceQuota.ObjectMeta.Labels = map[string]string{"bar": "baz"}
+			expectedResourceQuota.ObjectMeta.Annotations = map[string]string{"foo": "bar"}
 			expectedResourceQuota.SetName(ResourceQuotaName)
 			expectedResourceQuota.SetNamespace(namespace)
 
@@ -251,8 +251,8 @@ var _ = Describe("ProjectControlReconcile", func() {
 
 			expectedResourceQuota := existingResourceQuota.DeepCopy()
 			expectedResourceQuota.SetOwnerReferences([]metav1.OwnerReference{existingOwnerRef, *ownerRef})
-			expectedResourceQuota.ObjectMeta.Labels = map[string]string{"bar":"baz"}
-			expectedResourceQuota.ObjectMeta.Annotations = map[string]string{"foo":"bar"}
+			expectedResourceQuota.ObjectMeta.Labels = map[string]string{"bar": "baz"}
+			expectedResourceQuota.ObjectMeta.Annotations = map[string]string{"foo": "bar"}
 			expectedResourceQuota.Spec.Hard[secrets] = quantity
 
 			c.EXPECT().Patch(ctx, expectedResourceQuota, gomock.Any()).Return(nil)


### PR DESCRIPTION
**How to categorize this PR?**
/area robustness
/kind enhancement

**What this PR does / why we need it**:
This PR enhances the Project controller to merge `annotations` and `labels` defined on the resource quota configuration with project resource quotas.

This is needed in case resource quotas need to be updated by an automation script. In this case you could update the default resource quota configuration and set a special annotation to mark it as "already updated". The automation script can then skip such resource quotas and only update those resource quotas that are not marked as "already updated".

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Labels and annotations on the `ResourceQuota` `config` get merged with the respective fields on existing `ResourceQuota`s
```
