### PR TITLE
Cleanup duplicated watches in gardenlet (2)

### DIFF
--- a/cmd/gardenlet/app/gardenlet.go
+++ b/cmd/gardenlet/app/gardenlet.go
@@ -31,7 +31,6 @@ import (
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
 	clientmapbuilder "github.com/gardener/gardener/pkg/client/kubernetes/clientmap/builder"
@@ -218,16 +217,15 @@ These so-called control plane components are hosted in Kubernetes clusters thems
 // Gardenlet represents all the parameters required to start the
 // Gardenlet.
 type Gardenlet struct {
-	Config                 *config.GardenletConfiguration
-	Identity               *gardencorev1beta1.Gardener
-	GardenClusterIdentity  string
-	ClientMap              clientmap.ClientMap
-	K8sGardenCoreInformers gardencoreinformers.SharedInformerFactory
-	Logger                 *logrus.Logger
-	Recorder               record.EventRecorder
-	LeaderElection         *leaderelection.LeaderElectionConfig
-	HealthManager          healthz.Manager
-	CertificateManager     *certificate.Manager
+	Config                *config.GardenletConfiguration
+	Identity              *gardencorev1beta1.Gardener
+	GardenClusterIdentity string
+	ClientMap             clientmap.ClientMap
+	Logger                *logrus.Logger
+	Recorder              record.EventRecorder
+	LeaderElection        *leaderelection.LeaderElectionConfig
+	HealthManager         healthz.Manager
+	CertificateManager    *certificate.Manager
 }
 
 // NewGardenlet is the main entry point of instantiating a new Gardenlet.
@@ -400,15 +398,14 @@ func NewGardenlet(ctx context.Context, cfg *config.GardenletConfiguration) (*Gar
 	}
 
 	return &Gardenlet{
-		Identity:               identity,
-		GardenClusterIdentity:  clusterIdentity,
-		Config:                 cfg,
-		Logger:                 logger,
-		Recorder:               recorder,
-		ClientMap:              clientMap,
-		K8sGardenCoreInformers: gardencoreinformers.NewSharedInformerFactory(k8sGardenClient.GardenCore(), 0),
-		LeaderElection:         leaderElectionConfig,
-		CertificateManager:     certificateManager,
+		Identity:              identity,
+		GardenClusterIdentity: clusterIdentity,
+		Config:                cfg,
+		Logger:                logger,
+		Recorder:              recorder,
+		ClientMap:             clientMap,
+		LeaderElection:        leaderElectionConfig,
+		CertificateManager:    certificateManager,
 	}, nil
 }
 
@@ -498,7 +495,6 @@ func (g *Gardenlet) Run(ctx context.Context) error {
 func (g *Gardenlet) startControllers(ctx context.Context) error {
 	return controller.NewGardenletControllerFactory(
 		g.ClientMap,
-		g.K8sGardenCoreInformers,
 		g.Config,
 		g.Identity,
 		g.GardenClusterIdentity,

--- a/pkg/controllermanager/controller/controllerregistration/controllerregistration_seed_control.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerregistration_seed_control.go
@@ -103,7 +103,7 @@ func (r *controllerRegistrationSeedReconciler) Reconcile(ctx context.Context, re
 		return reconcile.Result{}, err
 	}
 
-	secrets, err := gardenpkg.ReadGardenSecretsFromReader(ctx, r.gardenClient.Client(), gutil.ComputeGardenNamespace(seed.Name))
+	secrets, err := gardenpkg.ReadGardenSecrets(ctx, r.gardenClient.Client(), gutil.ComputeGardenNamespace(seed.Name))
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/controllermanager/controller/controllerregistration/controllerregistration_seed_control.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerregistration_seed_control.go
@@ -103,7 +103,7 @@ func (r *controllerRegistrationSeedReconciler) Reconcile(ctx context.Context, re
 		return reconcile.Result{}, err
 	}
 
-	secrets, err := gardenpkg.ReadGardenSecrets(ctx, r.gardenClient.Client(), gutil.ComputeGardenNamespace(seed.Name))
+	secrets, err := gardenpkg.ReadGardenSecrets(ctx, r.gardenClient.Client(), gutil.ComputeGardenNamespace(seed.Name), logger)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/gardenlet/controller/factory.go
+++ b/pkg/gardenlet/controller/factory.go
@@ -185,7 +185,10 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 		return fmt.Errorf("failed initializing Seed controller: %w", err)
 	}
 
-	shootController := shootcontroller.NewShootController(f.clientMap, f.k8sGardenCoreInformers, f.cfg, f.identity, f.gardenClusterIdentity, imageVector, f.recorder)
+	shootController, err := shootcontroller.NewShootController(ctx, f.clientMap, logger.Logger, f.cfg, f.identity, f.gardenClusterIdentity, imageVector, f.recorder)
+	if err != nil {
+		return fmt.Errorf("failed initializing Shoot controller: %w", err)
+	}
 
 	// Initialize the Controller metrics collection.
 	gardenmetrics.RegisterControllerMetrics(

--- a/pkg/gardenlet/controller/factory.go
+++ b/pkg/gardenlet/controller/factory.go
@@ -25,8 +25,6 @@ import (
 	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
-	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
 	"github.com/gardener/gardener/pkg/controllerutils"
@@ -55,7 +53,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/component-base/version"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -67,19 +64,17 @@ const DefaultImageVector = "images.yaml"
 
 // GardenletControllerFactory contains information relevant to controllers for the Garden API group.
 type GardenletControllerFactory struct {
-	cfg                    *config.GardenletConfiguration
-	gardenClusterIdentity  string
-	identity               *gardencorev1beta1.Gardener
-	clientMap              clientmap.ClientMap
-	k8sGardenCoreInformers gardencoreinformers.SharedInformerFactory
-	recorder               record.EventRecorder
-	healthManager          healthz.Manager
+	clientMap             clientmap.ClientMap
+	cfg                   *config.GardenletConfiguration
+	identity              *gardencorev1beta1.Gardener
+	gardenClusterIdentity string
+	recorder              record.EventRecorder
+	healthManager         healthz.Manager
 }
 
 // NewGardenletControllerFactory creates a new factory for controllers for the Garden API group.
 func NewGardenletControllerFactory(
 	clientMap clientmap.ClientMap,
-	gardenCoreInformerFactory gardencoreinformers.SharedInformerFactory,
 	cfg *config.GardenletConfiguration,
 	identity *gardencorev1beta1.Gardener,
 	gardenClusterIdentity string,
@@ -87,29 +82,23 @@ func NewGardenletControllerFactory(
 	healthManager healthz.Manager,
 ) *GardenletControllerFactory {
 	return &GardenletControllerFactory{
-		cfg:                    cfg,
-		identity:               identity,
-		gardenClusterIdentity:  gardenClusterIdentity,
-		clientMap:              clientMap,
-		k8sGardenCoreInformers: gardenCoreInformerFactory,
-		recorder:               recorder,
-		healthManager:          healthManager,
+		clientMap:             clientMap,
+		cfg:                   cfg,
+		identity:              identity,
+		gardenClusterIdentity: gardenClusterIdentity,
+		recorder:              recorder,
+		healthManager:         healthManager,
 	}
 }
 
 // Run starts all the controllers for the Garden API group. It also performs bootstrapping tasks.
 func (f *GardenletControllerFactory) Run(ctx context.Context) error {
-	var (
-		seedInformer  = f.k8sGardenCoreInformers.Core().V1beta1().Seeds().Informer()
-		shootInformer = f.k8sGardenCoreInformers.Core().V1beta1().Shoots().Informer()
-	)
-
-	k8sGardenClient, err := f.clientMap.GetClient(ctx, keys.ForGarden())
+	gardenClientSet, err := f.clientMap.GetClient(ctx, keys.ForGarden())
 	if err != nil {
 		return fmt.Errorf("failed to get garden client: %+v", err)
 	}
 
-	if err := addAllFieldIndexes(ctx, k8sGardenClient.Cache()); err != nil {
+	if err := addAllFieldIndexes(ctx, gardenClientSet.Cache()); err != nil {
 		return err
 	}
 
@@ -117,13 +106,8 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to start ClientMap: %+v", err)
 	}
 
-	f.k8sGardenCoreInformers.Start(ctx.Done())
-	if !cache.WaitForCacheSync(ctx.Done(), seedInformer.HasSynced, shootInformer.HasSynced) {
-		return fmt.Errorf("timed out waiting for Garden core caches to sync")
-	}
-
 	// Register Seed object
-	if err := f.registerSeed(ctx, k8sGardenClient); err != nil {
+	if err := f.registerSeed(ctx, gardenClientSet.Client()); err != nil {
 		return fmt.Errorf("failed to register the seed: %+v", err)
 	}
 
@@ -137,7 +121,7 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 	}
 
 	gardenNamespace := &corev1.Namespace{}
-	runtime.Must(k8sGardenClient.Client().Get(ctx, kutil.Key(v1beta1constants.GardenNamespace), gardenNamespace))
+	runtime.Must(gardenClientSet.Client().Get(ctx, kutil.Key(v1beta1constants.GardenNamespace), gardenNamespace))
 
 	// Initialize the workqueue metrics collection.
 	gardenmetrics.RegisterWorkqueMetrics()
@@ -168,7 +152,7 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 		return fmt.Errorf("failed initializing ControllerInstallation controller: %w", err)
 	}
 
-	extensionsController := extensionscontroller.NewController(k8sGardenClient, seedClient, f.cfg.SeedConfig.Name, logger.Logger, f.recorder)
+	extensionsController := extensionscontroller.NewController(gardenClientSet, seedClient, f.cfg.SeedConfig.Name, logger.Logger, f.recorder)
 
 	managedSeedController, err := managedseedcontroller.NewManagedSeedController(ctx, f.clientMap, f.cfg, imageVector, f.recorder, logger.Logger)
 	if err != nil {
@@ -247,7 +231,7 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 }
 
 // registerSeed reconciles the seed resource if gardenlet is configured to take care about it.
-func (f *GardenletControllerFactory) registerSeed(ctx context.Context, gardenClient kubernetes.Interface) error {
+func (f *GardenletControllerFactory) registerSeed(ctx context.Context, gardenClient client.Client) error {
 	seed := &gardencorev1beta1.Seed{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: f.cfg.SeedConfig.Name,
@@ -260,7 +244,7 @@ func (f *GardenletControllerFactory) registerSeed(ctx context.Context, gardenCli
 		return fmt.Errorf("could not convert gardenlet configuration: %+v", err)
 	}
 
-	operationResult, err := controllerutils.GetAndCreateOrMergePatch(ctx, gardenClient.Client(), seed, func() error {
+	operationResult, err := controllerutils.GetAndCreateOrMergePatch(ctx, gardenClient, seed, func() error {
 		seed.Labels = utils.MergeStringMaps(map[string]string{
 			v1beta1constants.GardenRole: v1beta1constants.GardenRoleSeed,
 		}, f.cfg.SeedConfig.Labels)
@@ -281,7 +265,7 @@ func (f *GardenletControllerFactory) registerSeed(ctx context.Context, gardenCli
 	}
 
 	// Verify that seed namespace exists.
-	return gardenClient.Client().Get(ctx, kutil.Key(gutil.ComputeGardenNamespace(f.cfg.SeedConfig.Name)), &corev1.Namespace{})
+	return gardenClient.Get(ctx, kutil.Key(gutil.ComputeGardenNamespace(f.cfg.SeedConfig.Name)), &corev1.Namespace{})
 }
 
 // addAllFieldIndexes adds all field indexes used by gardenlet to the given FieldIndexer (i.e. cache).

--- a/pkg/gardenlet/controller/seed/seed_control.go
+++ b/pkg/gardenlet/controller/seed/seed_control.go
@@ -175,7 +175,7 @@ func (r *reconciler) reconcile(ctx context.Context, gardenClient client.Client, 
 	seedObj, err := seedpkg.
 		NewBuilder().
 		WithSeedObject(seed).
-		Build()
+		Build(ctx)
 	if err != nil {
 		message := fmt.Sprintf("Failed to create a Seed object (%s).", err.Error())
 		conditionSeedBootstrapped = gardencorev1beta1helper.UpdatedCondition(conditionSeedBootstrapped, gardencorev1beta1.ConditionUnknown, gardencorev1beta1.ConditionCheckError, message)

--- a/pkg/gardenlet/controller/seed/seed_control.go
+++ b/pkg/gardenlet/controller/seed/seed_control.go
@@ -308,11 +308,7 @@ func (r *reconciler) reconcile(ctx context.Context, gardenClient client.Client, 
 		return err
 	}
 
-	gardenSecrets, err := garden.ReadGardenSecretsFromReader(
-		ctx,
-		gardenClient,
-		gutil.ComputeGardenNamespace(seed.Name),
-	)
+	gardenSecrets, err := garden.ReadGardenSecrets(ctx, gardenClient, gutil.ComputeGardenNamespace(seed.Name))
 	if err != nil {
 		conditionSeedBootstrapped = gardencorev1beta1helper.UpdatedCondition(conditionSeedBootstrapped, gardencorev1beta1.ConditionFalse, "GardenSecretsError", err.Error())
 		_ = r.patchSeedStatus(ctx, gardenClient, log, seed, seedKubernetesVersion, capacity, allocatable, conditionSeedBootstrapped)

--- a/pkg/gardenlet/controller/seed/seed_control.go
+++ b/pkg/gardenlet/controller/seed/seed_control.go
@@ -308,7 +308,7 @@ func (r *reconciler) reconcile(ctx context.Context, gardenClient client.Client, 
 		return err
 	}
 
-	gardenSecrets, err := garden.ReadGardenSecrets(ctx, gardenClient, gutil.ComputeGardenNamespace(seed.Name))
+	gardenSecrets, err := garden.ReadGardenSecrets(ctx, gardenClient, gutil.ComputeGardenNamespace(seed.Name), log)
 	if err != nil {
 		conditionSeedBootstrapped = gardencorev1beta1helper.UpdatedCondition(conditionSeedBootstrapped, gardencorev1beta1.ConditionFalse, "GardenSecretsError", err.Error())
 		_ = r.patchSeedStatus(ctx, gardenClient, log, seed, seedKubernetesVersion, capacity, allocatable, conditionSeedBootstrapped)

--- a/pkg/gardenlet/controller/shoot/seed_registration_control_test.go
+++ b/pkg/gardenlet/controller/shoot/seed_registration_control_test.go
@@ -19,70 +19,54 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement/encoding"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	fakeclientmap "github.com/gardener/gardener/pkg/client/kubernetes/clientmap/fake"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
-	mockclientmap "github.com/gardener/gardener/pkg/client/kubernetes/clientmap/mock"
-	mockkubernetes "github.com/gardener/gardener/pkg/client/kubernetes/mock"
 	"github.com/gardener/gardener/pkg/features"
 	configv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	. "github.com/gardener/gardener/pkg/gardenlet/controller/shoot"
 	gardenerlogger "github.com/gardener/gardener/pkg/logger"
-	mockrecord "github.com/gardener/gardener/pkg/mock/client-go/tools/record"
-	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
-	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 
-	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-const (
-	name      = "test"
-	namespace = "garden"
-)
+var _ = Describe("SeedRegistrationReconciler", func() {
+	const (
+		name      = "test"
+		namespace = "garden"
+	)
 
-var _ = Describe("DefaultSeedRegistrationControl", func() {
 	var (
-		ctrl *gomock.Controller
-
-		gardenClient *mockkubernetes.MockInterface
-		clientMap    *mockclientmap.MockClientMap
-		recorder     *mockrecord.MockEventRecorder
-		c            *mockclient.MockClient
-
-		seedRegistrationControl SeedRegistrationControlInterface
-
 		ctx context.Context
+		c   client.Client
 
-		shoot func(string) *gardencorev1beta1.Shoot
+		reconciler reconcile.Reconciler
+		request    reconcile.Request
+
+		newShoot            func(string) *gardencorev1beta1.Shoot
+		expectedManagedSeed *seedmanagementv1alpha1.ManagedSeed
 	)
 
 	BeforeEach(func() {
-		ctrl = gomock.NewController(GinkgoT())
+		ctx = context.Background()
+		c = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).Build()
+		clientMap := fakeclientmap.NewClientMap().AddRuntimeClient(keys.ForGarden(), c)
 
-		gardenClient = mockkubernetes.NewMockInterface(ctrl)
-		clientMap = mockclientmap.NewMockClientMap(ctrl)
-		recorder = mockrecord.NewMockEventRecorder(ctrl)
-		c = mockclient.NewMockClient(ctrl)
-
-		clientMap.EXPECT().GetClient(context.TODO(), keys.ForGarden()).Return(gardenClient, nil)
-		gardenClient.EXPECT().Client().Return(c).AnyTimes()
-
-		seedRegistrationControl = NewDefaultSeedRegistrationControl(clientMap, recorder, gardenerlogger.NewNopLogger())
-
-		ctx = context.TODO()
-
-		shoot = func(useAsSeed string) *gardencorev1beta1.Shoot {
+		newShoot = func(useAsSeed string) *gardencorev1beta1.Shoot {
 			var annotations map[string]string
 			if useAsSeed != "" {
 				annotations = map[string]string{
@@ -100,375 +84,341 @@ var _ = Describe("DefaultSeedRegistrationControl", func() {
 				},
 			}
 		}
+		request = reconcile.Request{NamespacedName: client.ObjectKey{Namespace: namespace, Name: name}}
+
+		reconciler = NewSeedRegistrationReconciler(clientMap, record.NewFakeRecorder(1), gardenerlogger.NewNopLogger())
 	})
 
 	AfterEach(func() {
-		ctrl.Finish()
+		managedSeed := &seedmanagementv1alpha1.ManagedSeed{}
+		err := c.Get(ctx, request.NamespacedName, managedSeed)
+		if expectedManagedSeed == nil {
+			Expect(err).To(BeNotFoundError())
+		} else {
+			Expect(err).NotTo(HaveOccurred())
+
+			// fake client sets metadata
+			managedSeed.ResourceVersion = ""
+			managedSeed.SetGroupVersionKind(schema.GroupVersionKind{})
+
+			// fake client does some back and forth marshalling on get, which removes the trailing newline in the config's
+			// raw extension, that the json marshaller put there earlier
+			// hence, add back the trailing newline in order to compare successfully
+			if gardenlet := managedSeed.Spec.Gardenlet; gardenlet != nil {
+				if len(gardenlet.Config.Raw) != 0 {
+					gardenlet.Config.Raw = append(gardenlet.Config.Raw, '\n')
+				}
+			}
+
+			Expect(managedSeed).To(DeepEqual(expectedManagedSeed))
+		}
 	})
 
 	Describe("#Reconcile", func() {
+		It("should do nothing if shoot is gone", func() {
+			Expect(reconciler.Reconcile(ctx, request)).To(Equal(reconcile.Result{}))
+		})
+
 		Context("reconcile", func() {
 			Context("no-gardenlet", func() {
 				It("should create the correct ManagedSeed resource, all defaults", func() {
-					shoot := shoot("true,no-gardenlet")
-					shootedSeed, err := gardencorev1beta1helper.ReadShootedSeed(shoot)
-					Expect(err).ToNot(HaveOccurred())
+					shoot := newShoot("true,no-gardenlet")
+					Expect(c.Create(ctx, shoot)).To(Succeed())
 
-					c.EXPECT().Get(ctx, kutil.Key(namespace, name), gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeed{})).DoAndReturn(
-						func(_ context.Context, _ client.ObjectKey, ms *seedmanagementv1alpha1.ManagedSeed) error {
-							return apierrors.NewNotFound(seedmanagementv1alpha1.Resource("managedseed"), name)
+					expectedManagedSeed = &seedmanagementv1alpha1.ManagedSeed{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      name,
+							Namespace: namespace,
+							OwnerReferences: []metav1.OwnerReference{
+								*metav1.NewControllerRef(shoot, gardencorev1beta1.SchemeGroupVersion.WithKind("Shoot")),
+							},
 						},
-					).Times(2)
-					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeed{})).DoAndReturn(
-						func(_ context.Context, ms *seedmanagementv1alpha1.ManagedSeed, _ ...client.CreateOption) error {
-							Expect(ms).To(Equal(&seedmanagementv1alpha1.ManagedSeed{
+						Spec: seedmanagementv1alpha1.ManagedSeedSpec{
+							Shoot: &seedmanagementv1alpha1.Shoot{
+								Name: name,
+							},
+							SeedTemplate: &gardencorev1beta1.SeedTemplate{
 								ObjectMeta: metav1.ObjectMeta{
-									Name:      name,
-									Namespace: namespace,
-									OwnerReferences: []metav1.OwnerReference{
-										*metav1.NewControllerRef(shoot, gardencorev1beta1.SchemeGroupVersion.WithKind("Shoot")),
-									},
+									Labels: shoot.Labels,
 								},
-								Spec: seedmanagementv1alpha1.ManagedSeedSpec{
-									Shoot: &seedmanagementv1alpha1.Shoot{
-										Name: name,
+								Spec: gardencorev1beta1.SeedSpec{
+									Backup: &gardencorev1beta1.SeedBackup{},
+									SecretRef: &corev1.SecretReference{
+										Name:      "seed-" + name,
+										Namespace: v1beta1constants.GardenNamespace,
 									},
-									SeedTemplate: &gardencorev1beta1.SeedTemplate{
-										ObjectMeta: metav1.ObjectMeta{
-											Labels: shoot.Labels,
+									Settings: &gardencorev1beta1.SeedSettings{
+										ExcessCapacityReservation: &gardencorev1beta1.SeedSettingExcessCapacityReservation{
+											Enabled: true,
 										},
-										Spec: gardencorev1beta1.SeedSpec{
-											Backup: &gardencorev1beta1.SeedBackup{},
-											SecretRef: &corev1.SecretReference{
-												Name:      "seed-" + name,
-												Namespace: v1beta1constants.GardenNamespace,
-											},
-											Settings: &gardencorev1beta1.SeedSettings{
-												ExcessCapacityReservation: &gardencorev1beta1.SeedSettingExcessCapacityReservation{
-													Enabled: true,
-												},
-												Scheduling: &gardencorev1beta1.SeedSettingScheduling{
-													Visible: true,
-												},
-												ShootDNS: &gardencorev1beta1.SeedSettingShootDNS{
-													Enabled: true,
-												},
-											},
+										Scheduling: &gardencorev1beta1.SeedSettingScheduling{
+											Visible: true,
+										},
+										ShootDNS: &gardencorev1beta1.SeedSettingShootDNS{
+											Enabled: true,
 										},
 									},
 								},
-							}))
-							return nil
+							},
 						},
-					)
+					}
 
-					result, err := seedRegistrationControl.Reconcile(ctx, shoot, shootedSeed)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(result).To(Equal(reconcile.Result{}))
+					Expect(reconciler.Reconcile(ctx, request)).To(Equal(reconcile.Result{}))
 				})
 
 				It("should create the correct ManagedSeed resource, all custom", func() {
-					shoot := shoot("true,no-gardenlet,disable-dns,disable-capacity-reservation,protected,invisible,minimumVolumeSize=20Gi,apiServer.replicas=2,apiServer.autoscaler.minReplicas=2,apiServer.autoscaler.maxReplicas=5,blockCIDRs=169.254.169.254/32,shootDefaults.pods=100.96.0.0/11,shootDefaults.services=100.64.0.0/13,backup.provider=gcp,backup.region=europe-north1,loadBalancerServices.annotations.foo=bar,ingress.controller.kind=nginx")
-					shootedSeed, err := gardencorev1beta1helper.ReadShootedSeed(shoot)
-					Expect(err).ToNot(HaveOccurred())
+					shoot := newShoot("true,no-gardenlet,disable-dns,disable-capacity-reservation,protected,invisible,minimumVolumeSize=20Gi,apiServer.replicas=2,apiServer.autoscaler.minReplicas=2,apiServer.autoscaler.maxReplicas=5,blockCIDRs=169.254.169.254/32,shootDefaults.pods=100.96.0.0/11,shootDefaults.services=100.64.0.0/13,backup.provider=gcp,backup.region=europe-north1,loadBalancerServices.annotations.foo=bar,ingress.controller.kind=nginx")
+					Expect(c.Create(ctx, shoot)).To(Succeed())
 
-					c.EXPECT().Get(ctx, kutil.Key(namespace, name), gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeed{})).DoAndReturn(
-						func(_ context.Context, _ client.ObjectKey, ms *seedmanagementv1alpha1.ManagedSeed) error {
-							return apierrors.NewNotFound(seedmanagementv1alpha1.Resource("managedseed"), name)
+					expectedManagedSeed = &seedmanagementv1alpha1.ManagedSeed{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      name,
+							Namespace: namespace,
+							OwnerReferences: []metav1.OwnerReference{
+								*metav1.NewControllerRef(shoot, gardencorev1beta1.SchemeGroupVersion.WithKind("Shoot")),
+							},
 						},
-					).Times(2)
-					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeed{})).DoAndReturn(
-						func(_ context.Context, ms *seedmanagementv1alpha1.ManagedSeed, _ ...client.CreateOption) error {
-							Expect(ms).To(Equal(&seedmanagementv1alpha1.ManagedSeed{
+						Spec: seedmanagementv1alpha1.ManagedSeedSpec{
+							Shoot: &seedmanagementv1alpha1.Shoot{
+								Name: name,
+							},
+							SeedTemplate: &gardencorev1beta1.SeedTemplate{
 								ObjectMeta: metav1.ObjectMeta{
-									Name:      name,
-									Namespace: namespace,
-									OwnerReferences: []metav1.OwnerReference{
-										*metav1.NewControllerRef(shoot, gardencorev1beta1.SchemeGroupVersion.WithKind("Shoot")),
-									},
+									Labels: shoot.Labels,
 								},
-								Spec: seedmanagementv1alpha1.ManagedSeedSpec{
-									Shoot: &seedmanagementv1alpha1.Shoot{
-										Name: name,
+								Spec: gardencorev1beta1.SeedSpec{
+									Backup: &gardencorev1beta1.SeedBackup{
+										Provider: "gcp",
+										Region:   pointer.String("europe-north1"),
 									},
-									SeedTemplate: &gardencorev1beta1.SeedTemplate{
-										ObjectMeta: metav1.ObjectMeta{
-											Labels: shoot.Labels,
+									Networks: gardencorev1beta1.SeedNetworks{
+										ShootDefaults: &gardencorev1beta1.ShootNetworks{
+											Pods:     pointer.String("100.96.0.0/11"),
+											Services: pointer.String("100.64.0.0/13"),
 										},
-										Spec: gardencorev1beta1.SeedSpec{
-											Backup: &gardencorev1beta1.SeedBackup{
-												Provider: "gcp",
-												Region:   pointer.String("europe-north1"),
-											},
-											Networks: gardencorev1beta1.SeedNetworks{
-												ShootDefaults: &gardencorev1beta1.ShootNetworks{
-													Pods:     pointer.String("100.96.0.0/11"),
-													Services: pointer.String("100.64.0.0/13"),
-												},
-												BlockCIDRs: []string{"169.254.169.254/32"},
-											},
-											SecretRef: &corev1.SecretReference{
-												Name:      "seed-" + name,
-												Namespace: v1beta1constants.GardenNamespace,
-											},
-											Taints: []gardencorev1beta1.SeedTaint{
-												{
-													Key: gardencorev1beta1.SeedTaintProtected,
-												},
-											},
-											Volume: &gardencorev1beta1.SeedVolume{
-												MinimumSize: quantityPtr(resource.MustParse("20Gi")),
-											},
-											Settings: &gardencorev1beta1.SeedSettings{
-												ExcessCapacityReservation: &gardencorev1beta1.SeedSettingExcessCapacityReservation{
-													Enabled: false,
-												},
-												Scheduling: &gardencorev1beta1.SeedSettingScheduling{
-													Visible: false,
-												},
-												ShootDNS: &gardencorev1beta1.SeedSettingShootDNS{
-													Enabled: false,
-												},
-												LoadBalancerServices: &gardencorev1beta1.SeedSettingLoadBalancerServices{
-													Annotations: map[string]string{"foo": "bar"},
-												},
-											},
-											Ingress: &gardencorev1beta1.Ingress{
-												Controller: gardencorev1beta1.IngressController{
-													Kind: "nginx",
-												},
-											},
+										BlockCIDRs: []string{"169.254.169.254/32"},
+									},
+									SecretRef: &corev1.SecretReference{
+										Name:      "seed-" + name,
+										Namespace: v1beta1constants.GardenNamespace,
+									},
+									Taints: []gardencorev1beta1.SeedTaint{
+										{
+											Key: gardencorev1beta1.SeedTaintProtected,
+										},
+									},
+									Volume: &gardencorev1beta1.SeedVolume{
+										MinimumSize: quantityPtr(resource.MustParse("20Gi")),
+									},
+									Settings: &gardencorev1beta1.SeedSettings{
+										ExcessCapacityReservation: &gardencorev1beta1.SeedSettingExcessCapacityReservation{
+											Enabled: false,
+										},
+										Scheduling: &gardencorev1beta1.SeedSettingScheduling{
+											Visible: false,
+										},
+										ShootDNS: &gardencorev1beta1.SeedSettingShootDNS{
+											Enabled: false,
+										},
+										LoadBalancerServices: &gardencorev1beta1.SeedSettingLoadBalancerServices{
+											Annotations: map[string]string{"foo": "bar"},
+										},
+									},
+									Ingress: &gardencorev1beta1.Ingress{
+										Controller: gardencorev1beta1.IngressController{
+											Kind: "nginx",
 										},
 									},
 								},
-							}))
-							return nil
+							},
 						},
-					)
+					}
 
-					result, err := seedRegistrationControl.Reconcile(ctx, shoot, shootedSeed)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(result).To(Equal(reconcile.Result{}))
+					Expect(reconciler.Reconcile(ctx, request)).To(Equal(reconcile.Result{}))
 				})
 			})
 
 			Context("gardenlet", func() {
 				It("should create the correct ManagedSeed resource, all defaults", func() {
-					shoot := shoot("true")
-					shootedSeed, err := gardencorev1beta1helper.ReadShootedSeed(shoot)
-					Expect(err).ToNot(HaveOccurred())
+					shoot := newShoot("true")
+					Expect(c.Create(ctx, shoot)).To(Succeed())
 
-					c.EXPECT().Get(ctx, kutil.Key(namespace, name), gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeed{})).DoAndReturn(
-						func(_ context.Context, _ client.ObjectKey, ms *seedmanagementv1alpha1.ManagedSeed) error {
-							return apierrors.NewNotFound(seedmanagementv1alpha1.Resource("managedseed"), name)
+					expectedManagedSeed = &seedmanagementv1alpha1.ManagedSeed{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      name,
+							Namespace: namespace,
+							OwnerReferences: []metav1.OwnerReference{
+								*metav1.NewControllerRef(shoot, gardencorev1beta1.SchemeGroupVersion.WithKind("Shoot")),
+							},
 						},
-					).Times(2)
-					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeed{})).DoAndReturn(
-						func(_ context.Context, ms *seedmanagementv1alpha1.ManagedSeed, _ ...client.CreateOption) error {
-							Expect(ms).To(Equal(&seedmanagementv1alpha1.ManagedSeed{
-								ObjectMeta: metav1.ObjectMeta{
-									Name:      name,
-									Namespace: namespace,
-									OwnerReferences: []metav1.OwnerReference{
-										*metav1.NewControllerRef(shoot, gardencorev1beta1.SchemeGroupVersion.WithKind("Shoot")),
+						Spec: seedmanagementv1alpha1.ManagedSeedSpec{
+							Shoot: &seedmanagementv1alpha1.Shoot{
+								Name: name,
+							},
+							Gardenlet: &seedmanagementv1alpha1.Gardenlet{
+								Config: rawExtension(&configv1alpha1.GardenletConfiguration{
+									TypeMeta: metav1.TypeMeta{
+										APIVersion: "gardenlet.config.gardener.cloud/v1alpha1",
+										Kind:       "GardenletConfiguration",
 									},
-								},
-								Spec: seedmanagementv1alpha1.ManagedSeedSpec{
-									Shoot: &seedmanagementv1alpha1.Shoot{
-										Name: name,
+									Resources: &configv1alpha1.ResourcesConfiguration{
+										Capacity: corev1.ResourceList{
+											gardencorev1beta1.ResourceShoots: resource.MustParse("250"),
+										},
 									},
-									Gardenlet: &seedmanagementv1alpha1.Gardenlet{
-										Config: rawExtension(&configv1alpha1.GardenletConfiguration{
-											TypeMeta: metav1.TypeMeta{
-												APIVersion: "gardenlet.config.gardener.cloud/v1alpha1",
-												Kind:       "GardenletConfiguration",
+									SeedConfig: &configv1alpha1.SeedConfig{
+										SeedTemplate: gardencorev1beta1.SeedTemplate{
+											ObjectMeta: metav1.ObjectMeta{
+												Labels: shoot.Labels,
 											},
-											Resources: &configv1alpha1.ResourcesConfiguration{
-												Capacity: corev1.ResourceList{
-													gardencorev1beta1.ResourceShoots: resource.MustParse("250"),
-												},
-											},
-											SeedConfig: &configv1alpha1.SeedConfig{
-												SeedTemplate: gardencorev1beta1.SeedTemplate{
-													ObjectMeta: metav1.ObjectMeta{
-														Labels: shoot.Labels,
+											Spec: gardencorev1beta1.SeedSpec{
+												Backup: &gardencorev1beta1.SeedBackup{},
+												Settings: &gardencorev1beta1.SeedSettings{
+													ExcessCapacityReservation: &gardencorev1beta1.SeedSettingExcessCapacityReservation{
+														Enabled: true,
 													},
-													Spec: gardencorev1beta1.SeedSpec{
-														Backup: &gardencorev1beta1.SeedBackup{},
-														Settings: &gardencorev1beta1.SeedSettings{
-															ExcessCapacityReservation: &gardencorev1beta1.SeedSettingExcessCapacityReservation{
-																Enabled: true,
-															},
-															Scheduling: &gardencorev1beta1.SeedSettingScheduling{
-																Visible: true,
-															},
-															ShootDNS: &gardencorev1beta1.SeedSettingShootDNS{
-																Enabled: true,
-															},
-														},
+													Scheduling: &gardencorev1beta1.SeedSettingScheduling{
+														Visible: true,
+													},
+													ShootDNS: &gardencorev1beta1.SeedSettingShootDNS{
+														Enabled: true,
 													},
 												},
 											},
-										}),
-										Bootstrap:       bootstrapPtr(seedmanagementv1alpha1.BootstrapToken),
-										MergeWithParent: pointer.Bool(true),
+										},
 									},
-								},
-							}))
-							return nil
+								}),
+								Bootstrap:       bootstrapPtr(seedmanagementv1alpha1.BootstrapToken),
+								MergeWithParent: pointer.Bool(true),
+							},
 						},
-					)
+					}
 
-					result, err := seedRegistrationControl.Reconcile(ctx, shoot, shootedSeed)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(result).To(Equal(reconcile.Result{}))
+					Expect(reconciler.Reconcile(ctx, request)).To(Equal(reconcile.Result{}))
 				})
 
 				It("should create the correct ManagedSeed resource, all custom", func() {
-					shoot := shoot("true,disable-dns,disable-capacity-reservation,protected,invisible,minimumVolumeSize=20Gi,apiServer.replicas=2,apiServer.autoscaler.minReplicas=2,apiServer.autoscaler.maxReplicas=5,blockCIDRs=169.254.169.254/32,shootDefaults.pods=100.96.0.0/11,shootDefaults.services=100.64.0.0/13,backup.provider=gcp,backup.region=europe-north1,use-serviceaccount-bootstrapping,with-secret-ref,featureGates.Logging=false,resources.capacity.shoots=100,loadBalancerServices.annotations.foo=bar,ingress.controller.kind=nginx")
-					shootedSeed, err := gardencorev1beta1helper.ReadShootedSeed(shoot)
-					Expect(err).ToNot(HaveOccurred())
+					shoot := newShoot("true,disable-dns,disable-capacity-reservation,protected,invisible,minimumVolumeSize=20Gi,apiServer.replicas=2,apiServer.autoscaler.minReplicas=2,apiServer.autoscaler.maxReplicas=5,blockCIDRs=169.254.169.254/32,shootDefaults.pods=100.96.0.0/11,shootDefaults.services=100.64.0.0/13,backup.provider=gcp,backup.region=europe-north1,use-serviceaccount-bootstrapping,with-secret-ref,featureGates.Logging=false,resources.capacity.shoots=100,loadBalancerServices.annotations.foo=bar,ingress.controller.kind=nginx")
+					Expect(c.Create(ctx, shoot)).To(Succeed())
 
-					c.EXPECT().Get(ctx, kutil.Key(namespace, name), gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeed{})).DoAndReturn(
-						func(_ context.Context, _ client.ObjectKey, ms *seedmanagementv1alpha1.ManagedSeed) error {
-							return apierrors.NewNotFound(seedmanagementv1alpha1.Resource("managedseed"), name)
+					expectedManagedSeed = &seedmanagementv1alpha1.ManagedSeed{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      name,
+							Namespace: namespace,
+							OwnerReferences: []metav1.OwnerReference{
+								*metav1.NewControllerRef(shoot, gardencorev1beta1.SchemeGroupVersion.WithKind("Shoot")),
+							},
 						},
-					).Times(2)
-					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeed{})).DoAndReturn(
-						func(_ context.Context, ms *seedmanagementv1alpha1.ManagedSeed, _ ...client.CreateOption) error {
-							Expect(ms).To(Equal(&seedmanagementv1alpha1.ManagedSeed{
-								ObjectMeta: metav1.ObjectMeta{
-									Name:      name,
-									Namespace: namespace,
-									OwnerReferences: []metav1.OwnerReference{
-										*metav1.NewControllerRef(shoot, gardencorev1beta1.SchemeGroupVersion.WithKind("Shoot")),
+						Spec: seedmanagementv1alpha1.ManagedSeedSpec{
+							Shoot: &seedmanagementv1alpha1.Shoot{
+								Name: name,
+							},
+							Gardenlet: &seedmanagementv1alpha1.Gardenlet{
+								Config: rawExtension(&configv1alpha1.GardenletConfiguration{
+									TypeMeta: metav1.TypeMeta{
+										APIVersion: "gardenlet.config.gardener.cloud/v1alpha1",
+										Kind:       "GardenletConfiguration",
 									},
-								},
-								Spec: seedmanagementv1alpha1.ManagedSeedSpec{
-									Shoot: &seedmanagementv1alpha1.Shoot{
-										Name: name,
+									Resources: &configv1alpha1.ResourcesConfiguration{
+										Capacity: corev1.ResourceList{
+											gardencorev1beta1.ResourceShoots: resource.MustParse("100"),
+										},
 									},
-									Gardenlet: &seedmanagementv1alpha1.Gardenlet{
-										Config: rawExtension(&configv1alpha1.GardenletConfiguration{
-											TypeMeta: metav1.TypeMeta{
-												APIVersion: "gardenlet.config.gardener.cloud/v1alpha1",
-												Kind:       "GardenletConfiguration",
+									FeatureGates: map[string]bool{
+										string(features.Logging): false,
+									},
+									SeedConfig: &configv1alpha1.SeedConfig{
+										SeedTemplate: gardencorev1beta1.SeedTemplate{
+											ObjectMeta: metav1.ObjectMeta{
+												Labels: shoot.Labels,
 											},
-											Resources: &configv1alpha1.ResourcesConfiguration{
-												Capacity: corev1.ResourceList{
-													gardencorev1beta1.ResourceShoots: resource.MustParse("100"),
+											Spec: gardencorev1beta1.SeedSpec{
+												Backup: &gardencorev1beta1.SeedBackup{
+													Provider: "gcp",
+													Region:   pointer.String("europe-north1"),
 												},
-											},
-											FeatureGates: map[string]bool{
-												string(features.Logging): false,
-											},
-											SeedConfig: &configv1alpha1.SeedConfig{
-												SeedTemplate: gardencorev1beta1.SeedTemplate{
-													ObjectMeta: metav1.ObjectMeta{
-														Labels: shoot.Labels,
+												Networks: gardencorev1beta1.SeedNetworks{
+													ShootDefaults: &gardencorev1beta1.ShootNetworks{
+														Pods:     pointer.String("100.96.0.0/11"),
+														Services: pointer.String("100.64.0.0/13"),
 													},
-													Spec: gardencorev1beta1.SeedSpec{
-														Backup: &gardencorev1beta1.SeedBackup{
-															Provider: "gcp",
-															Region:   pointer.String("europe-north1"),
-														},
-														Networks: gardencorev1beta1.SeedNetworks{
-															ShootDefaults: &gardencorev1beta1.ShootNetworks{
-																Pods:     pointer.String("100.96.0.0/11"),
-																Services: pointer.String("100.64.0.0/13"),
-															},
-															BlockCIDRs: []string{"169.254.169.254/32"},
-														},
-														SecretRef: &corev1.SecretReference{
-															Name:      "seed-" + name,
-															Namespace: v1beta1constants.GardenNamespace,
-														},
-														Taints: []gardencorev1beta1.SeedTaint{
-															{
-																Key: gardencorev1beta1.SeedTaintProtected,
-															},
-														},
-														Volume: &gardencorev1beta1.SeedVolume{
-															MinimumSize: quantityPtr(resource.MustParse("20Gi")),
-														},
-														Settings: &gardencorev1beta1.SeedSettings{
-															ExcessCapacityReservation: &gardencorev1beta1.SeedSettingExcessCapacityReservation{
-																Enabled: false,
-															},
-															Scheduling: &gardencorev1beta1.SeedSettingScheduling{
-																Visible: false,
-															},
-															ShootDNS: &gardencorev1beta1.SeedSettingShootDNS{
-																Enabled: false,
-															},
-															LoadBalancerServices: &gardencorev1beta1.SeedSettingLoadBalancerServices{
-																Annotations: map[string]string{"foo": "bar"},
-															},
-														},
-														Ingress: &gardencorev1beta1.Ingress{
-															Controller: gardencorev1beta1.IngressController{
-																Kind: "nginx",
-															},
-														},
+													BlockCIDRs: []string{"169.254.169.254/32"},
+												},
+												SecretRef: &corev1.SecretReference{
+													Name:      "seed-" + name,
+													Namespace: v1beta1constants.GardenNamespace,
+												},
+												Taints: []gardencorev1beta1.SeedTaint{
+													{
+														Key: gardencorev1beta1.SeedTaintProtected,
+													},
+												},
+												Volume: &gardencorev1beta1.SeedVolume{
+													MinimumSize: quantityPtr(resource.MustParse("20Gi")),
+												},
+												Settings: &gardencorev1beta1.SeedSettings{
+													ExcessCapacityReservation: &gardencorev1beta1.SeedSettingExcessCapacityReservation{
+														Enabled: false,
+													},
+													Scheduling: &gardencorev1beta1.SeedSettingScheduling{
+														Visible: false,
+													},
+													ShootDNS: &gardencorev1beta1.SeedSettingShootDNS{
+														Enabled: false,
+													},
+													LoadBalancerServices: &gardencorev1beta1.SeedSettingLoadBalancerServices{
+														Annotations: map[string]string{"foo": "bar"},
+													},
+												},
+												Ingress: &gardencorev1beta1.Ingress{
+													Controller: gardencorev1beta1.IngressController{
+														Kind: "nginx",
 													},
 												},
 											},
-										}),
-										Bootstrap:       bootstrapPtr(seedmanagementv1alpha1.BootstrapServiceAccount),
-										MergeWithParent: pointer.Bool(true),
+										},
 									},
-								},
-							}))
-							return nil
+								}),
+								Bootstrap:       bootstrapPtr(seedmanagementv1alpha1.BootstrapServiceAccount),
+								MergeWithParent: pointer.Bool(true),
+							},
 						},
-					)
+					}
 
-					result, err := seedRegistrationControl.Reconcile(ctx, shoot, shootedSeed)
-					Expect(err).ToNot(HaveOccurred())
-					Expect(result).To(Equal(reconcile.Result{}))
+					Expect(reconciler.Reconcile(ctx, request)).To(Equal(reconcile.Result{}))
 				})
 			})
 		})
 
 		Context("delete", func() {
 			It("should delete the ManagedSeed resource", func() {
-				shoot := shoot("")
-				shootedSeed, err := gardencorev1beta1helper.ReadShootedSeed(shoot)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(shootedSeed).To(BeNil())
+				shoot := newShoot("")
+				Expect(c.Create(ctx, shoot)).To(Succeed())
 
-				c.EXPECT().Get(ctx, kutil.Key(namespace, name), gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeed{})).DoAndReturn(
-					func(_ context.Context, _ client.ObjectKey, ms *seedmanagementv1alpha1.ManagedSeed) error {
-						*ms = seedmanagementv1alpha1.ManagedSeed{
-							ObjectMeta: metav1.ObjectMeta{
-								Name:      name,
-								Namespace: namespace,
-								OwnerReferences: []metav1.OwnerReference{
-									*metav1.NewControllerRef(shoot, gardencorev1beta1.SchemeGroupVersion.WithKind("Shoot")),
-								},
-							},
-						}
-						return nil
+				// create pre-existing ManagedSeed
+				managedSeed := &seedmanagementv1alpha1.ManagedSeed{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      name,
+						Namespace: namespace,
+						OwnerReferences: []metav1.OwnerReference{
+							*metav1.NewControllerRef(shoot, gardencorev1beta1.SchemeGroupVersion.WithKind("Shoot")),
+						},
 					},
-				)
-				c.EXPECT().Delete(ctx, gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeed{})).DoAndReturn(
-					func(_ context.Context, ms *seedmanagementv1alpha1.ManagedSeed, _ ...client.DeleteOption) error {
-						Expect(ms.Name).To(Equal(name))
-						Expect(ms.Namespace).To(Equal(namespace))
-						return nil
-					},
-				)
+				}
+				Expect(c.Create(ctx, managedSeed)).To(Succeed())
 
-				result, err := seedRegistrationControl.Reconcile(ctx, shoot, shootedSeed)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(result).To(Equal(reconcile.Result{}))
+				Expect(reconciler.Reconcile(ctx, request)).To(Equal(reconcile.Result{}))
+
+				expectedManagedSeed = nil
 			})
 		})
 	})
 })
 
 func rawExtension(cfg *configv1alpha1.GardenletConfiguration) runtime.RawExtension {
-	re, _ := encoding.EncodeGardenletConfiguration(cfg)
+	re, err := encoding.EncodeGardenletConfiguration(cfg)
+	Expect(err).NotTo(HaveOccurred())
+	re.Object = nil
 	return *re
 }
 

--- a/pkg/gardenlet/controller/shoot/shoot.go
+++ b/pkg/gardenlet/controller/shoot/shoot.go
@@ -21,32 +21,31 @@ import (
 	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
-	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
-	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/gardenlet"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	confighelper "github.com/gardener/gardener/pkg/gardenlet/apis/config/helper"
-	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"k8s.io/apimachinery/pkg/labels"
+	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
+	runtimecache "sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 // Controller controls Shoots.
 type Controller struct {
-	clientMap              clientmap.ClientMap
-	k8sGardenCoreInformers gardencoreinformers.SharedInformerFactory
+	clientMap   clientmap.ClientMap
+	gardenCache runtimecache.Cache
+	logger      logrus.FieldLogger
 
 	config                        *config.GardenletConfiguration
 	gardenClusterIdentity         string
@@ -57,15 +56,12 @@ type Controller struct {
 	imageVector                   imagevector.ImageVector
 	shootReconciliationDueTracker *reconciliationDueTracker
 
-	shootLister gardencorelisters.ShootLister
-
 	shootCareQueue        workqueue.RateLimitingInterface
 	shootQueue            workqueue.RateLimitingInterface
 	shootSeedQueue        workqueue.RateLimitingInterface
 	seedRegistrationQueue workqueue.RateLimitingInterface
 
-	hasSyncedFuncs []cache.InformerSynced
-
+	hasSyncedFuncs         []cache.InformerSynced
 	numberOfRunningWorkers int
 	workerCh               chan int
 }
@@ -73,29 +69,39 @@ type Controller struct {
 // NewShootController takes a Kubernetes client for the Garden clusters <k8sGardenClient>, a struct
 // holding information about the acting Gardener, a <shootInformer>, and a <recorder> for
 // event recording. It creates a new Gardener controller.
-func NewShootController(clientMap clientmap.ClientMap, k8sGardenCoreInformers gardencoreinformers.SharedInformerFactory, config *config.GardenletConfiguration, identity *gardencorev1beta1.Gardener,
-	gardenClusterIdentity string, imageVector imagevector.ImageVector, recorder record.EventRecorder) *Controller {
-	var (
-		gardenCoreV1beta1Informer = k8sGardenCoreInformers.Core().V1beta1()
+func NewShootController(
+	ctx context.Context,
+	clientMap clientmap.ClientMap,
+	logger logrus.FieldLogger,
+	config *config.GardenletConfiguration,
+	identity *gardencorev1beta1.Gardener,
+	gardenClusterIdentity string,
+	imageVector imagevector.ImageVector,
+	recorder record.EventRecorder,
+) (*Controller, error) {
+	gardenClient, err := clientMap.GetClient(ctx, keys.ForGarden())
+	if err != nil {
+		return nil, err
+	}
 
-		shootInformer = gardenCoreV1beta1Informer.Shoots()
-		shootLister   = shootInformer.Lister()
-	)
+	shootInformer, err := gardenClient.Cache().GetInformer(ctx, &gardencorev1beta1.Shoot{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get Shoot Informer: %w", err)
+	}
 
 	shootController := &Controller{
-		clientMap:              clientMap,
-		k8sGardenCoreInformers: k8sGardenCoreInformers,
+		clientMap:   clientMap,
+		gardenCache: gardenClient.Cache(),
+		logger:      logger,
 
 		config:                        config,
 		identity:                      identity,
 		gardenClusterIdentity:         gardenClusterIdentity,
-		careReconciler:                NewCareReconciler(clientMap, logger.Logger, imageVector, identity, gardenClusterIdentity, config),
-		seedRegistrationReconciler:    NewSeedRegistrationReconciler(clientMap, recorder, logger.Logger),
+		careReconciler:                NewCareReconciler(clientMap, logger, imageVector, identity, gardenClusterIdentity, config),
+		seedRegistrationReconciler:    NewSeedRegistrationReconciler(clientMap, recorder, logger),
 		recorder:                      recorder,
 		imageVector:                   imageVector,
 		shootReconciliationDueTracker: newReconciliationDueTracker(),
-
-		shootLister: shootLister,
 
 		shootCareQueue:        workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "shoot-care"),
 		shootQueue:            workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "shoot"),
@@ -105,7 +111,7 @@ func NewShootController(clientMap clientmap.ClientMap, k8sGardenCoreInformers ga
 		workerCh: make(chan int),
 	}
 
-	shootInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+	shootInformer.AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: controllerutils.ShootFilterFunc(confighelper.SeedNameFromSeedConfig(config.SeedConfig)),
 		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc: func(obj interface{}) {
@@ -116,7 +122,7 @@ func NewShootController(clientMap clientmap.ClientMap, k8sGardenCoreInformers ga
 		},
 	})
 
-	shootInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+	shootInformer.AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: controllerutils.ShootFilterFunc(confighelper.SeedNameFromSeedConfig(config.SeedConfig)),
 		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc:    shootController.shootCareAdd,
@@ -124,7 +130,7 @@ func NewShootController(clientMap clientmap.ClientMap, k8sGardenCoreInformers ga
 		},
 	})
 
-	shootInformer.Informer().AddEventHandler(cache.FilteringResourceEventHandler{
+	shootInformer.AddEventHandler(cache.FilteringResourceEventHandler{
 		FilterFunc: controllerutils.ShootFilterFunc(confighelper.SeedNameFromSeedConfig(config.SeedConfig)),
 		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc:    shootController.seedRegistrationAdd,
@@ -133,10 +139,10 @@ func NewShootController(clientMap clientmap.ClientMap, k8sGardenCoreInformers ga
 	})
 
 	shootController.hasSyncedFuncs = []cache.InformerSynced{
-		shootInformer.Informer().HasSynced,
+		shootInformer.HasSynced,
 	}
 
-	return shootController
+	return shootController, nil
 }
 
 // Run runs the Controller until the given stop channel can be read from.
@@ -144,7 +150,7 @@ func (c *Controller) Run(ctx context.Context, shootWorkers, shootCareWorkers int
 	var waitGroup sync.WaitGroup
 
 	if !cache.WaitForCacheSync(ctx.Done(), c.hasSyncedFuncs...) {
-		logger.Logger.Error("Timed out waiting for caches to sync")
+		c.logger.Error("Timed out waiting for caches to sync")
 		return
 	}
 
@@ -152,7 +158,7 @@ func (c *Controller) Run(ctx context.Context, shootWorkers, shootCareWorkers int
 	go func() {
 		for res := range c.workerCh {
 			c.numberOfRunningWorkers += res
-			logger.Logger.Debugf("Current number of running Shoot workers is %d", c.numberOfRunningWorkers)
+			c.logger.Debugf("Current number of running Shoot workers is %d", c.numberOfRunningWorkers)
 		}
 	}()
 
@@ -163,13 +169,13 @@ func (c *Controller) Run(ctx context.Context, shootWorkers, shootCareWorkers int
 
 	// Update Shoots before starting the workers.
 	shootFilterFunc := controllerutils.ShootFilterFunc(confighelper.SeedNameFromSeedConfig(c.config.SeedConfig))
-	shoots, err := c.shootLister.List(labels.Everything())
-	if err != nil {
-		logger.Logger.Errorf("Failed to fetch shoots resources: %v", err.Error())
+	shoots := &gardencorev1beta1.ShootList{}
+	if err := c.gardenCache.List(ctx, shoots); err != nil {
+		c.logger.Errorf("Failed to fetch shoots resources: %v", err.Error())
 		return
 	}
-	for _, shoot := range shoots {
-		if !shootFilterFunc(shoot) {
+	for _, shoot := range shoots.Items {
+		if !shootFilterFunc(&shoot) {
 			continue
 		}
 
@@ -177,13 +183,13 @@ func (c *Controller) Run(ctx context.Context, shootWorkers, shootCareWorkers int
 		if shoot.Status.LastOperation != nil && shoot.Status.LastOperation.State == gardencorev1beta1.LastOperationStateProcessing {
 			newShoot := shoot.DeepCopy()
 			newShoot.Status.LastOperation.State = gardencorev1beta1.LastOperationStateAborted
-			if _, err := gardenClient.GardenCore().CoreV1beta1().Shoots(newShoot.Namespace).UpdateStatus(ctx, newShoot, kubernetes.DefaultUpdateOptions()); err != nil {
-				panic(fmt.Sprintf("Failed to update shoot status [%v]: %v ", newShoot.Name, err.Error()))
+			if err := gardenClient.Client().Status().Update(ctx, newShoot); err != nil {
+				panic(fmt.Sprintf("Failed to update shoot status [%s]: %v ", client.ObjectKeyFromObject(newShoot).String(), err.Error()))
 			}
 		}
 	}
 
-	logger.Logger.Info("Shoot controller initialized.")
+	c.logger.Info("Shoot controller initialized.")
 
 	for i := 0; i < shootWorkers; i++ {
 		controllerutils.CreateWorker(ctx, c.shootQueue, "Shoot", reconcile.Func(c.reconcileShootRequest), &waitGroup, c.workerCh)
@@ -212,10 +218,10 @@ func (c *Controller) Run(ctx context.Context, shootWorkers, shootCareWorkers int
 			queueLengths                = shootQueueLength + shootCareQueueLength + shootSeedQueueLength + seedRegistrationQueueLength
 		)
 		if queueLengths == 0 && c.numberOfRunningWorkers == 0 {
-			logger.Logger.Debug("No running Shoot worker and no items left in the queues. Terminated Shoot controller...")
+			c.logger.Debug("No running Shoot worker and no items left in the queues. Terminated Shoot controller...")
 			break
 		}
-		logger.Logger.Debugf("Waiting for %d Shoot worker(s) to finish (%d item(s) left in the queues)...", c.numberOfRunningWorkers, queueLengths)
+		c.logger.Debugf("Waiting for %d Shoot worker(s) to finish (%d item(s) left in the queues)...", c.numberOfRunningWorkers, queueLengths)
 		time.Sleep(5 * time.Second)
 	}
 

--- a/pkg/gardenlet/controller/shoot/shoot.go
+++ b/pkg/gardenlet/controller/shoot/shoot.go
@@ -57,7 +57,6 @@ type Controller struct {
 	imageVector                   imagevector.ImageVector
 	shootReconciliationDueTracker *reconciliationDueTracker
 
-	seedLister  gardencorelisters.SeedLister
 	shootLister gardencorelisters.ShootLister
 
 	shootCareQueue        workqueue.RateLimitingInterface
@@ -79,9 +78,6 @@ func NewShootController(clientMap clientmap.ClientMap, k8sGardenCoreInformers ga
 	var (
 		gardenCoreV1beta1Informer = k8sGardenCoreInformers.Core().V1beta1()
 
-		seedInformer = gardenCoreV1beta1Informer.Seeds()
-		seedLister   = seedInformer.Lister()
-
 		shootInformer = gardenCoreV1beta1Informer.Shoots()
 		shootLister   = shootInformer.Lister()
 	)
@@ -99,7 +95,6 @@ func NewShootController(clientMap clientmap.ClientMap, k8sGardenCoreInformers ga
 		imageVector:                   imageVector,
 		shootReconciliationDueTracker: newReconciliationDueTracker(),
 
-		seedLister:  seedLister,
 		shootLister: shootLister,
 
 		shootCareQueue:        workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "shoot-care"),
@@ -138,7 +133,6 @@ func NewShootController(clientMap clientmap.ClientMap, k8sGardenCoreInformers ga
 	})
 
 	shootController.hasSyncedFuncs = []cache.InformerSynced{
-		seedInformer.Informer().HasSynced,
 		shootInformer.Informer().HasSynced,
 	}
 

--- a/pkg/gardenlet/controller/shoot/shoot.go
+++ b/pkg/gardenlet/controller/shoot/shoot.go
@@ -89,7 +89,7 @@ func NewShootController(clientMap clientmap.ClientMap, k8sGardenCoreInformers ga
 		config:                        config,
 		identity:                      identity,
 		gardenClusterIdentity:         gardenClusterIdentity,
-		careReconciler:                NewCareReconciler(clientMap, gardenCoreV1beta1Informer, imageVector, identity, gardenClusterIdentity, config),
+		careReconciler:                NewCareReconciler(clientMap, imageVector, identity, gardenClusterIdentity, config),
 		seedRegistrationControl:       NewDefaultSeedRegistrationControl(clientMap, recorder, logger.Logger),
 		recorder:                      recorder,
 		imageVector:                   imageVector,

--- a/pkg/gardenlet/controller/shoot/shoot.go
+++ b/pkg/gardenlet/controller/shoot/shoot.go
@@ -89,7 +89,7 @@ func NewShootController(clientMap clientmap.ClientMap, k8sGardenCoreInformers ga
 		config:                        config,
 		identity:                      identity,
 		gardenClusterIdentity:         gardenClusterIdentity,
-		careReconciler:                NewCareReconciler(clientMap, imageVector, identity, gardenClusterIdentity, config),
+		careReconciler:                NewCareReconciler(clientMap, logger.Logger, imageVector, identity, gardenClusterIdentity, config),
 		seedRegistrationReconciler:    NewSeedRegistrationReconciler(clientMap, recorder, logger.Logger),
 		recorder:                      recorder,
 		imageVector:                   imageVector,

--- a/pkg/gardenlet/controller/shoot/shoot_care_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_care_control.go
@@ -268,7 +268,7 @@ func (s *careReconciler) care(ctx context.Context, shootObj *gardencorev1beta1.S
 
 	// Only read Garden secrets once because we don't rely on up-to-date secrets for health checks.
 	if s.gardenSecrets == nil {
-		secrets, err := garden.ReadGardenSecretsFromReader(careCtx, gardenClient.Client(), gutil.ComputeGardenNamespace(*shoot.Spec.SeedName))
+		secrets, err := garden.ReadGardenSecrets(careCtx, gardenClient.Client(), gutil.ComputeGardenNamespace(*shoot.Spec.SeedName))
 		if err != nil {
 			return fmt.Errorf("error reading Garden secrets: %w", err)
 		}

--- a/pkg/gardenlet/controller/shoot/shoot_care_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_care_control.go
@@ -23,7 +23,6 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
-	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
@@ -101,31 +100,35 @@ func shootReconciliationFinishedSuccessful(oldShoot, newShoot *gardencorev1beta1
 
 // NewCareReconciler returns an implementation of reconcile.Reconciler which is dedicated to execute care operations
 // on shoots, e.g., health checks or garbage collection.
-func NewCareReconciler(clientMap clientmap.ClientMap, k8sGardenCoreInformers gardencoreinformers.Interface, imageVector imagevector.ImageVector, identity *gardencorev1beta1.Gardener, gardenClusterIdentity string, config *config.GardenletConfiguration) reconcile.Reconciler {
+func NewCareReconciler(
+	clientMap clientmap.ClientMap,
+	imageVector imagevector.ImageVector,
+	identity *gardencorev1beta1.Gardener,
+	gardenClusterIdentity string,
+	config *config.GardenletConfiguration,
+) reconcile.Reconciler {
 	return &careReconciler{
-		clientMap:              clientMap,
-		k8sGardenCoreInformers: k8sGardenCoreInformers,
-		imageVector:            imageVector,
-		identity:               identity,
-		gardenClusterIdentity:  gardenClusterIdentity,
-		config:                 config,
+		clientMap:             clientMap,
+		imageVector:           imageVector,
+		identity:              identity,
+		gardenClusterIdentity: gardenClusterIdentity,
+		config:                config,
 	}
 }
 
 type careReconciler struct {
-	clientMap              clientmap.ClientMap
-	k8sGardenCoreInformers gardencoreinformers.Interface
-	imageVector            imagevector.ImageVector
-	identity               *gardencorev1beta1.Gardener
-	gardenClusterIdentity  string
-	config                 *config.GardenletConfiguration
+	clientMap             clientmap.ClientMap
+	imageVector           imagevector.ImageVector
+	identity              *gardencorev1beta1.Gardener
+	gardenClusterIdentity string
+	config                *config.GardenletConfiguration
 
 	gardenSecrets map[string]*corev1.Secret
 }
 
-func (c *careReconciler) conditionThresholdsToProgressingMapping() map[gardencorev1beta1.ConditionType]time.Duration {
+func (r *careReconciler) conditionThresholdsToProgressingMapping() map[gardencorev1beta1.ConditionType]time.Duration {
 	out := make(map[gardencorev1beta1.ConditionType]time.Duration)
-	for _, threshold := range c.config.Controllers.ShootCare.ConditionThresholds {
+	for _, threshold := range r.config.Controllers.ShootCare.ConditionThresholds {
 		out[gardencorev1beta1.ConditionType(threshold.Type)] = threshold.Duration.Duration
 	}
 	return out
@@ -160,7 +163,7 @@ func shootClientInitializer(ctx context.Context, o *operation.Operation) func() 
 	}
 }
 
-func careSetupFailure(ctx context.Context, gardenClient kubernetes.Interface, shoot *gardencorev1beta1.Shoot, message string, conditions, constraints []gardencorev1beta1.Condition) error {
+func careSetupFailure(ctx context.Context, gardenClient client.Client, shoot *gardencorev1beta1.Shoot, message string, conditions, constraints []gardencorev1beta1.Condition) error {
 	updatedConditions := make([]gardencorev1beta1.Condition, 0, len(conditions))
 	for _, cond := range conditions {
 		updatedConditions = append(updatedConditions, gardencorev1beta1helper.UpdatedConditionUnknownErrorMessage(cond, message))
@@ -176,37 +179,40 @@ func careSetupFailure(ctx context.Context, gardenClient kubernetes.Interface, sh
 		return nil
 	}
 
-	return patchShootStatus(ctx, gardenClient.Client(), shoot, updatedConditions, updatedConstraints)
+	return patchShootStatus(ctx, gardenClient, shoot, updatedConditions, updatedConstraints)
 }
 
-func (s *careReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	shootLister := s.k8sGardenCoreInformers.Shoots().Lister()
-
-	shootObj, err := shootLister.Shoots(req.Namespace).Get(req.Name)
-	if apierrors.IsNotFound(err) {
-		logger.Logger.Infof("[SHOOT CARE] Stopping care operations for Shoot %s/%s since it has been deleted", req.Namespace, req.Name)
-		return reconcile.Result{}, nil
-	}
+func (r *careReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	gardenClient, err := r.clientMap.GetClient(ctx, keys.ForGarden())
 	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("failed to get garden client: %w", err)
+	}
+
+	shoot := &gardencorev1beta1.Shoot{}
+	if err := gardenClient.Client().Get(ctx, req.NamespacedName, shoot); err != nil {
+		if apierrors.IsNotFound(err) {
+			logger.Logger.Infof("[SHOOT CARE] Stopping care operations for Shoot %s/%s since it has been deleted", req.Namespace, req.Name)
+			return reconcile.Result{}, nil
+		}
 		logger.Logger.Infof("[SHOOT CARE] %s - unable to retrieve object from store: %s/%s", req.Namespace, req.Name, err)
 		return reconcile.Result{}, err
 	}
 
 	// if shoot has not been scheduled, requeue
-	if shootObj.Spec.SeedName == nil {
+	if shoot.Spec.SeedName == nil {
 		return reconcile.Result{}, fmt.Errorf("shoot %s/%s has not yet been scheduled on a Seed", req.Namespace, req.Name)
 	}
 
 	// if shoot is no longer managed by this gardenlet (e.g., due to migration to another seed) then don't requeue
-	if !controllerutils.ShootIsManagedByThisGardenlet(shootObj, s.config) {
+	if !controllerutils.ShootIsManagedByThisGardenlet(shoot, r.config) {
 		return reconcile.Result{}, nil
 	}
 
-	if err := s.care(ctx, shootObj); err != nil {
+	if err := r.care(ctx, gardenClient, shoot); err != nil {
 		return reconcile.Result{}, err
 	}
 
-	return reconcile.Result{RequeueAfter: s.config.Controllers.ShootCare.SyncPeriod.Duration}, nil
+	return reconcile.Result{RequeueAfter: r.config.Controllers.ShootCare.SyncPeriod.Duration}, nil
 }
 
 var (
@@ -220,21 +226,15 @@ var (
 	NewGarbageCollector = defaultNewGarbageCollector
 )
 
-func (s *careReconciler) care(ctx context.Context, shootObj *gardencorev1beta1.Shoot) error {
+func (r *careReconciler) care(ctx context.Context, gardenClientSet kubernetes.Interface, shoot *gardencorev1beta1.Shoot) error {
 	var (
-		shoot       = shootObj.DeepCopy()
-		shootLogger = logger.NewShootLogger(logger.Logger, shoot.Name, shoot.Namespace)
+		gardenClient    = gardenClientSet.Client()
+		shootLogger     = logger.NewShootLogger(logger.Logger, shoot.Name, shoot.Namespace)
+		careCtx, cancel = context.WithTimeout(ctx, r.config.Controllers.ShootCare.SyncPeriod.Duration)
 	)
-
-	careCtx, cancel := context.WithTimeout(ctx, s.config.Controllers.ShootCare.SyncPeriod.Duration)
 	defer cancel()
 
 	shootLogger.Debugf("[SHOOT CARE] %s/%s", shoot.Namespace, shoot.Name)
-
-	gardenClient, err := s.clientMap.GetClient(careCtx, keys.ForGarden())
-	if err != nil {
-		return fmt.Errorf("failed to get garden client: %w", err)
-	}
 
 	// Initialize conditions based on the current status.
 	var conditions []gardencorev1beta1.Condition
@@ -256,7 +256,7 @@ func (s *careReconciler) care(ctx context.Context, shootObj *gardencorev1beta1.S
 		constraints = append(constraints, gardencorev1beta1helper.GetOrInitCondition(shoot.Status.Constraints, constr))
 	}
 
-	seedClient, err := s.clientMap.GetClient(careCtx, keys.ForSeedWithName(*shoot.Spec.SeedName))
+	seedClient, err := r.clientMap.GetClient(careCtx, keys.ForSeedWithName(*shoot.Spec.SeedName))
 	if err != nil {
 		shootLogger.Errorf("seedClient cannot be constructed: %s", err.Error())
 
@@ -267,24 +267,24 @@ func (s *careReconciler) care(ctx context.Context, shootObj *gardencorev1beta1.S
 	}
 
 	// Only read Garden secrets once because we don't rely on up-to-date secrets for health checks.
-	if s.gardenSecrets == nil {
-		secrets, err := garden.ReadGardenSecrets(careCtx, gardenClient.Client(), gutil.ComputeGardenNamespace(*shoot.Spec.SeedName))
+	if r.gardenSecrets == nil {
+		secrets, err := garden.ReadGardenSecrets(careCtx, gardenClient, gutil.ComputeGardenNamespace(*shoot.Spec.SeedName))
 		if err != nil {
 			return fmt.Errorf("error reading Garden secrets: %w", err)
 		}
-		s.gardenSecrets = secrets
+		r.gardenSecrets = secrets
 	}
 
 	operation, err := NewOperation(
 		careCtx,
-		gardenClient,
+		gardenClientSet,
 		seedClient,
-		s.config,
-		s.identity,
-		s.gardenClusterIdentity,
-		s.gardenSecrets,
-		s.imageVector,
-		s.clientMap,
+		r.config,
+		r.identity,
+		r.gardenClusterIdentity,
+		r.gardenSecrets,
+		r.imageVector,
+		r.clientMap,
 		shoot,
 		shootLogger,
 	)
@@ -306,7 +306,7 @@ func (s *careReconciler) care(ctx context.Context, shootObj *gardencorev1beta1.S
 		return nil
 	}
 
-	staleExtensionHealthCheckThreshold := confighelper.StaleExtensionHealthChecksThreshold(s.config.Controllers.ShootCare.StaleExtensionHealthChecks)
+	staleExtensionHealthCheckThreshold := confighelper.StaleExtensionHealthChecksThreshold(r.config.Controllers.ShootCare.StaleExtensionHealthChecks)
 	initializeShootClients := shootClientInitializer(careCtx, operation)
 
 	var updatedConditions, updatedConstraints, seedConditions []gardencorev1beta1.Condition
@@ -317,7 +317,7 @@ func (s *careReconciler) care(ctx context.Context, shootObj *gardencorev1beta1.S
 			shootHealth := NewHealthCheck(operation, initializeShootClients)
 			updatedConditions = shootHealth.Check(
 				ctx,
-				s.conditionThresholdsToProgressingMapping(),
+				r.conditionThresholdsToProgressingMapping(),
 				staleExtensionHealthCheckThreshold,
 				conditions,
 			)
@@ -357,7 +357,7 @@ func (s *careReconciler) care(ctx context.Context, shootObj *gardencorev1beta1.S
 	// Update Shoot status if necessary
 	if gardencorev1beta1helper.ConditionsNeedUpdate(conditions, updatedConditions) ||
 		gardencorev1beta1helper.ConditionsNeedUpdate(constraints, updatedConstraints) {
-		if err := patchShootStatus(ctx, gardenClient.Client(), shoot, updatedConditions, updatedConstraints); err != nil {
+		if err := patchShootStatus(ctx, gardenClient, shoot, updatedConditions, updatedConstraints); err != nil {
 			operation.Logger.Errorf("Could not update Shoot status: %+v", err)
 			return nil // We do not want to run in the exponential backoff for the condition checks.
 		}
@@ -370,7 +370,7 @@ func (s *careReconciler) care(ctx context.Context, shootObj *gardencorev1beta1.S
 		shoot.Status.LastErrors,
 		updatedConditions...,
 	)))
-	if err := gardenClient.Client().Patch(ctx, shoot, metaPatch); err != nil {
+	if err := gardenClient.Patch(ctx, shoot, metaPatch); err != nil {
 		operation.Logger.Errorf("Could not update Shoot health label: %+v", err)
 		return nil // We do not want to run in the exponential backoff for the condition checks.
 	}

--- a/pkg/gardenlet/controller/shoot/shoot_care_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_care_control.go
@@ -268,7 +268,7 @@ func (s *careReconciler) care(ctx context.Context, shootObj *gardencorev1beta1.S
 
 	// Only read Garden secrets once because we don't rely on up-to-date secrets for health checks.
 	if s.gardenSecrets == nil {
-		secrets, err := garden.ReadGardenSecrets(careCtx, gardenClient.Client(), s.k8sGardenCoreInformers.Seeds().Lister(), gutil.ComputeGardenNamespace(*shoot.Spec.SeedName))
+		secrets, err := garden.ReadGardenSecretsFromReader(careCtx, gardenClient.Client(), gutil.ComputeGardenNamespace(*shoot.Spec.SeedName))
 		if err != nil {
 			return fmt.Errorf("error reading Garden secrets: %w", err)
 		}

--- a/pkg/gardenlet/controller/shoot/shoot_care_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_care_control.go
@@ -284,7 +284,6 @@ func (s *careReconciler) care(ctx context.Context, shootObj *gardencorev1beta1.S
 		s.gardenClusterIdentity,
 		s.gardenSecrets,
 		s.imageVector,
-		s.k8sGardenCoreInformers,
 		s.clientMap,
 		shoot,
 		shootLogger,

--- a/pkg/gardenlet/controller/shoot/shoot_care_control_test.go
+++ b/pkg/gardenlet/controller/shoot/shoot_care_control_test.go
@@ -53,12 +53,13 @@ import (
 
 var _ = Describe("Shoot Care Control", func() {
 	var (
+		log           logrus.FieldLogger
 		careControl   reconcile.Reconciler
 		gardenletConf *config.GardenletConfiguration
 	)
 
 	BeforeSuite(func() {
-		logger.Logger = logger.NewNopLogger()
+		log = logger.NewNopLogger()
 	})
 
 	AfterEach(func() {
@@ -169,7 +170,7 @@ var _ = Describe("Shoot Care Control", func() {
 				It("should report a setup failure", func() {
 					operationFunc := opFunc(nil, errors.New("foo"))
 					defer test.WithVars(&NewOperation, operationFunc)()
-					careControl = NewCareReconciler(clientMapBuilder.Build(), nil, nil, "", gardenletConf)
+					careControl = NewCareReconciler(clientMapBuilder.Build(), log, nil, nil, "", gardenletConf)
 
 					Expect(careControl.Reconcile(ctx, req)).To(Equal(reconcile.Result{RequeueAfter: careSyncPeriod}))
 
@@ -188,7 +189,7 @@ var _ = Describe("Shoot Care Control", func() {
 				It("should report a setup failure", func() {
 					operationFunc := opFunc(nil, errors.New("foo"))
 					defer test.WithVars(&NewOperation, operationFunc)()
-					careControl = NewCareReconciler(clientMapBuilder.Build(), nil, nil, "", gardenletConf)
+					careControl = NewCareReconciler(clientMapBuilder.Build(), log, nil, nil, "", gardenletConf)
 
 					_, err := careControl.Reconcile(ctx, req)
 					Expect(err).To(MatchError("error reading Garden secrets: need an internal domain secret but found none"))
@@ -209,7 +210,7 @@ var _ = Describe("Shoot Care Control", func() {
 				})
 
 				It("should report a setup failure", func() {
-					careControl = NewCareReconciler(clientMapBuilder.Build(), nil, nil, "", gardenletConf)
+					careControl = NewCareReconciler(clientMapBuilder.Build(), log, nil, nil, "", gardenletConf)
 					Expect(careControl.Reconcile(ctx, req)).To(Equal(reconcile.Result{RequeueAfter: careSyncPeriod}))
 
 					updatedShoot := &gardencorev1beta1.Shoot{}
@@ -255,7 +256,7 @@ var _ = Describe("Shoot Care Control", func() {
 					test.WithVar(&NewOperation, operationFunc),
 					test.WithVar(&NewGarbageCollector, nopGarbageCollectorFunc()),
 				)
-				careControl = NewCareReconciler(clientMap, nil, nil, "", gardenletConf)
+				careControl = NewCareReconciler(clientMap, log, nil, nil, "", gardenletConf)
 			})
 
 			AfterEach(func() {
@@ -669,7 +670,7 @@ func opFunc(op *operation.Operation, err error) NewOperationFunc {
 		_ imagevector.ImageVector,
 		_ clientmap.ClientMap,
 		_ *gardencorev1beta1.Shoot,
-		_ *logrus.Entry,
+		_ logrus.FieldLogger,
 	) (*operation.Operation, error) {
 		return op, err
 	}

--- a/pkg/gardenlet/controller/shoot/shoot_care_control_test.go
+++ b/pkg/gardenlet/controller/shoot/shoot_care_control_test.go
@@ -24,7 +24,6 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	gardencoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
-	"github.com/gardener/gardener/pkg/client/core/informers/externalversions/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
 	fakeclientmap "github.com/gardener/gardener/pkg/client/kubernetes/clientmap/fake"
@@ -669,7 +668,6 @@ func opFunc(op *operation.Operation, err error) NewOperationFunc {
 		_ string,
 		_ map[string]*corev1.Secret,
 		_ imagevector.ImageVector,
-		_ v1beta1.Interface,
 		_ clientmap.ClientMap,
 		_ *gardencorev1beta1.Shoot,
 		_ *logrus.Entry,

--- a/pkg/gardenlet/controller/shoot/shoot_care_control_test.go
+++ b/pkg/gardenlet/controller/shoot/shoot_care_control_test.go
@@ -53,6 +53,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
+// TODO(timebertt): some of these tests are broken in this commit
+//  they will be fixed in a later commit, once listers are completely eliminated in the care controller
 var _ = Describe("Shoot Care Control", func() {
 	var (
 		careControl   reconcile.Reconciler

--- a/pkg/gardenlet/controller/shoot/shoot_care_control_types.go
+++ b/pkg/gardenlet/controller/shoot/shoot_care_control_types.go
@@ -82,7 +82,7 @@ type NewOperationFunc func(
 	imageVector imagevector.ImageVector,
 	clientMap clientmap.ClientMap,
 	shoot *gardencorev1beta1.Shoot,
-	logger *logrus.Entry,
+	logger logrus.FieldLogger,
 ) (
 	*operation.Operation,
 	error,
@@ -99,7 +99,7 @@ var defaultNewOperationFunc = func(
 	imageVector imagevector.ImageVector,
 	clientMap clientmap.ClientMap,
 	shoot *gardencorev1beta1.Shoot,
-	logger *logrus.Entry,
+	logger logrus.FieldLogger,
 ) (
 	*operation.Operation,
 	error,

--- a/pkg/gardenlet/controller/shoot/shoot_care_control_types.go
+++ b/pkg/gardenlet/controller/shoot/shoot_care_control_types.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	"github.com/gardener/gardener/pkg/client/core/informers/externalversions/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
@@ -81,7 +80,6 @@ type NewOperationFunc func(
 	gardenClusterIdentity string,
 	secrets map[string]*corev1.Secret,
 	imageVector imagevector.ImageVector,
-	k8sGardenCoreInformers v1beta1.Interface,
 	clientMap clientmap.ClientMap,
 	shoot *gardencorev1beta1.Shoot,
 	logger *logrus.Entry,
@@ -99,7 +97,6 @@ var defaultNewOperationFunc = func(
 	gardenClusterIdentity string,
 	secrets map[string]*corev1.Secret,
 	imageVector imagevector.ImageVector,
-	k8sGardenCoreInformers v1beta1.Interface,
 	clientMap clientmap.ClientMap,
 	shoot *gardencorev1beta1.Shoot,
 	logger *logrus.Entry,
@@ -116,7 +113,7 @@ var defaultNewOperationFunc = func(
 		WithSecrets(secrets).
 		WithImageVector(imageVector).
 		WithGardenFrom(gardenClient.Client(), shoot.Namespace).
-		WithSeedFrom(k8sGardenCoreInformers, *shoot.Spec.SeedName).
+		WithSeedFrom(gardenClient.Client(), *shoot.Spec.SeedName).
 		WithShootFromCluster(gardenClient, seedClient, shoot).
 		Build(ctx, clientMap)
 }

--- a/pkg/gardenlet/controller/shoot/shoot_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control.go
@@ -263,7 +263,7 @@ func (c *Controller) initializeOperation(ctx context.Context, logger *logrus.Ent
 	seedObj, err := seedpkg.
 		NewBuilder().
 		WithSeedObject(seed).
-		Build()
+		Build(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -272,9 +272,9 @@ func (c *Controller) initializeOperation(ctx context.Context, logger *logrus.Ent
 		NewBuilder().
 		WithShootObject(shoot).
 		WithCloudProfileObject(cloudProfile).
-		WithShootSecretFromReader(gardenClient.Client()).
+		WithShootSecretFrom(gardenClient.Client()).
 		WithProjectName(project.Name).
-		WithExposureClassFromReader(gardenClient.Client()).
+		WithExposureClassFrom(gardenClient.Client()).
 		WithDisableDNS(!seedObj.Info.Spec.Settings.ShootDNS.Enabled).
 		WithInternalDomain(gardenObj.InternalDomain).
 		WithDefaultDomains(gardenObj.DefaultDomains).

--- a/pkg/gardenlet/controller/shoot/shoot_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control.go
@@ -244,8 +244,8 @@ func shouldPrepareShootForMigration(shoot *gardencorev1beta1.Shoot) bool {
 
 const taskID = "initializeOperation"
 
-func (c *Controller) initializeOperation(ctx context.Context, logger *logrus.Entry, gardenClient kubernetes.Interface, shoot *gardencorev1beta1.Shoot, project *gardencorev1beta1.Project, cloudProfile *gardencorev1beta1.CloudProfile, seed *gardencorev1beta1.Seed) (*operation.Operation, error) {
-	gardenSecrets, err := garden.ReadGardenSecrets(ctx, gardenClient.Client(), gutil.ComputeGardenNamespace(seed.Name))
+func (c *Controller) initializeOperation(ctx context.Context, logger logrus.FieldLogger, gardenClient kubernetes.Interface, shoot *gardencorev1beta1.Shoot, project *gardencorev1beta1.Project, cloudProfile *gardencorev1beta1.CloudProfile, seed *gardencorev1beta1.Seed) (*operation.Operation, error) {
+	gardenSecrets, err := garden.ReadGardenSecrets(ctx, gardenClient.Client(), gutil.ComputeGardenNamespace(seed.Name), logger)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gardenlet/controller/shoot/shoot_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control.go
@@ -245,7 +245,7 @@ func shouldPrepareShootForMigration(shoot *gardencorev1beta1.Shoot) bool {
 const taskID = "initializeOperation"
 
 func (c *Controller) initializeOperation(ctx context.Context, logger *logrus.Entry, gardenClient kubernetes.Interface, shoot *gardencorev1beta1.Shoot, project *gardencorev1beta1.Project, cloudProfile *gardencorev1beta1.CloudProfile, seed *gardencorev1beta1.Seed) (*operation.Operation, error) {
-	gardenSecrets, err := garden.ReadGardenSecretsFromReader(ctx, gardenClient.Client(), gutil.ComputeGardenNamespace(seed.Name))
+	gardenSecrets, err := garden.ReadGardenSecrets(ctx, gardenClient.Client(), gutil.ComputeGardenNamespace(seed.Name))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/gardenlet/controller/shoot/shoot_control_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_delete.go
@@ -606,9 +606,8 @@ func (c *Controller) removeFinalizerFrom(ctx context.Context, gardenClient kuber
 
 	// Wait until the above modifications are reflected in the cache to prevent unwanted reconcile
 	// operations (sometimes the cache is not synced fast enough).
-	return retryutils.UntilTimeout(ctx, time.Second, 30*time.Second, func(context.Context) (done bool, err error) {
-		// TODO(timebertt): switch to c-r cache here, once shoot controller uses c-r informers
-		shoot, err := c.shootLister.Shoots(shoot.Namespace).Get(shoot.Name)
+	return retryutils.UntilTimeout(ctx, time.Second, 30*time.Second, func(context.Context) (bool, error) {
+		err := c.gardenCache.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)
 		if apierrors.IsNotFound(err) {
 			return retryutils.Ok()
 		}

--- a/pkg/gardenlet/controller/shoot/shoot_control_migrate.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_migrate.go
@@ -43,7 +43,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-func (c *Controller) prepareShootForMigration(ctx context.Context, logger *logrus.Entry, gardenClient kubernetes.Interface, shoot *gardencorev1beta1.Shoot, project *gardencorev1beta1.Project, cloudProfile *gardencorev1beta1.CloudProfile, seed *gardencorev1beta1.Seed) (reconcile.Result, error) {
+func (c *Controller) prepareShootForMigration(ctx context.Context, logger logrus.FieldLogger, gardenClient kubernetes.Interface, shoot *gardencorev1beta1.Shoot, project *gardencorev1beta1.Project, cloudProfile *gardencorev1beta1.CloudProfile, seed *gardencorev1beta1.Seed) (reconcile.Result, error) {
 	var (
 		err error
 

--- a/pkg/logger/logrus.go
+++ b/pkg/logger/logrus.go
@@ -83,7 +83,7 @@ func AddWriter(logger *logrus.Logger, writer io.Writer) *logrus.Logger {
 // and the project in the Garden cluster to the output. If an <operationID> is provided it will be printed for every
 // log message.
 // Example output: time="2017-06-08T13:00:49+02:00" level=info msg="Creating namespace in seed cluster" shoot=core/crazy-botany.
-func NewShootLogger(logger *logrus.Logger, shoot, project string) *logrus.Entry {
+func NewShootLogger(logger logrus.FieldLogger, shoot, project string) *logrus.Entry {
 	return logger.WithField("shoot", fmt.Sprintf("%s/%s", project, shoot))
 }
 

--- a/pkg/operation/garden/garden.go
+++ b/pkg/operation/garden/garden.go
@@ -53,8 +53,8 @@ func (b *Builder) WithProject(project *gardencorev1beta1.Project) *Builder {
 	return b
 }
 
-// WithProjectFromReader sets the projectFunc attribute after fetching it from the lister.
-func (b *Builder) WithProjectFromReader(reader client.Reader, namespace string) *Builder {
+// WithProjectFrom sets the projectFunc attribute after fetching it from the given reader.
+func (b *Builder) WithProjectFrom(reader client.Reader, namespace string) *Builder {
 	b.projectFunc = func(ctx context.Context) (*gardencorev1beta1.Project, error) {
 		project, _, err := gutil.ProjectAndNamespaceFromReader(ctx, reader, namespace)
 		return project, err

--- a/pkg/operation/garden/garden.go
+++ b/pkg/operation/garden/garden.go
@@ -21,7 +21,6 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	gardencorelisters "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/logger"
@@ -167,63 +166,11 @@ func DomainIsDefaultDomain(domain string, defaultDomains []*Domain) *Domain {
 	return nil
 }
 
-// ReadGardenSecrets reads the Kubernetes Secrets from the Garden cluster which are independent of Shoot clusters.
-// The Secret objects are stored on the Controller in order to pass them to created Garden objects later.
-func ReadGardenSecrets(ctx context.Context, rd client.Reader, seedLister gardencorelisters.SeedLister, namespace string) (map[string]*corev1.Secret, error) {
-	return readGardenSecretsFromCache(
-		ctx,
-		func(ctx context.Context, namespace string, selector labels.Selector) ([]corev1.Secret, error) {
-			secrets := &corev1.SecretList{}
-			if err := rd.List(ctx, secrets, &client.MatchingLabelsSelector{Selector: selector}, client.InNamespace(namespace)); err != nil {
-				return nil, err
-			}
-			return secrets.Items, nil
-		},
-		func(_ context.Context) ([]*gardencorev1beta1.Seed, error) {
-			return seedLister.List(labels.Everything())
-		},
-		namespace,
-	)
-}
-
-// ReadGardenSecretsFromReader reads the Kubernetes Secrets from the Garden cluster which are independent of Shoot clusters.
-// The Secret objects are stored on the Controller in order to pass them to created Garden objects later.
-func ReadGardenSecretsFromReader(ctx context.Context, rd client.Reader, namespace string) (map[string]*corev1.Secret, error) {
-	return readGardenSecretsFromCache(
-		ctx,
-		func(ctx context.Context, namespace string, selector labels.Selector) ([]corev1.Secret, error) {
-			secretList := &corev1.SecretList{}
-			if err := rd.List(ctx, secretList, client.InNamespace(namespace), client.MatchingLabelsSelector{Selector: selector}); err != nil {
-				return nil, err
-			}
-
-			return secretList.Items, nil
-		},
-		func(ctx context.Context) ([]*gardencorev1beta1.Seed, error) {
-			seedList := &gardencorev1beta1.SeedList{}
-			if err := rd.List(ctx, seedList); err != nil {
-				return nil, err
-			}
-
-			out := make([]*gardencorev1beta1.Seed, 0, len(seedList.Items))
-			for _, seed := range seedList.Items {
-				out = append(out, seed.DeepCopy())
-			}
-			return out, nil
-		},
-		namespace,
-	)
-}
-
-type (
-	listSecretsFunc func(ctx context.Context, namespace string, selector labels.Selector) ([]corev1.Secret, error)
-	listSeedsFunc   func(ctx context.Context) ([]*gardencorev1beta1.Seed, error)
-)
-
 var gardenRoleReq = utils.MustNewRequirement(v1beta1constants.GardenRole, selection.Exists)
 
-// TODO(timebertt): simplify this and only use client.Reader, once listers are eliminated
-func readGardenSecretsFromCache(ctx context.Context, secretLister listSecretsFunc, seedLister listSeedsFunc, namespace string) (map[string]*corev1.Secret, error) {
+// ReadGardenSecrets reads the Kubernetes Secrets from the Garden cluster which are independent of Shoot clusters.
+// The Secret objects are stored on the Controller in order to pass them to created Garden objects later.
+func ReadGardenSecrets(ctx context.Context, c client.Reader, namespace string) (map[string]*corev1.Secret, error) {
 	var (
 		logInfo                             []string
 		secretsMap                          = make(map[string]*corev1.Secret)
@@ -232,12 +179,12 @@ func readGardenSecretsFromCache(ctx context.Context, secretLister listSecretsFun
 		numberOfAlertingSecrets             = 0
 	)
 
-	secretsGardenRole, err := secretLister(ctx, namespace, labels.NewSelector().Add(gardenRoleReq))
-	if err != nil {
+	secretList := &corev1.SecretList{}
+	if err := c.List(ctx, secretList, client.InNamespace(namespace), client.MatchingLabelsSelector{Selector: labels.NewSelector().Add(gardenRoleReq)}); err != nil {
 		return nil, err
 	}
 
-	for _, secret := range secretsGardenRole {
+	for _, secret := range secretList.Items {
 		// Retrieving default domain secrets based on all secrets in the Garden namespace which have
 		// a label indicating the Garden role default-domain.
 		if secret.Labels[v1beta1constants.GardenRole] == v1beta1constants.GardenRoleDefaultDomain {
@@ -301,11 +248,11 @@ func readGardenSecretsFromCache(ctx context.Context, secretLister listSecretsFun
 	}
 
 	// Check if an internal domain secret is required
-	seeds, err := seedLister(ctx)
-	if err != nil {
+	seedList := &gardencorev1beta1.SeedList{}
+	if err := c.List(ctx, seedList); err != nil {
 		return nil, err
 	}
-	for _, seed := range seeds {
+	for _, seed := range seedList.Items {
 		if !seed.Spec.Settings.ShootDNS.Enabled {
 			continue
 		}

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -66,7 +66,7 @@ func NewBuilder() *Builder {
 		imageVectorFunc: func() (imagevector.ImageVector, error) {
 			return nil, fmt.Errorf("image vector is required but not set")
 		},
-		loggerFunc: func() (*logrus.Entry, error) {
+		loggerFunc: func() (logrus.FieldLogger, error) {
 			return nil, fmt.Errorf("logger is required but not set")
 		},
 		secretsFunc: func() (map[string]*corev1.Secret, error) {
@@ -128,8 +128,8 @@ func (b *Builder) WithImageVector(imageVector imagevector.ImageVector) *Builder 
 }
 
 // WithLogger sets the loggerFunc attribute at the Builder.
-func (b *Builder) WithLogger(logger *logrus.Entry) *Builder {
-	b.loggerFunc = func() (*logrus.Entry, error) { return logger, nil }
+func (b *Builder) WithLogger(logger logrus.FieldLogger) *Builder {
+	b.loggerFunc = func() (logrus.FieldLogger, error) { return logger, nil }
 	return b
 }
 

--- a/pkg/operation/seed/types.go
+++ b/pkg/operation/seed/types.go
@@ -15,12 +15,14 @@
 package seed
 
 import (
+	"context"
+
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 )
 
 // Builder is an object that builds Seed objects.
 type Builder struct {
-	seedObjectFunc func() (*gardencorev1beta1.Seed, error)
+	seedObjectFunc func(context.Context) (*gardencorev1beta1.Seed, error)
 }
 
 // Seed is an object containing information about a Seed cluster.

--- a/pkg/operation/types.go
+++ b/pkg/operation/types.go
@@ -46,7 +46,7 @@ type Builder struct {
 	loggerFunc                func() (*logrus.Entry, error)
 	secretsFunc               func() (map[string]*corev1.Secret, error)
 	seedFunc                  func(context.Context) (*seed.Seed, error)
-	shootFunc                 func(context.Context, client.Client, *garden.Garden, *seed.Seed) (*shoot.Shoot, error)
+	shootFunc                 func(context.Context, client.Reader, *garden.Garden, *seed.Seed) (*shoot.Shoot, error)
 }
 
 // Operation contains all data required to perform an operation on a Shoot cluster.

--- a/pkg/operation/types.go
+++ b/pkg/operation/types.go
@@ -43,7 +43,7 @@ type Builder struct {
 	gardenClusterIdentityFunc func() (string, error)
 	imageVectorFunc           func() (imagevector.ImageVector, error)
 	exposureClassFunc         func(string) (*config.ExposureClassHandler, error)
-	loggerFunc                func() (*logrus.Entry, error)
+	loggerFunc                func() (logrus.FieldLogger, error)
 	secretsFunc               func() (map[string]*corev1.Secret, error)
 	seedFunc                  func(context.Context) (*seed.Seed, error)
 	shootFunc                 func(context.Context, client.Reader, *garden.Garden, *seed.Seed) (*shoot.Shoot, error)
@@ -52,7 +52,7 @@ type Builder struct {
 // Operation contains all data required to perform an operation on a Shoot cluster.
 type Operation struct {
 	Config                    *config.GardenletConfiguration
-	Logger                    *logrus.Entry
+	Logger                    logrus.FieldLogger
 	GardenerInfo              *gardencorev1beta1.Gardener
 	GardenClusterIdentity     string
 	Secrets                   map[string]*corev1.Secret


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind cleanup

**What this PR does / why we need it**:

This PR cleans up usages of the generated informers (client-go style) in gardenlet's Shoot controller.
It replaces them with informers from the controller-runtime cache to prevent duplicated watches if the `CachedRuntimeClients` feature gate is enabled.
To ease the transition, the PR also refactors the seed registration controller to the `reconcile.Reconciler` interface.

Now, the use of generated informers and listers is completely eliminated in gardenlet.
Hence, it should now be safer to turn on the `CachedRuntimeClients` feature gate again.

(similar to #4503, #3658 ff., #3746 ff.)

**Which issue(s) this PR fixes**:
Part of #2822, #4251

**Special notes for your reviewer**:

Performed some additional cleanups like in https://github.com/gardener/gardener/pull/4503 along the way (mainly related to logging and fake clients in unit tests).

/squash

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
