### PR TITLE
Document supported options for cri.name

### DIFF
--- a/hack/api-reference/core.md
+++ b/hack/api-reference/core.md
@@ -2334,7 +2334,7 @@ CRIName
 </em>
 </td>
 <td>
-<p>The name of the CRI library</p>
+<p>The name of the CRI library. Supported values are <code>docker</code> and <code>containerd</code>.</p>
 </td>
 </tr>
 <tr>

--- a/hack/api-reference/extensions.md
+++ b/hack/api-reference/extensions.md
@@ -2003,7 +2003,7 @@ CRIName
 </em>
 </td>
 <td>
-<p>Name is a mandatory string containing the name of the CRI library.</p>
+<p>Name is a mandatory string containing the name of the CRI library. Supported values are <code>docker</code> and <code>containerd</code>.</p>
 </td>
 </tr>
 </tbody>

--- a/pkg/apis/core/v1alpha1/generated.proto
+++ b/pkg/apis/core/v1alpha1/generated.proto
@@ -226,7 +226,7 @@ message BackupEntryStatus {
 
 // CRI contains information about the Container Runtimes.
 message CRI {
-  // The name of the CRI library
+  // The name of the CRI library. Supported values are `docker` and `containerd`.
   optional string name = 1;
 
   // ContainerRuntimes is the list of the required container runtimes supported for a worker pool.

--- a/pkg/apis/core/v1alpha1/types_shoot.go
+++ b/pkg/apis/core/v1alpha1/types_shoot.go
@@ -1125,7 +1125,7 @@ type DataVolume struct {
 
 // CRI contains information about the Container Runtimes.
 type CRI struct {
-	// The name of the CRI library
+	// The name of the CRI library. Supported values are `docker` and `containerd`.
 	Name CRIName `json:"name" protobuf:"bytes,1,opt,name=name"`
 	// ContainerRuntimes is the list of the required container runtimes supported for a worker pool.
 	// +optional

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -225,7 +225,7 @@ message BackupEntryStatus {
 
 // CRI contains information about the Container Runtimes.
 message CRI {
-  // The name of the CRI library
+  // The name of the CRI library. Supported values are `docker` and `containerd`.
   optional string name = 1;
 
   // ContainerRuntimes is the list of the required container runtimes supported for a worker pool.

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -1132,7 +1132,7 @@ type DataVolume struct {
 
 // CRI contains information about the Container Runtimes.
 type CRI struct {
-	// The name of the CRI library
+	// The name of the CRI library. Supported values are `docker` and `containerd`.
 	Name CRIName `json:"name" protobuf:"bytes,1,opt,name=name,casttype=CRIName"`
 	// ContainerRuntimes is the list of the required container runtimes supported for a worker pool.
 	// +optional

--- a/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
+++ b/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
@@ -218,7 +218,7 @@ const (
 
 // CRI config is a structure contains configurations of the CRI library
 type CRIConfig struct {
-	// Name is a mandatory string containing the name of the CRI library.
+	// Name is a mandatory string containing the name of the CRI library. Supported values are `docker` and `containerd`.
 	Name CRIName `json:"name"`
 }
 

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -1374,7 +1374,7 @@ func schema_pkg_apis_core_v1alpha1_CRI(ref common.ReferenceCallback) common.Open
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The name of the CRI library",
+							Description: "The name of the CRI library. Supported values are `docker` and `containerd`.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -8350,7 +8350,7 @@ func schema_pkg_apis_core_v1beta1_CRI(ref common.ReferenceCallback) common.OpenA
 				Properties: map[string]spec.Schema{
 					"name": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The name of the CRI library",
+							Description: "The name of the CRI library. Supported values are `docker` and `containerd`.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
Document supported options for cri.name in API docs

**Which issue(s) this PR fixes**:
related to #4110

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
