### PR TITLE
landscaper gardenlet nit for image vector

### DIFF
--- a/landscaper/pkg/gardenlet/controller/gardenlet_chart_values.go
+++ b/landscaper/pkg/gardenlet/controller/gardenlet_chart_values.go
@@ -21,6 +21,7 @@ import (
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/managedseed"
 	"github.com/gardener/gardener/pkg/utils"
+	"sigs.k8s.io/yaml"
 )
 
 func (g Landscaper) computeGardenletChartValues(bootstrapKubeconfig []byte) (map[string]interface{}, error) {
@@ -67,11 +68,19 @@ func setImageVectorOverwrites(values map[string]interface{}, imageVectorOverwrit
 
 	// Set image vector
 	if imageVectorOverwrite != nil {
-		gardenletValues.(map[string]interface{})["imageVectorOverwrite"] = string(*imageVectorOverwrite)
+		yamlImageVector, err := yaml.JSONToYAML(*imageVectorOverwrite)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert image vector to yaml: %w", err)
+		}
+		gardenletValues.(map[string]interface{})["imageVectorOverwrite"] = string(yamlImageVector)
 	}
 
 	if componentImageVectorOverwrites != nil {
-		gardenletValues.(map[string]interface{})["componentImageVectorOverwrites"] = string(*componentImageVectorOverwrites)
+		yamlImageVector, err := yaml.JSONToYAML(*componentImageVectorOverwrites)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert component image vector to yaml: %w", err)
+		}
+		gardenletValues.(map[string]interface{})["componentImageVectorOverwrites"] = string(yamlImageVector)
 	}
 
 	return utils.SetToValuesMap(values, gardenletValues, "global", "gardenlet")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/kind enhancement

**What this PR does / why we need it**:

The gardenlet ladnscaper always writes the image vector overwrite as yaml (instead of json).
This is aligned with existing practice and is better for readability when testing / debugging.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

I think it is safe to add it to the v1.26 release milestone as the landscaper-gardenlet is not actively used yet. (not deployed to any landscape or is undergoing extensive tests).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
