### PR TITLE
[release-v1.26] Automated cherry pick of #4327: When defaulting and maintaining OS version, prefer older and supported version over newer but deprecated

### DIFF
--- a/pkg/apis/core/helper/helpers.go
+++ b/pkg/apis/core/helper/helpers.go
@@ -97,8 +97,8 @@ func DetermineLatestMachineImageVersion(versions []core.MachineImageVersion, fil
 	return core.MachineImageVersion{}, fmt.Errorf("the latest machine version has been removed")
 }
 
-// DetermineLatestExpirableVersion determines the latest and latest non-deprecated version from a slice of ExpirableVersions.
-// When filterPreviewVersions is set, versions with classification preview are not considered.l
+// DetermineLatestExpirableVersion determines the latest expirable version and the latest non-deprecated version from a slice of ExpirableVersions.
+// When filterPreviewVersions is set, versions with classification preview are not considered.
 func DetermineLatestExpirableVersion(versions []core.ExpirableVersion, filterPreviewVersions bool) (core.ExpirableVersion, core.ExpirableVersion, error) {
 
 	var (

--- a/pkg/apis/core/helper/helpers.go
+++ b/pkg/apis/core/helper/helpers.go
@@ -73,12 +73,19 @@ func DetermineLatestMachineImageVersions(images []core.MachineImage) (map[string
 	return resultMapVersions, nil
 }
 
-// DetermineLatestMachineImageVersion determines the latest MachineImageVersion from a slice of MachineImageVersion
-// when filterPreviewVersions is set, versions with classification preview are not considered
+// DetermineLatestMachineImageVersion determines the latest MachineImageVersion from a slice of MachineImageVersion.
+// When filterPreviewVersions is set, versions with classification preview are not considered.
+// It will prefer older but non-deprecated versions over newer but deprecated versions.
 func DetermineLatestMachineImageVersion(versions []core.MachineImageVersion, filterPreviewVersions bool) (core.MachineImageVersion, error) {
-	latestVersion, err := DetermineLatestExpirableVersion(ToExpirableVersions(versions), filterPreviewVersions)
+	latestVersion, latestNonDeprecatedVersion, err := DetermineLatestExpirableVersion(ToExpirableVersions(versions), filterPreviewVersions)
 	if err != nil {
 		return core.MachineImageVersion{}, err
+	}
+
+	for _, version := range versions {
+		if version.Version == latestNonDeprecatedVersion.Version {
+			return version, nil
+		}
 	}
 
 	for _, version := range versions {
@@ -90,18 +97,22 @@ func DetermineLatestMachineImageVersion(versions []core.MachineImageVersion, fil
 	return core.MachineImageVersion{}, fmt.Errorf("the latest machine version has been removed")
 }
 
-// DetermineLatestExpirableVersion determines the latest ExpirableVersion from a slice of ExpirableVersions
-// when filterPreviewVersions is set, versions with classification preview are not considered
-func DetermineLatestExpirableVersion(versions []core.ExpirableVersion, filterPreviewVersions bool) (core.ExpirableVersion, error) {
+// DetermineLatestExpirableVersion determines the latest and latest non-deprecated version from a slice of ExpirableVersions.
+// When filterPreviewVersions is set, versions with classification preview are not considered.l
+func DetermineLatestExpirableVersion(versions []core.ExpirableVersion, filterPreviewVersions bool) (core.ExpirableVersion, core.ExpirableVersion, error) {
+
 	var (
-		latestSemVerVersion    *semver.Version
-		latestExpirableVersion core.ExpirableVersion
+		latestSemVerVersion              *semver.Version
+		latestNonDeprecatedSemVerVersion *semver.Version
+
+		latestExpirableVersion              core.ExpirableVersion
+		latestNonDeprecatedExpirableVersion core.ExpirableVersion
 	)
 
 	for _, version := range versions {
 		v, err := semver.NewVersion(version.Version)
 		if err != nil {
-			return core.ExpirableVersion{}, fmt.Errorf("error while parsing expirable version '%s': %s", version.Version, err.Error())
+			return core.ExpirableVersion{}, core.ExpirableVersion{}, fmt.Errorf("error while parsing expirable version '%s': %s", version.Version, err.Error())
 		}
 
 		if filterPreviewVersions && version.Classification != nil && *version.Classification == core.ClassificationPreview {
@@ -112,13 +123,20 @@ func DetermineLatestExpirableVersion(versions []core.ExpirableVersion, filterPre
 			latestSemVerVersion = v
 			latestExpirableVersion = version
 		}
+
+		if version.Classification != nil && *version.Classification != core.ClassificationDeprecated {
+			if latestNonDeprecatedSemVerVersion == nil || v.GreaterThan(latestNonDeprecatedSemVerVersion) {
+				latestNonDeprecatedSemVerVersion = v
+				latestNonDeprecatedExpirableVersion = version
+			}
+		}
 	}
 
 	if latestSemVerVersion == nil {
-		return core.ExpirableVersion{}, fmt.Errorf("unable to determine latest expirable version")
+		return core.ExpirableVersion{}, core.ExpirableVersion{}, fmt.Errorf("unable to determine latest expirable version")
 	}
 
-	return latestExpirableVersion, nil
+	return latestExpirableVersion, latestNonDeprecatedExpirableVersion, nil
 }
 
 // ToExpirableVersions converts MachineImageVersion to ExpirableVersion

--- a/pkg/apis/core/helper/helpers.go
+++ b/pkg/apis/core/helper/helpers.go
@@ -82,12 +82,14 @@ func DetermineLatestMachineImageVersion(versions []core.MachineImageVersion, fil
 		return core.MachineImageVersion{}, err
 	}
 
+	// Try to find non-deprecated version first.
 	for _, version := range versions {
 		if version.Version == latestNonDeprecatedVersion.Version {
 			return version, nil
 		}
 	}
 
+	// It looks like there is no non-deprecated version, now look also into the deprecated versions
 	for _, version := range versions {
 		if version.Version == latestVersion.Version {
 			return version, nil

--- a/pkg/apis/core/helper/helpers_test.go
+++ b/pkg/apis/core/helper/helpers_test.go
@@ -444,33 +444,47 @@ var _ = Describe("helper", func() {
 	)
 
 	classificationPreview := core.ClassificationPreview
+	classificationDeprecated := core.ClassificationDeprecated
+	classificationSupported := core.ClassificationSupported
 	previewVersion := core.MachineImageVersion{
 		ExpirableVersion: core.ExpirableVersion{
-			Version:        "1.1.1",
+			Version:        "1.1.2",
 			Classification: &classificationPreview,
 		},
 	}
+	deprecatedVersion := core.MachineImageVersion{
+		ExpirableVersion: core.ExpirableVersion{
+			Version:        "1.1.1",
+			Classification: &classificationDeprecated,
+		},
+	}
+
 	var versions = []core.MachineImageVersion{
 		{
 			ExpirableVersion: core.ExpirableVersion{
-				Version: "1.0.0",
+				Version:        "1.0.0",
+				Classification: &classificationDeprecated,
 			},
 		},
 		{
 			ExpirableVersion: core.ExpirableVersion{
-				Version: "1.0.1",
+				Version:        "1.0.1",
+				Classification: &classificationDeprecated,
 			},
 		},
 		{
 			ExpirableVersion: core.ExpirableVersion{
-				Version: "1.0.2",
+				Version:        "1.0.2",
+				Classification: &classificationDeprecated,
 			},
 		},
 		{
 			ExpirableVersion: core.ExpirableVersion{
-				Version: "1.1.0",
+				Version:        "1.1.0",
+				Classification: &classificationSupported,
 			},
 		},
+		deprecatedVersion,
 		previewVersion,
 	}
 
@@ -484,8 +498,9 @@ var _ = Describe("helper", func() {
 			Expect(result).To(Equal(expectation))
 		},
 
-		Entry("should determine latest expirable version", versions, false, previewVersion, false),
-		Entry("should determine latest expirable version - without preview versions", versions, true, core.MachineImageVersion{ExpirableVersion: core.ExpirableVersion{Version: "1.1.0"}}, false),
+		Entry("should determine latest expirable version - do not ignore preview version", versions, false, previewVersion, false),
+		Entry("should determine latest expirable version - prefer older supported version over newer deprecated one", versions, true, core.MachineImageVersion{ExpirableVersion: core.ExpirableVersion{Version: "1.1.0", Classification: &classificationSupported}}, false),
+		Entry("should determine latest expirable version - select deprecated version when there is no supported one", []core.MachineImageVersion{previewVersion, deprecatedVersion}, true, core.MachineImageVersion{ExpirableVersion: core.ExpirableVersion{Version: "1.1.1", Classification: &classificationDeprecated}}, false),
 		Entry("should return an error - only preview versions", []core.MachineImageVersion{previewVersion}, true, nil, true),
 		Entry("should return an error - empty version slice", []core.MachineImageVersion{}, true, nil, true),
 	)

--- a/pkg/apis/core/helper/helpers_test.go
+++ b/pkg/apis/core/helper/helpers_test.go
@@ -458,6 +458,12 @@ var _ = Describe("helper", func() {
 			Classification: &classificationDeprecated,
 		},
 	}
+	supportedVersion := core.MachineImageVersion{
+		ExpirableVersion: core.ExpirableVersion{
+			Version:        "1.1.0",
+			Classification: &classificationSupported,
+		},
+	}
 
 	var versions = []core.MachineImageVersion{
 		{
@@ -478,12 +484,7 @@ var _ = Describe("helper", func() {
 				Classification: &classificationDeprecated,
 			},
 		},
-		{
-			ExpirableVersion: core.ExpirableVersion{
-				Version:        "1.1.0",
-				Classification: &classificationSupported,
-			},
-		},
+		supportedVersion,
 		deprecatedVersion,
 		previewVersion,
 	}
@@ -499,7 +500,9 @@ var _ = Describe("helper", func() {
 		},
 
 		Entry("should determine latest expirable version - do not ignore preview version", versions, false, previewVersion, false),
-		Entry("should determine latest expirable version - prefer older supported version over newer deprecated one", versions, true, core.MachineImageVersion{ExpirableVersion: core.ExpirableVersion{Version: "1.1.0", Classification: &classificationSupported}}, false),
+		Entry("should determine latest expirable version - prefer older supported version over newer deprecated one (full list of versions)", versions, true, core.MachineImageVersion{ExpirableVersion: core.ExpirableVersion{Version: "1.1.0", Classification: &classificationSupported}}, false),
+		Entry("should determine latest expirable version - prefer older supported version over newer deprecated one (latest non-deprecated version is earlier in the list)", []core.MachineImageVersion{supportedVersion, deprecatedVersion}, true, core.MachineImageVersion{ExpirableVersion: core.ExpirableVersion{Version: "1.1.0", Classification: &classificationSupported}}, false),
+		Entry("should determine latest expirable version - prefer older supported version over newer deprecated one (latest deprecated version is earlier in the list)", []core.MachineImageVersion{deprecatedVersion, supportedVersion}, true, core.MachineImageVersion{ExpirableVersion: core.ExpirableVersion{Version: "1.1.0", Classification: &classificationSupported}}, false),
 		Entry("should determine latest expirable version - select deprecated version when there is no supported one", []core.MachineImageVersion{previewVersion, deprecatedVersion}, true, core.MachineImageVersion{ExpirableVersion: core.ExpirableVersion{Version: "1.1.1", Classification: &classificationDeprecated}}, false),
 		Entry("should return an error - only preview versions", []core.MachineImageVersion{previewVersion}, true, nil, true),
 		Entry("should return an error - empty version slice", []core.MachineImageVersion{}, true, nil, true),

--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -903,6 +903,7 @@ func toExpirableVersions(versions []gardencorev1beta1.MachineImageVersion) []gar
 func GetLatestQualifyingShootMachineImage(image gardencorev1beta1.MachineImage, predicates ...VersionPredicate) (bool, *gardencorev1beta1.ShootMachineImage, error) {
 	predicates = append(predicates, FilterExpiredVersion())
 
+	// Try to find non-deprecated version first
 	qualifyingVersionFound, latestNonDeprecatedImageVersion, err := GetLatestQualifyingVersion(toExpirableVersions(image.Versions), append(predicates, FilterDeprecatedVersion())...)
 	if err != nil {
 		return false, nil, err
@@ -911,6 +912,7 @@ func GetLatestQualifyingShootMachineImage(image gardencorev1beta1.MachineImage, 
 		return true, &gardencorev1beta1.ShootMachineImage{Name: image.Name, Version: &latestNonDeprecatedImageVersion.Version}, nil
 	}
 
+	// It looks like there is no non-deprecated version, now look also into the deprecated versions
 	qualifyingVersionFound, latestImageVersion, err := GetLatestQualifyingVersion(toExpirableVersions(image.Versions), predicates...)
 	if err != nil {
 		return false, nil, err

--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -897,10 +897,20 @@ func toExpirableVersions(versions []gardencorev1beta1.MachineImageVersion) []gar
 	return expVersions
 }
 
-// GetLatestQualifyingShootMachineImage determines the latest qualifying version in a machine image and returns that as a ShootMachineImage
+// GetLatestQualifyingShootMachineImage determines the latest qualifying version in a machine image and returns that as a ShootMachineImage.
 // A version qualifies if its classification is not preview and the version is not expired.
+// Older but non-deprecated version is preferred over newer but deprecated one.
 func GetLatestQualifyingShootMachineImage(image gardencorev1beta1.MachineImage, predicates ...VersionPredicate) (bool, *gardencorev1beta1.ShootMachineImage, error) {
 	predicates = append(predicates, FilterExpiredVersion())
+
+	qualifyingVersionFound, latestNonDeprecatedImageVersion, err := GetLatestQualifyingVersion(toExpirableVersions(image.Versions), append(predicates, FilterDeprecatedVersion())...)
+	if err != nil {
+		return false, nil, err
+	}
+	if qualifyingVersionFound {
+		return true, &gardencorev1beta1.ShootMachineImage{Name: image.Name, Version: &latestNonDeprecatedImageVersion.Version}, nil
+	}
+
 	qualifyingVersionFound, latestImageVersion, err := GetLatestQualifyingVersion(toExpirableVersions(image.Versions), predicates...)
 	if err != nil {
 		return false, nil, err
@@ -1124,7 +1134,7 @@ func FilterNonConsecutiveMinorVersion(currentSemVerVersion semver.Version) Versi
 }
 
 // FilterSameVersion returns a VersionPredicate(closure) that evaluates whether a given version v is equal to the currentSemVerVersion
-// returns true it it is equal
+// returns true if it is equal
 func FilterSameVersion(currentSemVerVersion semver.Version) VersionPredicate {
 	return func(_ gardencorev1beta1.ExpirableVersion, v *semver.Version) (bool, error) {
 		return v.Equal(&currentSemVerVersion), nil
@@ -1140,10 +1150,18 @@ func FilterLowerVersion(currentSemVerVersion semver.Version) VersionPredicate {
 }
 
 // FilterExpiredVersion returns a closure that evaluates whether a given expirable version is expired
-// returns true it it is expired
+// returns true if it is expired
 func FilterExpiredVersion() func(expirableVersion gardencorev1beta1.ExpirableVersion, version *semver.Version) (bool, error) {
 	return func(expirableVersion gardencorev1beta1.ExpirableVersion, _ *semver.Version) (bool, error) {
 		return expirableVersion.ExpirationDate != nil && (time.Now().UTC().After(expirableVersion.ExpirationDate.UTC()) || time.Now().UTC().Equal(expirableVersion.ExpirationDate.UTC())), nil
+	}
+}
+
+// FilterDeprecatedVersion returns a closure that evaluates whether a given expirable version is deprecated
+// returns true if it is deprecated
+func FilterDeprecatedVersion() func(expirableVersion gardencorev1beta1.ExpirableVersion, version *semver.Version) (bool, error) {
+	return func(expirableVersion gardencorev1beta1.ExpirableVersion, _ *semver.Version) (bool, error) {
+		return expirableVersion.Classification != nil && *expirableVersion.Classification == gardencorev1beta1.ClassificationDeprecated, nil
 	}
 }
 

--- a/pkg/apis/core/v1beta1/helper/helper_test.go
+++ b/pkg/apis/core/v1beta1/helper/helper_test.go
@@ -1016,6 +1016,8 @@ var _ = Describe("helper", func() {
 
 	Describe("Version helper", func() {
 		var previewClassification = gardencorev1beta1.ClassificationPreview
+		var deprecatedClassification = gardencorev1beta1.ClassificationDeprecated
+		var supportedClassification = gardencorev1beta1.ClassificationSupported
 
 		DescribeTable("#GetLatestQualifyingShootMachineImage",
 			func(original gardencorev1beta1.MachineImage, expectVersionToBeFound bool, expected *gardencorev1beta1.ShootMachineImage, expectError bool) {
@@ -1093,6 +1095,98 @@ var _ = Describe("helper", func() {
 				},
 				false,
 				nil,
+				false,
+			),
+			Entry("Expect older but supported version to be preferred over newer but deprecated one",
+				gardencorev1beta1.MachineImage{
+					Name: "gardenlinux",
+					Versions: []gardencorev1beta1.MachineImageVersion{
+						{
+							ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+								Version:        "1.17.1",
+								Classification: &deprecatedClassification,
+							},
+						},
+						{
+							ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+								Version:        "1.16.1",
+								Classification: &supportedClassification,
+							},
+						},
+						{
+							ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+								Version:        "1.15.0",
+								Classification: &previewClassification,
+							},
+						},
+						{
+							ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+								Version:        "1.14.3",
+								ExpirationDate: &expirationDateInThePast,
+							},
+						},
+						{
+							ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+								Version:        "1.13.1",
+								ExpirationDate: &expirationDateInThePast,
+							},
+						},
+					},
+				},
+				true,
+				&gardencorev1beta1.ShootMachineImage{
+					Name:    "gardenlinux",
+					Version: pointer.String("1.16.1"),
+				},
+				false,
+			),
+			Entry("Expect latest deprecated version to be selected when there is no supported version",
+				gardencorev1beta1.MachineImage{
+					Name: "gardenlinux",
+					Versions: []gardencorev1beta1.MachineImageVersion{
+						{
+							ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+								Version:        "1.17.3",
+								Classification: &previewClassification,
+							},
+						},
+						{
+							ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+								Version:        "1.17.2",
+								ExpirationDate: &expirationDateInThePast,
+							},
+						},
+						{
+							ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+								Version:        "1.17.1",
+								Classification: &deprecatedClassification,
+							},
+						},
+						{
+							ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+								Version:        "1.16.1",
+								Classification: &deprecatedClassification,
+							},
+						},
+						{
+							ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+								Version:        "1.15.0",
+								Classification: &previewClassification,
+							},
+						},
+						{
+							ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+								Version:        "1.14.3",
+								ExpirationDate: &expirationDateInThePast,
+							},
+						},
+					},
+				},
+				true,
+				&gardencorev1beta1.ShootMachineImage{
+					Name:    "gardenlinux",
+					Version: pointer.String("1.17.1"),
+				},
 				false,
 			),
 		)
@@ -1466,6 +1560,35 @@ var _ = Describe("helper", func() {
 				),
 				Entry("Should not filter version.",
 					FilterExpiredVersion(),
+					nil,
+					gardencorev1beta1.ExpirableVersion{},
+					false,
+					false,
+				),
+				// #FilterDeprecatedVersion
+				Entry("Should filter version - version is deprecated",
+					FilterDeprecatedVersion(),
+					nil,
+					gardencorev1beta1.ExpirableVersion{Classification: &deprecatedClassification},
+					true,
+					false,
+				),
+				Entry("Should not filter version - version has preview classification",
+					FilterDeprecatedVersion(),
+					nil,
+					gardencorev1beta1.ExpirableVersion{Classification: &previewClassification},
+					false,
+					false,
+				),
+				Entry("Should not filter version - version has supported classification",
+					FilterDeprecatedVersion(),
+					nil,
+					gardencorev1beta1.ExpirableVersion{Classification: &supportedClassification},
+					false,
+					false,
+				),
+				Entry("Should not filter version - version has no classification",
+					FilterDeprecatedVersion(),
 					nil,
 					gardencorev1beta1.ExpirableVersion{},
 					false,

--- a/pkg/apis/core/validation/cloudprofile.go
+++ b/pkg/apis/core/validation/cloudprofile.go
@@ -158,7 +158,7 @@ func validateKubernetesSettings(kubernetes core.KubernetesSettings, fldPath *fie
 	if len(kubernetes.Versions) == 0 {
 		allErrs = append(allErrs, field.Required(fldPath.Child("versions"), "must provide at least one Kubernetes version"))
 	}
-	latestKubernetesVersion, err := helper.DetermineLatestExpirableVersion(kubernetes.Versions, false)
+	latestKubernetesVersion, _, err := helper.DetermineLatestExpirableVersion(kubernetes.Versions, false)
 	if err != nil {
 		allErrs = append(allErrs, field.Invalid(fldPath.Child("versions"), latestKubernetesVersion.Version, "failed to determine the latest kubernetes version from the cloud profile"))
 	}


### PR DESCRIPTION
/area/ops-productivity
/kind/bug
/merge squash

Cherry pick of #4327 on release-v1.26.

#4327: When defaulting and maintaining OS version, prefer older and supported version over newer but deprecated

**Release Notes:**
```bugfix operator
A bug that the shoot maintenance controller was upgrading the OS version to higher but deprecated version instead of using lower and supported has been fixed.
```
```bugfix operator
A bug that the OS version of worker pool is defaulted to higher and deprecated version instead of lower and supported is now fixed.
```