### PR TITLE
Only execute test-cov when instructed to

### DIFF
--- a/.ci/verify
+++ b/.ci/verify
@@ -51,5 +51,12 @@ if [ $use_cache = yes ] ; then
     mv "$cache" "$concourse_cache_dir/$cache_name"
   done
 else
-  make verify-extended
+  if [ -n "${TEST_COV}" ] ; then
+    # supposed to be run in release jobs
+    make verify-extended
+  else
+    make install-requirements
+    # run test instead of test-cov to speed-up jobs, as coverage slows down tests significantly
+    make check-generate verify
+  fi
 fi


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/component cicd
/kind enhancement

**What this PR does / why we need it**:

Only execute `test-cov` when instructed to in `.ci/verify`.

This is done in order to configure only the release jobs to run `test-cov`.
The head-update jobs now won't run `test-cov` anymore, which
- slows down tests significantly ⏳ 
- burns CPU time and makes other concurrent jobs fail ❌ 
- increases noisy of CI signals, which wastes time when developers need to check failed jobs 🧑‍💻 
- burns money 💸 
- burns electricity 🔌⚡
- produces CO2 💨 
- speeds up climate change 🌍🌳🔥

So I think, we can now definitely agree, that `test-cov` is bad 😄 
