### PR TITLE
make component-cli parameters configurable

### DIFF
--- a/.ci/component_descriptor
+++ b/.ci/component_descriptor
@@ -27,6 +27,9 @@ component-cli component-archive resources add \
 "${COMPONENT_ARCHIVE_PATH}" \
 "$repo_root_dir/landscaper/resources.yaml"
 
+# print component descriptor for debugging in the ci
+cat "${COMPONENT_ARCHIVE_PATH}/component-descriptor.yaml"
+
 # Create CTF tar archive at CTF_PATH based on directory in component archive layout (packed automatically)
 # Pushed by CI to private registry if CTF is found at CTF_PATH.
 component-cli ctf add "${CTF_PATH}" -f "${COMPONENT_ARCHIVE_PATH}"

--- a/hack/.ci/component_descriptor
+++ b/hack/.ci/component_descriptor
@@ -1,5 +1,18 @@
 #!/usr/bin/env bash
 
+# Configuration Options:
+#
+# COMPONENT_PREFIXES: Set the image prefix that should be used to
+#                     determine if an image is defined by another component.
+#                     Defaults to "eu.gcr.io/gardener-project/gardener"
+#
+# GENERIC_DEPENDENCIES: Set images that are generic dependencies with no specific tag.
+#                       Defaults to "hyperkube,kube-apiserver,kube-controller-manager,kube-scheduler,kube-proxy"
+#
+# COMPONENT_CLI_ARGS: Set all component-cli arguments.
+#                     This should be used with care as all defaults are overwritten.
+#
+
 set -e
 
 repo_root_dir="$1"
@@ -9,12 +22,26 @@ descriptor_out_file="${COMPONENT_DESCRIPTOR_PATH}"
 echo "Enriching component descriptor from ${BASE_DEFINITION_PATH}"
 
 if [[ -f "$repo_root_dir/charts/images.yaml" ]]; then
+  # default environment variables
+  if [[ -z "${COMPONENT_PREFIXES}" ]]; then
+    COMPONENT_PREFIXES="eu.gcr.io/gardener-project/gardener"
+  fi
+  if [[ -z "${GENERIC_DEPENDENCIES}" ]]; then
+    GENERIC_DEPENDENCIES="hyperkube,kube-apiserver,kube-controller-manager,kube-scheduler,kube-proxy"
+  fi
+
+  if [[ -z "${COMPONENT_CLI_ARGS}" ]]; then
+    COMPONENT_CLI_ARGS="
+    --comp-desc ${BASE_DEFINITION_PATH} \
+    --image-vector "$repo_root_dir/charts/images.yaml" \
+    --component-prefixes "${COMPONENT_PREFIXES}" \
+    --generic-dependencies "${GENERIC_DEPENDENCIES}" \
+    "
+  fi
+
   # translates all images defined the images.yaml into component descriptor resources.
   # For detailed documentation see https://github.com/gardener/component-cli/blob/main/docs/reference/components-cli_image-vector_add.md
-  component-cli image-vector add --comp-desc ${BASE_DEFINITION_PATH} \
-    --image-vector "$repo_root_dir/charts/images.yaml" \
-    --component-prefixes eu.gcr.io/gardener-project/gardener \
-    --generic-dependencies hyperkube,kube-apiserver,kube-controller-manager,kube-scheduler,kube-proxy
+  component-cli image-vector add ${COMPONENT_CLI_ARGS}
 fi
 
 if [[ -d "$repo_root_dir/charts/" ]]; then


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:

Makes the component-cli parameters that are used in the central component-descriptor script configurable.
The current configuration does not change but now it is possible to optionally overwrite the args if needed.

**Special notes for your reviewer**:

I also added a debugging output so that the component-descriptor is printed in the ci log for better and easier debugging.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
