### PR TITLE
Promote MountHostCADirectories feature gate to GA

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -23,13 +23,25 @@ The following tables are a summary of the feature gates that you can set on diff
 | Logging | `false` | `Alpha` | `0.13` | |
 | HVPA | `false` | `Alpha` | `0.31` | |
 | HVPAForShootedSeed | `false` | `Alpha` | `0.32` | |
+| ManagedIstio | `false` | `Alpha` | `1.5` | `1.18` |
 | ManagedIstio | `true` | `Beta` | `1.19` | |
+| APIServerSNI | `false` | `Alpha` | `1.7` | `1.18` |
 | APIServerSNI | `true` | `Beta` | `1.19` | |
-| MountHostCADirectories | `false` | `Alpha` | `1.11.0` | `1.25.0` |
-| MountHostCADirectories | `true` | `Beta` | `1.26.0` | |
-| SeedChange | `false` | `Alpha` | `1.12.0` | |
-| SeedKubeScheduler | `false` | `Alpha` | `1.15.0` | |
-| ReversedVPN | `false` | `Alpha` | `1.22.0` | |
+| SeedChange | `false` | `Alpha` | `1.12` | |
+| SeedKubeScheduler | `false` | `Alpha` | `1.15` | |
+| ReversedVPN | `false` | `Alpha` | `1.22` | |
+
+## Feature gates for graduated or deprecated features
+
+| Feature | Default | Stage | Since | Until |
+| --- | --- | --- | --- | --- |
+| NodeLocalDNS | `false` | `Alpha` | `1.7` | |
+| NodeLocalDNS | | `Removed` | `1.26` | |
+| KonnectivityTunnel | `false` | `Alpha` | `1.6` | |
+| KonnectivityTunnel | | `Removed` | `1.27` | |
+| MountHostCADirectories | `false` | `Alpha` | `1.11` | `1.25` |
+| MountHostCADirectories | `true` | `Beta` | `1.26` | `1.27` |
+| MountHostCADirectories | `true` | `GA` | `1.27` | |
 
 ## Using a feature
 

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -69,6 +69,7 @@ const (
 	// owner @danielfoehrKn
 	// alpha: v1.11.0
 	// beta: v1.26.0
+	// GA: v1.27.0
 	MountHostCADirectories featuregate.Feature = "MountHostCADirectories"
 
 	// SeedChange enables updating the `spec.seedName` field during shoot validation from a non-empty value

--- a/pkg/gardenlet/features/features.go
+++ b/pkg/gardenlet/features/features.go
@@ -31,7 +31,7 @@ var (
 		features.ManagedIstio:           {Default: true, PreRelease: featuregate.Beta},
 		features.APIServerSNI:           {Default: true, PreRelease: featuregate.Beta},
 		features.CachedRuntimeClients:   {Default: false, PreRelease: featuregate.Alpha},
-		features.MountHostCADirectories: {Default: true, PreRelease: featuregate.Beta},
+		features.MountHostCADirectories: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // TODO (ialidzhikov): remove MountHostCADirectories in v1.29.
 		features.SeedKubeScheduler:      {Default: false, PreRelease: featuregate.Alpha},
 		features.ReversedVPN:            {Default: false, PreRelease: featuregate.Alpha},
 	}


### PR DESCRIPTION
/kind enhancement

Fixes #4147

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `MountHostCADirectories` feature gate in the `gardenlet` has been promoted to GA.
```
