### PR TITLE
Fix integration test

### DIFF
--- a/test/framework/template.go
+++ b/test/framework/template.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/Masterminds/sprig"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 )
 
@@ -32,7 +33,10 @@ func (f *CommonFramework) RenderAndDeployTemplate(ctx context.Context, k8sClient
 		return fmt.Errorf("could not find template in %q", templateFilepath)
 	}
 
-	tpl, err := template.ParseFiles(templateFilepath)
+	tpl, err := template.
+		New(templateName).
+		Funcs(sprig.HtmlFuncMap()).
+		ParseFiles(templateFilepath)
 	if err != nil {
 		return fmt.Errorf("unable to parse template in %s: %w", templateFilepath, err)
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
This PR fixes a bug in the integration test introduced by #4562.

```
 s: "template: guestbook-app.yaml.tpl:45: function \"semverCompare\" not defined",
```

**Special notes for your reviewer**:
I ran the test locally against a test cluster successfully.
Thanks to @stoyanr for reporting.
/invite @stoyanr 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
