### PR TITLE
Ensure new osc name for different cri configuration

### DIFF
--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -327,7 +327,7 @@ func (o *operatingSystemConfig) forEachWorkerPoolAndPurpose(fn func(*extensionsv
 			extensionsv1alpha1.OperatingSystemConfigPurposeProvision,
 			extensionsv1alpha1.OperatingSystemConfigPurposeReconcile,
 		} {
-			oscName := Key(worker.Name, o.values.KubernetesVersion) + purposeToKeySuffix(purpose)
+			oscName := Key(worker.Name, o.values.KubernetesVersion, worker.CRI) + purposeToKeySuffix(purpose)
 
 			osc, ok := o.oscs[oscName]
 			if !ok {
@@ -412,7 +412,7 @@ func (o *operatingSystemConfig) newDeployer(osc *extensionsv1alpha1.OperatingSys
 		osc:                     osc,
 		worker:                  worker,
 		purpose:                 purpose,
-		key:                     Key(worker.Name, o.values.KubernetesVersion),
+		key:                     Key(worker.Name, o.values.KubernetesVersion, worker.CRI),
 		apiServerURL:            o.values.APIServerURL,
 		caBundle:                caBundle,
 		clusterDNSAddress:       o.values.ClusterDNSAddress,
@@ -592,13 +592,18 @@ func (d *deployer) deploy(ctx context.Context, operation string) (extensionsv1al
 }
 
 // Key returns the key that can be used as secret name based on the provided worker name and Kubernetes version.
-func Key(workerName string, kubernetesVersion *semver.Version) string {
+func Key(workerName string, kubernetesVersion *semver.Version, criConfig *gardencorev1beta1.CRI) string {
 	if kubernetesVersion == nil {
 		return ""
 	}
 
 	kubernetesMajorMinorVersion := fmt.Sprintf("%d.%d", kubernetesVersion.Major(), kubernetesVersion.Minor())
-	return fmt.Sprintf("cloud-config-%s-%s", workerName, utils.ComputeSHA256Hex([]byte(kubernetesMajorMinorVersion))[:5])
+
+	var criName gardencorev1beta1.CRIName
+	if criConfig != nil {
+		criName = criConfig.Name
+	}
+	return fmt.Sprintf("cloud-config-%s-%s", workerName, utils.ComputeSHA256Hex([]byte(kubernetesMajorMinorVersion + string(criName)))[:5])
 }
 
 func purposeToKeySuffix(purpose extensionsv1alpha1.OperatingSystemConfigPurpose) string {

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -591,7 +591,7 @@ func (d *deployer) deploy(ctx context.Context, operation string) (extensionsv1al
 	return d.osc, err
 }
 
-// Key returns the key that can be used as secret name based on the provided worker name and Kubernetes version.
+// Key returns the key that can be used as secret name based on the provided worker name, Kubernetes version and CRI configuration.
 func Key(workerName string, kubernetesVersion *semver.Version, criConfig *gardencorev1beta1.CRI) string {
 	if kubernetesVersion == nil {
 		return ""

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -600,7 +600,7 @@ func Key(workerName string, kubernetesVersion *semver.Version, criConfig *garden
 	kubernetesMajorMinorVersion := fmt.Sprintf("%d.%d", kubernetesVersion.Major(), kubernetesVersion.Minor())
 
 	var criName gardencorev1beta1.CRIName
-	if criConfig != nil {
+	if criConfig != nil && criConfig.Name != gardencorev1beta1.CRINameDocker {
 		criName = criConfig.Name
 	}
 	return fmt.Sprintf("cloud-config-%s-%s", workerName, utils.ComputeSHA256Hex([]byte(kubernetesMajorMinorVersion + string(criName)))[:5])

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
@@ -196,7 +196,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 				if worker.CRI != nil {
 					criName = extensionsv1alpha1.CRIName(worker.CRI.Name)
 					criConfig = &extensionsv1alpha1.CRIConfig{Name: extensionsv1alpha1.CRIName(worker.CRI.Name)}
-					configHash = "-77ac3"
+					configHash = "-cf2c8"
 				} else {
 					criName = extensionsv1alpha1.CRINameDocker
 					configHash = "-77ac3"
@@ -585,19 +585,20 @@ var _ = Describe("OperatingSystemConfig", func() {
 					},
 					worker2Name: {
 						Downloader: Data{
-							Content: "foobar-cloud-config-" + worker2Name + "-77ac3-downloader",
-							Command: pointer.String("foo-cloud-config-" + worker2Name + "-77ac3-downloader"),
+							Content: "foobar-cloud-config-" + worker2Name + "-cf2c8-downloader",
+							Command: pointer.String("foo-cloud-config-" + worker2Name + "-cf2c8-downloader"),
+
 							Units: []string{
-								"bar-cloud-config-" + worker2Name + "-77ac3-downloader",
-								"baz-cloud-config-" + worker2Name + "-77ac3-downloader",
+								"bar-cloud-config-" + worker2Name + "-cf2c8-downloader",
+								"baz-cloud-config-" + worker2Name + "-cf2c8-downloader",
 							},
 						},
 						Original: Data{
-							Content: "foobar-cloud-config-" + worker2Name + "-77ac3-original",
-							Command: pointer.String("foo-cloud-config-" + worker2Name + "-77ac3-original"),
+							Content: "foobar-cloud-config-" + worker2Name + "-cf2c8-original",
+							Command: pointer.String("foo-cloud-config-" + worker2Name + "-cf2c8-original"),
 							Units: []string{
-								"bar-cloud-config-" + worker2Name + "-77ac3-original",
-								"baz-cloud-config-" + worker2Name + "-77ac3-original",
+								"bar-cloud-config-" + worker2Name + "-cf2c8-original",
+								"baz-cloud-config-" + worker2Name + "-cf2c8-original",
 							},
 						},
 					},
@@ -759,11 +760,16 @@ var _ = Describe("OperatingSystemConfig", func() {
 		var workerName = "foo"
 
 		It("should return an empty string", func() {
-			Expect(Key(workerName, nil)).To(BeEmpty())
+			Expect(Key(workerName, nil, nil)).To(BeEmpty())
 		})
 
-		It("should return the expected key", func() {
-			Expect(Key(workerName, semver.MustParse("1.2.3"))).To(Equal("cloud-config-" + workerName + "-77ac3"))
+		It("is different for different worker.cri configurations", func() {
+			containerDKey := Key(workerName, semver.MustParse("1.2.3"), &gardencorev1beta1.CRI{Name: gardencorev1beta1.CRINameContainerD})
+			dockerKey := Key(workerName, semver.MustParse("1.2.3"), &gardencorev1beta1.CRI{Name: gardencorev1beta1.CRINameDocker})
+			nilKey := Key(workerName, semver.MustParse("1.2.3"), nil)
+			Expect(containerDKey).NotTo(Equal(dockerKey))
+			Expect(containerDKey).NotTo(Equal(nilKey))
+			Expect(dockerKey).NotTo(Equal(nilKey))
 		})
 	})
 })

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
@@ -189,18 +189,21 @@ var _ = Describe("OperatingSystemConfig", func() {
 			expected = make([]*extensionsv1alpha1.OperatingSystemConfig, 0, 2*len(workers))
 			for _, worker := range workers {
 				var (
-					criName   extensionsv1alpha1.CRIName
-					criConfig *extensionsv1alpha1.CRIConfig
+					criName    extensionsv1alpha1.CRIName
+					criConfig  *extensionsv1alpha1.CRIConfig
+					configHash string
 				)
 				if worker.CRI != nil {
 					criName = extensionsv1alpha1.CRIName(worker.CRI.Name)
 					criConfig = &extensionsv1alpha1.CRIConfig{Name: extensionsv1alpha1.CRIName(worker.CRI.Name)}
+					configHash = "-77ac3"
 				} else {
 					criName = extensionsv1alpha1.CRINameDocker
+					configHash = "-77ac3"
 				}
 
 				downloaderUnits, downloaderFiles, _ := downloaderConfigFn(
-					"cloud-config-"+worker.Name+"-77ac3",
+					"cloud-config-"+worker.Name+configHash,
 					apiServerURL,
 				)
 				originalUnits, originalFiles, _ := originalConfigFn(components.Context{
@@ -219,7 +222,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 
 				oscDownloader := &extensionsv1alpha1.OperatingSystemConfig{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "cloud-config-" + worker.Name + "-77ac3-downloader",
+						Name:      "cloud-config-" + worker.Name + configHash + "-downloader",
 						Namespace: namespace,
 						Annotations: map[string]string{
 							v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
@@ -240,7 +243,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 
 				oscOriginal := &extensionsv1alpha1.OperatingSystemConfig{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "cloud-config-" + worker.Name + "-77ac3-original",
+						Name:      "cloud-config-" + worker.Name + configHash + "-original",
 						Namespace: namespace,
 						Annotations: map[string]string{
 							v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
@@ -314,16 +317,16 @@ var _ = Describe("OperatingSystemConfig", func() {
 
 			BeforeEach(func() {
 				extensions := make([]gardencorev1alpha1.ExtensionResourceState, 0, 2*len(workers))
-				for _, worker := range workers {
+				for _, osc := range expected {
 					extensions = append(extensions,
 						gardencorev1alpha1.ExtensionResourceState{
-							Name:    pointer.String("cloud-config-" + worker.Name + "-77ac3-downloader"),
+							Name:    pointer.String(osc.Name),
 							Kind:    extensionsv1alpha1.OperatingSystemConfigResource,
 							Purpose: pointer.String(string(extensionsv1alpha1.OperatingSystemConfigPurposeProvision)),
 							State:   &runtime.RawExtension{Raw: stateDownloader},
 						},
 						gardencorev1alpha1.ExtensionResourceState{
-							Name:    pointer.String("cloud-config-" + worker.Name + "-77ac3-original"),
+							Name:    pointer.String(osc.Name),
 							Kind:    extensionsv1alpha1.OperatingSystemConfigResource,
 							Purpose: pointer.String(string(extensionsv1alpha1.OperatingSystemConfigPurposeReconcile)),
 							State:   &runtime.RawExtension{Raw: stateOriginal},

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
@@ -766,10 +766,13 @@ var _ = Describe("OperatingSystemConfig", func() {
 		It("is different for different worker.cri configurations", func() {
 			containerDKey := Key(workerName, semver.MustParse("1.2.3"), &gardencorev1beta1.CRI{Name: gardencorev1beta1.CRINameContainerD})
 			dockerKey := Key(workerName, semver.MustParse("1.2.3"), &gardencorev1beta1.CRI{Name: gardencorev1beta1.CRINameDocker})
-			nilKey := Key(workerName, semver.MustParse("1.2.3"), nil)
 			Expect(containerDKey).NotTo(Equal(dockerKey))
-			Expect(containerDKey).NotTo(Equal(nilKey))
-			Expect(dockerKey).NotTo(Equal(nilKey))
+		})
+
+		It("is the same for `cri=nil` and `cri.name=docker`", func() {
+			dockerKey := Key(workerName, semver.MustParse("1.2.3"), &gardencorev1beta1.CRI{Name: gardencorev1beta1.CRINameDocker})
+			nilKey := Key(workerName, semver.MustParse("1.2.3"), nil)
+			Expect(dockerKey).To(Equal(nilKey))
 		})
 	})
 })

--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -234,7 +234,7 @@ func (b *Botanist) generateCloudConfigExecutorResourcesForWorker(
 ) {
 	var (
 		registry   = managedresources.NewRegistry(kubernetes.ShootScheme, kubernetes.ShootCodec, kubernetes.ShootSerializer)
-		secretName = operatingsystemconfig.Key(worker.Name, b.Shoot.KubernetesVersion)
+		secretName = operatingsystemconfig.Key(worker.Name, b.Shoot.KubernetesVersion, worker.CRI)
 	)
 
 	var kubeletDataVolume *gardencorev1beta1.DataVolume


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind bug

**What this PR does / why we need it**:
Changing `cri.name=containerd` to `cri=nil` doesn't work as expected: A node rollout happens, but the new node still starts `containerd`, which shouldn't be the case. Because the `operatingsystemconfig` name stays the same for the nodes in the new worker pool (it is currently only depending on k8s major.minor version and worker.name), the same `osc.spec.criconfig` is applied to new and old nodes. Therefore, we cannot simply update this property, but have to ensure that a new `operatingsystemconfig` is created.

**Which issue(s) this PR fixes**:
Fixes #4254

**Special notes for your reviewer**:
With this implementation, `cri=nil` and `cri.name=docker` will get different `operatingsystemconfig` names. Will this be an issue in our efforts to prevent a node rollout from happening when users switch from `cri=nil` to `cri.name=docker`?

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bug user
Switching an existing worker pool from `containerd` to `docker` no longer starts `containerd` on the new node
```
