### PR TITLE
Add validation for MachineImageVersion.cri!=nil

### DIFF
--- a/pkg/apis/core/validation/cloudprofile.go
+++ b/pkg/apis/core/validation/cloudprofile.go
@@ -320,6 +320,10 @@ func validateMachineImages(machineImages []core.MachineImage, fldPath *field.Pat
 				allErrs = append(allErrs, field.Invalid(versionsPath.Child("version"), machineVersion.Version, "could not parse version. Use a semantic version. In case there is no semantic version for this image use the extensibility provider (define mapping in the CloudProfile) to map to the actual non semantic version"))
 			}
 
+			if machineVersion.CRI == nil {
+				allErrs = append(allErrs, field.Required(versionsPath.Child("cri"), fmt.Sprintf("must provide at least one supported container runtime for machine image %q", image.Name)))
+			}
+
 			allErrs = append(allErrs, validateExpirableVersion(machineVersion.ExpirableVersion, helper.ToExpirableVersions(image.Versions), versionsPath)...)
 			allErrs = append(allErrs, validateContainerRuntimesInterfaces(machineVersion.CRI, versionsPath.Child("cri"))...)
 		}

--- a/pkg/apis/core/validation/cloudprofile_test.go
+++ b/pkg/apis/core/validation/cloudprofile_test.go
@@ -202,6 +202,7 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 										ExpirableVersion: core.ExpirableVersion{
 											Version: "1.2.3",
 										},
+										CRI: []core.CRI{{Name: core.CRINameDocker}},
 									},
 								},
 							},
@@ -407,6 +408,7 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 										Version:        "3.4.6",
 										Classification: &supportedClassification,
 									},
+									CRI: []core.CRI{{Name: core.CRINameDocker}},
 								},
 							},
 						},
@@ -418,6 +420,7 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 										Version:        "3.4.5",
 										Classification: &previewClassification,
 									},
+									CRI: []core.CRI{{Name: core.CRINameDocker}},
 								},
 							},
 						},
@@ -457,6 +460,7 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 										Version:        "0.1.2",
 										Classification: &supportedClassification,
 									},
+									CRI: []core.CRI{{Name: core.CRINameDocker}},
 								},
 							},
 						},
@@ -468,6 +472,7 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 										Version:        "a.b.c",
 										Classification: &supportedClassification,
 									},
+									CRI: []core.CRI{{Name: core.CRINameDocker}},
 								},
 							},
 						},
@@ -484,6 +489,41 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 					}))))
 				})
 
+				It("should forbid machine image versions without a list of supported CRIs", func() {
+					cloudProfile.Spec.MachineImages = []core.MachineImage{
+						{
+							Name: "some-machineimage",
+							Versions: []core.MachineImageVersion{
+								{
+									ExpirableVersion: core.ExpirableVersion{
+										Version:        "2.0.0",
+										Classification: &supportedClassification,
+									},
+									CRI: []core.CRI{{Name: core.CRINameDocker}},
+								},
+							},
+						},
+						{
+							Name: "xy",
+							Versions: []core.MachineImageVersion{
+								{
+									ExpirableVersion: core.ExpirableVersion{
+										Version:        "1.0.0",
+										Classification: &supportedClassification,
+									},
+								},
+							},
+						},
+					}
+
+					errorList := ValidateCloudProfile(cloudProfile)
+
+					Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeRequired),
+						"Field": Equal("spec.machineImages[1].versions[0].cri"),
+					}))))
+				})
+
 				It("should allow expiration date on latest machine image version", func() {
 					expirationDate := &metav1.Time{Time: time.Now().AddDate(0, 0, 1)}
 					cloudProfile.Spec.MachineImages = []core.MachineImage{
@@ -496,12 +536,14 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 										ExpirationDate: expirationDate,
 										Classification: &previewClassification,
 									},
+									CRI: []core.CRI{{Name: core.CRINameDocker}},
 								},
 								{
 									ExpirableVersion: core.ExpirableVersion{
 										Version:        "0.1.1",
 										Classification: &supportedClassification,
 									},
+									CRI: []core.CRI{{Name: core.CRINameDocker}},
 								},
 							},
 						},
@@ -514,6 +556,7 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 										ExpirationDate: expirationDate,
 										Classification: &supportedClassification,
 									},
+									CRI: []core.CRI{{Name: core.CRINameDocker}},
 								},
 							},
 						},
@@ -534,6 +577,7 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 										Version:        "0.1.2",
 										Classification: &classification,
 									},
+									CRI: []core.CRI{{Name: core.CRINameDocker}},
 								},
 							},
 						},
@@ -831,6 +875,7 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 										Version:        "1.2.3",
 										Classification: &supportedClassification,
 									},
+									CRI: []core.CRI{{Name: core.CRINameDocker}},
 								},
 							},
 						},
@@ -881,6 +926,7 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 							Version:        "2135.6.2",
 							Classification: &deprecatedClassification,
 						},
+						CRI: []core.CRI{{Name: core.CRINameDocker}},
 					},
 					{
 						ExpirableVersion: core.ExpirableVersion{
@@ -888,6 +934,7 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 							Classification: &deprecatedClassification,
 							ExpirationDate: dateInThePast,
 						},
+						CRI: []core.CRI{{Name: core.CRINameDocker}},
 					},
 					{
 						ExpirableVersion: core.ExpirableVersion{
@@ -895,6 +942,7 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 							Classification: &deprecatedClassification,
 							ExpirationDate: dateInThePast,
 						},
+						CRI: []core.CRI{{Name: core.CRINameDocker}},
 					},
 				}
 				cloudProfileNew.Spec.MachineImages[0].Versions = versions[0:1]
@@ -961,6 +1009,7 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 									ExpirableVersion: core.ExpirableVersion{
 										Version: "1.2.3",
 									},
+									CRI: []core.CRI{{Name: core.CRINameDocker}},
 								},
 							},
 						},
@@ -1006,12 +1055,14 @@ var _ = Describe("CloudProfile Validation Tests ", func() {
 						ExpirableVersion: core.ExpirableVersion{
 							Version: "1.17.2",
 						},
+						CRI: []core.CRI{{Name: core.CRINameDocker}},
 					},
 					{
 						ExpirableVersion: core.ExpirableVersion{
 							Version:        "1.17.1",
 							ExpirationDate: dateInThePast,
 						},
+						CRI: []core.CRI{{Name: core.CRINameDocker}},
 					},
 				}
 				cloudProfile.Spec.MachineImages[0].Versions = versions


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Previously, it was possible to have an empty list of supported CRIs, because `docker` was always implicitly supported. In the context of the dockershim removal, we're changing this, therefore, we require an explicit list of supported CRIs to be specified for all MachineImageVersions.
With #4500 we're ensuring that already existing Cloud Profiles are migrated, such that Gardener can safely assume that the CRI list is not empty and `docker` is explicitly specified.

**Which issue(s) this PR fixes**:
related #4110

**Special notes for your reviewer**:
I'm not sure which test data would need to be adapted in order to make this work. I assume we have integration test Cloud Profiles which don't specify `.spec.machineImages[].versions[].cri.name` everywhere and would therefore fail to run?

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
Cloud Profiles now need to specify a list of supported CRIs for each MachineImageVersion in `.spec.machineImages[].versions[].cri.name`.
```

/cc @BeckerMax @timuthy 
