### PR TITLE
Revert "Ensure new osc name for different cri configuration (#4289)"

### DIFF
--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -335,7 +335,7 @@ func (o *operatingSystemConfig) forEachWorkerPoolAndPurpose(fn func(*extensionsv
 			extensionsv1alpha1.OperatingSystemConfigPurposeProvision,
 			extensionsv1alpha1.OperatingSystemConfigPurposeReconcile,
 		} {
-			oscName := Key(worker.Name, o.values.KubernetesVersion, worker.CRI) + purposeToKeySuffix(purpose)
+			oscName := Key(worker.Name, o.values.KubernetesVersion) + purposeToKeySuffix(purpose)
 
 			osc, ok := o.oscs[oscName]
 			if !ok {
@@ -430,7 +430,7 @@ func (o *operatingSystemConfig) newDeployer(osc *extensionsv1alpha1.OperatingSys
 		osc:                     osc,
 		worker:                  worker,
 		purpose:                 purpose,
-		key:                     Key(worker.Name, o.values.KubernetesVersion, worker.CRI),
+		key:                     Key(worker.Name, o.values.KubernetesVersion),
 		apiServerURL:            o.values.APIServerURL,
 		caBundle:                caBundle,
 		clusterDNSAddress:       o.values.ClusterDNSAddress,
@@ -615,19 +615,14 @@ func (d *deployer) deploy(ctx context.Context, operation string) (extensionsv1al
 	return d.osc, err
 }
 
-// Key returns the key that can be used as secret name based on the provided worker name, Kubernetes version and CRI configuration.
-func Key(workerName string, kubernetesVersion *semver.Version, criConfig *gardencorev1beta1.CRI) string {
+// Key returns the key that can be used as secret name based on the provided worker name and Kubernetes version.
+func Key(workerName string, kubernetesVersion *semver.Version) string {
 	if kubernetesVersion == nil {
 		return ""
 	}
 
 	kubernetesMajorMinorVersion := fmt.Sprintf("%d.%d", kubernetesVersion.Major(), kubernetesVersion.Minor())
-
-	var criName gardencorev1beta1.CRIName
-	if criConfig != nil && criConfig.Name != gardencorev1beta1.CRINameDocker {
-		criName = criConfig.Name
-	}
-	return fmt.Sprintf("cloud-config-%s-%s", workerName, utils.ComputeSHA256Hex([]byte(kubernetesMajorMinorVersion + string(criName)))[:5])
+	return fmt.Sprintf("cloud-config-%s-%s", workerName, utils.ComputeSHA256Hex([]byte(kubernetesMajorMinorVersion))[:5])
 }
 
 func purposeToKeySuffix(purpose extensionsv1alpha1.OperatingSystemConfigPurpose) string {

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
@@ -189,21 +189,18 @@ var _ = Describe("OperatingSystemConfig", func() {
 			expected = make([]*extensionsv1alpha1.OperatingSystemConfig, 0, 2*len(workers))
 			for _, worker := range workers {
 				var (
-					criName    extensionsv1alpha1.CRIName
-					criConfig  *extensionsv1alpha1.CRIConfig
-					configHash string
+					criName   extensionsv1alpha1.CRIName
+					criConfig *extensionsv1alpha1.CRIConfig
 				)
 				if worker.CRI != nil {
 					criName = extensionsv1alpha1.CRIName(worker.CRI.Name)
 					criConfig = &extensionsv1alpha1.CRIConfig{Name: extensionsv1alpha1.CRIName(worker.CRI.Name)}
-					configHash = "-cf2c8"
 				} else {
 					criName = extensionsv1alpha1.CRINameDocker
-					configHash = "-77ac3"
 				}
 
 				downloaderUnits, downloaderFiles, _ := downloaderConfigFn(
-					"cloud-config-"+worker.Name+configHash,
+					"cloud-config-"+worker.Name+"-77ac3",
 					apiServerURL,
 				)
 				originalUnits, originalFiles, _ := originalConfigFn(components.Context{
@@ -222,7 +219,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 
 				oscDownloader := &extensionsv1alpha1.OperatingSystemConfig{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "cloud-config-" + worker.Name + configHash + "-downloader",
+						Name:      "cloud-config-" + worker.Name + "-77ac3-downloader",
 						Namespace: namespace,
 						Annotations: map[string]string{
 							v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
@@ -243,7 +240,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 
 				oscOriginal := &extensionsv1alpha1.OperatingSystemConfig{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "cloud-config-" + worker.Name + configHash + "-original",
+						Name:      "cloud-config-" + worker.Name + "-77ac3-original",
 						Namespace: namespace,
 						Annotations: map[string]string{
 							v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
@@ -317,16 +314,16 @@ var _ = Describe("OperatingSystemConfig", func() {
 
 			BeforeEach(func() {
 				extensions := make([]gardencorev1alpha1.ExtensionResourceState, 0, 2*len(workers))
-				for _, osc := range expected {
+				for _, worker := range workers {
 					extensions = append(extensions,
 						gardencorev1alpha1.ExtensionResourceState{
-							Name:    pointer.String(osc.Name),
+							Name:    pointer.String("cloud-config-" + worker.Name + "-77ac3-downloader"),
 							Kind:    extensionsv1alpha1.OperatingSystemConfigResource,
 							Purpose: pointer.String(string(extensionsv1alpha1.OperatingSystemConfigPurposeProvision)),
 							State:   &runtime.RawExtension{Raw: stateDownloader},
 						},
 						gardencorev1alpha1.ExtensionResourceState{
-							Name:    pointer.String(osc.Name),
+							Name:    pointer.String("cloud-config-" + worker.Name + "-77ac3-original"),
 							Kind:    extensionsv1alpha1.OperatingSystemConfigResource,
 							Purpose: pointer.String(string(extensionsv1alpha1.OperatingSystemConfigPurposeReconcile)),
 							State:   &runtime.RawExtension{Raw: stateOriginal},
@@ -585,20 +582,19 @@ var _ = Describe("OperatingSystemConfig", func() {
 					},
 					worker2Name: {
 						Downloader: Data{
-							Content: "foobar-cloud-config-" + worker2Name + "-cf2c8-downloader",
-							Command: pointer.String("foo-cloud-config-" + worker2Name + "-cf2c8-downloader"),
-
+							Content: "foobar-cloud-config-" + worker2Name + "-77ac3-downloader",
+							Command: pointer.String("foo-cloud-config-" + worker2Name + "-77ac3-downloader"),
 							Units: []string{
-								"bar-cloud-config-" + worker2Name + "-cf2c8-downloader",
-								"baz-cloud-config-" + worker2Name + "-cf2c8-downloader",
+								"bar-cloud-config-" + worker2Name + "-77ac3-downloader",
+								"baz-cloud-config-" + worker2Name + "-77ac3-downloader",
 							},
 						},
 						Original: Data{
-							Content: "foobar-cloud-config-" + worker2Name + "-cf2c8-original",
-							Command: pointer.String("foo-cloud-config-" + worker2Name + "-cf2c8-original"),
+							Content: "foobar-cloud-config-" + worker2Name + "-77ac3-original",
+							Command: pointer.String("foo-cloud-config-" + worker2Name + "-77ac3-original"),
 							Units: []string{
-								"bar-cloud-config-" + worker2Name + "-cf2c8-original",
-								"baz-cloud-config-" + worker2Name + "-cf2c8-original",
+								"bar-cloud-config-" + worker2Name + "-77ac3-original",
+								"baz-cloud-config-" + worker2Name + "-77ac3-original",
 							},
 						},
 					},
@@ -760,19 +756,11 @@ var _ = Describe("OperatingSystemConfig", func() {
 		var workerName = "foo"
 
 		It("should return an empty string", func() {
-			Expect(Key(workerName, nil, nil)).To(BeEmpty())
+			Expect(Key(workerName, nil)).To(BeEmpty())
 		})
 
-		It("is different for different worker.cri configurations", func() {
-			containerDKey := Key(workerName, semver.MustParse("1.2.3"), &gardencorev1beta1.CRI{Name: gardencorev1beta1.CRINameContainerD})
-			dockerKey := Key(workerName, semver.MustParse("1.2.3"), &gardencorev1beta1.CRI{Name: gardencorev1beta1.CRINameDocker})
-			Expect(containerDKey).NotTo(Equal(dockerKey))
-		})
-
-		It("is the same for `cri=nil` and `cri.name=docker`", func() {
-			dockerKey := Key(workerName, semver.MustParse("1.2.3"), &gardencorev1beta1.CRI{Name: gardencorev1beta1.CRINameDocker})
-			nilKey := Key(workerName, semver.MustParse("1.2.3"), nil)
-			Expect(dockerKey).To(Equal(nilKey))
+		It("should return the expected key", func() {
+			Expect(Key(workerName, semver.MustParse("1.2.3"))).To(Equal("cloud-config-" + workerName + "-77ac3"))
 		})
 	})
 })

--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -247,7 +247,7 @@ func (b *Botanist) generateCloudConfigExecutorResourcesForWorker(
 ) {
 	var (
 		registry   = managedresources.NewRegistry(kubernetes.ShootScheme, kubernetes.ShootCodec, kubernetes.ShootSerializer)
-		secretName = operatingsystemconfig.Key(worker.Name, b.Shoot.KubernetesVersion, worker.CRI)
+		secretName = operatingsystemconfig.Key(worker.Name, b.Shoot.KubernetesVersion)
 	)
 
 	var kubeletDataVolume *gardencorev1beta1.DataVolume


### PR DESCRIPTION
This reverts commit a4e338de1b07ac708d64ee22f96e4198d768ad04.

Fixes: #4390

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug

**What this PR does / why we need it**:
This reverts changing the operatingsystemconfig name for clusters using `containerd`. For existing clusters, this name change lead to #4390, therefore this implementation is not a feasible solution for #4254

**Which issue(s) this PR fixes**:
Fixes #4390

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A fix included in v1.27.0 and v1.27.1  was reverted, because it introduced a regression which caused clusters configured with `containerd` as a runtime to fail to reconcile (see https://github.com/gardener/gardener/issues/4390 for more details). This now means that bug https://github.com/gardener/gardener/issues/4254 still exists in gardener >1.27.1.
```
