### PR TITLE
Create the garden ns in the Seed cluster as part of `make start-gardenlet`

### DIFF
--- a/hack/local-development/start-gardenlet
+++ b/hack/local-development/start-gardenlet
@@ -106,6 +106,10 @@ if [ ! -f "$file_imagevector_overwrite" ]; then
 else
   trap cleanup_imagevector_overwrite EXIT
 
+  # garden namespace is required for the gardenlet leader election
+  kubectl   --kubeconfig="$SEED_KUBECONFIG" get    namespace garden &>/dev/null || \
+    kubectl --kubeconfig="$SEED_KUBECONFIG" create namespace garden
+
   echo "Starting gardenlet for seed $SEED_NAME..."
 
   KUBECONFIG="$SEED_KUBECONFIG" \


### PR DESCRIPTION
/area dev-productivity
/kind bug

Before https://github.com/gardener/gardener/pull/4270 gardenlet was started with `KUBECONFIG` pointing to the the local/remote garden cluster. Hence, gardenlet was using this local/remote garden cluster for its leader election.
After https://github.com/gardener/gardener/pull/4270 gardenlet is started with `KUBECONFIG` pointing to `SEED_KUBECONFIG`. Hence gardenlet tries to acquire leadership in the Seed cluster but the garden ns initially does not exist there. And `make start-gardenlet SEED_NAME=<NAME>` fails with the error described in https://github.com/gardener/gardener/issues/4414.

Fixes https://github.com/gardener/gardener/issues/4414

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
