### PR TITLE
Undo addon-resizer for metrics-server.

### DIFF
--- a/charts/images.go
+++ b/charts/images.go
@@ -19,8 +19,6 @@ limitations under the License.
 package charts
 
 const (
-	// ImageNameAlertmanager is a constant for an image in the image vector with name 'addon-resizer'.
-	ImageNameAddonResizer = "addon-resizer"
 	// ImageNameAlertmanager is a constant for an image in the image vector with name 'alertmanager'.
 	ImageNameAlertmanager = "alertmanager"
 	// ImageNameAlpine is a constant for an image in the image vector with name 'alpine'.

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -124,10 +124,6 @@ images:
   sourceRepository: github.com/kubernetes-sigs/metrics-server
   repository: k8s.gcr.io/metrics-server/metrics-server
   tag: v0.4.3
-- name: addon-resizer
-  sourceRepository: github.com/kubernetes/autoscaler
-  repository: k8s.gcr.io/addon-resizer
-  tag: "1.8.11"
 
 # Shoot core addons
 - name: vpn-shoot

--- a/pkg/operation/botanist/component/metricsserver/metrics_server.go
+++ b/pkg/operation/botanist/component/metricsserver/metrics_server.go
@@ -28,11 +28,13 @@ import (
 
 	resourcesv1alpha1 "github.com/gardener/gardener-resource-manager/api/resources/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
 	apiregistrationv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -50,7 +52,6 @@ const (
 	serviceName        = "metrics-server"
 	serviceAccountName = "metrics-server"
 	containerName      = "metrics-server"
-	addonResizerName   = "metrics-server-nanny"
 
 	servicePort   int32 = 443
 	containerPort int32 = 8443
@@ -73,15 +74,15 @@ func New(
 	client client.Client,
 	namespace string,
 	image string,
-	imageAddonResizer string,
+	vpaEnabled bool,
 	kubeAPIServerHost *string,
 ) Interface {
 	return &metricsServer{
 		client:            client,
 		namespace:         namespace,
 		image:             image,
+		vpaEnabled:        vpaEnabled,
 		kubeAPIServerHost: kubeAPIServerHost,
-		imageAddonResizer: imageAddonResizer,
 	}
 }
 
@@ -89,9 +90,10 @@ type metricsServer struct {
 	client            client.Client
 	namespace         string
 	image             string
-	imageAddonResizer string
+	vpaEnabled        bool
 	kubeAPIServerHost *string
-	secrets           Secrets
+
+	secrets Secrets
 }
 
 func (m *metricsServer) Deploy(ctx context.Context) error {
@@ -145,11 +147,6 @@ func (m *metricsServer) computeResourcesData() (map[string][]byte, error) {
 					APIGroups: []string{""},
 					Resources: []string{"pods", "nodes", "nodes/stats", "namespaces", "configmaps"},
 					Verbs:     []string{"get", "list", "watch"},
-				},
-				{
-					APIGroups: []string{"apps"},
-					Resources: []string{"deployments"},
-					Verbs:     []string{"get", "list", "update", "watch"},
 				},
 			},
 		}
@@ -265,9 +262,6 @@ func (m *metricsServer) computeResourcesData() (map[string][]byte, error) {
 					managedresources.LabelKeyOrigin: managedresources.LabelValueGardener,
 					v1beta1constants.GardenRole:     v1beta1constants.GardenRoleSystemComponent,
 				}),
-				Annotations: map[string]string{
-					resourcesv1alpha1.PreserveResources: "true",
-				},
 			},
 			Spec: appsv1.DeploymentSpec{
 				RevisionHistoryLimit: pointer.Int32(1),
@@ -352,59 +346,17 @@ func (m *metricsServer) computeResourcesData() (map[string][]byte, error) {
 							},
 							Resources: corev1.ResourceRequirements{
 								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("20m"),
-									corev1.ResourceMemory: resource.MustParse("40Mi"),
+									corev1.ResourceCPU:    resource.MustParse("50m"),
+									corev1.ResourceMemory: resource.MustParse("150Mi"),
 								},
 								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("20m"),
-									corev1.ResourceMemory: resource.MustParse("40Mi"),
+									corev1.ResourceCPU:    resource.MustParse("500m"),
+									corev1.ResourceMemory: resource.MustParse("1Gi"),
 								},
 							},
 							VolumeMounts: []corev1.VolumeMount{{
 								Name:      volumeMountNameServer,
 								MountPath: volumeMountPathServer,
-							}},
-						}, {
-							Name:            addonResizerName,
-							Image:           m.imageAddonResizer,
-							ImagePullPolicy: corev1.PullIfNotPresent,
-							Command: []string{
-								"/pod_nanny",
-								"--cpu=20m",
-								"--extra-cpu=2m",
-								"--memory=40Mi",
-								"--extra-memory=14Mi",
-								"--threshold=5",
-								"--deployment=" + deploymentName,
-								"--container=" + containerName,
-								"--poll-period=300000",
-								"--minClusterSize=10",
-								"--use-metrics=false",
-							},
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("40m"),
-									corev1.ResourceMemory: resource.MustParse("25Mi"),
-								},
-								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("40m"),
-									corev1.ResourceMemory: resource.MustParse("25Mi"),
-								},
-							},
-							Env: []corev1.EnvVar{{
-								Name: "MY_POD_NAME",
-								ValueFrom: &corev1.EnvVarSource{
-									FieldRef: &corev1.ObjectFieldSelector{
-										FieldPath: "metadata.name",
-									},
-								},
-							}, {
-								Name: "MY_POD_NAMESPACE",
-								ValueFrom: &corev1.EnvVarSource{
-									FieldRef: &corev1.ObjectFieldSelector{
-										FieldPath: "metadata.namespace",
-									},
-								},
 							}},
 						}},
 						Volumes: []corev1.Volume{{
@@ -419,6 +371,8 @@ func (m *metricsServer) computeResourcesData() (map[string][]byte, error) {
 				},
 			},
 		}
+
+		vpa *autoscalingv1beta2.VerticalPodAutoscaler
 	)
 
 	if m.kubeAPIServerHost != nil {
@@ -426,6 +380,37 @@ func (m *metricsServer) computeResourcesData() (map[string][]byte, error) {
 			Name:  "KUBERNETES_SERVICE_HOST",
 			Value: *m.kubeAPIServerHost,
 		})
+	}
+
+	if m.vpaEnabled {
+		vpaUpdateMode := autoscalingv1beta2.UpdateModeAuto
+		vpa = &autoscalingv1beta2.VerticalPodAutoscaler{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "metrics-server",
+				Namespace: metav1.NamespaceSystem,
+			},
+			Spec: autoscalingv1beta2.VerticalPodAutoscalerSpec{
+				TargetRef: &autoscalingv1.CrossVersionObjectReference{
+					APIVersion: appsv1.SchemeGroupVersion.String(),
+					Kind:       "Deployment",
+					Name:       deployment.Name,
+				},
+				UpdatePolicy: &autoscalingv1beta2.PodUpdatePolicy{
+					UpdateMode: &vpaUpdateMode,
+				},
+				ResourcePolicy: &autoscalingv1beta2.PodResourcePolicy{
+					ContainerPolicies: []autoscalingv1beta2.ContainerResourcePolicy{
+						{
+							ContainerName: autoscalingv1beta2.DefaultContainerResourcePolicy,
+							MinAllowed: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("50m"),
+								corev1.ResourceMemory: resource.MustParse("150Mi"),
+							},
+						},
+					},
+				},
+			},
+		}
 	}
 
 	return registry.AddAllAndSerialize(
@@ -438,6 +423,7 @@ func (m *metricsServer) computeResourcesData() (map[string][]byte, error) {
 		service,
 		apiService,
 		deployment,
+		vpa,
 	)
 }
 

--- a/pkg/operation/botanist/metricsserver.go
+++ b/pkg/operation/botanist/metricsserver.go
@@ -32,11 +32,6 @@ func (b *Botanist) DefaultMetricsServer() (metricsserver.Interface, error) {
 		return nil, err
 	}
 
-	imageAddonResizer, err := b.ImageVector.FindImage(charts.ImageNameAddonResizer, imagevector.RuntimeVersion(b.ShootVersion()), imagevector.TargetVersion(b.ShootVersion()))
-	if err != nil {
-		return nil, err
-	}
-
 	var kubeAPIServerHost *string
 	if b.APIServerSNIEnabled() {
 		kubeAPIServerHost = pointer.String(b.outOfClusterAPIServerFQDN())
@@ -46,7 +41,7 @@ func (b *Botanist) DefaultMetricsServer() (metricsserver.Interface, error) {
 		b.K8sSeedClient.Client(),
 		b.Shoot.SeedNamespace,
 		image.String(),
-		imageAddonResizer.String(),
+		b.Shoot.WantsVerticalPodAutoscaler,
 		kubeAPIServerHost,
 	), nil
 }

--- a/pkg/operation/botanist/metricsserver_test.go
+++ b/pkg/operation/botanist/metricsserver_test.go
@@ -69,23 +69,15 @@ var _ = Describe("MetricsServer", func() {
 			defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.APIServerSNI, true)()
 
 			kubernetesClient.EXPECT().Client()
-			botanist.ImageVector = imagevector.ImageVector{{Name: "metrics-server"}, {Name: "addon-resizer"}}
+			botanist.ImageVector = imagevector.ImageVector{{Name: "metrics-server"}}
 
 			metricsServer, err := botanist.DefaultMetricsServer()
 			Expect(metricsServer).NotTo(BeNil())
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		It("should return an error because the metric-server image cannot be found", func() {
-			botanist.ImageVector = imagevector.ImageVector{{Name: "addon-resizer"}}
-
-			metricsServer, err := botanist.DefaultMetricsServer()
-			Expect(metricsServer).To(BeNil())
-			Expect(err).To(HaveOccurred())
-		})
-
-		It("should return an error because the addon-resizer image cannot be found", func() {
-			botanist.ImageVector = imagevector.ImageVector{{Name: "metrics-server"}}
+		It("should return an error because the image cannot be found", func() {
+			botanist.ImageVector = imagevector.ImageVector{}
 
 			metricsServer, err := botanist.DefaultMetricsServer()
 			Expect(metricsServer).To(BeNil())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane auto-scaling
/kind impediment

**What this PR does / why we need it**:
Undo addon-resizer for metrics-server in favour of later introducing it under feature-gate.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This undoes #4216, #4386 and #4402.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
