### PR TITLE
Re-discover K8s version during shoot reconciliation

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_delete.go
@@ -302,7 +302,7 @@ func (c *Controller) runDeleteShootFlow(ctx context.Context, o *operation.Operat
 		})
 		initializeShootClients = g.Add(flow.Task{
 			Name:         "Initializing connection to Shoot",
-			Fn:           flow.TaskFn(botanist.InitializeShootClients).DoIf(cleanupShootResources).RetryUntilTimeout(defaultInterval, 2*time.Minute),
+			Fn:           flow.TaskFn(botanist.InitializeDesiredShootClients).DoIf(cleanupShootResources).RetryUntilTimeout(defaultInterval, 2*time.Minute),
 			Dependencies: flow.NewTaskIDs(deployCloudProviderSecret, waitUntilKubeAPIServerIsReady, deployInternalDomainDNSRecord, waitUntilControlPlaneExposureReady),
 		})
 

--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -289,7 +289,7 @@ func (c *Controller) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		})
 		initializeShootClients = g.Add(flow.Task{
 			Name:         "Initializing connection to Shoot",
-			Fn:           flow.TaskFn(botanist.InitializeShootClients).RetryUntilTimeout(defaultInterval, 2*time.Minute),
+			Fn:           flow.TaskFn(botanist.InitializeDesiredShootClients).RetryUntilTimeout(defaultInterval, 2*time.Minute),
 			Dependencies: flow.NewTaskIDs(waitUntilKubeAPIServerIsReady, waitUntilControlPlaneExposureReady, waitUntilControlPlaneExposureDeleted, deployInternalDomainDNSRecord),
 		})
 		_ = g.Add(flow.Task{

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -39,6 +39,7 @@ import (
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/version"
 
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
@@ -333,6 +334,20 @@ func (o *Operation) InitializeSeedClients(ctx context.Context) error {
 // a Kubernetes client as well as a Chart renderer for the Shoot cluster will be initialized and attached to
 // the already existing Operation object.
 func (o *Operation) InitializeShootClients(ctx context.Context) error {
+	return o.initShootClients(ctx, false)
+}
+
+// InitializeDesiredShootClients will use the Seed Kubernetes client to read the gardener Secret in the Seed
+// cluster which contains a Kubeconfig that can be used to authenticate against the Shoot cluster. With it,
+// a Kubernetes client as well as a Chart renderer for the Shoot cluster will be initialized and attached to
+// the already existing Operation object.
+// In contrast to InitializeShootClients, InitializeDesiredShootClients returns an error if the discovered version
+// via the client does not match the desired Kubernetes version from the shoot spec.
+func (o *Operation) InitializeDesiredShootClients(ctx context.Context) error {
+	return o.initShootClients(ctx, true)
+}
+
+func (o *Operation) initShootClients(ctx context.Context, versionMatchRequired bool) error {
 	if o.K8sShootClient != nil {
 		return nil
 	}
@@ -352,6 +367,22 @@ func (o *Operation) InitializeShootClients(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	if versionMatchRequired {
+		var (
+			shootClientVersion = shootClient.Version()
+			kubeVersion        = o.Shoot.GetInfo().Spec.Kubernetes.Version
+		)
+
+		ok, err := version.CompareVersions(shootClientVersion, "=", kubeVersion)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return fmt.Errorf("shoot client version %q does not match desired version %q", shootClientVersion, kubeVersion)
+		}
+	}
+
 	o.K8sShootClient = shootClient
 
 	return nil

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -343,6 +343,8 @@ func (o *Operation) InitializeShootClients(ctx context.Context) error {
 // the already existing Operation object.
 // In contrast to InitializeShootClients, InitializeDesiredShootClients returns an error if the discovered version
 // via the client does not match the desired Kubernetes version from the shoot spec.
+// This is especially useful, if the client is initialized after a rolling update of the Kube-Apiserver
+// and you want to ensure that the discovered version matches the expected version.
 func (o *Operation) InitializeDesiredShootClients(ctx context.Context) error {
 	return o.initShootClients(ctx, true)
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug

**What this PR does / why we need it**:
This PR let the client initialization check if the discovered Kubernetes version matches the one configured in the shoot reconciliation. Only if the version matches, subsequent steps can reliably use the version information stored in the client, e.g. Helm charts using `.Capabilities.KubeVersion.GitVersion` ([example](https://github.com/gardener/gardener/blob/77e09dd522d7bfb682cc35d0be437201b606061b/charts/shoot-addons/charts/nginx-ingress/templates/clusterrole.yaml#L15)).

**Special notes for your reviewer**:
During a Kubernetes version upgrade I noticed that the version information after the [InitializeShootClients step](https://github.com/gardener/gardener/blob/3e1884edffbdf061f1ed1a822b2f7e09a39c413d/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go#L292) was still set to the previous version (KAS Deployment had already been rolled). There is a short amount of time when the KAS service still points to an old and running KAS pod and thus answers with the previous version. This feature is actually desired by Kubernetes to prevent failing requests during a rolling update (see [kubernetes/kubernetes#74416](https://github.com/kubernetes/kubernetes/pull/74416)).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed which caused Gardener's internal clients to use the old Kubernetes version instead the new one after a shoot cluster upgrade had been triggered. This rarely led to situations where two reconciliations in a row were necessary to get an upgraded shoot into a healthy state.
```
