### PR TITLE
Add profiling to control plane components and gardenlet

### DIFF
--- a/charts/gardener/controlplane/charts/runtime/templates/admission-controller/configmap-componentconfig.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/admission-controller/configmap-componentconfig.yaml
@@ -51,4 +51,9 @@ data:
         operationMode: {{ required ".Values.global.admission.config.server.resourceAdmissionConfiguration.operationMode is required" .Values.global.admission.config.server.resourceAdmissionConfiguration.operationMode }}
       {{- end }}
       enableDebugHandlers: {{ .Values.global.admission.config.server.enableDebugHandlers }}
+    {{- if .Values.global.admission.config.debugging }}
+    debugging:
+      enableProfiling: {{ .Values.global.admission.config.debugging.enableProfiling | default false }}
+      enableContentionProfiling: {{ .Values.global.admission.config.debugging.enableContentionProfiling | default false }}
+    {{- end }}
 {{- end }}

--- a/charts/gardener/controlplane/charts/runtime/templates/controller-manager/configmap-componentconfig.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/controller-manager/configmap-componentconfig.yaml
@@ -150,6 +150,11 @@ data:
           serverCertPath: /etc/gardener-controller-manager/srv/gardener-controller-manager.crt
           serverKeyPath: /etc/gardener-controller-manager/srv/gardener-controller-manager.key
       {{- end }}
+    {{- if .Values.global.controller.config.debugging }}
+    debugging:
+      enableProfiling: {{ .Values.global.controller.config.debugging.enableProfiling | default false }}
+      enableContentionProfiling: {{ .Values.global.controller.config.debugging.enableContentionProfiling | default false }}
+    {{- end }}
     {{- if .Values.global.controller.config.featureGates }}
     featureGates:
 {{ toYaml .Values.global.controller.config.featureGates | indent 6 }}

--- a/charts/gardener/controlplane/charts/runtime/templates/scheduler/configmap-componentconfig.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/scheduler/configmap-componentconfig.yaml
@@ -46,6 +46,11 @@ data:
       metrics:
         bindAddress: {{ required ".Values.global.scheduler.config.server.metrics.bindAddress is required" .Values.global.scheduler.config.server.metrics.bindAddress }}
         port: {{ required ".Values.global.scheduler.config.server.metrics.port is required" .Values.global.scheduler.config.server.metrics.port }}
+    {{- if .Values.global.scheduler.config.debugging }}
+    debugging:
+      enableProfiling: {{ .Values.global.scheduler.config.debugging.enableProfiling | default false }}
+      enableContentionProfiling: {{ .Values.global.scheduler.config.debugging.enableContentionProfiling | default false }}
+    {{- end }}
     {{- if .Values.global.scheduler.config.schedulers }}
     schedulers:
       {{- if .Values.global.scheduler.config.schedulers.backupBucket }}

--- a/charts/gardener/controlplane/values.yaml
+++ b/charts/gardener/controlplane/values.yaml
@@ -313,6 +313,9 @@ global:
       #     apiGroup: rbac.authorization.k8s.io
       #   operationMode: log
         enableDebugHandlers: false
+      debugging:
+        enableProfiling: false
+        enableContentionProfiling: false
     seedRestriction:
       enabled: false
 

--- a/charts/gardener/controlplane/values.yaml
+++ b/charts/gardener/controlplane/values.yaml
@@ -464,6 +464,9 @@ global:
         metrics:
           bindAddress: 0.0.0.0
           port: 19251
+      debugging:
+        enableProfiling: false
+        enableContentionProfiling: false
 #     schedulers:
 #       backupBucket:
 #         concurrentSyncs: 5

--- a/charts/gardener/controlplane/values.yaml
+++ b/charts/gardener/controlplane/values.yaml
@@ -421,6 +421,9 @@ global:
               -----BEGIN RSA PRIVATE KEY-----
               ...
               -----END RSA PRIVATE KEY-----
+      debugging:
+        enableProfiling: false
+        enableContentionProfiling: false
       featureGates: {}
 
   # Gardener scheduler configuration values

--- a/charts/gardener/gardenlet/charts/runtime/templates/configmap-componentconfig.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/configmap-componentconfig.yaml
@@ -158,6 +158,11 @@ data:
           serverCertPath: /etc/gardenlet/srv/gardenlet.crt
           serverKeyPath: /etc/gardenlet/srv/gardenlet.key
         {{- end }}
+    {{- if .Values.global.gardenlet.config.debugging }}
+    debugging:
+      enableProfiling: {{ .Values.global.gardenlet.config.debugging.enableProfiling | default false }}
+      enableContentionProfiling: {{ .Values.global.gardenlet.config.debugging.enableContentionProfiling | default false }}
+    {{- end }}
     {{- if .Values.global.gardenlet.config.featureGates }}
     featureGates:
 {{ toYaml .Values.global.gardenlet.config.featureGates | indent 6 }}

--- a/charts/gardener/gardenlet/values.yaml
+++ b/charts/gardener/gardenlet/values.yaml
@@ -132,6 +132,9 @@ global:
         #     -----BEGIN RSA PRIVATE KEY-----
         #     ...
         #     -----END RSA PRIVATE KEY-----
+      debugging:
+        enableProfiling: false
+        enableContentionProfiling: false
       featureGates: {}
       # sni: # SNI configuration used for APIServerSNI and ManagedIstio feature gates.
       #   ingress:

--- a/cmd/gardener-admission-controller/app/gardener_admission_controller.go
+++ b/cmd/gardener-admission-controller/app/gardener_admission_controller.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	goruntime "runtime"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -47,6 +48,7 @@ import (
 	seedauthorizergraph "github.com/gardener/gardener/pkg/admissioncontroller/webhooks/auth/seed/graph"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	gardenerhealthz "github.com/gardener/gardener/pkg/healthz"
+	"github.com/gardener/gardener/pkg/server/routes"
 	"github.com/gardener/gardener/pkg/utils"
 )
 
@@ -144,6 +146,15 @@ func (o *options) run(ctx context.Context) error {
 	})
 	if err != nil {
 		return err
+	}
+
+	if o.config.Debugging.EnableProfiling {
+		if err := (routes.Profiling{}).AddToManager(mgr); err != nil {
+			return fmt.Errorf("failed adding profiling handlers to manager: %w", err)
+		}
+		if o.config.Debugging.EnableContentionProfiling {
+			goruntime.SetBlockProfileRate(1)
+		}
 	}
 
 	log.Info("setting up healthcheck endpoints")

--- a/docs/README.md
+++ b/docs/README.md
@@ -143,5 +143,6 @@
 
 * [Alerting](monitoring/alerting.md)
 * [Connectivity](monitoring/connectivity.md)
-* [User Alerts](monitoring/user_alerts.md)
 * [Operator Alerts](monitoring/operator_alerts.md)
+* [Profiling Gardener Components](monitoring/profiling.md)
+* [User Alerts](monitoring/user_alerts.md)

--- a/docs/monitoring/profiling.md
+++ b/docs/monitoring/profiling.md
@@ -1,0 +1,101 @@
+# Profiling Gardener Components
+
+Similar to Kubernetes, Gardener components support profiling using [standard Go tools](https://golang.org/doc/diagnostics#profiling) for analyzing CPU and memory usage by different code sections and more.
+This document shows how to enable and use profiling handlers with Gardener components.
+
+Enabling profiling handlers and the ports on which they are exposed differs between components.
+However, once the handlers are enabled, they provide profiles via the same HTTP endpoint paths, from which you can retrieve them via `curl`/`wget` or directly using `go tool pprof`.
+(You might need to use `kubectl port-forward` in order to access HTTP endpoints of Gardener components running in clusters.)
+
+For example (gardener-controller-manager):
+```shell
+$ curl http://localhost:2718/debug/pprof/heap > /tmp/heap-controller-manager
+$ go tool pprof /tmp/heap-controller-manager
+Type: inuse_space
+Time: Sep 3, 2021 at 10:05am (CEST)
+Entering interactive mode (type "help" for commands, "o" for options)
+(pprof)
+```
+or 
+```
+$ go tool pprof http://localhost:2718/debug/pprof/heap
+Fetching profile over HTTP from http://localhost:2718/debug/pprof/heap
+Saved profile in /Users/timebertt/pprof/pprof.alloc_objects.alloc_space.inuse_objects.inuse_space.008.pb.gz
+Type: inuse_space
+Time: Sep 3, 2021 at 10:05am (CEST)
+Entering interactive mode (type "help" for commands, "o" for options)
+(pprof)
+```
+
+## gardener-apiserver
+
+gardener-apiserver provides the same flags as kube-apiserver for enabling profiling handlers (enabled by default):
+
+```
+--contention-profiling    Enable lock contention profiling, if profiling is enabled
+--profiling               Enable profiling via web interface host:port/debug/pprof/ (default true)
+```
+
+The handlers are served on the same port as the API endpoints (configured via `--secure-port`).
+This means, you will also have to authenticate against the API server according to the configured authentication and authorization policy.
+
+For example, in the [local-setup](../development/local_setup.md) you can use:
+
+```shell
+$ curl -k --cert ./hack/local-development/local-garden/certificates/certs/default-admin.crt --key ./hack/local-development/local-garden/certificates/keys/default-admin.key https://localhost:8443/debug/pprof/heap > /tmp/heap-apiserver
+$ go tool pprof /tmp/heap-apiserver
+```
+
+## gardener-controller-manager, gardenlet
+
+gardener-controller-manager and gardenlet allow enabling profiling handlers via their respective component configs (currently disabled by default):
+
+```yaml
+apiVersion: gardenlet.config.gardener.cloud/v1alpha1
+kind: GardenletConfiguration
+# ...
+server:
+  https:
+    port: 2720
+debugging:
+  enableProfiling: true
+  enableContentionProfiling: true
+```
+
+The handlers are served on the same port as configured in `server.http(s).port` via HTTP or HTTPS respectively.
+
+For example (gardenlet with HTTPS configured):
+
+```bash
+$ curl -k https://localhost:2720/debug/pprof/heap > /tmp/heap-gardenlet
+$ go tool pprof /tmp/heap-gardenlet
+```
+
+## gardener-admission-controller, gardener-scheduler
+
+gardener-admission-controller and gardener-scheduler also allow enabling profiling handlers via their respective component configs (currently disabled by default):
+
+```yaml
+apiVersion: admissioncontroller.config.gardener.cloud/v1alpha1
+kind: AdmissionControllerConfiguration
+# ...
+server:
+  metrics:
+    port: 2723
+debugging:
+  enableProfiling: true
+  enableContentionProfiling: true
+```
+
+However, the handlers are served on the same port as configured in `server.metrics.port` via HTTP.
+
+For example (gardener-admission-controller):
+
+```bash
+$ curl http://localhost:2723/debug/pprof/heap > /tmp/heap-admission-controller
+$ go tool pprof /tmp/heap-admission-controller
+```
+
+## gardener-seed-admission-controller
+
+gardener-seed-admission-controller doesn't support profiling yet. See [gardener/gardener#4567](https://github.com/gardener/gardener/issues/4567).

--- a/docs/monitoring/profiling.md
+++ b/docs/monitoring/profiling.md
@@ -8,7 +8,7 @@ However, once the handlers are enabled, they provide profiles via the same HTTP 
 (You might need to use `kubectl port-forward` in order to access HTTP endpoints of Gardener components running in clusters.)
 
 For example (gardener-controller-manager):
-```shell
+```bash
 $ curl http://localhost:2718/debug/pprof/heap > /tmp/heap-controller-manager
 $ go tool pprof /tmp/heap-controller-manager
 Type: inuse_space
@@ -17,7 +17,7 @@ Entering interactive mode (type "help" for commands, "o" for options)
 (pprof)
 ```
 or 
-```
+```bash
 $ go tool pprof http://localhost:2718/debug/pprof/heap
 Fetching profile over HTTP from http://localhost:2718/debug/pprof/heap
 Saved profile in /Users/timebertt/pprof/pprof.alloc_objects.alloc_space.inuse_objects.inuse_space.008.pb.gz
@@ -41,7 +41,7 @@ This means, you will also have to authenticate against the API server according 
 
 For example, in the [local-setup](../development/local_setup.md) you can use:
 
-```shell
+```bash
 $ curl -k --cert ./hack/local-development/local-garden/certificates/certs/default-admin.crt --key ./hack/local-development/local-garden/certificates/keys/default-admin.key https://localhost:8443/debug/pprof/heap > /tmp/heap-apiserver
 $ go tool pprof /tmp/heap-apiserver
 ```

--- a/example/20-componentconfig-gardener-admission-controller.yaml
+++ b/example/20-componentconfig-gardener-admission-controller.yaml
@@ -28,3 +28,6 @@ server:
       apiGroup: rbac.authorization.k8s.io
     operationMode: block
   enableDebugHandlers: true
+debugging:
+  enableProfiling: false
+  enableContentionProfiling: false

--- a/example/20-componentconfig-gardener-controller-manager.yaml
+++ b/example/20-componentconfig-gardener-controller-manager.yaml
@@ -73,6 +73,9 @@ server:
   http:
     bindAddress: 0.0.0.0
     port: 2718
+debugging:
+  enableProfiling: false
+  enableContentionProfiling: false
 featureGates:
   CachedRuntimeClients: true
   UseDNSRecords: true

--- a/example/20-componentconfig-gardener-scheduler.yaml
+++ b/example/20-componentconfig-gardener-scheduler.yaml
@@ -21,6 +21,9 @@ server:
   metrics:
     bindAddress: 0.0.0.0
     port: 19252
+debugging:
+  enableProfiling: false
+  enableContentionProfiling: false
 #schedulers:
 #  backupBucket:
 #    concurrentSyncs: 5 # defaults to 5

--- a/example/20-componentconfig-gardenlet.yaml
+++ b/example/20-componentconfig-gardenlet.yaml
@@ -88,6 +88,9 @@ server:
   # tls:
   #   serverCertPath: dev/tls/gardenlet.crt
   #   serverKeyPath: dev/tls/gardenlet.key
+debugging:
+  enableProfiling: false
+  enableContentionProfiling: false
 featureGates:
   Logging: true
   HVPA: true

--- a/landscaper/pkg/gardenlet/chart/charttest/charttest.go
+++ b/landscaper/pkg/gardenlet/chart/charttest/charttest.go
@@ -755,6 +755,10 @@ func ComputeExpectedGardenletConfiguration(
 				Port:        2720,
 			},
 		}},
+		Debugging: baseconfigv1alpha1.DebuggingConfiguration{
+			EnableProfiling:           pointer.Bool(false),
+			EnableContentionProfiling: pointer.Bool(false),
+		},
 		FeatureGates: featureGates,
 		Resources: &gardenletconfigv1alpha1.ResourcesConfiguration{
 			Capacity: corev1.ResourceList{

--- a/pkg/admissioncontroller/apis/config/types.go
+++ b/pkg/admissioncontroller/apis/config/types.go
@@ -33,6 +33,8 @@ type AdmissionControllerConfiguration struct {
 	LogLevel string
 	// Server defines the configuration of the HTTP server.
 	Server ServerConfiguration
+	// Debugging holds configuration for Debugging related features.
+	Debugging componentbaseconfig.DebuggingConfiguration
 }
 
 // ServerConfiguration contains details for the HTTP(S) servers.

--- a/pkg/admissioncontroller/apis/config/v1alpha1/types.go
+++ b/pkg/admissioncontroller/apis/config/v1alpha1/types.go
@@ -33,6 +33,8 @@ type AdmissionControllerConfiguration struct {
 	LogLevel string `json:"logLevel"`
 	// Server defines the configuration of the HTTP server.
 	Server ServerConfiguration `json:"server"`
+	// Debugging holds configuration for Debugging related features.
+	Debugging componentbaseconfigv1alpha1.DebuggingConfiguration `json:"debugging"`
 }
 
 // ServerConfiguration contains details for the HTTP(S) servers.

--- a/pkg/admissioncontroller/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/admissioncontroller/apis/config/v1alpha1/zz_generated.conversion.go
@@ -118,6 +118,9 @@ func autoConvert_v1alpha1_AdmissionControllerConfiguration_To_config_AdmissionCo
 	if err := Convert_v1alpha1_ServerConfiguration_To_config_ServerConfiguration(&in.Server, &out.Server, s); err != nil {
 		return err
 	}
+	if err := configv1alpha1.Convert_v1alpha1_DebuggingConfiguration_To_config_DebuggingConfiguration(&in.Debugging, &out.Debugging, s); err != nil {
+		return err
+	}
 	return nil
 }
 
@@ -132,6 +135,9 @@ func autoConvert_config_AdmissionControllerConfiguration_To_v1alpha1_AdmissionCo
 	}
 	out.LogLevel = in.LogLevel
 	if err := Convert_config_ServerConfiguration_To_v1alpha1_ServerConfiguration(&in.Server, &out.Server, s); err != nil {
+		return err
+	}
+	if err := configv1alpha1.Convert_config_DebuggingConfiguration_To_v1alpha1_DebuggingConfiguration(&in.Debugging, &out.Debugging, s); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/admissioncontroller/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/admissioncontroller/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -31,6 +31,7 @@ func (in *AdmissionControllerConfiguration) DeepCopyInto(out *AdmissionControlle
 	out.TypeMeta = in.TypeMeta
 	out.GardenClientConnection = in.GardenClientConnection
 	in.Server.DeepCopyInto(&out.Server)
+	in.Debugging.DeepCopyInto(&out.Debugging)
 	return
 }
 

--- a/pkg/admissioncontroller/apis/config/zz_generated.deepcopy.go
+++ b/pkg/admissioncontroller/apis/config/zz_generated.deepcopy.go
@@ -31,6 +31,7 @@ func (in *AdmissionControllerConfiguration) DeepCopyInto(out *AdmissionControlle
 	out.TypeMeta = in.TypeMeta
 	out.GardenClientConnection = in.GardenClientConnection
 	in.Server.DeepCopyInto(&out.Server)
+	out.Debugging = in.Debugging
 	return
 }
 

--- a/pkg/controllermanager/apis/config/types.go
+++ b/pkg/controllermanager/apis/config/types.go
@@ -41,6 +41,8 @@ type ControllerManagerConfiguration struct {
 	KubernetesLogLevel klog.Level
 	// Server defines the configuration of the HTTP server.
 	Server ServerConfiguration
+	// Debugging holds configuration for Debugging related features.
+	Debugging componentbaseconfig.DebuggingConfiguration
 	// FeatureGates is a map of feature names to bools that enable or disable alpha/experimental
 	// features. This field modifies piecemeal the built-in default values from
 	// "github.com/gardener/gardener/pkg/controllermanager/features/features.go".

--- a/pkg/controllermanager/apis/config/v1alpha1/types.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/types.go
@@ -43,6 +43,8 @@ type ControllerManagerConfiguration struct {
 	KubernetesLogLevel klog.Level `json:"kubernetesLogLevel"`
 	// Server defines the configuration of the HTTP server.
 	Server ServerConfiguration `json:"server"`
+	// Debugging holds configuration for Debugging related features.
+	Debugging componentbaseconfigv1alpha1.DebuggingConfiguration `json:"debugging"`
 	// FeatureGates is a map of feature names to bools that enable or disable alpha/experimental
 	// features. This field modifies piecemeal the built-in default values from
 	// "github.com/gardener/gardener/pkg/controllermanager/features/features.go".

--- a/pkg/controllermanager/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/zz_generated.conversion.go
@@ -369,6 +369,9 @@ func autoConvert_v1alpha1_ControllerManagerConfiguration_To_config_ControllerMan
 	if err := Convert_v1alpha1_ServerConfiguration_To_config_ServerConfiguration(&in.Server, &out.Server, s); err != nil {
 		return err
 	}
+	if err := configv1alpha1.Convert_v1alpha1_DebuggingConfiguration_To_config_DebuggingConfiguration(&in.Debugging, &out.Debugging, s); err != nil {
+		return err
+	}
 	out.FeatureGates = *(*map[string]bool)(unsafe.Pointer(&in.FeatureGates))
 	return nil
 }
@@ -392,6 +395,9 @@ func autoConvert_config_ControllerManagerConfiguration_To_v1alpha1_ControllerMan
 	out.LogFormat = in.LogFormat
 	out.KubernetesLogLevel = klog.Level(in.KubernetesLogLevel)
 	if err := Convert_config_ServerConfiguration_To_v1alpha1_ServerConfiguration(&in.Server, &out.Server, s); err != nil {
+		return err
+	}
+	if err := configv1alpha1.Convert_config_DebuggingConfiguration_To_v1alpha1_DebuggingConfiguration(&in.Debugging, &out.Debugging, s); err != nil {
 		return err
 	}
 	out.FeatureGates = *(*map[string]bool)(unsafe.Pointer(&in.FeatureGates))

--- a/pkg/controllermanager/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -86,6 +86,7 @@ func (in *ControllerManagerConfiguration) DeepCopyInto(out *ControllerManagerCon
 	in.Controllers.DeepCopyInto(&out.Controllers)
 	in.LeaderElection.DeepCopyInto(&out.LeaderElection)
 	out.Server = in.Server
+	in.Debugging.DeepCopyInto(&out.Debugging)
 	if in.FeatureGates != nil {
 		in, out := &in.FeatureGates, &out.FeatureGates
 		*out = make(map[string]bool, len(*in))

--- a/pkg/controllermanager/apis/config/zz_generated.deepcopy.go
+++ b/pkg/controllermanager/apis/config/zz_generated.deepcopy.go
@@ -86,6 +86,7 @@ func (in *ControllerManagerConfiguration) DeepCopyInto(out *ControllerManagerCon
 	in.Controllers.DeepCopyInto(&out.Controllers)
 	out.LeaderElection = in.LeaderElection
 	out.Server = in.Server
+	out.Debugging = in.Debugging
 	if in.FeatureGates != nil {
 		in, out := &in.FeatureGates, &out.FeatureGates
 		*out = make(map[string]bool, len(*in))

--- a/pkg/gardenlet/apis/config/helper/helpers_test.go
+++ b/pkg/gardenlet/apis/config/helper/helpers_test.go
@@ -25,6 +25,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
+	"k8s.io/utils/pointer"
 )
 
 var _ = Describe("helper", func() {
@@ -94,6 +96,10 @@ var _ = Describe("helper", func() {
 				TypeMeta: metav1.TypeMeta{
 					APIVersion: configv1alpha1.SchemeGroupVersion.String(),
 					Kind:       "GardenletConfiguration",
+				},
+				Debugging: componentbaseconfigv1alpha1.DebuggingConfiguration{
+					EnableProfiling:           pointer.Bool(false),
+					EnableContentionProfiling: pointer.Bool(false),
 				},
 			}))
 		})

--- a/pkg/gardenlet/apis/config/types.go
+++ b/pkg/gardenlet/apis/config/types.go
@@ -52,6 +52,8 @@ type GardenletConfiguration struct {
 	KubernetesLogLevel *klog.Level
 	// Server defines the configuration of the HTTP server.
 	Server *ServerConfiguration
+	// Debugging holds configuration for Debugging related features.
+	Debugging componentbaseconfig.DebuggingConfiguration
 	// FeatureGates is a map of feature names to bools that enable or disable alpha/experimental
 	// features. This field modifies piecemeal the built-in default values from
 	// "github.com/gardener/gardener/pkg/gardenlet/features/features.go".

--- a/pkg/gardenlet/apis/config/v1alpha1/defaults.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/defaults.go
@@ -117,6 +117,8 @@ func SetDefaults_GardenletConfiguration(obj *GardenletConfiguration) {
 		obj.Server.HTTPS.Port = 2720
 	}
 
+	// TODO: consider enabling profiling by default (like in k8s components)
+
 	if obj.SNI == nil {
 		obj.SNI = &SNI{}
 	}

--- a/pkg/gardenlet/apis/config/v1alpha1/types.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/types.go
@@ -63,6 +63,8 @@ type GardenletConfiguration struct {
 	// Server defines the configuration of the HTTP server.
 	// +optional
 	Server *ServerConfiguration `json:"server,omitempty"`
+	// Debugging holds configuration for Debugging related features.
+	Debugging componentbaseconfigv1alpha1.DebuggingConfiguration `json:"debugging"`
 	// FeatureGates is a map of feature names to bools that enable or disable alpha/experimental
 	// features. This field modifies piecemeal the built-in default values from
 	// "github.com/gardener/gardener/pkg/gardenlet/features/features.go".

--- a/pkg/gardenlet/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/zz_generated.conversion.go
@@ -711,6 +711,9 @@ func autoConvert_v1alpha1_GardenletConfiguration_To_config_GardenletConfiguratio
 	out.LogFormat = (*string)(unsafe.Pointer(in.LogFormat))
 	out.KubernetesLogLevel = (*klog.Level)(unsafe.Pointer(in.KubernetesLogLevel))
 	out.Server = (*config.ServerConfiguration)(unsafe.Pointer(in.Server))
+	if err := configv1alpha1.Convert_v1alpha1_DebuggingConfiguration_To_config_DebuggingConfiguration(&in.Debugging, &out.Debugging, s); err != nil {
+		return err
+	}
 	out.FeatureGates = *(*map[string]bool)(unsafe.Pointer(&in.FeatureGates))
 	if in.SeedConfig != nil {
 		in, out := &in.SeedConfig, &out.SeedConfig
@@ -783,6 +786,9 @@ func autoConvert_config_GardenletConfiguration_To_v1alpha1_GardenletConfiguratio
 	out.LogFormat = (*string)(unsafe.Pointer(in.LogFormat))
 	out.KubernetesLogLevel = (*klog.Level)(unsafe.Pointer(in.KubernetesLogLevel))
 	out.Server = (*ServerConfiguration)(unsafe.Pointer(in.Server))
+	if err := configv1alpha1.Convert_config_DebuggingConfiguration_To_v1alpha1_DebuggingConfiguration(&in.Debugging, &out.Debugging, s); err != nil {
+		return err
+	}
 	out.FeatureGates = *(*map[string]bool)(unsafe.Pointer(&in.FeatureGates))
 	if in.SeedConfig != nil {
 		in, out := &in.SeedConfig, &out.SeedConfig

--- a/pkg/gardenlet/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -351,6 +351,7 @@ func (in *GardenletConfiguration) DeepCopyInto(out *GardenletConfiguration) {
 		*out = new(ServerConfiguration)
 		(*in).DeepCopyInto(*out)
 	}
+	in.Debugging.DeepCopyInto(&out.Debugging)
 	if in.FeatureGates != nil {
 		in, out := &in.FeatureGates, &out.FeatureGates
 		*out = make(map[string]bool, len(*in))

--- a/pkg/gardenlet/apis/config/zz_generated.deepcopy.go
+++ b/pkg/gardenlet/apis/config/zz_generated.deepcopy.go
@@ -351,6 +351,7 @@ func (in *GardenletConfiguration) DeepCopyInto(out *GardenletConfiguration) {
 		*out = new(ServerConfiguration)
 		(*in).DeepCopyInto(*out)
 	}
+	out.Debugging = in.Debugging
 	if in.FeatureGates != nil {
 		in, out := &in.FeatureGates, &out.FeatureGates
 		*out = make(map[string]bool, len(*in))

--- a/pkg/gardenlet/controller/managedseed/managedseed_valueshelper_test.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_valueshelper_test.go
@@ -109,6 +109,10 @@ var _ = Describe("ValuesHelper", func() {
 					},
 				},
 			},
+			Debugging: componentbaseconfig.DebuggingConfiguration{
+				EnableProfiling:           false,
+				EnableContentionProfiling: false,
+			},
 			FeatureGates: map[string]bool{
 				string(features.Logging): true,
 				string(features.HVPA):    true,
@@ -228,6 +232,10 @@ var _ = Describe("ValuesHelper", func() {
 						},
 					},
 				},
+				Debugging: componentbaseconfigv1alpha1.DebuggingConfiguration{
+					EnableProfiling:           pointer.Bool(false),
+					EnableContentionProfiling: pointer.Bool(false),
+				},
 				FeatureGates: map[string]bool{
 					string(features.Logging):              false,
 					string(features.HVPA):                 true,
@@ -284,6 +292,10 @@ var _ = Describe("ValuesHelper", func() {
 									"bindAddress": "0.0.0.0",
 									"port":        float64(2720),
 								},
+							},
+							"debugging": map[string]interface{}{
+								"enableProfiling":           false,
+								"enableContentionProfiling": false,
 							},
 							"featureGates": map[string]interface{}{
 								"Logging":              false,

--- a/pkg/scheduler/apis/config/types.go
+++ b/pkg/scheduler/apis/config/types.go
@@ -64,6 +64,8 @@ type SchedulerConfiguration struct {
 	// Server defines the configuration of the HTTP server. This is deprecated in favor of
 	// HealthServer.
 	Server ServerConfiguration
+	// Debugging holds configuration for Debugging related features.
+	Debugging componentbaseconfig.DebuggingConfiguration
 	// Scheduler defines the configuration of the schedulers.
 	Schedulers SchedulerControllerConfiguration
 	// FeatureGates is a map of feature names to bools that enable or disable alpha/experimental

--- a/pkg/scheduler/apis/config/v1alpha1/types.go
+++ b/pkg/scheduler/apis/config/v1alpha1/types.go
@@ -63,6 +63,8 @@ type SchedulerConfiguration struct {
 	// Server defines the configuration of the HTTP server. This is deprecated in favor of
 	// HealthServer.
 	Server ServerConfiguration `json:"server,omitempty"`
+	// Debugging holds configuration for Debugging related features.
+	Debugging componentbaseconfigv1alpha1.DebuggingConfiguration `json:"debugging"`
 	// Scheduler defines the configuration of the schedulers.
 	Schedulers SchedulerControllerConfiguration `json:"schedulers"`
 	// FeatureGates is a map of feature names to bools that enable or disable alpha/experimental

--- a/pkg/scheduler/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/scheduler/apis/config/v1alpha1/zz_generated.conversion.go
@@ -131,6 +131,9 @@ func autoConvert_v1alpha1_SchedulerConfiguration_To_config_SchedulerConfiguratio
 	if err := Convert_v1alpha1_ServerConfiguration_To_config_ServerConfiguration(&in.Server, &out.Server, s); err != nil {
 		return err
 	}
+	if err := configv1alpha1.Convert_v1alpha1_DebuggingConfiguration_To_config_DebuggingConfiguration(&in.Debugging, &out.Debugging, s); err != nil {
+		return err
+	}
 	if err := Convert_v1alpha1_SchedulerControllerConfiguration_To_config_SchedulerControllerConfiguration(&in.Schedulers, &out.Schedulers, s); err != nil {
 		return err
 	}
@@ -153,6 +156,9 @@ func autoConvert_config_SchedulerConfiguration_To_v1alpha1_SchedulerConfiguratio
 	out.LogLevel = in.LogLevel
 	out.LogFormat = in.LogFormat
 	if err := Convert_config_ServerConfiguration_To_v1alpha1_ServerConfiguration(&in.Server, &out.Server, s); err != nil {
+		return err
+	}
+	if err := configv1alpha1.Convert_config_DebuggingConfiguration_To_v1alpha1_DebuggingConfiguration(&in.Debugging, &out.Debugging, s); err != nil {
 		return err
 	}
 	if err := Convert_config_SchedulerControllerConfiguration_To_v1alpha1_SchedulerControllerConfiguration(&in.Schedulers, &out.Schedulers, s); err != nil {

--- a/pkg/scheduler/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/scheduler/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -47,6 +47,7 @@ func (in *SchedulerConfiguration) DeepCopyInto(out *SchedulerConfiguration) {
 	out.ClientConnection = in.ClientConnection
 	in.LeaderElection.DeepCopyInto(&out.LeaderElection)
 	in.Server.DeepCopyInto(&out.Server)
+	in.Debugging.DeepCopyInto(&out.Debugging)
 	in.Schedulers.DeepCopyInto(&out.Schedulers)
 	if in.FeatureGates != nil {
 		in, out := &in.FeatureGates, &out.FeatureGates

--- a/pkg/scheduler/apis/config/zz_generated.deepcopy.go
+++ b/pkg/scheduler/apis/config/zz_generated.deepcopy.go
@@ -64,6 +64,7 @@ func (in *SchedulerConfiguration) DeepCopyInto(out *SchedulerConfiguration) {
 	out.ClientConnection = in.ClientConnection
 	out.LeaderElection = in.LeaderElection
 	in.Server.DeepCopyInto(&out.Server)
+	out.Debugging = in.Debugging
 	in.Schedulers.DeepCopyInto(&out.Schedulers)
 	if in.FeatureGates != nil {
 		in, out := &in.FeatureGates, &out.FeatureGates

--- a/pkg/server/routes/profiling.go
+++ b/pkg/server/routes/profiling.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package routes
+
+import (
+	"net/http"
+	"net/http/pprof"
+
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/gardener/gardener/pkg/server"
+)
+
+var (
+	profilingHandlers = map[string]http.HandlerFunc{
+		"/debug/pprof":         redirectTo("/debug/pprof/"),
+		"/debug/pprof/":        pprof.Index,
+		"/debug/pprof/profile": pprof.Profile,
+		"/debug/pprof/symbol":  pprof.Symbol,
+		"/debug/pprof/trace":   pprof.Trace,
+	}
+)
+
+// Profiling adds handlers for pprof under /debug/pprof.
+// This is similar to routes.Profiling from the API server library (uses the same paths).
+// But instead of adding handlers to a mux.PathRecorderMux, it allows adding it to a server.Builder or manager.Manager.
+type Profiling struct{}
+
+// AddToBuilder adds the profiling handlers to the given Builder.
+func (Profiling) AddToBuilder(builder *server.Builder) {
+	for path, handler := range profilingHandlers {
+		builder.WithHandler(path, handler)
+	}
+}
+
+// AddToManager adds the profiling handlers to the given Manager.
+func (Profiling) AddToManager(mgr manager.Manager) error {
+	for path, handler := range profilingHandlers {
+		if err := mgr.AddMetricsExtraHandler(path, handler); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// redirectTo redirects request to a certain destination.
+func redirectTo(to string) func(http.ResponseWriter, *http.Request) {
+	return func(rw http.ResponseWriter, req *http.Request) {
+		http.Redirect(rw, req, to, http.StatusFound)
+	}
+}

--- a/plugin/pkg/managedseed/validator/admission_test.go
+++ b/plugin/pkg/managedseed/validator/admission_test.go
@@ -43,6 +43,7 @@ import (
 	"k8s.io/apiserver/pkg/admission"
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/testing"
+	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"k8s.io/utils/pointer"
 )
 
@@ -456,6 +457,10 @@ var _ = Describe("ManagedSeed", func() {
 						TypeMeta: metav1.TypeMeta{
 							APIVersion: configv1alpha1.SchemeGroupVersion.String(),
 							Kind:       "GardenletConfiguration",
+						},
+						Debugging: componentbaseconfigv1alpha1.DebuggingConfiguration{
+							EnableProfiling:           pointer.Bool(false),
+							EnableContentionProfiling: pointer.Bool(false),
 						},
 						SeedConfig: &configv1alpha1.SeedConfig{
 							SeedTemplate: gardencorev1beta1.SeedTemplate{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity ops-productivity
/kind enhancement

**What this PR does / why we need it**:

Adds profiling options and handlers (disabled by default) to gardener-admission-controller, gardener-controller-manager, gardener-scheduler and gardenlet like described in https://github.com/gardener/gardener/issues/4567.
It also adds a document on how to enable and use them.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/4567

**Special notes for your reviewer**:

✅ In draft, because I want to give this a test spin in our dev environment first.
✅ If this looks good and you like the approach, I can continue the work and add profiling options and handlers to the other components as well.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Gardener components now support enabling profiling handlers. See this [document](https://github.com/gardener/gardener/blob/master/docs/monitoring/profiling.md) for more details.
```
