### PR TITLE
add preconditions for control plane migration

### DIFF
--- a/docs/usage/control_plane_migration.md
+++ b/docs/usage/control_plane_migration.md
@@ -2,7 +2,7 @@
 
 ## Preconditions
 
-To be able to use this feature you need to enable the feature gate `SeedChange` in your `garden-apiserver`
+To be able to use this feature you need to enable the feature gate `SeedChange` in your `gardener-apiserver`
 by adding the following command flag: `--feature-flags=SeedChange=true`.
 
 Also, the involved Seeds need to have enabled BackupBuckets.

--- a/docs/usage/control_plane_migration.md
+++ b/docs/usage/control_plane_migration.md
@@ -3,7 +3,7 @@
 ## Preconditions
 
 To be able to use this feature you need to enable the feature gate `SeedChange` in your `gardener-apiserver`
-by adding the following command flag: `--feature-flags=SeedChange=true`.
+by adding the following command flag: `--feature-gates=SeedChange=true`.
 
 Also, the involved Seeds need to have enabled BackupBuckets.
 

--- a/docs/usage/control_plane_migration.md
+++ b/docs/usage/control_plane_migration.md
@@ -1,5 +1,12 @@
 # Control Plane Migration
 
+## Preconditions
+
+To be able to use this feature you need to enable the feature gate `SeedChange` in your `garden-apiserver`
+by adding the following command flag: `--feature-flags=SeedChange=true`.
+
+Also, the involved Seeds need to have enabled BackupBuckets.
+
 ## ShootState
 
 `ShootState` is an API resource which stores non-reconstructible state and data required to completely recreate a `Shoot`'s control plane on a new `Seed`.  The `ShootState` resource is created on `Shoot` creation in its `Project` namespace and the required state/data is persisted during `Shoot` creation or reconciliation.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind enhancement

**What this PR does / why we need it**:
Adds a brief precondition section to indicate what needs to be done so control plane migration works.

