### PR TITLE
Delete DNSRecord resources explicitly during migration

### DIFF
--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -301,6 +301,16 @@ func (s *Shoot) GetExtensionComponentsForMigration() []component.DeployMigrateWa
 	}
 }
 
+// GetDNSRecordComponentsForMigration returns a list of component.DeployMigrateWaiters of DNSRecord components that
+// should be migrated by the shoot controller.
+func (s *Shoot) GetDNSRecordComponentsForMigration() []component.DeployMigrateWaiter {
+	return []component.DeployMigrateWaiter{
+		s.Components.Extensions.IngressDNSRecord,
+		s.Components.Extensions.ExternalDNSRecord,
+		s.Components.Extensions.InternalDNSRecord,
+	}
+}
+
 // GetIngressFQDN returns the fully qualified domain name of ingress sub-resource for the Shoot cluster. The
 // end result is '<subDomain>.<ingressPrefix>.<clusterDomain>'.
 func (s *Shoot) GetIngressFQDN(subDomain string) string {


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane-migration
/kind bug

**What this PR does / why we need it**:

Ensures that any `DNSRecord` resources are deleted explicitly at the end of the migration flow. This is needed so that these resources can be annotated with `confirmation.gardener.cloud/deletion=true` prior to being deleted.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```other operator
NONE
```
