### PR TITLE
Validate cri support for updated machine.Image

### DIFF
--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -831,11 +831,12 @@ func validateMachineImagesConstraints(constraints []core.MachineImage, image, ol
 }
 
 func validateContainerRuntimeConstraints(constraints []core.MachineImage, worker, oldWorker core.Worker, fldPath *field.Path) field.ErrorList {
-	if apiequality.Semantic.DeepEqual(worker.CRI, oldWorker.CRI) {
+	if worker.CRI == nil || worker.Machine.Image == nil {
 		return nil
 	}
 
-	if worker.CRI == nil || worker.Machine.Image == nil {
+	if apiequality.Semantic.DeepEqual(worker.CRI, oldWorker.CRI) &&
+		apiequality.Semantic.DeepEqual(worker.Machine.Image, oldWorker.Machine.Image) {
 		return nil
 	}
 

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -937,27 +937,6 @@ var _ = Describe("validator", func() {
 		})
 
 		Context("tests for unknown provider", func() {
-			var workers = []core.Worker{
-				{
-					Name: "worker-name",
-					Machine: core.Machine{
-						Type: "machine-type-1",
-					},
-					Minimum: 1,
-					Maximum: 1,
-					Volume: &core.Volume{
-						VolumeSize: "10Gi",
-						Type:       &volumeType,
-					},
-					Zones: []string{"europe-a"},
-				},
-			}
-
-			BeforeEach(func() {
-				cloudProfile = *cloudProfileBase.DeepCopy()
-				shoot = *shootBase.DeepCopy()
-				shoot.Spec.Provider.Workers = workers
-			})
 
 			Context("networking settings checks", func() {
 				It("should reject because the shoot node and the seed node networks intersect", func() {
@@ -1537,11 +1516,14 @@ var _ = Describe("validator", func() {
 				})
 
 				Context("update Shoot", func() {
-					It("should keep machine image of the old shoot (unset in new shoot)", func() {
+					BeforeEach(func() {
 						shoot.Spec.Provider.Workers[0].Machine.Image = &core.ShootMachineImage{
 							Name:    imageName1,
 							Version: nonExpiredVersion1,
 						}
+					})
+
+					It("should keep machine image of the old shoot (unset in new shoot)", func() {
 						newShoot := shoot.DeepCopy()
 						newShoot.Spec.Provider.Workers[0].Machine.Image = nil
 
@@ -1557,10 +1539,7 @@ var _ = Describe("validator", func() {
 					})
 
 					It("should keep machine image of the old shoot (version unset in new shoot)", func() {
-						shoot.Spec.Provider.Workers[0].Machine.Image = &core.ShootMachineImage{
-							Name:    imageName1,
-							Version: nonExpiredVersion1,
-						}
+
 						newShoot := shoot.DeepCopy()
 						newShoot.Spec.Provider.Workers[0].Machine.Image = &core.ShootMachineImage{
 							Name: imageName1,
@@ -1578,10 +1557,6 @@ var _ = Describe("validator", func() {
 					})
 
 					It("should use updated machine image version as specified", func() {
-						shoot.Spec.Provider.Workers[0].Machine.Image = &core.ShootMachineImage{
-							Name:    imageName1,
-							Version: nonExpiredVersion1,
-						}
 						newShoot := shoot.DeepCopy()
 						newShoot.Spec.Provider.Workers[0].Machine.Image = &core.ShootMachineImage{
 							Name:    imageName1,


### PR DESCRIPTION

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug

**What this PR does / why we need it**:
Before this change if a worker pool was updated to a new Image/Version
combination which does not support the selected `cri.Name` the validation
returned early with `allow` because `worker.CRI` did not change.

Now we validate the configuration if either CRI.Name or the Image changes.

**Which issue(s) this PR fixes**:
Fixes #4308 

**Special notes for your reviewer**:
During working on this bugfix, we realized that our defaulting logic for MachineImage and Version could lead to an invalid configuration of ContainerRuntime and MachineImageVersion. We don't make any changes in this PR to the defaulting logic and look at the defaulting decisions in more detail in the context of #4305.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Updating to a MachineImageVersion which doesn't support the chosen CRI configuration will now result in a validation error.
```

cc @BeckerMax 


