### PR TITLE
Fix migration flow when cloud prvider config injection is required

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control.go
@@ -837,6 +837,47 @@ func computeOperationType(shoot *gardencorev1beta1.Shoot) gardencorev1beta1.Last
 	return v1beta1helper.ComputeOperationType(shoot.ObjectMeta, shoot.Status.LastOperation)
 }
 
+func needsControlPlaneDeployment(ctx context.Context, o *operation.Operation, kubeAPIServerDeploymentFound bool, infrastructure *extensionsv1alpha1.Infrastructure) (bool, error) {
+	var (
+		namespace = o.Shoot.SeedNamespace
+		name      = o.Shoot.GetInfo().Name
+	)
+
+	// If the `ControlPlane` resource and the kube-apiserver deployment do no longer exist then we don't want to re-deploy it.
+	// The reason for the second condition is that some providers inject a cloud-provider-config into the kube-apiserver deployment
+	// which is needed for it to run.
+	exists, markedForDeletion, err := extensionResourceStillExists(ctx, o.K8sSeedClient.APIReader(), &extensionsv1alpha1.ControlPlane{}, namespace, name)
+	if err != nil {
+		return false, err
+	}
+
+	switch {
+	// treat `ControlPlane` in deletion as if it is already gone. If it is marked for deletion, we also shouldn't wait
+	// for it to be reconciled, as it can potentially block the whole deletion flow (deletion depends on other control
+	// plane components like kcm and grm) which are scaled up later in the flow
+	case (!exists || markedForDeletion) && !kubeAPIServerDeploymentFound:
+		return false, nil
+	// The infrastructure resource has not been found, no need to redeploy the control plane
+	case infrastructure == nil:
+		return false, nil
+	// The infrastructure resource has been found with a non-nil provider status, so redeploy the control plane
+	case infrastructure.Status.ProviderStatus != nil:
+		return true, nil
+	default:
+		return false, nil
+	}
+}
+
+func extensionResourceStillExists(ctx context.Context, reader client.Reader, obj client.Object, namespace, name string) (bool, bool, error) {
+	if err := reader.Get(ctx, kutil.Key(namespace, name), obj); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, false, nil
+		}
+		return false, false, err
+	}
+	return true, obj.GetDeletionTimestamp() != nil, nil
+}
+
 func shootKey(shoot *gardencorev1beta1.Shoot) string {
 	return shoot.Namespace + "/" + shoot.Name
 }

--- a/pkg/gardenlet/controller/shoot/shoot_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control.go
@@ -855,7 +855,7 @@ func needsControlPlaneDeployment(ctx context.Context, o *operation.Operation, ku
 	// treat `ControlPlane` in deletion as if it is already gone. If it is marked for deletion, we also shouldn't wait
 	// for it to be reconciled, as it can potentially block the whole deletion flow (deletion depends on other control
 	// plane components like kcm and grm) which are scaled up later in the flow
-	case (!exists || markedForDeletion) && !kubeAPIServerDeploymentFound:
+	case !exists && !kubeAPIServerDeploymentFound || markedForDeletion:
 		return false, nil
 	// The infrastructure resource has not been found, no need to redeploy the control plane
 	case infrastructure == nil:

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -303,6 +303,12 @@ func (b *Botanist) deployOrRestoreControlPlane(ctx context.Context, controlPlane
 	return controlPlane.Deploy(ctx)
 }
 
+// RestoreControlPlane restores the ControlPlane custom resource (purpose normal)
+func (b *Botanist) RestoreControlPlane(ctx context.Context) error {
+	b.Shoot.Components.Extensions.ControlPlane.SetInfrastructureProviderStatus(b.Shoot.Components.Extensions.Infrastructure.ProviderStatus())
+	return b.Shoot.Components.Extensions.ControlPlane.Restore(ctx, b.GetShootState())
+}
+
 // RestartControlPlanePods restarts (deletes) pods of the shoot control plane.
 func (b *Botanist) RestartControlPlanePods(ctx context.Context) error {
 	return b.K8sSeedClient.Client().DeleteAllOf(

--- a/pkg/operation/botanist/managedresources.go
+++ b/pkg/operation/botanist/managedresources.go
@@ -38,19 +38,14 @@ func (b *Botanist) WaitUntilManagedResourcesDeleted(ctx context.Context) error {
 	return b.waitUntilManagedResourceAreDeleted(ctx, client.InNamespace(b.Shoot.SeedNamespace), client.MatchingLabels{managedresources.LabelKeyOrigin: managedresources.LabelValueGardener})
 }
 
-// WaitUntilAllManagedResourcesDeleted waits until all managed resources are gone or the context is cancelled.
-func (b *Botanist) WaitUntilAllManagedResourcesDeleted(ctx context.Context) error {
-	return b.waitUntilManagedResourceAreDeleted(ctx, client.InNamespace(b.Shoot.SeedNamespace))
-}
-
 func (b *Botanist) waitUntilManagedResourceAreDeleted(ctx context.Context, listOpt ...client.ListOption) error {
 	return managedresources.WaitUntilListDeleted(ctx, b.K8sSeedClient.Client(), &resourcesv1alpha1.ManagedResourceList{}, listOpt...)
 }
 
-// KeepObjectsForAllManagedResources sets ManagedResource.Spec.KeepObjects to true.
-func (b *Botanist) KeepObjectsForAllManagedResources(ctx context.Context) error {
+// KeepObjectsForManagedResources sets ManagedResource.Spec.KeepObjects to true.
+func (b *Botanist) KeepObjectsForManagedResources(ctx context.Context) error {
 	managedResources := &resourcesv1alpha1.ManagedResourceList{}
-	if err := b.K8sSeedClient.Client().List(ctx, managedResources, client.InNamespace(b.Shoot.SeedNamespace)); err != nil {
+	if err := b.K8sSeedClient.Client().List(ctx, managedResources, client.InNamespace(b.Shoot.SeedNamespace), client.MatchingLabels{managedresources.LabelKeyOrigin: managedresources.LabelValueGardener}); err != nil {
 		return fmt.Errorf("failed to list all managed resource, %w", err)
 	}
 
@@ -61,13 +56,4 @@ func (b *Botanist) KeepObjectsForAllManagedResources(ctx context.Context) error 
 	}
 
 	return nil
-}
-
-// DeleteAllManagedResourcesObjects deletes all managed resources from the Shoot namespace in the Seed.
-func (b *Botanist) DeleteAllManagedResourcesObjects(ctx context.Context) error {
-	return b.K8sSeedClient.Client().DeleteAllOf(
-		ctx,
-		&resourcesv1alpha1.ManagedResource{},
-		client.InNamespace(b.Shoot.SeedNamespace),
-	)
 }

--- a/pkg/operation/botanist/migration.go
+++ b/pkg/operation/botanist/migration.go
@@ -26,24 +26,31 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// MigrateAllExtensionResources migrates all extension CRs.
-func (b *Botanist) MigrateAllExtensionResources(ctx context.Context) (err error) {
-	return b.runParallelTaskForEachComponent(ctx, b.Shoot.GetExtensionComponentsForMigration(), func(c component.DeployMigrateWaiter) func(context.Context) error {
+// MigrateExtensionResourcesInParallel migrates extension CRs.
+func (b *Botanist) MigrateExtensionResourcesInParallel(ctx context.Context) (err error) {
+	return b.runParallelTaskForEachComponent(ctx, b.Shoot.GetExtensionComponentsForParallelMigration(), func(c component.DeployMigrateWaiter) func(context.Context) error {
 		return c.Migrate
 	})
 }
 
-// WaitUntilAllExtensionResourcesMigrated waits until all extension CRs were successfully migrated.
-func (b *Botanist) WaitUntilAllExtensionResourcesMigrated(ctx context.Context) error {
-	return b.runParallelTaskForEachComponent(ctx, b.Shoot.GetExtensionComponentsForMigration(), func(c component.DeployMigrateWaiter) func(context.Context) error {
+// WaitUntilExtensionResourcesMigrated waits until extension CRs have been successfully migrated.
+func (b *Botanist) WaitUntilExtensionResourcesMigrated(ctx context.Context) error {
+	return b.runParallelTaskForEachComponent(ctx, b.Shoot.GetExtensionComponentsForParallelMigration(), func(c component.DeployMigrateWaiter) func(context.Context) error {
 		return c.WaitMigrate
 	})
 }
 
-// DestroyAllExtensionResources deletes all extension CRs from the Shoot namespace.
-func (b *Botanist) DestroyAllExtensionResources(ctx context.Context) error {
-	return b.runParallelTaskForEachComponent(ctx, b.Shoot.GetExtensionComponentsForMigration(), func(c component.DeployMigrateWaiter) func(context.Context) error {
+// DestroyExtensionResourcesInParallel deletes extension CRs from the Shoot namespace.
+func (b *Botanist) DestroyExtensionResourcesInParallel(ctx context.Context) error {
+	return b.runParallelTaskForEachComponent(ctx, b.Shoot.GetExtensionComponentsForParallelMigration(), func(c component.DeployMigrateWaiter) func(context.Context) error {
 		return c.Destroy
+	})
+}
+
+// WaitUntilExtensionResourcesDeleted waits until extension CRs have been deleted from the Shoot namespace.
+func (b *Botanist) WaitUntilExtensionResourcesDeleted(ctx context.Context) error {
+	return b.runParallelTaskForEachComponent(ctx, b.Shoot.GetExtensionComponentsForParallelMigration(), func(c component.DeployMigrateWaiter) func(context.Context) error {
+		return c.WaitCleanup
 	})
 }
 

--- a/pkg/operation/botanist/migration_test.go
+++ b/pkg/operation/botanist/migration_test.go
@@ -102,28 +102,24 @@ var _ = Describe("migration", func() {
 	Describe("#MigrateAllExtensionResources", func() {
 		It("should call the Migrate() func of all extension components", func() {
 			containerRuntime.EXPECT().Migrate(ctx)
-			controlPlane.EXPECT().Migrate(ctx)
 			controlPlaneExposure.EXPECT().Migrate(ctx)
 			extension.EXPECT().Migrate(ctx)
-			infrastructure.EXPECT().Migrate(ctx)
 			network.EXPECT().Migrate(ctx)
 			operatingSystemConfig.EXPECT().Migrate(ctx)
 			worker.EXPECT().Migrate(ctx)
 
-			Expect(botanist.MigrateAllExtensionResources(ctx)).To(Succeed())
+			Expect(botanist.MigrateExtensionResourcesInParallel(ctx)).To(Succeed())
 		})
 
 		It("should return an error if not all the Migrate() func of all extension components succeed", func() {
 			containerRuntime.EXPECT().Migrate(ctx)
-			controlPlane.EXPECT().Migrate(ctx).Return(fakeErr)
 			controlPlaneExposure.EXPECT().Migrate(ctx)
-			extension.EXPECT().Migrate(ctx)
-			infrastructure.EXPECT().Migrate(ctx)
+			extension.EXPECT().Migrate(ctx).Return(fakeErr)
 			network.EXPECT().Migrate(ctx)
 			operatingSystemConfig.EXPECT().Migrate(ctx)
 			worker.EXPECT().Migrate(ctx)
 
-			err := botanist.MigrateAllExtensionResources(ctx)
+			err := botanist.MigrateExtensionResourcesInParallel(ctx)
 			Expect(err).To(BeAssignableToTypeOf(&multierror.Error{}))
 			Expect(err.(*multierror.Error).Errors).To(ConsistOf(Equal(fakeErr)))
 		})
@@ -132,28 +128,24 @@ var _ = Describe("migration", func() {
 	Describe("#WaitUntilAllExtensionResourcesMigrated", func() {
 		It("should call the Migrate() func of all extension components", func() {
 			containerRuntime.EXPECT().WaitMigrate(ctx)
-			controlPlane.EXPECT().WaitMigrate(ctx)
 			controlPlaneExposure.EXPECT().WaitMigrate(ctx)
 			extension.EXPECT().WaitMigrate(ctx)
-			infrastructure.EXPECT().WaitMigrate(ctx)
 			network.EXPECT().WaitMigrate(ctx)
 			operatingSystemConfig.EXPECT().WaitMigrate(ctx)
 			worker.EXPECT().WaitMigrate(ctx)
 
-			Expect(botanist.WaitUntilAllExtensionResourcesMigrated(ctx)).To(Succeed())
+			Expect(botanist.WaitUntilExtensionResourcesMigrated(ctx)).To(Succeed())
 		})
 
 		It("should return an error if not all the WaitMigrate() func of all extension components succeed", func() {
 			containerRuntime.EXPECT().WaitMigrate(ctx)
-			controlPlane.EXPECT().WaitMigrate(ctx)
 			controlPlaneExposure.EXPECT().WaitMigrate(ctx)
 			extension.EXPECT().WaitMigrate(ctx)
-			infrastructure.EXPECT().WaitMigrate(ctx)
 			network.EXPECT().WaitMigrate(ctx).Return(fakeErr)
 			operatingSystemConfig.EXPECT().WaitMigrate(ctx)
 			worker.EXPECT().WaitMigrate(ctx).Return(fakeErr)
 
-			err := botanist.WaitUntilAllExtensionResourcesMigrated(ctx)
+			err := botanist.WaitUntilExtensionResourcesMigrated(ctx)
 			Expect(err).To(BeAssignableToTypeOf(&multierror.Error{}))
 			Expect(err.(*multierror.Error).Errors).To(ConsistOf(Equal(fakeErr), Equal(fakeErr)))
 		})
@@ -162,28 +154,24 @@ var _ = Describe("migration", func() {
 	Describe("#DestroyAllExtensionResources", func() {
 		It("should call the Destroy() func of all extension components", func() {
 			containerRuntime.EXPECT().Destroy(ctx)
-			controlPlane.EXPECT().Destroy(ctx)
 			controlPlaneExposure.EXPECT().Destroy(ctx)
 			extension.EXPECT().Destroy(ctx)
-			infrastructure.EXPECT().Destroy(ctx)
 			network.EXPECT().Destroy(ctx)
 			operatingSystemConfig.EXPECT().Destroy(ctx)
 			worker.EXPECT().Destroy(ctx)
 
-			Expect(botanist.DestroyAllExtensionResources(ctx)).To(Succeed())
+			Expect(botanist.DestroyExtensionResourcesInParallel(ctx)).To(Succeed())
 		})
 
 		It("should return an error if not all the Destroy() func of all extension components succeed", func() {
 			containerRuntime.EXPECT().Destroy(ctx).Return(fakeErr)
-			controlPlane.EXPECT().Destroy(ctx)
 			controlPlaneExposure.EXPECT().Destroy(ctx).Return(fakeErr)
 			extension.EXPECT().Destroy(ctx)
-			infrastructure.EXPECT().Destroy(ctx)
 			network.EXPECT().Destroy(ctx)
 			operatingSystemConfig.EXPECT().Destroy(ctx)
 			worker.EXPECT().Destroy(ctx)
 
-			err := botanist.DestroyAllExtensionResources(ctx)
+			err := botanist.DestroyExtensionResourcesInParallel(ctx)
 			Expect(err).To(BeAssignableToTypeOf(&multierror.Error{}))
 			Expect(err.(*multierror.Error).Errors).To(ConsistOf(Equal(fakeErr), Equal(fakeErr)))
 		})

--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -346,15 +346,14 @@ func (s *Shoot) UpdateInfoStatus(ctx context.Context, c client.Client, useStrate
 	return nil
 }
 
-// GetExtensionComponentsForMigration returns a list of component.DeployMigrateWaiters of extension components that
-// should be migrated by the shoot controller.
-func (s *Shoot) GetExtensionComponentsForMigration() []component.DeployMigrateWaiter {
+// GetExtensionComponentsForParallelMigration returns a list of component.DeployMigrateWaiters of
+// extension components that should be migrated by the shoot controller in parallel.
+// Note that this method does not return ControlPlane and Infrastructure components as they require specific handling during migration.
+func (s *Shoot) GetExtensionComponentsForParallelMigration() []component.DeployMigrateWaiter {
 	return []component.DeployMigrateWaiter{
 		s.Components.Extensions.ContainerRuntime,
-		s.Components.Extensions.ControlPlane,
 		s.Components.Extensions.ControlPlaneExposure,
 		s.Components.Extensions.Extension,
-		s.Components.Extensions.Infrastructure,
 		s.Components.Extensions.Network,
 		s.Components.Extensions.OperatingSystemConfig,
 		s.Components.Extensions.Worker,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind bug

**What this PR does / why we need it**:
For providers that require the `cloud-provider-config` secret to be injected in the kube-apiserver deployment, if the migration flow is interrupted after the `Controlplane` resource has been migrated but before the kube-apiserver deployment is deleted and the migration flow gets restarted it will fail. Additionally, for hibernated shoots on azure the `Controlplane` has to be "woken up" so that the remedy controller gets scaled up and the additional resources it manages can be properly cleaned up.

This PR adds a few additional steps to the migration flow that restore the `Controlplane` resource if the kube-apiserver deployment still exists.

**Which issue(s) this PR fixes**:
Fixes #4484

**Special notes for your reviewer**:
The migration flow now only handles managedresources deployed by gardenlet. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed migration flow for shoots on providers that require the `cloud-provider-config` secret to be injected in some control plane components.
```
```bugfix operator
Fixed migration flow for hibernated clusters on azure where resources managed by the remedy controller were not removed due to the remedy controller being scaled down to 0.
```
