### PR TITLE
Make use of `kutil.IgnoreAlreadyExists` where possible

### DIFF
--- a/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
@@ -124,7 +124,7 @@ func (a *genericActuator) deployMachineSetsAndMachines(ctx context.Context, logg
 		for _, machineSet := range machineSets {
 			// Create the MachineSet if not already exists. We do not care about the MachineSet status
 			// because the MCM will update it
-			if err := a.client.Create(ctx, &machineSet); err != nil && !apierrors.IsAlreadyExists(err) {
+			if err := a.client.Create(ctx, &machineSet); kutil.IgnoreAlreadyExists(err) != nil {
 				return err
 			}
 		}
@@ -132,8 +132,7 @@ func (a *genericActuator) deployMachineSetsAndMachines(ctx context.Context, logg
 		// Deploy each machine owned by the MachineSet which was restored above
 		for _, machine := range wantedMachineDeployment.State.Machines {
 			// Create the machine if it not exists already
-			err := a.client.Create(ctx, &machine)
-			if err != nil && !apierrors.IsAlreadyExists(err) {
+			if err := a.client.Create(ctx, &machine); kutil.IgnoreAlreadyExists(err) != nil {
 				return err
 			}
 

--- a/extensions/pkg/terraformer/state.go
+++ b/extensions/pkg/terraformer/state.go
@@ -206,11 +206,7 @@ func CreateState(ctx context.Context, c client.Client, namespace, name string, o
 		configMap.SetOwnerReferences(kutil.MergeOwnerReferences(configMap.OwnerReferences, *ownerRef))
 	}
 
-	if err := c.Create(ctx, configMap); err != nil && !apierrors.IsAlreadyExists(err) {
-		return err
-	}
-
-	return nil
+	return kutil.IgnoreAlreadyExists(c.Create(ctx, configMap))
 }
 
 // Initialize implements StateConfigMapInitializer

--- a/landscaper/pkg/gardenlet/controller/gardenlet_reconcile.go
+++ b/landscaper/pkg/gardenlet/controller/gardenlet_reconcile.go
@@ -99,7 +99,7 @@ func (g *Landscaper) Reconcile(ctx context.Context) error {
 	}
 
 	gardenNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.GardenNamespace}}
-	if err := g.seedClient.Client().Create(ctx, gardenNamespace); err != nil && !apierrors.IsAlreadyExists(err) {
+	if err := g.seedClient.Client().Create(ctx, gardenNamespace); kutil.IgnoreAlreadyExists(err) != nil {
 		return err
 	}
 

--- a/pkg/operation/botanist/component/clusterautoscaler/cluster_autoscaler.go
+++ b/pkg/operation/botanist/component/clusterautoscaler/cluster_autoscaler.go
@@ -34,7 +34,6 @@ import (
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -117,7 +116,7 @@ func (c *clusterAutoscaler) Deploy(ctx context.Context) error {
 		command       = c.computeCommand()
 	)
 
-	if err := c.client.Create(ctx, serviceAccount); err != nil && !apierrors.IsAlreadyExists(err) {
+	if err := c.client.Create(ctx, serviceAccount); kutil.IgnoreAlreadyExists(err) != nil {
 		return err
 	}
 

--- a/pkg/operation/botanist/component/istio/ingress_gateway.go
+++ b/pkg/operation/botanist/component/istio/ingress_gateway.go
@@ -21,11 +21,11 @@ import (
 	v1alpha1constants "github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
 	networkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -89,7 +89,7 @@ func (i *ingress) Deploy(ctx context.Context) error {
 				Labels: getIngressGatewayNamespaceLabels(i.values.Labels),
 			},
 		},
-	); err != nil && !apierrors.IsAlreadyExists(err) {
+	); kutil.IgnoreAlreadyExists(err) != nil {
 		return err
 	}
 

--- a/pkg/operation/botanist/component/istio/istiod.go
+++ b/pkg/operation/botanist/component/istio/istiod.go
@@ -20,9 +20,9 @@ import (
 
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -71,7 +71,7 @@ func (i *istiod) Deploy(ctx context.Context) error {
 				},
 			},
 		},
-	); err != nil && !apierrors.IsAlreadyExists(err) {
+	); kutil.IgnoreAlreadyExists(err) != nil {
 		return err
 	}
 

--- a/pkg/operation/botanist/component/kubescheduler/kube_scheduler.go
+++ b/pkg/operation/botanist/component/kubescheduler/kube_scheduler.go
@@ -36,7 +36,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -148,7 +147,7 @@ func (k *kubeScheduler) Deploy(ctx context.Context) error {
 		command              = k.computeCommand(port)
 	)
 
-	if err := k.client.Create(ctx, configMap); err != nil && !apierrors.IsAlreadyExists(err) {
+	if err := k.client.Create(ctx, configMap); kutil.IgnoreAlreadyExists(err) != nil {
 		return err
 	}
 

--- a/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server.go
+++ b/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server.go
@@ -37,7 +37,6 @@ import (
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -221,19 +220,19 @@ func (v *vpnSeedServer) Deploy(ctx context.Context) error {
 		vpaUpdateMode = autoscalingv1beta2.UpdateModeAuto
 	)
 
-	if err := v.client.Create(ctx, configMap); err != nil && !apierrors.IsAlreadyExists(err) {
+	if err := v.client.Create(ctx, configMap); kutil.IgnoreAlreadyExists(err) != nil {
 		return err
 	}
 
-	if err := v.client.Create(ctx, serverSecret); err != nil && !apierrors.IsAlreadyExists(err) {
+	if err := v.client.Create(ctx, serverSecret); kutil.IgnoreAlreadyExists(err) != nil {
 		return err
 	}
 
-	if err := v.client.Create(ctx, tlsAuthSecret); err != nil && !apierrors.IsAlreadyExists(err) {
+	if err := v.client.Create(ctx, tlsAuthSecret); kutil.IgnoreAlreadyExists(err) != nil {
 		return err
 	}
 
-	if err := v.client.Create(ctx, dhSecret); err != nil && !apierrors.IsAlreadyExists(err) {
+	if err := v.client.Create(ctx, dhSecret); kutil.IgnoreAlreadyExists(err) != nil {
 		return err
 	}
 

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -518,10 +518,8 @@ func (o *Operation) EnsureShootStateExists(ctx context.Context) error {
 		}
 	)
 
-	if err = o.K8sGardenClient.Client().Create(ctx, shootState); err != nil {
-		if !apierrors.IsAlreadyExists(err) {
-			return err
-		}
+	if err = o.K8sGardenClient.Client().Create(ctx, shootState); kutil.IgnoreAlreadyExists(err) != nil {
+		return err
 	}
 
 	if err = o.K8sGardenClient.Client().Get(ctx, client.ObjectKeyFromObject(shootState), shootState); err != nil {

--- a/test/integration/envtest/seedadmissioncontroller/extensioncrds_test.go
+++ b/test/integration/envtest/seedadmissioncontroller/extensioncrds_test.go
@@ -33,6 +33,7 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/test"
 )
 
@@ -83,9 +84,7 @@ var _ = Describe("Extension CRDs Webhook Handler", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
-		if err := c.Create(ctx, ns); err != nil && !apierrors.IsAlreadyExists(err) {
-			Expect(err).NotTo(HaveOccurred())
-		}
+		Expect(kutil.IgnoreAlreadyExists(c.Create(ctx, ns))).NotTo(HaveOccurred())
 
 		By("applying CRDs")
 		applier, err := kubernetes.NewChartApplierForConfig(restConfig)

--- a/test/integration/shoots/logging/utils.go
+++ b/test/integration/shoots/logging/utils.go
@@ -25,13 +25,13 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/retry"
 	"github.com/gardener/gardener/test/framework"
 
 	"github.com/onsi/ginkgo"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/pointer"
@@ -120,10 +120,7 @@ func encode(obj runtime.Object) []byte {
 
 func create(ctx context.Context, c client.Client, obj client.Object) error {
 	obj.SetResourceVersion("")
-	if err := c.Create(ctx, obj); !apierrors.IsAlreadyExists(err) {
-		return err
-	}
-	return nil
+	return kutil.IgnoreAlreadyExists(c.Create(ctx, obj))
 }
 
 func getShootNamesapce(number int) *corev1.Namespace {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:
Make use of `kutil.IgnoreAlreadyExists` where possible.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
