### PR TITLE
Ensure backup entry name is generated only once using non-empty strings

### DIFF
--- a/pkg/operation/botanist/backupentry.go
+++ b/pkg/operation/botanist/backupentry.go
@@ -20,8 +20,6 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	corebackupentry "github.com/gardener/gardener/pkg/operation/botanist/component/backupentry"
-	gutil "github.com/gardener/gardener/pkg/utils/gardener"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 )
@@ -36,7 +34,7 @@ func (b *Botanist) DefaultCoreBackupEntry() component.DeployMigrateWaiter {
 		b.K8sGardenClient.Client(),
 		&corebackupentry.Values{
 			Namespace:      b.Shoot.Info.Namespace,
-			Name:           gutil.GenerateBackupEntryName(b.Shoot.Info.Status.TechnicalID, b.Shoot.Info.Status.UID),
+			Name:           b.Shoot.BackupEntryName,
 			ShootPurpose:   b.Shoot.Info.Spec.Purpose,
 			OwnerReference: ownerRef,
 			SeedName:       b.Shoot.Info.Spec.SeedName,

--- a/pkg/operation/botanist/etcd.go
+++ b/pkg/operation/botanist/etcd.go
@@ -30,7 +30,6 @@ import (
 	"github.com/gardener/gardener/pkg/operation/botanist/component/etcd"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/flow"
-	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
 	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
@@ -106,7 +105,7 @@ func (b *Botanist) DeployEtcd(ctx context.Context) error {
 		b.Shoot.Components.ControlPlane.EtcdMain.SetBackupConfig(&etcd.BackupConfig{
 			Provider:             b.Seed.Info.Spec.Backup.Provider,
 			SecretRefName:        genericactuator.BackupSecretName,
-			Prefix:               gutil.GenerateBackupEntryName(b.Shoot.Info.Status.TechnicalID, b.Shoot.Info.Status.UID),
+			Prefix:               b.Shoot.BackupEntryName,
 			Container:            string(secret.Data[genericactuator.DataKeyBackupBucketName]),
 			FullSnapshotSchedule: snapshotSchedule,
 		})

--- a/pkg/operation/botanist/etcd_test.go
+++ b/pkg/operation/botanist/etcd_test.go
@@ -277,7 +277,8 @@ var _ = Describe("Etcd", func() {
 						UID:         shootUID,
 					},
 				},
-				SeedNamespace: namespace,
+				SeedNamespace:   namespace,
+				BackupEntryName: namespace + "--" + string(shootUID),
 			}
 
 			etcdMain.EXPECT().SetSecrets(etcd.Secrets{

--- a/pkg/operation/care/health.go
+++ b/pkg/operation/care/health.go
@@ -32,7 +32,6 @@ import (
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/operation/shoot"
 	"github.com/gardener/gardener/pkg/utils/flow"
-	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 
@@ -162,8 +161,7 @@ func (h *Health) retrieveExtensions(ctx context.Context) ([]runtime.Object, erro
 	// Get BackupEntries separately as they are not namespaced i.e., they cannot be narrowed down
 	// to a shoot namespace like other extension resources above.
 	be := &extensionsv1alpha1.BackupEntry{}
-	beName := gutil.GenerateBackupEntryName(h.shoot.Info.Status.TechnicalID, h.shoot.Info.Status.UID)
-	if err := h.seedClient.Client().Get(ctx, kutil.Key(beName), be); client.IgnoreNotFound(err) != nil {
+	if err := h.seedClient.Client().Get(ctx, kutil.Key(h.shoot.BackupEntryName), be); client.IgnoreNotFound(err) != nil {
 		return nil, err
 	}
 	extensions = append(extensions, be)

--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -283,6 +283,13 @@ func (b *Builder) Build(ctx context.Context, c client.Client) (*Shoot, error) {
 
 	shoot.Purpose = gardencorev1beta1helper.GetPurpose(shootObject)
 
+	// Determine backup entry name
+	backupEntryName, err := gutil.GenerateBackupEntryName(shootObject.Status.TechnicalID, shootObject.UID)
+	if err != nil {
+		return nil, err
+	}
+	shoot.BackupEntryName = backupEntryName
+
 	return shoot, nil
 }
 

--- a/pkg/operation/shoot/types.go
+++ b/pkg/operation/shoot/types.go
@@ -81,6 +81,7 @@ type Shoot struct {
 	NodeLocalDNSEnabled        bool
 	Networks                   *Networks
 	ExposureClass              *gardencorev1alpha1.ExposureClass
+	BackupEntryName            string
 
 	Components     *Components
 	ETCDEncryption *etcdencryption.EncryptionConfig

--- a/pkg/utils/gardener/backupentry.go
+++ b/pkg/utils/gardener/backupentry.go
@@ -15,6 +15,7 @@
 package gardener
 
 import (
+	"fmt"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/types"
@@ -23,8 +24,14 @@ import (
 var backupEntryDelimiter = "--"
 
 // GenerateBackupEntryName returns BackupEntry resource name created from provided <seedNamespace> and <shootUID>.
-func GenerateBackupEntryName(shootTechnicalID string, shootUID types.UID) string {
-	return shootTechnicalID + backupEntryDelimiter + string(shootUID)
+func GenerateBackupEntryName(shootTechnicalID string, shootUID types.UID) (string, error) {
+	if shootTechnicalID == "" {
+		return "", fmt.Errorf("can't generate backup entry name with an empty shoot technical ID")
+	}
+	if shootUID == "" {
+		return "", fmt.Errorf("can't generate backup entry name with an empty shoot UID")
+	}
+	return shootTechnicalID + backupEntryDelimiter + string(shootUID), nil
 }
 
 // ExtractShootDetailsFromBackupEntryName returns Shoot resource technicalID its UID from provided <backupEntryName>.

--- a/pkg/utils/gardener/backupentry_test.go
+++ b/pkg/utils/gardener/backupentry_test.go
@@ -31,7 +31,19 @@ var _ = Describe("BackupEntry", func() {
 
 	Describe("#GenerateBackupEntryName", func() {
 		It("should compute the correct name", func() {
-			Expect(GenerateBackupEntryName(shootTechnicalID, shootUID)).To(Equal(backupEntryName))
+			result, err := GenerateBackupEntryName(shootTechnicalID, shootUID)
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(result).To(Equal(backupEntryName))
+		})
+
+		It("should fail if the shoot technical ID is empty", func() {
+			_, err := GenerateBackupEntryName("", shootUID)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should fail if the shoot UID is empty", func() {
+			_, err := GenerateBackupEntryName(shootTechnicalID, "")
+			Expect(err).To(HaveOccurred())
 		})
 	})
 


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind bug

**What this PR does / why we need it**:
* Ensures that the backup entry name is generated only once during the shoot reconciliation.
* Ensures that attempting to generate the backup entry name with empty shoot technical ID or UID is treated as an error.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This is intended as a quick fix to a recently observed issue that is caused by generating a backup entry name `--` when deploying `Etcd` resources. It does not fix the root cause of the issue (likely some kind of data race), just aims to prevent it from happening by ensuring the backup entry name is generated correctly.
See https://github.com/gardener/gardener-extension-provider-azure/issues/328#issuecomment-879824536.

**Release note**:

```other operator
Ensured that the backup entry name is generated only once using non-empty strings to prevent issues with backup entry names generated as `--`.
```
