### PR TITLE
Prevent Grafana of being deployed on a testing shoot

### DIFF
--- a/pkg/operation/botanist/monitoring.go
+++ b/pkg/operation/botanist/monitoring.go
@@ -289,6 +289,10 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 }
 
 func (b *Botanist) DeploySeedGrafana(ctx context.Context) error {
+	if b.Shoot.Purpose == gardencorev1beta1.ShootPurposeTesting {
+		return b.DeleteGrafana(ctx)
+	}
+
 	var (
 		credentials         = b.LoadSecret(common.MonitoringIngressCredentials)
 		credentialsUsers    = b.LoadSecret(common.MonitoringIngressCredentialsUsers)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind bug

**What this PR does / why we need it**:
With this PR Grafana is prevent from being deployed on shoots for testing purposes.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Grafana is no longer deployed for shoot clusters with `testing` purpose.
```
