### PR TITLE
Replace errors pkg

### DIFF
--- a/cmd/gardener-controller-manager/app/gardener_controller_manager.go
+++ b/cmd/gardener-controller-manager/app/gardener_controller_manager.go
@@ -315,7 +315,7 @@ func (g *Gardener) Run(ctx context.Context) error {
 		}
 		leaderElector, err := leaderelection.NewLeaderElector(*g.LeaderElection)
 		if err != nil {
-			return fmt.Errorf("couldn't create leader elector: %v", err)
+			return fmt.Errorf("couldn't create leader elector: %w", err)
 		}
 		leaderElector.Run(leaderElectionCtx)
 		return nil

--- a/cmd/gardener-scheduler/app/gardener_scheduler.go
+++ b/cmd/gardener-scheduler/app/gardener_scheduler.go
@@ -245,7 +245,7 @@ func (g *GardenerScheduler) Run(ctx context.Context) error {
 
 		leaderElector, err := leaderelection.NewLeaderElector(*g.LeaderElection)
 		if err != nil {
-			return fmt.Errorf("couldn't create leader elector: %v", err)
+			return fmt.Errorf("couldn't create leader elector: %w", err)
 		}
 
 		leaderElector.Run(leaderElectionCtx)

--- a/cmd/gardenlet/app/gardenlet.go
+++ b/cmd/gardenlet/app/gardenlet.go
@@ -149,7 +149,7 @@ func run(ctx context.Context, o *Options) error {
 	if len(o.ConfigFile) > 0 {
 		c, err := o.loadConfigFromFile(o.ConfigFile)
 		if err != nil {
-			return fmt.Errorf("unable to read the configuration file: %v", err)
+			return fmt.Errorf("unable to read the configuration file: %w", err)
 		}
 
 		if errs := configvalidation.ValidateGardenletConfiguration(c, nil, false); len(errs) > 0 {
@@ -385,7 +385,7 @@ func NewGardenlet(ctx context.Context, cfg *config.GardenletConfiguration) (*Gar
 
 	gardenClusterIdentity := &corev1.ConfigMap{}
 	if err := k8sGardenClient.Client().Get(ctx, kutil.Key(metav1.NamespaceSystem, v1beta1constants.ClusterIdentity), gardenClusterIdentity); err != nil {
-		return nil, fmt.Errorf("unable to get Gardener`s cluster-identity ConfigMap: %v", err)
+		return nil, fmt.Errorf("unable to get Gardener`s cluster-identity ConfigMap: %w", err)
 	}
 
 	clusterIdentity, ok := gardenClusterIdentity.Data[v1beta1constants.ClusterIdentity]
@@ -480,7 +480,7 @@ func (g *Gardenlet) Run(ctx context.Context) error {
 		}
 		leaderElector, err := leaderelection.NewLeaderElector(*g.LeaderElection)
 		if err != nil {
-			return fmt.Errorf("couldn't create leader elector: %v", err)
+			return fmt.Errorf("couldn't create leader elector: %w", err)
 		}
 		leaderElector.Run(leaderElectionCtx)
 		return nil
@@ -522,7 +522,7 @@ func determineGardenletIdentity() (*gardencorev1beta1.Gardener, error) {
 
 	gardenletName, err = os.Hostname()
 	if err != nil {
-		return nil, fmt.Errorf("unable to get hostname: %v", err)
+		return nil, fmt.Errorf("unable to get hostname: %w", err)
 	}
 
 	// If running inside a Kubernetes cluster (as container) we can read the container id from the proc file system.
@@ -561,7 +561,7 @@ func determineGardenletIdentity() (*gardencorev1beta1.Gardener, error) {
 	if gardenletID == "" {
 		gardenletID, err = utils.GenerateRandomString(64)
 		if err != nil {
-			return nil, fmt.Errorf("unable to generate gardenletID: %v", err)
+			return nil, fmt.Errorf("unable to generate gardenletID: %w", err)
 		}
 	}
 

--- a/cmd/utils/config.go
+++ b/cmd/utils/config.go
@@ -29,7 +29,7 @@ import (
 func MakeLeaderElectionConfig(cfg componentbaseconfig.LeaderElectionConfiguration, lockObjectNamespace string, lockObjectName string, client k8s.Interface, recorder record.EventRecorder) (*leaderelection.LeaderElectionConfig, error) {
 	hostname, err := os.Hostname()
 	if err != nil {
-		return nil, fmt.Errorf("unable to get hostname: %v", err)
+		return nil, fmt.Errorf("unable to get hostname: %w", err)
 	}
 
 	lock, err := resourcelock.New(
@@ -44,7 +44,7 @@ func MakeLeaderElectionConfig(cfg componentbaseconfig.LeaderElectionConfiguratio
 		},
 	)
 	if err != nil {
-		return nil, fmt.Errorf("couldn't create resource lock: %v", err)
+		return nil, fmt.Errorf("couldn't create resource lock: %w", err)
 	}
 
 	return &leaderelection.LeaderElectionConfig{

--- a/extensions/pkg/controller/controlplane/genericactuator/actuator.go
+++ b/extensions/pkg/controller/controlplane/genericactuator/actuator.go
@@ -17,6 +17,7 @@ package genericactuator
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"time"
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
@@ -34,7 +35,6 @@ import (
 	secretutil "github.com/gardener/gardener/pkg/utils/secrets"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -135,13 +135,13 @@ func (a *actuator) InjectConfig(config *rest.Config) error {
 	var err error
 	a.clientset, err = kubernetes.NewForConfig(config)
 	if err != nil {
-		return errors.Wrap(err, "could not create Kubernetes client")
+		return fmt.Errorf("could not create Kubernetes client: %w", err)
 	}
 
 	// Create Gardener clientset
 	a.gardenerClientset, err = gardenerkubernetes.NewWithConfig(gardenerkubernetes.WithRESTConfig(config))
 	if err != nil {
-		return errors.Wrap(err, "could not create Gardener client")
+		return fmt.Errorf("could not create Gardener client: %w", err)
 	}
 
 	a.chartApplier = a.gardenerClientset.ChartApplier()
@@ -194,7 +194,7 @@ func (a *actuator) reconcileControlPlaneExposure(
 		a.logger.Info("Deploying control plane exposure secrets", "controlplane", kutil.ObjectName(cp))
 		deployedSecrets, err := a.exposureSecrets.Deploy(ctx, a.clientset, a.gardenerClientset, cp.Namespace)
 		if err != nil {
-			return false, errors.Wrapf(err, "could not deploy control plane exposure secrets for controlplane '%s'", kutil.ObjectName(cp))
+			return false, fmt.Errorf("could not deploy control plane exposure secrets for controlplane '%s': %w", kutil.ObjectName(cp), err)
 		}
 		// Compute needed checksums
 		checksums = controlplane.ComputeChecksums(deployedSecrets, nil)
@@ -210,7 +210,7 @@ func (a *actuator) reconcileControlPlaneExposure(
 	a.logger.Info("Applying control plane exposure chart", "controlplaneexposure", kutil.ObjectName(cp), "values", values)
 	version := cluster.Shoot.Spec.Kubernetes.Version
 	if err := a.controlPlaneExposureChart.Apply(ctx, a.chartApplier, cp.Namespace, a.imageVector, a.gardenerClientset.Version(), version, values); err != nil {
-		return false, errors.Wrapf(err, "could not apply control plane exposure chart for controlplane '%s'", kutil.ObjectName(cp))
+		return false, fmt.Errorf("could not apply control plane exposure chart for controlplane '%s': %w", kutil.ObjectName(cp), err)
 	}
 
 	return false, nil
@@ -226,7 +226,7 @@ func (a *actuator) reconcileControlPlane(
 
 	if len(a.shootWebhooks) > 0 {
 		if err := ReconcileShootWebhooks(ctx, a.client, cp.Namespace, a.providerName, a.webhookServerPort, a.shootWebhooks); err != nil {
-			return false, errors.Wrapf(err, "could not reconcile shoot webhooks")
+			return false, fmt.Errorf("could not reconcile shoot webhooks: %w", err)
 		}
 	}
 
@@ -234,7 +234,7 @@ func (a *actuator) reconcileControlPlane(
 	a.logger.Info("Deploying secrets", "controlplane", kutil.ObjectName(cp))
 	deployedSecrets, err := a.secrets.Deploy(ctx, a.clientset, a.gardenerClientset, cp.Namespace)
 	if err != nil {
-		return false, errors.Wrapf(err, "could not deploy secrets for controlplane '%s'", kutil.ObjectName(cp))
+		return false, fmt.Errorf("could not deploy secrets for controlplane '%s': %w", kutil.ObjectName(cp), err)
 	}
 
 	// Get config chart values
@@ -247,7 +247,7 @@ func (a *actuator) reconcileControlPlane(
 		// Apply config chart
 		a.logger.Info("Applying configuration chart", "controlplane", kutil.ObjectName(cp))
 		if err := a.configChart.Apply(ctx, a.chartApplier, cp.Namespace, nil, "", "", values); err != nil {
-			return false, errors.Wrapf(err, "could not apply configuration chart for controlplane '%s'", kutil.ObjectName(cp))
+			return false, fmt.Errorf("could not apply configuration chart for controlplane '%s': %w", kutil.ObjectName(cp), err)
 		}
 	}
 
@@ -265,7 +265,7 @@ func (a *actuator) reconcileControlPlane(
 	if extensionscontroller.IsHibernated(cluster) {
 		dep := &appsv1.Deployment{}
 		if err := a.client.Get(ctx, client.ObjectKey{Namespace: cp.Namespace, Name: v1beta1constants.DeploymentNameKubeAPIServer}, dep); client.IgnoreNotFound(err) != nil {
-			return false, errors.Wrapf(err, "could not get deployment '%s/%s'", cp.Namespace, v1beta1constants.DeploymentNameKubeAPIServer)
+			return false, fmt.Errorf("could not get deployment '%s/%s': %w", cp.Namespace, v1beta1constants.DeploymentNameKubeAPIServer, err)
 		}
 
 		// If the cluster is hibernated, check if kube-apiserver has been already scaled down. If it is not yet scaled down
@@ -297,13 +297,13 @@ func (a *actuator) reconcileControlPlane(
 	version := cluster.Shoot.Spec.Kubernetes.Version
 	a.logger.Info("Applying control plane chart", "controlplane", kutil.ObjectName(cp))
 	if err := a.controlPlaneChart.Apply(ctx, a.chartApplier, cp.Namespace, a.imageVector, a.gardenerClientset.Version(), version, values); err != nil {
-		return false, errors.Wrapf(err, "could not apply control plane chart for controlplane '%s'", kutil.ObjectName(cp))
+		return false, fmt.Errorf("could not apply control plane chart for controlplane '%s': %w", kutil.ObjectName(cp), err)
 	}
 
 	// Create shoot chart renderer
 	chartRenderer, err := a.chartRendererFactory.NewChartRendererForShoot(version)
 	if err != nil {
-		return false, errors.Wrapf(err, "could not create chart renderer for shoot '%s'", cp.Namespace)
+		return false, fmt.Errorf("could not create chart renderer for shoot '%s': %w", cp.Namespace, err)
 	}
 
 	// Get control plane shoot chart values
@@ -313,7 +313,7 @@ func (a *actuator) reconcileControlPlane(
 	}
 
 	if err := managedresources.RenderChartAndCreate(ctx, cp.Namespace, ControlPlaneShootChartResourceName, false, a.client, chartRenderer, a.controlPlaneShootChart, values, a.imageVector, metav1.NamespaceSystem, version, true, false); err != nil {
-		return false, errors.Wrapf(err, "could not apply control plane shoot chart for controlplane '%s'", kutil.ObjectName(cp))
+		return false, fmt.Errorf("could not apply control plane shoot chart for controlplane '%s': %w", kutil.ObjectName(cp), err)
 	}
 
 	if a.controlPlaneShootCRDsChart != nil {
@@ -324,7 +324,7 @@ func (a *actuator) reconcileControlPlane(
 		}
 
 		if err := managedresources.RenderChartAndCreate(ctx, cp.Namespace, ControlPlaneShootCRDsChartResourceName, false, a.client, chartRenderer, a.controlPlaneShootCRDsChart, values, a.imageVector, metav1.NamespaceSystem, version, true, false); err != nil {
-			return false, errors.Wrapf(err, "could not apply control plane shoot CRDs chart for controlplane '%s'", kutil.ObjectName(cp))
+			return false, fmt.Errorf("could not apply control plane shoot CRDs chart for controlplane '%s': %w", kutil.ObjectName(cp), err)
 		}
 	}
 
@@ -335,7 +335,7 @@ func (a *actuator) reconcileControlPlane(
 	}
 
 	if err := managedresources.RenderChartAndCreate(ctx, cp.Namespace, StorageClassesChartResourceName, false, a.client, chartRenderer, a.storageClassesChart, values, a.imageVector, metav1.NamespaceSystem, version, true, true); err != nil {
-		return false, errors.Wrapf(err, "could not apply storage classes chart for controlplane '%s'", kutil.ObjectName(cp))
+		return false, fmt.Errorf("could not apply storage classes chart for controlplane '%s': %w", kutil.ObjectName(cp), err)
 	}
 
 	return requeue, nil
@@ -365,7 +365,7 @@ func (a *actuator) deleteControlPlaneExposure(
 	if a.controlPlaneExposureChart != nil {
 		a.logger.Info("Deleting control plane exposure with objects", "controlplane", kutil.ObjectName(cp))
 		if err := a.controlPlaneExposureChart.Delete(ctx, a.client, cp.Namespace); client.IgnoreNotFound(err) != nil {
-			return errors.Wrapf(err, "could not delete control plane exposure objects for controlplane '%s'", kutil.ObjectName(cp))
+			return fmt.Errorf("could not delete control plane exposure objects for controlplane '%s': %w", kutil.ObjectName(cp), err)
 		}
 	}
 
@@ -373,7 +373,7 @@ func (a *actuator) deleteControlPlaneExposure(
 	if a.exposureSecrets != nil {
 		a.logger.Info("Deleting secrets for control plane with purpose exposure", "controlplane", kutil.ObjectName(cp))
 		if err := a.exposureSecrets.Delete(ctx, a.clientset, cp.Namespace); client.IgnoreNotFound(err) != nil {
-			return errors.Wrapf(err, "could not delete secrets for controlplane exposure '%s'", kutil.ObjectName(cp))
+			return fmt.Errorf("could not delete secrets for controlplane exposure '%s': %w", kutil.ObjectName(cp), err)
 		}
 	}
 
@@ -389,70 +389,70 @@ func (a *actuator) deleteControlPlane(
 ) error {
 	// Delete the managed resources
 	if err := managedresources.Delete(ctx, a.client, cp.Namespace, StorageClassesChartResourceName, false); err != nil {
-		return errors.Wrapf(err, "could not delete managed resource containing storage classes chart for controlplane '%s'", kutil.ObjectName(cp))
+		return fmt.Errorf("could not delete managed resource containing storage classes chart for controlplane '%s': %w", kutil.ObjectName(cp), err)
 	}
 	if a.controlPlaneShootCRDsChart != nil {
 		if err := managedresources.Delete(ctx, a.client, cp.Namespace, ControlPlaneShootCRDsChartResourceName, false); err != nil {
-			return errors.Wrapf(err, "could not delete managed resource containing shoot CRDs chart for controlplane '%s'", kutil.ObjectName(cp))
+			return fmt.Errorf("could not delete managed resource containing shoot CRDs chart for controlplane '%s': %w", kutil.ObjectName(cp), err)
 		}
 
 		// Wait for shoot CRDs chart ManagedResource deletion before deleting the shoot chart ManagedResource
 		timeoutCtx1, cancel := context.WithTimeout(ctx, 2*time.Minute)
 		defer cancel()
 		if err := managedresources.WaitUntilDeleted(timeoutCtx1, a.client, cp.Namespace, ControlPlaneShootCRDsChartResourceName); err != nil {
-			return errors.Wrapf(err, "error while waiting for managed resource containing shoot CRDs chart for controlplane '%s' to be deleted", kutil.ObjectName(cp))
+			return fmt.Errorf("error while waiting for managed resource containing shoot CRDs chart for controlplane '%s' to be deleted: %w", kutil.ObjectName(cp), err)
 		}
 	}
 	if err := managedresources.Delete(ctx, a.client, cp.Namespace, ControlPlaneShootChartResourceName, false); err != nil {
-		return errors.Wrapf(err, "could not delete managed resource containing shoot chart for controlplane '%s'", kutil.ObjectName(cp))
+		return fmt.Errorf("could not delete managed resource containing shoot chart for controlplane '%s': %w", kutil.ObjectName(cp), err)
 	}
 
 	timeoutCtx2, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 	if err := managedresources.WaitUntilDeleted(timeoutCtx2, a.client, cp.Namespace, StorageClassesChartResourceName); err != nil {
-		return errors.Wrapf(err, "error while waiting for managed resource containing storage classes chart for controlplane '%s' to be deleted", kutil.ObjectName(cp))
+		return fmt.Errorf("error while waiting for managed resource containing storage classes chart for controlplane '%s' to be deleted: %w", kutil.ObjectName(cp), err)
 	}
 
 	timeoutCtx3, cancel := context.WithTimeout(ctx, 2*time.Minute)
 	defer cancel()
 	if err := managedresources.WaitUntilDeleted(timeoutCtx3, a.client, cp.Namespace, ControlPlaneShootChartResourceName); err != nil {
-		return errors.Wrapf(err, "error while waiting for managed resource containing shoot chart for controlplane '%s' to be deleted", kutil.ObjectName(cp))
+		return fmt.Errorf("error while waiting for managed resource containing shoot chart for controlplane '%s' to be deleted: %w", kutil.ObjectName(cp), err)
 	}
 
 	// Delete control plane objects
 	a.logger.Info("Deleting control plane objects", "controlplane", kutil.ObjectName(cp))
 	if err := a.controlPlaneChart.Delete(ctx, a.client, cp.Namespace); client.IgnoreNotFound(err) != nil {
-		return errors.Wrapf(err, "could not delete control plane objects for controlplane '%s'", kutil.ObjectName(cp))
+		return fmt.Errorf("could not delete control plane objects for controlplane '%s': %w", kutil.ObjectName(cp), err)
 	}
 
 	if a.configChart != nil {
 		// Delete config objects
 		a.logger.Info("Deleting configuration objects", "controlplane", kutil.ObjectName(cp))
 		if err := a.configChart.Delete(ctx, a.client, cp.Namespace); client.IgnoreNotFound(err) != nil {
-			return errors.Wrapf(err, "could not delete configuration objects for controlplane '%s'", kutil.ObjectName(cp))
+			return fmt.Errorf("could not delete configuration objects for controlplane '%s': %w", kutil.ObjectName(cp), err)
 		}
 	}
 
 	// Delete secrets
 	a.logger.Info("Deleting secrets", "controlplane", kutil.ObjectName(cp))
 	if err := a.secrets.Delete(ctx, a.clientset, cp.Namespace); client.IgnoreNotFound(err) != nil {
-		return errors.Wrapf(err, "could not delete secrets for controlplane '%s'", kutil.ObjectName(cp))
+		return fmt.Errorf("could not delete secrets for controlplane '%s': %w", kutil.ObjectName(cp), err)
 	}
 
 	if len(a.shootWebhooks) > 0 {
 		networkPolicy := extensionswebhookshoot.GetNetworkPolicyMeta(cp.Namespace, a.providerName)
 		if err := a.client.Delete(ctx, networkPolicy); client.IgnoreNotFound(err) != nil {
-			return errors.Wrapf(err, "could not delete network policy for shoot webhooks in namespace '%s'", cp.Namespace)
+			return fmt.Errorf("could not delete network policy for shoot webhooks in namespace '%s': %w", cp.Namespace, err)
 		}
 
 		if err := managedresources.Delete(ctx, a.client, cp.Namespace, ShootWebhooksResourceName, false); err != nil {
-			return errors.Wrapf(err, "could not delete managed resource containing shoot webhooks for controlplane '%s'", kutil.ObjectName(cp))
+			return fmt.Errorf("could not delete managed resource containing shoot webhooks for controlplane '%s': %w", kutil.ObjectName(cp), err)
 		}
 
 		timeoutCtx4, cancel := context.WithTimeout(ctx, 2*time.Minute)
 		defer cancel()
 		if err := managedresources.WaitUntilDeleted(timeoutCtx4, a.client, cp.Namespace, ShootWebhooksResourceName); err != nil {
-			return errors.Wrapf(err, "error while waiting for managed resource containing shoot webhooks for controlplane '%s' to be deleted", kutil.ObjectName(cp))
+			return fmt.Errorf("error while waiting for managed resource containing shoot webhooks for controlplane '%s' to be deleted: %w", kutil.ObjectName(cp), err)
 		}
 	}
 
@@ -469,7 +469,7 @@ func (a *actuator) computeChecksums(
 	// Get cloud provider secret and config from cluster
 	cpSecret := &corev1.Secret{}
 	if err := a.client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: v1beta1constants.SecretNameCloudProvider}, cpSecret); err != nil {
-		return nil, errors.Wrapf(err, "could not get secret '%s/%s'", namespace, v1beta1constants.SecretNameCloudProvider)
+		return nil, fmt.Errorf("could not get secret '%s/%s': %w", namespace, v1beta1constants.SecretNameCloudProvider, err)
 	}
 
 	csSecrets := controlplane.MergeSecretMaps(deployedSecrets, map[string]*corev1.Secret{
@@ -480,7 +480,7 @@ func (a *actuator) computeChecksums(
 	if len(a.configName) != 0 {
 		cpConfigMap := &corev1.ConfigMap{}
 		if err := a.client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: a.configName}, cpConfigMap); err != nil {
-			return nil, errors.Wrapf(err, "could not get configmap '%s/%s'", namespace, a.configName)
+			return nil, fmt.Errorf("could not get configmap '%s/%s': %w", namespace, a.configName, err)
 		}
 
 		csConfigMaps = map[string]*corev1.ConfigMap{
@@ -535,15 +535,15 @@ func (a *actuator) Migrate(
 ) error {
 	// Keep objects for shoot managed resources so that they are not deleted from the shoot during the migration
 	if err := managedresources.SetKeepObjects(ctx, a.client, cp.Namespace, ControlPlaneShootChartResourceName, true); err != nil {
-		return errors.Wrapf(err, "could not keep objects of managed resource containing shoot chart for controlplane '%s'", kutil.ObjectName(cp))
+		return fmt.Errorf("could not keep objects of managed resource containing shoot chart for controlplane '%s': %w", kutil.ObjectName(cp), err)
 	}
 	if a.controlPlaneShootCRDsChart != nil {
 		if err := managedresources.SetKeepObjects(ctx, a.client, cp.Namespace, ControlPlaneShootCRDsChartResourceName, true); err != nil {
-			return errors.Wrapf(err, "could not keep objects of managed resource containing shoot CRDs chart for controlplane '%s'", kutil.ObjectName(cp))
+			return fmt.Errorf("could not keep objects of managed resource containing shoot CRDs chart for controlplane '%s': %w", kutil.ObjectName(cp), err)
 		}
 	}
 	if err := managedresources.SetKeepObjects(ctx, a.client, cp.Namespace, StorageClassesChartResourceName, true); err != nil {
-		return errors.Wrapf(err, "could not keep objects of managed resource containing storage classes chart for controlplane '%s'", kutil.ObjectName(cp))
+		return fmt.Errorf("could not keep objects of managed resource containing storage classes chart for controlplane '%s': %w", kutil.ObjectName(cp), err)
 	}
 
 	return a.Delete(ctx, cp, cluster)
@@ -553,7 +553,7 @@ func (a *actuator) Migrate(
 // talk to the provider extension, and a managed resource that contains the MutatingWebhookConfiguration.
 func ReconcileShootWebhooks(ctx context.Context, c client.Client, namespace, providerName string, serverPort int, shootWebhooks []admissionregistrationv1beta1.MutatingWebhook) error {
 	if err := extensionswebhookshoot.EnsureNetworkPolicy(ctx, c, namespace, providerName, serverPort); err != nil {
-		return errors.Wrapf(err, "could not create or update network policy for shoot webhooks in namespace '%s'", namespace)
+		return fmt.Errorf("could not create or update network policy for shoot webhooks in namespace '%s': %w", namespace, err)
 	}
 
 	webhookConfiguration, err := marshalWebhooks(shootWebhooks, providerName)
@@ -563,7 +563,7 @@ func ReconcileShootWebhooks(ctx context.Context, c client.Client, namespace, pro
 	data := map[string][]byte{"mutatingwebhookconfiguration.yaml": webhookConfiguration}
 
 	if err := managedresources.Create(ctx, c, namespace, ShootWebhooksResourceName, false, "", data, nil, nil, nil); err != nil {
-		return errors.Wrapf(err, "could not create or update managed resource '%s/%s' containing shoot webhooks", namespace, ShootWebhooksResourceName)
+		return fmt.Errorf("could not create or update managed resource '%s/%s' containing shoot webhooks: %w", namespace, ShootWebhooksResourceName, err)
 	}
 
 	return nil

--- a/extensions/pkg/controller/healthcheck/general/daemonset.go
+++ b/extensions/pkg/controller/healthcheck/general/daemonset.go
@@ -101,7 +101,7 @@ func (healthChecker *DaemonSetHealthChecker) Check(ctx context.Context, request 
 			}, nil
 		}
 
-		err := fmt.Errorf("failed to retrieve DaemonSet %q in namespace %q: %v", healthChecker.name, request.Namespace, err)
+		err := fmt.Errorf("failed to retrieve DaemonSet %q in namespace %q: %w", healthChecker.name, request.Namespace, err)
 		healthChecker.logger.Error(err, "Health check failed")
 		return nil, err
 	}
@@ -122,7 +122,7 @@ func (healthChecker *DaemonSetHealthChecker) Check(ctx context.Context, request 
 // if it is healthy or not or an error
 func DaemonSetIsHealthy(daemonSet *appsv1.DaemonSet) (bool, error) {
 	if err := health.CheckDaemonSet(daemonSet); err != nil {
-		err := fmt.Errorf("daemonSet %q in namespace %q is unhealthy: %v", daemonSet.Name, daemonSet.Namespace, err)
+		err := fmt.Errorf("daemonSet %q in namespace %q is unhealthy: %w", daemonSet.Name, daemonSet.Namespace, err)
 		return false, err
 	}
 	return true, nil

--- a/extensions/pkg/controller/healthcheck/general/deployment.go
+++ b/extensions/pkg/controller/healthcheck/general/deployment.go
@@ -102,7 +102,7 @@ func (healthChecker *DeploymentHealthChecker) Check(ctx context.Context, request
 			}, nil
 		}
 
-		err := fmt.Errorf("failed to retrieve deployment %q in namespace %q: %v", healthChecker.name, request.Namespace, err)
+		err := fmt.Errorf("failed to retrieve deployment %q in namespace %q: %w", healthChecker.name, request.Namespace, err)
 		healthChecker.logger.Error(err, "Health check failed")
 		return nil, err
 	}
@@ -122,7 +122,7 @@ func (healthChecker *DeploymentHealthChecker) Check(ctx context.Context, request
 
 func deploymentIsHealthy(deployment *appsv1.Deployment) (bool, error) {
 	if err := health.CheckDeployment(deployment); err != nil {
-		err := fmt.Errorf("deployment %q in namespace %q is unhealthy: %v", deployment.Name, deployment.Namespace, err)
+		err := fmt.Errorf("deployment %q in namespace %q is unhealthy: %w", deployment.Name, deployment.Namespace, err)
 		return false, err
 	}
 	return true, nil

--- a/extensions/pkg/controller/healthcheck/general/managed_resource.go
+++ b/extensions/pkg/controller/healthcheck/general/managed_resource.go
@@ -73,7 +73,7 @@ func (healthChecker *ManagedResourceHealthChecker) Check(ctx context.Context, re
 			}, nil
 		}
 
-		err := fmt.Errorf("check Managed Resource failed. Unable to retrieve managed resource %q in namespace %q: %v", healthChecker.managedResourceName, request.Namespace, err)
+		err := fmt.Errorf("check Managed Resource failed. Unable to retrieve managed resource %q in namespace %q: %w", healthChecker.managedResourceName, request.Namespace, err)
 		healthChecker.logger.Error(err, "Health check failed")
 		return nil, err
 	}

--- a/extensions/pkg/controller/healthcheck/general/statefulsets.go
+++ b/extensions/pkg/controller/healthcheck/general/statefulsets.go
@@ -101,7 +101,7 @@ func (healthChecker *StatefulSetHealthChecker) Check(ctx context.Context, reques
 				Detail: fmt.Sprintf("StatefulSet %q in namespace %q not found", healthChecker.name, request.Namespace),
 			}, nil
 		}
-		err := fmt.Errorf("failed to retrieve StatefulSet %q in namespace %q: %v", healthChecker.name, request.Namespace, err)
+		err := fmt.Errorf("failed to retrieve StatefulSet %q in namespace %q: %w", healthChecker.name, request.Namespace, err)
 		healthChecker.logger.Error(err, "Health check failed")
 		return nil, err
 	}
@@ -120,7 +120,7 @@ func (healthChecker *StatefulSetHealthChecker) Check(ctx context.Context, reques
 
 func statefulSetIsHealthy(statefulSet *appsv1.StatefulSet) (bool, error) {
 	if err := health.CheckStatefulSet(statefulSet); err != nil {
-		err := fmt.Errorf("statefulSet %q in namespace %q is unhealthy: %v", statefulSet.Name, statefulSet.Namespace, err)
+		err := fmt.Errorf("statefulSet %q in namespace %q is unhealthy: %w", statefulSet.Name, statefulSet.Namespace, err)
 		return false, err
 	}
 	return true, nil

--- a/extensions/pkg/controller/healthcheck/worker/helpers.go
+++ b/extensions/pkg/controller/healthcheck/worker/helpers.go
@@ -87,7 +87,7 @@ func checkMachineDeploymentsHealthy(machineDeployments []machinev1alpha1.Machine
 		}
 
 		if err := CheckMachineDeployment(&deployment); err != nil {
-			return false, fmt.Errorf("machine deployment %q in namespace %q is unhealthy: %v", deployment.Name, deployment.Namespace, err)
+			return false, fmt.Errorf("machine deployment %q in namespace %q is unhealthy: %w", deployment.Name, deployment.Namespace, err)
 		}
 	}
 

--- a/extensions/pkg/controller/healthcheck/worker/nodes.go
+++ b/extensions/pkg/controller/healthcheck/worker/nodes.go
@@ -95,14 +95,14 @@ func (h *DefaultHealthChecker) DeepCopy() healthcheck.HealthCheck {
 func (h *DefaultHealthChecker) Check(ctx context.Context, request types.NamespacedName) (*healthcheck.SingleCheckResult, error) {
 	machineDeploymentList := &machinev1alpha1.MachineDeploymentList{}
 	if err := h.seedClient.List(ctx, machineDeploymentList, client.InNamespace(request.Namespace)); err != nil {
-		err := fmt.Errorf("unable to check nodes. Failed to list machine deployments in namespace %q: %v", request.Namespace, err)
+		err := fmt.Errorf("unable to check nodes. Failed to list machine deployments in namespace %q: %w", request.Namespace, err)
 		h.logger.Error(err, "Health check failed")
 		return nil, err
 	}
 
 	nodeList := &corev1.NodeList{}
 	if err := h.shootClient.List(ctx, nodeList); err != nil {
-		err := fmt.Errorf("unable to check nodes. Failed to list shoot nodes: %v", err)
+		err := fmt.Errorf("unable to check nodes. Failed to list shoot nodes: %w", err)
 		h.logger.Error(err, "Health check failed")
 		return nil, err
 	}
@@ -127,7 +127,7 @@ func (h *DefaultHealthChecker) Check(ctx context.Context, request types.Namespac
 	machineList := &machinev1alpha1.MachineList{}
 	if registeredNodes != desiredMachines || readyNodes != desiredMachines {
 		if err := h.seedClient.List(ctx, machineList, client.InNamespace(request.Namespace)); err != nil {
-			err := fmt.Errorf("unable to check nodes. Failed to list machines in namespace %q: %v", request.Namespace, err)
+			err := fmt.Errorf("unable to check nodes. Failed to list machines in namespace %q: %w", request.Namespace, err)
 			h.logger.Error(err, "Health check failed")
 			return nil, err
 		}

--- a/extensions/pkg/controller/operatingsystemconfig/oscommon/actuator/actuator_reconcile.go
+++ b/extensions/pkg/controller/operatingsystemconfig/oscommon/actuator/actuator_reconcile.go
@@ -25,7 +25,7 @@ import (
 func (a *Actuator) Reconcile(ctx context.Context, config *extensionsv1alpha1.OperatingSystemConfig) ([]byte, *string, []string, error) {
 	cloudConfig, cmd, err := CloudConfigFromOperatingSystemConfig(ctx, a.client, config, a.generator)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("could not generate cloud config: %v", err)
+		return nil, nil, nil, fmt.Errorf("could not generate cloud config: %w", err)
 	}
 
 	return cloudConfig, cmd, OperatingSystemConfigUnitNames(config), nil

--- a/extensions/pkg/controller/worker/state_actuator.go
+++ b/extensions/pkg/controller/worker/state_actuator.go
@@ -17,6 +17,7 @@ package worker
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"sort"
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
@@ -25,7 +26,6 @@ import (
 
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/util/retry"
@@ -53,7 +53,7 @@ func (a *genericStateActuator) InjectClient(client client.Client) error {
 func (a *genericStateActuator) Reconcile(ctx context.Context, worker *extensionsv1alpha1.Worker) error {
 	copyOfWorker := worker.DeepCopy()
 	if err := a.updateWorkerState(ctx, copyOfWorker); err != nil {
-		return errors.Wrapf(err, "failed to update the state in worker status")
+		return fmt.Errorf("failed to update the state in worker status: %w", err)
 	}
 
 	return nil

--- a/extensions/pkg/terraformer/state.go
+++ b/extensions/pkg/terraformer/state.go
@@ -177,7 +177,7 @@ func sniffJSONStateVersion(stateConfigMap []byte) (uint64, error) {
 	}
 	var sniff VersionSniff
 	if err := json.Unmarshal(stateConfigMap, &sniff); err != nil {
-		return 0, fmt.Errorf("the state file could not be parsed as JSON: %v", err)
+		return 0, fmt.Errorf("the state file could not be parsed as JSON: %w", err)
 	}
 
 	if sniff.Version == nil {

--- a/extensions/pkg/util/shoot.go
+++ b/extensions/pkg/util/shoot.go
@@ -24,7 +24,6 @@ import (
 	"github.com/gardener/gardener/pkg/utils/secrets"
 
 	"github.com/Masterminds/semver"
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -41,7 +40,7 @@ const CAChecksumAnnotation = "checksum/ca"
 func GetOrCreateShootKubeconfig(ctx context.Context, c client.Client, certificateConfig secrets.CertificateSecretConfig, namespace string) (*corev1.Secret, error) {
 	caSecret, ca, err := secrets.LoadCAFromSecret(ctx, c, namespace, v1beta1constants.SecretNameCACluster)
 	if err != nil {
-		return nil, fmt.Errorf("error fetching CA secret %s/%s: %v", namespace, v1beta1constants.SecretNameCACluster, err)
+		return nil, fmt.Errorf("error fetching CA secret %s/%s: %w", namespace, v1beta1constants.SecretNameCACluster, err)
 	}
 
 	var (
@@ -58,7 +57,7 @@ func GetOrCreateShootKubeconfig(ctx context.Context, c client.Client, certificat
 		}
 	)
 	if err := c.Get(ctx, key, &secret); client.IgnoreNotFound(err) != nil {
-		return nil, fmt.Errorf("error preparing kubeconfig: %v", err)
+		return nil, fmt.Errorf("error preparing kubeconfig: %w", err)
 	}
 
 	var (
@@ -83,7 +82,7 @@ func GetOrCreateShootKubeconfig(ctx context.Context, c client.Client, certificat
 
 	controlPlane, err := config.GenerateControlPlane()
 	if err != nil {
-		return nil, fmt.Errorf("error creating kubeconfig: %v", err)
+		return nil, fmt.Errorf("error creating kubeconfig: %w", err)
 	}
 
 	_, err = controllerutils.GetAndCreateOrMergePatch(ctx, c, &secret, func() error {
@@ -109,7 +108,7 @@ func kubeAPIServerServiceDNS(namespace string) string {
 func VersionMajorMinor(version string) (string, error) {
 	v, err := semver.NewVersion(version)
 	if err != nil {
-		return "", errors.Wrapf(err, "Invalid version string '%s'", version)
+		return "", fmt.Errorf("Invalid version string '%s': %w", version, err)
 	}
 	return fmt.Sprintf("%d.%d", v.Major(), v.Minor()), nil
 }
@@ -118,7 +117,7 @@ func VersionMajorMinor(version string) (string, error) {
 func VersionInfo(vs string) (*version.Info, error) {
 	v, err := semver.NewVersion(vs)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Invalid version string '%s'", vs)
+		return nil, fmt.Errorf("Invalid version string '%s': %w", vs, err)
 	}
 	return &version.Info{
 		Major:      fmt.Sprintf("%d", v.Major()),

--- a/extensions/pkg/webhook/cloudprovider/mutator.go
+++ b/extensions/pkg/webhook/cloudprovider/mutator.go
@@ -52,7 +52,7 @@ type mutator struct {
 func (m *mutator) InjectClient(client client.Client) error {
 	m.client = client
 	if _, err := inject.ClientInto(client, m.ensurer); err != nil {
-		return fmt.Errorf("could not inject the client into the ensurer: %v", err)
+		return fmt.Errorf("could not inject the client into the ensurer: %w", err)
 	}
 	return nil
 }
@@ -60,7 +60,7 @@ func (m *mutator) InjectClient(client client.Client) error {
 // InjectScheme injects the manager's scheme into the ensurer.
 func (m *mutator) InjectScheme(scheme *runtime.Scheme) error {
 	if _, err := inject.SchemeInto(scheme, m.ensurer); err != nil {
-		return fmt.Errorf("could not inject scheme into the ensurer: %v", err)
+		return fmt.Errorf("could not inject scheme into the ensurer: %w", err)
 	}
 	return nil
 }

--- a/extensions/pkg/webhook/cmd/options.go
+++ b/extensions/pkg/webhook/cmd/options.go
@@ -20,7 +20,6 @@ import (
 
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/pflag"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -222,7 +221,7 @@ func (c *AddToManagerConfig) AddToManager(mgr manager.Manager) ([]admissionregis
 
 	webhooks, err := c.Switch.WebhooksFactory(mgr)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "could not create webhooks")
+		return nil, nil, fmt.Errorf("could not create webhooks: %w", err)
 	}
 	webhookServer := mgr.GetWebhookServer()
 
@@ -241,12 +240,12 @@ func (c *AddToManagerConfig) AddToManager(mgr manager.Manager) ([]admissionregis
 
 	caBundle, err := extensionswebhook.GenerateCertificates(ctx, mgr, webhookServer.CertDir, c.Server.Namespace, c.serverName, c.Server.Mode, c.Server.URL)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "could not generate certificates")
+		return nil, nil, fmt.Errorf("could not generate certificates: %w", err)
 	}
 
 	seedWebhooks, shootWebhooks, err := extensionswebhook.RegisterWebhooks(ctx, mgr, c.Server.Namespace, c.serverName, servicePort, c.Server.Mode, c.Server.URL, caBundle, webhooks)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "could not create webhooks")
+		return nil, nil, fmt.Errorf("could not create webhooks: %w", err)
 	}
 
 	return seedWebhooks, shootWebhooks, nil
@@ -293,7 +292,7 @@ type AddToManagerSimple struct {
 func (s *AddToManagerSimple) AddToManager(mgr manager.Manager) error {
 	webhooks, err := s.Switch.WebhooksFactory(mgr)
 	if err != nil {
-		return errors.Wrapf(err, "could not create webhooks")
+		return fmt.Errorf("could not create webhooks: %w", err)
 	}
 
 	webhookServer := mgr.GetWebhookServer()

--- a/extensions/pkg/webhook/context/context.go
+++ b/extensions/pkg/webhook/context/context.go
@@ -16,10 +16,10 @@ package context
 
 import (
 	"context"
+	"fmt"
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 
-	"github.com/pkg/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -54,7 +54,7 @@ func (c *gardenContext) GetCluster(ctx context.Context) (*extensionscontroller.C
 	if c.cluster == nil {
 		cluster, err := extensionscontroller.GetCluster(ctx, c.client, c.object.GetNamespace())
 		if err != nil {
-			return nil, errors.Wrapf(err, "could not get cluster for namespace '%s'", c.object.GetNamespace())
+			return nil, fmt.Errorf("could not get cluster for namespace '%s': %w", c.object.GetNamespace(), err)
 		}
 		c.cluster = cluster
 	}

--- a/extensions/pkg/webhook/controlplane/checksums.go
+++ b/extensions/pkg/webhook/controlplane/checksums.go
@@ -16,10 +16,10 @@ package controlplane
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/gardener/gardener/pkg/utils"
 
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -31,7 +31,7 @@ func EnsureSecretChecksumAnnotation(ctx context.Context, template *corev1.PodTem
 	// Get secret from cluster
 	secret := &corev1.Secret{}
 	if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, secret); err != nil {
-		return errors.Wrapf(err, "could not get secret '%s/%s'", namespace, name)
+		return fmt.Errorf("could not get secret '%s/%s': %w", namespace, name, err)
 	}
 
 	// Add checksum annotation
@@ -45,7 +45,7 @@ func EnsureConfigMapChecksumAnnotation(ctx context.Context, template *corev1.Pod
 	// Get configmap from cluster
 	cm := &corev1.ConfigMap{}
 	if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, cm); err != nil {
-		return errors.Wrapf(err, "could not get configmap '%s/%s'", namespace, name)
+		return fmt.Errorf("could not get configmap '%s/%s': %w", namespace, name, err)
 	}
 
 	// Add checksum annotation

--- a/extensions/pkg/webhook/controlplane/genericmutator/mutator.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/mutator.go
@@ -16,6 +16,8 @@ package genericmutator
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig/oscommon/cloudinit"
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
@@ -28,7 +30,6 @@ import (
 	"github.com/coreos/go-systemd/v22/unit"
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	kubeletconfigv1beta1 "k8s.io/kubelet/config/v1beta1"
@@ -277,13 +278,13 @@ func (m *mutator) ensureKubeletServiceUnitContent(ctx context.Context, gctx gcon
 
 	// Deserialize unit options
 	if opts, err = m.unitSerializer.Deserialize(*content); err != nil {
-		return errors.Wrap(err, "could not deserialize kubelet.service unit content")
+		return fmt.Errorf("could not deserialize kubelet.service unit content: %w", err)
 	}
 
 	if oldContent != nil {
 		// Deserialize old unit options
 		if oldOpts, err = m.unitSerializer.Deserialize(*oldContent); err != nil {
-			return errors.Wrap(err, "could not deserialize old kubelet.service unit content")
+			return fmt.Errorf("could not deserialize old kubelet.service unit content: %w", err)
 		}
 	}
 
@@ -293,7 +294,7 @@ func (m *mutator) ensureKubeletServiceUnitContent(ctx context.Context, gctx gcon
 
 	// Serialize unit options
 	if *content, err = m.unitSerializer.Serialize(opts); err != nil {
-		return errors.Wrap(err, "could not serialize kubelet.service unit options")
+		return fmt.Errorf("could not serialize kubelet.service unit options: %w", err)
 	}
 
 	return nil
@@ -307,13 +308,13 @@ func (m *mutator) ensureKubeletConfigFileContent(ctx context.Context, gctx gcont
 
 	// Decode kubelet configuration from inline content
 	if kubeletConfig, err = m.kubeletConfigCodec.Decode(fci); err != nil {
-		return errors.Wrap(err, "could not decode kubelet configuration")
+		return fmt.Errorf("could not decode kubelet configuration: %w", err)
 	}
 
 	if oldFCI != nil {
 		// Decode old kubelet configuration from inline content
 		if oldKubeletConfig, err = m.kubeletConfigCodec.Decode(oldFCI); err != nil {
-			return errors.Wrap(err, "could not decode old kubelet configuration")
+			return fmt.Errorf("could not decode old kubelet configuration: %w", err)
 		}
 	}
 
@@ -324,7 +325,7 @@ func (m *mutator) ensureKubeletConfigFileContent(ctx context.Context, gctx gcont
 	// Encode kubelet configuration into inline content
 	var newFCI *extensionsv1alpha1.FileContentInline
 	if newFCI, err = m.kubeletConfigCodec.Encode(kubeletConfig, fci.Encoding); err != nil {
-		return errors.Wrap(err, "could not encode kubelet configuration")
+		return fmt.Errorf("could not encode kubelet configuration: %w", err)
 	}
 	*fci = *newFCI
 
@@ -339,13 +340,13 @@ func (m *mutator) ensureKubernetesGeneralConfiguration(ctx context.Context, gctx
 
 	// Decode kubernetes general configuration from inline content
 	if data, err = m.fciCodec.Decode(fci); err != nil {
-		return errors.Wrap(err, "could not decode kubernetes general configuration")
+		return fmt.Errorf("could not decode kubernetes general configuration: %w", err)
 	}
 
 	if oldFCI != nil {
 		// Decode kubernetes general configuration from inline content
 		if oldData, err = m.fciCodec.Decode(oldFCI); err != nil {
-			return errors.Wrap(err, "could not decode old kubernetes general configuration")
+			return fmt.Errorf("could not decode old kubernetes general configuration: %w", err)
 		}
 	}
 
@@ -358,7 +359,7 @@ func (m *mutator) ensureKubernetesGeneralConfiguration(ctx context.Context, gctx
 	// Encode kubernetes general configuration into inline content
 	var newFCI *extensionsv1alpha1.FileContentInline
 	if newFCI, err = m.fciCodec.Encode([]byte(s), fci.Encoding); err != nil {
-		return errors.Wrap(err, "could not encode kubernetes general configuration")
+		return fmt.Errorf("could not encode kubernetes general configuration: %w", err)
 	}
 	*fci = *newFCI
 
@@ -379,7 +380,7 @@ func (m *mutator) ensureKubeletCloudProviderConfig(ctx context.Context, gctx gco
 	// Encode cloud provider config into inline content
 	var fci *extensionsv1alpha1.FileContentInline
 	if fci, err = m.fciCodec.Encode([]byte(s), string(cloudinit.B64FileCodecID)); err != nil {
-		return errors.Wrap(err, "could not encode kubelet cloud provider config")
+		return fmt.Errorf("could not encode kubelet cloud provider config: %w", err)
 	}
 
 	// Ensure the cloud provider config file is part of the OperatingSystemConfig

--- a/extensions/pkg/webhook/handler.go
+++ b/extensions/pkg/webhook/handler.go
@@ -17,7 +17,6 @@ package webhook
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 
@@ -133,7 +132,7 @@ func (h *handler) Handle(ctx context.Context, req admission.Request) admission.R
 			}
 		}
 		if t == nil {
-			return admission.Errored(http.StatusBadRequest, errors.New(fmt.Sprintf("unexpected request kind %s", ar.Kind.String())))
+			return admission.Errored(http.StatusBadRequest, fmt.Errorf("unexpected request kind %s", ar.Kind.String()))
 		}
 	}
 

--- a/extensions/pkg/webhook/handler.go
+++ b/extensions/pkg/webhook/handler.go
@@ -17,11 +17,11 @@ package webhook
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -112,7 +112,7 @@ type handler struct {
 func (h *handler) InjectFunc(f inject.Func) error {
 	for _, mutator := range h.mutatorMap {
 		if err := f(mutator); err != nil {
-			return errors.Wrap(err, "could not inject into the mutator")
+			return fmt.Errorf("could not inject into the mutator: %w", err)
 		}
 	}
 	return nil
@@ -133,7 +133,7 @@ func (h *handler) Handle(ctx context.Context, req admission.Request) admission.R
 			}
 		}
 		if t == nil {
-			return admission.Errored(http.StatusBadRequest, errors.Errorf("unexpected request kind %s", ar.Kind.String()))
+			return admission.Errored(http.StatusBadRequest, errors.New(fmt.Sprintf("unexpected request kind %s", ar.Kind.String())))
 		}
 	}
 
@@ -147,7 +147,7 @@ func (h *handler) Handle(ctx context.Context, req admission.Request) admission.R
 			}
 		}
 		if mutator == nil {
-			return admission.Errored(http.StatusBadRequest, errors.Errorf("unexpected request kind %s", ar.Kind.String()))
+			return admission.Errored(http.StatusBadRequest, fmt.Errorf("unexpected request kind %s", ar.Kind.String()))
 		}
 	}
 
@@ -161,8 +161,8 @@ func handle(ctx context.Context, req admission.Request, m Mutator, t client.Obje
 	obj := t.DeepCopyObject().(client.Object)
 	_, _, err := decoder.Decode(req.Object.Raw, nil, obj)
 	if err != nil {
-		logger.Error(errors.WithStack(err), "could not decode request", "request", ar)
-		return admission.Errored(http.StatusBadRequest, fmt.Errorf("could not decode request %v: %v", ar, err))
+		logger.Error(err, "could not decode request", "request", ar)
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("could not decode request %v: %w", ar, err))
 	}
 
 	var oldObj client.Object
@@ -171,7 +171,7 @@ func handle(ctx context.Context, req admission.Request, m Mutator, t client.Obje
 	if len(req.OldObject.Raw) != 0 {
 		oldObj = t.DeepCopyObject().(client.Object)
 		if _, _, err := decoder.Decode(ar.OldObject.Raw, nil, oldObj); err != nil {
-			logger.Error(errors.WithStack(err), "could not decode old object", "object", oldObj)
+			logger.Error(err, "could not decode old object", "object", oldObj)
 			return admission.Errored(http.StatusBadRequest, fmt.Errorf("could not decode old object %v: %v", oldObj, err))
 		}
 	}
@@ -184,7 +184,7 @@ func handle(ctx context.Context, req admission.Request, m Mutator, t client.Obje
 	// Process the resource
 	newObj := obj.DeepCopyObject().(client.Object)
 	if err = m.Mutate(ctx, newObj, oldObj); err != nil {
-		logger.Error(errors.Wrap(err, "could not process"), "admission denied", "kind", ar.Kind.Kind, "namespace", obj.GetNamespace(), "name", obj.GetName())
+		logger.Error(fmt.Errorf("could not process: %w", err), "admission denied", "kind", ar.Kind.Kind, "namespace", obj.GetNamespace(), "name", obj.GetName())
 		return admission.Errored(http.StatusBadRequest, err)
 	}
 
@@ -214,7 +214,7 @@ func buildTypesMap(scheme *runtime.Scheme, types []client.Object) (map[metav1.Gr
 		// Get GVK from the type
 		gvk, err := apiutil.GVKForObject(t, scheme)
 		if err != nil {
-			return nil, errors.Wrapf(err, "could not get GroupVersionKind from object %v", t)
+			return nil, fmt.Errorf("could not get GroupVersionKind from object %v: %w", t, err)
 		}
 
 		// Add the type to the types map

--- a/extensions/pkg/webhook/handler_shootclient.go
+++ b/extensions/pkg/webhook/handler_shootclient.go
@@ -16,7 +16,6 @@ package webhook
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -134,7 +133,7 @@ func (h *handlerShootClient) Handle(ctx context.Context, req admission.Request) 
 	// Decode object
 	t, ok := h.typesMap[req.AdmissionRequest.Kind]
 	if !ok {
-		return admission.Errored(http.StatusBadRequest, errors.New(fmt.Sprintf("unexpected request kind %s", req.AdmissionRequest.Kind)))
+		return admission.Errored(http.StatusBadRequest, fmt.Errorf("unexpected request kind %s", req.AdmissionRequest.Kind))
 	}
 
 	return handle(ctx, req, mut, t, h.decoder, h.logger)

--- a/extensions/pkg/webhook/handler_shootclient.go
+++ b/extensions/pkg/webhook/handler_shootclient.go
@@ -16,12 +16,12 @@ package webhook
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
 
 	"github.com/go-logr/logr"
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -108,7 +108,7 @@ func (h *handlerShootClient) Handle(ctx context.Context, req admission.Request) 
 			v1beta1constants.LabelApp:  v1beta1constants.LabelKubernetes,
 			v1beta1constants.LabelRole: v1beta1constants.LabelAPIServer,
 		}); err != nil {
-			return errors.Wrapf(err, "error while listing all pods")
+			return fmt.Errorf("error while listing all pods: %w", err)
 		}
 
 		var shootNamespace string
@@ -125,7 +125,7 @@ func (h *handlerShootClient) Handle(ctx context.Context, req admission.Request) 
 
 		_, shootClient, err := util.NewClientForShoot(ctx, h.client, shootNamespace, client.Options{})
 		if err != nil {
-			return errors.Wrapf(err, "could not create shoot client")
+			return fmt.Errorf("could not create shoot client: %w", err)
 		}
 
 		return h.mutator.Mutate(ctx, new, old, shootClient)
@@ -134,7 +134,7 @@ func (h *handlerShootClient) Handle(ctx context.Context, req admission.Request) 
 	// Decode object
 	t, ok := h.typesMap[req.AdmissionRequest.Kind]
 	if !ok {
-		return admission.Errored(http.StatusBadRequest, errors.Errorf("unexpected request kind %s", req.AdmissionRequest.Kind))
+		return admission.Errored(http.StatusBadRequest, errors.New(fmt.Sprintf("unexpected request kind %s", req.AdmissionRequest.Kind)))
 	}
 
 	return handle(ctx, req, mut, t, h.decoder, h.logger)

--- a/extensions/pkg/webhook/registration.go
+++ b/extensions/pkg/webhook/registration.go
@@ -22,7 +22,6 @@ import (
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/utils/kubernetes"
 
-	"github.com/pkg/errors"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -114,13 +113,13 @@ func buildRule(mgr manager.Manager, t runtime.Object) (*admissionregistrationv1b
 	// Get GVK from the type
 	gvk, err := apiutil.GVKForObject(t, mgr.GetScheme())
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not get GroupVersionKind from object %v", t)
+		return nil, fmt.Errorf("could not get GroupVersionKind from object %v: %w", t, err)
 	}
 
 	// Get REST mapping from GVK
 	mapping, err := mgr.GetRESTMapper().RESTMapping(gvk.GroupKind(), gvk.Version)
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not get REST mapping from GroupVersionKind '%s'", gvk.String())
+		return nil, fmt.Errorf("could not get REST mapping from GroupVersionKind '%s': %w", gvk.String(), err)
 	}
 
 	// Create and return RuleWithOperations

--- a/extensions/pkg/webhook/validator.go
+++ b/extensions/pkg/webhook/validator.go
@@ -16,8 +16,8 @@ package webhook
 
 import (
 	"context"
+	"fmt"
 
-	"github.com/pkg/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 )
@@ -39,7 +39,7 @@ func (d *validationWrapper) Mutate(ctx context.Context, new, old client.Object) 
 // InjectFunc calls the inject.Func on the handler mutators.
 func (d *validationWrapper) InjectFunc(f inject.Func) error {
 	if err := f(d.Validator); err != nil {
-		return errors.Wrap(err, "could not inject into the validator")
+		return fmt.Errorf("could not inject into the validator: %w", err)
 	}
 	return nil
 }

--- a/extensions/test/tm/generator/helper.go
+++ b/extensions/test/tm/generator/helper.go
@@ -17,10 +17,11 @@
 package generator
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path"
 
-	"github.com/pkg/errors"
 	"sigs.k8s.io/yaml"
 )
 
@@ -28,14 +29,14 @@ import (
 func MarshalAndWriteConfig(filepath string, config interface{}) error {
 	raw, err := yaml.Marshal(config)
 	if err != nil {
-		return errors.Wrap(err, "unable to parse config")
+		return fmt.Errorf("unable to parse config: %w", err)
 	}
 
 	if err := os.MkdirAll(path.Dir(filepath), os.ModePerm); err != nil {
-		return errors.Wrapf(err, "unable to create path %s", path.Dir(filepath))
+		return fmt.Errorf("unable to create path %s: %w", path.Dir(filepath), err)
 	}
 	if err := os.WriteFile(filepath, raw, os.ModePerm); err != nil {
-		return errors.Wrapf(err, "unable to write config to %s", filepath)
+		return fmt.Errorf("unable to write config to %s: %w", filepath, err)
 	}
 
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,6 @@ require (
 	github.com/mholt/archiver v3.1.1+incompatible
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.13.0
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
 	github.com/robfig/cron v1.2.0
 	github.com/sirupsen/logrus v1.7.0

--- a/landscaper/pkg/gardenlet/controller/gardenlet_delete.go
+++ b/landscaper/pkg/gardenlet/controller/gardenlet_delete.go
@@ -64,7 +64,7 @@ func (g Landscaper) Delete(ctx context.Context) error {
 
 	applier := chart.NewGardenletChartApplier(chartApplier, values, g.chartPath)
 	if err := applier.Destroy(ctx); err != nil {
-		return fmt.Errorf("failed to delete the Gardenlet resources from the Seed cluster %q: %v", g.gardenletConfiguration.SeedConfig.Name, err)
+		return fmt.Errorf("failed to delete the Gardenlet resources from the Seed cluster %q: %w", g.gardenletConfiguration.SeedConfig.Name, err)
 	}
 
 	// delete the Seed secret containing the Seed cluster kubeconfig from the Garden cluster
@@ -95,7 +95,7 @@ func (g Landscaper) deleteSeedAndWait(ctx context.Context, seed *gardencorev1bet
 		}
 		return retry.Ok()
 	}); err != nil {
-		return fmt.Errorf("failed to delete seed %q: %v", g.gardenletConfiguration.SeedConfig.Name, err)
+		return fmt.Errorf("failed to delete seed %q: %w", g.gardenletConfiguration.SeedConfig.Name, err)
 	}
 
 	if err := retry.UntilTimeout(ctx, 10*time.Second, 10*time.Minute, func(ctx context.Context) (done bool, err error) {

--- a/pkg/apis/core/helper/helpers.go
+++ b/pkg/apis/core/helper/helpers.go
@@ -66,7 +66,7 @@ func DetermineLatestMachineImageVersions(images []core.MachineImage) (map[string
 	for _, image := range images {
 		latestMachineImageVersion, err := DetermineLatestMachineImageVersion(image.Versions, false)
 		if err != nil {
-			return nil, fmt.Errorf("failed to determine latest machine image version for image '%s': %v", image.Name, err)
+			return nil, fmt.Errorf("failed to determine latest machine image version for image '%s': %w", image.Name, err)
 		}
 		resultMapVersions[image.Name] = latestMachineImageVersion
 	}

--- a/pkg/apis/core/v1alpha1/helper/helper.go
+++ b/pkg/apis/core/v1alpha1/helper/helper.go
@@ -26,7 +26,6 @@ import (
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
 
 	"github.com/Masterminds/semver"
-	"github.com/pkg/errors"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -761,7 +760,7 @@ func WrapWithLastError(err error, lastError *gardencorev1alpha1.LastError) error
 	if err == nil || lastError == nil {
 		return err
 	}
-	return errors.Wrapf(err, "last error: %s", lastError.Description)
+	return fmt.Errorf("last error: %w: %s", err, lastError.Description)
 }
 
 // IsAPIServerExposureManaged returns true, if the Object is managed by Gardener for API server exposure.

--- a/pkg/apis/core/v1beta1/helper/errors.go
+++ b/pkg/apis/core/v1beta1/helper/errors.go
@@ -23,7 +23,6 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	utilerrors "github.com/gardener/gardener/pkg/utils/errors"
 
-	errors2 "github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -170,7 +169,7 @@ func NewWrappedLastErrors(description string, err error) *WrappedLastErrors {
 		lastErrors = append(lastErrors, *LastErrorWithTaskID(
 			partError.Error(),
 			utilerrors.GetID(partError),
-			DetermineErrorCodes(errors2.Cause(partError))...))
+			DetermineErrorCodes(errors.Unwrap(partError))...))
 	}
 
 	return &WrappedLastErrors{

--- a/pkg/apis/core/v1beta1/helper/errors.go
+++ b/pkg/apis/core/v1beta1/helper/errors.go
@@ -169,7 +169,7 @@ func NewWrappedLastErrors(description string, err error) *WrappedLastErrors {
 		lastErrors = append(lastErrors, *LastErrorWithTaskID(
 			partError.Error(),
 			utilerrors.GetID(partError),
-			DetermineErrorCodes(errors.Unwrap(partError))...))
+			DetermineErrorCodes(utilerrors.Unwrap(partError))...))
 	}
 
 	return &WrappedLastErrors{

--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -25,7 +25,6 @@ import (
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
 
 	"github.com/Masterminds/semver"
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -965,7 +964,7 @@ func WrapWithLastError(err error, lastError *gardencorev1beta1.LastError) error 
 	if err == nil || lastError == nil {
 		return err
 	}
-	return errors.Wrapf(err, "last error: %s", lastError.Description)
+	return fmt.Errorf("last error: %w: %s", err, lastError.Description)
 }
 
 // IsAPIServerExposureManaged returns true, if the Object is managed by Gardener for API server exposure.

--- a/pkg/chartrenderer/default.go
+++ b/pkg/chartrenderer/default.go
@@ -52,7 +52,7 @@ func NewForConfig(cfg *rest.Config) (Interface, error) {
 
 	sv, err := disc.ServerVersion()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get kubernetes server version %v", err)
+		return nil, fmt.Errorf("failed to get kubernetes server version %w", err)
 	}
 
 	return NewWithServerVersion(sv), nil
@@ -71,7 +71,7 @@ func NewWithServerVersion(serverVersion *version.Info) Interface {
 func DiscoverCapabilities(disc discovery.DiscoveryInterface) (*chartutil.Capabilities, error) {
 	sv, err := disc.ServerVersion()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get kubernetes server version %v", err)
+		return nil, fmt.Errorf("failed to get kubernetes server version %w", err)
 	}
 
 	return &chartutil.Capabilities{KubeVersion: sv}, nil

--- a/pkg/client/kubernetes/pods.go
+++ b/pkg/client/kubernetes/pods.go
@@ -74,7 +74,7 @@ func (p *podExecutor) Execute(namespace, name, containerName, command, commandAr
 
 	executor, err := remotecommand.NewSPDYExecutor(p.config, http.MethodPost, request.URL())
 	if err != nil {
-		return nil, fmt.Errorf("failed to initialized the command exector: %v", err)
+		return nil, fmt.Errorf("failed to initialized the command exector: %w", err)
 	}
 
 	err = executor.Stream(remotecommand.StreamOptions{
@@ -120,7 +120,7 @@ func (c *clientSet) ForwardPodPort(namespace, name string, local, remote int) (c
 func (c *clientSet) CheckForwardPodPort(namespace, name string, local, remote int) error {
 	fw, stopChan, err := c.setupForwardPodPort(namespace, name, local, remote)
 	if err != nil {
-		return fmt.Errorf("could not setup pod port forwarding: %v", err)
+		return fmt.Errorf("could not setup pod port forwarding: %w", err)
 	}
 
 	errChan := make(chan error)
@@ -131,7 +131,7 @@ func (c *clientSet) CheckForwardPodPort(namespace, name string, local, remote in
 
 	select {
 	case err = <-errChan:
-		return fmt.Errorf("error forwarding ports: %v", err)
+		return fmt.Errorf("error forwarding ports: %w", err)
 	case <-fw.Ready:
 		return nil
 	case <-time.After(time.Second * 5):

--- a/pkg/controllermanager/controller/bastion/bastion_control.go
+++ b/pkg/controllermanager/controller/bastion/bastion_control.go
@@ -144,7 +144,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 			return reconcile.Result{}, client.IgnoreNotFound(r.gardenClient.Delete(ctx, bastion))
 		}
 
-		return reconcile.Result{}, fmt.Errorf("could not get shoot %v: %v", shootKey, err)
+		return reconcile.Result{}, fmt.Errorf("could not get shoot %v: %w", shootKey, err)
 	}
 
 	// delete the bastion if the shoot is marked for deletion

--- a/pkg/controllermanager/controller/certificatesigningrequest/csr_autoapprove_control.go
+++ b/pkg/controllermanager/controller/certificatesigningrequest/csr_autoapprove_control.go
@@ -91,7 +91,7 @@ func (r *csrReconciler) Reconcile(ctx context.Context, request reconcile.Request
 
 	x509cr, err := utils.DecodeCertificateRequest(csr.Spec.Request)
 	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("unable to parse csr %q: %v", csr.Name, err)
+		return reconcile.Result{}, fmt.Errorf("unable to parse csr %q: %w", csr.Name, err)
 	}
 
 	if !gutil.IsSeedClientCert(x509cr, csr.Spec.Usages) {

--- a/pkg/controllermanager/controller/controllerregistration/controllerregistration_seed_control.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerregistration_seed_control.go
@@ -424,7 +424,7 @@ func deployNeededInstallations(
 			controllerDeployment = &gardencorev1beta1.ControllerDeployment{}
 
 			if err := c.Get(ctx, kutil.Key(controllerRegistration.Spec.Deployment.DeploymentRefs[0].Name), controllerDeployment); err != nil {
-				return fmt.Errorf("cannot deploy ControllerInstallation because the referenced ControllerDeployment cannot be retrieved: %v", err)
+				return fmt.Errorf("cannot deploy ControllerInstallation because the referenced ControllerDeployment cannot be retrieved: %w", err)
 			}
 		}
 
@@ -559,7 +559,7 @@ func seedSelectorMatches(deployment *gardencorev1beta1.ControllerRegistrationDep
 
 	seedSelector, err := metav1.LabelSelectorAsSelector(selector)
 	if err != nil {
-		return false, fmt.Errorf("label selector conversion failed: %v for seedSelector: %v", *selector, err)
+		return false, fmt.Errorf("label selector conversion failed: %v for seedSelector: %w", *selector, err)
 	}
 
 	return seedSelector.Matches(labels.Set(seedLabels)), nil

--- a/pkg/gardenlet/bootstrap/bootstrap.go
+++ b/pkg/gardenlet/bootstrap/bootstrap.go
@@ -50,14 +50,14 @@ func RequestBootstrapKubeconfig(ctx context.Context, logger logrus.FieldLogger, 
 
 	certData, privateKeyData, csrName, err := certificate.RequestCertificate(ctx, logger, boostrapClientSet.Kubernetes(), certificateSubject, []string{}, []net.IP{})
 	if err != nil {
-		return nil, "", "", fmt.Errorf("unable to bootstrap the kubeconfig for the Garden cluster: %v", err)
+		return nil, "", "", fmt.Errorf("unable to bootstrap the kubeconfig for the Garden cluster: %w", err)
 	}
 
 	logger.Infof("Storing kubeconfig with bootstrapped certificate into secret (%s/%s) on target cluster '%s'", gardenClientConnection.KubeconfigSecret.Namespace, gardenClientConnection.KubeconfigSecret.Name, bootstrapTargetCluster)
 
 	kubeconfig, err := bootstraputil.UpdateGardenKubeconfigSecret(ctx, boostrapClientSet.RESTConfig(), certData, privateKeyData, seedClient, gardenClientConnection)
 	if err != nil {
-		return nil, "", "", fmt.Errorf("unable to update secret (%s/%s) with bootstrapped kubeconfig: %v", gardenClientConnection.KubeconfigSecret.Namespace, gardenClientConnection.KubeconfigSecret.Name, err)
+		return nil, "", "", fmt.Errorf("unable to update secret (%s/%s) with bootstrapped kubeconfig: %w", gardenClientConnection.KubeconfigSecret.Namespace, gardenClientConnection.KubeconfigSecret.Name, err)
 	}
 
 	logger.Infof("Deleting secret (%s/%s) containing the bootstrap kubeconfig from target cluster '%s')", gardenClientConnection.BootstrapKubeconfig.Namespace, gardenClientConnection.BootstrapKubeconfig.Name, bootstrapTargetCluster)

--- a/pkg/gardenlet/bootstrap/certificate/certificate.go
+++ b/pkg/gardenlet/bootstrap/certificate/certificate.go
@@ -48,7 +48,7 @@ func RequestCertificate(ctx context.Context, logger logrus.FieldLogger, client k
 
 	privateKeyData, err := keyutil.MakeEllipticPrivateKeyPEM()
 	if err != nil {
-		return nil, nil, "", fmt.Errorf("error generating client certificate private key: %v", err)
+		return nil, nil, "", fmt.Errorf("error generating client certificate private key: %w", err)
 	}
 
 	certData, csrName, err := requestCertificate(ctx, logger, client, privateKeyData, certificateSubject, dnsSANs, ipSANs)
@@ -70,11 +70,11 @@ var DigestedName = bootstraputil.DigestedName
 func requestCertificate(ctx context.Context, logger logrus.FieldLogger, client kubernetesclientset.Interface, privateKeyData []byte, certificateSubject *pkix.Name, dnsSANs []string, ipSANs []net.IP) (certData []byte, csrName string, err error) {
 	privateKey, err := keyutil.ParsePrivateKeyPEM(privateKeyData)
 	if err != nil {
-		return nil, "", fmt.Errorf("invalid private key for certificate request: %v", err)
+		return nil, "", fmt.Errorf("invalid private key for certificate request: %w", err)
 	}
 	csrData, err := certutil.MakeCSR(privateKey, certificateSubject, dnsSANs, ipSANs)
 	if err != nil {
-		return nil, "", fmt.Errorf("unable to generate certificate request: %v", err)
+		return nil, "", fmt.Errorf("unable to generate certificate request: %w", err)
 	}
 
 	usages := []certificatesv1.KeyUsage{

--- a/pkg/gardenlet/bootstrap/certificate/certificate_rotation.go
+++ b/pkg/gardenlet/bootstrap/certificate/certificate_rotation.go
@@ -188,7 +188,7 @@ func getCurrentCertificate(ctx context.Context, logger logrus.FieldLogger, seedC
 
 	cert, err := tls.X509KeyPair(restConfig.CertData, restConfig.KeyData)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse X509 certificate from kubeconfig in secret %s/%s on the target cluster: %v", secretNamespace, secretName, err)
+		return nil, fmt.Errorf("failed to parse X509 certificate from kubeconfig in secret %s/%s on the target cluster: %w", secretNamespace, secretName, err)
 	}
 
 	if len(cert.Certificate) < 1 {
@@ -197,7 +197,7 @@ func getCurrentCertificate(ctx context.Context, logger logrus.FieldLogger, seedC
 
 	certs, err := x509.ParseCertificates(cert.Certificate[0])
 	if err != nil {
-		return nil, fmt.Errorf("the X509 certificate from kubeconfig in secret %s/%s on the target cluster cannot be parsed: %v", secretNamespace, secretName, err)
+		return nil, fmt.Errorf("the X509 certificate from kubeconfig in secret %s/%s on the target cluster cannot be parsed: %w", secretNamespace, secretName, err)
 	}
 
 	if len(certs) < 1 {
@@ -227,7 +227,7 @@ func rotateCertificate(ctx context.Context, logger logrus.FieldLogger, clientMap
 
 	_, err = bootstraputil.UpdateGardenKubeconfigSecret(ctx, gardenClient.RESTConfig(), certData, privateKeyData, seedClient, gardenClientConnection)
 	if err != nil {
-		return fmt.Errorf("unable to update secret (%s/%s) on the target cluster during certificate rotation: %v", gardenClientConnection.KubeconfigSecret.Namespace, gardenClientConnection.KubeconfigSecret.Name, err)
+		return fmt.Errorf("unable to update secret (%s/%s) on the target cluster during certificate rotation: %w", gardenClientConnection.KubeconfigSecret.Namespace, gardenClientConnection.KubeconfigSecret.Name, err)
 	}
 
 	return nil

--- a/pkg/gardenlet/controller/backupentry/backup_entry_actuator.go
+++ b/pkg/gardenlet/controller/backupentry/backup_entry_actuator.go
@@ -32,7 +32,6 @@ import (
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -269,7 +268,7 @@ func (a *actuator) deployBackupEntryExtensionSecret(ctx context.Context) error {
 
 	coreSecret, err := kutil.GetSecretByReference(ctx, a.gardenClient.Client(), coreSecretRef)
 	if err != nil {
-		return errors.Wrapf(err, "could not get secret referred in core backup bucket")
+		return fmt.Errorf("could not get secret referred in core backup bucket: %w", err)
 	}
 
 	// create secret for extension BackupEntry in seed
@@ -278,7 +277,7 @@ func (a *actuator) deployBackupEntryExtensionSecret(ctx context.Context) error {
 		extensionSecret.Data = coreSecret.DeepCopy().Data
 		return nil
 	}); err != nil {
-		return errors.Wrapf(err, "could not reconcile extension secret in seed")
+		return fmt.Errorf("could not reconcile extension secret in seed: %w", err)
 	}
 
 	return nil

--- a/pkg/gardenlet/controller/bastion/bastion_reconciler.go
+++ b/pkg/gardenlet/controller/bastion/bastion_reconciler.go
@@ -103,7 +103,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	shoot := gardencorev1beta1.Shoot{}
 	shootKey := kutil.Key(bastion.Namespace, bastion.Spec.ShootRef.Name)
 	if err := gardenClient.Client().Get(ctx, shootKey, &shoot); err != nil {
-		return reconcile.Result{}, fmt.Errorf("could not get shoot %v: %v", shootKey, err)
+		return reconcile.Result{}, fmt.Errorf("could not get shoot %v: %w", shootKey, err)
 	}
 
 	if bastion.DeletionTimestamp != nil {
@@ -132,7 +132,7 @@ func (r *reconciler) reconcileBastion(
 	// ensure finalizer is set
 	if !controllerutil.ContainsFinalizer(bastion, finalizerName) {
 		if err := controllerutils.PatchAddFinalizers(ctx, gardenClient, bastion, finalizerName); err != nil {
-			return fmt.Errorf("failed ensure %q finalizer on bastion: %v", finalizerName, err)
+			return fmt.Errorf("failed ensure %q finalizer on bastion: %w", finalizerName, err)
 		}
 		// the patch above already triggers a reconcile, so we can stop here
 		return nil
@@ -162,7 +162,7 @@ func (r *reconciler) reconcileBastion(
 			logger.Errorf("failed patching ready condition of Bastion: %v", patchErr)
 		}
 
-		return fmt.Errorf("failed to ensure bastion extension resource: %v", err)
+		return fmt.Errorf("failed to ensure bastion extension resource: %w", err)
 	}
 
 	// wait for the extension controller to reconcile possible changes
@@ -181,7 +181,7 @@ func (r *reconciler) reconcileBastion(
 			logger.Errorf("failed patching ready condition of Bastion: %v", patchErr)
 		}
 
-		return fmt.Errorf("failed wait for bastion extension resource to be reconciled: %v", err)
+		return fmt.Errorf("failed wait for bastion extension resource to be reconciled: %w", err)
 	}
 
 	// copy over the extension's status to the garden and set the condition
@@ -191,7 +191,7 @@ func (r *reconciler) reconcileBastion(
 	bastion.Status.ObservedGeneration = &bastion.Generation
 
 	if err := gardenClient.Status().Patch(ctx, bastion, patch); err != nil {
-		return fmt.Errorf("failed patching ready condition of Bastion: %v", err)
+		return fmt.Errorf("failed patching ready condition of Bastion: %w", err)
 	}
 	return nil
 }
@@ -220,7 +220,7 @@ func (r *reconciler) cleanupBastion(
 
 	err := seedClient.Delete(ctx, extBastion)
 	if client.IgnoreNotFound(err) != nil {
-		return fmt.Errorf("failed to delete bastion extension resource: %v", err)
+		return fmt.Errorf("failed to delete bastion extension resource: %w", err)
 	}
 
 	// cleanup completed in seed cluster

--- a/pkg/gardenlet/controller/federatedseed/networkpolicy/helper/helper.go
+++ b/pkg/gardenlet/controller/federatedseed/networkpolicy/helper/helper.go
@@ -84,7 +84,7 @@ func EnsureNetworkPolicy(ctx context.Context, seedClient client.Client, namespac
 		MutatePolicy(&policy, egressRules)
 		return nil
 	}); err != nil {
-		return fmt.Errorf("failed to create / update NetworkPolicy %q in namespace %q: %v", AllowToSeedAPIServer, namespace, err)
+		return fmt.Errorf("failed to create / update NetworkPolicy %q in namespace %q: %w", AllowToSeedAPIServer, namespace, err)
 	}
 	return nil
 }

--- a/pkg/gardenlet/controller/federatedseed/networkpolicy/namespace_control.go
+++ b/pkg/gardenlet/controller/federatedseed/networkpolicy/namespace_control.go
@@ -84,7 +84,7 @@ func (r *namespaceReconciler) Reconcile(ctx context.Context, request reconcile.R
 		}
 		err := r.seedClient.Delete(ctx, policy)
 		if client.IgnoreNotFound(err) != nil {
-			return reconcile.Result{}, fmt.Errorf("unable to delete NetworkPolicy %q from namespace %q: %v", policy.Name, namespace.Name, err)
+			return reconcile.Result{}, fmt.Errorf("unable to delete NetworkPolicy %q from namespace %q: %w", policy.Name, namespace.Name, err)
 		} else if err == nil {
 			r.log.Infof("Deleting NetworkPolicy %q from namespace %q", policy.Name, namespace.Name)
 		}

--- a/pkg/gardenlet/controller/seed/seed_lease_control.go
+++ b/pkg/gardenlet/controller/seed/seed_lease_control.go
@@ -72,7 +72,7 @@ func (c *Controller) reconcileSeedLeaseKey(key string) error {
 
 	if err := c.checkSeedConnection(ctx, seed); err != nil {
 		c.healthManager.Set(false)
-		return fmt.Errorf("[SEED LEASE] cannot establish connection with Seed %s: %v", key, err)
+		return fmt.Errorf("[SEED LEASE] cannot establish connection with Seed %s: %w", key, err)
 	}
 
 	var (

--- a/pkg/gardenlet/controller/shoot/shoot_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control.go
@@ -130,7 +130,7 @@ func (c *Controller) checkSeedAndSyncClusterResource(ctx context.Context, shoot 
 
 	seed, err := c.seedLister.Get(*seedName)
 	if err != nil {
-		return fmt.Errorf("could not find seed %s: %v", *seedName, err)
+		return fmt.Errorf("could not find seed %s: %w", *seedName, err)
 	}
 
 	// Don't wait for the Seed to be ready if it is already marked for deletion. In this case
@@ -138,12 +138,12 @@ func (c *Controller) checkSeedAndSyncClusterResource(ctx context.Context, shoot 
 	// Don't block the Shoot deletion flow in this case to allow proper cleanup.
 	if seed.DeletionTimestamp == nil {
 		if err := health.CheckSeed(seed, c.identity); err != nil {
-			return fmt.Errorf("seed is not yet ready: %v", err)
+			return fmt.Errorf("seed is not yet ready: %w", err)
 		}
 	}
 
 	if err := c.syncClusterResourceToSeed(ctx, shoot, project, cloudProfile, seed); err != nil {
-		return fmt.Errorf("could not sync cluster resource to seed: %v", err)
+		return fmt.Errorf("could not sync cluster resource to seed: %w", err)
 	}
 
 	return nil
@@ -214,12 +214,12 @@ func (c *Controller) reconcileShootRequest(ctx context.Context, req reconcile.Re
 		c.shootReconciliationDueTracker.off(key)
 
 		if err := c.isSeedReadyForMigration(seed); err != nil {
-			return reconcile.Result{}, fmt.Errorf("target Seed is not available to host the Control Plane of Shoot %s: %v", shoot.GetName(), err)
+			return reconcile.Result{}, fmt.Errorf("target Seed is not available to host the Control Plane of Shoot %s: %w", shoot.GetName(), err)
 		}
 
 		hasBastions, err := c.shootHasBastions(ctx, shoot, gardenClient)
 		if err != nil {
-			return reconcile.Result{}, fmt.Errorf("failed to check for related Bastions: %v", err)
+			return reconcile.Result{}, fmt.Errorf("failed to check for related Bastions: %w", err)
 		}
 		if hasBastions {
 			return reconcile.Result{}, errors.New("Shoot has still Bastions")
@@ -328,7 +328,7 @@ func (c *Controller) deleteShoot(ctx context.Context, logger *logrus.Entry, gard
 
 	hasBastions, err := c.shootHasBastions(ctx, shoot, gardenClient)
 	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to check for related Bastions: %v", err)
+		return reconcile.Result{}, fmt.Errorf("failed to check for related Bastions: %w", err)
 	}
 	if hasBastions {
 		return reconcile.Result{}, errors.New("Shoot has still Bastions")
@@ -407,7 +407,7 @@ func (c *Controller) shootHasBastions(ctx context.Context, shoot *gardencorev1be
 	listOptions := client.ListOptions{Namespace: shoot.Namespace, Limit: 1}
 
 	if err := gardenClient.Client().List(ctx, &bastionList, &listOptions); err != nil {
-		return false, fmt.Errorf("failed to list related Bastions: %v", err)
+		return false, fmt.Errorf("failed to list related Bastions: %w", err)
 	}
 
 	return len(bastionList.Items) > 0, nil
@@ -651,7 +651,7 @@ func (c *Controller) patchShootStatusOperationSuccess(
 	if len(shootSeedNamespace) > 0 {
 		isHibernated, err = c.isHibernationActive(ctx, shootSeedNamespace, seedName)
 		if err != nil {
-			return fmt.Errorf("error updating Shoot (%s/%s) after successful reconciliation when checking for active hibernation: %v", shoot.Namespace, shoot.Name, err)
+			return fmt.Errorf("error updating Shoot (%s/%s) after successful reconciliation when checking for active hibernation: %w", shoot.Namespace, shoot.Name, err)
 		}
 	}
 
@@ -783,7 +783,7 @@ func (c *Controller) isHibernationActive(ctx context.Context, shootSeedNamespace
 
 	shoot := cluster.Shoot
 	if shoot == nil {
-		return false, fmt.Errorf("shoot is missing in cluster resource: %v", err)
+		return false, fmt.Errorf("shoot is missing in cluster resource: %w", err)
 	}
 
 	return v1beta1helper.HibernationIsEnabled(shoot), nil

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/configcodec.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/configcodec.go
@@ -15,10 +15,11 @@
 package kubelet
 
 import (
+	"fmt"
+
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	oscutils "github.com/gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig/utils"
 
-	"github.com/pkg/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -67,12 +68,12 @@ func (c *configCodec) Encode(kubeletConfig *kubeletconfigv1beta1.KubeletConfigur
 	// Encode kubelet configuration to YAML
 	data, err := runtime.Encode(c.codec, kubeletConfig)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not encode kubelet configuration to YAML")
+		return nil, fmt.Errorf("could not encode kubelet configuration to YAML: %w", err)
 	}
 
 	fci, err := c.fciCodec.Encode(data, encoding)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not encode kubelet config file content data")
+		return nil, fmt.Errorf("could not encode kubelet config file content data: %w", err)
 	}
 
 	return fci, nil
@@ -82,13 +83,13 @@ func (c *configCodec) Encode(kubeletConfig *kubeletconfigv1beta1.KubeletConfigur
 func (c *configCodec) Decode(fci *extensionsv1alpha1.FileContentInline) (*kubeletconfigv1beta1.KubeletConfiguration, error) {
 	data, err := c.fciCodec.Decode(fci)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not decode kubelet config file content data")
+		return nil, fmt.Errorf("could not decode kubelet config file content data: %w", err)
 	}
 
 	// Decode kubelet configuration from YAML
 	kubeletConfig := &kubeletconfigv1beta1.KubeletConfiguration{}
 	if err := runtime.DecodeInto(c.codec, data, kubeletConfig); err != nil {
-		return nil, errors.Wrap(err, "could not decode kubelet configuration from YAML")
+		return nil, fmt.Errorf("could not decode kubelet configuration from YAML: %w", err)
 	}
 
 	return kubeletConfig, nil

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/utils/filecontentinlinecodec.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/utils/filecontentinlinecodec.go
@@ -15,10 +15,10 @@
 package utils
 
 import (
+	"fmt"
+
 	"github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig/oscommon/cloudinit"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-
-	"github.com/pkg/errors"
 )
 
 // FileContentInlineCodec contains methods for encoding and decoding byte slices
@@ -48,7 +48,7 @@ func (c *fileContentInlineCodec) Encode(data []byte, encoding string) (*extensio
 	// Encode data using the file codec, if needed
 	if fileCodec != nil {
 		if data, err = fileCodec.Encode(data); err != nil {
-			return nil, errors.Wrap(err, "could not encode data using file codec")
+			return nil, fmt.Errorf("could not encode data using file codec: %w", err)
 		}
 	}
 
@@ -71,7 +71,7 @@ func (c *fileContentInlineCodec) Decode(fci *extensionsv1alpha1.FileContentInlin
 	// Decode data using the file codec, if needed
 	if fileCodec != nil {
 		if data, err = fileCodec.Decode(data); err != nil {
-			return nil, errors.Wrap(err, "could not decode data using file codec")
+			return nil, fmt.Errorf("could not decode data using file codec: %w", err)
 		}
 	}
 
@@ -84,7 +84,7 @@ func getFileCodec(encoding string) (cloudinit.FileCodec, error) {
 	}
 	fileCodecID, err := cloudinit.ParseFileCodecID(encoding)
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not parse file codec ID '%s'", encoding)
+		return nil, fmt.Errorf("could not parse file codec ID '%s': %w", encoding, err)
 	}
 	return cloudinit.FileCodecForID(fileCodecID), nil
 }

--- a/pkg/operation/botanist/component/gardenerkubescheduler/gardener_kube_scheduler.go
+++ b/pkg/operation/botanist/component/gardenerkubescheduler/gardener_kube_scheduler.go
@@ -16,10 +16,10 @@ package gardenerkubescheduler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
-	"github.com/pkg/errors"
 	admissionv1 "k8s.io/api/admission/v1"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
@@ -112,7 +112,7 @@ func (k *kubeScheduler) Deploy(ctx context.Context) error {
 
 	componentConfigYAML, componentConfigChecksum, err := k.config.Config()
 	if err != nil {
-		return errors.Wrap(err, "generate component config failed")
+		return fmt.Errorf("generate component config failed: %w", err)
 	}
 
 	if k.image == nil || len(k.image.String()) == 0 {
@@ -362,7 +362,7 @@ func (k *kubeScheduler) Deploy(ctx context.Context) error {
 		namespace.Labels = utils.MergeStringMaps(namespace.Labels, getLabels())
 		return nil
 	}); err != nil {
-		return errors.Wrap(err, "update of Namespace failed")
+		return fmt.Errorf("update of Namespace failed: %w", err)
 	}
 
 	resources, err := registry.AddAllAndSerialize(

--- a/pkg/operation/botanist/component/gardenerkubescheduler/gardener_kube_scheduler_bootstrap.go
+++ b/pkg/operation/botanist/component/gardenerkubescheduler/gardener_kube_scheduler_bootstrap.go
@@ -15,6 +15,8 @@
 package gardenerkubescheduler
 
 import (
+	"errors"
+
 	"github.com/gardener/gardener/pkg/features"
 	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
@@ -30,7 +32,6 @@ import (
 	schedulerconfigv20v1beta1 "github.com/gardener/gardener/third_party/kube-scheduler/v20/v1beta1"
 
 	"github.com/Masterminds/semver"
-	"github.com/pkg/errors"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/operation/botanist/component/kubecontrollermanager/waiter.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/waiter.go
@@ -43,7 +43,7 @@ func (k *kubeControllerManager) WaitForControllerToBeActive(ctx context.Context)
 	// Check whether the kube-controller-manager deployment exists
 	if err := k.seedClient.Get(ctx, kutil.Key(k.namespace, v1beta1constants.DeploymentNameKubeControllerManager), &appsv1.Deployment{}); err != nil {
 		if apierrors.IsNotFound(err) {
-			return fmt.Errorf("kube controller manager deployment not found: %v", err)
+			return fmt.Errorf("kube controller manager deployment not found: %w", err)
 		}
 		return err
 	}

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -625,7 +625,7 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 				// kube-apiserver in case the end-user deleted the configmap before/simultaneously to the shoot
 				// deletion.
 				if !apierrors.IsNotFound(err) || b.Shoot.Info.DeletionTimestamp == nil {
-					return fmt.Errorf("retrieving audit policy from the ConfigMap '%v' failed with reason '%v'", apiServerConfig.AuditConfig.AuditPolicy.ConfigMapRef.Name, err)
+					return fmt.Errorf("retrieving audit policy from the ConfigMap '%v' failed with reason '%w'", apiServerConfig.AuditConfig.AuditPolicy.ConfigMapRef.Name, err)
 				}
 			} else {
 				defaultValues["auditConfig"] = map[string]interface{}{

--- a/pkg/operation/botanist/extension.go
+++ b/pkg/operation/botanist/extension.go
@@ -35,7 +35,7 @@ func (b *Botanist) DefaultExtension(ctx context.Context) (extension.Interface, e
 
 	extensions, err := mergeExtensions(controllerRegistrations.Items, b.Shoot.Info.Spec.Extensions, b.Shoot.SeedNamespace)
 	if err != nil {
-		return nil, fmt.Errorf("cannot calculate required extensions for shoot %s: %v", b.Shoot.Info.Name, err)
+		return nil, fmt.Errorf("cannot calculate required extensions for shoot %s: %w", b.Shoot.Info.Name, err)
 	}
 
 	return extension.New(

--- a/pkg/operation/botanist/managedresources.go
+++ b/pkg/operation/botanist/managedresources.go
@@ -73,7 +73,7 @@ func (b *Botanist) waitUntilManagedResourceAreDeleted(ctx context.Context, listO
 func (b *Botanist) KeepObjectsForAllManagedResources(ctx context.Context) error {
 	managedResources := &resourcesv1alpha1.ManagedResourceList{}
 	if err := b.K8sSeedClient.Client().List(ctx, managedResources, client.InNamespace(b.Shoot.SeedNamespace)); err != nil {
-		return fmt.Errorf("failed to list all managed resource, %v", err)
+		return fmt.Errorf("failed to list all managed resource, %w", err)
 	}
 
 	for _, resource := range managedResources.Items {

--- a/pkg/operation/botanist/networkpolicies.go
+++ b/pkg/operation/botanist/networkpolicies.go
@@ -66,7 +66,7 @@ func (b *Botanist) DefaultNetworkPolicies(sniPhase component.Phase) (component.D
 	}
 	seedDNSServerAddress, err := common.ComputeOffsetIP(seedServiceCIDR, 10)
 	if err != nil {
-		return nil, fmt.Errorf("cannot calculate CoreDNS ClusterIP: %v", err)
+		return nil, fmt.Errorf("cannot calculate CoreDNS ClusterIP: %w", err)
 	}
 
 	return NewNetworkPoliciesDeployer(

--- a/pkg/operation/botanist/waiter.go
+++ b/pkg/operation/botanist/waiter.go
@@ -27,7 +27,6 @@ import (
 	"github.com/gardener/gardener/pkg/utils/retry"
 
 	"github.com/Masterminds/semver"
-	errorspkg "github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -128,7 +127,7 @@ func (b *Botanist) WaitUntilKubeAPIServerReady(ctx context.Context) error {
 
 		newestPod, err2 := kutil.NewestPodForDeployment(ctx, b.K8sSeedClient.APIReader(), deployment)
 		if err2 != nil {
-			return errorspkg.Wrapf(err, "failure to find the newest pod for deployment to read the logs: %s", err2.Error())
+			return fmt.Errorf("failure to find the newest pod for deployment to read the logs: %s: %w", err2.Error(), err)
 		}
 		if newestPod == nil {
 			return err
@@ -140,7 +139,7 @@ func (b *Botanist) WaitUntilKubeAPIServerReady(ctx context.Context) error {
 
 		logs, err2 := kutil.MostRecentCompleteLogs(ctx, b.K8sSeedClient.Kubernetes().CoreV1().Pods(newestPod.Namespace), newestPod, "kube-apiserver", tailLines, headBytes)
 		if err2 != nil {
-			return errorspkg.Wrapf(err, "failure to read the logs: %s", err2.Error())
+			return fmt.Errorf("failure to read the logs: %s: %w", err2.Error(), err)
 		}
 
 		errWithLogs := fmt.Errorf("%s, logs of newest pod:\n%s", err.Error(), logs)

--- a/pkg/operation/botanist/worker.go
+++ b/pkg/operation/botanist/worker.go
@@ -29,7 +29,6 @@ import (
 	"github.com/gardener/gardener/pkg/utils/secrets"
 
 	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -147,7 +146,7 @@ func (b *Botanist) WaitUntilCloudConfigUpdatedForAllWorkerPools(ctx context.Cont
 	defer cancel()
 
 	if err := managedresources.WaitUntilHealthy(timeoutCtx, b.K8sSeedClient.Client(), b.Shoot.SeedNamespace, CloudConfigExecutionManagedResourceName); err != nil {
-		return errors.Wrapf(err, "the cloud-config user data scripts for the worker nodes were not populated yet")
+		return fmt.Errorf("the cloud-config user data scripts for the worker nodes were not populated yet: %w", err)
 	}
 
 	timeoutCtx2, cancel2 := context.WithTimeout(ctx, TimeoutWaitCloudConfigUpdated)

--- a/pkg/operation/etcdencryption/encryptionconfiguration.go
+++ b/pkg/operation/etcdencryption/encryptionconfiguration.go
@@ -103,7 +103,7 @@ func NewEncryptionKeyName(t time.Time) string {
 func NewEncryptionKeySecret(r io.Reader) (string, error) {
 	buf := make([]byte, common.EtcdEncryptionKeySecretLen)
 	if _, err := io.ReadFull(r, buf); err != nil {
-		return "", fmt.Errorf("could not read enough data: %v", err)
+		return "", fmt.Errorf("could not read enough data: %w", err)
 	}
 
 	sEnc := base64.StdEncoding.EncodeToString(buf)

--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -502,22 +502,22 @@ func ToNetworks(s *gardencorev1beta1.Shoot) (*Networks, error) {
 
 	_, svc, err := net.ParseCIDR(*s.Spec.Networking.Services)
 	if err != nil {
-		return nil, fmt.Errorf("cannot parse shoot's network cidr %v", err)
+		return nil, fmt.Errorf("cannot parse shoot's network cidr %w", err)
 	}
 
 	_, pods, err := net.ParseCIDR(*s.Spec.Networking.Pods)
 	if err != nil {
-		return nil, fmt.Errorf("cannot parse shoot's network cidr %v", err)
+		return nil, fmt.Errorf("cannot parse shoot's network cidr %w", err)
 	}
 
 	apiserver, err := common.ComputeOffsetIP(svc, 1)
 	if err != nil {
-		return nil, fmt.Errorf("cannot calculate default/kubernetes ClusterIP: %v", err)
+		return nil, fmt.Errorf("cannot calculate default/kubernetes ClusterIP: %w", err)
 	}
 
 	coreDNS, err := common.ComputeOffsetIP(svc, 10)
 	if err != nil {
-		return nil, fmt.Errorf("cannot calculate CoreDNS ClusterIP: %v", err)
+		return nil, fmt.Errorf("cannot calculate CoreDNS ClusterIP: %w", err)
 	}
 
 	return &Networks{

--- a/pkg/scheduler/controller/shoot/scheduler_control.go
+++ b/pkg/scheduler/controller/shoot/scheduler_control.go
@@ -217,7 +217,7 @@ func filterSeedsMatchingLabelSelector(seedList []gardencorev1beta1.Seed, seedSel
 	}
 	selector, err := metav1.LabelSelectorAsSelector(&seedSelector.LabelSelector)
 	if err != nil {
-		return nil, fmt.Errorf("label selector conversion failed: %v for seedSelector: %v", seedSelector.LabelSelector, err)
+		return nil, fmt.Errorf("label selector conversion failed: %v for seedSelector: %w", seedSelector.LabelSelector, err)
 	}
 
 	var matchingSeeds []gardencorev1beta1.Seed

--- a/pkg/utils/errors/errors_test.go
+++ b/pkg/utils/errors/errors_test.go
@@ -15,6 +15,7 @@
 package errors_test
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -25,7 +26,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/pkg/errors"
 )
 
 func TestErrors(t *testing.T) {
@@ -54,7 +54,7 @@ var _ = Describe("Errors", func() {
 		It("should return an error with cause and suppressed equal to the given errors", func() {
 			err := utilerrors.WithSuppressed(err1, err2)
 
-			Expect(errors.Cause(err)).To(BeIdenticalTo(err1))
+			Expect(errors.Unwrap(err)).To(BeIdenticalTo(err1))
 			Expect(utilerrors.Suppressed(err)).To(BeIdenticalTo(err2))
 		})
 	})
@@ -166,7 +166,7 @@ var _ = Describe("Errors", func() {
 				}),
 			)
 
-			Expect(utilerrors.WasCanceled(errors.Cause(err))).To(BeTrue())
+			Expect(utilerrors.WasCanceled(errors.Unwrap(err))).To(BeTrue())
 		})
 
 		It("Should stop execution on error", func() {

--- a/pkg/utils/errors/errors_test.go
+++ b/pkg/utils/errors/errors_test.go
@@ -15,7 +15,6 @@
 package errors_test
 
 import (
-	"errors"
 	"fmt"
 	"testing"
 
@@ -54,7 +53,7 @@ var _ = Describe("Errors", func() {
 		It("should return an error with cause and suppressed equal to the given errors", func() {
 			err := utilerrors.WithSuppressed(err1, err2)
 
-			Expect(errors.Unwrap(err)).To(BeIdenticalTo(err1))
+			Expect(utilerrors.Unwrap(err)).To(BeIdenticalTo(err1))
 			Expect(utilerrors.Suppressed(err)).To(BeIdenticalTo(err2))
 		})
 	})
@@ -166,7 +165,7 @@ var _ = Describe("Errors", func() {
 				}),
 			)
 
-			Expect(utilerrors.WasCanceled(errors.Unwrap(err))).To(BeTrue())
+			Expect(utilerrors.WasCanceled(utilerrors.Unwrap(err))).To(BeTrue())
 		})
 
 		It("Should stop execution on error", func() {

--- a/pkg/utils/errors/unwrap.go
+++ b/pkg/utils/errors/unwrap.go
@@ -16,54 +16,31 @@ package errors
 
 import "errors"
 
-// Unwraps and returns the root error. Multiple wrappings either via `fmt.Errorf` or via `causer` implementations are properly taken into account.
-func Unwrap(err error) error {
-	var (
-		cdone      bool
-		res, udone = unwrapErr(err)
-	)
-
-	for !(udone && cdone) {
-		res, cdone = unwrapCauser(res)
-		res, udone = unwrapErr(res)
-	}
-
-	return res
-}
-
-func unwrapErr(err error) (error, bool) {
-	if err == nil || errors.Unwrap(err) == nil {
-		// this most likely is the root error
-		return err, true
-	}
-
-	for err != nil {
-		var e = errors.Unwrap(err)
-		if e == nil {
-			break
-		}
-		err = e
-	}
-	return err, false
-}
-
 type causer interface {
 	Cause() error
 }
 
-func unwrapCauser(err error) (error, bool) {
-	if _, ok := err.(causer); !ok {
-		// this most likely is the root cause error
-		return err, true
-	}
+// Unwraps and returns the root error. Multiple wrappings either via `fmt.Errorf` or via `causer` implementations are properly taken into account.
+func Unwrap(err error) error {
+	var cdone, udone bool
 
-	for err != nil {
-		cause, ok := err.(causer)
-		if !ok {
-			break
+	for !(udone && cdone) {
+		if err == nil || errors.Unwrap(err) == nil {
+			// this most likely is the root error
+			udone = true
+		} else {
+			err = errors.Unwrap(err)
+			udone = false
 		}
-		err = cause.Cause()
+
+		if cause, ok := err.(causer); !ok {
+			// this most likely is the root cause error
+			cdone = true
+		} else {
+			err = cause.Cause()
+			cdone = false
+		}
 	}
 
-	return err, false
+	return err
 }

--- a/pkg/utils/errors/unwrap.go
+++ b/pkg/utils/errors/unwrap.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors
+
+import "errors"
+
+// Unwrap and returns the root error.
+func Unwrap(err error) error {
+	type causer interface {
+		Cause() error
+	}
+
+	cause, ok := err.(causer)
+	if ok {
+		return unwraperr(cause.Cause())
+	}
+
+	return unwraperr(err)
+}
+
+func unwraperr(err error) error {
+	unwerr := errors.Unwrap(err)
+	if unwerr == nil {
+		return err
+	}
+
+	return unwraperr(errors.Unwrap(err))
+}

--- a/pkg/utils/errors/unwrap.go
+++ b/pkg/utils/errors/unwrap.go
@@ -16,11 +16,7 @@ package errors
 
 import "errors"
 
-// Unwrap and returns the root error.
-//
-// It will try to get Cause error (if err implements the 'causer'
-// interface) and will unwrap again; it will iterate through again
-// until gets the root error.
+// Unwraps and returns the root error. Multiple wrappings either via `fmt.Errorf` or via `causer` implementations are properly taken into account.
 func Unwrap(err error) error {
 	var (
 		cdone      bool

--- a/pkg/utils/errors/unwrap_test.go
+++ b/pkg/utils/errors/unwrap_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,34 +18,42 @@ import (
 	"errors"
 	"fmt"
 
-	utilerrors "github.com/gardener/gardener/pkg/utils/errors"
+	//utilerrors "github.com/gardener/gardener/pkg/utils/errors"
 
+	utilerrors "github.com/gardener/gardener/pkg/utils/errors"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
 )
 
 var _ = Describe("Unwrap", func() {
 	var (
-		singleErr  = errors.New("single")
-		wrappedErr = fmt.Errorf("outer err:%w", singleErr)
-		nilErr     error
+		singleErr     = errors.New("single")
+		wrappedErr    = fmt.Errorf("outer err:%w", singleErr)
+		nilErr        error
+		mulWrappedErr = fmt.Errorf(
+			"error 3: %w",
+			fmt.Errorf(
+				"error 2: %w",
+				fmt.Errorf("error 1:%w", singleErr)),
+		)
+
+		fatalErr   = errors.New("fatal")
+		err1       = utilerrors.WithSuppressed(singleErr, fatalErr)
+		wrErr1     = fmt.Errorf("err 1: %w", err1)
+		causedErr1 = utilerrors.WithSuppressed(wrErr1, singleErr)
+		wrErr2     = fmt.Errorf("err 2: %w", causedErr1)
 	)
 
-	Describe("#SingleError", func() {
-		It("should return the input error as root error if single error is passed", func() {
-			Expect(utilerrors.Unwrap(singleErr)).To(BeIdenticalTo(singleErr))
-		})
-	})
+	DescribeTable("#Wrapped Errors",
+		func(in error, m types.GomegaMatcher) { Expect(utilerrors.Unwrap(in)).To(m) },
 
-	Describe("#WrappedError", func() {
-		It("should return the root error if wrapped error is passed", func() {
-			Expect(utilerrors.Unwrap(wrappedErr)).To(BeIdenticalTo(singleErr))
-		})
-	})
-
-	Describe("#NilError", func() {
-		It("should return nil if nil error is passed", func() {
-			Expect(utilerrors.Unwrap(nilErr)).To(BeNil())
-		})
-	})
+		Entry("return same error", singleErr, BeIdenticalTo(singleErr)),
+		Entry("return root error", wrappedErr, BeIdenticalTo(singleErr)),
+		Entry("return nil error", nilErr, BeNil()),
+		Entry("return root err from nested err", mulWrappedErr, BeIdenticalTo(singleErr)),
+		Entry("return cause error", err1, BeIdenticalTo(singleErr)),
+		Entry("return nested cause error", wrErr2, BeIdenticalTo(singleErr)),
+	)
 })

--- a/pkg/utils/errors/unwrap_test.go
+++ b/pkg/utils/errors/unwrap_test.go
@@ -1,0 +1,51 @@
+// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package errors_test
+
+import (
+	"errors"
+	"fmt"
+
+	utilerrors "github.com/gardener/gardener/pkg/utils/errors"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Unwrap", func() {
+	var (
+		singleErr  = errors.New("single")
+		wrappedErr = fmt.Errorf("outer err:%w", singleErr)
+		nilErr     error
+	)
+
+	Describe("#SingleError", func() {
+		It("should return the input error as root error if single error is passed", func() {
+			Expect(utilerrors.Unwrap(singleErr)).To(BeIdenticalTo(singleErr))
+		})
+	})
+
+	Describe("#WrappedError", func() {
+		It("should return the root error if wrapped error is passed", func() {
+			Expect(utilerrors.Unwrap(wrappedErr)).To(BeIdenticalTo(singleErr))
+		})
+	})
+
+	Describe("#NilError", func() {
+		It("should return nil if nil error is passed", func() {
+			Expect(utilerrors.Unwrap(nilErr)).To(BeNil())
+		})
+	})
+})

--- a/pkg/utils/errors/unwrap_test.go
+++ b/pkg/utils/errors/unwrap_test.go
@@ -39,11 +39,14 @@ var _ = Describe("Unwrap", func() {
 				fmt.Errorf("error 1:%w", singleErr)),
 		)
 
-		fatalErr   = errors.New("fatal")
-		err1       = utilerrors.WithSuppressed(singleErr, fatalErr)
-		wrErr1     = fmt.Errorf("err 1: %w", err1)
-		causedErr1 = utilerrors.WithSuppressed(wrErr1, singleErr)
-		wrErr2     = fmt.Errorf("err 2: %w", causedErr1)
+		fatalErr       = errors.New("fatal")
+		suppressedErr1 = utilerrors.WithSuppressed(singleErr, fatalErr)
+		wrappedErr1    = fmt.Errorf("err 1: %w", suppressedErr1)
+		seppressedErr2 = utilerrors.WithSuppressed(wrappedErr1, singleErr)
+		wrappedErr2    = fmt.Errorf("err 2: %w", seppressedErr2)
+
+		wrappedErr3 = fmt.Errorf("err 3: %w", wrappedErr2)
+		supperssed3 = utilerrors.WithSuppressed(wrappedErr3, singleErr)
 	)
 
 	DescribeTable("#Wrapped Errors",
@@ -53,7 +56,8 @@ var _ = Describe("Unwrap", func() {
 		Entry("return root error", wrappedErr, BeIdenticalTo(singleErr)),
 		Entry("return nil error", nilErr, BeNil()),
 		Entry("return root err from nested err", mulWrappedErr, BeIdenticalTo(singleErr)),
-		Entry("return cause error", err1, BeIdenticalTo(singleErr)),
-		Entry("return nested cause error", wrErr2, BeIdenticalTo(singleErr)),
+		Entry("return cause error", suppressedErr1, BeIdenticalTo(singleErr)),
+		Entry("return nested cause error", wrappedErr2, BeIdenticalTo(singleErr)),
+		Entry("return deeper nested cause error", supperssed3, BeIdenticalTo(singleErr)),
 	)
 })

--- a/pkg/utils/flow/flow.go
+++ b/pkg/utils/flow/flow.go
@@ -18,7 +18,6 @@ package flow
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
@@ -227,11 +226,11 @@ func (e *execution) runNode(ctx context.Context, id TaskID) {
 
 		if err != nil {
 			log.WithError(err).Error("Error")
+			err = fmt.Errorf("task %q failed: %w", id, err)
 		} else {
 			log.Info("Succeeded")
 		}
 
-		err = fmt.Errorf("task %q failed: %w", id, err)
 		e.done <- &nodeResult{TaskID: id, Error: err}
 	}()
 }
@@ -380,7 +379,7 @@ func Causes(err error) *multierror.Error {
 		causes = make([]error, 0, len(errs))
 	)
 	for _, err := range errs {
-		causes = append(causes, errors.Unwrap(err))
+		causes = append(causes, utilerrors.Unwrap(err))
 	}
 	return &multierror.Error{Errors: causes}
 }

--- a/pkg/utils/flow/flow.go
+++ b/pkg/utils/flow/flow.go
@@ -18,6 +18,7 @@ package flow
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -25,7 +26,6 @@ import (
 	utilerrors "github.com/gardener/gardener/pkg/utils/errors"
 
 	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -231,7 +231,7 @@ func (e *execution) runNode(ctx context.Context, id TaskID) {
 			log.Info("Succeeded")
 		}
 
-		err = errors.Wrapf(err, "task %q failed", id)
+		err = fmt.Errorf("task %q failed: %w", id, err)
 		e.done <- &nodeResult{TaskID: id, Error: err}
 	}()
 }
@@ -380,7 +380,7 @@ func Causes(err error) *multierror.Error {
 		causes = make([]error, 0, len(errs))
 	)
 	for _, err := range errs {
-		causes = append(causes, errors.Cause(err))
+		causes = append(causes, errors.Unwrap(err))
 	}
 	return &multierror.Error{Errors: causes}
 }

--- a/pkg/utils/kubernetes/kubernetes.go
+++ b/pkg/utils/kubernetes/kubernetes.go
@@ -344,7 +344,7 @@ func FetchEventMessages(ctx context.Context, scheme *runtime.Scheme, reader clie
 	}
 	eventList := &corev1.EventList{}
 	if err := reader.List(ctx, eventList, fieldSelector); err != nil {
-		return "", fmt.Errorf("error '%v' occurred while fetching more details", err)
+		return "", fmt.Errorf("error '%w' occurred while fetching more details", err)
 	}
 
 	if len(eventList.Items) > 0 {
@@ -533,7 +533,7 @@ func NewestPodForDeployment(ctx context.Context, c client.Reader, deployment *ap
 
 	podSelector, err := metav1.LabelSelectorAsSelector(newestReplicaSet.Spec.Selector)
 	if err != nil {
-		return nil, fmt.Errorf("failed to convert the pod selector from ReplicaSet %s/%s: %v", newestReplicaSet.Namespace, newestReplicaSet.Name, err)
+		return nil, fmt.Errorf("failed to convert the pod selector from ReplicaSet %s/%s: %w", newestReplicaSet.Namespace, newestReplicaSet.Name, err)
 	}
 
 	listOpts = append(listOpts, client.MatchingLabelsSelector{Selector: podSelector})

--- a/pkg/utils/secrets/rsa_private_key.go
+++ b/pkg/utils/secrets/rsa_private_key.go
@@ -79,7 +79,7 @@ func (s *RSASecretConfig) GenerateFromInfoData(infoData infodata.InfoData) (Data
 
 	privateKey, err := utils.DecodePrivateKey(data.PrivateKey)
 	if err != nil {
-		return nil, fmt.Errorf("could not load privateKey secret %s: %v", s.Name, err)
+		return nil, fmt.Errorf("could not load privateKey secret %s: %w", s.Name, err)
 	}
 
 	return s.generateWithPrivateKey(privateKey)

--- a/pkg/utils/secrets/secrets.go
+++ b/pkg/utils/secrets/secrets.go
@@ -16,10 +16,10 @@ package secrets
 
 import (
 	"context"
+	"fmt"
 
 	gardenerkubernetes "github.com/gardener/gardener/pkg/client/kubernetes"
 
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -58,14 +58,14 @@ func (s *Secrets) Deploy(
 	// Generate CAs
 	_, cas, err := GenerateCertificateAuthorities(ctx, gcs, existingSecrets, s.CertificateSecretConfigs, namespace)
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not generate CA secrets in namespace '%s'", namespace)
+		return nil, fmt.Errorf("could not generate CA secrets in namespace '%s': %w", namespace, err)
 	}
 
 	// Generate cluster secrets
 	secretConfigs := s.SecretConfigsFunc(cas, namespace)
 	clusterSecrets, err := GenerateClusterSecrets(ctx, gcs, existingSecrets, secretConfigs, namespace)
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not generate cluster secrets in namespace '%s'", namespace)
+		return nil, fmt.Errorf("could not generate cluster secrets in namespace '%s': %w", namespace, err)
 	}
 
 	return clusterSecrets, nil
@@ -84,7 +84,7 @@ func (s *Secrets) Delete(ctx context.Context, cs kubernetes.Interface, namespace
 func getSecrets(ctx context.Context, cs kubernetes.Interface, namespace string) (map[string]*corev1.Secret, error) {
 	secretList, err := cs.CoreV1().Secrets(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not list secrets in namespace '%s'", namespace)
+		return nil, fmt.Errorf("could not list secrets in namespace '%s': %w", namespace, err)
 	}
 	result := make(map[string]*corev1.Secret, len(secretList.Items))
 	for _, secret := range secretList.Items {

--- a/plugin/pkg/global/extensionvalidation/admission.go
+++ b/plugin/pkg/global/extensionvalidation/admission.go
@@ -125,7 +125,7 @@ var _ admission.ValidationInterface = &ExtensionValidator{}
 // Validate makes admissions decisions based on the extension types.
 func (e *ExtensionValidator) Validate(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) error {
 	if err := e.waitUntilReady(a); err != nil {
-		return fmt.Errorf("err while waiting for ready %v", err)
+		return fmt.Errorf("err while waiting for ready %w", err)
 	}
 
 	switch a.GetKind().GroupKind() {

--- a/plugin/pkg/global/resourcereferencemanager/admission.go
+++ b/plugin/pkg/global/resourcereferencemanager/admission.go
@@ -653,7 +653,7 @@ func (r *ReferenceManager) ensureShootReferences(ctx context.Context, attributes
 
 			// Check if the resource actually exists
 			if err := r.lookupResource(ctx, gv.WithResource(apiResource.Name), shoot.Namespace, resource.ResourceRef.Name); err != nil {
-				return fmt.Errorf("failed to resolve shoot resource reference %q: %v", resource.Name, err)
+				return fmt.Errorf("failed to resolve shoot resource reference %q: %w", resource.Name, err)
 			}
 		}
 
@@ -665,7 +665,7 @@ func (r *ReferenceManager) ensureShootReferences(ctx context.Context, attributes
 				continue
 			}
 			if err := r.lookupSecret(ctx, shoot.Namespace, *dnsProvider.SecretName); err != nil {
-				return fmt.Errorf("failed to reference DNS provider secret %v", err)
+				return fmt.Errorf("failed to reference DNS provider secret %w", err)
 			}
 		}
 	}

--- a/plugin/pkg/shoot/exposureclass/admission.go
+++ b/plugin/pkg/shoot/exposureclass/admission.go
@@ -111,7 +111,7 @@ func (e *ExposureClass) ValidateInitialization() error {
 // with the ones from the referenced ExposureClass.
 func (e *ExposureClass) Admit(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) error {
 	if err := e.waitUntilReady(a); err != nil {
-		return fmt.Errorf("err while waiting for ready %v", err)
+		return fmt.Errorf("err while waiting for ready %w", err)
 	}
 
 	if a.GetKind().GroupKind() != core.Kind("Shoot") {

--- a/plugin/pkg/shoot/oidc/clusteropenidconnectpreset/admission.go
+++ b/plugin/pkg/shoot/oidc/clusteropenidconnectpreset/admission.go
@@ -143,7 +143,7 @@ func (c *ClusterOpenIDConnectPreset) Admit(ctx context.Context, a admission.Attr
 
 	coidcs, err := c.clusterOIDCLister.List(labels.Everything())
 	if err != nil {
-		return apierrors.NewInternalError(fmt.Errorf("could not list existing clusteropenidconnectpresets: %v", err))
+		return apierrors.NewInternalError(fmt.Errorf("could not list existing clusteropenidconnectpresets: %w", err))
 	}
 	if len(coidcs) == 0 {
 		return nil
@@ -151,7 +151,7 @@ func (c *ClusterOpenIDConnectPreset) Admit(ctx context.Context, a admission.Attr
 
 	projects, err := c.projectLister.List(labels.Everything())
 	if err != nil {
-		return apierrors.NewInternalError(fmt.Errorf("could not list existing projects: %v", err))
+		return apierrors.NewInternalError(fmt.Errorf("could not list existing projects: %w", err))
 	}
 	if len(projects) == 0 {
 		return nil
@@ -187,11 +187,11 @@ func filterClusterOIDCs(oidcs []*settingsv1alpha1.ClusterOpenIDConnectPreset, sh
 		spec := oidc.Spec
 		projectSelector, err := metav1.LabelSelectorAsSelector(spec.ProjectSelector)
 		if err != nil {
-			return nil, fmt.Errorf("label selector conversion failed: %v for projectSelector: %v", *spec.ShootSelector, err)
+			return nil, fmt.Errorf("label selector conversion failed: %v for projectSelector: %w", *spec.ShootSelector, err)
 		}
 		shootSelector, err := metav1.LabelSelectorAsSelector(spec.ShootSelector)
 		if err != nil {
-			return nil, fmt.Errorf("label selector conversion failed: %v for shootSelector: %v", *spec.ShootSelector, err)
+			return nil, fmt.Errorf("label selector conversion failed: %v for shootSelector: %w", *spec.ShootSelector, err)
 		}
 
 		// check if the Shoot / project labels match the selector

--- a/plugin/pkg/shoot/oidc/openidconnectpreset/admission.go
+++ b/plugin/pkg/shoot/oidc/openidconnectpreset/admission.go
@@ -149,7 +149,7 @@ func filterOIDCs(oidcs []*settingsv1alpha1.OpenIDConnectPreset, shoot *core.Shoo
 		spec := oidc.Spec
 		selector, err := metav1.LabelSelectorAsSelector(spec.ShootSelector)
 		if err != nil {
-			return nil, fmt.Errorf("label selector conversion failed: %v for shootSelector: %v", *spec.ShootSelector, err)
+			return nil, fmt.Errorf("label selector conversion failed: %v for shootSelector: %w", *spec.ShootSelector, err)
 		}
 
 		// check if the Shoot labels match the selector

--- a/plugin/pkg/shoot/tolerationrestriction/admission.go
+++ b/plugin/pkg/shoot/tolerationrestriction/admission.go
@@ -130,7 +130,7 @@ var _ admission.ValidationInterface = &TolerationRestriction{}
 // Admit defaults shoot tolerations with both global and project defaults.
 func (t *TolerationRestriction) Admit(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) error {
 	if err := t.waitUntilReady(a); err != nil {
-		return fmt.Errorf("err while waiting for ready %v", err)
+		return fmt.Errorf("err while waiting for ready %w", err)
 	}
 
 	if a.GetKind().GroupKind() != core.Kind("Shoot") {
@@ -182,7 +182,7 @@ func (t *TolerationRestriction) admitShoot(shoot *core.Shoot) error {
 // Validate makes admissions decisions based on the allowed project tolerations or globally allowed tolerations.
 func (t *TolerationRestriction) Validate(ctx context.Context, a admission.Attributes, o admission.ObjectInterfaces) error {
 	if err := t.waitUntilReady(a); err != nil {
-		return fmt.Errorf("err while waiting for ready %v", err)
+		return fmt.Errorf("err while waiting for ready %w", err)
 	}
 
 	if a.GetKind().GroupKind() != core.Kind("Shoot") {

--- a/test/framework/config/config.go
+++ b/test/framework/config/config.go
@@ -16,10 +16,10 @@ package config
 
 import (
 	"flag"
+	"fmt"
 	"os"
 
 	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 	"github.com/spf13/viper"
 	"k8s.io/apimachinery/pkg/util/sets"
 )
@@ -62,7 +62,7 @@ func applyConfig(fs *flag.FlagSet) error {
 		}
 
 		if err := f.Value.Set(viper.GetString(f.Name)); err != nil {
-			allErrs = multierror.Append(allErrs, errors.Errorf("unable to set configuration for flag %s: %s", f.Name, err.Error()))
+			allErrs = multierror.Append(allErrs, fmt.Errorf("unable to set configuration for flag %s: %w", f.Name, err))
 		}
 	})
 

--- a/test/framework/errors.go
+++ b/test/framework/errors.go
@@ -14,7 +14,7 @@
 
 package framework
 
-import "github.com/pkg/errors"
+import "errors"
 
 var (
 	// ErrNoRepositoriesFound no repositories found in repository file

--- a/test/framework/gardener_utils.go
+++ b/test/framework/gardener_utils.go
@@ -32,7 +32,6 @@ import (
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 	"github.com/gardener/gardener/pkg/utils/retry"
 
-	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -47,7 +46,7 @@ func (f *GardenerFramework) GetSeeds(ctx context.Context) ([]gardencorev1beta1.S
 	seeds := &gardencorev1beta1.SeedList{}
 	err := f.GardenClient.Client().List(ctx, seeds)
 	if err != nil {
-		return nil, errors.Wrap(err, "could not get Seeds from Garden cluster")
+		return nil, fmt.Errorf("could not get Seeds from Garden cluster: %w", err)
 	}
 
 	return seeds.Items, nil
@@ -58,7 +57,7 @@ func (f *GardenerFramework) GetSeed(ctx context.Context, seedName string) (*gard
 	seed := &gardencorev1beta1.Seed{}
 	err := f.GardenClient.Client().Get(ctx, client.ObjectKey{Name: seedName}, seed)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "could not get Seed from Shoot in Garden cluster")
+		return nil, nil, fmt.Errorf("could not get Seed from Shoot in Garden cluster: %w", err)
 	}
 
 	seedSecretRef := seed.Spec.SecretRef
@@ -66,7 +65,7 @@ func (f *GardenerFramework) GetSeed(ctx context.Context, seedName string) (*gard
 		Scheme: kubernetes.SeedScheme,
 	}))
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "could not construct Seed client")
+		return nil, nil, fmt.Errorf("could not construct Seed client: %w", err)
 	}
 	return seed, seedClient, nil
 }
@@ -83,7 +82,7 @@ func (f *GardenerFramework) GetShootProject(ctx context.Context, shootNamespace 
 		ns      = &corev1.Namespace{}
 	)
 	if err := f.GardenClient.Client().Get(ctx, client.ObjectKey{Name: shootNamespace}, ns); err != nil {
-		return nil, errors.Wrap(err, "could not get the Shoot namespace in Garden cluster")
+		return nil, fmt.Errorf("could not get the Shoot namespace in Garden cluster: %w", err)
 	}
 
 	if ns.Labels == nil {
@@ -95,7 +94,7 @@ func (f *GardenerFramework) GetShootProject(ctx context.Context, shootNamespace 
 	}
 
 	if err := f.GardenClient.Client().Get(ctx, client.ObjectKey{Name: projectName}, project); err != nil {
-		return nil, errors.Wrap(err, "could not get Project in Garden cluster")
+		return nil, fmt.Errorf("could not get Project in Garden cluster: %w", err)
 	}
 	return project, nil
 }
@@ -473,7 +472,7 @@ func shootIsUnschedulable(events []corev1.Event) bool {
 func (f *GardenerFramework) GetCloudProfile(ctx context.Context, name string) (*gardencorev1beta1.CloudProfile, error) {
 	cloudProfile := &gardencorev1beta1.CloudProfile{}
 	if err := f.GardenClient.Client().Get(ctx, client.ObjectKey{Name: name}, cloudProfile); err != nil {
-		return nil, errors.Wrap(err, fmt.Sprintf("could not get CloudProfile '%s' in Garden cluster", name))
+		return nil, fmt.Errorf("could not get CloudProfile '%s' in Garden cluster: %w", name, err)
 	}
 	return cloudProfile, nil
 }

--- a/test/framework/helm.go
+++ b/test/framework/helm.go
@@ -25,7 +25,6 @@ import (
 
 	"github.com/mholt/archiver"
 	"github.com/onsi/ginkgo"
-	"github.com/pkg/errors"
 	"k8s.io/helm/pkg/downloader"
 	"k8s.io/helm/pkg/getter"
 	"k8s.io/helm/pkg/helm/environment"
@@ -48,7 +47,7 @@ func (f *CommonFramework) RenderAndDeployChart(ctx context.Context, k8sClient ku
 	ginkgo.By("Downloading chart artifacts")
 	err = f.DownloadChartArtifacts(ctx, helmRepo, f.ChartDir, c.Name, c.Version)
 	if err != nil {
-		return errors.Wrapf(err, "unable to download chart artifacts for chart %s with version %s", c.Name, c.Version)
+		return fmt.Errorf("unable to download chart artifacts for chart %s with version %s: %w", c.Name, c.Version, err)
 	}
 
 	return f.DeployChart(ctx, k8sClient, c.Namespace, f.ChartDir, c.ReleaseName, values)
@@ -157,7 +156,7 @@ func EnsureRepositoryDirectories(helm Helm) error {
 		if err != nil {
 			if os.IsNotExist(err) {
 				if err := os.MkdirAll(p, os.ModePerm); err != nil {
-					return errors.Wrapf(err, "unable to create %s", p)
+					return fmt.Errorf("unable to create %s: %w", p, err)
 				}
 				continue
 			}

--- a/test/framework/http_utils.go
+++ b/test/framework/http_utils.go
@@ -17,11 +17,10 @@ package framework
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 // HTTPGet performs an HTTP GET request with context
@@ -80,7 +79,7 @@ func testHTTPEndpointWith(ctx context.Context, url string, mutator func(*http.Re
 		return err
 	}
 	if r.StatusCode != http.StatusOK {
-		return errors.Errorf("http request should return %d but returned %d instead", http.StatusOK, r.StatusCode)
+		return errors.New(fmt.Sprintf("http request should return %d but returned %d instead", http.StatusOK, r.StatusCode))
 	}
 	return nil
 }

--- a/test/framework/http_utils.go
+++ b/test/framework/http_utils.go
@@ -17,7 +17,6 @@ package framework
 import (
 	"context"
 	"crypto/tls"
-	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -79,7 +78,7 @@ func testHTTPEndpointWith(ctx context.Context, url string, mutator func(*http.Re
 		return err
 	}
 	if r.StatusCode != http.StatusOK {
-		return errors.New(fmt.Sprintf("http request should return %d but returned %d instead", http.StatusOK, r.StatusCode))
+		return fmt.Errorf("http request should return %d but returned %d instead", http.StatusOK, r.StatusCode)
 	}
 	return nil
 }

--- a/test/framework/k8s_utils.go
+++ b/test/framework/k8s_utils.go
@@ -129,7 +129,7 @@ func (f *CommonFramework) WaitUntilNamespaceIsDeleted(ctx context.Context, k8sCl
 			}
 			return retry.MinorError(err)
 		}
-		return retry.MinorError(errors.New(fmt.Sprintf("Namespace %q is not deleted yet", ns)))
+		return retry.MinorError(fmt.Errorf("Namespace %q is not deleted yet", ns))
 	})
 }
 

--- a/test/framework/k8s_utils.go
+++ b/test/framework/k8s_utils.go
@@ -16,6 +16,7 @@ package framework
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -28,7 +29,6 @@ import (
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 	"github.com/gardener/gardener/pkg/utils/retry"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -129,7 +129,7 @@ func (f *CommonFramework) WaitUntilNamespaceIsDeleted(ctx context.Context, k8sCl
 			}
 			return retry.MinorError(err)
 		}
-		return retry.MinorError(errors.Errorf("Namespace %q is not deleted yet", ns))
+		return retry.MinorError(errors.New(fmt.Sprintf("Namespace %q is not deleted yet", ns)))
 	})
 }
 
@@ -255,7 +255,7 @@ func ScaleDeployment(timeout time.Duration, client client.Client, desiredReplica
 		return nil, nil
 	}
 	if err != nil {
-		return nil, fmt.Errorf("failed to retrieve the replica count of deployment %q: '%v'", name, err)
+		return nil, fmt.Errorf("failed to retrieve the replica count of deployment %q: '%w'", name, err)
 	}
 	if replicas == nil || *replicas == *desiredReplicas {
 		return replicas, nil
@@ -263,12 +263,12 @@ func ScaleDeployment(timeout time.Duration, client client.Client, desiredReplica
 
 	// scale the deployment
 	if err := kubernetes.ScaleDeployment(ctxSetup, client, kutil.Key(namespace, name), *desiredReplicas); err != nil {
-		return nil, fmt.Errorf("failed to scale the replica count of deployment %q: '%v'", name, err)
+		return nil, fmt.Errorf("failed to scale the replica count of deployment %q: '%w'", name, err)
 	}
 
 	// wait until scaled
 	if err := WaitUntilDeploymentScaled(ctxSetup, client, namespace, name, *desiredReplicas); err != nil {
-		return nil, fmt.Errorf("failed to wait until deployment %q is scaled: '%v'", name, err)
+		return nil, fmt.Errorf("failed to wait until deployment %q is scaled: '%w'", name, err)
 	}
 	return replicas, nil
 }

--- a/test/framework/managedseedframework.go
+++ b/test/framework/managedseedframework.go
@@ -16,6 +16,7 @@ package framework
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"time"
 
@@ -28,7 +29,6 @@ import (
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
 	"github.com/onsi/ginkgo"
-	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/test/framework/shootframework.go
+++ b/test/framework/shootframework.go
@@ -16,6 +16,7 @@ package framework
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"time"
@@ -29,7 +30,6 @@ import (
 	"github.com/gardener/gardener/pkg/utils/retry"
 
 	"github.com/onsi/ginkgo"
-	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsscheme "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
@@ -184,12 +184,12 @@ func (f *ShootFramework) AddShoot(ctx context.Context, shootName, shootNamespace
 	)
 
 	if err := f.GardenClient.Client().Get(ctx, client.ObjectKey{Namespace: shootNamespace, Name: shootName}, shoot); err != nil {
-		return errors.Wrapf(err, "could not get shoot")
+		return fmt.Errorf("could not get shoot: %w", err)
 	}
 
 	f.CloudProfile, err = f.GardenerFramework.GetCloudProfile(ctx, shoot.Spec.CloudProfileName)
 	if err != nil {
-		return errors.Wrapf(err, "unable to get cloudprofile %s", shoot.Spec.CloudProfileName)
+		return fmt.Errorf("unable to get cloudprofile %s: %w", shoot.Spec.CloudProfileName, err)
 	}
 
 	f.Project, err = f.GetShootProject(ctx, shootNamespace)
@@ -221,14 +221,14 @@ func (f *ShootFramework) AddShoot(ctx context.Context, shootName, shootNamespace
 	)
 	err = shootSchemeBuilder.AddToScheme(shootScheme)
 	if err != nil {
-		return errors.Wrap(err, "could not add schemes to shoot scheme")
+		return fmt.Errorf("could not add schemes to shoot scheme: %w", err)
 	}
 	if err := retry.UntilTimeout(ctx, k8sClientInitPollInterval, k8sClientInitTimeout, func(ctx context.Context) (bool, error) {
 		shootClient, err = kubernetes.NewClientFromSecret(ctx, f.SeedClient.Client(), ComputeTechnicalID(f.Project.Name, shoot), gardencorev1beta1.GardenerName, kubernetes.WithClientOptions(client.Options{
 			Scheme: shootScheme,
 		}))
 		if err != nil {
-			return retry.MinorError(errors.Wrap(err, "could not construct Shoot client"))
+			return retry.MinorError(fmt.Errorf("could not construct Shoot client: %w", err))
 		}
 		return retry.Ok()
 	}); err != nil {
@@ -306,7 +306,7 @@ func (f *ShootFramework) UpdateShoot(ctx context.Context, update func(shoot *gar
 func (f *ShootFramework) GetCloudProfile(ctx context.Context) (*gardencorev1beta1.CloudProfile, error) {
 	cloudProfile := &gardencorev1beta1.CloudProfile{}
 	if err := f.GardenClient.Client().Get(ctx, client.ObjectKey{Name: f.Shoot.Spec.CloudProfileName}, cloudProfile); err != nil {
-		return nil, errors.Wrap(err, "could not get Seed's CloudProvider in Garden cluster")
+		return nil, fmt.Errorf("could not get Seed's CloudProvider in Garden cluster: %w", err)
 	}
 	return cloudProfile, nil
 }

--- a/test/framework/shootmigrationtest.go
+++ b/test/framework/shootmigrationtest.go
@@ -16,7 +16,6 @@ package framework
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"reflect"
@@ -187,16 +186,16 @@ func (t *ShootMigrationTest) PopulateAfterMigrationComparisonElements(ctx contex
 // CompareElementsAfterMigration compares the Machine details, Node names and Pod statuses before and after migration and returns error if there are diferences.
 func (t *ShootMigrationTest) CompareElementsAfterMigration() error {
 	if !reflect.DeepEqual(t.ComparisonElementsBeforeMigration.MachineNames, t.ComparisonElementsAfterMigration.MachineNames) {
-		return errors.New(fmt.Sprintf("initial Machines %s, do not match after-migrate Machines %s", t.ComparisonElementsBeforeMigration.MachineNames, t.ComparisonElementsAfterMigration.MachineNames))
+		return fmt.Errorf("initial Machines %s, do not match after-migrate Machines %s", t.ComparisonElementsBeforeMigration.MachineNames, t.ComparisonElementsAfterMigration.MachineNames)
 	}
 	if !reflect.DeepEqual(t.ComparisonElementsBeforeMigration.MachineNodes, t.ComparisonElementsAfterMigration.MachineNodes) {
-		return errors.New(fmt.Sprintf("initial Machine Nodes (label) %s, do not match after-migrate Machine Nodes (label) %s", t.ComparisonElementsBeforeMigration.MachineNodes, t.ComparisonElementsAfterMigration.MachineNodes))
+		return fmt.Errorf("initial Machine Nodes (label) %s, do not match after-migrate Machine Nodes (label) %s", t.ComparisonElementsBeforeMigration.MachineNodes, t.ComparisonElementsAfterMigration.MachineNodes)
 	}
 	if !reflect.DeepEqual(t.ComparisonElementsBeforeMigration.NodeNames, t.ComparisonElementsAfterMigration.NodeNames) {
-		return errors.New(fmt.Sprintf("initial Nodes %s, do not match after-migrate Nodes %s", t.ComparisonElementsBeforeMigration.NodeNames, t.ComparisonElementsAfterMigration.NodeNames))
+		return fmt.Errorf("initial Nodes %s, do not match after-migrate Nodes %s", t.ComparisonElementsBeforeMigration.NodeNames, t.ComparisonElementsAfterMigration.NodeNames)
 	}
 	if !reflect.DeepEqual(t.ComparisonElementsAfterMigration.MachineNodes, t.ComparisonElementsAfterMigration.NodeNames) {
-		return errors.New(fmt.Sprintf("machine Nodes (label) %s, do not match after-migrate Nodes %s", t.ComparisonElementsAfterMigration.MachineNodes, t.ComparisonElementsAfterMigration.NodeNames))
+		return fmt.Errorf("machine Nodes (label) %s, do not match after-migrate Nodes %s", t.ComparisonElementsAfterMigration.MachineNodes, t.ComparisonElementsAfterMigration.NodeNames)
 	}
 	return nil
 }
@@ -230,7 +229,7 @@ func (t *ShootMigrationTest) CheckObjectsTimestamp(ctx context.Context, mrExclud
 					t.GardenerFramework.Logger.Infof("Object: %s %s/%s Created At: %s", obj.GetKind(), obj.GetNamespace(), obj.GetName(), createionTimestamp)
 					if t.MigrationTime.Before(&createionTimestamp) {
 						t.GardenerFramework.Logger.Errorf("object: %s %s/%s Created At: %s is created after the Shoot migration %s", obj.GetKind(), obj.GetNamespace(), obj.GetName(), createionTimestamp, t.MigrationTime)
-						return errors.New(fmt.Sprintf("object: %s %s/%s Created At: %s is created after the Shoot migration %s", obj.GetKind(), obj.GetNamespace(), obj.GetName(), createionTimestamp, t.MigrationTime))
+						return fmt.Errorf("object: %s %s/%s Created At: %s is created after the Shoot migration %s", obj.GetKind(), obj.GetNamespace(), obj.GetName(), createionTimestamp, t.MigrationTime)
 					}
 				}
 			}
@@ -285,7 +284,7 @@ func (t *ShootMigrationTest) CheckForOrphanedNonNamespacedResources(ctx context.
 		return err
 	}
 	if len(leakedObjects) > 0 {
-		return errors.New(fmt.Sprintf("the following object(s) still exists in the source seed %v", leakedObjects))
+		return fmt.Errorf("the following object(s) still exists in the source seed %v", leakedObjects)
 	}
 	return nil
 }

--- a/test/framework/shootmigrationtest.go
+++ b/test/framework/shootmigrationtest.go
@@ -196,6 +196,7 @@ func (t *ShootMigrationTest) CompareElementsAfterMigration() error {
 	}
 	if !reflect.DeepEqual(t.ComparisonElementsAfterMigration.MachineNodes, t.ComparisonElementsAfterMigration.NodeNames) {
 		return fmt.Errorf("machine Nodes (label) %s, do not match after-migrate Nodes %s", t.ComparisonElementsAfterMigration.MachineNodes, t.ComparisonElementsAfterMigration.NodeNames)
+
 	}
 	return nil
 }

--- a/test/framework/shootmigrationtest.go
+++ b/test/framework/shootmigrationtest.go
@@ -16,6 +16,7 @@ package framework
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"reflect"
@@ -30,8 +31,6 @@ import (
 	"github.com/gardener/gardener/pkg/utils"
 
 	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
-
-	"github.com/pkg/errors"
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -188,16 +187,16 @@ func (t *ShootMigrationTest) PopulateAfterMigrationComparisonElements(ctx contex
 // CompareElementsAfterMigration compares the Machine details, Node names and Pod statuses before and after migration and returns error if there are diferences.
 func (t *ShootMigrationTest) CompareElementsAfterMigration() error {
 	if !reflect.DeepEqual(t.ComparisonElementsBeforeMigration.MachineNames, t.ComparisonElementsAfterMigration.MachineNames) {
-		return errors.Errorf("initial Machines %s, do not match after-migrate Machines %s", t.ComparisonElementsBeforeMigration.MachineNames, t.ComparisonElementsAfterMigration.MachineNames)
+		return errors.New(fmt.Sprintf("initial Machines %s, do not match after-migrate Machines %s", t.ComparisonElementsBeforeMigration.MachineNames, t.ComparisonElementsAfterMigration.MachineNames))
 	}
 	if !reflect.DeepEqual(t.ComparisonElementsBeforeMigration.MachineNodes, t.ComparisonElementsAfterMigration.MachineNodes) {
-		return errors.Errorf("initial Machine Nodes (label) %s, do not match after-migrate Machine Nodes (label) %s", t.ComparisonElementsBeforeMigration.MachineNodes, t.ComparisonElementsAfterMigration.MachineNodes)
+		return errors.New(fmt.Sprintf("initial Machine Nodes (label) %s, do not match after-migrate Machine Nodes (label) %s", t.ComparisonElementsBeforeMigration.MachineNodes, t.ComparisonElementsAfterMigration.MachineNodes))
 	}
 	if !reflect.DeepEqual(t.ComparisonElementsBeforeMigration.NodeNames, t.ComparisonElementsAfterMigration.NodeNames) {
-		return errors.Errorf("initial Nodes %s, do not match after-migrate Nodes %s", t.ComparisonElementsBeforeMigration.NodeNames, t.ComparisonElementsAfterMigration.NodeNames)
+		return errors.New(fmt.Sprintf("initial Nodes %s, do not match after-migrate Nodes %s", t.ComparisonElementsBeforeMigration.NodeNames, t.ComparisonElementsAfterMigration.NodeNames))
 	}
 	if !reflect.DeepEqual(t.ComparisonElementsAfterMigration.MachineNodes, t.ComparisonElementsAfterMigration.NodeNames) {
-		return errors.Errorf("machine Nodes (label) %s, do not match after-migrate Nodes %s", t.ComparisonElementsAfterMigration.MachineNodes, t.ComparisonElementsAfterMigration.NodeNames)
+		return errors.New(fmt.Sprintf("machine Nodes (label) %s, do not match after-migrate Nodes %s", t.ComparisonElementsAfterMigration.MachineNodes, t.ComparisonElementsAfterMigration.NodeNames))
 	}
 	return nil
 }
@@ -231,7 +230,7 @@ func (t *ShootMigrationTest) CheckObjectsTimestamp(ctx context.Context, mrExclud
 					t.GardenerFramework.Logger.Infof("Object: %s %s/%s Created At: %s", obj.GetKind(), obj.GetNamespace(), obj.GetName(), createionTimestamp)
 					if t.MigrationTime.Before(&createionTimestamp) {
 						t.GardenerFramework.Logger.Errorf("object: %s %s/%s Created At: %s is created after the Shoot migration %s", obj.GetKind(), obj.GetNamespace(), obj.GetName(), createionTimestamp, t.MigrationTime)
-						return errors.Errorf("object: %s %s/%s Created At: %s is created after the Shoot migration %s", obj.GetKind(), obj.GetNamespace(), obj.GetName(), createionTimestamp, t.MigrationTime)
+						return errors.New(fmt.Sprintf("object: %s %s/%s Created At: %s is created after the Shoot migration %s", obj.GetKind(), obj.GetNamespace(), obj.GetName(), createionTimestamp, t.MigrationTime))
 					}
 				}
 			}
@@ -286,7 +285,7 @@ func (t *ShootMigrationTest) CheckForOrphanedNonNamespacedResources(ctx context.
 		return err
 	}
 	if len(leakedObjects) > 0 {
-		return errors.Errorf("the following object(s) still exists in the source seed %v", leakedObjects)
+		return errors.New(fmt.Sprintf("the following object(s) still exists in the source seed %v", leakedObjects))
 	}
 	return nil
 }

--- a/test/framework/template.go
+++ b/test/framework/template.go
@@ -17,7 +17,6 @@ package framework
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"html/template"
 	"os"
@@ -30,7 +29,7 @@ import (
 func (f *CommonFramework) RenderAndDeployTemplate(ctx context.Context, k8sClient kubernetes.Interface, templateName string, values interface{}) error {
 	templateFilepath := filepath.Join(f.TemplatesDir, templateName)
 	if _, err := os.Stat(templateFilepath); err != nil {
-		return errors.New(fmt.Sprintf("could not find template in %q", templateFilepath))
+		return fmt.Errorf("could not find template in %q", templateFilepath)
 	}
 
 	tpl, err := template.ParseFiles(templateFilepath)

--- a/test/framework/template.go
+++ b/test/framework/template.go
@@ -17,24 +17,25 @@ package framework
 import (
 	"bytes"
 	"context"
+	"errors"
+	"fmt"
 	"html/template"
 	"os"
 	"path/filepath"
 
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	"github.com/pkg/errors"
 )
 
 // RenderAndDeployTemplate renders a template from the resource template directory and deploys it to the cluster
 func (f *CommonFramework) RenderAndDeployTemplate(ctx context.Context, k8sClient kubernetes.Interface, templateName string, values interface{}) error {
 	templateFilepath := filepath.Join(f.TemplatesDir, templateName)
 	if _, err := os.Stat(templateFilepath); err != nil {
-		return errors.Errorf("could not find template in '%s'", templateFilepath)
+		return errors.New(fmt.Sprintf("could not find template in %q", templateFilepath))
 	}
 
 	tpl, err := template.ParseFiles(templateFilepath)
 	if err != nil {
-		return errors.Wrapf(err, "unable to parse template in %s", templateFilepath)
+		return fmt.Errorf("unable to parse template in %s: %w", templateFilepath, err)
 	}
 
 	var writer bytes.Buffer

--- a/test/framework/utils.go
+++ b/test/framework/utils.go
@@ -15,6 +15,7 @@
 package framework
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"reflect"
@@ -24,7 +25,6 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/hashicorp/go-multierror"
 	"github.com/onsi/ginkgo"
-	"github.com/pkg/errors"
 	apimachineryRuntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"sigs.k8s.io/yaml"
@@ -200,7 +200,7 @@ func (v *TextValidation) validate(text []byte, validationFunc func([][]byte) err
 
 		matches := re.FindAll(text, -1)
 		if err := validationFunc(matches); err != nil {
-			allErrs = multierror.Append(allErrs, errors.Wrapf(err, "RegExp %s validation failed: %s", reString, description))
+			allErrs = multierror.Append(allErrs, fmt.Errorf("RegExp %s validation failed: %s: %w", reString, description, err))
 		}
 	}
 

--- a/test/integration/shoots/applications/networking.go
+++ b/test/integration/shoots/applications/networking.go
@@ -35,7 +35,6 @@ import (
 	"github.com/gardener/gardener/test/framework"
 	"github.com/gardener/gardener/test/framework/resources/templates"
 	"github.com/hashicorp/go-multierror"
-	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -86,7 +85,7 @@ var _ = ginkgo.Describe("Shoot network testing", func() {
 				ginkgo.By(fmt.Sprintf("Testing %s to %s", from.GetName(), to.GetName()))
 				reader, err := podExecutor.Execute(ctx, from.Namespace, from.Name, "net-curl", fmt.Sprintf("curl -L %s:80 --fail -m 10", to.Status.PodIP))
 				if err != nil {
-					res = multierror.Append(res, errors.Wrapf(err, "%s to %s", from.GetName(), to.GetName()))
+					res = multierror.Append(res, fmt.Errorf("%s to %s: %w", from.GetName(), to.GetName(), err))
 					continue
 				}
 				data, err := io.ReadAll(reader)

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -346,7 +346,6 @@ github.com/pelletier/go-toml
 github.com/pierrec/lz4
 github.com/pierrec/lz4/internal/xxh32
 # github.com/pkg/errors v0.9.1
-## explicit
 github.com/pkg/errors
 # github.com/prometheus/client_golang v1.11.0 => github.com/prometheus/client_golang v1.11.0
 ## explicit


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
- It replaces `github.com/pkg/errors` with `errors` from the stdlib. It introduces appropriate changes where needed so the functionality to remain unchanged (this is achieved by Introducing custom `Unwrap` method);
- Replaces verb `%v` with `%w` to actually wrap the error where is needed;


**Which issue(s) this PR fixes**:
Fixes #4280 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
