### PR TITLE
Upgrade fluent-bit-to-loki plugin to v.36.2 and add telegraf into the…

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -208,7 +208,7 @@ images:
 - name: fluent-bit-plugin-installer
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/fluent-bit-to-loki
-  tag: "v0.36.1"
+  tag: "v0.36.2"
 - name: loki
   sourceRepository: github.com/grafana/loki
   repository: grafana/loki
@@ -216,7 +216,7 @@ images:
 - name: loki-curator
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/loki-curator
-  tag: "v0.36.1"
+  tag: "v0.36.2"
 - name: kube-rbac-proxy
   sourceRepository: github.com/brancz/kube-rbac-proxy
   repository: quay.io/brancz/kube-rbac-proxy
@@ -228,7 +228,7 @@ images:
 - name: telegraf
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/telegraf-iptables
-  tag: "v0.36.1"
+  tag: "v0.36.2"
 
 # VPA
 - name: vpa-admission-controller

--- a/hack/.ci/set_dependency_version
+++ b/hack/.ci/set_dependency_version
@@ -114,7 +114,7 @@ elif name == 'vpn2':
 elif name == 'external-dns-management':
     names = ['dns-controller-manager']
 elif name == 'logging':
-    names = ['fluent-bit-plugin-installer', 'loki-curator']
+    names = ['fluent-bit-plugin-installer', 'loki-curator', 'telegraf']
 elif name == 'etcd-custom-image':
     names = ['etcd']
 else:


### PR DESCRIPTION
… set_dependency_version script

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
With this PR we upgrading the `fluent-bit-to-loki` output plugin to v0.36.2.
The new version introduces two bug fixes.
1. The Loki clients wrapped by the `Sorting` client are not leaking anymore.
2. The parallel processing of the input is removed in order to avoid the `Entry Out Of Order` issue without increasing the `BatchID` setting.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.
Also we add the `telegraf` component into the [hack/.ci/set_dependency_version](https://github.com/gardener/gardener/blob/1ab6be7c84ba36c10a799c2e07ac07a97ccda912/hack/.ci/set_dependency_version#L117) script
Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator https://github.com/gardener/logging/pull/108 @vlvasilev 
Disable the parallel input processing of the `fluent-bit-to-loki` output plugin
```
```bugfix operator https://github.com/gardener/logging/pull/107 @vlvasilev 
The Sorted client does not leak Promtail Loki clients anymore.
```
``` other developer
The `telegraf` component is added into hack/.ci/set_dependency_version script
```