### PR TITLE
Increased connect timeout of reversed vpn envoy sidecar.

### DIFF
--- a/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server.go
+++ b/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server.go
@@ -925,7 +925,7 @@ var envoyConfig = `static_resources:
           - upgrade_type: CONNECT
   clusters:
   - name: dynamic_forward_proxy_cluster
-    connect_timeout: 1s
+    connect_timeout: 20s
     lb_policy: CLUSTER_PROVIDED
     cluster_type:
       name: envoy.clusters.dynamic_forward_proxy

--- a/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server_test.go
+++ b/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server_test.go
@@ -150,7 +150,7 @@ var _ = Describe("VpnSeedServer", func() {
           - upgrade_type: CONNECT
   clusters:
   - name: dynamic_forward_proxy_cluster
-    connect_timeout: 1s
+    connect_timeout: 20s
     lb_policy: CLUSTER_PROVIDED
     cluster_type:
       name: envoy.clusters.dynamic_forward_proxy


### PR DESCRIPTION
The establishment of the reversed vpn connection seem to take around 5s.
This in conjunction with the fact that the reversed vpn connection may
need to be re-established quite often depending on the load on the istio
ingress gateway can cause the time frame without connectivity between
seed and shoot to be quite longer than the 1s connect timeout previously
configured.
This change increases the connect timeout with a good buffer so that
also `kubectl exec` and potentially also web hooks should no longer
fail, but rather stall until the vpn connection has been re-established.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
The establishment of the reversed vpn connection seem to take around 5s.
This in conjunction with the fact that the reversed vpn connection may
need to be re-established quite often depending on the load on the istio
ingress gateway can cause the time frame without connectivity between
seed and shoot to be quite longer than the 1s connect timeout previously
configured.
This change increases the connect timeout with a good buffer so that
also `kubectl exec` and potentially also web hooks should no longer
fail, but rather stall until the vpn connection has been re-established.

**Which issue(s) this PR fixes**:
Fixes #4302 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
