### PR TITLE
Add zone annotation to domain secrets

### DIFF
--- a/charts/gardener/controlplane/charts/utils-common/templates/_secret-default-domain.yaml
+++ b/charts/gardener/controlplane/charts/utils-common/templates/_secret-default-domain.yaml
@@ -15,6 +15,9 @@ metadata:
   annotations:
     dns.gardener.cloud/provider: {{ ( required ".defaultDomains[].provider is required" $domain.provider ) }}
     dns.gardener.cloud/domain: {{ ( required ".defaultDomains[].domain is required" $domain.domain ) }}
+    {{- if $domain.zone }}
+    dns.gardener.cloud/zone: {{ $domain.zone }}
+    {{- end }}
 type: Opaque
 data:
 {{ toYaml $domain.credentials | indent 2 }}

--- a/charts/gardener/controlplane/charts/utils-common/templates/_secret_internal-domain.yaml
+++ b/charts/gardener/controlplane/charts/utils-common/templates/_secret_internal-domain.yaml
@@ -14,6 +14,9 @@ metadata:
   annotations:
     dns.gardener.cloud/provider: {{ ( required ".internalDomain.provider is required" .Values.global.internalDomain.provider ) }}
     dns.gardener.cloud/domain: {{ ( required ".internalDomain.domain is required" .Values.global.internalDomain.domain ) }}
+    {{- if .Values.global.internalDomain.zone }}
+    dns.gardener.cloud/zone: {{ .Values.global.internalDomain.zone }}
+    {{- end }}
 type: Opaque
 data:
 {{ toYaml .Values.global.internalDomain.credentials | indent 2 }}


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Adds the `dns.gardener.cloud/zone` annotation to the internal and default domain secrets. This annotation results in specifying the `DNSRecord` zone in the resource spec, thus avoiding getting the zone from the provider and potential errors (or throttling) due to hitting rate limits if too many shoots are being reconciled at the same time. It is only used if the `UseDNSRecords` feature gate is set to true.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```other operator
NONE
```
