### PR TITLE
Perform reads and modifications to Shoot.Info in a concurrency safe way

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_care_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_care_control.go
@@ -392,7 +392,7 @@ func retrieveSeedConditions(ctx context.Context, operation *operation.Operation)
 	}
 
 	seed := &gardencorev1beta1.Seed{}
-	if err := operation.K8sGardenClient.Client().Get(ctx, kutil.Key(operation.Shoot.Info.Name), seed); client.IgnoreNotFound(err) != nil {
+	if err := operation.K8sGardenClient.Client().Get(ctx, kutil.Key(operation.Shoot.GetInfo().Name), seed); client.IgnoreNotFound(err) != nil {
 		return nil, err
 	}
 	return seed.Status.Conditions, nil

--- a/pkg/gardenlet/controller/shoot/shoot_care_control_test.go
+++ b/pkg/gardenlet/controller/shoot/shoot_care_control_test.go
@@ -247,15 +247,15 @@ var _ = Describe("Shoot Care Control", func() {
 					WithClientSetForKey(keys.ForSeedWithName(seedName), seedClientSet).
 					Build()
 
-				operationFunc = opFunc(&operation.Operation{
+				op := &operation.Operation{
 					K8sGardenClient: gardenClientSet,
 					K8sSeedClient:   seedClientSet,
 					ManagedSeed:     managedSeed,
-					Shoot: &operationshoot.Shoot{
-						Info: shoot,
-					},
-					Logger: logger.NewNopLogger().WithContext(context.Background()),
-				}, nil)
+					Shoot:           &operationshoot.Shoot{},
+					Logger:          logger.NewNopLogger().WithContext(context.Background()),
+				}
+				op.Shoot.SetInfo(shoot)
+				operationFunc = opFunc(op, nil)
 
 				revertFns = append(revertFns,
 					test.WithVar(&NewOperation, operationFunc),

--- a/pkg/gardenlet/controller/shoot/shoot_control_migrate.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_migrate.go
@@ -86,7 +86,7 @@ func (c *Controller) runPrepareShootControlPlaneMigration(o *operation.Operation
 		kubeAPIServerDeploymentFound = true
 	)
 
-	for _, lastError := range o.Shoot.Info.Status.LastErrors {
+	for _, lastError := range o.Shoot.GetInfo().Status.LastErrors {
 		if lastError.TaskID != nil {
 			tasksWithErrors = append(tasksWithErrors, *lastError.TaskID)
 		}
@@ -145,7 +145,7 @@ func (c *Controller) runPrepareShootControlPlaneMigration(o *operation.Operation
 	var (
 		nonTerminatingNamespace = botanist.SeedNamespaceObject.Status.Phase != corev1.NamespaceTerminating
 		cleanupShootResources   = nonTerminatingNamespace && kubeAPIServerDeploymentFound
-		wakeupRequired          = (o.Shoot.Info.Status.IsHibernated || (!o.Shoot.Info.Status.IsHibernated && o.Shoot.HibernationEnabled)) && cleanupShootResources
+		wakeupRequired          = (o.Shoot.GetInfo().Status.IsHibernated || (!o.Shoot.GetInfo().Status.IsHibernated && o.Shoot.HibernationEnabled)) && cleanupShootResources
 		defaultTimeout          = 10 * time.Minute
 		defaultInterval         = 5 * time.Second
 
@@ -295,11 +295,11 @@ func (c *Controller) runPrepareShootControlPlaneMigration(o *operation.Operation
 		ErrorContext:     errorContext,
 		ErrorCleaner:     o.CleanShootTaskErrorAndUpdateStatusLabel,
 	}); err != nil {
-		o.Logger.Errorf("Failed to prepare Shoot %q for migration: %+v", o.Shoot.Info.Name, err)
+		o.Logger.Errorf("Failed to prepare Shoot %q for migration: %+v", o.Shoot.GetInfo().Name, err)
 		return gardencorev1beta1helper.NewWrappedLastErrors(gardencorev1beta1helper.FormatLastErrDescription(err), flow.Errors(err))
 	}
 
-	o.Logger.Infof("Successfully prepared Shoot's control plane for migration %q", o.Shoot.Info.Name)
+	o.Logger.Infof("Successfully prepared Shoot's control plane for migration %q", o.Shoot.GetInfo().Name)
 	return nil
 }
 

--- a/pkg/gardenlet/controller/shoot/shoot_control_migrate.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_migrate.go
@@ -145,7 +145,7 @@ func (c *Controller) runPrepareShootControlPlaneMigration(o *operation.Operation
 	var (
 		nonTerminatingNamespace = botanist.SeedNamespaceObject.Status.Phase != corev1.NamespaceTerminating
 		cleanupShootResources   = nonTerminatingNamespace && kubeAPIServerDeploymentFound
-		wakeupRequired          = (o.Shoot.GetInfo().Status.IsHibernated || (!o.Shoot.GetInfo().Status.IsHibernated && o.Shoot.HibernationEnabled)) && cleanupShootResources
+		wakeupRequired          = (o.Shoot.GetInfo().Status.IsHibernated || o.Shoot.HibernationEnabled) && cleanupShootResources
 		defaultTimeout          = 10 * time.Minute
 		defaultInterval         = 5 * time.Second
 

--- a/pkg/gardenlet/controller/shoot/shoot_control_migrate.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_migrate.go
@@ -70,7 +70,7 @@ func (c *Controller) prepareShootForMigration(ctx context.Context, logger *logru
 
 	if flowErr := c.runPrepareShootControlPlaneMigration(o); flowErr != nil {
 		c.recorder.Event(shoot, corev1.EventTypeWarning, gardencorev1beta1.EventMigrationPreparationFailed, flowErr.Description)
-		updateErr := c.patchShootStatusOperationError(ctx, gardenClient.Client(), o, o.Shoot.Info, flowErr.Description, gardencorev1beta1.LastOperationTypeMigrate, flowErr.LastErrors...)
+		updateErr := c.patchShootStatusOperationError(ctx, gardenClient.Client(), o, shoot, flowErr.Description, gardencorev1beta1.LastOperationTypeMigrate, flowErr.LastErrors...)
 		return reconcile.Result{}, utilerrors.WithSuppressed(errors.New(flowErr.Description), updateErr)
 	}
 

--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -31,8 +31,6 @@ import (
 	"github.com/gardener/gardener/pkg/utils/flow"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	retryutils "github.com/gardener/gardener/pkg/utils/retry"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // runReconcileShootFlow reconciles the Shoot cluster's state.
@@ -45,7 +43,7 @@ func (c *Controller) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		err             error
 	)
 
-	for _, lastError := range o.Shoot.Info.Status.LastErrors {
+	for _, lastError := range o.Shoot.GetInfo().Status.LastErrors {
 		if lastError.TaskID != nil {
 			tasksWithErrors = append(tasksWithErrors, *lastError.TaskID)
 		}
@@ -82,11 +80,11 @@ func (c *Controller) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		defaultInterval                = 5 * time.Second
 		dnsEnabled                     = !o.Shoot.DisableDNS
 		allowBackup                    = o.Seed.Info.Spec.Backup != nil
-		staticNodesCIDR                = o.Shoot.Info.Spec.Networking.Nodes != nil
+		staticNodesCIDR                = o.Shoot.GetInfo().Spec.Networking.Nodes != nil
 		useSNI                         = botanist.APIServerSNIEnabled()
-		generation                     = o.Shoot.Info.Generation
+		generation                     = o.Shoot.GetInfo().Generation
 		sniPhase                       = botanist.Shoot.Components.ControlPlane.KubeAPIServerSNIPhase
-		requestControlPlanePodsRestart = controllerutils.HasTask(o.Shoot.Info.Annotations, v1beta1constants.ShootTaskRestartControlPlanePods)
+		requestControlPlanePodsRestart = controllerutils.HasTask(o.Shoot.GetInfo().Annotations, v1beta1constants.ShootTaskRestartControlPlanePods)
 
 		g                      = flow.NewGraph("Shoot cluster reconciliation")
 		ensureShootStateExists = g.Add(flow.Task{
@@ -354,7 +352,7 @@ func (c *Controller) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 				if err := botanist.DeployManagedResourceForAddons(ctx); err != nil {
 					return err
 				}
-				if controllerutils.HasTask(o.Shoot.Info.Annotations, v1beta1constants.ShootTaskRestartCoreAddons) {
+				if controllerutils.HasTask(o.Shoot.GetInfo().Annotations, v1beta1constants.ShootTaskRestartCoreAddons) {
 					return removeTaskAnnotation(ctx, o, generation, v1beta1constants.ShootTaskRestartCoreAddons)
 				}
 				return nil
@@ -378,7 +376,7 @@ func (c *Controller) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		})
 		nginxLBReady = g.Add(flow.Task{
 			Name:         "Waiting until nginx ingress LoadBalancer is ready",
-			Fn:           flow.TaskFn(botanist.WaitUntilNginxIngressServiceIsReady).DoIf(gardencorev1beta1helper.NginxIngressEnabled(botanist.Shoot.Info.Spec.Addons)).SkipIf(o.Shoot.HibernationEnabled),
+			Fn:           flow.TaskFn(botanist.WaitUntilNginxIngressServiceIsReady).DoIf(gardencorev1beta1helper.NginxIngressEnabled(botanist.Shoot.GetInfo().Spec.Addons)).SkipIf(o.Shoot.HibernationEnabled),
 			Dependencies: flow.NewTaskIDs(deployManagedResourcesForAddons, initializeShootClients, waitUntilWorkerReady, ensureShootClusterIdentity),
 		})
 		deployIngressDomainDNSRecord = g.Add(flow.Task{
@@ -519,19 +517,19 @@ func (c *Controller) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		ErrorContext:     errorContext,
 		ErrorCleaner:     o.CleanShootTaskErrorAndUpdateStatusLabel,
 	}); err != nil {
-		o.Logger.Errorf("Failed to reconcile Shoot %q: %+v", o.Shoot.Info.Name, err)
+		o.Logger.Errorf("Failed to reconcile Shoot %q: %+v", o.Shoot.GetInfo().Name, err)
 		return gardencorev1beta1helper.NewWrappedLastErrors(gardencorev1beta1helper.FormatLastErrDescription(err), flow.Errors(err))
 	}
 
 	// ensure that shoot client is invalidated after it has been hibernated
 	if o.Shoot.HibernationEnabled {
-		if err := o.ClientMap.InvalidateClient(keys.ForShoot(o.Shoot.Info)); err != nil {
+		if err := o.ClientMap.InvalidateClient(keys.ForShoot(o.Shoot.GetInfo())); err != nil {
 			err = fmt.Errorf("failed to invalidate shoot client: %w", err)
 			return gardencorev1beta1helper.NewWrappedLastErrors(gardencorev1beta1helper.FormatLastErrDescription(err), err)
 		}
 	}
 
-	o.Logger.Infof("Successfully reconciled Shoot %q", o.Shoot.Info.Name)
+	o.Logger.Infof("Successfully reconciled Shoot %q", o.Shoot.GetInfo().Name)
 	return nil
 }
 
@@ -539,7 +537,7 @@ func removeTaskAnnotation(ctx context.Context, o *operation.Operation, generatio
 	// Check if shoot generation was changed mid-air, i.e., whether we need to wait for the next reconciliation until we
 	// can safely remove the task annotations to ensure all required tasks are executed.
 	shoot := &gardencorev1beta1.Shoot{}
-	if err := o.K8sGardenClient.APIReader().Get(ctx, kutil.Key(o.Shoot.Info.Namespace, o.Shoot.Info.Name), shoot); err != nil {
+	if err := o.K8sGardenClient.APIReader().Get(ctx, kutil.Key(o.Shoot.GetInfo().Namespace, o.Shoot.GetInfo().Name), shoot); err != nil {
 		return err
 	}
 
@@ -547,12 +545,8 @@ func removeTaskAnnotation(ctx context.Context, o *operation.Operation, generatio
 		return nil
 	}
 
-	shoot = o.Shoot.Info.DeepCopy()
-	patch := client.MergeFrom(shoot.DeepCopy())
-	controllerutils.RemoveTasks(shoot.Annotations, tasksToRemove...)
-	if err := o.K8sGardenClient.Client().Patch(ctx, shoot, patch); err != nil {
-		return err
-	}
-	o.Shoot.Info = shoot
-	return nil
+	return o.Shoot.UpdateInfo(ctx, o.K8sGardenClient.Client(), func(shoot *gardencorev1beta1.Shoot) error {
+		controllerutils.RemoveTasks(shoot.Annotations, tasksToRemove...)
+		return nil
+	})
 }

--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -547,7 +547,12 @@ func removeTaskAnnotation(ctx context.Context, o *operation.Operation, generatio
 		return nil
 	}
 
-	oldObj := o.Shoot.Info.DeepCopy()
-	controllerutils.RemoveTasks(o.Shoot.Info.Annotations, tasksToRemove...)
-	return o.K8sGardenClient.Client().Patch(ctx, o.Shoot.Info, client.MergeFrom(oldObj))
+	shoot = o.Shoot.Info.DeepCopy()
+	patch := client.MergeFrom(shoot.DeepCopy())
+	controllerutils.RemoveTasks(shoot.Annotations, tasksToRemove...)
+	if err := o.K8sGardenClient.Client().Patch(ctx, shoot, patch); err != nil {
+		return err
+	}
+	o.Shoot.Info = shoot
+	return nil
 }

--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -545,7 +545,7 @@ func removeTaskAnnotation(ctx context.Context, o *operation.Operation, generatio
 		return nil
 	}
 
-	return o.Shoot.UpdateInfo(ctx, o.K8sGardenClient.Client(), func(shoot *gardencorev1beta1.Shoot) error {
+	return o.Shoot.UpdateInfo(ctx, o.K8sGardenClient.Client(), false, func(shoot *gardencorev1beta1.Shoot) error {
 		controllerutils.RemoveTasks(shoot.Annotations, tasksToRemove...)
 		return nil
 	})

--- a/pkg/operation/botanist/addons_test.go
+++ b/pkg/operation/botanist/addons_test.go
@@ -196,7 +196,7 @@ var _ = Describe("addons", func() {
 		})
 
 		It("does nothing when nginx is disabled", func() {
-			b.Shoot.Info.Spec.Addons.NginxIngress.Enabled = false
+			b.Shoot.GetInfo().Spec.Addons.NginxIngress.Enabled = false
 
 			b.SetNginxIngressAddress(address, client)
 
@@ -338,7 +338,7 @@ var _ = Describe("addons", func() {
 
 			BeforeEach(func() {
 				b.ShootState = shootState
-				b.Shoot.Info.Status = gardencorev1beta1.ShootStatus{
+				b.Shoot.GetInfo().Status = gardencorev1beta1.ShootStatus{
 					LastOperation: &gardencorev1beta1.LastOperation{
 						Type: gardencorev1beta1.LastOperationTypeRestore,
 					},

--- a/pkg/operation/botanist/addons_test.go
+++ b/pkg/operation/botanist/addons_test.go
@@ -95,27 +95,6 @@ var _ = Describe("addons", func() {
 					},
 				},
 				Shoot: &shoot.Shoot{
-					Info: &gardencorev1beta1.Shoot{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      shootName,
-							Namespace: shootNamespace,
-						},
-						Spec: gardencorev1beta1.ShootSpec{
-							DNS: &gardencorev1beta1.DNS{
-								Domain: pointer.String(externalDomain),
-							},
-							Addons: &gardencorev1beta1.Addons{
-								NginxIngress: &gardencorev1beta1.NginxIngress{
-									Addon: gardencorev1beta1.Addon{
-										Enabled: true,
-									},
-								},
-							},
-						},
-						Status: gardencorev1beta1.ShootStatus{
-							ClusterIdentity: pointer.String("shoot-cluster-identity"),
-						},
-					},
 					SeedNamespace:         seedNamespace,
 					ExternalClusterDomain: pointer.String(externalDomain),
 					ExternalDomain: &garden.Domain{
@@ -137,6 +116,27 @@ var _ = Describe("addons", func() {
 				Logger: logrus.NewEntry(logger.NewNopLogger()),
 			},
 		}
+		b.Shoot.SetInfo(&gardencorev1beta1.Shoot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      shootName,
+				Namespace: shootNamespace,
+			},
+			Spec: gardencorev1beta1.ShootSpec{
+				DNS: &gardencorev1beta1.DNS{
+					Domain: pointer.String(externalDomain),
+				},
+				Addons: &gardencorev1beta1.Addons{
+					NginxIngress: &gardencorev1beta1.NginxIngress{
+						Addon: gardencorev1beta1.Addon{
+							Enabled: true,
+						},
+					},
+				},
+			},
+			Status: gardencorev1beta1.ShootStatus{
+				ClusterIdentity: pointer.String("shoot-cluster-identity"),
+			},
+		})
 
 		renderer := cr.NewWithServerVersion(&version.Info{})
 		mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{corev1.SchemeGroupVersion, dnsv1alpha1.SchemeGroupVersion})

--- a/pkg/operation/botanist/backupentry.go
+++ b/pkg/operation/botanist/backupentry.go
@@ -26,18 +26,18 @@ import (
 
 // DefaultCoreBackupEntry creates the default deployer for the core.gardener.cloud/v1beta1.BackupEntry resource.
 func (b *Botanist) DefaultCoreBackupEntry() component.DeployMigrateWaiter {
-	ownerRef := metav1.NewControllerRef(b.Shoot.Info, gardencorev1beta1.SchemeGroupVersion.WithKind("Shoot"))
+	ownerRef := metav1.NewControllerRef(b.Shoot.GetInfo(), gardencorev1beta1.SchemeGroupVersion.WithKind("Shoot"))
 	ownerRef.BlockOwnerDeletion = pointer.Bool(false)
 
 	return corebackupentry.New(
 		b.Logger,
 		b.K8sGardenClient.Client(),
 		&corebackupentry.Values{
-			Namespace:      b.Shoot.Info.Namespace,
+			Namespace:      b.Shoot.GetInfo().Namespace,
 			Name:           b.Shoot.BackupEntryName,
-			ShootPurpose:   b.Shoot.Info.Spec.Purpose,
+			ShootPurpose:   b.Shoot.GetInfo().Spec.Purpose,
 			OwnerReference: ownerRef,
-			SeedName:       b.Shoot.Info.Spec.SeedName,
+			SeedName:       b.Shoot.GetInfo().Spec.SeedName,
 			BucketName:     string(b.Seed.Info.UID),
 		},
 		corebackupentry.DefaultInterval,

--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -25,7 +25,6 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	"github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/pkg/features"
 	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 	"github.com/gardener/gardener/pkg/operation"
@@ -213,25 +212,5 @@ func (b *Botanist) RequiredExtensionsReady(ctx context.Context) error {
 		return fmt.Errorf("extension controllers missing or unready: %+v", requiredExtensions)
 	}
 
-	return nil
-}
-
-// UpdateShootAndCluster updates the given `core.gardener.cloud/v1beta1.Shoot` resource in the garden cluster after
-// applying the given transform function to it. It will also update the `shoot` field in the
-// extensions.gardener.cloud/v1alpha1.Cluster` resource in the seed cluster with the updated shoot information.
-func (b *Botanist) UpdateShootAndCluster(ctx context.Context, shoot *gardencorev1beta1.Shoot, transform func() error) error {
-	shootPatch := client.StrategicMergeFrom(shoot.DeepCopy())
-	if err := transform(); err != nil {
-		return err
-	}
-	if err := b.K8sGardenClient.Client().Patch(ctx, shoot, shootPatch); err != nil {
-		return err
-	}
-
-	if err := extensions.SyncClusterResourceToSeed(ctx, b.K8sSeedClient.Client(), b.Shoot.SeedNamespace, shoot, nil, nil); err != nil {
-		return err
-	}
-
-	b.Shoot.Info = shoot
 	return nil
 }

--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -50,7 +50,7 @@ func New(ctx context.Context, o *operation.Operation) (*Botanist, error) {
 	)
 
 	// Determine all default domain secrets and check whether the used Shoot domain matches a default domain.
-	if o.Shoot != nil && o.Shoot.Info.Spec.DNS != nil && o.Shoot.Info.Spec.DNS.Domain != nil {
+	if o.Shoot != nil && o.Shoot.GetInfo().Spec.DNS != nil && o.Shoot.GetInfo().Spec.DNS.Domain != nil {
 		var (
 			prefix            = fmt.Sprintf("%s-", v1beta1constants.GardenRoleDefaultDomain)
 			defaultDomainKeys = o.GetSecretKeysOfRole(v1beta1constants.GardenRoleDefaultDomain)
@@ -58,7 +58,7 @@ func New(ctx context.Context, o *operation.Operation) (*Botanist, error) {
 		sort.Slice(defaultDomainKeys, func(i, j int) bool { return len(defaultDomainKeys[i]) >= len(defaultDomainKeys[j]) })
 		for _, key := range defaultDomainKeys {
 			defaultDomain := strings.SplitAfter(key, prefix)[1]
-			if strings.HasSuffix(*(o.Shoot.Info.Spec.DNS.Domain), defaultDomain) {
+			if strings.HasSuffix(*(o.Shoot.GetInfo().Spec.DNS.Domain), defaultDomain) {
 				b.DefaultDomainSecret = b.Secrets[prefix+defaultDomain]
 				break
 			}
@@ -182,7 +182,7 @@ func (b *Botanist) RequiredExtensionsReady(ctx context.Context) error {
 		return err
 	}
 
-	requiredExtensions := shootpkg.ComputeRequiredExtensions(b.Shoot.Info, b.Seed.Info, controllerRegistrationList, b.Garden.InternalDomain, b.Shoot.ExternalDomain,
+	requiredExtensions := shootpkg.ComputeRequiredExtensions(b.Shoot.GetInfo(), b.Seed.Info, controllerRegistrationList, b.Garden.InternalDomain, b.Shoot.ExternalDomain,
 		gardenletfeatures.FeatureGate.Enabled(features.UseDNSRecords))
 
 	for _, controllerInstallation := range controllerInstallationList.Items {

--- a/pkg/operation/botanist/cleanup.go
+++ b/pkg/operation/botanist/cleanup.go
@@ -174,7 +174,7 @@ func cleanResourceFn(cleanOps utilclient.CleanOps, c client.Client, list client.
 func (b *Botanist) CleanWebhooks(ctx context.Context) error {
 	var (
 		c       = b.K8sShootClient.Client()
-		ensurer = utilclient.GoneBeforeEnsurer(b.Shoot.Info.GetDeletionTimestamp().Time)
+		ensurer = utilclient.GoneBeforeEnsurer(b.Shoot.GetInfo().GetDeletionTimestamp().Time)
 		ops     = utilclient.NewCleanOps(utilclient.DefaultCleaner(), ensurer)
 	)
 
@@ -193,7 +193,7 @@ func (b *Botanist) CleanWebhooks(ctx context.Context) error {
 func (b *Botanist) CleanExtendedAPIs(ctx context.Context) error {
 	var (
 		c           = b.K8sShootClient.Client()
-		ensurer     = utilclient.GoneBeforeEnsurer(b.Shoot.Info.GetDeletionTimestamp().Time)
+		ensurer     = utilclient.GoneBeforeEnsurer(b.Shoot.GetInfo().GetDeletionTimestamp().Time)
 		defaultOps  = utilclient.NewCleanOps(utilclient.DefaultCleaner(), ensurer)
 		crdCleanOps = utilclient.NewCleanOps(utilclient.DefaultCleaner(), ensurer)
 	)
@@ -216,7 +216,7 @@ func (b *Botanist) CleanExtendedAPIs(ctx context.Context) error {
 func (b *Botanist) CleanKubernetesResources(ctx context.Context) error {
 	var (
 		c       = b.K8sShootClient.Client()
-		ensurer = utilclient.GoneBeforeEnsurer(b.Shoot.Info.GetDeletionTimestamp().Time)
+		ensurer = utilclient.GoneBeforeEnsurer(b.Shoot.GetInfo().GetDeletionTimestamp().Time)
 		ops     = utilclient.NewCleanOps(utilclient.DefaultCleaner(), ensurer)
 	)
 
@@ -225,7 +225,7 @@ func (b *Botanist) CleanKubernetesResources(ctx context.Context) error {
 		return err
 	}
 
-	if metav1.HasAnnotation(b.Shoot.Info.ObjectMeta, v1beta1constants.AnnotationShootSkipCleanup) {
+	if metav1.HasAnnotation(b.Shoot.GetInfo().ObjectMeta, v1beta1constants.AnnotationShootSkipCleanup) {
 		return flow.Parallel(
 			cleanResourceFn(ops, c, &corev1.ServiceList{}, ServiceCleanOption, cleanOptions),
 			cleanResourceFn(ops, c, &corev1.PersistentVolumeClaimList{}, PersistentVolumeClaimCleanOption, cleanOptions),
@@ -284,7 +284,7 @@ func (b *Botanist) getCleanOptions(
 		finalizeAfter      = defaultFinalizeAfter
 	)
 
-	if v, ok := b.Shoot.Info.Annotations[annotationKey]; ok {
+	if v, ok := b.Shoot.GetInfo().Annotations[annotationKey]; ok {
 		seconds, err := strconv.Atoi(v)
 		if err != nil {
 			return nil, err

--- a/pkg/operation/botanist/clusterautoscaler.go
+++ b/pkg/operation/botanist/clusterautoscaler.go
@@ -35,7 +35,7 @@ func (b *Botanist) DefaultClusterAutoscaler() (clusterautoscaler.Interface, erro
 		b.Shoot.SeedNamespace,
 		image.String(),
 		b.Shoot.GetReplicas(1),
-		b.Shoot.Info.Spec.Kubernetes.ClusterAutoscaler,
+		b.Shoot.GetInfo().Spec.Kubernetes.ClusterAutoscaler,
 	), nil
 }
 

--- a/pkg/operation/botanist/clusterautoscaler_test.go
+++ b/pkg/operation/botanist/clusterautoscaler_test.go
@@ -61,7 +61,8 @@ var _ = Describe("ClusterAutoscaler", func() {
 			kubernetesClient.EXPECT().Version()
 
 			botanist.K8sSeedClient = kubernetesClient
-			botanist.Shoot = &shootpkg.Shoot{Info: &gardencorev1beta1.Shoot{}}
+			botanist.Shoot = &shootpkg.Shoot{}
+			botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{})
 		})
 
 		It("should successfully create a cluster-autoscaler interface", func() {

--- a/pkg/operation/botanist/clusteridentity.go
+++ b/pkg/operation/botanist/clusteridentity.go
@@ -18,27 +18,25 @@ import (
 	"context"
 	"fmt"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/clusteridentity"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // EnsureShootClusterIdentity ensures that Shoot's `status.clusterIdentity` field is set and updates the Cluster resource in
 // the seed if necessary.
 func (b *Botanist) EnsureShootClusterIdentity(ctx context.Context) error {
-	if b.Shoot.Info.Status.ClusterIdentity == nil {
-		clusterIdentity := fmt.Sprintf("%s-%s-%s", b.Shoot.SeedNamespace, b.Shoot.Info.Status.UID, b.GardenClusterIdentity)
+	if b.Shoot.GetInfo().Status.ClusterIdentity == nil {
+		clusterIdentity := fmt.Sprintf("%s-%s-%s", b.Shoot.SeedNamespace, b.Shoot.GetInfo().Status.UID, b.GardenClusterIdentity)
 
-		shoot := b.Shoot.Info.DeepCopy()
-		patch := client.MergeFrom(shoot.DeepCopy())
-		shoot.Status.ClusterIdentity = &clusterIdentity
-		if err := b.K8sGardenClient.Client().Status().Patch(ctx, shoot, patch); err != nil {
+		if err := b.Shoot.UpdateInfoStatus(ctx, b.K8sGardenClient.Client(), func(shoot *gardencorev1beta1.Shoot) error {
+			shoot.Status.ClusterIdentity = &clusterIdentity
+			return nil
+		}); err != nil {
 			return err
 		}
-		b.Shoot.Info = shoot
 
-		if err := extensions.SyncClusterResourceToSeed(ctx, b.K8sSeedClient.Client(), b.Shoot.SeedNamespace, b.Shoot.Info, nil, nil); err != nil {
+		if err := extensions.SyncClusterResourceToSeed(ctx, b.K8sSeedClient.Client(), b.Shoot.SeedNamespace, b.Shoot.GetInfo(), nil, nil); err != nil {
 			return err
 		}
 	}
@@ -53,7 +51,7 @@ func (b *Botanist) DefaultClusterIdentity() clusteridentity.Interface {
 
 // DeployClusterIdentity deploys the shoot's cluster-identity.
 func (b *Botanist) DeployClusterIdentity(ctx context.Context) error {
-	if v := b.Shoot.Info.Status.ClusterIdentity; v != nil {
+	if v := b.Shoot.GetInfo().Status.ClusterIdentity; v != nil {
 		b.Shoot.Components.SystemComponents.ClusterIdentity.SetIdentity(*v)
 	}
 

--- a/pkg/operation/botanist/clusteridentity.go
+++ b/pkg/operation/botanist/clusteridentity.go
@@ -29,7 +29,7 @@ func (b *Botanist) EnsureShootClusterIdentity(ctx context.Context) error {
 	if b.Shoot.GetInfo().Status.ClusterIdentity == nil {
 		clusterIdentity := fmt.Sprintf("%s-%s-%s", b.Shoot.SeedNamespace, b.Shoot.GetInfo().Status.UID, b.GardenClusterIdentity)
 
-		if err := b.Shoot.UpdateInfoStatus(ctx, b.K8sGardenClient.Client(), func(shoot *gardencorev1beta1.Shoot) error {
+		if err := b.Shoot.UpdateInfoStatus(ctx, b.K8sGardenClient.Client(), false, func(shoot *gardencorev1beta1.Shoot) error {
 			shoot.Status.ClusterIdentity = &clusterIdentity
 			return nil
 		}); err != nil {

--- a/pkg/operation/botanist/clusteridentity.go
+++ b/pkg/operation/botanist/clusteridentity.go
@@ -30,12 +30,13 @@ func (b *Botanist) EnsureShootClusterIdentity(ctx context.Context) error {
 	if b.Shoot.Info.Status.ClusterIdentity == nil {
 		clusterIdentity := fmt.Sprintf("%s-%s-%s", b.Shoot.SeedNamespace, b.Shoot.Info.Status.UID, b.GardenClusterIdentity)
 
-		patch := client.MergeFrom(b.Shoot.Info.DeepCopy())
-		b.Shoot.Info.Status.ClusterIdentity = &clusterIdentity
-
-		if err := b.K8sGardenClient.Client().Status().Patch(ctx, b.Shoot.Info, patch); err != nil {
+		shoot := b.Shoot.Info.DeepCopy()
+		patch := client.MergeFrom(shoot.DeepCopy())
+		shoot.Status.ClusterIdentity = &clusterIdentity
+		if err := b.K8sGardenClient.Client().Status().Patch(ctx, shoot, patch); err != nil {
 			return err
 		}
+		b.Shoot.Info = shoot
 
 		if err := extensions.SyncClusterResourceToSeed(ctx, b.K8sSeedClient.Client(), b.Shoot.SeedNamespace, b.Shoot.Info, nil, nil); err != nil {
 			return err

--- a/pkg/operation/botanist/clusteridentity_test.go
+++ b/pkg/operation/botanist/clusteridentity_test.go
@@ -108,7 +108,6 @@ var _ = Describe("ClusterIdentity", func() {
 				K8sGardenClient: gardenInterface,
 				K8sSeedClient:   seedInterface,
 				Shoot: &shootpkg.Shoot{
-					Info:          shoot,
 					SeedNamespace: shootSeedNamespace,
 					Components: &shootpkg.Components{
 						SystemComponents: &shootpkg.SystemComponents{
@@ -119,6 +118,7 @@ var _ = Describe("ClusterIdentity", func() {
 				GardenClusterIdentity: gardenClusterIdentity,
 			},
 		}
+		botanist.Shoot.SetInfo(shoot)
 	})
 
 	AfterEach(func() {

--- a/pkg/operation/botanist/clusteridentity_test.go
+++ b/pkg/operation/botanist/clusteridentity_test.go
@@ -146,7 +146,7 @@ var _ = Describe("ClusterIdentity", func() {
 
 	Describe("#DeployClusterIdentity", func() {
 		BeforeEach(func() {
-			botanist.Shoot.Info.Status.ClusterIdentity = &expectedShootClusterIdentity
+			botanist.Shoot.GetInfo().Status.ClusterIdentity = &expectedShootClusterIdentity
 			clusterIdentity.EXPECT().SetIdentity(expectedShootClusterIdentity)
 		})
 

--- a/pkg/operation/botanist/containerruntime.go
+++ b/pkg/operation/botanist/containerruntime.go
@@ -27,7 +27,7 @@ func (b *Botanist) DefaultContainerRuntime() containerruntime.Interface {
 		b.K8sSeedClient.Client(),
 		&containerruntime.Values{
 			Namespace: b.Shoot.SeedNamespace,
-			Workers:   b.Shoot.Info.Spec.Provider.Workers,
+			Workers:   b.Shoot.GetInfo().Spec.Provider.Workers,
 		},
 		containerruntime.DefaultInterval,
 		containerruntime.DefaultSevereThreshold,

--- a/pkg/operation/botanist/containerruntime_test.go
+++ b/pkg/operation/botanist/containerruntime_test.go
@@ -54,6 +54,7 @@ var _ = Describe("ContainerRuntime", func() {
 			},
 			ShootState: shootState,
 		}}
+		botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{})
 	})
 
 	AfterEach(func() {

--- a/pkg/operation/botanist/containerruntime_test.go
+++ b/pkg/operation/botanist/containerruntime_test.go
@@ -75,13 +75,13 @@ var _ = Describe("ContainerRuntime", func() {
 
 		Context("restore", func() {
 			BeforeEach(func() {
-				botanist.Shoot.Info = &gardencorev1beta1.Shoot{
+				botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
 					Status: gardencorev1beta1.ShootStatus{
 						LastOperation: &gardencorev1beta1.LastOperation{
 							Type: gardencorev1beta1.LastOperationTypeRestore,
 						},
 					},
-				}
+				})
 			})
 
 			It("should restore successfully", func() {

--- a/pkg/operation/botanist/controlplane_test.go
+++ b/pkg/operation/botanist/controlplane_test.go
@@ -72,6 +72,7 @@ var _ = Describe("controlplane", func() {
 				},
 			},
 		}
+		botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{})
 	})
 
 	AfterEach(func() {

--- a/pkg/operation/botanist/controlplane_test.go
+++ b/pkg/operation/botanist/controlplane_test.go
@@ -135,13 +135,13 @@ var _ = Describe("controlplane", func() {
 
 			BeforeEach(func() {
 				botanist.ShootState = shootState
-				botanist.Shoot.Info = &gardencorev1beta1.Shoot{
+				botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
 					Status: gardencorev1beta1.ShootStatus{
 						LastOperation: &gardencorev1beta1.LastOperation{
 							Type: gardencorev1beta1.LastOperationTypeRestore,
 						},
 					},
-				}
+				})
 			})
 
 			It("should restore successfully", func() {
@@ -174,13 +174,13 @@ var _ = Describe("controlplane", func() {
 
 			BeforeEach(func() {
 				botanist.ShootState = shootState
-				botanist.Shoot.Info = &gardencorev1beta1.Shoot{
+				botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
 					Status: gardencorev1beta1.ShootStatus{
 						LastOperation: &gardencorev1beta1.LastOperation{
 							Type: gardencorev1beta1.LastOperationTypeRestore,
 						},
 					},
-				}
+				})
 			})
 
 			It("should restore successfully", func() {

--- a/pkg/operation/botanist/dns.go
+++ b/pkg/operation/botanist/dns.go
@@ -230,7 +230,7 @@ func (b *Botanist) AdditionalDNSProviders(ctx context.Context) (map[string]compo
 	additionalProviders := map[string]component.DeployWaiter{}
 
 	if b.NeedsAdditionalDNSProviders() {
-		for i, provider := range b.Shoot.Info.Spec.DNS.Providers {
+		for i, provider := range b.Shoot.GetInfo().Spec.DNS.Providers {
 			p := provider
 			if p.Primary != nil && *p.Primary {
 				continue
@@ -265,7 +265,7 @@ func (b *Botanist) AdditionalDNSProviders(ctx context.Context) (map[string]compo
 			secret := &corev1.Secret{}
 			if err := b.K8sGardenClient.Client().Get(
 				ctx,
-				kutil.Key(b.Shoot.Info.Namespace, *secretName),
+				kutil.Key(b.Shoot.GetInfo().Namespace, *secretName),
 				secret,
 			); err != nil {
 				return nil, fmt.Errorf("could not get dns provider secret %q: %+v", *secretName, err)
@@ -328,8 +328,8 @@ func (b *Botanist) AdditionalDNSProviders(ctx context.Context) (map[string]compo
 // NeedsExternalDNS returns true if the Shoot cluster needs external DNS.
 func (b *Botanist) NeedsExternalDNS() bool {
 	return !b.Shoot.DisableDNS &&
-		b.Shoot.Info.Spec.DNS != nil &&
-		b.Shoot.Info.Spec.DNS.Domain != nil &&
+		b.Shoot.GetInfo().Spec.DNS != nil &&
+		b.Shoot.GetInfo().Spec.DNS.Domain != nil &&
 		b.Shoot.ExternalClusterDomain != nil &&
 		!strings.HasSuffix(*b.Shoot.ExternalClusterDomain, ".nip.io") &&
 		b.Shoot.ExternalDomain != nil &&
@@ -347,8 +347,8 @@ func (b *Botanist) NeedsInternalDNS() bool {
 // are needed.
 func (b *Botanist) NeedsAdditionalDNSProviders() bool {
 	return !b.Shoot.DisableDNS &&
-		b.Shoot.Info.Spec.DNS != nil &&
-		len(b.Shoot.Info.Spec.DNS.Providers) > 0
+		b.Shoot.GetInfo().Spec.DNS != nil &&
+		len(b.Shoot.GetInfo().Spec.DNS.Providers) > 0
 }
 
 // APIServerSNIPodMutatorEnabled returns false if the value of the Shoot annotation
@@ -360,7 +360,7 @@ func (b *Botanist) APIServerSNIPodMutatorEnabled() bool {
 		return false
 	}
 
-	vs, ok := b.Shoot.Info.GetAnnotations()[v1beta1constants.AnnotationShootAPIServerSNIPodInjector]
+	vs, ok := b.Shoot.GetInfo().GetAnnotations()[v1beta1constants.AnnotationShootAPIServerSNIPodInjector]
 	if !ok {
 		return true
 	}
@@ -506,7 +506,7 @@ func (d dnsRestoreDeployer) Destroy(_ context.Context) error { return nil }
 
 func (b *Botanist) newDNSComponentsTargetingAPIServerAddress() {
 	if b.NeedsInternalDNS() {
-		ownerID := *b.Shoot.Info.Status.ClusterIdentity + "-" + DNSInternalName
+		ownerID := *b.Shoot.GetInfo().Status.ClusterIdentity + "-" + DNSInternalName
 
 		b.Shoot.Components.Extensions.DNS.InternalOwner = dns.NewOwner(
 			b.K8sSeedClient.Client(),
@@ -535,7 +535,7 @@ func (b *Botanist) newDNSComponentsTargetingAPIServerAddress() {
 	}
 
 	if b.NeedsExternalDNS() {
-		ownerID := *b.Shoot.Info.Status.ClusterIdentity + "-" + DNSExternalName
+		ownerID := *b.Shoot.GetInfo().Status.ClusterIdentity + "-" + DNSExternalName
 
 		b.Shoot.Components.Extensions.DNS.ExternalOwner = dns.NewOwner(
 			b.K8sSeedClient.Client(),

--- a/pkg/operation/botanist/dns_test.go
+++ b/pkg/operation/botanist/dns_test.go
@@ -78,9 +78,6 @@ var _ = Describe("dns", func() {
 					},
 				},
 				Shoot: &shootpkg.Shoot{
-					Info: &gardencorev1beta1.Shoot{
-						ObjectMeta: metav1.ObjectMeta{Namespace: shootNS},
-					},
 					Components: &shootpkg.Components{
 						Extensions: &shootpkg.Extensions{
 							DNS: &shootpkg.DNS{},
@@ -92,6 +89,9 @@ var _ = Describe("dns", func() {
 				Logger: logrus.NewEntry(logger.NewNopLogger()),
 			},
 		}
+		b.Shoot.SetInfo(&gardencorev1beta1.Shoot{
+			ObjectMeta: metav1.ObjectMeta{Namespace: shootNS},
+		})
 
 		s = runtime.NewScheme()
 		Expect(dnsv1alpha1.AddToScheme(s)).NotTo(HaveOccurred())

--- a/pkg/operation/botanist/dns_test.go
+++ b/pkg/operation/botanist/dns_test.go
@@ -116,7 +116,7 @@ var _ = Describe("dns", func() {
 	Context("DefaultExternalDNSProvider", func() {
 		It("should create when calling Deploy and dns is enabled", func() {
 			b.Shoot.DisableDNS = false
-			b.Shoot.Info.Spec.DNS = &gardencorev1beta1.DNS{Domain: pointer.String("foo")}
+			b.Shoot.GetInfo().Spec.DNS = &gardencorev1beta1.DNS{Domain: pointer.String("foo")}
 			b.Shoot.ExternalClusterDomain = pointer.String("baz")
 			b.Shoot.ExternalDomain = &garden.Domain{Provider: "valid-provider"}
 
@@ -314,7 +314,7 @@ var _ = Describe("dns", func() {
 
 		It("should return error when provider is without Type", func() {
 			b.Shoot.DisableDNS = false
-			b.Shoot.Info.Spec.DNS = &gardencorev1beta1.DNS{
+			b.Shoot.GetInfo().Spec.DNS = &gardencorev1beta1.DNS{
 				Providers: []gardencorev1beta1.DNSProvider{{}},
 			}
 
@@ -325,7 +325,7 @@ var _ = Describe("dns", func() {
 
 		It("should return error when provider is without secretName", func() {
 			b.Shoot.DisableDNS = false
-			b.Shoot.Info.Spec.DNS = &gardencorev1beta1.DNS{
+			b.Shoot.GetInfo().Spec.DNS = &gardencorev1beta1.DNS{
 				Providers: []gardencorev1beta1.DNSProvider{{
 					Type: pointer.String("foo"),
 				}},
@@ -338,7 +338,7 @@ var _ = Describe("dns", func() {
 
 		It("should return error when provider is without secret", func() {
 			b.Shoot.DisableDNS = false
-			b.Shoot.Info.Spec.DNS = &gardencorev1beta1.DNS{
+			b.Shoot.GetInfo().Spec.DNS = &gardencorev1beta1.DNS{
 				Providers: []gardencorev1beta1.DNSProvider{{
 					Type:       pointer.String("foo"),
 					SecretName: pointer.String("not-existing-secret"),
@@ -352,7 +352,7 @@ var _ = Describe("dns", func() {
 
 		It("should add providers", func() {
 			b.Shoot.DisableDNS = false
-			b.Shoot.Info.Spec.DNS = &gardencorev1beta1.DNS{
+			b.Shoot.GetInfo().Spec.DNS = &gardencorev1beta1.DNS{
 				Providers: []gardencorev1beta1.DNSProvider{
 					{
 						Type:    pointer.String("primary-skip"),
@@ -452,33 +452,33 @@ var _ = Describe("dns", func() {
 
 		It("should be false when Shoot's DNS is nil", func() {
 			b.Shoot.DisableDNS = false
-			b.Shoot.Info.Spec.DNS = nil
+			b.Shoot.GetInfo().Spec.DNS = nil
 			Expect(b.NeedsExternalDNS()).To(BeFalse())
 		})
 
 		It("should be false when Shoot DNS's domain is nil", func() {
 			b.Shoot.DisableDNS = false
-			b.Shoot.Info.Spec.DNS = &gardencorev1beta1.DNS{Domain: nil}
+			b.Shoot.GetInfo().Spec.DNS = &gardencorev1beta1.DNS{Domain: nil}
 			Expect(b.NeedsExternalDNS()).To(BeFalse())
 		})
 
 		It("should be false when Shoot ExternalClusterDomain is nil", func() {
 			b.Shoot.DisableDNS = false
-			b.Shoot.Info.Spec.DNS = &gardencorev1beta1.DNS{Domain: pointer.String("foo")}
+			b.Shoot.GetInfo().Spec.DNS = &gardencorev1beta1.DNS{Domain: pointer.String("foo")}
 			b.Shoot.ExternalClusterDomain = nil
 			Expect(b.NeedsExternalDNS()).To(BeFalse())
 		})
 
 		It("should be false when Shoot ExternalClusterDomain is in nip.io", func() {
 			b.Shoot.DisableDNS = false
-			b.Shoot.Info.Spec.DNS = &gardencorev1beta1.DNS{Domain: pointer.String("foo")}
+			b.Shoot.GetInfo().Spec.DNS = &gardencorev1beta1.DNS{Domain: pointer.String("foo")}
 			b.Shoot.ExternalClusterDomain = pointer.String("foo.nip.io")
 			Expect(b.NeedsExternalDNS()).To(BeFalse())
 		})
 
 		It("should be false when Shoot ExternalDomain is nil", func() {
 			b.Shoot.DisableDNS = false
-			b.Shoot.Info.Spec.DNS = &gardencorev1beta1.DNS{Domain: pointer.String("foo")}
+			b.Shoot.GetInfo().Spec.DNS = &gardencorev1beta1.DNS{Domain: pointer.String("foo")}
 			b.Shoot.ExternalClusterDomain = pointer.String("baz")
 			b.Shoot.ExternalDomain = nil
 
@@ -487,7 +487,7 @@ var _ = Describe("dns", func() {
 
 		It("should be false when Shoot ExternalDomain provider is unamanaged", func() {
 			b.Shoot.DisableDNS = false
-			b.Shoot.Info.Spec.DNS = &gardencorev1beta1.DNS{Domain: pointer.String("foo")}
+			b.Shoot.GetInfo().Spec.DNS = &gardencorev1beta1.DNS{Domain: pointer.String("foo")}
 			b.Shoot.ExternalClusterDomain = pointer.String("baz")
 			b.Shoot.ExternalDomain = &garden.Domain{Provider: "unmanaged"}
 
@@ -496,7 +496,7 @@ var _ = Describe("dns", func() {
 
 		It("should be true when Shoot ExternalDomain provider is valid", func() {
 			b.Shoot.DisableDNS = false
-			b.Shoot.Info.Spec.DNS = &gardencorev1beta1.DNS{Domain: pointer.String("foo")}
+			b.Shoot.GetInfo().Spec.DNS = &gardencorev1beta1.DNS{Domain: pointer.String("foo")}
 			b.Shoot.ExternalClusterDomain = pointer.String("baz")
 			b.Shoot.ExternalDomain = &garden.Domain{Provider: "valid-provider"}
 
@@ -537,19 +537,19 @@ var _ = Describe("dns", func() {
 
 		It("should be false when Shoot's DNS is nil", func() {
 			b.Shoot.DisableDNS = false
-			b.Shoot.Info.Spec.DNS = nil
+			b.Shoot.GetInfo().Spec.DNS = nil
 			Expect(b.NeedsAdditionalDNSProviders()).To(BeFalse())
 		})
 
 		It("should be false when there are no Shoot DNS Providers", func() {
 			b.Shoot.DisableDNS = false
-			b.Shoot.Info.Spec.DNS = &gardencorev1beta1.DNS{}
+			b.Shoot.GetInfo().Spec.DNS = &gardencorev1beta1.DNS{}
 			Expect(b.NeedsAdditionalDNSProviders()).To(BeFalse())
 		})
 
 		It("should be true when there are Shoot DNS Providers", func() {
 			b.Shoot.DisableDNS = false
-			b.Shoot.Info.Spec.DNS = &gardencorev1beta1.DNS{
+			b.Shoot.GetInfo().Spec.DNS = &gardencorev1beta1.DNS{
 				Providers: []gardencorev1beta1.DNSProvider{
 					{Type: pointer.String("foo")},
 					{Type: pointer.String("bar")},
@@ -573,7 +573,7 @@ var _ = Describe("dns", func() {
 		It("returns true when feature gate is enabled", func() {
 			Expect(gardenletfeatures.FeatureGate.Set("APIServerSNI=true")).ToNot(HaveOccurred())
 			b.Garden.InternalDomain = &garden.Domain{Provider: "some-provider"}
-			b.Shoot.Info.Spec.DNS = &gardencorev1beta1.DNS{Domain: pointer.String("foo")}
+			b.Shoot.GetInfo().Spec.DNS = &gardencorev1beta1.DNS{Domain: pointer.String("foo")}
 			b.Shoot.ExternalClusterDomain = pointer.String("baz")
 			b.Shoot.ExternalDomain = &garden.Domain{Provider: "valid-provider"}
 
@@ -596,25 +596,25 @@ var _ = Describe("dns", func() {
 			BeforeEach(func() {
 				Expect(gardenletfeatures.FeatureGate.Set("APIServerSNI=true")).ToNot(HaveOccurred())
 				b.Garden.InternalDomain = &garden.Domain{Provider: "some-provider"}
-				b.Shoot.Info.Spec.DNS = &gardencorev1beta1.DNS{Domain: pointer.String("foo")}
+				b.Shoot.GetInfo().Spec.DNS = &gardencorev1beta1.DNS{Domain: pointer.String("foo")}
 				b.Shoot.ExternalClusterDomain = pointer.String("baz")
 				b.Shoot.ExternalDomain = &garden.Domain{Provider: "valid-provider"}
 			})
 
 			It("returns true when Shoot annotations are nil", func() {
-				b.Shoot.Info.Annotations = nil
+				b.Shoot.GetInfo().Annotations = nil
 
 				Expect(b.APIServerSNIPodMutatorEnabled()).To(BeTrue())
 			})
 
 			It("returns true when Shoot annotations does not have the annotation", func() {
-				b.Shoot.Info.Annotations = map[string]string{"foo": "bar"}
+				b.Shoot.GetInfo().Annotations = map[string]string{"foo": "bar"}
 
 				Expect(b.APIServerSNIPodMutatorEnabled()).To(BeTrue())
 			})
 
 			It("returns true when Shoot annotations exist, but it's not a 'disable", func() {
-				b.Shoot.Info.Annotations = map[string]string{
+				b.Shoot.GetInfo().Annotations = map[string]string{
 					"alpha.featuregates.shoot.gardener.cloud/apiserver-sni-pod-injector": "not-disable",
 				}
 
@@ -622,7 +622,7 @@ var _ = Describe("dns", func() {
 			})
 
 			It("returns false when Shoot annotations exist and it's a disable", func() {
-				b.Shoot.Info.Annotations = map[string]string{
+				b.Shoot.GetInfo().Annotations = map[string]string{
 					"alpha.featuregates.shoot.gardener.cloud/apiserver-sni-pod-injector": "disable",
 				}
 
@@ -664,9 +664,9 @@ var _ = Describe("dns", func() {
 		})
 
 		It("sets owners and entries which create DNSOwner and DNSEntry", func() {
-			b.Shoot.Info.Status.ClusterIdentity = pointer.String("shoot-cluster-identity")
+			b.Shoot.GetInfo().Status.ClusterIdentity = pointer.String("shoot-cluster-identity")
 			b.Shoot.DisableDNS = false
-			b.Shoot.Info.Spec.DNS = &gardencorev1beta1.DNS{Domain: pointer.String("foo")}
+			b.Shoot.GetInfo().Spec.DNS = &gardencorev1beta1.DNS{Domain: pointer.String("foo")}
 			b.Shoot.InternalClusterDomain = "bar"
 			b.Shoot.ExternalClusterDomain = pointer.String("baz")
 			b.Shoot.ExternalDomain = &garden.Domain{Provider: "valid-provider"}

--- a/pkg/operation/botanist/dnsrecord.go
+++ b/pkg/operation/botanist/dnsrecord.go
@@ -25,8 +25,8 @@ import (
 // DefaultExternalDNSRecord creates the default deployer for the external DNSRecord resource.
 func (b *Botanist) DefaultExternalDNSRecord() extensionsdnsrecord.Interface {
 	values := &extensionsdnsrecord.Values{
-		Name:       b.Shoot.Info.Name + "-" + DNSExternalName,
-		SecretName: b.Shoot.Info.Name + "-" + DNSExternalName,
+		Name:       b.Shoot.GetInfo().Name + "-" + DNSExternalName,
+		SecretName: b.Shoot.GetInfo().Name + "-" + DNSExternalName,
 		Namespace:  b.Shoot.SeedNamespace,
 		TTL:        b.Config.Controllers.Shoot.DNSEntryTTLSeconds,
 	}
@@ -51,8 +51,8 @@ func (b *Botanist) DefaultExternalDNSRecord() extensionsdnsrecord.Interface {
 // DefaultInternalDNSRecord creates the default deployer for the internal DNSRecord resource.
 func (b *Botanist) DefaultInternalDNSRecord() extensionsdnsrecord.Interface {
 	values := &extensionsdnsrecord.Values{
-		Name:       b.Shoot.Info.Name + "-" + DNSInternalName,
-		SecretName: b.Shoot.Info.Name + "-" + DNSInternalName,
+		Name:       b.Shoot.GetInfo().Name + "-" + DNSInternalName,
+		SecretName: b.Shoot.GetInfo().Name + "-" + DNSInternalName,
 		Namespace:  b.Shoot.SeedNamespace,
 		TTL:        b.Config.Controllers.Shoot.DNSEntryTTLSeconds,
 	}

--- a/pkg/operation/botanist/dnsrecord_test.go
+++ b/pkg/operation/botanist/dnsrecord_test.go
@@ -313,7 +313,7 @@ var _ = Describe("dnsrecord", func() {
 
 			BeforeEach(func() {
 				b.ShootState = shootState
-				b.Shoot.Info.Status = gardencorev1beta1.ShootStatus{
+				b.Shoot.GetInfo().Status = gardencorev1beta1.ShootStatus{
 					LastOperation: &gardencorev1beta1.LastOperation{
 						Type: gardencorev1beta1.LastOperationTypeRestore,
 					},
@@ -369,7 +369,7 @@ var _ = Describe("dnsrecord", func() {
 
 			BeforeEach(func() {
 				b.ShootState = shootState
-				b.Shoot.Info.Status = gardencorev1beta1.ShootStatus{
+				b.Shoot.GetInfo().Status = gardencorev1beta1.ShootStatus{
 					LastOperation: &gardencorev1beta1.LastOperation{
 						Type: gardencorev1beta1.LastOperationTypeRestore,
 					},

--- a/pkg/operation/botanist/dnsrecord_test.go
+++ b/pkg/operation/botanist/dnsrecord_test.go
@@ -110,17 +110,6 @@ var _ = Describe("dnsrecord", func() {
 					},
 				},
 				Shoot: &shoot.Shoot{
-					Info: &gardencorev1beta1.Shoot{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      shootName,
-							Namespace: shootNamespace,
-						},
-						Spec: gardencorev1beta1.ShootSpec{
-							DNS: &gardencorev1beta1.DNS{
-								Domain: pointer.String(externalDomain),
-							},
-						},
-					},
 					SeedNamespace:         seedNamespace,
 					ExternalClusterDomain: pointer.String(externalDomain),
 					ExternalDomain: &garden.Domain{
@@ -152,6 +141,17 @@ var _ = Describe("dnsrecord", func() {
 				Logger: logrus.NewEntry(logger.NewNopLogger()),
 			},
 		}
+		b.Shoot.SetInfo(&gardencorev1beta1.Shoot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      shootName,
+				Namespace: shootNamespace,
+			},
+			Spec: gardencorev1beta1.ShootSpec{
+				DNS: &gardencorev1beta1.DNS{
+					Domain: pointer.String(externalDomain),
+				},
+			},
+		})
 
 		renderer := cr.NewWithServerVersion(&version.Info{})
 		chartApplier := kubernetes.NewChartApplier(renderer, kubernetes.NewApplier(client, meta.NewDefaultRESTMapper([]schema.GroupVersion{})))

--- a/pkg/operation/botanist/dnsresources_test.go
+++ b/pkg/operation/botanist/dnsresources_test.go
@@ -17,13 +17,13 @@ package botanist_test
 import (
 	"context"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
 	"k8s.io/utils/pointer"
 
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/features"
 	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 	"github.com/gardener/gardener/pkg/logger"
@@ -75,20 +75,6 @@ var _ = Describe("dnsrecord", func() {
 		b = &Botanist{
 			Operation: &operation.Operation{
 				Shoot: &shoot.Shoot{
-					Info: &gardencorev1beta1.Shoot{
-						Spec: gardencorev1beta1.ShootSpec{
-							DNS: &gardencorev1beta1.DNS{
-								Domain: pointer.String(externalDomain),
-							},
-							Addons: &gardencorev1beta1.Addons{
-								NginxIngress: &gardencorev1beta1.NginxIngress{
-									Addon: gardencorev1beta1.Addon{
-										Enabled: true,
-									},
-								},
-							},
-						},
-					},
 					ExternalClusterDomain: pointer.String(externalDomain),
 					ExternalDomain: &garden.Domain{
 						Provider: externalProvider,
@@ -119,6 +105,20 @@ var _ = Describe("dnsrecord", func() {
 				Logger: logrus.NewEntry(logger.NewNopLogger()),
 			},
 		}
+		b.Shoot.SetInfo(&gardencorev1beta1.Shoot{
+			Spec: gardencorev1beta1.ShootSpec{
+				DNS: &gardencorev1beta1.DNS{
+					Domain: pointer.String(externalDomain),
+				},
+				Addons: &gardencorev1beta1.Addons{
+					NginxIngress: &gardencorev1beta1.NginxIngress{
+						Addon: gardencorev1beta1.Addon{
+							Enabled: true,
+						},
+					},
+				},
+			},
+		})
 	})
 
 	AfterEach(func() {

--- a/pkg/operation/botanist/etcd.go
+++ b/pkg/operation/botanist/etcd.go
@@ -44,7 +44,7 @@ var NewEtcd = etcd.New
 
 // DefaultEtcd returns a deployer for the etcd.
 func (b *Botanist) DefaultEtcd(role string, class etcd.Class) (etcd.Interface, error) {
-	defragmentationSchedule, err := determineDefragmentationSchedule(b.Shoot.Info, b.ManagedSeed, class)
+	defragmentationSchedule, err := determineDefragmentationSchedule(b.Shoot.GetInfo(), b.ManagedSeed, class)
 	if err != nil {
 		return nil, err
 	}
@@ -67,13 +67,13 @@ func (b *Botanist) DefaultEtcd(role string, class etcd.Class) (etcd.Interface, e
 
 	scaleDownUpdateMode := hvpav1alpha1.UpdateModeMaintenanceWindow
 	if (class == etcd.ClassImportant && b.Shoot.Purpose == gardencorev1beta1.ShootPurposeProduction) ||
-		(metav1.HasAnnotation(b.Shoot.Info.ObjectMeta, v1beta1constants.ShootAlphaControlPlaneScaleDownDisabled)) {
+		(metav1.HasAnnotation(b.Shoot.GetInfo().ObjectMeta, v1beta1constants.ShootAlphaControlPlaneScaleDownDisabled)) {
 		scaleDownUpdateMode = hvpav1alpha1.UpdateModeOff
 	}
 
 	e.SetHVPAConfig(&etcd.HVPAConfig{
 		Enabled:               hvpaEnabled,
-		MaintenanceTimeWindow: *b.Shoot.Info.Spec.Maintenance.TimeWindow,
+		MaintenanceTimeWindow: *b.Shoot.GetInfo().Spec.Maintenance.TimeWindow,
 		ScaleDownUpdateMode:   &scaleDownUpdateMode,
 	})
 
@@ -97,7 +97,7 @@ func (b *Botanist) DeployEtcd(ctx context.Context) error {
 			return err
 		}
 
-		snapshotSchedule, err := determineBackupSchedule(b.Shoot.Info)
+		snapshotSchedule, err := determineBackupSchedule(b.Shoot.GetInfo())
 		if err != nil {
 			return err
 		}

--- a/pkg/operation/botanist/etcd_test.go
+++ b/pkg/operation/botanist/etcd_test.go
@@ -93,15 +93,15 @@ var _ = Describe("Etcd", func() {
 				Info: &gardencorev1beta1.Seed{},
 			}
 			botanist.Shoot = &shootpkg.Shoot{
-				Info: &gardencorev1beta1.Shoot{
-					Spec: gardencorev1beta1.ShootSpec{
-						Maintenance: &gardencorev1beta1.Maintenance{
-							TimeWindow: &maintenanceTimeWindow,
-						},
-					},
-				},
 				SeedNamespace: namespace,
 			}
+			botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
+				Spec: gardencorev1beta1.ShootSpec{
+					Maintenance: &gardencorev1beta1.Maintenance{
+						TimeWindow: &maintenanceTimeWindow,
+					},
+				},
+			})
 		})
 
 		Context("no shooted seed", func() {
@@ -266,20 +266,20 @@ var _ = Describe("Etcd", func() {
 						EtcdEvents: etcdEvents,
 					},
 				},
-				Info: &gardencorev1beta1.Shoot{
-					Spec: gardencorev1beta1.ShootSpec{
-						Maintenance: &gardencorev1beta1.Maintenance{
-							TimeWindow: &maintenanceTimeWindow,
-						},
-					},
-					Status: gardencorev1beta1.ShootStatus{
-						TechnicalID: namespace,
-						UID:         shootUID,
-					},
-				},
 				SeedNamespace:   namespace,
 				BackupEntryName: namespace + "--" + string(shootUID),
 			}
+			botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
+				Spec: gardencorev1beta1.ShootSpec{
+					Maintenance: &gardencorev1beta1.Maintenance{
+						TimeWindow: &maintenanceTimeWindow,
+					},
+				},
+				Status: gardencorev1beta1.ShootStatus{
+					TechnicalID: namespace,
+					UID:         shootUID,
+				},
+			})
 
 			etcdMain.EXPECT().SetSecrets(etcd.Secrets{
 				CA:     component.Secret{Name: secretNameCA, Checksum: checksumCA},

--- a/pkg/operation/botanist/etcd_test.go
+++ b/pkg/operation/botanist/etcd_test.go
@@ -223,7 +223,7 @@ var _ = Describe("Etcd", func() {
 
 		It("should return an error because the maintenance time window cannot be parsed", func() {
 			defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.HVPA, true)()
-			botanist.Shoot.Info.Spec.Maintenance.TimeWindow = &gardencorev1beta1.MaintenanceTimeWindow{
+			botanist.Shoot.GetInfo().Spec.Maintenance.TimeWindow = &gardencorev1beta1.MaintenanceTimeWindow{
 				Begin: "foobar",
 				End:   "barfoo",
 			}
@@ -371,7 +371,7 @@ var _ = Describe("Etcd", func() {
 					backupSecret.DeepCopyInto(obj.(*corev1.Secret))
 					return nil
 				})
-				botanist.Shoot.Info.Spec.Maintenance.TimeWindow = &gardencorev1beta1.MaintenanceTimeWindow{
+				botanist.Shoot.GetInfo().Spec.Maintenance.TimeWindow = &gardencorev1beta1.MaintenanceTimeWindow{
 					Begin: "foobar",
 					End:   "barfoo",
 				}

--- a/pkg/operation/botanist/extension.go
+++ b/pkg/operation/botanist/extension.go
@@ -33,9 +33,9 @@ func (b *Botanist) DefaultExtension(ctx context.Context) (extension.Interface, e
 		return nil, err
 	}
 
-	extensions, err := mergeExtensions(controllerRegistrations.Items, b.Shoot.Info.Spec.Extensions, b.Shoot.SeedNamespace)
+	extensions, err := mergeExtensions(controllerRegistrations.Items, b.Shoot.GetInfo().Spec.Extensions, b.Shoot.SeedNamespace)
 	if err != nil {
-		return nil, fmt.Errorf("cannot calculate required extensions for shoot %s: %w", b.Shoot.Info.Name, err)
+		return nil, fmt.Errorf("cannot calculate required extensions for shoot %s: %w", b.Shoot.GetInfo().Name, err)
 	}
 
 	return extension.New(

--- a/pkg/operation/botanist/extension_test.go
+++ b/pkg/operation/botanist/extension_test.go
@@ -71,11 +71,11 @@ var _ = Describe("Extensions", func() {
 						Extension: extension,
 					},
 				},
-				Info:          &gardencorev1beta1.Shoot{},
 				SeedNamespace: namespace,
 			},
 			ShootState: shootState,
 		}}
+		botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{})
 
 		gardenClientInterface.EXPECT().Client().Return(gardenClient).AnyTimes()
 	})
@@ -295,13 +295,13 @@ var _ = Describe("Extensions", func() {
 
 		Context("restore", func() {
 			BeforeEach(func() {
-				botanist.Shoot.Info = &gardencorev1beta1.Shoot{
+				botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
 					Status: gardencorev1beta1.ShootStatus{
 						LastOperation: &gardencorev1beta1.LastOperation{
 							Type: gardencorev1beta1.LastOperationTypeRestore,
 						},
 					},
-				}
+				})
 			})
 
 			It("should restore successfully", func() {

--- a/pkg/operation/botanist/extension_test.go
+++ b/pkg/operation/botanist/extension_test.go
@@ -142,7 +142,7 @@ var _ = Describe("Extensions", func() {
 
 		DescribeTable("#DefaultExtension",
 			func(registrations []gardencorev1beta1.ControllerRegistration, extensions []gardencorev1beta1.Extension, conditionMatcher gomegatypes.GomegaMatcher) {
-				botanist.Shoot.Info.Spec.Extensions = extensions
+				botanist.Shoot.GetInfo().Spec.Extensions = extensions
 				gardenClient.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerRegistrationList{})).DoAndReturn(func(_ context.Context, list client.ObjectList, _ ...client.ListOption) error {
 					(&gardencorev1beta1.ControllerRegistrationList{Items: registrations}).DeepCopyInto(list.(*gardencorev1beta1.ControllerRegistrationList))
 					return nil

--- a/pkg/operation/botanist/infrastructure.go
+++ b/pkg/operation/botanist/infrastructure.go
@@ -64,7 +64,7 @@ func (b *Botanist) WaitForInfrastructure(ctx context.Context) error {
 	}
 
 	if nodesCIDR := b.Shoot.Components.Extensions.Infrastructure.NodesCIDR(); nodesCIDR != nil {
-		if err := b.Shoot.UpdateInfo(ctx, b.K8sGardenClient.Client(), func(shoot *gardencorev1beta1.Shoot) error {
+		if err := b.Shoot.UpdateInfo(ctx, b.K8sGardenClient.Client(), true, func(shoot *gardencorev1beta1.Shoot) error {
 			shoot.Spec.Networking.Nodes = nodesCIDR
 			return nil
 		}); err != nil {

--- a/pkg/operation/botanist/infrastructure.go
+++ b/pkg/operation/botanist/infrastructure.go
@@ -17,12 +17,12 @@ package botanist
 import (
 	"context"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/infrastructure"
 	"github.com/gardener/gardener/pkg/utils/secrets"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // DefaultInfrastructure creates the default deployer for the Infrastructure custom resource.
@@ -32,11 +32,11 @@ func (b *Botanist) DefaultInfrastructure() infrastructure.Interface {
 		b.K8sSeedClient.Client(),
 		&infrastructure.Values{
 			Namespace:         b.Shoot.SeedNamespace,
-			Name:              b.Shoot.Info.Name,
-			Type:              b.Shoot.Info.Spec.Provider.Type,
-			ProviderConfig:    b.Shoot.Info.Spec.Provider.InfrastructureConfig,
-			Region:            b.Shoot.Info.Spec.Region,
-			AnnotateOperation: controllerutils.HasTask(b.Shoot.Info.Annotations, v1beta1constants.ShootTaskDeployInfrastructure) || b.isRestorePhase(),
+			Name:              b.Shoot.GetInfo().Name,
+			Type:              b.Shoot.GetInfo().Spec.Provider.Type,
+			ProviderConfig:    b.Shoot.GetInfo().Spec.Provider.InfrastructureConfig,
+			Region:            b.Shoot.GetInfo().Spec.Region,
+			AnnotateOperation: controllerutils.HasTask(b.Shoot.GetInfo().Annotations, v1beta1constants.ShootTaskDeployInfrastructure) || b.isRestorePhase(),
 		},
 		infrastructure.DefaultInterval,
 		infrastructure.DefaultSevereThreshold,
@@ -64,15 +64,14 @@ func (b *Botanist) WaitForInfrastructure(ctx context.Context) error {
 	}
 
 	if nodesCIDR := b.Shoot.Components.Extensions.Infrastructure.NodesCIDR(); nodesCIDR != nil {
-		shoot := b.Shoot.Info.DeepCopy()
-		patch := client.StrategicMergeFrom(shoot.DeepCopy())
-		shoot.Spec.Networking.Nodes = nodesCIDR
-		if err := b.K8sGardenClient.Client().Patch(ctx, shoot, patch); err != nil {
+		if err := b.Shoot.UpdateInfo(ctx, b.K8sGardenClient.Client(), func(shoot *gardencorev1beta1.Shoot) error {
+			shoot.Spec.Networking.Nodes = nodesCIDR
+			return nil
+		}); err != nil {
 			return err
 		}
-		b.Shoot.Info = shoot
 
-		if err := extensions.SyncClusterResourceToSeed(ctx, b.K8sSeedClient.Client(), b.Shoot.SeedNamespace, b.Shoot.Info, nil, nil); err != nil {
+		if err := extensions.SyncClusterResourceToSeed(ctx, b.K8sSeedClient.Client(), b.Shoot.SeedNamespace, b.Shoot.GetInfo(), nil, nil); err != nil {
 			return err
 		}
 	}

--- a/pkg/operation/botanist/infrastructure_test.go
+++ b/pkg/operation/botanist/infrastructure_test.go
@@ -146,12 +146,12 @@ var _ = Describe("Infrastructure", func() {
 			kubernetesGardenInterface.EXPECT().Client().Return(kubernetesGardenClient)
 			updatedShoot := shoot.DeepCopy()
 			updatedShoot.Spec.Networking.Nodes = nodesCIDR
-			test.EXPECTPatch(ctx, kubernetesGardenClient, updatedShoot, shoot, types.StrategicMergePatchType)
+			test.EXPECTPatch(ctx, kubernetesGardenClient, updatedShoot, shoot, types.MergePatchType)
 
 			kubernetesSeedInterface.EXPECT().Client().Return(kubernetesSeedClient)
 
 			Expect(botanist.WaitForInfrastructure(ctx)).To(Succeed())
-			Expect(botanist.Shoot.Info).To(Equal(updatedShoot))
+			Expect(botanist.Shoot.GetInfo()).To(Equal(updatedShoot))
 		})
 
 		It("should successfully wait (w/o provider status, w/o nodes cidr)", func() {
@@ -159,14 +159,14 @@ var _ = Describe("Infrastructure", func() {
 			infrastructure.EXPECT().NodesCIDR()
 
 			Expect(botanist.WaitForInfrastructure(ctx)).To(Succeed())
-			Expect(botanist.Shoot.Info).To(Equal(shoot))
+			Expect(botanist.Shoot.GetInfo()).To(Equal(shoot))
 		})
 
 		It("should return the error during wait", func() {
 			infrastructure.EXPECT().Wait(ctx).Return(fakeErr)
 
 			Expect(botanist.WaitForInfrastructure(ctx)).To(MatchError(fakeErr))
-			Expect(botanist.Shoot.Info).To(Equal(shoot))
+			Expect(botanist.Shoot.GetInfo()).To(Equal(shoot))
 		})
 
 		It("should return the error during nodes cidr update", func() {
@@ -176,10 +176,10 @@ var _ = Describe("Infrastructure", func() {
 			kubernetesGardenInterface.EXPECT().Client().Return(kubernetesGardenClient)
 			updatedShoot := shoot.DeepCopy()
 			updatedShoot.Spec.Networking.Nodes = nodesCIDR
-			test.EXPECTPatch(ctx, kubernetesGardenClient, updatedShoot, shoot, types.StrategicMergePatchType, fakeErr)
+			test.EXPECTPatch(ctx, kubernetesGardenClient, updatedShoot, shoot, types.MergePatchType, fakeErr)
 
 			Expect(botanist.WaitForInfrastructure(ctx)).To(MatchError(fakeErr))
-			Expect(botanist.Shoot.Info).To(Equal(shoot))
+			Expect(botanist.Shoot.GetInfo()).To(Equal(shoot))
 		})
 	})
 })

--- a/pkg/operation/botanist/infrastructure_test.go
+++ b/pkg/operation/botanist/infrastructure_test.go
@@ -64,6 +64,7 @@ var _ = Describe("Infrastructure", func() {
 			},
 			ShootState: shootState,
 		}}
+		botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{})
 	})
 
 	AfterEach(func() {

--- a/pkg/operation/botanist/infrastructure_test.go
+++ b/pkg/operation/botanist/infrastructure_test.go
@@ -89,13 +89,13 @@ var _ = Describe("Infrastructure", func() {
 
 		Context("restore", func() {
 			BeforeEach(func() {
-				botanist.Shoot.Info = &gardencorev1beta1.Shoot{
+				botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
 					Status: gardencorev1beta1.ShootStatus{
 						LastOperation: &gardencorev1beta1.LastOperation{
 							Type: gardencorev1beta1.LastOperationTypeRestore,
 						},
 					},
-				}
+				})
 			})
 
 			It("should restore successfully", func() {
@@ -136,7 +136,7 @@ var _ = Describe("Infrastructure", func() {
 
 			botanist.K8sGardenClient = kubernetesGardenInterface
 			botanist.K8sSeedClient = kubernetesSeedInterface
-			botanist.Shoot.Info = shoot
+			botanist.Shoot.SetInfo(shoot)
 		})
 
 		It("should successfully wait (w/ provider status, w/ nodes cidr)", func() {

--- a/pkg/operation/botanist/infrastructure_test.go
+++ b/pkg/operation/botanist/infrastructure_test.go
@@ -146,7 +146,7 @@ var _ = Describe("Infrastructure", func() {
 			kubernetesGardenInterface.EXPECT().Client().Return(kubernetesGardenClient)
 			updatedShoot := shoot.DeepCopy()
 			updatedShoot.Spec.Networking.Nodes = nodesCIDR
-			test.EXPECTPatch(ctx, kubernetesGardenClient, updatedShoot, shoot, types.MergePatchType)
+			test.EXPECTPatch(ctx, kubernetesGardenClient, updatedShoot, shoot, types.StrategicMergePatchType)
 
 			kubernetesSeedInterface.EXPECT().Client().Return(kubernetesSeedClient)
 
@@ -176,7 +176,7 @@ var _ = Describe("Infrastructure", func() {
 			kubernetesGardenInterface.EXPECT().Client().Return(kubernetesGardenClient)
 			updatedShoot := shoot.DeepCopy()
 			updatedShoot.Spec.Networking.Nodes = nodesCIDR
-			test.EXPECTPatch(ctx, kubernetesGardenClient, updatedShoot, shoot, types.MergePatchType, fakeErr)
+			test.EXPECTPatch(ctx, kubernetesGardenClient, updatedShoot, shoot, types.StrategicMergePatchType, fakeErr)
 
 			Expect(botanist.WaitForInfrastructure(ctx)).To(MatchError(fakeErr))
 			Expect(botanist.Shoot.GetInfo()).To(Equal(shoot))

--- a/pkg/operation/botanist/kubeapiserver.go
+++ b/pkg/operation/botanist/kubeapiserver.go
@@ -61,7 +61,7 @@ func (b *Botanist) computeKubeAPIServerAutoscalingConfig() kubeapiserver.Autosca
 		minReplicas = 2
 	}
 
-	if metav1.HasAnnotation(b.Shoot.Info.ObjectMeta, v1beta1constants.ShootAlphaControlPlaneScaleDownDisabled) {
+	if metav1.HasAnnotation(b.Shoot.GetInfo().ObjectMeta, v1beta1constants.ShootAlphaControlPlaneScaleDownDisabled) {
 		minReplicas = 4
 		scaleDownDisabledForHvpa = true
 	}
@@ -142,7 +142,7 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 // DeleteKubeAPIServer deletes the kube-apiserver deployment in the Seed cluster which holds the Shoot's control plane.
 func (b *Botanist) DeleteKubeAPIServer(ctx context.Context) error {
 	// invalidate shoot client here before deleting API server
-	if err := b.ClientMap.InvalidateClient(keys.ForShoot(b.Shoot.Info)); err != nil {
+	if err := b.ClientMap.InvalidateClient(keys.ForShoot(b.Shoot.GetInfo())); err != nil {
 		return err
 	}
 	b.K8sShootClient = nil

--- a/pkg/operation/botanist/kubeapiserver_test.go
+++ b/pkg/operation/botanist/kubeapiserver_test.go
@@ -70,7 +70,6 @@ var _ = Describe("KubeAPIServer", func() {
 				K8sSeedClient: k8sSeedClient,
 				Garden:        &gardenpkg.Garden{},
 				Shoot: &shootpkg.Shoot{
-					Info:          &gardencorev1beta1.Shoot{},
 					SeedNamespace: shootNamespace,
 					Components: &shootpkg.Components{
 						ControlPlane: &shootpkg.ControlPlane{
@@ -80,6 +79,7 @@ var _ = Describe("KubeAPIServer", func() {
 				},
 			},
 		}
+		botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{})
 	})
 
 	AfterEach(func() {

--- a/pkg/operation/botanist/kubeapiserver_test.go
+++ b/pkg/operation/botanist/kubeapiserver_test.go
@@ -140,7 +140,7 @@ var _ = Describe("KubeAPIServer", func() {
 				),
 				Entry("shoot disables scale down",
 					func() {
-						botanist.Shoot.Info.Annotations = map[string]string{"alpha.control-plane.scaling.shoot.gardener.cloud/scale-down-disabled": "true"}
+						botanist.Shoot.GetInfo().Annotations = map[string]string{"alpha.control-plane.scaling.shoot.gardener.cloud/scale-down-disabled": "true"}
 					},
 					nil, nil,
 					kubeapiserver.AutoscalingConfig{
@@ -257,7 +257,7 @@ var _ = Describe("KubeAPIServer", func() {
 					func() {
 						botanist.Shoot.DisableDNS = false
 						botanist.Garden.InternalDomain = &gardenpkg.Domain{}
-						botanist.Shoot.Info.Spec.DNS = nil
+						botanist.Shoot.GetInfo().Spec.DNS = nil
 					},
 					featureGatePtr(features.APIServerSNI), pointer.Bool(true),
 					kubeapiserver.SNIConfig{
@@ -270,7 +270,7 @@ var _ = Describe("KubeAPIServer", func() {
 						botanist.Garden.InternalDomain = &gardenpkg.Domain{}
 						botanist.Shoot.ExternalDomain = &gardenpkg.Domain{}
 						botanist.Shoot.ExternalClusterDomain = pointer.StringPtr("some-domain")
-						botanist.Shoot.Info.Spec.DNS = &gardencorev1beta1.DNS{
+						botanist.Shoot.GetInfo().Spec.DNS = &gardencorev1beta1.DNS{
 							Domain:    pointer.StringPtr("some-domain"),
 							Providers: []gardencorev1beta1.DNSProvider{{}},
 						}
@@ -286,11 +286,11 @@ var _ = Describe("KubeAPIServer", func() {
 						botanist.Garden.InternalDomain = &gardenpkg.Domain{}
 						botanist.Shoot.ExternalDomain = &gardenpkg.Domain{}
 						botanist.Shoot.ExternalClusterDomain = pointer.StringPtr("some-domain")
-						botanist.Shoot.Info.Spec.DNS = &gardencorev1beta1.DNS{
+						botanist.Shoot.GetInfo().Spec.DNS = &gardencorev1beta1.DNS{
 							Domain:    pointer.StringPtr("some-domain"),
 							Providers: []gardencorev1beta1.DNSProvider{{}},
 						}
-						botanist.Shoot.Info.Annotations = map[string]string{"alpha.featuregates.shoot.gardener.cloud/apiserver-sni-pod-injector": "disable"}
+						botanist.Shoot.GetInfo().Annotations = map[string]string{"alpha.featuregates.shoot.gardener.cloud/apiserver-sni-pod-injector": "disable"}
 					},
 					featureGatePtr(features.APIServerSNI), pointer.Bool(true),
 					kubeapiserver.SNIConfig{
@@ -369,10 +369,10 @@ var _ = Describe("KubeAPIServer", func() {
 
 	Describe("#DeleteKubeAPIServer", func() {
 		It("should properly invalidate the client and destroy the component", func() {
-			clientMap := fakeclientmap.NewClientMap().AddClient(keys.ForShoot(botanist.Shoot.Info), k8sSeedClient)
+			clientMap := fakeclientmap.NewClientMap().AddClient(keys.ForShoot(botanist.Shoot.GetInfo()), k8sSeedClient)
 			botanist.ClientMap = clientMap
 
-			shootClient, err := botanist.ClientMap.GetClient(ctx, keys.ForShoot(botanist.Shoot.Info))
+			shootClient, err := botanist.ClientMap.GetClient(ctx, keys.ForShoot(botanist.Shoot.GetInfo()))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(shootClient).To(Equal(k8sSeedClient))
 
@@ -383,7 +383,7 @@ var _ = Describe("KubeAPIServer", func() {
 
 			Expect(botanist.DeleteKubeAPIServer(ctx)).To(Succeed())
 
-			shootClient, err = clientMap.GetClient(ctx, keys.ForShoot(botanist.Shoot.Info))
+			shootClient, err = clientMap.GetClient(ctx, keys.ForShoot(botanist.Shoot.GetInfo()))
 			Expect(err).To(MatchError("clientSet for key \"/\" not found"))
 			Expect(shootClient).To(BeNil())
 

--- a/pkg/operation/botanist/kubeapiserverexposure_test.go
+++ b/pkg/operation/botanist/kubeapiserverexposure_test.go
@@ -66,13 +66,13 @@ var _ = Describe("KubeAPIServerExposure", func() {
 			Operation: &operation.Operation{
 				K8sSeedClient: fakeClientSet,
 				Shoot: &shoot.Shoot{
-					Info:          &gardencorev1beta1.Shoot{},
 					SeedNamespace: namespace,
 				},
 				Garden: &garden.Garden{},
 				Logger: logrus.NewEntry(logger.NewNopLogger()),
 			},
 		}
+		botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{})
 	})
 
 	AfterEach(func() {

--- a/pkg/operation/botanist/kubeapiserverexposure_test.go
+++ b/pkg/operation/botanist/kubeapiserverexposure_test.go
@@ -97,7 +97,7 @@ var _ = Describe("KubeAPIServerExposure", func() {
 			BeforeEach(func() {
 				Expect(gardenletfeatures.FeatureGate.Set("APIServerSNI=true")).ToNot(HaveOccurred())
 				botanist.Garden.InternalDomain = &garden.Domain{Provider: "some-provider"}
-				botanist.Shoot.Info.Spec.DNS = &gardencorev1beta1.DNS{Domain: pointer.String("foo")}
+				botanist.Shoot.GetInfo().Spec.DNS = &gardencorev1beta1.DNS{Domain: pointer.String("foo")}
 				botanist.Shoot.ExternalClusterDomain = pointer.String("baz")
 				botanist.Shoot.ExternalDomain = &garden.Domain{Provider: "valid-provider"}
 			})

--- a/pkg/operation/botanist/kubecontrollermanager.go
+++ b/pkg/operation/botanist/kubecontrollermanager.go
@@ -45,7 +45,7 @@ func (b *Botanist) DefaultKubeControllerManager() (kubecontrollermanager.Interfa
 	}
 
 	scaleDownUpdateMode := hvpav1alpha1.UpdateModeAuto
-	if metav1.HasAnnotation(b.Shoot.Info.ObjectMeta, v1beta1constants.ShootAlphaControlPlaneScaleDownDisabled) {
+	if metav1.HasAnnotation(b.Shoot.GetInfo().ObjectMeta, v1beta1constants.ShootAlphaControlPlaneScaleDownDisabled) {
 		scaleDownUpdateMode = hvpav1alpha1.UpdateModeOff
 	}
 
@@ -55,7 +55,7 @@ func (b *Botanist) DefaultKubeControllerManager() (kubecontrollermanager.Interfa
 		b.Shoot.SeedNamespace,
 		b.Shoot.KubernetesVersion,
 		image.String(),
-		b.Shoot.Info.Spec.Kubernetes.KubeControllerManager,
+		b.Shoot.GetInfo().Spec.Kubernetes.KubeControllerManager,
 		b.Shoot.Networks.Pods,
 		b.Shoot.Networks.Services,
 		&kubecontrollermanager.HVPAConfig{
@@ -96,7 +96,7 @@ func (b *Botanist) ScaleKubeControllerManagerToOne(ctx context.Context) error {
 }
 
 func (b *Botanist) determineKubeControllerManagerReplicas(ctx context.Context) (int32, error) {
-	if b.Shoot.Info.Status.LastOperation != nil && b.Shoot.Info.Status.LastOperation.Type == gardencorev1beta1.LastOperationTypeCreate {
+	if b.Shoot.GetInfo().Status.LastOperation != nil && b.Shoot.GetInfo().Status.LastOperation.Type == gardencorev1beta1.LastOperationTypeCreate {
 		if b.Shoot.HibernationEnabled {
 			// shoot is being created with .spec.hibernation.enabled=true, don't deploy KCM at all
 			return 0, nil
@@ -106,7 +106,7 @@ func (b *Botanist) determineKubeControllerManagerReplicas(ctx context.Context) (
 		return 1, nil
 	}
 
-	if b.Shoot.HibernationEnabled == b.Shoot.Info.Status.IsHibernated {
+	if b.Shoot.HibernationEnabled == b.Shoot.GetInfo().Status.IsHibernated {
 		// shoot is being reconciled with .spec.hibernation.enabled=.status.isHibernated, so keep the replicas which
 		// are controlled by the dependency-watchdog
 		return kutil.CurrentReplicaCountForDeployment(ctx, b.K8sSeedClient.Client(), b.Shoot.SeedNamespace, v1beta1constants.DeploymentNameKubeControllerManager)

--- a/pkg/operation/botanist/kubecontrollermanager_test.go
+++ b/pkg/operation/botanist/kubecontrollermanager_test.go
@@ -142,12 +142,12 @@ var _ = Describe("KubeControllerManager", func() {
 
 			Context("last operation is nil or not of type 'create'", func() {
 				BeforeEach(func() {
-					botanist.Shoot.Info.Status.LastOperation = nil
+					botanist.Shoot.GetInfo().Status.LastOperation = nil
 				})
 
 				It("hibernation status unequal (true/false)", func() {
 					botanist.Shoot.HibernationEnabled = true
-					botanist.Shoot.Info.Status.IsHibernated = false
+					botanist.Shoot.GetInfo().Status.IsHibernated = false
 
 					kubeControllerManager.EXPECT().SetReplicaCount(int32(1))
 
@@ -156,7 +156,7 @@ var _ = Describe("KubeControllerManager", func() {
 
 				It("hibernation status unequal (false/true)", func() {
 					botanist.Shoot.HibernationEnabled = false
-					botanist.Shoot.Info.Status.IsHibernated = true
+					botanist.Shoot.GetInfo().Status.IsHibernated = true
 
 					kubeControllerManager.EXPECT().SetReplicaCount(int32(1))
 
@@ -165,7 +165,7 @@ var _ = Describe("KubeControllerManager", func() {
 
 				It("hibernation status equal (true/true)", func() {
 					botanist.Shoot.HibernationEnabled = true
-					botanist.Shoot.Info.Status.IsHibernated = true
+					botanist.Shoot.GetInfo().Status.IsHibernated = true
 
 					var replicas int32 = 4
 					kubernetesClient.EXPECT().Client().Return(c)
@@ -180,7 +180,7 @@ var _ = Describe("KubeControllerManager", func() {
 
 				It("hibernation status equal (false/false)", func() {
 					botanist.Shoot.HibernationEnabled = false
-					botanist.Shoot.Info.Status.IsHibernated = false
+					botanist.Shoot.GetInfo().Status.IsHibernated = false
 
 					var replicas int32 = 4
 					kubernetesClient.EXPECT().Client().Return(c)
@@ -196,7 +196,7 @@ var _ = Describe("KubeControllerManager", func() {
 
 			Context("last operation is not nil and of type 'create'", func() {
 				BeforeEach(func() {
-					botanist.Shoot.Info.Status.LastOperation = &gardencorev1beta1.LastOperation{Type: gardencorev1beta1.LastOperationTypeCreate}
+					botanist.Shoot.GetInfo().Status.LastOperation = &gardencorev1beta1.LastOperation{Type: gardencorev1beta1.LastOperationTypeCreate}
 				})
 
 				It("hibernation enabled", func() {

--- a/pkg/operation/botanist/kubecontrollermanager_test.go
+++ b/pkg/operation/botanist/kubecontrollermanager_test.go
@@ -70,9 +70,9 @@ var _ = Describe("KubeControllerManager", func() {
 			botanist.Logger = logger.NewFieldLogger(logger.NewNopLogger(), "", "")
 			botanist.K8sSeedClient = kubernetesClient
 			botanist.Shoot = &shootpkg.Shoot{
-				Info:     &gardencorev1beta1.Shoot{},
 				Networks: &shootpkg.Networks{},
 			}
+			botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{})
 		})
 
 		It("should successfully create a kube-controller-manager interface", func() {
@@ -129,9 +129,9 @@ var _ = Describe("KubeControllerManager", func() {
 						KubeControllerManager: kubeControllerManager,
 					},
 				},
-				Info:          &gardencorev1beta1.Shoot{},
 				SeedNamespace: namespace,
 			}
+			botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{})
 		})
 
 		Context("successfully deployment", func() {

--- a/pkg/operation/botanist/kubescheduler.go
+++ b/pkg/operation/botanist/kubescheduler.go
@@ -36,7 +36,7 @@ func (b *Botanist) DefaultKubeScheduler() (kubescheduler.Interface, error) {
 		b.Shoot.KubernetesVersion,
 		image.String(),
 		b.Shoot.GetReplicas(1),
-		b.Shoot.Info.Spec.Kubernetes.KubeScheduler,
+		b.Shoot.GetInfo().Spec.Kubernetes.KubeScheduler,
 	), nil
 }
 

--- a/pkg/operation/botanist/kubescheduler_test.go
+++ b/pkg/operation/botanist/kubescheduler_test.go
@@ -56,7 +56,8 @@ var _ = Describe("KubeScheduler", func() {
 			kubernetesClient.EXPECT().Version()
 
 			botanist.K8sSeedClient = kubernetesClient
-			botanist.Shoot = &shootpkg.Shoot{Info: &gardencorev1beta1.Shoot{}}
+			botanist.Shoot = &shootpkg.Shoot{}
+			botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{})
 		})
 
 		It("should successfully create a kube-scheduler interface", func() {

--- a/pkg/operation/botanist/metricsserver_test.go
+++ b/pkg/operation/botanist/metricsserver_test.go
@@ -60,9 +60,9 @@ var _ = Describe("MetricsServer", func() {
 
 			botanist.K8sSeedClient = kubernetesClient
 			botanist.Shoot = &shootpkg.Shoot{
-				Info:       &gardencorev1beta1.Shoot{},
 				DisableDNS: true,
 			}
+			botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{})
 		})
 
 		It("should successfully create a metrics-server interface", func() {

--- a/pkg/operation/botanist/migration.go
+++ b/pkg/operation/botanist/migration.go
@@ -60,7 +60,7 @@ func (b *Botanist) runParallelTaskForEachComponent(ctx context.Context, componen
 
 func (b *Botanist) isRestorePhase() bool {
 	return b.Shoot != nil &&
-		b.Shoot.Info != nil &&
-		b.Shoot.Info.Status.LastOperation != nil &&
-		b.Shoot.Info.Status.LastOperation.Type == gardencorev1beta1.LastOperationTypeRestore
+		b.Shoot.GetInfo() != nil &&
+		b.Shoot.GetInfo().Status.LastOperation != nil &&
+		b.Shoot.GetInfo().Status.LastOperation.Type == gardencorev1beta1.LastOperationTypeRestore
 }

--- a/pkg/operation/botanist/monitoring.go
+++ b/pkg/operation/botanist/monitoring.go
@@ -174,7 +174,7 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 			"services": b.Shoot.Networks.Services.String(),
 		}
 		prometheusConfig = map[string]interface{}{
-			"kubernetesVersion": b.Shoot.Info.Spec.Kubernetes.Version,
+			"kubernetesVersion": b.Shoot.GetInfo().Spec.Kubernetes.Version,
 			"nodeLocalDNS": map[string]interface{}{
 				"enabled": b.Shoot.NodeLocalDNSEnabled,
 			},
@@ -213,8 +213,8 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 				"apiserver":           fmt.Sprintf("https://%s", gutil.GetAPIServerDomain(b.Shoot.InternalClusterDomain)),
 				"apiserverServerName": gutil.GetAPIServerDomain(b.Shoot.InternalClusterDomain),
 				"sniEnabled":          b.APIServerSNIEnabled(),
-				"provider":            b.Shoot.Info.Spec.Provider.Type,
-				"name":                b.Shoot.Info.Name,
+				"provider":            b.Shoot.GetInfo().Spec.Provider.Type,
+				"name":                b.Shoot.GetInfo().Name,
 				"project":             b.Garden.Project.Name,
 			},
 			"ignoreAlerts":            b.Shoot.IgnoreAlerts,
@@ -257,7 +257,7 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 	coreValues := map[string]interface{}{
 		"global": map[string]interface{}{
 			"shootKubeVersion": map[string]interface{}{
-				"gitVersion": b.Shoot.Info.Spec.Kubernetes.Version,
+				"gitVersion": b.Shoot.GetInfo().Spec.Kubernetes.Version,
 			},
 		},
 		"prometheus":               prometheus,
@@ -283,8 +283,8 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 			emailConfigs     = []map[string]interface{}{}
 		)
 
-		if b.Shoot.Info.Spec.Monitoring != nil && b.Shoot.Info.Spec.Monitoring.Alerting != nil {
-			for _, email := range b.Shoot.Info.Spec.Monitoring.Alerting.EmailReceivers {
+		if b.Shoot.GetInfo().Spec.Monitoring != nil && b.Shoot.GetInfo().Spec.Monitoring.Alerting != nil {
+			for _, email := range b.Shoot.GetInfo().Spec.Monitoring.Alerting.EmailReceivers {
 				for _, key := range alertingSMTPKeys {
 					secret := b.Secrets[key]
 

--- a/pkg/operation/botanist/namespaces.go
+++ b/pkg/operation/botanist/namespaces.go
@@ -44,13 +44,13 @@ func (b *Botanist) DeploySeedNamespace(ctx context.Context) error {
 
 	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, b.K8sSeedClient.Client(), namespace, func() error {
 		namespace.Annotations = map[string]string{
-			v1beta1constants.ShootUID: string(b.Shoot.Info.Status.UID),
+			v1beta1constants.ShootUID: string(b.Shoot.GetInfo().Status.UID),
 		}
 		namespace.Labels = map[string]string{
 			v1beta1constants.GardenRole:              v1beta1constants.GardenRoleShoot,
 			v1beta1constants.LabelSeedProvider:       b.Seed.Info.Spec.Provider.Type,
-			v1beta1constants.LabelShootProvider:      b.Shoot.Info.Spec.Provider.Type,
-			v1beta1constants.LabelNetworkingProvider: b.Shoot.Info.Spec.Networking.Type,
+			v1beta1constants.LabelShootProvider:      b.Shoot.GetInfo().Spec.Provider.Type,
+			v1beta1constants.LabelNetworkingProvider: b.Shoot.GetInfo().Spec.Networking.Type,
 			v1beta1constants.LabelBackupProvider:     b.Seed.Info.Spec.Provider.Type,
 		}
 

--- a/pkg/operation/botanist/namespaces_test.go
+++ b/pkg/operation/botanist/namespaces_test.go
@@ -90,7 +90,7 @@ var _ = Describe("Namespaces", func() {
 					},
 				},
 			}}
-			botanist.Shoot.Info = &gardencorev1beta1.Shoot{
+			botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
 				Spec: gardencorev1beta1.ShootSpec{
 					Provider: gardencorev1beta1.Provider{
 						Type: shootProviderType,
@@ -102,7 +102,7 @@ var _ = Describe("Namespaces", func() {
 				Status: gardencorev1beta1.ShootStatus{
 					UID: uid,
 				},
-			}
+			})
 
 			obj = &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operation/botanist/network.go
+++ b/pkg/operation/botanist/network.go
@@ -28,9 +28,9 @@ func (b *Botanist) DefaultNetwork() component.DeployMigrateWaiter {
 		b.K8sSeedClient.Client(),
 		&network.Values{
 			Namespace:      b.Shoot.SeedNamespace,
-			Name:           b.Shoot.Info.Name,
-			Type:           b.Shoot.Info.Spec.Networking.Type,
-			ProviderConfig: b.Shoot.Info.Spec.Networking.ProviderConfig,
+			Name:           b.Shoot.GetInfo().Name,
+			Type:           b.Shoot.GetInfo().Spec.Networking.Type,
+			ProviderConfig: b.Shoot.GetInfo().Spec.Networking.ProviderConfig,
 			PodCIDR:        b.Shoot.Networks.Pods,
 			ServiceCIDR:    b.Shoot.Networks.Services,
 		},

--- a/pkg/operation/botanist/network_test.go
+++ b/pkg/operation/botanist/network_test.go
@@ -75,13 +75,13 @@ var _ = Describe("Network", func() {
 
 		Context("restore", func() {
 			BeforeEach(func() {
-				botanist.Shoot.Info = &gardencorev1beta1.Shoot{
+				botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
 					Status: gardencorev1beta1.ShootStatus{
 						LastOperation: &gardencorev1beta1.LastOperation{
 							Type: gardencorev1beta1.LastOperationTypeRestore,
 						},
 					},
-				}
+				})
 			})
 
 			It("should restore successfully", func() {

--- a/pkg/operation/botanist/network_test.go
+++ b/pkg/operation/botanist/network_test.go
@@ -54,6 +54,7 @@ var _ = Describe("Network", func() {
 			},
 			ShootState: shootState,
 		}}
+		botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{})
 	})
 
 	AfterEach(func() {

--- a/pkg/operation/botanist/networkpolicies.go
+++ b/pkg/operation/botanist/networkpolicies.go
@@ -35,10 +35,10 @@ func (b *Botanist) DefaultNetworkPolicies(sniPhase component.Phase) (component.D
 	if v := b.Shoot.GetNodeNetwork(); v != nil {
 		shootCIDRNetworks = append(shootCIDRNetworks, *v)
 	}
-	if v := b.Shoot.Info.Spec.Networking.Pods; v != nil {
+	if v := b.Shoot.GetInfo().Spec.Networking.Pods; v != nil {
 		shootCIDRNetworks = append(shootCIDRNetworks, *v)
 	}
-	if v := b.Shoot.Info.Spec.Networking.Services; v != nil {
+	if v := b.Shoot.GetInfo().Spec.Networking.Services; v != nil {
 		shootCIDRNetworks = append(shootCIDRNetworks, *v)
 	}
 

--- a/pkg/operation/botanist/networkpolicies_test.go
+++ b/pkg/operation/botanist/networkpolicies_test.go
@@ -127,9 +127,9 @@ var _ = Describe("Networkpolicies", func() {
 			"w/ network CIDRs",
 			component.PhaseUnknown,
 			func() {
-				botanist.Shoot.Info.Spec.Networking.Pods = &podCIDRShoot
-				botanist.Shoot.Info.Spec.Networking.Services = &serviceCIDRShoot
-				botanist.Shoot.Info.Spec.Networking.Nodes = &nodeCIDRShoot
+				botanist.Shoot.GetInfo().Spec.Networking.Pods = &podCIDRShoot
+				botanist.Shoot.GetInfo().Spec.Networking.Services = &serviceCIDRShoot
+				botanist.Shoot.GetInfo().Spec.Networking.Nodes = &nodeCIDRShoot
 				botanist.Seed.Info.Spec.Networks.Nodes = &nodeCIDRSeed
 				botanist.Seed.Info.Spec.Networks.BlockCIDRs = blockCIDRs
 			},

--- a/pkg/operation/botanist/networkpolicies_test.go
+++ b/pkg/operation/botanist/networkpolicies_test.go
@@ -81,7 +81,6 @@ var _ = Describe("Networkpolicies", func() {
 					},
 				},
 				Shoot: &shootpkg.Shoot{
-					Info: &gardencorev1beta1.Shoot{},
 					Networks: &shootpkg.Networks{
 						CoreDNS: []byte{20, 0, 0, 10},
 					},
@@ -89,6 +88,7 @@ var _ = Describe("Networkpolicies", func() {
 				},
 			},
 		}
+		botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{})
 	})
 
 	DescribeTable("#DefaultNetworkPolicies",

--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -65,7 +65,7 @@ func (b *Botanist) DefaultOperatingSystemConfig() (operatingsystemconfig.Interfa
 		&operatingsystemconfig.Values{
 			Namespace:         b.Shoot.SeedNamespace,
 			KubernetesVersion: b.Shoot.KubernetesVersion,
-			Workers:           b.Shoot.Info.Spec.Provider.Workers,
+			Workers:           b.Shoot.GetInfo().Spec.Provider.Workers,
 			DownloaderValues: operatingsystemconfig.DownloaderValues{
 				APIServerURL: fmt.Sprintf("https://%s", b.Shoot.ComputeOutOfClusterAPIServerAddress(b.APIServerAddress, true)),
 			},
@@ -73,8 +73,8 @@ func (b *Botanist) DefaultOperatingSystemConfig() (operatingsystemconfig.Interfa
 				ClusterDNSAddress:       clusterDNSAddress,
 				ClusterDomain:           gardencorev1beta1.DefaultDomain,
 				Images:                  images,
-				KubeletConfigParameters: components.KubeletConfigParametersFromCoreV1beta1KubeletConfig(b.Shoot.Info.Spec.Kubernetes.Kubelet),
-				KubeletCLIFlags:         components.KubeletCLIFlagsFromCoreV1beta1KubeletConfig(b.Shoot.Info.Spec.Kubernetes.Kubelet),
+				KubeletConfigParameters: components.KubeletConfigParametersFromCoreV1beta1KubeletConfig(b.Shoot.GetInfo().Spec.Kubernetes.Kubelet),
+				KubeletCLIFlags:         components.KubeletCLIFlagsFromCoreV1beta1KubeletConfig(b.Shoot.GetInfo().Spec.Kubernetes.Kubelet),
 				MachineTypes:            b.Shoot.CloudProfile.Spec.MachineTypes,
 			},
 		},
@@ -160,7 +160,7 @@ func (b *Botanist) DeployManagedResourceForCloudConfigExecutor(ctx context.Conte
 
 	var (
 		managedResource                  = managedresources.NewForShoot(b.K8sSeedClient.Client(), b.Shoot.SeedNamespace, CloudConfigExecutionManagedResourceName, false)
-		managedResourceSecretsCount      = len(b.Shoot.Info.Spec.Provider.Workers) + 1
+		managedResourceSecretsCount      = len(b.Shoot.GetInfo().Spec.Provider.Workers) + 1
 		managedResourceSecretLabels      = map[string]string{SecretLabelKeyManagedResource: CloudConfigExecutionManagedResourceName}
 		managedResourceSecretNamesWanted = sets.NewString()
 		managedResourceSecretNameToData  = make(map[string]map[string][]byte, managedResourceSecretsCount)
@@ -172,7 +172,7 @@ func (b *Botanist) DeployManagedResourceForCloudConfigExecutor(ctx context.Conte
 	)
 
 	// Generate cloud-config user-data executor scripts for all worker pools.
-	for _, worker := range b.Shoot.Info.Spec.Provider.Workers {
+	for _, worker := range b.Shoot.GetInfo().Spec.Provider.Workers {
 		oscData, ok := workerNameToOperatingSystemConfigMaps[worker.Name]
 		if !ok {
 			return fmt.Errorf("did not find osc data for worker pool %q", worker.Name)

--- a/pkg/operation/botanist/operatingsystemconfig_test.go
+++ b/pkg/operation/botanist/operatingsystemconfig_test.go
@@ -88,11 +88,6 @@ var _ = Describe("operatingsystemconfig", func() {
 					},
 				},
 				Purpose: "development",
-				Info: &gardencorev1beta1.Shoot{
-					Status: gardencorev1beta1.ShootStatus{
-						TechnicalID: "shoot--garden-testing",
-					},
-				},
 			},
 			Seed: &seedpkg.Seed{
 				Info: &gardencorev1beta1.Seed{
@@ -105,6 +100,11 @@ var _ = Describe("operatingsystemconfig", func() {
 			},
 			ShootState: shootState,
 		}}
+		botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
+			Status: gardencorev1beta1.ShootStatus{
+				TechnicalID: "shoot--garden-testing",
+			},
+		})
 	})
 
 	AfterEach(func() {
@@ -179,13 +179,13 @@ var _ = Describe("operatingsystemconfig", func() {
 
 		Context("restore", func() {
 			BeforeEach(func() {
-				botanist.Shoot.Info = &gardencorev1beta1.Shoot{
+				botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
 					Status: gardencorev1beta1.ShootStatus{
 						LastOperation: &gardencorev1beta1.LastOperation{
 							Type: gardencorev1beta1.LastOperationTypeRestore,
 						},
 					},
-				}
+				})
 
 				operatingSystemConfig.EXPECT().SetCABundle(pointer.String("\n" + string(ca)))
 			})
@@ -260,7 +260,7 @@ var _ = Describe("operatingsystemconfig", func() {
 
 			botanist.Shoot.SeedNamespace = namespace
 			botanist.Shoot.KubernetesVersion = semver.MustParse("1.2.3")
-			botanist.Shoot.Info = &gardencorev1beta1.Shoot{
+			botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
 				Spec: gardencorev1beta1.ShootSpec{
 					Provider: gardencorev1beta1.Provider{
 						Workers: []gardencorev1beta1.Worker{
@@ -277,7 +277,7 @@ var _ = Describe("operatingsystemconfig", func() {
 						},
 					},
 				},
-			}
+			})
 
 			kubernetesInterfaceShoot.EXPECT().Client().Return(kubernetesClientShoot).AnyTimes()
 			kubernetesInterfaceSeed.EXPECT().Client().Return(kubernetesClientSeed).AnyTimes()

--- a/pkg/operation/botanist/resource_manager.go
+++ b/pkg/operation/botanist/resource_manager.go
@@ -55,7 +55,7 @@ func (b *Botanist) DefaultResourceManager() (resourcemanager.Interface, error) {
 	// grm is scaled down later on as part of the HibernateControlPlane step, so we only specify replicas=0 if
 	// the shoot is already hibernated.
 	replicas := int32(1)
-	if b.Shoot.HibernationEnabled && b.Shoot.Info.Status.IsHibernated {
+	if b.Shoot.HibernationEnabled && b.Shoot.GetInfo().Status.IsHibernated {
 		replicas = 0
 	}
 

--- a/pkg/operation/botanist/resources.go
+++ b/pkg/operation/botanist/resources.go
@@ -35,9 +35,9 @@ const (
 func (b *Botanist) DeployReferencedResources(ctx context.Context) error {
 	// Read referenced objects into a slice of unstructured objects
 	var unstructuredObjs []*unstructured.Unstructured
-	for _, resource := range b.Shoot.Info.Spec.Resources {
+	for _, resource := range b.Shoot.GetInfo().Spec.Resources {
 		// Read the resource from the Garden cluster
-		obj, err := unstructuredutils.GetObjectByRef(ctx, b.K8sGardenClient.Client(), &resource.ResourceRef, b.Shoot.Info.Namespace)
+		obj, err := unstructuredutils.GetObjectByRef(ctx, b.K8sGardenClient.Client(), &resource.ResourceRef, b.Shoot.GetInfo().Namespace)
 		if err != nil {
 			return err
 		}

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -58,14 +58,6 @@ func (b *Botanist) GenerateAndSaveSecrets(ctx context.Context) error {
 		}
 	}
 
-	// remove operation annotation
-	if err := b.Shoot.UpdateInfo(ctx, b.K8sGardenClient.Client(), false, func(shoot *gardencorev1beta1.Shoot) error {
-		delete(shoot.Annotations, v1beta1constants.GardenerOperation)
-		return nil
-	}); err != nil {
-		return err
-	}
-
 	if b.Shoot.GetInfo().DeletionTimestamp == nil {
 		if b.Shoot.ReversedVPNEnabled {
 			if err := b.cleanupTunnelSecrets(ctx, &gardenerResourceDataList, "vpn-seed", "vpn-seed-tlsauth", "vpn-shoot"); err != nil {
@@ -250,7 +242,11 @@ func (b *Botanist) rotateKubeconfigSecrets(ctx context.Context, gardenerResource
 		gardenerResourceDataList.Delete(secretName)
 	}
 
-	return nil
+	// remove operation annotation
+	return b.Shoot.UpdateInfo(ctx, b.K8sGardenClient.Client(), false, func(shoot *gardencorev1beta1.Shoot) error {
+		delete(shoot.Annotations, v1beta1constants.GardenerOperation)
+		return nil
+	})
 }
 
 func (b *Botanist) rotateSSHKeypairSecrets(ctx context.Context, gardenerResourceDataList *gardencorev1alpha1helper.GardenerResourceDataList) error {
@@ -277,7 +273,11 @@ func (b *Botanist) rotateSSHKeypairSecrets(ctx context.Context, gardenerResource
 	}
 	gardenerResourceDataList.Delete(v1beta1constants.SecretNameSSHKeyPair)
 
-	return nil
+	// remove operation annotation
+	return b.Shoot.UpdateInfo(ctx, b.K8sGardenClient.Client(), false, func(shoot *gardencorev1beta1.Shoot) error {
+		delete(shoot.Annotations, v1beta1constants.GardenerOperation)
+		return nil
+	})
 }
 
 func (b *Botanist) deleteBasicAuthDependantSecrets(ctx context.Context, gardenerResourceDataList *gardencorev1alpha1helper.GardenerResourceDataList) error {

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -59,7 +59,7 @@ func (b *Botanist) GenerateAndSaveSecrets(ctx context.Context) error {
 	}
 
 	// remove operation annotation
-	if err := b.Shoot.UpdateInfo(ctx, b.K8sGardenClient.Client(), func(shoot *gardencorev1beta1.Shoot) error {
+	if err := b.Shoot.UpdateInfo(ctx, b.K8sGardenClient.Client(), false, func(shoot *gardencorev1beta1.Shoot) error {
 		delete(shoot.Annotations, v1beta1constants.GardenerOperation)
 		return nil
 	}); err != nil {

--- a/pkg/operation/botanist/vpnseedserver_test.go
+++ b/pkg/operation/botanist/vpnseedserver_test.go
@@ -68,19 +68,19 @@ var _ = Describe("VPNSeedServer", func() {
 
 			botanist.K8sSeedClient = kubernetesClient
 			botanist.Shoot = &shootpkg.Shoot{
-				Info: &gardencorev1beta1.Shoot{
-					Spec: gardencorev1beta1.ShootSpec{
-						Networking: gardencorev1beta1.Networking{
-							Nodes: pointer.String("10.0.0.0/24"),
-						},
-					},
-				},
 				DisableDNS: true,
 				Networks: &shootpkg.Networks{
 					Services: &net.IPNet{IP: net.IP{10, 0, 0, 1}, Mask: net.CIDRMask(10, 24)},
 					Pods:     &net.IPNet{IP: net.IP{10, 0, 0, 2}, Mask: net.CIDRMask(10, 24)},
 				},
 			}
+			botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
+				Spec: gardencorev1beta1.ShootSpec{
+					Networking: gardencorev1beta1.Networking{
+						Nodes: pointer.String("10.0.0.0/24"),
+					},
+				},
+			})
 			botanist.Config = &config.GardenletConfiguration{
 				SNI: &config.SNI{
 					Ingress: &config.SNIIngress{

--- a/pkg/operation/botanist/waiter.go
+++ b/pkg/operation/botanist/waiter.go
@@ -139,7 +139,7 @@ func (b *Botanist) WaitUntilEndpointsDoNotContainPodIPs(ctx context.Context) err
 	b.Logger.Info("waiting until there are no Endpoints containing Pod IPs in the shoot cluster...")
 
 	var podsNetwork *net.IPNet
-	if val := b.Shoot.Info.Spec.Networking.Pods; val != nil {
+	if val := b.Shoot.GetInfo().Spec.Networking.Pods; val != nil {
 		var err error
 		_, podsNetwork, err = net.ParseCIDR(*val)
 		if err != nil {

--- a/pkg/operation/botanist/wanted_secrets.go
+++ b/pkg/operation/botanist/wanted_secrets.go
@@ -160,7 +160,7 @@ func (b *Botanist) generateWantedSecretConfigs(basicAuthAPIServer *secrets.Basic
 	}
 
 	if b.Shoot.ExternalClusterDomain != nil {
-		apiServerCertDNSNames = append(apiServerCertDNSNames, *(b.Shoot.Info.Spec.DNS.Domain), gutil.GetAPIServerDomain(*b.Shoot.ExternalClusterDomain))
+		apiServerCertDNSNames = append(apiServerCertDNSNames, *(b.Shoot.GetInfo().Spec.DNS.Domain), gutil.GetAPIServerDomain(*b.Shoot.ExternalClusterDomain))
 	}
 
 	secretList := []secrets.ConfigInterface{

--- a/pkg/operation/botanist/worker.go
+++ b/pkg/operation/botanist/worker.go
@@ -40,10 +40,10 @@ func (b *Botanist) DefaultWorker() worker.Interface {
 		b.K8sSeedClient.Client(),
 		&worker.Values{
 			Namespace:         b.Shoot.SeedNamespace,
-			Name:              b.Shoot.Info.Name,
-			Type:              b.Shoot.Info.Spec.Provider.Type,
-			Region:            b.Shoot.Info.Spec.Region,
-			Workers:           b.Shoot.Info.Spec.Provider.Workers,
+			Name:              b.Shoot.GetInfo().Name,
+			Type:              b.Shoot.GetInfo().Spec.Provider.Type,
+			Region:            b.Shoot.GetInfo().Spec.Region,
+			Workers:           b.Shoot.GetInfo().Spec.Provider.Workers,
 			KubernetesVersion: b.Shoot.KubernetesVersion,
 		},
 		worker.DefaultInterval,
@@ -163,7 +163,7 @@ func (b *Botanist) WaitUntilCloudConfigUpdatedForAllWorkerPools(ctx context.Cont
 			return retry.SevereError(err)
 		}
 
-		if err := CloudConfigUpdatedForAllWorkerPools(b.Shoot.Info.Spec.Provider.Workers, workerPoolToNodes, workerPoolToCloudConfigSecretChecksum); err != nil {
+		if err := CloudConfigUpdatedForAllWorkerPools(b.Shoot.GetInfo().Spec.Provider.Workers, workerPoolToNodes, workerPoolToCloudConfigSecretChecksum); err != nil {
 			return retry.MinorError(err)
 		}
 

--- a/pkg/operation/botanist/worker_test.go
+++ b/pkg/operation/botanist/worker_test.go
@@ -112,13 +112,13 @@ var _ = Describe("Worker", func() {
 
 		Context("restore", func() {
 			BeforeEach(func() {
-				botanist.Shoot.Info = &gardencorev1beta1.Shoot{
+				botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
 					Status: gardencorev1beta1.ShootStatus{
 						LastOperation: &gardencorev1beta1.LastOperation{
 							Type: gardencorev1beta1.LastOperationTypeRestore,
 						},
 					},
-				}
+				})
 			})
 
 			It("should restore successfully", func() {
@@ -327,7 +327,7 @@ var _ = Describe("Worker", func() {
 			defer func() { TimeoutWaitCloudConfigUpdated = oldTimeout }()
 			TimeoutWaitCloudConfigUpdated = time.Millisecond
 
-			botanist.Shoot.Info = &gardencorev1beta1.Shoot{
+			botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
 				Spec: gardencorev1beta1.ShootSpec{
 					Provider: gardencorev1beta1.Provider{
 						Workers: []gardencorev1beta1.Worker{
@@ -335,7 +335,7 @@ var _ = Describe("Worker", func() {
 						},
 					},
 				},
-			}
+			})
 
 			gomock.InOrder(
 				seedInterface.EXPECT().Client().Return(seedClient),
@@ -391,7 +391,7 @@ var _ = Describe("Worker", func() {
 			defer func() { TimeoutWaitCloudConfigUpdated = oldTimeout }()
 			TimeoutWaitCloudConfigUpdated = time.Millisecond
 
-			botanist.Shoot.Info = &gardencorev1beta1.Shoot{
+			botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
 				Spec: gardencorev1beta1.ShootSpec{
 					Provider: gardencorev1beta1.Provider{
 						Workers: []gardencorev1beta1.Worker{
@@ -399,7 +399,7 @@ var _ = Describe("Worker", func() {
 						},
 					},
 				},
-			}
+			})
 
 			gomock.InOrder(
 				seedInterface.EXPECT().Client().Return(seedClient),

--- a/pkg/operation/botanist/worker_test.go
+++ b/pkg/operation/botanist/worker_test.go
@@ -82,6 +82,7 @@ var _ = Describe("Worker", func() {
 			},
 			ShootState: shootState,
 		}}
+		botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{})
 	})
 
 	AfterEach(func() {

--- a/pkg/operation/care/constraints.go
+++ b/pkg/operation/care/constraints.go
@@ -76,8 +76,8 @@ func (c *Constraint) Check(
 	constraints []gardencorev1beta1.Condition,
 ) []gardencorev1beta1.Condition {
 	updatedConstraints := c.constraintsChecks(ctx, constraints)
-	lastOp := c.shoot.Info.Status.LastOperation
-	lastErrors := c.shoot.Info.Status.LastErrors
+	lastOp := c.shoot.GetInfo().Status.LastOperation
+	lastErrors := c.shoot.GetInfo().Status.LastErrors
 	return PardonConditions(updatedConstraints, lastOp, lastErrors)
 }
 
@@ -85,7 +85,7 @@ func (c *Constraint) constraintsChecks(
 	ctx context.Context,
 	constraints []gardencorev1beta1.Condition,
 ) []gardencorev1beta1.Condition {
-	if c.shoot.HibernationEnabled || c.shoot.Info.Status.IsHibernated {
+	if c.shoot.HibernationEnabled || c.shoot.GetInfo().Status.IsHibernated {
 		return shootHibernatedConstraints(constraints...)
 	}
 

--- a/pkg/operation/care/garbage_collection.go
+++ b/pkg/operation/care/garbage_collection.go
@@ -54,7 +54,7 @@ func NewGarbageCollection(op *operation.Operation, shootClientInit ShootClientIn
 // objects. It receives a botanist object <botanist> which stores the Shoot object.
 func (g *GarbageCollection) Collect(ctx context.Context) {
 	var (
-		qualifiedShootName = fmt.Sprintf("%s/%s", g.shoot.Info.Namespace, g.shoot.Info.Name)
+		qualifiedShootName = fmt.Sprintf("%s/%s", g.shoot.GetInfo().Namespace, g.shoot.GetInfo().Name)
 		wg                 sync.WaitGroup
 	)
 
@@ -99,7 +99,7 @@ func (g *GarbageCollection) performGarbageCollectionSeed(ctx context.Context) er
 // cluster, i.e., it deletes evicted pods (mitigation for https://github.com/kubernetes/kubernetes/issues/55051).
 func (g *GarbageCollection) performGarbageCollectionShoot(ctx context.Context, shootClient client.Client) error {
 	namespace := metav1.NamespaceSystem
-	if g.shoot.Info.DeletionTimestamp != nil {
+	if g.shoot.GetInfo().DeletionTimestamp != nil {
 		namespace = metav1.NamespaceAll
 	}
 

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -423,7 +423,7 @@ func (o *Operation) ReportShootProgress(ctx context.Context, stats *flow.Stats) 
 		lastUpdateTime = metav1.Now()
 	)
 
-	if err := o.Shoot.UpdateInfoStatus(ctx, o.K8sGardenClient.Client(), func(shoot *gardencorev1beta1.Shoot) error {
+	if err := o.Shoot.UpdateInfoStatus(ctx, o.K8sGardenClient.Client(), true, func(shoot *gardencorev1beta1.Shoot) error {
 		if shoot.Status.LastOperation == nil {
 			return fmt.Errorf("last operation of Shoot %s/%s is unset", shoot.Namespace, shoot.Name)
 		}
@@ -445,7 +445,7 @@ func (o *Operation) ReportShootProgress(ctx context.Context, stats *flow.Stats) 
 // If the status.LastErrors array is empty then status.LastErrors is also removed. It also re-evaluates the shoot status
 // in case the last error list is empty now, and if necessary, updates the status label on the shoot.
 func (o *Operation) CleanShootTaskErrorAndUpdateStatusLabel(ctx context.Context, taskID string) {
-	if err := o.Shoot.UpdateInfoStatus(ctx, o.K8sGardenClient.Client(), func(shoot *gardencorev1beta1.Shoot) error {
+	if err := o.Shoot.UpdateInfoStatus(ctx, o.K8sGardenClient.Client(), false, func(shoot *gardencorev1beta1.Shoot) error {
 		shoot.Status.LastErrors = gardencorev1beta1helper.DeleteLastErrorByTaskID(shoot.Status.LastErrors, taskID)
 		return nil
 	}); err != nil {
@@ -454,7 +454,7 @@ func (o *Operation) CleanShootTaskErrorAndUpdateStatusLabel(ctx context.Context,
 	}
 
 	if len(o.Shoot.GetInfo().Status.LastErrors) == 0 {
-		if err := o.Shoot.UpdateInfo(ctx, o.K8sGardenClient.Client(), func(shoot *gardencorev1beta1.Shoot) error {
+		if err := o.Shoot.UpdateInfo(ctx, o.K8sGardenClient.Client(), false, func(shoot *gardencorev1beta1.Shoot) error {
 			kutil.SetMetaDataLabel(&shoot.ObjectMeta, v1beta1constants.ShootStatus, string(shootpkg.ComputeStatus(
 				shoot.Status.LastOperation,
 				shoot.Status.LastErrors,

--- a/pkg/operation/operation_test.go
+++ b/pkg/operation/operation_test.go
@@ -69,15 +69,14 @@ var _ = Describe("operation", func() {
 				Seed: &operationseed.Seed{
 					Info: seed,
 				},
-				Shoot: &operationshoot.Shoot{
-					Info: shoot,
-				},
+				Shoot: &operationshoot.Shoot{},
 			}
 		)
 
 		shoot.Status = gardencorev1beta1.ShootStatus{
 			TechnicalID: operationshoot.ComputeTechnicalID(projectName, shoot),
 		}
+		o.Shoot.SetInfo(shoot)
 
 		Expect(o.ComputeIngressHost(prefix)).To(matcher)
 	},
@@ -121,10 +120,9 @@ var _ = Describe("operation", func() {
 			k8sGardenRuntimeClient = mockclient.NewMockClient(ctrl)
 			o = &Operation{
 				K8sGardenClient: gardenClient,
-				Shoot: &operationshoot.Shoot{
-					Info: shoot,
-				},
+				Shoot:           &operationshoot.Shoot{},
 			}
+			o.Shoot.SetInfo(shoot)
 		})
 
 		Describe("#EnsureShootStateExists", func() {

--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -321,16 +321,20 @@ func (s *Shoot) SetInfo(shoot *gardencorev1beta1.Shoot) {
 
 // UpdateInfo updates the shoot resource managed by this operation in a concurrency safe way,
 // using the given context, client, and mutate function.
-// It performs a patch using client.MergeFrom rather than client.StrategicMergeFrom, so any changes to list fields
-// will overwrite the changed fields rather than using the specified patch strategy.
+// It performs a patch using either client.MergeFrom or client.StrategicMergeFrom depending on useStrategicMerge.
 // This method is protected by a RW mutex, so only a single SetInfo, UpdateInfo, or UpdateInfoStatus operation can be
 // executed at any point in time.
-func (s *Shoot) UpdateInfo(ctx context.Context, c client.Client, f func(*gardencorev1beta1.Shoot) error) error {
+func (s *Shoot) UpdateInfo(ctx context.Context, c client.Client, useStrategicMerge bool, f func(*gardencorev1beta1.Shoot) error) error {
 	s.infoMutex.Lock()
 	defer s.infoMutex.Unlock()
 
 	shoot := s.info.DeepCopy()
-	patch := client.MergeFrom(shoot.DeepCopy())
+	var patch client.Patch
+	if useStrategicMerge {
+		patch = client.StrategicMergeFrom(shoot.DeepCopy())
+	} else {
+		patch = client.MergeFrom(shoot.DeepCopy())
+	}
 	if err := f(shoot); err != nil {
 		return err
 	}
@@ -343,16 +347,20 @@ func (s *Shoot) UpdateInfo(ctx context.Context, c client.Client, f func(*gardenc
 
 // UpdateInfoStatus updates the status of the shoot resource managed by this operation in a concurrency safe way,
 // using the given context, client, and mutate function.
-// It performs a patch using client.MergeFrom rather than client.StrategicMergeFrom, so any changes to list fields
-// will overwrite the changed fields rather than using the specified patch strategy.
+// It performs a patch using either client.MergeFrom or client.StrategicMergeFrom depending on useStrategicMerge.
 // This method is protected by a RW mutex, so only a single SetInfo, UpdateInfo or UpdateInfoStatus operation can be
 // executed at any point in time.
-func (s *Shoot) UpdateInfoStatus(ctx context.Context, c client.Client, f func(*gardencorev1beta1.Shoot) error) error {
+func (s *Shoot) UpdateInfoStatus(ctx context.Context, c client.Client, useStrategicMerge bool, f func(*gardencorev1beta1.Shoot) error) error {
 	s.infoMutex.Lock()
 	defer s.infoMutex.Unlock()
 
 	shoot := s.info.DeepCopy()
-	patch := client.MergeFrom(shoot.DeepCopy())
+	var patch client.Patch
+	if useStrategicMerge {
+		patch = client.StrategicMergeFrom(shoot.DeepCopy())
+	} else {
+		patch = client.MergeFrom(shoot.DeepCopy())
+	}
 	if err := f(shoot); err != nil {
 		return err
 	}

--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -292,12 +292,12 @@ func (b *Builder) Build(ctx context.Context, c client.Client) (*Shoot, error) {
 	return shoot, nil
 }
 
-// GetInfo returns the shoot resource managed by this operation in a concurrency safe way.
+// GetInfo returns the shoot resource of this Shoot in a concurrency safe way.
 // This method is protected by a RW mutex, so it will block on all concurrent SetInfo, UpdateInfo, or UpdateInfoStatus
 // executions, but not on concurrent GetInfo executions.
 // This method should be used only for reading the data of the returned shoot resource. The returned shoot
 // resource MUST NOT BE MODIFIED (except in test code) since this might interfere with other concurrent reads and writes.
-// To properly update the shoot resource managed by this operation use UpdateInfo or UpdateInfoStatus.
+// To properly update the shoot resource of this Shoot use UpdateInfo or UpdateInfoStatus.
 func (s *Shoot) GetInfo() *gardencorev1beta1.Shoot {
 	s.infoMutex.RLock()
 	defer s.infoMutex.RUnlock()
@@ -305,13 +305,13 @@ func (s *Shoot) GetInfo() *gardencorev1beta1.Shoot {
 	return s.info
 }
 
-// SetInfo sets the shoot resource managed by this operation in a concurrency safe way.
+// SetInfo sets the shoot resource of this Shoot in a concurrency safe way.
 // This method is protected by a RW mutex, so only a single SetInfo, UpdateInfo, or UpdateInfoStatus operation can be
 // executed at any point in time.
 // This method does not update the shoot resource in the cluster and so should be used only in exceptional situations,
 // or as a convenience in test code. The shoot passed as a parameter MUST NOT BE MODIFIED after the call to SetInfo
 // (except in test code) since this might interfere with other concurrent reads and writes.
-// To properly update the shoot resource managed by this operation use UpdateInfo or UpdateInfoStatus.
+// To properly update the shoot resource of this Shoot use UpdateInfo or UpdateInfoStatus.
 func (s *Shoot) SetInfo(shoot *gardencorev1beta1.Shoot) {
 	s.infoMutex.Lock()
 	defer s.infoMutex.Unlock()
@@ -319,7 +319,7 @@ func (s *Shoot) SetInfo(shoot *gardencorev1beta1.Shoot) {
 	s.info = shoot
 }
 
-// UpdateInfo updates the shoot resource managed by this operation in a concurrency safe way,
+// UpdateInfo updates the shoot resource of this Shoot in a concurrency safe way,
 // using the given context, client, and mutate function.
 // It performs a patch using either client.MergeFrom or client.StrategicMergeFrom depending on useStrategicMerge.
 // This method is protected by a RW mutex, so only a single SetInfo, UpdateInfo, or UpdateInfoStatus operation can be
@@ -345,7 +345,7 @@ func (s *Shoot) UpdateInfo(ctx context.Context, c client.Client, useStrategicMer
 	return nil
 }
 
-// UpdateInfoStatus updates the status of the shoot resource managed by this operation in a concurrency safe way,
+// UpdateInfoStatus updates the status of the shoot resource of this Shoot in a concurrency safe way,
 // using the given context, client, and mutate function.
 // It performs a patch using either client.MergeFrom or client.StrategicMergeFrom depending on useStrategicMerge.
 // This method is protected by a RW mutex, so only a single SetInfo, UpdateInfo or UpdateInfoStatus operation can be

--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -391,10 +391,11 @@ func (s *Shoot) GetDNSRecordComponentsForMigration() []component.DeployMigrateWa
 // GetIngressFQDN returns the fully qualified domain name of ingress sub-resource for the Shoot cluster. The
 // end result is '<subDomain>.<ingressPrefix>.<clusterDomain>'.
 func (s *Shoot) GetIngressFQDN(subDomain string) string {
-	if s.GetInfo().Spec.DNS == nil || s.GetInfo().Spec.DNS.Domain == nil {
+	shoot := s.GetInfo()
+	if shoot.Spec.DNS == nil || shoot.Spec.DNS.Domain == nil {
 		return ""
 	}
-	return fmt.Sprintf("%s.%s.%s", subDomain, gutil.IngressPrefix, *(s.GetInfo().Spec.DNS.Domain))
+	return fmt.Sprintf("%s.%s.%s", subDomain, gutil.IngressPrefix, *shoot.Spec.DNS.Domain)
 }
 
 // GetWorkerNames returns a list of names of the worker groups in the Shoot manifest.
@@ -472,9 +473,10 @@ func (s *Shoot) ComputeOutOfClusterAPIServerAddress(apiServerAddress string, use
 
 // IPVSEnabled returns true if IPVS is enabled for the shoot.
 func (s *Shoot) IPVSEnabled() bool {
-	return s.GetInfo().Spec.Kubernetes.KubeProxy != nil &&
-		s.GetInfo().Spec.Kubernetes.KubeProxy.Mode != nil &&
-		*s.GetInfo().Spec.Kubernetes.KubeProxy.Mode == gardencorev1beta1.ProxyModeIPVS
+	shoot := s.GetInfo()
+	return shoot.Spec.Kubernetes.KubeProxy != nil &&
+		shoot.Spec.Kubernetes.KubeProxy.Mode != nil &&
+		*shoot.Spec.Kubernetes.KubeProxy.Mode == gardencorev1beta1.ProxyModeIPVS
 }
 
 // IsLoggingEnabled return true if the Shoot controlplane logging is enabled

--- a/pkg/operation/shoot/shoot_test.go
+++ b/pkg/operation/shoot/shoot_test.go
@@ -53,9 +53,8 @@ var _ = Describe("shoot", func() {
 			ctrl = gomock.NewController(GinkgoT())
 			c = mockclient.NewMockClient(ctrl)
 
-			shoot = &Shoot{
-				Info: &gardencorev1beta1.Shoot{},
-			}
+			shoot = &Shoot{}
+			shoot.SetInfo(&gardencorev1beta1.Shoot{})
 		})
 
 		AfterEach(func() {
@@ -332,16 +331,16 @@ var _ = Describe("shoot", func() {
 				internalDomain := "foo"
 				s := &Shoot{
 					InternalClusterDomain: internalDomain,
-					Info: &gardencorev1beta1.Shoot{
-						Spec: gardencorev1beta1.ShootSpec{
-							DNS: &gardencorev1beta1.DNS{
-								Providers: []gardencorev1beta1.DNSProvider{
-									{Type: &unmanaged},
-								},
+				}
+				s.SetInfo(&gardencorev1beta1.Shoot{
+					Spec: gardencorev1beta1.ShootSpec{
+						DNS: &gardencorev1beta1.DNS{
+							Providers: []gardencorev1beta1.DNSProvider{
+								{Type: &unmanaged},
 							},
 						},
 					},
-				}
+				})
 
 				Expect(s.ComputeOutOfClusterAPIServerAddress("", false)).To(Equal("api." + internalDomain))
 			})
@@ -350,8 +349,8 @@ var _ = Describe("shoot", func() {
 				internalDomain := "foo"
 				s := &Shoot{
 					InternalClusterDomain: internalDomain,
-					Info:                  &gardencorev1beta1.Shoot{},
 				}
+				s.SetInfo(&gardencorev1beta1.Shoot{})
 
 				Expect(s.ComputeOutOfClusterAPIServerAddress("", true)).To(Equal("api." + internalDomain))
 			})
@@ -360,8 +359,8 @@ var _ = Describe("shoot", func() {
 				externalDomain := "foo"
 				s := &Shoot{
 					ExternalClusterDomain: &externalDomain,
-					Info:                  &gardencorev1beta1.Shoot{},
 				}
+				s.SetInfo(&gardencorev1beta1.Shoot{})
 
 				Expect(s.ComputeOutOfClusterAPIServerAddress("", false)).To(Equal("api." + externalDomain))
 			})

--- a/pkg/operation/shoot/shoot_test.go
+++ b/pkg/operation/shoot/shoot_test.go
@@ -119,18 +119,18 @@ var _ = Describe("shoot", func() {
 
 		Describe("#IPVSEnabled", func() {
 			It("should return false when KubeProxy is null", func() {
-				shoot.Info.Spec.Kubernetes.KubeProxy = nil
+				shoot.GetInfo().Spec.Kubernetes.KubeProxy = nil
 				Expect(shoot.IPVSEnabled()).To(BeFalse())
 			})
 
 			It("should return false when KubeProxy.Mode is null", func() {
-				shoot.Info.Spec.Kubernetes.KubeProxy = &gardencorev1beta1.KubeProxyConfig{}
+				shoot.GetInfo().Spec.Kubernetes.KubeProxy = &gardencorev1beta1.KubeProxyConfig{}
 				Expect(shoot.IPVSEnabled()).To(BeFalse())
 			})
 
 			It("should return false when KubeProxy.Mode is not IPVS", func() {
 				mode := gardencorev1beta1.ProxyModeIPTables
-				shoot.Info.Spec.Kubernetes.KubeProxy = &gardencorev1beta1.KubeProxyConfig{
+				shoot.GetInfo().Spec.Kubernetes.KubeProxy = &gardencorev1beta1.KubeProxyConfig{
 					Mode: &mode,
 				}
 				Expect(shoot.IPVSEnabled()).To(BeFalse())
@@ -138,7 +138,7 @@ var _ = Describe("shoot", func() {
 
 			It("should return true when KubeProxy.Mode is IPVS", func() {
 				mode := gardencorev1beta1.ProxyModeIPVS
-				shoot.Info.Spec.Kubernetes.KubeProxy = &gardencorev1beta1.KubeProxyConfig{
+				shoot.GetInfo().Spec.Kubernetes.KubeProxy = &gardencorev1beta1.KubeProxyConfig{
 					Mode: &mode,
 				}
 				Expect(shoot.IPVSEnabled()).To(BeTrue())

--- a/pkg/operation/shoot/types.go
+++ b/pkg/operation/shoot/types.go
@@ -17,6 +17,7 @@ package shoot
 import (
 	"context"
 	"net"
+	"sync"
 
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -59,6 +60,7 @@ type Builder struct {
 // Shoot is an object containing information about a Shoot cluster.
 type Shoot struct {
 	Info         *gardencorev1beta1.Shoot
+	InfoMutex    sync.RWMutex
 	Secret       *corev1.Secret
 	CloudProfile *gardencorev1beta1.CloudProfile
 

--- a/pkg/operation/shoot/types.go
+++ b/pkg/operation/shoot/types.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"net"
 	"sync"
+	"sync/atomic"
 
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -59,8 +60,8 @@ type Builder struct {
 
 // Shoot is an object containing information about a Shoot cluster.
 type Shoot struct {
-	info      *gardencorev1beta1.Shoot
-	infoMutex sync.RWMutex
+	info      atomic.Value
+	infoMutex sync.Mutex
 
 	Secret       *corev1.Secret
 	CloudProfile *gardencorev1beta1.CloudProfile

--- a/pkg/operation/shoot/types.go
+++ b/pkg/operation/shoot/types.go
@@ -59,8 +59,9 @@ type Builder struct {
 
 // Shoot is an object containing information about a Shoot cluster.
 type Shoot struct {
-	Info         *gardencorev1beta1.Shoot
-	InfoMutex    sync.RWMutex
+	info      *gardencorev1beta1.Shoot
+	infoMutex sync.RWMutex
+
 	Secret       *corev1.Secret
 	CloudProfile *gardencorev1beta1.CloudProfile
 


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind bug

**What this PR does / why we need it**:
* Ensures that patch operations on `b.Shoot.Info` (or `o.Shoot.Info`) are always performed on a copy, and the result is written back to `b.Shoot.Info` via a single pointer assignment. This is important to ensure that data races due to other goroutines reading from `b.Shoot.Info` while it's being patched are avoided as much as possible.
* Replaces usages of `o.Shoot.Info` in `shoot_control.go` with the shoot object that was used to initialize the operation. This is a cosmetic change that doesn't have a real functional impact (the 2 pointers are equal), but is important for consistency. The original pointer can be written to safely in this file without copying since at this point there are no concurrent goroutines reading from it.
* Replaces all naked usages of `b.Shoot.Info` in production code that could be executed concurrently with the newly introduced methods `GetInfo()`, `UpdateInfo()`, and `UpdateInfoStatus()` that perform reading and modification in a concurrency safe way.
* Introduces another new method `SetInfo()` and replaces all naked assignments to `b.Shoot.Info` in test code with this method.
* Renames `Info` to `info`, ensuring that it can only be read from and written to using the above methods.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
There are several issues with the current patching approach that are hopefully addressed by this change:

* Most importantly, it is dangerous to pass an object to `Patch` functions that is concurrently read from (or even written to) by other goroutines. There is a lot happening during patching (decoding, conversion, etc.) and a possibility that the object is invalid at some point during this operation. This wouldn't matter in single-threaded code, but in multi-threaded code this could lead to issues similar to what we observed in https://github.com/gardener/gardener-extension-provider-azure/issues/328#issuecomment-879824536, due to the read taking place exactly at the point when the object is invalid (e.g status is empty).
* If the patch operation failed, we would have a mismatch between `b.Shoot.Info` (which was already updated) and the actual resource (which was not updated due to the error). This could lead to other unforseen issues, especially if the reconciliation is allowed to continue after such an error.

All places where `o.Shoot.Info` is modified and the associated patch operations are therefore refactored to follow this pattern:

```go
	shoot = o.Shoot.Info.DeepCopy()
	patch := client.MergeFrom(shoot.DeepCopy())
	// Modify shoot ...
	if err := o.K8sGardenClient.Client().Patch(ctx, shoot, patch); err != nil {
		return err
	}
	o.Shoot.Info = shoot
```

Note that this doesn't completely address all potential issues:
* The pointer `o.Shoot.Info` is still unprotected and therefore data races are still possible because [assignment to a pointer is also not inherently an atomic operation](https://stackoverflow.com/questions/34750323/is-variable-assignment-atomic-in-go) (although it's much faster than `Patch` and therefore the probability for a data race is much lower).
* If multiple modifications and patches happen concurrently to each other (assuming this is actually possible), at the end one would overwrite the result of the other (the shoot resource itself would be updated but the change to `o.Shoot.Info` would be lost). 

To address the above:
* The `Info` field is renamed to `info` of type `atomic.Value`.
* All usages of naked `Info` are replaced by appropriate methods. There are four such methods: `GetInfo`, `SetInfo`, `UpdateInfo`, and `UpdateInfoStatus`. They all perform appropriate atomic loading and storing of the `info` value.
* All updates to `info` (`UpdateInfo`, `UpdateInfoStatus`) are protected with a `sync.Mutex` to ensure that there is only one concurrent update, and performed on a copy of the value stored in `info`, in order to protect readers (`GetInfo` itself is not protected apart from loading the value atomically).
* All methods are appropriately documented how to use them correctly.

The above approach seems to be a pattern, see the `ReadMostly` example in https://pkg.go.dev/sync/atomic#Value.

Note that it's still possible to cause data races by using `GetInfo` and `SetInfo` in production code inappropriately. I couldn't think of a way to prevent this aside from doing a copy inside these methods, which would result in massive unneeded copying. I think it's still much better than before since it would be hard not to notice the explicit documentation, and if this happens errors could still be prevented by proper reviewing.

**Release note**:

```other operator
Improved handling of the shoot resource in the shoot controller to ensure that data races are avoided as much as possible.
```
