### PR TITLE
[release-v1.27] Automated cherry pick of #4355: Fix typo in osc executor script

### DIFF
--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/executor_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/executor_test.go
@@ -325,7 +325,7 @@ fi
 # effective.
 if ! diff "$PATH_CLOUDCONFIG" "$PATH_CLOUDCONFIG_OLD" >/dev/null || \
    ! diff "$PATH_CCD_SCRIPT_CHECKSUM" "$PATH_CCD_SCRIPT_CHECKSUM_OLD" >/dev/null || \
-   [[ "$HYPERKUBE_IMAGE_USED_FOR_LAST_COPY_KUBELET" != "$LAST_DOWNLOADED_HYPERKUBE_IMAGE" ]] || \; then
+   [[ "$HYPERKUBE_IMAGE_USED_FOR_LAST_COPY_KUBELET" != "$LAST_DOWNLOADED_HYPERKUBE_IMAGE" ]] ||
    [[ "$HYPERKUBE_IMAGE_USED_FOR_LAST_COPY_KUBECTL" != "$LAST_DOWNLOADED_HYPERKUBE_IMAGE" ]]; then
 
   echo "Seen newer cloud config or cloud config downloader version or hyperkube image"

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/templates/scripts/execute-cloud-config.tpl.sh
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/templates/scripts/execute-cloud-config.tpl.sh
@@ -192,7 +192,7 @@ fi
 # effective.
 if ! diff "$PATH_CLOUDCONFIG" "$PATH_CLOUDCONFIG_OLD" >/dev/null || \
    ! diff "$PATH_CCD_SCRIPT_CHECKSUM" "$PATH_CCD_SCRIPT_CHECKSUM_OLD" >/dev/null || \
-   [[ "$HYPERKUBE_IMAGE_USED_FOR_LAST_COPY_KUBELET" != "$LAST_DOWNLOADED_HYPERKUBE_IMAGE" ]] || \; then
+   [[ "$HYPERKUBE_IMAGE_USED_FOR_LAST_COPY_KUBELET" != "$LAST_DOWNLOADED_HYPERKUBE_IMAGE" ]] ||
    [[ "$HYPERKUBE_IMAGE_USED_FOR_LAST_COPY_KUBECTL" != "$LAST_DOWNLOADED_HYPERKUBE_IMAGE" ]]; then
 
   echo "Seen newer cloud config or cloud config downloader version or hyperkube image"


### PR DESCRIPTION
/area/ops-productivity
/area/quality
/kind/bug

Cherry pick of #4355 on release-v1.27.

#4355: Fix typo in osc executor script

**Release Notes:**
```bugfix operator
A bug in the cloud config downloader script that was generating error messages like `bash: line 161: ;: command not found` has been fixed.
```