### PR TITLE
Local setup now uses only the gardenlet SA token and nothing else

### DIFF
--- a/charts/gardener/gardenlet/charts/runtime/templates/clusterrole-gardenlet.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/clusterrole-gardenlet.yaml
@@ -358,7 +358,7 @@ rules:
   - get
   - watch
   - update
-# Istio releated rules that are required even when ManagedIstio and APIServerSNI feature gates are not enabled due to clean up logic.
+# Istio related rules that are required even when ManagedIstio and APIServerSNI feature gates are not enabled due to clean up logic.
 - apiGroups:
   - networking.istio.io
   resources:

--- a/charts/gardener/gardenlet/charts/runtime/templates/clusterrole-managed-istio.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/clusterrole-managed-istio.yaml
@@ -1,7 +1,3 @@
-{{- if .Values.global.gardenlet.enabled }}
-{{- if .Values.global.gardenlet.config.featureGates }}
-{{- if .Values.global.gardenlet.config.featureGates.ManagedIstio }}
-# Istio releated rules that are required only when ManagedIstio feature gate is enabled.
 ---
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
@@ -14,6 +10,10 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 rules:
+{{- if .Values.global.gardenlet.enabled }}
+{{- if .Values.global.gardenlet.config.featureGates }}
+{{- if .Values.global.gardenlet.config.featureGates.ManagedIstio }}
+# Istio related rules that are required only when ManagedIstio feature gate is enabled.
 - apiGroups:
   - networking.istio.io
   resources:

--- a/charts/gardener/gardenlet/charts/runtime/templates/clusterrolebinding-managed-istio.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/clusterrolebinding-managed-istio.yaml
@@ -1,7 +1,6 @@
-{{- if .Values.global.gardenlet.enabled }}
-{{- if .Values.global.gardenlet.config.featureGates }}
-{{- if .Values.global.gardenlet.config.featureGates.ManagedIstio }}
-# Istio releated rules that are required only when ManagedIstio feature gate is enabled.
+# ManagedIstio feature gate related ClusterRoleBinding.
+# It is nice to have the binding even when the feature gate is disabled.
+# In this case the clusterrole is having no rules and the gardenlet is granted with no permissions.
 ---
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRoleBinding
@@ -21,6 +20,3 @@ subjects:
 - kind: ServiceAccount
   name: "{{ required ".Values.global.gardenlet.serviceAccountName is required" .Values.global.gardenlet.serviceAccountName }}"
   namespace: garden
-{{- end }}
-{{- end }}
-{{- end }}

--- a/hack/local-development/start-gardenlet
+++ b/hack/local-development/start-gardenlet
@@ -91,7 +91,7 @@ if [ -z "${SEED_KUBECONFIG:-}" ]; then
   if [ -z "$seedKubeconfigName" ] || [ -z "$seedKubeconfigNamespace" ]; then
     echo "Seed $SEED_NAME does not have a .spec.secretRef with name and namespace set, pointing to a Secret"
     echo "containing the kubeconfig for that seed. Please either update your seed (see docs/development/local_setup.md)"
-    echo "or provide the kuebconfig explicitly via the SEED_KUBECONFIG environment variable."
+    echo "or provide the kubeconfig explicitly via the SEED_KUBECONFIG environment variable."
     exit 1
   fi
 
@@ -101,28 +101,36 @@ if [ -z "${SEED_KUBECONFIG:-}" ]; then
 fi
 
 # generate temporary chart values
-GARDENLET_CHARTS_DIR=charts/gardener/gardenlet
+GARDENLET_CHARTS_DIR=$REPO_ROOT/charts/gardener/gardenlet
 GARDENLET_CHARTS_RUNTIME_DIR="$GARDENLET_CHARTS_DIR/charts/runtime"
-tmpConfig="$DEV_DIR/20-componentconfig-gardenlet-seed-$SEED_NAME-tmp.yaml"
-chartValues="$DEV_DIR/gardenlet-charts-values.yaml"
-$YQ eval 'del(.apiVersion, .kind)' "$configFile" | $YQ eval '{"config": .}' - > "$tmpConfig"
-$YQ eval-all 'select(fi==0).global.gardenlet * select(fi==1)' "$GARDENLET_CHARTS_DIR/values.yaml" "$tmpConfig" | $YQ eval '{"global": {"gardenlet": . }}' - > "$chartValues"
-rm "$tmpConfig"
+tmpConfig="${configFile}.tmp"
+gardenletChartValues="$DEV_DIR/gardenlet-charts-values.yaml"
+$YQ eval 'del(.apiVersion, .kind)' "$configFile" |
+  $YQ eval '{"config": .}' - > "$tmpConfig"
+$YQ eval-all 'select(fi==0).global.gardenlet * select(fi==1)' "$GARDENLET_CHARTS_DIR/values.yaml" "$tmpConfig" |
+  $YQ eval '{"global": {"gardenlet": . }}' - > "$gardenletChartValues"
+rm -f "$tmpConfig"
+
+# garden namespace is required for the gardenlet leader election, service account, roles and role bindings.
+kubectl   --kubeconfig="$SEED_KUBECONFIG" get    namespace garden &>/dev/null || \
+  kubectl --kubeconfig="$SEED_KUBECONFIG" create namespace garden
 
 # apply RBAC resources in seed cluster
-helm template gardenlet "$GARDENLET_CHARTS_RUNTIME_DIR" -f "$chartValues" | $YQ eval 'select(.apiVersion=="rbac.authorization.k8s.io/v1")' - |
+helm template gardenlet "$GARDENLET_CHARTS_RUNTIME_DIR" -f "$gardenletChartValues" |
+  $YQ eval 'select(.apiVersion=="rbac.authorization.k8s.io/v1")' - |
   kubectl --kubeconfig="$SEED_KUBECONFIG" auth reconcile --remove-extra-permissions --remove-extra-subjects -f -
-helm template gardenlet "$GARDENLET_CHARTS_RUNTIME_DIR" -s templates/serviceaccount.yaml -f "$chartValues" |
+helm template gardenlet "$GARDENLET_CHARTS_RUNTIME_DIR" -s templates/serviceaccount.yaml -f "$gardenletChartValues" |
   kubectl --kubeconfig="$SEED_KUBECONFIG" apply -f -
-rm "$chartValues"
+rm -f "$gardenletChartValues"
 
-# backup gardenlet seed kubeconfig
-cp "$SEED_KUBECONFIG" "$DEV_DIR/gardenlet-seed-$SEED_NAME-original.conf"
+# keep original seed kubeconfig as is
+SEED_KUBECONFIG_GARDENLET_TOKEN="$DEV_DIR/gardenlet-seed-$SEED_NAME-token.conf"
+cp "$SEED_KUBECONFIG" "$SEED_KUBECONFIG_GARDENLET_TOKEN"
 
-# replace the token in gardenlet seed kubeconfig with the one from the gardenlet serviceaccount
-secretName=$(kubectl --kubeconfig="$SEED_KUBECONFIG" --namespace garden get serviceaccount gardenlet -o jsonpath='{.secrets[0].name}')
-token=$(kubectl --kubeconfig="$SEED_KUBECONFIG" --namespace garden get secret "$secretName" -o jsonpath='{.data.token}' | base64 --decode)
-TOKEN_VALUE="$token" $YQ eval --inplace '.users[0].user.token = strenv(TOKEN_VALUE)' "$SEED_KUBECONFIG"
+# use the token of the gardenlet service account to authenticated against the seed API
+token=$(kubectl --kubeconfig="$SEED_KUBECONFIG" --namespace garden get secret $(kubectl --kubeconfig="$SEED_KUBECONFIG" --namespace garden get serviceaccount gardenlet -o jsonpath='{.secrets[0].name}') -o jsonpath='{.data.token}' | base64 --decode)
+user=$(kubectl --kubeconfig="$SEED_KUBECONFIG" config view --raw --minify -o json | $YQ eval '.["current-context"] as $currentContext | .contexts[] | select(.name == $currentContext) | .context.user' -)
+USER_VALUE=$user TOKEN_VALUE=$token $YQ eval --inplace '.users = [{"name": strenv(USER_VALUE), "user": {"token": strenv(TOKEN_VALUE)}}]' $SEED_KUBECONFIG_GARDENLET_TOKEN
 
 file_imagevector_overwrite="$(mktemp_imagevector_overwrite github.com/gardener/gardener "$REPO_ROOT" "$REPO_ROOT"/charts)"
 if [ ! -f "$file_imagevector_overwrite" ]; then
@@ -130,13 +138,9 @@ if [ ! -f "$file_imagevector_overwrite" ]; then
 else
   trap cleanup_imagevector_overwrite EXIT
 
-  # garden namespace is required for the gardenlet leader election
-  kubectl   --kubeconfig="$SEED_KUBECONFIG" get    namespace garden &>/dev/null || \
-    kubectl --kubeconfig="$SEED_KUBECONFIG" create namespace garden
-
   echo "Starting gardenlet for seed $SEED_NAME..."
 
-  KUBECONFIG="$SEED_KUBECONFIG" \
+  KUBECONFIG="${SEED_KUBECONFIG_GARDENLET_TOKEN}" \
   GARDEN_KUBECONFIG="$GARDEN_KUBECONFIG" \
   IMAGEVECTOR_OVERWRITE="$file_imagevector_overwrite" \
   GO111MODULE=on \


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Local setup now uses only the gardenlet SA token and nothing else.
The kubeconfig allows different authentication methods like client certificates, and if it is set for the current user, simply adding token to the user still allows the gardenlet to use the certificate. This way the gardenlet specific RBACs are not used.


When ManagedIstio is not enabled, use empty rules list in its clusterrole. This way, `k auth reconcile` updates the RBACs instead of skipping them and eventually letting gardenlet keep running with already granted permissions.


**Which issue(s) this PR fixes**:
Follow up on #4444

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
