### PR TITLE
Fix validation of DNSRecords with DNS names starting with a wildcard

### DIFF
--- a/pkg/apis/extensions/validation/dnsrecord.go
+++ b/pkg/apis/extensions/validation/dnsrecord.go
@@ -15,6 +15,8 @@
 package validation
 
 import (
+	"strings"
+
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils"
 
@@ -65,7 +67,7 @@ func ValidateDNSRecordSpec(spec *extensionsv1alpha1.DNSRecordSpec, fldPath *fiel
 	}
 
 	// This will return FieldValueRequired for an empty spec.Name
-	allErrs = append(allErrs, validation.IsFullyQualifiedDomainName(fldPath.Child("name"), spec.Name)...)
+	allErrs = append(allErrs, validation.IsFullyQualifiedDomainName(fldPath.Child("name"), strings.TrimPrefix(spec.Name, "*."))...)
 
 	validRecordTypes := []string{string(extensionsv1alpha1.DNSRecordTypeA), string(extensionsv1alpha1.DNSRecordTypeCNAME), string(extensionsv1alpha1.DNSRecordTypeTXT)}
 	if !utils.ValueExists(string(spec.RecordType), validRecordTypes) {

--- a/pkg/apis/extensions/validation/dnsrecord_test.go
+++ b/pkg/apis/extensions/validation/dnsrecord_test.go
@@ -184,6 +184,13 @@ var _ = Describe("DNSRecord validation tests", func() {
 
 			Expect(errorList).To(BeEmpty())
 		})
+
+		It("should allow valid resources with wildcard names", func() {
+			dns.Spec.Name = "*.test.example.com"
+			errorList := ValidateDNSRecord(dns)
+
+			Expect(errorList).To(BeEmpty())
+		})
 	})
 
 	Describe("#ValidateDNSRecordUpdate", func() {


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind bug

**What this PR does / why we need it**:
Fixes the validation of `DNSRecord` resources with DNS names starting with a wildcard, e.g. `*.ingress....`. This bug would cause reconciling shoots with `nginxIngress` addon enabled to fail with a validation error if #4499 is merged and the `UseDNSRecords` feature gate is set to `true`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```other operator
NONE
```
