### PR TITLE
Add v1beta1 CRD version for seeds < 1.16

### DIFF
--- a/charts/seed-bootstrap/charts/extensions/templates/crd-dnsrecord.yaml
+++ b/charts/seed-bootstrap/charts/extensions/templates/crd-dnsrecord.yaml
@@ -1,3 +1,4 @@
+{{- if semverCompare ">= 1.16-0" .Capabilities.KubeVersion.GitVersion }}
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -271,3 +272,278 @@ spec:
     storage: true
     subresources:
       status: { }
+{{- else -}}
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: dnsrecords.extensions.gardener.cloud
+  labels:
+    gardener.cloud/deletion-protected: "true"
+spec:
+  additionalPrinterColumns:
+    - JSONPath: .spec.type
+      description: The DNS record provider type.
+      name: Type
+      type: string
+    - JSONPath: .spec.name
+      description: The DNS record domain name.
+      name: Domain Name
+      type: string
+    - JSONPath: .spec.recordType
+      description: The DNS record type (A, CNAME, or TXT).
+      name: Record Type
+      type: string
+    - JSONPath: .status.lastOperation.state
+      name: Status
+      type: string
+    - JSONPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+  group: extensions.gardener.cloud
+  names:
+    kind: DNSRecord
+    listKind: DNSRecordList
+    plural: dnsrecords
+    shortNames:
+      - dns
+    singular: dnsrecord
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: DNSRecord is a specification for a DNSRecord resource.
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: DNSRecordSpec is the spec of a DNSRecord resource.
+          properties:
+            name:
+              description: Name is the fully qualified domain name, e.g. "api.<shoot
+                domain>".
+              type: string
+            providerConfig:
+              description: ProviderConfig is the provider specific configuration.
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            recordType:
+              description: RecordType is the DNS record type. Only A, CNAME, and TXT
+                records are currently supported.
+              type: string
+            region:
+              description: Region is the region of this DNS record. If not specified,
+                the region specified in SecretRef will be used. If that is also not
+                specified, the extension controller will use its default region.
+              type: string
+            secretRef:
+              description: SecretRef is a reference to a secret that contains the
+                cloud provider specific credentials.
+              properties:
+                name:
+                  description: Name is unique within a namespace to reference a secret
+                    resource.
+                  type: string
+                namespace:
+                  description: Namespace defines the space within which the secret
+                    name must be unique.
+                  type: string
+              type: object
+            ttl:
+              description: TTL is the time to live in seconds. Defaults to 120.
+              format: int64
+              type: integer
+            type:
+              description: Type contains the instance of the resource's kind.
+              type: string
+            values:
+              description: Values is a list of IP addresses for A records, a single
+                hostname for CNAME records, or a list of texts for TXT records.
+              items:
+                type: string
+              type: array
+            zone:
+              description: Zone is the DNS hosted zone of this DNS record. If not
+                specified, it will be determined automatically by getting all hosted
+                zones of the account and searching for the longest zone name that
+                is a suffix of Name.
+              type: string
+          required:
+            - name
+            - recordType
+            - secretRef
+            - type
+            - values
+          type: object
+        status:
+          description: DNSRecordStatus is the status of a DNSRecord resource.
+          properties:
+            conditions:
+              description: Conditions represents the latest available observations
+                of a Seed's current state.
+              items:
+                description: Condition holds the information about the state of a
+                  resource.
+                properties:
+                  codes:
+                    description: Well-defined error codes in case the condition reports
+                      a problem.
+                    items:
+                      description: ErrorCode is a string alias.
+                      type: string
+                    type: array
+                  lastTransitionTime:
+                    description: Last time the condition transitioned from one status
+                      to another.
+                    format: date-time
+                    type: string
+                  lastUpdateTime:
+                    description: Last time the condition was updated.
+                    format: date-time
+                    type: string
+                  message:
+                    description: A human readable message indicating details about
+                      the transition.
+                    type: string
+                  reason:
+                    description: The reason for the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of True, False, Unknown.
+                    type: string
+                  type:
+                    description: Type of the Shoot condition.
+                    type: string
+                required:
+                  - lastTransitionTime
+                  - lastUpdateTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                type: object
+              type: array
+            lastError:
+              description: LastError holds information about the last occurred error
+                during an operation.
+              properties:
+                codes:
+                  description: Well-defined error codes of the last error(s).
+                  items:
+                    description: ErrorCode is a string alias.
+                    type: string
+                  type: array
+                description:
+                  description: A human readable message indicating details about the
+                    last error.
+                  type: string
+                lastUpdateTime:
+                  description: Last time the error was reported
+                  format: date-time
+                  type: string
+                taskID:
+                  description: ID of the task which caused this last error
+                  type: string
+              required:
+                - description
+              type: object
+            lastOperation:
+              description: LastOperation holds information about the last operation
+                on the resource.
+              properties:
+                description:
+                  description: A human readable message indicating details about the
+                    last operation.
+                  type: string
+                lastUpdateTime:
+                  description: Last time the operation state transitioned from one
+                    to another.
+                  format: date-time
+                  type: string
+                progress:
+                  description: The progress in percentage (0-100) of the last operation.
+                  format: int32
+                  type: integer
+                state:
+                  description: Status of the last operation, one of Aborted, Processing,
+                    Succeeded, Error, Failed.
+                  type: string
+                type:
+                  description: Type of the last operation, one of Create, Reconcile,
+                    Delete.
+                  type: string
+              required:
+                - description
+                - lastUpdateTime
+                - progress
+                - state
+                - type
+              type: object
+            observedGeneration:
+              description: ObservedGeneration is the most recent generation observed
+                for this resource.
+              format: int64
+              type: integer
+            providerStatus:
+              description: ProviderStatus contains provider-specific status.
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            resources:
+              description: Resources holds a list of named resource references that
+                can be referred to in the state by their names.
+              items:
+                description: NamedResourceReference is a named reference to a resource.
+                properties:
+                  name:
+                    description: Name of the resource reference.
+                    type: string
+                  resourceRef:
+                    description: ResourceRef is a reference to a resource.
+                    properties:
+                      apiVersion:
+                        description: API version of the referent
+                        type: string
+                      kind:
+                        description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
+                        type: string
+                      name:
+                        description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                        type: string
+                    required:
+                      - kind
+                      - name
+                    type: object
+                required:
+                  - name
+                  - resourceRef
+                type: object
+              type: array
+            state:
+              description: State can be filled by the operating controller with what
+                ever data it needs.
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+            zone:
+              description: Zone is the DNS hosted zone of this DNS record.
+              type: string
+          type: object
+      required:
+        - spec
+      type: object
+  version: v1alpha1
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+{{- end }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind regression

**What this PR does / why we need it**:
This PR adds a `apiextensions.k8s.io/v1beta1` version for `DNSRecord` which is required for seeds running Kubernetes 1.15 (still supported by Gardener).

**Which issue(s) this PR fixes**:
Fixes #4427

**Special notes for your reviewer**:
/cc @ialidzhikov @stoyanr 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed which caused seed clusters running Kubernetes v1.15 not to get ready.
```
