### PR TITLE
Add wait period for the tunnel connection health check

### DIFF
--- a/pkg/operation/botanist/tunnel.go
+++ b/pkg/operation/botanist/tunnel.go
@@ -17,8 +17,12 @@ package botanist
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/operation/common"
+	"github.com/gardener/gardener/pkg/operation/shoot"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/retry"
 
 	"github.com/sirupsen/logrus"
@@ -54,4 +58,48 @@ func CheckTunnelConnection(ctx context.Context, shootClient kubernetes.Interface
 
 	logger.Info("Tunnel connection has been established.")
 	return retry.Ok()
+}
+
+// CheckAndWaitForTunnelConnection checks until the tunnel connection between the control plane and the shoot networks
+// is established, or until the configured timeout.
+func CheckAndWaitForTunnelConnection(ctx context.Context, shootClient kubernetes.Interface, shoot *shoot.Shoot, logger logrus.FieldLogger, tunnelName string, timeout time.Duration) error {
+	timeoutCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	return retry.Until(timeoutCtx, 5*time.Second, func(ctx context.Context) (bool, error) {
+		done, err := CheckTunnelConnection(ctx, shootClient, logger, common.VPNTunnel)
+
+		// If the tunnel connection check failed but is not yet "done" (i.e., will be retried, hence, it didn't fail
+		// with a severe error), and if the classic VPN solution is used for the shoot cluster then let's try to fetch
+		// the last events of the vpn-shoot service (potentially indicating an error with the load balancer service).
+		if err != nil &&
+			!done &&
+			!shoot.ReversedVPNEnabled {
+
+			logger.Errorf("error %v occurred while checking the tunnel connection", err)
+
+			service := &corev1.Service{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: corev1.SchemeGroupVersion.String(),
+					Kind:       "Service",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "vpn-shoot",
+					Namespace: metav1.NamespaceSystem,
+				},
+			}
+
+			eventsErrorMessage, err2 := kutil.FetchEventMessages(ctx, shootClient.Client().Scheme(), shootClient.Client(), service, corev1.EventTypeWarning, 2)
+			if err2 != nil {
+				logger.Errorf("error %v occurred while fetching events for VPN load balancer service", err2)
+				return retry.SevereError(fmt.Errorf("'%w' occurred but could not fetch events for more information", err))
+			}
+
+			if eventsErrorMessage != "" {
+				return retry.SevereError(fmt.Errorf("%s\n\n%s", err.Error(), eventsErrorMessage))
+			}
+		}
+
+		return done, err
+	})
 }

--- a/pkg/operation/botanist/waiter.go
+++ b/pkg/operation/botanist/waiter.go
@@ -53,45 +53,7 @@ func (b *Botanist) WaitUntilVpnShootServiceIsReady(ctx context.Context) error {
 // WaitUntilTunnelConnectionExists waits until a port forward connection to the tunnel pod (vpn-shoot) in the kube-system
 // namespace of the Shoot cluster can be established.
 func (b *Botanist) WaitUntilTunnelConnectionExists(ctx context.Context) error {
-	timeoutCtx, cancel := context.WithTimeout(ctx, 15*time.Minute)
-	defer cancel()
-
-	return retry.Until(timeoutCtx, 5*time.Second, func(ctx context.Context) (bool, error) {
-		done, err := CheckTunnelConnection(ctx, b.K8sShootClient, b.Logger, common.VPNTunnel)
-
-		// If the tunnel connection check failed but is not yet "done" (i.e., will be retried, hence, it didn't fail
-		// with a severe error), and if the classic VPN solution is used for the shoot cluster then let's try to fetch
-		// the last events of the vpn-shoot service (potentially indicating an error with the load balancer service).
-		if err != nil &&
-			!done &&
-			!b.Shoot.ReversedVPNEnabled {
-
-			b.Logger.Errorf("error %v occurred while checking the tunnel connection", err)
-
-			service := &corev1.Service{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: corev1.SchemeGroupVersion.String(),
-					Kind:       "Service",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "vpn-shoot",
-					Namespace: metav1.NamespaceSystem,
-				},
-			}
-
-			eventsErrorMessage, err2 := kutil.FetchEventMessages(ctx, b.K8sShootClient.Client().Scheme(), b.K8sShootClient.Client(), service, corev1.EventTypeWarning, 2)
-			if err2 != nil {
-				b.Logger.Errorf("error %v occurred while fetching events for VPN load balancer service", err2)
-				return retry.SevereError(fmt.Errorf("'%w' occurred but could not fetch events for more information", err))
-			}
-
-			if eventsErrorMessage != "" {
-				return retry.SevereError(fmt.Errorf("%s\n\n%s", err.Error(), eventsErrorMessage))
-			}
-		}
-
-		return done, err
-	})
+	return CheckAndWaitForTunnelConnection(ctx, b.K8sShootClient, b.Shoot, b.Logger, common.VPNTunnel, 15*time.Minute)
 }
 
 // WaitUntilNodesDeleted waits until no nodes exist in the shoot cluster anymore.

--- a/pkg/operation/care/health.go
+++ b/pkg/operation/care/health.go
@@ -318,7 +318,7 @@ func (h *Health) checkSystemComponents(
 		return &c, nil
 	}
 
-	if established, err := botanist.CheckTunnelConnection(ctx, h.shootClient, logrus.NewEntry(logger.NewNopLogger()), common.VPNTunnel); err != nil || !established {
+	if err := botanist.CheckAndWaitForTunnelConnection(ctx, h.shootClient, h.shoot, logrus.NewEntry(logger.NewNopLogger()), common.VPNTunnel, 2*time.Minute); err != nil {
 		msg := "Tunnel connection has not been established"
 		if err != nil {
 			msg += fmt.Sprintf(" (%+v)", err)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
This PR adds wait period when the health check is checking for established tunnel connection.
Sometimes the `vpn-shoot` pod requires some time to be ready and the health check may report issues with the system components where in fact there is not any. The message observed is `Tunnel connection has not been established: could not forward to vpn-shoot pod...`. This could be quite annoying when monitoring large number of `shoot` clusters.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
