### PR TITLE
Fix CSR approvals for Gardenlet renewals

### DIFF
--- a/pkg/admissioncontroller/webhooks/auth/seed/authorizer.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/authorizer.go
@@ -123,7 +123,7 @@ func (a *authorizer) Authorize(_ context.Context, attrs auth.Attributes) (auth.D
 			return a.authorize(seedName, graph.VertexTypeCertificateSigningRequest, attrs,
 				[]string{"get"},
 				[]string{"create"},
-				nil,
+				[]string{"seedclient"},
 			)
 		case cloudProfileResource:
 			return a.authorizeRead(seedName, graph.VertexTypeCloudProfile, attrs)

--- a/pkg/admissioncontroller/webhooks/auth/seed/authorizer_test.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/authorizer_test.go
@@ -1730,8 +1730,9 @@ var _ = Describe("Seed", func() {
 			})
 
 			DescribeTable("should allow without consulting the graph because verb is create",
-				func(verb string) {
+				func(verb, subresource string) {
 					attrs.Verb = verb
+					attrs.Subresource = subresource
 
 					decision, reason, err := authorizer.Authorize(ctx, attrs)
 					Expect(err).NotTo(HaveOccurred())
@@ -1739,7 +1740,8 @@ var _ = Describe("Seed", func() {
 					Expect(reason).To(BeEmpty())
 				},
 
-				Entry("create", "create"),
+				Entry("create", "create", ""),
+				Entry("create with subresource", "create", "seedclient"),
 			)
 
 			DescribeTable("should deny because verb is not allowed",
@@ -1767,12 +1769,13 @@ var _ = Describe("Seed", func() {
 				decision, reason, err := authorizer.Authorize(ctx, attrs)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(decision).To(Equal(auth.DecisionNoOpinion))
-				Expect(reason).To(ContainSubstring("only the following subresources are allowed for this resource type: []"))
+				Expect(reason).To(ContainSubstring("only the following subresources are allowed for this resource type: [seedclient]"))
 			})
 
 			DescribeTable("should return correct result if path exists",
-				func(verb string) {
+				func(verb, subresource string) {
 					attrs.Verb = verb
+					attrs.Subresource = subresource
 
 					graph.EXPECT().HasPathFrom(graphpkg.VertexTypeCertificateSigningRequest, "", name, graphpkg.VertexTypeSeed, "", seedName).Return(true)
 					decision, reason, err := authorizer.Authorize(ctx, attrs)
@@ -1787,7 +1790,8 @@ var _ = Describe("Seed", func() {
 					Expect(reason).To(ContainSubstring("no relationship found"))
 				},
 
-				Entry("get", "get"),
+				Entry("get", "get", ""),
+				Entry("get with subresource", "get", "seedclient"),
 			)
 
 			It("should allow because seed name is ambiguous", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bug

**What this PR does / why we need it**:
This PR fixes the auto approval for Certificate Signing Requests being created by Gardenlet.

**Special notes for your reviewer**:
The subresource `seedclient` was not considered valid in the `SeedAuthorizer` (see [SubjectAccessReview](https://github.com/gardener/gardener/blob/1ab6be7c84ba36c10a799c2e07ac07a97ccda912/pkg/controllermanager/controller/certificatesigningrequest/csr_autoapprove_control.go#L103)).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
A bug has been fixed which prevented the CSR auto-approval process for Gardenlet certificates when the `SeedAuthorizer` is enabled. Hence, the user certificate used by Gardenlet to connect to the Garden cluster was not renewed successfully.
```
