### PR TITLE
Disallow kubeconfig rotation for cluster in deletion

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -31,6 +31,7 @@ The following tables are a summary of the feature gates that you can set on diff
 | SeedKubeScheduler | `false` | `Alpha` | `1.15` | |
 | ReversedVPN | `false` | `Alpha` | `1.22` | |
 | UseDNSRecords | `false` | `Alpha` | `1.27.0` | |
+| DisallowKubeconfigRotationForShootInDeletion | `false` | `Alpha` | `1.28` | |
 
 ## Feature gates for graduated or deprecated features
 
@@ -91,3 +92,4 @@ A *General Availability* (GA) feature is also referred to as a *stable* feature.
 * `ReversedVPN` reverses the connection setup of the vpn tunnel between the Seed and the Shoot cluster(s). It allows Seed and Shoot clusters to be in different networks with only direct access in one direction (Shoot -> Seed). In addition to that, it reduces the amount of load balancers required, i.e. no load balancers are required for the vpn tunnel anymore. It requires `APIServerSNI` and kubernetes version `1.18` or higher to work. Details can be found in [GEP-14](../proposals/14-reversed-cluster-vpn.md).
 * `AdminKubeconfigRequest` enables the `AdminKubeconfigRequest` endpoint on Shoot resources. See [GEP-16](../proposals/16-adminkubeconfig-subresource.md) for more details.
 * `UseDNSRecords` enables using `DNSRecord` resources for Gardener DNS records instead of `DNSProvider`, `DNSEntry`, and `DNSOwner` resources. See [Contract: `DNSRecord` resources](../extensions/dnsrecord.md) for more details.
+* `DisallowKubeconfigRotationForShootInDeletion` when enabled, does not allow kubeconfig rotation to be requested for shoot cluster that is already in deletion phase, i.e. `metadata.deletionTimestamp` is set.

--- a/docs/usage/shoot_operations.md
+++ b/docs/usage/shoot_operations.md
@@ -36,6 +36,7 @@ kubectl -n garden-<project-name> annotate shoot <shoot-name> gardener.cloud/oper
 ## Rotate kubeconfig credentials
 
 Annotate the shoot with `gardener.cloud/operation=rotate-kubeconfig-credentials` to make the `gardenlet` exchange the credentials in your shoot cluster's kubeconfig.
+This operation is now allowed for shoot clusters that are already in deletion.
 Please note that only the token (and basic auth password, if enabled) are exchanged. The cluster CAs remain the same.
 
 ```bash

--- a/hack/local-development/start-apiserver
+++ b/hack/local-development/start-apiserver
@@ -53,6 +53,7 @@ apiserver_flags="
   --feature-gates SeedChange=true \
   --feature-gates AdminKubeconfigRequest=true \
   --feature-gates UseDNSRecords=false \
+  --feature-gates DisallowKubeconfigRotationForShootInDeletion=true \
   --shoot-admin-kubeconfig-max-expiration=1h \
   --enable-admission-plugins=ShootVPAEnabledByDefault \
   --v 2"

--- a/hack/local-development/start-apiserver
+++ b/hack/local-development/start-apiserver
@@ -53,7 +53,7 @@ apiserver_flags="
   --feature-gates SeedChange=true \
   --feature-gates AdminKubeconfigRequest=true \
   --feature-gates UseDNSRecords=false \
-  --feature-gates DisallowKubeconfigRotationForShootInDeletion=true \
+  --feature-gates DisallowKubeconfigRotationForShootInDeletion=false \
   --shoot-admin-kubeconfig-max-expiration=1h \
   --enable-admission-plugins=ShootVPAEnabledByDefault \
   --v 2"

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -105,8 +105,8 @@ func ValidateShootUpdate(newShoot, oldShoot *core.Shoot) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&newShoot.ObjectMeta, &oldShoot.ObjectMeta, field.NewPath("metadata"))...)
-	allErrs = append(allErrs, ValidateShootSpecUpdate(&newShoot.Spec, &oldShoot.Spec, newShoot.ObjectMeta, field.NewPath("spec"))...)
 	allErrs = append(allErrs, ValidateShootObjectMetaUpdate(newShoot.ObjectMeta, oldShoot.ObjectMeta, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, ValidateShootSpecUpdate(&newShoot.Spec, &oldShoot.Spec, newShoot.ObjectMeta, field.NewPath("spec"))...)
 	allErrs = append(allErrs, ValidateShoot(newShoot)...)
 
 	return allErrs

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -106,6 +106,7 @@ func ValidateShootUpdate(newShoot, oldShoot *core.Shoot) field.ErrorList {
 
 	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&newShoot.ObjectMeta, &oldShoot.ObjectMeta, field.NewPath("metadata"))...)
 	allErrs = append(allErrs, ValidateShootSpecUpdate(&newShoot.Spec, &oldShoot.Spec, newShoot.ObjectMeta, field.NewPath("spec"))...)
+	allErrs = append(allErrs, ValidateShootObjectMetaUpdate(newShoot.ObjectMeta, oldShoot.ObjectMeta, field.NewPath("metadata"))...)
 	allErrs = append(allErrs, ValidateShoot(newShoot)...)
 
 	return allErrs
@@ -127,6 +128,36 @@ func ValidateShootTemplateUpdate(newShootTemplate, oldShootTemplate *core.ShootT
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, ValidateShootSpecUpdate(&newShootTemplate.Spec, &oldShootTemplate.Spec, newShootTemplate.ObjectMeta, fldPath.Child("spec"))...)
+
+	return allErrs
+}
+
+// ValidateShootObjectMetaUpdate validates the object metadata of a Shoot object.
+func ValidateShootObjectMetaUpdate(newMeta, oldMeta metav1.ObjectMeta, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, validateShootKubeconfigRotation(newMeta, oldMeta, fldPath)...)
+
+	return allErrs
+}
+
+// validateShootKubeconfigRotation validates that shoot in deletion cannot rotate its kubeconfig.
+func validateShootKubeconfigRotation(newMeta, oldMeta metav1.ObjectMeta, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if newMeta.DeletionTimestamp == nil {
+		return allErrs
+	}
+
+	// already set operation is valid use case
+	if oldOperation, oldOk := oldMeta.Annotations[v1beta1constants.GardenerOperation]; oldOk && oldOperation == v1beta1constants.ShootOperationRotateKubeconfigCredentials {
+		return allErrs
+	}
+
+	// disallow kubeconfig rotation
+	if operation, ok := newMeta.Annotations[v1beta1constants.GardenerOperation]; ok && operation == v1beta1constants.ShootOperationRotateKubeconfigCredentials {
+		allErrs = append(allErrs, field.Invalid(fldPath.Child("annotations").Key(v1beta1constants.GardenerOperation), v1beta1constants.ShootOperationRotateKubeconfigCredentials, "kubeconfig rotations is not allowed for clusters in deletion"))
+	}
 
 	return allErrs
 }

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -2158,14 +2158,14 @@ var _ = Describe("Shoot Validation Tests", func() {
 						Expect(errorList).To(HaveLen(0))
 					}
 				},
-				Entry("it should allow kubeconfig rotation for cluster not in deletion", nil, map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, false, false),
-				Entry("it should allow reconcile operation for cluster in deletion", nil, map[string]string{"gardener.cloud/operation": "reconcile"}, true, false),
-				Entry("it should allow any annotations for cluster in deletion", nil, map[string]string{"foo": "bar"}, true, false),
-				Entry("it should allow other update request for cluster in deletion and already requested kubeconfig rotation operation", map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, map[string]string{"gardener.cloud/operation": "reconcile"}, true, false),
-				Entry("it should allow any annotations for cluster in deletion with already requested kubeconfig rotation", map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, map[string]string{"foo": "bar"}, true, false),
-				Entry("it should allow update request for cluster in deletion with already requested kubeconfig rotation", map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials", "foo": "bar"}, true, false),
-				Entry("it should not allow kubeconfig rotation for cluster in deletion", nil, map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, true, true),
-				Entry("it should not allow kubeconfig rotation for cluster in deletion with already requested operation", map[string]string{"gardener.cloud/operation": "some-other-operation"}, map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, true, true),
+				Entry("should allow kubeconfig rotation for cluster not in deletion", nil, map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, false, false),
+				Entry("should allow reconcile operation for cluster in deletion", nil, map[string]string{"gardener.cloud/operation": "reconcile"}, true, false),
+				Entry("should allow any annotations for cluster in deletion", nil, map[string]string{"foo": "bar"}, true, false),
+				Entry("should allow other update request for cluster in deletion and already requested kubeconfig rotation operation", map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, map[string]string{"gardener.cloud/operation": "reconcile"}, true, false),
+				Entry("should allow any annotations for cluster in deletion with already requested kubeconfig rotation", map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, map[string]string{"foo": "bar"}, true, false),
+				Entry("should allow update request for cluster in deletion with already requested kubeconfig rotation", map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials", "foo": "bar"}, true, false),
+				Entry("should not allow kubeconfig rotation for cluster in deletion", nil, map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, true, true),
+				Entry("should not allow kubeconfig rotation for cluster in deletion with already requested operation", map[string]string{"gardener.cloud/operation": "some-other-operation"}, map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, true, true),
 			)
 
 			DescribeTable("DisallowKubeconfigRotationForShootInDeletion=false",
@@ -2186,14 +2186,14 @@ var _ = Describe("Shoot Validation Tests", func() {
 
 					Expect(errorList).To(HaveLen(0))
 				},
-				Entry("it should allow kubeconfig rotation for cluster not in deletion", nil, map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, false),
-				Entry("it should allow reconcile operation for cluster in deletion", nil, map[string]string{"gardener.cloud/operation": "reconcile"}, true),
-				Entry("it should allow any annotations for cluster in deletion", nil, map[string]string{"foo": "bar"}, true),
-				Entry("it should allow other update request for cluster in deletion and already requested kubeconfig rotation operation", map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, map[string]string{"gardener.cloud/operation": "reconcile"}, true),
-				Entry("it should allow any annotations for cluster in deletion with already requested kubeconfig rotation", map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, map[string]string{"foo": "bar"}, true),
-				Entry("it should allow update request for cluster in deletion with already requested kubeconfig rotation", map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials", "foo": "bar"}, true),
-				Entry("it should allow kubeconfig rotation for cluster in deletion", nil, map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, true),
-				Entry("it should allow kubeconfig rotation for cluster in deletion with already requested operation", map[string]string{"gardener.cloud/operation": "some-other-operation"}, map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, true),
+				Entry("should allow kubeconfig rotation for cluster not in deletion", nil, map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, false),
+				Entry("should allow reconcile operation for cluster in deletion", nil, map[string]string{"gardener.cloud/operation": "reconcile"}, true),
+				Entry("should allow any annotations for cluster in deletion", nil, map[string]string{"foo": "bar"}, true),
+				Entry("should allow other update request for cluster in deletion and already requested kubeconfig rotation operation", map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, map[string]string{"gardener.cloud/operation": "reconcile"}, true),
+				Entry("should allow any annotations for cluster in deletion with already requested kubeconfig rotation", map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, map[string]string{"foo": "bar"}, true),
+				Entry("should allow update request for cluster in deletion with already requested kubeconfig rotation", map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials", "foo": "bar"}, true),
+				Entry("should allow kubeconfig rotation for cluster in deletion", nil, map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, true),
+				Entry("should allow kubeconfig rotation for cluster in deletion with already requested operation", map[string]string{"gardener.cloud/operation": "some-other-operation"}, map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, true),
 			)
 		})
 	})

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -2130,43 +2130,72 @@ var _ = Describe("Shoot Validation Tests", func() {
 			Expect(errorList).To(HaveLen(0))
 		})
 
-		DescribeTable("kubeconfig rotation",
-			func(oldAnnotations, newAnnotations map[string]string, newSetDeletionTimestamp, expectedError bool) {
-				now := metav1.NewTime(time.Now())
-				newShoot := prepareShootForUpdate(shoot)
-				if oldAnnotations != nil {
-					shoot.Annotations = oldAnnotations
-				}
+		Describe("kubeconfig rotation", func() {
+			DescribeTable("DisallowKubeconfigRotationForShootInDeletion=true",
+				func(oldAnnotations, newAnnotations map[string]string, newSetDeletionTimestamp, expectedError bool) {
+					defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.DisallowKubeconfigRotationForShootInDeletion, true)()
+					now := metav1.NewTime(time.Now())
+					newShoot := prepareShootForUpdate(shoot)
+					if oldAnnotations != nil {
+						shoot.Annotations = oldAnnotations
+					}
 
-				if newSetDeletionTimestamp {
-					newShoot.DeletionTimestamp = &now
-				}
-				newShoot.Annotations = newAnnotations
+					if newSetDeletionTimestamp {
+						newShoot.DeletionTimestamp = &now
+					}
+					newShoot.Annotations = newAnnotations
 
-				errorList := ValidateShootObjectMetaUpdate(newShoot.ObjectMeta, shoot.ObjectMeta, field.NewPath("metadata"))
+					errorList := ValidateShootObjectMetaUpdate(newShoot.ObjectMeta, shoot.ObjectMeta, field.NewPath("metadata"))
 
-				if expectedError {
-					Expect(errorList).ToNot(HaveLen(0))
-					Expect(errorList).To(ConsistOfFields(Fields{
-						"Type":   Equal(field.ErrorTypeInvalid),
-						"Field":  Equal("metadata.annotations[gardener.cloud/operation]"),
-						"Detail": ContainSubstring(`kubeconfig rotations is not allowed for clusters in deletion`),
-					}))
-				} else {
+					if expectedError {
+						Expect(errorList).ToNot(HaveLen(0))
+						Expect(errorList).To(ConsistOfFields(Fields{
+							"Type":   Equal(field.ErrorTypeInvalid),
+							"Field":  Equal("metadata.annotations[gardener.cloud/operation]"),
+							"Detail": ContainSubstring(`kubeconfig rotations is not allowed for clusters in deletion`),
+						}))
+					} else {
+						Expect(errorList).To(HaveLen(0))
+					}
+				},
+				Entry("it should allow kubeconfig rotation for cluster not in deletion", nil, map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, false, false),
+				Entry("it should allow reconcile operation for cluster in deletion", nil, map[string]string{"gardener.cloud/operation": "reconcile"}, true, false),
+				Entry("it should allow any annotations for cluster in deletion", nil, map[string]string{"foo": "bar"}, true, false),
+				Entry("it should allow other update request for cluster in deletion and already requested kubeconfig rotation operation", map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, map[string]string{"gardener.cloud/operation": "reconcile"}, true, false),
+				Entry("it should allow any annotations for cluster in deletion with already requested kubeconfig rotation", map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, map[string]string{"foo": "bar"}, true, false),
+				Entry("it should allow update request for cluster in deletion with already requested kubeconfig rotation", map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials", "foo": "bar"}, true, false),
+				Entry("it should not allow kubeconfig rotation for cluster in deletion", nil, map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, true, true),
+				Entry("it should not allow kubeconfig rotation for cluster in deletion with already requested operation", map[string]string{"gardener.cloud/operation": "some-other-operation"}, map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, true, true),
+			)
+
+			DescribeTable("DisallowKubeconfigRotationForShootInDeletion=false",
+				func(oldAnnotations, newAnnotations map[string]string, newSetDeletionTimestamp bool) {
+					defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.DisallowKubeconfigRotationForShootInDeletion, false)()
+					now := metav1.NewTime(time.Now())
+					newShoot := prepareShootForUpdate(shoot)
+					if oldAnnotations != nil {
+						shoot.Annotations = oldAnnotations
+					}
+
+					if newSetDeletionTimestamp {
+						newShoot.DeletionTimestamp = &now
+					}
+					newShoot.Annotations = newAnnotations
+
+					errorList := ValidateShootObjectMetaUpdate(newShoot.ObjectMeta, shoot.ObjectMeta, field.NewPath("metadata"))
+
 					Expect(errorList).To(HaveLen(0))
-				}
-			},
-			Entry("it should allow kubeconfig rotation for cluster not in deletion", nil, map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, false, false),
-
-			Entry("it should allow reconcile operation for cluster in deletion", nil, map[string]string{"gardener.cloud/operation": "reconcile"}, true, false),
-			Entry("it should allow any annotations for cluster in deletion", nil, map[string]string{"foo": "bar"}, true, false),
-			Entry("it should allow other update request for cluster in deletion and already requested kubeconfig rotation operation", map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, map[string]string{"gardener.cloud/operation": "reconcile"}, true, false),
-			Entry("it should allow any annotations for cluster in deletion with already requested kubeconfig rotation", map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, map[string]string{"foo": "bar"}, true, false),
-			Entry("it should allow update request for cluster in deletion with already requested kubeconfig rotation", map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials", "foo": "bar"}, true, false),
-
-			Entry("it should not allow kubeconfig rotation for cluster in deletion", nil, map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, true, true),
-			Entry("it should not allow kubeconfig rotation for cluster in deletion with already requested operation", map[string]string{"gardener.cloud/operation": "some-other-operation"}, map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, true, true),
-		)
+				},
+				Entry("it should allow kubeconfig rotation for cluster not in deletion", nil, map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, false),
+				Entry("it should allow reconcile operation for cluster in deletion", nil, map[string]string{"gardener.cloud/operation": "reconcile"}, true),
+				Entry("it should allow any annotations for cluster in deletion", nil, map[string]string{"foo": "bar"}, true),
+				Entry("it should allow other update request for cluster in deletion and already requested kubeconfig rotation operation", map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, map[string]string{"gardener.cloud/operation": "reconcile"}, true),
+				Entry("it should allow any annotations for cluster in deletion with already requested kubeconfig rotation", map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, map[string]string{"foo": "bar"}, true),
+				Entry("it should allow update request for cluster in deletion with already requested kubeconfig rotation", map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials", "foo": "bar"}, true),
+				Entry("it should allow kubeconfig rotation for cluster in deletion", nil, map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, true),
+				Entry("it should allow kubeconfig rotation for cluster in deletion with already requested operation", map[string]string{"gardener.cloud/operation": "some-other-operation"}, map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, true),
+			)
+		})
 	})
 
 	Describe("#ValidateShootStatus, #ValidateShootStatusUpdate", func() {

--- a/pkg/apiserver/features/features.go
+++ b/pkg/apiserver/features/features.go
@@ -23,9 +23,10 @@ import (
 )
 
 var featureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	features.SeedChange:             {Default: false, PreRelease: featuregate.Alpha},
-	features.AdminKubeconfigRequest: {Default: false, PreRelease: featuregate.Alpha},
-	features.UseDNSRecords:          {Default: false, PreRelease: featuregate.Alpha},
+	features.SeedChange:                                   {Default: false, PreRelease: featuregate.Alpha},
+	features.AdminKubeconfigRequest:                       {Default: false, PreRelease: featuregate.Alpha},
+	features.UseDNSRecords:                                {Default: false, PreRelease: featuregate.Alpha},
+	features.DisallowKubeconfigRotationForShootInDeletion: {Default: false, PreRelease: featuregate.Alpha},
 }
 
 // RegisterFeatureGates registers the feature gates of the Gardener API Server.

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -99,7 +99,7 @@ const (
 	UseDNSRecords featuregate.Feature = "UseDNSRecords"
 
 	// DisallowKubeconfigRotationForShootInDeletion when enabled disallows kubeconfig rotations to be requested
-	// for shoots that are already in deleting phase.
+	// for shoots that are already in the deletion phase, i.e. `metadata.deletionTimestamp` is set
 	// owner: @vpnachev
 	// alpha: v1.28.0
 	DisallowKubeconfigRotationForShootInDeletion featuregate.Feature = "DisallowKubeconfigRotationForShootInDeletion"

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -97,4 +97,10 @@ const (
 	// owner: @stoyanr
 	// alpha: v1.27.0
 	UseDNSRecords featuregate.Feature = "UseDNSRecords"
+
+	// DisallowKubeconfigRotationForShootInDeletion when enabled disallows kubeconfig rotations to be requested
+	// for shoots that are already in deleting phase.
+	// owner: @vpnachev
+	// alpha: v1.28.0
+	DisallowKubeconfigRotationForShootInDeletion featuregate.Feature = "DisallowKubeconfigRotationForShootInDeletion"
 )

--- a/pkg/utils/test/test.go
+++ b/pkg/utils/test/test.go
@@ -144,7 +144,7 @@ func WithFeatureGate(gate featuregate.FeatureGate, f featuregate.Feature, value 
 
 	return func() {
 		if err := gate.(featuregate.MutableFeatureGate).Set(fmt.Sprintf("%s=%v", f, originalValue)); err != nil {
-			ginkgo.Fail(fmt.Sprintf("cound not restore feature gate %s=%v: %v", f, originalValue, err))
+			ginkgo.Fail(fmt.Sprintf("could not restore feature gate %s=%v: %v", f, originalValue, err))
 		}
 	}
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
Disallow kubeconfig rotation for cluster in deletion.

**Which issue(s) this PR fixes**:
Fixes #4346 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Gardener API server now has a feature gate `DisallowKubeconfigRotationForShootInDeletion` , disabled by default, that  disallows kubeconfig rotation to be requested for shoot cluster in deletion.
```
