### PR TITLE
Adapt deprecated label key usage in NetworkPolicies related to several components

### DIFF
--- a/charts/seed-bootstrap/charts/loki/templates/allow-prometheus-to-loki-telegraf.yaml
+++ b/charts/seed-bootstrap/charts/loki/templates/allow-prometheus-to-loki-telegraf.yaml
@@ -16,7 +16,7 @@ spec:
     - podSelector:
         matchLabels:
           app: prometheus
-          garden.sapcloud.io/role: monitoring
+          gardener.cloud/role: monitoring
           role: monitoring
     ports:
     - port: telegraf

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/networkpolicy.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/networkpolicy.yaml
@@ -12,7 +12,7 @@ spec:
   podSelector:
     matchLabels:
       app: kubernetes
-      garden.sapcloud.io/role: controlplane
+      gardener.cloud/role: controlplane
       role: apiserver
   egress:
   - to:

--- a/charts/seed-monitoring/charts/alertmanager/templates/allow-alertmanager-network-policy.yaml
+++ b/charts/seed-monitoring/charts/alertmanager/templates/allow-alertmanager-network-policy.yaml
@@ -10,7 +10,7 @@ spec:
   podSelector:
     matchLabels:
       component: alertmanager
-      garden.sapcloud.io/role: monitoring
+      gardener.cloud/role: monitoring
       role: monitoring
   ingress:
   - from:

--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/allow-from-prometheus-network-policy.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/allow-from-prometheus-network-policy.yaml
@@ -16,7 +16,7 @@ spec:
     - podSelector:
         matchLabels:
           app: prometheus
-          garden.sapcloud.io/role: monitoring
+          gardener.cloud/role: monitoring
           role: monitoring
     ports:
     - port: metrics

--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/allow-prometheus-network-policy.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/allow-prometheus-network-policy.yaml
@@ -10,7 +10,7 @@ spec:
   podSelector:
     matchLabels:
       app: prometheus
-      garden.sapcloud.io/role: monitoring
+      gardener.cloud/role: monitoring
       role: monitoring
   egress:
   - to:

--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/allow-prometheus-network-policy.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/allow-prometheus-network-policy.yaml
@@ -67,7 +67,7 @@ spec:
     - podSelector:
         matchLabels:
           component: grafana
-          garden.sapcloud.io/role: monitoring
+          gardener.cloud/role: monitoring
     - podSelector:
         matchLabels:
           app: nginx-ingress

--- a/charts/seed-monitoring/charts/grafana/templates/grafana-network-policy.yaml
+++ b/charts/seed-monitoring/charts/grafana/templates/grafana-network-policy.yaml
@@ -10,7 +10,7 @@ spec:
   podSelector:
     matchLabels:
       component: grafana
-      garden.sapcloud.io/role: monitoring
+      gardener.cloud/role: monitoring
   egress:
   - to:
     - podSelector:

--- a/charts/seed-monitoring/charts/grafana/templates/grafana-network-policy.yaml
+++ b/charts/seed-monitoring/charts/grafana/templates/grafana-network-policy.yaml
@@ -16,7 +16,7 @@ spec:
     - podSelector:
         matchLabels:
           app: prometheus
-          garden.sapcloud.io/role: monitoring
+          gardener.cloud/role: monitoring
           role: monitoring
     ports:
     - protocol: TCP

--- a/docs/development/seed_network_policies.md
+++ b/docs/development/seed_network_policies.md
@@ -68,7 +68,7 @@ These are the logging and monitoring related network policies:
 ```
 NAME                              POD-SELECTOR                                                             
 allow-from-prometheus             networking.gardener.cloud/from-prometheus=allowed
-allow-grafana                     component=grafana,garden.sapcloud.io/role=monitoring
+allow-grafana                     component=grafana,gardener.cloud/role=monitoring
 allow-prometheus                  app=prometheus,gardener.cloud/role=monitoring,role=monitoring
 allow-to-aggregate-prometheus     networking.gardener.cloud/to-aggregate-prometheus=allowed
 allow-to-loki                     networking.gardener.cloud/to-loki=allowed

--- a/docs/development/seed_network_policies.md
+++ b/docs/development/seed_network_policies.md
@@ -39,23 +39,23 @@ These policies are the same for every Shoot control plane.
 ```
 NAME                              POD-SELECTOR      
 # Pods that need to access the Shoot API server. Used by all Kubernetes control plane components.
-allow-to-shoot-apiserver          networking.gardener.cloud/to-shoot-apiserver=allowed 
+allow-to-shoot-apiserver          networking.gardener.cloud/to-shoot-apiserver=allowed
 
 # allows access to kube-dns/core-dns pods for DNS queries                       
 allow-to-dns                      networking.gardener.cloud/to-dns=allowed
 
 # allows access to private IP address ranges 
-allow-to-private-networks         networking.gardener.cloud/to-private-networks=allowed  
+allow-to-private-networks         networking.gardener.cloud/to-private-networks=allowed
 
 # allows access to all but private IP address ranges 
-allow-to-public-networks          networking.gardener.cloud/to-public-networks=allowed                     
+allow-to-public-networks          networking.gardener.cloud/to-public-networks=allowed
 
 # allows Ingress to etcd pods from the Shoot's Kubernetes API Server
-allow-etcd                        app=etcd-statefulset,garden.sapcloud.io/role=controlplane   
+allow-etcd                        app=etcd-statefulset,garden.sapcloud.io/role=controlplane
 
 # used by the Shoot API server to allows ingress from pods labeled
 # with'networking.gardener.cloud/to-shoot-apiserver=allowed', from Prometheus, and allows Egress to etcd pods
-allow-kube-apiserver              app=kubernetes,garden.sapcloud.io/role=controlplane,role=apiserver       
+allow-kube-apiserver              app=kubernetes,gardener.cloud/role=controlplane,role=apiserver
 ```
 
 

--- a/docs/development/seed_network_policies.md
+++ b/docs/development/seed_network_policies.md
@@ -67,11 +67,11 @@ Please checkout [the Community Meeting for more information](https://www.youtube
 These are the logging and monitoring related network policies:
 ```
 NAME                              POD-SELECTOR                                                             
-allow-from-prometheus             networking.gardener.cloud/from-prometheus=allowed                        
-allow-grafana                     component=grafana,garden.sapcloud.io/role=monitoring                     
-allow-prometheus                  app=prometheus,garden.sapcloud.io/role=monitoring,role=monitoring        
+allow-from-prometheus             networking.gardener.cloud/from-prometheus=allowed
+allow-grafana                     component=grafana,garden.sapcloud.io/role=monitoring
+allow-prometheus                  app=prometheus,gardener.cloud/role=monitoring,role=monitoring
 allow-to-aggregate-prometheus     networking.gardener.cloud/to-aggregate-prometheus=allowed
-allow-to-loki                     networking.gardener.cloud/to-loki=allowed 
+allow-to-loki                     networking.gardener.cloud/to-loki=allowed
 ```
 
 Let's take for instance a look at the network policy `from-prometheus`.

--- a/extensions/test/e2e/framework/networkpolicies/agnostic.go
+++ b/extensions/test/e2e/framework/networkpolicies/agnostic.go
@@ -52,9 +52,9 @@ func (a *Agnostic) KubeControllerManagerSecured() *SourcePod {
 	return &SourcePod{
 		Ports: NewSinglePort(10257),
 		Pod: NewPod("kube-controller-manager-https", labels.Set{
-			v1beta1constants.LabelApp:             v1beta1constants.LabelKubernetes,
-			v1beta1constants.DeprecatedGardenRole: v1beta1constants.GardenRoleControlPlane,
-			v1beta1constants.LabelRole:            kubecontrollermanager.LabelRole,
+			v1beta1constants.LabelApp:   v1beta1constants.LabelKubernetes,
+			v1beta1constants.GardenRole: v1beta1constants.GardenRoleControlPlane,
+			v1beta1constants.LabelRole:  kubecontrollermanager.LabelRole,
 		}),
 		ExpectedPolicies: sets.NewString(
 			"allow-to-public-networks",
@@ -73,9 +73,9 @@ func (a *Agnostic) KubeSchedulerSecured() *SourcePod {
 	return &SourcePod{
 		Ports: NewSinglePort(10259),
 		Pod: NewPod("kube-scheduler-https", labels.Set{
-			v1beta1constants.LabelApp:             v1beta1constants.LabelKubernetes,
-			v1beta1constants.DeprecatedGardenRole: v1beta1constants.GardenRoleControlPlane,
-			v1beta1constants.LabelRole:            kubescheduler.LabelRole,
+			v1beta1constants.LabelApp:   v1beta1constants.LabelKubernetes,
+			v1beta1constants.GardenRole: v1beta1constants.GardenRoleControlPlane,
+			v1beta1constants.LabelRole:  kubescheduler.LabelRole,
 		}),
 		ExpectedPolicies: sets.NewString(
 			"allow-from-prometheus",
@@ -166,8 +166,8 @@ func (a *Agnostic) Grafana() *SourcePod {
 	return &SourcePod{
 		Ports: NewSinglePort(3000),
 		Pod: NewPod("grafana", labels.Set{
-			"component":                           "grafana",
-			v1beta1constants.DeprecatedGardenRole: "monitoring",
+			"component":                 "grafana",
+			v1beta1constants.GardenRole: "monitoring",
 		}),
 		ExpectedPolicies: sets.NewString(
 			"allow-grafana",
@@ -182,9 +182,9 @@ func (a *Agnostic) KubeStateMetricsShoot() *SourcePod {
 	return &SourcePod{
 		Ports: NewSinglePort(8080),
 		Pod: NewPod("kube-state-metrics-shoot", labels.Set{
-			"component":                           "kube-state-metrics",
-			v1beta1constants.DeprecatedGardenRole: "monitoring",
-			"type":                                "shoot",
+			"component":                 "kube-state-metrics",
+			v1beta1constants.GardenRole: "monitoring",
+			"type":                      "shoot",
 		}),
 		ExpectedPolicies: sets.NewString(
 			"allow-from-prometheus",
@@ -220,9 +220,9 @@ func (a *Agnostic) Prometheus() *SourcePod {
 	return &SourcePod{
 		Ports: NewSinglePort(9090),
 		Pod: NewPod("prometheus", labels.Set{
-			v1beta1constants.LabelApp:             "prometheus",
-			v1beta1constants.DeprecatedGardenRole: "monitoring",
-			v1beta1constants.LabelRole:            "monitoring",
+			v1beta1constants.LabelApp:   "prometheus",
+			v1beta1constants.GardenRole: "monitoring",
+			v1beta1constants.LabelRole:  "monitoring",
 		}),
 		ExpectedPolicies: sets.NewString(
 			"allow-prometheus",
@@ -240,8 +240,8 @@ func (a *Agnostic) Prometheus() *SourcePod {
 func (a *Agnostic) AddonManager() *SourcePod {
 	return &SourcePod{
 		Pod: NewPod("gardener-resource-manager", labels.Set{
-			v1beta1constants.LabelApp:             "gardener-resource-manager",
-			v1beta1constants.DeprecatedGardenRole: v1beta1constants.GardenRoleControlPlane,
+			v1beta1constants.LabelApp:   "gardener-resource-manager",
+			v1beta1constants.GardenRole: v1beta1constants.GardenRoleControlPlane,
 		}),
 		ExpectedPolicies: sets.NewString(
 			"allow-to-dns",

--- a/pkg/operation/botanist/component/etcd/etcd.go
+++ b/pkg/operation/botanist/component/etcd/etcd.go
@@ -268,9 +268,9 @@ func (e *etcd) Deploy(ctx context.Context) error {
 						PodSelector: &metav1.LabelSelector{
 							// TODO: Replace below map with a function call to the to-be-introduced kubeapiserver package.
 							MatchLabels: map[string]string{
-								v1beta1constants.DeprecatedGardenRole: v1beta1constants.GardenRoleControlPlane,
-								v1beta1constants.LabelApp:             v1beta1constants.LabelKubernetes,
-								v1beta1constants.LabelRole:            v1beta1constants.LabelAPIServer,
+								v1beta1constants.GardenRole: v1beta1constants.GardenRoleControlPlane,
+								v1beta1constants.LabelApp:   v1beta1constants.LabelKubernetes,
+								v1beta1constants.LabelRole:  v1beta1constants.LabelAPIServer,
 							},
 						},
 					},

--- a/pkg/operation/botanist/component/etcd/etcd_test.go
+++ b/pkg/operation/botanist/component/etcd/etcd_test.go
@@ -132,9 +132,9 @@ var _ = Describe("Etcd", func() {
 							{
 								PodSelector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{
-										"garden.sapcloud.io/role": "controlplane",
-										"app":                     "kubernetes",
-										"role":                    "apiserver",
+										"gardener.cloud/role": "controlplane",
+										"app":                 "kubernetes",
+										"role":                "apiserver",
 									},
 								},
 							},

--- a/pkg/operation/botanist/component/etcd/etcd_test.go
+++ b/pkg/operation/botanist/component/etcd/etcd_test.go
@@ -141,9 +141,9 @@ var _ = Describe("Etcd", func() {
 							{
 								PodSelector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{
-										"garden.sapcloud.io/role": "monitoring",
-										"app":                     "prometheus",
-										"role":                    "monitoring",
+										"gardener.cloud/role": "monitoring",
+										"app":                 "prometheus",
+										"role":                "monitoring",
 									},
 								},
 							},

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
@@ -275,7 +275,7 @@ func (k *kubeAPIServer) SetAutoscalingReplicas(replicas *int32) {
 // GetLabels returns the labels for the kube-apiserver.
 func GetLabels() map[string]string {
 	return utils.MergeStringMaps(getLabels(), map[string]string{
-		v1beta1constants.DeprecatedGardenRole: v1beta1constants.GardenRoleControlPlane,
+		v1beta1constants.GardenRole: v1beta1constants.GardenRoleControlPlane,
 	})
 }
 

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
@@ -730,9 +730,9 @@ var _ = Describe("KubeAPIServer", func() {
 									From: []networkingv1.NetworkPolicyPeer{{
 										PodSelector: &metav1.LabelSelector{
 											MatchLabels: map[string]string{
-												"garden.sapcloud.io/role": "monitoring",
-												"app":                     "prometheus",
-												"role":                    "monitoring",
+												"gardener.cloud/role": "monitoring",
+												"app":                 "prometheus",
+												"role":                "monitoring",
 											},
 										},
 									}},
@@ -827,9 +827,9 @@ var _ = Describe("KubeAPIServer", func() {
 									From: []networkingv1.NetworkPolicyPeer{{
 										PodSelector: &metav1.LabelSelector{
 											MatchLabels: map[string]string{
-												"garden.sapcloud.io/role": "monitoring",
-												"app":                     "prometheus",
-												"role":                    "monitoring",
+												"gardener.cloud/role": "monitoring",
+												"app":                 "prometheus",
+												"role":                "monitoring",
 											},
 										},
 									}},

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
@@ -605,9 +605,9 @@ var _ = Describe("KubeAPIServer", func() {
 							From: []networkingv1.NetworkPolicyPeer{{
 								PodSelector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{
-										"app":                     "kubernetes",
-										"garden.sapcloud.io/role": "controlplane",
-										"role":                    "apiserver",
+										"app":                 "kubernetes",
+										"gardener.cloud/role": "controlplane",
+										"role":                "apiserver",
 									},
 								},
 							}},
@@ -649,9 +649,9 @@ var _ = Describe("KubeAPIServer", func() {
 							To: []networkingv1.NetworkPolicyPeer{{
 								PodSelector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{
-										"app":                     "kubernetes",
-										"garden.sapcloud.io/role": "controlplane",
-										"role":                    "apiserver",
+										"app":                 "kubernetes",
+										"gardener.cloud/role": "controlplane",
+										"role":                "apiserver",
 									},
 								},
 							}},
@@ -696,9 +696,9 @@ var _ = Describe("KubeAPIServer", func() {
 						Spec: networkingv1.NetworkPolicySpec{
 							PodSelector: metav1.LabelSelector{
 								MatchLabels: map[string]string{
-									"app":                     "kubernetes",
-									"garden.sapcloud.io/role": "controlplane",
-									"role":                    "apiserver",
+									"app":                 "kubernetes",
+									"gardener.cloud/role": "controlplane",
+									"role":                "apiserver",
 								},
 							},
 							Egress: []networkingv1.NetworkPolicyEgressRule{{
@@ -777,9 +777,9 @@ var _ = Describe("KubeAPIServer", func() {
 						Spec: networkingv1.NetworkPolicySpec{
 							PodSelector: metav1.LabelSelector{
 								MatchLabels: map[string]string{
-									"app":                     "kubernetes",
-									"garden.sapcloud.io/role": "controlplane",
-									"role":                    "apiserver",
+									"app":                 "kubernetes",
+									"gardener.cloud/role": "controlplane",
+									"role":                "apiserver",
 								},
 							},
 							Egress: []networkingv1.NetworkPolicyEgressRule{

--- a/pkg/operation/botanist/component/monitoring/prometheus.go
+++ b/pkg/operation/botanist/component/monitoring/prometheus.go
@@ -21,8 +21,8 @@ import (
 // GetPrometheusLabels returns the labels for the Prometheus.
 func GetPrometheusLabels() map[string]string {
 	return map[string]string{
-		v1beta1constants.DeprecatedGardenRole: "monitoring",
-		v1beta1constants.LabelApp:             "prometheus",
-		v1beta1constants.LabelRole:            "monitoring",
+		v1beta1constants.GardenRole: "monitoring",
+		v1beta1constants.LabelApp:   "prometheus",
+		v1beta1constants.LabelRole:  "monitoring",
 	}
 }

--- a/pkg/operation/botanist/component/networkpolicies/global.go
+++ b/pkg/operation/botanist/component/networkpolicies/global.go
@@ -111,9 +111,9 @@ func getGlobalNetworkPolicyTransformers(values GlobalValues) []networkPolicyTran
 								},
 								PodSelector: &metav1.LabelSelector{
 									MatchLabels: map[string]string{
-										v1beta1constants.DeprecatedGardenRole: v1beta1constants.GardenRoleControlPlane,
-										v1beta1constants.LabelApp:             v1beta1constants.LabelKubernetes,
-										v1beta1constants.LabelRole:            v1beta1constants.LabelAPIServer,
+										v1beta1constants.GardenRole: v1beta1constants.GardenRoleControlPlane,
+										v1beta1constants.LabelApp:   v1beta1constants.LabelKubernetes,
+										v1beta1constants.LabelRole:  v1beta1constants.LabelAPIServer,
 									},
 								},
 							}},

--- a/pkg/operation/botanist/component/networkpolicies/global_test.go
+++ b/pkg/operation/botanist/component/networkpolicies/global_test.go
@@ -74,9 +74,9 @@ func constructNPAllowToAllShootAPIServers(namespace string, sniEnabled bool) *ne
 					},
 					PodSelector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
-							"garden.sapcloud.io/role": "controlplane",
-							"app":                     "kubernetes",
-							"role":                    "apiserver",
+							"gardener.cloud/role": "controlplane",
+							"app":                 "kubernetes",
+							"role":                "apiserver",
 						},
 					},
 				}},


### PR DESCRIPTION
/kind cleanup

https://github.com/gardener/gardener/pull/3384 adds the `gardener.cloud/role` label key to almost all controlplane Pods. 
This PR adapts the controlplane NetworkPolicies (related to kube-apiserver, prometheus, grafana and alertmanager) to do not rely on the deprecated `garden.sapcloud.io/role` label key.

Part of #1649

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
