### PR TITLE
Fix gardenlet seed RBAC permissions related to APIServerSNI feature gate

### DIFF
--- a/charts/gardener/gardenlet/charts/runtime/templates/_feature-gates.tpl
+++ b/charts/gardener/gardenlet/charts/runtime/templates/_feature-gates.tpl
@@ -1,0 +1,11 @@
+{{- define "gardenlet.apiserver-sni-enabled" -}}
+{{- if .Values.global.gardenlet.config.featureGates -}}
+{{- if hasKey .Values.global.gardenlet.config.featureGates "APIServerSNI" -}}
+{{- .Values.global.gardenlet.config.featureGates.APIServerSNI -}}
+{{- else -}}
+true
+{{- end -}}
+{{- else -}}
+true
+{{- end -}}
+{{- end -}}

--- a/charts/gardener/gardenlet/charts/runtime/templates/clusterrole-apiserver-sni.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/clusterrole-apiserver-sni.yaml
@@ -1,0 +1,65 @@
+{{- if .Values.global.gardenlet.enabled }}
+---
+apiVersion: {{ include "rbacversion" . }}
+kind: ClusterRole
+metadata:
+  name: gardener.cloud:system:gardenlet:apiserver-sni
+  labels:
+    app: gardener
+    role: gardenlet
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+rules:
+{{- if eq (include "gardenlet.apiserver-sni-enabled" .) "true" }}
+# Istio related rules that are required only when APIServerSNI feature gate is enabled.
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - envoyfilters
+  - gateways
+  - virtualservices
+  verbs:
+  - create
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - envoyfilters
+  - gateways
+  resourceNames:
+  - proxy-protocol
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - virtualservices
+  resourceNames:
+  - proxy-protocol-blackhole
+  verbs:
+  - get
+  - patch
+  - update
+{{- else }}
+# Istio related rules that are required only when APIServerSNI feature gate is disabled.
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - envoyfilters
+  - gateways
+  resourceNames:
+  - proxy-protocol
+  verbs:
+  - delete
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - virtualservices
+  resourceNames:
+  - proxy-protocol-blackhole
+  verbs:
+  - delete
+{{- end }}
+{{- end }}

--- a/charts/gardener/gardenlet/charts/runtime/templates/clusterrole-managed-istio.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/clusterrole-managed-istio.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.gardenlet.enabled }}
 ---
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
@@ -10,7 +11,6 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 rules:
-{{- if .Values.global.gardenlet.enabled }}
 {{- if .Values.global.gardenlet.config.featureGates }}
 {{- if .Values.global.gardenlet.config.featureGates.ManagedIstio }}
 # Istio related rules that are required only when ManagedIstio feature gate is enabled.

--- a/charts/gardener/gardenlet/charts/runtime/templates/clusterrolebinding-apiserver-sni.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/clusterrolebinding-apiserver-sni.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.global.gardenlet.enabled }}
+---
+apiVersion: {{ include "rbacversion" . }}
+kind: ClusterRoleBinding
+metadata:
+  name: gardener.cloud:system:gardenlet:apiserver-sni
+  labels:
+    app: gardener
+    role: gardenlet
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gardener.cloud:system:gardenlet:apiserver-sni
+subjects:
+- kind: ServiceAccount
+  name: "{{ required ".Values.global.gardenlet.serviceAccountName is required" .Values.global.gardenlet.serviceAccountName }}"
+  namespace: garden
+{{- end }}

--- a/charts/gardener/gardenlet/charts/runtime/templates/clusterrolebinding-managed-istio.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/clusterrolebinding-managed-istio.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.gardenlet.enabled }}
 # ManagedIstio feature gate related ClusterRoleBinding.
 # It is nice to have the binding even when the feature gate is disabled.
 # In this case the clusterrole is having no rules and the gardenlet is granted with no permissions.
@@ -20,3 +21,4 @@ subjects:
 - kind: ServiceAccount
   name: "{{ required ".Values.global.gardenlet.serviceAccountName is required" .Values.global.gardenlet.serviceAccountName }}"
   namespace: garden
+{{- end }}

--- a/landscaper/pkg/gardenlet/chart/gardenlet_chart_test.go
+++ b/landscaper/pkg/gardenlet/chart/gardenlet_chart_test.go
@@ -439,6 +439,8 @@ var _ = Describe("#Gardenlet Chart Test", func() {
 			VPA: pointer.Bool(true),
 		}, nil, nil, nil),
 		Entry("verify Gardenlet RBACs when ManagedIstio is enabled", nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, map[string]bool{string(features.ManagedIstio): true}),
+		Entry("verify Gardenlet RBACs when APIServerSNI is enabled", nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, map[string]bool{string(features.APIServerSNI): true}),
+		Entry("verify Gardenlet RBACs when APIServerSNI is disabled", nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, map[string]bool{string(features.APIServerSNI): false}),
 	)
 })
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
Fix gardenlet seed RBAC permissions related to APIServerSNI feature gate.

This PR addresses the findings in https://github.com/gardener/gardener/pull/4481#issuecomment-896247846 when gardenlet is started with 
```yaml
featureGates:
  APIServerSNI: true
  ManagedIstio: false
```


I also add a small fix to not render managed istio clusterrole(binding) only when gardenlet is not enabled in the chart. It was so before #4480 but I overlooked the if statements back then and introduced a small bug.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Gardenlet is now provided with the required permissions in the seed cluster to properly deploy or destroy resources related to the APIServerSNI feature.
```
