### PR TITLE
[release-v1.27] Automated cherry pick of #4423: Allow the creation of the project garden

### DIFF
--- a/plugin/pkg/project/validator/admission.go
+++ b/plugin/pkg/project/validator/admission.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	gardencore "github.com/gardener/gardener/pkg/apis/core"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -70,7 +71,7 @@ func (v *handler) Validate(_ context.Context, a admission.Attributes, _ admissio
 	}
 
 	// TODO: Remove this admission plugin in favor of static validation in a future release, see https://github.com/gardener/gardener/pull/4228.
-	if project.Spec.Namespace != nil && !strings.HasPrefix(*project.Spec.Namespace, gutil.ProjectNamespacePrefix) {
+	if project.Spec.Namespace != nil && *project.Spec.Namespace != v1beta1constants.GardenNamespace && !strings.HasPrefix(*project.Spec.Namespace, gutil.ProjectNamespacePrefix) {
 		return admission.NewForbidden(a, fmt.Errorf(".spec.namespace must start with %s", gutil.ProjectNamespacePrefix))
 	}
 

--- a/plugin/pkg/project/validator/admission_test.go
+++ b/plugin/pkg/project/validator/admission_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/gardener/gardener/pkg/apis/core"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	. "github.com/gardener/gardener/plugin/pkg/project/validator"
 
 	. "github.com/onsi/ginkgo"
@@ -59,6 +60,14 @@ var _ = Describe("Admission", func() {
 
 		It("should allow creating the project(namespace non-nil)", func() {
 			project.Spec.Namespace = &namespaceName
+
+			attrs := admission.NewAttributesRecord(&project, nil, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+
+			Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
+		})
+
+		It("should allow creating the project (namespace is 'garden')", func() {
+			project.Spec.Namespace = pointer.String(v1beta1constants.GardenNamespace)
 
 			attrs := admission.NewAttributesRecord(&project, nil, core.Kind("Project").WithVersion("version"), "", project.Name, core.Resource("projects").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 


### PR DESCRIPTION
/area/control-plane
/kind/bug

Cherry pick of #4423 on release-v1.27.

#4423: Allow the creation of the project garden

**Release Notes:**
```bugfix operator
An issue that was not allowing creation of garden Project (with .spec.namespace=garden) is now fixed.
```