### PR TITLE
Fixed open vpn warnings about group/other accessible keys.

### DIFF
--- a/charts/shoot-core/components/charts/vpn-shoot/templates/deployment.yaml
+++ b/charts/shoot-core/components/charts/vpn-shoot/templates/deployment.yaml
@@ -96,11 +96,14 @@ spec:
       - name: vpn-shoot
         secret:
           secretName: vpn-shoot
+          defaultMode: 0400
       - name: vpn-shoot-tlsauth
         secret:
           secretName: vpn-shoot-tlsauth
+          defaultMode: 0400
       {{- if not .Values.reversedVPN.enabled }}
       - name: vpn-shoot-dh
         secret:
           secretName: vpn-shoot-dh
+          defaultMode: 0400
       {{- end }}

--- a/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server.go
+++ b/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server.go
@@ -410,7 +410,8 @@ func (v *vpnSeedServer) Deploy(ctx context.Context) error {
 							Name: DeploymentName,
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
-									SecretName: DeploymentName,
+									SecretName:  DeploymentName,
+									DefaultMode: pointer.Int32Ptr(0400),
 								},
 							},
 						},
@@ -418,7 +419,8 @@ func (v *vpnSeedServer) Deploy(ctx context.Context) error {
 							Name: VpnSeedServerTLSAuth,
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
-									SecretName: VpnSeedServerTLSAuth,
+									SecretName:  VpnSeedServerTLSAuth,
+									DefaultMode: pointer.Int32Ptr(0400),
 								},
 							},
 						},
@@ -426,7 +428,8 @@ func (v *vpnSeedServer) Deploy(ctx context.Context) error {
 							Name: vpnSeedServerDH,
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
-									SecretName: vpnSeedServerDH,
+									SecretName:  vpnSeedServerDH,
+									DefaultMode: pointer.Int32Ptr(0400),
 								},
 							},
 						},

--- a/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server_test.go
+++ b/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server_test.go
@@ -308,7 +308,8 @@ var _ = Describe("VpnSeedServer", func() {
 									Name: DeploymentName,
 									VolumeSource: corev1.VolumeSource{
 										Secret: &corev1.SecretVolumeSource{
-											SecretName: DeploymentName,
+											SecretName:  DeploymentName,
+											DefaultMode: pointer.Int32(0400),
 										},
 									},
 								},
@@ -316,7 +317,8 @@ var _ = Describe("VpnSeedServer", func() {
 									Name: VpnSeedServerTLSAuth,
 									VolumeSource: corev1.VolumeSource{
 										Secret: &corev1.SecretVolumeSource{
-											SecretName: VpnSeedServerTLSAuth,
+											SecretName:  VpnSeedServerTLSAuth,
+											DefaultMode: pointer.Int32(0400),
 										},
 									},
 								},
@@ -324,7 +326,8 @@ var _ = Describe("VpnSeedServer", func() {
 									Name: "vpn-seed-server-dh",
 									VolumeSource: corev1.VolumeSource{
 										Secret: &corev1.SecretVolumeSource{
-											SecretName: "vpn-seed-server-dh",
+											SecretName:  "vpn-seed-server-dh",
+											DefaultMode: pointer.Int32(0400),
 										},
 									},
 								},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind cleanup

**What this PR does / why we need it**:
It sets the default mode property of the secret volumes so that the secret files are only accessible by the owner. This is anyway the recommended approach for secret/keys. It also makes the corresponding warning messages from open vpn disappear.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
None
```
