### PR TITLE
update landscaper gardenlet blueprint 

### DIFF
--- a/landscaper/pkg/gardenlet/blueprint.yaml
+++ b/landscaper/pkg/gardenlet/blueprint.yaml
@@ -116,5 +116,5 @@ deployExecutions:
             kind: Imports
       {{ toYaml .imports | indent 6 }}
 
-          {{ $resource := getResource .cd "name" "gardenlet-landscaper" }}
+          {{ $resource := getResource .cd "name" "landscaper-gardenlet" }}
           image: {{ $resource.access.imageReference }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug

**What this PR does / why we need it**:

Update landscaper gardenlet blueprint to properly reference the landscaper-gardenlet resource in the component descriptor.

The gardenlet landscaper OCI image is a `resource`  in the g/g component descriptor like so:

```
  - access:
      imageReference: <>/gardener-project/gardener/landscaper-gardenlet:v1.25.1-mod1
      type: ociRegistry
    extraIdentity: {}
    labels:
    - name: cloud.gardener.cnudie/migration/original_ref
      value: <>/gardener-project/gardener/landscaper-gardenlet:v1.25.1
    - name: cloud.gardener.cnudie/sdo/lssd
      value:
        processingRules:
        - purge_berkeleydb_to_public
    name: landscaper-gardenlet
    relation: local
    srcRefs: []
    type: ociImage
    version: v1.25.1
```


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

I think it is safe to add it to the v1.26 release milestone as the landscaper-gardenlet is not actively used yet. (not deployed to any landscape or is undergoing extensive tests).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The blueprint of the Gardenlet landscaper has been fixed to properly reference the gardenlet-landscaper OCI image
```
