### PR TITLE
Add RBAC rules required for control plane migration

### DIFF
--- a/charts/gardener/gardenlet/charts/runtime/templates/clusterrole-gardenlet.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/clusterrole-gardenlet.yaml
@@ -38,6 +38,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - pods/exec
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
   - configmaps
   - namespaces
   - secrets
@@ -216,6 +222,21 @@ rules:
   - get
   - list
   - watch
+  - patch
+  - update
+- apiGroups:
+  - extensions.gardener.cloud
+  resources:
+  - backupbuckets/status
+  - backupentries/status
+  - containerruntimes/status
+  - controlplanes/status
+  - extensions/status
+  - infrastructures/status
+  - networks/status
+  - operatingsystemconfigs/status
+  - workers/status
+  verbs:
   - patch
   - update
 - apiGroups:

--- a/landscaper/pkg/gardenlet/chart/charttest/charttest.go
+++ b/landscaper/pkg/gardenlet/chart/charttest/charttest.go
@@ -196,6 +196,11 @@ func getGardenletClusterRole(labels map[string]string) *rbacv1.ClusterRole {
 			},
 			{
 				APIGroups: []string{""},
+				Resources: []string{"pods/exec"},
+				Verbs:     []string{"create"},
+			},
+			{
+				APIGroups: []string{""},
 				Resources: []string{"configmaps", "namespaces", "secrets", "serviceaccounts", "services"},
 				Verbs:     []string{"create", "delete", "deletecollection", "get", "list", "watch", "patch", "update"},
 			},
@@ -272,6 +277,11 @@ func getGardenletClusterRole(labels map[string]string) *rbacv1.ClusterRole {
 				APIGroups: []string{"extensions.gardener.cloud"},
 				Resources: []string{"backupbuckets", "backupentries", "bastions", "clusters", "containerruntimes", "controlplanes", "extensions", "infrastructures", "networks", "operatingsystemconfigs", "workers"},
 				Verbs:     []string{"create", "delete", "get", "list", "watch", "patch", "update"},
+			},
+			{
+				APIGroups: []string{"extensions.gardener.cloud"},
+				Resources: []string{"backupbuckets/status", "backupentries/status", "containerruntimes/status", "controlplanes/status", "extensions/status", "infrastructures/status", "networks/status", "operatingsystemconfigs/status", "workers/status"},
+				Verbs:     []string{"patch", "update"},
 			},
 			{
 				APIGroups: []string{"resources.gardener.cloud"},


### PR DESCRIPTION
/area quality
/kind bug
/kind regression

#4129 is regressing the control plane migrations as required RBAC rules for successful migrations are missing in the gardenlet ClusterRole.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
