### PR TITLE
Perform reads and modifications to ShootState in a concurrency safe way

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -238,7 +238,7 @@ func (c *Controller) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		persistETCDEncryptionConfiguration = g.Add(flow.Task{
 			Name:         "Persisting etcd encryption configuration in ShootState",
 			Fn:           flow.TaskFn(botanist.PersistEncryptionConfiguration),
-			Dependencies: flow.NewTaskIDs(deployNamespace, ensureShootStateExists, generateEncryptionConfigurationMetaData, generateSecrets),
+			Dependencies: flow.NewTaskIDs(deployNamespace, ensureShootStateExists, generateEncryptionConfigurationMetaData),
 		})
 		createOrUpdateETCDEncryptionConfiguration = g.Add(flow.Task{
 			Name:         "Applying etcd encryption configuration",

--- a/pkg/operation/botanist/addons_test.go
+++ b/pkg/operation/botanist/addons_test.go
@@ -337,7 +337,7 @@ var _ = Describe("addons", func() {
 			var shootState = &gardencorev1alpha1.ShootState{}
 
 			BeforeEach(func() {
-				b.ShootState = shootState
+				b.SetShootState(shootState)
 				b.Shoot.GetInfo().Status = gardencorev1beta1.ShootStatus{
 					LastOperation: &gardencorev1beta1.LastOperation{
 						Type: gardencorev1beta1.LastOperationTypeRestore,

--- a/pkg/operation/botanist/backupentry.go
+++ b/pkg/operation/botanist/backupentry.go
@@ -49,7 +49,7 @@ func (b *Botanist) DefaultCoreBackupEntry() component.DeployMigrateWaiter {
 // the Shoot is in the restore phase of the control plane migration.
 func (b *Botanist) DeployBackupEntry(ctx context.Context) error {
 	if b.isRestorePhase() {
-		return b.Shoot.Components.BackupEntry.Restore(ctx, b.ShootState)
+		return b.Shoot.Components.BackupEntry.Restore(ctx, b.GetShootState())
 	}
 	return b.Shoot.Components.BackupEntry.Deploy(ctx)
 }

--- a/pkg/operation/botanist/containerruntime.go
+++ b/pkg/operation/botanist/containerruntime.go
@@ -39,7 +39,7 @@ func (b *Botanist) DefaultContainerRuntime() containerruntime.Interface {
 // the Shoot is in the restore phase of the control plane migration
 func (b *Botanist) DeployContainerRuntime(ctx context.Context) error {
 	if b.isRestorePhase() {
-		return b.Shoot.Components.Extensions.ContainerRuntime.Restore(ctx, b.ShootState)
+		return b.Shoot.Components.Extensions.ContainerRuntime.Restore(ctx, b.GetShootState())
 	}
 	return b.Shoot.Components.Extensions.ContainerRuntime.Deploy(ctx)
 }

--- a/pkg/operation/botanist/containerruntime_test.go
+++ b/pkg/operation/botanist/containerruntime_test.go
@@ -52,8 +52,8 @@ var _ = Describe("ContainerRuntime", func() {
 					},
 				},
 			},
-			ShootState: shootState,
 		}}
+		botanist.SetShootState(shootState)
 		botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{})
 	})
 

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -263,7 +263,7 @@ func (b *Botanist) DeployControlPlaneExposure(ctx context.Context) error {
 
 func (b *Botanist) deployOrRestoreControlPlane(ctx context.Context, controlPlane extensionscontrolplane.Interface) error {
 	if b.isRestorePhase() {
-		return controlPlane.Restore(ctx, b.ShootState)
+		return controlPlane.Restore(ctx, b.GetShootState())
 	}
 	return controlPlane.Deploy(ctx)
 }

--- a/pkg/operation/botanist/controlplane_test.go
+++ b/pkg/operation/botanist/controlplane_test.go
@@ -135,7 +135,7 @@ var _ = Describe("controlplane", func() {
 			var shootState = &gardencorev1alpha1.ShootState{}
 
 			BeforeEach(func() {
-				botanist.ShootState = shootState
+				botanist.SetShootState(shootState)
 				botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
 					Status: gardencorev1beta1.ShootStatus{
 						LastOperation: &gardencorev1beta1.LastOperation{
@@ -174,7 +174,7 @@ var _ = Describe("controlplane", func() {
 			var shootState = &gardencorev1alpha1.ShootState{}
 
 			BeforeEach(func() {
-				botanist.ShootState = shootState
+				botanist.SetShootState(shootState)
 				botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
 					Status: gardencorev1beta1.ShootStatus{
 						LastOperation: &gardencorev1beta1.LastOperation{

--- a/pkg/operation/botanist/dnsrecord.go
+++ b/pkg/operation/botanist/dnsrecord.go
@@ -140,7 +140,7 @@ func (b *Botanist) MigrateInternalDNSRecord(ctx context.Context) error {
 
 func (b *Botanist) deployOrRestoreDNSRecord(ctx context.Context, dnsRecord component.DeployMigrateWaiter) error {
 	if b.isRestorePhase() {
-		return dnsRecord.Restore(ctx, b.ShootState)
+		return dnsRecord.Restore(ctx, b.GetShootState())
 	}
 	return dnsRecord.Deploy(ctx)
 }

--- a/pkg/operation/botanist/dnsrecord_test.go
+++ b/pkg/operation/botanist/dnsrecord_test.go
@@ -312,7 +312,7 @@ var _ = Describe("dnsrecord", func() {
 			var shootState = &gardencorev1alpha1.ShootState{}
 
 			BeforeEach(func() {
-				b.ShootState = shootState
+				b.SetShootState(shootState)
 				b.Shoot.GetInfo().Status = gardencorev1beta1.ShootStatus{
 					LastOperation: &gardencorev1beta1.LastOperation{
 						Type: gardencorev1beta1.LastOperationTypeRestore,
@@ -368,7 +368,7 @@ var _ = Describe("dnsrecord", func() {
 			var shootState = &gardencorev1alpha1.ShootState{}
 
 			BeforeEach(func() {
-				b.ShootState = shootState
+				b.SetShootState(shootState)
 				b.Shoot.GetInfo().Status = gardencorev1beta1.ShootStatus{
 					LastOperation: &gardencorev1beta1.LastOperation{
 						Type: gardencorev1beta1.LastOperationTypeRestore,

--- a/pkg/operation/botanist/extension.go
+++ b/pkg/operation/botanist/extension.go
@@ -55,7 +55,7 @@ func (b *Botanist) DefaultExtension(ctx context.Context) (extension.Interface, e
 // the Shoot is in the restore phase of the control plane migration.
 func (b *Botanist) DeployExtensions(ctx context.Context) error {
 	if b.isRestorePhase() {
-		return b.Shoot.Components.Extensions.Extension.Restore(ctx, b.ShootState)
+		return b.Shoot.Components.Extensions.Extension.Restore(ctx, b.GetShootState())
 	}
 	return b.Shoot.Components.Extensions.Extension.Deploy(ctx)
 }

--- a/pkg/operation/botanist/extension_test.go
+++ b/pkg/operation/botanist/extension_test.go
@@ -73,8 +73,8 @@ var _ = Describe("Extensions", func() {
 				},
 				SeedNamespace: namespace,
 			},
-			ShootState: shootState,
 		}}
+		botanist.SetShootState(shootState)
 		botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{})
 
 		gardenClientInterface.EXPECT().Client().Return(gardenClient).AnyTimes()

--- a/pkg/operation/botanist/infrastructure.go
+++ b/pkg/operation/botanist/infrastructure.go
@@ -50,7 +50,7 @@ func (b *Botanist) DeployInfrastructure(ctx context.Context) error {
 	b.Shoot.Components.Extensions.Infrastructure.SetSSHPublicKey(b.LoadSecret(v1beta1constants.SecretNameSSHKeyPair).Data[secrets.DataKeySSHAuthorizedKeys])
 
 	if b.isRestorePhase() {
-		return b.Shoot.Components.Extensions.Infrastructure.Restore(ctx, b.ShootState)
+		return b.Shoot.Components.Extensions.Infrastructure.Restore(ctx, b.GetShootState())
 	}
 
 	return b.Shoot.Components.Extensions.Infrastructure.Deploy(ctx)

--- a/pkg/operation/botanist/infrastructure_test.go
+++ b/pkg/operation/botanist/infrastructure_test.go
@@ -59,8 +59,8 @@ var _ = Describe("Infrastructure", func() {
 					},
 				},
 			},
-			ShootState: shootState,
 		}}
+		botanist.SetShootState(shootState)
 		botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{})
 		botanist.StoreSecret("ssh-keypair", &corev1.Secret{Data: map[string][]byte{"id_rsa.pub": sshPublicKey}})
 	})

--- a/pkg/operation/botanist/network.go
+++ b/pkg/operation/botanist/network.go
@@ -44,7 +44,7 @@ func (b *Botanist) DefaultNetwork() component.DeployMigrateWaiter {
 // the Shoot is in the restore phase of the control plane migration
 func (b *Botanist) DeployNetwork(ctx context.Context) error {
 	if b.isRestorePhase() {
-		return b.Shoot.Components.Extensions.Network.Restore(ctx, b.ShootState)
+		return b.Shoot.Components.Extensions.Network.Restore(ctx, b.GetShootState())
 	}
 
 	return b.Shoot.Components.Extensions.Network.Deploy(ctx)

--- a/pkg/operation/botanist/network_test.go
+++ b/pkg/operation/botanist/network_test.go
@@ -52,8 +52,8 @@ var _ = Describe("Network", func() {
 					},
 				},
 			},
-			ShootState: shootState,
 		}}
+		botanist.SetShootState(shootState)
 		botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{})
 	})
 

--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -106,7 +106,7 @@ func (b *Botanist) DeployOperatingSystemConfig(ctx context.Context) error {
 	}
 
 	if b.isRestorePhase() {
-		return b.Shoot.Components.Extensions.OperatingSystemConfig.Restore(ctx, b.ShootState)
+		return b.Shoot.Components.Extensions.OperatingSystemConfig.Restore(ctx, b.GetShootState())
 	}
 
 	return b.Shoot.Components.Extensions.OperatingSystemConfig.Deploy(ctx)

--- a/pkg/operation/botanist/operatingsystemconfig_test.go
+++ b/pkg/operation/botanist/operatingsystemconfig_test.go
@@ -84,13 +84,13 @@ var _ = Describe("operatingsystemconfig", func() {
 				},
 				Purpose: "development",
 			},
-			Seed:       &seedpkg.Seed{},
-			ShootState: shootState,
+			Seed: &seedpkg.Seed{},
 		}}
 		botanist.StoreSecret(v1beta1constants.SecretNameCACluster, &corev1.Secret{Data: map[string][]byte{"ca.crt": ca}})
 		botanist.StoreSecret(v1beta1constants.SecretNameCAKubelet, &corev1.Secret{Data: map[string][]byte{"ca.crt": caKubelet}})
 		botanist.StoreSecret(v1beta1constants.SecretNameSSHKeyPair, &corev1.Secret{Data: map[string][]byte{"id_rsa.pub": sshPublicKey}})
 		botanist.StoreSecret(v1beta1constants.SecretNameOldSSHKeyPair, &corev1.Secret{Data: map[string][]byte{"id_rsa.pub": sshPublicKeyOld}})
+		botanist.SetShootState(shootState)
 		botanist.Seed.SetInfo(&gardencorev1beta1.Seed{
 			Spec: gardencorev1beta1.SeedSpec{
 				DNS: gardencorev1beta1.SeedDNS{

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -16,8 +16,8 @@ package botanist
 
 import (
 	"context"
-	"reflect"
 
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	gardencorev1alpha1helper "github.com/gardener/gardener/pkg/apis/core/v1alpha1/helper"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
@@ -44,64 +44,64 @@ import (
 // credentials are computed which will be used to secure the Ingress resources and the kube-apiserver itself.
 // Server certificates for the exposed monitoring endpoints (via Ingress) are generated as well.
 func (b *Botanist) GenerateAndSaveSecrets(ctx context.Context) error {
-	gardenerResourceDataList := gardencorev1alpha1helper.GardenerResourceDataList(b.ShootState.Spec.Gardener).DeepCopy()
-
-	switch b.Shoot.GetInfo().Annotations[v1beta1constants.GardenerOperation] {
-	case v1beta1constants.ShootOperationRotateKubeconfigCredentials:
-		if err := b.rotateKubeconfigSecrets(ctx, &gardenerResourceDataList); err != nil {
-			return err
-		}
-
-	case v1beta1constants.ShootOperationRotateSSHKeypair:
-		if err := b.rotateSSHKeypairSecrets(ctx, &gardenerResourceDataList); err != nil {
-			return err
-		}
-	}
-
-	if b.Shoot.GetInfo().DeletionTimestamp == nil {
-		if b.Shoot.ReversedVPNEnabled {
-			if err := b.cleanupTunnelSecrets(ctx, &gardenerResourceDataList, "vpn-seed", "vpn-seed-tlsauth", "vpn-shoot"); err != nil {
+	return b.SaveGardenerResourceDataInShootState(ctx, func(gardenerResourceData *[]gardencorev1alpha1.GardenerResourceData) error {
+		gardenerResourceDataList := gardencorev1alpha1helper.GardenerResourceDataList(*gardenerResourceData)
+		switch b.Shoot.GetInfo().Annotations[v1beta1constants.GardenerOperation] {
+		case v1beta1constants.ShootOperationRotateKubeconfigCredentials:
+			if err := b.rotateKubeconfigSecrets(ctx, &gardenerResourceDataList); err != nil {
 				return err
 			}
-		} else {
-			if err := b.cleanupTunnelSecrets(ctx, &gardenerResourceDataList, vpnseedserver.DeploymentName, vpnseedserver.VpnShootSecretName, vpnseedserver.VpnSeedServerTLSAuth); err != nil {
+
+		case v1beta1constants.ShootOperationRotateSSHKeypair:
+			if err := b.rotateSSHKeypairSecrets(ctx, &gardenerResourceDataList); err != nil {
 				return err
 			}
 		}
-	}
 
-	shootWantsBasicAuth := gardencorev1beta1helper.ShootWantsBasicAuthentication(b.Shoot.GetInfo())
-	shootHasBasicAuth := gardenerResourceDataList.Get(common.BasicAuthSecretName) != nil
-	if shootWantsBasicAuth != shootHasBasicAuth {
-		if err := b.deleteBasicAuthDependantSecrets(ctx, &gardenerResourceDataList); err != nil {
+		if b.Shoot.GetInfo().DeletionTimestamp == nil {
+			if b.Shoot.ReversedVPNEnabled {
+				if err := b.cleanupTunnelSecrets(ctx, &gardenerResourceDataList, "vpn-seed", "vpn-seed-tlsauth", "vpn-shoot"); err != nil {
+					return err
+				}
+			} else {
+				if err := b.cleanupTunnelSecrets(ctx, &gardenerResourceDataList, vpnseedserver.DeploymentName, vpnseedserver.VpnShootSecretName, vpnseedserver.VpnSeedServerTLSAuth); err != nil {
+					return err
+				}
+			}
+		}
+
+		shootWantsBasicAuth := gardencorev1beta1helper.ShootWantsBasicAuthentication(b.Shoot.GetInfo())
+		shootHasBasicAuth := gardenerResourceDataList.Get(common.BasicAuthSecretName) != nil
+		if shootWantsBasicAuth != shootHasBasicAuth {
+			if err := b.deleteBasicAuthDependantSecrets(ctx, &gardenerResourceDataList); err != nil {
+				return err
+			}
+		}
+
+		secretsManager := shootsecrets.NewSecretsManager(
+			gardenerResourceDataList,
+			b.generateStaticTokenConfig(),
+			b.wantedCertificateAuthorities(),
+			b.generateWantedSecretConfigs,
+		)
+
+		if shootWantsBasicAuth {
+			secretsManager = secretsManager.WithAPIServerBasicAuthConfig(basicAuthSecretAPIServer)
+		}
+
+		if err := secretsManager.Generate(); err != nil {
 			return err
 		}
-	}
 
-	secretsManager := shootsecrets.NewSecretsManager(
-		gardenerResourceDataList,
-		b.generateStaticTokenConfig(),
-		b.wantedCertificateAuthorities(),
-		b.generateWantedSecretConfigs,
-	)
+		*gardenerResourceData = secretsManager.GardenerResourceDataList
 
-	if shootWantsBasicAuth {
-		secretsManager = secretsManager.WithAPIServerBasicAuthConfig(basicAuthSecretAPIServer)
-	}
-
-	if err := secretsManager.Generate(); err != nil {
-		return err
-	}
-
-	if reflect.DeepEqual(secretsManager.GardenerResourceDataList, gardencorev1alpha1helper.GardenerResourceDataList(b.ShootState.Spec.Gardener)) {
 		return nil
-	}
-	return b.SaveGardenerResourcesInShootState(ctx, secretsManager.GardenerResourceDataList)
+	})
 }
 
 // DeploySecrets takes all existing secrets from the ShootState resource and deploys them in the shoot's control plane.
 func (b *Botanist) DeploySecrets(ctx context.Context) error {
-	gardenerResourceDataList := gardencorev1alpha1helper.GardenerResourceDataList(b.ShootState.Spec.Gardener)
+	gardenerResourceDataList := gardencorev1alpha1helper.GardenerResourceDataList(b.GetShootState().Spec.Gardener)
 	existingSecrets, err := b.fetchExistingSecrets(ctx)
 	if err != nil {
 		return err

--- a/pkg/operation/botanist/worker.go
+++ b/pkg/operation/botanist/worker.go
@@ -60,7 +60,7 @@ func (b *Botanist) DeployWorker(ctx context.Context) error {
 	b.Shoot.Components.Extensions.Worker.SetWorkerNameToOperatingSystemConfigsMap(b.Shoot.Components.Extensions.OperatingSystemConfig.WorkerNameToOperatingSystemConfigsMap())
 
 	if b.isRestorePhase() {
-		return b.Shoot.Components.Extensions.Worker.Restore(ctx, b.ShootState)
+		return b.Shoot.Components.Extensions.Worker.Restore(ctx, b.GetShootState())
 	}
 
 	return b.Shoot.Components.Extensions.Worker.Deploy(ctx)

--- a/pkg/operation/botanist/worker_test.go
+++ b/pkg/operation/botanist/worker_test.go
@@ -77,8 +77,8 @@ var _ = Describe("Worker", func() {
 					},
 				},
 			},
-			ShootState: shootState,
 		}}
+		botanist.SetShootState(shootState)
 		botanist.StoreSecret("ssh-keypair", &corev1.Secret{Data: map[string][]byte{"id_rsa.pub": sshPublicKey}})
 		botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{})
 	})

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -44,6 +44,7 @@ import (
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -525,7 +526,7 @@ func (o *Operation) EnsureShootStateExists(ctx context.Context) error {
 	if err = o.K8sGardenClient.Client().Get(ctx, client.ObjectKeyFromObject(shootState), shootState); err != nil {
 		return err
 	}
-	o.ShootState = shootState
+	o.SetShootState(shootState)
 	gardenerResourceList := gardencorev1alpha1helper.GardenerResourceDataList(shootState.Spec.Gardener)
 	o.Shoot.ETCDEncryption, err = etcdencryption.GetEncryptionConfig(gardenerResourceList)
 	return err
@@ -549,14 +550,46 @@ func (o *Operation) DeleteShootState(ctx context.Context) error {
 	return client.IgnoreNotFound(o.K8sGardenClient.Client().Delete(ctx, shootState))
 }
 
-// SaveGardenerResourcesInShootState saves the provided GardenerResourcesDataList in the ShootState's `gardener` field
-func (o *Operation) SaveGardenerResourcesInShootState(ctx context.Context, resourceList gardencorev1alpha1helper.GardenerResourceDataList) error {
-	shootState := o.ShootState.DeepCopy()
-	shootState.Spec.Gardener = resourceList
-	if err := o.K8sGardenClient.Client().Patch(ctx, shootState, client.MergeFrom(o.ShootState)); err != nil {
+// GetShootState returns the shootstate resource of this Shoot in a concurrency safe way.
+// This method should be used only for reading the data of the returned shootstate resource. The returned shootstate
+// resource MUST NOT BE MODIFIED (except in test code) since this might interfere with other concurrent reads and writes.
+// To properly update the shootstate resource of this Shoot use SaveGardenerResourceDataInShootState.
+func (o *Operation) GetShootState() *gardencorev1alpha1.ShootState {
+	return o.shootState.Load().(*gardencorev1alpha1.ShootState)
+}
+
+// SetShootState sets the shootstate resource of this Shoot in a concurrency safe way.
+// This method is not protected by a mutex and does not update the shootstate resource in the cluster and so
+// should be used only in exceptional situations, or as a convenience in test code. The shootstate passed as a parameter
+// MUST NOT BE MODIFIED after the call to SetShootState (except in test code) since this might interfere with other concurrent reads and writes.
+// To properly update the shootstate resource of this Shoot use SaveGardenerResourceDataInShootState.
+func (o *Operation) SetShootState(shootState *gardencorev1alpha1.ShootState) {
+	o.shootState.Store(shootState)
+}
+
+// SaveGardenerResourceDataInShootState updates the shootstate resource of this Shoot in a concurrency safe way,
+// using the given context and mutate function.
+// The mutate function should modify the passed GardenerResourceData so that changes are persisted.
+// This method is protected by a mutex, so only a single SaveGardenerResourceDataInShootState operation can be
+// executed at any point in time.
+func (o *Operation) SaveGardenerResourceDataInShootState(ctx context.Context, f func(*[]gardencorev1alpha1.GardenerResourceData) error) error {
+	o.shootStateMutex.Lock()
+	defer o.shootStateMutex.Unlock()
+
+	shootState := o.GetShootState().DeepCopy()
+	original := shootState.DeepCopy()
+	patch := client.MergeFromWithOptions(original, client.MergeFromWithOptimisticLock{})
+
+	if err := f(&shootState.Spec.Gardener); err != nil {
 		return err
 	}
-	o.ShootState = shootState
+	if equality.Semantic.DeepEqual(original.Spec.Gardener, shootState.Spec.Gardener) {
+		return nil
+	}
+	if err := o.K8sGardenClient.Client().Patch(ctx, shootState, patch); err != nil {
+		return err
+	}
+	o.SetShootState(shootState)
 	return nil
 }
 

--- a/pkg/operation/shootsecrets/secrets_manager.go
+++ b/pkg/operation/shootsecrets/secrets_manager.go
@@ -61,7 +61,7 @@ func NewSecretsManager(
 	secretConfigGenerator SecretConfigGeneratorFunc,
 ) *SecretsManager {
 	return &SecretsManager{
-		GardenerResourceDataList:    gardenerResourceDataList.DeepCopy(),
+		GardenerResourceDataList:    gardenerResourceDataList,
 		staticTokenConfig:           staticTokenConfig,
 		certificateAuthorityConfigs: certificateAuthorityConfigs,
 		secretConfigGenerator:       secretConfigGenerator,

--- a/pkg/operation/shootsecrets/secrets_manager_test.go
+++ b/pkg/operation/shootsecrets/secrets_manager_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	gardencorev1alpha1helper "github.com/gardener/gardener/pkg/apis/core/v1alpha1/helper"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/infodata"
@@ -177,39 +176,6 @@ var _ = Describe("SecretsManager", func() {
 			Expect(len(staticTokenInfoData.(*secrets.StaticTokenInfoData).Tokens)).To(Equal(2))
 			Expect(staticTokenInfoData.(*secrets.StaticTokenInfoData).Tokens["barID"]).NotTo(Equal(""))
 			Expect(staticTokenInfoData.(*secrets.StaticTokenInfoData).Tokens["fooID"]).To(Equal("foo"))
-		})
-
-		It("should not use the same slice for the resourceDataList", func() {
-			preExistingSecretsCount := 38
-			resourceData := []gardencorev1alpha1.GardenerResourceData{
-				{
-					Name: staticTokenConfig.Name,
-					Type: string(secrets.StaticTokenDataType),
-					Data: runtime.RawExtension{Raw: []byte(`{"tokens":{"fooID":"foo","barID":"bar"}}`)},
-				},
-			}
-			for i := 0; i < preExistingSecretsCount; i++ {
-				resourceData = append(
-					resourceData,
-					gardencorev1alpha1.GardenerResourceData{
-						Name: fmt.Sprintf("%s-%d", caName, i),
-						Type: string(secrets.CertificateDataType),
-						Data: runtime.RawExtension{Raw: []byte(fmt.Sprintf(`{"privateKey":"%s","certificate":"%s"}`, cakey, cacert))},
-					})
-			}
-
-			resourceList := gardencorev1alpha1helper.GardenerResourceDataList(resourceData)
-			Expect(resourceList.Get(staticTokenConfig.Name)).ToNot(BeNil())
-			resourceList.Delete(staticTokenConfig.Name)
-			Expect(resourceList.Get(staticTokenConfig.Name)).To(BeNil())
-
-			secretsManager := NewSecretsManager(resourceList, staticTokenConfig, nil, secretsConfigGenerator)
-			err := secretsManager.Generate()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(resourceList.Get(staticTokenConfig.Name)).To(BeNil())
-			Expect(secretsManager.GardenerResourceDataList.Get(staticTokenConfig.Name)).ToNot(BeNil())
-			resourceList2 := gardencorev1alpha1helper.GardenerResourceDataList(resourceData)
-			Expect(resourceList2.Get(staticTokenConfig.Name)).To(BeNil())
 		})
 
 		It("should remove outdated token entries from generated static token info data", func() {

--- a/pkg/operation/types.go
+++ b/pkg/operation/types.go
@@ -17,8 +17,8 @@ package operation
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 
-	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
@@ -58,6 +58,9 @@ type Operation struct {
 	secrets      map[string]*corev1.Secret
 	secretsMutex sync.RWMutex
 
+	shootState      atomic.Value
+	shootStateMutex sync.Mutex
+
 	Config                    *config.GardenletConfiguration
 	Logger                    logrus.FieldLogger
 	GardenerInfo              *gardencorev1beta1.Gardener
@@ -66,7 +69,6 @@ type Operation struct {
 	Garden                    *garden.Garden
 	Seed                      *seed.Seed
 	Shoot                     *shoot.Shoot
-	ShootState                *gardencorev1alpha1.ShootState
 	ManagedSeed               *seedmanagementv1alpha1.ManagedSeed
 	ManagedSeedAPIServer      *gardencorev1beta1helper.ShootedSeedAPIServer
 	ClientMap                 clientmap.ClientMap

--- a/pkg/utils/test/test.go
+++ b/pkg/utils/test/test.go
@@ -192,6 +192,17 @@ func EXPECTPatch(ctx context.Context, c *mockclient.MockClient, expectedObj, mer
 		expectedPatch = client.StrategicMergeFrom(mergeFrom.DeepCopyObject().(client.Object))
 	}
 
+	return expectPatch(ctx, c, expectedObj, expectedPatch, rets...)
+}
+
+// EXPECTPatchWithOptimisticLock is a helper function for a GoMock call with the mock client
+// expecting a merge patch with optimistic lock.
+func EXPECTPatchWithOptimisticLock(ctx context.Context, c *mockclient.MockClient, expectedObj, mergeFrom client.Object, rets ...interface{}) *gomock.Call {
+	expectedPatch := client.MergeFromWithOptions(mergeFrom, client.MergeFromWithOptimisticLock{})
+	return expectPatch(ctx, c, expectedObj, expectedPatch, rets...)
+}
+
+func expectPatch(ctx context.Context, c *mockclient.MockClient, expectedObj client.Object, expectedPatch client.Patch, rets ...interface{}) *gomock.Call {
 	expectedData, expectedErr := expectedPatch.Data(expectedObj)
 	Expect(expectedErr).To(BeNil())
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind bug

**What this PR does / why we need it**:
Perform reads and writes to the ShootState resource in a concurrency safe way similar to what was done for the Shoot.Info and Seed.Info (#4459 and #4465). Generally we are mostly concerned with protecting the `ShotState.Spec.Garden` list which can be modified in multiple places (currently when generating secrets and the etcd encryption config).
The PR also switchese to using a json merge patch with optimistic locking when patching the ShootState and fixes the following bug:
If the ETCD encryption data has to be updated (e.g. the `shoot.gardener.cloud/etcd-encryption-force-plaintext-secrets=true` annotation is set in the etcd encryption secret) the updated data is not properly persisted in the ShootState, if the ETCD encryption data and secret already exist from a previous reconciliation.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Reads and writes to the ShootState resource are now performed in a concurrency safe way.
```
```other operator
The ShootState.Spec.Gardener is now patched via a json merge patch with optimistic lock. 
```
```other operator
If the etcd encryption secret and its corresponding data in the ShootState exist and the secret is annotated with `shoot.gardener.cloud/etcd-encryption-force-plaintext-secrets=true", the change will be properly reflected in the ShootState as well.
```