### PR TITLE
Increase timeouts in hostnameresolver tests

### DIFF
--- a/pkg/gardenlet/controller/networkpolicy/hostnameresolver/resolver_test.go
+++ b/pkg/gardenlet/controller/networkpolicy/hostnameresolver/resolver_test.go
@@ -94,10 +94,10 @@ var _ = Describe("resolver", func() {
 
 		Eventually(func() bool { //nolint:unlambda
 			return r.HasSynced()
-		}, time.Millisecond*10, time.Millisecond).Should(BeTrue(), "HasSync should be true after start")
+		}).Should(BeTrue(), "HasSync should be true after start")
 		Eventually(func() uint8 { //nolint:unlambda
 			return updateCount
-		}, time.Millisecond*10, time.Millisecond).Should(BeEquivalentTo(1), "update should be called once")
+		}).Should(BeEquivalentTo(1), "update should be called once")
 
 		Expect(r.Subset()).To(ConsistOf(corev1.EndpointSubset{
 			Addresses: []corev1.EndpointAddress{
@@ -127,10 +127,10 @@ var _ = Describe("resolver", func() {
 
 		Eventually(func() bool { //nolint:unlambda
 			return r.HasSynced()
-		}, time.Millisecond*10, time.Millisecond).Should(BeFalse(), "HasSync should always be false")
+		}).Should(BeFalse(), "HasSync should always be false")
 		Eventually(func() uint8 { //nolint:unlambda
 			return updateCount
-		}, time.Millisecond*10, time.Millisecond).Should(BeZero(), "update should never be called")
+		}).Should(BeZero(), "update should never be called")
 
 		close(done)
 	})
@@ -142,15 +142,15 @@ var _ = Describe("resolver", func() {
 
 		Eventually(func() bool { //nolint:unlambda
 			return r.HasSynced()
-		}, time.Millisecond*50, time.Millisecond).Should(BeTrue(), "HasSync should be true after start")
+		}).Should(BeTrue(), "HasSync should be true after start")
 
 		Eventually(func() uint8 { //nolint:unlambda
 			return updateCount
-		}, time.Millisecond*10, time.Millisecond).Should(BeEquivalentTo(1), "update should be called")
+		}).Should(BeEquivalentTo(1), "update should be called")
 
 		Consistently(func() []corev1.EndpointSubset { //nolint:unlambda
 			return r.Subset()
-		}, time.Millisecond*10, time.Millisecond).Should(ConsistOf(corev1.EndpointSubset{
+		}).Should(ConsistOf(corev1.EndpointSubset{
 			Addresses: []corev1.EndpointAddress{
 				{IP: "1.2.3.4"}, {IP: "5.6.7.8"},
 			},
@@ -161,7 +161,7 @@ var _ = Describe("resolver", func() {
 
 		Eventually(func() []corev1.EndpointSubset { //nolint:unlambda
 			return r.Subset()
-		}, time.Millisecond*10, time.Millisecond).Should(ConsistOf(corev1.EndpointSubset{
+		}).Should(ConsistOf(corev1.EndpointSubset{
 			Addresses: []corev1.EndpointAddress{{IP: "5.6.7.8"}},
 			Ports:     []corev1.EndpointPort{{Protocol: corev1.ProtocolTCP, Port: 1234}},
 		}))


### PR DESCRIPTION
**How to categorize this PR?**
/kind flake

**What this PR does / why we need it**:
Increase timeouts in hostnameresolver tests to minimize flakes in pipelines ([example](https://concourse.ci.gardener.cloud/teams/gardener/pipelines/gardener-master/jobs/master-pull-request-job/builds/1615#L611af2fe:476))

Before:
```
$ ginkgo build ./pkg/gardenlet/controller/networkpolicy/hostnameresolver
Compiling hostnameresolver...
    compiled hostnameresolver.test

$ stress -p 32 ./pkg/gardenlet/controller/networkpolicy/hostnameresolver/hostnameresolver.test | grep 'runs so far'
461 runs so far, 2 failures
920 runs so far, 4 failures
1368 runs so far, 7 failures
1798 runs so far, 9 failures
2203 runs so far, 9 failures
2582 runs so far, 10 failures
2946 runs so far, 11 failures
3285 runs so far, 12 failures
3618 runs so far, 13 failures
3933 runs so far, 14 failures
4251 runs so far, 15 failures
^C
```

After:
```
$ ginkgo build ./pkg/gardenlet/controller/networkpolicy/hostnameresolver
Compiling hostnameresolver...
    compiled hostnameresolver.test

$ stress -p 32 ./pkg/gardenlet/controller/networkpolicy/hostnameresolver/hostnameresolver.test
663 runs so far, 0 failures
1356 runs so far, 0 failures
2023 runs so far, 0 failures
2583 runs so far, 0 failures
3050 runs so far, 0 failures
3504 runs so far, 0 failures
3908 runs so far, 0 failures
4297 runs so far, 0 failures
^C
```