### PR TITLE
[release-v1.27] Automated cherry pick of #4365: Upgrade cluster-autoscaler

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -81,7 +81,7 @@ images:
   sourceRepository: github.com/gardener/autoscaler
   repository: eu.gcr.io/gardener-project/gardener/autoscaler/cluster-autoscaler
   targetVersion: "< 1.16"
-  tag: "v0.10.1"
+  tag: "v0.10.2"
 - name: vpn-seed
   sourceRepository: github.com/gardener/vpn
   repository: eu.gcr.io/gardener-project/gardener/vpn-seed


### PR DESCRIPTION
Cherry pick of #4365 on release-v1.27.

#4365: Upgrade cluster-autoscaler

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
``` bugfix user github.com/gardener/autoscaler #81 @ialidzhikov
Avoids panics when VM type isn't found during scale from zero
```

``` bugfix user github.com/gardener/autoscaler #81 @ialidzhikov
Fetches the VM from the correct map for MCM provider Azure and hence doesn't panic anymore
```

