### PR TITLE
remove component descriptor os workaround

### DIFF
--- a/.ci/component_descriptor
+++ b/.ci/component_descriptor
@@ -30,7 +30,3 @@ component-cli component-archive resources add \
 # Create CTF tar archive at CTF_PATH based on directory in component archive layout (packed automatically)
 # Pushed by CI to private registry if CTF is found at CTF_PATH.
 component-cli ctf add "${CTF_PATH}" -f "${COMPONENT_ARCHIVE_PATH}"
-
-# Also upload the ctf to an open source repo
-# todo: remove as soon as the default component repository is public
-component-cli ctf push --repo-ctx="eu.gcr.io/gardener-project/development" "${CTF_PATH}"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->


**What this PR does / why we need it**:

Removes the previously introduced workaround for the open-source component descriptors.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
