### PR TITLE
Remove 'experimental' disclaimer for `Seed{Authorizer,Restriction}` features

### DIFF
--- a/docs/deployment/gardenlet_api_access.md
+++ b/docs/deployment/gardenlet_api_access.md
@@ -104,8 +104,6 @@ Please note that you should activate the [`SeedRestriction`](#seedrestriction-ad
 
 > [1] The reason for the fact that `Webhook` authorization plugin should appear after `RBAC` is that the `kube-apiserver` will be depending on the `gardener-admission-controller` (serving the webhook). However, the `gardener-admission-controller` can only start when `gardener-apiserver` runs, but `gardener-apiserver` itself can only start when `kube-apiserver` runs. If `Webhook` is before `RBAC` then `gardener-apiserver` might not be able to start, leading to a deadlock.
 
-⚠️ This authorization plugin is still in development and should only be used for experimental or testing purposes.
-
 ### Authorizer Decisions
 
 As mentioned earlier, it's the authorizer's job to evaluate API requests and return one of the following decisions:
@@ -223,8 +221,6 @@ The `SeedRestriction` is implemented as [Kubernetes admission webhook](https://k
 🎛 In order to activate it, you have to set `.global.admission.seedRestriction.enabled=true` when using the [Gardener `controlplane` Helm chart](../../charts/gardener/controlplane).
 This will add an additional webhook in the existing `ValidatingWebhookConfiguration` of the `gardener-admission-controller` which contains the configuration for the `SeedRestriction` handler.
 Please note that it should only be activated when the `SeedAuthorizer` is active as well.
-
-⚠️ This admission plugin is still in development and should only be used for experimental or testing purposes.
 
 ### Admission Decisions
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security documentation
/kind enhancement

**What this PR does / why we need it**:
This PR removes the 'experimental' disclaimer for the `Seed{Authorizer,Restriction}` features. It is considered ready and can be used for production landscapes.

**Which issue(s) this PR fixes**:
Fixes #1723 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Similar to the [`NodeAuthorizer`](https://kubernetes.io/docs/reference/access-authn-authz/node/) and [`NodeRestriction`](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#noderestriction) features in Kubernetes (preventing kubelets from accessing resources which aren't associated with their responsible `Node`s), Gardener does now have a `SeedAuthorizer` and `SeedRestriction` feature (preventing gardenlets from accessing resources which aren't associated with their `Seed`s). If you want to enable it for your landscapes then please consult [this document](https://github.com/gardener/gardener/blob/master/docs/deployment/gardenlet_api_access.md).
```
