### PR TITLE
[release-v1.27] Automated cherry pick of #4362: Increased connect timeout of reversed vpn envoy sidecar.

### DIFF
--- a/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server.go
+++ b/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server.go
@@ -922,7 +922,7 @@ var envoyConfig = `static_resources:
           - upgrade_type: CONNECT
   clusters:
   - name: dynamic_forward_proxy_cluster
-    connect_timeout: 1s
+    connect_timeout: 20s
     lb_policy: CLUSTER_PROVIDED
     cluster_type:
       name: envoy.clusters.dynamic_forward_proxy

--- a/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server_test.go
+++ b/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server_test.go
@@ -150,7 +150,7 @@ var _ = Describe("VpnSeedServer", func() {
           - upgrade_type: CONNECT
   clusters:
   - name: dynamic_forward_proxy_cluster
-    connect_timeout: 1s
+    connect_timeout: 20s
     lb_policy: CLUSTER_PROVIDED
     cluster_type:
       name: envoy.clusters.dynamic_forward_proxy


### PR DESCRIPTION
/area/networking
/kind/bug

Cherry pick of #4362 on release-v1.27.

#4362: Increased connect timeout of reversed vpn envoy sidecar.

**Release Notes:**
```other operator

```