### PR TITLE
Clean up migration logic in resource-manager deployment

### DIFF
--- a/pkg/operation/botanist/resource_manager.go
+++ b/pkg/operation/botanist/resource_manager.go
@@ -23,13 +23,11 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/resourcemanager"
-	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
 	"k8s.io/utils/pointer"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // DefaultResourceManager returns an instance of Gardener Resource Manager with defaults configured for being deployed in a Shoot namespace
@@ -72,14 +70,6 @@ func (b *Botanist) DefaultResourceManager() (resourcemanager.Interface, error) {
 func (b *Botanist) DeployGardenerResourceManager(ctx context.Context) error {
 	kubeCfg := component.Secret{Name: resourcemanager.SecretName, Checksum: b.LoadCheckSum(resourcemanager.SecretName)}
 	b.Shoot.Components.ControlPlane.ResourceManager.SetSecrets(resourcemanager.Secrets{Kubeconfig: kubeCfg})
-
-	// TODO (ialidzhikov): remove in a future version
-	deploymentKeys := []client.ObjectKey{
-		kutil.Key(b.Shoot.SeedNamespace, v1beta1constants.DeploymentNameGardenerResourceManager),
-	}
-	if err := common.DeleteDeploymentsHavingDeprecatedRoleLabelKey(ctx, b.K8sSeedClient.Client(), deploymentKeys); err != nil {
-		return err
-	}
 
 	return b.Shoot.Components.ControlPlane.ResourceManager.Deploy(ctx)
 }


### PR DESCRIPTION
/kind cleanup

The corresponding migration logic was introduced with https://github.com/gardener/gardener/pull/3384 to make possible removal of deprecated label from `.spec.selector` of Deployment (the field is immutable).

Part of https://github.com/gardener/gardener/issues/1649

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
