### PR TITLE
Make KAS certificate DNS-1123 compliant

### DIFF
--- a/pkg/operation/botanist/wanted_secrets.go
+++ b/pkg/operation/botanist/wanted_secrets.go
@@ -169,7 +169,7 @@ func (b *Botanist) generateWantedSecretConfigs(basicAuthAPIServer *secrets.Basic
 			CertificateSecretConfig: &secrets.CertificateSecretConfig{
 				Name: "kube-apiserver",
 
-				CommonName:   user.APIServerUser,
+				CommonName:   v1beta1constants.DeploymentNameKubeAPIServer,
 				Organization: nil,
 				DNSNames:     apiServerCertDNSNames,
 				IPAddresses:  apiServerIPAddresses,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
Today, Gardener creates a server certificate for Kube-Apiserver which contains `Common Name: system:apiserver`. This is not a permissible host name according to [DNS-1123](https://datatracker.ietf.org/doc/html/rfc1123#page-13) (colon character is invalid) which is why some clients fail to verify the certificate. This PR rectifies the used host name to `Common Name: kube-apiserver`. Please note that this is only applied to new clusters.

**Special notes for your reviewer**:
/invite @mvladev @plkokanov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
Earlier, Gardener created certificates with `Common Name: system:apiserver` for the Kube-Apiserver. In order to be [DNS-1123](https://datatracker.ietf.org/doc/html/rfc1123#page-13) compliant, this certificate field is changed to `Common Name: kube-apiserver` for new shoot clusters.
```
