### PR TITLE
Re-set osc.spec.criconfig on re-deploy

### DIFF
--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -576,6 +576,7 @@ func (d *deployer) deploy(ctx context.Context, operation string) (extensionsv1al
 		d.osc.Spec.Units = units
 		d.osc.Spec.Files = files
 
+		d.osc.Spec.CRIConfig = nil
 		if d.worker.CRI != nil {
 			d.osc.Spec.CRIConfig = &extensionsv1alpha1.CRIConfig{
 				Name: extensionsv1alpha1.CRIName(d.worker.CRI.Name),

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/original_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/original_test.go
@@ -123,7 +123,7 @@ var _ = Describe("Original", func() {
 			}))
 		})
 
-		It("should compute the units and files w/ docker", func() {
+		It("should compute the units and files w/ containerd", func() {
 			var order []string
 			for _, component := range Components(extensionsv1alpha1.CRINameContainerD) {
 				order = append(order, component.Name())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind bug

**What this PR does / why we need it**:
Re-set osc.spec.criconfig on re-deploy

Now that it is possible to modify the CRI for existing worker pools, the osc needs to take into account that a worker pool formerly set to `containerd` is reconfigured with `worker.CRI==nil`. The OSC object is only re-created when k8s major or minor version is changed or the worker name is updated and therefore needs to take this update path into account.

**Which issue(s) this PR fixes**:
Fixes #4254

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Switching an existing worker pool from `containerd` to `docker` no longer starts `containerd` on the new node
```
