### PR TITLE
Prevent Docker Hub rate limits in the vpntunnel test

### DIFF
--- a/test/framework/resources/templates/logger-app.yaml.tpl
+++ b/test/framework/resources/templates/logger-app.yaml.tpl
@@ -18,7 +18,7 @@ spec:
     spec:
       containers:
       - name: logger
-        image: eu.gcr.io/gardener-project/3rd/k8s_gcr_io/logs-generator:v0.1.1
+        image: k8s.gcr.io/logs-generator:v0.1.1
         args:
           - /bin/sh
           - -c

--- a/test/framework/resources/templates/vpntunnel-copy.yaml.tpl
+++ b/test/framework/resources/templates/vpntunnel-copy.yaml.tpl
@@ -28,9 +28,20 @@ spec:
         volumeMounts:
         - name: source-data
           mountPath: /data
+      - image: eu.gcr.io/gardener-project/3rd/alpine:3.13.5
+        name: install-kubectl
+        command:
+        - /bin/sh
+        - -c
+        - |-
+          wget https://storage.googleapis.com/kubernetes-release/release/v{{ .KubeVersion }}/bin/linux/amd64/kubectl -O /data/kubectl;
+          chmod +x /data/kubectl;
+        volumeMounts:
+        - name: source-data
+          mountPath: /data
       containers:
-      - image: bitnami/kubectl:{{ .KubeVersion }}
-        name: hyperkube
+      - image: eu.gcr.io/gardener-project/3rd/busybox:1.29.2
+        name: source-container
         command:
         - sleep
         - "3600"
@@ -42,7 +53,7 @@ spec:
           mountPath: /data
         - name: kubecfg
           mountPath: /secret
-      - image: bitnami/kubectl:{{ .KubeVersion }}
+      - image: eu.gcr.io/gardener-project/3rd/busybox:1.29.2
         name: target-container
         command:
         - sleep

--- a/test/framework/resources/templates/vpntunnel.yaml.tpl
+++ b/test/framework/resources/templates/vpntunnel.yaml.tpl
@@ -27,7 +27,7 @@ spec:
               sleep 3600;
             done
       - name: logger
-        image: eu.gcr.io/gardener-project/3rd/k8s_gcr_io/logs-generator:v0.1.1
+        image: k8s.gcr.io/logs-generator:v0.1.1
         args:
           - /bin/sh
           - -c

--- a/test/integration/shoots/vpntunnel/vpntunnel.go
+++ b/test/integration/shoots/vpntunnel/vpntunnel.go
@@ -40,7 +40,7 @@ import (
 
 const (
 	deploymentName = "logging-pod"
-	namespace      = "default"
+	namespace      = metav1.NamespaceDefault
 	logsCount      = 100000
 	logsDuration   = "1s"
 	loggerAppLabel = "vpnTunnelTesting"
@@ -177,7 +177,7 @@ var _ = ginkgo.Describe("Shoot vpn tunnel testing", func() {
 		podExecutor := framework.NewPodExecutor(f.ShootClient)
 		for _, pod := range pods.Items {
 			ginkgo.By(fmt.Sprintf("Copy data to target-container in pod %s", pod.Name))
-			reader, err := podExecutor.Execute(ctx, pod.Namespace, pod.Name, "hyperkube", fmt.Sprintf("kubectl cp /data/data %s/%s:/data/data -c target-container", pod.Namespace, pod.Name))
+			reader, err := podExecutor.Execute(ctx, pod.Namespace, pod.Name, "source-container", fmt.Sprintf("/data/kubectl cp /data/data %s/%s:/data/data -c target-container", pod.Namespace, pod.Name))
 			if apierrors.IsNotFound(err) {
 				f.Logger.Infof("Aborting as pod %s was not found anymore: %s", pod.Name, err)
 				break


### PR DESCRIPTION
/area testing
/kind enhancement

Similar to https://github.com/gardener/gardener/issues/4160, currently the vpntunnel integration test can fail/flake because of Docker Hub rate limits:

```
time="2021-07-06T11:50:12Z" level=info msg="At 2021-07-06 11:45:19 +0000 UTC - event for copy-pod-f6db9c488-q2cg6: {kubelet shoot--it--tm60j-w2k-worker-1-z1-557d8-cw522} Failed: Failed to pull image \"bitnami/kubectl:1.21.2\": rpc error: code = Unknown desc = Error response from daemon: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit"
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
