### PR TITLE
Implement GetProviderType() for v1beta1.Shoot

### DIFF
--- a/pkg/apis/core/types_cloudprofile.go
+++ b/pkg/apis/core/types_cloudprofile.go
@@ -71,6 +71,7 @@ type CloudProfileSpec struct {
 	VolumeTypes []VolumeType
 }
 
+// GetProviderType gets the type of the provider.
 func (c *CloudProfile) GetProviderType() string {
 	return c.Spec.Type
 }

--- a/pkg/apis/core/types_seed.go
+++ b/pkg/apis/core/types_seed.go
@@ -81,6 +81,7 @@ type SeedSpec struct {
 	Ingress *Ingress
 }
 
+// GetProviderType gets the type of the provider.
 func (s *Seed) GetProviderType() string {
 	return s.Spec.Provider.Type
 }

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -100,6 +100,7 @@ type ShootSpec struct {
 	ExposureClassName *string
 }
 
+// GetProviderType gets the type of the provider.
 func (s *Shoot) GetProviderType() string {
 	return s.Spec.Provider.Type
 }

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -121,6 +121,11 @@ type ShootSpec struct {
 	ExposureClassName *string `json:"exposureClassName,omitempty" protobuf:"bytes,18,opt,name=exposureClassName"`
 }
 
+// GetProviderType gets the type of the provider.
+func (s *Shoot) GetProviderType() string {
+	return s.Spec.Provider.Type
+}
+
 // ShootStatus holds the most recently observed status of the Shoot cluster.
 type ShootStatus struct {
 	// Conditions represents the latest available observations of a Shoots's current state.


### PR DESCRIPTION
/area quality
/kind enhancement

The core.Object interface is mainly used in the `GardenCoreProviderType` extension predicate. Currently only the internal core.Shoot implements the core.Object interface which makes impossible to use `GardenCoreProviderType` predicate for v1beta1.Shoot.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
