### PR TITLE
Fix staticcheck findings and bump golangci-lint

### DIFF
--- a/hack/install-requirements.sh
+++ b/hack/install-requirements.sh
@@ -21,7 +21,7 @@ echo "> Installing requirements"
 GO111MODULE=off go get -u golang.org/x/tools/cmd/goimports
 
 export GO111MODULE=on
-curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.27.0
+curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.41.1
 curl -s "https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3" | bash -s -- --version 'v3.5.4'
 
 platform=$(uname -s)

--- a/pkg/client/kubernetes/cache/cache.go
+++ b/pkg/client/kubernetes/cache/cache.go
@@ -47,9 +47,7 @@ func (c *aggregator) cacheForObject(obj runtime.Object) cache.Cache {
 
 func (c *aggregator) cacheForKind(kind schema.GroupVersionKind) cache.Cache {
 	gvk := kind
-	if strings.HasSuffix(gvk.Kind, "List") {
-		gvk.Kind = gvk.Kind[:len(gvk.Kind)-4]
-	}
+	gvk.Kind = strings.TrimSuffix(gvk.Kind, "List")
 
 	cache, ok := c.gvkToCache[gvk]
 	if !ok {

--- a/pkg/utils/kubernetes/client/client.go
+++ b/pkg/utils/kubernetes/client/client.go
@@ -70,7 +70,7 @@ func NewObjectsRemaining(obj runtime.Object) error {
 		}
 		return r
 	case client.Object:
-		return objectsRemaining{remaining.(client.Object)}
+		return objectsRemaining{remaining}
 	}
 	return fmt.Errorf("type %T does neither implement client.Object nor client.ObjectList", obj)
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:
With version 1.41.0, `golangci-lint` configured a bunch of new staticchecks: https://github.com/golangci/golangci-lint/releases/tag/v1.41.0, which also created two findings in the codebase. This PR addresses the findings and updates `golangci-lint`, such that we see these in the PR validation phase and in `make verify` once people update their local installations.

With version 1.41.1 of `golangci-lint`, executing `make verify` showed these errors
```
make verify
> Check
Executing golangci-lint
pkg/client/kubernetes/cache/cache.go:50:2: S1017: should replace this if statement with an unconditional strings.TrimSuffix (gosimple)
	if strings.HasSuffix(gvk.Kind, "List") {
	^
pkg/utils/kubernetes/client/client.go:73:27: S1040: type assertion to the same type: remaining already has type client.Object (gosimple)
		return objectsRemaining{remaining.(client.Object)}
		                        ^
make: *** [check] Error 1
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Added new staticchecks by bumping `golangci-lint`. Please make sure to update your local installation of `golangci-lint`, e.g. by running `make install-requirements`
```
