### PR TITLE
Upgrade gardener fluent-bit-to-loki plugin to v0.36.1

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -208,7 +208,7 @@ images:
 - name: fluent-bit-plugin-installer
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/fluent-bit-to-loki
-  tag: "v0.35.0"
+  tag: "v0.36.1"
 - name: loki
   sourceRepository: github.com/grafana/loki
   repository: grafana/loki
@@ -216,9 +216,9 @@ images:
 - name: loki-curator
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/loki-curator
-  tag: "v0.35.0"
+  tag: "v0.36.1"
 - name: kube-rbac-proxy
-  sourceRepository: https://github.com/brancz/kube-rbac-proxy
+  sourceRepository: github.com/brancz/kube-rbac-proxy
   repository: quay.io/brancz/kube-rbac-proxy
   tag: v0.8.0
 - name: promtail
@@ -226,9 +226,9 @@ images:
   repository: "docker.io/grafana/promtail"
   tag: "2.1.0"
 - name: telegraf
-  sourceRepository: https://github.com/influxdata/telegraf
-  repository: eu.gcr.io/gardener-project/3rd/telegraf
-  tag: 1.18.0-alpine-iptables
+  sourceRepository: github.com/gardener/logging
+  repository: eu.gcr.io/gardener-project/gardener/telegraf-iptables
+  tag: "v0.36.1"
 
 # VPA
 - name: vpa-admission-controller

--- a/charts/seed-bootstrap/charts/fluent-bit/templates/_fluent-bit-config.tpl
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/_fluent-bit-config.tpl
@@ -95,24 +95,25 @@
         LogLevel info
         BatchWait 40s
         BatchSize 30720
-        Labels {test="fluent-bit-go"}
+        Labels {origin="seed"}
         LineFormat json
         SortByTimestamp true
         DropSingleKey false
         AutoKubernetesLabels false
         LabelSelector gardener.cloud/role:shoot
-        RemoveKeys kubernetes,stream,time,tag
+        RemoveKeys kubernetes,stream,time,tag,gardenuser
         LabelMapPath /fluent-bit/etc/kubernetes_label_map.json
         DynamicHostPath {"kubernetes": {"namespace_name": "namespace"}}
         DynamicHostPrefix http://loki.
         DynamicHostSuffix .svc:3100/loki/api/v1/push
         DynamicHostRegex ^shoot-
+        DynamicTenant user gardenuser user
         MaxRetries 3
         Timeout 10s
         MinBackoff 30s
         Buffer true
         BufferType dque
-        QueueDir  /fluent-bit/buffers/operator
+        QueueDir  /fluent-bit/buffers/seed
         QueueSegmentSize 300
         QueueSync normal
         QueueName gardener-kubernetes-operator
@@ -124,42 +125,6 @@
         ControllerSyncTimeout 120s
         NumberOfBatchIDs 5
         TenantID operator
-    
-    [Output]
-        Name gardenerloki
-        Match {{ .Values.exposedComponentsTagPrefix }}.kubernetes.*
-        Url http://loki.garden.svc:3100/loki/api/v1/push
-        LogLevel info
-        BatchWait 40s
-        BatchSize 30720
-        Labels {test="fluent-bit-go", lang="Golang"}
-        LineFormat json
-        SortByTimestamp true
-        DropSingleKey false
-        AutoKubernetesLabels true
-        LabelSelector gardener.cloud/role:shoot
-        RemoveKeys kubernetes,stream,type,time,tag
-        LabelMapPath /fluent-bit/etc/kubernetes_label_map.json
-        DynamicHostPath {"kubernetes": {"namespace_name": "namespace"}}
-        DynamicHostPrefix http://loki.
-        DynamicHostSuffix .svc:3100/loki/api/v1/push
-        DynamicHostRegex ^shoot-
-        MaxRetries 3
-        Timeout 10s
-        MinBackoff 30s
-        Buffer true
-        BufferType dque
-        QueueDir  /fluent-bit/buffers/user
-        QueueSegmentSize 300
-        QueueSync normal
-        QueueName gardener-kubernetes-user
-        FallbackToTagWhenMetadataIsMissing true
-        SendDeletedClustersLogsToDefaultClient true
-        TagKey tag
-        DropLogEntryWithoutK8sMetadata true
-        ControllerSyncTimeout 120s
-        NumberOfBatchIDs 5
-        TenantID user
 
     [Output]
         Name gardenerloki
@@ -168,7 +133,7 @@
         LogLevel info
         BatchWait 60s
         BatchSize 30720
-        Labels {test="fluent-bit-go"}
+        Labels {origin="seed-journald"}
         LineFormat json
         SortByTimestamp true
         DropSingleKey false
@@ -182,7 +147,7 @@
         QueueDir  /fluent-bit/buffers
         QueueSegmentSize 300
         QueueSync normal
-        QueueName gardener-journald
+        QueueName seed-journald
         NumberOfBatchIDs 5
 {{ end }}
 {{- end }}

--- a/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-configmap.yaml
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-configmap.yaml
@@ -192,16 +192,20 @@ data:
 {{ if .Values.additionalFilters }}
 {{- toString .Values.additionalFilters | indent 4 }}
 {{- end }}
+
+    [FILTER]
+        Name record_modifier
+        Match {{ .Values.exposedComponentsTagPrefix }}.*
+        Record gardenuser user
+
+    [FILTER]
+        Name                rewrite_tag
+        Match               {{ .Values.exposedComponentsTagPrefix }}.*
+        Rule                $tag ^.+? kubernetes.$TAG false
     # Scripts
     [FILTER]
         Name                lua
         Match               kubernetes.*
-        script              modify_severity.lua
-        call                cb_modify
-
-    [FILTER]
-        Name                lua
-        Match               {{ .Values.exposedComponentsTagPrefix }}.kubernetes.*
         script              modify_severity.lua
         call                cb_modify
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
With this PR we:
1. Upgrade the fluent-bit-to-loki plugin to v0.36.1.
2. Remove the user tenant plugin instance as v0.36.1 supports a dynamic one.
3. Use our own version of the [Telegraf](https://github.com/influxdata/telegraf) image which has tables installed.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer https://github.com/gardener/logging/pull/103 @vlvasilev
Pprof profiling can be activated for the fluent-bit-to-loki-output plugin via the `Pprof` flag in the fluent-bit configuration.
```
```other operator https://github.com/gardener/logging/pull/102 @vlvasilev
Gardener-fluent-bit-to-loki-output plugin processes the input in parallel, using a new Goroutine per log message.
```
```other operator https://github.com/gardener/logging/pull/100 @vlvasilev
Additional Loki TenantID can be added via "DynamicTenant" option in the fluent-bit configuration.
```
```bugfix operator https://github.com/gardener/logging/pull/99 @vlvasilev
When buffered Loki client is deleted during runtime all of its stored logs are sent before deleting the client.
Also, the underlying file of a buffered Loki client is deleted.
```

``` other developer github.com/gardener/logging #104 @vlvasilev
Add Telegraf image to the ci pipeline
```