### PR TITLE
Allow the creation of the project garden

### DIFF
--- a/plugin/pkg/project/validator/admission.go
+++ b/plugin/pkg/project/validator/admission.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	gardencore "github.com/gardener/gardener/pkg/apis/core"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -71,7 +72,6 @@ func (v *handler) Validate(_ context.Context, a admission.Attributes, _ admissio
 
 	// TODO: Remove this admission plugin in favor of static validation in a future release, see https://github.com/gardener/gardener/pull/4228.
 	if project.Spec.Namespace != nil && *project.Spec.Namespace != v1beta1constants.GardenNamespace && !strings.HasPrefix(*project.Spec.Namespace, gutil.ProjectNamespacePrefix) {
-
 		return admission.NewForbidden(a, fmt.Errorf(".spec.namespace must start with %s", gutil.ProjectNamespacePrefix))
 	}
 

--- a/plugin/pkg/project/validator/admission.go
+++ b/plugin/pkg/project/validator/admission.go
@@ -70,7 +70,8 @@ func (v *handler) Validate(_ context.Context, a admission.Attributes, _ admissio
 	}
 
 	// TODO: Remove this admission plugin in favor of static validation in a future release, see https://github.com/gardener/gardener/pull/4228.
-	if project.Spec.Namespace != nil && *project.Spec.Namespace != "garden" && !strings.HasPrefix(*project.Spec.Namespace, gutil.ProjectNamespacePrefix) {
+	if project.Spec.Namespace != nil && *project.Spec.Namespace != v1beta1constants.GardenNamespace && !strings.HasPrefix(*project.Spec.Namespace, gutil.ProjectNamespacePrefix) {
+
 		return admission.NewForbidden(a, fmt.Errorf(".spec.namespace must start with %s", gutil.ProjectNamespacePrefix))
 	}
 

--- a/plugin/pkg/project/validator/admission.go
+++ b/plugin/pkg/project/validator/admission.go
@@ -70,7 +70,7 @@ func (v *handler) Validate(_ context.Context, a admission.Attributes, _ admissio
 	}
 
 	// TODO: Remove this admission plugin in favor of static validation in a future release, see https://github.com/gardener/gardener/pull/4228.
-	if project.Spec.Namespace != nil && !strings.HasPrefix(*project.Spec.Namespace, gutil.ProjectNamespacePrefix) {
+	if project.Spec.Namespace != nil && *project.Spec.Namespace != "garden" && !strings.HasPrefix(*project.Spec.Namespace, gutil.ProjectNamespacePrefix) {
 		return admission.NewForbidden(a, fmt.Errorf(".spec.namespace must start with %s", gutil.ProjectNamespacePrefix))
 	}
 

--- a/plugin/pkg/project/validator/admission_test.go
+++ b/plugin/pkg/project/validator/admission_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/gardener/gardener/pkg/apis/core"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	. "github.com/gardener/gardener/plugin/pkg/project/validator"
 
 	. "github.com/onsi/ginkgo"
@@ -34,7 +35,6 @@ var _ = Describe("Admission", func() {
 			project          core.Project
 			admissionHandler admission.ValidationInterface
 
-			gardenProject = "garden"
 			namespaceName = "garden-my-project"
 			projectName   = "my-project"
 			projectBase   = core.Project{
@@ -66,8 +66,8 @@ var _ = Describe("Admission", func() {
 			Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
 		})
 
-		It("should allow creating the project(special garden project)", func() {
-			project.Spec.Namespace = &gardenProject
+		It("should allow creating the project (namespace is 'garden')", func() {
+			project.Spec.Namespace = pointer.String(v1beta1constants.GardenNamespace)
 
 			attrs := admission.NewAttributesRecord(&project, nil, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 

--- a/plugin/pkg/project/validator/admission_test.go
+++ b/plugin/pkg/project/validator/admission_test.go
@@ -34,6 +34,7 @@ var _ = Describe("Admission", func() {
 			project          core.Project
 			admissionHandler admission.ValidationInterface
 
+			gardenProject = "garden"
 			namespaceName = "garden-my-project"
 			projectName   = "my-project"
 			projectBase   = core.Project{
@@ -59,6 +60,14 @@ var _ = Describe("Admission", func() {
 
 		It("should allow creating the project(namespace non-nil)", func() {
 			project.Spec.Namespace = &namespaceName
+
+			attrs := admission.NewAttributesRecord(&project, nil, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+
+			Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
+		})
+
+		It("should allow creating the project(special garden project)", func() {
+			project.Spec.Namespace = &gardenProject
 
 			attrs := admission.NewAttributesRecord(&project, nil, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
The ProjectValidator admission plugin now allows the creation of the project `garden`

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/4420

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue that was not allowing creation of garden Project (with .spec.namespace=garden) is now fixed.
```
