### PR TITLE
Viewer roles definition

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
@@ -94,6 +94,21 @@ metadata:
 rules:
 - apiGroups:
   - core.gardener.cloud
+  resources:
+  - backupbuckets
+  - backupentries
+  - cloudprofiles
+  - controllerinstallations
+  - plants
+  - quotas
+  - projects
+  - seeds
+  - shoots
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - seedmanagement.gardener.cloud
   - dashboard.gardener.cloud
   - settings.gardener.cloud

--- a/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
@@ -176,7 +176,6 @@ aggregationRule:
       gardener.cloud/role: project-viewer
 rules: []
 
-
 # Cluster role with cluster role binding allowing all authenticated users to read some global resources
 ---
 apiVersion: {{ include "rbacversion" . }}

--- a/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
@@ -83,6 +83,100 @@ aggregationRule:
       gardener.cloud/role: project-member
 rules: []
 
+# Cluster role granting viewer permissions for the resources in the gardener API group 
+---
+apiVersion: {{ include "rbacversion" . }}
+kind: ClusterRole
+metadata:
+  name: gardener.cloud:viewer
+  labels:
+    gardener.cloud/role: viewer
+rules:
+- apiGroups:
+  - core.gardener.cloud
+  - seedmanagement.gardener.cloud
+  - dashboard.gardener.cloud
+  - settings.gardener.cloud
+  - operations.gardener.cloud
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - events
+  - namespaces
+  - resourcequotas
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - events.k8s.io
+  resources:
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterroles
+  - clusterrolebindings
+  - roles
+  - rolebindings
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - apiregistration.k8s.io
+  resources:
+  - apiservices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+
+# Aggregated cluster role specifying permissions for the users with view access for a Gardener landscape.
+# IMPORTANT: You need to define a corresponding ClusterRoleBinding binding specific users
+#            to this ClusterRole on your own (users bound to this role have viewer access to
+#            the Garden system).
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: gardener.cloud:system:viewers
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      gardener.cloud/role: viewer
+  - matchLabels:
+      gardener.cloud/role: project-viewer
+rules: []
+
+
 # Cluster role with cluster role binding allowing all authenticated users to read some global resources
 ---
 apiVersion: {{ include "rbacversion" . }}


### PR DESCRIPTION
Implement viewer role that will allow only get/list/watch permissions for Kubernetes and Gardener resources for all Gardener projects without access to secrets

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
Implements viewer roles for Gardener
**Which issue(s) this PR fixes**:
Fixes #4495 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
New Gardener role `gardener.cloud:system:viewers` for managing viewer permissions (without access to view secrets) for all Gardener and Kubernetes resources across all Gardener projects
```
