### PR TITLE
Add metrics/v1beta1 types to shoot scheme

### DIFF
--- a/pkg/client/kubernetes/types.go
+++ b/pkg/client/kubernetes/types.go
@@ -36,6 +36,7 @@ import (
 	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	apiregistrationscheme "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/scheme"
+	metricsv1beta1 "k8s.io/metrics/pkg/apis/metrics/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -118,6 +119,7 @@ func init() {
 		apiextensionsscheme.AddToScheme,
 		apiregistrationscheme.AddToScheme,
 		autoscalingv1beta2.AddToScheme,
+		metricsv1beta1.AddToScheme,
 	)
 	utilruntime.Must(shootSchemeBuilder.AddToScheme(ShootScheme))
 


### PR DESCRIPTION
**How to categorize this PR?**

/area quality
/kind bug

**What this PR does / why we need it**:
Adds `metrics/v1beta1` types to the shoot scheme to prevent integration test failures such as:
```
no kind is registered for the type v1beta1.PodMetrics in scheme "pkg/client/kubernetes/types.go:56"
```

For reference, the `metricsv1beta1.PodMetrics` type is used in https://github.com/gardener/gardener/blob/2d32009b705de07803f66e95f52bdb61dabddee9/test/integration/shoots/applications/metrics.go#L87-L88.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```other operator
NONE
```
