### PR TITLE
Perform reads and modifications to Seed.Info in a concurrency safe way

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control.go
@@ -277,7 +277,7 @@ func (c *Controller) initializeOperation(ctx context.Context, logger logrus.Fiel
 		WithShootSecretFrom(gardenClient.Client()).
 		WithProjectName(project.Name).
 		WithExposureClassFrom(gardenClient.Client()).
-		WithDisableDNS(!seedObj.Info.Spec.Settings.ShootDNS.Enabled).
+		WithDisableDNS(!seed.Spec.Settings.ShootDNS.Enabled).
 		WithInternalDomain(gardenObj.InternalDomain).
 		WithDefaultDomains(gardenObj.DefaultDomains).
 		Build(ctx, gardenClient.Client())
@@ -507,7 +507,7 @@ func (c *Controller) reconcileShoot(ctx context.Context, logger logrus.FieldLogg
 	}
 
 	c.recorder.Event(shoot, corev1.EventTypeNormal, gardencorev1beta1.EventReconciled, "Reconciled Shoot cluster state")
-	if err := c.patchShootStatusOperationSuccess(ctx, gardenClient.Client(), o, shoot, o.Shoot.SeedNamespace, &o.Seed.Info.Name, operationType); err != nil {
+	if err := c.patchShootStatusOperationSuccess(ctx, gardenClient.Client(), o, shoot, o.Shoot.SeedNamespace, &seed.Name, operationType); err != nil {
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -79,7 +79,7 @@ func (c *Controller) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		defaultTimeout                 = 30 * time.Second
 		defaultInterval                = 5 * time.Second
 		dnsEnabled                     = !o.Shoot.DisableDNS
-		allowBackup                    = o.Seed.Info.Spec.Backup != nil
+		allowBackup                    = o.Seed.GetInfo().Spec.Backup != nil
 		staticNodesCIDR                = o.Shoot.GetInfo().Spec.Networking.Nodes != nil
 		useSNI                         = botanist.APIServerSNIEnabled()
 		generation                     = o.Shoot.GetInfo().Generation

--- a/pkg/operation/botanist/backupentry.go
+++ b/pkg/operation/botanist/backupentry.go
@@ -38,7 +38,7 @@ func (b *Botanist) DefaultCoreBackupEntry() component.DeployMigrateWaiter {
 			ShootPurpose:   b.Shoot.GetInfo().Spec.Purpose,
 			OwnerReference: ownerRef,
 			SeedName:       b.Shoot.GetInfo().Spec.SeedName,
-			BucketName:     string(b.Seed.Info.UID),
+			BucketName:     string(b.Seed.GetInfo().UID),
 		},
 		corebackupentry.DefaultInterval,
 		corebackupentry.DefaultTimeout,

--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -182,11 +182,11 @@ func (b *Botanist) RequiredExtensionsReady(ctx context.Context) error {
 		return err
 	}
 
-	requiredExtensions := shootpkg.ComputeRequiredExtensions(b.Shoot.GetInfo(), b.Seed.Info, controllerRegistrationList, b.Garden.InternalDomain, b.Shoot.ExternalDomain,
+	requiredExtensions := shootpkg.ComputeRequiredExtensions(b.Shoot.GetInfo(), b.Seed.GetInfo(), controllerRegistrationList, b.Garden.InternalDomain, b.Shoot.ExternalDomain,
 		gardenletfeatures.FeatureGate.Enabled(features.UseDNSRecords))
 
 	for _, controllerInstallation := range controllerInstallationList.Items {
-		if controllerInstallation.Spec.SeedRef.Name != b.Seed.Info.Name {
+		if controllerInstallation.Spec.SeedRef.Name != b.Seed.GetInfo().Name {
 			continue
 		}
 

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -236,8 +236,8 @@ func (b *Botanist) DefaultControlPlane(purpose extensionsv1alpha1.Purpose) exten
 		values.Region = b.Shoot.GetInfo().Spec.Region
 
 	case extensionsv1alpha1.Exposure:
-		values.Type = b.Seed.Info.Spec.Provider.Type
-		values.Region = b.Seed.Info.Spec.Provider.Region
+		values.Type = b.Seed.GetInfo().Spec.Provider.Type
+		values.Region = b.Seed.GetInfo().Spec.Provider.Region
 	}
 
 	return extensionscontrolplane.New(

--- a/pkg/operation/botanist/etcd.go
+++ b/pkg/operation/botanist/etcd.go
@@ -91,7 +91,7 @@ func (b *Botanist) DeployEtcd(ctx context.Context) error {
 	b.Shoot.Components.ControlPlane.EtcdMain.SetSecrets(secrets)
 	b.Shoot.Components.ControlPlane.EtcdEvents.SetSecrets(secrets)
 
-	if b.Seed.Info.Spec.Backup != nil {
+	if b.Seed.GetInfo().Spec.Backup != nil {
 		secret := &corev1.Secret{}
 		if err := b.K8sSeedClient.Client().Get(ctx, kutil.Key(b.Shoot.SeedNamespace, genericactuator.BackupSecretName), secret); err != nil {
 			return err
@@ -103,7 +103,7 @@ func (b *Botanist) DeployEtcd(ctx context.Context) error {
 		}
 
 		b.Shoot.Components.ControlPlane.EtcdMain.SetBackupConfig(&etcd.BackupConfig{
-			Provider:             b.Seed.Info.Spec.Backup.Provider,
+			Provider:             b.Seed.GetInfo().Spec.Backup.Provider,
 			SecretRefName:        genericactuator.BackupSecretName,
 			Prefix:               b.Shoot.BackupEntryName,
 			Container:            string(secret.Data[genericactuator.DataKeyBackupBucketName]),

--- a/pkg/operation/botanist/etcd_test.go
+++ b/pkg/operation/botanist/etcd_test.go
@@ -89,12 +89,11 @@ var _ = Describe("Etcd", func() {
 
 		BeforeEach(func() {
 			botanist.K8sSeedClient = kubernetesClient
-			botanist.Seed = &seedpkg.Seed{
-				Info: &gardencorev1beta1.Seed{},
-			}
+			botanist.Seed = &seedpkg.Seed{}
 			botanist.Shoot = &shootpkg.Shoot{
 				SeedNamespace: namespace,
 			}
+			botanist.Seed.SetInfo(&gardencorev1beta1.Seed{})
 			botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
 				Spec: gardencorev1beta1.ShootSpec{
 					Maintenance: &gardencorev1beta1.Maintenance{
@@ -254,9 +253,7 @@ var _ = Describe("Etcd", func() {
 			botanist.StoreCheckSum(secretNameCA, checksumCA)
 			botanist.StoreCheckSum(secretNameServer, checksumServer)
 			botanist.StoreCheckSum(secretNameClient, checksumClient)
-			botanist.Seed = &seedpkg.Seed{
-				Info: &gardencorev1beta1.Seed{},
-			}
+			botanist.Seed = &seedpkg.Seed{}
 			botanist.Shoot = &shootpkg.Shoot{
 				Components: &shootpkg.Components{
 					ControlPlane: &shootpkg.ControlPlane{
@@ -267,6 +264,7 @@ var _ = Describe("Etcd", func() {
 				SeedNamespace:   namespace,
 				BackupEntryName: namespace + "--" + string(shootUID),
 			}
+			botanist.Seed.SetInfo(&gardencorev1beta1.Seed{})
 			botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
 				Spec: gardencorev1beta1.ShootSpec{
 					Maintenance: &gardencorev1beta1.Maintenance{
@@ -313,7 +311,7 @@ var _ = Describe("Etcd", func() {
 
 		Context("w/o backup", func() {
 			BeforeEach(func() {
-				botanist.Seed.Info.Spec.Backup = nil
+				botanist.Seed.GetInfo().Spec.Backup = nil
 			})
 
 			It("should set the secrets and deploy", func() {
@@ -335,7 +333,7 @@ var _ = Describe("Etcd", func() {
 			)
 
 			BeforeEach(func() {
-				botanist.Seed.Info.Spec.Backup = &gardencorev1beta1.SeedBackup{
+				botanist.Seed.GetInfo().Spec.Backup = &gardencorev1beta1.SeedBackup{
 					Provider: backupProvider,
 				}
 			})

--- a/pkg/operation/botanist/logging.go
+++ b/pkg/operation/botanist/logging.go
@@ -60,7 +60,7 @@ func (b *Botanist) DeploySeedLogging(ctx context.Context) error {
 		lokiValues["rbacSidecarEnabled"] = true
 		lokiValues["kubeRBACProxyKubeconfigCheckSum"] = b.LoadCheckSum(logging.SecretNameLokiKubeRBACProxyKubeconfig)
 		lokiValues["ingress"] = map[string]interface{}{
-			"class": getIngressClass(b.Seed.Info.Spec.Ingress),
+			"class": getIngressClass(b.Seed.GetInfo().Spec.Ingress),
 			"hosts": []map[string]interface{}{
 				{
 					"hostName":    b.ComputeLokiHost(),

--- a/pkg/operation/botanist/monitoring.go
+++ b/pkg/operation/botanist/monitoring.go
@@ -135,7 +135,7 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 				"enabled": b.Shoot.NodeLocalDNSEnabled,
 			},
 			"ingress": map[string]interface{}{
-				"class":           getIngressClass(b.Seed.Info.Spec.Ingress),
+				"class":           getIngressClass(b.Seed.GetInfo().Spec.Ingress),
 				"basicAuthSecret": basicAuth,
 				"hosts":           hosts,
 			},
@@ -146,8 +146,8 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 			"apiserverServiceIP": b.Shoot.Networks.APIServer.String(),
 			"seed": map[string]interface{}{
 				"apiserver": b.K8sSeedClient.RESTConfig().Host,
-				"region":    b.Seed.Info.Spec.Provider.Region,
-				"provider":  b.Seed.Info.Spec.Provider.Type,
+				"region":    b.Seed.GetInfo().Spec.Provider.Region,
+				"provider":  b.Seed.GetInfo().Spec.Provider.Type,
 			},
 			"rules": map[string]interface{}{
 				"optional": map[string]interface{}{
@@ -265,7 +265,7 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 
 		alertManagerValues, err := b.InjectSeedShootImages(map[string]interface{}{
 			"ingress": map[string]interface{}{
-				"class":           getIngressClass(b.Seed.Info.Spec.Ingress),
+				"class":           getIngressClass(b.Seed.GetInfo().Spec.Ingress),
 				"basicAuthSecret": basicAuthUsers,
 				"hosts":           hosts,
 			},
@@ -425,7 +425,7 @@ func (b *Botanist) deployGrafanaCharts(ctx context.Context, role, dashboards, ba
 
 	values, err := b.InjectSeedShootImages(map[string]interface{}{
 		"ingress": map[string]interface{}{
-			"class":           getIngressClass(b.Seed.Info.Spec.Ingress),
+			"class":           getIngressClass(b.Seed.GetInfo().Spec.Ingress),
 			"basicAuthSecret": basicAuth,
 			"hosts":           hosts,
 		},

--- a/pkg/operation/botanist/namespaces.go
+++ b/pkg/operation/botanist/namespaces.go
@@ -52,10 +52,10 @@ func (b *Botanist) DeploySeedNamespace(ctx context.Context) error {
 		}
 		namespace.Labels = map[string]string{
 			v1beta1constants.GardenRole:              v1beta1constants.GardenRoleShoot,
-			v1beta1constants.LabelSeedProvider:       b.Seed.Info.Spec.Provider.Type,
+			v1beta1constants.LabelSeedProvider:       b.Seed.GetInfo().Spec.Provider.Type,
 			v1beta1constants.LabelShootProvider:      b.Shoot.GetInfo().Spec.Provider.Type,
 			v1beta1constants.LabelNetworkingProvider: b.Shoot.GetInfo().Spec.Networking.Type,
-			v1beta1constants.LabelBackupProvider:     b.Seed.Info.Spec.Provider.Type,
+			v1beta1constants.LabelBackupProvider:     b.Seed.GetInfo().Spec.Provider.Type,
 		}
 
 		requiredExtensions, err := getShootRequiredExtensionTypes(ctx, b)
@@ -67,8 +67,8 @@ func (b *Botanist) DeploySeedNamespace(ctx context.Context) error {
 			namespace.Labels[v1beta1constants.LabelExtensionPrefix+extensionType] = "true"
 		}
 
-		if b.Seed.Info.Spec.Backup != nil {
-			namespace.Labels[v1beta1constants.LabelBackupProvider] = b.Seed.Info.Spec.Backup.Provider
+		if b.Seed.GetInfo().Spec.Backup != nil {
+			namespace.Labels[v1beta1constants.LabelBackupProvider] = b.Seed.GetInfo().Spec.Backup.Provider
 		}
 
 		return nil

--- a/pkg/operation/botanist/namespaces_test.go
+++ b/pkg/operation/botanist/namespaces_test.go
@@ -107,6 +107,7 @@ var _ = Describe("Namespaces", func() {
 		botanist = &Botanist{Operation: &operation.Operation{
 			K8sSeedClient:   seedKubernetesClient,
 			K8sGardenClient: gardenKubernetesClient,
+			Seed:            &seed.Seed{},
 			Shoot:           &shoot.Shoot{SeedNamespace: namespace},
 			Garden:          &garden.Garden{},
 		}}
@@ -128,7 +129,7 @@ var _ = Describe("Namespaces", func() {
 		)
 
 		BeforeEach(func() {
-			botanist.Seed = &seed.Seed{Info: &gardencorev1beta1.Seed{
+			botanist.Seed.SetInfo(&gardencorev1beta1.Seed{
 				Spec: gardencorev1beta1.SeedSpec{
 					Provider: gardencorev1beta1.SeedProvider{
 						Type: seedProviderType,
@@ -139,7 +140,7 @@ var _ = Describe("Namespaces", func() {
 						},
 					},
 				},
-			}}
+			})
 
 			defaultShootInfo = &gardencorev1beta1.Shoot{
 				Spec: gardencorev1beta1.ShootSpec{
@@ -200,7 +201,7 @@ var _ = Describe("Namespaces", func() {
 		})
 
 		It("should successfully deploy the namespace w/ dedicated backup provider", func() {
-			botanist.Seed.Info.Spec.Backup = &gardencorev1beta1.SeedBackup{Provider: backupProviderType}
+			botanist.Seed.GetInfo().Spec.Backup = &gardencorev1beta1.SeedBackup{Provider: backupProviderType}
 			obj.Labels["backup.gardener.cloud/provider"] = backupProviderType
 
 			gomock.InOrder(

--- a/pkg/operation/botanist/networkpolicies.go
+++ b/pkg/operation/botanist/networkpolicies.go
@@ -42,25 +42,25 @@ func (b *Botanist) DefaultNetworkPolicies(sniPhase component.Phase) (component.D
 		shootCIDRNetworks = append(shootCIDRNetworks, *v)
 	}
 
-	shootNetworkPeers, err := networkpolicies.NetworkPolicyPeersWithExceptions(shootCIDRNetworks, b.Seed.Info.Spec.Networks.BlockCIDRs...)
+	shootNetworkPeers, err := networkpolicies.NetworkPolicyPeersWithExceptions(shootCIDRNetworks, b.Seed.GetInfo().Spec.Networks.BlockCIDRs...)
 	if err != nil {
 		return nil, err
 	}
 
-	seedCIDRNetworks := []string{b.Seed.Info.Spec.Networks.Pods, b.Seed.Info.Spec.Networks.Services}
-	if v := b.Seed.Info.Spec.Networks.Nodes; v != nil {
+	seedCIDRNetworks := []string{b.Seed.GetInfo().Spec.Networks.Pods, b.Seed.GetInfo().Spec.Networks.Services}
+	if v := b.Seed.GetInfo().Spec.Networks.Nodes; v != nil {
 		seedCIDRNetworks = append(seedCIDRNetworks, *v)
 	}
 
 	allCIDRNetworks := append(seedCIDRNetworks, shootCIDRNetworks...)
-	allCIDRNetworks = append(allCIDRNetworks, b.Seed.Info.Spec.Networks.BlockCIDRs...)
+	allCIDRNetworks = append(allCIDRNetworks, b.Seed.GetInfo().Spec.Networks.BlockCIDRs...)
 
 	privateNetworkPeers, err := networkpolicies.ToNetworkPolicyPeersWithExceptions(networkpolicies.AllPrivateNetworkBlocks(), allCIDRNetworks...)
 	if err != nil {
 		return nil, err
 	}
 
-	_, seedServiceCIDR, err := net.ParseCIDR(b.Seed.Info.Spec.Networks.Services)
+	_, seedServiceCIDR, err := net.ParseCIDR(b.Seed.GetInfo().Spec.Networks.Services)
 	if err != nil {
 		return nil, err
 	}
@@ -79,7 +79,7 @@ func (b *Botanist) DefaultNetworkPolicies(sniPhase component.Phase) (component.D
 				// When disabling SNI (previously enabled), the control plane is transitioning between states, thus
 				// it needs to be ensured that the traffic from old clients can still reach the API server.
 				SNIEnabled:           sniPhase == component.PhaseEnabled || sniPhase == component.PhaseEnabling || sniPhase == component.PhaseDisabling,
-				BlockedAddresses:     b.Seed.Info.Spec.Networks.BlockCIDRs,
+				BlockedAddresses:     b.Seed.GetInfo().Spec.Networks.BlockCIDRs,
 				PrivateNetworkPeers:  privateNetworkPeers,
 				DenyAllTraffic:       true,
 				NodeLocalIPVSAddress: pointer.String(common.NodeLocalIPVSAddress),

--- a/pkg/operation/botanist/networkpolicies_test.go
+++ b/pkg/operation/botanist/networkpolicies_test.go
@@ -70,16 +70,7 @@ var _ = Describe("Networkpolicies", func() {
 		botanist = &Botanist{
 			Operation: &operation.Operation{
 				K8sSeedClient: clientInterface,
-				Seed: &seedpkg.Seed{
-					Info: &gardencorev1beta1.Seed{
-						Spec: gardencorev1beta1.SeedSpec{
-							Networks: gardencorev1beta1.SeedNetworks{
-								Pods:     podCIDRSeed,
-								Services: serviceCIDRSeed,
-							},
-						},
-					},
-				},
+				Seed:          &seedpkg.Seed{},
 				Shoot: &shootpkg.Shoot{
 					Networks: &shootpkg.Networks{
 						CoreDNS: []byte{20, 0, 0, 10},
@@ -88,6 +79,14 @@ var _ = Describe("Networkpolicies", func() {
 				},
 			},
 		}
+		botanist.Seed.SetInfo(&gardencorev1beta1.Seed{
+			Spec: gardencorev1beta1.SeedSpec{
+				Networks: gardencorev1beta1.SeedNetworks{
+					Pods:     podCIDRSeed,
+					Services: serviceCIDRSeed,
+				},
+			},
+		})
 		botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{})
 	})
 
@@ -130,8 +129,8 @@ var _ = Describe("Networkpolicies", func() {
 				botanist.Shoot.GetInfo().Spec.Networking.Pods = &podCIDRShoot
 				botanist.Shoot.GetInfo().Spec.Networking.Services = &serviceCIDRShoot
 				botanist.Shoot.GetInfo().Spec.Networking.Nodes = &nodeCIDRShoot
-				botanist.Seed.Info.Spec.Networks.Nodes = &nodeCIDRSeed
-				botanist.Seed.Info.Spec.Networks.BlockCIDRs = blockCIDRs
+				botanist.Seed.GetInfo().Spec.Networks.Nodes = &nodeCIDRSeed
+				botanist.Seed.GetInfo().Spec.Networks.BlockCIDRs = blockCIDRs
 			},
 			func(client client.Client, namespace string, values networkpolicies.Values) {
 				Expect(client).To(Equal(c))

--- a/pkg/operation/botanist/operatingsystemconfig_test.go
+++ b/pkg/operation/botanist/operatingsystemconfig_test.go
@@ -84,21 +84,20 @@ var _ = Describe("operatingsystemconfig", func() {
 				},
 				Purpose: "development",
 			},
-			Seed: &seedpkg.Seed{
-				Info: &gardencorev1beta1.Seed{
-					Spec: gardencorev1beta1.SeedSpec{
-						DNS: gardencorev1beta1.SeedDNS{
-							IngressDomain: &ingressDomain,
-						},
-					},
-				},
-			},
+			Seed:       &seedpkg.Seed{},
 			ShootState: shootState,
 		}}
 		botanist.StoreSecret(v1beta1constants.SecretNameCACluster, &corev1.Secret{Data: map[string][]byte{"ca.crt": ca}})
 		botanist.StoreSecret(v1beta1constants.SecretNameCAKubelet, &corev1.Secret{Data: map[string][]byte{"ca.crt": caKubelet}})
 		botanist.StoreSecret(v1beta1constants.SecretNameSSHKeyPair, &corev1.Secret{Data: map[string][]byte{"id_rsa.pub": sshPublicKey}})
 		botanist.StoreSecret(v1beta1constants.SecretNameOldSSHKeyPair, &corev1.Secret{Data: map[string][]byte{"id_rsa.pub": sshPublicKeyOld}})
+		botanist.Seed.SetInfo(&gardencorev1beta1.Seed{
+			Spec: gardencorev1beta1.SeedSpec{
+				DNS: gardencorev1beta1.SeedDNS{
+					IngressDomain: &ingressDomain,
+				},
+			},
+		})
 		botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
 			Status: gardencorev1beta1.ShootStatus{
 				TechnicalID: "shoot--garden-testing",

--- a/pkg/operation/botanist/resource_manager.go
+++ b/pkg/operation/botanist/resource_manager.go
@@ -39,7 +39,7 @@ func (b *Botanist) DefaultResourceManager() (resourcemanager.Interface, error) {
 
 	cfg := resourcemanager.Values{
 		AlwaysUpdate:               pointer.Bool(true),
-		ClusterIdentity:            b.Seed.Info.Status.ClusterIdentity,
+		ClusterIdentity:            b.Seed.GetInfo().Status.ClusterIdentity,
 		ConcurrentSyncs:            pointer.Int32(20),
 		HealthSyncPeriod:           utils.DurationPtr(time.Minute),
 		MaxConcurrentHealthWorkers: pointer.Int32(10),

--- a/pkg/operation/botanist/wanted_secrets.go
+++ b/pkg/operation/botanist/wanted_secrets.go
@@ -151,7 +151,7 @@ func (b *Botanist) generateWantedSecretConfigs(basicAuthAPIServer *secrets.Basic
 		endUserCrtValidity = common.EndUserCrtValidity
 	)
 
-	if !b.Seed.Info.Spec.Settings.ShootDNS.Enabled {
+	if !b.Seed.GetInfo().Spec.Settings.ShootDNS.Enabled {
 		if addr := net.ParseIP(b.APIServerAddress); addr != nil {
 			apiServerIPAddresses = append(apiServerIPAddresses, addr)
 		} else {

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -178,7 +178,7 @@ func (b *Builder) WithShootFromCluster(gardenClient, seedClient kubernetes.Inter
 			WithShootSecretFrom(gardenClient.Client()).
 			WithProjectName(gardenObj.Project.Name).
 			WithExposureClassFrom(gardenClient.Client()).
-			WithDisableDNS(!seedObj.Info.Spec.Settings.ShootDNS.Enabled).
+			WithDisableDNS(!seedObj.GetInfo().Spec.Settings.ShootDNS.Enabled).
 			WithInternalDomain(gardenObj.InternalDomain).
 			WithDefaultDomains(gardenObj.DefaultDomains).
 			Build(ctx, c)
@@ -321,7 +321,7 @@ func (o *Operation) InitializeSeedClients(ctx context.Context) error {
 		return nil
 	}
 
-	seedClient, err := o.ClientMap.GetClient(ctx, keys.ForSeed(o.Seed.Info))
+	seedClient, err := o.ClientMap.GetClient(ctx, keys.ForSeed(o.Seed.GetInfo()))
 	if err != nil {
 		return fmt.Errorf("failed to get seed client: %w", err)
 	}

--- a/pkg/operation/operation_test.go
+++ b/pkg/operation/operation_test.go
@@ -66,9 +66,7 @@ var _ = Describe("operation", func() {
 				},
 			}
 			o = &Operation{
-				Seed: &operationseed.Seed{
-					Info: seed,
-				},
+				Seed:  &operationseed.Seed{},
 				Shoot: &operationshoot.Shoot{},
 			}
 		)
@@ -76,6 +74,8 @@ var _ = Describe("operation", func() {
 		shoot.Status = gardencorev1beta1.ShootStatus{
 			TechnicalID: operationshoot.ComputeTechnicalID(projectName, shoot),
 		}
+
+		o.Seed.SetInfo(seed)
 		o.Shoot.SetInfo(shoot)
 
 		Expect(o.ComputeIngressHost(prefix)).To(matcher)

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -114,13 +114,92 @@ func (b *Builder) Build(ctx context.Context) (*Seed, error) {
 	if err != nil {
 		return nil, err
 	}
-	seed.Info = seedObject
+	seed.SetInfo(seedObject)
 
 	if seedObject.Spec.Settings != nil && seedObject.Spec.Settings.LoadBalancerServices != nil {
 		seed.LoadBalancerServiceAnnotations = seedObject.Spec.Settings.LoadBalancerServices.Annotations
 	}
 
 	return seed, nil
+}
+
+// GetInfo returns the seed resource of this Seed in a concurrency safe way.
+// This method is protected by a RW mutex, so it will block on all concurrent SetInfo, UpdateInfo, or UpdateInfoStatus
+// executions, but not on concurrent GetInfo executions.
+// This method should be used only for reading the data of the returned seed resource. The returned seed
+// resource MUST NOT BE MODIFIED (except in test code) since this might interfere with other concurrent reads and writes.
+// To properly update the seed resource of this Seed use UpdateInfo or UpdateInfoStatus.
+func (s *Seed) GetInfo() *gardencorev1beta1.Seed {
+	s.infoMutex.RLock()
+	defer s.infoMutex.RUnlock()
+
+	return s.info
+}
+
+// SetInfo sets the seed resource of this Seed in a concurrency safe way.
+// This method is protected by a RW mutex, so only a single SetInfo, UpdateInfo, or UpdateInfoStatus operation can be
+// executed at any point in time.
+// This method does not update the seed resource in the cluster and so should be used only in exceptional situations,
+// or as a convenience in test code. The seed passed as a parameter MUST NOT BE MODIFIED after the call to SetInfo
+// (except in test code) since this might interfere with other concurrent reads and writes.
+// To properly update the seed resource of this Seed use UpdateInfo or UpdateInfoStatus.
+func (s *Seed) SetInfo(seed *gardencorev1beta1.Seed) {
+	s.infoMutex.Lock()
+	defer s.infoMutex.Unlock()
+
+	s.info = seed
+}
+
+// UpdateInfo updates the seed resource of this Seed in a concurrency safe way,
+// using the given context, client, and mutate function.
+// It performs a patch using either client.MergeFrom or client.StrategicMergeFrom depending on useStrategicMerge.
+// This method is protected by a RW mutex, so only a single SetInfo, UpdateInfo, or UpdateInfoStatus operation can be
+// executed at any point in time.
+func (s *Seed) UpdateInfo(ctx context.Context, c client.Client, useStrategicMerge bool, f func(*gardencorev1beta1.Seed) error) error {
+	s.infoMutex.Lock()
+	defer s.infoMutex.Unlock()
+
+	seed := s.info.DeepCopy()
+	var patch client.Patch
+	if useStrategicMerge {
+		patch = client.StrategicMergeFrom(seed.DeepCopy())
+	} else {
+		patch = client.MergeFrom(seed.DeepCopy())
+	}
+	if err := f(seed); err != nil {
+		return err
+	}
+	if err := c.Patch(ctx, seed, patch); err != nil {
+		return err
+	}
+	s.info = seed
+	return nil
+}
+
+// UpdateInfoStatus updates the status of the seed resource of this Seed in a concurrency safe way,
+// using the given context, client, and mutate function.
+// It performs a patch using either client.MergeFrom or client.StrategicMergeFrom depending on useStrategicMerge.
+// This method is protected by a RW mutex, so only a single SetInfo, UpdateInfo or UpdateInfoStatus operation can be
+// executed at any point in time.
+func (s *Seed) UpdateInfoStatus(ctx context.Context, c client.Client, useStrategicMerge bool, f func(*gardencorev1beta1.Seed) error) error {
+	s.infoMutex.Lock()
+	defer s.infoMutex.Unlock()
+
+	seed := s.info.DeepCopy()
+	var patch client.Patch
+	if useStrategicMerge {
+		patch = client.StrategicMergeFrom(seed.DeepCopy())
+	} else {
+		patch = client.MergeFrom(seed.DeepCopy())
+	}
+	if err := f(seed); err != nil {
+		return err
+	}
+	if err := c.Status().Patch(ctx, seed, patch); err != nil {
+		return err
+	}
+	s.info = seed
+	return nil
 }
 
 const (
@@ -270,7 +349,7 @@ func RunReconcileSeedFlow(
 
 	vpaGK := schema.GroupKind{Group: "autoscaling.k8s.io", Kind: "VerticalPodAutoscaler"}
 
-	vpaEnabled := seed.Info.Spec.Settings == nil || seed.Info.Spec.Settings.VerticalPodAutoscaler == nil || seed.Info.Spec.Settings.VerticalPodAutoscaler.Enabled
+	vpaEnabled := seed.GetInfo().Spec.Settings == nil || seed.GetInfo().Spec.Settings.VerticalPodAutoscaler == nil || seed.GetInfo().Spec.Settings.VerticalPodAutoscaler.Enabled
 	if !vpaEnabled {
 		// VPA is a prerequisite. If it's not enabled via the seed spec it must be provided through some other mechanism.
 		if _, err := seedClient.RESTMapper().RESTMapping(vpaGK); err != nil {
@@ -623,7 +702,7 @@ func RunReconcileSeedFlow(
 		}
 	}
 
-	if !seed.Info.Spec.Settings.ExcessCapacityReservation.Enabled {
+	if !seed.GetInfo().Spec.Settings.ExcessCapacityReservation.Enabled {
 		if err := common.DeleteReserveExcessCapacity(ctx, seedClient); client.IgnoreNotFound(err) != nil {
 			return err
 		}
@@ -792,16 +871,16 @@ func RunReconcileSeedFlow(
 		return err
 	}
 
-	if seed.Info.Status.ClusterIdentity == nil {
+	if seed.GetInfo().Status.ClusterIdentity == nil {
 		seedClusterIdentity, err := determineClusterIdentity(ctx, seedClient)
 		if err != nil {
 			return err
 		}
 
-		seedCopy := seed.Info.DeepCopy()
-		seed.Info.Status.ClusterIdentity = &seedClusterIdentity
-
-		if err := gardenClient.Status().Patch(ctx, seed.Info, client.MergeFrom(seedCopy)); err != nil {
+		if err := seed.UpdateInfoStatus(ctx, gardenClient, false, func(seed *gardencorev1beta1.Seed) error {
+			seed.Status.ClusterIdentity = &seedClusterIdentity
+			return nil
+		}); err != nil {
 			return err
 		}
 	}
@@ -812,7 +891,7 @@ func RunReconcileSeedFlow(
 			"ingressClass": getIngressClass(managedIngress(seed)),
 			"images":       imagevector.ImageMapToValues(images),
 		},
-		"reserveExcessCapacity": seed.Info.Spec.Settings.ExcessCapacityReservation.Enabled,
+		"reserveExcessCapacity": seed.GetInfo().Spec.Settings.ExcessCapacityReservation.Enabled,
 		"replicas": map[string]interface{}{
 			"reserve-excess-capacity": desiredExcessCapacity(),
 		},
@@ -825,7 +904,7 @@ func RunReconcileSeedFlow(
 		"aggregatePrometheus": map[string]interface{}{
 			"resources":  monitoringResources["aggregate-prometheus"],
 			"storage":    seed.GetValidVolumeSize("20Gi"),
-			"seed":       seed.Info.Name,
+			"seed":       seed.GetInfo().Name,
 			"hostName":   prometheusHost,
 			"secretName": prometheusTLSOverride,
 		},
@@ -918,11 +997,11 @@ func runCreateSeedFlow(
 		}
 	}
 
-	dnsEntry := getManagedIngressDNSEntry(seedClient, seed.GetIngressFQDN("*"), *seed.Info.Status.ClusterIdentity, ingressLoadBalancerAddress, log)
-	dnsOwner := getManagedIngressDNSOwner(seedClient, *seed.Info.Status.ClusterIdentity)
-	dnsRecord := getManagedIngressDNSRecord(seedClient, seed.Info.Spec.DNS, secretData, seed.GetIngressFQDN("*"), ingressLoadBalancerAddress, log)
+	dnsEntry := getManagedIngressDNSEntry(seedClient, seed.GetIngressFQDN("*"), *seed.GetInfo().Status.ClusterIdentity, ingressLoadBalancerAddress, log)
+	dnsOwner := getManagedIngressDNSOwner(seedClient, *seed.GetInfo().Status.ClusterIdentity)
+	dnsRecord := getManagedIngressDNSRecord(seedClient, seed.GetInfo().Spec.DNS, secretData, seed.GetIngressFQDN("*"), ingressLoadBalancerAddress, log)
 
-	networkPolicies, err := defaultNetworkPolicies(seedClient, seed.Info, anySNI)
+	networkPolicies, err := defaultNetworkPolicies(seedClient, seed.GetInfo(), anySNI)
 	if err != nil {
 		return err
 	}
@@ -956,7 +1035,7 @@ func runCreateSeedFlow(
 		_ = g.Add(flow.Task{
 			Name: "Deploying managed ingress DNS record",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return deployDNSResources(ctx, dnsEntry, dnsOwner, dnsRecord, deployDNSProviderTask(seedClient, seed.Info.Spec.DNS), destroyDNSProviderTask(seedClient))
+				return deployDNSResources(ctx, dnsEntry, dnsOwner, dnsRecord, deployDNSProviderTask(seedClient, seed.GetInfo().Spec.DNS), destroyDNSProviderTask(seedClient))
 			}).DoIf(managedIngress(seed)),
 		})
 		_ = g.Add(flow.Task{
@@ -971,7 +1050,7 @@ func runCreateSeedFlow(
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Deploying cluster-identity",
-			Fn:           clusteridentity.NewForSeed(seedClient, v1beta1constants.GardenNamespace, *seed.Info.Status.ClusterIdentity).Deploy,
+			Fn:           clusteridentity.NewForSeed(seedClient, v1beta1constants.GardenNamespace, *seed.GetInfo().Status.ClusterIdentity).Deploy,
 			Dependencies: flow.NewTaskIDs(deployResourceManager),
 		})
 		_ = g.Add(flow.Task{
@@ -1037,9 +1116,9 @@ func RunDeleteSeedFlow(
 
 	// setup for flow graph
 	var (
-		dnsEntry        = getManagedIngressDNSEntry(seedClient, seed.GetIngressFQDN("*"), *seed.Info.Status.ClusterIdentity, "", log)
-		dnsOwner        = getManagedIngressDNSOwner(seedClient, *seed.Info.Status.ClusterIdentity)
-		dnsRecord       = getManagedIngressDNSRecord(seedClient, seed.Info.Spec.DNS, secretData, seed.GetIngressFQDN("*"), "", log)
+		dnsEntry        = getManagedIngressDNSEntry(seedClient, seed.GetIngressFQDN("*"), *seed.GetInfo().Status.ClusterIdentity, "", log)
+		dnsOwner        = getManagedIngressDNSOwner(seedClient, *seed.GetInfo().Status.ClusterIdentity)
+		dnsRecord       = getManagedIngressDNSRecord(seedClient, seed.GetInfo().Spec.DNS, secretData, seed.GetIngressFQDN("*"), "", log)
 		autoscaler      = clusterautoscaler.NewBootstrapper(seedClient, v1beta1constants.GardenNamespace)
 		gsac            = seedadmissioncontroller.New(seedClient, v1beta1constants.GardenNamespace, "")
 		resourceManager = resourcemanager.New(seedClient, v1beta1constants.GardenNamespace, "", 0, resourcemanager.Values{})
@@ -1064,7 +1143,7 @@ func RunDeleteSeedFlow(
 		})
 		noControllerInstallations = g.Add(flow.Task{
 			Name:         "Ensuring no ControllerInstallations are left",
-			Fn:           ensureNoControllerInstallations(gardenClient, seed.Info.Name),
+			Fn:           ensureNoControllerInstallations(gardenClient, seed.GetInfo().Name),
 			Dependencies: flow.NewTaskIDs(destroyDNSRecord),
 		})
 		destroyClusterIdentity = g.Add(flow.Task{
@@ -1211,7 +1290,7 @@ func ensureNoControllerInstallations(c client.Client, seedName string) func(ctx 
 // updateDNSProviderSecret updates the DNSProvider secret in the garden namespace of the seed. This is only needed
 // if the `UseDNSRecords` feature gate is not enabled.
 func updateDNSProviderSecret(ctx context.Context, seedClient client.Client, secret *corev1.Secret, secretData map[string][]byte, seed *Seed) error {
-	if dnsConfig := seed.Info.Spec.DNS; dnsConfig.Provider != nil && !gardenletfeatures.FeatureGate.Enabled(features.UseDNSRecords) {
+	if dnsConfig := seed.GetInfo().Spec.DNS; dnsConfig.Provider != nil && !gardenletfeatures.FeatureGate.Enabled(features.UseDNSRecords) {
 		_, err := controllerutils.GetAndCreateOrMergePatch(ctx, seedClient, secret, func() error {
 			secret.Type = corev1.SecretTypeOpaque
 			secret.Data = secretData
@@ -1283,7 +1362,7 @@ func emptyDNSProviderSecret() *corev1.Secret {
 }
 
 func getDNSProviderSecretData(ctx context.Context, gardenClient client.Client, seed *Seed) (map[string][]byte, error) {
-	if dnsConfig := seed.Info.Spec.DNS; dnsConfig.Provider != nil {
+	if dnsConfig := seed.GetInfo().Spec.DNS; dnsConfig.Provider != nil {
 		secret, err := kutil.GetSecretByReference(ctx, gardenClient, &dnsConfig.Provider.SecretRef)
 		if err != nil {
 			return nil, err
@@ -1294,7 +1373,7 @@ func getDNSProviderSecretData(ctx context.Context, gardenClient client.Client, s
 }
 
 func managedIngress(seed *Seed) bool {
-	return seed.Info.Spec.DNS.Provider != nil && seed.Info.Spec.Ingress != nil
+	return seed.GetInfo().Spec.DNS.Provider != nil && seed.GetInfo().Spec.Ingress != nil
 }
 
 func getManagedIngressDNSEntry(c client.Client, seedFQDN string, seedClusterIdentity, loadBalancerAddress string, log logrus.FieldLogger) component.DeployWaiter {
@@ -1381,10 +1460,13 @@ func (s *Seed) GetIngressFQDN(subDomain string) string {
 
 // IngressDomain returns the ingress domain for the seed.
 func (s *Seed) IngressDomain() string {
-	if s.Info.Spec.DNS.IngressDomain != nil {
-		return *s.Info.Spec.DNS.IngressDomain
-	} else if s.Info.Spec.Ingress != nil {
-		return s.Info.Spec.Ingress.Domain
+	s.infoMutex.RLock()
+	defer s.infoMutex.RUnlock()
+
+	if s.info.Spec.DNS.IngressDomain != nil {
+		return *s.info.Spec.DNS.IngressDomain
+	} else if s.info.Spec.Ingress != nil {
+		return s.info.Spec.Ingress.Domain
 	}
 	return ""
 }
@@ -1406,13 +1488,16 @@ func (s *Seed) CheckMinimumK8SVersion(version string) (string, error) {
 // GetValidVolumeSize is to get a valid volume size.
 // If the given size is smaller than the minimum volume size permitted by cloud provider on which seed cluster is running, it will return the minimum size.
 func (s *Seed) GetValidVolumeSize(size string) string {
-	if s.Info.Spec.Volume == nil || s.Info.Spec.Volume.MinimumSize == nil {
+	s.infoMutex.RLock()
+	defer s.infoMutex.RUnlock()
+
+	if s.info.Spec.Volume == nil || s.info.Spec.Volume.MinimumSize == nil {
 		return size
 	}
 
 	qs, err := resource.ParseQuantity(size)
-	if err == nil && qs.Cmp(*s.Info.Spec.Volume.MinimumSize) < 0 {
-		return s.Info.Spec.Volume.MinimumSize.String()
+	if err == nil && qs.Cmp(*s.info.Spec.Volume.MinimumSize) < 0 {
+		return s.info.Spec.Volume.MinimumSize.String()
 	}
 
 	return size
@@ -1479,7 +1564,7 @@ func getIngressClass(seedIngressEnabled bool) string {
 const annotationSeedIngressClass = "seed.gardener.cloud/ingress-class"
 
 func migrateIngressClassForShootIngresses(ctx context.Context, gardenClient, seedClient client.Client, seed *Seed, newClass string) error {
-	if oldClass, ok := seed.Info.Annotations[annotationSeedIngressClass]; ok && oldClass == newClass {
+	if oldClass, ok := seed.GetInfo().Annotations[annotationSeedIngressClass]; ok && oldClass == newClass {
 		return nil
 	}
 
@@ -1503,10 +1588,10 @@ func migrateIngressClassForShootIngresses(ctx context.Context, gardenClient, see
 		}
 	}
 
-	seedCopy := seed.Info.DeepCopy()
-	metav1.SetMetaDataAnnotation(&seed.Info.ObjectMeta, annotationSeedIngressClass, newClass)
-
-	return gardenClient.Patch(ctx, seed.Info, client.MergeFrom(seedCopy))
+	return seed.UpdateInfo(ctx, gardenClient, false, func(seed *gardencorev1beta1.Seed) error {
+		metav1.SetMetaDataAnnotation(&seed.ObjectMeta, annotationSeedIngressClass, newClass)
+		return nil
+	})
 }
 
 func switchIngressClass(ctx context.Context, seedClient client.Client, ingressKey types.NamespacedName, newClass string) error {
@@ -1528,8 +1613,8 @@ func computeNginxIngress(seed *Seed) map[string]interface{} {
 		"ingressClass": v1beta1constants.SeedNginxIngressClass,
 	}
 
-	if seed.Info.Spec.Ingress != nil && seed.Info.Spec.Ingress.Controller.ProviderConfig != nil {
-		values["config"] = seed.Info.Spec.Ingress.Controller.ProviderConfig
+	if seed.GetInfo().Spec.Ingress != nil && seed.GetInfo().Spec.Ingress.Controller.ProviderConfig != nil {
+		values["config"] = seed.GetInfo().Spec.Ingress.Controller.ProviderConfig
 	}
 
 	return values

--- a/pkg/operation/seed/seed_test.go
+++ b/pkg/operation/seed/seed_test.go
@@ -97,14 +97,13 @@ var _ = Describe("seed", func() {
 		It("should return the size because no minimum size was set", func() {
 			var (
 				size = "20Gi"
-				seed = &Seed{
-					Info: &gardencorev1beta1.Seed{
-						Spec: gardencorev1beta1.SeedSpec{
-							Volume: nil,
-						},
-					},
-				}
+				seed = &Seed{}
 			)
+			seed.SetInfo(&gardencorev1beta1.Seed{
+				Spec: gardencorev1beta1.SeedSpec{
+					Volume: nil,
+				},
+			})
 
 			Expect(seed.GetValidVolumeSize(size)).To(Equal(size))
 		})
@@ -114,16 +113,15 @@ var _ = Describe("seed", func() {
 				size                = "20Gi"
 				minimumSize         = "25Gi"
 				minimumSizeQuantity = resource.MustParse(minimumSize)
-				seed                = &Seed{
-					Info: &gardencorev1beta1.Seed{
-						Spec: gardencorev1beta1.SeedSpec{
-							Volume: &gardencorev1beta1.SeedVolume{
-								MinimumSize: &minimumSizeQuantity,
-							},
-						},
-					},
-				}
+				seed                = &Seed{}
 			)
+			seed.SetInfo(&gardencorev1beta1.Seed{
+				Spec: gardencorev1beta1.SeedSpec{
+					Volume: &gardencorev1beta1.SeedVolume{
+						MinimumSize: &minimumSizeQuantity,
+					},
+				},
+			})
 
 			Expect(seed.GetValidVolumeSize(size)).To(Equal(minimumSize))
 		})
@@ -133,16 +131,15 @@ var _ = Describe("seed", func() {
 				size                = "30Gi"
 				minimumSize         = "25Gi"
 				minimumSizeQuantity = resource.MustParse(minimumSize)
-				seed                = &Seed{
-					Info: &gardencorev1beta1.Seed{
-						Spec: gardencorev1beta1.SeedSpec{
-							Volume: &gardencorev1beta1.SeedVolume{
-								MinimumSize: &minimumSizeQuantity,
-							},
-						},
-					},
-				}
+				seed                = &Seed{}
 			)
+			seed.SetInfo(&gardencorev1beta1.Seed{
+				Spec: gardencorev1beta1.SeedSpec{
+					Volume: &gardencorev1beta1.SeedVolume{
+						MinimumSize: &minimumSizeQuantity,
+					},
+				},
+			})
 
 			Expect(seed.GetValidVolumeSize(size)).To(Equal(size))
 		})

--- a/pkg/operation/seed/types.go
+++ b/pkg/operation/seed/types.go
@@ -17,6 +17,7 @@ package seed
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 )
@@ -28,8 +29,8 @@ type Builder struct {
 
 // Seed is an object containing information about a Seed cluster.
 type Seed struct {
-	info      *gardencorev1beta1.Seed
-	infoMutex sync.RWMutex
+	info      atomic.Value
+	infoMutex sync.Mutex
 
 	LoadBalancerServiceAnnotations map[string]string
 }

--- a/pkg/operation/seed/types.go
+++ b/pkg/operation/seed/types.go
@@ -16,6 +16,7 @@ package seed
 
 import (
 	"context"
+	"sync"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 )
@@ -27,6 +28,8 @@ type Builder struct {
 
 // Seed is an object containing information about a Seed cluster.
 type Seed struct {
-	Info                           *gardencorev1beta1.Seed
+	info      *gardencorev1beta1.Seed
+	infoMutex sync.RWMutex
+
 	LoadBalancerServiceAnnotations map[string]string
 }


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind bug

**What this PR does / why we need it**:
* Ensures that patch operations on `Seed.Info` are always performed on a copy, and the result is written back to `Seed.Info` via a single pointer assignment. 
* Replaces usages of `o.Seed.Info` in `shoot_control.go` with the seed object that was used to initialize the operation. This is a cosmetic change that doesn't have a real functional impact (the 2 pointers are equal), but is important for consistency. 
* Replaces all naked usages of `Seed.Info` in production code that could be executed concurrently with the newly introduced methods `GetInfo()`, `UpdateInfo()`, and `UpdateInfoStatus()` that perform reading and modification in a concurrency safe way.
* Introduces another new method `SetInfo()` and replaces all naked assignments to `Seed.Info` in test code with this method.
* Renames `Info` to `info`, ensuring that it can only be read from and written to using the above methods.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
* This is a similar change for `Seed.Info` to what was introduced for `Shoot.Info` with #4459. You may want to a look at that PR as well for additional motivation, explanations, etc.
* Unlike `Shoot.Info`, there are currently no concurrent reads / writes to `Seed.Info` that might lead to issues. So the purpose of this PR is mainly to avoid falling into the same trap with `Seed.Info` in the future, if for any reason such concurrent reads and writes are introduced. It also removes the inconsistency of having `Seed.Info` but `Shoot.GetInfo()`.

**Release note**:

```other operator
Improved handling of the seed resource in the seed controller to ensure that potential data races are avoided in the future.
```
