### PR TITLE
Adapt deprecated label key usage in NetworkPolicies (2)

### DIFF
--- a/charts/seed-bootstrap/charts/loki/templates/statefulset.yaml
+++ b/charts/seed-bootstrap/charts/loki/templates/statefulset.yaml
@@ -21,6 +21,7 @@ spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
+      garden.sapcloud.io/role: logging
 {{ toYaml .Values.labels | indent 6 }}
   template:
     metadata:
@@ -30,6 +31,7 @@ spec:
         networking.gardener.cloud/to-dns: allowed
         networking.gardener.cloud/to-shoot-apiserver: allowed
 {{- end}}
+        garden.sapcloud.io/role: logging
 {{ toYaml .Values.labels | indent 8 }}
       annotations:
 {{ include "loki.statefulset.annotations" . | indent 8 }}

--- a/charts/seed-bootstrap/charts/loki/values.yaml
+++ b/charts/seed-bootstrap/charts/loki/values.yaml
@@ -18,8 +18,6 @@ rbacSidecarEnabled: false
 kubeRBACProxyKubeconfigCheckSum: bed9a4ef5410793c023b3551308661a1a1acafe9f93c9393714ce4f2c0134ac3
 
 labels:
-  # deprecated label
-  garden.sapcloud.io/role: logging
   gardener.cloud/role: logging
   app: loki
   role: logging


### PR DESCRIPTION
/kind cleanup

Second part of #4572. The loki chart/component was the last one with the deprecated role label key in NetworkPolicies.
This PR adapts the loki related NetworkPolicies to do not rely on the deprecated `garden.sapcloud.io/role` label key.

Part of #1649

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
