### PR TITLE
[GEP-17] Add handling of owner DNSRecord resources

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_delete.go
@@ -547,10 +547,15 @@ func (c *Controller) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 			Fn:           flow.TaskFn(botanist.DestroyInternalDNSResources),
 			Dependencies: flow.NewTaskIDs(syncPoint),
 		})
+		destroyOwnerDomainDNSRecord = g.Add(flow.Task{
+			Name:         "Destroying owner domain DNS record",
+			Fn:           flow.TaskFn(botanist.DestroyOwnerDNSResources),
+			Dependencies: flow.NewTaskIDs(syncPoint),
+		})
 		deleteDNSProviders = g.Add(flow.Task{
 			Name:         "Deleting additional DNS providers",
 			Fn:           flow.TaskFn(botanist.DeleteDNSProviders),
-			Dependencies: flow.NewTaskIDs(destroyInternalDomainDNSRecord),
+			Dependencies: flow.NewTaskIDs(destroyInternalDomainDNSRecord, destroyOwnerDomainDNSRecord),
 		})
 		destroyReferencedResources = g.Add(flow.Task{
 			Name:         "Deleting referenced resources",

--- a/pkg/gardenlet/controller/shoot/shoot_control_migrate.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_migrate.go
@@ -244,15 +244,20 @@ func (c *Controller) runPrepareShootControlPlaneMigration(ctx context.Context, o
 			Fn:           flow.TaskFn(botanist.MigrateInternalDNSResources),
 			Dependencies: flow.NewTaskIDs(waitUntilAPIServerDeleted),
 		})
+		migrateOwnerDNSRecord = g.Add(flow.Task{
+			Name:         "Migrating owner domain DNS record",
+			Fn:           flow.TaskFn(botanist.MigrateOwnerDNSResources),
+			Dependencies: flow.NewTaskIDs(waitUntilAPIServerDeleted),
+		})
 		destroyDNSRecords = g.Add(flow.Task{
 			Name:         "Deleting DNSRecords from the Shoot namespace",
 			Fn:           botanist.DestroyDNSRecords,
-			Dependencies: flow.NewTaskIDs(migrateIngressDNSRecord, migrateExternalDNSRecord, migrateInternalDNSRecord),
+			Dependencies: flow.NewTaskIDs(migrateIngressDNSRecord, migrateExternalDNSRecord, migrateInternalDNSRecord, migrateOwnerDNSRecord),
 		})
 		destroyDNSProviders = g.Add(flow.Task{
 			Name:         "Deleting DNS providers",
 			Fn:           flow.TaskFn(botanist.DeleteDNSProviders),
-			Dependencies: flow.NewTaskIDs(migrateIngressDNSRecord, migrateExternalDNSRecord, migrateInternalDNSRecord),
+			Dependencies: flow.NewTaskIDs(migrateIngressDNSRecord, migrateExternalDNSRecord, migrateInternalDNSRecord, migrateOwnerDNSRecord),
 		})
 		createETCDSnapshot = g.Add(flow.Task{
 			Name:         "Creating ETCD Snapshot",

--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -155,6 +155,11 @@ func (c *Controller) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Fn:           flow.TaskFn(botanist.DeployReferencedResources).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(deployNamespace),
 		})
+		deployOwnerDomainDNSRecord = g.Add(flow.Task{
+			Name:         "Deploying owner domain DNS record",
+			Fn:           flow.TaskFn(botanist.DeployOwnerDNSResources),
+			Dependencies: flow.NewTaskIDs(deployReferencedResources),
+		})
 		deployInternalDomainDNSRecord = g.Add(flow.Task{
 			Name:         "Deploying internal domain DNS record",
 			Fn:           flow.TaskFn(botanist.DeployInternalDNSResources).DoIf(!o.Shoot.HibernationEnabled),
@@ -408,7 +413,7 @@ func (c *Controller) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		_ = g.Add(flow.Task{
 			Name:         "Deploying additional DNS providers",
 			Fn:           flow.TaskFn(botanist.DeployAdditionalDNSProviders).DoIf(!o.Shoot.HibernationEnabled),
-			Dependencies: flow.NewTaskIDs(deployInternalDomainDNSRecord, deployExternalDomainDNSRecord, deployIngressDomainDNSRecord),
+			Dependencies: flow.NewTaskIDs(deployInternalDomainDNSRecord, deployExternalDomainDNSRecord, deployIngressDomainDNSRecord, deployOwnerDomainDNSRecord),
 		})
 		vpnLBReady = g.Add(flow.Task{
 			Name:         "Waiting until vpn-shoot LoadBalancer is ready",

--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -85,6 +85,7 @@ func New(ctx context.Context, o *operation.Operation) (*Botanist, error) {
 	o.Shoot.Components.Extensions.ExternalDNSRecord = b.DefaultExternalDNSRecord()
 	o.Shoot.Components.Extensions.InternalDNSRecord = b.DefaultInternalDNSRecord()
 	o.Shoot.Components.Extensions.IngressDNSRecord = b.DefaultIngressDNSRecord()
+	o.Shoot.Components.Extensions.OwnerDNSRecord = b.DefaultOwnerDNSRecord()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operation/botanist/dns.go
+++ b/pkg/operation/botanist/dns.go
@@ -42,6 +42,8 @@ const (
 	DNSInternalName = "internal"
 	// DNSExternalName is a constant for a DNS resources used for the external domain name.
 	DNSExternalName = "external"
+	// DNSOwnerName is a constant for a DNS resources used for the owner domain name.
+	DNSOwnerName = "owner"
 	// DNSProviderRoleAdditional is a constant for additionally managed DNS providers.
 	DNSProviderRoleAdditional = "managed-dns-provider"
 	// DNSRealmAnnotation is the annotation key for restricting provider access for shoot DNS entries

--- a/pkg/operation/botanist/dnsrecord.go
+++ b/pkg/operation/botanist/dnsrecord.go
@@ -17,6 +17,7 @@ package botanist
 import (
 	"context"
 
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	extensionsdnsrecord "github.com/gardener/gardener/pkg/operation/botanist/component/extensions/dnsrecord"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
@@ -74,6 +75,35 @@ func (b *Botanist) DefaultInternalDNSRecord() extensionsdnsrecord.Interface {
 	)
 }
 
+// DefaultOwnerDNSRecord creates the default deployer for the owner DNSRecord resource.
+func (b *Botanist) DefaultOwnerDNSRecord() extensionsdnsrecord.Interface {
+	values := &extensionsdnsrecord.Values{
+		Name:       b.Shoot.GetInfo().Name + "-" + DNSOwnerName,
+		SecretName: b.Shoot.GetInfo().Name + "-" + DNSInternalName,
+		Namespace:  b.Shoot.SeedNamespace,
+		CreateOnly: true,
+		TTL:        b.Config.Controllers.Shoot.DNSEntryTTLSeconds,
+	}
+	if b.NeedsInternalDNS() {
+		values.Type = b.Garden.InternalDomain.Provider
+		if b.Garden.InternalDomain.Zone != "" {
+			values.Zone = &b.Garden.InternalDomain.Zone
+		}
+		values.SecretData = b.Garden.InternalDomain.SecretData
+		values.DNSName = gutil.GetOwnerDomain(b.Shoot.InternalClusterDomain)
+		values.RecordType = extensionsv1alpha1.DNSRecordTypeTXT
+		values.Values = []string{*b.Seed.GetInfo().Status.ClusterIdentity}
+	}
+	return extensionsdnsrecord.New(
+		b.Logger,
+		b.K8sSeedClient.Client(),
+		values,
+		extensionsdnsrecord.DefaultInterval,
+		extensionsdnsrecord.DefaultSevereThreshold,
+		extensionsdnsrecord.DefaultTimeout,
+	)
+}
+
 // DeployOrDestroyExternalDNSRecord deploys, restores, or destroys the external DNSRecord and waits for the operation to complete.
 func (b *Botanist) DeployOrDestroyExternalDNSRecord(ctx context.Context) error {
 	if b.NeedsExternalDNS() {
@@ -88,6 +118,14 @@ func (b *Botanist) DeployOrDestroyInternalDNSRecord(ctx context.Context) error {
 		return b.deployInternalDNSRecord(ctx)
 	}
 	return b.DestroyInternalDNSRecord(ctx)
+}
+
+// DeployOrDestroyOwnerDNSRecord deploys, restores, or destroys the owner DNSRecord and waits for the operation to complete.
+func (b *Botanist) DeployOrDestroyOwnerDNSRecord(ctx context.Context) error {
+	if b.NeedsInternalDNS() {
+		return b.DeployOwnerDNSRecord(ctx)
+	}
+	return b.DestroyOwnerDNSRecord(ctx)
 }
 
 // deployExternalDNSRecord deploys or restores the external DNSRecord and waits for the operation to complete.
@@ -106,6 +144,14 @@ func (b *Botanist) deployInternalDNSRecord(ctx context.Context) error {
 	return b.Shoot.Components.Extensions.InternalDNSRecord.Wait(ctx)
 }
 
+// DeployOwnerDNSRecord deploys or restores the owner DNSRecord and waits for the operation to complete.
+func (b *Botanist) DeployOwnerDNSRecord(ctx context.Context) error {
+	if err := b.deployOrRestoreDNSRecord(ctx, b.Shoot.Components.Extensions.OwnerDNSRecord); err != nil {
+		return err
+	}
+	return b.Shoot.Components.Extensions.OwnerDNSRecord.Wait(ctx)
+}
+
 // DestroyExternalDNSRecord destroys the external DNSRecord and waits for the operation to complete.
 func (b *Botanist) DestroyExternalDNSRecord(ctx context.Context) error {
 	if err := b.Shoot.Components.Extensions.ExternalDNSRecord.Destroy(ctx); err != nil {
@@ -122,6 +168,14 @@ func (b *Botanist) DestroyInternalDNSRecord(ctx context.Context) error {
 	return b.Shoot.Components.Extensions.InternalDNSRecord.WaitCleanup(ctx)
 }
 
+// DestroyOwnerDNSRecord destroys the owner DNSRecord and waits for the operation to complete.
+func (b *Botanist) DestroyOwnerDNSRecord(ctx context.Context) error {
+	if err := b.Shoot.Components.Extensions.OwnerDNSRecord.Destroy(ctx); err != nil {
+		return err
+	}
+	return b.Shoot.Components.Extensions.OwnerDNSRecord.WaitCleanup(ctx)
+}
+
 // MigrateExternalDNSRecord migrates the external DNSRecord and waits for the operation to complete.
 func (b *Botanist) MigrateExternalDNSRecord(ctx context.Context) error {
 	if err := b.Shoot.Components.Extensions.ExternalDNSRecord.Migrate(ctx); err != nil {
@@ -136,6 +190,14 @@ func (b *Botanist) MigrateInternalDNSRecord(ctx context.Context) error {
 		return err
 	}
 	return b.Shoot.Components.Extensions.InternalDNSRecord.WaitMigrate(ctx)
+}
+
+// MigrateOwnerDNSRecord migrates the owner DNSRecord and waits for the operation to complete.
+func (b *Botanist) MigrateOwnerDNSRecord(ctx context.Context) error {
+	if err := b.Shoot.Components.Extensions.OwnerDNSRecord.Migrate(ctx); err != nil {
+		return err
+	}
+	return b.Shoot.Components.Extensions.OwnerDNSRecord.WaitMigrate(ctx)
 }
 
 func (b *Botanist) deployOrRestoreDNSRecord(ctx context.Context, dnsRecord component.DeployMigrateWaiter) error {

--- a/pkg/operation/botanist/dnsresources.go
+++ b/pkg/operation/botanist/dnsresources.go
@@ -96,6 +96,18 @@ func (b *Botanist) DeployIngressDNSResources(ctx context.Context) error {
 	}
 }
 
+// DeployOwnerDNSResources deploys or deletes the owner DNSRecord resource depending on whether
+// the `UseDNSRecords` feature gate is enabled or not.
+// * If the feature gate is enabled, the DNSRecord resource is deployed (or restored).
+// * Otherwise, it is deleted (owner DNS resources can't be properly maintained without the feature gate).
+func (b *Botanist) DeployOwnerDNSResources(ctx context.Context) error {
+	if gardenletfeatures.FeatureGate.Enabled(features.UseDNSRecords) {
+		return b.DeployOrDestroyOwnerDNSRecord(ctx)
+	} else {
+		return b.DestroyOwnerDNSRecord(ctx)
+	}
+}
+
 // DestroyInternalDNSResources deletes all internal DNS resources (DNSProvider, DNSEntry, DNSOwner, and DNSRecord)
 // that currently exist, to ensure that the DNS record is deleted.
 func (b *Botanist) DestroyInternalDNSResources(ctx context.Context) error {
@@ -123,6 +135,11 @@ func (b *Botanist) DestroyIngressDNSResources(ctx context.Context) error {
 	return b.DestroyIngressDNSRecord(ctx)
 }
 
+// DestroyOwnerDNSResources deletes the owner DNSRecord resource if it exists.
+func (b *Botanist) DestroyOwnerDNSResources(ctx context.Context) error {
+	return b.DestroyOwnerDNSRecord(ctx)
+}
+
 // MigrateInternalDNSResources migrates or deletes all internal DNS resources (DNSProvider, DNSEntry, DNSOwner, and DNSRecord)
 // that currently exist, in the appropriate order to ensure that the DNS record is not deleted.
 func (b *Botanist) MigrateInternalDNSResources(ctx context.Context) error {
@@ -148,4 +165,16 @@ func (b *Botanist) MigrateIngressDNSResources(ctx context.Context) error {
 		return err
 	}
 	return b.MigrateIngressDNSRecord(ctx)
+}
+
+// MigrateOwnerDNSResources migrates or deletes the owner DNSRecord resource depending on whether
+// the `UseDNSRecords` feature gate is enabled or not.
+// * If the feature gate is enabled, the DNSRecord resource is migrated.
+// * Otherwise, it is deleted (owner DNS resources can't be properly maintained without the feature gate).
+func (b *Botanist) MigrateOwnerDNSResources(ctx context.Context) error {
+	if gardenletfeatures.FeatureGate.Enabled(features.UseDNSRecords) {
+		return b.MigrateOwnerDNSRecord(ctx)
+	} else {
+		return b.DestroyOwnerDNSRecord(ctx)
+	}
 }

--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -368,6 +368,7 @@ func (s *Shoot) GetDNSRecordComponentsForMigration() []component.DeployMigrateWa
 		s.Components.Extensions.IngressDNSRecord,
 		s.Components.Extensions.ExternalDNSRecord,
 		s.Components.Extensions.InternalDNSRecord,
+		s.Components.Extensions.OwnerDNSRecord,
 	}
 }
 

--- a/pkg/operation/shoot/types.go
+++ b/pkg/operation/shoot/types.go
@@ -125,6 +125,7 @@ type Extensions struct {
 	ExternalDNSRecord     dnsrecord.Interface
 	InternalDNSRecord     dnsrecord.Interface
 	IngressDNSRecord      dnsrecord.Interface
+	OwnerDNSRecord        dnsrecord.Interface
 	Extension             extension.Interface
 	Infrastructure        infrastructure.Interface
 	Network               component.DeployMigrateWaiter

--- a/pkg/utils/gardener/dns.go
+++ b/pkg/utils/gardener/dns.go
@@ -40,6 +40,10 @@ const (
 	// a Shoot cluster. For example, when a Shoot specifies domain 'cluster.example.com', the apiserver domain would be
 	// 'api.cluster.example.com'.
 	APIServerFQDNPrefix = "api"
+	// OwnerFQDNPrefix is the part of a FQDN which will be used to construct the domain name for the owner of
+	// a Shoot cluster. For example, when a Shoot specifies domain 'cluster.example.com', the owner domain would be
+	// 'owner.cluster.example.com'.
+	OwnerFQDNPrefix = "owner"
 	// IngressPrefix is the part of a FQDN which will be used to construct the domain name for an ingress controller of
 	// a Shoot cluster. For example, when a Shoot specifies domain 'cluster.example.com', the ingress domain would be
 	// '*.<IngressPrefix>.cluster.example.com'.
@@ -85,10 +89,16 @@ func GetDomainInfoFromAnnotations(annotations map[string]string) (provider strin
 	return
 }
 
-// GetAPIServerDomain returns the fully qualified domain name of for the api-server for the Shoot cluster. The
+// GetAPIServerDomain returns the fully qualified domain name for the api-server of the Shoot cluster. The
 // end result is 'api.<domain>'.
 func GetAPIServerDomain(domain string) string {
 	return fmt.Sprintf("%s.%s", APIServerFQDNPrefix, domain)
+}
+
+// GetOwnerDomain returns the fully qualified domain name for the owner of the Shoot cluster. The
+// end result is 'owner.<domain>'.
+func GetOwnerDomain(domain string) string {
+	return fmt.Sprintf("%s.%s", OwnerFQDNPrefix, domain)
 }
 
 // GenerateDNSProviderName creates a name for the dns provider out of the passed `secretName` and `providerType`.


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind enhancement

**What this PR does / why we need it**:

Adds handling of owner `DNSRecord` resources for shoots. They are of type `TXT` and contain the identity of the seed that is currently hosting the shoot's control plane ("owns" the shoot). They will be used by "owner election" mechanisms needed by the control plane migration.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This PR is in general ready for review and merge, but the functionality it introduces is so far only used in the CPM "bad case" PoC (https://github.com/stoyanr/gardener/commits/cpm-poc/master). So I am keeping it in `Draft` until there is a decision to productize the PoC as proposed.

**Release note**:

```other operator
NONE
```
