### PR TITLE
Raise requirement for seed K8s versions to 1.18

### DIFF
--- a/docs/usage/supported_k8s_versions.md
+++ b/docs/usage/supported_k8s_versions.md
@@ -10,9 +10,9 @@ in `admissionregistration.k8s.io/v1` version which is only served in Kubernetes 
 
 ## Seed cluster versions
 
-:warning: The minimum version of a seed cluster that can be connected to Gardener is **`1.15.x`**.
-
-> If `ManagedIstio` feature gate is enabled in gardenlet, the minimum version of a seed cluster is **`1.16.x`**. Additionally `TokenRequest` and `TokenRequestProjection` feature gates must be enabled and [Service Account Token Volume Projection](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection) set as well.
+:warning: The minimum version of a seed cluster that can be connected to Gardener is **`1.18.x`**.
+Kubernetes `1.18` sets the common ground for several Gardener features, e.g. `SeedKubeScheduler` ([ref](https://github.com/gardener/gardener/blob/master/docs/deployment/feature_gates.md#list-of-feature-gates)).
+It also enables the Gardener code base to leverage more advanced Kubernetes features, like [Server-Side Apply](https://kubernetes.io/docs/reference/using-api/server-side-apply/), in the future.
 
 ## Shoot cluster versions
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/area robustness
/kind enhancement

**What this PR does / why we need it**:
This PR raises the minimum supported K8s for seed clusters to `1.18`. See the linked issue for more details about the motivation.

**Which issue(s) this PR fixes**:
Fixes #4083

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
Gardener now requires seed clusters to run at least Kubernetes version `1.18`. Please update your seed clusters if necessary before updating to this Gardener version. Older Kubernetes releases will not be supported any more. Please note, the version support for shoot clusters is not affected by this change.
```
