### PR TITLE
Remove SeedSelector from GardenletConfiguration

### DIFF
--- a/charts/gardener/gardenlet/charts/runtime/templates/configmap-componentconfig.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/configmap-componentconfig.yaml
@@ -162,10 +162,6 @@ data:
     featureGates:
 {{ toYaml .Values.global.gardenlet.config.featureGates | indent 6 }}
     {{- end }}
-    {{- if .Values.global.gardenlet.config.seedSelector }}
-    seedSelector:
-{{ toYaml .Values.global.gardenlet.config.seedSelector | indent 6 }}
-    {{- end }}
     {{- if .Values.global.gardenlet.config.seedConfig }}
     seedConfig:
 {{ toYaml .Values.global.gardenlet.config.seedConfig | indent 6 }}

--- a/charts/gardener/gardenlet/values.yaml
+++ b/charts/gardener/gardenlet/values.yaml
@@ -155,7 +155,6 @@ global:
       #       labels:
       #         istio: ingressgateway-handler-2
 
-    # seedSelector: {}
     # seedConfig: {}
     # logging:
     #   fluentBit:

--- a/cmd/gardenlet/app/gardenlet.go
+++ b/cmd/gardenlet/app/gardenlet.go
@@ -323,7 +323,6 @@ func NewGardenlet(ctx context.Context, cfg *config.GardenletConfiguration) (*Gar
 	}
 
 	seedClientMapBuilder := clientmapbuilder.NewSeedClientMapBuilder().
-		WithInCluster(true).
 		WithClientConnectionConfig(&cfg.SeedClientConnection.ClientConnectionConfiguration)
 	shootClientMapBuilder := clientmapbuilder.NewShootClientMapBuilder().
 		WithClientConnectionConfig(&cfg.ShootClientConnection.ClientConnectionConfiguration)

--- a/cmd/gardenlet/app/gardenlet.go
+++ b/cmd/gardenlet/app/gardenlet.go
@@ -323,7 +323,7 @@ func NewGardenlet(ctx context.Context, cfg *config.GardenletConfiguration) (*Gar
 	}
 
 	seedClientMapBuilder := clientmapbuilder.NewSeedClientMapBuilder().
-		WithInCluster(cfg.SeedSelector == nil).
+		WithInCluster(true).
 		WithClientConnectionConfig(&cfg.SeedClientConnection.ClientConnectionConfiguration)
 	shootClientMapBuilder := clientmapbuilder.NewShootClientMapBuilder().
 		WithClientConnectionConfig(&cfg.ShootClientConnection.ClientConnectionConfiguration)

--- a/docs/concepts/gardenlet.md
+++ b/docs/concepts/gardenlet.md
@@ -111,29 +111,6 @@ for example, using command  `kubectl certificate approve  seed-csr-<...>`).
 If that doesn’t happen within 15 minutes,
 the gardenlet repeats the process and creates another CSR.
 
-## Seed Config versus Seed Selector
-
-The usage of the gardenlet is flexible:
-
-| Usage | Description |
-|:---|:---|
-| `seedConfig` | Run one gardenlet per seed cluster inside the seed cluster itself.|
-| `seedSelector` | Use one gardenlet to manage multiple seed clusters. The gardenlet can run outside of the seed cluster.|
-
-> For production use it’s recommended to go for the `seedConfig` option,
-> because it makes scaling easier and leads to a better distribution of responsibilities.
-
-* Provide a `seedConfig` that contains information about the seed cluster itself
-  if you want the gardenlet in the standard way,
-  see [the example gardenlet configuration](../../example/20-componentconfig-gardenlet.yaml).
-  Once bootstrapped, the gardenlet creates and updates its `Seed` object itself.
-
-* Provide a `seedSelector` that incorporates a label selector for the
-  targeted seed clusters if you want the gardenlet to manage multiple seeds,
-  see [the example gardenlet configuration](../../example/20-componentconfig-gardenlet.yaml).
-  In this case, you have to create the `Seed` objects
-  together with a `kubeconfig` pointing to the cluster yourself.
-
 ## Component Configuration
 
 In the component configuration for the gardenlet, it’s possible to define:
@@ -166,13 +143,7 @@ It’s used as a liveness probe in the `Deployment` of the gardenlet.
 If the gardenlet fails to renew its lease
 then the endpoint returns `500 Internal Server Error`, otherwise it returns `200 OK`.
 
-> ⚠️<br> In case the gardenlet is managing multiple seeds
-> (that is, a seed selector is used) then the `/healthz`
-> reports `500 Internal Server Error` if there is at least one seed
-> for which it couldn’t renew its lease. Only if it can renew the lease
-> for all seeds it reports `200 OK`.
-
-Please note, that the `/healthz` only indicates whether the gardenlet
+Please note that the `/healthz` only indicates whether the gardenlet
 could successfully probe the Seed's API server and renew the lease with
 the Garden cluster.
 It does *not* show that the Gardener extension API server (with the Gardener resource groups)

--- a/docs/concepts/gardenlet.md
+++ b/docs/concepts/gardenlet.md
@@ -137,9 +137,8 @@ When using `make start-gardenlet`, the corresponding script will automatically
 fetch the seed cluster's `kubeconfig` based on the `seedConfig.spec.secretRef`
 and set the environment accordingly.
 
-When running the Gardenlet without the help of the Makefile, set the
-environment variable `KUBECONFIG` to the seed cluster's kubeconfig and
-`GARDEN_KUBECONFIG` to the garden cluster's kubeconfig.
+On startup, gardenlet registers a `Seed` resource using the given template
+in `seedConfig` if it's not present already.
 
 ## Component Configuration
 

--- a/docs/concepts/gardenlet.md
+++ b/docs/concepts/gardenlet.md
@@ -111,6 +111,36 @@ for example, using command  `kubectl certificate approve  seed-csr-<...>`).
 If that doesn’t happen within 15 minutes,
 the gardenlet repeats the process and creates another CSR.
 
+## Configuring the Seed to work with
+
+The Gardenlet works with a single seed, which must be configured in the
+`GardenletConfiguration` under `.seedConfig`. This must be a copy of the
+`Seed` resource, for example (see `example/20-componentconfig-gardenlet.yaml`
+for a more complete example):
+
+```yaml
+apiVersion: gardenlet.config.gardener.cloud/v1alpha1
+kind: GardenletConfiguration
+seedConfig:
+  metadata:
+    name: my-seed
+  spec:
+    provider:
+      type: aws
+    # ...
+    secretRef:
+      name: my-seed-secret
+      namespace: garden
+```
+
+When using `make start-gardenlet`, the corresponding script will automatically
+fetch the seed cluster's `kubeconfig` based on the `seedConfig.spec.secretRef`
+and set the environment accordingly.
+
+When running the Gardenlet without the help of the Makefile, set the
+environment variable `KUBECONFIG` to the seed cluster's kubeconfig and
+`GARDEN_KUBECONFIG` to the garden cluster's kubeconfig.
+
 ## Component Configuration
 
 In the component configuration for the gardenlet, it’s possible to define:

--- a/docs/deployment/deploy_gardenlet_manually.md
+++ b/docs/deployment/deploy_gardenlet_manually.md
@@ -2,16 +2,16 @@
 
 Manually deploying a gardenlet is required in the following cases:
 
-- The Kubernetes cluster to be registered as a seed cluster has no public endpoint, 
-  because it is behind a firewall. 
+- The Kubernetes cluster to be registered as a seed cluster has no public endpoint,
+  because it is behind a firewall.
   The gardenlet must then be deployed into the cluster itself.
 
-- The Kubernetes cluster to be registered as a seed cluster is managed externally 
+- The Kubernetes cluster to be registered as a seed cluster is managed externally
   (the Kubernetes cluster is not a shoot cluster, so [Automatic Deployment of Gardenlets](deploy_gardenlet_automatically.md) cannot be used).
 
-- The gardenlet runs outside of the Kubernetes cluster 
-  that should be registered as a seed cluster. 
-  (The gardenlet is not restricted to run in the seed cluster or 
+- The gardenlet runs outside of the Kubernetes cluster
+  that should be registered as a seed cluster.
+  (The gardenlet is not restricted to run in the seed cluster or
   to be deployed into a Kubernetes cluster at all).
 
 > Once you’ve deployed a gardenlet manually, for example, behind a firewall, you can deploy new gardenlets automatically. The manually deployed gardenlet is then used as a template for the new gardenlets. More information: [Automatic Deployment of Gardenlets](deploy_gardenlet_automatically.md).
@@ -19,15 +19,15 @@ Manually deploying a gardenlet is required in the following cases:
 ## Prerequisites
 
 ### Kubernetes cluster that should be registered as a seed cluster
-    
+
 - Verify that the cluster has a [supported Kubernetes version](../usage/supported_k8s_versions.md).
-  
-- Determine the nodes, pods, and services CIDR of the cluster. 
+
+- Determine the nodes, pods, and services CIDR of the cluster.
   You need to configure this information in the `Seed` configuration.
   Gardener uses this information to check that the shoot cluster isn’t created with overlapping CIDR ranges.
 
 - Every Seed cluster needs an Ingress controller which distributes external requests to internal components like grafana and prometheus. Gardener supports two approaches to achieve this:
-    
+
 a. Gardener managed Ingress controller and DNS records. For this configure the following lines in your [Seed resource](../../example/50-seed.yaml):
 ```yaml
 spec:
@@ -49,7 +49,7 @@ spec:
 
 b. Self-managed DNS record and Ingress controller:
 
-:warning:  
+:warning:
 There should exist a DNS record `*.ingress.<SEED-CLUSTER-DOMAIN>` where `<SEED-CLUSTER-DOMAIN>` is the value of the `.dns.ingressDomain` field of [a Seed cluster resource](../../example/50-seed.yaml) (or the [respective Gardenlet configuration](../../example/20-componentconfig-gardenlet.yaml#L84-L85)).
 
 *This is how it could be done for the Nginx ingress controller*
@@ -77,27 +77,27 @@ spec:
 
 ### `kubeconfig` for the Seed Cluster
 
-The `kubeconfig` is required to deploy the gardenlet Helm chart to the seed cluster. 
-The gardenlet requires certain privileges to be able to operate. 
-These privileges are described in RBAC resources in the gardenlet Helm chart (see [charts/gardener/gardenlet/charts/runtime/templates](../../charts/gardener/gardenlet/charts/runtime/templates)). 
-The Helm chart contains a service account `gardenlet` 
+The `kubeconfig` is required to deploy the gardenlet Helm chart to the seed cluster.
+The gardenlet requires certain privileges to be able to operate.
+These privileges are described in RBAC resources in the gardenlet Helm chart (see [charts/gardener/gardenlet/charts/runtime/templates](../../charts/gardener/gardenlet/charts/runtime/templates)).
+The Helm chart contains a service account `gardenlet`
 that the gardenlet deployment uses by default to talk to the Seed API server.
 
-> If the gardenlet isn’t deployed in the seed cluster, 
-> the gardenlet can be configured to use a `kubeconfig`, 
-> which also requires the above-mentioned privileges, from a mounted directory. 
-> The `kubeconfig` is specified in section `seedClientConnection.kubeconfig` 
+> If the gardenlet isn’t deployed in the seed cluster,
+> the gardenlet can be configured to use a `kubeconfig`,
+> which also requires the above-mentioned privileges, from a mounted directory.
+> The `kubeconfig` is specified in section `seedClientConnection.kubeconfig`
 > of the [Gardenlet configuration](../../example/20-componentconfig-gardenlet.yaml).
-> This configuration option isn’t used in the following,  
-> as this procedure only describes the recommended setup option 
-> where the gardenlet is running in the seed cluster itself. 
+> This configuration option isn’t used in the following,
+> as this procedure only describes the recommended setup option
+> where the gardenlet is running in the seed cluster itself.
 
 ## Procedure Overview
 
 1. Prepare the garden cluster:
     1. [Create a bootstrap token secret in the `kube-system` namespace of the garden cluster](#create-a-bootstrap-token-secret-in-the-kube-system-namespace-of-the-garden-cluster)
     1. [Create RBAC roles for the gardenlet to allow bootstrapping in the garden cluster](#create-rbac-roles-for-the-gardenlet-to-allow-bootstrapping-in-the-garden-cluster)
-   
+
 1. [Prepare the gardenlet Helm chart](#prepare-the-gardenlet-helm-chart).
 1. [Automatically register shoot cluster as a seed cluster](#automatically-register-shoot-cluster-as-a-seed-cluster).
 1. [Deploy the gardenlet](#deploy-the-gardenlet)
@@ -105,32 +105,32 @@ that the gardenlet deployment uses by default to talk to the Seed API server.
 
 ## Create a bootstrap token secret in the `kube-system` namespace of the garden cluster
 
-The gardenlet needs to talk to the [Gardener API server](../concepts/apiserver.md) residing in the garden cluster. 
+The gardenlet needs to talk to the [Gardener API server](../concepts/apiserver.md) residing in the garden cluster.
 
-The gardenlet can be configured with an already existing garden cluster `kubeconfig` in one of the following ways: 
+The gardenlet can be configured with an already existing garden cluster `kubeconfig` in one of the following ways:
 
-  - Either by specifying `gardenClientConnection.kubeconfig` 
+  - Either by specifying `gardenClientConnection.kubeconfig`
     in the [Gardenlet configuration](../../example/20-componentconfig-gardenlet.yaml) or
 
-  - by supplying the environment variable `GARDEN_KUBECONFIG` pointing to 
+  - by supplying the environment variable `GARDEN_KUBECONFIG` pointing to
     a mounted `kubeconfig` file).
 
-The preferred way however, is to use the gardenlets ability to request 
-a signed certificate for the garden cluster by leveraging 
+The preferred way however, is to use the gardenlets ability to request
+a signed certificate for the garden cluster by leveraging
 [Kubernetes Certificate Signing Requests](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/).
-The gardenlet performs a TLS bootstrapping process that is similar to the 
+The gardenlet performs a TLS bootstrapping process that is similar to the
 [Kubelet TLS Bootstrapping](https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/).
-Make sure that the API server of the garden cluster has 
-[bootstrap token authentication](https://kubernetes.io/docs/reference/access-authn-authz/bootstrap-tokens/#enabling-bootstrap-token-authentication) 
+Make sure that the API server of the garden cluster has
+[bootstrap token authentication](https://kubernetes.io/docs/reference/access-authn-authz/bootstrap-tokens/#enabling-bootstrap-token-authentication)
 enabled.
 
-The client credentials required for the gardenlets TLS bootstrapping process, 
+The client credentials required for the gardenlets TLS bootstrapping process,
 need to be either `token` or `certificate` (OIDC isn’t supported) and have permissions
 to create a Certificate Signing Request ([CSR](https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/)).
-It’s recommended to use [bootstrap tokens](https://kubernetes.io/docs/reference/access-authn-authz/bootstrap-tokens/) 
+It’s recommended to use [bootstrap tokens](https://kubernetes.io/docs/reference/access-authn-authz/bootstrap-tokens/)
 due to their desirable security properties (such as a limited token lifetime).
 
-Therefore, first create a bootstrap token secret for the garden cluster: 
+Therefore, first create a bootstrap token secret for the garden cluster:
 
 ``` yaml
 apiVersion: v1
@@ -158,20 +158,20 @@ stringData:
   usage-bootstrap-signing: "true"
 ```
 
-When you later prepare the gardenlet Helm chart, 
+When you later prepare the gardenlet Helm chart,
 a `kubeconfig` based on this token is shared with the gardenlet upon deployment.
 
 ## Create RBAC roles for the gardenlet to allow bootstrapping in the garden cluster
-   
-This step is only required if the gardenlet you deploy is the first gardenlet 
-in the Gardener installation. 
-Additionally, when using the [control plane chart](../../charts/gardener/controlplane), 
-the following resources are already contained in the Helm chart, 
-that is, if you use it you can skip these steps as the needed RBAC roles already exist. 
+
+This step is only required if the gardenlet you deploy is the first gardenlet
+in the Gardener installation.
+Additionally, when using the [control plane chart](../../charts/gardener/controlplane),
+the following resources are already contained in the Helm chart,
+that is, if you use it you can skip these steps as the needed RBAC roles already exist.
 
 The gardenlet uses the configured bootstrap `kubeconfig` in `gardenClientConnection.bootstrapKubeconfig` to request a signed certificate for the user `gardener.cloud:system:seed:<seed-name>` in the group `gardener.cloud:system:seeds`.
 
-Create a `ClusterRole` and `ClusterRoleBinding` that grant full admin permissions to authenticated gardenlets.  
+Create a `ClusterRole` and `ClusterRoleBinding` that grant full admin permissions to authenticated gardenlets.
 
 Create the following resources in the garden cluster:
 
@@ -243,17 +243,17 @@ Please take a look into [this document](gardenlet_api_access.md).
 
 ## Prepare the gardenlet Helm chart
 
-This section only describes the minimal configuration, 
-using the global configuration values of the gardenlet Helm chart. 
-For an overview over all values, see the [configuration values](../../charts/gardener/gardenlet/values.yaml). 
+This section only describes the minimal configuration,
+using the global configuration values of the gardenlet Helm chart.
+For an overview over all values, see the [configuration values](../../charts/gardener/gardenlet/values.yaml).
 We refer to the global configuration values as _gardenlet configuration_ in the remaining procedure.
 
 1.  Create a gardenlet configuration `gardenlet-values.yaml` based on [this template](https://github.com/gardener/gardener/blob/master/charts/gardener/gardenlet/values.yaml).
-    
+
 2.  Create a bootstrap `kubeconfig` based on the bootstrap token created in the garden cluster.
 
     Replace the `<bootstrap-token>` with `token-id.token-secret` (from our previous example: `07401b.f395accd246ae52d`) from the bootstrap token secret.
-    
+
     ```yaml
     apiVersion: v1
     kind: Config
@@ -275,7 +275,7 @@ We refer to the global configuration values as _gardenlet configuration_ in the 
     ```
 
 3.  In section `gardenClientConnection.bootstrapKubeconfig` of your gardenlet configuration, provide the bootstrap `kubeconfig` together with a name and namespace to the gardenlet Helm chart.
-    
+
     ```yaml
     gardenClientConnection:
       bootstrapKubeconfig:
@@ -284,14 +284,14 @@ We refer to the global configuration values as _gardenlet configuration_ in the 
         kubeconfig: |
           <bootstrap-kubeconfig>  # will be base64 encoded by helm
     ```
-    
+
     The bootstrap `kubeconfig` is stored in the specified secret.
-    
-4.  In section `gardenClientConnection.kubeconfigSecret` of your gardenlet configuration, 
-    define a name and a namespace where the gardenlet stores 
-    the real `kubeconfig` that it creates during the bootstrap process. If the secret doesn't exist, 
-    the gardenlet creates it for you. 
-    
+
+4.  In section `gardenClientConnection.kubeconfigSecret` of your gardenlet configuration,
+    define a name and a namespace where the gardenlet stores
+    the real `kubeconfig` that it creates during the bootstrap process. If the secret doesn't exist,
+    the gardenlet creates it for you.
+
     ```yaml
     gardenClientConnection:
       kubeconfigSecret:
@@ -301,15 +301,15 @@ We refer to the global configuration values as _gardenlet configuration_ in the 
 
 ## Automatically register shoot cluster as a seed cluster
 
-A seed cluster can either be registered by manually creating 
-the [`Seed` resource](../../example/50-seed.yaml) 
-or automatically by the gardenlet.  
-This functionality is useful for managed seed clusters, 
-as the gardenlet in the garden cluster deploys a copy of itself 
-into the cluster with automatic registration of the `Seed` configured.  
+A seed cluster can either be registered by manually creating
+the [`Seed` resource](../../example/50-seed.yaml)
+or automatically by the gardenlet.
+This functionality is useful for managed seed clusters,
+as the gardenlet in the garden cluster deploys a copy of itself
+into the cluster with automatic registration of the `Seed` configured.
 However, it can also be used to have a streamlined seed cluster registration process when manually deploying the gardenlet.
 
-> This procedure doesn’t describe all the possible configurations 
+> This procedure doesn’t describe all the possible configurations
 > for the `Seed` resource. For more information, see:
 > * [Example Seed resource](../../example/50-seed.yaml)
 > * [Configurable Seed settings](../usage/seed_settings.md).
@@ -317,12 +317,9 @@ However, it can also be used to have a streamlined seed cluster registration pro
 ### Adjust the gardenlet component configuration
 
 1. Supply the `Seed` resource in section `seedConfig` of your gardenlet configuration `gardenlet-values.yaml`.
-
-    > Note that with the `seedConfig` supplied, the gardenlet is only responsible to create and reconcile this one configured seed (in the previous example: `sweet-seed`). The gardenlet can also be configured to reconcile (but not create!) multiple Seeds [based on a label selector](../concepts/gardenlet.md#seed-config-vs-seed-selector), which is only recommended [for a development setup](../development/local_setup.md#appendix).
-
 1. Add the `seedConfig` to your gardenlet configuration `gardenlet-values.yaml`.
 The field `seedConfig.spec.provider.type` specifies the infrastructure provider type (for example, `aws`) of the seed cluster.
-For all supported infrastructure providers, see [Known Extension Implementations](../../extensions/README.md#known-extension-implementations).   
+For all supported infrastructure providers, see [Known Extension Implementations](../../extensions/README.md#known-extension-implementations).
 
     ```yaml
     ....
@@ -346,18 +343,18 @@ For all supported infrastructure providers, see [Known Extension Implementations
 
 ### Optional: Enable backup and restore
 
-The seed cluster can be set up with backup and restore 
-for the main `etcds` of shoot clusters. 
+The seed cluster can be set up with backup and restore
+for the main `etcds` of shoot clusters.
 
 Gardener uses [etcd-backup-restore](https://github.com/gardener/etcd-backup-restore)
-that [integrates with different storage providers](https://github.com/gardener/etcd-backup-restore/blob/master/doc/usage/getting_started.md#usage) 
+that [integrates with different storage providers](https://github.com/gardener/etcd-backup-restore/blob/master/doc/usage/getting_started.md#usage)
 to store the shoot cluster's main `etcd` backups.
 Make sure to obtain client credentials that have sufficient permissions with the chosen storage provider.
 
 Create a secret in the garden cluster with client credentials for the storage provider.
-The format of the secret is cloud provider specific and can be found 
-in the repository of the respective Gardener extension. 
-For example, the secret for AWS S3 can be found in the AWS provider extension 
+The format of the secret is cloud provider specific and can be found
+in the repository of the respective Gardener extension.
+For example, the secret for AWS S3 can be found in the AWS provider extension
 ([30-etcd-backup-secret.yaml](https://github.com/gardener/gardener-extension-provider-aws/blob/master/example/30-etcd-backup-secret.yaml)).
 
 ```yaml
@@ -388,12 +385,12 @@ seedConfig:
 
 ## Deploy the gardenlet
 
-> The gardenlet doesn’t have to run in the same Kubernetes cluster as the seed cluster 
-> it’s registering and reconciling, but it is in most cases advantageous 
-> to use in-cluster communication to talk to the Seed API server. 
+> The gardenlet doesn’t have to run in the same Kubernetes cluster as the seed cluster
+> it’s registering and reconciling, but it is in most cases advantageous
+> to use in-cluster communication to talk to the Seed API server.
 > Running a gardenlet outside of the cluster is mostly used for local development.
 
-The `gardenlet-values.yaml` looks something like this 
+The `gardenlet-values.yaml` looks something like this
 (with automatic Seed registration and backup for shoot clusters enabled):
 
 ```yaml
@@ -418,7 +415,7 @@ global:
                 server: <my-garden-cluster-endpoint>
               name: my-kubernetes-cluster
             ....
-            
+
         kubeconfigSecret:
           name: gardenlet-kubeconfig
           namespace: garden
@@ -467,37 +464,37 @@ This helm chart creates:
 ## Check that the gardenlet is successfully deployed
 
 1.  Check that the gardenlets certificate bootstrap was successful.
-    
+
     Check if the secret `gardenlet-kubeconfig` in the namespace `garden` in the seed cluster
     is created and contains a `kubeconfig` with a valid certificate.
-    
+
     1. Get the `kubeconfig` from the created secret.
-    
+
         ```
         $ kubectl -n garden get secret gardenlet-kubeconfig -o json | jq -r .data.kubeconfig | base64 -d
         ```
-    
+
     1. Test against the garden cluster and verify it’s working.
-    
+
     1. Extract the `client-certificate-data` from the user `gardenlet`.
-    
+
     1. View the certificate:
-    
+
         ```
         $ openssl x509 -in ./gardenlet-cert -noout -text
         ```
-    
-        Check that the certificate is valid for a year (that is the lifetime of new certificates). 
-    
+
+        Check that the certificate is valid for a year (that is the lifetime of new certificates).
+
 2.  Check that the bootstrap secret `gardenlet-bootstrap-kubeconfig` has been deleted from the seed cluster in namespace `garden`.
-    
+
 3.  Check that the seed cluster is registered and `READY` in the garden cluster.
-    
+
     Check that the seed cluster `sweet-seed` exists and all conditions indicate that it’s available.
     If so, the [Gardenlet is sending regular heartbeats](../concepts/gardenlet.md#heartbeats) and the [seed bootstrapping](../usage/seed_bootstrapping.md) was successful.
-    
+
     Check that the conditions on the `Seed` resource look similar to the following:
-    
+
     ```bash
     $ kubectl get seed sweet-seed -o json | jq .status.conditions
     [

--- a/docs/usage/managed_seed.md
+++ b/docs/usage/managed_seed.md
@@ -8,8 +8,8 @@ An existing shoot can be registered as a seed by creating a `ManagedSeed` resour
     * `gardenlet` deployment parameters, such as the number of replicas, the image, etc.
     * The `GardenletConfiguration` resource that contains controllers configuration, feature gates, and a `seedConfig` section that contains the `Seed` spec and parts of its metadata.
     * Additional configuration parameters, such as the garden connection bootstrap mechanism (see [TLS Bootstrapping](../concepts/gardenlet.md#tls-bootstrapping)), and whether to merge the provided configuration with the configuration of the parent `gardenlet`.
-    
-Either the `seedTemplate` or the `gardenlet` section must be specified, but not both: 
+
+Either the `seedTemplate` or the `gardenlet` section must be specified, but not both:
 
 * If the `seedTemplate` section is specified, `gardenlet` is not deployed to the shoot, and a new `Seed` resource is created based on the template.
 * If the `gardenlet` section is specified, `gardenlet` is deployed to the shoot, and it registers a new seed upon startup based on the `seedConfig` section of the `GardenletConfiguration` resource.
@@ -17,9 +17,9 @@ Either the `seedTemplate` or the `gardenlet` section must be specified, but not 
 Note the following important aspects:
 
 * Unlike the `Seed` resource, the `ManagedSeed` resource is namespaced. Currently, managed seeds are restricted to the `garden` namespace.
-* The newly created `Seed` resource always has the same name as the `ManagedSeed` resource. Attempting to specify a different name in `seedTemplate` or `seedConfig` will fail. 
+* The newly created `Seed` resource always has the same name as the `ManagedSeed` resource. Attempting to specify a different name in `seedTemplate` or `seedConfig` will fail.
 * The `ManagedSeed` resource must always refer to an existing shoot. Attempting to create a `ManagedSeed` referring to a non-existing shoot will fail.
-* A shoot that is being referred to by a `ManagedSeed` cannot be deleted. Attempting to delete such a shoot will fail.  
+* A shoot that is being referred to by a `ManagedSeed` cannot be deleted. Attempting to delete such a shoot will fail.
 * You can omit practically everything from the `seedTemplate` or `gardenlet` section, including all or most of the `Seed` spec fields. Proper defaults will be supplied in all cases, based either on the most common use cases or the information already available in the `Shoot` resource.
 * Some `Seed` spec fields, for example the provider type and region, networking CIDRs for pods, services, and nodes, etc., must be the same as the corresponding `Shoot` spec fields of the shoot that is being registered as seed. Attempting to use different values (except empty ones, so that they are supplied by the defaulting mechanims) will fail.
 
@@ -55,9 +55,6 @@ spec:
   shoot:
     name: crazy-botany
   seedTemplate:
-    metadata:
-      labels:
-        seed.gardener.cloud/gardenlet: local
     spec:
       dns:
         ingressDomain: ""
@@ -68,8 +65,6 @@ spec:
         type: ""
         region: ""
 ```
-
-Note the `seed.gardener.cloud/gardenlet: local` label above. It stands for the label that is used in a `seedSelector` field of a `gardenlet` that takes care of multiple seeds. This label can be omitted if the `seedSelector` field selects all seeds. If there is no gardenlet running outside the cluster and selecting the seed, it won't be reconciled and no shoots will be scheduled on it.
 
 For an example that uses non-default configuration, see [55-managed-seed-seedtemplate.yaml](../../example/55-managedseed-seedtemplate.yaml)
 
@@ -97,6 +92,6 @@ Option | Description
 `apiServer.autoscaler.maxReplicas` | Controls the maximum number of `kube-apiserver` replicas for the shooted seed cluster.
 `apiServer.replicas` | Controls how many `kube-apiserver` replicas the shooted seed cluster gets by default.
 
-For backward compatibility, it is still possible to specify these options via the `shoot.gardener.cloud/managed-seed-api-server` annotation, using exactly the same syntax as before. 
+For backward compatibility, it is still possible to specify these options via the `shoot.gardener.cloud/managed-seed-api-server` annotation, using exactly the same syntax as before.
 
 If you use any of these fields in any or your `use-as-seed` annotations, instead of removing the annotation completely as mentioned above, simply rename it to `managed-seed-api-server`, keeping these fields, and removing everything else.

--- a/docs/usage/shooted_seed.md
+++ b/docs/usage/shooted_seed.md
@@ -56,7 +56,7 @@ It is strongly recommended to use such resources directly to register shoots as 
 Option | Description
 --- | ---
 `true` | Registers the cluster as a seed cluster. Automatically deploys the gardenlet into the shoot cluster, unless specified otherwise (e.g. setting the `no-gardenlet` flag).
-`no-gardenlet` | Prevents the automatic deployment of the gardenlet into the shoot cluster. Instead, the `Seed` object will be created with the assumption that another gardenlet will be responsible for managing it (according to its `seedSelector` configuration).
+`no-gardenlet` | Prevents the automatic deployment of the gardenlet into the shoot cluster. Instead, the `Seed` object will be created with the assumption that another gardenlet will be responsible for managing it (according to its `seedConfig` configuration).
 `disable-capacity-reservation` | Set `spec.settings.excessCapacity.enabled` in the seed cluster to false (see [/example/50-seed.yaml](../../example/50-seed.yaml)).
 `invisible` | Set `spec.settings.scheduling.visible` in the seed cluster to false  (see [/example/50-seed.yaml](../../example/50-seed.yaml))
 `visible` | Set `spec.settings.scheduling.visible` in the seed cluster to true  (see [/example/50-seed.yaml](../../example/50-seed.yaml)) (**default**).

--- a/example/55-managedseed-seedtemplate.yaml
+++ b/example/55-managedseed-seedtemplate.yaml
@@ -8,10 +8,7 @@ spec:
     name: crazy-botany
   # seedTemplate is a template for a Seed object, that should be used to register a given cluster as a Seed.
   # When seedTemplate is specified, the ManagedSeed controller will not deploy a gardenlet into the cluster
-  # and an existing gardenlet reconciling the new Seed is required.    
+  # and an existing gardenlet reconciling the new Seed is required.
   seedTemplate:
-#   metadata:
-#     labels:
-#       seed.gardener.cloud/gardenlet: local # Label to use in seedSelector of the existing gardenlet 
     spec: # Seed spec
 #     <See `spec` in `50-seed.yaml` for more details>

--- a/landscaper/pkg/gardenlet/apis/imports/validation/validation.go
+++ b/landscaper/pkg/gardenlet/apis/imports/validation/validation.go
@@ -71,10 +71,6 @@ func ValidateLandscaperImports(imports *imports.Imports) field.ErrorList {
 func validateGardenletConfiguration(gardenletConfig *gardenletconfig.GardenletConfiguration, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if gardenletConfig.SeedSelector != nil {
-		allErrs = append(allErrs, field.Forbidden(fldPath.Child("seedSelector"), "seed selector is forbidden, provide a seedConfig instead."))
-	}
-
 	if gardenletConfig.SeedConfig == nil {
 		return append(allErrs, field.Required(fldPath.Child("seedConfig"), "the seed configuration has to be provided. This is used to automatically register the seed."))
 	}

--- a/landscaper/pkg/gardenlet/apis/imports/validation/validation_test.go
+++ b/landscaper/pkg/gardenlet/apis/imports/validation/validation_test.go
@@ -115,31 +115,6 @@ var _ = Describe("ValidateLandscaperImports", func() {
 		})
 
 		Context("validate Gardenlet configuration", func() {
-			It("should validate that the Seed selector is not set", func() {
-				// only pick one required Gardenlet component configuration to show that the configuration is indeed verified
-				// neither seedSelector nor seedConfig are provided. One of them has to be set to
-				// pass the validation of the GardenletConfiguration
-				gardenletConfiguration.SeedSelector = &metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						"x": "y",
-					},
-				}
-				gardenletConfiguration.SeedConfig = nil
-				landscaperGardenletImport.ComponentConfiguration = &gardenletConfiguration
-
-				errorList := ValidateLandscaperImports(landscaperGardenletImport)
-				Expect(errorList).To(ConsistOf(
-					PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":  Equal(field.ErrorTypeForbidden),
-						"Field": Equal("componentConfiguration.seedSelector"),
-					})),
-					PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":  Equal(field.ErrorTypeRequired),
-						"Field": Equal("componentConfiguration.seedConfig"),
-					})),
-				))
-			})
-
 			It("should validate that the kubeconfig in the GardenClientConnection is not set", func() {
 				gardenletConfiguration.GardenClientConnection = &gardenletconfigv1alpha1.GardenClientConnection{
 					ClientConnectionConfiguration: componentbaseconfigv1alpha1.ClientConnectionConfiguration{

--- a/pkg/apis/seedmanagement/validation/managedseed.go
+++ b/pkg/apis/seedmanagement/validation/managedseed.go
@@ -293,11 +293,6 @@ func validateImage(image *seedmanagement.Image, fldPath *field.Path) field.Error
 func validateGardenletConfiguration(gardenletConfig *config.GardenletConfiguration, bootstrap seedmanagement.Bootstrap, mergeWithParent bool, fldPath *field.Path, inTemplate bool) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	// Ensure seed selector is not specified
-	if gardenletConfig.SeedSelector != nil {
-		allErrs = append(allErrs, field.Forbidden(fldPath.Child("seedSelector"), "seed selector is forbidden"))
-	}
-
 	// Ensure name is not specified since it will be set by the controller
 	if gardenletConfig.SeedConfig != nil && gardenletConfig.SeedConfig.Name != "" {
 		allErrs = append(allErrs, field.Forbidden(fldPath.Child("seedConfig", "metadata", "name"), "seed name is forbidden"))

--- a/pkg/client/kubernetes/clientmap/builder/deleg_builder_test.go
+++ b/pkg/client/kubernetes/clientmap/builder/deleg_builder_test.go
@@ -73,7 +73,7 @@ var _ = Describe("DelegatingClientMapBuilder", func() {
 	Context("#seedClientMapFunc", func() {
 		It("should be set correctly by WithSeedClientMap", func() {
 			builder := NewDelegatingClientMapBuilder().WithSeedClientMap(fakeSeedClientMap)
-			Expect(builder.seedClientMapFunc(nil, nil)).To(BeIdenticalTo(fakeSeedClientMap))
+			Expect(builder.seedClientMapFunc(nil)).To(BeIdenticalTo(fakeSeedClientMap))
 		})
 
 		It("should be set correctly by WithSeedClientMapBuilder", func() {
@@ -154,7 +154,7 @@ var _ = Describe("DelegatingClientMapBuilder", func() {
 			builder := NewDelegatingClientMapBuilder().
 				WithLogger(fakeLogger).
 				WithGardenClientMap(fakeGardenClientMap)
-			builder.seedClientMapFunc = func(clientmap.ClientMap, logrus.FieldLogger) (clientmap.ClientMap, error) {
+			builder.seedClientMapFunc = func(logrus.FieldLogger) (clientmap.ClientMap, error) {
 				return nil, fakeErr
 			}
 			clientMap, err := builder.Build()

--- a/pkg/client/kubernetes/clientmap/builder/seed_builder.go
+++ b/pkg/client/kubernetes/clientmap/builder/seed_builder.go
@@ -31,7 +31,6 @@ import (
 // clients for Seed clusters.
 type SeedClientMapBuilder struct {
 	gardenClientFunc       func(ctx context.Context) (kubernetes.Interface, error)
-	inCluster              bool
 	clientConnectionConfig *baseconfig.ClientConnectionConfiguration
 
 	logger logrus.FieldLogger
@@ -64,13 +63,6 @@ func (b *SeedClientMapBuilder) WithGardenClientSet(clientSet kubernetes.Interfac
 	return b
 }
 
-// WithInCluster sets the inCluster attribute of the builder. If true, the created ClientSets will use in-cluster communication
-// (using the provided ClientConnectionConfig.Kubeconfig or fallback to mounted ServiceAccount if unset).
-func (b *SeedClientMapBuilder) WithInCluster(inCluster bool) *SeedClientMapBuilder {
-	b.inCluster = inCluster
-	return b
-}
-
 // WithClientConnectionConfig sets the ClientConnectionConfiguration that should be used by ClientSets created by this ClientMap.
 func (b *SeedClientMapBuilder) WithClientConnectionConfig(cfg *baseconfig.ClientConnectionConfiguration) *SeedClientMapBuilder {
 	b.clientConnectionConfig = cfg
@@ -91,7 +83,6 @@ func (b *SeedClientMapBuilder) Build() (clientmap.ClientMap, error) {
 
 	return internal.NewSeedClientMap(&internal.SeedClientSetFactory{
 		GetGardenClient:        b.gardenClientFunc,
-		InCluster:              b.inCluster,
 		ClientConnectionConfig: *b.clientConnectionConfig,
 	}, b.logger), nil
 }

--- a/pkg/client/kubernetes/clientmap/builder/seed_builder.go
+++ b/pkg/client/kubernetes/clientmap/builder/seed_builder.go
@@ -15,22 +15,18 @@
 package builder
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/sirupsen/logrus"
 	baseconfig "k8s.io/component-base/config"
 
-	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/internal"
-	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
 )
 
 // SeedClientMapBuilder can build a ClientMap which can be used to construct a ClientMap for requesting and storing
 // clients for Seed clusters.
 type SeedClientMapBuilder struct {
-	gardenClientFunc       func(ctx context.Context) (kubernetes.Interface, error)
 	clientConnectionConfig *baseconfig.ClientConnectionConfiguration
 
 	logger logrus.FieldLogger
@@ -47,22 +43,6 @@ func (b *SeedClientMapBuilder) WithLogger(logger logrus.FieldLogger) *SeedClient
 	return b
 }
 
-// WithGardenClientMap sets the ClientMap that should be used to retrieve Garden clients.
-func (b *SeedClientMapBuilder) WithGardenClientMap(clientMap clientmap.ClientMap) *SeedClientMapBuilder {
-	b.gardenClientFunc = func(ctx context.Context) (kubernetes.Interface, error) {
-		return clientMap.GetClient(ctx, keys.ForGarden())
-	}
-	return b
-}
-
-// WithGardenClientSet sets the ClientSet that should be used as the Garden client.
-func (b *SeedClientMapBuilder) WithGardenClientSet(clientSet kubernetes.Interface) *SeedClientMapBuilder {
-	b.gardenClientFunc = func(ctx context.Context) (kubernetes.Interface, error) {
-		return clientSet, nil
-	}
-	return b
-}
-
 // WithClientConnectionConfig sets the ClientConnectionConfiguration that should be used by ClientSets created by this ClientMap.
 func (b *SeedClientMapBuilder) WithClientConnectionConfig(cfg *baseconfig.ClientConnectionConfiguration) *SeedClientMapBuilder {
 	b.clientConnectionConfig = cfg
@@ -74,15 +54,11 @@ func (b *SeedClientMapBuilder) Build() (clientmap.ClientMap, error) {
 	if b.logger == nil {
 		return nil, fmt.Errorf("logger is required but not set")
 	}
-	if b.gardenClientFunc == nil {
-		return nil, fmt.Errorf("garden client is required but not set")
-	}
 	if b.clientConnectionConfig == nil {
 		return nil, fmt.Errorf("clientConnectionConfig is required but not set")
 	}
 
 	return internal.NewSeedClientMap(&internal.SeedClientSetFactory{
-		GetGardenClient:        b.gardenClientFunc,
 		ClientConnectionConfig: *b.clientConnectionConfig,
 	}, b.logger), nil
 }

--- a/pkg/client/kubernetes/clientmap/builder/seed_builder_test.go
+++ b/pkg/client/kubernetes/clientmap/builder/seed_builder_test.go
@@ -69,13 +69,6 @@ var _ = Describe("SeedClientMapBuilder", func() {
 		})
 	})
 
-	Context("#inCluster", func() {
-		It("should be correctly set by WithInCluster", func() {
-			builder := NewSeedClientMapBuilder().WithInCluster(true)
-			Expect(builder.inCluster).To(BeTrue())
-		})
-	})
-
 	Context("#clientConnectionConfig", func() {
 		It("should be correctly set by WithClientConnectionConfig", func() {
 			builder := NewSeedClientMapBuilder().WithClientConnectionConfig(clientConnectionConfig)

--- a/pkg/client/kubernetes/clientmap/builder/seed_builder_test.go
+++ b/pkg/client/kubernetes/clientmap/builder/seed_builder_test.go
@@ -15,11 +15,6 @@
 package builder
 
 import (
-	"context"
-
-	fakeclientmap "github.com/gardener/gardener/pkg/client/kubernetes/clientmap/fake"
-	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
-	fakeclientset "github.com/gardener/gardener/pkg/client/kubernetes/fake"
 	"github.com/gardener/gardener/pkg/logger"
 
 	. "github.com/onsi/ginkgo"
@@ -29,23 +24,14 @@ import (
 )
 
 var _ = Describe("SeedClientMapBuilder", func() {
-
 	var (
-		ctx context.Context
-
-		fakeLogger          logrus.FieldLogger
-		fakeGardenClientMap *fakeclientmap.ClientMap
-		fakeGardenClientSet *fakeclientset.ClientSet
+		fakeLogger logrus.FieldLogger
 
 		clientConnectionConfig *baseconfig.ClientConnectionConfiguration
 	)
 
 	BeforeEach(func() {
-		ctx = context.TODO()
-
 		fakeLogger = logger.NewNopLogger()
-		fakeGardenClientSet = fakeclientset.NewClientSet()
-		fakeGardenClientMap = fakeclientmap.NewClientMapBuilder().WithClientSetForKey(keys.ForGarden(), fakeGardenClientSet).Build()
 
 		clientConnectionConfig = &baseconfig.ClientConnectionConfiguration{}
 	})
@@ -54,18 +40,6 @@ var _ = Describe("SeedClientMapBuilder", func() {
 		It("should be correctly set by WithLogger", func() {
 			builder := NewSeedClientMapBuilder().WithLogger(fakeLogger)
 			Expect(builder.logger).To(BeEquivalentTo(fakeLogger))
-		})
-	})
-
-	Context("#gardenClientFunc", func() {
-		It("should be correctly set by WithGardenClientSet", func() {
-			builder := NewSeedClientMapBuilder().WithGardenClientSet(fakeGardenClientSet)
-			Expect(builder.gardenClientFunc(ctx)).To(BeEquivalentTo(fakeGardenClientSet))
-		})
-
-		It("should be correctly set by WithGardenClientMap", func() {
-			builder := NewSeedClientMapBuilder().WithGardenClientMap(fakeGardenClientMap)
-			Expect(builder.gardenClientFunc(ctx)).To(BeEquivalentTo(fakeGardenClientSet))
 		})
 	})
 
@@ -83,14 +57,8 @@ var _ = Describe("SeedClientMapBuilder", func() {
 			Expect(clientMap).To(BeNil())
 		})
 
-		It("should fail if garden ClientMap was not set", func() {
-			clientMap, err := NewSeedClientMapBuilder().WithLogger(fakeLogger).Build()
-			Expect(err).To(MatchError("garden client is required but not set"))
-			Expect(clientMap).To(BeNil())
-		})
-
 		It("should fail if clientConnectionConfig was not set", func() {
-			clientMap, err := NewSeedClientMapBuilder().WithLogger(fakeLogger).WithGardenClientSet(fakeGardenClientSet).Build()
+			clientMap, err := NewSeedClientMapBuilder().WithLogger(fakeLogger).Build()
 			Expect(err).To(MatchError("clientConnectionConfig is required but not set"))
 			Expect(clientMap).To(BeNil())
 		})
@@ -98,7 +66,6 @@ var _ = Describe("SeedClientMapBuilder", func() {
 		It("should succeed to build ClientMap", func() {
 			clientSet, err := NewSeedClientMapBuilder().
 				WithLogger(fakeLogger).
-				WithGardenClientMap(fakeGardenClientMap).
 				WithClientConnectionConfig(clientConnectionConfig).
 				Build()
 			Expect(err).NotTo(HaveOccurred())

--- a/pkg/client/kubernetes/clientmap/internal/seed_clientmap.go
+++ b/pkg/client/kubernetes/clientmap/internal/seed_clientmap.go
@@ -16,6 +16,7 @@ package internal
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/sirupsen/logrus"
 	baseconfig "k8s.io/component-base/config"
@@ -50,6 +51,11 @@ func (f *SeedClientSetFactory) CalculateClientSetHash(ctx context.Context, k cli
 
 // NewClientSet creates a new ClientSet for a Seed cluster.
 func (f *SeedClientSetFactory) NewClientSet(ctx context.Context, k clientmap.ClientSetKey) (kubernetes.Interface, error) {
+	_, ok := k.(SeedClientSetKey)
+	if !ok {
+		return nil, fmt.Errorf("unsupported ClientSetKey: expected %T, but got %T", SeedClientSetKey(""), k)
+	}
+
 	return NewClientFromFile(
 		"",
 		f.ClientConnectionConfig.Kubeconfig,

--- a/pkg/client/kubernetes/clientmap/internal/seed_clientmap.go
+++ b/pkg/client/kubernetes/clientmap/internal/seed_clientmap.go
@@ -16,17 +16,13 @@ package internal
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/sirupsen/logrus"
-	corev1 "k8s.io/api/core/v1"
 	baseconfig "k8s.io/component-base/config"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
-	"github.com/gardener/gardener/pkg/utils"
 )
 
 // seedClientMap is a ClientMap for requesting and storing clients for Seed clusters.
@@ -43,70 +39,27 @@ func NewSeedClientMap(factory *SeedClientSetFactory, logger logrus.FieldLogger) 
 
 // SeedClientSetFactory is a ClientSetFactory that can produce new ClientSets to Seed clusters.
 type SeedClientSetFactory struct {
-	// GetGardenClient is a func that will be used to get a client to the garden cluster to retrieve the Seed's
-	// kubeconfig secret (if InCluster=false).
-	GetGardenClient func(ctx context.Context) (kubernetes.Interface, error)
 	// ClientConnectionConfiguration is the configuration that will be used by created ClientSets.
 	ClientConnectionConfig baseconfig.ClientConnectionConfiguration
 }
 
-// CalculateClientSetHash returns "" if the gardenlet uses in-cluster communication. Otherwise, it calculates a SHA256
-// hash of the kubeconfig in the seed secret.
+// CalculateClientSetHash always returns "" and nil.
 func (f *SeedClientSetFactory) CalculateClientSetHash(ctx context.Context, k clientmap.ClientSetKey) (string, error) {
-	key, ok := k.(SeedClientSetKey)
-	if !ok {
-		return "", fmt.Errorf("unsupported ClientSetKey: expected %T got %T", SeedClientSetKey(""), k)
-	}
-
-	secretRef, gardenClient, err := f.getSeedSecretRef(ctx, key)
-	if err != nil {
-		return "", err
-	}
-
-	kubeconfigSecret := &corev1.Secret{}
-	if err := gardenClient.Client().Get(ctx, client.ObjectKey{Namespace: secretRef.Namespace, Name: secretRef.Name}, kubeconfigSecret); err != nil {
-		return "", err
-	}
-
-	return utils.ComputeSHA256Hex(kubeconfigSecret.Data[kubernetes.KubeConfig]), nil
+	return "", nil
 }
 
 // NewClientSet creates a new ClientSet for a Seed cluster.
 func (f *SeedClientSetFactory) NewClientSet(ctx context.Context, k clientmap.ClientSetKey) (kubernetes.Interface, error) {
-	key, ok := k.(SeedClientSetKey)
-	if !ok {
-		return nil, fmt.Errorf("unsupported ClientSetKey: expected %T got %T", SeedClientSetKey(""), k)
-	}
-
-	secretRef, gardenClient, err := f.getSeedSecretRef(ctx, key)
-	if err != nil {
-		return nil, err
-	}
-
-	return NewClientFromSecret(ctx, gardenClient.Client(), secretRef.Namespace, secretRef.Name,
+	return NewClientFromFile(
+		"",
+		f.ClientConnectionConfig.Kubeconfig,
 		kubernetes.WithClientConnectionOptions(f.ClientConnectionConfig),
-		kubernetes.WithClientOptions(client.Options{
-			Scheme: kubernetes.SeedScheme,
-		}),
+		kubernetes.WithClientOptions(
+			client.Options{
+				Scheme: kubernetes.SeedScheme,
+			},
+		),
 	)
-}
-
-func (f *SeedClientSetFactory) getSeedSecretRef(ctx context.Context, key SeedClientSetKey) (*corev1.SecretReference, kubernetes.Interface, error) {
-	gardenClient, err := f.GetGardenClient(ctx)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get garden client: %w", err)
-	}
-
-	seed := &gardencorev1beta1.Seed{}
-	if err := gardenClient.Client().Get(ctx, client.ObjectKey{Name: key.Key()}, seed); err != nil {
-		return nil, nil, fmt.Errorf("failed to get Seed object %q: %w", key.Key(), err)
-	}
-
-	if seed.Spec.SecretRef == nil {
-		return nil, nil, fmt.Errorf("seed %q does not have a secretRef", key.Key())
-	}
-
-	return seed.Spec.SecretRef, gardenClient, nil
 }
 
 // SeedClientSetKey is a ClientSetKey for a Seed cluster.

--- a/pkg/client/kubernetes/clientmap/internal/seed_clientmap_test.go
+++ b/pkg/client/kubernetes/clientmap/internal/seed_clientmap_test.go
@@ -26,13 +26,11 @@ import (
 	fakeclientset "github.com/gardener/gardener/pkg/client/kubernetes/fake"
 	. "github.com/gardener/gardener/pkg/client/kubernetes/test"
 	"github.com/gardener/gardener/pkg/logger"
-	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	baseconfig "k8s.io/component-base/config"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -40,10 +38,8 @@ import (
 
 var _ = Describe("SeedClientMap", func() {
 	var (
-		ctx              context.Context
-		ctrl             *gomock.Controller
-		c                *mockclient.MockClient
-		fakeGardenClient *fakeclientset.ClientSet
+		ctx  context.Context
+		ctrl *gomock.Controller
 
 		cm                     clientmap.ClientMap
 		key                    clientmap.ClientSetKey
@@ -56,8 +52,6 @@ var _ = Describe("SeedClientMap", func() {
 	BeforeEach(func() {
 		ctx = context.TODO()
 		ctrl = gomock.NewController(GinkgoT())
-		c = mockclient.NewMockClient(ctrl)
-		fakeGardenClient = fakeclientset.NewClientSetBuilder().WithClient(c).Build()
 
 		seed = &gardencorev1beta1.Seed{
 			ObjectMeta: metav1.ObjectMeta{
@@ -81,9 +75,6 @@ var _ = Describe("SeedClientMap", func() {
 			Burst:              43,
 		}
 		factory = &internal.SeedClientSetFactory{
-			GetGardenClient: func(ctx context.Context) (kubernetes.Interface, error) {
-				return fakeGardenClient, nil
-			},
 			ClientConnectionConfig: clientConnectionConfig,
 		}
 		cm = internal.NewSeedClientMap(factory, logger.NewNopLogger())
@@ -94,54 +85,9 @@ var _ = Describe("SeedClientMap", func() {
 	})
 
 	Context("#GetClient", func() {
-		It("should fail if ClientSetKey type is unsupported", func() {
-			key = fakeKey{}
-			cs, err := cm.GetClient(ctx, key)
-			Expect(cs).To(BeNil())
-			Expect(err).To(MatchError(ContainSubstring("unsupported ClientSetKey")))
-		})
-
-		It("should fail if GetGardenClient fails", func() {
-			fakeErr := fmt.Errorf("fake")
-			factory.GetGardenClient = func(ctx context.Context) (kubernetes.Interface, error) {
-				return nil, fakeErr
-			}
-
-			cs, err := cm.GetClient(ctx, key)
-			Expect(cs).To(BeNil())
-			Expect(err).To(MatchError(ContainSubstring("failed to get garden client: fake")))
-		})
-
-		It("should fail if it cannot get Seed object", func() {
-			c.EXPECT().Get(ctx, client.ObjectKey{Name: seed.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).
-				Return(apierrors.NewNotFound(gardencorev1beta1.Resource("seed"), seed.Name))
-
-			cs, err := cm.GetClient(ctx, key)
-			Expect(cs).To(BeNil())
-			Expect(err).To(MatchError(ContainSubstring("failed to get Seed object")))
-		})
-
-		It("should fail if Seed object does not have a secretRef", func() {
-			seed.Spec.SecretRef = nil
-			c.EXPECT().Get(ctx, client.ObjectKey{Name: seed.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).
-				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
-					seed.DeepCopyInto(obj.(*gardencorev1beta1.Seed))
-					return nil
-				})
-
-			cs, err := cm.GetClient(ctx, key)
-			Expect(cs).To(BeNil())
-			Expect(err).To(MatchError(ContainSubstring("does not have a secretRef")))
-		})
-
 		It("should fail if NewClientFromSecret fails", func() {
 			fakeErr := fmt.Errorf("fake")
-			c.EXPECT().Get(ctx, client.ObjectKey{Name: seed.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).
-				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
-					seed.DeepCopyInto(obj.(*gardencorev1beta1.Seed))
-					return nil
-				})
-			internal.NewClientFromSecret = func(ctx context.Context, c client.Client, namespace, secretName string, fns ...kubernetes.ConfigFunc) (kubernetes.Interface, error) {
+			internal.NewClientFromFile = func(masterURL, kubeconfigPath string, fns ...kubernetes.ConfigFunc) (kubernetes.Interface, error) {
 				return nil, fakeErr
 			}
 
@@ -152,19 +98,9 @@ var _ = Describe("SeedClientMap", func() {
 
 		It("should correctly construct a new ClientSet", func() {
 			fakeCS := fakeclientset.NewClientSet()
-			c.EXPECT().Get(ctx, client.ObjectKey{Name: seed.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).
-				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
-					seed.DeepCopyInto(obj.(*gardencorev1beta1.Seed))
-					return nil
-				}).Times(2)
-			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: seed.Spec.SecretRef.Namespace, Name: seed.Spec.SecretRef.Name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
-				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
-					return nil
-				})
-			internal.NewClientFromSecret = func(ctx context.Context, c client.Client, namespace, secretName string, fns ...kubernetes.ConfigFunc) (kubernetes.Interface, error) {
-				Expect(c).To(BeIdenticalTo(fakeGardenClient.Client()))
-				Expect(namespace).To(Equal(seed.Spec.SecretRef.Namespace))
-				Expect(secretName).To(Equal(seed.Spec.SecretRef.Name))
+			internal.NewClientFromFile = func(masterURL, kubeconfigPath string, fns ...kubernetes.ConfigFunc) (kubernetes.Interface, error) {
+				Expect(masterURL).To(BeEmpty())
+				Expect(kubeconfigPath).To(Equal(clientConnectionConfig.Kubeconfig))
 				Expect(fns).To(ConsistOfConfigFuncs(
 					kubernetes.WithClientConnectionOptions(clientConnectionConfig),
 					kubernetes.WithClientOptions(client.Options{Scheme: kubernetes.SeedScheme}),
@@ -179,55 +115,10 @@ var _ = Describe("SeedClientMap", func() {
 	})
 
 	Context("#CalculateClientSetHash", func() {
-		It("should fail if ClientSetKey type is unsupported", func() {
+		It("should always return the same identifier", func() {
 			key = fakeKey{}
 			hash, err := factory.CalculateClientSetHash(ctx, key)
 			Expect(hash).To(BeEmpty())
-			Expect(err).To(MatchError(ContainSubstring("unsupported ClientSetKey")))
-		})
-
-		It("should fail if getSeedSecretRef fails", func() {
-			fakeErr := fmt.Errorf("fake")
-			factory.GetGardenClient = func(ctx context.Context) (kubernetes.Interface, error) {
-				return nil, fakeErr
-			}
-
-			hash, err := factory.CalculateClientSetHash(ctx, key)
-			Expect(hash).To(BeEmpty())
-			Expect(err).To(MatchError(ContainSubstring("failed to get garden client: fake")))
-		})
-
-		It("should fail if Get Seed Secret fails", func() {
-			fakeErr := fmt.Errorf("fake")
-			c.EXPECT().Get(ctx, client.ObjectKey{Name: seed.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).
-				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
-					seed.DeepCopyInto(obj.(*gardencorev1beta1.Seed))
-					return nil
-				})
-			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: seed.Spec.SecretRef.Namespace, Name: seed.Spec.SecretRef.Name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
-				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
-					return fakeErr
-				})
-
-			hash, err := factory.CalculateClientSetHash(ctx, key)
-			Expect(hash).To(BeEmpty())
-			Expect(err).To(MatchError("fake"))
-		})
-
-		It("should correctly calculate hash", func() {
-			c.EXPECT().Get(ctx, client.ObjectKey{Name: seed.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).
-				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
-					seed.DeepCopyInto(obj.(*gardencorev1beta1.Seed))
-					return nil
-				})
-			c.EXPECT().Get(ctx, client.ObjectKey{Namespace: seed.Spec.SecretRef.Namespace, Name: seed.Spec.SecretRef.Name}, gomock.AssignableToTypeOf(&corev1.Secret{})).
-				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
-					(&corev1.Secret{}).DeepCopyInto(obj.(*corev1.Secret))
-					return nil
-				})
-
-			hash, err := factory.CalculateClientSetHash(ctx, key)
-			Expect(hash).To(Equal("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})

--- a/pkg/controllerutils/seedfilter.go
+++ b/pkg/controllerutils/seedfilter.go
@@ -40,22 +40,20 @@ func LabelsMatchFor(l map[string]string, labelSelector *metav1.LabelSelector) bo
 	return selector.Matches(labels.Set(l))
 }
 
-// SeedFilterFunc returns a filtering func for the seeds and the given label selector.
-func SeedFilterFunc(seedName string, labelSelector *metav1.LabelSelector) func(obj interface{}) bool {
+// SeedFilterFunc returns a filtering func for the seeds.
+func SeedFilterFunc(seedName string) func(obj interface{}) bool {
 	return func(obj interface{}) bool {
 		seed, ok := obj.(*gardencorev1beta1.Seed)
 		if !ok {
 			return false
 		}
-		if len(seedName) > 0 {
-			return seed.Name == seedName
-		}
-		return LabelsMatchFor(seed.Labels, labelSelector)
+
+		return seed.Name == seedName
 	}
 }
 
-// ShootFilterFunc returns a filtering func for the seeds and the given label selector.
-func ShootFilterFunc(seedName string, seedLister gardencorelisters.SeedLister, labelSelector *metav1.LabelSelector) func(obj interface{}) bool {
+// ShootFilterFunc returns a filtering func for the seeds.
+func ShootFilterFunc(seedName string, seedLister gardencorelisters.SeedLister) func(obj interface{}) bool {
 	return func(obj interface{}) bool {
 		shoot, ok := obj.(*gardencorev1beta1.Shoot)
 		if !ok {
@@ -64,27 +62,18 @@ func ShootFilterFunc(seedName string, seedLister gardencorelisters.SeedLister, l
 		if shoot.Spec.SeedName == nil {
 			return false
 		}
-		if len(seedName) > 0 {
-			if shoot.Status.SeedName == nil || *shoot.Spec.SeedName == *shoot.Status.SeedName {
-				return *shoot.Spec.SeedName == seedName
-			}
-			return *shoot.Status.SeedName == seedName
-		}
+
 		if shoot.Status.SeedName == nil || *shoot.Spec.SeedName == *shoot.Status.SeedName {
-			return SeedLabelsMatch(seedLister, *shoot.Spec.SeedName, labelSelector)
+			return *shoot.Spec.SeedName == seedName
 		}
-		return SeedLabelsMatch(seedLister, *shoot.Status.SeedName, labelSelector)
+
+		return *shoot.Status.SeedName == seedName
 	}
 }
 
-// ShootIsManagedByThisGardenlet checks if the given shoot is managed by this gardenlet by comparing it with the seed name from the GardenletConfiguration
-// or by checking whether the seed labels match the seed selector from the GardenletConfiguration.
+// ShootIsManagedByThisGardenlet checks if the given shoot is managed by this gardenlet by comparing it with the seed name from the GardenletConfiguration.
 func ShootIsManagedByThisGardenlet(shoot *gardencorev1beta1.Shoot, gc *config.GardenletConfiguration, seedLister gardencorelisters.SeedLister) bool {
-	seedName := confighelper.SeedNameFromSeedConfig(gc.SeedConfig)
-	if len(seedName) > 0 {
-		return *shoot.Spec.SeedName == seedName
-	}
-	return SeedLabelsMatch(seedLister, *shoot.Spec.SeedName, gc.SeedSelector)
+	return *shoot.Spec.SeedName == confighelper.SeedNameFromSeedConfig(gc.SeedConfig)
 }
 
 // SeedLabelsMatch fetches the given seed via a lister by its name and then checks whether the given label selector matches
@@ -109,22 +98,20 @@ func seedLabelsMatchWithClient(ctx context.Context, c client.Reader, seedName st
 	return LabelsMatchFor(seed.Labels, labelSelector)
 }
 
-// ControllerInstallationFilterFunc returns a filtering func for the seeds and the given label selector.
-func ControllerInstallationFilterFunc(seedName string, seedLister gardencorelisters.SeedLister, labelSelector *metav1.LabelSelector) func(obj interface{}) bool {
+// ControllerInstallationFilterFunc returns a filtering func for the seeds.
+func ControllerInstallationFilterFunc(seedName string, seedLister gardencorelisters.SeedLister) func(obj interface{}) bool {
 	return func(obj interface{}) bool {
 		controllerInstallation, ok := obj.(*gardencorev1beta1.ControllerInstallation)
 		if !ok {
 			return false
 		}
-		if len(seedName) > 0 {
-			return controllerInstallation.Spec.SeedRef.Name == seedName
-		}
-		return SeedLabelsMatch(seedLister, controllerInstallation.Spec.SeedRef.Name, labelSelector)
+
+		return controllerInstallation.Spec.SeedRef.Name == seedName
 	}
 }
 
-// BackupBucketFilterFunc returns a filtering func for the seeds and the given label selector.
-func BackupBucketFilterFunc(ctx context.Context, c client.Reader, seedName string, labelSelector *metav1.LabelSelector) func(obj interface{}) bool {
+// BackupBucketFilterFunc returns a filtering func for the seeds.
+func BackupBucketFilterFunc(ctx context.Context, c client.Reader, seedName string) func(obj interface{}) bool {
 	return func(obj interface{}) bool {
 		backupBucket, ok := obj.(*gardencorev1beta1.BackupBucket)
 		if !ok {
@@ -133,15 +120,13 @@ func BackupBucketFilterFunc(ctx context.Context, c client.Reader, seedName strin
 		if backupBucket.Spec.SeedName == nil {
 			return false
 		}
-		if len(seedName) > 0 {
-			return *backupBucket.Spec.SeedName == seedName
-		}
-		return seedLabelsMatchWithClient(ctx, c, *backupBucket.Spec.SeedName, labelSelector)
+
+		return *backupBucket.Spec.SeedName == seedName
 	}
 }
 
-// BackupEntryFilterFunc returns a filtering func for the seeds and the given label selector.
-func BackupEntryFilterFunc(ctx context.Context, c client.Reader, seedName string, labelSelector *metav1.LabelSelector) func(obj interface{}) bool {
+// BackupEntryFilterFunc returns a filtering func for the seeds.
+func BackupEntryFilterFunc(ctx context.Context, c client.Reader, seedName string) func(obj interface{}) bool {
 	return func(obj interface{}) bool {
 		backupEntry, ok := obj.(*gardencorev1beta1.BackupEntry)
 		if !ok {
@@ -150,31 +135,24 @@ func BackupEntryFilterFunc(ctx context.Context, c client.Reader, seedName string
 		if backupEntry.Spec.SeedName == nil {
 			return false
 		}
-		if len(seedName) > 0 {
-			if backupEntry.Status.SeedName == nil || *backupEntry.Spec.SeedName == *backupEntry.Status.SeedName {
-				return *backupEntry.Spec.SeedName == seedName
-			}
-			return *backupEntry.Status.SeedName == seedName
-		}
+
 		if backupEntry.Status.SeedName == nil || *backupEntry.Spec.SeedName == *backupEntry.Status.SeedName {
-			return seedLabelsMatchWithClient(ctx, c, *backupEntry.Spec.SeedName, labelSelector)
+			return *backupEntry.Spec.SeedName == seedName
 		}
-		return seedLabelsMatchWithClient(ctx, c, *backupEntry.Status.SeedName, labelSelector)
+
+		return *backupEntry.Status.SeedName == seedName
 	}
 }
 
-// BackupEntryIsManagedByThisGardenlet checks if the given BackupEntry is managed by this gardenlet by comparing it with the seed name from the GardenletConfiguration
-// or by checking whether the seed labels match the seed selector from the GardenletConfiguration.
+// BackupEntryIsManagedByThisGardenlet checks if the given BackupEntry is managed by this gardenlet by comparing it with the seed name from the GardenletConfiguration.
 func BackupEntryIsManagedByThisGardenlet(ctx context.Context, c client.Reader, backupEntry *gardencorev1beta1.BackupEntry, gc *config.GardenletConfiguration) bool {
 	seedName := confighelper.SeedNameFromSeedConfig(gc.SeedConfig)
-	if len(seedName) > 0 {
-		return backupEntry.Spec.SeedName != nil && *backupEntry.Spec.SeedName == seedName
-	}
-	return seedLabelsMatchWithClient(ctx, c, *backupEntry.Spec.SeedName, gc.SeedSelector)
+
+	return backupEntry.Spec.SeedName != nil && *backupEntry.Spec.SeedName == seedName
 }
 
-// BastionFilterFunc returns a filtering func for the seeds and the given label selector.
-func BastionFilterFunc(ctx context.Context, c client.Reader, seedName string, labelSelector *metav1.LabelSelector) func(obj interface{}) bool {
+// BastionFilterFunc returns a filtering func for the seeds.
+func BastionFilterFunc(ctx context.Context, c client.Reader, seedName string) func(obj interface{}) bool {
 	return func(obj interface{}) bool {
 		bastion, ok := obj.(*operationsv1alpha1.Bastion)
 		if !ok {
@@ -183,25 +161,20 @@ func BastionFilterFunc(ctx context.Context, c client.Reader, seedName string, la
 		if bastion.Spec.SeedName == nil {
 			return false
 		}
-		if len(seedName) > 0 {
-			return *bastion.Spec.SeedName == seedName
-		}
-		return seedLabelsMatchWithClient(ctx, c, *bastion.Spec.SeedName, labelSelector)
+
+		return *bastion.Spec.SeedName == seedName
 	}
 }
 
-// BastionIsManagedByThisGardenlet checks if the given Bastion is managed by this gardenlet by comparing it with the seed name from the GardenletConfiguration
-// or by checking whether the seed labels match the seed selector from the GardenletConfiguration.
+// BastionIsManagedByThisGardenlet checks if the given Bastion is managed by this gardenlet by comparing it with the seed name from the GardenletConfiguration.
 func BastionIsManagedByThisGardenlet(ctx context.Context, c client.Reader, bastion *operationsv1alpha1.Bastion, gc *config.GardenletConfiguration) bool {
 	seedName := confighelper.SeedNameFromSeedConfig(gc.SeedConfig)
-	if len(seedName) > 0 {
-		return bastion.Spec.SeedName != nil && *bastion.Spec.SeedName == seedName
-	}
-	return seedLabelsMatchWithClient(ctx, c, *bastion.Spec.SeedName, gc.SeedSelector)
+
+	return bastion.Spec.SeedName != nil && *bastion.Spec.SeedName == seedName
 }
 
 // ManagedSeedFilterFunc returns a filtering func for ManagedSeeds that checks if the ManagedSeed references a Shoot scheduled on a Seed, for which the gardenlet is responsible..
-func ManagedSeedFilterFunc(ctx context.Context, c client.Reader, seedName string, labelSelector *metav1.LabelSelector) func(obj interface{}) bool {
+func ManagedSeedFilterFunc(ctx context.Context, c client.Reader, seedName string) func(obj interface{}) bool {
 	return func(obj interface{}) bool {
 		managedSeed, ok := obj.(*seedmanagementv1alpha1.ManagedSeed)
 		if !ok {
@@ -217,22 +190,18 @@ func ManagedSeedFilterFunc(ctx context.Context, c client.Reader, seedName string
 		if shoot.Spec.SeedName == nil {
 			return false
 		}
-		if len(seedName) > 0 {
-			if shoot.Status.SeedName == nil || *shoot.Spec.SeedName == *shoot.Status.SeedName {
-				return *shoot.Spec.SeedName == seedName
-			}
-			return *shoot.Status.SeedName == seedName
-		}
+
 		if shoot.Status.SeedName == nil || *shoot.Spec.SeedName == *shoot.Status.SeedName {
-			return seedLabelsMatchWithClient(ctx, c, *shoot.Spec.SeedName, labelSelector)
+			return *shoot.Spec.SeedName == seedName
 		}
-		return seedLabelsMatchWithClient(ctx, c, *shoot.Status.SeedName, labelSelector)
+
+		return *shoot.Status.SeedName == seedName
 	}
 }
 
 // SeedOfManagedSeedFilterFunc returns a filtering func for Seeds that checks if the Seed is owned by a ManagedSeed
 // that references a Shoot scheduled on a Seed, for which the gardenlet is responsible.
-func SeedOfManagedSeedFilterFunc(ctx context.Context, c client.Reader, seedName string, labelSelector *metav1.LabelSelector) func(obj interface{}) bool {
+func SeedOfManagedSeedFilterFunc(ctx context.Context, c client.Reader, seedName string) func(obj interface{}) bool {
 	return func(obj interface{}) bool {
 		seed, ok := obj.(*gardencorev1beta1.Seed)
 		if !ok {
@@ -242,6 +211,6 @@ func SeedOfManagedSeedFilterFunc(ctx context.Context, c client.Reader, seedName 
 		if err := c.Get(ctx, kutil.Key(gardencorev1beta1constants.GardenNamespace, seed.Name), managedSeed); err != nil {
 			return false
 		}
-		return ManagedSeedFilterFunc(ctx, c, seedName, labelSelector)(managedSeed)
+		return ManagedSeedFilterFunc(ctx, c, seedName)(managedSeed)
 	}
 }

--- a/pkg/controllerutils/seedfilter.go
+++ b/pkg/controllerutils/seedfilter.go
@@ -21,7 +21,6 @@ import (
 	gardencorev1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
-	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	confighelper "github.com/gardener/gardener/pkg/gardenlet/apis/config/helper"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -53,7 +52,7 @@ func SeedFilterFunc(seedName string) func(obj interface{}) bool {
 }
 
 // ShootFilterFunc returns a filtering func for the seeds.
-func ShootFilterFunc(seedName string, seedLister gardencorelisters.SeedLister) func(obj interface{}) bool {
+func ShootFilterFunc(seedName string) func(obj interface{}) bool {
 	return func(obj interface{}) bool {
 		shoot, ok := obj.(*gardencorev1beta1.Shoot)
 		if !ok {
@@ -72,23 +71,12 @@ func ShootFilterFunc(seedName string, seedLister gardencorelisters.SeedLister) f
 }
 
 // ShootIsManagedByThisGardenlet checks if the given shoot is managed by this gardenlet by comparing it with the seed name from the GardenletConfiguration.
-func ShootIsManagedByThisGardenlet(shoot *gardencorev1beta1.Shoot, gc *config.GardenletConfiguration, seedLister gardencorelisters.SeedLister) bool {
-	return *shoot.Spec.SeedName == confighelper.SeedNameFromSeedConfig(gc.SeedConfig)
-}
-
-// SeedLabelsMatch fetches the given seed via a lister by its name and then checks whether the given label selector matches
-// the seed labels.
-func SeedLabelsMatch(seedLister gardencorelisters.SeedLister, seedName string, labelSelector *metav1.LabelSelector) bool {
-	seed, err := seedLister.Get(seedName)
-	if err != nil {
-		return false
-	}
-
-	return LabelsMatchFor(seed.Labels, labelSelector)
+func ShootIsManagedByThisGardenlet(shoot *gardencorev1beta1.Shoot, gc *config.GardenletConfiguration) bool {
+	return *shoot.Spec.SeedName == confighelper.SeedNameFromSeedConfig(&gc.SeedConfig)
 }
 
 // ControllerInstallationFilterFunc returns a filtering func for the seeds.
-func ControllerInstallationFilterFunc(seedName string, seedLister gardencorelisters.SeedLister) func(obj interface{}) bool {
+func ControllerInstallationFilterFunc(seedName string) func(obj interface{}) bool {
 	return func(obj interface{}) bool {
 		controllerInstallation, ok := obj.(*gardencorev1beta1.ControllerInstallation)
 		if !ok {
@@ -135,7 +123,7 @@ func BackupEntryFilterFunc(ctx context.Context, c client.Reader, seedName string
 
 // BackupEntryIsManagedByThisGardenlet checks if the given BackupEntry is managed by this gardenlet by comparing it with the seed name from the GardenletConfiguration.
 func BackupEntryIsManagedByThisGardenlet(ctx context.Context, c client.Reader, backupEntry *gardencorev1beta1.BackupEntry, gc *config.GardenletConfiguration) bool {
-	seedName := confighelper.SeedNameFromSeedConfig(gc.SeedConfig)
+	seedName := confighelper.SeedNameFromSeedConfig(&gc.SeedConfig)
 
 	return backupEntry.Spec.SeedName != nil && *backupEntry.Spec.SeedName == seedName
 }
@@ -157,7 +145,7 @@ func BastionFilterFunc(ctx context.Context, c client.Reader, seedName string) fu
 
 // BastionIsManagedByThisGardenlet checks if the given Bastion is managed by this gardenlet by comparing it with the seed name from the GardenletConfiguration.
 func BastionIsManagedByThisGardenlet(ctx context.Context, c client.Reader, bastion *operationsv1alpha1.Bastion, gc *config.GardenletConfiguration) bool {
-	seedName := confighelper.SeedNameFromSeedConfig(gc.SeedConfig)
+	seedName := confighelper.SeedNameFromSeedConfig(&gc.SeedConfig)
 
 	return bastion.Spec.SeedName != nil && *bastion.Spec.SeedName == seedName
 }

--- a/pkg/controllerutils/seedfilter.go
+++ b/pkg/controllerutils/seedfilter.go
@@ -87,17 +87,6 @@ func SeedLabelsMatch(seedLister gardencorelisters.SeedLister, seedName string, l
 	return LabelsMatchFor(seed.Labels, labelSelector)
 }
 
-// seedLabelsMatchWithClient fetches the given seed by its name from the client and then checks whether the given
-// label selector matches the seed labels.
-func seedLabelsMatchWithClient(ctx context.Context, c client.Reader, seedName string, labelSelector *metav1.LabelSelector) bool {
-	seed := &gardencorev1beta1.Seed{}
-	if err := c.Get(ctx, client.ObjectKey{Name: seedName}, seed); err != nil {
-		return false
-	}
-
-	return LabelsMatchFor(seed.Labels, labelSelector)
-}
-
 // ControllerInstallationFilterFunc returns a filtering func for the seeds.
 func ControllerInstallationFilterFunc(seedName string, seedLister gardencorelisters.SeedLister) func(obj interface{}) bool {
 	return func(obj interface{}) bool {

--- a/pkg/controllerutils/seedfilter.go
+++ b/pkg/controllerutils/seedfilter.go
@@ -25,19 +25,8 @@ import (
 	confighelper "github.com/gardener/gardener/pkg/gardenlet/apis/config/helper"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/labels"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-// LabelsMatchFor checks whether the given label selector matches for the given set of labels.
-func LabelsMatchFor(l map[string]string, labelSelector *metav1.LabelSelector) bool {
-	selector, err := metav1.LabelSelectorAsSelector(labelSelector)
-	if err != nil {
-		return false
-	}
-	return selector.Matches(labels.Set(l))
-}
 
 // SeedFilterFunc returns a filtering func for the seeds.
 func SeedFilterFunc(seedName string) func(obj interface{}) bool {
@@ -72,7 +61,7 @@ func ShootFilterFunc(seedName string) func(obj interface{}) bool {
 
 // ShootIsManagedByThisGardenlet checks if the given shoot is managed by this gardenlet by comparing it with the seed name from the GardenletConfiguration.
 func ShootIsManagedByThisGardenlet(shoot *gardencorev1beta1.Shoot, gc *config.GardenletConfiguration) bool {
-	return *shoot.Spec.SeedName == confighelper.SeedNameFromSeedConfig(&gc.SeedConfig)
+	return *shoot.Spec.SeedName == confighelper.SeedNameFromSeedConfig(gc.SeedConfig)
 }
 
 // ControllerInstallationFilterFunc returns a filtering func for the seeds.
@@ -88,7 +77,7 @@ func ControllerInstallationFilterFunc(seedName string) func(obj interface{}) boo
 }
 
 // BackupBucketFilterFunc returns a filtering func for the seeds.
-func BackupBucketFilterFunc(ctx context.Context, c client.Reader, seedName string) func(obj interface{}) bool {
+func BackupBucketFilterFunc(seedName string) func(obj interface{}) bool {
 	return func(obj interface{}) bool {
 		backupBucket, ok := obj.(*gardencorev1beta1.BackupBucket)
 		if !ok {
@@ -103,7 +92,7 @@ func BackupBucketFilterFunc(ctx context.Context, c client.Reader, seedName strin
 }
 
 // BackupEntryFilterFunc returns a filtering func for the seeds.
-func BackupEntryFilterFunc(ctx context.Context, c client.Reader, seedName string) func(obj interface{}) bool {
+func BackupEntryFilterFunc(seedName string) func(obj interface{}) bool {
 	return func(obj interface{}) bool {
 		backupEntry, ok := obj.(*gardencorev1beta1.BackupEntry)
 		if !ok {
@@ -122,14 +111,14 @@ func BackupEntryFilterFunc(ctx context.Context, c client.Reader, seedName string
 }
 
 // BackupEntryIsManagedByThisGardenlet checks if the given BackupEntry is managed by this gardenlet by comparing it with the seed name from the GardenletConfiguration.
-func BackupEntryIsManagedByThisGardenlet(ctx context.Context, c client.Reader, backupEntry *gardencorev1beta1.BackupEntry, gc *config.GardenletConfiguration) bool {
-	seedName := confighelper.SeedNameFromSeedConfig(&gc.SeedConfig)
+func BackupEntryIsManagedByThisGardenlet(backupEntry *gardencorev1beta1.BackupEntry, gc *config.GardenletConfiguration) bool {
+	seedName := confighelper.SeedNameFromSeedConfig(gc.SeedConfig)
 
 	return backupEntry.Spec.SeedName != nil && *backupEntry.Spec.SeedName == seedName
 }
 
 // BastionFilterFunc returns a filtering func for the seeds.
-func BastionFilterFunc(ctx context.Context, c client.Reader, seedName string) func(obj interface{}) bool {
+func BastionFilterFunc(seedName string) func(obj interface{}) bool {
 	return func(obj interface{}) bool {
 		bastion, ok := obj.(*operationsv1alpha1.Bastion)
 		if !ok {
@@ -144,8 +133,8 @@ func BastionFilterFunc(ctx context.Context, c client.Reader, seedName string) fu
 }
 
 // BastionIsManagedByThisGardenlet checks if the given Bastion is managed by this gardenlet by comparing it with the seed name from the GardenletConfiguration.
-func BastionIsManagedByThisGardenlet(ctx context.Context, c client.Reader, bastion *operationsv1alpha1.Bastion, gc *config.GardenletConfiguration) bool {
-	seedName := confighelper.SeedNameFromSeedConfig(&gc.SeedConfig)
+func BastionIsManagedByThisGardenlet(bastion *operationsv1alpha1.Bastion, gc *config.GardenletConfiguration) bool {
+	seedName := confighelper.SeedNameFromSeedConfig(gc.SeedConfig)
 
 	return bastion.Spec.SeedName != nil && *bastion.Spec.SeedName == seedName
 }

--- a/pkg/controllerutils/seedfilter_test.go
+++ b/pkg/controllerutils/seedfilter_test.go
@@ -234,13 +234,13 @@ var _ = Describe("seedfilter", func() {
 
 		Describe("#BackupEntryFilterFunc", func() {
 			It("should return false if the specified object is not a BackupEntry", func() {
-				f := controllerutils.BackupEntryFilterFunc(ctx, c, seedName)
+				f := controllerutils.BackupEntryFilterFunc(seedName)
 				Expect(f(shoot)).To(BeFalse())
 			})
 
 			DescribeTable("filter BackupEntry by seedName",
 				func(specSeedName, statusSeedName *string, filterSeedName string, match gomegatypes.GomegaMatcher) {
-					f := controllerutils.BackupEntryFilterFunc(ctx, c, filterSeedName)
+					f := controllerutils.BackupEntryFilterFunc(filterSeedName)
 					backupEntry.Spec.SeedName = specSeedName
 					backupEntry.Status.SeedName = statusSeedName
 					Expect(f(backupEntry)).To(match)
@@ -268,7 +268,7 @@ var _ = Describe("seedfilter", func() {
 							},
 						},
 					}
-					Expect(controllerutils.BackupEntryIsManagedByThisGardenlet(ctx, c, backupEntry, gc)).To(match)
+					Expect(controllerutils.BackupEntryIsManagedByThisGardenlet(backupEntry, gc)).To(match)
 				},
 				Entry("BackupEntry is not managed by this seed", otherSeed, BeFalse()),
 				Entry("BackupEntry is managed by this seed", seedName, BeTrue()),

--- a/pkg/gardenlet/apis/config/types.go
+++ b/pkg/gardenlet/apis/config/types.go
@@ -54,12 +54,10 @@ type GardenletConfiguration struct {
 	// "github.com/gardener/gardener/pkg/gardenlet/features/features.go".
 	// Default: nil
 	FeatureGates map[string]bool
-	// SeedConfig contains configuration for the seed cluster. Must not be set if seed selector is set.
+	// SeedConfig contains configuration for the seed cluster.
 	// In this case the gardenlet creates the `Seed` object itself based on the provided config.
 	SeedConfig *SeedConfig
-	// SeedSelector contains an optional list of labels on `Seed` resources that shall be managed by
-	// this gardenlet instance. In this case the `Seed` object is not managed by the Gardenlet and must
-	// be created by an operator/administrator.
+	// SeedSelector is not supported anymore and must not be set. Use an explicit SeedConfig instead.
 	SeedSelector *metav1.LabelSelector
 	// Logging contains an optional configurations for the logging stack deployed
 	// by the Gardenlet in the seed clusters.

--- a/pkg/gardenlet/apis/config/types.go
+++ b/pkg/gardenlet/apis/config/types.go
@@ -55,10 +55,7 @@ type GardenletConfiguration struct {
 	// Default: nil
 	FeatureGates map[string]bool
 	// SeedConfig contains configuration for the seed cluster.
-	// In this case the gardenlet creates the `Seed` object itself based on the provided config.
 	SeedConfig *SeedConfig
-	// SeedSelector is not supported anymore and must not be set. Use an explicit SeedConfig instead.
-	SeedSelector *metav1.LabelSelector
 	// Logging contains an optional configurations for the logging stack deployed
 	// by the Gardenlet in the seed clusters.
 	Logging *Logging

--- a/pkg/gardenlet/apis/config/v1alpha1/types.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/types.go
@@ -67,6 +67,7 @@ type GardenletConfiguration struct {
 	// +optional
 	FeatureGates map[string]bool `json:"featureGates,omitempty"`
 	// SeedConfig contains configuration for the seed cluster.
+	// +optional
 	SeedConfig *SeedConfig `json:"seedConfig,omitempty"`
 	// Logging contains an optional configurations for the logging stack deployed
 	// by the Gardenlet in the seed clusters.

--- a/pkg/gardenlet/apis/config/v1alpha1/types.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/types.go
@@ -67,12 +67,7 @@ type GardenletConfiguration struct {
 	// +optional
 	FeatureGates map[string]bool `json:"featureGates,omitempty"`
 	// SeedConfig contains configuration for the seed cluster.
-	// In this case the gardenlet creates the `Seed` object itself based on the provided config.
-	// +optional
 	SeedConfig *SeedConfig `json:"seedConfig,omitempty"`
-	// SeedSelector is not supported anymore and must not be set. Use an explicit SeedConfig instead.
-	// +optional
-	SeedSelector *metav1.LabelSelector `json:"seedSelector,omitempty"`
 	// Logging contains an optional configurations for the logging stack deployed
 	// by the Gardenlet in the seed clusters.
 	// +optional

--- a/pkg/gardenlet/apis/config/v1alpha1/types.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/types.go
@@ -66,13 +66,11 @@ type GardenletConfiguration struct {
 	// Default: nil
 	// +optional
 	FeatureGates map[string]bool `json:"featureGates,omitempty"`
-	// SeedConfig contains configuration for the seed cluster. Must not be set if seed selector is set.
+	// SeedConfig contains configuration for the seed cluster.
 	// In this case the gardenlet creates the `Seed` object itself based on the provided config.
 	// +optional
 	SeedConfig *SeedConfig `json:"seedConfig,omitempty"`
-	// SeedSelector contains an optional list of labels on `Seed` resources that shall be managed by
-	// this gardenlet instance. In this case the `Seed` object is not managed by the Gardenlet and must
-	// be created by an operator/administrator.
+	// SeedSelector is not supported anymore and must not be set. Use an explicit SeedConfig instead.
 	// +optional
 	SeedSelector *metav1.LabelSelector `json:"seedSelector,omitempty"`
 	// Logging contains an optional configurations for the logging stack deployed

--- a/pkg/gardenlet/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/zz_generated.conversion.go
@@ -710,7 +710,6 @@ func autoConvert_v1alpha1_GardenletConfiguration_To_config_GardenletConfiguratio
 	} else {
 		out.SeedConfig = nil
 	}
-	out.SeedSelector = (*v1.LabelSelector)(unsafe.Pointer(in.SeedSelector))
 	if in.Logging != nil {
 		in, out := &in.Logging, &out.Logging
 		*out = new(config.Logging)
@@ -782,7 +781,6 @@ func autoConvert_config_GardenletConfiguration_To_v1alpha1_GardenletConfiguratio
 	} else {
 		out.SeedConfig = nil
 	}
-	out.SeedSelector = (*v1.LabelSelector)(unsafe.Pointer(in.SeedSelector))
 	if in.Logging != nil {
 		in, out := &in.Logging, &out.Logging
 		*out = new(Logging)

--- a/pkg/gardenlet/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -358,11 +358,6 @@ func (in *GardenletConfiguration) DeepCopyInto(out *GardenletConfiguration) {
 		*out = new(SeedConfig)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.SeedSelector != nil {
-		in, out := &in.SeedSelector, &out.SeedSelector
-		*out = new(v1.LabelSelector)
-		(*in).DeepCopyInto(*out)
-	}
 	if in.Logging != nil {
 		in, out := &in.Logging, &out.Logging
 		*out = new(Logging)

--- a/pkg/gardenlet/apis/config/validation/validation.go
+++ b/pkg/gardenlet/apis/config/validation/validation.go
@@ -46,10 +46,6 @@ func ValidateGardenletConfiguration(cfg *config.GardenletConfiguration, fldPath 
 		}
 	}
 
-	if !inTemplate && cfg.SeedSelector != nil {
-		allErrs = append(allErrs, field.Forbidden(fldPath.Child("SeedSelector"), "seedSelector must not be set"))
-	}
-
 	if !inTemplate && cfg.SeedConfig == nil {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("seedConfig"), cfg, "seed config must be set"))
 	}

--- a/pkg/gardenlet/apis/config/validation/validation.go
+++ b/pkg/gardenlet/apis/config/validation/validation.go
@@ -46,8 +46,12 @@ func ValidateGardenletConfiguration(cfg *config.GardenletConfiguration, fldPath 
 		}
 	}
 
-	if !inTemplate && (cfg.SeedConfig == nil && cfg.SeedSelector == nil) || (cfg.SeedConfig != nil && cfg.SeedSelector != nil) {
-		allErrs = append(allErrs, field.Invalid(fldPath.Child("seedConfig"), cfg, "either seed config or seed selector is required"))
+	if !inTemplate && cfg.SeedSelector != nil {
+		allErrs = append(allErrs, field.Forbidden(fldPath.Child("SeedSelector"), "seedSelector must not be set"))
+	}
+
+	if !inTemplate && cfg.SeedConfig == nil {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("seedConfig"), cfg, "seed config must be set"))
 	}
 
 	if cfg.SeedConfig != nil {

--- a/pkg/gardenlet/apis/config/validation/validation_test.go
+++ b/pkg/gardenlet/apis/config/validation/validation_test.go
@@ -242,21 +242,9 @@ var _ = Describe("GardenletConfiguration", func() {
 			})
 		})
 
-		Context("seed selector/config", func() {
-			It("should forbid specifying neither a seed selector nor a seed config", func() {
-				cfg.SeedSelector = nil
+		Context("seed config", func() {
+			It("should require a seedConfig", func() {
 				cfg.SeedConfig = nil
-
-				errorList := ValidateGardenletConfiguration(cfg, nil, false)
-
-				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("seedConfig"),
-				}))))
-			})
-
-			It("should forbid specifying both a seed selector and a seed config", func() {
-				cfg.SeedSelector = &metav1.LabelSelector{}
 
 				errorList := ValidateGardenletConfiguration(cfg, nil, false)
 

--- a/pkg/gardenlet/apis/config/zz_generated.deepcopy.go
+++ b/pkg/gardenlet/apis/config/zz_generated.deepcopy.go
@@ -358,11 +358,6 @@ func (in *GardenletConfiguration) DeepCopyInto(out *GardenletConfiguration) {
 		*out = new(SeedConfig)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.SeedSelector != nil {
-		in, out := &in.SeedSelector, &out.SeedSelector
-		*out = new(v1.LabelSelector)
-		(*in).DeepCopyInto(*out)
-	}
 	if in.Logging != nil {
 		in, out := &in.Logging, &out.Logging
 		*out = new(Logging)

--- a/pkg/gardenlet/bootstrap/certificate/certificate_rotation.go
+++ b/pkg/gardenlet/bootstrap/certificate/certificate_rotation.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -58,7 +57,6 @@ type Manager struct {
 	gardenClientConnection *config.GardenClientConnection
 	targetClusterName      string
 	seedName               string
-	seedSelector           *metav1.LabelSelector
 }
 
 // NewCertificateRotation creates a certificate manager that can be used to rotate gardenlet's client certificate for the Garden cluster
@@ -73,7 +71,6 @@ func NewCertificateManager(clientMap clientmap.ClientMap, seedClient client.Clie
 		gardenClientConnection: config.GardenClientConnection,
 		seedName:               seedName,
 		targetClusterName:      gardenletTargetClusterName,
-		seedSelector:           config.SeedSelector,
 	}
 }
 
@@ -103,14 +100,12 @@ func (cr *Manager) ScheduleCertificateRotation(ctx context.Context, gardenletCan
 		if err != nil {
 			msg := fmt.Sprintf("Failed to rotate the kubeconfig for the Garden API Server. Certificate expires in %s (%s): %v", certificateExpirationTime.UTC().Sub(time.Now().UTC()).Round(time.Second).String(), certificateExpirationTime.Round(time.Second).String(), err)
 			cr.logger.Error(msg)
-			seeds, err := cr.getTargetedSeeds(ctx)
+			seed, err := cr.getTargetedSeed(ctx)
 			if err != nil {
 				cr.logger.Warnf("failed to record event on seeds announcing the failed certificate rotation: %v", err)
 				return
 			}
-			for _, seed := range seeds {
-				recorder.Event(&seed, corev1.EventTypeWarning, EventGardenletCertificateRotationFailed, msg)
-			}
+			recorder.Event(seed, corev1.EventTypeWarning, EventGardenletCertificateRotationFailed, msg)
 			return
 		}
 
@@ -223,33 +218,21 @@ func rotateCertificate(ctx context.Context, logger logrus.FieldLogger, clientMap
 	return nil
 }
 
-// getTargetedSeeds returns the Seeds that this Gardenlet is reconciling
-func getTargetedSeeds(ctx context.Context, gardenClient client.Client, seedSelector *metav1.LabelSelector, seedName string) ([]gardencorev1beta1.Seed, error) {
-	if seedSelector != nil {
-		seedLabelSelector, err := metav1.LabelSelectorAsSelector(seedSelector)
-		if err != nil {
-			return nil, err
-		}
-
-		seeds := &gardencorev1beta1.SeedList{}
-		err = gardenClient.List(ctx, seeds, client.MatchingLabelsSelector{Selector: seedLabelSelector})
-		if err != nil {
-			return nil, err
-		}
-		return seeds.Items, nil
-	}
-
+// getTargetedSeed returns the Seed that this Gardenlet is reconciling
+func getTargetedSeed(ctx context.Context, gardenClient client.Client, seedName string) (*gardencorev1beta1.Seed, error) {
 	seed := &gardencorev1beta1.Seed{}
 	if err := gardenClient.Get(ctx, client.ObjectKey{Name: seedName}, seed); err != nil {
 		return nil, err
 	}
-	return []gardencorev1beta1.Seed{*seed}, nil
+
+	return seed, nil
 }
 
-func (cr *Manager) getTargetedSeeds(ctx context.Context) ([]gardencorev1beta1.Seed, error) {
+func (cr *Manager) getTargetedSeed(ctx context.Context) (*gardencorev1beta1.Seed, error) {
 	gardenClient, err := cr.clientMap.GetClient(ctx, keys.ForGarden())
 	if err != nil {
 		return nil, err
 	}
-	return getTargetedSeeds(ctx, gardenClient.Client(), cr.seedSelector, cr.seedName)
+
+	return getTargetedSeed(ctx, gardenClient.Client(), cr.seedName)
 }

--- a/pkg/gardenlet/bootstrap/certificate/certificate_rotation_test.go
+++ b/pkg/gardenlet/bootstrap/certificate/certificate_rotation_test.go
@@ -345,25 +345,6 @@ users:
 			})
 		})
 
-		Describe("#getTargetedSeed", func() {
-			It("should return a single Seed", func() {
-				mockSeedClient.EXPECT().Get(ctx, kutil.Key(seedName), gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, seed *gardencorev1beta1.Seed) error {
-					seed.ObjectMeta = metav1.ObjectMeta{
-						Name: seedName,
-					}
-					return nil
-				})
-
-				seed, err := getTargetedSeed(ctx, mockSeedClient, seedName)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(seed).To(Equal(&gardencorev1beta1.Seed{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: seedName,
-					},
-				}))
-			})
-		})
-
 		Describe("#waitForCertificateRotation", func() {
 			var (
 				testKubeconfig string

--- a/pkg/gardenlet/bootstrap/certificate/certificate_rotation_test.go
+++ b/pkg/gardenlet/bootstrap/certificate/certificate_rotation_test.go
@@ -345,7 +345,7 @@ users:
 			})
 		})
 
-		Describe("#getTargetedSeeds", func() {
+		Describe("#getTargetedSeed", func() {
 			It("should return a single Seed", func() {
 				mockSeedClient.EXPECT().Get(ctx, kutil.Key(seedName), gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, seed *gardencorev1beta1.Seed) error {
 					seed.ObjectMeta = metav1.ObjectMeta{
@@ -354,45 +354,13 @@ users:
 					return nil
 				})
 
-				seeds, err := getTargetedSeeds(ctx, mockSeedClient, nil, seedName)
+				seed, err := getTargetedSeed(ctx, mockSeedClient, seedName)
 				Expect(err).ToNot(HaveOccurred())
-				Expect(seeds).To(HaveLen(1))
-				Expect(seeds[0]).To(Equal(gardencorev1beta1.Seed{
+				Expect(seed).To(Equal(&gardencorev1beta1.Seed{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: seedName,
 					},
 				}))
-			})
-
-			It("should return all Seed matched by seedSelector", func() {
-				items := []gardencorev1beta1.Seed{
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "seed-one",
-						},
-					},
-					{
-						ObjectMeta: metav1.ObjectMeta{
-							Name: "seed-two",
-						},
-					},
-				}
-
-				seedSelector := &metav1.LabelSelector{MatchLabels: map[string]string{
-					"seed-kind": "promiscuous",
-				}}
-
-				seedLabelSelector, err := metav1.LabelSelectorAsSelector(seedSelector)
-				Expect(err).To(BeNil())
-				mockSeedClient.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.SeedList{}), client.MatchingLabelsSelector{Selector: seedLabelSelector}).DoAndReturn(func(_ context.Context, list *gardencorev1beta1.SeedList, _ ...client.ListOption) error {
-					*list = gardencorev1beta1.SeedList{Items: items}
-					return nil
-				})
-
-				seeds, err := getTargetedSeeds(ctx, mockSeedClient, seedSelector, seedName)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(seeds).To(HaveLen(2))
-				Expect(seeds).To(Equal(items))
 			})
 		})
 

--- a/pkg/gardenlet/controller/backupbucket/backup_bucket.go
+++ b/pkg/gardenlet/controller/backupbucket/backup_bucket.go
@@ -82,7 +82,7 @@ func NewBackupBucketController(ctx context.Context, clientMap clientmap.ClientMa
 	}
 
 	controller.backupBucketInformer.AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controllerutils.BackupBucketFilterFunc(ctx, controller.gardenClient, confighelper.SeedNameFromSeedConfig(controller.config.SeedConfig)),
+		FilterFunc: controllerutils.BackupBucketFilterFunc(confighelper.SeedNameFromSeedConfig(controller.config.SeedConfig)),
 		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc:    controller.backupBucketAdd,
 			UpdateFunc: controller.backupBucketUpdate,

--- a/pkg/gardenlet/controller/backupbucket/backup_bucket.go
+++ b/pkg/gardenlet/controller/backupbucket/backup_bucket.go
@@ -82,7 +82,7 @@ func NewBackupBucketController(ctx context.Context, clientMap clientmap.ClientMa
 	}
 
 	controller.backupBucketInformer.AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controllerutils.BackupBucketFilterFunc(ctx, controller.gardenClient, confighelper.SeedNameFromSeedConfig(controller.config.SeedConfig), controller.config.SeedSelector),
+		FilterFunc: controllerutils.BackupBucketFilterFunc(ctx, controller.gardenClient, confighelper.SeedNameFromSeedConfig(controller.config.SeedConfig)),
 		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc:    controller.backupBucketAdd,
 			UpdateFunc: controller.backupBucketUpdate,

--- a/pkg/gardenlet/controller/backupentry/backup_entry.go
+++ b/pkg/gardenlet/controller/backupentry/backup_entry.go
@@ -77,7 +77,7 @@ func NewBackupEntryController(ctx context.Context, clientMap clientmap.ClientMap
 	}
 
 	controller.backupEntryInformer.AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controllerutils.BackupEntryFilterFunc(ctx, controller.gardenClient, confighelper.SeedNameFromSeedConfig(controller.config.SeedConfig)),
+		FilterFunc: controllerutils.BackupEntryFilterFunc(confighelper.SeedNameFromSeedConfig(controller.config.SeedConfig)),
 		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc:    controller.backupEntryAdd,
 			UpdateFunc: controller.backupEntryUpdate,

--- a/pkg/gardenlet/controller/backupentry/backup_entry.go
+++ b/pkg/gardenlet/controller/backupentry/backup_entry.go
@@ -77,7 +77,7 @@ func NewBackupEntryController(ctx context.Context, clientMap clientmap.ClientMap
 	}
 
 	controller.backupEntryInformer.AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controllerutils.BackupEntryFilterFunc(ctx, controller.gardenClient, confighelper.SeedNameFromSeedConfig(controller.config.SeedConfig), controller.config.SeedSelector),
+		FilterFunc: controllerutils.BackupEntryFilterFunc(ctx, controller.gardenClient, confighelper.SeedNameFromSeedConfig(controller.config.SeedConfig)),
 		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc:    controller.backupEntryAdd,
 			UpdateFunc: controller.backupEntryUpdate,

--- a/pkg/gardenlet/controller/backupentry/backup_entry_reconciler.go
+++ b/pkg/gardenlet/controller/backupentry/backup_entry_reconciler.go
@@ -85,7 +85,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return r.migrateBackupEntry(ctx, gardenClient, be)
 	}
 
-	if !controllerutils.BackupEntryIsManagedByThisGardenlet(ctx, gardenClient.Client(), be, r.config) {
+	if !controllerutils.BackupEntryIsManagedByThisGardenlet(be, r.config) {
 		r.logger.Debugf("Skipping because BackupEntry is not managed by this gardenlet in seed %s", *be.Spec.SeedName)
 		return reconcile.Result{}, nil
 	}

--- a/pkg/gardenlet/controller/bastion/bastion.go
+++ b/pkg/gardenlet/controller/bastion/bastion.go
@@ -76,7 +76,7 @@ func NewBastionController(ctx context.Context, clientMap clientmap.ClientMap, co
 	}
 
 	bastionInformer.AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controllerutils.BastionFilterFunc(ctx, gardenClient.Client(), confighelper.SeedNameFromSeedConfig(config.SeedConfig)),
+		FilterFunc: controllerutils.BastionFilterFunc(confighelper.SeedNameFromSeedConfig(config.SeedConfig)),
 		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc:    controller.bastionAdd,
 			UpdateFunc: controller.bastionUpdate,

--- a/pkg/gardenlet/controller/bastion/bastion.go
+++ b/pkg/gardenlet/controller/bastion/bastion.go
@@ -76,7 +76,7 @@ func NewBastionController(ctx context.Context, clientMap clientmap.ClientMap, co
 	}
 
 	bastionInformer.AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controllerutils.BastionFilterFunc(ctx, gardenClient.Client(), confighelper.SeedNameFromSeedConfig(config.SeedConfig), config.SeedSelector),
+		FilterFunc: controllerutils.BastionFilterFunc(ctx, gardenClient.Client(), confighelper.SeedNameFromSeedConfig(config.SeedConfig)),
 		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc:    controller.bastionAdd,
 			UpdateFunc: controller.bastionUpdate,

--- a/pkg/gardenlet/controller/bastion/bastion_reconciler.go
+++ b/pkg/gardenlet/controller/bastion/bastion_reconciler.go
@@ -88,7 +88,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, err
 	}
 
-	if !controllerutils.BastionIsManagedByThisGardenlet(ctx, gardenClient.Client(), bastion, r.config) {
+	if !controllerutils.BastionIsManagedByThisGardenlet(bastion, r.config) {
 		logger.WithField("bastion-seed", *bastion.Spec.SeedName).Debug("Skipping because Bastion is not managed by this gardenlet")
 		return reconcile.Result{}, nil
 	}

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation.go
@@ -99,7 +99,7 @@ func NewController(clientMap clientmap.ClientMap, gardenCoreInformerFactory gard
 	}
 
 	controllerInstallationInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controllerutils.ControllerInstallationFilterFunc(confighelper.SeedNameFromSeedConfig(&config.SeedConfig)),
+		FilterFunc: controllerutils.ControllerInstallationFilterFunc(confighelper.SeedNameFromSeedConfig(config.SeedConfig)),
 		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc:    controller.controllerInstallationAdd,
 			UpdateFunc: controller.controllerInstallationUpdate,
@@ -108,7 +108,7 @@ func NewController(clientMap clientmap.ClientMap, gardenCoreInformerFactory gard
 	})
 
 	controllerInstallationInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controllerutils.ControllerInstallationFilterFunc(confighelper.SeedNameFromSeedConfig(&config.SeedConfig)),
+		FilterFunc: controllerutils.ControllerInstallationFilterFunc(confighelper.SeedNameFromSeedConfig(config.SeedConfig)),
 		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc: controller.controllerInstallationCareAdd,
 		},

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation.go
@@ -99,7 +99,7 @@ func NewController(clientMap clientmap.ClientMap, gardenCoreInformerFactory gard
 	}
 
 	controllerInstallationInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controllerutils.ControllerInstallationFilterFunc(confighelper.SeedNameFromSeedConfig(config.SeedConfig), seedLister),
+		FilterFunc: controllerutils.ControllerInstallationFilterFunc(confighelper.SeedNameFromSeedConfig(&config.SeedConfig)),
 		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc:    controller.controllerInstallationAdd,
 			UpdateFunc: controller.controllerInstallationUpdate,
@@ -108,7 +108,7 @@ func NewController(clientMap clientmap.ClientMap, gardenCoreInformerFactory gard
 	})
 
 	controllerInstallationInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controllerutils.ControllerInstallationFilterFunc(confighelper.SeedNameFromSeedConfig(config.SeedConfig), seedLister),
+		FilterFunc: controllerutils.ControllerInstallationFilterFunc(confighelper.SeedNameFromSeedConfig(&config.SeedConfig)),
 		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc: controller.controllerInstallationCareAdd,
 		},

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation.go
@@ -99,7 +99,7 @@ func NewController(clientMap clientmap.ClientMap, gardenCoreInformerFactory gard
 	}
 
 	controllerInstallationInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controllerutils.ControllerInstallationFilterFunc(confighelper.SeedNameFromSeedConfig(config.SeedConfig), seedLister, config.SeedSelector),
+		FilterFunc: controllerutils.ControllerInstallationFilterFunc(confighelper.SeedNameFromSeedConfig(config.SeedConfig), seedLister),
 		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc:    controller.controllerInstallationAdd,
 			UpdateFunc: controller.controllerInstallationUpdate,
@@ -108,7 +108,7 @@ func NewController(clientMap clientmap.ClientMap, gardenCoreInformerFactory gard
 	})
 
 	controllerInstallationInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controllerutils.ControllerInstallationFilterFunc(confighelper.SeedNameFromSeedConfig(config.SeedConfig), seedLister, config.SeedSelector),
+		FilterFunc: controllerutils.ControllerInstallationFilterFunc(confighelper.SeedNameFromSeedConfig(config.SeedConfig), seedLister),
 		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc: controller.controllerInstallationCareAdd,
 		},

--- a/pkg/gardenlet/controller/factory.go
+++ b/pkg/gardenlet/controller/factory.go
@@ -115,11 +115,9 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 		return fmt.Errorf("timed out waiting for Garden core caches to sync")
 	}
 
-	// Register Seed object if desired
-	if f.cfg.SeedConfig != nil {
-		if err := f.registerSeed(ctx, k8sGardenClient); err != nil {
-			return fmt.Errorf("failed to register the seed: %+v", err)
-		}
+	// Register Seed object
+	if err := f.registerSeed(ctx, k8sGardenClient); err != nil {
+		return fmt.Errorf("failed to register the seed: %+v", err)
 	}
 
 	imageVector, err := imagevector.ReadGlobalImageVectorWithEnvOverride(filepath.Join(charts.Path, DefaultImageVector))

--- a/pkg/gardenlet/controller/federatedseed/seed_control.go
+++ b/pkg/gardenlet/controller/federatedseed/seed_control.go
@@ -138,7 +138,7 @@ func (c *Controller) seedDelete(obj interface{}) {
 // Run starts the FederatedSeed Controller
 func (c *Controller) Run(ctx context.Context, workers int) {
 	c.seedInformer.AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controllerutils.SeedFilterFunc(confighelper.SeedNameFromSeedConfig(c.config.SeedConfig), c.config.SeedSelector),
+		FilterFunc: controllerutils.SeedFilterFunc(confighelper.SeedNameFromSeedConfig(c.config.SeedConfig)),
 		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc:    c.seedAdd,
 			UpdateFunc: c.seedUpdate,

--- a/pkg/gardenlet/controller/managedseed/managedseed.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed.go
@@ -110,7 +110,7 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 	var waitGroup sync.WaitGroup
 
 	c.managedSeedInformer.AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controllerutils.ManagedSeedFilterFunc(ctx, c.gardenClient.Cache(), confighelper.SeedNameFromSeedConfig(c.config.SeedConfig), c.config.SeedSelector),
+		FilterFunc: controllerutils.ManagedSeedFilterFunc(ctx, c.gardenClient.Cache(), confighelper.SeedNameFromSeedConfig(c.config.SeedConfig)),
 		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc:    c.managedSeedAdd,
 			UpdateFunc: c.managedSeedUpdate,
@@ -120,7 +120,7 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 
 	// Add event handler for controlled seeds
 	c.seedInformer.AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controllerutils.SeedOfManagedSeedFilterFunc(ctx, c.gardenClient.Cache(), confighelper.SeedNameFromSeedConfig(c.config.SeedConfig), c.config.SeedSelector),
+		FilterFunc: controllerutils.SeedOfManagedSeedFilterFunc(ctx, c.gardenClient.Cache(), confighelper.SeedNameFromSeedConfig(c.config.SeedConfig)),
 		Handler: &kutils.ControlledResourceEventHandler{
 			ControllerTypes: []kutils.ControllerType{
 				{

--- a/pkg/gardenlet/controller/managedseed/managedseed_actuator.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_actuator.go
@@ -633,9 +633,6 @@ func (a *actuator) prepareGardenletChartValues(
 	// Set the seed name
 	gardenletConfig.SeedConfig.SeedTemplate.Name = objectMeta.Name
 
-	// Ensure seed selector is not set
-	gardenletConfig.SeedSelector = nil
-
 	// Get gardenlet chart values
 	return a.vp.GetGardenletChartValues(
 		ensureGardenletEnvironment(deployment, shoot.Spec.DNS),

--- a/pkg/gardenlet/controller/managedseed/managedseed_actuator_test.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_actuator_test.go
@@ -490,7 +490,6 @@ var _ = Describe("Actuator", func() {
 					Kubeconfig: "kubeconfig",
 				},
 			}
-			mergedGardenletConfig.SeedSelector = &metav1.LabelSelector{}
 
 			vh.EXPECT().MergeGardenletDeployment(managedSeed.Spec.Gardenlet.Deployment, shoot).Return(mergedDeployment, nil)
 			vh.EXPECT().MergeGardenletConfiguration(managedSeed.Spec.Gardenlet.Config.Object).Return(mergedGardenletConfig, nil)
@@ -552,7 +551,7 @@ var _ = Describe("Actuator", func() {
 						},
 						Spec: seedTemplate.Spec,
 					}))
-					Expect(gc.SeedSelector).To(BeNil())
+
 					return gardenletChartValues, nil
 				},
 			)

--- a/pkg/gardenlet/controller/seed/seed.go
+++ b/pkg/gardenlet/controller/seed/seed.go
@@ -120,7 +120,7 @@ func NewSeedController(
 	})
 
 	controllerInstallationInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controllerutils.ControllerInstallationFilterFunc(confighelper.SeedNameFromSeedConfig(config.SeedConfig), seedLister),
+		FilterFunc: controllerutils.ControllerInstallationFilterFunc(confighelper.SeedNameFromSeedConfig(config.SeedConfig)),
 		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc:    seedController.controllerInstallationOfSeedAdd,
 			UpdateFunc: seedController.controllerInstallationOfSeedUpdate,

--- a/pkg/gardenlet/controller/seed/seed_lease_control.go
+++ b/pkg/gardenlet/controller/seed/seed_lease_control.go
@@ -71,9 +71,7 @@ func (c *Controller) reconcileSeedLeaseKey(key string) error {
 	}
 
 	if err := c.checkSeedConnection(ctx, seed); err != nil {
-		c.lock.Lock()
-		c.leaseMap[seed.Name] = false
-		c.lock.Unlock()
+		c.healthManager.Set(false)
 		return fmt.Errorf("[SEED LEASE] cannot establish connection with Seed %s: %v", key, err)
 	}
 
@@ -83,9 +81,7 @@ func (c *Controller) reconcileSeedLeaseKey(key string) error {
 	)
 
 	if err := c.seedLeaseControl.Sync(seedCopy.Name, *seedOwnerReference); err != nil {
-		c.lock.Lock()
-		c.leaseMap[seed.Name] = false
-		c.lock.Unlock()
+		c.healthManager.Set(false)
 		return err
 	}
 
@@ -94,9 +90,7 @@ func (c *Controller) reconcileSeedLeaseKey(key string) error {
 		return fmt.Errorf("failed to get garden client: %w", err)
 	}
 
-	c.lock.Lock()
-	c.leaseMap[seed.Name] = true
-	c.lock.Unlock()
+	c.healthManager.Set(true)
 
 	bldr, err := helper.NewConditionBuilder(gardencorev1beta1.SeedGardenletReady)
 	if err != nil {

--- a/pkg/gardenlet/controller/shoot/shoot.go
+++ b/pkg/gardenlet/controller/shoot/shoot.go
@@ -111,7 +111,7 @@ func NewShootController(clientMap clientmap.ClientMap, k8sGardenCoreInformers ga
 	}
 
 	shootInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controllerutils.ShootFilterFunc(confighelper.SeedNameFromSeedConfig(config.SeedConfig), seedLister),
+		FilterFunc: controllerutils.ShootFilterFunc(confighelper.SeedNameFromSeedConfig(config.SeedConfig)),
 		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				shootController.shootAdd(obj, false)
@@ -122,7 +122,7 @@ func NewShootController(clientMap clientmap.ClientMap, k8sGardenCoreInformers ga
 	})
 
 	shootInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controllerutils.ShootFilterFunc(confighelper.SeedNameFromSeedConfig(config.SeedConfig), seedLister),
+		FilterFunc: controllerutils.ShootFilterFunc(confighelper.SeedNameFromSeedConfig(config.SeedConfig)),
 		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc:    shootController.shootCareAdd,
 			UpdateFunc: shootController.shootCareUpdate,
@@ -130,7 +130,7 @@ func NewShootController(clientMap clientmap.ClientMap, k8sGardenCoreInformers ga
 	})
 
 	shootInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controllerutils.ShootFilterFunc(confighelper.SeedNameFromSeedConfig(config.SeedConfig), seedLister),
+		FilterFunc: controllerutils.ShootFilterFunc(confighelper.SeedNameFromSeedConfig(config.SeedConfig)),
 		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc:    shootController.seedRegistrationAdd,
 			UpdateFunc: shootController.seedRegistrationUpdate,
@@ -168,7 +168,7 @@ func (c *Controller) Run(ctx context.Context, shootWorkers, shootCareWorkers int
 	}
 
 	// Update Shoots before starting the workers.
-	shootFilterFunc := controllerutils.ShootFilterFunc(confighelper.SeedNameFromSeedConfig(c.config.SeedConfig), c.seedLister)
+	shootFilterFunc := controllerutils.ShootFilterFunc(confighelper.SeedNameFromSeedConfig(c.config.SeedConfig))
 	shoots, err := c.shootLister.List(labels.Everything())
 	if err != nil {
 		logger.Logger.Errorf("Failed to fetch shoots resources: %v", err.Error())

--- a/pkg/gardenlet/controller/shoot/shoot.go
+++ b/pkg/gardenlet/controller/shoot/shoot.go
@@ -111,7 +111,7 @@ func NewShootController(clientMap clientmap.ClientMap, k8sGardenCoreInformers ga
 	}
 
 	shootInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controllerutils.ShootFilterFunc(confighelper.SeedNameFromSeedConfig(config.SeedConfig), seedLister, config.SeedSelector),
+		FilterFunc: controllerutils.ShootFilterFunc(confighelper.SeedNameFromSeedConfig(config.SeedConfig), seedLister),
 		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
 				shootController.shootAdd(obj, false)
@@ -122,7 +122,7 @@ func NewShootController(clientMap clientmap.ClientMap, k8sGardenCoreInformers ga
 	})
 
 	shootInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controllerutils.ShootFilterFunc(confighelper.SeedNameFromSeedConfig(config.SeedConfig), seedLister, config.SeedSelector),
+		FilterFunc: controllerutils.ShootFilterFunc(confighelper.SeedNameFromSeedConfig(config.SeedConfig), seedLister),
 		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc:    shootController.shootCareAdd,
 			UpdateFunc: shootController.shootCareUpdate,
@@ -130,7 +130,7 @@ func NewShootController(clientMap clientmap.ClientMap, k8sGardenCoreInformers ga
 	})
 
 	shootInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controllerutils.ShootFilterFunc(confighelper.SeedNameFromSeedConfig(config.SeedConfig), seedLister, config.SeedSelector),
+		FilterFunc: controllerutils.ShootFilterFunc(confighelper.SeedNameFromSeedConfig(config.SeedConfig), seedLister),
 		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc:    shootController.seedRegistrationAdd,
 			UpdateFunc: shootController.seedRegistrationUpdate,
@@ -168,7 +168,7 @@ func (c *Controller) Run(ctx context.Context, shootWorkers, shootCareWorkers int
 	}
 
 	// Update Shoots before starting the workers.
-	shootFilterFunc := controllerutils.ShootFilterFunc(confighelper.SeedNameFromSeedConfig(c.config.SeedConfig), c.seedLister, c.config.SeedSelector)
+	shootFilterFunc := controllerutils.ShootFilterFunc(confighelper.SeedNameFromSeedConfig(c.config.SeedConfig), c.seedLister)
 	shoots, err := c.shootLister.List(labels.Everything())
 	if err != nil {
 		logger.Logger.Errorf("Failed to fetch shoots resources: %v", err.Error())

--- a/pkg/gardenlet/controller/shoot/shoot_care_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_care_control.go
@@ -198,7 +198,7 @@ func (s *careReconciler) Reconcile(ctx context.Context, req reconcile.Request) (
 	}
 
 	// if shoot is no longer managed by this gardenlet (e.g., due to migration to another seed) then don't requeue
-	if !controllerutils.ShootIsManagedByThisGardenlet(shootObj, s.config, s.k8sGardenCoreInformers.Seeds().Lister()) {
+	if !controllerutils.ShootIsManagedByThisGardenlet(shootObj, s.config) {
 		return reconcile.Result{}, nil
 	}
 

--- a/pkg/gardenlet/controller/shoot/shoot_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control.go
@@ -234,7 +234,7 @@ func (c *Controller) reconcileShootRequest(ctx context.Context, req reconcile.Re
 	}
 
 	// if shoot is no longer managed by this gardenlet (e.g., due to migration to another seed) then don't requeue
-	if !controllerutils.ShootIsManagedByThisGardenlet(shoot, c.config, c.seedLister) {
+	if !controllerutils.ShootIsManagedByThisGardenlet(shoot, c.config) {
 		log.Debugf("Skipping because Shoot is not managed by this gardenlet in seed %s", *shoot.Spec.SeedName)
 		return reconcile.Result{}, nil
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind technical-debt

**What this PR does / why we need it**:
This PR removes the `SeedSelector` field from the `GardenletConfiguration` struct.

**Which issue(s) this PR fixes**:
Part of #4078.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
Gardenlet does not support seedSelectors anymore; configure an explicit seedConfig in the GardenletConfiguration instead
```
