### PR TITLE
Don't get cluster resources for extension resources in garden namespace

### DIFF
--- a/docs/extensions/cluster.md
+++ b/docs/extensions/cluster.md
@@ -48,6 +48,14 @@ There are some fields in the `Shoot` specification that might be interesting to 
 * `.spec.hibernation.enabled={true,false}`: Extension controllers might want to behave differently if the shoot is hibernated or not (probably they might want to scale down their control plane components, for example).
 * `.status.lastOperation.state=Failed`: If Gardener sets the shoot's last operation state to `Failed` it means that Gardener won't automatically retry to finish the reconciliation/deletion flow because an error occurred that could not be resolved within the last `24h` (default). In this case end-users are expected to manually re-trigger the reconciliation flow in case they want Gardener to try again. Extension controllers are expected to follow the same principle. This means they have to read the shoot state out of the `Cluster` resource.
 
+## Extension resources not associated with a shoot
+
+In some cases, Gardener may create extension resources that are not associated with a shoot, but are needed to support some functionality internal to Gardener. Such resources will be created in the `garden` namespace of a seed cluster.
+
+For example, if the [managed ingress controller](../deployment/deploy_gardenlet_manually.md) is active on the seed, Gardener will create a [DNSProvider / DNSEntry](dns.md) or a [DNSRecord](dnsrecord.md) resource(s) in the `garden` namespace of the seed cluster for the ingress DNS record.
+
+Extension controllers that may be expected to reconcile extension resources in the `garden` namespace should make sure that they can tolerate the absence of a cluster resource. This means that they should not attempt to read the cluster resource in such cases, or if they do they should ignore the "not found" error.
+
 ## References and additional resources
 
 * [`Cluster` API (Golang specification)](../../pkg/apis/extensions/v1alpha1/types_cluster.go)

--- a/extensions/pkg/predicate/predicate.go
+++ b/extensions/pkg/predicate/predicate.go
@@ -58,6 +58,11 @@ type shootNotFailedMapper struct {
 }
 
 func (s *shootNotFailedMapper) Map(e event.GenericEvent) bool {
+	// Return true for resources in the garden namespace, as they are not associated with a shoot
+	if e.Object.GetNamespace() == v1beta1constants.GardenNamespace {
+		return true
+	}
+
 	// Wait for cache sync because of backing client cache.
 	if !s.Cache.WaitForCacheSync(s.Context) {
 		err := errors.New("failed to wait for caches to sync")

--- a/extensions/pkg/predicate/predicate_test.go
+++ b/extensions/pkg/predicate/predicate_test.go
@@ -20,6 +20,7 @@ import (
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	mockcache "github.com/gardener/gardener/pkg/mock/controller-runtime/cache"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
@@ -258,11 +259,11 @@ var _ = Describe("Predicate", func() {
 			e = event.GenericEvent{
 				Object: infrastructure,
 			}
-
-			cache.EXPECT().WaitForCacheSync(gomock.Any()).Return(true)
 		})
 
 		It("should return true because shoot has no last operation", func() {
+			cache.EXPECT().WaitForCacheSync(gomock.Any()).Return(true)
+
 			meta := &metav1.ObjectMeta{Generation: 1}
 			status := &gardencorev1beta1.ShootStatus{
 				ObservedGeneration: 1,
@@ -278,6 +279,8 @@ var _ = Describe("Predicate", func() {
 		})
 
 		It("should return true because shoot last operation state is not failed", func() {
+			cache.EXPECT().WaitForCacheSync(gomock.Any()).Return(true)
+
 			meta := &metav1.ObjectMeta{Generation: 1}
 			status := &gardencorev1beta1.ShootStatus{
 				ObservedGeneration: 1,
@@ -294,6 +297,8 @@ var _ = Describe("Predicate", func() {
 		})
 
 		It("should return false because shoot is failed", func() {
+			cache.EXPECT().WaitForCacheSync(gomock.Any()).Return(true)
+
 			meta := &metav1.ObjectMeta{Generation: 1}
 			status := &gardencorev1beta1.ShootStatus{
 				ObservedGeneration: 1,
@@ -310,6 +315,8 @@ var _ = Describe("Predicate", func() {
 		})
 
 		It("should return true because shoot is failed but observed generation is outdated", func() {
+			cache.EXPECT().WaitForCacheSync(gomock.Any()).Return(true)
+
 			meta := &metav1.ObjectMeta{Generation: 2}
 			status := &gardencorev1beta1.ShootStatus{
 				ObservedGeneration: 1,
@@ -321,6 +328,14 @@ var _ = Describe("Predicate", func() {
 				cluster.DeepCopyInto(actual)
 				return nil
 			})
+
+			gomega.Expect(mapper.Map(e)).To(gomega.BeTrue())
+		})
+
+		It("should return true because the resource is in the garden namespace", func() {
+			e = event.GenericEvent{
+				Object: &extensionsv1alpha1.Infrastructure{ObjectMeta: metav1.ObjectMeta{Namespace: v1beta1constants.GardenNamespace}},
+			}
 
 			gomega.Expect(mapper.Map(e)).To(gomega.BeTrue())
 		})


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Avoids trying to get a `Cluster` resources in mappers and reconcilers for extension resources in `garden` namespace, since such resources are not associated with a shoot and a `Cluster` resource does not exist (and should not be created as it's irrelevant).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Currently, the only extension resource for which this is relevant is `DNSRecord`, as we need to create DNS recrods for the so called "managed ingress" case for seeds. Without this change, a fake cluster resource must be created to avoid errors, see https://github.com/gardener/gardener/pull/4253/commits/d42529ceef1c19030379be5986ab395785f76bb2#r660659389.

Based on #4231, in Draft until that one is merged.

**Release note**:

```other operator
NONE
```
