### PR TITLE
make test-cov run the same suites as test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,7 @@ test-integration:
 
 .PHONY: test-cov
 test-cov:
-	@./hack/test-cover.sh ./cmd/... ./extensions/... ./pkg/... ./plugin/... ./landscaper/...
+	@./hack/test-cover.sh ./cmd/... ./extensions/pkg/... ./extensions/test/e2e/framework/... ./pkg/... ./plugin/... ./landscaper/...
 
 .PHONY: test-cov-clean
 test-cov-clean:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug

**What this PR does / why we need it**:

Follow-up on https://github.com/gardener/gardener/pull/4265.
I missed to adapt the `test-cov` rule to execute the same test suites as `test`.

**Which issue(s) this PR fixes**:

`make verify-extended` still runs the extension backup bucket test with test-cov, e.g. during the release:
https://concourse.ci.gardener.cloud/teams/gardener/pipelines/gardener-master/jobs/master-release-job/builds/12#L60eb31fa:407

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
