### PR TITLE
Switch base images to GCR copies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #############      builder       #############
-FROM golang:1.16.6 AS builder
+FROM eu.gcr.io/gardener-project/3rd/golang:1.16.6 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener
 COPY . .
@@ -9,7 +9,7 @@ ARG EFFECTIVE_VERSION
 RUN make install EFFECTIVE_VERSION=$EFFECTIVE_VERSION
 
 ############# base
-FROM alpine:3.13.5 AS base
+FROM eu.gcr.io/gardener-project/3rd/alpine:3.13.5 AS base
 
 #############      apiserver     #############
 FROM base AS apiserver


### PR DESCRIPTION
/kind bug

This is most probably breaking the multi-arch build (as the GCR copies are not multi-arch) of gardener images (for example `make docker-images-ppc`) but I don't think we have other options to workaround https://github.com/gardener/cc-utils/issues/636.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
