### PR TITLE
[release-v1.24] Automated cherry pick of #4268: Fix the SNI transition for the kube-apiserver Service

### DIFF
--- a/pkg/operation/botanist/component/clusterautoscaler/cluster_autoscaler.go
+++ b/pkg/operation/botanist/component/clusterautoscaler/cluster_autoscaler.go
@@ -151,13 +151,14 @@ func (c *clusterAutoscaler) Deploy(ctx context.Context) error {
 		service.Spec.Selector = getLabels()
 		service.Spec.Type = corev1.ServiceTypeClusterIP
 		service.Spec.ClusterIP = corev1.ClusterIPNone
-		service.Spec.Ports = kutil.ReconcileServicePorts(service.Spec.Ports, []corev1.ServicePort{
+		desiredPorts := []corev1.ServicePort{
 			{
 				Name:     portNameMetrics,
 				Protocol: corev1.ProtocolTCP,
 				Port:     portMetrics,
 			},
-		})
+		}
+		service.Spec.Ports = kutil.ReconcileServicePorts(service.Spec.Ports, desiredPorts, corev1.ServiceTypeClusterIP)
 		return nil
 	}); err != nil {
 		return err

--- a/pkg/operation/botanist/component/kubeapiserverexposure/kube_apiserver_service.go
+++ b/pkg/operation/botanist/component/kubeapiserverexposure/kube_apiserver_service.go
@@ -171,7 +171,7 @@ func (s *service) Deploy(ctx context.Context) error {
 				TargetPort: intstr.FromInt(8132),
 			})
 		}
-		obj.Spec.Ports = kutil.ReconcileServicePorts(obj.Spec.Ports, desiredPorts)
+		obj.Spec.Ports = kutil.ReconcileServicePorts(obj.Spec.Ports, desiredPorts, s.values.serviceType)
 
 		return nil
 	}); err != nil {

--- a/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager.go
@@ -182,13 +182,14 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 		service.Spec.Selector = getLabels()
 		service.Spec.Type = corev1.ServiceTypeClusterIP
 		service.Spec.ClusterIP = corev1.ClusterIPNone
-		service.Spec.Ports = kutil.ReconcileServicePorts(service.Spec.Ports, []corev1.ServicePort{
+		desiredPorts := []corev1.ServicePort{
 			{
 				Name:     portNameMetrics,
 				Protocol: corev1.ProtocolTCP,
 				Port:     port,
 			},
-		})
+		}
+		service.Spec.Ports = kutil.ReconcileServicePorts(service.Spec.Ports, desiredPorts, corev1.ServiceTypeClusterIP)
 		return nil
 	}); err != nil {
 		return err

--- a/pkg/operation/botanist/component/kubescheduler/kube_scheduler.go
+++ b/pkg/operation/botanist/component/kubescheduler/kube_scheduler.go
@@ -147,13 +147,14 @@ func (k *kubeScheduler) Deploy(ctx context.Context) error {
 		service.Labels = getLabels()
 		service.Spec.Selector = getLabels()
 		service.Spec.Type = corev1.ServiceTypeClusterIP
-		service.Spec.Ports = kutil.ReconcileServicePorts(service.Spec.Ports, []corev1.ServicePort{
+		desiredPorts := []corev1.ServicePort{
 			{
 				Name:     portNameMetrics,
 				Protocol: corev1.ProtocolTCP,
 				Port:     port,
 			},
-		})
+		}
+		service.Spec.Ports = kutil.ReconcileServicePorts(service.Spec.Ports, desiredPorts, corev1.ServiceTypeClusterIP)
 		return nil
 	}); err != nil {
 		return err

--- a/pkg/operation/botanist/component/resourcemanager/resource_manager.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager.go
@@ -334,7 +334,7 @@ func (r *resourceManager) ensureService(ctx context.Context) error {
 		service.Spec.Selector = appLabel()
 		service.Spec.Type = corev1.ServiceTypeClusterIP
 		service.Spec.ClusterIP = corev1.ClusterIPNone
-		service.Spec.Ports = kutil.ReconcileServicePorts(service.Spec.Ports, []corev1.ServicePort{
+		desiredPorts := []corev1.ServicePort{
 			{
 				Name:     metricsPortName,
 				Protocol: corev1.ProtocolTCP,
@@ -345,7 +345,8 @@ func (r *resourceManager) ensureService(ctx context.Context) error {
 				Protocol: corev1.ProtocolTCP,
 				Port:     healthPort,
 			},
-		})
+		}
+		service.Spec.Ports = kutil.ReconcileServicePorts(service.Spec.Ports, desiredPorts, corev1.ServiceTypeClusterIP)
 		return nil
 	})
 	return err

--- a/pkg/utils/kubernetes/kubernetes_test.go
+++ b/pkg/utils/kubernetes/kubernetes_test.go
@@ -796,14 +796,15 @@ var _ = Describe("kubernetes", func() {
 	)
 
 	DescribeTable("#ReconcileServicePorts",
-		func(existingPorts []corev1.ServicePort, matcher gomegatypes.GomegaMatcher) {
-			Expect(ReconcileServicePorts(existingPorts, desiredPorts)).To(matcher)
+		func(existingPorts []corev1.ServicePort, serviceType corev1.ServiceType, matcher gomegatypes.GomegaMatcher) {
+			Expect(ReconcileServicePorts(existingPorts, desiredPorts, serviceType)).To(matcher)
 		},
-		Entry("existing ports is nil", nil, ConsistOf(port1, port2, port3)),
-		Entry("no existing ports", []corev1.ServicePort{}, ConsistOf(port1, port2, port3)),
-		Entry("existing but undesired ports", []corev1.ServicePort{{Name: "foo"}}, ConsistOf(port1, port2, port3)),
-		Entry("existing and desired ports", []corev1.ServicePort{{Name: port1.Name, NodePort: 1337}}, ConsistOf(corev1.ServicePort{Name: port1.Name, Protocol: port1.Protocol, Port: port1.Port, NodePort: 1337}, port2, port3)),
-		Entry("existing and both desired and undesired ports", []corev1.ServicePort{{Name: "foo"}, {Name: port1.Name, NodePort: 1337}}, ConsistOf(corev1.ServicePort{Name: port1.Name, Protocol: port1.Protocol, Port: port1.Port, NodePort: 1337}, port2, port3)),
+		Entry("existing ports is nil", nil, corev1.ServiceTypeLoadBalancer, ConsistOf(port1, port2, port3)),
+		Entry("no existing ports", []corev1.ServicePort{}, corev1.ServiceTypeLoadBalancer, ConsistOf(port1, port2, port3)),
+		Entry("existing but undesired ports", []corev1.ServicePort{{Name: "foo"}}, corev1.ServiceTypeLoadBalancer, ConsistOf(port1, port2, port3)),
+		Entry("existing and desired ports when spec.type=LoadBalancer", []corev1.ServicePort{{Name: port1.Name, NodePort: 1337}}, corev1.ServiceTypeLoadBalancer, ConsistOf(corev1.ServicePort{Name: port1.Name, Protocol: port1.Protocol, Port: port1.Port, NodePort: 1337}, port2, port3)),
+		Entry("existing and desired ports when spec.type=ClusterIP", []corev1.ServicePort{{Name: port1.Name, NodePort: 1337}}, corev1.ServiceTypeClusterIP, ConsistOf(port1, port2, port3)),
+		Entry("existing and both desired and undesired ports", []corev1.ServicePort{{Name: "foo"}, {Name: port1.Name, NodePort: 1337}}, corev1.ServiceTypeLoadBalancer, ConsistOf(corev1.ServicePort{Name: port1.Name, Protocol: port1.Protocol, Port: port1.Port, NodePort: 1337}, port2, port3)),
 	)
 
 	Describe("#WaitUntilLoadBalancerIsReady", func() {


### PR DESCRIPTION
/area/quality
/kind/bug
/kind/regression

Cherry pick of #4268 on release-v1.24.

#4268: Fix the SNI transition for the kube-apiserver Service

**Release Notes:**
```bugfix operator
An issue causing the SNI transition step to fail for a cluster that still didn't transitioned to SNI is now fixed.
```