### PR TITLE
Improve local setup to respect gardenlet RBAC roles

### DIFF
--- a/hack/local-development/start-gardenlet
+++ b/hack/local-development/start-gardenlet
@@ -100,6 +100,21 @@ if [ -z "${SEED_KUBECONFIG:-}" ]; then
     base64 -d > "$SEED_KUBECONFIG"
 fi
 
+# generate RBAC roles
+GARDENLET_CHARTS_DIR=charts/gardener/gardenlet
+GARDENLET_CHARTS_RUNTIME_DIR="$GARDENLET_CHARTS_DIR/charts/runtime"
+helm template gardenlet "$GARDENLET_CHARTS_RUNTIME_DIR" -s templates/clusterrole-gardenlet.yaml -f "$GARDENLET_CHARTS_DIR/values.yaml" | kubectl --kubeconfig="$SEED_KUBECONFIG" apply -f -
+helm template gardenlet "$GARDENLET_CHARTS_RUNTIME_DIR" -s templates/clusterrolebinding-gardenlet.yaml -f "$GARDENLET_CHARTS_DIR/values.yaml" | kubectl --kubeconfig="$SEED_KUBECONFIG" apply -f -
+helm template gardenlet "$GARDENLET_CHARTS_RUNTIME_DIR" -s templates/serviceaccount.yaml -f "$GARDENLET_CHARTS_DIR/values.yaml" | kubectl --kubeconfig="$SEED_KUBECONFIG" apply -f -
+
+# backup gardenlet seed kubeconfig
+cp "$SEED_KUBECONFIG" "$DEV_DIR/gardenlet-seed-$SEED_NAME-ORIGINAl.conf"
+
+# start using appropriate token in the gardenlet seed kubeconfig
+secret=$(kubectl --kubeconfig="$SEED_KUBECONFIG" --namespace garden get serviceaccount gardenlet -o jsonpath='{.secrets[0].name}')
+token=$(kubectl --kubeconfig="$SEED_KUBECONFIG" --namespace garden get secret "$secret" -o jsonpath='{.data.token}' | base64 --decode)
+TOKEN_VALUE="$token" $YQ eval --inplace '.users[0].user.token = strenv(TOKEN_VALUE)' "$SEED_KUBECONFIG"
+
 file_imagevector_overwrite="$(mktemp_imagevector_overwrite github.com/gardener/gardener "$REPO_ROOT" "$REPO_ROOT"/charts)"
 if [ ! -f "$file_imagevector_overwrite" ]; then
   echo "failed to generate local image vector override: $file_imagevector_overwrite"

--- a/hack/local-development/start-gardenlet
+++ b/hack/local-development/start-gardenlet
@@ -100,19 +100,27 @@ if [ -z "${SEED_KUBECONFIG:-}" ]; then
     base64 -d > "$SEED_KUBECONFIG"
 fi
 
+
 # apply RBAC resources in seed cluster
 GARDENLET_CHARTS_DIR=charts/gardener/gardenlet
 GARDENLET_CHARTS_RUNTIME_DIR="$GARDENLET_CHARTS_DIR/charts/runtime"
-helm template gardenlet "$GARDENLET_CHARTS_RUNTIME_DIR" -s templates/clusterrole-gardenlet.yaml -f "$GARDENLET_CHARTS_DIR/values.yaml" | kubectl --kubeconfig="$SEED_KUBECONFIG" apply -f -
-helm template gardenlet "$GARDENLET_CHARTS_RUNTIME_DIR" -s templates/clusterrolebinding-gardenlet.yaml -f "$GARDENLET_CHARTS_DIR/values.yaml" | kubectl --kubeconfig="$SEED_KUBECONFIG" apply -f -
-helm template gardenlet "$GARDENLET_CHARTS_RUNTIME_DIR" -s templates/serviceaccount.yaml -f "$GARDENLET_CHARTS_DIR/values.yaml" | kubectl --kubeconfig="$SEED_KUBECONFIG" apply -f -
+tmpConfig="$DEV_DIR/20-componentconfig-gardenlet-seed-$SEED_NAME-tmp.yaml"
+chartValues="$DEV_DIR/gardenlet-charts-values.yaml"
+$YQ eval 'del(.apiVersion, .kind)' "$configFile" | yq eval '{"config": .}' - > "$tmpConfig"
+$YQ eval-all 'select(fi==0).global.gardenlet * select(fi==1)' "$GARDENLET_CHARTS_DIR/values.yaml" "$tmpConfig" | yq eval '{"global": {"gardenlet": . }}' - > "$chartValues"
+
+helm template gardenlet "$GARDENLET_CHARTS_RUNTIME_DIR" | yaml2json | jq 'select(.apiVersion=="rbac.authorization.k8s.io/v1")' |
+  kubectl --kubeconfig="$SEED_KUBECONFIG" auth reconcile --remove-extra-permissions --remove-extra-subjects -f -
+
+helm template gardenlet "$GARDENLET_CHARTS_RUNTIME_DIR" -s templates/serviceaccount.yaml -f "$chartValues" |
+  kubectl --kubeconfig="$SEED_KUBECONFIG" apply -f -
 
 # backup gardenlet seed kubeconfig
 cp "$SEED_KUBECONFIG" "$DEV_DIR/gardenlet-seed-$SEED_NAME-original.conf"
 
 # replace the token in gardenlet seed kubeconfig with the one from the gardenlet serviceaccount
-secret=$(kubectl --kubeconfig="$SEED_KUBECONFIG" --namespace garden get serviceaccount gardenlet -o jsonpath='{.secrets[0].name}')
-token=$(kubectl --kubeconfig="$SEED_KUBECONFIG" --namespace garden get secret "$secret" -o jsonpath='{.data.token}' | base64 --decode)
+secretName=$(kubectl --kubeconfig="$SEED_KUBECONFIG" --namespace garden get serviceaccount gardenlet -o jsonpath='{.secrets[0].name}')
+token=$(kubectl --kubeconfig="$SEED_KUBECONFIG" --namespace garden get secret "$secretName" -o jsonpath='{.data.token}' | base64 --decode)
 TOKEN_VALUE="$token" $YQ eval --inplace '.users[0].user.token = strenv(TOKEN_VALUE)' "$SEED_KUBECONFIG"
 
 file_imagevector_overwrite="$(mktemp_imagevector_overwrite github.com/gardener/gardener "$REPO_ROOT" "$REPO_ROOT"/charts)"

--- a/hack/local-development/start-gardenlet
+++ b/hack/local-development/start-gardenlet
@@ -100,7 +100,7 @@ if [ -z "${SEED_KUBECONFIG:-}" ]; then
     base64 -d > "$SEED_KUBECONFIG"
 fi
 
-# generate RBAC roles
+# apply RBAC resources in seed cluster
 GARDENLET_CHARTS_DIR=charts/gardener/gardenlet
 GARDENLET_CHARTS_RUNTIME_DIR="$GARDENLET_CHARTS_DIR/charts/runtime"
 helm template gardenlet "$GARDENLET_CHARTS_RUNTIME_DIR" -s templates/clusterrole-gardenlet.yaml -f "$GARDENLET_CHARTS_DIR/values.yaml" | kubectl --kubeconfig="$SEED_KUBECONFIG" apply -f -
@@ -108,9 +108,9 @@ helm template gardenlet "$GARDENLET_CHARTS_RUNTIME_DIR" -s templates/clusterrole
 helm template gardenlet "$GARDENLET_CHARTS_RUNTIME_DIR" -s templates/serviceaccount.yaml -f "$GARDENLET_CHARTS_DIR/values.yaml" | kubectl --kubeconfig="$SEED_KUBECONFIG" apply -f -
 
 # backup gardenlet seed kubeconfig
-cp "$SEED_KUBECONFIG" "$DEV_DIR/gardenlet-seed-$SEED_NAME-ORIGINAl.conf"
+cp "$SEED_KUBECONFIG" "$DEV_DIR/gardenlet-seed-$SEED_NAME-original.conf"
 
-# start using appropriate token in the gardenlet seed kubeconfig
+# replace the token in gardenlet seed kubeconfig with the one from the gardenlet serviceaccount
 secret=$(kubectl --kubeconfig="$SEED_KUBECONFIG" --namespace garden get serviceaccount gardenlet -o jsonpath='{.secrets[0].name}')
 token=$(kubectl --kubeconfig="$SEED_KUBECONFIG" --namespace garden get secret "$secret" -o jsonpath='{.data.token}' | base64 --decode)
 TOKEN_VALUE="$token" $YQ eval --inplace '.users[0].user.token = strenv(TOKEN_VALUE)' "$SEED_KUBECONFIG"

--- a/hack/local-development/start-gardenlet
+++ b/hack/local-development/start-gardenlet
@@ -100,20 +100,21 @@ if [ -z "${SEED_KUBECONFIG:-}" ]; then
     base64 -d > "$SEED_KUBECONFIG"
 fi
 
-
-# apply RBAC resources in seed cluster
+# generate temporary chart values
 GARDENLET_CHARTS_DIR=charts/gardener/gardenlet
 GARDENLET_CHARTS_RUNTIME_DIR="$GARDENLET_CHARTS_DIR/charts/runtime"
 tmpConfig="$DEV_DIR/20-componentconfig-gardenlet-seed-$SEED_NAME-tmp.yaml"
 chartValues="$DEV_DIR/gardenlet-charts-values.yaml"
-$YQ eval 'del(.apiVersion, .kind)' "$configFile" | yq eval '{"config": .}' - > "$tmpConfig"
-$YQ eval-all 'select(fi==0).global.gardenlet * select(fi==1)' "$GARDENLET_CHARTS_DIR/values.yaml" "$tmpConfig" | yq eval '{"global": {"gardenlet": . }}' - > "$chartValues"
+$YQ eval 'del(.apiVersion, .kind)' "$configFile" | $YQ eval '{"config": .}' - > "$tmpConfig"
+$YQ eval-all 'select(fi==0).global.gardenlet * select(fi==1)' "$GARDENLET_CHARTS_DIR/values.yaml" "$tmpConfig" | $YQ eval '{"global": {"gardenlet": . }}' - > "$chartValues"
+rm "$tmpConfig"
 
-helm template gardenlet "$GARDENLET_CHARTS_RUNTIME_DIR" | yaml2json | jq 'select(.apiVersion=="rbac.authorization.k8s.io/v1")' |
+# apply RBAC resources in seed cluster
+helm template gardenlet "$GARDENLET_CHARTS_RUNTIME_DIR" -f "$chartValues" | $YQ eval 'select(.apiVersion=="rbac.authorization.k8s.io/v1")' - |
   kubectl --kubeconfig="$SEED_KUBECONFIG" auth reconcile --remove-extra-permissions --remove-extra-subjects -f -
-
 helm template gardenlet "$GARDENLET_CHARTS_RUNTIME_DIR" -s templates/serviceaccount.yaml -f "$chartValues" |
   kubectl --kubeconfig="$SEED_KUBECONFIG" apply -f -
+rm "$chartValues"
 
 # backup gardenlet seed kubeconfig
 cp "$SEED_KUBECONFIG" "$DEV_DIR/gardenlet-seed-$SEED_NAME-original.conf"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR updates the local setup so the gardenlet starts respect RBAC roles. 

**Which issue(s) this PR fixes**:
Fixes #4219 
