### PR TITLE
Increase revisionHistoryLimit for ManagedSeed gardenlet

### DIFF
--- a/hack/api-reference/seedmanagement.md
+++ b/hack/api-reference/seedmanagement.md
@@ -421,7 +421,7 @@ int32
 </td>
 <td>
 <em>(Optional)</em>
-<p>RevisionHistoryLimit is the number of old gardenlet ReplicaSets to retain to allow rollback. Defaults to 1.</p>
+<p>RevisionHistoryLimit is the number of old gardenlet ReplicaSets to retain to allow rollback. Defaults to 10.</p>
 </td>
 </tr>
 <tr>

--- a/landscaper/pkg/gardenlet/apis/imports/v1alpha1/defaults.go
+++ b/landscaper/pkg/gardenlet/apis/imports/v1alpha1/defaults.go
@@ -106,7 +106,7 @@ func SetDefaultsDeploymentConfiguration(obj *seedmanagementv1alpha1.GardenletDep
 
 	// Set default revision history limit
 	if obj.RevisionHistoryLimit == nil {
-		obj.RevisionHistoryLimit = pointer.Int32(1)
+		obj.RevisionHistoryLimit = pointer.Int32(10)
 	}
 
 	if obj.VPA == nil {

--- a/landscaper/pkg/gardenlet/apis/imports/v1alpha1/defaults_test.go
+++ b/landscaper/pkg/gardenlet/apis/imports/v1alpha1/defaults_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Defaults", func() {
 			Expect(obj).To(Equal(&Imports{
 				DeploymentConfiguration: &seedmanagementv1alpha1.GardenletDeployment{
 					ReplicaCount:         pointer.Int32(1),
-					RevisionHistoryLimit: pointer.Int32(1),
+					RevisionHistoryLimit: pointer.Int32(10),
 					VPA:                  pointer.Bool(false),
 				},
 				ComponentConfiguration: runtime.RawExtension{Object: &configv1alpha1.GardenletConfiguration{
@@ -77,7 +77,7 @@ var _ = Describe("Defaults", func() {
 
 			Expect(config).To(Equal(&seedmanagementv1alpha1.GardenletDeployment{
 				ReplicaCount:         pointer.Int32(1),
-				RevisionHistoryLimit: pointer.Int32(1),
+				RevisionHistoryLimit: pointer.Int32(10),
 				VPA:                  pointer.Bool(false),
 			}))
 		})

--- a/pkg/apis/seedmanagement/types_managedseed.go
+++ b/pkg/apis/seedmanagement/types_managedseed.go
@@ -95,7 +95,7 @@ type Gardenlet struct {
 type GardenletDeployment struct {
 	// ReplicaCount is the number of gardenlet replicas. Defaults to 1.
 	ReplicaCount *int32
-	// RevisionHistoryLimit is the number of old gardenlet ReplicaSets to retain to allow rollback. Defaults to 1.
+	// RevisionHistoryLimit is the number of old gardenlet ReplicaSets to retain to allow rollback. Defaults to 10.
 	RevisionHistoryLimit *int32
 	// ServiceAccountName is the name of the ServiceAccount to use to run gardenlet pods.
 	ServiceAccountName *string

--- a/pkg/apis/seedmanagement/v1alpha1/defaults_managedseed.go
+++ b/pkg/apis/seedmanagement/v1alpha1/defaults_managedseed.go
@@ -51,7 +51,7 @@ func SetDefaults_GardenletDeployment(obj *GardenletDeployment) {
 
 	// Set default revision history limit
 	if obj.RevisionHistoryLimit == nil {
-		obj.RevisionHistoryLimit = pointer.Int32(1)
+		obj.RevisionHistoryLimit = pointer.Int32(10)
 	}
 
 	// Set default image

--- a/pkg/apis/seedmanagement/v1alpha1/defaults_managedseed_test.go
+++ b/pkg/apis/seedmanagement/v1alpha1/defaults_managedseed_test.go
@@ -214,7 +214,7 @@ var _ = Describe("Defaults", func() {
 
 			Expect(obj).To(Equal(&GardenletDeployment{
 				ReplicaCount:         pointer.Int32(1),
-				RevisionHistoryLimit: pointer.Int32(1),
+				RevisionHistoryLimit: pointer.Int32(10),
 				Image:                &Image{},
 				VPA:                  pointer.Bool(true),
 			}))

--- a/pkg/apis/seedmanagement/v1alpha1/generated.proto
+++ b/pkg/apis/seedmanagement/v1alpha1/generated.proto
@@ -59,7 +59,7 @@ message GardenletDeployment {
   // +optional
   optional int32 replicaCount = 1;
 
-  // RevisionHistoryLimit is the number of old gardenlet ReplicaSets to retain to allow rollback. Defaults to 1.
+  // RevisionHistoryLimit is the number of old gardenlet ReplicaSets to retain to allow rollback. Defaults to 10.
   // +optional
   optional int32 revisionHistoryLimit = 2;
 

--- a/pkg/apis/seedmanagement/v1alpha1/types_managedseed.go
+++ b/pkg/apis/seedmanagement/v1alpha1/types_managedseed.go
@@ -109,7 +109,7 @@ type GardenletDeployment struct {
 	// ReplicaCount is the number of gardenlet replicas. Defaults to 1.
 	// +optional
 	ReplicaCount *int32 `json:"replicaCount,omitempty" protobuf:"varint,1,opt,name=replicaCount"`
-	// RevisionHistoryLimit is the number of old gardenlet ReplicaSets to retain to allow rollback. Defaults to 1.
+	// RevisionHistoryLimit is the number of old gardenlet ReplicaSets to retain to allow rollback. Defaults to 10.
 	// +optional
 	RevisionHistoryLimit *int32 `json:"revisionHistoryLimit,omitempty" protobuf:"varint,2,opt,name=revisionHistoryLimit"`
 	// ServiceAccountName is the name of the ServiceAccount to use to run gardenlet pods.

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -14556,7 +14556,7 @@ func schema_pkg_apis_seedmanagement_v1alpha1_GardenletDeployment(ref common.Refe
 					},
 					"revisionHistoryLimit": {
 						SchemaProps: spec.SchemaProps{
-							Description: "RevisionHistoryLimit is the number of old gardenlet ReplicaSets to retain to allow rollback. Defaults to 1.",
+							Description: "RevisionHistoryLimit is the number of old gardenlet ReplicaSets to retain to allow rollback. Defaults to 10.",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:

Increase default `revisionHistoryLimit` for ManagedSeed gardenlet from `1` to `10`.
This is done to help operators figure out why and when the gardenlet was rolled and similar.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The default `revisionHistoryLimit` for gardenlets deployed by `ManagedSeeds` was increased to `10`.
```
