### PR TITLE
Adding VPA limits proportion to requests for node-exporter

### DIFF
--- a/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
@@ -107,8 +107,13 @@ spec:
             cpu: 50m
             memory: 50Mi
           limits:
-            cpu: 50m
-            memory: 50Mi
+          {{- if .Values.global.vpaEnabled }}
+            cpu: 150m
+            memory: 150Mi
+          {{- else }}
+            cpu: 200m
+            memory: 2000Mi
+          {{- end }}
         volumeMounts:
         - name: host
           readOnly: true

--- a/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
@@ -112,7 +112,7 @@ spec:
             memory: 150Mi
           {{- else }}
             cpu: 200m
-            memory: 2000Mi
+            memory: 200Mi
           {{- end }}
         volumeMounts:
         - name: host


### PR DESCRIPTION
The VPA limits vs requests ratio is set to 1 which makes
the vpa recommend resources resulting in thrashing like behavior.
Increasing the limits vs requests ratio to 3 if VPA enabled
else 4 if not. This should give a scale ratio for VPA to recommend
resources and keep it stable

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area auto-scaling

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
