### PR TITLE
Added readiness probe to vpn-seed-server deployment.

### DIFF
--- a/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server_test.go
+++ b/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server_test.go
@@ -236,6 +236,20 @@ var _ = Describe("VpnSeedServer", func() {
 											Value: podNetwork,
 										},
 									},
+									ReadinessProbe: &corev1.Probe{
+										Handler: corev1.Handler{
+											TCPSocket: &corev1.TCPSocketAction{
+												Port: intstr.FromInt(1194),
+											},
+										},
+									},
+									LivenessProbe: &corev1.Probe{
+										Handler: corev1.Handler{
+											TCPSocket: &corev1.TCPSocketAction{
+												Port: intstr.FromInt(1194),
+											},
+										},
+									},
 									Resources: corev1.ResourceRequirements{
 										Requests: corev1.ResourceList{
 											corev1.ResourceCPU:    resource.MustParse("100m"),
@@ -278,6 +292,20 @@ var _ = Describe("VpnSeedServer", func() {
 										"2",
 										"-c",
 										"/etc/envoy/envoy.yaml",
+									},
+									ReadinessProbe: &corev1.Probe{
+										Handler: corev1.Handler{
+											TCPSocket: &corev1.TCPSocketAction{
+												Port: intstr.FromInt(9443),
+											},
+										},
+									},
+									LivenessProbe: &corev1.Probe{
+										Handler: corev1.Handler{
+											TCPSocket: &corev1.TCPSocketAction{
+												Port: intstr.FromInt(9443),
+											},
+										},
 									},
 									Resources: corev1.ResourceRequirements{
 										Requests: corev1.ResourceList{


### PR DESCRIPTION
The readiness probe checks with netcat that the two server ports are open.
As a side effect the open vpn server port was extracted into a constant.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Adds readiness probes to the containers of the vpn-seed-server deployment.

**Which issue(s) this PR fixes**:
Fixes #4303 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
