### PR TITLE
Replace cluster specific envoy filter for reversed vpn with a static one.

### DIFF
--- a/charts/images.go
+++ b/charts/images.go
@@ -121,4 +121,6 @@ const (
 	ImageNameVpnShoot = "vpn-shoot"
 	// ImageNameVpnShootClient is a constant for an image in the image vector with name 'vpn-shoot-client'.
 	ImageNameVpnShootClient = "vpn-shoot-client"
+	// ImageNameExtAuthzServer is a constant for an image in the image vector with name 'ext-authz-server'.
+	ImageNameExtAuthzServer = "ext-authz-server"
 )

--- a/charts/images.go
+++ b/charts/images.go
@@ -43,6 +43,8 @@ const (
 	ImageNameDependencyWatchdog = "dependency-watchdog"
 	// ImageNameEtcdDruid is a constant for an image in the image vector with name 'etcd-druid'.
 	ImageNameEtcdDruid = "etcd-druid"
+	// ImageNameExtAuthzServer is a constant for an image in the image vector with name 'ext-authz-server'.
+	ImageNameExtAuthzServer = "ext-authz-server"
 	// ImageNameFluentBit is a constant for an image in the image vector with name 'fluent-bit'.
 	ImageNameFluentBit = "fluent-bit"
 	// ImageNameFluentBitPluginInstaller is a constant for an image in the image vector with name 'fluent-bit-plugin-installer'.
@@ -121,6 +123,4 @@ const (
 	ImageNameVpnShoot = "vpn-shoot"
 	// ImageNameVpnShootClient is a constant for an image in the image vector with name 'vpn-shoot-client'.
 	ImageNameVpnShootClient = "vpn-shoot-client"
-	// ImageNameExtAuthzServer is a constant for an image in the image vector with name 'ext-authz-server'.
-	ImageNameExtAuthzServer = "ext-authz-server"
 )

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -95,7 +95,7 @@ images:
 - name: vpn-seed-server
   sourceRepository: github.com/gardener/vpn2
   repository: eu.gcr.io/gardener-project/gardener/vpn-seed-server
-  tag: "0.4.0"
+  tag: "0.5.0"
 
 # Monitoring
 - name: alertmanager
@@ -139,7 +139,7 @@ images:
 - name: vpn-shoot-client
   sourceRepository: github.com/gardener/vpn2
   repository: eu.gcr.io/gardener-project/gardener/vpn-shoot-client
-  tag: "0.4.0"
+  tag: "0.5.0"
 - name: coredns
   sourceRepository: github.com/coredns/coredns
   repository: coredns/coredns
@@ -283,6 +283,12 @@ images:
   sourceRepository: github.com/istio/istio
   repository: gcr.io/istio-release/pilot
   tag: "1.10.2-distroless"
+
+# External Authz Server
+- name: ext-authz-server
+  sourceRepository: github.com/gardener/ext-authz-server
+  repository: eu.gcr.io/gardener-project/gardener/ext-authz-server
+  tag: "0.1.0"
 
 # API Server SNI
 - name: apiserver-proxy

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -284,7 +284,7 @@ images:
   repository: gcr.io/istio-release/pilot
   tag: "1.10.2-distroless"
 
-# External Authz Server
+# External Authorization Server for the Istio Endpoint of Reversed VPN
 - name: ext-authz-server
   sourceRepository: github.com/gardener/ext-authz-server
   repository: eu.gcr.io/gardener-project/gardener/ext-authz-server

--- a/charts/istio/istio-ingress/templates/envoy-filter.yaml
+++ b/charts/istio/istio-ingress/templates/envoy-filter.yaml
@@ -228,3 +228,44 @@ spec:
             accept_http_10: true
           upgrade_configs:
           - upgrade_type: CONNECT
+
+---
+
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: reversed-vpn
+  namespace: {{ .Release.Namespace }}
+spec:
+  configPatches:
+  - applyTo: NETWORK_FILTER
+    match:
+      context: GATEWAY
+      listener:
+        filterChain:
+          filter:
+            name: envoy.filters.network.http_connection_manager
+        name: 0.0.0.0_8132
+        portNumber: 8132
+    patch:
+      operation: MERGE
+      value:
+        name: envoy.filters.network.http_connection_manager
+        typed_config:
+          '@type': type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+          route_config:
+            virtual_hosts:
+            - domains:
+              - api.*
+              name: reversed-vpn
+              routes:
+              - match:
+                  connect_matcher: {}
+                route:
+                  cluster_header: Reversed-VPN
+                  upgrade_configs:
+                  - connect_config: {}
+                    upgrade_type: CONNECT
+  workloadSelector:
+    labels:
+{{ .Values.labels | toYaml | indent 6 }}

--- a/charts/istio/istio-ingress/templates/envoy-filter.yaml
+++ b/charts/istio/istio-ingress/templates/envoy-filter.yaml
@@ -287,7 +287,7 @@ spec:
           transport_api_version: V3
           grpc_service:
             envoy_grpc:
-              cluster_name: outbound|9001||auth-server.garden.svc.cluster.local
+              cluster_name: outbound|9001||reversed-vpn-auth-server.garden.svc.cluster.local
             timeout: 0.250s
   workloadSelector:
     labels:

--- a/charts/istio/istio-ingress/templates/envoy-filter.yaml
+++ b/charts/istio/istio-ingress/templates/envoy-filter.yaml
@@ -266,6 +266,30 @@ spec:
                   upgrade_configs:
                   - connect_config: {}
                     upgrade_type: CONNECT
+  - applyTo: HTTP_FILTER
+    match:
+      context: GATEWAY
+      listener:
+        name: 0.0.0.0_8132
+        portNumber: 8132
+        filterChain:
+          filter:
+            name: "envoy.filters.network.http_connection_manager"
+            subFilter:
+              name: "envoy.filters.http.router"
+    patch:
+      operation: INSERT_BEFORE
+      filterClass: AUTHZ # This filter will run *after* the Istio authz filter.
+      value:
+        name: envoy.filters.http.ext_authz
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthz
+          transport_api_version: V3
+          grpc_service:
+            envoy_grpc:
+              cluster_name: outbound|9001||auth-server.garden.svc.cluster.local
+            timeout: 0.250s
   workloadSelector:
     labels:
 {{ .Values.labels | toYaml | indent 6 }}
+

--- a/charts/istio/istio-ingress/templates/gateway.yaml
+++ b/charts/istio/istio-ingress/templates/gateway.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.istio.io/v1beta1
+kind: Gateway
+metadata:
+  name: reversed-vpn-auth-server
+  namespace: {{ .Release.Namespace }}
+spec:
+  selector:
+{{ .Values.labels | toYaml | indent 4 }}
+  servers:
+  - hosts:
+    - reversed-vpn-auth-server.garden.svc.cluster.local
+    port:
+      name: tls-tunnel
+      number: 8132
+      protocol: HTTP

--- a/charts/shoot-core/components/charts/vpn-shoot/templates/deployment.yaml
+++ b/charts/shoot-core/components/charts/vpn-shoot/templates/deployment.yaml
@@ -63,6 +63,8 @@ spec:
           value: {{ .Values.endpoint }}
         - name: OPENVPN_PORT
           value: {{ .Values.port | quote }}
+        - name: REVERSED_VPN_HEADER
+          value: {{ .Values.reversedVPN.header }}
       {{- end }}
         - name: SERVICE_NETWORK
           value: {{ .Values.serviceNetwork }}

--- a/charts/shoot-core/components/charts/vpn-shoot/values.yaml
+++ b/charts/shoot-core/components/charts/vpn-shoot/values.yaml
@@ -14,3 +14,4 @@ endpoint: 10.0.0.1
 port: 8132
 reversedVPN:
   enabled: false
+  header: outbound|1194||vpn-seed-server.shoot--project--shoot-name.svc.cluster.local

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -77,10 +77,6 @@ const (
 	// the vpn-seed-server pod.
 	DeploymentNameVPNSeedServer = "vpn-seed-server"
 
-	// DeploymentNameExternalAuthz is a constant for the name of a Kubernetes deployment object that contains
-	// the external authorization server.
-	DeploymentNameExternalAuthz = "auth-server"
-
 	// DeploymentNameKubeScheduler is a constant for the name of a Kubernetes deployment object that contains
 	// the kube-scheduler pod.
 	DeploymentNameKubeScheduler = "kube-scheduler"

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -77,6 +77,10 @@ const (
 	// the vpn-seed-server pod.
 	DeploymentNameVPNSeedServer = "vpn-seed-server"
 
+	// DeploymentNameExternalAuthz is a constant for the name of a Kubernetes deployment object that contains
+	// the external authorization server.
+	DeploymentNameExternalAuthz = "auth-server"
+
 	// DeploymentNameKubeScheduler is a constant for the name of a Kubernetes deployment object that contains
 	// the kube-scheduler pod.
 	DeploymentNameKubeScheduler = "kube-scheduler"

--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -457,6 +457,7 @@ func (b *Botanist) generateCoreAddonsChart(ctx context.Context) (*chartrenderer.
 				},
 				"reversedVPN": map[string]interface{}{
 					"enabled": true,
+					"header":  "outbound|1194||" + vpnseedserver.ServiceName + "." + b.Shoot.SeedNamespace + ".svc.cluster.local",
 				},
 				"podAnnotations": map[string]interface{}{
 					"checksum/secret-vpn-shoot-client": b.LoadCheckSum(vpnseedserver.VpnShootSecretName),

--- a/pkg/operation/botanist/component/extauthzserver/external_authz_server.go
+++ b/pkg/operation/botanist/component/extauthzserver/external_authz_server.go
@@ -47,18 +47,13 @@ const (
 	ServiceName = DeploymentName
 )
 
-// Interface contains functions for a auth-server deployer.
-type Interface interface {
-	component.DeployWaiter
-}
-
 // NewExtAuthServer creates a new instance of DeployWaiter for the auth-server.
 func NewExtAuthServer(
 	client client.Client,
 	namespace string,
 	imageExtAuthzServer string,
 	replicas int32,
-) Interface {
+) component.DeployWaiter {
 	return &authServer{
 		client:              client,
 		namespace:           namespace,

--- a/pkg/operation/botanist/component/extauthzserver/external_authz_server.go
+++ b/pkg/operation/botanist/component/extauthzserver/external_authz_server.go
@@ -1,0 +1,304 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extauthzserver
+
+import (
+	"context"
+	"fmt"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/controllerutils"
+	"github.com/gardener/gardener/pkg/operation/botanist/component"
+	"github.com/gardener/gardener/pkg/operation/botanist/component/vpnseedserver"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+
+	protobuftypes "github.com/gogo/protobuf/types"
+	istionetworkingv1beta1 "istio.io/api/networking/v1beta1"
+	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// AuthServerPort is the port exposed by the external authorization server
+	AuthServerPort = 9001
+	// DeploymentName is the name of the external authorization server deployment.
+	DeploymentName = v1beta1constants.DeploymentNameExternalAuthz
+	// ServiceName is the name of the external authorization server service.
+	ServiceName = DeploymentName
+)
+
+// Interface contains functions for a auth-server deployer.
+type Interface interface {
+	component.DeployWaiter
+}
+
+// New creates a new instance of DeployWaiter for the auth-server.
+func New(
+	client client.Client,
+	namespace string,
+	imageExtAuthzServer string,
+	replicas int32,
+) Interface {
+	return &authServer{
+		client:              client,
+		namespace:           namespace,
+		imageExtAuthzServer: imageExtAuthzServer,
+		replicas:            replicas,
+	}
+}
+
+type authServer struct {
+	client              client.Client
+	namespace           string
+	imageExtAuthzServer string
+	replicas            int32
+}
+
+func (a *authServer) Deploy(ctx context.Context) error {
+
+	var (
+		deployment      = a.emptyDeployment()
+		destinationRule = a.emptyDestinationRule()
+		gateway         = a.emptyGateway()
+		service         = a.emptyService()
+		virtualService  = a.emptyVirtualService()
+		vpa             = a.emptyVPA()
+
+		gatewaySelectors = map[string]string{"app": "istio-ingressgateway", "istio": "ingressgateway"}
+		vpaUpdateMode    = autoscalingv1beta2.UpdateModeAuto
+	)
+
+	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, a.client, deployment, func() error {
+		maxSurge := intstr.FromInt(100)
+		maxUnavailable := intstr.FromInt(0)
+		deployment.Labels = map[string]string{
+			v1beta1constants.LabelApp: DeploymentName,
+		}
+		deployment.Spec = appsv1.DeploymentSpec{
+			Replicas:             pointer.Int32(a.replicas),
+			RevisionHistoryLimit: pointer.Int32(1),
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{
+				v1beta1constants.LabelApp: DeploymentName,
+			}},
+			Strategy: appsv1.DeploymentStrategy{
+				RollingUpdate: &appsv1.RollingUpdateDeployment{
+					MaxUnavailable: &maxUnavailable,
+					MaxSurge:       &maxSurge,
+				},
+				Type: appsv1.RollingUpdateDeploymentStrategyType,
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						v1beta1constants.LabelApp: DeploymentName,
+					},
+				},
+				Spec: corev1.PodSpec{
+					AutomountServiceAccountToken: pointer.Bool(false),
+					PriorityClassName:            "system-cluster-critical",
+					DNSPolicy:                    corev1.DNSDefault, // make sure to not use the coredns for DNS resolution.
+					Containers: []corev1.Container{
+						{
+							Name:            DeploymentName,
+							Image:           a.imageExtAuthzServer,
+							ImagePullPolicy: corev1.PullIfNotPresent,
+							Ports: []corev1.ContainerPort{
+								{
+									Name:          "grpc-authz",
+									ContainerPort: 9001,
+									Protocol:      corev1.ProtocolTCP,
+								},
+							},
+							Resources: corev1.ResourceRequirements{
+								Requests: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("100m"),
+									corev1.ResourceMemory: resource.MustParse("100Mi"),
+								},
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("1"),
+									corev1.ResourceMemory: resource.MustParse("500Mi"),
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, a.client, destinationRule, func() error {
+		destinationRule.Spec = istionetworkingv1beta1.DestinationRule{
+			ExportTo: []string{"*"},
+			Host:     fmt.Sprintf("%s.%s.svc.cluster.local", DeploymentName, a.namespace),
+			TrafficPolicy: &istionetworkingv1beta1.TrafficPolicy{
+				ConnectionPool: &istionetworkingv1beta1.ConnectionPoolSettings{
+					Tcp: &istionetworkingv1beta1.ConnectionPoolSettings_TCPSettings{
+						MaxConnections: 5000,
+						TcpKeepalive: &istionetworkingv1beta1.ConnectionPoolSettings_TCPSettings_TcpKeepalive{
+							Interval: &protobuftypes.Duration{
+								Seconds: 75,
+							},
+							Time: &protobuftypes.Duration{
+								Seconds: 7200,
+							},
+						},
+					},
+				},
+				Tls: &istionetworkingv1beta1.ClientTLSSettings{
+					Mode: istionetworkingv1beta1.ClientTLSSettings_DISABLE,
+				},
+			},
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, a.client, gateway, func() error {
+		gateway.Spec = istionetworkingv1beta1.Gateway{
+			Selector: gatewaySelectors,
+			Servers: []*istionetworkingv1beta1.Server{
+				{
+					Hosts: []string{fmt.Sprintf("%s.%s.svc.cluster.local", DeploymentName, a.namespace)},
+					Port: &istionetworkingv1beta1.Port{
+						Name:     "tls-tunnel",
+						Number:   vpnseedserver.GatewayPort,
+						Protocol: "HTTP",
+					},
+				},
+			},
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, a.client, service, func() error {
+		service.Annotations = map[string]string{
+			"networking.istio.io/exportTo": "*",
+		}
+		service.Spec.Type = corev1.ServiceTypeClusterIP
+		service.Spec.Ports = []corev1.ServicePort{
+			{
+				Name:       "grpc-authz",
+				Port:       AuthServerPort,
+				TargetPort: intstr.FromInt(AuthServerPort),
+				Protocol:   corev1.ProtocolTCP,
+			},
+		}
+		service.Spec.Selector = map[string]string{
+			v1beta1constants.LabelApp: DeploymentName,
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, a.client, virtualService, func() error {
+		virtualService.Spec = istionetworkingv1beta1.VirtualService{
+			ExportTo: []string{"*"},
+			Hosts:    []string{fmt.Sprintf("%s.%s.svc.cluster.local", DeploymentName, a.namespace)},
+			Http: []*istionetworkingv1beta1.HTTPRoute{{
+				Route: []*istionetworkingv1beta1.HTTPRouteDestination{{
+					Destination: &istionetworkingv1beta1.Destination{
+						Host: DeploymentName,
+						Port: &istionetworkingv1beta1.PortSelector{Number: AuthServerPort},
+					},
+				}},
+			}},
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, a.client, vpa, func() error {
+		vpa.Spec.TargetRef = &autoscalingv1.CrossVersionObjectReference{
+			APIVersion: appsv1.SchemeGroupVersion.String(),
+			Kind:       "Deployment",
+			Name:       DeploymentName,
+		}
+		vpa.Spec.UpdatePolicy = &autoscalingv1beta2.PodUpdatePolicy{
+			UpdateMode: &vpaUpdateMode,
+		}
+		vpa.Spec.ResourcePolicy = &autoscalingv1beta2.PodResourcePolicy{
+			ContainerPolicies: []autoscalingv1beta2.ContainerResourcePolicy{
+				{
+					ContainerName: DeploymentName,
+					MinAllowed: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("100m"),
+						corev1.ResourceMemory: resource.MustParse("100Mi"),
+					},
+				},
+			},
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (a *authServer) Destroy(ctx context.Context) error {
+	return kutil.DeleteObjects(
+		ctx,
+		a.client,
+		a.emptyDeployment(),
+		a.emptyDestinationRule(),
+		a.emptyGateway(),
+		a.emptyService(),
+		a.emptyVirtualService(),
+		a.emptyVPA(),
+	)
+}
+
+func (a *authServer) Wait(_ context.Context) error        { return nil }
+func (a *authServer) WaitCleanup(_ context.Context) error { return nil }
+
+func (a *authServer) emptyDeployment() *appsv1.Deployment {
+	return &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: DeploymentName, Namespace: a.namespace}}
+}
+
+func (a *authServer) emptyDestinationRule() *networkingv1beta1.DestinationRule {
+	return &networkingv1beta1.DestinationRule{ObjectMeta: metav1.ObjectMeta{Name: DeploymentName, Namespace: a.namespace}}
+}
+
+func (a *authServer) emptyGateway() *networkingv1beta1.Gateway {
+	return &networkingv1beta1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: DeploymentName, Namespace: a.namespace}}
+}
+
+func (a *authServer) emptyService() *corev1.Service {
+	return &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: ServiceName, Namespace: a.namespace}}
+}
+
+func (a *authServer) emptyVirtualService() *networkingv1beta1.VirtualService {
+	return &networkingv1beta1.VirtualService{ObjectMeta: metav1.ObjectMeta{Name: DeploymentName, Namespace: a.namespace}}
+}
+
+func (a *authServer) emptyVPA() *autoscalingv1beta2.VerticalPodAutoscaler {
+	return &autoscalingv1beta2.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: DeploymentName + "-vpa", Namespace: a.namespace}}
+}

--- a/pkg/operation/botanist/component/extauthzserver/external_authz_server.go
+++ b/pkg/operation/botanist/component/extauthzserver/external_authz_server.go
@@ -52,8 +52,8 @@ type Interface interface {
 	component.DeployWaiter
 }
 
-// New creates a new instance of DeployWaiter for the auth-server.
-func New(
+// NewExtAuthServer creates a new instance of DeployWaiter for the auth-server.
+func NewExtAuthServer(
 	client client.Client,
 	namespace string,
 	imageExtAuthzServer string,

--- a/pkg/operation/botanist/component/extauthzserver/external_authz_server.go
+++ b/pkg/operation/botanist/component/extauthzserver/external_authz_server.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
@@ -144,7 +144,7 @@ func (a *authServer) Deploy(ctx context.Context) error {
 	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, a.client, destinationRule, func() error {
 		destinationRule.Spec = istionetworkingv1beta1.DestinationRule{
 			ExportTo: []string{"*"},
-			Host:     fmt.Sprintf("%s.%s.svc.%s", DeploymentName, a.namespace, v1beta1.DefaultDomain),
+			Host:     fmt.Sprintf("%s.%s.svc.%s", DeploymentName, a.namespace, gardencorev1beta1.DefaultDomain),
 			TrafficPolicy: &istionetworkingv1beta1.TrafficPolicy{
 				ConnectionPool: &istionetworkingv1beta1.ConnectionPoolSettings{
 					Tcp: &istionetworkingv1beta1.ConnectionPoolSettings_TCPSettings{
@@ -193,7 +193,7 @@ func (a *authServer) Deploy(ctx context.Context) error {
 	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, a.client, virtualService, func() error {
 		virtualService.Spec = istionetworkingv1beta1.VirtualService{
 			ExportTo: []string{"*"},
-			Hosts:    []string{fmt.Sprintf("%s.%s.svc.%s", DeploymentName, a.namespace, v1beta1.DefaultDomain)},
+			Hosts:    []string{fmt.Sprintf("%s.%s.svc.%s", DeploymentName, a.namespace, gardencorev1beta1.DefaultDomain)},
 			Http: []*istionetworkingv1beta1.HTTPRoute{{
 				Route: []*istionetworkingv1beta1.HTTPRouteDestination{{
 					Destination: &istionetworkingv1beta1.Destination{

--- a/pkg/operation/botanist/component/extauthzserver/external_authz_server_suite_test.go
+++ b/pkg/operation/botanist/component/extauthzserver/external_authz_server_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extauthzserver_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestExtAuthzServer(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Botanist Component ExtAuthzServer Suite")
+}

--- a/pkg/operation/botanist/component/extauthzserver/external_authz_server_test.go
+++ b/pkg/operation/botanist/component/extauthzserver/external_authz_server_test.go
@@ -1,0 +1,361 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package extauthzserver
+
+import (
+	"context"
+	"fmt"
+
+	protobuftypes "github.com/gogo/protobuf/types"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	istioapinetworkingv1beta1 "istio.io/api/networking/v1beta1"
+	istionetworkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
+	istionetworkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/operation/botanist/component"
+	"github.com/gardener/gardener/pkg/operation/botanist/component/vpnseedserver"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+)
+
+var _ = Describe("ExtAuthzServer", func() {
+	var (
+		ctx context.Context
+		c   client.Client
+
+		defaultDepWaiter component.DeployWaiter
+		namespace        = "shoot--foo--bar"
+
+		image                      = "eu.gcr.io/gardener-project/gardener/ext-authz-server:0.1.0"
+		replicas             int32 = 1
+		revisionHistoryLimit int32 = 1
+		maxSurge                   = intstr.FromInt(100)
+		maxUnavailable             = intstr.FromInt(0)
+		vpaUpdateMode              = autoscalingv1beta2.UpdateModeAuto
+
+		deploymentName = DeploymentName
+		serviceName    = DeploymentName
+		vpaName        = fmt.Sprintf("%s-vpa", DeploymentName)
+
+		expectedDeployment      *appsv1.Deployment
+		expectedDestinationRule *istionetworkingv1beta1.DestinationRule
+		expectedGateway         *istionetworkingv1beta1.Gateway
+		expectedService         *corev1.Service
+		expectedVirtualService  *istionetworkingv1beta1.VirtualService
+		expectedVpa             *autoscalingv1beta2.VerticalPodAutoscaler
+	)
+
+	BeforeEach(func() {
+		ctx = context.TODO()
+		s := runtime.NewScheme()
+		Expect(istionetworkingv1beta1.AddToScheme(s)).To(Succeed())
+		Expect(istionetworkingv1alpha3.AddToScheme(s)).To(Succeed())
+		Expect(corev1.AddToScheme(s)).To(Succeed())
+		Expect(appsv1.AddToScheme(s)).To(Succeed())
+		Expect(autoscalingv1beta2.AddToScheme(s)).To(Succeed())
+
+		c = fake.NewClientBuilder().WithScheme(s).Build()
+
+		var err error
+		Expect(err).NotTo(HaveOccurred())
+
+		expectedDeployment = &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      deploymentName,
+				Namespace: namespace,
+				Labels: map[string]string{
+					"app": DeploymentName,
+				},
+				ResourceVersion: "1",
+			},
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Deployment",
+				APIVersion: "apps/v1",
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas:             &replicas,
+				RevisionHistoryLimit: &revisionHistoryLimit,
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{
+					v1beta1constants.LabelApp: DeploymentName,
+				}},
+				Strategy: appsv1.DeploymentStrategy{
+					RollingUpdate: &appsv1.RollingUpdateDeployment{
+						MaxUnavailable: &maxUnavailable,
+						MaxSurge:       &maxSurge,
+					},
+					Type: appsv1.RollingUpdateDeploymentStrategyType,
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{
+							v1beta1constants.LabelApp: DeploymentName,
+						},
+					},
+					Spec: corev1.PodSpec{
+						AutomountServiceAccountToken: pointer.Bool(false),
+						PriorityClassName:            "system-cluster-critical",
+						DNSPolicy:                    corev1.DNSDefault, // make sure to not use the coredns for DNS resolution.
+						Containers: []corev1.Container{
+							{
+								Name:            DeploymentName,
+								Image:           image,
+								ImagePullPolicy: corev1.PullIfNotPresent,
+								Ports: []corev1.ContainerPort{
+									{
+										Name:          "grpc-authz",
+										ContainerPort: 9001,
+										Protocol:      corev1.ProtocolTCP,
+									},
+								},
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("100m"),
+										corev1.ResourceMemory: resource.MustParse("100Mi"),
+									},
+									Limits: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("1"),
+										corev1.ResourceMemory: resource.MustParse("500Mi"),
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		expectedDestinationRule = &istionetworkingv1beta1.DestinationRule{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: istionetworkingv1beta1.SchemeGroupVersion.String(),
+				Kind:       "DestinationRule",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            deploymentName,
+				Namespace:       namespace,
+				ResourceVersion: "1",
+			},
+			Spec: istioapinetworkingv1beta1.DestinationRule{
+				ExportTo: []string{"*"},
+				Host:     fmt.Sprintf("%s.%s.svc.cluster.local", DeploymentName, namespace),
+				TrafficPolicy: &istioapinetworkingv1beta1.TrafficPolicy{
+					ConnectionPool: &istioapinetworkingv1beta1.ConnectionPoolSettings{
+						Tcp: &istioapinetworkingv1beta1.ConnectionPoolSettings_TCPSettings{
+							MaxConnections: 5000,
+							TcpKeepalive: &istioapinetworkingv1beta1.ConnectionPoolSettings_TCPSettings_TcpKeepalive{
+								Interval: &protobuftypes.Duration{
+									Seconds: 75,
+								},
+								Time: &protobuftypes.Duration{
+									Seconds: 7200,
+								},
+							},
+						},
+					},
+					Tls: &istioapinetworkingv1beta1.ClientTLSSettings{
+						Mode: istioapinetworkingv1beta1.ClientTLSSettings_DISABLE,
+					},
+				},
+			},
+		}
+
+		expectedGateway = &istionetworkingv1beta1.Gateway{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: istionetworkingv1beta1.SchemeGroupVersion.String(),
+				Kind:       "Gateway",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            deploymentName,
+				Namespace:       namespace,
+				ResourceVersion: "1",
+			},
+			Spec: istioapinetworkingv1beta1.Gateway{
+				Selector: map[string]string{
+					"app":   "istio-ingressgateway",
+					"istio": "ingressgateway",
+				},
+				Servers: []*istioapinetworkingv1beta1.Server{
+					{
+						Hosts: []string{fmt.Sprintf("%s.%s.svc.cluster.local", DeploymentName, namespace)},
+						Port: &istioapinetworkingv1beta1.Port{
+							Name:     "tls-tunnel",
+							Number:   vpnseedserver.GatewayPort,
+							Protocol: "HTTP",
+						},
+					},
+				},
+			},
+		}
+
+		expectedService = &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      serviceName,
+				Namespace: namespace,
+				Annotations: map[string]string{
+					"networking.istio.io/exportTo": "*",
+				},
+				ResourceVersion: "1",
+			},
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Service",
+				APIVersion: "v1",
+			},
+			Spec: corev1.ServiceSpec{
+				Selector: map[string]string{
+					"app": deploymentName,
+				},
+				Type: corev1.ServiceTypeClusterIP,
+				Ports: []corev1.ServicePort{
+					{
+						Name:       "grpc-authz",
+						Port:       AuthServerPort,
+						TargetPort: intstr.FromInt(AuthServerPort),
+						Protocol:   corev1.ProtocolTCP,
+					},
+				},
+			},
+		}
+
+		expectedVirtualService = &istionetworkingv1beta1.VirtualService{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: istionetworkingv1beta1.SchemeGroupVersion.String(),
+				Kind:       "VirtualService",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            deploymentName,
+				Namespace:       namespace,
+				ResourceVersion: "1",
+			},
+			Spec: istioapinetworkingv1beta1.VirtualService{
+				ExportTo: []string{"*"},
+				Hosts:    []string{fmt.Sprintf("%s.%s.svc.cluster.local", DeploymentName, namespace)},
+				Http: []*istioapinetworkingv1beta1.HTTPRoute{{
+					Route: []*istioapinetworkingv1beta1.HTTPRouteDestination{{
+						Destination: &istioapinetworkingv1beta1.Destination{
+							Host: DeploymentName,
+							Port: &istioapinetworkingv1beta1.PortSelector{Number: AuthServerPort},
+						},
+					}},
+				}},
+			},
+		}
+
+		expectedVpa = &autoscalingv1beta2.VerticalPodAutoscaler{
+			ObjectMeta: metav1.ObjectMeta{Name: vpaName, Namespace: namespace, ResourceVersion: "1"},
+			TypeMeta:   metav1.TypeMeta{Kind: "VerticalPodAutoscaler", APIVersion: "autoscaling.k8s.io/v1beta2"},
+			Spec: autoscalingv1beta2.VerticalPodAutoscalerSpec{
+				TargetRef: &autoscalingv1.CrossVersionObjectReference{
+					APIVersion: appsv1.SchemeGroupVersion.String(),
+					Kind:       "Deployment",
+					Name:       DeploymentName,
+				},
+				UpdatePolicy: &autoscalingv1beta2.PodUpdatePolicy{
+					UpdateMode: &vpaUpdateMode,
+				},
+				ResourcePolicy: &autoscalingv1beta2.PodResourcePolicy{
+					ContainerPolicies: []autoscalingv1beta2.ContainerResourcePolicy{
+						{
+							ContainerName: DeploymentName,
+							MinAllowed: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("100m"),
+								corev1.ResourceMemory: resource.MustParse("100Mi"),
+							},
+						},
+					},
+				},
+			},
+		}
+	})
+
+	JustBeforeEach(func() {
+		defaultDepWaiter = NewExtAuthServer(c, namespace, image, replicas)
+	})
+
+	Describe("#Deploy", func() {
+		It("succeeds", func() {
+			Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
+
+			actualDeployment := &appsv1.Deployment{}
+			Expect(c.Get(ctx, kutil.Key(expectedDeployment.Namespace, expectedDeployment.Name), actualDeployment)).To(Succeed())
+			Expect(actualDeployment).To(DeepEqual(expectedDeployment))
+
+			actualDestinationRule := &istionetworkingv1beta1.DestinationRule{}
+			Expect(c.Get(ctx, kutil.Key(expectedDestinationRule.Namespace, expectedDestinationRule.Name), actualDestinationRule)).To(Succeed())
+			Expect(actualDestinationRule).To(DeepEqual(expectedDestinationRule))
+
+			actualGateway := &istionetworkingv1beta1.Gateway{}
+			Expect(c.Get(ctx, kutil.Key(expectedGateway.Namespace, expectedGateway.Name), actualGateway)).To(Succeed())
+			Expect(actualGateway).To(DeepEqual(expectedGateway))
+
+			actualService := &corev1.Service{}
+			Expect(c.Get(ctx, kutil.Key(expectedService.Namespace, expectedService.Name), actualService)).To(Succeed())
+			Expect(actualService).To(DeepEqual(expectedService))
+
+			actualVirtualService := &istionetworkingv1beta1.VirtualService{}
+			Expect(c.Get(ctx, kutil.Key(expectedVirtualService.Namespace, expectedVirtualService.Name), actualVirtualService)).To(Succeed())
+			Expect(actualVirtualService).To(DeepEqual(expectedVirtualService))
+
+			actualVpa := &autoscalingv1beta2.VerticalPodAutoscaler{}
+			Expect(c.Get(ctx, kutil.Key(expectedVpa.Namespace, expectedVpa.Name), actualVpa)).To(Succeed())
+			Expect(actualVpa).To(DeepEqual(expectedVpa))
+
+		})
+
+		It("destroy succeeds", func() {
+			Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
+
+			Expect(c.Get(ctx, kutil.Key(expectedDeployment.Namespace, expectedDeployment.Name), &appsv1.Deployment{})).To(Succeed())
+			Expect(c.Get(ctx, kutil.Key(expectedDestinationRule.Namespace, expectedDestinationRule.Name), &istionetworkingv1beta1.DestinationRule{})).To(Succeed())
+			Expect(c.Get(ctx, kutil.Key(expectedGateway.Namespace, expectedGateway.Name), &istionetworkingv1beta1.Gateway{})).To(Succeed())
+			Expect(c.Get(ctx, kutil.Key(expectedService.Namespace, expectedService.Name), &corev1.Service{})).To(Succeed())
+			Expect(c.Get(ctx, kutil.Key(expectedVirtualService.Namespace, expectedVirtualService.Name), &istionetworkingv1beta1.VirtualService{})).To(Succeed())
+			Expect(c.Get(ctx, kutil.Key(expectedVpa.Namespace, expectedVpa.Name), &autoscalingv1beta2.VerticalPodAutoscaler{})).To(Succeed())
+
+			Expect(defaultDepWaiter.Destroy(ctx)).To(Succeed())
+
+			Expect(c.Get(ctx, kutil.Key(expectedDeployment.Namespace, expectedDeployment.Name), &appsv1.Deployment{})).To(BeNotFoundError())
+			Expect(c.Get(ctx, kutil.Key(expectedDestinationRule.Namespace, expectedDestinationRule.Name), &istionetworkingv1beta1.DestinationRule{})).To(BeNotFoundError())
+			Expect(c.Get(ctx, kutil.Key(expectedGateway.Namespace, expectedGateway.Name), &istionetworkingv1beta1.Gateway{})).To(BeNotFoundError())
+			Expect(c.Get(ctx, kutil.Key(expectedService.Namespace, expectedService.Name), &corev1.Service{})).To(BeNotFoundError())
+			Expect(c.Get(ctx, kutil.Key(expectedVirtualService.Namespace, expectedVirtualService.Name), &istionetworkingv1beta1.VirtualService{})).To(BeNotFoundError())
+			Expect(c.Get(ctx, kutil.Key(expectedVpa.Namespace, expectedVpa.Name), &autoscalingv1beta2.VerticalPodAutoscaler{})).To(BeNotFoundError())
+		})
+
+	})
+
+	Describe("#Wait", func() {
+		It("should succeed because it's not implemented", func() {
+			Expect(defaultDepWaiter.Wait(ctx)).To(Succeed())
+		})
+	})
+
+	Describe("#WaitCleanup", func() {
+		It("should succeed because it's not implemented", func() {
+			Expect(defaultDepWaiter.WaitCleanup(ctx)).To(Succeed())
+		})
+	})
+})

--- a/pkg/operation/botanist/component/extauthzserver/external_authz_server_test.go
+++ b/pkg/operation/botanist/component/extauthzserver/external_authz_server_test.go
@@ -38,7 +38,6 @@ import (
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
-	"github.com/gardener/gardener/pkg/operation/botanist/component/vpnseedserver"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
@@ -64,7 +63,6 @@ var _ = Describe("ExtAuthzServer", func() {
 
 		expectedDeployment      *appsv1.Deployment
 		expectedDestinationRule *istionetworkingv1beta1.DestinationRule
-		expectedGateway         *istionetworkingv1beta1.Gateway
 		expectedService         *corev1.Service
 		expectedVirtualService  *istionetworkingv1beta1.VirtualService
 		expectedVpa             *autoscalingv1beta2.VerticalPodAutoscaler
@@ -183,34 +181,6 @@ var _ = Describe("ExtAuthzServer", func() {
 			},
 		}
 
-		expectedGateway = &istionetworkingv1beta1.Gateway{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: istionetworkingv1beta1.SchemeGroupVersion.String(),
-				Kind:       "Gateway",
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:            deploymentName,
-				Namespace:       namespace,
-				ResourceVersion: "1",
-			},
-			Spec: istioapinetworkingv1beta1.Gateway{
-				Selector: map[string]string{
-					"app":   "istio-ingressgateway",
-					"istio": "ingressgateway",
-				},
-				Servers: []*istioapinetworkingv1beta1.Server{
-					{
-						Hosts: []string{fmt.Sprintf("%s.%s.svc.cluster.local", DeploymentName, namespace)},
-						Port: &istioapinetworkingv1beta1.Port{
-							Name:     "tls-tunnel",
-							Number:   vpnseedserver.GatewayPort,
-							Protocol: "HTTP",
-						},
-					},
-				},
-			},
-		}
-
 		expectedService = &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      serviceName,
@@ -307,10 +277,6 @@ var _ = Describe("ExtAuthzServer", func() {
 			Expect(c.Get(ctx, kutil.Key(expectedDestinationRule.Namespace, expectedDestinationRule.Name), actualDestinationRule)).To(Succeed())
 			Expect(actualDestinationRule).To(DeepEqual(expectedDestinationRule))
 
-			actualGateway := &istionetworkingv1beta1.Gateway{}
-			Expect(c.Get(ctx, kutil.Key(expectedGateway.Namespace, expectedGateway.Name), actualGateway)).To(Succeed())
-			Expect(actualGateway).To(DeepEqual(expectedGateway))
-
 			actualService := &corev1.Service{}
 			Expect(c.Get(ctx, kutil.Key(expectedService.Namespace, expectedService.Name), actualService)).To(Succeed())
 			Expect(actualService).To(DeepEqual(expectedService))
@@ -330,7 +296,6 @@ var _ = Describe("ExtAuthzServer", func() {
 
 			Expect(c.Get(ctx, kutil.Key(expectedDeployment.Namespace, expectedDeployment.Name), &appsv1.Deployment{})).To(Succeed())
 			Expect(c.Get(ctx, kutil.Key(expectedDestinationRule.Namespace, expectedDestinationRule.Name), &istionetworkingv1beta1.DestinationRule{})).To(Succeed())
-			Expect(c.Get(ctx, kutil.Key(expectedGateway.Namespace, expectedGateway.Name), &istionetworkingv1beta1.Gateway{})).To(Succeed())
 			Expect(c.Get(ctx, kutil.Key(expectedService.Namespace, expectedService.Name), &corev1.Service{})).To(Succeed())
 			Expect(c.Get(ctx, kutil.Key(expectedVirtualService.Namespace, expectedVirtualService.Name), &istionetworkingv1beta1.VirtualService{})).To(Succeed())
 			Expect(c.Get(ctx, kutil.Key(expectedVpa.Namespace, expectedVpa.Name), &autoscalingv1beta2.VerticalPodAutoscaler{})).To(Succeed())
@@ -339,7 +304,6 @@ var _ = Describe("ExtAuthzServer", func() {
 
 			Expect(c.Get(ctx, kutil.Key(expectedDeployment.Namespace, expectedDeployment.Name), &appsv1.Deployment{})).To(BeNotFoundError())
 			Expect(c.Get(ctx, kutil.Key(expectedDestinationRule.Namespace, expectedDestinationRule.Name), &istionetworkingv1beta1.DestinationRule{})).To(BeNotFoundError())
-			Expect(c.Get(ctx, kutil.Key(expectedGateway.Namespace, expectedGateway.Name), &istionetworkingv1beta1.Gateway{})).To(BeNotFoundError())
 			Expect(c.Get(ctx, kutil.Key(expectedService.Namespace, expectedService.Name), &corev1.Service{})).To(BeNotFoundError())
 			Expect(c.Get(ctx, kutil.Key(expectedVirtualService.Namespace, expectedVirtualService.Name), &istionetworkingv1beta1.VirtualService{})).To(BeNotFoundError())
 			Expect(c.Get(ctx, kutil.Key(expectedVpa.Namespace, expectedVpa.Name), &autoscalingv1beta2.VerticalPodAutoscaler{})).To(BeNotFoundError())

--- a/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server.go
+++ b/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server.go
@@ -29,9 +29,7 @@ import (
 
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	protobuftypes "github.com/gogo/protobuf/types"
-	istionetworkingv1alpha3 "istio.io/api/networking/v1alpha3"
 	istionetworkingv1beta1 "istio.io/api/networking/v1beta1"
-	networkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
@@ -210,11 +208,8 @@ func (v *vpnSeedServer) Deploy(ctx context.Context) error {
 		service         = v.emptyService()
 		deployment      = v.emptyDeployment()
 		networkPolicy   = v.emptyNetworkPolicy()
-		gateway         = v.emptyGateway()
-		virtualService  = v.emptyVirtualService()
 		destinationRule = v.emptyDestinationRule()
 		vpa             = v.emptyVPA()
-		envoyFilter     = v.emptyEnvoyFilter()
 		igwSelectors    = v.getIngressGatewaySelectors()
 
 		vpaUpdateMode = autoscalingv1beta2.UpdateModeAuto
@@ -511,25 +506,6 @@ func (v *vpnSeedServer) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, v.client, gateway, func() error {
-		gateway.Spec = istionetworkingv1beta1.Gateway{
-			Selector: igwSelectors,
-			Servers: []*istionetworkingv1beta1.Server{
-				{
-					Hosts: []string{*v.kubeAPIServerHost},
-					Port: &istionetworkingv1beta1.Port{
-						Name:     "tls-tunnel",
-						Number:   GatewayPort,
-						Protocol: "HTTP",
-					},
-				},
-			},
-		}
-		return nil
-	}); err != nil {
-		return err
-	}
-
 	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, v.client, destinationRule, func() error {
 		destinationRule.Spec = istionetworkingv1beta1.DestinationRule{
 			ExportTo: []string{"*"},
@@ -550,30 +526,6 @@ func (v *vpnSeedServer) Deploy(ctx context.Context) error {
 				},
 				Tls: &istionetworkingv1beta1.ClientTLSSettings{
 					Mode: istionetworkingv1beta1.ClientTLSSettings_DISABLE,
-				},
-			},
-		}
-		return nil
-	}); err != nil {
-		return err
-	}
-	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, v.client, virtualService, func() error {
-		virtualService.Spec = istionetworkingv1beta1.VirtualService{
-			ExportTo: []string{"*"},
-			Hosts:    []string{*v.kubeAPIServerHost},
-			Gateways: []string{DeploymentName},
-			Http: []*istionetworkingv1beta1.HTTPRoute{
-				{
-					Route: []*istionetworkingv1beta1.HTTPRouteDestination{
-						{
-							Destination: &istionetworkingv1beta1.Destination{
-								Port: &istionetworkingv1beta1.PortSelector{
-									Number: openVPNPort,
-								},
-								Host: DeploymentName,
-							},
-						},
-					},
 				},
 			},
 		}
@@ -639,186 +591,6 @@ func (v *vpnSeedServer) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	envoyFilterSelector := v.istioIngressGateway.Labels
-	if v.sniConfig != nil && v.exposureClassHandlerName != nil {
-		envoyFilterSelector = igwSelectors
-	}
-
-	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, v.client, envoyFilter, func() error {
-		envoyFilter.ObjectMeta.Name = envoyFilter.Name
-		envoyFilter.ObjectMeta.Namespace = envoyFilter.Namespace
-		envoyFilter.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
-			{
-				APIVersion:         "v1",
-				Kind:               "Namespace",
-				Name:               v.namespace,
-				UID:                v.namespaceUID,
-				Controller:         pointer.Bool(false),
-				BlockOwnerDeletion: pointer.Bool(false),
-			},
-		}
-		envoyFilter.Spec.WorkloadSelector = &istionetworkingv1alpha3.WorkloadSelector{
-			Labels: envoyFilterSelector,
-		}
-		envoyFilter.Spec.ConfigPatches = []*istionetworkingv1alpha3.EnvoyFilter_EnvoyConfigObjectPatch{
-			{
-				ApplyTo: istionetworkingv1alpha3.EnvoyFilter_NETWORK_FILTER,
-				Match: &istionetworkingv1alpha3.EnvoyFilter_EnvoyConfigObjectMatch{
-					Context: istionetworkingv1alpha3.EnvoyFilter_GATEWAY,
-					ObjectTypes: &istionetworkingv1alpha3.EnvoyFilter_EnvoyConfigObjectMatch_Listener{
-						Listener: &istionetworkingv1alpha3.EnvoyFilter_ListenerMatch{
-							Name:       fmt.Sprintf("0.0.0.0_%d", GatewayPort),
-							PortNumber: GatewayPort,
-							FilterChain: &istionetworkingv1alpha3.EnvoyFilter_ListenerMatch_FilterChainMatch{
-								Filter: &istionetworkingv1alpha3.EnvoyFilter_ListenerMatch_FilterMatch{
-									Name: "envoy.filters.network.http_connection_manager",
-								},
-							},
-						},
-					},
-				},
-				Patch: &istionetworkingv1alpha3.EnvoyFilter_Patch{
-					Operation: istionetworkingv1alpha3.EnvoyFilter_Patch_MERGE,
-					Value: &protobuftypes.Struct{
-						Fields: map[string]*protobuftypes.Value{
-							"name": {
-								Kind: &protobuftypes.Value_StringValue{
-									StringValue: "envoy.filters.network.http_connection_manager",
-								},
-							},
-							"typed_config": {
-								Kind: &protobuftypes.Value_StructValue{
-									StructValue: &protobuftypes.Struct{
-										Fields: map[string]*protobuftypes.Value{
-											"@type": {
-												Kind: &protobuftypes.Value_StringValue{
-													StringValue: "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-												},
-											},
-											"route_config": {
-												Kind: &protobuftypes.Value_StructValue{
-													StructValue: &protobuftypes.Struct{
-														Fields: map[string]*protobuftypes.Value{
-															"virtual_hosts": {
-																Kind: &protobuftypes.Value_ListValue{
-																	ListValue: &protobuftypes.ListValue{
-																		Values: []*protobuftypes.Value{
-																			{
-																				Kind: &protobuftypes.Value_StructValue{
-																					StructValue: &protobuftypes.Struct{
-																						Fields: map[string]*protobuftypes.Value{
-																							"name": {
-																								Kind: &protobuftypes.Value_StringValue{
-																									StringValue: v.namespace,
-																								},
-																							},
-																							"domains": {
-																								Kind: &protobuftypes.Value_ListValue{
-																									ListValue: &protobuftypes.ListValue{
-																										Values: []*protobuftypes.Value{
-																											{
-																												Kind: &protobuftypes.Value_StringValue{
-																													StringValue: fmt.Sprintf("%s:%d", *v.kubeAPIServerHost, GatewayPort),
-																												},
-																											},
-																										},
-																									},
-																								},
-																							},
-																							"routes": {
-																								Kind: &protobuftypes.Value_ListValue{
-																									ListValue: &protobuftypes.ListValue{
-																										Values: []*protobuftypes.Value{
-																											{
-																												Kind: &protobuftypes.Value_StructValue{
-																													StructValue: &protobuftypes.Struct{
-																														Fields: map[string]*protobuftypes.Value{
-																															"match": {
-																																Kind: &protobuftypes.Value_StructValue{
-																																	StructValue: &protobuftypes.Struct{
-																																		Fields: map[string]*protobuftypes.Value{
-																																			"connect_matcher": {
-																																				Kind: &protobuftypes.Value_StructValue{
-																																					StructValue: &protobuftypes.Struct{},
-																																				},
-																																			},
-																																		},
-																																	},
-																																},
-																															},
-																															"route": {
-																																Kind: &protobuftypes.Value_StructValue{
-																																	StructValue: &protobuftypes.Struct{
-																																		Fields: map[string]*protobuftypes.Value{
-																																			"cluster": {
-																																				Kind: &protobuftypes.Value_StringValue{
-																																					StringValue: fmt.Sprintf("outbound|%d||%s.%s.svc.cluster.local", openVPNPort, ServiceName, v.namespace),
-																																				},
-																																			},
-																																			"upgrade_configs": {
-																																				Kind: &protobuftypes.Value_ListValue{
-																																					ListValue: &protobuftypes.ListValue{
-																																						Values: []*protobuftypes.Value{
-																																							{
-																																								Kind: &protobuftypes.Value_StructValue{
-																																									StructValue: &protobuftypes.Struct{
-																																										Fields: map[string]*protobuftypes.Value{
-																																											"upgrade_type": {
-																																												Kind: &protobuftypes.Value_StringValue{
-																																													StringValue: "CONNECT",
-																																												},
-																																											},
-																																											"connect_config": {
-																																												Kind: &protobuftypes.Value_StructValue{
-																																													StructValue: &protobuftypes.Struct{},
-																																												},
-																																											},
-																																										},
-																																									},
-																																								},
-																																							},
-																																						},
-																																					},
-																																				},
-																																			},
-																																		},
-																																	},
-																																},
-																															},
-																														},
-																													},
-																												},
-																											},
-																										},
-																									},
-																								},
-																							},
-																						},
-																					},
-																				},
-																			},
-																		},
-																	},
-																},
-															},
-														},
-													},
-												},
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				},
-			},
-		}
-		return nil
-	}); err != nil {
-		return err
-	}
-
 	// TODO(rfranzke): Remove in a future release.
 	return kutil.DeleteObjects(ctx, v.client,
 		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: v.namespace, Name: "vpn-seed-server-envoy-config"}},
@@ -834,12 +606,9 @@ func (v *vpnSeedServer) Destroy(ctx context.Context) error {
 		v.client,
 		v.emptyNetworkPolicy(),
 		v.emptyDeployment(),
-		v.emptyGateway(),
 		v.emptyDestinationRule(),
-		v.emptyVirtualService(),
 		v.emptyService(),
 		v.emptyVPA(),
-		v.emptyEnvoyFilter(),
 		// TODO(rfranzke): Remove in a future release.
 		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: v.namespace, Name: "vpn-seed-server-envoy-config"}},
 		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: v.namespace, Name: DeploymentName}},
@@ -873,28 +642,12 @@ func (v *vpnSeedServer) emptyNetworkPolicy() *networkingv1.NetworkPolicy {
 	return &networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "allow-to-vpn-seed-server", Namespace: v.namespace}}
 }
 
-func (v *vpnSeedServer) emptyGateway() *networkingv1beta1.Gateway {
-	return &networkingv1beta1.Gateway{ObjectMeta: metav1.ObjectMeta{Name: DeploymentName, Namespace: v.namespace}}
-}
-
-func (v *vpnSeedServer) emptyVirtualService() *networkingv1beta1.VirtualService {
-	return &networkingv1beta1.VirtualService{ObjectMeta: metav1.ObjectMeta{Name: DeploymentName, Namespace: v.namespace}}
-}
-
 func (v *vpnSeedServer) emptyDestinationRule() *networkingv1beta1.DestinationRule {
 	return &networkingv1beta1.DestinationRule{ObjectMeta: metav1.ObjectMeta{Name: DeploymentName, Namespace: v.namespace}}
 }
 
 func (v *vpnSeedServer) emptyVPA() *autoscalingv1beta2.VerticalPodAutoscaler {
 	return &autoscalingv1beta2.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: DeploymentName + "-vpa", Namespace: v.namespace}}
-}
-
-func (v *vpnSeedServer) emptyEnvoyFilter() *networkingv1alpha3.EnvoyFilter {
-	var namespace = v.istioIngressGateway.Namespace
-	if v.sniConfig != nil && v.exposureClassHandlerName != nil {
-		namespace = *v.sniConfig.Ingress.Namespace
-	}
-	return &networkingv1alpha3.EnvoyFilter{ObjectMeta: metav1.ObjectMeta{Name: v.namespace + "-vpn", Namespace: namespace}}
 }
 
 func (v *vpnSeedServer) getIngressGatewaySelectors() map[string]string {

--- a/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server_test.go
+++ b/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server_test.go
@@ -30,9 +30,7 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	istionetworkingv1alpha3 "istio.io/api/networking/v1alpha3"
 	istionetworkingv1beta1 "istio.io/api/networking/v1beta1"
-	networkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
@@ -430,25 +428,6 @@ var _ = Describe("VpnSeedServer", func() {
 			},
 		}
 
-		gateway = &networkingv1beta1.Gateway{
-			ObjectMeta: metav1.ObjectMeta{Name: DeploymentName, Namespace: namespace},
-			Spec: istionetworkingv1beta1.Gateway{
-				Selector: map[string]string{
-					"app": "istio-ingressgateway",
-				},
-				Servers: []*istionetworkingv1beta1.Server{
-					{
-						Hosts: []string{kubeAPIServerHost},
-						Port: &istionetworkingv1beta1.Port{
-							Name:     "tls-tunnel",
-							Number:   8132,
-							Protocol: "HTTP",
-						},
-					},
-				},
-			},
-		}
-
 		networkPolicy = &networkingv1.NetworkPolicy{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "allow-to-vpn-seed-server",
@@ -542,29 +521,6 @@ var _ = Describe("VpnSeedServer", func() {
 			},
 		}
 
-		virtualService = &networkingv1beta1.VirtualService{
-			ObjectMeta: metav1.ObjectMeta{Name: DeploymentName, Namespace: namespace},
-			Spec: istionetworkingv1beta1.VirtualService{
-				ExportTo: []string{"*"},
-				Hosts:    []string{kubeAPIServerHost},
-				Gateways: []string{DeploymentName},
-				Http: []*istionetworkingv1beta1.HTTPRoute{
-					{
-						Route: []*istionetworkingv1beta1.HTTPRouteDestination{
-							{
-								Destination: &istionetworkingv1beta1.Destination{
-									Port: &istionetworkingv1beta1.PortSelector{
-										Number: 1194,
-									},
-									Host: DeploymentName,
-								},
-							},
-						},
-					},
-				},
-			},
-		}
-
 		vpa = &autoscalingv1beta2.VerticalPodAutoscaler{
 			ObjectMeta: metav1.ObjectMeta{Name: DeploymentName + "-vpa", Namespace: namespace},
 			Spec: autoscalingv1beta2.VerticalPodAutoscalerSpec{
@@ -590,180 +546,6 @@ var _ = Describe("VpnSeedServer", func() {
 							MinAllowed: corev1.ResourceList{
 								corev1.ResourceCPU:    resource.MustParse("20m"),
 								corev1.ResourceMemory: resource.MustParse("20Mi"),
-							},
-						},
-					},
-				},
-			},
-		}
-
-		envoyFilter = &networkingv1alpha3.EnvoyFilter{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      namespace + "-vpn",
-				Namespace: istioNamespace,
-				OwnerReferences: []metav1.OwnerReference{{
-					APIVersion:         "v1",
-					Kind:               "Namespace",
-					Name:               namespace,
-					UID:                namespaceUID,
-					BlockOwnerDeletion: pointer.Bool(false),
-					Controller:         pointer.Bool(false),
-				}},
-			},
-			Spec: istionetworkingv1alpha3.EnvoyFilter{
-				WorkloadSelector: &istionetworkingv1alpha3.WorkloadSelector{
-					Labels: istioLabels,
-				},
-				ConfigPatches: []*istionetworkingv1alpha3.EnvoyFilter_EnvoyConfigObjectPatch{
-					{
-						ApplyTo: istionetworkingv1alpha3.EnvoyFilter_NETWORK_FILTER,
-						Match: &istionetworkingv1alpha3.EnvoyFilter_EnvoyConfigObjectMatch{
-							Context: istionetworkingv1alpha3.EnvoyFilter_GATEWAY,
-							ObjectTypes: &istionetworkingv1alpha3.EnvoyFilter_EnvoyConfigObjectMatch_Listener{
-								Listener: &istionetworkingv1alpha3.EnvoyFilter_ListenerMatch{
-									Name:       fmt.Sprintf("0.0.0.0_%d", 8132),
-									PortNumber: 8132,
-									FilterChain: &istionetworkingv1alpha3.EnvoyFilter_ListenerMatch_FilterChainMatch{
-										Filter: &istionetworkingv1alpha3.EnvoyFilter_ListenerMatch_FilterMatch{
-											Name: "envoy.filters.network.http_connection_manager",
-										},
-									},
-								},
-							},
-						},
-						Patch: &istionetworkingv1alpha3.EnvoyFilter_Patch{
-							Operation: istionetworkingv1alpha3.EnvoyFilter_Patch_MERGE,
-							Value: &protobuftypes.Struct{
-								Fields: map[string]*protobuftypes.Value{
-									"name": {
-										Kind: &protobuftypes.Value_StringValue{
-											StringValue: "envoy.filters.network.http_connection_manager",
-										},
-									},
-									"typed_config": {
-										Kind: &protobuftypes.Value_StructValue{
-											StructValue: &protobuftypes.Struct{
-												Fields: map[string]*protobuftypes.Value{
-													"@type": {
-														Kind: &protobuftypes.Value_StringValue{
-															StringValue: "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
-														},
-													},
-													"route_config": {
-														Kind: &protobuftypes.Value_StructValue{
-															StructValue: &protobuftypes.Struct{
-																Fields: map[string]*protobuftypes.Value{
-																	"virtual_hosts": {
-																		Kind: &protobuftypes.Value_ListValue{
-																			ListValue: &protobuftypes.ListValue{
-																				Values: []*protobuftypes.Value{
-																					{
-																						Kind: &protobuftypes.Value_StructValue{
-																							StructValue: &protobuftypes.Struct{
-																								Fields: map[string]*protobuftypes.Value{
-																									"name": {
-																										Kind: &protobuftypes.Value_StringValue{
-																											StringValue: namespace,
-																										},
-																									},
-																									"domains": {
-																										Kind: &protobuftypes.Value_ListValue{
-																											ListValue: &protobuftypes.ListValue{
-																												Values: []*protobuftypes.Value{
-																													{
-																														Kind: &protobuftypes.Value_StringValue{
-																															StringValue: fmt.Sprintf("%s:%d", kubeAPIServerHost, 8132),
-																														},
-																													},
-																												},
-																											},
-																										},
-																									},
-																									"routes": {
-																										Kind: &protobuftypes.Value_ListValue{
-																											ListValue: &protobuftypes.ListValue{
-																												Values: []*protobuftypes.Value{
-																													{
-																														Kind: &protobuftypes.Value_StructValue{
-																															StructValue: &protobuftypes.Struct{
-																																Fields: map[string]*protobuftypes.Value{
-																																	"match": {
-																																		Kind: &protobuftypes.Value_StructValue{
-																																			StructValue: &protobuftypes.Struct{
-																																				Fields: map[string]*protobuftypes.Value{
-																																					"connect_matcher": {
-																																						Kind: &protobuftypes.Value_StructValue{
-																																							StructValue: &protobuftypes.Struct{},
-																																						},
-																																					},
-																																				},
-																																			},
-																																		},
-																																	},
-																																	"route": {
-																																		Kind: &protobuftypes.Value_StructValue{
-																																			StructValue: &protobuftypes.Struct{
-																																				Fields: map[string]*protobuftypes.Value{
-																																					"cluster": {
-																																						Kind: &protobuftypes.Value_StringValue{
-																																							StringValue: "outbound|1194||" + ServiceName + "." + namespace + ".svc.cluster.local",
-																																						},
-																																					},
-																																					"upgrade_configs": {
-																																						Kind: &protobuftypes.Value_ListValue{
-																																							ListValue: &protobuftypes.ListValue{
-																																								Values: []*protobuftypes.Value{
-																																									{
-																																										Kind: &protobuftypes.Value_StructValue{
-																																											StructValue: &protobuftypes.Struct{
-																																												Fields: map[string]*protobuftypes.Value{
-																																													"upgrade_type": {
-																																														Kind: &protobuftypes.Value_StringValue{
-																																															StringValue: "CONNECT",
-																																														},
-																																													},
-																																													"connect_config": {
-																																														Kind: &protobuftypes.Value_StructValue{
-																																															StructValue: &protobuftypes.Struct{},
-																																														},
-																																													},
-																																												},
-																																											},
-																																										},
-																																									},
-																																								},
-																																							},
-																																						},
-																																					},
-																																				},
-																																			},
-																																		},
-																																	},
-																																},
-																															},
-																														},
-																													},
-																												},
-																											},
-																										},
-																									},
-																								},
-																							},
-																						},
-																					},
-																				},
-																			},
-																		},
-																	},
-																},
-															},
-														},
-													},
-												},
-											},
-										},
-									},
-								},
 							},
 						},
 					},
@@ -875,23 +657,6 @@ var _ = Describe("VpnSeedServer", func() {
 				Expect(vpnSeedServer.Deploy(ctx)).To(MatchError(fakeErr))
 			})
 
-			It("should fail because the gateway cannot be created", func() {
-				gomock.InOrder(
-					c.EXPECT().Create(ctx, configMap),
-					c.EXPECT().Create(ctx, secretServer),
-					c.EXPECT().Create(ctx, secretTLSAuth),
-					c.EXPECT().Create(ctx, secretDH),
-					c.EXPECT().Get(ctx, kutil.Key(namespace, "allow-to-vpn-seed-server"), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()),
-					c.EXPECT().Get(ctx, kutil.Key(namespace, DeploymentName), gomock.AssignableToTypeOf(&appsv1.Deployment{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&appsv1.Deployment{}), gomock.Any()),
-					c.EXPECT().Get(ctx, kutil.Key(namespace, DeploymentName), gomock.AssignableToTypeOf(&networkingv1beta1.Gateway{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1beta1.Gateway{}), gomock.Any()).Return(fakeErr),
-				)
-
-				Expect(vpnSeedServer.Deploy(ctx)).To(MatchError(fakeErr))
-			})
-
 			It("should fail because the destinationRule cannot be created", func() {
 				gomock.InOrder(
 					c.EXPECT().Create(ctx, configMap),
@@ -902,31 +667,8 @@ var _ = Describe("VpnSeedServer", func() {
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()),
 					c.EXPECT().Get(ctx, kutil.Key(namespace, DeploymentName), gomock.AssignableToTypeOf(&appsv1.Deployment{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&appsv1.Deployment{}), gomock.Any()),
-					c.EXPECT().Get(ctx, kutil.Key(namespace, DeploymentName), gomock.AssignableToTypeOf(&networkingv1beta1.Gateway{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1beta1.Gateway{}), gomock.Any()),
 					c.EXPECT().Get(ctx, kutil.Key(namespace, DeploymentName), gomock.AssignableToTypeOf(&networkingv1beta1.DestinationRule{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1beta1.DestinationRule{}), gomock.Any()).Return(fakeErr),
-				)
-
-				Expect(vpnSeedServer.Deploy(ctx)).To(MatchError(fakeErr))
-			})
-
-			It("should fail because the virtualService cannot be created", func() {
-				gomock.InOrder(
-					c.EXPECT().Create(ctx, configMap),
-					c.EXPECT().Create(ctx, secretServer),
-					c.EXPECT().Create(ctx, secretTLSAuth),
-					c.EXPECT().Create(ctx, secretDH),
-					c.EXPECT().Get(ctx, kutil.Key(namespace, "allow-to-vpn-seed-server"), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()),
-					c.EXPECT().Get(ctx, kutil.Key(namespace, DeploymentName), gomock.AssignableToTypeOf(&appsv1.Deployment{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&appsv1.Deployment{}), gomock.Any()),
-					c.EXPECT().Get(ctx, kutil.Key(namespace, DeploymentName), gomock.AssignableToTypeOf(&networkingv1beta1.Gateway{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1beta1.Gateway{}), gomock.Any()),
-					c.EXPECT().Get(ctx, kutil.Key(namespace, DeploymentName), gomock.AssignableToTypeOf(&networkingv1beta1.DestinationRule{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1beta1.DestinationRule{}), gomock.Any()),
-					c.EXPECT().Get(ctx, kutil.Key(namespace, DeploymentName), gomock.AssignableToTypeOf(&networkingv1beta1.VirtualService{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1beta1.VirtualService{}), gomock.Any()).Return(fakeErr),
 				)
 
 				Expect(vpnSeedServer.Deploy(ctx)).To(MatchError(fakeErr))
@@ -942,12 +684,8 @@ var _ = Describe("VpnSeedServer", func() {
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()),
 					c.EXPECT().Get(ctx, kutil.Key(namespace, DeploymentName), gomock.AssignableToTypeOf(&appsv1.Deployment{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&appsv1.Deployment{}), gomock.Any()),
-					c.EXPECT().Get(ctx, kutil.Key(namespace, DeploymentName), gomock.AssignableToTypeOf(&networkingv1beta1.Gateway{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1beta1.Gateway{}), gomock.Any()),
 					c.EXPECT().Get(ctx, kutil.Key(namespace, DeploymentName), gomock.AssignableToTypeOf(&networkingv1beta1.DestinationRule{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1beta1.DestinationRule{}), gomock.Any()),
-					c.EXPECT().Get(ctx, kutil.Key(namespace, DeploymentName), gomock.AssignableToTypeOf(&networkingv1beta1.VirtualService{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1beta1.VirtualService{}), gomock.Any()),
 					c.EXPECT().Get(ctx, kutil.Key(namespace, ServiceName), gomock.AssignableToTypeOf(&corev1.Service{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Service{}), gomock.Any()).Return(fakeErr),
 				)
@@ -965,12 +703,8 @@ var _ = Describe("VpnSeedServer", func() {
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()),
 					c.EXPECT().Get(ctx, kutil.Key(namespace, DeploymentName), gomock.AssignableToTypeOf(&appsv1.Deployment{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&appsv1.Deployment{}), gomock.Any()),
-					c.EXPECT().Get(ctx, kutil.Key(namespace, DeploymentName), gomock.AssignableToTypeOf(&networkingv1beta1.Gateway{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1beta1.Gateway{}), gomock.Any()),
 					c.EXPECT().Get(ctx, kutil.Key(namespace, DeploymentName), gomock.AssignableToTypeOf(&networkingv1beta1.DestinationRule{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1beta1.DestinationRule{}), gomock.Any()),
-					c.EXPECT().Get(ctx, kutil.Key(namespace, DeploymentName), gomock.AssignableToTypeOf(&networkingv1beta1.VirtualService{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1beta1.VirtualService{}), gomock.Any()),
 					c.EXPECT().Get(ctx, kutil.Key(namespace, ServiceName), gomock.AssignableToTypeOf(&corev1.Service{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Service{}), gomock.Any()),
 					c.EXPECT().Get(ctx, kutil.Key(namespace, DeploymentName+"-vpa"), gomock.AssignableToTypeOf(&autoscalingv1beta2.VerticalPodAutoscaler{})),
@@ -1008,20 +742,10 @@ var _ = Describe("VpnSeedServer", func() {
 						Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(deployment(nil)))
 						}),
-					c.EXPECT().Get(ctx, kutil.Key(namespace, DeploymentName), gomock.AssignableToTypeOf(&networkingv1beta1.Gateway{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1beta1.Gateway{}), gomock.Any()).
-						Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-							Expect(obj).To(DeepEqual(gateway))
-						}),
 					c.EXPECT().Get(ctx, kutil.Key(namespace, DeploymentName), gomock.AssignableToTypeOf(&networkingv1beta1.DestinationRule{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1beta1.DestinationRule{}), gomock.Any()).
 						Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(destinationRule))
-						}),
-					c.EXPECT().Get(ctx, kutil.Key(namespace, DeploymentName), gomock.AssignableToTypeOf(&networkingv1beta1.VirtualService{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1beta1.VirtualService{}), gomock.Any()).
-						Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-							Expect(obj).To(DeepEqual(virtualService))
 						}),
 					c.EXPECT().Get(ctx, kutil.Key(namespace, ServiceName), gomock.AssignableToTypeOf(&corev1.Service{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Service{}), gomock.Any()).
@@ -1033,10 +757,6 @@ var _ = Describe("VpnSeedServer", func() {
 						Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(vpa))
 						}),
-					c.EXPECT().Get(ctx, kutil.Key(istioNamespace, namespace+"-vpn"), gomock.AssignableToTypeOf(&networkingv1alpha3.EnvoyFilter{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1alpha3.EnvoyFilter{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-						Expect(obj).To(DeepEqual(envoyFilter))
-					}),
 					c.EXPECT().Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName + "-envoy-config"}}),
 					c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
 					c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName + "-tlsauth"}}),
@@ -1077,20 +797,10 @@ var _ = Describe("VpnSeedServer", func() {
 						Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(deployment(&nodeNetwork)))
 						}),
-					c.EXPECT().Get(ctx, kutil.Key(namespace, DeploymentName), gomock.AssignableToTypeOf(&networkingv1beta1.Gateway{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1beta1.Gateway{}), gomock.Any()).
-						Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-							Expect(obj).To(DeepEqual(gateway))
-						}),
 					c.EXPECT().Get(ctx, kutil.Key(namespace, DeploymentName), gomock.AssignableToTypeOf(&networkingv1beta1.DestinationRule{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1beta1.DestinationRule{}), gomock.Any()).
 						Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(destinationRule))
-						}),
-					c.EXPECT().Get(ctx, kutil.Key(namespace, DeploymentName), gomock.AssignableToTypeOf(&networkingv1beta1.VirtualService{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1beta1.VirtualService{}), gomock.Any()).
-						Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-							Expect(obj).To(DeepEqual(virtualService))
 						}),
 					c.EXPECT().Get(ctx, kutil.Key(namespace, ServiceName), gomock.AssignableToTypeOf(&corev1.Service{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Service{}), gomock.Any()).
@@ -1102,10 +812,6 @@ var _ = Describe("VpnSeedServer", func() {
 						Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 							Expect(obj).To(DeepEqual(vpa))
 						}),
-					c.EXPECT().Get(ctx, kutil.Key(istioNamespace, namespace+"-vpn"), gomock.AssignableToTypeOf(&networkingv1alpha3.EnvoyFilter{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1alpha3.EnvoyFilter{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-						Expect(obj).To(DeepEqual(envoyFilter))
-					}),
 					c.EXPECT().Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName + "-envoy-config"}}),
 					c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
 					c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName + "-tlsauth"}}),
@@ -1135,34 +841,11 @@ var _ = Describe("VpnSeedServer", func() {
 			Expect(vpnSeedServer.Destroy(ctx)).To(MatchError(fakeErr))
 		})
 
-		It("should fail because the gateway cannot be deleted", func() {
-			gomock.InOrder(
-				c.EXPECT().Delete(ctx, &networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "allow-to-vpn-seed-server"}}),
-				c.EXPECT().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
-				c.EXPECT().Delete(ctx, &networkingv1beta1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}).Return(fakeErr),
-			)
-
-			Expect(vpnSeedServer.Destroy(ctx)).To(MatchError(fakeErr))
-		})
-
 		It("should fail because the destinationRule cannot be deleted", func() {
 			gomock.InOrder(
 				c.EXPECT().Delete(ctx, &networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "allow-to-vpn-seed-server"}}),
 				c.EXPECT().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
-				c.EXPECT().Delete(ctx, &networkingv1beta1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
 				c.EXPECT().Delete(ctx, &networkingv1beta1.DestinationRule{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}).Return(fakeErr),
-			)
-
-			Expect(vpnSeedServer.Destroy(ctx)).To(MatchError(fakeErr))
-		})
-
-		It("should fail because the virtualService cannot be deleted", func() {
-			gomock.InOrder(
-				c.EXPECT().Delete(ctx, &networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "allow-to-vpn-seed-server"}}),
-				c.EXPECT().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
-				c.EXPECT().Delete(ctx, &networkingv1beta1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
-				c.EXPECT().Delete(ctx, &networkingv1beta1.DestinationRule{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
-				c.EXPECT().Delete(ctx, &networkingv1beta1.VirtualService{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}).Return(fakeErr),
 			)
 
 			Expect(vpnSeedServer.Destroy(ctx)).To(MatchError(fakeErr))
@@ -1172,9 +855,7 @@ var _ = Describe("VpnSeedServer", func() {
 			gomock.InOrder(
 				c.EXPECT().Delete(ctx, &networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "allow-to-vpn-seed-server"}}),
 				c.EXPECT().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
-				c.EXPECT().Delete(ctx, &networkingv1beta1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
 				c.EXPECT().Delete(ctx, &networkingv1beta1.DestinationRule{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
-				c.EXPECT().Delete(ctx, &networkingv1beta1.VirtualService{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
 				c.EXPECT().Delete(ctx, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: ServiceName}}).Return(fakeErr),
 			)
 
@@ -1185,9 +866,7 @@ var _ = Describe("VpnSeedServer", func() {
 			gomock.InOrder(
 				c.EXPECT().Delete(ctx, &networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "allow-to-vpn-seed-server"}}),
 				c.EXPECT().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
-				c.EXPECT().Delete(ctx, &networkingv1beta1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
 				c.EXPECT().Delete(ctx, &networkingv1beta1.DestinationRule{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
-				c.EXPECT().Delete(ctx, &networkingv1beta1.VirtualService{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
 				c.EXPECT().Delete(ctx, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: ServiceName}}),
 				c.EXPECT().Delete(ctx, &autoscalingv1beta2.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName + "-vpa"}}).Return(fakeErr),
 			)
@@ -1199,12 +878,9 @@ var _ = Describe("VpnSeedServer", func() {
 			gomock.InOrder(
 				c.EXPECT().Delete(ctx, &networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "allow-to-vpn-seed-server"}}),
 				c.EXPECT().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
-				c.EXPECT().Delete(ctx, &networkingv1beta1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
 				c.EXPECT().Delete(ctx, &networkingv1beta1.DestinationRule{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
-				c.EXPECT().Delete(ctx, &networkingv1beta1.VirtualService{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
 				c.EXPECT().Delete(ctx, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: ServiceName}}),
 				c.EXPECT().Delete(ctx, &autoscalingv1beta2.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName + "-vpa"}}),
-				c.EXPECT().Delete(ctx, &networkingv1alpha3.EnvoyFilter{ObjectMeta: metav1.ObjectMeta{Namespace: istioNamespace, Name: namespace + "-vpn"}}),
 				c.EXPECT().Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName + "-envoy-config"}}).Return(fakeErr),
 			)
 
@@ -1215,12 +891,9 @@ var _ = Describe("VpnSeedServer", func() {
 			gomock.InOrder(
 				c.EXPECT().Delete(ctx, &networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "allow-to-vpn-seed-server"}}),
 				c.EXPECT().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
-				c.EXPECT().Delete(ctx, &networkingv1beta1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
 				c.EXPECT().Delete(ctx, &networkingv1beta1.DestinationRule{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
-				c.EXPECT().Delete(ctx, &networkingv1beta1.VirtualService{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
 				c.EXPECT().Delete(ctx, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: ServiceName}}),
 				c.EXPECT().Delete(ctx, &autoscalingv1beta2.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName + "-vpa"}}),
-				c.EXPECT().Delete(ctx, &networkingv1alpha3.EnvoyFilter{ObjectMeta: metav1.ObjectMeta{Namespace: istioNamespace, Name: namespace + "-vpn"}}),
 				c.EXPECT().Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName + "-envoy-config"}}),
 				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}).Return(fakeErr),
 			)
@@ -1232,12 +905,9 @@ var _ = Describe("VpnSeedServer", func() {
 			gomock.InOrder(
 				c.EXPECT().Delete(ctx, &networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "allow-to-vpn-seed-server"}}),
 				c.EXPECT().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
-				c.EXPECT().Delete(ctx, &networkingv1beta1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
 				c.EXPECT().Delete(ctx, &networkingv1beta1.DestinationRule{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
-				c.EXPECT().Delete(ctx, &networkingv1beta1.VirtualService{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
 				c.EXPECT().Delete(ctx, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: ServiceName}}),
 				c.EXPECT().Delete(ctx, &autoscalingv1beta2.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName + "-vpa"}}),
-				c.EXPECT().Delete(ctx, &networkingv1alpha3.EnvoyFilter{ObjectMeta: metav1.ObjectMeta{Namespace: istioNamespace, Name: namespace + "-vpn"}}),
 				c.EXPECT().Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName + "-envoy-config"}}),
 				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
 				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName + "-tlsauth"}}).Return(fakeErr),
@@ -1250,12 +920,9 @@ var _ = Describe("VpnSeedServer", func() {
 			gomock.InOrder(
 				c.EXPECT().Delete(ctx, &networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "allow-to-vpn-seed-server"}}),
 				c.EXPECT().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
-				c.EXPECT().Delete(ctx, &networkingv1beta1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
 				c.EXPECT().Delete(ctx, &networkingv1beta1.DestinationRule{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
-				c.EXPECT().Delete(ctx, &networkingv1beta1.VirtualService{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
 				c.EXPECT().Delete(ctx, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: ServiceName}}),
 				c.EXPECT().Delete(ctx, &autoscalingv1beta2.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName + "-vpa"}}),
-				c.EXPECT().Delete(ctx, &networkingv1alpha3.EnvoyFilter{ObjectMeta: metav1.ObjectMeta{Namespace: istioNamespace, Name: namespace + "-vpn"}}),
 				c.EXPECT().Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName + "-envoy-config"}}),
 				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
 				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName + "-tlsauth"}}),
@@ -1269,12 +936,9 @@ var _ = Describe("VpnSeedServer", func() {
 			gomock.InOrder(
 				c.EXPECT().Delete(ctx, &networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "allow-to-vpn-seed-server"}}),
 				c.EXPECT().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
-				c.EXPECT().Delete(ctx, &networkingv1beta1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
 				c.EXPECT().Delete(ctx, &networkingv1beta1.DestinationRule{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
-				c.EXPECT().Delete(ctx, &networkingv1beta1.VirtualService{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
 				c.EXPECT().Delete(ctx, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: ServiceName}}),
 				c.EXPECT().Delete(ctx, &autoscalingv1beta2.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName + "-vpa"}}),
-				c.EXPECT().Delete(ctx, &networkingv1alpha3.EnvoyFilter{ObjectMeta: metav1.ObjectMeta{Namespace: istioNamespace, Name: namespace + "-vpn"}}),
 				c.EXPECT().Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName + "-envoy-config"}}),
 				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
 				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName + "-tlsauth"}}),

--- a/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server_test.go
+++ b/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server_test.go
@@ -31,6 +31,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	istionetworkingv1beta1 "istio.io/api/networking/v1beta1"
+	networkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
@@ -761,6 +762,9 @@ var _ = Describe("VpnSeedServer", func() {
 					c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
 					c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName + "-tlsauth"}}),
 					c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName + "-dh"}}),
+					c.EXPECT().Delete(ctx, &networkingv1beta1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
+					c.EXPECT().Delete(ctx, &networkingv1beta1.VirtualService{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
+					c.EXPECT().Delete(ctx, &networkingv1alpha3.EnvoyFilter{ObjectMeta: metav1.ObjectMeta{Namespace: istioNamespace, Name: namespace + "-vpn"}}),
 				)
 				Expect(vpnSeedServer.Deploy(ctx)).To(Succeed())
 			})
@@ -816,6 +820,9 @@ var _ = Describe("VpnSeedServer", func() {
 					c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
 					c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName + "-tlsauth"}}),
 					c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName + "-dh"}}),
+					c.EXPECT().Delete(ctx, &networkingv1beta1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
+					c.EXPECT().Delete(ctx, &networkingv1beta1.VirtualService{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
+					c.EXPECT().Delete(ctx, &networkingv1alpha3.EnvoyFilter{ObjectMeta: metav1.ObjectMeta{Namespace: istioNamespace, Name: namespace + "-vpn"}}),
 				)
 
 				Expect(vpnSeedServer.Deploy(ctx)).To(Succeed())
@@ -943,6 +950,9 @@ var _ = Describe("VpnSeedServer", func() {
 				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
 				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName + "-tlsauth"}}),
 				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName + "-dh"}}),
+				c.EXPECT().Delete(ctx, &networkingv1beta1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
+				c.EXPECT().Delete(ctx, &networkingv1beta1.VirtualService{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
+				c.EXPECT().Delete(ctx, &networkingv1alpha3.EnvoyFilter{ObjectMeta: metav1.ObjectMeta{Namespace: istioNamespace, Name: namespace + "-vpn"}}),
 			)
 			Expect(vpnSeedServer.Destroy(ctx)).To(Succeed())
 		})

--- a/pkg/operation/seed/components.go
+++ b/pkg/operation/seed/components.go
@@ -221,6 +221,6 @@ func defaultExternalAuthzServer(
 		c,
 		v1beta1constants.GardenNamespace,
 		image.String(),
-		1,
+		3,
 	), nil
 }

--- a/pkg/operation/seed/components.go
+++ b/pkg/operation/seed/components.go
@@ -217,9 +217,9 @@ func defaultExternalAuthzServer(
 		return nil, err
 	}
 
-	return extauthzserver.New(
+	return extauthzserver.NewExtAuthServer(
 		c,
-		"garden",
+		v1beta1constants.GardenNamespace,
 		image.String(),
 		1,
 	), nil

--- a/pkg/operation/seed/components.go
+++ b/pkg/operation/seed/components.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/dependencywatchdog"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/etcd"
+	"github.com/gardener/gardener/pkg/operation/botanist/component/extauthzserver"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/gardenerkubescheduler"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/kubeapiserver"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/networkpolicies"
@@ -201,4 +202,25 @@ func defaultDependencyWatchdogs(
 		ValuesProbe: dependencywatchdog.ValuesProbe{ProbeDependantsList: dependencyWatchdogProbeConfigurations},
 	})
 	return
+}
+
+func defaultExternalAuthzServer(
+	c client.Client,
+	seedVersion string,
+	imageVector imagevector.ImageVector,
+) (
+	extAuthzServer component.DeployWaiter,
+	err error,
+) {
+	image, err := imageVector.FindImage(charts.ImageNameExtAuthzServer, imagevector.RuntimeVersion(seedVersion), imagevector.TargetVersion(seedVersion))
+	if err != nil {
+		return nil, err
+	}
+
+	return extauthzserver.New(
+		c,
+		"garden",
+		image.String(),
+		1,
+	), nil
 }

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -1199,7 +1199,7 @@ func RunDeleteSeedFlow(
 		clusterIdentity = clusteridentity.NewForSeed(seedClient, v1beta1constants.GardenNamespace, "")
 		dwdEndpoint     = dependencywatchdog.New(seedClient, v1beta1constants.GardenNamespace, dependencywatchdog.Values{Role: dependencywatchdog.RoleEndpoint})
 		dwdProbe        = dependencywatchdog.New(seedClient, v1beta1constants.GardenNamespace, dependencywatchdog.Values{Role: dependencywatchdog.RoleProbe})
-		extAuthzServer  = extauthzserver.New(seedClient, v1beta1constants.GardenNamespace, "", 1)
+		extAuthzServer  = extauthzserver.NewExtAuthServer(seedClient, v1beta1constants.GardenNamespace, "", 1)
 	)
 	scheduler, err := gardenerkubescheduler.Bootstrap(seedClient, v1beta1constants.GardenNamespace, nil, kubernetesVersion)
 	if err != nil {


### PR DESCRIPTION
Co-authored-by: Sebastian Stauch <sebastian.stauch@sap.com>

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Replace cluster specific envoy filter for reversed vpn with a static one.
As described in #4381, the previous approach with cluster specific envoy filters causes connections to be reset
when a new cluster is created or an existing one is deleted, i.e. in case a reconfiguration happens on the istio
ingress gateway/envoy proxy. In this change the per cluster approach is replaced with a single static envoy filter
so that no reconfigurations happen on cluster creation/deletion.
To prevent opening a general hole into the cluster an authorisation server was added as well to ensure that only requests with a target following a given regular expression can pass through.

**Which issue(s) this PR fixes**:
Fixes #4381

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
Shoot clusters with `ReversedVPN` enabled will have to be reconciled once in case their existing VPN connection gets reset, which happened in the old setup during shoot cluster creation/deletion.
```
