### PR TITLE
Remove the MountHostCADirectories feature gate

### DIFF
--- a/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
@@ -268,7 +268,6 @@ spec:
         # locations are taken from
         # https://github.com/golang/go/blob/1bb247a469e306c57a5e0eaba788efb8b3b1acef/src/crypto/x509/root_linux.go#L7-L15
         # we cannot be sure on which Node OS the Seed Cluster is running so, it's safer to mount them all
-          {{- if .Values.mountHostCADirectories.enabled }}
         - name: fedora-rhel6-openelec-cabundle
           mountPath: /etc/pki/tls
           readOnly: true
@@ -281,26 +280,6 @@ spec:
         - name: usr-share-cacerts
           mountPath: /usr/share/ca-certificates
           readOnly: true
-          {{- else }}
-        - name: debian-family-cabundle
-          mountPath: /etc/ssl/certs/ca-certificates.crt
-          readOnly: true
-        - name: fedora-rhel6-cabundle
-          mountPath: /etc/pki/tls/certs/ca-bundle.crt
-          readOnly: true
-        - name: opensuse-cabundle
-          mountPath: /etc/ssl/ca-bundle.pem
-          readOnly: true
-        - name: openelec-cabundle
-          mountPath: /etc/pki/tls/cacert.pem
-          readOnly: true
-        - name: centos-rhel7-cabundle
-          mountPath: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
-          readOnly: true
-        - name:  alpine-linux-cabundle
-          mountPath: /etc/ssl/cert.pem
-          readOnly: true
-          {{- end }}
         {{- end }}
       {{- if .Values.sni.podMutatorEnabled }}
       - name: apiserver-proxy-pod-mutator
@@ -445,7 +424,6 @@ spec:
       # locations are taken from
       # https://github.com/golang/go/blob/1bb247a469e306c57a5e0eaba788efb8b3b1acef/src/crypto/x509/root_linux.go#L7-L15
       # we cannot be sure on which Node OS the Seed Cluster is running so, it's safer to mount them all
-        {{- if .Values.mountHostCADirectories.enabled }}
       - hostPath:
           path: /etc/pki/tls
           type: "DirectoryOrCreate"
@@ -462,24 +440,4 @@ spec:
           path: /usr/share/ca-certificates
           type: "DirectoryOrCreate"
         name: usr-share-cacerts
-        {{- else }}
-      - name: debian-family-cabundle
-        hostPath:
-          path: /etc/ssl/certs/ca-certificates.crt
-      - name: fedora-rhel6-cabundle
-        hostPath:
-          path: /etc/pki/tls/certs/ca-bundle.crt
-      - name: opensuse-cabundle
-        hostPath:
-          path: /etc/ssl/ca-bundle.pem
-      - name: openelec-cabundle
-        hostPath:
-          path: /etc/pki/tls/cacert.pem
-      - name: centos-rhel7-cabundle
-        hostPath:
-          path: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
-      - name: alpine-linux-cabundle
-        hostPath:
-          path: /etc/ssl/cert.pem
-        {{- end }}
       {{- end }}

--- a/charts/seed-controlplane/charts/kube-apiserver/values.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/values.yaml
@@ -112,9 +112,6 @@ sni:
   podMutatorEnabled: false
   # apiserverFQDN: foo.bar.
 
-mountHostCADirectories:
-  enabled: false
-
 # watchCacheSizes:
 #   default: 100
 #   resources:

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -45,6 +45,7 @@ The following tables are a summary of the feature gates that you can set on diff
 | MountHostCADirectories | `false` | `Alpha` | `1.11` | `1.25` |
 | MountHostCADirectories | `true` | `Beta` | `1.26` | `1.27` |
 | MountHostCADirectories | `true` | `GA` | `1.27` | |
+| MountHostCADirectories | | `Removed` | `1.30` | |
 
 ## Using a feature
 

--- a/example/20-componentconfig-gardenlet.yaml
+++ b/example/20-componentconfig-gardenlet.yaml
@@ -95,7 +95,6 @@ featureGates:
   ManagedIstio: true
   APIServerSNI: true
   CachedRuntimeClients: true
-  MountHostCADirectories: true
   SeedKubeScheduler: false
   ReversedVPN: false
   UseDNSRecords: false

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -65,13 +65,6 @@ const (
 	// alpha: v1.7.0
 	CachedRuntimeClients featuregate.Feature = "CachedRuntimeClients"
 
-	// MountHostCADirectories enables mounting common CA certificate directories in the Shoot API server pod that might be required for webhooks or OIDC.
-	// owner @danielfoehrKn
-	// alpha: v1.11.0
-	// beta: v1.26.0
-	// GA: v1.27.0
-	MountHostCADirectories featuregate.Feature = "MountHostCADirectories"
-
 	// SeedChange enables updating the `spec.seedName` field during shoot validation from a non-empty value
 	// in order to trigger shoot control plane migration.
 	// owner: @stoyanr

--- a/pkg/gardenlet/features/features.go
+++ b/pkg/gardenlet/features/features.go
@@ -25,16 +25,15 @@ var (
 	// FeatureGate is a shared global FeatureGate for Gardenlet flags.
 	FeatureGate  = featuregate.NewFeatureGate()
 	featureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-		features.Logging:                {Default: false, PreRelease: featuregate.Alpha},
-		features.HVPA:                   {Default: false, PreRelease: featuregate.Alpha},
-		features.HVPAForShootedSeed:     {Default: false, PreRelease: featuregate.Alpha},
-		features.ManagedIstio:           {Default: true, PreRelease: featuregate.Beta},
-		features.APIServerSNI:           {Default: true, PreRelease: featuregate.Beta},
-		features.CachedRuntimeClients:   {Default: false, PreRelease: featuregate.Alpha},
-		features.MountHostCADirectories: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // TODO (ialidzhikov): remove MountHostCADirectories in v1.29.
-		features.SeedKubeScheduler:      {Default: false, PreRelease: featuregate.Alpha},
-		features.ReversedVPN:            {Default: false, PreRelease: featuregate.Alpha},
-		features.UseDNSRecords:          {Default: false, PreRelease: featuregate.Alpha},
+		features.Logging:              {Default: false, PreRelease: featuregate.Alpha},
+		features.HVPA:                 {Default: false, PreRelease: featuregate.Alpha},
+		features.HVPAForShootedSeed:   {Default: false, PreRelease: featuregate.Alpha},
+		features.ManagedIstio:         {Default: true, PreRelease: featuregate.Beta},
+		features.APIServerSNI:         {Default: true, PreRelease: featuregate.Beta},
+		features.CachedRuntimeClients: {Default: false, PreRelease: featuregate.Alpha},
+		features.SeedKubeScheduler:    {Default: false, PreRelease: featuregate.Alpha},
+		features.ReversedVPN:          {Default: false, PreRelease: featuregate.Alpha},
+		features.UseDNSRecords:        {Default: false, PreRelease: featuregate.Alpha},
 	}
 )
 

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -335,8 +335,7 @@ func getResourcesForAPIServer(nodeCount int32, scalingClass string) (string, str
 
 func (b *Botanist) deployKubeAPIServer(ctx context.Context) error {
 	var (
-		hvpaEnabled            = gardenletfeatures.FeatureGate.Enabled(features.HVPA)
-		mountHostCADirectories = gardenletfeatures.FeatureGate.Enabled(features.MountHostCADirectories)
+		hvpaEnabled = gardenletfeatures.FeatureGate.Enabled(features.HVPA)
 	)
 
 	if b.ManagedSeed != nil {
@@ -555,10 +554,6 @@ func (b *Botanist) deployKubeAPIServer(ctx context.Context) error {
 	serviceAccountConfigVals["issuer"] = serviceAccountTokenIssuerURL
 	defaultValues["serviceAccountConfig"] = serviceAccountConfigVals
 	defaultValues["admissionPlugins"] = admissionPlugins
-
-	defaultValues["mountHostCADirectories"] = map[string]interface{}{
-		"enabled": mountHostCADirectories,
-	}
 
 	values, err := b.InjectSeedShootImages(defaultValues,
 		charts.ImageNameVpnSeed,


### PR DESCRIPTION
/kind cleanup

Part of #4147

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
gardenlet's `MountHostCADirectories` feature gate that is GA since v1.27 is unconditionally enabled, and can no longer be specified in the gardenlet's configuration.
```
