### PR TITLE
Fix infrastructure config validation

### DIFF
--- a/extensions/pkg/controller/infrastructure/reconciler.go
+++ b/extensions/pkg/controller/infrastructure/reconciler.go
@@ -243,8 +243,8 @@ func (r *reconciler) validateConfig(ctx context.Context, infrastructure *extensi
 	}
 
 	if allErrs := r.configValidator.Validate(ctx, infrastructure); len(allErrs) > 0 {
-		if internalErrs := allErrs.Filter(field.NewErrorTypeMatcher(field.ErrorTypeInternal)); len(internalErrs) > 0 {
-			return internalErrs.ToAggregate()
+		if filteredErrs := allErrs.Filter(field.NewErrorTypeMatcher(field.ErrorTypeInternal)); len(filteredErrs) < len(allErrs) {
+			return allErrs.ToAggregate()
 		}
 		return gardencorev1beta1helper.NewErrorWithCodes(allErrs.ToAggregate().Error(), gardencorev1beta1.ErrorConfigurationProblem)
 	}


### PR DESCRIPTION
**How to categorize this PR?**

/area ops-productivity
/kind bug

**What this PR does / why we need it**:
Fixes an issue with the error categorization of infrastructure `ConfigValidator` errors (see #4547)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```other operator
NONE
```
