### PR TITLE
Fix potential race condition in the Shoot deletion flow

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_delete.go
@@ -278,7 +278,7 @@ func (c *Controller) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 				createOrUpdateETCDEncryptionConfiguration,
 			).InsertIf(!staticNodesCIDR),
 		})
-		_ = g.Add(flow.Task{
+		scaleUpKubeAPIServer = g.Add(flow.Task{
 			Name: "Scale up Kubernetes API server",
 			Fn: flow.TaskFn(botanist.ScaleKubeAPIServerToOne).
 				RetryUntilTimeout(defaultInterval, defaultTimeout).
@@ -288,7 +288,7 @@ func (c *Controller) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 		waitUntilKubeAPIServerIsReady = g.Add(flow.Task{
 			Name:         "Waiting until Kubernetes API server reports readiness",
 			Fn:           flow.TaskFn(botanist.Shoot.Components.ControlPlane.KubeAPIServer.Wait).DoIf(cleanupShootResources),
-			Dependencies: flow.NewTaskIDs(deployKubeAPIServer),
+			Dependencies: flow.NewTaskIDs(deployKubeAPIServer, scaleUpKubeAPIServer),
 		})
 		deployControlPlaneExposure = g.Add(flow.Task{
 			Name:         "Deploying shoot control plane exposure components",


### PR DESCRIPTION
/area quality
/kind bug

Currently  both `Scale up Kubernetes API server` and `Waiting until Kubernetes API server reports readiness` tasks depend on `Deploying Kubernetes API server` task. So on deletion of a hibernated Shoot there is a race condition where `Waiting until Kubernetes API server reports readiness` and `Initializing connection to Shoot` tasks can be executed before `Scale up Kubernetes API server` task. In such case `b.K8sShootClient` will be nil (as `Initializing connection to Shoot` task won't initialize any Shoot client) and any future interaction with `b.K8sShootClient` will lead to nil pointer dereference (see the panic in https://github.com/gardener/gardener/issues/4437).
So if I have to summarize, there is relatively rare race condition that happens when `Initializing connection to Shoot` task is executed before `Scale up Kubernetes API server` task (right now the deletion flow allows this). So in the few gardenlet logs with such panic, I was able to see that it was always the case that execution of `Initializing connection to Shoot` before `Scale up Kubernetes API server` led to this panic

To locally reproduce the panic from #4437, some mock error or some `time.Sleep` in the `ScaleKubeAPIServerToOne` func would be enough:

```diff
 // ScaleKubeAPIServerToOne scales kube-apiserver replicas to one.
 func (b *Botanist) ScaleKubeAPIServerToOne(ctx context.Context) error {
-       return kubernetes.ScaleDeployment(ctx, b.K8sSeedClient.Client(), kutil.Key(b.Shoot.SeedNamespace, v1beta1constants.DeploymentNameKubeAPIServer), 1)
+       return fmt.Errorf("mock error")
 }
```

Fixes https://github.com/gardener/gardener/issues/4437


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
A potential race condition in gardenlet that can lead to nil pointer dereference during the deletion of hibernated Shoot is now fixed. 
```
