### PR TITLE
Add required RBAC for istiod

### DIFF
--- a/charts/istio/istio-istiod/templates/clusterrole.yaml
+++ b/charts/istio/istio-istiod/templates/clusterrole.yaml
@@ -39,6 +39,7 @@ rules:
   - security.istio.io
   - networking.istio.io
   - authentication.istio.io
+  - telemetry.istio.io
   verbs:
   - get
   - watch


### PR DESCRIPTION
/kind bug
/kind regression

Ref to the upstream ClusterRole - https://github.com/istio/istio/blob/1.10.1/manifests/charts/base/templates/clusterrole.yaml

Fixes https://github.com/gardener/gardener/issues/4266

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
