### PR TITLE
Disclaimer for removal date of deprecated fields in ControllerRegistration

### DIFF
--- a/hack/api-reference/core.md
+++ b/hack/api-reference/core.md
@@ -3033,7 +3033,8 @@ string
 <td>
 <em>(Optional)</em>
 <p>Type is the deployment type.
-Deprecated: Declare type via <code>ControllerDeployment</code> instead.</p>
+Deprecated: Declare type via <code>ControllerDeployment</code> instead.
+ATTENTION: This field will be deleted with Gardener v1.32.</p>
 </td>
 </tr>
 <tr>
@@ -3048,7 +3049,8 @@ k8s.io/apimachinery/pkg/runtime.RawExtension
 <td>
 <em>(Optional)</em>
 <p>ProviderConfig contains type-specific configuration.
-Deprecated: Use <code>DeploymentRefs</code> instead.</p>
+Deprecated: Use <code>DeploymentRefs</code> instead.
+ATTENTION: This field will be deleted with Gardener v1.32.</p>
 </td>
 </tr>
 <tr>

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -473,11 +473,13 @@ message ControllerRegistration {
 message ControllerRegistrationDeployment {
   // Type is the deployment type.
   // Deprecated: Declare type via `ControllerDeployment` instead.
+  // ATTENTION: This field will be deleted with Gardener v1.32.
   // +optional
   optional string type = 1;
 
   // ProviderConfig contains type-specific configuration.
   // Deprecated: Use `DeploymentRefs` instead.
+  // ATTENTION: This field will be deleted with Gardener v1.32.
   // +optional
   optional k8s.io.apimachinery.pkg.runtime.RawExtension providerConfig = 2;
 

--- a/pkg/apis/core/v1beta1/types_controllerregistration.go
+++ b/pkg/apis/core/v1beta1/types_controllerregistration.go
@@ -85,10 +85,12 @@ type DeploymentRef struct {
 type ControllerRegistrationDeployment struct {
 	// Type is the deployment type.
 	// Deprecated: Declare type via `ControllerDeployment` instead.
+	// ATTENTION: This field will be deleted with Gardener v1.32.
 	// +optional
 	Type *string `json:"type,omitempty" protobuf:"bytes,1,opt,name=type"`
 	// ProviderConfig contains type-specific configuration.
 	// Deprecated: Use `DeploymentRefs` instead.
+	// ATTENTION: This field will be deleted with Gardener v1.32.
 	// +optional
 	ProviderConfig *runtime.RawExtension `json:"providerConfig,omitempty" protobuf:"bytes,2,opt,name=providerConfig"`
 	// Policy controls how the controller is deployed. It defaults to 'OnDemand'.

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -9187,14 +9187,14 @@ func schema_pkg_apis_core_v1beta1_ControllerRegistrationDeployment(ref common.Re
 				Properties: map[string]spec.Schema{
 					"type": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Type is the deployment type. Deprecated: Declare type via `ControllerDeployment` instead.",
+							Description: "Type is the deployment type. Deprecated: Declare type via `ControllerDeployment` instead. ATTENTION: This field will be deleted with Gardener v1.32.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"providerConfig": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ProviderConfig contains type-specific configuration. Deprecated: Use `DeploymentRefs` instead.",
+							Description: "ProviderConfig contains type-specific configuration. Deprecated: Use `DeploymentRefs` instead. ATTENTION: This field will be deleted with Gardener v1.32.",
 							Ref:         ref("k8s.io/apimachinery/pkg/runtime.RawExtension"),
 						},
 					},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:
Add a disclaimer with information when the deprecated fields in the `ControllerRegistration` resource will be deleted.

**Special notes for your reviewer**:
This is a prerequisite to allow end-users/project members to read `ControllerRegistration` resources in the garden cluster, i.e., allowing them to discover the registered extension kind/types.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
The `.spec.deployment.{type,providerConfig}` fields in the `ControllerRegistration` resource (deprecated since `v1.23`) will be removed from the API starting with `v1.32`. Please consider adapting to `ControllerDeployment`s now (see https://github.com/gardener/gardener/blob/master/docs/extensions/controllerregistration.md and https://github.com/gardener/gardener/pull/3995).
```
