### PR TITLE
Name the reemiters from the fluent-bit embeded rewrite tag filters

### DIFF
--- a/charts/seed-bootstrap/charts/fluent-bit/templates/_helpers.tpl
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/_helpers.tpl
@@ -195,6 +195,7 @@ filter-kubernetes.conf: |-
       Name                rewrite_tag
       Match               {{ .Values.exposedComponentsTagPrefix }}.*
       Rule                $tag ^.+? kubernetes.$TAG false
+      Emitter_Name        re_emitted-reversed-rewrite-tag
   # Scripts
   [FILTER]
       Name                lua

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -583,7 +583,7 @@ func RunReconcileSeedFlow(
     Name          rewrite_tag
     Match         kubernetes.*
     Rule          $tag ^kubernetes\.var\.log\.containers\.(` + strings.Join(userAllowedComponents, "-.+?|") + `-.+?)_ ` + userExposedComponentTagPrefix + `.$TAG true
-    Emitter_Name  re_emitted
+    Emitter_Name  re_emitted-garden-embedded-rewrite-tag
 `
 		filters.WriteString(fmt.Sprintln(loggingRewriteTagFilter))
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
With this PR the fluent-bit re-emitters from the embedded rewrite tag filters have different names in order to be differentiated when they have been dubbing. Until now they have a random ID  and no one knows which ID for which re-emitter is.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
All of the fluent-bit embeded re-emitters have their own unique name for debugging purposes.
```
