### PR TITLE
Fix BackupEntry operation annotation removal

### DIFF
--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -199,6 +199,13 @@ func ComputeOperationType(meta metav1.ObjectMeta, lastOperation *gardencorev1bet
 	return gardencorev1beta1.LastOperationTypeReconcile
 }
 
+// HasOperationAnnotation returns true if the operation annotation is present and its value is "reconcile", "restore, or "migrate".
+func HasOperationAnnotation(meta metav1.ObjectMeta) bool {
+	return meta.Annotations[v1beta1constants.GardenerOperation] == v1beta1constants.GardenerOperationReconcile ||
+		meta.Annotations[v1beta1constants.GardenerOperation] == v1beta1constants.GardenerOperationRestore ||
+		meta.Annotations[v1beta1constants.GardenerOperation] == v1beta1constants.GardenerOperationMigrate
+}
+
 // TaintsHave returns true if the given key is part of the taints list.
 func TaintsHave(taints []gardencorev1beta1.SeedTaint, key string) bool {
 	for _, taint := range taints {

--- a/pkg/apis/core/v1beta1/helper/helper_test.go
+++ b/pkg/apis/core/v1beta1/helper/helper_test.go
@@ -358,6 +358,16 @@ var _ = Describe("helper", func() {
 			),
 		)
 
+		DescribeTable("#HasOperationAnnotation",
+			func(objectMeta metav1.ObjectMeta, expected bool) {
+				Expect(HasOperationAnnotation(objectMeta)).To(Equal(expected))
+			},
+			Entry("reconcile", metav1.ObjectMeta{Annotations: map[string]string{v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile}}, true),
+			Entry("restore", metav1.ObjectMeta{Annotations: map[string]string{v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationRestore}}, true),
+			Entry("migrate", metav1.ObjectMeta{Annotations: map[string]string{v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationMigrate}}, true),
+			Entry("not present", metav1.ObjectMeta{}, false),
+		)
+
 		DescribeTable("#TaintsHave",
 			func(taints []gardencorev1beta1.SeedTaint, key string, expectation bool) {
 				Expect(TaintsHave(taints, key)).To(Equal(expectation))

--- a/pkg/apis/core/v1beta1/helper/helper_test.go
+++ b/pkg/apis/core/v1beta1/helper/helper_test.go
@@ -365,6 +365,7 @@ var _ = Describe("helper", func() {
 			Entry("reconcile", metav1.ObjectMeta{Annotations: map[string]string{v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile}}, true),
 			Entry("restore", metav1.ObjectMeta{Annotations: map[string]string{v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationRestore}}, true),
 			Entry("migrate", metav1.ObjectMeta{Annotations: map[string]string{v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationMigrate}}, true),
+			Entry("unknown", metav1.ObjectMeta{Annotations: map[string]string{v1beta1constants.GardenerOperation: "unknown"}}, false),
 			Entry("not present", metav1.ObjectMeta{}, false),
 		)
 

--- a/pkg/controllerutils/miscellaneous.go
+++ b/pkg/controllerutils/miscellaneous.go
@@ -20,6 +20,7 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/utils"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -102,6 +103,10 @@ func ReconcileOncePer24hDuration(objectMeta metav1.ObjectMeta, observedGeneratio
 	}
 
 	if objectMeta.Generation != observedGeneration {
+		return 0
+	}
+
+	if v1beta1helper.HasOperationAnnotation(objectMeta) {
 		return 0
 	}
 

--- a/pkg/controllerutils/miscellaneous_test.go
+++ b/pkg/controllerutils/miscellaneous_test.go
@@ -131,6 +131,7 @@ var _ = Describe("controller", func() {
 
 		Entry("deletion timestamp set", metav1.ObjectMeta{DeletionTimestamp: &deletionTimestamp}, int64(0), nil, time.Duration(0)),
 		Entry("generation not equal observed generation", metav1.ObjectMeta{Generation: int64(1)}, int64(0), nil, time.Duration(0)),
+		Entry("operation annotation is set", metav1.ObjectMeta{Annotations: map[string]string{v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile}}, int64(0), nil, time.Duration(0)),
 		Entry("last operation is nil", metav1.ObjectMeta{}, int64(0), nil, time.Duration(0)),
 		Entry("last operation state is succeeded", metav1.ObjectMeta{}, int64(0), &gardencorev1beta1.LastOperation{State: gardencorev1beta1.LastOperationStateSucceeded}, time.Duration(0)),
 		Entry("last operation type is not create or reconcile", metav1.ObjectMeta{}, int64(0), &gardencorev1beta1.LastOperation{State: gardencorev1beta1.LastOperationStateSucceeded, Type: gardencorev1beta1.LastOperationTypeRestore}, time.Duration(0)),

--- a/pkg/gardenlet/controller/backupentry/backup_entry_controller.go
+++ b/pkg/gardenlet/controller/backupentry/backup_entry_controller.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/logger"
 
@@ -55,7 +56,7 @@ func (c *Controller) backupEntryUpdate(_, newObj interface{}) {
 	// If the generation did not change for an update event (i.e., no changes to the .spec section have
 	// been made), we do not want to add the BackupEntry to the queue. The periodic reconciliation is handled
 	// elsewhere by adding the BackupEntry to the queue to dedicated times.
-	if newBackupEntry.Generation == newBackupEntry.Status.ObservedGeneration {
+	if newBackupEntry.Generation == newBackupEntry.Status.ObservedGeneration && !v1beta1helper.HasOperationAnnotation(newBackupEntry.ObjectMeta) {
 		backupEntryLogger.Debug("Do not need to do anything as the Update event occurred due to .status field changes")
 		return
 	}

--- a/pkg/gardenlet/controller/backupentry/backup_entry_reconciler.go
+++ b/pkg/gardenlet/controller/backupentry/backup_entry_reconciler.go
@@ -32,6 +32,7 @@ import (
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	"github.com/gardener/gardener/pkg/logger"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -77,6 +78,15 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, err
 	}
 
+	// Remove the operation annotation if its value is not "restore"
+	backupEntryLogger := logger.NewFieldLogger(logger.Logger, "backupentry", kutil.ObjectName(be))
+	if operationType, ok := be.Annotations[v1beta1constants.GardenerOperation]; ok && operationType != v1beta1constants.GardenerOperationRestore {
+		if updateErr := removeGardenerOperationAnnotation(ctx, gardenClient.Client(), be); updateErr != nil {
+			backupEntryLogger.Errorf("Could not remove %q annotation: %+v", v1beta1constants.GardenerOperation, updateErr)
+			return reconcile.Result{}, updateErr
+		}
+	}
+
 	if be.DeletionTimestamp != nil {
 		return r.deleteBackupEntry(ctx, gardenClient, be)
 	}
@@ -86,7 +96,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	if !controllerutils.BackupEntryIsManagedByThisGardenlet(be, r.config) {
-		r.logger.Debugf("Skipping because BackupEntry is not managed by this gardenlet in seed %s", *be.Spec.SeedName)
+		backupEntryLogger.Debugf("Skipping because BackupEntry is not managed by this gardenlet in seed %s", *be.Spec.SeedName)
 		return reconcile.Result{}, nil
 	}
 
@@ -95,7 +105,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 }
 
 func (r *reconciler) reconcileBackupEntry(ctx context.Context, gardenClient kubernetes.Interface, backupEntry *gardencorev1beta1.BackupEntry) (reconcile.Result, error) {
-	backupEntryLogger := logger.NewFieldLogger(logger.Logger, "backupentry", backupEntry.Name)
+	backupEntryLogger := logger.NewFieldLogger(r.logger, "backupentry", kutil.ObjectName(backupEntry))
 
 	if !controllerutil.ContainsFinalizer(backupEntry, gardencorev1beta1.GardenerName) {
 		if err := controllerutils.PatchAddFinalizers(ctx, gardenClient.Client(), backupEntry, gardencorev1beta1.GardenerName); err != nil {
@@ -141,16 +151,18 @@ func (r *reconciler) reconcileBackupEntry(ctx context.Context, gardenClient kube
 		return reconcile.Result{}, updateErr
 	}
 
-	if updateErr := removeGardenerOperationAnnotation(ctx, gardenClient.Client(), backupEntry); updateErr != nil {
-		backupEntryLogger.Errorf("Could not remove %q annotation: %+v", v1beta1constants.GardenerOperation, updateErr)
-		return reconcile.Result{}, updateErr
+	if kutil.HasMetaDataAnnotation(&backupEntry.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationRestore) {
+		if updateErr := removeGardenerOperationAnnotation(ctx, gardenClient.Client(), backupEntry); updateErr != nil {
+			backupEntryLogger.Errorf("Could not remove %q annotation: %+v", v1beta1constants.GardenerOperation, updateErr)
+			return reconcile.Result{}, updateErr
+		}
 	}
 
 	return reconcile.Result{}, nil
 }
 
 func (r *reconciler) deleteBackupEntry(ctx context.Context, gardenClient kubernetes.Interface, backupEntry *gardencorev1beta1.BackupEntry) (reconcile.Result, error) {
-	backupEntryLogger := logger.NewFieldLogger(r.logger, "backupentry", backupEntry.Name)
+	backupEntryLogger := logger.NewFieldLogger(r.logger, "backupentry", kutil.ObjectName(backupEntry))
 	if !sets.NewString(backupEntry.Finalizers...).Has(gardencorev1beta1.GardenerName) {
 		backupEntryLogger.Debug("Do not need to do anything as the BackupEntry does not have my finalizer")
 		return reconcile.Result{}, nil
@@ -205,7 +217,7 @@ func shouldMigrateBackupEntry(be *gardencorev1beta1.BackupEntry) bool {
 }
 
 func (r *reconciler) migrateBackupEntry(ctx context.Context, gardenClient kubernetes.Interface, backupEntry *gardencorev1beta1.BackupEntry) (reconcile.Result, error) {
-	backupEntryLogger := logger.NewFieldLogger(r.logger, "backupentry", backupEntry.Name)
+	backupEntryLogger := logger.NewFieldLogger(r.logger, "backupentry", kutil.ObjectName(backupEntry))
 	if !sets.NewString(backupEntry.Finalizers...).Has(gardencorev1beta1.GardenerName) {
 		backupEntryLogger.Debug("Do not need to do anything as the BackupEntry does not have my finalizer")
 		return reconcile.Result{}, nil

--- a/pkg/registry/core/backupentry/strategy.go
+++ b/pkg/registry/core/backupentry/strategy.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/gardener/gardener/pkg/api"
 	"github.com/gardener/gardener/pkg/apis/core"
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/apis/core/validation"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -77,14 +76,6 @@ func mustIncreaseGeneration(oldBackupEntry, newBackupEntry *core.BackupEntry) bo
 	oldPresent, _ := strconv.ParseBool(oldBackupEntry.ObjectMeta.Annotations[core.BackupEntryForceDeletion])
 	newPresent, _ := strconv.ParseBool(newBackupEntry.ObjectMeta.Annotations[core.BackupEntryForceDeletion])
 	if oldPresent != newPresent && newPresent {
-		return true
-	}
-
-	oldOperationAnnotation := oldBackupEntry.ObjectMeta.Annotations[v1beta1constants.GardenerOperation]
-	newOperationAnnotation := newBackupEntry.ObjectMeta.Annotations[v1beta1constants.GardenerOperation]
-	if (newOperationAnnotation == v1beta1constants.GardenerOperationRestore ||
-		newOperationAnnotation == v1beta1constants.GardenerOperationReconcile) &&
-		newOperationAnnotation != oldOperationAnnotation {
 		return true
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**

/area backup
/kind bug

**What this PR does / why we need it**:
Fixes a bug that caused the shoot reconciliation to fail if `gardenlet` was restarted just before removing the operation annotation from a `BackupEntry`.

**Which issue(s) this PR fixes**:
Fixes #4540

**Special notes for your reviewer**:
See the discussion in #4540 and in this PR regarding why this approach for fixing the issue was chosen over other possible approaches.

**Release note**:

```bugfix user
Fixed a bug that caused the shoot reconciliation to fail if `gardenlet` was restarted just before removing the operation annotation from a `BackupEntry`.
```
