### PR TITLE
[release-v1.28] Automated cherry pick of #4451: Keep kube-apiserver HPA scale down mode `Auto` even when scale down is disabled.

### DIFF
--- a/pkg/operation/botanist/component/kubeapiserver/hvpa.go
+++ b/pkg/operation/botanist/component/kubeapiserver/hvpa.go
@@ -125,12 +125,7 @@ func (k *kubeAPIServer) reconcileHVPA(ctx context.Context, hvpa *hvpav1alpha1.Hv
 			},
 			ScaleDown: hvpav1alpha1.ScaleType{
 				UpdatePolicy: hvpav1alpha1.UpdatePolicy{
-					/*
-					 * HPA update mode needs to be always `Auto` because it is not supported in HPA.
-					 * To disable HPA scale down it is sufficient to set HPA minReplicas and
-					 * maxReplicas to be the same.
-					 */
-					UpdateMode: &updateModeAuto,
+					UpdateMode: &updateModeAuto, // HPA does not work with update mode 'Off' and needs to be always 'Auto' even though scale down is disabled.
 				},
 			},
 			Template: hvpav1alpha1.HpaTemplate{

--- a/pkg/operation/botanist/component/kubeapiserver/hvpa.go
+++ b/pkg/operation/botanist/component/kubeapiserver/hvpa.go
@@ -125,7 +125,12 @@ func (k *kubeAPIServer) reconcileHVPA(ctx context.Context, hvpa *hvpav1alpha1.Hv
 			},
 			ScaleDown: hvpav1alpha1.ScaleType{
 				UpdatePolicy: hvpav1alpha1.UpdatePolicy{
-					UpdateMode: &scaleDownUpdateMode,
+					/*
+					 * HPA update mode needs to be always `Auto` because it is not supported in HPA.
+					 * To disable HPA scale down it is sufficient to set HPA minReplicas and
+					 * maxReplicas to be the same.
+					 */
+					UpdateMode: &updateModeAuto,
 				},
 			},
 			Template: hvpav1alpha1.HpaTemplate{

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
@@ -304,7 +304,7 @@ var _ = Describe("KubeAPIServer", func() {
 								},
 								ScaleDown: hvpav1alpha1.ScaleType{
 									UpdatePolicy: hvpav1alpha1.UpdatePolicy{
-										UpdateMode: &expectedScaleDownUpdateMode,
+										UpdateMode: pointer.StringPtr("Auto"),
 									},
 								},
 								Template: hvpav1alpha1.HpaTemplate{


### PR DESCRIPTION
/area/auto-scaling
/area/control-plane
/kind/bug

Cherry pick of #4451 on release-v1.28.

#4451: Keep kube-apiserver HPA scale down mode `Auto` even when scale down is disabled.

**Release Notes:**
```bugfix operator
Keep kube-apiserver HPA scale down mode `Auto` even when scale down is disabled. The scale down is naturally disabled because `minReplicas` and `maxReplicas` are set to be equal.
```