### PR TITLE
Improve golang build from source in prepare_release

### DIFF
--- a/hack/.ci/prepare_release
+++ b/hack/.ci/prepare_release
@@ -33,7 +33,7 @@ apk add --no-cache \
     sed
 
 # create virtual package with the dev tools
-echo "Installing dev tools"
+echo "Installing dev tools in a virtual package"
 apk add --no-cache --virtual .build-deps \
     gcc \
     go \
@@ -41,7 +41,8 @@ apk add --no-cache --virtual .build-deps \
 
 GOLANG_VERSION="$(sed -rn 's/FROM (eu\.gcr\.io\/gardener-project\/3rd\/golang|golang):([^ ]+).*/\2/p' < "$repo_root_dir/Dockerfile")"
 
-# alpine is using musl-libc instead of glibc, therefore we cannot use the avilable pre-built binaries from golang, but have to build them ourselves from source.
+# As we cannot expect alpine to provide and maintain all golang versions via apk, we need to find another way to install the required golang version.
+# Alpine is using musl-libc instead of glibc, therefore we cannot use the available pre-built binaries from golang, but have to build them ourselves from source.
 # refs:
 #   - https://stackoverflow.com/a/45987284
 #   - https://github.com/docker-library/golang/blob/f300e60ca19c3b98cfcf01ca112af2ac10104320/1.16/alpine3.14/Dockerfile
@@ -62,14 +63,10 @@ cd /usr/local/go/src
 echo "Executing make on go $GOLANG_VERSION"
 ./make.bash -v
 
-echo "Uninstalling dev tools"
+echo "Deleting the virtual package for go"
 apk del --no-network .build-deps
 
-echo "Configure just-installed go to be used globally"
-echo "export PATH=$PATH" > /etc/profile.d/golang.sh
 export GOROOT="/usr/local/go"
-echo "export GOROOT=$GOROOT" >> /etc/profile.d/golang.sh
-
 export GOPATH="$(mktemp -d)"
 export GOBIN="$GOPATH/bin"
 export PATH="$GOBIN:$PATH"

--- a/hack/.ci/prepare_release
+++ b/hack/.ci/prepare_release
@@ -25,34 +25,50 @@ apk add --no-cache \
     ca-certificates \
     make \
     bash \
-    go \
     git \
-    musl-dev \
     curl \
     openssl \
     tar \
     gzip \
-    gcc \
     sed
+
+# create virtual package with the dev tools
+echo "Installing dev tools"
+apk add --no-cache --virtual .build-deps \
+    gcc \
+    go \
+    musl-dev
 
 GOLANG_VERSION="$(sed -rn 's/FROM (eu\.gcr\.io\/gardener-project\/3rd\/golang|golang):([^ ]+).*/\2/p' < "$repo_root_dir/Dockerfile")"
 
-export \
-    GOROOT="$(go env GOROOT)" \
-    GOOS="$(go env GOOS)" \
-    GOARCH="$(go env GOARCH)" \
-    GOHOSTOS="$(go env GOHOSTOS)" \
-    GOHOSTARCH="$(go env GOHOSTARCH)"
-
-echo "Downloading go $GOLANG_VERSION"
+# alpine is using musl-libc instead of glibc, therefore we cannot use the avilable pre-built binaries from golang, but have to build them ourselves from source.
+# refs:
+#   - https://stackoverflow.com/a/45987284
+#   - https://github.com/docker-library/golang/blob/f300e60ca19c3b98cfcf01ca112af2ac10104320/1.16/alpine3.14/Dockerfile
+echo "Downloading go src $GOLANG_VERSION"
+rm -rf /usr/local/go
 wget -q -O - "https://golang.org/dl/go$GOLANG_VERSION.src.tar.gz" | tar zx -C /usr/local
+
+# Configure golang environment
+echo "Building and installing go $GOLANG_VERSION"
+export \
+  PATH="/usr/local/go/bin":$PATH \
+  GOARCH="$(go env GOARCH)" \
+  GOOS="$(go env GOOS)" \
+  GOROOT_BOOTSTRAP="$(go env GOROOT)"
+export GOHOSTOS="$GOOS" \
+  GOHOSTARCH="$GOARCH"
 cd /usr/local/go/src
 echo "Executing make on go $GOLANG_VERSION"
-./make.bash
+./make.bash -v
 
-# Make the newly "installed from source" go the default one
-export PATH="/usr/local/go/bin:$PATH"
+echo "Uninstalling dev tools"
+apk del --no-network .build-deps
+
+echo "Configure just-installed go to be used globally"
+echo "export PATH=$PATH" > /etc/profile.d/golang.sh
 export GOROOT="/usr/local/go"
+echo "export GOROOT=$GOROOT" >> /etc/profile.d/golang.sh
 
 export GOPATH="$(mktemp -d)"
 export GOBIN="$GOPATH/bin"

--- a/hack/.ci/prepare_release
+++ b/hack/.ci/prepare_release
@@ -61,7 +61,7 @@ export GOHOSTOS="$GOOS" \
   GOHOSTARCH="$GOARCH"
 cd /usr/local/go/src
 echo "Executing make on go $GOLANG_VERSION"
-./make.bash -v
+./make.bash
 
 echo "Deleting the virtual package for go"
 apk del --no-network .build-deps


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement
/component cicd
/milestone v1.26

**What this PR does / why we need it**:
Improve golang build from source in prepare_release
Remove the go installed from apk
Configure globally golang env variables
Set the GOROOT_BOOTSTRAP env variable before building go from source
Add documentation why we are building from source but installing pre-built binaries.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
