### PR TITLE
[release-v1.30] Automated cherry pick of #4594: Prevent Grafana of being deployed on a testing shoot

### DIFF
--- a/pkg/operation/botanist/monitoring.go
+++ b/pkg/operation/botanist/monitoring.go
@@ -289,6 +289,10 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 }
 
 func (b *Botanist) DeploySeedGrafana(ctx context.Context) error {
+	if b.Shoot.Purpose == gardencorev1beta1.ShootPurposeTesting {
+		return b.DeleteGrafana(ctx)
+	}
+
 	var (
 		credentials         = b.LoadSecret(common.MonitoringIngressCredentials)
 		credentialsUsers    = b.LoadSecret(common.MonitoringIngressCredentialsUsers)


### PR DESCRIPTION
/kind/bug
/area/logging

Cherry pick of #4594 on release-v1.30.

#4594: Prevent Grafana of being deployed on a testing shoot

**Release Notes:**
```bugfix user
Grafana is no longer deployed for shoot clusters with `testing` purpose.
```