### PR TITLE
Fix Gardenlet config ExposureClass handler config

### DIFF
--- a/pkg/gardenlet/apis/config/validation/validation.go
+++ b/pkg/gardenlet/apis/config/validation/validation.go
@@ -96,9 +96,10 @@ func ValidateGardenletConfiguration(cfg *config.GardenletConfiguration, fldPath 
 		}
 
 		if handler.SNI != nil && handler.SNI.Ingress != nil && handler.SNI.Ingress.ServiceExternalIP != nil {
-			if !cfg.FeatureGates[string(features.APIServerSNI)] {
+			if apiServerSNIEnabled, ok := cfg.FeatureGates[string(features.APIServerSNI)]; ok && !apiServerSNIEnabled {
 				allErrs = append(allErrs, field.Forbidden(handlerPath.Child("sni", "ingress", "serviceExternalIP"), "cannot use an external service ip when APIServerSNI feature gate is disabled"))
 			}
+
 			if ip := net.ParseIP(*handler.SNI.Ingress.ServiceExternalIP); ip == nil {
 				allErrs = append(allErrs, field.Invalid(handlerPath.Child("sni", "ingress", "serviceExternalIP"), handler.SNI.Ingress.ServiceExternalIP, "external service ip is invalid"))
 			}

--- a/pkg/gardenlet/apis/config/validation/validation_test.go
+++ b/pkg/gardenlet/apis/config/validation/validation_test.go
@@ -63,9 +63,7 @@ var _ = Describe("GardenletConfiguration", func() {
 					SyncJitterPeriod: &metav1.Duration{Duration: 5 * time.Minute},
 				},
 			},
-			FeatureGates: map[string]bool{
-				"APIServerSNI": true,
-			},
+			FeatureGates: map[string]bool{},
 			SeedConfig: &config.SeedConfig{
 				SeedTemplate: gardencore.SeedTemplate{
 					ObjectMeta: metav1.ObjectMeta{
@@ -401,8 +399,17 @@ var _ = Describe("GardenletConfiguration", func() {
 			})
 
 			Context("serviceExternalIP", func() {
-				It("should allow to use an external service ip as APIServerSNI feature gate is enabled and loadbalancer ip is valid", func() {
+				It("should allow to use an external service ip as loadbalancer ip is valid", func() {
 					cfg.ExposureClassHandlers[0].SNI.Ingress.ServiceExternalIP = pointer.StringPtr("1.1.1.1")
+
+					errorList := ValidateGardenletConfiguration(cfg, nil, false)
+
+					Expect(errorList).To(BeEmpty())
+				})
+
+				It("should allow to use an external service ip as APIServerSNI feature gate is explicitly activated", func() {
+					cfg.ExposureClassHandlers[0].SNI.Ingress.ServiceExternalIP = pointer.StringPtr("1.1.1.1")
+					cfg.FeatureGates["APIServerSNI"] = true
 
 					errorList := ValidateGardenletConfiguration(cfg, nil, false)
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug

**What this PR does / why we need it**:
Don't require that the feature gate `APIServerSNI` is set to `true` (which is the default) when an ExposureClassHandler with a `serviceExternalIP` is configured in the GardenletConfig. The validation will in this case only fail if the `APIServerSNI` feature flag is set to `false`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```NONE

```
