### PR TITLE
Put SSH keypair rotation on maintenance behind a feature gate

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -30,8 +30,9 @@ The following tables are a summary of the feature gates that you can set on diff
 | SeedChange | `false` | `Alpha` | `1.12` | |
 | SeedKubeScheduler | `false` | `Alpha` | `1.15` | |
 | ReversedVPN | `false` | `Alpha` | `1.22` | |
-| UseDNSRecords | `false` | `Alpha` | `1.27.0` | |
+| UseDNSRecords | `false` | `Alpha` | `1.27` | |
 | DisallowKubeconfigRotationForShootInDeletion | `false` | `Alpha` | `1.28` | |
+| RotateSSHKeypairOnMaintenance | `false` | `Alpha` | `1.28` | |
 
 ## Feature gates for graduated or deprecated features
 
@@ -93,3 +94,4 @@ A *General Availability* (GA) feature is also referred to as a *stable* feature.
 * `AdminKubeconfigRequest` enables the `AdminKubeconfigRequest` endpoint on Shoot resources. See [GEP-16](../proposals/16-adminkubeconfig-subresource.md) for more details.
 * `UseDNSRecords` enables using `DNSRecord` resources for Gardener DNS records instead of `DNSProvider`, `DNSEntry`, and `DNSOwner` resources. See [Contract: `DNSRecord` resources](../extensions/dnsrecord.md) for more details.
 * `DisallowKubeconfigRotationForShootInDeletion` when enabled, does not allow kubeconfig rotation to be requested for shoot cluster that is already in deletion phase, i.e. `metadata.deletionTimestamp` is set.
+* `RotateSSHKeypairOnMaintenance` enables SSH keypair rotation in the maintenance controller of the gardener-controller-manager. Details can be found in [GEP-15](../proposals/15-manage-bastions-and-ssh-key-pair-rotation.md).

--- a/example/20-componentconfig-gardener-controller-manager.yaml
+++ b/example/20-componentconfig-gardener-controller-manager.yaml
@@ -75,3 +75,4 @@ server:
 featureGates:
   CachedRuntimeClients: true
   UseDNSRecords: false
+  RotateSSHKeypairOnMaintenance: false

--- a/pkg/controllermanager/features/features.go
+++ b/pkg/controllermanager/features/features.go
@@ -25,8 +25,9 @@ var (
 	// FeatureGate is a shared global FeatureGate for Gardener Controller Manager flags.
 	FeatureGate  = featuregate.NewFeatureGate()
 	featureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-		features.CachedRuntimeClients: {Default: false, PreRelease: featuregate.Alpha},
-		features.UseDNSRecords:        {Default: false, PreRelease: featuregate.Alpha},
+		features.CachedRuntimeClients:          {Default: false, PreRelease: featuregate.Alpha},
+		features.UseDNSRecords:                 {Default: false, PreRelease: featuregate.Alpha},
+		features.RotateSSHKeypairOnMaintenance: {Default: false, PreRelease: featuregate.Alpha},
 	}
 )
 

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -103,4 +103,9 @@ const (
 	// owner: @vpnachev
 	// alpha: v1.28.0
 	DisallowKubeconfigRotationForShootInDeletion featuregate.Feature = "DisallowKubeconfigRotationForShootInDeletion"
+
+	// RotateSSHKeypairOnMaintenance enables SSH keypair rotation in the maintenance controller of the gardener-controller-manager.
+	// owner: @petersutter @xrstf
+	// alpha: v1.28.0
+	RotateSSHKeypairOnMaintenance featuregate.Feature = "RotateSSHKeypairOnMaintenance"
 )


### PR DESCRIPTION
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

As there are still items to work on (https://github.com/gardener/gardener/issues/4395, https://github.com/gardener/gardener/issues/4396) and to give a better control to the gardener operators on the rollout of the feature, with @petersutter we decided to put the SSH keypair rotation on maintenance feature behind a feature gate in the gardener-controller-manager.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The SSH keypair rotation on maintenance window is now set behind a new alpha feature gate in gardener-controller-manager - `RotateSSHKeypairOnMaintenance `.
```
