### PR TITLE
Deploy Grafana twice: after Logging and after Monitoring stack

### DIFF
--- a/charts/images.go
+++ b/charts/images.go
@@ -33,8 +33,6 @@ const (
 	ImageNameApiserverProxySidecar = "apiserver-proxy-sidecar"
 	// ImageNameBlackboxExporter is a constant for an image in the image vector with name 'blackbox-exporter'.
 	ImageNameBlackboxExporter = "blackbox-exporter"
-	// ImageNameBusybox is a constant for an image in the image vector with name 'busybox'.
-	ImageNameBusybox = "busybox"
 	// ImageNameClusterAutoscaler is a constant for an image in the image vector with name 'cluster-autoscaler'.
 	ImageNameClusterAutoscaler = "cluster-autoscaler"
 	// ImageNameConfigmapReloader is a constant for an image in the image vector with name 'configmap-reloader'.

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -188,10 +188,6 @@ images:
   tag: "0.9.0"
 
 # Miscellaenous
-- name: busybox
-  sourceRepository: github.com/mirror/busybox
-  repository: busybox
-  tag: "1.29.2"
 - name: alpine
   repository: alpine
   tag: "3.10.3"

--- a/charts/seed-monitoring/charts/grafana/templates/grafana-deployment.yaml
+++ b/charts/seed-monitoring/charts/grafana/templates/grafana-deployment.yaml
@@ -29,10 +29,6 @@ spec:
         role: {{ .Values.role }}
         networking.gardener.cloud/to-loki: allowed
     spec:
-      initContainers:
-      - name: init-prometheus
-        image: {{ index .Values.images "busybox" }}
-        command: ['sh', '-c', 'until wget -T 5 -qO- http://prometheus-web/-/healthy > /dev/null; do echo waiting for Prometheus; sleep 2; done;']
       containers:
       - name: grafana
         image: {{ index .Values.images "grafana" }}

--- a/charts/seed-monitoring/charts/grafana/values.yaml
+++ b/charts/seed-monitoring/charts/grafana/values.yaml
@@ -1,6 +1,5 @@
 images:
   grafana: image-repository:image-tag
-  busybox: image-repository:image-tag
 
 ingress:
   class: nginx


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
When a shoot creation is stuck at worker creation, the logs from the not joining nodes are not visible in any UI, since Grafana is deployed alongside the monitoring stack, which is deployed after successful reconciliation of the worker. With this PR we deploy the Grafana after deploying the worker but we don't wait for it to be successfully reconciled. This approach sometimes leads to exclusion of the MCM dashboard from operators Grafana because the ConfigMap containing it is deployed after the deployment of the worker. In such a case, the aggregation of all extension dashboards precedes the deployment of the MCM one. The missing dashboard will be added after the next shoot reconciliation. To avoid the absence of the MCM dashboard and all dashboards in the future which will be deployed after the worker the Grafana is deployed a second time after the monitoring stack.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @istvanballok @wyb1 
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixes a bug that prevented dashboards with node information to be shown in Grafana when a shoot was stuck in worker creation.
```
