### PR TITLE
Fix empty seed when preparing shoot for migration

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control.go
@@ -223,7 +223,7 @@ func (c *Controller) reconcileShootRequest(ctx context.Context, request reconcil
 		}
 
 		sourceSeed := &gardencorev1beta1.Seed{}
-		if err := gardenClient.Client().Get(ctx, client.ObjectKey{Name: *shoot.Status.SeedName}, seed); err != nil {
+		if err := gardenClient.Client().Get(ctx, client.ObjectKey{Name: *shoot.Status.SeedName}, sourceSeed); err != nil {
 			return reconcile.Result{}, err
 		}
 


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane-migration
/kind bug

**What this PR does / why we need it**:
Fixes the control plane migration that is currently broken with the following error:
```
{"level":"info","msg":"Error syncing Shoot garden-dev/i500152-gcp: need an internal domain secret but found none","time":"2021-08-25T15:58:46+03:00"}
```

The above error is due to an empty seed being passed to the `prepareShootForMigration` function. The issue was introduced with #4510.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```other operator
NONE
```
