### PR TITLE
Ensure proper istio RBAC permissions when `ManagedIstio` feature gate is enabled by default

### DIFF
--- a/charts/gardener/gardenlet/charts/runtime/templates/_feature-gates.tpl
+++ b/charts/gardener/gardenlet/charts/runtime/templates/_feature-gates.tpl
@@ -9,3 +9,15 @@ true
 true
 {{- end -}}
 {{- end -}}
+
+{{- define "gardenlet.managed-istio-enabled" }}
+{{- if .Values.global.gardenlet.config.featureGates }}
+{{- if hasKey .Values.global.gardenlet.config.featureGates "ManagedIstio" }}
+{{ .Values.global.gardenlet.config.featureGates.ManagedIstio }}
+{{- else }}
+true
+{{- end }}
+{{- else }}
+true
+{{- end }}
+{{- end -}}

--- a/charts/gardener/gardenlet/charts/runtime/templates/_feature-gates.tpl
+++ b/charts/gardener/gardenlet/charts/runtime/templates/_feature-gates.tpl
@@ -10,14 +10,14 @@ true
 {{- end -}}
 {{- end -}}
 
-{{- define "gardenlet.managed-istio-enabled" }}
-{{- if .Values.global.gardenlet.config.featureGates }}
-{{- if hasKey .Values.global.gardenlet.config.featureGates "ManagedIstio" }}
-{{ .Values.global.gardenlet.config.featureGates.ManagedIstio }}
-{{- else }}
+{{- define "gardenlet.managed-istio-enabled" -}}
+{{- if .Values.global.gardenlet.config.featureGates -}}
+{{- if hasKey .Values.global.gardenlet.config.featureGates "ManagedIstio" -}}
+{{- .Values.global.gardenlet.config.featureGates.ManagedIstio -}}
+{{- else -}}
 true
-{{- end }}
-{{- else }}
+{{- end -}}
+{{- else -}}
 true
-{{- end }}
+{{- end -}}
 {{- end -}}

--- a/charts/gardener/gardenlet/charts/runtime/templates/clusterrole-managed-istio.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/clusterrole-managed-istio.yaml
@@ -11,8 +11,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 rules:
-{{- if .Values.global.gardenlet.config.featureGates }}
-{{- if .Values.global.gardenlet.config.featureGates.ManagedIstio }}
+{{- if eq (include "gardenlet.managed-istio-enabled" .) "true" }}
 # Istio related rules that are required only when ManagedIstio feature gate is enabled.
 - apiGroups:
   - networking.istio.io
@@ -55,6 +54,5 @@ rules:
   - get
   - patch
   - update
-{{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security 
/kind impediment

**What this PR does / why we need it**:
I found some RBAC issues while bootstrapping a seed from scratch (with gardenlet installed on it) in the gardener release `v1.28.1`. I think the same issues exist in the master branch as well. 

```
level=error msg="Seed bootstrapping failed: failed to apply manifests: 4 errors occurred: [could not apply object of kind \"DestinationRule\" \"istio-system/default\": destinationrules.networking.istio.io \ "default\" is forbidden: User \"system:serviceaccount:garden:gardenlet\" cannot get resource \"destinationrules\" in API group \"networking.istio.io\" in the namespace \"istio-system\", could not apply object of kind \"PeerAuthentication\" \"istio-system/default\": peerauthentications.security.istio.io \"default\" is forbidden: User \"system:serviceaccount:garden:gardenlet\" cannot get resource \"peerauthentications\" in API group \"security.istio.io\" in the namespace \"istio-system\", could not apply object of kind \"Sidecar\" \"istio-system/default\": sidecars.networking.istio.io \"default\" is forbidden: User \"system:serviceaccount:garden:gardenlet\" cannot get resource \"sidecars\" in API group \"networking.istio.io\" in the namespace \"istio-system\", could not apply object of kind \"ValidatingWebhookConfiguration\" \"/istiod\": validatingwebhookconfigurations.admissionregistration.k8s.io \"istiod\" is forbidden: User \"system:serviceaccount:garden:gardenlet\" cannot get resource \"validatingwebhookconfigurations\" in API group \"admissionregistration.k8s.io\" at the cluster scope]" seed=test-aws-seed
```

Ensure proper istio RBAC permissions when `ManagedIstio` feature gate is enabled by default.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

Only the commit https://github.com/gardener/gardener/pull/4481/commits/aed80ede310bfaf0ab7dbaa6e30d61739545d017 is relevant.

 I have based this PR on #4494 because I wanted to add the template definition `gardenlet.managed-istio-enabled` in the file `charts/gardener/gardenlet/charts/runtime/templates/_feature-gates.tpl` which was introduced in #4494.

I will rebase this PR after #4494 is merged.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Ensure proper istio RBAC permissions when `ManagedIstio` feature gate is enabled by default.
```
