### PR TITLE
Prevent deletion of shoots that are in Migrate or Restore phase

### DIFF
--- a/pkg/apis/core/types_common.go
+++ b/pkg/apis/core/types_common.go
@@ -72,6 +72,8 @@ const (
 	LastOperationTypeDelete LastOperationType = "Delete"
 	// LastOperationTypeRestore indicates a 'restore' operation.
 	LastOperationTypeRestore LastOperationType = "Restore"
+	// LastOperationTypeMigrate indicates a 'migrate' operation.
+	LastOperationTypeMigrate LastOperationType = "Migrate"
 )
 
 // LastOperationState is a string alias.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
When a `shoot` is in `Migrate` or `Restore` phase, (especially if any of those operation has failed) it is very possible that if `Delete` process is triggered, some resources of the shoot will leak, depending on which step is finished successfully and which not. This PR will prevent the administrator of that shoot to set the `confirmation.gardener.cloud.deletion` annotation, restricting the deletion.
In order to ensure smooth deletion, the processes `Migrate` and `Restore` have to finish successfully.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Deletion of shoots that are in Migrate or Restore phase is now forbidden.
```
