### PR TITLE
Nit: Fix typo in doc string

### DIFF
--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -341,11 +341,11 @@ const (
 	// only want to expand those when there are pending pods that need a lot of those resources.
 	// This is the default value.
 	ClusterAutoscalerExpanderLeastWaste ExpanderMode = "least-waste"
-	// ClusterAutoscalerExpanderRandom selects the node group that would be able to schedule the most pods when scaling up.
+	// ClusterAutoscalerExpanderMostPods selects the node group that would be able to schedule the most pods when scaling up.
 	// This is useful when you are using nodeSelector to make sure certain pods land on certain nodes.
 	// Note that this won't cause the autoscaler to select bigger nodes vs. smaller, as it can add multiple smaller nodes at once.
 	ClusterAutoscalerExpanderMostPods ExpanderMode = "most-pods"
-	// ClusterAutoscalerExpanderRandom selects the node group that has the highest priority assigned by the user. For configurations,
+	// ClusterAutoscalerExpanderPriority selects the node group that has the highest priority assigned by the user. For configurations,
 	// See: https://github.com/gardener/autoscaler/blob/machine-controller-manager-provider/cluster-autoscaler/expander/priority/readme.md
 	ClusterAutoscalerExpanderPriority ExpanderMode = "priority"
 	// ClusterAutoscalerExpanderRandom should be used when you don't have a particular need

--- a/pkg/apis/core/v1alpha1/types_shoot.go
+++ b/pkg/apis/core/v1alpha1/types_shoot.go
@@ -405,11 +405,11 @@ const (
 	// only want to expand those when there are pending pods that need a lot of those resources.
 	// This is the default value.
 	ClusterAutoscalerExpanderLeastWaste ExpanderMode = "least-waste"
-	// ClusterAutoscalerExpanderRandom selects the node group that would be able to schedule the most pods when scaling up.
+	// ClusterAutoscalerExpanderMostPods selects the node group that would be able to schedule the most pods when scaling up.
 	// This is useful when you are using nodeSelector to make sure certain pods land on certain nodes.
 	// Note that this won't cause the autoscaler to select bigger nodes vs. smaller, as it can add multiple smaller nodes at once.
 	ClusterAutoscalerExpanderMostPods ExpanderMode = "most-pods"
-	// ClusterAutoscalerExpanderRandom selects the node group that has the highest priority assigned by the user. For configurations,
+	// ClusterAutoscalerExpanderPriority selects the node group that has the highest priority assigned by the user. For configurations,
 	// See: https://github.com/gardener/autoscaler/blob/machine-controller-manager-provider/cluster-autoscaler/expander/priority/readme.md
 	ClusterAutoscalerExpanderPriority ExpanderMode = "priority"
 	// ClusterAutoscalerExpanderRandom should be used when you don't have a particular need

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -412,11 +412,11 @@ const (
 	// only want to expand those when there are pending pods that need a lot of those resources.
 	// This is the default value.
 	ClusterAutoscalerExpanderLeastWaste ExpanderMode = "least-waste"
-	// ClusterAutoscalerExpanderRandom selects the node group that would be able to schedule the most pods when scaling up.
+	// ClusterAutoscalerExpanderMostPods selects the node group that would be able to schedule the most pods when scaling up.
 	// This is useful when you are using nodeSelector to make sure certain pods land on certain nodes.
 	// Note that this won't cause the autoscaler to select bigger nodes vs. smaller, as it can add multiple smaller nodes at once.
 	ClusterAutoscalerExpanderMostPods ExpanderMode = "most-pods"
-	// ClusterAutoscalerExpanderRandom selects the node group that has the highest priority assigned by the user. For configurations,
+	// ClusterAutoscalerExpanderPriority selects the node group that has the highest priority assigned by the user. For configurations,
 	// See: https://github.com/gardener/autoscaler/blob/machine-controller-manager-provider/cluster-autoscaler/expander/priority/readme.md
 	ClusterAutoscalerExpanderPriority ExpanderMode = "priority"
 	// ClusterAutoscalerExpanderRandom should be used when you don't have a particular need


### PR DESCRIPTION
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
