### PR TITLE
optionally require external shoot client

### DIFF
--- a/extensions/pkg/util/shoot_clients.go
+++ b/extensions/pkg/util/shoot_clients.go
@@ -16,6 +16,7 @@ package util
 
 import (
 	"context"
+	"os"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/chartrenderer"
@@ -65,16 +66,26 @@ func NewShootClients(c client.Client, clientset kubernetes.Interface, gardenerCl
 	}
 }
 
-// NewClientForShoot returns the rest config and the client for the given shoot namespace.
+// NewClientForShoot returns the rest config and the client for the given shoot namespace. It first looks to use the endpoint given by
+// v1beta1constants.SecretNameGardenerInternal and, if it cannot find that, then from v1beta1constants.SecretNameGardener.
+// However, if the environment variable GARDENER_SHOOT_CLIENT=external, then it *only* checks for the external endpoint,
+// i.e. v1beta1constants.SecretNameGardener. This is useful when connecting from outside the seed cluster on which the shoot kube-apiserver
+// is running.
 func NewClientForShoot(ctx context.Context, c client.Client, namespace string, opts client.Options) (*rest.Config, client.Client, error) {
 	var (
 		gardenerSecret = &corev1.Secret{}
 		err            error
 	)
 
-	if err = c.Get(ctx, kutil.Key(namespace, v1beta1constants.SecretNameGardenerInternal), gardenerSecret); err != nil && apierrors.IsNotFound(err) {
+	// do we try the internal one first?
+	if os.Getenv("GARDENER_SHOOT_CLIENT") != "external" {
+		if err = c.Get(ctx, kutil.Key(namespace, v1beta1constants.SecretNameGardenerInternal), gardenerSecret); err != nil && apierrors.IsNotFound(err) {
+			err = c.Get(ctx, kutil.Key(namespace, v1beta1constants.SecretNameGardener), gardenerSecret)
+		}
+	} else {
 		err = c.Get(ctx, kutil.Key(namespace, v1beta1constants.SecretNameGardener), gardenerSecret)
 	}
+
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
Signed-off-by: Avi Deitcher <avi@deitcher.net>

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

(honestly wasn't 100% sure how to categorize it, so maintainers should feel free to change_

**What this PR does / why we need it**:

[util.NewShootForClient](https://pkg.go.dev/github.com/gardener/gardener/extensions/pkg/util#NewClientForShoot) _always_ tries to create a client for the internal endpoint, and only if that fails to be created, the external endpoint. This can be a problem where the connection to the shoot kube-apiserver is from outside the seed cluster on which it is running. 

If the env var `GARDENER_SHOOT_CLIENT=external`, then it _only_ uses the external; if it is not set, or is set to anything else, it continues to behave as it normally does.


**Special notes for your reviewer**:

As discussed in Slack with @rfranzke and @timebertt 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
Support option requiring shoot connection to be external
```
