### PR TITLE
do not fail and block deletions when no SSH keypair secret exists

### DIFF
--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -16,7 +16,6 @@ package botanist
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 
 	gardencorev1alpha1helper "github.com/gardener/gardener/pkg/apis/core/v1alpha1/helper"
@@ -251,7 +250,8 @@ func (b *Botanist) rotateKubeconfigSecrets(ctx context.Context, gardenerResource
 func (b *Botanist) rotateSSHKeypairSecrets(ctx context.Context, gardenerResourceDataList *gardencorev1alpha1helper.GardenerResourceDataList) error {
 	currentSecret := gardenerResourceDataList.Get(v1beta1constants.SecretNameSSHKeyPair)
 	if currentSecret == nil {
-		return fmt.Errorf("no Secret named %s loaded", v1beta1constants.SecretNameSSHKeyPair)
+		b.Logger.Debugf("No %s Secret loaded, not rotating keypair.", v1beta1constants.SecretNameSSHKeyPair)
+		return nil
 	}
 
 	// copy current key to old secret


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug

**What this PR does / why we need it**:
This makes it so that a broken shoot without an SSH keypair does not block the deletion anymore.

**Which issue(s) this PR fixes**:
Fixes #4393

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
