### PR TITLE
Fix minor nits about containerd's config.toml file

### DIFF
--- a/docs/extensions/operatingsystemconfig.md
+++ b/docs/extensions/operatingsystemconfig.md
@@ -207,7 +207,7 @@ spec:
 To support ContainerD, an OS extension must :
 1. The operating system must have built-in  [ContainerD](https://containerd.io/) and the  [Client CLI](https://github.com/projectatomic/containerd/blob/master/docs/cli.md/)
 1. ContainerD must listen on its default socket path: `unix:///run/containerd/containerd.sock`
-1. ContainerD must be configured to work with the default configuration file in: `/etc/containerd.config.toml` (Created by Gardener).
+1. ContainerD must be configured to work with the default configuration file in: `/etc/containerd/config.toml` (Created by Gardener).
 
 If CRI configurations are not supported it is recommended create a validating webhook running in the garden cluster that prevents specifying the `.spec.providers.workers[].cri` section in the `Shoot` objects.
 

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/containerd/initializer_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/containerd/initializer_test.go
@@ -98,7 +98,7 @@ const (
 	initScript              = `#!/bin/bash
 
 FILE=/etc/containerd/config.toml
-if [ ! -f "$FILE" ]; then
+if [ ! -s "$FILE" ]; then
   mkdir -p /etc/containerd
   containerd config default > "$FILE"
 fi

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/containerd/templates/scripts/init.tpl.sh
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/containerd/templates/scripts/init.tpl.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 FILE=/etc/containerd/config.toml
-if [ ! -f "$FILE" ]; then
+if [ ! -s "$FILE" ]; then
   mkdir -p /etc/containerd
   containerd config default > "$FILE"
 fi


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind enhancement

**What this PR does / why we need it**:
Now the config.toml file will be populated also if it is empty. 
This is needed to increase the probability that the pause image can be injected here https://github.com/gardener/gardener/blob/f7174cd44959967ab15b470ae20512ff6cd19412/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/containerd/templates/scripts/init.tpl.sh#L9-L12

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
