### PR TITLE
Increase initial delay of CoreDNS readiness probe

### DIFF
--- a/charts/shoot-core/components/charts/coredns/templates/coredns-deployment.yaml
+++ b/charts/shoot-core/components/charts/coredns/templates/coredns-deployment.yaml
@@ -13,6 +13,7 @@ spec:
     type: RollingUpdate
     rollingUpdate:
       maxUnavailable: 0
+      maxSurge: 1
   selector:
     matchLabels:
       k8s-app: kube-dns
@@ -104,7 +105,11 @@ spec:
             path: /ready
             port: 8181
             scheme: HTTP
-          initialDelaySeconds: 5
+          initialDelaySeconds: 30
+          periodSeconds: 10
+          timeoutSeconds: 2
+          successThreshold: 1
+          failureThreshold: 1
       dnsPolicy: Default
       volumes:
         - name: config-volume


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
Increase initial delay of CoreDNS readiness probe
This way the newly created coredns pods have more time to start-up and populate their caches before to start serve client requests.

The idea behind this change is to make coredns more stable during rollouts and especially when it is restarted via https://github.com/gardener/gardener/blob/master/docs/usage/shoot_maintenance.md#restart-some-core-addons

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The initial delay of the CoreDNS readiness probe is increased from 5 to 30 seconds to give more time to the newly started pods to initialize their cache.
```
