### PR TITLE
Cleanup remaining `context.TODO()` occurrences

### DIFF
--- a/cmd/utils/miscellaneous.go
+++ b/cmd/utils/miscellaneous.go
@@ -15,8 +15,6 @@
 package utils
 
 import (
-	"context"
-
 	coreinstall "github.com/gardener/gardener/pkg/apis/core/install"
 	seedmanagementinstall "github.com/gardener/gardener/pkg/apis/seedmanagement/install"
 	"github.com/gardener/gardener/pkg/logger"
@@ -42,15 +40,4 @@ func CreateRecorder(kubeClient k8s.Interface, eventSourceName string) record.Eve
 	eventBroadcaster.StartLogging(logger.Logger.Debugf)
 	eventBroadcaster.StartRecordingToSink(&typedcorev1.EventSinkImpl{Interface: typedcorev1.New(kubeClient.CoreV1().RESTClient()).Events("")})
 	return eventBroadcaster.NewRecorder(scheme, corev1.EventSource{Component: eventSourceName})
-}
-
-// ContextFromStopChannel creates a new context from a given stop channel.
-func ContextFromStopChannel(stopCh <-chan struct{}) context.Context {
-	ctx, cancel := context.WithCancel(context.Background())
-	go func() {
-		defer cancel()
-		<-stopCh
-	}()
-
-	return ctx
 }

--- a/extensions/pkg/controller/backupbucket/mapper.go
+++ b/extensions/pkg/controller/backupbucket/mapper.go
@@ -16,6 +16,7 @@ package backupbucket
 
 import (
 	"context"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -27,15 +28,22 @@ import (
 	extensionshandler "github.com/gardener/gardener/extensions/pkg/handler"
 	extensionspredicate "github.com/gardener/gardener/extensions/pkg/predicate"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	ctxutils "github.com/gardener/gardener/pkg/utils/context"
 )
 
 type secretToBackupBucketMapper struct {
+	ctx        context.Context
 	client     client.Client
 	predicates []predicate.Predicate
 }
 
 func (m *secretToBackupBucketMapper) InjectClient(c client.Client) error {
 	m.client = c
+	return nil
+}
+
+func (m *secretToBackupBucketMapper) InjectStopChannel(stopCh <-chan struct{}) error {
+	m.ctx = ctxutils.FromStopChannel(stopCh)
 	return nil
 }
 
@@ -49,13 +57,16 @@ func (m *secretToBackupBucketMapper) InjectFunc(f inject.Func) error {
 }
 
 func (m *secretToBackupBucketMapper) Map(obj client.Object) []reconcile.Request {
+	ctx, cancel := context.WithTimeout(m.ctx, 5*time.Second)
+	defer cancel()
+
 	secret, ok := obj.(*corev1.Secret)
 	if !ok {
 		return nil
 	}
 
 	backupBucketList := &extensionsv1alpha1.BackupBucketList{}
-	if err := m.client.List(context.Background(), backupBucketList); err != nil {
+	if err := m.client.List(ctx, backupBucketList); err != nil {
 		return nil
 	}
 

--- a/extensions/pkg/controller/backupbucket/mapper.go
+++ b/extensions/pkg/controller/backupbucket/mapper.go
@@ -55,7 +55,7 @@ func (m *secretToBackupBucketMapper) Map(obj client.Object) []reconcile.Request 
 	}
 
 	backupBucketList := &extensionsv1alpha1.BackupBucketList{}
-	if err := m.client.List(context.TODO(), backupBucketList); err != nil {
+	if err := m.client.List(context.Background(), backupBucketList); err != nil {
 		return nil
 	}
 

--- a/extensions/pkg/controller/backupentry/controller.go
+++ b/extensions/pkg/controller/backupentry/controller.go
@@ -88,14 +88,14 @@ func add(mgr manager.Manager, args AddArgs, predicates []predicate.Predicate) er
 	if args.IgnoreOperationAnnotation {
 		if err := ctrl.Watch(
 			&source.Kind{Type: &corev1.Namespace{}},
-			extensionshandler.EnqueueRequestsFromMapper(NamespaceToBackupEntryMapper(mgr.GetClient(), predicates), extensionshandler.UpdateWithNew),
+			extensionshandler.EnqueueRequestsFromMapper(NamespaceToBackupEntryMapper(predicates), extensionshandler.UpdateWithNew),
 		); err != nil {
 			return err
 		}
 
 		if err := ctrl.Watch(
 			&source.Kind{Type: &corev1.Secret{}},
-			extensionshandler.EnqueueRequestsFromMapper(SecretToBackupEntryMapper(mgr.GetClient(), predicates), extensionshandler.UpdateWithNew),
+			extensionshandler.EnqueueRequestsFromMapper(SecretToBackupEntryMapper(predicates), extensionshandler.UpdateWithNew),
 		); err != nil {
 			return err
 		}

--- a/extensions/pkg/controller/backupentry/mapper.go
+++ b/extensions/pkg/controller/backupentry/mapper.go
@@ -16,6 +16,7 @@ package backupentry
 
 import (
 	"context"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -27,21 +28,36 @@ import (
 	extensionspredicate "github.com/gardener/gardener/extensions/pkg/predicate"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	ctxutils "github.com/gardener/gardener/pkg/utils/context"
 )
 
 type secretToBackupEntryMapper struct {
+	ctx        context.Context
 	client     client.Client
 	predicates []predicate.Predicate
 }
 
+func (m *secretToBackupEntryMapper) InjectClient(c client.Client) error {
+	m.client = c
+	return nil
+}
+
+func (m *secretToBackupEntryMapper) InjectStopChannel(stopCh <-chan struct{}) error {
+	m.ctx = ctxutils.FromStopChannel(stopCh)
+	return nil
+}
+
 func (m *secretToBackupEntryMapper) Map(obj client.Object) []reconcile.Request {
+	ctx, cancel := context.WithTimeout(m.ctx, 5*time.Second)
+	defer cancel()
+
 	secret, ok := obj.(*corev1.Secret)
 	if !ok {
 		return nil
 	}
 
 	backupEntryList := &extensionsv1alpha1.BackupEntryList{}
-	if err := m.client.List(context.Background(), backupEntryList); err != nil {
+	if err := m.client.List(ctx, backupEntryList); err != nil {
 		return nil
 	}
 
@@ -63,23 +79,37 @@ func (m *secretToBackupEntryMapper) Map(obj client.Object) []reconcile.Request {
 
 // SecretToBackupEntryMapper returns a mapper that returns requests for BackupEntry whose
 // referenced secrets have been modified.
-func SecretToBackupEntryMapper(client client.Client, predicates []predicate.Predicate) extensionshandler.Mapper {
-	return &secretToBackupEntryMapper{client, predicates}
+func SecretToBackupEntryMapper(predicates []predicate.Predicate) extensionshandler.Mapper {
+	return &secretToBackupEntryMapper{predicates: predicates}
 }
 
 type namespaceToBackupEntryMapper struct {
+	ctx        context.Context
 	client     client.Client
 	predicates []predicate.Predicate
 }
 
+func (m *namespaceToBackupEntryMapper) InjectClient(c client.Client) error {
+	m.client = c
+	return nil
+}
+
+func (m *namespaceToBackupEntryMapper) InjectStopChannel(stopCh <-chan struct{}) error {
+	m.ctx = ctxutils.FromStopChannel(stopCh)
+	return nil
+}
+
 func (m *namespaceToBackupEntryMapper) Map(obj client.Object) []reconcile.Request {
+	ctx, cancel := context.WithTimeout(m.ctx, 5*time.Second)
+	defer cancel()
+
 	namespace, ok := obj.(*corev1.Namespace)
 	if !ok {
 		return nil
 	}
 
 	backupEntryList := &extensionsv1alpha1.BackupEntryList{}
-	if err := m.client.List(context.Background(), backupEntryList); err != nil {
+	if err := m.client.List(ctx, backupEntryList); err != nil {
 		return nil
 	}
 
@@ -105,6 +135,6 @@ func (m *namespaceToBackupEntryMapper) Map(obj client.Object) []reconcile.Reques
 
 // NamespaceToBackupEntryMapper returns a mapper that returns requests for BackupEntry whose
 // associated Shoot's seed namespace have been modified.
-func NamespaceToBackupEntryMapper(client client.Client, predicates []predicate.Predicate) extensionshandler.Mapper {
-	return &namespaceToBackupEntryMapper{client, predicates}
+func NamespaceToBackupEntryMapper(predicates []predicate.Predicate) extensionshandler.Mapper {
+	return &namespaceToBackupEntryMapper{predicates: predicates}
 }

--- a/extensions/pkg/controller/backupentry/mapper.go
+++ b/extensions/pkg/controller/backupentry/mapper.go
@@ -41,7 +41,7 @@ func (m *secretToBackupEntryMapper) Map(obj client.Object) []reconcile.Request {
 	}
 
 	backupEntryList := &extensionsv1alpha1.BackupEntryList{}
-	if err := m.client.List(context.TODO(), backupEntryList); err != nil {
+	if err := m.client.List(context.Background(), backupEntryList); err != nil {
 		return nil
 	}
 
@@ -79,7 +79,7 @@ func (m *namespaceToBackupEntryMapper) Map(obj client.Object) []reconcile.Reques
 	}
 
 	backupEntryList := &extensionsv1alpha1.BackupEntryList{}
-	if err := m.client.List(context.TODO(), backupEntryList); err != nil {
+	if err := m.client.List(context.Background(), backupEntryList); err != nil {
 		return nil
 	}
 

--- a/extensions/pkg/controller/worker/mapper.go
+++ b/extensions/pkg/controller/worker/mapper.go
@@ -16,6 +16,7 @@ package worker
 
 import (
 	"context"
+	"time"
 
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -124,13 +125,16 @@ func (m *machineToObjectMapper) InjectFunc(f inject.Func) error {
 }
 
 func (m *machineToObjectMapper) Map(obj client.Object) []reconcile.Request {
+	ctx, cancel := context.WithTimeout(m.ctx, 5*time.Second)
+	defer cancel()
+
 	machine, ok := obj.(*machinev1alpha1.Machine)
 	if !ok {
 		return nil
 	}
 
 	objList := m.newObjListFunc()
-	if err := m.client.List(m.ctx, objList, client.InNamespace(machine.Namespace)); err != nil {
+	if err := m.client.List(ctx, objList, client.InNamespace(machine.Namespace)); err != nil {
 		return nil
 	}
 

--- a/extensions/pkg/controller/worker/mapper_test.go
+++ b/extensions/pkg/controller/worker/mapper_test.go
@@ -170,11 +170,15 @@ var _ = Describe("Worker Mapper", func() {
 		var (
 			resourceName = "machineSet"
 			namespace    = "shoot"
+			stopCh       = make(chan struct{})
 		)
 
 		It("should find all objects for the passed worker", func() {
 			mapper := worker.MachineToWorkerMapper(nil)
 			ExpectInject(inject.ClientInto(c, mapper))
+			ok, err := inject.StopChannelInto(stopCh, mapper)
+			Expect(ok).To(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
 
 			c.EXPECT().
 				List(
@@ -222,6 +226,9 @@ var _ = Describe("Worker Mapper", func() {
 				mapper = worker.MachineToWorkerMapper(predicates)
 			)
 			ExpectInject(inject.ClientInto(c, mapper))
+			ok, err := inject.StopChannelInto(stopCh, mapper)
+			Expect(ok).To(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
 
 			c.EXPECT().
 				List(
@@ -255,6 +262,9 @@ var _ = Describe("Worker Mapper", func() {
 		It("should find no objects because list is empty", func() {
 			mapper := worker.MachineToWorkerMapper(nil)
 			ExpectInject(inject.ClientInto(c, mapper))
+			ok, err := inject.StopChannelInto(stopCh, mapper)
+			Expect(ok).To(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
 
 			c.EXPECT().
 				List(
@@ -278,6 +288,10 @@ var _ = Describe("Worker Mapper", func() {
 
 		It("should find no objects because the passed object is no worker", func() {
 			mapper := worker.MachineToWorkerMapper(nil)
+			ok, err := inject.StopChannelInto(stopCh, mapper)
+			Expect(ok).To(BeTrue())
+			Expect(err).NotTo(HaveOccurred())
+
 			result := mapper.Map(&extensionsv1alpha1.Cluster{})
 			Expect(result).To(BeNil())
 		})

--- a/pkg/gardenlet/controller/shoot/shoot_control_migrate.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_migrate.go
@@ -68,7 +68,7 @@ func (c *Controller) prepareShootForMigration(ctx context.Context, logger logrus
 		return reconcile.Result{}, utilerrors.WithSuppressed(operationErr, updateErr)
 	}
 
-	if flowErr := c.runPrepareShootControlPlaneMigration(o); flowErr != nil {
+	if flowErr := c.runPrepareShootControlPlaneMigration(ctx, o); flowErr != nil {
 		c.recorder.Event(shoot, corev1.EventTypeWarning, gardencorev1beta1.EventMigrationPreparationFailed, flowErr.Description)
 		updateErr := c.patchShootStatusOperationError(ctx, gardenClient.Client(), o, shoot, flowErr.Description, gardencorev1beta1.LastOperationTypeMigrate, flowErr.LastErrors...)
 		return reconcile.Result{}, utilerrors.WithSuppressed(errors.New(flowErr.Description), updateErr)
@@ -77,9 +77,8 @@ func (c *Controller) prepareShootForMigration(ctx context.Context, logger logrus
 	return c.finalizeShootPrepareForMigration(ctx, gardenClient.Client(), shoot, o)
 }
 
-func (c *Controller) runPrepareShootControlPlaneMigration(o *operation.Operation) *gardencorev1beta1helper.WrappedLastErrors {
+func (c *Controller) runPrepareShootControlPlaneMigration(ctx context.Context, o *operation.Operation) *gardencorev1beta1helper.WrappedLastErrors {
 	var (
-		ctx                          = context.TODO()
 		botanist                     *botanistpkg.Botanist
 		err                          error
 		tasksWithErrors              []string

--- a/test/framework/gardenerframework.go
+++ b/test/framework/gardenerframework.go
@@ -147,14 +147,14 @@ func RegisterGardenerFrameworkFlags() *GardenerConfig {
 
 // NewShootFramework creates a new shoot framework with the current gardener framework
 // and a shoot
-func (f *GardenerFramework) NewShootFramework(shoot *gardencorev1beta1.Shoot) (*ShootFramework, error) {
+func (f *GardenerFramework) NewShootFramework(ctx context.Context, shoot *gardencorev1beta1.Shoot) (*ShootFramework, error) {
 	shootFramework := &ShootFramework{
 		GardenerFramework: f,
 		Config: &ShootConfig{
 			GardenerConfig: f.GardenerFrameworkConfig,
 		},
 	}
-	if err := shootFramework.AddShoot(context.TODO(), shoot.GetName(), shoot.GetNamespace()); err != nil {
+	if err := shootFramework.AddShoot(ctx, shoot.GetName(), shoot.GetNamespace()); err != nil {
 		return nil, err
 	}
 	return shootFramework, nil

--- a/test/framework/shootcreationframework.go
+++ b/test/framework/shootcreationframework.go
@@ -367,7 +367,7 @@ func (f *ShootCreationFramework) CreateShoot(ctx context.Context, initializeShoo
 
 	if err := f.GardenerFramework.CreateShoot(ctx, f.Shoot); err != nil {
 		f.Logger.Fatalf("Cannot create shoot %s: %s", f.Shoot.GetName(), err.Error())
-		shootFramework, err2 := f.newShootFramework()
+		shootFramework, err2 := f.newShootFramework(ctx)
 		if err2 != nil {
 			f.Logger.Fatalf("Cannot dump shoot state %s: %s", f.Shoot.GetName(), err.Error())
 		} else {
@@ -377,7 +377,7 @@ func (f *ShootCreationFramework) CreateShoot(ctx context.Context, initializeShoo
 	}
 
 	f.Logger.Infof("Successfully created shoot %s", f.Shoot.GetName())
-	shootFramework, err := f.newShootFramework()
+	shootFramework, err := f.newShootFramework(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -435,8 +435,8 @@ func (f *ShootCreationFramework) InitializeShootWithFlags(ctx context.Context) e
 }
 
 // newShootFramework creates a new ShootFramework with the Shoot created by the ShootCreationFramework
-func (f *ShootCreationFramework) newShootFramework() (*ShootFramework, error) {
-	shootFramework, err := f.GardenerFramework.NewShootFramework(f.Shoot)
+func (f *ShootCreationFramework) newShootFramework(ctx context.Context) (*ShootFramework, error) {
+	shootFramework, err := f.GardenerFramework.NewShootFramework(ctx, f.Shoot)
 	if err != nil {
 		return nil, err
 	}

--- a/test/framework/shootmigrationtest.go
+++ b/test/framework/shootmigrationtest.go
@@ -87,7 +87,7 @@ func NewShootMigrationTest(f *GardenerFramework, cfg *ShootMigrationConfig) *Sho
 func (t *ShootMigrationTest) MigrateShoot(ctx context.Context) error {
 	// Dump gardener state if delete shoot is in exit handler
 	if os.Getenv("TM_PHASE") == "Exit" {
-		if shootFramework, err := t.GardenerFramework.NewShootFramework(&t.Shoot); err == nil {
+		if shootFramework, err := t.GardenerFramework.NewShootFramework(ctx, &t.Shoot); err == nil {
 			shootFramework.DumpState(ctx)
 		} else {
 			t.GardenerFramework.DumpState(ctx)

--- a/test/system/shoot_deletion/delete_test.go
+++ b/test/system/shoot_deletion/delete_test.go
@@ -65,7 +65,7 @@ var _ = Describe("Shoot deletion testing", func() {
 
 		// Dump gardener state if delete shoot is in exit handler
 		if os.Getenv("TM_PHASE") == "Exit" {
-			if shootFramework, err := f.NewShootFramework(shoot); err == nil {
+			if shootFramework, err := f.NewShootFramework(ctx, shoot); err == nil {
 				shootFramework.DumpState(ctx)
 			} else {
 				f.DumpState(ctx)
@@ -73,7 +73,7 @@ var _ = Describe("Shoot deletion testing", func() {
 		}
 
 		if err := f.DeleteShootAndWaitForDeletion(ctx, shoot); err != nil && !apierrors.IsNotFound(err) {
-			if shootFramework, err := f.NewShootFramework(shoot); err == nil {
+			if shootFramework, err := f.NewShootFramework(ctx, shoot); err == nil {
 				shootFramework.DumpState(ctx)
 			}
 			f.Logger.Fatalf("Cannot delete shoot %s: %s", *shootName, err.Error())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind cleanup

**What this PR does / why we need it**:
Cleanup remaining `context.TODO()` occurrences.

**Which issue(s) this PR fixes**:
Fixes #1648

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
