### PR TITLE
Increase per node resources for metrics-server.

### DIFF
--- a/pkg/operation/botanist/component/metricsserver/metrics_server.go
+++ b/pkg/operation/botanist/component/metricsserver/metrics_server.go
@@ -371,9 +371,9 @@ func (m *metricsServer) computeResourcesData() (map[string][]byte, error) {
 							Command: []string{
 								"/pod_nanny",
 								"--cpu=20m",
-								"--extra-cpu=1m",
+								"--extra-cpu=2m",
 								"--memory=40Mi",
-								"--extra-memory=2Mi",
+								"--extra-memory=14Mi",
 								"--threshold=5",
 								"--deployment=" + deploymentName,
 								"--container=" + containerName,

--- a/pkg/operation/botanist/component/metricsserver/metrics_server_test.go
+++ b/pkg/operation/botanist/component/metricsserver/metrics_server_test.go
@@ -265,9 +265,9 @@ spec:
       - command:
         - /pod_nanny
         - --cpu=20m
-        - --extra-cpu=1m
+        - --extra-cpu=2m
         - --memory=40Mi
-        - --extra-memory=2Mi
+        - --extra-memory=14Mi
         - --threshold=5
         - --deployment=metrics-server
         - --container=metrics-server
@@ -391,9 +391,9 @@ spec:
       - command:
         - /pod_nanny
         - --cpu=20m
-        - --extra-cpu=1m
+        - --extra-cpu=2m
         - --memory=40Mi
-        - --extra-memory=2Mi
+        - --extra-memory=14Mi
         - --threshold=5
         - --deployment=metrics-server
         - --container=metrics-server


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane auto-scaling
/kind impediment

**What this PR does / why we need it**:
Increase per node resources for metrics-server to better support nodes with lots of pods in them.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
While the increased base memory in #4386 proved enough while testing with varying number of nodes, nodes that have a lot of pods like those in shooted seeds seem to need more memory per node.

The shooted seeds in the landscape seem to need anything from `5Mi` to `8Mi` per node. But I have configured `14Mi` per node erring on the side of caution because the `requests` and `limits` are the same.

cc @vpnachev @ialidzhikov  

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
