### PR TITLE
Upgrade istio images to distroless and 1.10.2

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -254,11 +254,11 @@ images:
 - name: istio-proxy
   sourceRepository: github.com/istio/istio
   repository: gcr.io/istio-release/proxyv2
-  tag: "1.10.1"
+  tag: "1.10.2-distroless"
 - name: istio-istiod
   sourceRepository: github.com/istio/istio
   repository: gcr.io/istio-release/pilot
-  tag: "1.10.1"
+  tag: "1.10.2-distroless"
 
 # API Server SNI
 - name: apiserver-proxy

--- a/charts/istio/istio-istiod/templates/deployment.yaml
+++ b/charts/istio/istio-istiod/templates/deployment.yaml
@@ -34,7 +34,6 @@ spec:
         - "discovery"
         - --monitoringAddr=:15014
         - --grpcAddr=
-        - --httpAddr=localhost:8080
         - --httpsAddr=:{{ .Values.ports.https }}
         - --log_output_level=all:warn,ads:error
         - --domain={{ .Values.trustDomain }}
@@ -45,14 +44,14 @@ spec:
           protocol: TCP
         - containerPort: {{ .Values.ports.https }}
           protocol: TCP
+        - containerPort: 8080
+          protocol: TCP
         readinessProbe:
-          exec:
-            command:
-            - curl
-            - -s
-            - http://localhost:8080/ready
-          initialDelaySeconds: 5
-          periodSeconds: 5
+          httpGet:
+            path: /ready
+            port: 8080
+          initialDelaySeconds: 1
+          periodSeconds: 3
           timeoutSeconds: 5
         env:
         - name: JWT_POLICY


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:

Distroless images offer way less attack surface available in the images.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`ManagedIstio` now uses distroless images.
```

```other operator
`ManagedIstio` is now upgraded to `1.10.2`
```
