### PR TITLE
Improve messages in generic extension reconcilers

### DIFF
--- a/extensions/pkg/controller/backupbucket/reconciler.go
+++ b/extensions/pkg/controller/backupbucket/reconciler.go
@@ -106,7 +106,7 @@ func (r *reconciler) reconcile(ctx context.Context, bb *extensionsv1alpha1.Backu
 		return reconcile.Result{}, fmt.Errorf("failed to ensure finalizer on bucket secret: %+v", err)
 	}
 
-	r.logger.Info("Starting the reconciliation of backupbucket", "backupbucket", bb.Name)
+	r.logger.Info("Starting the reconciliation of backupbucket", "backupbucket", kutil.ObjectName(bb))
 	if err := r.actuator.Reconcile(ctx, bb); err != nil {
 		_ = r.statusUpdater.Error(ctx, bb, extensionscontroller.ReconcileErrCauseOrErr(err), operationType, "Error reconciling backupbucket")
 		return extensionscontroller.ReconcileErr(err)
@@ -121,7 +121,7 @@ func (r *reconciler) reconcile(ctx context.Context, bb *extensionsv1alpha1.Backu
 
 func (r *reconciler) delete(ctx context.Context, bb *extensionsv1alpha1.BackupBucket) (reconcile.Result, error) {
 	if !controllerutil.ContainsFinalizer(bb, FinalizerName) {
-		r.logger.Info("Deleting backupbucket causes a no-op as there is no finalizer.", "backupbucket", bb.Name)
+		r.logger.Info("Deleting backupbucket causes a no-op as there is no finalizer", "backupbucket", kutil.ObjectName(bb))
 		return reconcile.Result{}, nil
 	}
 
@@ -130,7 +130,7 @@ func (r *reconciler) delete(ctx context.Context, bb *extensionsv1alpha1.BackupBu
 		return reconcile.Result{}, err
 	}
 
-	r.logger.Info("Starting the deletion of backupbucket", "backupbucket", bb.Name)
+	r.logger.Info("Starting the deletion of backupbucket", "backupbucket", kutil.ObjectName(bb))
 	if err := r.actuator.Delete(ctx, bb); err != nil {
 		_ = r.statusUpdater.Error(ctx, bb, extensionscontroller.ReconcileErrCauseOrErr(err), operationType, "Error deleting backupbucket")
 		return extensionscontroller.ReconcileErr(err)
@@ -148,7 +148,7 @@ func (r *reconciler) delete(ctx context.Context, bb *extensionsv1alpha1.BackupBu
 		return reconcile.Result{}, fmt.Errorf("failed to remove finalizer on bucket secret: %+v", err)
 	}
 
-	r.logger.Info("Removing finalizer.", "backupbucket", bb.Name)
+	r.logger.Info("Removing finalizer", "backupbucket", kutil.ObjectName(bb))
 	if err := controllerutils.RemoveFinalizer(ctx, r.reader, r.client, bb, FinalizerName); err != nil {
 		return reconcile.Result{}, fmt.Errorf("error removing finalizer from backupbucket: %+v", err)
 	}

--- a/extensions/pkg/controller/healthcheck/reconciler.go
+++ b/extensions/pkg/controller/healthcheck/reconciler.go
@@ -36,6 +36,7 @@ import (
 	gardenv1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 type reconciler struct {
@@ -93,12 +94,12 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	if acc.GetDeletionTimestamp() != nil {
-		r.logger.V(6).Info("Do not perform HealthCheck for extension resource. Extension is being deleted.", "name", acc.GetName(), "namespace", acc.GetNamespace())
+		r.logger.V(6).Info("Do not perform HealthCheck for extension resource. Extension is being deleted.", "healthcheck", kutil.ObjectName(acc))
 		return reconcile.Result{}, nil
 	}
 
 	if isInMigration(acc) {
-		r.logger.Info("Do not perform HealthCheck for extension resource. Extension is being migrated.", "name", acc.GetName(), "namespace", acc.GetNamespace())
+		r.logger.Info("Do not perform HealthCheck for extension resource. Extension is being migrated.", "healthecheck", kutil.ObjectName(acc))
 		return reconcile.Result{}, nil
 	}
 
@@ -121,11 +122,11 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 			return reconcile.Result{}, err
 		}
 
-		r.logger.V(6).Info("Do not perform HealthCheck for extension resource. Shoot is hibernated.", "name", acc.GetName(), "namespace", acc.GetNamespace(), "kind", acc.GetObjectKind().GroupVersionKind().Kind)
+		r.logger.V(6).Info("Do not perform HealthCheck for extension resource. Shoot is hibernated.", "healthcheck", kutil.ObjectName(acc), "kind", acc.GetObjectKind().GroupVersionKind().Kind)
 		return reconcile.Result{}, nil
 	}
 
-	r.logger.V(6).Info("Performing health check", "name", acc.GetName(), "namespace", acc.GetNamespace(), "kind", acc.GetObjectKind().GroupVersionKind().Kind)
+	r.logger.V(6).Info("Performing healthcheck", "healthcheck", kutil.ObjectName(acc), "kind", acc.GetObjectKind().GroupVersionKind().Kind)
 	return r.performHealthCheck(ctx, request, extension)
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
It improves logging and errors messages in `extensions/pkg/controllers`:
- use everywhere one standard way to log resources' namespace and name (by using `kutil.ObjectName`);
- remove some redundant messages so all controllers now should log same kind and number of messages;
- where needed unify messages.

**Which issue(s) this PR fixes**:
Fixes #4311 
