### PR TITLE
Allow to configure a loadbalancer ip for Seed ingress gateways

### DIFF
--- a/charts/istio/istio-ingress/templates/service.yaml
+++ b/charts/istio/istio-ingress/templates/service.yaml
@@ -26,3 +26,6 @@ spec:
 {{- if .Values.ports }}
 {{ toYaml .Values.ports | indent 2 }}
 {{- end }}
+{{- if .Values.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.loadBalancerIP }}
+{{- end }}

--- a/charts/istio/istio-ingress/values.yaml
+++ b/charts/istio/istio-ingress/values.yaml
@@ -6,6 +6,7 @@ trustDomain: cluster.local
 istiodNamespace: istio-system
 deployNamespace: false
 serviceType: LoadBalancer
+# loadBalancerIP: 1.2.3.4
 ports: []
 # ports:
 # - name: tls

--- a/example/20-componentconfig-gardenlet.yaml
+++ b/example/20-componentconfig-gardenlet.yaml
@@ -111,6 +111,7 @@ featureGates:
 #   ingress:
 #     serviceName: istio-ingress
 #     namespace: istio-ingress
+#     serviceExternalIP: 10.8.10.10 # Optional external ip for the ingress gateway load balancer.
 #     labels:
 #       istio: ingressgateway
 # exposureClassHandlers:
@@ -125,5 +126,6 @@ featureGates:
 #   sni:
 #     ingress:
 #       namespace: ingress-internal
+#       serviceExternalIP: 10.8.10.11 # Optional external ip for the ingress gateway load balancer.
 #       labels:
 #         network: internal

--- a/pkg/gardenlet/apis/config/types.go
+++ b/pkg/gardenlet/apis/config/types.go
@@ -387,6 +387,10 @@ type SNIIngress struct {
 	// ServiceName is the name of the ingressgateway Service.
 	// Defaults to "istio-ingressgateway".
 	ServiceName *string
+	// ServiceExternalIP is the external ip which should be assigned to the
+	// load balancer service of the ingress gateway.
+	// Compability is depending on the respecitve provider cloud-controller-manager.
+	ServiceExternalIP *string
 	// Namespace is the namespace in which the ingressgateway is deployed in.
 	// Defaults to "istio-ingress".
 	Namespace *string
@@ -412,8 +416,4 @@ type ExposureClassHandler struct {
 type LoadBalancerServiceConfig struct {
 	// Annotations is a key value map to annotate the underlying load balancer services.
 	Annotations map[string]string
-	// LoadBalancerIP is the external ip which should be assigned to the loadbalancer service.
-	// This is only compatible with the APIServerSNI (default) feature gate and
-	// depending on the respective infrastructure cloud-controller-manager compatibility.
-	LoadBalancerIP *string
 }

--- a/pkg/gardenlet/apis/config/types.go
+++ b/pkg/gardenlet/apis/config/types.go
@@ -412,4 +412,8 @@ type ExposureClassHandler struct {
 type LoadBalancerServiceConfig struct {
 	// Annotations is a key value map to annotate the underlying load balancer services.
 	Annotations map[string]string
+	// LoadBalancerIP is the external ip which should be assigned to the loadbalancer service.
+	// This is only compatible with the APIServerSNI (default) feature gate and
+	// depending on the respective infrastructure cloud-controller-manager compatibility.
+	LoadBalancerIP *string
 }

--- a/pkg/gardenlet/apis/config/types.go
+++ b/pkg/gardenlet/apis/config/types.go
@@ -389,7 +389,7 @@ type SNIIngress struct {
 	ServiceName *string
 	// ServiceExternalIP is the external ip which should be assigned to the
 	// load balancer service of the ingress gateway.
-	// Compability is depending on the respecitve provider cloud-controller-manager.
+	// Compatibility is depending on the respective provider cloud-controller-manager.
 	ServiceExternalIP *string
 	// Namespace is the namespace in which the ingressgateway is deployed in.
 	// Defaults to "istio-ingress".

--- a/pkg/gardenlet/apis/config/v1alpha1/types.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/types.go
@@ -464,7 +464,8 @@ type SNIIngress struct {
 	ServiceName *string `json:"serviceName,omitempty"`
 	// ServiceExternalIP is the external ip which should be assigned to the
 	// load balancer service of the ingress gateway.
-	// Compability is depending on the respecitve provider cloud-controller-manager.
+	// Compatibility is depending on the respective provider cloud-controller-manager.
+	// +optional
 	ServiceExternalIP *string `json:"serviceExternalIP,omitempty"`
 	// Namespace is the namespace in which the ingressgateway is deployed in.
 	// Defaults to "istio-ingress".

--- a/pkg/gardenlet/apis/config/v1alpha1/types.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/types.go
@@ -490,6 +490,10 @@ type ExposureClassHandler struct {
 type LoadBalancerServiceConfig struct {
 	// Annotations is a key value map to annotate the underlying load balancer services.
 	Annotations map[string]string `json:"annotations"`
+	// LoadBalancerIP is the external ip which should be assigned to the loadbalancer service.
+	// This is only compatible with the APIServerSNI (default) feature gate and
+	// depending on the respective infrastructure cloud-controller-manager compatibility.
+	LoadBalancerIP *string `json:"loadBalancerIP,omitempty"`
 }
 
 const (

--- a/pkg/gardenlet/apis/config/v1alpha1/types.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/types.go
@@ -462,6 +462,10 @@ type SNIIngress struct {
 	// Defaults to "istio-ingressgateway".
 	// +optional
 	ServiceName *string `json:"serviceName,omitempty"`
+	// ServiceExternalIP is the external ip which should be assigned to the
+	// load balancer service of the ingress gateway.
+	// Compability is depending on the respecitve provider cloud-controller-manager.
+	ServiceExternalIP *string `json:"serviceExternalIP,omitempty"`
 	// Namespace is the namespace in which the ingressgateway is deployed in.
 	// Defaults to "istio-ingress".
 	// +optional
@@ -490,10 +494,6 @@ type ExposureClassHandler struct {
 type LoadBalancerServiceConfig struct {
 	// Annotations is a key value map to annotate the underlying load balancer services.
 	Annotations map[string]string `json:"annotations"`
-	// LoadBalancerIP is the external ip which should be assigned to the loadbalancer service.
-	// This is only compatible with the APIServerSNI (default) feature gate and
-	// depending on the respective infrastructure cloud-controller-manager compatibility.
-	LoadBalancerIP *string `json:"loadBalancerIP,omitempty"`
 }
 
 const (

--- a/pkg/gardenlet/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/zz_generated.conversion.go
@@ -900,6 +900,7 @@ func Convert_config_LeaderElectionConfiguration_To_v1alpha1_LeaderElectionConfig
 
 func autoConvert_v1alpha1_LoadBalancerServiceConfig_To_config_LoadBalancerServiceConfig(in *LoadBalancerServiceConfig, out *config.LoadBalancerServiceConfig, s conversion.Scope) error {
 	out.Annotations = *(*map[string]string)(unsafe.Pointer(&in.Annotations))
+	out.LoadBalancerIP = (*string)(unsafe.Pointer(in.LoadBalancerIP))
 	return nil
 }
 
@@ -910,6 +911,7 @@ func Convert_v1alpha1_LoadBalancerServiceConfig_To_config_LoadBalancerServiceCon
 
 func autoConvert_config_LoadBalancerServiceConfig_To_v1alpha1_LoadBalancerServiceConfig(in *config.LoadBalancerServiceConfig, out *LoadBalancerServiceConfig, s conversion.Scope) error {
 	out.Annotations = *(*map[string]string)(unsafe.Pointer(&in.Annotations))
+	out.LoadBalancerIP = (*string)(unsafe.Pointer(in.LoadBalancerIP))
 	return nil
 }
 

--- a/pkg/gardenlet/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/zz_generated.conversion.go
@@ -900,7 +900,6 @@ func Convert_config_LeaderElectionConfiguration_To_v1alpha1_LeaderElectionConfig
 
 func autoConvert_v1alpha1_LoadBalancerServiceConfig_To_config_LoadBalancerServiceConfig(in *LoadBalancerServiceConfig, out *config.LoadBalancerServiceConfig, s conversion.Scope) error {
 	out.Annotations = *(*map[string]string)(unsafe.Pointer(&in.Annotations))
-	out.LoadBalancerIP = (*string)(unsafe.Pointer(in.LoadBalancerIP))
 	return nil
 }
 
@@ -911,7 +910,6 @@ func Convert_v1alpha1_LoadBalancerServiceConfig_To_config_LoadBalancerServiceCon
 
 func autoConvert_config_LoadBalancerServiceConfig_To_v1alpha1_LoadBalancerServiceConfig(in *config.LoadBalancerServiceConfig, out *LoadBalancerServiceConfig, s conversion.Scope) error {
 	out.Annotations = *(*map[string]string)(unsafe.Pointer(&in.Annotations))
-	out.LoadBalancerIP = (*string)(unsafe.Pointer(in.LoadBalancerIP))
 	return nil
 }
 
@@ -1064,6 +1062,7 @@ func Convert_config_SNI_To_v1alpha1_SNI(in *config.SNI, out *SNI, s conversion.S
 
 func autoConvert_v1alpha1_SNIIngress_To_config_SNIIngress(in *SNIIngress, out *config.SNIIngress, s conversion.Scope) error {
 	out.ServiceName = (*string)(unsafe.Pointer(in.ServiceName))
+	out.ServiceExternalIP = (*string)(unsafe.Pointer(in.ServiceExternalIP))
 	out.Namespace = (*string)(unsafe.Pointer(in.Namespace))
 	out.Labels = *(*map[string]string)(unsafe.Pointer(&in.Labels))
 	return nil
@@ -1076,6 +1075,7 @@ func Convert_v1alpha1_SNIIngress_To_config_SNIIngress(in *SNIIngress, out *confi
 
 func autoConvert_config_SNIIngress_To_v1alpha1_SNIIngress(in *config.SNIIngress, out *SNIIngress, s conversion.Scope) error {
 	out.ServiceName = (*string)(unsafe.Pointer(in.ServiceName))
+	out.ServiceExternalIP = (*string)(unsafe.Pointer(in.ServiceExternalIP))
 	out.Namespace = (*string)(unsafe.Pointer(in.Namespace))
 	out.Labels = *(*map[string]string)(unsafe.Pointer(&in.Labels))
 	return nil

--- a/pkg/gardenlet/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -536,6 +536,11 @@ func (in *LoadBalancerServiceConfig) DeepCopyInto(out *LoadBalancerServiceConfig
 			(*out)[key] = val
 		}
 	}
+	if in.LoadBalancerIP != nil {
+		in, out := &in.LoadBalancerIP, &out.LoadBalancerIP
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/gardenlet/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -536,11 +536,6 @@ func (in *LoadBalancerServiceConfig) DeepCopyInto(out *LoadBalancerServiceConfig
 			(*out)[key] = val
 		}
 	}
-	if in.LoadBalancerIP != nil {
-		in, out := &in.LoadBalancerIP, &out.LoadBalancerIP
-		*out = new(string)
-		**out = **in
-	}
 	return
 }
 
@@ -693,6 +688,11 @@ func (in *SNIIngress) DeepCopyInto(out *SNIIngress) {
 	*out = *in
 	if in.ServiceName != nil {
 		in, out := &in.ServiceName, &out.ServiceName
+		*out = new(string)
+		**out = **in
+	}
+	if in.ServiceExternalIP != nil {
+		in, out := &in.ServiceExternalIP, &out.ServiceExternalIP
 		*out = new(string)
 		**out = **in
 	}

--- a/pkg/gardenlet/apis/config/validation/validation.go
+++ b/pkg/gardenlet/apis/config/validation/validation.go
@@ -97,7 +97,7 @@ func ValidateGardenletConfiguration(cfg *config.GardenletConfiguration, fldPath 
 
 		if handler.SNI != nil && handler.SNI.Ingress != nil && handler.SNI.Ingress.ServiceExternalIP != nil {
 			if !cfg.FeatureGates[string(features.APIServerSNI)] {
-				allErrs = append(allErrs, field.Invalid(handlerPath.Child("sni", "ingress", "serviceExternalIP"), handler.SNI.Ingress.ServiceExternalIP, "cannot use an external service ip when APIServerSNI feature gate is disabled"))
+				allErrs = append(allErrs, field.Forbidden(handlerPath.Child("sni", "ingress", "serviceExternalIP"), "cannot use an external service ip when APIServerSNI feature gate is disabled"))
 			}
 			if ip := net.ParseIP(*handler.SNI.Ingress.ServiceExternalIP); ip == nil {
 				allErrs = append(allErrs, field.Invalid(handlerPath.Child("sni", "ingress", "serviceExternalIP"), handler.SNI.Ingress.ServiceExternalIP, "external service ip is invalid"))

--- a/pkg/gardenlet/apis/config/validation/validation_test.go
+++ b/pkg/gardenlet/apis/config/validation/validation_test.go
@@ -427,7 +427,7 @@ var _ = Describe("GardenletConfiguration", func() {
 
 					errorList := ValidateGardenletConfiguration(cfg, nil, false)
 					Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":  Equal(field.ErrorTypeInvalid),
+						"Type":  Equal(field.ErrorTypeForbidden),
 						"Field": Equal("exposureClassHandlers[0].sni.ingress.serviceExternalIP"),
 					}))))
 				})

--- a/pkg/gardenlet/apis/config/zz_generated.deepcopy.go
+++ b/pkg/gardenlet/apis/config/zz_generated.deepcopy.go
@@ -536,6 +536,11 @@ func (in *LoadBalancerServiceConfig) DeepCopyInto(out *LoadBalancerServiceConfig
 			(*out)[key] = val
 		}
 	}
+	if in.LoadBalancerIP != nil {
+		in, out := &in.LoadBalancerIP, &out.LoadBalancerIP
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/gardenlet/apis/config/zz_generated.deepcopy.go
+++ b/pkg/gardenlet/apis/config/zz_generated.deepcopy.go
@@ -536,11 +536,6 @@ func (in *LoadBalancerServiceConfig) DeepCopyInto(out *LoadBalancerServiceConfig
 			(*out)[key] = val
 		}
 	}
-	if in.LoadBalancerIP != nil {
-		in, out := &in.LoadBalancerIP, &out.LoadBalancerIP
-		*out = new(string)
-		**out = **in
-	}
 	return
 }
 
@@ -693,6 +688,11 @@ func (in *SNIIngress) DeepCopyInto(out *SNIIngress) {
 	*out = *in
 	if in.ServiceName != nil {
 		in, out := &in.ServiceName, &out.ServiceName
+		*out = new(string)
+		**out = **in
+	}
+	if in.ServiceExternalIP != nil {
+		in, out := &in.ServiceExternalIP, &out.ServiceExternalIP
 		*out = new(string)
 		**out = **in
 	}

--- a/pkg/operation/botanist/component/istio/ingress_gateway.go
+++ b/pkg/operation/botanist/component/istio/ingress_gateway.go
@@ -45,6 +45,7 @@ type IngressValues struct {
 	Image           string            `json:"image,omitempty"`
 	Annotations     map[string]string `json:"annotations,omitempty"`
 	IstiodNamespace string            `json:"istiodNamespace,omitempty"`
+	LoadBalancerIP  *string           `json:"loadBalancerIP,omitempty"`
 	Labels          map[string]string `json:"labels,omitempty"`
 	// Ports is a list of all Ports the istio-ingress gateways is listening on.
 	// Port 15021 and 15000 cannot be used.

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -698,6 +698,7 @@ func RunReconcileSeedFlow(
 			IstiodNamespace: common.IstioNamespace,
 			Annotations:     seed.LoadBalancerServiceAnnotations,
 			Ports:           []corev1.ServicePort{},
+			LoadBalancerIP:  conf.SNI.Ingress.ServiceExternalIP,
 			Labels:          conf.SNI.Ingress.Labels,
 		}
 
@@ -729,7 +730,7 @@ func RunReconcileSeedFlow(
 					IstiodNamespace: common.IstioNamespace,
 					Annotations:     utils.MergeStringMaps(seed.LoadBalancerServiceAnnotations, handler.LoadBalancerService.Annotations),
 					Ports:           defaultIngressGatewayConfig.Ports,
-					LoadBalancerIP:  handler.LoadBalancerService.LoadBalancerIP,
+					LoadBalancerIP:  handler.SNI.Ingress.ServiceExternalIP,
 					Labels:          gutil.GetMandatoryExposureClassHandlerSNILabels(handler.SNI.Ingress.Labels, handler.Name),
 				},
 				*handler.SNI.Ingress.Namespace,

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -729,6 +729,7 @@ func RunReconcileSeedFlow(
 					IstiodNamespace: common.IstioNamespace,
 					Annotations:     utils.MergeStringMaps(seed.LoadBalancerServiceAnnotations, handler.LoadBalancerService.Annotations),
 					Ports:           defaultIngressGatewayConfig.Ports,
+					LoadBalancerIP:  handler.LoadBalancerService.LoadBalancerIP,
 					Labels:          gutil.GetMandatoryExposureClassHandlerSNILabels(handler.SNI.Ingress.Labels, handler.Name),
 				},
 				*handler.SNI.Ingress.Namespace,


### PR DESCRIPTION
**How to categorize this PR?**
/area open-source
/kind enhancement

**What this PR does / why we need it**:
Allow to define an external ip for the load balancer service belonging to Seed ingress gateways (default one + exposure class handler ones) via the `GardenletConfiguration`.

For exposure class handler ingress gateways this will only be configurable in combination with the `APIServerSNI` feature flag (default).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The external ip attached to the load balancer service belonging to a Seed ingress gateway can now be defined in the configuration for the Gardenlet. This is possible for the default ingress gateway and for the ExposureClass handler ingress gateways. For ExposureClass handler ingress gateways this will only work in combination with the `APIServerSNI` feature flag (default).

```

cc @kon-angelo, @RaphaelVogel 