### PR TITLE
Incude generation of charts/images.go to makefile generate target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,13 +203,13 @@ check:
 generate:
 	@GO111MODULE=off hack/update-protobuf.sh
 	@GO111MODULE=off hack/update-codegen.sh --parallel
-	@hack/generate-parallel.sh cmd extensions pkg plugin landscaper test
+	@hack/generate-parallel.sh charts cmd extensions pkg plugin landscaper test
 
 .PHONY: generate-sequential
 generate-sequential:
 	@GO111MODULE=off hack/update-protobuf.sh
 	@GO111MODULE=off hack/update-codegen.sh
-	@hack/generate.sh ./cmd/... ./extensions/... ./pkg/... ./plugin/... ./landscaper/... ./test/...
+	@hack/generate.sh ./charts/... ./cmd/... ./extensions/... ./pkg/... ./plugin/... ./landscaper/... ./test/...
 
 .PHONY: generate-extensions-crds
 generate-extensions-crds:

--- a/charts/images.go
+++ b/charts/images.go
@@ -71,6 +71,8 @@ const (
 	ImageNameKubeControllerManager = "kube-controller-manager"
 	// ImageNameKubeProxy is a constant for an image in the image vector with name 'kube-proxy'.
 	ImageNameKubeProxy = "kube-proxy"
+	// ImageNameKubeRbacProxy is a constant for an image in the image vector with name 'kube-rbac-proxy'.
+	ImageNameKubeRbacProxy = "kube-rbac-proxy"
 	// ImageNameKubeScheduler is a constant for an image in the image vector with name 'kube-scheduler'.
 	ImageNameKubeScheduler = "kube-scheduler"
 	// ImageNameKubeStateMetrics is a constant for an image in the image vector with name 'kube-state-metrics'.
@@ -83,12 +85,6 @@ const (
 	ImageNameLoki = "loki"
 	// ImageNameLokiCurator is a constant for an image in the image vector with name 'loki-curator'.
 	ImageNameLokiCurator = "loki-curator"
-	// ImageNameKubeRBACKProxy is a constant for an image in the image vector with name 'kube-rbac-proxy'.
-	ImageNameKubeRBACKProxy = "kube-rbac-proxy"
-	// PromtailImageName is the image of grafana/promtail image
-	PromtailImageName = "promtail"
-	// ImageNameTelegraf is a constant for an image in the image vector with name 'telegraf'.
-	ImageNameTelegraf = "telegraf"
 	// ImageNameMetricsServer is a constant for an image in the image vector with name 'metrics-server'.
 	ImageNameMetricsServer = "metrics-server"
 	// ImageNameNginxIngressController is a constant for an image in the image vector with name 'nginx-ingress-controller'.
@@ -105,6 +101,10 @@ const (
 	ImageNamePauseContainer = "pause-container"
 	// ImageNamePrometheus is a constant for an image in the image vector with name 'prometheus'.
 	ImageNamePrometheus = "prometheus"
+	// ImageNamePromtail is a constant for an image in the image vector with name 'promtail'.
+	ImageNamePromtail = "promtail"
+	// ImageNameTelegraf is a constant for an image in the image vector with name 'telegraf'.
+	ImageNameTelegraf = "telegraf"
 	// ImageNameVpaAdmissionController is a constant for an image in the image vector with name 'vpa-admission-controller'.
 	ImageNameVpaAdmissionController = "vpa-admission-controller"
 	// ImageNameVpaExporter is a constant for an image in the image vector with name 'vpa-exporter'.

--- a/hack/install-requirements.sh
+++ b/hack/install-requirements.sh
@@ -19,6 +19,7 @@ set -e
 echo "> Installing requirements"
 
 GO111MODULE=off go get -u golang.org/x/tools/cmd/goimports
+GO111MODULE=off go get -u github.com/bronze1man/yaml2json
 
 export GO111MODULE=on
 curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.41.1

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/promtail/component.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/promtail/component.go
@@ -82,7 +82,7 @@ func (component) Config(ctx components.Context) ([]extensionsv1alpha1.Unit, []ex
 
 	return []extensionsv1alpha1.Unit{
 			*getPromtailUnit(
-				execStartPreCopyBinaryFromContainer("promtail", ctx.Images[charts.PromtailImageName]),
+				execStartPreCopyBinaryFromContainer("promtail", ctx.Images[charts.ImageNamePromtail]),
 				"/bin/sh "+PathSetActiveJournalFileScript,
 				v1beta1constants.OperatingSystemConfigFilePathBinaries+`/promtail -config.file=`+PathPromtailConfig),
 		},

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/promtail/config_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/promtail/config_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Promtail", func() {
 				CABundle:      &cABundle,
 				ClusterDomain: clusterDomain,
 				Images: map[string]*imagevector.Image{
-					charts.PromtailImageName: promtailImage,
+					charts.ImageNamePromtail: promtailImage,
 				},
 				LokiIngress:           lokiIngress,
 				PromtailRBACAuthToken: promtailRBACAuthToken,
@@ -139,7 +139,7 @@ ExecStart=/opt/bin/promtail -config.file=` + PathPromtailConfig)},
 				CABundle:      &cABundle,
 				ClusterDomain: clusterDomain,
 				Images: map[string]*imagevector.Image{
-					charts.PromtailImageName: promtailImage,
+					charts.ImageNamePromtail: promtailImage,
 				},
 				LokiIngress:           lokiIngress,
 				PromtailRBACAuthToken: "",
@@ -183,7 +183,7 @@ ExecStart=/bin/sh -c "echo service ` + UnitName + ` is removed!; while true; do 
 				CABundle:      &cABundle,
 				ClusterDomain: clusterDomain,
 				Images: map[string]*imagevector.Image{
-					charts.PromtailImageName: promtailImage,
+					charts.ImageNamePromtail: promtailImage,
 				},
 				LokiIngress:           "",
 				PromtailRBACAuthToken: promtailRBACAuthToken,

--- a/pkg/operation/botanist/logging.go
+++ b/pkg/operation/botanist/logging.go
@@ -38,7 +38,7 @@ func (b *Botanist) DeploySeedLogging(ctx context.Context) error {
 	images, err := b.InjectSeedSeedImages(map[string]interface{}{},
 		charts.ImageNameLoki,
 		charts.ImageNameLokiCurator,
-		charts.ImageNameKubeRBACKProxy,
+		charts.ImageNameKubeRbacProxy,
 		charts.ImageNameTelegraf,
 	)
 	if err != nil {

--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -46,7 +46,7 @@ import (
 
 // DefaultOperatingSystemConfig creates the default deployer for the OperatingSystemConfig custom resource.
 func (b *Botanist) DefaultOperatingSystemConfig() (operatingsystemconfig.Interface, error) {
-	images, err := imagevector.FindImages(b.ImageVector, []string{charts.ImageNameHyperkube, charts.ImageNamePauseContainer, charts.PromtailImageName}, imagevector.RuntimeVersion(b.ShootVersion()), imagevector.TargetVersion(b.ShootVersion()))
+	images, err := imagevector.FindImages(b.ImageVector, []string{charts.ImageNameHyperkube, charts.ImageNamePauseContainer, charts.ImageNamePromtail}, imagevector.RuntimeVersion(b.ShootVersion()), imagevector.TargetVersion(b.ShootVersion()))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Incude generation of charts/images.go to makefile generate target.
After https://github.com/gardener/gardener/pull/3707 we maintain golang constants with the name of the images from charts/images.yaml. 


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
