### PR TITLE
Reconcile network policies explicitly after infrastructure readiness

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -181,9 +181,25 @@ func (c *Controller) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Dependencies: flow.NewTaskIDs(deployInfrastructure),
 		})
 		_ = g.Add(flow.Task{
-			Name:         "Deploying network policies",
+			Name:         "Reconciling network policies",
 			Fn:           flow.TaskFn(botanist.Shoot.Components.NetworkPolicies.Deploy).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			Dependencies: flow.NewTaskIDs(deployNamespace).InsertIf(!staticNodesCIDR, waitUntilInfrastructureReady),
+			Dependencies: flow.NewTaskIDs(deployNamespace),
+		})
+		// If the nodes CIDR is not static then it might be assigned only after the Infrastructure reconciliation. Hence,
+		// we might need to reconcile the network policies again after this step (because it might be only known afterwards).
+		_ = g.Add(flow.Task{
+			Name: "Reconciling network policies now that infrastructure is ready",
+			Fn: flow.TaskFn(func(ctx context.Context) error {
+				if botanist.Shoot.GetNodeNetwork() != nil {
+					o.Shoot.Components.NetworkPolicies, err = botanist.DefaultNetworkPolicies(sniPhase)
+					if err != nil {
+						return err
+					}
+					return botanist.Shoot.Components.NetworkPolicies.Deploy(ctx)
+				}
+				return nil
+			}).RetryUntilTimeout(defaultInterval, defaultTimeout).DoIf(!staticNodesCIDR),
+			Dependencies: flow.NewTaskIDs(waitUntilInfrastructureReady),
 		})
 		deployBackupEntryInGarden = g.Add(flow.Task{
 			Name: "Deploying backup entry",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind bug

**What this PR does / why we need it**:
Earlier, the `NetworkPolicy`s were only deployed immediately after the shoot namespace was created if the nodes CIDR was static (this is the case for the vast majority of shoots). If the `.spec.networking.nodes` was `nil` in the `Shoot` then the `Infrastructure` reconciliation was required to finish first before deploying the `NetworkPolicy`s.

For some provider extensions it is not possible to have static nodes CIDRs (e.g., MetalStack or EquinixMetal/Packet), hence, `.spec.networking.nodes` is `nil` and might be only populated later (or never).

However, the `Infrastructure` reconciliation might only be possible after the `NetworkPolicy`s were created. For example, provider extensions using Terraform create a `Pod` in the shoot namespace that might require communicating with the seed's API server. Without this PR, this is not possible as the required `NetworkPolicy`s don't exist yet. The reconciliation ends in a deadlock and can never finish.

With this PR, we have the following changes:
1. The `NetworkPolicy`s are always deployed right after the shoot namespace is created.
2. If the nodes CIDR was not at the beginning of the reconciliation but gets set after the `Infrastructure` reconciliation then the `NetworkPolicy`s are reconciled again (based on the now known nodes network).

Note that this change doesn't have any effect on the vast majority of shoots.

/cc @deitch 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed preventing gardenlet from properly reconciling the `NetworkPolicy`s in the shoot namespaces in the seed for shoots without static node CIDRs.
```
