### PR TITLE
Add DNSRecord controller utility functions

### DIFF
--- a/extensions/pkg/controller/dnsrecord/utils.go
+++ b/extensions/pkg/controller/dnsrecord/utils.go
@@ -14,9 +14,37 @@
 
 package dnsrecord
 
-import "strings"
+import (
+	"strings"
+)
 
-// MatchesDomain returns true if the given hostname matches (is a subdomain) of the given domain, false otherwise.
-func MatchesDomain(hostname, domain string) bool {
-	return strings.HasSuffix(hostname, "."+domain) || domain == hostname
+const (
+	// metaRecordPrefix is the prefix of meta DNS records that may exist if the shoot was previously reconciled
+	// with the dns-external controller.
+	metaRecordPrefix = "comment-"
+)
+
+// MatchesDomain returns true if the given name matches (is a subdomain) of the given domain, false otherwise.
+func MatchesDomain(name, domain string) bool {
+	return strings.HasSuffix(name, "."+domain) || domain == name
+}
+
+// FindZoneForName returns the zone ID for the longest zone domain from the given zones map that is matched by the given name.
+// If the given name doesn't match any of the zone domains in the given zones map, an empty string is returned.
+func FindZoneForName(zones map[string]string, name string) string {
+	longestZoneName, result := "", ""
+	for zoneName, zoneId := range zones {
+		if MatchesDomain(name, zoneName) && len(zoneName) > len(longestZoneName) {
+			longestZoneName, result = zoneName, zoneId
+		}
+	}
+	return result
+}
+
+// GetMetaRecordName returns the meta record name for the given name.
+func GetMetaRecordName(name string) string {
+	if strings.HasPrefix(name, "*.") {
+		return "*." + metaRecordPrefix + name[2:]
+	}
+	return metaRecordPrefix + name
 }

--- a/extensions/pkg/controller/dnsrecord/utils_test.go
+++ b/extensions/pkg/controller/dnsrecord/utils_test.go
@@ -24,13 +24,42 @@ import (
 
 var _ = Describe("Utils", func() {
 	DescribeTable("#MatchesDomain",
-		func(hostname, domain string, expected bool) {
-			Expect(MatchesDomain(hostname, domain)).To(Equal(expected))
+		func(name, domain string, expected bool) {
+			Expect(MatchesDomain(name, domain)).To(Equal(expected))
 		},
 
 		Entry("sub-sub-domain matches domain", "api.test.example.com", "example.com", true),
 		Entry("sub-domain matches domain", "test.example.com", "example.com", true),
 		Entry("domain matches domain", "example.com", "example.com", true),
 		Entry("different domain doesn't match domain (even though it's a suffix)", "testexample.com", "example.com", false),
+	)
+
+	var zones = map[string]string{
+		"example.com":      "1",
+		"test.example.com": "2",
+		"foo.com":          "3",
+	}
+
+	DescribeTable("#FindZoneForName",
+		func(zones map[string]string, name, expected string) {
+			Expect(FindZoneForName(zones, name)).To(Equal(expected))
+		},
+
+		Entry("", zones, "api.test.example.com", "2"),
+		Entry("", zones, "test.example.com", "2"),
+		Entry("", zones, "foo.example.com", "1"),
+		Entry("", zones, "bar.com", ""),
+		Entry("", zones, "apitest.example.com", "1"),
+		Entry("", zones, "testexample.com", ""),
+	)
+
+	DescribeTable("#GetMetaRecordName",
+		func(name, expected string) {
+			Expect(GetMetaRecordName(name)).To(Equal(expected))
+		},
+
+		Entry("regular name", "api.test.example.com", "comment-api.test.example.com"),
+		Entry("wildcard name", "*.test.example.com", "*.comment-test.example.com"),
+		Entry("empty name", "", "comment-"),
 	)
 })


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Adds utility functions that should be be used by provider-specific `DNSRecord` controller implementations.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```other operator
NONE
```
