### PR TITLE
Refactor kube-apiserver-kubelet Helm chart into Golang component

### DIFF
--- a/charts/shoot-core/components/charts/kube-apiserver-kubelet/templates/kube-apiserver-kubelet-rbac.yaml
+++ b/charts/shoot-core/components/charts/kube-apiserver-kubelet/templates/kube-apiserver-kubelet-rbac.yaml
@@ -1,33 +1,15 @@
+# TODO(rfranzke): Delete this Helm chart in a future version.
 ---
 apiVersion: {{ template "rbacversion" . }}
 kind: ClusterRole
 metadata:
   name: system:apiserver:kubelet
-rules:
-- apiGroups: [""]
-  resources:
-  - nodes/proxy
-  - nodes/stats
-  - nodes/log
-  - nodes/spec
-  - nodes/metrics
-  verbs:
-  - '*'
-- nonResourceURLs:
-  - '*'
-  verbs:
-  - '*'
+  annotations:
+    resources.gardener.cloud/mode: Ignore
 ---
 apiVersion: {{ template "rbacversion" . }}
 kind: ClusterRoleBinding
 metadata:
   name: system:apiserver:kubelet
   annotations:
-    resources.gardener.cloud/delete-on-invalid-update: "true"
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: system:apiserver:kubelet
-subjects:
-- kind: User
-  name: system:kube-apiserver:kubelet
+    resources.gardener.cloud/mode: Ignore

--- a/pkg/operation/botanist/component/kubeapiserver/shoot_resources.go
+++ b/pkg/operation/botanist/component/kubeapiserver/shoot_resources.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubeapiserver
+
+import (
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/managedresources"
+
+	resourcesv1alpha1 "github.com/gardener/gardener-resource-manager/api/resources/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (k *kubeAPIServer) emptyManagedResource() *resourcesv1alpha1.ManagedResource {
+	return &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: ManagedResourceName, Namespace: k.namespace}}
+}
+
+func (k *kubeAPIServer) emptyManagedResourceSecret() *corev1.Secret {
+	return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: managedresources.SecretName(ManagedResourceName, true), Namespace: k.namespace}}
+}
+
+func (k *kubeAPIServer) computeShootResourcesData() (map[string][]byte, error) {
+	var (
+		registry = managedresources.NewRegistry(kubernetes.ShootScheme, kubernetes.ShootCodec, kubernetes.ShootSerializer)
+
+		clusterRole = &rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "system:apiserver:kubelet",
+			},
+			Rules: []rbacv1.PolicyRule{
+				{
+					APIGroups: []string{""},
+					Resources: []string{
+						"nodes/proxy",
+						"nodes/stats",
+						"nodes/log",
+						"nodes/spec",
+						"nodes/metrics",
+					},
+					Verbs: []string{"*"},
+				},
+				{
+					NonResourceURLs: []string{"*"},
+					Verbs:           []string{"*"},
+				},
+			},
+		}
+
+		clusterRoleBinding = &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "system:apiserver:kubelet",
+				Annotations: map[string]string{resourcesv1alpha1.DeleteOnInvalidUpdate: "true"},
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: rbacv1.GroupName,
+				Kind:     "ClusterRole",
+				Name:     clusterRole.Name,
+			},
+			Subjects: []rbacv1.Subject{{
+				Kind: rbacv1.UserKind,
+				Name: UserName,
+			}},
+		}
+	)
+
+	return registry.AddAllAndSerialize(
+		clusterRole,
+		clusterRoleBinding,
+	)
+}

--- a/pkg/operation/botanist/wanted_secrets.go
+++ b/pkg/operation/botanist/wanted_secrets.go
@@ -183,7 +183,7 @@ func (b *Botanist) generateWantedSecretConfigs(basicAuthAPIServer *secrets.Basic
 			CertificateSecretConfig: &secrets.CertificateSecretConfig{
 				Name: "kube-apiserver-kubelet",
 
-				CommonName:   "system:kube-apiserver:kubelet",
+				CommonName:   kubeapiserver.UserName,
 				Organization: nil,
 				DNSNames:     nil,
 				IPAddresses:  nil,

--- a/pkg/operation/care/checker.go
+++ b/pkg/operation/care/checker.go
@@ -26,6 +26,7 @@ import (
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/operation/botanist"
+	"github.com/gardener/gardener/pkg/operation/botanist/component/kubeapiserver"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/metricsserver"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/namespaces"
 	"github.com/gardener/gardener/pkg/operation/common"
@@ -537,6 +538,7 @@ var managedResourcesShoot = sets.NewString(
 	common.ManagedResourceShootCoreName,
 	common.ManagedResourceAddonsName,
 	metricsserver.ManagedResourceName,
+	kubeapiserver.ManagedResourceName,
 )
 
 func makeDeploymentLister(ctx context.Context, c client.Client, namespace string, selector labels.Selector) kutil.DeploymentLister {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test
"/priority" identifiers: normal|critical|blocker

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity quality robustness
/kind technical-debt test
/priority 3
/topology seed
/platform all
/exp intermediate
/merge squash

**What this PR does / why we need it**:
This PR refactors the `shoot-core/kube-apiserver-kubelet` Helm chart into a Golang component. The chart cannot be deleted yet in order to ensure a smooth migration from the `shoot-core` to the new `shoot-core-kube-apiserver` `ManagedResource`.

**Which issue(s) this PR fixes**:
Part of #2754

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       improvement|noteworthy|action
- target_group:   user|operator|developer
-->
```improvement operator
NONE
```
