### PR TITLE
Add checking for empty status during flow executions

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_delete.go
@@ -44,6 +44,10 @@ import (
 // runDeleteShootFlow deletes a Shoot cluster entirely.
 // It receives an Operation object <o> which stores the Shoot object and an ErrorContext which contains error from the previous operation.
 func (c *Controller) runDeleteShootFlow(ctx context.Context, o *operation.Operation) *gardencorev1beta1helper.WrappedLastErrors {
+	checkCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	go checkShootStatus(checkCtx, o)
+
 	var (
 		botanist                             *botanistpkg.Botanist
 		kubeAPIServerDeploymentFound         = true


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind test

**What this PR does / why we need it**:
Adds checking for empty status fields during the shoot and seed flow executions. This is intended to help verify whether there could be any leftover data races after the fixes introduced with #4459.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
In its current form, this PR is not intended to be merged, but it still could be used to produce `gardenlet` images for use in dedicated seeds for checking concurrency issues during shoot / seed reconciliation. It's therefore marked as `Draft`.

With @timuthy we discussed merging a similar change but with an additional checking for a special annotation before starting the checking goroutine. However, the aggressive checking performed by this goroutine significantly increases the CPU usage while shoot reconciliations are in progress, which could interfere badly with other shoots on the same seed. Therefore, we think it could only be enabled on special seeds that are created temporarily just for this purpose.

**Release note**:

```other operator
NONE
```
