### PR TITLE
[release-v1.26] Automated cherry pick of #4470: Remove symmetric keys from valid OIDC signing algorithms

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -71,11 +71,9 @@ var (
 		string(core.CRINameContainerD),
 		string(core.CRINameDocker),
 	)
-	// https://datatracker.ietf.org/doc/html/rfc7518#section-3.1
+
+	// assymetric algorithms from https://datatracker.ietf.org/doc/html/rfc7518#section-3.1
 	availableOIDCSigningAlgs = sets.NewString(
-		"HS256",
-		"HS384",
-		"HS512",
 		"RS256",
 		"RS384",
 		"RS512",

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -1356,7 +1356,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				})), PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":   Equal(field.ErrorTypeNotSupported),
 					"Field":  Equal("spec.kubernetes.kubeAPIServer.oidcConfig.signingAlgs[0]"),
-					"Detail": Equal("supported values: \"ES256\", \"ES384\", \"ES512\", \"HS256\", \"HS384\", \"HS512\", \"PS256\", \"PS384\", \"PS512\", \"RS256\", \"RS384\", \"RS512\", \"none\""),
+					"Detail": Equal("supported values: \"ES256\", \"ES384\", \"ES512\", \"PS256\", \"PS384\", \"PS512\", \"RS256\", \"RS384\", \"RS512\", \"none\""),
 				})), PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeInvalid),
 					"Field": Equal("spec.kubernetes.kubeAPIServer.oidcConfig.usernameClaim"),


### PR DESCRIPTION
/area/control-plane
/kind/enhancement

Cherry pick of #4470 on release-v1.26.

#4470: Remove symmetric keys from valid OIDC signing algorithms

**Release Notes:**
```bugfix user
The symmetric keys `HS256`, `HS384` and `HS512` are now removed from the valid OIDC Signing algorithms as they are not supported by the kubernetes API server.
```