### PR TITLE
Enforce seed allocatable capacity during admission

### DIFF
--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -236,7 +236,7 @@ func (v *ValidateShoot) Admit(ctx context.Context, a admission.Attributes, o adm
 	validationContext.addMetadataAnnotations(a)
 
 	var allErrs field.ErrorList
-	allErrs = append(allErrs, validationContext.defaultOrValidateShootNetworks()...)
+	allErrs = append(allErrs, validationContext.validateShootNetworks()...)
 	allErrs = append(allErrs, validationContext.validateKubernetes()...)
 	allErrs = append(allErrs, validationContext.validateRegion()...)
 	allErrs = append(allErrs, validationContext.validateProvider()...)
@@ -467,7 +467,7 @@ func (c *validationContext) addMetadataAnnotations(a admission.Attributes) {
 	}
 }
 
-func (c *validationContext) defaultOrValidateShootNetworks() field.ErrorList {
+func (c *validationContext) validateShootNetworks() field.ErrorList {
 	var (
 		allErrs field.ErrorList
 		path    = field.NewPath("spec", "networking")

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -282,10 +282,6 @@ func (c *validationContext) validateProjectMembership(a admission.Attributes) er
 				return apierrors.NewBadRequest(fmt.Sprintf("the length of the shoot name and the project name must not exceed %d characters (project: %s; shoot: %s)", lengthLimit, c.project.Name, c.shoot.Name))
 			}
 		}
-		// TODO: move this to static project validation?
-		if strings.Contains(c.project.Name, "--") {
-			return apierrors.NewBadRequest(fmt.Sprintf("the project name must not contain two consecutive hyphens (project: %s)", c.project.Name))
-		}
 
 		if c.project.DeletionTimestamp != nil {
 			return admission.NewForbidden(a, fmt.Errorf("cannot create shoot '%s' in project '%s' that is already marked for deletion", c.shoot.Name, c.project.Name))

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -679,7 +679,7 @@ var _ = Describe("validator", func() {
 
 				err := admissionHandler.Admit(context.TODO(), attrs, nil)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("cannot create shoot '%s' on seed '%s' already marked for deletion", shoot.Name, seed.Name)))
+				Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("cannot schedule shoot '%s' on seed '%s' that is already marked for deletion", shoot.Name, seed.Name)))
 			})
 
 			It("should allow no-op updates", func() {

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -242,23 +242,6 @@ var _ = Describe("validator", func() {
 		})
 
 		Context("name/project length checks", func() {
-			It("should reject Shoot resources with two consecutive hyphens in project name", func() {
-				twoConsecutiveHyphensName := "n--o"
-				project.ObjectMeta = metav1.ObjectMeta{
-					Name: twoConsecutiveHyphensName,
-				}
-
-				Expect(coreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&project)).To(Succeed())
-				Expect(coreInformerFactory.Core().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
-				Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
-				attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
-
-				err := admissionHandler.Admit(context.TODO(), attrs, nil)
-
-				Expect(err).To(BeBadRequestError())
-				Expect(err.Error()).To(ContainSubstring("consecutive hyphens"))
-			})
-
 			It("should reject create operations on Shoot resources in projects which shall be deleted", func() {
 				deletionTimestamp := metav1.NewTime(time.Now())
 				project.ObjectMeta.DeletionTimestamp = &deletionTimestamp

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -2089,18 +2089,43 @@ var _ = Describe("validator", func() {
 
 		Context("control plane migration", func() {
 			It("should fail to change Seed name, because Seed doesn't have configuration for backup", func() {
-				oldShoot := shoot.DeepCopy()
-				oldShoot.Spec.SeedName = pointer.String("oldSeedName")
+				oldSeedName := fmt.Sprintf("old-%s", seedName)
+				oldSeed := seed.DeepCopy()
+				oldSeed.Name = oldSeedName
 				seed.Spec.Backup = nil
+
+				oldShoot := shoot.DeepCopy()
+				oldShoot.Spec.SeedName = &oldSeedName
 
 				Expect(coreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&project)).To(Succeed())
 				Expect(coreInformerFactory.Core().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
 				Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+				Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(oldSeed)).To(Succeed())
 				attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
 
 				err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
-				Expect(err).To(HaveOccurred())
+				Expect(err).To(MatchError(ContainSubstring(fmt.Sprintf("backup is not configured for seed %q", seedName))))
+			})
+
+			It("should fail to change Seed name, because old Seed doesn't have configuration for backup", func() {
+				oldSeedName := fmt.Sprintf("old-%s", seedName)
+				oldSeed := seed.DeepCopy()
+				oldSeed.Name = oldSeedName
+				oldSeed.Spec.Backup = nil
+
+				oldShoot := shoot.DeepCopy()
+				oldShoot.Spec.SeedName = &oldSeedName
+
+				Expect(coreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&project)).To(Succeed())
+				Expect(coreInformerFactory.Core().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
+				Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+				Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(oldSeed)).To(Succeed())
+				attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+
+				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+				Expect(err).To(MatchError(ContainSubstring(fmt.Sprintf("backup is not configured for old seed %q", oldSeedName))))
 			})
 
 			It("should fail to change Seed name, because cloud provider for new Seed is not equal to cloud provider for old Seed", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:
This PR adds a check to the `ShootValidator` admission plugin to deny `{CREATE,UPDATE} shoot` requests with `spec.seedName` set to a Seed, which has reached its maximum capacity for shoots (`Seed.status.allocatable.shoots`).

**Which issue(s) this PR fixes**:
Fixes #4513

**Special notes for your reviewer**:

I performed a few prefactorings to clean up the admission plugin to make it more readable and comprehensible.
/squash

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
Gardener now enforces the Seeds' capacity limits for shoot clusters when manually scheduling Shoots (i.e., when setting `Shoot.spec.seedName`).
If your requests are denied by gardener-apiserver because of this, unset `spec.seedName` and let gardener-scheduler pick the best Seed with available capacity for you.
```
