### PR TITLE
Consider status.seedName when calculating seed usage

### DIFF
--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -1385,3 +1385,25 @@ func ShootWantsAnonymousAuthentication(kubeAPIServerConfig *gardencorev1beta1.Ku
 	}
 	return *kubeAPIServerConfig.EnableAnonymousAuthentication
 }
+
+// CalculateSeedUsage returns a map representing the number of shoots per seed from the given list of shoots.
+// It takes both spec.seedName and status.seedName into account.
+func CalculateSeedUsage(shootList []gardencorev1beta1.Shoot) map[string]int {
+	m := map[string]int{}
+
+	for _, shoot := range shootList {
+		var (
+			specSeed   = pointer.StringDeref(shoot.Spec.SeedName, "")
+			statusSeed = pointer.StringDeref(shoot.Status.SeedName, "")
+		)
+
+		if specSeed != "" {
+			m[specSeed]++
+		}
+		if statusSeed != "" && specSeed != statusSeed {
+			m[statusSeed]++
+		}
+	}
+
+	return m
+}

--- a/pkg/scheduler/controller/shoot/reconciler.go
+++ b/pkg/scheduler/controller/shoot/reconciler.go
@@ -25,8 +25,8 @@ import (
 	"github.com/gardener/gardener/pkg/scheduler/controller/common"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	cidrvalidation "github.com/gardener/gardener/pkg/utils/validation/cidr"
-	"github.com/go-logr/logr"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -233,7 +233,7 @@ func filterCandidates(shoot *gardencorev1beta1.Shoot, shootList []gardencorev1be
 	var (
 		candidates      []gardencorev1beta1.Seed
 		candidateErrors = make(map[string]error)
-		seedUsage       = generateSeedUsageMap(shootList)
+		seedUsage       = gardencorev1beta1helper.CalculateSeedUsage(shootList)
 	)
 
 	for _, seed := range seedList {
@@ -271,7 +271,7 @@ func getSeedWithLeastShootsDeployed(seedList []gardencorev1beta1.Seed, shootList
 	var (
 		bestCandidate gardencorev1beta1.Seed
 		min           *int
-		seedUsage     = generateSeedUsageMap(shootList)
+		seedUsage     = gardencorev1beta1helper.CalculateSeedUsage(shootList)
 	)
 
 	for _, seed := range seedList {
@@ -345,18 +345,6 @@ func determineCandidatesWithMinimalDistanceStrategy(seeds []gardencorev1beta1.Se
 		}
 	}
 	return candidates
-}
-
-func generateSeedUsageMap(shootList []gardencorev1beta1.Shoot) map[string]int {
-	m := map[string]int{}
-
-	for _, shoot := range shootList {
-		if seed := shoot.Spec.SeedName; seed != nil {
-			m[*seed]++
-		}
-	}
-
-	return m
 }
 
 func networksAreDisjointed(seed *gardencorev1beta1.Seed, shoot *gardencorev1beta1.Shoot) (bool, error) {

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -376,13 +376,8 @@ func getNumberOfShootsOnSeed(shootLister corelisters.ShootLister, seedName strin
 		return 0, fmt.Errorf("could not list all shoots: %w", err)
 	}
 
-	count := int64(0)
-	for _, shoot := range allShoots {
-		if seed := shoot.Spec.SeedName; seed != nil && *seed == seedName {
-			count++
-		}
-	}
-	return count, nil
+	seedUsage := helper.CalculateSeedUsage(allShoots)
+	return int64(seedUsage[seedName]), nil
 }
 
 func (c *validationContext) validateDeletion(a admission.Attributes) error {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:

This PR adapts the scheduler's and the shoot admission's calculation for the seed usage to also consider Shoots with `status.seedName == seedName` as scheduled on the seed in question.

**Which issue(s) this PR fixes**:
See https://github.com/gardener/gardener/pull/4521#discussion_r698450370

**Special notes for your reviewer**:

/invite @plkokanov @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Gardener now considers Shoots, that are currently in migration between Seeds, when calculating the Seed usage for adhering to Seed capacity settings (`Seed.status.{capacity,allocatable}`).
```
