### PR TITLE
Add migration to Cloud Profile adding docker runtime to all MachineImageVersions

### DIFF
--- a/pkg/controllermanager/controller/cloudprofile/cloudprofile.go
+++ b/pkg/controllermanager/controller/cloudprofile/cloudprofile.go
@@ -17,6 +17,7 @@ package cloudprofile
 import (
 	"context"
 	"fmt"
+	"github.com/sirupsen/logrus"
 	"sync"
 	"time"
 
@@ -25,8 +26,6 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
 	"github.com/gardener/gardener/pkg/controllermanager"
 	"github.com/gardener/gardener/pkg/controllerutils"
-	"github.com/gardener/gardener/pkg/logger"
-
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
@@ -42,6 +41,8 @@ type Controller struct {
 	cloudProfileQueue      workqueue.RateLimitingInterface
 	workerCh               chan int
 	numberOfRunningWorkers int
+
+	logger *logrus.Logger
 }
 
 // NewCloudProfileController takes a Kubernetes client <k8sGardenClient> and a <k8sGardenCoreInformers> for the Garden clusters.
@@ -50,6 +51,7 @@ func NewCloudProfileController(
 	ctx context.Context,
 	clientMap clientmap.ClientMap,
 	recorder record.EventRecorder,
+	logger *logrus.Logger,
 ) (
 	*Controller,
 	error,
@@ -66,8 +68,9 @@ func NewCloudProfileController(
 
 	cloudProfileController := &Controller{
 		cloudProfileQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "cloudprofile"),
-		reconciler:        NewCloudProfileReconciler(logger.Logger, gardenClient.Client(), recorder),
+		reconciler:        NewCloudProfileReconciler(logger, gardenClient.Client(), recorder),
 		workerCh:          make(chan int),
+		logger:            logger,
 	}
 
 	cloudProfileInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -87,18 +90,18 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 
 	// Check if informers cache has been populated
 	if !cache.WaitForCacheSync(ctx.Done(), c.hasSyncedFuncs...) {
-		logger.Logger.Error("Time out waiting for caches to sync")
+		c.logger.Error("Time out waiting for caches to sync")
 		return
 	}
 
 	go func() {
 		for res := range c.workerCh {
 			c.numberOfRunningWorkers += res
-			logger.Logger.Debugf("Current number of running CloudProfile workers is %d", c.numberOfRunningWorkers)
+			c.logger.Debugf("Current number of running CloudProfile workers is %d", c.numberOfRunningWorkers)
 		}
 	}()
 
-	logger.Logger.Info("CloudProfile controller initialized.")
+	c.logger.Info("CloudProfile controller initialized.")
 
 	// Start the workers
 	for i := 0; i < workers; i++ {
@@ -110,10 +113,10 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 
 	for {
 		if c.cloudProfileQueue.Len() == 0 && c.numberOfRunningWorkers == 0 {
-			logger.Logger.Debug("No running CloudProfile worker and no items left in the queues. Terminated CloudProfile controller...")
+			c.logger.Debug("No running CloudProfile worker and no items left in the queues. Terminated CloudProfile controller...")
 			break
 		}
-		logger.Logger.Debugf("Waiting for %d CloudProfile worker(s) to finish (%d item(s) left in the queues)...", c.numberOfRunningWorkers, c.cloudProfileQueue.Len())
+		c.logger.Debugf("Waiting for %d CloudProfile worker(s) to finish (%d item(s) left in the queues)...", c.numberOfRunningWorkers, c.cloudProfileQueue.Len())
 		time.Sleep(5 * time.Second)
 	}
 

--- a/pkg/controllermanager/controller/cloudprofile/cloudprofile.go
+++ b/pkg/controllermanager/controller/cloudprofile/cloudprofile.go
@@ -17,7 +17,6 @@ package cloudprofile
 import (
 	"context"
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"sync"
 	"time"
 
@@ -26,7 +25,9 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
 	"github.com/gardener/gardener/pkg/controllermanager"
 	"github.com/gardener/gardener/pkg/controllerutils"
+
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"

--- a/pkg/controllermanager/controller/cloudprofile/cloudprofile_control.go
+++ b/pkg/controllermanager/controller/cloudprofile/cloudprofile_control.go
@@ -138,11 +138,6 @@ func migrateMachineImageVersionCRISupport(cloudProfile *gardencorev1beta1.CloudP
 	var migrationHappened bool
 	for i, image := range cloudProfile.Spec.MachineImages {
 		for j, version := range image.Versions {
-			if version.CRI == nil {
-				cloudProfile.Spec.MachineImages[i].Versions[j].CRI = []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}}
-				migrationHappened = true
-				continue
-			}
 			if containsDockerCRIName(version.CRI) {
 				continue
 			}

--- a/pkg/controllermanager/controller/cloudprofile/cloudprofile_control.go
+++ b/pkg/controllermanager/controller/cloudprofile/cloudprofile_control.go
@@ -36,7 +36,7 @@ import (
 func (c *Controller) cloudProfileAdd(obj interface{}) {
 	key, err := cache.MetaNamespaceKeyFunc(obj)
 	if err != nil {
-		logger.Logger.Errorf("Couldn't get key for object %+v: %v", obj, err)
+		c.logger.Errorf("Couldn't get key for object %+v: %v", obj, err)
 		return
 	}
 	c.cloudProfileQueue.Add(key)
@@ -49,7 +49,7 @@ func (c *Controller) cloudProfileUpdate(_, newObj interface{}) {
 func (c *Controller) cloudProfileDelete(obj interface{}) {
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 	if err != nil {
-		logger.Logger.Errorf("Couldn't get key for object %+v: %v", obj, err)
+		c.logger.Errorf("Couldn't get key for object %+v: %v", obj, err)
 		return
 	}
 	c.cloudProfileQueue.Add(key)
@@ -81,7 +81,7 @@ func (r *cloudProfileReconciler) Reconcile(ctx context.Context, request reconcil
 		return reconcile.Result{}, err
 	}
 
-	cloudProfileLogger := logger.NewFieldLogger(logger.Logger, "cloudprofile", cloudProfile.Name)
+	cloudProfileLogger := logger.NewFieldLogger(r.logger, "cloudprofile", cloudProfile.Name)
 
 	// The deletionTimestamp labels the CloudProfile as intended to get deleted. Before deletion, it has to be ensured that
 	// no Shoots and Seed are assigned to the CloudProfile anymore. If this is the case then the controller will remove
@@ -101,7 +101,7 @@ func (r *cloudProfileReconciler) Reconcile(ctx context.Context, request reconcil
 			cloudProfileLogger.Infof("No Shoots are referencing the CloudProfile. Deletion accepted.")
 
 			if err := controllerutils.PatchRemoveFinalizers(ctx, r.gardenClient, cloudProfile, gardencorev1beta1.GardenerName); client.IgnoreNotFound(err) != nil {
-				logger.Logger.Errorf("could not remove finalizer from CloudProfile: %s", err.Error())
+				cloudProfileLogger.Errorf("could not remove finalizer from CloudProfile: %s", err.Error())
 				return reconcile.Result{}, err
 			}
 			return reconcile.Result{}, nil
@@ -115,7 +115,7 @@ func (r *cloudProfileReconciler) Reconcile(ctx context.Context, request reconcil
 	}
 
 	if err := controllerutils.PatchAddFinalizers(ctx, r.gardenClient, cloudProfile, gardencorev1beta1.GardenerName); err != nil {
-		logger.Logger.Errorf("could not add finalizer to CloudProfile: %s", err.Error())
+		cloudProfileLogger.Errorf("could not add finalizer to CloudProfile: %s", err.Error())
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/controllermanager/controller/cloudprofile/cloudprofile_control.go
+++ b/pkg/controllermanager/controller/cloudprofile/cloudprofile_control.go
@@ -111,7 +111,7 @@ func (r *cloudProfileReconciler) Reconcile(ctx context.Context, request reconcil
 		cloudProfileLogger.Info(message)
 		r.recorder.Event(cloudProfile, corev1.EventTypeNormal, v1beta1constants.EventResourceReferenced, message)
 
-		return reconcile.Result{}, fmt.Errorf("CloudProfile %q still has references", cloudProfile.Name)
+		return reconcile.Result{}, fmt.Errorf("Cannot delete CloudProfile %q, because the following Shoots are still referencing it: %+v", cloudProfile.Name, associatedShoots)
 	}
 
 	if err := controllerutils.PatchAddFinalizers(ctx, r.gardenClient, cloudProfile, gardencorev1beta1.GardenerName); err != nil {

--- a/pkg/controllermanager/controller/cloudprofile/cloudprofile_control_test.go
+++ b/pkg/controllermanager/controller/cloudprofile/cloudprofile_control_test.go
@@ -285,4 +285,54 @@ var _ = Describe("Controller", func() {
 			})
 		})
 	})
+
+	Describe("migrateMachineImageVersionCRISupport", func() {
+		var cloudProfile *gardencorev1beta1.CloudProfile
+		var cloudProfileName = "test-cloudprofile"
+
+		BeforeEach(func() {
+			cloudProfile = &gardencorev1beta1.CloudProfile{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            cloudProfileName,
+					ResourceVersion: "42",
+				},
+				Spec: gardencorev1beta1.CloudProfileSpec{
+					MachineImages: []gardencorev1beta1.MachineImage{
+						{
+							Name: "test-image-without-cri",
+							Versions: []gardencorev1beta1.MachineImageVersion{
+								{ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "1.0.0"}},
+							},
+						},
+					},
+				},
+			}
+		})
+
+		It("should add `docker` to the list of supported Container Runtimes if it is `nil`", func() {
+			migrationHappened := migrateMachineImageVersionCRISupport(cloudProfile)
+
+			Expect(migrationHappened).To(BeTrue())
+			Expect(len(cloudProfile.Spec.MachineImages[0].Versions[0].CRI)).To(Equal(1))
+			Expect(cloudProfile.Spec.MachineImages[0].Versions[0].CRI[0].Name).To(Equal(gardencorev1beta1.CRINameDocker))
+		})
+
+		It("should add `docker` to the list of supported Container Runtimes if it is not in the list yet", func() {
+			cloudProfile.Spec.MachineImages[0].Versions[0].CRI = []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}}
+
+			migrationHappened := migrateMachineImageVersionCRISupport(cloudProfile)
+
+			Expect(migrationHappened).To(BeTrue())
+			Expect(len(cloudProfile.Spec.MachineImages[0].Versions[0].CRI)).To(Equal(2))
+			Expect(cloudProfile.Spec.MachineImages[0].Versions[0].CRI).To(ContainElement(gardencorev1beta1.CRI{Name: gardencorev1beta1.CRINameDocker}))
+		})
+
+		It("should not indicate a migration happened when `docker` is already in the list of supported Container Runtimes", func() {
+			cloudProfile.Spec.MachineImages[0].Versions[0].CRI = []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameContainerD}, {Name: gardencorev1beta1.CRINameDocker}}
+
+			migrationHappened := migrateMachineImageVersionCRISupport(cloudProfile)
+
+			Expect(migrationHappened).To(BeFalse())
+		})
+	})
 })

--- a/pkg/controllermanager/controller/cloudprofile/cloudprofile_control_test.go
+++ b/pkg/controllermanager/controller/cloudprofile/cloudprofile_control_test.go
@@ -1,0 +1,288 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudprofile
+
+import (
+	"context"
+	"fmt"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions/core/v1beta1"
+	fakeclientmap "github.com/gardener/gardener/pkg/client/kubernetes/clientmap/fake"
+	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
+	fakeclientset "github.com/gardener/gardener/pkg/client/kubernetes/fake"
+	"github.com/gardener/gardener/pkg/logger"
+	mockcache "github.com/gardener/gardener/pkg/mock/controller-runtime/cache"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+)
+
+var _ = Describe("Controller", func() {
+	var (
+		ctx  = context.TODO()
+		ctrl *gomock.Controller
+		c    *mockclient.MockClient
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		c = mockclient.NewMockClient(ctrl)
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Describe("Event handlers", func() {
+		var (
+			controller  *Controller
+			clientCache *mockcache.MockCache
+
+			cloudProfileName string
+		)
+
+		BeforeEach(func() {
+			clientCache = mockcache.NewMockCache(ctrl)
+
+			clientCache.EXPECT().GetInformer(ctx, &gardencorev1beta1.CloudProfile{}).DoAndReturn(
+				func(_ context.Context, obj runtime.Object) (cache.Informer, error) {
+					return gardencoreinformers.NewCloudProfileInformer(nil, 0, nil), nil
+				},
+			)
+
+			var err error
+			controller, err = NewCloudProfileController(ctx, fakeclientmap.NewClientMapBuilder().WithClientSetForKey(keys.ForGarden(), fakeclientset.NewClientSetBuilder().WithCache(clientCache).Build()).Build(), &record.FakeRecorder{}, logger.NewNopLogger())
+			Expect(err).To(Not(HaveOccurred()))
+
+			cloudProfileName = "test-cloudprofile"
+		})
+
+		Describe("#cloudProfileAdd", func() {
+			It("should do nothing because the object key computation fails", func() {
+				obj := "foo"
+
+				controller.cloudProfileAdd(obj)
+
+				Expect(controller.cloudProfileQueue.Len()).To(BeZero())
+			})
+
+			It("should add the object to the queue", func() {
+				obj := &gardencorev1beta1.CloudProfile{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: cloudProfileName,
+					},
+				}
+
+				controller.cloudProfileAdd(obj)
+
+				Expect(controller.cloudProfileQueue.Len()).To(Equal(1))
+				item, _ := controller.cloudProfileQueue.Get()
+				Expect(item).To(Equal(cloudProfileName))
+			})
+
+			It("should add the object to the queue", func() {
+				obj := &gardencorev1beta1.CloudProfile{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: cloudProfileName,
+					},
+				}
+
+				controller.cloudProfileAdd(obj)
+
+				Expect(controller.cloudProfileQueue.Len()).To(Equal(1))
+				item, _ := controller.cloudProfileQueue.Get()
+				Expect(item).To(Equal(cloudProfileName))
+			})
+		})
+
+		Describe("#cloudProfileUpdate", func() {
+			It("should do nothing because the object key computation fails", func() {
+				controller.cloudProfileUpdate(nil, nil)
+
+				Expect(controller.cloudProfileQueue.Len()).To(BeZero())
+			})
+
+			It("should add the object to the queue", func() {
+				obj := &gardencorev1beta1.CloudProfile{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: cloudProfileName,
+					},
+				}
+
+				controller.cloudProfileUpdate(nil, obj)
+
+				Expect(controller.cloudProfileQueue.Len()).To(Equal(1))
+				item, _ := controller.cloudProfileQueue.Get()
+				Expect(item).To(Equal(cloudProfileName))
+			})
+		})
+	})
+
+	Describe("cloudProfileReconciler", func() {
+		const finalizerName = gardencorev1beta1.GardenerName
+
+		var (
+			cloudProfileName string
+			fakeErr          error
+			reconciler       reconcile.Reconciler
+			cloudProfile     *gardencorev1beta1.CloudProfile
+		)
+
+		BeforeEach(func() {
+			cloudProfileName = "test-cloudprofile"
+			fakeErr = fmt.Errorf("fake err")
+			reconciler = NewCloudProfileReconciler(logger.NewNopLogger(), c, &record.FakeRecorder{})
+			cloudProfile = &gardencorev1beta1.CloudProfile{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            cloudProfileName,
+					ResourceVersion: "42",
+				},
+			}
+		})
+
+		It("should return nil because object not found", func() {
+			c.EXPECT().Get(ctx, kutil.Key(cloudProfileName), gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
+
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: cloudProfileName}})
+			Expect(result).To(Equal(reconcile.Result{}))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should return err because object reading failed", func() {
+			c.EXPECT().Get(ctx, kutil.Key(cloudProfileName), gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{})).Return(fakeErr)
+
+			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: cloudProfileName}})
+			Expect(result).To(Equal(reconcile.Result{}))
+			Expect(err).To(MatchError(fakeErr))
+		})
+
+		Context("when deletion timestamp not set", func() {
+			BeforeEach(func() {
+				c.EXPECT().Get(ctx, kutil.Key(cloudProfileName), gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.CloudProfile) error {
+					*obj = *cloudProfile
+					return nil
+				})
+			})
+
+			It("should ensure the finalizer (error)", func() {
+				errToReturn := apierrors.NewNotFound(schema.GroupResource{}, cloudProfileName)
+
+				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
+					Expect(patch.Data(o)).To(BeEquivalentTo(fmt.Sprintf(`{"metadata":{"finalizers":["%s"],"resourceVersion":"42"}}`, finalizerName)))
+					return errToReturn
+				})
+
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: cloudProfileName}})
+				Expect(result).To(Equal(reconcile.Result{}))
+				Expect(err).To(MatchError(err))
+			})
+
+			It("should ensure the finalizer (no error)", func() {
+				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
+					Expect(patch.Data(o)).To(BeEquivalentTo(fmt.Sprintf(`{"metadata":{"finalizers":["%s"],"resourceVersion":"42"}}`, finalizerName)))
+					return nil
+				})
+
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: cloudProfileName}})
+				Expect(result).To(Equal(reconcile.Result{}))
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+		Context("when deletion timestamp set", func() {
+			BeforeEach(func() {
+				now := metav1.Now()
+				cloudProfile.DeletionTimestamp = &now
+				cloudProfile.Finalizers = []string{finalizerName}
+
+				c.EXPECT().Get(ctx, kutil.Key(cloudProfileName), gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.CloudProfile) error {
+					*obj = *cloudProfile
+					return nil
+				})
+			})
+
+			It("should do nothing because finalizer is not present", func() {
+				cloudProfile.Finalizers = nil
+
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: cloudProfileName}})
+				Expect(result).To(Equal(reconcile.Result{}))
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should return an error because Shoot referencing CloudProfile exists", func() {
+				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{})).DoAndReturn(func(_ context.Context, obj *gardencorev1beta1.ShootList, _ ...client.ListOption) error {
+					(&gardencorev1beta1.ShootList{Items: []gardencorev1beta1.Shoot{
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: "test-shoot", Namespace: "test-namespace"},
+							Spec: gardencorev1beta1.ShootSpec{
+								CloudProfileName: cloudProfileName,
+							},
+						},
+					}}).DeepCopyInto(obj)
+					return nil
+				})
+
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: cloudProfileName}})
+				Expect(result).To(Equal(reconcile.Result{}))
+				Expect(err).To(MatchError(ContainSubstring("Cannot delete CloudProfile")))
+			})
+
+			It("should remove the finalizer (error)", func() {
+				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{})).DoAndReturn(func(_ context.Context, obj *gardencorev1beta1.ShootList, _ ...client.ListOption) error {
+					(&gardencorev1beta1.ShootList{}).DeepCopyInto(obj)
+					return nil
+				})
+
+				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
+					Expect(patch.Data(o)).To(BeEquivalentTo(`{"metadata":{"finalizers":null,"resourceVersion":"42"}}`))
+					return fakeErr
+				})
+
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: cloudProfileName}})
+				Expect(result).To(Equal(reconcile.Result{}))
+				Expect(err).To(MatchError(fakeErr))
+			})
+
+			It("should remove the finalizer (no error)", func() {
+				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ShootList{})).DoAndReturn(func(_ context.Context, obj *gardencorev1beta1.ShootList, _ ...client.ListOption) error {
+					(&gardencorev1beta1.ShootList{}).DeepCopyInto(obj)
+					return nil
+				})
+
+				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
+					Expect(patch.Data(o)).To(BeEquivalentTo(`{"metadata":{"finalizers":null,"resourceVersion":"42"}}`))
+					return nil
+				})
+
+				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: cloudProfileName}})
+				Expect(result).To(Equal(reconcile.Result{}))
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+	})
+})

--- a/pkg/controllermanager/controller/cloudprofile/cloudprofile_control_test.go
+++ b/pkg/controllermanager/controller/cloudprofile/cloudprofile_control_test.go
@@ -17,6 +17,7 @@ package cloudprofile
 import (
 	"context"
 	"fmt"
+
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions/core/v1beta1"
 	fakeclientmap "github.com/gardener/gardener/pkg/client/kubernetes/clientmap/fake"
@@ -24,7 +25,12 @@ import (
 	fakeclientset "github.com/gardener/gardener/pkg/client/kubernetes/fake"
 	"github.com/gardener/gardener/pkg/logger"
 	mockcache "github.com/gardener/gardener/pkg/mock/controller-runtime/cache"
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -34,12 +40,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	"github.com/golang/mock/gomock"
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-
-	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 )
 
 var _ = Describe("Controller", func() {

--- a/pkg/controllermanager/controller/cloudprofile/cloudprofile_suite_test.go
+++ b/pkg/controllermanager/controller/cloudprofile/cloudprofile_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudprofile
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestCloudProfile(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ControllerManager CloudProfile Controller Suite")
+}

--- a/pkg/controllermanager/controller/factory.go
+++ b/pkg/controllermanager/controller/factory.go
@@ -104,7 +104,7 @@ func (f *GardenControllerFactory) Run(ctx context.Context) error {
 	}
 	metricsCollectors = append(metricsCollectors, bastionController)
 
-	cloudProfileController, err := cloudprofilecontroller.NewCloudProfileController(ctx, f.clientMap, f.recorder)
+	cloudProfileController, err := cloudprofilecontroller.NewCloudProfileController(ctx, f.clientMap, f.recorder, logger.Logger)
 	if err != nil {
 		return fmt.Errorf("failed initializing CloudProfile controller: %w", err)
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Previously, docker was implicitly supported by each `MachineImageVersion`. In order to simplify the rest of the codebase and to allow producing images without `docker` support in the future, we require an explicit definition of `docker` for each `MachineImageVersion`. In order to relieve operators from the manual and error-prone task of doing this by hand, we're migrating Cloud Profiles for them automatically.

**Note:** As long as the migration code is in, it is impossible to add a `MachineImageVersion` without `docker` support!

**Which issue(s) this PR fixes**:
related #4110

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Gardener will add `docker` explicitly to the list of supported container runtimes for all MachineImageVersions in your Cloud Profile. This is not a functional change: Previously, `docker` support was implicitly assumed for all MachineImageVersions. This is now changed in the context of the [dockershim removal](https://github.com/gardener/gardener/blob/master/docs/usage/docker-shim-removal.md).
```

/cc @BeckerMax @timuthy 
