### PR TITLE
Allow authenticated users to read `ExposureClass` resources

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
@@ -99,6 +99,7 @@ rules:
   - core.gardener.cloud
   resources:
   - cloudprofiles
+  - exposureclasses
   - seeds
   verbs:
   - get


### PR DESCRIPTION
**What this PR does / why we need it**:
User can now reference an `ExposureClass` in their Shoots. Therefore it would be handy if authenticated users could lookup which `ExposureClass` exists.

cc @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
Authenticated users can now read/list/watch `ExposureClass` resources.
```
