### PR TITLE
Add infrastructure config validator

### DIFF
--- a/docs/extensions/infrastructure.md
+++ b/docs/extensions/infrastructure.md
@@ -118,7 +118,20 @@ One example for this is the [GCP infrastructure controller](https://github.com/g
 As Gardener cannot know which information is required by providers it simply mirrors the `Shoot`, `Seed`, and `CloudProfile` resources into the seed.
 They are part of the [`Cluster` extension resource](cluster.md) and can be used to extract information that is not part of the `Infrastructure` resource itself.
 
+## Implementation details
+
+### `Actuator` interface
+
+Most existing infrastructure controller implementations follow a common pattern where a generic `Reconciler` delegates to [an `Actuator` interface](../../extensions/pkg/controller/infrastructure/actuator.go) that contains the methods `Reconcile`, `Delete`, `Migrate`, and `Restore`. These methods are called by the generic `Reconciler` for the respective operations, and should be implemented by the extension according to the contract described here and the [migration guidelines](migration.md).
+
+### `ConfigValidator` interface
+
+For infrastructure controllers, the generic `Reconciler` also delegates to [a `ConfigValidator` interface](../../extensions/pkg/controller/infrastructure/configvalidator.go) that contains a single `Validate` method. This method is called by the generic `Reconciler` at the beginning of every reconciliation, and can be implemented by the extension to validate the `.spec.providerConfig` part of the `Infrastructure` resource with the respective cloud provider, typically the existence and validity of cloud provider resources such as AWS VPCs or GCP Cloud NAT IPs.
+
+The `Validate` method returns a list of errors. If this list is non-empty, the generic `Reconciler` will fail with an error. This error will have the error code `ERR_CONFIGURATION_PROBLEM`, unless there is at least one error in the list that has its `ErrorType` field set to `field.ErrorTypeInternal`.
+
 ## References and additional resources
 
 * [`Infrastructure` API (Golang specification)](../../pkg/apis/extensions/v1alpha1/types_infrastructure.go)
-* [Exemplary implementation for the Azure provider](https://github.com/gardener/gardener-extension-provider-azure/tree/master/pkg/controller/infrastructure)
+* [Sample implementation for the Azure provider](https://github.com/gardener/gardener-extension-provider-azure/tree/master/pkg/controller/infrastructure)
+* [Sample ConfigValidator implementation](https://github.com/gardener/gardener-extension-provider-aws/tree/master/pkg/controller/infrastructure/configvalidator.go)

--- a/extensions/pkg/controller/infrastructure/configvalidator.go
+++ b/extensions/pkg/controller/infrastructure/configvalidator.go
@@ -24,5 +24,8 @@ import (
 // ConfigValidator validates the provider config of infrastructures resource with the cloud provider.
 type ConfigValidator interface {
 	// Validate validates the provider config of the given infrastructure resource with the cloud provider.
+	// If the returned error list is non-empty, the reconciliation will fail with an error.
+	// This error will have the error code ERR_CONFIGURATION_PROBLEM, unless there is at least one error in the list
+	// that has its ErrorType field set to field.ErrorTypeInternal.
 	Validate(ctx context.Context, infra *extensionsv1alpha1.Infrastructure) field.ErrorList
 }

--- a/extensions/pkg/controller/infrastructure/configvalidator.go
+++ b/extensions/pkg/controller/infrastructure/configvalidator.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package infrastructure
+
+import (
+	"context"
+
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// ConfigValidator validates the provider config of infrastructures resource with the cloud provider.
+type ConfigValidator interface {
+	// Validate validates the provider config of the given infrastructure resource with the cloud provider.
+	Validate(ctx context.Context, infra *extensionsv1alpha1.Infrastructure) field.ErrorList
+}

--- a/extensions/pkg/controller/infrastructure/controller.go
+++ b/extensions/pkg/controller/infrastructure/controller.go
@@ -38,6 +38,8 @@ const (
 type AddArgs struct {
 	// Actuator is an infrastructure actuator.
 	Actuator Actuator
+	// ConfigValidator is an infrastructure config validator.
+	ConfigValidator ConfigValidator
 	// ControllerOptions are the controller options used for creating a controller.
 	// The options.Reconciler is always overridden with a reconciler created from the
 	// given actuator.
@@ -77,7 +79,7 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 // Add creates a new Infrastructure Controller and adds it to the Manager.
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager, args AddArgs) error {
-	args.ControllerOptions.Reconciler = NewReconciler(args.Actuator)
+	args.ControllerOptions.Reconciler = NewReconciler(args.Actuator, args.ConfigValidator)
 	return add(mgr, args)
 }
 


### PR DESCRIPTION
**How to categorize this PR?**

/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
Introduces `ConfigValidator` interface for infrastructure resources. If the interface is implemented by a provider extension, it will be used to validate the infrastructure config before the resources is reconciled (or restored). Validation errors will be reported as `ERR_CONFIGURATION_PROBLEM`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This is part of the solution proposed for https://github.com/gardener/gardener-extension-provider-gcp/issues/309. A corresponding PR for `provider-gcp` will follow. I plan to also use this in `provider-aws` (rework the existing VPC checks) and `provider-openstack` (checking `floatingPoolName`).

**Release note**:

```other operator
NONE
```
