### PR TITLE
Cleanup shebang and options in hack/test*.sh

### DIFF
--- a/hack/test-cover-clean.sh
+++ b/hack/test-cover-clean.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2020 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
 #
@@ -13,7 +13,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-set -e
+
+set -o errexit
+set -o nounset
+set -o pipefail
 
 echo "> Test Cover Clean"
 

--- a/hack/test-cover.sh
+++ b/hack/test-cover.sh
@@ -13,7 +13,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-set -e
+
+set -o errexit
+set -o nounset
+set -o pipefail
 
 echo "> Test Cover"
 

--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -13,7 +13,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 set -o errexit
+set -o nounset
 set -o pipefail
 
 ENVTEST_K8S_VERSION=${ENVTEST_K8S_VERSION:-"1.20"}

--- a/hack/test-prometheus.sh
+++ b/hack/test-prometheus.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
 #
@@ -13,7 +13,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-set -e
+
+set -o errexit
+set -o nounset
+set -o pipefail
 
 echo "> Test Prometheus"
 

--- a/hack/test.sh
+++ b/hack/test.sh
@@ -13,7 +13,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-set -e
+
+set -o errexit
+set -o nounset
+set -o pipefail
 
 echo "> Test"
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug

**What this PR does / why we need it**:

Cleanup shebang and options in `hack/test*.sh`, use the same in all of these hack scripts.
The missing option `pipefail` in `hack/test.sh` caused `make test` to exit with `0` even if there were failing tests, e.g.:

- https://concourse.ci.gardener.cloud/teams/gardener/pipelines/gardener-master/jobs/master-head-update-job/builds/434#L60e7b9d1:486
- https://concourse.ci.gardener.cloud/teams/gardener/pipelines/gardener-master/jobs/master-head-update-job/builds/448#L60eb2cbf:512

(Don't know why it was failing for PR jobs but not for master-head-update jobs, though)
