### PR TITLE
[release-v1.26] Manual cherry pick of #4451: Keep kube-apiserver HPA scale down mode Auto even when scale down is disabled.

### DIFF
--- a/charts/seed-controlplane/charts/kube-apiserver/templates/hvpa.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/hvpa.yaml
@@ -22,7 +22,7 @@ spec:
         updateMode: "Auto"
     scaleDown:
       updatePolicy:
-        updateMode: {{ .Values.scaleDownUpdateMode | quote }}
+        updateMode: "Auto" # HPA does not work with update mode 'Off' and needs to be always 'Auto' even though scale down is disabled.
     template:
       metadata:
         labels:


### PR DESCRIPTION
/area/auto-scaling
/area/control-plane
/kind/bug

Cherry pick of #4451 on release-v1.26.

#4451: Keep kube-apiserver HPA scale down mode `Auto` even when scale down is disabled.

**Special notes for your reviewer**:

Automatic cherry-pick failed due to conflicts.

**Release Notes:**
```bugfix operator
Keep kube-apiserver HPA scale down mode `Auto` even when scale down is disabled. The scale down is naturally disabled because `minReplicas` and `maxReplicas` are set to be equal.
```