### PR TITLE
Increase base memory for metrics-server.

### DIFF
--- a/pkg/operation/botanist/component/metricsserver/metrics_server.go
+++ b/pkg/operation/botanist/component/metricsserver/metrics_server.go
@@ -352,12 +352,12 @@ func (m *metricsServer) computeResourcesData() (map[string][]byte, error) {
 							},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("50m"),
-									corev1.ResourceMemory: resource.MustParse("150Mi"),
+									corev1.ResourceCPU:    resource.MustParse("20m"),
+									corev1.ResourceMemory: resource.MustParse("40Mi"),
 								},
 								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("500m"),
-									corev1.ResourceMemory: resource.MustParse("1Gi"),
+									corev1.ResourceCPU:    resource.MustParse("20m"),
+									corev1.ResourceMemory: resource.MustParse("40Mi"),
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{{
@@ -372,7 +372,7 @@ func (m *metricsServer) computeResourcesData() (map[string][]byte, error) {
 								"/pod_nanny",
 								"--cpu=20m",
 								"--extra-cpu=1m",
-								"--memory=15Mi",
+								"--memory=40Mi",
 								"--extra-memory=2Mi",
 								"--threshold=5",
 								"--deployment=" + deploymentName,

--- a/pkg/operation/botanist/component/metricsserver/metrics_server_test.go
+++ b/pkg/operation/botanist/component/metricsserver/metrics_server_test.go
@@ -254,11 +254,11 @@ spec:
           periodSeconds: 10
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: 20m
+            memory: 40Mi
           requests:
-            cpu: 50m
-            memory: 150Mi
+            cpu: 20m
+            memory: 40Mi
         volumeMounts:
         - mountPath: /srv/metrics-server/tls
           name: metrics-server
@@ -266,7 +266,7 @@ spec:
         - /pod_nanny
         - --cpu=20m
         - --extra-cpu=1m
-        - --memory=15Mi
+        - --memory=40Mi
         - --extra-memory=2Mi
         - --threshold=5
         - --deployment=metrics-server
@@ -380,11 +380,11 @@ spec:
           periodSeconds: 10
         resources:
           limits:
-            cpu: 500m
-            memory: 1Gi
+            cpu: 20m
+            memory: 40Mi
           requests:
-            cpu: 50m
-            memory: 150Mi
+            cpu: 20m
+            memory: 40Mi
         volumeMounts:
         - mountPath: /srv/metrics-server/tls
           name: metrics-server
@@ -392,7 +392,7 @@ spec:
         - /pod_nanny
         - --cpu=20m
         - --extra-cpu=1m
-        - --memory=15Mi
+        - --memory=40Mi
         - --extra-memory=2Mi
         - --threshold=5
         - --deployment=metrics-server


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane auto-scaling
/kind impediment

**What this PR does / why we need it**:
Increase base memory for metrics-server.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
`15Mi` added in #4216 was cutting too close.

cc @vpnachev I think this PR should be included in any release that includes #4216.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
