### PR TITLE
[release-v1.28] Automated cherry pick of #4509: Fixes for concurrent access of Operation object

### DIFF
--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -307,7 +307,7 @@ func (b *Botanist) generateCoreAddonsChart(ctx context.Context) (*chartrenderer.
 			"kubeconfig":        kubeProxySecret.Data["kubeconfig"],
 			"kubernetesVersion": b.Shoot.Info.Spec.Kubernetes.Version,
 			"podAnnotations": map[string]interface{}{
-				"checksum/secret-kube-proxy": b.CheckSums["kube-proxy"],
+				"checksum/secret-kube-proxy": b.LoadCheckSum("kube-proxy"),
 			},
 			"enableIPVS": b.Shoot.IPVSEnabled(),
 		}
@@ -493,7 +493,7 @@ func (b *Botanist) generateCoreAddonsChart(ctx context.Context) (*chartrenderer.
 					"enabled": true,
 				},
 				"podAnnotations": map[string]interface{}{
-					"checksum/secret-vpn-shoot-client": b.CheckSums[vpnseedserver.VpnShootSecretName],
+					"checksum/secret-vpn-shoot-client": b.LoadCheckSum(vpnseedserver.VpnShootSecretName),
 				},
 			}
 		)
@@ -525,7 +525,7 @@ func (b *Botanist) generateCoreAddonsChart(ctx context.Context) (*chartrenderer.
 					"enabled": false,
 				},
 				"podAnnotations": map[string]interface{}{
-					"checksum/secret-vpn-shoot": b.CheckSums["vpn-shoot"],
+					"checksum/secret-vpn-shoot": b.LoadCheckSum("vpn-shoot"),
 				},
 			}
 		)

--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -279,7 +279,7 @@ func (b *Botanist) DeployManagedResourceForAddons(ctx context.Context) error {
 func (b *Botanist) generateCoreAddonsChart(ctx context.Context) (*chartrenderer.RenderedChart, error) {
 	var (
 		kasFQDN         = b.outOfClusterAPIServerFQDN()
-		kubeProxySecret = b.Secrets["kube-proxy"]
+		kubeProxySecret = b.LoadSecret("kube-proxy")
 		global          = map[string]interface{}{
 			"kubernetesVersion": b.Shoot.Info.Spec.Kubernetes.Version,
 			"podNetwork":        b.Shoot.Networks.Pods.String(),
@@ -361,8 +361,8 @@ func (b *Botanist) generateCoreAddonsChart(ctx context.Context) (*chartrenderer.
 		}
 	}
 
-	if _, ok := b.Secrets[common.VPASecretName]; ok {
-		verticalPodAutoscaler["admissionController"].(map[string]interface{})["caCert"] = b.Secrets[common.VPASecretName].Data[secrets.DataKeyCertificateCA]
+	if vpaSecret := b.LoadSecret(common.VPASecretName); vpaSecret != nil {
+		verticalPodAutoscaler["admissionController"].(map[string]interface{})["caCert"] = vpaSecret.Data[secrets.DataKeyCertificateCA]
 	}
 
 	proxyConfig := b.Shoot.Info.Spec.Kubernetes.KubeProxy
@@ -441,7 +441,7 @@ func (b *Botanist) generateCoreAddonsChart(ctx context.Context) (*chartrenderer.
 			"port": "8443",
 		},
 		"webhook": map[string]interface{}{
-			"caBundle": b.Secrets[v1beta1constants.SecretNameCACluster].Data[secrets.DataKeyCertificateCA],
+			"caBundle": b.LoadSecret(v1beta1constants.SecretNameCACluster).Data[secrets.DataKeyCertificateCA],
 		},
 		"podMutatorEnabled": b.APIServerSNIPodMutatorEnabled(),
 	}
@@ -476,8 +476,8 @@ func (b *Botanist) generateCoreAddonsChart(ctx context.Context) (*chartrenderer.
 
 	if b.Shoot.ReversedVPNEnabled {
 		var (
-			vpnTLSAuthSecret = b.Secrets[vpnseedserver.VpnSeedServerTLSAuth]
-			vpnShootSecret   = b.Secrets[vpnseedserver.VpnShootSecretName]
+			vpnTLSAuthSecret = b.LoadSecret(vpnseedserver.VpnSeedServerTLSAuth)
+			vpnShootSecret   = b.LoadSecret(vpnseedserver.VpnShootSecretName)
 			vpnShootConfig   = map[string]interface{}{
 				"endpoint":       b.outOfClusterAPIServerFQDN(),
 				"port":           "8132",
@@ -510,8 +510,8 @@ func (b *Botanist) generateCoreAddonsChart(ctx context.Context) (*chartrenderer.
 		values["vpn-shoot"] = common.GenerateAddonConfig(vpnShoot, true)
 	} else {
 		var (
-			vpnTLSAuthSecret = b.Secrets["vpn-seed-tlsauth"]
-			vpnShootSecret   = b.Secrets["vpn-shoot"]
+			vpnTLSAuthSecret = b.LoadSecret("vpn-seed-tlsauth")
+			vpnShootSecret   = b.LoadSecret("vpn-shoot")
 			vpnShootConfig   = map[string]interface{}{
 				"podNetwork":     b.Shoot.Networks.Pods.String(),
 				"serviceNetwork": b.Shoot.Networks.Services.String(),
@@ -531,7 +531,7 @@ func (b *Botanist) generateCoreAddonsChart(ctx context.Context) (*chartrenderer.
 		)
 
 		// OpenVPN related values
-		if openvpnDiffieHellmanSecret, ok := b.Secrets[v1beta1constants.GardenRoleOpenVPNDiffieHellman]; ok {
+		if openvpnDiffieHellmanSecret := b.LoadSecret(v1beta1constants.GardenRoleOpenVPNDiffieHellman); openvpnDiffieHellmanSecret != nil {
 			vpnShootConfig["diffieHellmanKey"] = openvpnDiffieHellmanSecret.Data["dh2048.pem"]
 		}
 

--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -60,7 +60,7 @@ func New(ctx context.Context, o *operation.Operation) (*Botanist, error) {
 		for _, key := range defaultDomainKeys {
 			defaultDomain := strings.SplitAfter(key, prefix)[1]
 			if strings.HasSuffix(*(o.Shoot.Info.Spec.DNS.Domain), defaultDomain) {
-				b.DefaultDomainSecret = b.Secrets[prefix+defaultDomain]
+				b.DefaultDomainSecret = b.LoadSecret(prefix + defaultDomain)
 				break
 			}
 		}

--- a/pkg/operation/botanist/clusterautoscaler.go
+++ b/pkg/operation/botanist/clusterautoscaler.go
@@ -43,7 +43,7 @@ func (b *Botanist) DefaultClusterAutoscaler() (clusterautoscaler.Interface, erro
 func (b *Botanist) DeployClusterAutoscaler(ctx context.Context) error {
 	if b.Shoot.WantsClusterAutoscaler {
 		b.Shoot.Components.ControlPlane.ClusterAutoscaler.SetSecrets(clusterautoscaler.Secrets{
-			Kubeconfig: component.Secret{Name: clusterautoscaler.SecretName, Checksum: b.CheckSums[clusterautoscaler.SecretName]},
+			Kubeconfig: component.Secret{Name: clusterautoscaler.SecretName, Checksum: b.LoadCheckSum(clusterautoscaler.SecretName)},
 		})
 		b.Shoot.Components.ControlPlane.ClusterAutoscaler.SetNamespaceUID(b.SeedNamespaceObject.UID)
 		b.Shoot.Components.ControlPlane.ClusterAutoscaler.SetMachineDeployments(b.Shoot.Components.Extensions.Worker.MachineDeployments())

--- a/pkg/operation/botanist/clusterautoscaler_test.go
+++ b/pkg/operation/botanist/clusterautoscaler_test.go
@@ -99,9 +99,7 @@ var _ = Describe("ClusterAutoscaler", func() {
 			clusterAutoscaler = mockclusterautoscaler.NewMockInterface(ctrl)
 			worker = mockworker.NewMockInterface(ctrl)
 
-			botanist.CheckSums = map[string]string{
-				secretName: checksum,
-			}
+			botanist.StoreCheckSum(secretName, checksum)
 			botanist.SeedNamespaceObject = &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					UID: namespaceUID,

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -62,8 +62,8 @@ func (b *Botanist) DeployVerticalPodAutoscaler(ctx context.Context) error {
 		admissionController = map[string]interface{}{
 			"replicas": b.Shoot.GetReplicas(1),
 			"podAnnotations": map[string]interface{}{
-				"checksum/secret-vpa-tls-certs":            b.CheckSums[common.VPASecretName],
-				"checksum/secret-vpa-admission-controller": b.CheckSums["vpa-admission-controller"],
+				"checksum/secret-vpa-tls-certs":            b.LoadCheckSum(common.VPASecretName),
+				"checksum/secret-vpa-admission-controller": b.LoadCheckSum("vpa-admission-controller"),
 			},
 			"podLabels": utils.MergeMaps(podLabels, map[string]interface{}{
 				v1beta1constants.LabelNetworkPolicyFromShootAPIServer: "allowed",
@@ -77,7 +77,7 @@ func (b *Botanist) DeployVerticalPodAutoscaler(ctx context.Context) error {
 		recommender = map[string]interface{}{
 			"replicas": b.Shoot.GetReplicas(1),
 			"podAnnotations": map[string]interface{}{
-				"checksum/secret-vpa-recommender": b.CheckSums["vpa-recommender"],
+				"checksum/secret-vpa-recommender": b.LoadCheckSum("vpa-recommender"),
 			},
 			"podLabels":                    podLabels,
 			"enableServiceAccount":         false,
@@ -87,7 +87,7 @@ func (b *Botanist) DeployVerticalPodAutoscaler(ctx context.Context) error {
 		updater = map[string]interface{}{
 			"replicas": b.Shoot.GetReplicas(1),
 			"podAnnotations": map[string]interface{}{
-				"checksum/secret-vpa-updater": b.CheckSums["vpa-updater"],
+				"checksum/secret-vpa-updater": b.LoadCheckSum("vpa-updater"),
 			},
 			"podLabels":              podLabels,
 			"enableServiceAccount":   false,
@@ -346,16 +346,16 @@ func (b *Botanist) deployKubeAPIServer(ctx context.Context) error {
 
 	var (
 		podAnnotations = map[string]interface{}{
-			"checksum/secret-ca":                     b.CheckSums[v1beta1constants.SecretNameCACluster],
-			"checksum/secret-ca-front-proxy":         b.CheckSums[v1beta1constants.SecretNameCAFrontProxy],
-			"checksum/secret-kube-apiserver":         b.CheckSums[v1beta1constants.DeploymentNameKubeAPIServer],
-			"checksum/secret-kube-aggregator":        b.CheckSums["kube-aggregator"],
-			"checksum/secret-kube-apiserver-kubelet": b.CheckSums["kube-apiserver-kubelet"],
-			"checksum/secret-static-token":           b.CheckSums[common.StaticTokenSecretName],
-			"checksum/secret-service-account-key":    b.CheckSums["service-account-key"],
-			"checksum/secret-etcd-ca":                b.CheckSums[etcd.SecretNameCA],
-			"checksum/secret-etcd-client-tls":        b.CheckSums[etcd.SecretNameClient],
-			"checksum/secret-etcd-encryption":        b.CheckSums[common.EtcdEncryptionSecretName],
+			"checksum/secret-ca":                     b.LoadCheckSum(v1beta1constants.SecretNameCACluster),
+			"checksum/secret-ca-front-proxy":         b.LoadCheckSum(v1beta1constants.SecretNameCAFrontProxy),
+			"checksum/secret-kube-apiserver":         b.LoadCheckSum(v1beta1constants.DeploymentNameKubeAPIServer),
+			"checksum/secret-kube-aggregator":        b.LoadCheckSum("kube-aggregator"),
+			"checksum/secret-kube-apiserver-kubelet": b.LoadCheckSum("kube-apiserver-kubelet"),
+			"checksum/secret-static-token":           b.LoadCheckSum(common.StaticTokenSecretName),
+			"checksum/secret-service-account-key":    b.LoadCheckSum("service-account-key"),
+			"checksum/secret-etcd-ca":                b.LoadCheckSum(etcd.SecretNameCA),
+			"checksum/secret-etcd-client-tls":        b.LoadCheckSum(etcd.SecretNameClient),
+			"checksum/secret-etcd-encryption":        b.LoadCheckSum(common.EtcdEncryptionSecretName),
 		}
 		defaultValues = map[string]interface{}{
 			"etcdServicePort":           etcd.PortEtcdClient,
@@ -379,10 +379,10 @@ func (b *Botanist) deployKubeAPIServer(ctx context.Context) error {
 	)
 
 	if b.Shoot.ReversedVPNEnabled {
-		podAnnotations["checksum/secret-"+vpnseedserver.VpnSeedServerTLSAuth] = b.CheckSums[vpnseedserver.VpnSeedServerTLSAuth]
+		podAnnotations["checksum/secret-"+vpnseedserver.VpnSeedServerTLSAuth] = b.LoadCheckSum(vpnseedserver.VpnSeedServerTLSAuth)
 	} else {
-		podAnnotations["checksum/secret-vpn-seed"] = b.CheckSums["vpn-seed"]
-		podAnnotations["checksum/secret-vpn-seed-tlsauth"] = b.CheckSums["vpn-seed-tlsauth"]
+		podAnnotations["checksum/secret-vpn-seed"] = b.LoadCheckSum("vpn-seed")
+		podAnnotations["checksum/secret-vpn-seed-tlsauth"] = b.LoadCheckSum("vpn-seed-tlsauth")
 	}
 
 	if v := b.Shoot.GetNodeNetwork(); v != nil {
@@ -400,7 +400,7 @@ func (b *Botanist) deployKubeAPIServer(ctx context.Context) error {
 	}
 
 	if gardencorev1beta1helper.ShootWantsBasicAuthentication(b.Shoot.Info) {
-		defaultValues["podAnnotations"].(map[string]interface{})["checksum/secret-"+common.BasicAuthSecretName] = b.CheckSums[common.BasicAuthSecretName]
+		defaultValues["podAnnotations"].(map[string]interface{})["checksum/secret-"+common.BasicAuthSecretName] = b.LoadCheckSum(common.BasicAuthSecretName)
 	}
 
 	foundDeployment := true

--- a/pkg/operation/botanist/etcd.go
+++ b/pkg/operation/botanist/etcd.go
@@ -83,9 +83,9 @@ func (b *Botanist) DefaultEtcd(role string, class etcd.Class) (etcd.Interface, e
 // DeployEtcd deploys the etcd main and events.
 func (b *Botanist) DeployEtcd(ctx context.Context) error {
 	secrets := etcd.Secrets{
-		CA:     component.Secret{Name: etcd.SecretNameCA, Checksum: b.CheckSums[etcd.SecretNameCA]},
-		Server: component.Secret{Name: etcd.SecretNameServer, Checksum: b.CheckSums[etcd.SecretNameServer]},
-		Client: component.Secret{Name: etcd.SecretNameClient, Checksum: b.CheckSums[etcd.SecretNameClient]},
+		CA:     component.Secret{Name: etcd.SecretNameCA, Checksum: b.LoadCheckSum(etcd.SecretNameCA)},
+		Server: component.Secret{Name: etcd.SecretNameServer, Checksum: b.LoadCheckSum(etcd.SecretNameServer)},
+		Client: component.Secret{Name: etcd.SecretNameClient, Checksum: b.LoadCheckSum(etcd.SecretNameClient)},
 	}
 
 	b.Shoot.Components.ControlPlane.EtcdMain.SetSecrets(secrets)

--- a/pkg/operation/botanist/etcd_test.go
+++ b/pkg/operation/botanist/etcd_test.go
@@ -251,11 +251,9 @@ var _ = Describe("Etcd", func() {
 			etcdMain, etcdEvents = mocketcd.NewMockInterface(ctrl), mocketcd.NewMockInterface(ctrl)
 
 			botanist.K8sSeedClient = kubernetesClient
-			botanist.CheckSums = map[string]string{
-				secretNameCA:     checksumCA,
-				secretNameServer: checksumServer,
-				secretNameClient: checksumClient,
-			}
+			botanist.StoreCheckSum(secretNameCA, checksumCA)
+			botanist.StoreCheckSum(secretNameServer, checksumServer)
+			botanist.StoreCheckSum(secretNameClient, checksumClient)
 			botanist.Seed = &seedpkg.Seed{
 				Info: &gardencorev1beta1.Seed{},
 			}

--- a/pkg/operation/botanist/etcdencryption.go
+++ b/pkg/operation/botanist/etcdencryption.go
@@ -96,11 +96,7 @@ func (b *Botanist) ApplyEncryptionConfiguration(ctx context.Context) error {
 		return err
 	}
 
-	func() {
-		b.mutex.Lock()
-		defer b.mutex.Unlock()
-		b.CheckSums[common.EtcdEncryptionSecretName] = checksum
-	}()
+	b.StoreCheckSum(common.EtcdEncryptionSecretName, checksum)
 
 	return nil
 }
@@ -122,11 +118,7 @@ func (b *Botanist) RewriteShootSecretsIfEncryptionConfigurationChanged(ctx conte
 		return nil
 	}
 
-	checksum := func() string {
-		b.mutex.RLock()
-		defer b.mutex.RUnlock()
-		return b.CheckSums[common.EtcdEncryptionSecretName]
-	}()
+	checksum := b.LoadCheckSum(common.EtcdEncryptionSecretName)
 	shortChecksum := kutil.TruncateLabelValue(checksum)
 
 	// Add checksum label to all secrets in shoot so that they get rewritten now, and also so that we don't rewrite them again in

--- a/pkg/operation/botanist/infrastructure.go
+++ b/pkg/operation/botanist/infrastructure.go
@@ -45,7 +45,7 @@ func (b *Botanist) DefaultInfrastructure() infrastructure.Interface {
 // DeployInfrastructure deploys the Infrastructure custom resource and triggers the restore operation in case
 // the Shoot is in the restore phase of the control plane migration.
 func (b *Botanist) DeployInfrastructure(ctx context.Context) error {
-	b.Shoot.Components.Extensions.Infrastructure.SetSSHPublicKey(b.Secrets[v1beta1constants.SecretNameSSHKeyPair].Data[secrets.DataKeySSHAuthorizedKeys])
+	b.Shoot.Components.Extensions.Infrastructure.SetSSHPublicKey(b.LoadSecret(v1beta1constants.SecretNameSSHKeyPair).Data[secrets.DataKeySSHAuthorizedKeys])
 
 	if b.isRestorePhase() {
 		return b.Shoot.Components.Extensions.Infrastructure.Restore(ctx, b.ShootState)

--- a/pkg/operation/botanist/infrastructure_test.go
+++ b/pkg/operation/botanist/infrastructure_test.go
@@ -52,9 +52,6 @@ var _ = Describe("Infrastructure", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		infrastructure = mockinfrastructure.NewMockInterface(ctrl)
 		botanist = &Botanist{Operation: &operation.Operation{
-			Secrets: map[string]*corev1.Secret{
-				"ssh-keypair": {Data: map[string][]byte{"id_rsa.pub": sshPublicKey}},
-			},
 			Shoot: &shootpkg.Shoot{
 				Components: &shootpkg.Components{
 					Extensions: &shootpkg.Extensions{
@@ -64,6 +61,7 @@ var _ = Describe("Infrastructure", func() {
 			},
 			ShootState: shootState,
 		}}
+		botanist.StoreSecret("ssh-keypair", &corev1.Secret{Data: map[string][]byte{"id_rsa.pub": sshPublicKey}})
 	})
 
 	AfterEach(func() {

--- a/pkg/operation/botanist/kubecontrollermanager.go
+++ b/pkg/operation/botanist/kubecontrollermanager.go
@@ -74,10 +74,10 @@ func (b *Botanist) DeployKubeControllerManager(ctx context.Context) error {
 
 	b.Shoot.Components.ControlPlane.KubeControllerManager.SetReplicaCount(replicaCount)
 	b.Shoot.Components.ControlPlane.KubeControllerManager.SetSecrets(kubecontrollermanager.Secrets{
-		CA:                component.Secret{Name: v1beta1constants.SecretNameCACluster, Checksum: b.CheckSums[v1beta1constants.SecretNameCACluster]},
-		ServiceAccountKey: component.Secret{Name: v1beta1constants.SecretNameServiceAccountKey, Checksum: b.CheckSums[v1beta1constants.SecretNameServiceAccountKey]},
-		Kubeconfig:        component.Secret{Name: kubecontrollermanager.SecretName, Checksum: b.CheckSums[kubecontrollermanager.SecretName]},
-		Server:            component.Secret{Name: kubecontrollermanager.SecretNameServer, Checksum: b.CheckSums[kubecontrollermanager.SecretNameServer]},
+		CA:                component.Secret{Name: v1beta1constants.SecretNameCACluster, Checksum: b.LoadCheckSum(v1beta1constants.SecretNameCACluster)},
+		ServiceAccountKey: component.Secret{Name: v1beta1constants.SecretNameServiceAccountKey, Checksum: b.LoadCheckSum(v1beta1constants.SecretNameServiceAccountKey)},
+		Kubeconfig:        component.Secret{Name: kubecontrollermanager.SecretName, Checksum: b.LoadCheckSum(kubecontrollermanager.SecretName)},
+		Server:            component.Secret{Name: kubecontrollermanager.SecretNameServer, Checksum: b.LoadCheckSum(kubecontrollermanager.SecretNameServer)},
 	})
 
 	return b.Shoot.Components.ControlPlane.KubeControllerManager.Deploy(ctx)

--- a/pkg/operation/botanist/kubecontrollermanager_test.go
+++ b/pkg/operation/botanist/kubecontrollermanager_test.go
@@ -117,12 +117,10 @@ var _ = Describe("KubeControllerManager", func() {
 			kubeControllerManager = mockkubecontrollermanager.NewMockInterface(ctrl)
 
 			botanist.K8sSeedClient = kubernetesClient
-			botanist.CheckSums = map[string]string{
-				secretName:                  checksum,
-				secretNameServer:            checksumServer,
-				secretNameCA:                checksumCA,
-				secretNameServiceAccountKey: checksumServiceAccountKey,
-			}
+			botanist.StoreCheckSum(secretName, checksum)
+			botanist.StoreCheckSum(secretNameServer, checksumServer)
+			botanist.StoreCheckSum(secretNameCA, checksumCA)
+			botanist.StoreCheckSum(secretNameServiceAccountKey, checksumServiceAccountKey)
 			botanist.Shoot = &shootpkg.Shoot{
 				Components: &shootpkg.Components{
 					ControlPlane: &shootpkg.ControlPlane{

--- a/pkg/operation/botanist/kubescheduler.go
+++ b/pkg/operation/botanist/kubescheduler.go
@@ -43,8 +43,8 @@ func (b *Botanist) DefaultKubeScheduler() (kubescheduler.Interface, error) {
 // DeployKubeScheduler deploys the Kubernetes scheduler.
 func (b *Botanist) DeployKubeScheduler(ctx context.Context) error {
 	b.Shoot.Components.ControlPlane.KubeScheduler.SetSecrets(kubescheduler.Secrets{
-		Kubeconfig: component.Secret{Name: kubescheduler.SecretName, Checksum: b.CheckSums[kubescheduler.SecretName]},
-		Server:     component.Secret{Name: kubescheduler.SecretNameServer, Checksum: b.CheckSums[kubescheduler.SecretNameServer]},
+		Kubeconfig: component.Secret{Name: kubescheduler.SecretName, Checksum: b.LoadCheckSum(kubescheduler.SecretName)},
+		Server:     component.Secret{Name: kubescheduler.SecretNameServer, Checksum: b.LoadCheckSum(kubescheduler.SecretNameServer)},
 	})
 
 	return b.Shoot.Components.ControlPlane.KubeScheduler.Deploy(ctx)

--- a/pkg/operation/botanist/kubescheduler_test.go
+++ b/pkg/operation/botanist/kubescheduler_test.go
@@ -92,10 +92,8 @@ var _ = Describe("KubeScheduler", func() {
 		BeforeEach(func() {
 			kubeScheduler = mockkubescheduler.NewMockInterface(ctrl)
 
-			botanist.CheckSums = map[string]string{
-				secretName:       checksum,
-				secretNameServer: checksumServer,
-			}
+			botanist.StoreCheckSum(secretName, checksum)
+			botanist.StoreCheckSum(secretNameServer, checksumServer)
 			botanist.Shoot = &shootpkg.Shoot{
 				Components: &shootpkg.Components{
 					ControlPlane: &shootpkg.ControlPlane{

--- a/pkg/operation/botanist/logging.go
+++ b/pkg/operation/botanist/logging.go
@@ -58,7 +58,7 @@ func (b *Botanist) DeploySeedLogging(ctx context.Context) error {
 
 	if b.isShootNodeLoggingEnabled() {
 		lokiValues["rbacSidecarEnabled"] = true
-		lokiValues["kubeRBACProxyKubeconfigCheckSum"] = b.CheckSums[logging.SecretNameLokiKubeRBACProxyKubeconfig]
+		lokiValues["kubeRBACProxyKubeconfigCheckSum"] = b.LoadCheckSum(logging.SecretNameLokiKubeRBACProxyKubeconfig)
 		lokiValues["ingress"] = map[string]interface{}{
 			"class": getIngressClass(b.Seed.Info.Spec.Ingress),
 			"hosts": []map[string]interface{}{

--- a/pkg/operation/botanist/metricsserver.go
+++ b/pkg/operation/botanist/metricsserver.go
@@ -49,8 +49,8 @@ func (b *Botanist) DefaultMetricsServer() (metricsserver.Interface, error) {
 // DeployMetricsServer deploys the metrics-server.
 func (b *Botanist) DeployMetricsServer(ctx context.Context) error {
 	b.Shoot.Components.SystemComponents.MetricsServer.SetSecrets(metricsserver.Secrets{
-		CA:     component.Secret{Name: metricsserver.SecretNameCA, Checksum: b.CheckSums[metricsserver.SecretNameCA], Data: b.Secrets[metricsserver.SecretNameCA].Data},
-		Server: component.Secret{Name: metricsserver.SecretNameServer, Checksum: b.CheckSums[metricsserver.SecretNameServer], Data: b.Secrets[metricsserver.SecretNameServer].Data},
+		CA:     component.Secret{Name: metricsserver.SecretNameCA, Checksum: b.LoadCheckSum(metricsserver.SecretNameCA), Data: b.Secrets[metricsserver.SecretNameCA].Data},
+		Server: component.Secret{Name: metricsserver.SecretNameServer, Checksum: b.LoadCheckSum(metricsserver.SecretNameServer), Data: b.Secrets[metricsserver.SecretNameServer].Data},
 	})
 
 	return b.Shoot.Components.SystemComponents.MetricsServer.Deploy(ctx)

--- a/pkg/operation/botanist/metricsserver.go
+++ b/pkg/operation/botanist/metricsserver.go
@@ -49,8 +49,8 @@ func (b *Botanist) DefaultMetricsServer() (metricsserver.Interface, error) {
 // DeployMetricsServer deploys the metrics-server.
 func (b *Botanist) DeployMetricsServer(ctx context.Context) error {
 	b.Shoot.Components.SystemComponents.MetricsServer.SetSecrets(metricsserver.Secrets{
-		CA:     component.Secret{Name: metricsserver.SecretNameCA, Checksum: b.LoadCheckSum(metricsserver.SecretNameCA), Data: b.Secrets[metricsserver.SecretNameCA].Data},
-		Server: component.Secret{Name: metricsserver.SecretNameServer, Checksum: b.LoadCheckSum(metricsserver.SecretNameServer), Data: b.Secrets[metricsserver.SecretNameServer].Data},
+		CA:     component.Secret{Name: metricsserver.SecretNameCA, Checksum: b.LoadCheckSum(metricsserver.SecretNameCA), Data: b.LoadSecret(metricsserver.SecretNameCA).Data},
+		Server: component.Secret{Name: metricsserver.SecretNameServer, Checksum: b.LoadCheckSum(metricsserver.SecretNameServer), Data: b.LoadSecret(metricsserver.SecretNameServer).Data},
 	})
 
 	return b.Shoot.Components.SystemComponents.MetricsServer.Deploy(ctx)

--- a/pkg/operation/botanist/metricsserver_test.go
+++ b/pkg/operation/botanist/metricsserver_test.go
@@ -103,10 +103,8 @@ var _ = Describe("MetricsServer", func() {
 
 			botanist.StoreCheckSum(secretCAName, secretCAChecksum)
 			botanist.StoreCheckSum(secretServerName, secretServerChecksum)
-			botanist.Secrets = map[string]*corev1.Secret{
-				secretCAName:     {},
-				secretServerName: {},
-			}
+			botanist.StoreSecret(secretCAName, &corev1.Secret{})
+			botanist.StoreSecret(secretServerName, &corev1.Secret{})
 			botanist.Shoot = &shootpkg.Shoot{
 				Components: &shootpkg.Components{
 					SystemComponents: &shootpkg.SystemComponents{

--- a/pkg/operation/botanist/metricsserver_test.go
+++ b/pkg/operation/botanist/metricsserver_test.go
@@ -101,10 +101,8 @@ var _ = Describe("MetricsServer", func() {
 		BeforeEach(func() {
 			metricsServer = mockmetricsserver.NewMockInterface(ctrl)
 
-			botanist.CheckSums = map[string]string{
-				secretCAName:     secretCAChecksum,
-				secretServerName: secretServerChecksum,
-			}
+			botanist.StoreCheckSum(secretCAName, secretCAChecksum)
+			botanist.StoreCheckSum(secretServerName, secretServerChecksum)
 			botanist.Secrets = map[string]*corev1.Secret{
 				secretCAName:     {},
 				secretServerName: {},

--- a/pkg/operation/botanist/monitoring.go
+++ b/pkg/operation/botanist/monitoring.go
@@ -239,7 +239,7 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 			charts.ImageNameBlackboxExporter,
 		}
 		podAnnotations = map[string]interface{}{
-			"checksum/secret-prometheus": b.CheckSums["prometheus"],
+			"checksum/secret-prometheus": b.LoadCheckSum("prometheus"),
 		}
 	)
 

--- a/pkg/operation/botanist/monitoring.go
+++ b/pkg/operation/botanist/monitoring.go
@@ -53,8 +53,8 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 	}
 
 	var (
-		credentials           = b.Secrets[common.MonitoringIngressCredentials]
-		credentialsUsers      = b.Secrets[common.MonitoringIngressCredentialsUsers]
+		credentials           = b.LoadSecret(common.MonitoringIngressCredentials)
+		credentialsUsers      = b.LoadSecret(common.MonitoringIngressCredentialsUsers)
 		basicAuth             = utils.CreateSHA1Secret(credentials.Data[secrets.DataKeyUserName], credentials.Data[secrets.DataKeyPassword])
 		basicAuthUsers        = utils.CreateSHA1Secret(credentialsUsers.Data[secrets.DataKeyUserName], credentialsUsers.Data[secrets.DataKeyPassword])
 		alertingRules         = strings.Builder{}
@@ -286,7 +286,7 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 		if b.Shoot.Info.Spec.Monitoring != nil && b.Shoot.Info.Spec.Monitoring.Alerting != nil {
 			for _, email := range b.Shoot.Info.Spec.Monitoring.Alerting.EmailReceivers {
 				for _, key := range alertingSMTPKeys {
-					secret := b.Secrets[key]
+					secret := b.LoadSecret(key)
 
 					if string(secret.Data["auth_type"]) != "smtp" {
 						continue
@@ -353,7 +353,7 @@ func (b *Botanist) getCustomAlertingConfigs(ctx context.Context, alertingSecretK
 	}
 
 	for _, key := range alertingSecretKeys {
-		secret := b.Secrets[key]
+		secret := b.LoadSecret(key)
 
 		if string(secret.Data["auth_type"]) == "none" {
 

--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -88,13 +88,13 @@ func (b *Botanist) DefaultOperatingSystemConfig() (operatingsystemconfig.Interfa
 // case the Shoot is in the restore phase of the control plane migration.
 func (b *Botanist) DeployOperatingSystemConfig(ctx context.Context) error {
 	b.Shoot.Components.Extensions.OperatingSystemConfig.SetCABundle(b.getOperatingSystemConfigCABundle())
-	b.Shoot.Components.Extensions.OperatingSystemConfig.SetKubeletCACertificate(string(b.Secrets[v1beta1constants.SecretNameCAKubelet].Data[secrets.DataKeyCertificateCA]))
+	b.Shoot.Components.Extensions.OperatingSystemConfig.SetKubeletCACertificate(string(b.LoadSecret(v1beta1constants.SecretNameCAKubelet).Data[secrets.DataKeyCertificateCA]))
 
 	publicKeys := []string{
-		string(b.Secrets[v1beta1constants.SecretNameSSHKeyPair].Data[secrets.DataKeySSHAuthorizedKeys]),
+		string(b.LoadSecret(v1beta1constants.SecretNameSSHKeyPair).Data[secrets.DataKeySSHAuthorizedKeys]),
 	}
 
-	if secret, exists := b.Secrets[v1beta1constants.SecretNameOldSSHKeyPair]; exists {
+	if secret := b.LoadSecret(v1beta1constants.SecretNameOldSSHKeyPair); secret != nil {
 		publicKeys = append(publicKeys, string(secret.Data[secrets.DataKeySSHAuthorizedKeys]))
 	}
 
@@ -119,7 +119,7 @@ func (b *Botanist) getOperatingSystemConfigCABundle() *string {
 		caBundle = *cloudProfileCaBundle
 	}
 
-	if caCert, ok := b.Secrets[v1beta1constants.SecretNameCACluster].Data[secrets.DataKeyCertificateCA]; ok && len(caCert) != 0 {
+	if caCert, ok := b.LoadSecret(v1beta1constants.SecretNameCACluster).Data[secrets.DataKeyCertificateCA]; ok && len(caCert) != 0 {
 		caBundle = fmt.Sprintf("%s\n%s", caBundle, caCert)
 	}
 

--- a/pkg/operation/botanist/operatingsystemconfig_test.go
+++ b/pkg/operation/botanist/operatingsystemconfig_test.go
@@ -74,12 +74,6 @@ var _ = Describe("operatingsystemconfig", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		operatingSystemConfig = mockoperatingsystemconfig.NewMockInterface(ctrl)
 		botanist = &Botanist{Operation: &operation.Operation{
-			Secrets: map[string]*corev1.Secret{
-				v1beta1constants.SecretNameCACluster:     {Data: map[string][]byte{"ca.crt": ca}},
-				v1beta1constants.SecretNameCAKubelet:     {Data: map[string][]byte{"ca.crt": caKubelet}},
-				v1beta1constants.SecretNameSSHKeyPair:    {Data: map[string][]byte{"id_rsa.pub": sshPublicKey}},
-				v1beta1constants.SecretNameOldSSHKeyPair: {Data: map[string][]byte{"id_rsa.pub": sshPublicKeyOld}},
-			},
 			Shoot: &shootpkg.Shoot{
 				CloudProfile: &gardencorev1beta1.CloudProfile{},
 				Components: &shootpkg.Components{
@@ -105,6 +99,10 @@ var _ = Describe("operatingsystemconfig", func() {
 			},
 			ShootState: shootState,
 		}}
+		botanist.StoreSecret(v1beta1constants.SecretNameCACluster, &corev1.Secret{Data: map[string][]byte{"ca.crt": ca}})
+		botanist.StoreSecret(v1beta1constants.SecretNameCAKubelet, &corev1.Secret{Data: map[string][]byte{"ca.crt": caKubelet}})
+		botanist.StoreSecret(v1beta1constants.SecretNameSSHKeyPair, &corev1.Secret{Data: map[string][]byte{"id_rsa.pub": sshPublicKey}})
+		botanist.StoreSecret(v1beta1constants.SecretNameOldSSHKeyPair, &corev1.Secret{Data: map[string][]byte{"id_rsa.pub": sshPublicKeyOld}})
 	})
 
 	AfterEach(func() {
@@ -119,7 +117,7 @@ var _ = Describe("operatingsystemconfig", func() {
 
 		Context("deploy", func() {
 			It("should deploy successfully (no CA)", func() {
-				botanist.Secrets["ca"].Data["ca.crt"] = nil
+				botanist.LoadSecret("ca").Data["ca.crt"] = nil
 				operatingSystemConfig.EXPECT().SetCABundle(nil)
 
 				operatingSystemConfig.EXPECT().Deploy(ctx)
@@ -135,7 +133,7 @@ var _ = Describe("operatingsystemconfig", func() {
 
 			It("should deploy successfully (only CloudProfile CA)", func() {
 				botanist.Shoot.CloudProfile.Spec.CABundle = &caCloudProfile
-				botanist.Secrets["ca"].Data["ca.crt"] = nil
+				botanist.LoadSecret("ca").Data["ca.crt"] = nil
 				operatingSystemConfig.EXPECT().SetCABundle(&caCloudProfile)
 
 				operatingSystemConfig.EXPECT().Deploy(ctx)

--- a/pkg/operation/botanist/resource_manager.go
+++ b/pkg/operation/botanist/resource_manager.go
@@ -70,7 +70,7 @@ func (b *Botanist) DefaultResourceManager() (resourcemanager.Interface, error) {
 
 // DeployGardenerResourceManager deploys the gardener-resource-manager
 func (b *Botanist) DeployGardenerResourceManager(ctx context.Context) error {
-	kubeCfg := component.Secret{Name: resourcemanager.SecretName, Checksum: b.CheckSums[resourcemanager.SecretName]}
+	kubeCfg := component.Secret{Name: resourcemanager.SecretName, Checksum: b.LoadCheckSum(resourcemanager.SecretName)}
 	b.Shoot.Components.ControlPlane.ResourceManager.SetSecrets(resourcemanager.Secrets{Kubeconfig: kubeCfg})
 
 	// TODO (ialidzhikov): remove in a future version

--- a/pkg/operation/botanist/resource_manager_test.go
+++ b/pkg/operation/botanist/resource_manager_test.go
@@ -72,9 +72,7 @@ var _ = Describe("ResourceManager", func() {
 			kubernetesClient = mockkubernetes.NewMockInterface(ctrl)
 			c = mockclient.NewMockClient(ctrl)
 
-			botanist.CheckSums = map[string]string{
-				secretName: checksum,
-			}
+			botanist.StoreCheckSum(secretName, checksum)
 			botanist.Shoot = &shootpkg.Shoot{
 				Components: &shootpkg.Components{
 					ControlPlane: &shootpkg.ControlPlane{

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -138,16 +138,12 @@ func (b *Botanist) DeploySecrets(ctx context.Context) error {
 		}
 	}
 
-	func() {
-		b.mutex.Lock()
-		defer b.mutex.Unlock()
-		for name, secret := range secretsManager.DeployedSecrets {
-			b.Secrets[name] = secret
-		}
-		for name, secret := range b.Secrets {
-			b.StoreCheckSum(name, utils.ComputeSecretChecksum(secret.Data))
-		}
-	}()
+	for name, secret := range secretsManager.DeployedSecrets {
+		b.StoreSecret(name, secret)
+	}
+	for _, name := range b.AllSecretKeys() {
+		b.StoreCheckSum(name, utils.ComputeSecretChecksum(b.LoadSecret(name).Data))
+	}
 
 	wildcardCert, err := seed.GetWildcardCertificate(ctx, b.K8sSeedClient.Client())
 	if err != nil {
@@ -200,10 +196,7 @@ func (b *Botanist) DeployCloudProviderSecret(ctx context.Context) error {
 		return err
 	}
 
-	b.mutex.Lock()
-	defer b.mutex.Unlock()
-
-	b.Secrets[v1beta1constants.SecretNameCloudProvider] = b.Shoot.Secret
+	b.StoreSecret(v1beta1constants.SecretNameCloudProvider, b.Shoot.Secret)
 	b.StoreCheckSum(v1beta1constants.SecretNameCloudProvider, checksum)
 
 	return nil
@@ -400,7 +393,7 @@ func (b *Botanist) SyncShootCredentialsToGarden(ctx context.Context) error {
 				secretObj.Annotations = s.annotations
 				secretObj.Labels = s.labels
 				secretObj.Type = corev1.SecretTypeOpaque
-				secretObj.Data = b.Secrets[s.secretName].Data
+				secretObj.Data = b.LoadSecret(s.secretName).Data
 				return nil
 			})
 			return err

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -145,7 +145,7 @@ func (b *Botanist) DeploySecrets(ctx context.Context) error {
 			b.Secrets[name] = secret
 		}
 		for name, secret := range b.Secrets {
-			b.CheckSums[name] = utils.ComputeSecretChecksum(secret.Data)
+			b.StoreCheckSum(name, utils.ComputeSecretChecksum(secret.Data))
 		}
 	}()
 
@@ -204,7 +204,7 @@ func (b *Botanist) DeployCloudProviderSecret(ctx context.Context) error {
 	defer b.mutex.Unlock()
 
 	b.Secrets[v1beta1constants.SecretNameCloudProvider] = b.Shoot.Secret
-	b.CheckSums[v1beta1constants.SecretNameCloudProvider] = checksum
+	b.StoreCheckSum(v1beta1constants.SecretNameCloudProvider, checksum)
 
 	return nil
 }
@@ -332,7 +332,7 @@ func (b *Botanist) storeStaticTokenAsSecrets(ctx context.Context, staticToken *s
 			return err
 		}
 
-		b.CheckSums[secretName] = utils.ComputeSecretChecksum(secret.Data)
+		b.StoreCheckSum(secretName, utils.ComputeSecretChecksum(secret.Data))
 	}
 
 	return nil

--- a/pkg/operation/botanist/types.go
+++ b/pkg/operation/botanist/types.go
@@ -15,8 +15,6 @@
 package botanist
 
 import (
-	"sync"
-
 	"github.com/gardener/gardener/pkg/operation"
 
 	corev1 "k8s.io/api/core/v1"
@@ -26,5 +24,4 @@ import (
 type Botanist struct {
 	*operation.Operation
 	DefaultDomainSecret *corev1.Secret
-	mutex               sync.RWMutex
 }

--- a/pkg/operation/botanist/vpnseedserver.go
+++ b/pkg/operation/botanist/vpnseedserver.go
@@ -90,12 +90,12 @@ func (b *Botanist) DeployVPNServer(ctx context.Context) error {
 	openvpnDiffieHellmanSecret := map[string][]byte{"dh2048.pem": []byte(diffieHellmanKey)}
 	if dh, ok := b.Secrets[v1beta1constants.GardenRoleOpenVPNDiffieHellman]; ok {
 		openvpnDiffieHellmanSecret = dh.Data
-		checkSumDH = b.CheckSums[v1beta1constants.GardenRoleOpenVPNDiffieHellman]
+		checkSumDH = b.LoadCheckSum(v1beta1constants.GardenRoleOpenVPNDiffieHellman)
 	}
 
 	b.Shoot.Components.ControlPlane.VPNSeedServer.SetSecrets(vpnseedserver.Secrets{
-		TLSAuth:          component.Secret{Name: vpnseedserver.VpnSeedServerTLSAuth, Checksum: b.CheckSums[vpnseedserver.VpnSeedServerTLSAuth], Data: b.Secrets[vpnseedserver.VpnSeedServerTLSAuth].Data},
-		Server:           component.Secret{Name: vpnseedserver.DeploymentName, Checksum: b.CheckSums[vpnseedserver.DeploymentName], Data: b.Secrets[vpnseedserver.DeploymentName].Data},
+		TLSAuth:          component.Secret{Name: vpnseedserver.VpnSeedServerTLSAuth, Checksum: b.LoadCheckSum(vpnseedserver.VpnSeedServerTLSAuth), Data: b.Secrets[vpnseedserver.VpnSeedServerTLSAuth].Data},
+		Server:           component.Secret{Name: vpnseedserver.DeploymentName, Checksum: b.LoadCheckSum(vpnseedserver.DeploymentName), Data: b.Secrets[vpnseedserver.DeploymentName].Data},
 		DiffieHellmanKey: component.Secret{Name: v1beta1constants.GardenRoleOpenVPNDiffieHellman, Checksum: checkSumDH, Data: openvpnDiffieHellmanSecret},
 	})
 

--- a/pkg/operation/botanist/vpnseedserver.go
+++ b/pkg/operation/botanist/vpnseedserver.go
@@ -88,14 +88,14 @@ func (b *Botanist) DeployVPNServer(ctx context.Context) error {
 
 	checkSumDH := diffieHellmanKeyChecksum
 	openvpnDiffieHellmanSecret := map[string][]byte{"dh2048.pem": []byte(diffieHellmanKey)}
-	if dh, ok := b.Secrets[v1beta1constants.GardenRoleOpenVPNDiffieHellman]; ok {
+	if dh := b.LoadSecret(v1beta1constants.GardenRoleOpenVPNDiffieHellman); dh != nil {
 		openvpnDiffieHellmanSecret = dh.Data
 		checkSumDH = b.LoadCheckSum(v1beta1constants.GardenRoleOpenVPNDiffieHellman)
 	}
 
 	b.Shoot.Components.ControlPlane.VPNSeedServer.SetSecrets(vpnseedserver.Secrets{
-		TLSAuth:          component.Secret{Name: vpnseedserver.VpnSeedServerTLSAuth, Checksum: b.LoadCheckSum(vpnseedserver.VpnSeedServerTLSAuth), Data: b.Secrets[vpnseedserver.VpnSeedServerTLSAuth].Data},
-		Server:           component.Secret{Name: vpnseedserver.DeploymentName, Checksum: b.LoadCheckSum(vpnseedserver.DeploymentName), Data: b.Secrets[vpnseedserver.DeploymentName].Data},
+		TLSAuth:          component.Secret{Name: vpnseedserver.VpnSeedServerTLSAuth, Checksum: b.LoadCheckSum(vpnseedserver.VpnSeedServerTLSAuth), Data: b.LoadSecret(vpnseedserver.VpnSeedServerTLSAuth).Data},
+		Server:           component.Secret{Name: vpnseedserver.DeploymentName, Checksum: b.LoadCheckSum(vpnseedserver.DeploymentName), Data: b.LoadSecret(vpnseedserver.DeploymentName).Data},
 		DiffieHellmanKey: component.Secret{Name: v1beta1constants.GardenRoleOpenVPNDiffieHellman, Checksum: checkSumDH, Data: openvpnDiffieHellmanSecret},
 	})
 

--- a/pkg/operation/botanist/vpnseedserver_test.go
+++ b/pkg/operation/botanist/vpnseedserver_test.go
@@ -136,11 +136,9 @@ var _ = Describe("VPNSeedServer", func() {
 			botanist.StoreCheckSum(secretNameTLSAuth, secretChecksumTLSAuth)
 			botanist.StoreCheckSum(secretNameServer, secretChecksumServer)
 			botanist.StoreCheckSum(secretNameDH, secretChecksumDH)
-			botanist.Secrets = map[string]*corev1.Secret{
-				secretNameTLSAuth: {},
-				secretNameServer:  {},
-				secretNameDH:      {},
-			}
+			botanist.StoreSecret(secretNameTLSAuth, &corev1.Secret{})
+			botanist.StoreSecret(secretNameServer, &corev1.Secret{})
+			botanist.StoreSecret(secretNameDH, &corev1.Secret{})
 			botanist.Shoot = &shootpkg.Shoot{
 				Components: &shootpkg.Components{
 					ControlPlane: &shootpkg.ControlPlane{

--- a/pkg/operation/botanist/vpnseedserver_test.go
+++ b/pkg/operation/botanist/vpnseedserver_test.go
@@ -133,11 +133,9 @@ var _ = Describe("VPNSeedServer", func() {
 		BeforeEach(func() {
 			vpnSeedServer = mockvpnseedserver.NewMockInterface(ctrl)
 
-			botanist.CheckSums = map[string]string{
-				secretNameTLSAuth: secretChecksumTLSAuth,
-				secretNameServer:  secretChecksumServer,
-				secretNameDH:      secretChecksumDH,
-			}
+			botanist.StoreCheckSum(secretNameTLSAuth, secretChecksumTLSAuth)
+			botanist.StoreCheckSum(secretNameServer, secretChecksumServer)
+			botanist.StoreCheckSum(secretNameDH, secretChecksumDH)
 			botanist.Secrets = map[string]*corev1.Secret{
 				secretNameTLSAuth: {},
 				secretNameServer:  {},

--- a/pkg/operation/botanist/worker.go
+++ b/pkg/operation/botanist/worker.go
@@ -55,7 +55,7 @@ func (b *Botanist) DefaultWorker() worker.Interface {
 // DeployWorker deploys the Worker custom resource and triggers the restore operation in case
 // the Shoot is in the restore phase of the control plane migration
 func (b *Botanist) DeployWorker(ctx context.Context) error {
-	b.Shoot.Components.Extensions.Worker.SetSSHPublicKey(b.Secrets[v1beta1constants.SecretNameSSHKeyPair].Data[secrets.DataKeySSHAuthorizedKeys])
+	b.Shoot.Components.Extensions.Worker.SetSSHPublicKey(b.LoadSecret(v1beta1constants.SecretNameSSHKeyPair).Data[secrets.DataKeySSHAuthorizedKeys])
 	b.Shoot.Components.Extensions.Worker.SetInfrastructureProviderStatus(b.Shoot.Components.Extensions.Infrastructure.ProviderStatus())
 	b.Shoot.Components.Extensions.Worker.SetWorkerNameToOperatingSystemConfigsMap(b.Shoot.Components.Extensions.OperatingSystemConfig.WorkerNameToOperatingSystemConfigsMap())
 

--- a/pkg/operation/botanist/worker_test.go
+++ b/pkg/operation/botanist/worker_test.go
@@ -68,9 +68,6 @@ var _ = Describe("Worker", func() {
 		operatingSystemConfig = mockoperatingsystemconfig.NewMockInterface(ctrl)
 		infrastructure = mockinfrastructure.NewMockInterface(ctrl)
 		botanist = &Botanist{Operation: &operation.Operation{
-			Secrets: map[string]*corev1.Secret{
-				"ssh-keypair": {Data: map[string][]byte{"id_rsa.pub": sshPublicKey}},
-			},
 			Shoot: &shootpkg.Shoot{
 				Components: &shootpkg.Components{
 					Extensions: &shootpkg.Extensions{
@@ -82,6 +79,7 @@ var _ = Describe("Worker", func() {
 			},
 			ShootState: shootState,
 		}}
+		botanist.StoreSecret("ssh-keypair", &corev1.Secret{Data: map[string][]byte{"id_rsa.pub": sshPublicKey}})
 	})
 
 	AfterEach(func() {

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -54,6 +54,17 @@ func GetSecretKeysWithPrefix(kind string, m map[string]*corev1.Secret) []string 
 	return result
 }
 
+// FilterEntriesByPrefix returns a list of strings which begin with the given prefix.
+func FilterEntriesByPrefix(prefix string, entries []string) []string {
+	var result []string
+	for _, entry := range entries {
+		if strings.HasPrefix(entry, prefix) {
+			result = append(result, entry)
+		}
+	}
+	return result
+}
+
 // ComputeOffsetIP parses the provided <subnet> and offsets with the value of <offset>.
 // For example, <subnet> = 100.64.0.0/11 and <offset> = 10 the result would be 100.64.0.10
 // IPv6 and IPv4 is supported.

--- a/pkg/operation/common/utils_test.go
+++ b/pkg/operation/common/utils_test.go
@@ -389,4 +389,48 @@ var _ = Describe("common", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
+
+	Describe("#FilterEntriesByPrefix", func() {
+		var (
+			prefix  string
+			entries []string
+		)
+
+		BeforeEach(func() {
+			prefix = "role"
+			entries = []string{
+				"foo",
+				"bar",
+			}
+		})
+
+		It("should only return entries with prefix", func() {
+			expectedEntries := []string{
+				fmt.Sprintf("%s-%s", prefix, "foo"),
+				fmt.Sprintf("%s-%s", prefix, "bar"),
+			}
+
+			entries = append(entries, expectedEntries...)
+
+			result := FilterEntriesByPrefix(prefix, entries)
+			Expect(result).To(ContainElements(expectedEntries))
+		})
+
+		It("should return all entries", func() {
+			expectedEntries := []string{
+				fmt.Sprintf("%s-%s", prefix, "foo"),
+				fmt.Sprintf("%s-%s", prefix, "bar"),
+			}
+
+			entries = expectedEntries
+
+			result := FilterEntriesByPrefix(prefix, entries)
+			Expect(result).To(ContainElements(expectedEntries))
+		})
+
+		It("should return no entries", func() {
+			result := FilterEntriesByPrefix(prefix, entries)
+			Expect(result).To(BeEmpty())
+		})
+	})
 })

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -685,7 +685,7 @@ func (o *Operation) DeleteCheckSum(key string) {
 	delete(o.checkSums, key)
 }
 
-// StoreCheckSum stores the passed secret under the given key from the operation. Calling this function is thread-safe.
+// StoreSecret stores the passed secret under the given key from the operation. Calling this function is thread-safe.
 func (o *Operation) StoreSecret(key string, secret *corev1.Secret) {
 	o.secretsMutex.Lock()
 	defer o.secretsMutex.Unlock()
@@ -709,7 +709,9 @@ func (o *Operation) AllSecretKeys() []string {
 	return keys
 }
 
-// LoadCheckSum loads the secret under the given key from the operation. Calling this function is thread-safe.
+// LoadSecret loads the secret under the given key from the operation. Calling this function is thread-safe.
+// Be aware that the returned pointer and the underlying secret map refer to the same secret object.
+// If you need to modify the returned secret, copy it first and store the changes via `StoreSecret`.
 func (o *Operation) LoadSecret(key string) *corev1.Secret {
 	o.secretsMutex.RLock()
 	defer o.secretsMutex.RUnlock()

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -227,7 +227,6 @@ func (b *Builder) WithExposureClassHandlerFromConfig(cfg *config.GardenletConfig
 func (b *Builder) Build(ctx context.Context, clientMap clientmap.ClientMap) (*Operation, error) {
 	operation := &Operation{
 		ClientMap: clientMap,
-		CheckSums: make(map[string]string),
 	}
 
 	gardenClient, err := clientMap.GetClient(ctx, keys.ForGarden())
@@ -655,4 +654,33 @@ func (o *Operation) ToAdvertisedAddresses() []gardencorev1beta1.ShootAdvertisedA
 	}
 
 	return addresses
+}
+
+// StoreCheckSum stores the passed checksum under the given key from the operation. Calling this function is thread-safe.
+func (o *Operation) StoreCheckSum(key, value string) {
+	o.checkSumsMutex.Lock()
+	defer o.checkSumsMutex.Unlock()
+
+	if o.checkSums == nil {
+		o.checkSums = make(map[string]string)
+	}
+
+	o.checkSums[key] = value
+}
+
+// LoadCheckSum loads the checksum value under the given key from the operation. Calling this function is thread-safe.
+func (o *Operation) LoadCheckSum(key string) string {
+	o.checkSumsMutex.RLock()
+	defer o.checkSumsMutex.RUnlock()
+
+	val := o.checkSums[key]
+	return val
+}
+
+// DeleteCheckSum deletes the checksum entry under the given key from the operation. Calling this function is thread-safe.
+func (o *Operation) DeleteCheckSum(key string) {
+	o.checkSumsMutex.Lock()
+	defer o.checkSumsMutex.Unlock()
+
+	delete(o.checkSums, key)
 }

--- a/pkg/operation/types.go
+++ b/pkg/operation/types.go
@@ -55,11 +55,13 @@ type Operation struct {
 	checkSumsMutex sync.RWMutex
 	checkSums      map[string]string
 
+	secrets      map[string]*corev1.Secret
+	secretsMutex sync.RWMutex
+
 	Config                    *config.GardenletConfiguration
 	Logger                    *logrus.Entry
 	GardenerInfo              *gardencorev1beta1.Gardener
 	GardenClusterIdentity     string
-	Secrets                   map[string]*corev1.Secret
 	ImageVector               imagevector.ImageVector
 	Garden                    *garden.Garden
 	Seed                      *seed.Seed

--- a/pkg/operation/types.go
+++ b/pkg/operation/types.go
@@ -16,6 +16,7 @@ package operation
 
 import (
 	"context"
+	"sync"
 
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -51,12 +52,14 @@ type Builder struct {
 
 // Operation contains all data required to perform an operation on a Shoot cluster.
 type Operation struct {
+	checkSumsMutex sync.RWMutex
+	checkSums      map[string]string
+
 	Config                    *config.GardenletConfiguration
 	Logger                    *logrus.Entry
 	GardenerInfo              *gardencorev1beta1.Gardener
 	GardenClusterIdentity     string
 	Secrets                   map[string]*corev1.Secret
-	CheckSums                 map[string]string
 	ImageVector               imagevector.ImageVector
 	Garden                    *garden.Garden
 	Seed                      *seed.Seed


### PR DESCRIPTION
/kind/bug
/area/robustness

Cherry pick of #4509 on release-v1.28.

#4509: Fixes for concurrent access of Operation object

**Release Notes:**
```bugfix operator
A bug has been fixed which can cause the Gardenlet to panic when VPA is enabled for shoot clusters.
```