### PR TITLE
Fix .ci/verify for head-update job

### DIFF
--- a/.ci/verify
+++ b/.ci/verify
@@ -51,7 +51,7 @@ if [ $use_cache = yes ] ; then
     mv "$cache" "$concourse_cache_dir/$cache_name"
   done
 else
-  if [ -n "${TEST_COV}" ] ; then
+  if [ "${TEST_COV+yes}" = yes ] ; then
     # supposed to be run in release jobs
     make verify-extended
   else


### PR DESCRIPTION
/kind bug

Follow-up on https://github.com/gardener/gardener/pull/4288, didn't think about the unset case.

Fixes https://concourse.ci.gardener.cloud/teams/gardener/pipelines/gardener-master/jobs/master-head-update-job/builds/409#L60d5882d:265
```
git-gardener.gardener-master.master/.ci/verify: line 54: TEST_COV: unbound variable
```