### PR TITLE
Add controller artifact for bastion resources

### DIFF
--- a/pkg/gardenlet/controller/federatedseed/extensions/artifact.go
+++ b/pkg/gardenlet/controller/federatedseed/extensions/artifact.go
@@ -84,6 +84,12 @@ func newControllerArtifacts() controllerArtifacts {
 		newStateArtifact(gvk, func() client.Object { return &extensionsv1alpha1.BackupEntry{} }, extensionStateOrResourcesChanged),
 	)
 
+	gvk = extensionsv1alpha1.SchemeGroupVersion.WithKind(extensionsv1alpha1.BastionResource)
+	a.registerExtensionControllerArtifacts(
+		newControllerInstallationArtifact(gvk, func() client.ObjectList { return &extensionsv1alpha1.BastionList{} }, extensionTypeChanged),
+		disabledArtifact(),
+	)
+
 	gvk = extensionsv1alpha1.SchemeGroupVersion.WithKind(extensionsv1alpha1.ContainerRuntimeResource)
 	a.registerExtensionControllerArtifacts(
 		newControllerInstallationArtifact(gvk, func() client.ObjectList { return &extensionsv1alpha1.ContainerRuntimeList{} }, extensionTypeChanged),


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind bug

**What this PR does / why we need it**:
Adds the bastion resource to the list of controller artifacts. Without this, the logic to figure out which extensions have or don't have resources in the seed in order to properly remove them is broken, leading to extensions not being removed even after all their resources have been removed, simply because the corresponding reconciliation exits early. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
I used `disabledArtifact()` instead of `newStateArtifact(...)` since from a look at the code it seems `bastion` is more like `backupbucket` in that it's not actually migratable to a different seed and so no state needs to be managed. I haven't tested actual migration with bastion resources though and I could be wrong.
/cc @plkokanov @xrstf 

**Release note**:

```other operator
NONE
```
