### PR TITLE
[prepare-release] Use fullpath and do not forward stdout/stderr to /dev/null

### DIFF
--- a/hack/.ci/prepare_release
+++ b/hack/.ci/prepare_release
@@ -16,7 +16,7 @@
 
 set -e
 
-repo_root_dir="$1"
+repo_root_dir="$(realpath $1)"
 repo_base="$2"
 repo_name="$3"
 
@@ -48,7 +48,7 @@ echo "Downloading go $GOLANG_VERSION"
 wget -q -O - "https://golang.org/dl/go$GOLANG_VERSION.src.tar.gz" | tar zx -C /usr/local
 cd /usr/local/go/src
 echo "Executing make on go $GOLANG_VERSION"
-./make.bash > /dev/null 2>&1
+./make.bash
 
 # Make the newly "installed from source" go the default one
 export PATH="/usr/local/go/bin:$PATH"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery dev-productivity
/kind bug

**What this PR does / why we need it**:
Use fullpath and do not forward stdout/stderr to /dev/null

Currently there are issues releasing some of the extensions and they are failing with something like 
```
...
cp: cannot stat './.ci/..': No such file or directory
...
```

The reason for this is that the current dir is change here https://github.com/gardener/gardener/blob/278e9b4e584404e14ec1b0d214987a19f4352eb0/hack/.ci/prepare_release#L49 and then the relative path is no longer valid. 


Also, now it does not hide the logs/errors from make.bash from the golang installation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```developer bugfix

```


/cla