### PR TITLE
Only download hyperkube image once on shoot worker nodes

### DIFF
--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -396,6 +396,8 @@ const (
 	OperatingSystemConfigUnitNamePromtailService = "promtail.service"
 	// OperatingSystemConfigFilePathPromtailConfig is a constant for a path to a file in the operating system config that contains the kubelet configuration.
 	OperatingSystemConfigFilePathPromtailConfig = "/var/lib/promtail/config/config"
+	// OperatingSystemConfigFilePathBinaries is a constant for a path to a directory in the operating system config that contains the binaries.
+	OperatingSystemConfigFilePathBinaries = "/opt/bin"
 
 	// FluentBitConfigMapKubernetesFilter is a constant for the Fluent Bit ConfigMap's section regarding Kubernetes filters
 	FluentBitConfigMapKubernetesFilter = "filter-kubernetes.conf"

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/executor.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/executor.go
@@ -67,6 +67,9 @@ const (
 	// PathExecutionLastDate is the path on the shoot worker nodes at which the date of the last execution will be
 	// persisted.
 	PathExecutionLastDate = downloader.PathCCDDirectory + "/execution_last_date"
+	// PathHyperkubeDownloads is the path on the shoot worker nodes to which the binaries will be extracted from the
+	// hyperkube image.
+	PathHyperkubeDownloads = downloader.PathDownloadsDirectory + "/hyperkube"
 )
 
 // Script returns the executor script that applies the downloaded cloud-config user-data.
@@ -74,6 +77,7 @@ func Script(
 	bootstrapToken string,
 	cloudConfigUserData []byte,
 	hyperkubeImage *imagevector.Image,
+	kubernetesVersion string,
 	kubeletDataVolume *gardencorev1beta1.DataVolume,
 	reloadConfigCommand string,
 	units []string,
@@ -82,34 +86,38 @@ func Script(
 	error,
 ) {
 	values := map[string]interface{}{
-		"annotationKeyChecksum":          AnnotationKeyChecksum,
-		"pathKubeletDirectory":           kubelet.PathKubeletDirectory,
-		"pathDownloadsDirectory":         downloader.PathDownloadsDirectory,
-		"bootstrapToken":                 bootstrapToken,
-		"pathBinaries":                   v1beta1constants.OperatingSystemConfigFilePathBinaries,
-		"pathBootstrapToken":             downloader.PathBootstrapToken,
-		"pathCCDScript":                  downloader.PathCCDScript,
-		"pathCCDScriptChecksum":          downloader.PathCCDScriptChecksum,
-		"pathCredentialsServer":          downloader.PathCredentialsServer,
-		"pathCredentialsCACert":          downloader.PathCredentialsCACert,
-		"pathDownloadedCloudConfig":      downloader.PathDownloadedCloudConfig,
-		"pathDownloadedChecksum":         downloader.PathDownloadedCloudConfigChecksum,
-		"pathExecutionDelaySeconds":      PathExecutionDelaySeconds,
-		"pathExecutionLastDate":          PathExecutionLastDate,
-		"pathKubeletKubeconfigBootstrap": kubelet.PathKubeconfigBootstrap,
-		"pathKubeletKubeconfigReal":      kubelet.PathKubeconfigReal,
-		"bootstrapTokenPlaceholder":      downloader.BootstrapTokenPlaceholder,
-		"bootstrapTokenPlaceholderB64":   utils.EncodeBase64([]byte(downloader.BootstrapTokenPlaceholder)),
-		"cloudConfigUserData":            utils.EncodeBase64(cloudConfigUserData),
-		"cloudConfigDownloaderName":      downloader.Name,
-		"executionMinDelaySeconds":       downloader.UnitRestartSeconds,
-		"executionMaxDelaySeconds":       ExecutionMaxDelaySeconds,
-		"hyperkubeImage":                 hyperkubeImage.String(),
-		"reloadConfigCommand":            reloadConfigCommand,
-		"units":                          units,
-		"unitNameCloudConfigDownloader":  downloader.UnitName,
-		"unitNameDocker":                 docker.UnitName,
-		"unitNameVarLibMount":            varlibmount.UnitName,
+		"annotationKeyChecksum":            AnnotationKeyChecksum,
+		"pathKubeletDirectory":             kubelet.PathKubeletDirectory,
+		"pathDownloadsDirectory":           downloader.PathDownloadsDirectory,
+		"bootstrapToken":                   bootstrapToken,
+		"pathBinaries":                     v1beta1constants.OperatingSystemConfigFilePathBinaries,
+		"pathBootstrapToken":               downloader.PathBootstrapToken,
+		"pathCCDScript":                    downloader.PathCCDScript,
+		"pathCCDScriptChecksum":            downloader.PathCCDScriptChecksum,
+		"pathCredentialsServer":            downloader.PathCredentialsServer,
+		"pathCredentialsCACert":            downloader.PathCredentialsCACert,
+		"pathDockerBinary":                 docker.PathBinary,
+		"pathDownloadedCloudConfig":        downloader.PathDownloadedCloudConfig,
+		"pathDownloadedChecksum":           downloader.PathDownloadedCloudConfigChecksum,
+		"pathExecutionDelaySeconds":        PathExecutionDelaySeconds,
+		"pathExecutionLastDate":            PathExecutionLastDate,
+		"pathKubeletKubeconfigBootstrap":   kubelet.PathKubeconfigBootstrap,
+		"pathKubeletKubeconfigReal":        kubelet.PathKubeconfigReal,
+		"pathHyperkubeDownloads":           PathHyperkubeDownloads,
+		"pathScriptCopyKubernetesBinaries": kubelet.PathScriptCopyKubernetesBinaries,
+		"bootstrapTokenPlaceholder":        downloader.BootstrapTokenPlaceholder,
+		"bootstrapTokenPlaceholderB64":     utils.EncodeBase64([]byte(downloader.BootstrapTokenPlaceholder)),
+		"cloudConfigUserData":              utils.EncodeBase64(cloudConfigUserData),
+		"cloudConfigDownloaderName":        downloader.Name,
+		"executionMinDelaySeconds":         downloader.UnitRestartSeconds,
+		"executionMaxDelaySeconds":         ExecutionMaxDelaySeconds,
+		"hyperkubeImage":                   hyperkubeImage.String(),
+		"kubernetesVersion":                kubernetesVersion,
+		"reloadConfigCommand":              reloadConfigCommand,
+		"units":                            units,
+		"unitNameCloudConfigDownloader":    downloader.UnitName,
+		"unitNameDocker":                   docker.UnitName,
+		"unitNameVarLibMount":              varlibmount.UnitName,
 	}
 
 	if kubeletDataVolume != nil {

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/executor.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/executor.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/varlibmount"
 	"github.com/gardener/gardener/pkg/utils"
+	"github.com/gardener/gardener/pkg/utils/imagevector"
 
 	"github.com/Masterminds/sprig"
 	corev1 "k8s.io/api/core/v1"
@@ -72,7 +73,7 @@ const (
 func Script(
 	bootstrapToken string,
 	cloudConfigUserData []byte,
-	images map[string]interface{},
+	hyperkubeImage *imagevector.Image,
 	kubeletDataVolume *gardencorev1beta1.DataVolume,
 	reloadConfigCommand string,
 	units []string,
@@ -102,7 +103,7 @@ func Script(
 		"cloudConfigDownloaderName":      downloader.Name,
 		"executionMinDelaySeconds":       downloader.UnitRestartSeconds,
 		"executionMaxDelaySeconds":       ExecutionMaxDelaySeconds,
-		"images":                         images,
+		"hyperkubeImage":                 hyperkubeImage.String(),
 		"reloadConfigCommand":            reloadConfigCommand,
 		"units":                          units,
 		"unitNameCloudConfigDownloader":  downloader.UnitName,

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/executor.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/executor.go
@@ -86,6 +86,7 @@ func Script(
 		"pathKubeletDirectory":           kubelet.PathKubeletDirectory,
 		"pathDownloadsDirectory":         downloader.PathDownloadsDirectory,
 		"bootstrapToken":                 bootstrapToken,
+		"pathBinaries":                   v1beta1constants.OperatingSystemConfigFilePathBinaries,
 		"pathBootstrapToken":             downloader.PathBootstrapToken,
 		"pathCCDScript":                  downloader.PathCCDScript,
 		"pathCCDScriptChecksum":          downloader.PathCCDScriptChecksum,

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/executor_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/executor_test.go
@@ -384,15 +384,17 @@ const scriptCopyKubernetesBinary = `#!/bin/bash -eu
 
 BINARY="$1"
 
+PATH_HYPERKUBE_DOWNLOADS="/var/lib/cloud-config-downloader/downloads/hyperkube"
 PATH_LAST_DOWNLOADED_HYPERKUBE_IMAGE="/var/lib/cloud-config-downloader/downloads/hyperkube/last_downloaded_hyperkube_image"
 PATH_HYPERKUBE_IMAGE_USED_FOR_LAST_COPY=""
 
-if [[ "$1" == "kubelet" ]]; then
-  BINARY="kubelet"
+if [[ "$BINARY" == "kubelet" ]]; then
   PATH_HYPERKUBE_IMAGE_USED_FOR_LAST_COPY="/opt/bin/hyperkube_image_used_for_last_copy_of_kubelet"
-elif [[ "$1" == "kubectl" ]]; then
-  BINARY="kubectl"
+elif [[ "$BINARY" == "kubectl" ]]; then
   PATH_HYPERKUBE_IMAGE_USED_FOR_LAST_COPY="/opt/bin/hyperkube_image_used_for_last_copy_of_kubectl"
+else
+  echo "$BINARY cannot be handled. Only 'kubelet' and 'kubectl' are valid arguments."
+  exit 1
 fi
 
 LAST_DOWNLOADED_HYPERKUBE_IMAGE=""

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/executor_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/executor_test.go
@@ -201,6 +201,8 @@ if [[ "$LAST_DOWNLOADED_HYPERKUBE_IMAGE" != "` + hyperkubeImage.String() + `" ]]
 
   echo "Starting temporary hyperkube container to copy binaries to host"` +
 		copyKubernetesBinariesFn(hyperkubeImage) + `
+  chmod +x "$PATH_HYPERKUBE_DOWNLOADS/kubelet"
+  chmod +x "$PATH_HYPERKUBE_DOWNLOADS/kubectl"
 
   echo "` + hyperkubeImage.String() + `" > "$PATH_LAST_DOWNLOADED_HYPERKUBE_IMAGE"
   LAST_DOWNLOADED_HYPERKUBE_IMAGE="$(cat "$PATH_LAST_DOWNLOADED_HYPERKUBE_IMAGE")"
@@ -377,7 +379,5 @@ func copyKubernetesBinariesFromHyperkubeImageForVersionsGreaterEqual119(hyperkub
   HYPERKUBE_CONTAINER_ID="$(/usr/bin/docker run --rm -d -v "$PATH_HYPERKUBE_DOWNLOADS":"$PATH_HYPERKUBE_DOWNLOADS":rw "` + hyperkubeImage.String() + `")"
   /usr/bin/docker cp   "$HYPERKUBE_CONTAINER_ID":/kubelet "$PATH_HYPERKUBE_DOWNLOADS"
   /usr/bin/docker cp   "$HYPERKUBE_CONTAINER_ID":/kubectl "$PATH_HYPERKUBE_DOWNLOADS"
-  /usr/bin/docker stop "$HYPERKUBE_CONTAINER_ID"
-  chmod +x "$PATH_HYPERKUBE_DOWNLOADS/kubelet"
-  chmod +x "$PATH_HYPERKUBE_DOWNLOADS/kubectl"`
+  /usr/bin/docker stop "$HYPERKUBE_CONTAINER_ID"`
 }

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/templates/scripts/copy-kubernetes-binary.tpl.sh
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/templates/scripts/copy-kubernetes-binary.tpl.sh
@@ -1,0 +1,35 @@
+#!/bin/bash -eu
+
+BINARY="$1"
+
+PATH_HYPERKUBE_DOWNLOADS="{{ .pathHyperkubeDownloads }}"
+PATH_LAST_DOWNLOADED_HYPERKUBE_IMAGE="{{ .pathLastDownloadedHyperkubeImage }}"
+PATH_HYPERKUBE_IMAGE_USED_FOR_LAST_COPY=""
+
+if [[ "$1" == "kubelet" ]]; then
+  BINARY="kubelet"
+  PATH_HYPERKUBE_IMAGE_USED_FOR_LAST_COPY="{{ .pathHyperKubeImageUsedForLastCopyKubelet }}"
+elif [[ "$1" == "kubectl" ]]; then
+  BINARY="kubectl"
+  PATH_HYPERKUBE_IMAGE_USED_FOR_LAST_COPY="{{ .pathHyperKubeImageUsedForLastCopyKubectl }}"
+fi
+
+LAST_DOWNLOADED_HYPERKUBE_IMAGE=""
+if [[ -f "$PATH_LAST_DOWNLOADED_HYPERKUBE_IMAGE" ]]; then
+  LAST_DOWNLOADED_HYPERKUBE_IMAGE="$(cat "$PATH_LAST_DOWNLOADED_HYPERKUBE_IMAGE")"
+fi
+
+HYPERKUBE_IMAGE_USED_FOR_LAST_COPY=""
+if [[ -f "$PATH_HYPERKUBE_IMAGE_USED_FOR_LAST_COPY" ]]; then
+  HYPERKUBE_IMAGE_USED_FOR_LAST_COPY="$(cat "$PATH_HYPERKUBE_IMAGE_USED_FOR_LAST_COPY")"
+fi
+
+echo "Checking whether to copy new $BINARY binary from hyperkube image to {{ .pathBinaries }} folder..."
+if [[ "$HYPERKUBE_IMAGE_USED_FOR_LAST_COPY" != "$LAST_DOWNLOADED_HYPERKUBE_IMAGE" ]]; then
+  echo "$BINARY binary in {{ .pathBinaries }} is outdated (image used for last copy: $HYPERKUBE_IMAGE_USED_FOR_LAST_COPY). Need to update it to $LAST_DOWNLOADED_HYPERKUBE_IMAGE".
+  rm -f "{{ .pathBinaries }}/$BINARY" &&
+    cp "$PATH_HYPERKUBE_DOWNLOADS/$BINARY" "{{ .pathBinaries }}" &&
+    echo "$LAST_DOWNLOADED_HYPERKUBE_IMAGE" > "$PATH_HYPERKUBE_IMAGE_USED_FOR_LAST_COPY"
+else
+  echo "No need to copy $BINARY binary from a new hyperkube image because binary found in $PATH_HYPERKUBE_DOWNLOADS is up-to-date."
+fi

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/templates/scripts/copy-kubernetes-binary.tpl.sh
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/templates/scripts/copy-kubernetes-binary.tpl.sh
@@ -6,12 +6,13 @@ PATH_HYPERKUBE_DOWNLOADS="{{ .pathHyperkubeDownloads }}"
 PATH_LAST_DOWNLOADED_HYPERKUBE_IMAGE="{{ .pathLastDownloadedHyperkubeImage }}"
 PATH_HYPERKUBE_IMAGE_USED_FOR_LAST_COPY=""
 
-if [[ "$1" == "kubelet" ]]; then
-  BINARY="kubelet"
+if [[ "$BINARY" == "kubelet" ]]; then
   PATH_HYPERKUBE_IMAGE_USED_FOR_LAST_COPY="{{ .pathHyperKubeImageUsedForLastCopyKubelet }}"
-elif [[ "$1" == "kubectl" ]]; then
-  BINARY="kubectl"
+elif [[ "$BINARY" == "kubectl" ]]; then
   PATH_HYPERKUBE_IMAGE_USED_FOR_LAST_COPY="{{ .pathHyperKubeImageUsedForLastCopyKubectl }}"
+else
+  echo "$BINARY cannot be handled. Only 'kubelet' and 'kubectl' are valid arguments."
+  exit 1
 fi
 
 LAST_DOWNLOADED_HYPERKUBE_IMAGE=""

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/templates/scripts/execute-cloud-config.tpl.sh
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/templates/scripts/execute-cloud-config.tpl.sh
@@ -69,9 +69,9 @@ if [[ "$LAST_DOWNLOADED_HYPERKUBE_IMAGE" != "{{ .hyperkubeImage }}" ]]; then
   {{ .pathDockerBinary }} cp   "$HYPERKUBE_CONTAINER_ID":/kubelet "$PATH_HYPERKUBE_DOWNLOADS"
   {{ .pathDockerBinary }} cp   "$HYPERKUBE_CONTAINER_ID":/kubectl "$PATH_HYPERKUBE_DOWNLOADS"
   {{ .pathDockerBinary }} stop "$HYPERKUBE_CONTAINER_ID"
+{{- end }}
   chmod +x "$PATH_HYPERKUBE_DOWNLOADS/kubelet"
   chmod +x "$PATH_HYPERKUBE_DOWNLOADS/kubectl"
-{{- end }}
 
   echo "{{ .hyperkubeImage }}" > "$PATH_LAST_DOWNLOADED_HYPERKUBE_IMAGE"
   LAST_DOWNLOADED_HYPERKUBE_IMAGE="$(cat "$PATH_LAST_DOWNLOADED_HYPERKUBE_IMAGE")"

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/templates/scripts/execute-cloud-config.tpl.sh
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/templates/scripts/execute-cloud-config.tpl.sh
@@ -108,7 +108,7 @@ ANNOTATION_RESTART_SYSTEMD_SERVICES="worker.gardener.cloud/restart-systemd-servi
 
 # Try to find Node object for this machine if already registered to the cluster.
 if [[ -f "{{ .pathKubeletKubeconfigReal }}" ]]; then
-  {{`NODE="$(/opt/bin/kubectl --kubeconfig="`}}{{ .pathKubeletKubeconfigReal }}{{`" get node -l "kubernetes.io/hostname=$(hostname)" -o go-template="{{ if .items }}{{ (index .items 0).metadata.name }}{{ if (index (index .items 0).metadata.annotations \"$ANNOTATION_RESTART_SYSTEMD_SERVICES\") }} {{ index (index .items 0).metadata.annotations \"$ANNOTATION_RESTART_SYSTEMD_SERVICES\" }}{{ end }}{{ end }}")"`}}
+  {{`NODE="$(`}}{{ .pathBinaries }}{{`/kubectl --kubeconfig="`}}{{ .pathKubeletKubeconfigReal }}{{`" get node -l "kubernetes.io/hostname=$(hostname)" -o go-template="{{ if .items }}{{ (index .items 0).metadata.name }}{{ if (index (index .items 0).metadata.annotations \"$ANNOTATION_RESTART_SYSTEMD_SERVICES\") }} {{ index (index .items 0).metadata.annotations \"$ANNOTATION_RESTART_SYSTEMD_SERVICES\" }}{{ end }}{{ end }}")"`}}
 
   if [[ ! -z "$NODE" ]]; then
     NODENAME="$(echo "$NODE" | awk '{print $1}')"
@@ -125,7 +125,7 @@ if [[ -f "{{ .pathKubeletKubeconfigReal }}" ]]; then
     echo "Restarting systemd service $service due to $ANNOTATION_RESTART_SYSTEMD_SERVICES annotation"
     systemctl restart "$service" || true
   done
-  /opt/bin/kubectl --kubeconfig="{{ .pathKubeletKubeconfigReal }}" annotate node "$NODENAME" "${ANNOTATION_RESTART_SYSTEMD_SERVICES}-"
+  {{ .pathBinaries }}/kubectl --kubeconfig="{{ .pathKubeletKubeconfigReal }}" annotate node "$NODENAME" "${ANNOTATION_RESTART_SYSTEMD_SERVICES}-"
   if [[ ${restart_ccd} == "y" ]]; then
     echo "Restarting systemd service {{ .unitNameCloudConfigDownloader }} due to $ANNOTATION_RESTART_SYSTEMD_SERVICES annotation"
     systemctl restart "{{ .unitNameCloudConfigDownloader }}" || true
@@ -173,6 +173,6 @@ rm "$PATH_CLOUDCONFIG" "$PATH_CCD_SCRIPT_CHECKSUM"
 # Now that the most recent cloud-config user data was applied, let's update the checksum/cloud-config-data annotation on
 # the Node object if possible and store the current date.
 if [[ ! -z "$NODENAME" ]] && [[ -f "$PATH_CHECKSUM" ]]; then
-  /opt/bin/kubectl --kubeconfig="{{ .pathKubeletKubeconfigReal }}" annotate node "$NODENAME" "checksum/cloud-config-data=$(cat "$PATH_CHECKSUM")" --overwrite
+  {{ .pathBinaries }}/kubectl --kubeconfig="{{ .pathKubeletKubeconfigReal }}" annotate node "$NODENAME" "checksum/cloud-config-data=$(cat "$PATH_CHECKSUM")" --overwrite
 fi
 date +%s > "$PATH_EXECUTION_LAST_DATE"

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/templates/scripts/execute-cloud-config.tpl.sh
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/templates/scripts/execute-cloud-config.tpl.sh
@@ -50,9 +50,7 @@ function format-data-device() {
 format-data-device
 {{- end }}
 
-{{ range $name, $image := .images -}}
-docker-preload "{{ $name }}" "{{ $image }}"
-{{ end }}
+docker-preload "hyperkube" "{{ .hyperkubeImage }}"
 
 cat << 'EOF' | base64 -d > "$PATH_CLOUDCONFIG"
 {{ .cloudConfigUserData }}

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/containerd/component.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/containerd/component.go
@@ -19,7 +19,7 @@ import (
 	_ "embed"
 	"text/template"
 
-	gardencorev1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/logrotate"
@@ -49,7 +49,7 @@ func init() {
 
 const (
 	// UnitName is the name of the containerd service unit.
-	UnitName = gardencorev1beta1constants.OperatingSystemConfigUnitNameContainerDService
+	UnitName = v1beta1constants.OperatingSystemConfigUnitNameContainerDService
 	// UnitNameMonitor is the name of the containerd monitor service unit.
 	UnitNameMonitor = "containerd-monitor.service"
 	// PathSocketEndpoint is the path to the containerd unix domain socket.
@@ -69,7 +69,7 @@ func (containerd) Name() string {
 
 func (containerd) Config(_ components.Context) ([]extensionsv1alpha1.Unit, []extensionsv1alpha1.File, error) {
 	const (
-		pathHealthMonitor   = "/opt/bin/health-monitor-containerd"
+		pathHealthMonitor   = v1beta1constants.OperatingSystemConfigFilePathBinaries + "/health-monitor-containerd"
 		pathLogRotateConfig = "/etc/systemd/containerd.conf"
 	)
 

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/containerd/initializer.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/containerd/initializer.go
@@ -20,6 +20,7 @@ import (
 	"text/template"
 
 	"github.com/gardener/gardener/charts"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components"
 	"github.com/gardener/gardener/pkg/utils"
@@ -48,7 +49,7 @@ func init() {
 
 type initializer struct{}
 
-// New returns a new containerd initializer component.
+// NewInitializer returns a new containerd initializer component.
 func NewInitializer() *initializer {
 	return &initializer{}
 }
@@ -59,7 +60,7 @@ func (initializer) Name() string {
 
 func (initializer) Config(ctx components.Context) ([]extensionsv1alpha1.Unit, []extensionsv1alpha1.File, error) {
 	const (
-		pathScript          = "/opt/bin/init-containerd"
+		pathScript          = v1beta1constants.OperatingSystemConfigFilePathBinaries + "/init-containerd"
 		unitNameInitializer = "containerd-initializer.service"
 	)
 

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/docker/component.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/docker/component.go
@@ -19,7 +19,7 @@ import (
 	_ "embed"
 	"text/template"
 
-	gardencorev1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/logrotate"
@@ -49,7 +49,7 @@ func init() {
 
 const (
 	// UnitName is the name of the Docker service unit.
-	UnitName = gardencorev1beta1constants.OperatingSystemConfigUnitNameDockerService
+	UnitName = v1beta1constants.OperatingSystemConfigUnitNameDockerService
 	// UnitNameMonitor is the name of the Docker monitor service unit.
 	UnitNameMonitor = "docker-monitor.service"
 	// PathBinary is the path to the docker binary.
@@ -69,7 +69,7 @@ func (component) Name() string {
 
 func (component) Config(_ components.Context) ([]extensionsv1alpha1.Unit, []extensionsv1alpha1.File, error) {
 	const (
-		pathHealthMonitor   = "/opt/bin/health-monitor-docker"
+		pathHealthMonitor   = v1beta1constants.OperatingSystemConfigFilePathBinaries + "/health-monitor-docker"
 		pathLogRotateConfig = "/etc/systemd/docker.conf"
 	)
 

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/component.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/component.go
@@ -68,8 +68,8 @@ const (
 	PathKubeletConfig = v1beta1constants.OperatingSystemConfigFilePathKubeletConfig
 	// PathKubeletDirectory is the path for the kubelet's directory.
 	PathKubeletDirectory = "/var/lib/kubelet"
-	// PathScriptCopyKubernetesBinaries is the path for the script copying downloaded Kubernetes binaries.
-	PathScriptCopyKubernetesBinaries = PathKubeletDirectory + "/copy-kubernetes-binary.sh"
+	// PathScriptCopyKubernetesBinary is the path for the script copying downloaded Kubernetes binaries.
+	PathScriptCopyKubernetesBinary = PathKubeletDirectory + "/copy-kubernetes-binary.sh"
 
 	pathVolumePluginDirectory = "/var/lib/kubelet/volumeplugins"
 )
@@ -119,7 +119,7 @@ Restart=always
 RestartSec=5
 EnvironmentFile=/etc/environment
 EnvironmentFile=-/var/lib/kubelet/extra_args
-ExecStartPre=` + PathScriptCopyKubernetesBinaries + ` kubelet
+ExecStartPre=` + PathScriptCopyKubernetesBinary + ` kubelet
 ExecStart=` + v1beta1constants.OperatingSystemConfigFilePathBinaries + `/kubelet \
     ` + utils.Indent(strings.Join(cliFlags, " \\\n"), 4) + ` $KUBELET_EXTRA_ARGS`),
 			},
@@ -135,7 +135,7 @@ WantedBy=multi-user.target
 [Service]
 Restart=always
 EnvironmentFile=/etc/environment
-ExecStartPre=` + PathScriptCopyKubernetesBinaries + ` kubectl
+ExecStartPre=` + PathScriptCopyKubernetesBinary + ` kubectl
 ExecStart=` + pathHealthMonitor),
 			},
 		},

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/component_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/component_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Component", func() {
 	})
 
 	DescribeTable("#Config",
-		func(kubernetesVersion string, criName extensionsv1alpha1.CRIName, execStartPreFn func(string) string, kubeletFlags, kubeletConfig string) {
+		func(kubernetesVersion string, criName extensionsv1alpha1.CRIName, kubeletFlags, kubeletConfig string) {
 			ctx.CRIName = criName
 			ctx.KubernetesVersion = semver.MustParse(kubernetesVersion)
 			ctx.KubeletCACertificate = kubeletCACertificate
@@ -79,7 +79,7 @@ Restart=always
 RestartSec=5
 EnvironmentFile=/etc/environment
 EnvironmentFile=-/var/lib/kubelet/extra_args
-ExecStartPre=` + execStartPreFn("kubelet") + `
+ExecStartPre=/var/lib/kubelet/copy-kubernetes-binary.sh kubelet
 ExecStart=/opt/bin/kubelet \` + kubeletFlags),
 				},
 				extensionsv1alpha1.Unit{
@@ -94,7 +94,7 @@ WantedBy=multi-user.target
 [Service]
 Restart=always
 EnvironmentFile=/etc/environment
-ExecStartPre=` + execStartPreFn("kubectl") + `
+ExecStartPre=/var/lib/kubelet/copy-kubernetes-binary.sh kubectl
 ExecStart=/opt/bin/health-monitor-kubelet`),
 				},
 			))
@@ -136,7 +136,6 @@ ExecStart=/opt/bin/health-monitor-kubelet`),
 			"kubernetes 1.15, w/ docker",
 			"1.15.1",
 			extensionsv1alpha1.CRINameDocker,
-			execStartPreLess117,
 			kubeletFlagsDocker(extensionsv1alpha1.CRINameDocker, true),
 			kubeletConfig(true, false),
 		),
@@ -144,7 +143,6 @@ ExecStart=/opt/bin/health-monitor-kubelet`),
 			"kubernetes 1.15, w/ containerd",
 			"1.15.1",
 			extensionsv1alpha1.CRINameContainerD,
-			execStartPreLess117,
 			kubeletFlagsDocker(extensionsv1alpha1.CRINameContainerD, true),
 			kubeletConfig(true, false),
 		),
@@ -153,7 +151,6 @@ ExecStart=/opt/bin/health-monitor-kubelet`),
 			"kubernetes 1.16, w/ docker",
 			"1.16.1",
 			extensionsv1alpha1.CRINameDocker,
-			execStartPreLess117,
 			kubeletFlagsDocker(extensionsv1alpha1.CRINameDocker, true),
 			kubeletConfig(true, false),
 		),
@@ -161,7 +158,6 @@ ExecStart=/opt/bin/health-monitor-kubelet`),
 			"kubernetes 1.16, w/ containerd",
 			"1.16.1",
 			extensionsv1alpha1.CRINameContainerD,
-			execStartPreLess117,
 			kubeletFlagsDocker(extensionsv1alpha1.CRINameContainerD, true),
 			kubeletConfig(true, false),
 		),
@@ -170,7 +166,6 @@ ExecStart=/opt/bin/health-monitor-kubelet`),
 			"kubernetes 1.17, w/ docker",
 			"1.17.1",
 			extensionsv1alpha1.CRINameDocker,
-			execStartPreLess119,
 			kubeletFlagsDocker(extensionsv1alpha1.CRINameDocker, true),
 			kubeletConfig(true, false),
 		),
@@ -178,7 +173,6 @@ ExecStart=/opt/bin/health-monitor-kubelet`),
 			"kubernetes 1.17, w/ containerd",
 			"1.17.1",
 			extensionsv1alpha1.CRINameContainerD,
-			execStartPreLess119,
 			kubeletFlagsDocker(extensionsv1alpha1.CRINameContainerD, true),
 			kubeletConfig(true, false),
 		),
@@ -187,7 +181,6 @@ ExecStart=/opt/bin/health-monitor-kubelet`),
 			"kubernetes 1.18, w/ docker",
 			"1.18.1",
 			extensionsv1alpha1.CRINameDocker,
-			execStartPreLess119,
 			kubeletFlagsDocker(extensionsv1alpha1.CRINameDocker, true),
 			kubeletConfig(true, false),
 		),
@@ -195,7 +188,6 @@ ExecStart=/opt/bin/health-monitor-kubelet`),
 			"kubernetes 1.18, w/ containerd",
 			"1.18.1",
 			extensionsv1alpha1.CRINameContainerD,
-			execStartPreLess119,
 			kubeletFlagsDocker(extensionsv1alpha1.CRINameContainerD, true),
 			kubeletConfig(true, false),
 		),
@@ -204,7 +196,6 @@ ExecStart=/opt/bin/health-monitor-kubelet`),
 			"kubernetes 1.19, w/ docker",
 			"1.19.1",
 			extensionsv1alpha1.CRINameDocker,
-			execStartPreGreaterEqual119,
 			kubeletFlagsDocker(extensionsv1alpha1.CRINameDocker, false),
 			kubeletConfig(true, true),
 		),
@@ -212,7 +203,6 @@ ExecStart=/opt/bin/health-monitor-kubelet`),
 			"kubernetes 1.19, w/ containerd",
 			"1.19.1",
 			extensionsv1alpha1.CRINameContainerD,
-			execStartPreGreaterEqual119,
 			kubeletFlagsDocker(extensionsv1alpha1.CRINameContainerD, false),
 			kubeletConfig(true, true),
 		),
@@ -221,7 +211,6 @@ ExecStart=/opt/bin/health-monitor-kubelet`),
 			"kubernetes 1.20, w/ docker",
 			"1.20.1",
 			extensionsv1alpha1.CRINameDocker,
-			execStartPreGreaterEqual119,
 			kubeletFlagsDocker(extensionsv1alpha1.CRINameDocker, false),
 			kubeletConfig(true, true),
 		),
@@ -229,7 +218,6 @@ ExecStart=/opt/bin/health-monitor-kubelet`),
 			"kubernetes 1.20, w/ containerd",
 			"1.20.1",
 			extensionsv1alpha1.CRINameContainerD,
-			execStartPreGreaterEqual119,
 			kubeletFlagsDocker(extensionsv1alpha1.CRINameContainerD, false),
 			kubeletConfig(true, true),
 		),
@@ -364,18 +352,6 @@ kubelet_monitoring
 	hyperkubeImageRepo      = "hyperkube.io"
 	hyperkubeImageTag       = "v4.5.6"
 )
-
-func execStartPreLess117(binary string) string {
-	return `/usr/bin/docker run --rm -v /opt/bin:/opt/bin:rw ` + hyperkubeImageRepo + `:` + hyperkubeImageTag + ` /bin/sh -c "cp /usr/local/bin/` + binary + ` /opt/bin"`
-}
-
-func execStartPreLess119(binary string) string {
-	return `/usr/bin/docker run --rm -v /opt/bin:/opt/bin:rw --entrypoint /bin/sh ` + hyperkubeImageRepo + `:` + hyperkubeImageTag + ` -c "cp /usr/local/bin/` + binary + ` /opt/bin"`
-}
-
-func execStartPreGreaterEqual119(binary string) string {
-	return `/usr/bin/env sh -c "ID=\"$(/usr/bin/docker run --rm -d -v /opt/bin:/opt/bin:rw ` + hyperkubeImageRepo + `:` + hyperkubeImageTag + `)\"; /usr/bin/docker cp \"$ID\":/` + binary + ` /opt/bin; /usr/bin/docker stop \"$ID\"; chmod +x /opt/bin/` + binary + `"`
-}
 
 func unitConfigAfterCRI(criName extensionsv1alpha1.CRIName) string {
 	if criName == extensionsv1alpha1.CRINameContainerD {

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/config.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/config.go
@@ -98,7 +98,7 @@ func Config(kubernetesVersion *semver.Version, clusterDNSAddress, clusterDomain 
 		VolumeStatsAggPeriod:             metav1.Duration{Duration: time.Minute},
 	}
 
-	if versionConstraintK8sGreaterEqual119.Check(kubernetesVersion) {
+	if !versionConstraintK8sLess119.Check(kubernetesVersion) {
 		config.VolumePluginDir = pathVolumePluginDirectory
 	}
 

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/templates/scripts/health-monitor.tpl.sh
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/templates/scripts/health-monitor.tpl.sh
@@ -9,7 +9,7 @@ function kubelet_monitoring {
   local output=""
 
   function kubectl {
-    /opt/bin/kubectl --kubeconfig {{ .pathKubeletKubeconfigReal }} "$@"
+    {{ .pathBinaries }}/kubectl --kubeconfig {{ .pathKubeletKubeconfigReal }} "$@"
   }
 
   function restart_kubelet {

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/promtail/component.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/promtail/component.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 
 	"github.com/gardener/gardener/charts"
-	gardencorev1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/docker"
@@ -27,16 +27,14 @@ import (
 
 const (
 	// UnitName is the name of the promtail service.
-	UnitName = gardencorev1beta1constants.OperatingSystemConfigUnitNamePromtailService
+	UnitName = v1beta1constants.OperatingSystemConfigUnitNamePromtailService
 	// PathPromtailDirectory is the path for the promtail's directory.
 	PathPromtailDirectory = "/var/lib/promtail"
-	// PathPromtailBinary is the path for the promtail binary.
-	PathPromtailBinary = "/opt/bin"
 	// PathPromtailAuthToken is the path for the promtail authentication token,
 	// which is used to auth agains the Loki sidecar proxy.
 	PathPromtailAuthToken = PathPromtailDirectory + "/auth-token"
 	// PathPromtailConfig is the path for the promtail's configuration file
-	PathPromtailConfig = gardencorev1beta1constants.OperatingSystemConfigFilePathPromtailConfig
+	PathPromtailConfig = v1beta1constants.OperatingSystemConfigFilePathPromtailConfig
 	// PathPromtailCACert is the path for the loki-tls certificate authority.
 	PathPromtailCACert = PathPromtailDirectory + "/ca.crt"
 	// PromtailServerPort is the promtail listening port
@@ -59,7 +57,7 @@ func (component) Name() string {
 }
 
 func execStartPreCopyBinaryFromContainer(binaryName string, image *imagevector.Image) string {
-	return docker.PathBinary + ` run --rm -v /opt/bin:/opt/bin:rw --entrypoint /bin/sh ` + image.String() + ` -c "cp /usr/bin/` + binaryName + ` /opt/bin"`
+	return docker.PathBinary + ` run --rm -v ` + v1beta1constants.OperatingSystemConfigFilePathBinaries + `:` + v1beta1constants.OperatingSystemConfigFilePathBinaries + `:rw --entrypoint /bin/sh ` + image.String() + ` -c "cp /usr/bin/` + binaryName + ` ` + v1beta1constants.OperatingSystemConfigFilePathBinaries + `"`
 }
 
 func (component) Config(ctx components.Context) ([]extensionsv1alpha1.Unit, []extensionsv1alpha1.File, error) {
@@ -86,7 +84,7 @@ func (component) Config(ctx components.Context) ([]extensionsv1alpha1.Unit, []ex
 			*getPromtailUnit(
 				execStartPreCopyBinaryFromContainer("promtail", ctx.Images[charts.PromtailImageName]),
 				"/bin/sh "+PathSetActiveJournalFileScript,
-				PathPromtailBinary+`/promtail -config.file=`+PathPromtailConfig),
+				v1beta1constants.OperatingSystemConfigFilePathBinaries+`/promtail -config.file=`+PathPromtailConfig),
 		},
 		[]extensionsv1alpha1.File{
 			*promtailConfigFile,

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/promtail/config_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/promtail/config_test.go
@@ -18,21 +18,19 @@ import (
 	"github.com/gardener/gardener/charts"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components"
-	"gopkg.in/yaml.v3"
-
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v3"
 	"k8s.io/utils/pointer"
 )
 
 var _ = Describe("Promtail", func() {
 	Describe("#Config", func() {
 		var (
-			cABundle = "malskjdvbfnasufbaus"
-			//cABundleB64        = utils.EncodeBase64([]byte(cABundle))
+			cABundle           = "malskjdvbfnasufbaus"
 			clusterDomain      = "testClusterDomain.com"
 			promtailImageName  = "Promtail"
 			promtailRepository = "github.com/promtail"
@@ -90,7 +88,7 @@ RestartSec=5
 EnvironmentFile=/etc/environment
 ExecStartPre=/usr/bin/docker run --rm -v /opt/bin:/opt/bin:rw --entrypoint /bin/sh ` + promtailRepository + ":" + promtailImageTag + " -c " + "\"cp /usr/bin/promtail /opt/bin\"" + `
 ExecStartPre=/bin/sh ` + PathSetActiveJournalFileScript + `
-ExecStart=` + PathPromtailBinary + `/promtail -config.file=` + PathPromtailConfig)},
+ExecStart=/opt/bin/promtail -config.file=` + PathPromtailConfig)},
 			))
 
 			Expect(files).To(ConsistOf(

--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -252,7 +252,7 @@ func (b *Botanist) generateCloudConfigExecutorResourcesForWorker(
 		}
 	}
 
-	executorScript, err := ExecutorScriptFn(bootstrapToken, []byte(oscDataOriginal.Content), hyperkubeImage, kubeletDataVolume, *oscDataOriginal.Command, oscDataOriginal.Units)
+	executorScript, err := ExecutorScriptFn(bootstrapToken, []byte(oscDataOriginal.Content), hyperkubeImage, b.Shoot.KubernetesVersion.String(), kubeletDataVolume, *oscDataOriginal.Command, oscDataOriginal.Units)
 	if err != nil {
 		return "", nil, err
 	}

--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -144,11 +144,10 @@ func (b *Botanist) DeployManagedResourceForCloudConfigExecutor(ctx context.Conte
 	}
 	bootstrapToken := bootstraptoken.FromSecretData(bootstrapTokenSecret.Data)
 
-	imagesMap, err := imagevector.FindImages(b.ImageVector, []string{charts.ImageNameHyperkube}, imagevector.RuntimeVersion(b.ShootVersion()), imagevector.TargetVersion(b.ShootVersion()))
+	hyperkubeImage, err := b.ImageVector.FindImage(charts.ImageNameHyperkube, imagevector.RuntimeVersion(b.ShootVersion()), imagevector.TargetVersion(b.ShootVersion()))
 	if err != nil {
 		return err
 	}
-	images := imagevector.ImageMapToValues(imagesMap)
 
 	var (
 		managedResource                  = managedresources.NewForShoot(b.K8sSeedClient.Client(), b.Shoot.SeedNamespace, CloudConfigExecutionManagedResourceName, false)
@@ -170,7 +169,7 @@ func (b *Botanist) DeployManagedResourceForCloudConfigExecutor(ctx context.Conte
 			return fmt.Errorf("did not find osc data for worker pool %q", worker.Name)
 		}
 
-		secretName, data, err := b.generateCloudConfigExecutorResourcesForWorker(worker, oscData.Original, bootstrapToken, images)
+		secretName, data, err := b.generateCloudConfigExecutorResourcesForWorker(worker, oscData.Original, bootstrapToken, hyperkubeImage)
 		if err != nil {
 			return err
 		}
@@ -231,7 +230,7 @@ func (b *Botanist) generateCloudConfigExecutorResourcesForWorker(
 	worker gardencorev1beta1.Worker,
 	oscDataOriginal operatingsystemconfig.Data,
 	bootstrapToken string,
-	images map[string]interface{},
+	hyperkubeImage *imagevector.Image,
 ) (
 	string,
 	map[string][]byte,
@@ -253,7 +252,7 @@ func (b *Botanist) generateCloudConfigExecutorResourcesForWorker(
 		}
 	}
 
-	executorScript, err := ExecutorScriptFn(bootstrapToken, []byte(oscDataOriginal.Content), images, kubeletDataVolume, *oscDataOriginal.Command, oscDataOriginal.Units)
+	executorScript, err := ExecutorScriptFn(bootstrapToken, []byte(oscDataOriginal.Content), hyperkubeImage, kubeletDataVolume, *oscDataOriginal.Command, oscDataOriginal.Units)
 	if err != nil {
 		return "", nil, err
 	}

--- a/pkg/operation/botanist/operatingsystemconfig_test.go
+++ b/pkg/operation/botanist/operatingsystemconfig_test.go
@@ -306,8 +306,8 @@ var _ = Describe("operatingsystemconfig", func() {
 				// fake function for generation of executor script
 				oldExecutorScriptFn := ExecutorScriptFn
 				defer func() { ExecutorScriptFn = oldExecutorScriptFn }()
-				ExecutorScriptFn = func(bootstrapToken string, cloudConfigUserData []byte, images map[string]interface{}, kubeletDataVolume *gardencorev1beta1.DataVolume, reloadConfigCommand string, units []string) ([]byte, error) {
-					return []byte(fmt.Sprintf("%s_%s_%s_%s_%s_%s", bootstrapToken, cloudConfigUserData, images, kubeletDataVolume, reloadConfigCommand, units)), params.executorScriptFnError
+				ExecutorScriptFn = func(bootstrapToken string, cloudConfigUserData []byte, hyperkubeImage *imagevector.Image, kubeletDataVolume *gardencorev1beta1.DataVolume, reloadConfigCommand string, units []string) ([]byte, error) {
+					return []byte(fmt.Sprintf("%s_%s_%s_%s_%s_%s", bootstrapToken, cloudConfigUserData, hyperkubeImage.String(), kubeletDataVolume, reloadConfigCommand, units)), params.executorScriptFnError
 				}
 
 				// bootstrap token secret generation/retrieval
@@ -336,7 +336,7 @@ var _ = Describe("operatingsystemconfig", func() {
 
 							// managed resource secret reconciliation for executor scripts for worker pools
 							// worker pool 1
-							worker1ExecutorScript, _ := ExecutorScriptFn(bootstrapTokenID+"."+bootstrapTokenSecret, []byte(worker1OriginalContent), map[string]interface{}{"hyperkube": ":v"}, nil, worker1OriginalCommand, worker1OriginalUnits)
+							worker1ExecutorScript, _ := ExecutorScriptFn(bootstrapTokenID+"."+bootstrapTokenSecret, []byte(worker1OriginalContent), &imagevector.Image{Tag: pointer.String("v")}, nil, worker1OriginalCommand, worker1OriginalUnits)
 							kubernetesClientSeed.EXPECT().Get(ctx, kutil.Key(namespace, "managedresource-shoot-cloud-config-execution-"+worker1Name), gomock.AssignableToTypeOf(&corev1.Secret{}))
 							kubernetesClientSeed.EXPECT().Update(ctx, &corev1.Secret{
 								ObjectMeta: metav1.ObjectMeta{
@@ -362,7 +362,7 @@ metadata:
 							})
 
 							// worker pool 2
-							worker2ExecutorScript, _ := ExecutorScriptFn(bootstrapTokenID+"."+bootstrapTokenSecret, []byte(worker2OriginalContent), map[string]interface{}{"hyperkube": ":v"}, &gardencorev1beta1.DataVolume{Name: worker2KubeletDataVolumeName}, worker2OriginalCommand, worker2OriginalUnits)
+							worker2ExecutorScript, _ := ExecutorScriptFn(bootstrapTokenID+"."+bootstrapTokenSecret, []byte(worker2OriginalContent), &imagevector.Image{Tag: pointer.String("v")}, &gardencorev1beta1.DataVolume{Name: worker2KubeletDataVolumeName}, worker2OriginalCommand, worker2OriginalUnits)
 							kubernetesClientSeed.EXPECT().Get(ctx, kutil.Key(namespace, "managedresource-shoot-cloud-config-execution-"+worker2Name), gomock.AssignableToTypeOf(&corev1.Secret{}))
 							kubernetesClientSeed.EXPECT().Update(ctx, &corev1.Secret{
 								ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area cost storage scalability
/kind enhancement

**What this PR does / why we need it**:
Only download hyperkube image once on shoot worker nodes, see #4281 for the motivation.

**Which issue(s) this PR fixes**:
Fixes #4281

**Special notes for your reviewer**:
/squash

The PR contains three commits: The first two are just simplification steps towards the final goal (only downloading the `hyperkube` image once) which is contained in the third commit.

The idea is as follows:
1. Firstly, instead of repetitively `docker pull`ing the `hyperkube` image if it wasn't found, the `cloud-config-downloader` does now save the information of the last downloaded image in a file in the `/var/lib/cloud-config-downloader/downloads/hyperkube/last_downloaded_hyperkube_image` file and uses it to only download a dedicated image once.
2. Secondly, the `cloud-config-downloader` does now extract the Kubernetes binaries from the image (earlier, the `ExecPreStart` commands of the `kubelet` and `kubelet-monitor` units were doing so (potentially downloading the image again)). The extracted binaries are stored in `/var/lib/cloud-config-downloader/downloads/hyperkube`.
3. Thirdly, the `cloud-config-downloader` also creates a `copy-kubernetes-binary.sh` script in the `/var/lib/kubelet` directory.  The script copies the `kube{let,ctl}` binary from `/var/lib/cloud-config-downloader/downloads/hyperkube` to `/opt/bin` and stores the information from which `hyperkube` image the binaries were extracted from in `/opt/bin/last_copied_hyperkube_image`.
4. The `ExecPreStart` commands of the `kubelet` and `kubelet-monitor` units are now invoking this script. It only has an effect if binaries were recently extracted from a newer `hyperkube` image.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
The `hyperkube` image is now only downloaded exactly once per shoot worker node to prevent repetitive, undesired downloads in case the kubelet garbage-collects the image due to excessive root disk usage.
```
```noteworthy user
⚠️ The kubelets on the shoot worker nodes will be restarted in the respective maintenance time windows of the shoot clusters.
```
