### PR TITLE
Grafana Controlplane Logs Dashboard discover available components at runtime.

### DIFF
--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/controlplane-logs-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/controlplane-logs-dashboard.json
@@ -1,12 +1,21 @@
-{{- define "logging-dashboard" -}}
 {
     "annotations": {
-      "list": []
+      "list": [
+        {
+          "builtIn": 1,
+          "datasource": "-- Grafana --",
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
+          "type": "dashboard"
+        }
+      ]
     },
     "editable": true,
     "gnetId": null,
     "graphTooltip": 0,
-    "iteration": 1611650877419,
+    "iteration": 1626335460760,
     "links": [],
     "panels": [
       {
@@ -15,7 +24,6 @@
         "description": "Shows the percentage of replicas that are up and running.",
         "fieldConfig": {
           "defaults": {
-            "custom": {},
             "mappings": [],
             "thresholds": {
               "mode": "absolute",
@@ -61,12 +69,14 @@
             "fields": "",
             "values": false
           },
+          "text": {},
           "textMode": "auto"
         },
-        "pluginVersion": "7.2.1",
+        "pluginVersion": "7.5.7",
         "targets": [
           {
-            "expr": "count(up{job=\"$component\"} == 1) / count(up{job=\"$component\"})",
+            "exemplar": true,
+            "expr": "count(up{pod=~\"$pod\"} == 1) / count(up{pod=~\"$pod\"})",
             "format": "time_series",
             "instant": false,
             "interval": "",
@@ -90,7 +100,7 @@
         "description": "Shows the CPU usage and shows the requests and limits.",
         "fieldConfig": {
           "defaults": {
-            "custom": {}
+            "links": []
           },
           "overrides": []
         },
@@ -118,9 +128,10 @@
         "links": [],
         "nullPointMode": "null",
         "options": {
-          "dataLinks": []
+          "alertThreshold": true
         },
         "percentage": false,
+        "pluginVersion": "7.5.7",
         "pointradius": 2,
         "points": false,
         "renderer": "flot",
@@ -130,24 +141,30 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "sum(rate(container_cpu_usage_seconds_total{pod=~\"$component-(.+)\"}[$__rate_interval])) by (pod)",
+            "exemplar": true,
+            "expr": "sum(rate(container_cpu_usage_seconds_total{pod=~\"$pod\"}[$__rate_interval])) by (pod)",
             "format": "time_series",
+            "interval": "",
             "intervalFactor": 1,
-            "legendFormat": "{{ "{{" }}pod}}-current",
+            "legendFormat": "{{pod}}-current",
             "refId": "A"
           },
           {
-            "expr": "sum(kube_pod_container_resource_limits_cpu_cores{pod=~\"$component-(.+)\"}) by (pod)",
+            "exemplar": true,
+            "expr": "sum(kube_pod_container_resource_limits_cpu_cores{pod=~\"$pod\"}) by (pod)",
             "format": "time_series",
+            "interval": "",
             "intervalFactor": 1,
-            "legendFormat": "{{ "{{" }}pod}}-limits",
+            "legendFormat": "{{pod}}-limits",
             "refId": "C"
           },
           {
-            "expr": "sum(kube_pod_container_resource_requests_cpu_cores{pod=~\"$component-(.+)\"}) by (pod)",
+            "exemplar": true,
+            "expr": "sum(kube_pod_container_resource_requests_cpu_cores{pod=~\"$pod\"}) by (pod)",
             "format": "time_series",
+            "interval": "",
             "intervalFactor": 1,
-            "legendFormat": "{{ "{{" }}pod}}-requests",
+            "legendFormat": "{{pod}}-requests",
             "refId": "B"
           }
         ],
@@ -202,7 +219,7 @@
         "description": "Shows the memory usage.",
         "fieldConfig": {
           "defaults": {
-            "custom": {}
+            "links": []
           },
           "overrides": []
         },
@@ -230,9 +247,10 @@
         "links": [],
         "nullPointMode": "null",
         "options": {
-          "dataLinks": []
+          "alertThreshold": true
         },
         "percentage": false,
+        "pluginVersion": "7.5.7",
         "pointradius": 2,
         "points": false,
         "renderer": "flot",
@@ -242,24 +260,30 @@
         "steppedLine": false,
         "targets": [
           {
-            "expr": "sum(container_memory_working_set_bytes{pod=~\"$component-(.+)\"}) by (pod)",
+            "exemplar": true,
+            "expr": "sum(container_memory_working_set_bytes{pod=~\"$pod\"}) by (pod)",
             "format": "time_series",
+            "interval": "",
             "intervalFactor": 1,
-            "legendFormat": "{{ "{{" }}pod}}-current",
+            "legendFormat": "{{pod}}-current",
             "refId": "A"
           },
           {
-            "expr": "sum(kube_pod_container_resource_limits_memory_bytes{pod=~\"$component-(.+)\"}) by (pod)",
+            "exemplar": true,
+            "expr": "sum(kube_pod_container_resource_limits_memory_bytes{pod=~\"$pod\"}) by (pod)",
             "format": "time_series",
+            "interval": "",
             "intervalFactor": 1,
-            "legendFormat": "{{ "{{" }}pod}}-limits",
+            "legendFormat": "{{pod}}-limits",
             "refId": "B"
           },
           {
-            "expr": "sum(kube_pod_container_resource_requests_memory_bytes{pod=~\"$component-(.+)\"}) by (pod)",
+            "exemplar": true,
+            "expr": "sum(kube_pod_container_resource_requests_memory_bytes{pod=~\"$pod\"}) by (pod)",
             "format": "time_series",
+            "interval": "",
             "intervalFactor": 1,
-            "legendFormat": "{{ "{{" }}pod}}-requests",
+            "legendFormat": "{{pod}}-requests",
             "refId": "C"
           }
         ],
@@ -307,9 +331,7 @@
       {
         "datasource": "loki",
         "fieldConfig": {
-          "defaults": {
-            "custom": {}
-          },
+          "defaults": {},
           "overrides": []
         },
         "gridPos": {
@@ -321,6 +343,7 @@
         "id": 43,
         "interval": "",
         "options": {
+          "dedupStrategy": "none",
           "showLabels": false,
           "showTime": true,
           "sortOrder": "Descending",
@@ -328,7 +351,7 @@
         },
         "targets": [
           {
-            "expr": "{pod_name=~\"$component-(.+)\", container_name=~\"$container\", severity=~\"$severity\"} |~ \"$search\"",
+            "expr": "{pod_name=~\"$pod\", container_name=~\"$container\", severity=~\"$severity\"} |~ \"$search\"",
             "refId": "A"
           }
         ],
@@ -339,7 +362,7 @@
       }
     ],
     "refresh": "1m",
-    "schemaVersion": 26,
+    "schemaVersion": 27,
     "style": "dark",
     "tags": [
       "controlplane",
@@ -349,53 +372,32 @@
     "templating": {
       "list": [
         {
-          "allValue": "",
+          "allValue": ".+",
           "current": {
             "selected": true,
-            "text": "{{ (index . 0).PodPrefix }}",
-            "value": "{{ (index . 0).PodPrefix }}"
+            "tags": [],
+            "text": [
+              "All"
+            ],
+            "value": [
+              ".*"
+            ]
           },
-          "hide": 0,
-          "includeAll": false,
-          "label": "Component",
-          "multi": false,
-          "name": "component",
-          "options": [
-            {
-              "selected": true
-            }{{ range $i, $c := . }},
-            {
-              "selected": false,
-              "text": "{{ $c.PodPrefix }}",
-              "value": "{{ $c.PodPrefix }}"
-            }
-              {{- end }}
-          ],
-          "query": "",
-          "queryValue": "",
-          "skipUrlSync": false,
-          "type": "custom"
-        },
-        {
-          "allValue": null,
-          "current": {
-            "selected": false,
-            "text": "All",
-            "value": "$__all"
-          },
-          "datasource": "prometheus",
-          "definition": "label_values(kube_pod_container_info{type=~\"seed\", pod=~\"$component.+\"}, container)",
+          "datasource": "loki",
+          "definition": "label_values(pod_name)",
+          "description": null,
+          "error": null,
           "hide": 0,
           "includeAll": true,
-          "label": "Container",
-          "multi": false,
-          "name": "container",
+          "label": "pod",
+          "multi": true,
+          "name": "pod",
           "options": [],
-          "query": "label_values(kube_pod_container_info{type=~\"seed\", pod=~\"$component.+\"}, container)",
-          "refresh": 2,
+          "query": "label_values(pod_name)",
+          "refresh": 1,
           "regex": "",
           "skipUrlSync": false,
-          "sort": 0,
+          "sort": 1,
           "tagValuesQuery": "",
           "tags": [],
           "tagsQuery": "",
@@ -413,6 +415,46 @@
               "$__all"
             ]
           },
+          "datasource": "prometheus",
+          "definition": "label_values(kube_pod_container_info{type=~\"seed\", pod=~\"$pod\"}, container)",
+          "description": null,
+          "error": null,
+          "hide": 0,
+          "includeAll": true,
+          "label": "Container",
+          "multi": true,
+          "name": "container",
+          "options": [],
+          "query": {
+            "query": "label_values(kube_pod_container_info{type=~\"seed\", pod=~\"$pod\"}, container)",
+            "refId": "StandardVariableQuery"
+          },
+          "refresh": 2,
+          "regex": "",
+          "skipUrlSync": false,
+          "sort": 0,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
+        },
+        {
+          "allValue": ".*",
+          "current": {
+            "selected": true,
+            "tags": [],
+            "text": [
+              "All"
+            ],
+            "value": [
+              "$__all"
+            ]
+          },
+          "datasource": "loki",
+          "definition": "label_values(severity)",
+          "description": null,
+          "error": null,
           "hide": 0,
           "includeAll": true,
           "label": "Severity",
@@ -426,23 +468,13 @@
             },
             {
               "selected": false,
-              "text": "INFO",
-              "value": "INFO"
-            },
-            {
-              "selected": false,
-              "text": "WARN",
-              "value": "WARN"
-            },
-            {
-              "selected": false,
               "text": "ERR",
               "value": "ERR"
             },
             {
               "selected": false,
-              "text": "DBG",
-              "value": "DBG"
+              "text": "INFO",
+              "value": "INFO"
             },
             {
               "selected": false,
@@ -451,14 +483,20 @@
             },
             {
               "selected": false,
-              "text": "FATAL",
-              "value": "FATAL"
+              "text": "WARN",
+              "value": "WARN"
             }
           ],
-          "query": "INFO,WARN,ERR,DBG,NOTICE,FATAL",
-          "queryValue": "",
+          "query": "label_values(severity)",
+          "refresh": 0,
+          "regex": "",
           "skipUrlSync": false,
-          "type": "custom"
+          "sort": 0,
+          "tagValuesQuery": "",
+          "tags": [],
+          "tagsQuery": "",
+          "type": "query",
+          "useTags": false
         },
         {
           "current": {
@@ -466,6 +504,8 @@
             "text": "",
             "value": ""
           },
+          "description": null,
+          "error": null,
           "hide": 0,
           "label": "Search",
           "name": "search",
@@ -512,6 +552,6 @@
     },
     "timezone": "utc",
     "title": "Controlplane Logs Dashboard",
+    "uid": "FmVvNEink",
     "version": 1
   }
-{{- end -}}

--- a/charts/seed-monitoring/charts/grafana/templates/grafana-dashboards-configmap.yaml
+++ b/charts/seed-monitoring/charts/grafana/templates/grafana-dashboards-configmap.yaml
@@ -39,5 +39,3 @@ data:
 {{- if .Values.extensions.dashboards }}
 {{- toString .Values.extensions.dashboards | indent 2 }}
 {{ end }}
-  controlplane-logs-dashboard.json: |-
-{{ include "logging-dashboard" .Values.extensions.observedPods | indent 4 }}

--- a/charts/seed-monitoring/charts/grafana/values.yaml
+++ b/charts/seed-monitoring/charts/grafana/values.yaml
@@ -18,9 +18,6 @@ vpaEnabled: false
 role: operators
 extensions:
   dashboards: ""
-  observedPods:
-  - PodPrefix: example-pod
-    IsExposedToUser: true
 
 sni:
   enabled: false

--- a/docs/usage/logging.md
+++ b/docs/usage/logging.md
@@ -36,11 +36,7 @@ or with regex:
     * Kubernetes Pods
 
 ### Expose logs for component to User Grafana
-Exposing logs for a new component to the User's Grafana happens with adding a new `extensions.observedPods` section into: charts/seed-monitoring/charts/grafana/values.yaml
-
-* PodPrefix: The prefix of the pod e.g. `kube-apiserver`
-* IsExposedToUser: It is true when the component should be exposed to the end user
-
+Exposing logs for a new component to the User's Grafana is described [here](../extensions/logging-and-monitoring.md#how-to-expose-logs-to-the-users)
 ### Configuration
 #### Fluent-bit
 

--- a/pkg/operation/botanist/monitoring.go
+++ b/pkg/operation/botanist/monitoring.go
@@ -34,7 +34,6 @@ import (
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/secrets"
 
-	"gopkg.in/yaml.v2"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
@@ -53,16 +52,14 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 	}
 
 	var (
-		credentials           = b.Secrets[common.MonitoringIngressCredentials]
-		credentialsUsers      = b.Secrets[common.MonitoringIngressCredentialsUsers]
-		basicAuth             = utils.CreateSHA1Secret(credentials.Data[secrets.DataKeyUserName], credentials.Data[secrets.DataKeyPassword])
-		basicAuthUsers        = utils.CreateSHA1Secret(credentialsUsers.Data[secrets.DataKeyUserName], credentialsUsers.Data[secrets.DataKeyPassword])
-		alertingRules         = strings.Builder{}
-		scrapeConfigs         = strings.Builder{}
-		operatorsDashboards   = strings.Builder{}
-		usersDashboards       = strings.Builder{}
-		usersObservedPods     = make([]ObservedPod, 0)
-		operatorsObservedPods = make([]ObservedPod, 0)
+		credentials         = b.Secrets[common.MonitoringIngressCredentials]
+		credentialsUsers    = b.Secrets[common.MonitoringIngressCredentialsUsers]
+		basicAuth           = utils.CreateSHA1Secret(credentials.Data[secrets.DataKeyUserName], credentials.Data[secrets.DataKeyPassword])
+		basicAuthUsers      = utils.CreateSHA1Secret(credentialsUsers.Data[secrets.DataKeyUserName], credentialsUsers.Data[secrets.DataKeyPassword])
+		alertingRules       = strings.Builder{}
+		scrapeConfigs       = strings.Builder{}
+		operatorsDashboards = strings.Builder{}
+		usersDashboards     = strings.Builder{}
 	)
 
 	// Fetch component-specific monitoring configuration
@@ -106,49 +103,12 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 	// Need stable order before passing the dashboards to Grafana config to avoid unnecessary changes
 	kutil.ByName().Sort(existingConfigMaps)
 
-	// Apply controlplane user exposed pods
-	cpObservedPods := []ObservedPod{
-		{PodPrefix: "kube-apiserver", IsExposedToUser: true},
-		{PodPrefix: "kube-controller-manager", IsExposedToUser: true},
-		{PodPrefix: "kube-scheduler", IsExposedToUser: true},
-		{PodPrefix: "cluster-autoscaler", IsExposedToUser: true},
-	}
-
-	if b.Shoot.WantsVerticalPodAutoscaler {
-		vpaObservedPods := []ObservedPod{
-			{PodPrefix: "vpa-admission-controller", IsExposedToUser: true},
-			{PodPrefix: "vpa-recommender", IsExposedToUser: true},
-			{PodPrefix: "vpa-updater", IsExposedToUser: true},
-		}
-
-		cpObservedPods = append(cpObservedPods, vpaObservedPods...)
-	}
-
-	usersObservedPods = append(usersObservedPods, cpObservedPods...)
-	operatorsObservedPods = append(operatorsObservedPods, cpObservedPods...)
-
 	// Read extension monitoring configurations
 	for _, cm := range existingConfigMaps.Items {
 		alertingRules.WriteString(fmt.Sprintln(cm.Data[v1beta1constants.PrometheusConfigMapAlertingRules]))
 		scrapeConfigs.WriteString(fmt.Sprintln(cm.Data[v1beta1constants.PrometheusConfigMapScrapeConfig]))
 		operatorsDashboards.WriteString(fmt.Sprintln(cm.Data[v1beta1constants.GrafanaConfigMapOperatorDashboard]))
 		usersDashboards.WriteString(fmt.Sprintln(cm.Data[v1beta1constants.GrafanaConfigMapUserDashboard]))
-
-		components := cm.Data["observedComponents"]
-
-		var observedComponents ObservedComponents
-
-		err := yaml.Unmarshal([]byte(components), &observedComponents)
-		if err != nil {
-			return err
-		}
-		for _, pod := range observedComponents.ObservedPods {
-			if pod.IsExposedToUser {
-				usersObservedPods = append(usersObservedPods, pod)
-			}
-
-			operatorsObservedPods = append(operatorsObservedPods, pod)
-		}
 	}
 
 	alerting, err := b.getCustomAlertingConfigs(ctx, b.GetSecretKeysOfRole(v1beta1constants.GardenRoleAlerting))
@@ -268,11 +228,11 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 		return err
 	}
 
-	if err := b.deployGrafanaCharts(ctx, common.GrafanaOperatorsRole, operatorsDashboards.String(), basicAuth, common.GrafanaOperatorsPrefix, operatorsObservedPods); err != nil {
+	if err := b.deployGrafanaCharts(ctx, common.GrafanaOperatorsRole, operatorsDashboards.String(), basicAuth, common.GrafanaOperatorsPrefix); err != nil {
 		return err
 	}
 
-	if err := b.deployGrafanaCharts(ctx, common.GrafanaUsersRole, usersDashboards.String(), basicAuthUsers, common.GrafanaUsersPrefix, usersObservedPods); err != nil {
+	if err := b.deployGrafanaCharts(ctx, common.GrafanaUsersRole, usersDashboards.String(), basicAuthUsers, common.GrafanaUsersPrefix); err != nil {
 		return err
 	}
 
@@ -424,7 +384,7 @@ func (b *Botanist) getCustomAlertingConfigs(ctx context.Context, alertingSecretK
 	return configs, nil
 }
 
-func (b *Botanist) deployGrafanaCharts(ctx context.Context, role, dashboards, basicAuth, subDomain string, observedPods []ObservedPod) error {
+func (b *Botanist) deployGrafanaCharts(ctx context.Context, role, dashboards, basicAuth, subDomain string) error {
 	grafanaTLSOverride := common.GrafanaTLS
 	if b.ControlPlaneWildcardCert != nil {
 		grafanaTLSOverride = b.ControlPlaneWildcardCert.GetName()
@@ -446,8 +406,7 @@ func (b *Botanist) deployGrafanaCharts(ctx context.Context, role, dashboards, ba
 		"replicas": b.Shoot.GetReplicas(1),
 		"role":     role,
 		"extensions": map[string]interface{}{
-			"dashboards":   dashboards,
-			"observedPods": observedPods,
+			"dashboards": dashboards,
 		},
 		"vpaEnabled": b.Shoot.WantsVerticalPodAutoscaler,
 		"sni": map[string]interface{}{
@@ -581,17 +540,4 @@ func (b *Botanist) DeleteSeedMonitoring(ctx context.Context) error {
 	}
 
 	return kutil.DeleteObjects(ctx, b.K8sSeedClient.Client(), objects...)
-}
-
-// ObservedComponents is a struct from all observed pods
-type ObservedComponents struct {
-	ObservedPods []ObservedPod `yaml:"observedPods"`
-}
-
-// ObservedPod holds Pod configuration monitored by Grafana
-type ObservedPod struct {
-	// PodPrefix contains the prefix (deployment name) for a specific pod
-	PodPrefix string `yaml:"podPrefix"`
-	// IsExposedToUser is a flag which represents if the Pod logs should be exposed to the end users
-	IsExposedToUser bool `yaml:"isExposedToUser"`
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging, monitoring
/kind enhancement

**What this PR does / why we need it**:
With this PR we make the Grafana Controlplane Logs Dashboard discover the available pods, containers and severity during runtime based on the tenant ID.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Grafana discovers available logging components at runtime for "Controlplane Logs Dashboard"
```
