### PR TITLE
Maintenance controller now respects workers CRI configuration

### DIFF
--- a/pkg/controllermanager/controller/shoot/shoot_maintenance_control.go
+++ b/pkg/controllermanager/controller/shoot/shoot_maintenance_control.go
@@ -142,10 +142,14 @@ func (r *shootMaintenanceReconciler) reconcile(ctx context.Context, shoot *garde
 		return err
 	}
 
-	updatedMachineImages, reasonForImageUpdatePerPool, err := MaintainMachineImages(shootLogger, shoot, cloudProfile)
+	reasonForImageUpdatePerPool, err := MaintainMachineImages(shootLogger, shoot, cloudProfile)
 	if err != nil {
 		// continue execution to allow the kubernetes version update
 		shootLogger.Error(fmt.Sprintf("Could not maintain machine image version: %s", err.Error()))
+	}
+	for _, reason := range reasonForImageUpdatePerPool {
+		r.recorder.Eventf(shoot, corev1.EventTypeNormal, gardencorev1beta1.ShootEventImageVersionMaintenance, "%s",
+			fmt.Sprintf("Updated %s.", reason))
 	}
 
 	updatedKubernetesVersion, reasonForKubernetesUpdate, err := MaintainKubernetesVersion(shoot, cloudProfile, shootLogger)
@@ -184,9 +188,6 @@ func (r *shootMaintenanceReconciler) reconcile(ctx context.Context, shoot *garde
 		controllerutils.AddTasks(shoot.Annotations, v1beta1constants.ShootTaskRestartCoreAddons)
 	}
 
-	if updatedMachineImages != nil {
-		gardencorev1beta1helper.UpdateMachineImages(shoot.Spec.Provider.Workers, updatedMachineImages)
-	}
 	if updatedKubernetesVersion != nil {
 		shoot.Spec.Kubernetes.Version = *updatedKubernetesVersion
 	}
@@ -207,15 +208,19 @@ func (r *shootMaintenanceReconciler) reconcile(ctx context.Context, shoot *garde
 			fmt.Sprintf("Updated %s.", *reasonForKubernetesUpdate))
 	}
 
-	if updatedMachineImages != nil {
-		for _, reason := range reasonForImageUpdatePerPool {
-			r.recorder.Eventf(shoot, corev1.EventTypeNormal, gardencorev1beta1.ShootEventImageVersionMaintenance, "%s",
-				fmt.Sprintf("Updated %s.", reason))
-		}
-	}
-
 	shootLogger.Infof("[SHOOT MAINTENANCE] completed")
 	return nil
+}
+
+// MaintainMachineImages updates the machine images of a Shoot's worker pools if necessary
+func MaintainMachineImages(shootLogger *logrus.Entry, shoot *gardencorev1beta1.Shoot, cloudProfile *gardencorev1beta1.CloudProfile) ([]string, error) {
+	updatedMachineImages, reasonForImageUpdatePerPool, err := selectUpdatedMachineImages(shootLogger, shoot, cloudProfile)
+
+	if updatedMachineImages != nil {
+		gardencorev1beta1helper.UpdateMachineImages(shoot.Spec.Provider.Workers, updatedMachineImages)
+	}
+
+	return reasonForImageUpdatePerPool, err
 }
 
 // MaintainKubernetesVersion determines if a shoots kubernetes version has to be maintained and in case returns the target version
@@ -289,8 +294,7 @@ func hasMaintainNowAnnotation(shoot *gardencorev1beta1.Shoot) bool {
 	return ok && operation == v1beta1constants.ShootOperationMaintain
 }
 
-// MaintainMachineImages determines if a shoots machine images have to be maintained and in case returns the target images
-func MaintainMachineImages(logger *logrus.Entry, shoot *gardencorev1beta1.Shoot, cloudProfile *gardencorev1beta1.CloudProfile) (updatedMachineImages []*gardencorev1beta1.ShootMachineImage, reasons []string, error error) {
+func selectUpdatedMachineImages(logger *logrus.Entry, shoot *gardencorev1beta1.Shoot, cloudProfile *gardencorev1beta1.CloudProfile) (updatedMachineImages []*gardencorev1beta1.ShootMachineImage, reasons []string, error error) {
 	var (
 		shootMachineImagesForUpdate []*gardencorev1beta1.ShootMachineImage
 		reasonsForUpdate            []string

--- a/pkg/controllermanager/controller/shoot/shoot_maintenance_control.go
+++ b/pkg/controllermanager/controller/shoot/shoot_maintenance_control.go
@@ -147,11 +147,6 @@ func (r *shootMaintenanceReconciler) reconcile(ctx context.Context, shoot *garde
 		// continue execution to allow the kubernetes version update
 		shootLogger.Error(fmt.Sprintf("Could not maintain machine image version: %s", err.Error()))
 	}
-	for _, reason := range reasonForImageUpdatePerPool {
-		r.recorder.Eventf(shoot, corev1.EventTypeNormal, gardencorev1beta1.ShootEventImageVersionMaintenance, "%s",
-			fmt.Sprintf("Updated %s.", reason))
-		shootLogger.Debugf("[SHOOT MAINTENANCE] Updating %s", reason)
-	}
 
 	updatedKubernetesVersion, reasonForKubernetesUpdate, err := MaintainKubernetesVersion(shoot, cloudProfile, shootLogger)
 	if err != nil {
@@ -200,6 +195,12 @@ func (r *shootMaintenanceReconciler) reconcile(ctx context.Context, shoot *garde
 	if err := gardenClient.Update(ctx, shoot); err != nil {
 		shootLogger.Errorf("Failed to update Shoot spec: %+v", err)
 		return err
+	}
+
+	for _, reason := range reasonForImageUpdatePerPool {
+		r.recorder.Eventf(shoot, corev1.EventTypeNormal, gardencorev1beta1.ShootEventImageVersionMaintenance, "%s",
+			fmt.Sprintf("Updated %s.", reason))
+		shootLogger.Debugf("[SHOOT MAINTENANCE] Updating %s", reason)
 	}
 
 	if updatedKubernetesVersion != nil {

--- a/pkg/controllermanager/controller/shoot/shoot_maintenance_control.go
+++ b/pkg/controllermanager/controller/shoot/shoot_maintenance_control.go
@@ -315,7 +315,7 @@ func hasMaintainNowAnnotation(shoot *gardencorev1beta1.Shoot) bool {
 
 func filterForCRI(machineImageFromCloudProfile *gardencorev1beta1.MachineImage, workerCRI *gardencorev1beta1.CRI) *gardencorev1beta1.MachineImage {
 	if workerCRI == nil {
-		return machineImageFromCloudProfile
+		return filterForCRI(machineImageFromCloudProfile, &gardencorev1beta1.CRI{Name: gardencorev1beta1.CRINameDocker})
 	}
 
 	filteredMachineImages := gardencorev1beta1.MachineImage{Name: machineImageFromCloudProfile.Name,

--- a/pkg/controllermanager/controller/shoot/shoot_maintenance_control_test.go
+++ b/pkg/controllermanager/controller/shoot/shoot_maintenance_control_test.go
@@ -23,7 +23,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	. "github.com/onsi/gomega/gstruct"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 )
@@ -167,21 +166,17 @@ var _ = Describe("Shoot Maintenance", func() {
 			shoot.Spec.Maintenance.AutoUpdate.MachineImageVersion = false
 			cloudProfile.Spec.MachineImages[0].Versions[0].ExpirationDate = &expirationDateInThePast
 
-			workerImages, _, err := MaintainMachineImages(testlogger, shoot, cloudProfile)
+			_, err := MaintainMachineImages(testlogger, shoot, cloudProfile)
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(workerImages)).NotTo(Equal(0))
-			Expect(workerImages[0].Name).To(Equal(cloudProfile.Spec.MachineImages[0].Name))
-			Expect(workerImages[0].Version).To(PointTo(Equal(cloudProfile.Spec.MachineImages[0].Versions[1].Version)))
+			assertWorkerMachineImageVersion(&shoot.Spec.Provider.Workers[0], "CoreOs", "1.1.1")
 		})
 
 		It("should determine that the shoot worker machine images must be maintained - MaintenanceAutoUpdate set to true (nil is also is being defaulted to true in the API server)", func() {
-			workerImages, _, err := MaintainMachineImages(testlogger, shoot, cloudProfile)
+			_, err := MaintainMachineImages(testlogger, shoot, cloudProfile)
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(workerImages)).NotTo(Equal(0))
-			Expect(workerImages[0].Name).To(Equal(cloudProfile.Spec.MachineImages[0].Name))
-			Expect(workerImages[0].Version).To(PointTo(Equal(cloudProfile.Spec.MachineImages[0].Versions[1].Version)))
+			assertWorkerMachineImageVersion(&shoot.Spec.Provider.Workers[0], "CoreOs", "1.1.1")
 		})
 
 		It("should determine that the shoot worker machine images must be maintained - multiple worker pools", func() {
@@ -205,12 +200,11 @@ var _ = Describe("Shoot Maintenance", func() {
 			}
 
 			shoot.Spec.Provider.Workers = append(shoot.Spec.Provider.Workers, otherWorker)
-			workerImages, _, err := MaintainMachineImages(testlogger, shoot, cloudProfile)
+			_, err := MaintainMachineImages(testlogger, shoot, cloudProfile)
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(workerImages)).NotTo(Equal(0))
-			Expect(workerImages[0].Name).To(Equal(cloudProfile.Spec.MachineImages[0].Name))
-			Expect(workerImages[0].Version).To(PointTo(Equal(cloudProfile.Spec.MachineImages[0].Versions[1].Version)))
+			assertWorkerMachineImageVersion(&shoot.Spec.Provider.Workers[0], "CoreOs", "1.1.1")
+			assertWorkerMachineImageVersion(&shoot.Spec.Provider.Workers[1], "gardenlinux", "1.0.0")
 		})
 
 		It("should update to latest non-preview version - MaintenanceAutoUpdate set to true", func() {
@@ -221,21 +215,21 @@ var _ = Describe("Shoot Maintenance", func() {
 				},
 			}
 			cloudProfile.Spec.MachineImages[0].Versions = append(cloudProfile.Spec.MachineImages[0].Versions, highestPreviewVersion)
-			workerImages, _, err := MaintainMachineImages(testlogger, shoot, cloudProfile)
+
+			_, err := MaintainMachineImages(testlogger, shoot, cloudProfile)
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(workerImages)).NotTo(Equal(0))
-			Expect(workerImages[0].Name).To(Equal(cloudProfile.Spec.MachineImages[0].Name))
-			Expect(*workerImages[0].Version).To(Equal("1.1.1"))
+			assertWorkerMachineImageVersion(&shoot.Spec.Provider.Workers[0], "CoreOs", "1.1.1")
 		})
 
 		It("should determine that the shoot worker machine images must NOT to be maintained - ForceUpdate not required & MaintenanceAutoUpdate set to false", func() {
 			shoot.Spec.Maintenance.AutoUpdate.MachineImageVersion = false
 
-			workerImages, _, err := MaintainMachineImages(testlogger, shoot, cloudProfile)
+			expected := shoot.Spec.Provider.Workers[0].Machine.Image.DeepCopy()
+			_, err := MaintainMachineImages(testlogger, shoot, cloudProfile)
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(workerImages)).To(Equal(0))
+			Expect(shoot.Spec.Provider.Workers[0].Machine.Image).To(Equal(expected))
 		})
 
 		It("should determine that the shoot worker machine images must NOT to be maintained - already on latest qualifying machine image version.", func() {
@@ -258,20 +252,20 @@ var _ = Describe("Shoot Maintenance", func() {
 				},
 			}
 			shoot.Spec.Provider.Workers[0].Machine.Image.Version = &highestVersion
-			workerImages, _, err := MaintainMachineImages(testlogger, shoot, cloudProfile)
-
+			expected := shoot.Spec.Provider.Workers[0].Machine.Image.DeepCopy()
+			_, err := MaintainMachineImages(testlogger, shoot, cloudProfile)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(workerImages)).To(Equal(0))
+			Expect(shoot.Spec.Provider.Workers[0].Machine.Image).To(Equal(expected))
 		})
 
 		It("should determine that the shoot worker machine images must NOT be maintained - found no machineImageVersion with matching CRI", func() {
 			cloudProfile.Spec.MachineImages[0].Versions[0].CRI = []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}}
 			shoot.Spec.Provider.Workers[0].CRI = &gardencorev1beta1.CRI{Name: gardencorev1beta1.CRINameContainerD}
 
-			workerImages, _, err := MaintainMachineImages(testlogger, shoot, cloudProfile)
-
+			expected := shoot.Spec.Provider.Workers[0].Machine.Image.DeepCopy()
+			_, err := MaintainMachineImages(testlogger, shoot, cloudProfile)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(workerImages)).To(Equal(0))
+			Expect(shoot.Spec.Provider.Workers[0].Machine.Image).To(Equal(expected))
 		})
 
 		It("should determine that the shoot worker machine images must be maintained - cloud profile has no matching (machineImage.name & machineImage.version) machine image defined (the shoots image has been deleted from the cloudProfile) -> update to latest machineImage with same name", func() {
@@ -289,12 +283,10 @@ var _ = Describe("Shoot Maintenance", func() {
 				},
 			}
 
-			workerImages, _, err := MaintainMachineImages(testlogger, shoot, cloudProfile)
+			_, err := MaintainMachineImages(testlogger, shoot, cloudProfile)
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(workerImages)).NotTo(Equal(0))
-			Expect(workerImages[0].Name).To(Equal(cloudProfile.Spec.MachineImages[0].Name))
-			Expect(workerImages[0].Version).To(PointTo(Equal(cloudProfile.Spec.MachineImages[0].Versions[0].Version)))
+			assertWorkerMachineImageVersion(&shoot.Spec.Provider.Workers[0], "CoreOs", "1.1.1")
 		})
 
 		It("should determine that the Shoot is already using the latest qualifying version - Shoot is using a preview version (and there is no higher non-preview version).", func() {
@@ -306,16 +298,16 @@ var _ = Describe("Shoot Maintenance", func() {
 			}
 			cloudProfile.Spec.MachineImages[0].Versions = append(cloudProfile.Spec.MachineImages[0].Versions, highestExpiredVersion)
 			shoot.Spec.Provider.Workers[0].Machine.Image.Version = &highestExpiredVersion.Version
-			workerImages, _, err := MaintainMachineImages(testlogger, shoot, cloudProfile)
+			_, err := MaintainMachineImages(testlogger, shoot, cloudProfile)
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(len(workerImages)).To(Equal(0))
+			assertWorkerMachineImageVersion(&shoot.Spec.Provider.Workers[0], "CoreOs", "1.1.2")
 		})
 
 		It("should return an error - cloud profile has no matching (machineImage.name) machine image defined", func() {
 			cloudProfile.Spec.MachineImages = cloudProfile.Spec.MachineImages[1:]
 
-			_, _, err := MaintainMachineImages(testlogger, shoot, cloudProfile)
+			_, err := MaintainMachineImages(testlogger, shoot, cloudProfile)
 
 			Expect(err).NotTo(BeNil())
 		})
@@ -330,7 +322,7 @@ var _ = Describe("Shoot Maintenance", func() {
 			}
 			cloudProfile.Spec.MachineImages[0].Versions = append(cloudProfile.Spec.MachineImages[0].Versions, highestExpiredVersion)
 			shoot.Spec.Provider.Workers[0].Machine.Image.Version = &highestExpiredVersion.Version
-			_, _, err := MaintainMachineImages(testlogger, shoot, cloudProfile)
+			_, err := MaintainMachineImages(testlogger, shoot, cloudProfile)
 
 			Expect(err).To(HaveOccurred())
 		})
@@ -538,3 +530,8 @@ var _ = Describe("Shoot Maintenance", func() {
 		})
 	})
 })
+
+func assertWorkerMachineImageVersion(worker *gardencorev1beta1.Worker, imageName string, imageVersion string) {
+	ExpectWithOffset(1, worker.Machine.Image.Name).To(Equal(imageName))
+	ExpectWithOffset(1, *worker.Machine.Image.Version).To(Equal(imageVersion))
+}

--- a/pkg/controllermanager/controller/shoot/shoot_maintenance_control_test.go
+++ b/pkg/controllermanager/controller/shoot/shoot_maintenance_control_test.go
@@ -264,6 +264,16 @@ var _ = Describe("Shoot Maintenance", func() {
 			Expect(len(workerImages)).To(Equal(0))
 		})
 
+		It("should determine that the shoot worker machine images must NOT be maintained - found no machineImageVersion with matching CRI", func() {
+			cloudProfile.Spec.MachineImages[0].Versions[0].CRI = []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}}
+			shoot.Spec.Provider.Workers[0].CRI = &gardencorev1beta1.CRI{Name: gardencorev1beta1.CRINameContainerD}
+
+			workerImages, _, err := MaintainMachineImages(testlogger, shoot, cloudProfile)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(len(workerImages)).To(Equal(0))
+		})
+
 		It("should determine that the shoot worker machine images must be maintained - cloud profile has no matching (machineImage.name & machineImage.version) machine image defined (the shoots image has been deleted from the cloudProfile) -> update to latest machineImage with same name", func() {
 			cloudProfile.Spec.MachineImages = []gardencorev1beta1.MachineImage{
 				{

--- a/pkg/controllermanager/controller/shoot/shoot_maintenance_control_test.go
+++ b/pkg/controllermanager/controller/shoot/shoot_maintenance_control_test.go
@@ -128,12 +128,14 @@ var _ = Describe("Shoot Maintenance", func() {
 									ExpirableVersion: gardencorev1beta1.ExpirableVersion{
 										Version: "1.0.0",
 									},
+									CRI: []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
 								},
 								{
 									ExpirableVersion: gardencorev1beta1.ExpirableVersion{
 										Version:        "1.1.1",
 										ExpirationDate: &expirationDateInTheFuture,
 									},
+									CRI: []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
 								},
 							},
 						},
@@ -179,12 +181,12 @@ var _ = Describe("Shoot Maintenance", func() {
 			assertWorkerMachineImageVersion(&shoot.Spec.Provider.Workers[0], "CoreOs", "1.1.1")
 		})
 
-		It("updates shoot worker machine image to newest supported version, worker.cri=nil, MachineImageVersion.cri!=nil", func() {
+		It("should treat workers with `cri: nil` like `cri.name: docker` and not update if `docker` is not explicitly supported by the machine image", func() {
 			cloudProfile.Spec.MachineImages[0].Versions[1].CRI = []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}}
 
 			_, err := MaintainMachineImages(testlogger, shoot, cloudProfile)
 			Expect(err).NotTo(HaveOccurred())
-			assertWorkerMachineImageVersion(&shoot.Spec.Provider.Workers[0], "CoreOs", "1.1.1")
+			assertWorkerMachineImageVersion(&shoot.Spec.Provider.Workers[0], "CoreOs", "1.0.0")
 		})
 
 		It("should determine that the shoot worker machine images must be maintained - multiple worker pools", func() {
@@ -195,6 +197,7 @@ var _ = Describe("Shoot Maintenance", func() {
 						ExpirableVersion: gardencorev1beta1.ExpirableVersion{
 							Version: "1.0.0",
 						},
+						CRI: []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
 					},
 				},
 			})
@@ -250,11 +253,13 @@ var _ = Describe("Shoot Maintenance", func() {
 							ExpirableVersion: gardencorev1beta1.ExpirableVersion{
 								Version: "1.0.1",
 							},
+							CRI: []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
 						},
 						{
 							ExpirableVersion: gardencorev1beta1.ExpirableVersion{
 								Version: highestVersion,
 							},
+							CRI: []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
 						},
 					},
 				},
@@ -329,6 +334,7 @@ var _ = Describe("Shoot Maintenance", func() {
 								Version:        "1.1.1",
 								ExpirationDate: &expirationDateInTheFuture,
 							},
+							CRI: []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
 						},
 					},
 				},
@@ -346,6 +352,7 @@ var _ = Describe("Shoot Maintenance", func() {
 					Version:        "1.1.2",
 					Classification: &previewClassification,
 				},
+				CRI: []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
 			}
 			cloudProfile.Spec.MachineImages[0].Versions = append(cloudProfile.Spec.MachineImages[0].Versions, highestExpiredVersion)
 			shoot.Spec.Provider.Workers[0].Machine.Image.Version = &highestExpiredVersion.Version


### PR DESCRIPTION
**How to categorize this PR?**
/area control-plane
/kind bug

**What this PR does / why we need it**:
Without this fix the maintenance controller did not respect the `worker.cri` configuration when selecting a new machineImageVersion.

This change will especially become relevant when an MachineImageVersion deprecates the support for a certain containerruntime (like docker).

**Which issue(s) this PR fixes**:
Fixes #4305

**Special notes for your reviewer**:
See the commit messages for the reasoning behind the changes, for example the reasoning behind the refactoring.
As a follow-up we would open an issue to also refactor maintaining the K8s version similar to 584ef1a

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bug user
The maintenance controller now respects the CRI configuration when selecting a new MachineImageVersion.
```
```noteworthy operator
All MachineImageVersions in the Cloud Profile must have set an accurate set of supported Container Runtimes! Previously, support for the `docker` runtime was implicit, it now needs to be set explicitly. See our [dockershim removal document](https://github.com/gardener/gardener/blob/master/docs/usage/docker-shim-removal.md#what-should-i-do) for more information. To ease this transition this release adds adds `docker` to  the list of supported container runtimes for all MachineImageVersions in your Cloud Profile see #4500.
```

cc @voelzmo 
