### PR TITLE
Ignore the ServiceUnavailable error in the metrics-servers integration test

### DIFF
--- a/test/integration/shoots/applications/metrics.go
+++ b/test/integration/shoots/applications/metrics.go
@@ -86,7 +86,7 @@ var _ = ginkgo.Describe("Shoot application metrics testing", func() {
 			retry.Until(ctx, 30*time.Second, func(ctx context.Context) (bool, error) {
 				podMetrics := &metricsv1beta1.PodMetrics{}
 				if err := f.ShootClient.Client().Get(ctx, kutil.Key(f.Namespace, podName), podMetrics); err != nil {
-					if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) {
+					if apierrors.IsNotFound(err) || meta.IsNoMatchError(err) || apierrors.IsServiceUnavailable(err) {
 						f.Logger.Infof("No metrics for pod %s/%s available yet: %v", f.Namespace, podName, err)
 						return retry.MinorError(err)
 					}


### PR DESCRIPTION
/area testing
/kind enhancement

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
