### PR TITLE
Reuse seedadmissioncontroller webhook config

### DIFF
--- a/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller.go
+++ b/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller.go
@@ -291,75 +291,15 @@ func (g *gardenerSeedAdmissionController) Deploy(ctx context.Context) error {
 			},
 		}
 
-		failurePolicy                  = admissionregistrationv1beta1.Fail
-		validatingWebhookConfiguration = &admissionregistrationv1beta1.ValidatingWebhookConfiguration{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   Name,
-				Labels: getLabels(),
-			},
-			Webhooks: []admissionregistrationv1beta1.ValidatingWebhook{
-				{
-					Name: "crds.seed.admission.core.gardener.cloud",
-					Rules: []admissionregistrationv1beta1.RuleWithOperations{{
-						Rule: admissionregistrationv1beta1.Rule{
-							APIGroups:   []string{apiextensionsv1.GroupName},
-							APIVersions: []string{apiextensionsv1beta1.SchemeGroupVersion.Version, apiextensionsv1.SchemeGroupVersion.Version},
-							Resources:   []string{"customresourcedefinitions"},
-						},
-						Operations: []admissionregistrationv1beta1.OperationType{admissionregistrationv1beta1.Delete},
-					}},
-					FailurePolicy:     &failurePolicy,
-					NamespaceSelector: &metav1.LabelSelector{},
-					ObjectSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{gutil.DeletionProtected: "true"},
-					},
-					ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
-						CABundle: []byte(TLSCACert),
-						Service: &admissionregistrationv1beta1.ServiceReference{
-							Name:      service.Name,
-							Namespace: service.Namespace,
-							Path:      pointer.String(extensioncrds.WebhookPath),
-						},
-					},
-					AdmissionReviewVersions: []string{admissionv1beta1.SchemeGroupVersion.Version, admissionv1.SchemeGroupVersion.Version},
-					TimeoutSeconds:          pointer.Int32(10),
-				},
-				{
-					Name: "crs.seed.admission.core.gardener.cloud",
-					Rules: []admissionregistrationv1beta1.RuleWithOperations{{
-						Rule: admissionregistrationv1beta1.Rule{
-							APIGroups:   []string{extensionsv1alpha1.SchemeGroupVersion.Group},
-							APIVersions: []string{extensionsv1alpha1.SchemeGroupVersion.Version},
-							Resources: []string{
-								"backupbuckets",
-								"backupentries",
-								"bastions",
-								"containerruntimes",
-								"controlplanes",
-								"extensions",
-								"infrastructures",
-								"networks",
-								"operatingsystemconfigs",
-								"workers",
-							},
-						},
-						Operations: []admissionregistrationv1beta1.OperationType{admissionregistrationv1beta1.Delete},
-					}},
-					FailurePolicy:     &failurePolicy,
-					NamespaceSelector: &metav1.LabelSelector{},
-					ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
-						CABundle: []byte(TLSCACert),
-						Service: &admissionregistrationv1beta1.ServiceReference{
-							Name:      service.Name,
-							Namespace: service.Namespace,
-							Path:      pointer.String(extensioncrds.WebhookPath),
-						},
-					},
-					AdmissionReviewVersions: []string{admissionv1beta1.SchemeGroupVersion.Version, admissionv1.SchemeGroupVersion.Version},
-					TimeoutSeconds:          pointer.Int32(10),
-				},
+		webhookClientConfig = admissionregistrationv1beta1.WebhookClientConfig{
+			CABundle: []byte(TLSCACert),
+			Service: &admissionregistrationv1beta1.ServiceReference{
+				Name:      service.Name,
+				Namespace: service.Namespace,
+				Path:      pointer.String(extensioncrds.WebhookPath),
 			},
 		}
+		validatingWebhookConfiguration = GetValidatingWebhookConfig(webhookClientConfig)
 	)
 
 	resources, err := registry.AddAllAndSerialize(
@@ -382,6 +322,64 @@ func (g *gardenerSeedAdmissionController) Deploy(ctx context.Context) error {
 
 func (g *gardenerSeedAdmissionController) Destroy(ctx context.Context) error {
 	return managedresources.DeleteForSeed(ctx, g.client, g.namespace, managedResourceName)
+}
+
+// GetValidatingWebhookConfig returns the ValidatingWebhookConfiguration for the seedadmissioncontroller component for
+// reuse between the component and integration tests.
+func GetValidatingWebhookConfig(clientConfig admissionregistrationv1beta1.WebhookClientConfig) *admissionregistrationv1beta1.ValidatingWebhookConfiguration {
+	failurePolicy := admissionregistrationv1beta1.Fail
+
+	return &admissionregistrationv1beta1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   Name,
+			Labels: getLabels(),
+		},
+		Webhooks: []admissionregistrationv1beta1.ValidatingWebhook{{
+			Name: "crds.seed.admission.core.gardener.cloud",
+			Rules: []admissionregistrationv1beta1.RuleWithOperations{{
+				Rule: admissionregistrationv1beta1.Rule{
+					APIGroups:   []string{apiextensionsv1.GroupName},
+					APIVersions: []string{apiextensionsv1beta1.SchemeGroupVersion.Version, apiextensionsv1.SchemeGroupVersion.Version},
+					Resources:   []string{"customresourcedefinitions"},
+				},
+				Operations: []admissionregistrationv1beta1.OperationType{admissionregistrationv1beta1.Delete},
+			}},
+			FailurePolicy:     &failurePolicy,
+			NamespaceSelector: &metav1.LabelSelector{},
+			ObjectSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{gutil.DeletionProtected: "true"},
+			},
+			ClientConfig:            clientConfig,
+			AdmissionReviewVersions: []string{admissionv1beta1.SchemeGroupVersion.Version, admissionv1.SchemeGroupVersion.Version},
+			TimeoutSeconds:          pointer.Int32(10),
+		}, {
+			Name: "crs.seed.admission.core.gardener.cloud",
+			Rules: []admissionregistrationv1beta1.RuleWithOperations{{
+				Rule: admissionregistrationv1beta1.Rule{
+					APIGroups:   []string{extensionsv1alpha1.SchemeGroupVersion.Group},
+					APIVersions: []string{extensionsv1alpha1.SchemeGroupVersion.Version},
+					Resources: []string{
+						"backupbuckets",
+						"backupentries",
+						"bastions",
+						"containerruntimes",
+						"controlplanes",
+						"extensions",
+						"infrastructures",
+						"networks",
+						"operatingsystemconfigs",
+						"workers",
+					},
+				},
+				Operations: []admissionregistrationv1beta1.OperationType{admissionregistrationv1beta1.Delete},
+			}},
+			FailurePolicy:           &failurePolicy,
+			NamespaceSelector:       &metav1.LabelSelector{},
+			ClientConfig:            clientConfig,
+			AdmissionReviewVersions: []string{admissionv1beta1.SchemeGroupVersion.Version, admissionv1.SchemeGroupVersion.Version},
+			TimeoutSeconds:          pointer.Int32(10),
+		}},
+	}
 }
 
 func getLabels() map[string]string {

--- a/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller.go
+++ b/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller.go
@@ -364,6 +364,7 @@ func GetValidatingWebhookConfig(clientConfig admissionregistrationv1beta1.Webhoo
 						"bastions",
 						"containerruntimes",
 						"controlplanes",
+						"dnsrecords",
 						"extensions",
 						"infrastructures",
 						"networks",

--- a/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller_test.go
+++ b/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller_test.go
@@ -294,6 +294,7 @@ webhooks:
     - bastions
     - containerruntimes
     - controlplanes
+    - dnsrecords
     - extensions
     - infrastructures
     - networks

--- a/pkg/seedadmissioncontroller/webhooks/admission/podschedulername/admission.go
+++ b/pkg/seedadmissioncontroller/webhooks/admission/podschedulername/admission.go
@@ -28,8 +28,6 @@ const (
 	// shoot control plane pods.
 	GardenerShootControlPlaneSchedulerName = "gardener-shoot-controlplane-scheduler"
 
-	// HandlerName is the name of this admission webhook handler.
-	HandlerName = "pod_scheduler_name"
 	// WebhookPath is the HTTP handler path for this admission webhook handler.
 	// Note: In the future we might want to have additional scheduler names
 	// so lets have the handler be of pattern "/webhooks/default-pod-scheduler-name/{scheduler-name}"

--- a/test/integration/envtest/seedadmissioncontroller/seedadmission_suite_test.go
+++ b/test/integration/envtest/seedadmissioncontroller/seedadmission_suite_test.go
@@ -25,8 +25,6 @@ import (
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	corev1 "k8s.io/api/core/v1"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/utils/pointer"
@@ -40,7 +38,7 @@ import (
 
 	"github.com/gardener/gardener/cmd/utils"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/operation/botanist/component/seedadmissioncontroller"
 	"github.com/gardener/gardener/pkg/seedadmissioncontroller/webhooks/admission/extensioncrds"
 	"github.com/gardener/gardener/pkg/seedadmissioncontroller/webhooks/admission/podschedulername"
 	"github.com/gardener/gardener/test/framework"
@@ -112,60 +110,17 @@ var _ = AfterSuite(func() {
 })
 
 func getValidatingWebhookConfig() *admissionregistrationv1beta1.ValidatingWebhookConfiguration {
-	return &admissionregistrationv1beta1.ValidatingWebhookConfiguration{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "admissionregistration.k8s.io/v1beta1",
-			Kind:       "ValidatingWebhookConfiguration",
+	clientConfig := admissionregistrationv1beta1.WebhookClientConfig{
+		Service: &admissionregistrationv1beta1.ServiceReference{
+			Path: pointer.String(extensioncrds.WebhookPath),
 		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "gardener-seed-admission-controller",
-		},
-		Webhooks: []admissionregistrationv1beta1.ValidatingWebhook{{
-			Name: "crds.seed.admission.core.gardener.cloud",
-			Rules: []admissionregistrationv1beta1.RuleWithOperations{{
-				Rule: admissionregistrationv1beta1.Rule{
-					APIGroups:   []string{apiextensionsv1.GroupName},
-					APIVersions: []string{apiextensionsv1beta1.SchemeGroupVersion.Version, apiextensionsv1.SchemeGroupVersion.Version},
-					Resources:   []string{"customresourcedefinitions"},
-				},
-				Operations: []admissionregistrationv1beta1.OperationType{admissionregistrationv1beta1.Delete},
-			}},
-			ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
-				Service: &admissionregistrationv1beta1.ServiceReference{
-					Path: pointer.String(extensioncrds.WebhookPath),
-				},
-			},
-			AdmissionReviewVersions: []string{admissionv1beta1.SchemeGroupVersion.Version},
-		}, {
-			Name: "crs.seed.admission.core.gardener.cloud",
-			Rules: []admissionregistrationv1beta1.RuleWithOperations{{
-				Rule: admissionregistrationv1beta1.Rule{
-					APIGroups:   []string{extensionsv1alpha1.SchemeGroupVersion.Group},
-					APIVersions: []string{extensionsv1alpha1.SchemeGroupVersion.Version},
-					Resources: []string{
-						"backupbuckets",
-						"backupentries",
-						"bastions",
-						"containerruntimes",
-						"controlplanes",
-						"dnsrecords",
-						"extensions",
-						"infrastructures",
-						"networks",
-						"operatingsystemconfigs",
-						"workers",
-					},
-				},
-				Operations: []admissionregistrationv1beta1.OperationType{admissionregistrationv1beta1.Delete},
-			}},
-			ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
-				Service: &admissionregistrationv1beta1.ServiceReference{
-					Path: pointer.String(extensioncrds.WebhookPath),
-				},
-			},
-			AdmissionReviewVersions: []string{admissionv1beta1.SchemeGroupVersion.Version},
-		}},
 	}
+
+	webhookConfig := seedadmissioncontroller.GetValidatingWebhookConfig(clientConfig)
+	// envtest doesn't default the webhook config's GVK, so set it explicitly
+	webhookConfig.SetGroupVersionKind(admissionregistrationv1beta1.SchemeGroupVersion.WithKind("ValidatingWebhookConfiguration"))
+
+	return webhookConfig
 }
 
 func getMutatingWebhookConfig() *admissionregistrationv1beta1.MutatingWebhookConfiguration {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity testing
/kind technical-debt

**What this PR does / why we need it**:

Follow-up on https://github.com/gardener/gardener/pull/4231#discussion_r663909999:
Reuse the seedadmissioncontroller webhook config between integration test and components.
By this, I also noticed, that the validating webhook config was missing the `dnsrecords` resource, so I added it accordingly.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/squash

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
