### PR TITLE
Revert "Switch base images to GCR copies"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 #############      builder       #############
-FROM eu.gcr.io/gardener-project/3rd/golang:1.16.6 AS builder
+FROM golang:1.16.6 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener
 COPY . .
@@ -9,7 +9,7 @@ ARG EFFECTIVE_VERSION
 RUN make install EFFECTIVE_VERSION=$EFFECTIVE_VERSION
 
 ############# base
-FROM eu.gcr.io/gardener-project/3rd/alpine:3.13.5 AS base
+FROM alpine:3.13.5 AS base
 
 #############      apiserver     #############
 FROM base AS apiserver


### PR DESCRIPTION
/kind cleanup

This reverts commit 0990cb4d12b0905d354ea87734afae08e045e0bd.

https://github.com/gardener/cc-utils/issues/636 is now resolved

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
