### PR TITLE
Refactoring unit tests for the project activity controller

### DIFF
--- a/docs/concepts/controller-manager.md
+++ b/docs/concepts/controller-manager.md
@@ -71,7 +71,7 @@ This reconciler is enabled by default and works as following:
     1. `BackupEntry` resources.
     1. `Secret` resources that are referenced by a `SecretBinding` that is in use by a `Shoot` (not necessarily in the same namespace).
     1. `Quota` resources that are referenced by a `SecretBinding` that is in use by a `Shoot` (not necessarily in the same namespace).
-    1. The time period when the projet was used for the last time (`Project.Status.LastActivityTimestamp`) is longer than the configured `minimumLifetimeDays`
+    1. The time period when the projet was used for the last time (`status.lastActivityTimestamp`) is longer than the configured `minimumLifetimeDays`
 
 If a project is considered "stale" then its `.status.staleSinceTimestamp` will be set to the time when it was first detected to be stale.
 If it gets actively used again this timestamp will be removed.
@@ -89,7 +89,7 @@ The component configuration of the Gardener Controller Manager offers to configu
 
 Since the other two reconcilers are unable to actively monitor the relevant objects that are used in a `Project` (`Shoot`, `Plant`, etc.), there could be a situation where the user creates and deletes objects in a short period of time. In that case the `Stale Project Reconciler` could not see that there was any activity on that project and it will still mark it as a `Stale`, even though it is actively used.
 
-The `Project Activity Reconciler` is implemented to take care of such cases. An event handler will notify the reconciler for any acitivity (Currently only for `Shoots`) and then it will update the `Project.Status.LastActivityTimestamp`. This update will also trigger the `Stale Project Reconciler`.
+The `Project Activity Reconciler` is implemented to take care of such cases. An event handler will notify the reconciler for any acitivity (Currently only for `Shoots`) and then it will update the `status.lastActivityTimestamp`. This update will also trigger the `Stale Project Reconciler`.
 
 ### Event Controller
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
The unit tests of the `Project Activity Controller` are refactored as suggested in the last comments from [PR 4447](https://github.com/gardener/gardener/pull/4447).
Also, the documentation is fixed to follow the semantics. 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
