### PR TITLE
Keep kube-apiserver HPA scale down mode `Auto` even when scale down is disabled.

### DIFF
--- a/pkg/operation/botanist/component/kubeapiserver/hvpa.go
+++ b/pkg/operation/botanist/component/kubeapiserver/hvpa.go
@@ -125,12 +125,7 @@ func (k *kubeAPIServer) reconcileHVPA(ctx context.Context, hvpa *hvpav1alpha1.Hv
 			},
 			ScaleDown: hvpav1alpha1.ScaleType{
 				UpdatePolicy: hvpav1alpha1.UpdatePolicy{
-					/*
-					 * HPA update mode needs to be always `Auto` because it is not supported in HPA.
-					 * To disable HPA scale down it is sufficient to set HPA minReplicas and
-					 * maxReplicas to be the same.
-					 */
-					UpdateMode: &updateModeAuto,
+					UpdateMode: &updateModeAuto, // HPA does not work with update mode 'Off' and needs to be always 'Auto' even though scale down is disabled.
 				},
 			},
 			Template: hvpav1alpha1.HpaTemplate{

--- a/pkg/operation/botanist/component/kubeapiserver/hvpa.go
+++ b/pkg/operation/botanist/component/kubeapiserver/hvpa.go
@@ -125,7 +125,12 @@ func (k *kubeAPIServer) reconcileHVPA(ctx context.Context, hvpa *hvpav1alpha1.Hv
 			},
 			ScaleDown: hvpav1alpha1.ScaleType{
 				UpdatePolicy: hvpav1alpha1.UpdatePolicy{
-					UpdateMode: &scaleDownUpdateMode,
+					/*
+					 * HPA update mode needs to be always `Auto` because it is not supported in HPA.
+					 * To disable HPA scale down it is sufficient to set HPA minReplicas and
+					 * maxReplicas to be the same.
+					 */
+					UpdateMode: &updateModeAuto,
 				},
 			},
 			Template: hvpav1alpha1.HpaTemplate{

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
@@ -304,7 +304,7 @@ var _ = Describe("KubeAPIServer", func() {
 								},
 								ScaleDown: hvpav1alpha1.ScaleType{
 									UpdatePolicy: hvpav1alpha1.UpdatePolicy{
-										UpdateMode: &expectedScaleDownUpdateMode,
+										UpdateMode: pointer.StringPtr("Auto"),
 									},
 								},
 								Template: hvpav1alpha1.HpaTemplate{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane auto-scaling
/kind bug

**What this PR does / why we need it**:

Keep kube-apiserver HPA scale down mode `Auto` even when scale down is disabled. The scale down is naturally disabled because `minReplicas` and `maxReplicas` are set to be equal.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

HVPA [deletes the HPA resource ](https://github.com/gardener/hvpa-controller/blob/531ed4269a58f51bc7e5ab2ca17d0871cd8a6e53/controllers/hvpa_controller.go#L386-L388) if the [HPA scale down mode is switched off](https://github.com/gardener/hvpa-controller/blob/531ed4269a58f51bc7e5ab2ca17d0871cd8a6e53/controllers/hvpa_controller.go#L384) because HVPA v1 has no good way to control how the HPA recommendations are applied (in [HVPA v2](https://github.com/gardener/hvpa-controller/pull/76), [there is a possibility](https://github.com/gardener/hvpa-controller/blob/master/docs/proposals/HVPA-EP-0001/HVPA-EP-001.md#unpredictable-scaling-behaviour-with-0--vpaweight--100) to control this).

So, when the shoot [control-plane scale down is disabled](https://github.com/gardener/gardener/blob/35db6b62be458890e1c3fabb644a6d52acc435ab/pkg/apis/core/v1beta1/constants/types_constants.go#L223-L227), the HPA resource is effectively deleted. If the `kube-apiserver` was not already scaled up to `maxReplicas` when this happens, then HVPA will not pro-actively apply VPA recommendation (waiting for HPA to scale up to `maxReplicas` which will never happen).

When the shoot [control-plane scale down is disabled](https://github.com/gardener/gardener/blob/35db6b62be458890e1c3fabb644a6d52acc435ab/pkg/apis/core/v1beta1/constants/types_constants.go#L223-L227), HPA `minReplicas` and `maxReplicas` are already [set to be the same](https://github.com/gardener/gardener/blob/35db6b62be458890e1c3fabb644a6d52acc435ab/pkg/operation/botanist/kubeapiserver.go#L64-L67), which effectively disables scale down. So, this PR reverts the HPA scale down mode back to `Auto` to make sure the HPA resource (with `minReplicas` and `maxReplicas` same) remains in place.

An alternative would have been to make sure the `kube-apiserver` `Deployment` is scaled to `maxReplicas` but that change seems to require further refactoring in the codebase.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Keep kube-apiserver HPA scale down mode `Auto` even when scale down is disabled. The scale down is naturally disabled because `minReplicas` and `maxReplicas` are set to be equal.
```
