### PR TITLE
Deflake some more time-sensitive unit tests

### DIFF
--- a/cmd/gardenlet/app/gardenlet.go
+++ b/cmd/gardenlet/app/gardenlet.go
@@ -63,6 +63,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/util/clock"
 	kubernetesclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/record"
@@ -415,7 +416,7 @@ func (g *Gardenlet) Run(ctx context.Context) error {
 	defer controllerCancel()
 
 	// Initialize /healthz manager.
-	g.HealthManager = healthz.NewPeriodicHealthz(seedcontroller.LeaseResyncGracePeriodSeconds * time.Second)
+	g.HealthManager = healthz.NewPeriodicHealthz(clock.RealClock{}, seedcontroller.LeaseResyncGracePeriodSeconds*time.Second)
 
 	if g.CertificateManager != nil {
 		g.CertificateManager.ScheduleCertificateRotation(controllerCtx, controllerCancel, g.Recorder)

--- a/pkg/gardenlet/controller/shoot/shoot.go
+++ b/pkg/gardenlet/controller/shoot/shoot.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
@@ -254,7 +255,7 @@ func (c *Controller) getShootQueue(obj interface{}) workqueue.RateLimitingInterf
 
 func (c *Controller) newProgressReporter(reporterFn flow.ProgressReporterFn) flow.ProgressReporter {
 	if c.config.Controllers.Shoot != nil && c.config.Controllers.Shoot.ProgressReportPeriod != nil {
-		return flow.NewDelayingProgressReporter(reporterFn, c.config.Controllers.Shoot.ProgressReportPeriod.Duration)
+		return flow.NewDelayingProgressReporter(clock.RealClock{}, reporterFn, c.config.Controllers.Shoot.ProgressReportPeriod.Duration)
 	}
 	return flow.NewImmediateProgressReporter(reporterFn)
 }

--- a/test/integration/envtest/seedadmissioncontroller/extensioncrds_test.go
+++ b/test/integration/envtest/seedadmissioncontroller/extensioncrds_test.go
@@ -101,7 +101,7 @@ var _ = Describe("Extension CRDs Webhook Handler", func() {
 				}
 			}
 			return true
-		}, 1*time.Second, 50*time.Millisecond).Should(BeTrue())
+		}, 5*time.Second, 200*time.Millisecond).Should(BeTrue())
 	})
 
 	objectID := func(obj client.Object) string {
@@ -112,17 +112,17 @@ var _ = Describe("Extension CRDs Webhook Handler", func() {
 		Eventually(func() string {
 			err := c.Delete(ctx, obj)
 			return string(apierrors.ReasonForError(err))
-		}, 1*time.Second, 50*time.Millisecond).Should(ContainSubstring("annotation to delete"), objectID(obj))
+		}, 5*time.Second, 200*time.Millisecond).Should(ContainSubstring("annotation to delete"), objectID(obj))
 	}
 
 	testDeletionConfirmed := func(ctx context.Context, obj client.Object) {
 		Eventually(func() error {
 			return c.Delete(ctx, obj)
-		}, 1*time.Second, 50*time.Millisecond).ShouldNot(HaveOccurred(), objectID(obj))
+		}, 5*time.Second, 200*time.Millisecond).ShouldNot(HaveOccurred(), objectID(obj))
 		Eventually(func() bool {
 			err := c.Get(ctx, client.ObjectKeyFromObject(obj), obj)
 			return apierrors.IsNotFound(err) || meta.IsNoMatchError(err)
-		}, 1*time.Second, 50*time.Millisecond).Should(BeTrue(), objectID(obj))
+		}, 5*time.Second, 200*time.Millisecond).Should(BeTrue(), objectID(obj))
 	}
 
 	Context("extension resources", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind flake

**What this PR does / why we need it**:

Deflake some more time-sensitive unit tests by switching to `clock.FakeClock` and `retryfake.Ops`.

**Which issue(s) this PR fixes**:
Fixes https://concourse.ci.gardener.cloud/teams/gardener/pipelines/gardener-master/jobs/master-head-update-job/builds/5#L61286a1d:449
Fixes https://concourse.ci.gardener.cloud/teams/gardener/pipelines/gardener-master/jobs/master-head-update-job/builds/1#L612795f5:435
Fixes https://concourse.ci-2.gardener.cloud/teams/gardener/pipelines/gardener-master/jobs/master-head-update-job/builds/550#L6116ddb8:530
Hopefully fixes https://concourse.ci-2.gardener.cloud/teams/gardener/pipelines/gardener-master/jobs/master-head-update-job/builds/515#L6108d528:578

Before:
```
$ stress -p 128 ./pkg/healthz/healthz.test | grep 'runs so far'
...
10644 runs so far, 7 failures

$ stress -p 32 ./pkg/extensions/extensions.test | grep 'runs so far'
...
2016 runs so far, 6 failures

$ stress -p 256 ./pkg/utils/flow/flow.test -ginkgo.focus="ProgressReporterDelaying" | grep 'runs so far'
...
6037 runs so far, 9 failures
```

After:
```
$ stress -p 128 ./pkg/healthz/healthz.test | grep 'runs so far'
...
10790 runs so far, 0 failures

$ stress -p 32 ./pkg/extensions/extensions.test | grep 'runs so far'
...
2044 runs so far, 0 failures

$ stress -p 256 ./pkg/utils/flow/flow.test -ginkgo.focus="ProgressReporterDelaying" | grep 'runs so far'
...
6453 runs so far, 0 failures
```