### PR TITLE
Allow restore operation for migrated resources

### DIFF
--- a/extensions/pkg/controller/containerruntime/reconciler.go
+++ b/extensions/pkg/controller/containerruntime/reconciler.go
@@ -100,13 +100,17 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	operationType := gardencorev1beta1helper.ComputeOperationType(cr.ObjectMeta, cr.Status.LastOperation)
 
 	switch {
-	case extensionscontroller.IsMigrated(cr):
-		return reconcile.Result{}, nil
 	case operationType == gardencorev1beta1.LastOperationTypeMigrate:
+		if extensionscontroller.IsMigrated(cr) {
+			return reconcile.Result{}, nil
+		}
 		return r.migrate(ctx, cr, cluster)
 	case cr.DeletionTimestamp != nil:
+		if extensionscontroller.IsMigrated(cr) {
+			return reconcile.Result{}, nil
+		}
 		return r.delete(ctx, cr, cluster)
-	case cr.Annotations[v1beta1constants.GardenerOperation] == v1beta1constants.GardenerOperationRestore:
+	case operationType == gardencorev1beta1.LastOperationTypeRestore:
 		return r.restore(ctx, cr, cluster)
 	default:
 		return r.reconcile(ctx, cr, cluster, operationType)

--- a/extensions/pkg/controller/controlplane/genericactuator/actuator.go
+++ b/extensions/pkg/controller/controlplane/genericactuator/actuator.go
@@ -24,6 +24,7 @@ import (
 	"github.com/gardener/gardener/extensions/pkg/controller/controlplane"
 	"github.com/gardener/gardener/extensions/pkg/webhook"
 	extensionswebhookshoot "github.com/gardener/gardener/extensions/pkg/webhook/shoot"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	gardenerkubernetes "github.com/gardener/gardener/pkg/client/kubernetes"
@@ -272,17 +273,11 @@ func (a *actuator) reconcileControlPlane(
 		// then we requeue the `ControlPlane` CRD in order to give the provider-specific control plane components time to
 		// properly prepare the cluster for hibernation (whatever needs to be done). If the kube-apiserver is already scaled down
 		// then we allow continuing the reconciliation.
-		if cluster.Shoot.DeletionTimestamp == nil {
+		if cluster.Shoot.DeletionTimestamp == nil && (cluster.Shoot.Status.LastOperation == nil || cluster.Shoot.Status.LastOperation.Type != gardencorev1beta1.LastOperationTypeMigrate) {
 			if dep.Spec.Replicas != nil && *dep.Spec.Replicas > 0 {
 				requeue = true
 			} else {
 				scaledDown = true
-			}
-			// Similarly, if a hibernated shoot is deleted then we might need to wake up all the provider-specific components. We
-			// wait until the kube-apiserver is woken up again before we wake up the provider-specific components.
-		} else {
-			if dep.Spec.Replicas == nil || *dep.Spec.Replicas == 0 {
-				return true, nil
 			}
 		}
 	}

--- a/extensions/pkg/controller/network/reconciler.go
+++ b/extensions/pkg/controller/network/reconciler.go
@@ -96,13 +96,17 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	operationType := gardencorev1beta1helper.ComputeOperationType(network.ObjectMeta, network.Status.LastOperation)
 
 	switch {
-	case extensionscontroller.IsMigrated(network):
-		return reconcile.Result{}, nil
 	case operationType == gardencorev1beta1.LastOperationTypeMigrate:
+		if extensionscontroller.IsMigrated(network) {
+			return reconcile.Result{}, nil
+		}
 		return r.migrate(ctx, network, cluster)
 	case network.DeletionTimestamp != nil:
+		if extensionscontroller.IsMigrated(network) {
+			return reconcile.Result{}, nil
+		}
 		return r.delete(ctx, network, cluster)
-	case network.Annotations[v1beta1constants.GardenerOperation] == v1beta1constants.GardenerOperationRestore:
+	case operationType == gardencorev1beta1.LastOperationTypeRestore:
 		return r.restore(ctx, network, cluster)
 	default:
 		return r.reconcile(ctx, network, cluster, operationType)

--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -187,6 +187,8 @@ func ComputeOperationType(meta metav1.ObjectMeta, lastOperation *gardencorev1bet
 		return gardencorev1beta1.LastOperationTypeMigrate
 	case meta.DeletionTimestamp != nil:
 		return gardencorev1beta1.LastOperationTypeDelete
+	case meta.Annotations[v1beta1constants.GardenerOperation] == v1beta1constants.GardenerOperationRestore:
+		return gardencorev1beta1.LastOperationTypeRestore
 	case lastOperation == nil:
 		return gardencorev1beta1.LastOperationTypeCreate
 	case lastOperation.Type == gardencorev1beta1.LastOperationTypeCreate && lastOperation.State != gardencorev1beta1.LastOperationStateSucceeded:

--- a/pkg/gardenlet/controller/backupentry/backup_entry_reconciler.go
+++ b/pkg/gardenlet/controller/backupentry/backup_entry_reconciler.go
@@ -118,10 +118,6 @@ func (r *reconciler) reconcileBackupEntry(ctx context.Context, gardenClient kube
 	}
 
 	operationType := gardencorev1beta1helper.ComputeOperationType(backupEntry.ObjectMeta, backupEntry.Status.LastOperation)
-	if kutil.HasMetaDataAnnotation(&backupEntry.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationRestore) {
-		operationType = gardencorev1beta1.LastOperationTypeRestore
-	}
-
 	if updateErr := r.updateBackupEntryStatusOperationStart(ctx, gardenClient.Client(), backupEntry, operationType); updateErr != nil {
 		backupEntryLogger.Errorf("Could not update the status after reconciliation start: %+v", updateErr)
 		return reconcile.Result{}, updateErr


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind enhancement

**What this PR does / why we need it**:
This PR makes it possible to restore extension resources that have already been migrated. This is needed for #4584 

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
I've modified the `ComputeOperationType()` function so that it always returns the correct operation and we don't have to check for annotations on the resource outside of that function to determine whether the operation is `restore`, `migrate` or  `reconcile` 
I've removed the lines of code here: https://github.com/gardener/gardener/blob/cedb8b3aadd71cbfae984bd15261b949b0f096e1/extensions/pkg/controller/controlplane/genericactuator/actuator.go#L283-L287 
Since I have modified this check https://github.com/gardener/gardener/blob/cedb8b3aadd71cbfae984bd15261b949b0f096e1/extensions/pkg/controller/controlplane/genericactuator/actuator.go#L275 to also check if the current operation is NOT `migrate` 

If those lines of code are present, the `Controlplane` will get stuck in an infinite reconciliation loop when we try to restore it during migration if the shoot is hibernated as the replicas of the kube-apiserver are 0 at that time and the restore operation is never considered successful by the gardenlet as the `gardenr.cloud/operation=restore` annotation is still present on the resource. This all means that the migration flow can not continue to the next step to scale up the kube-apiserver. However, I could not find an easy way to resolve the check whether the operation is successful or not.  

I think that it's safe to remove lines [283-287](https://github.com/gardener/gardener/blob/cedb8b3aadd71cbfae984bd15261b949b0f096e1/extensions/pkg/controller/controlplane/genericactuator/actuator.go#L283-L287 ) since they are only called when a hibernated shoot is being deleted, but not when a shoot is created or during a normal wake up and they simply requeue the reconciliation until the kube-apiserver gets scaled up. If the requeue is skipped, the controlplane components will anyway be scaled up, but they will be restarted a few times before the kube-apiserver comes up. The original issue - [#260](https://github.com/gardener-attic/gardener-extensions/pull/260) seems to be fixed without those lines. @rfranzke @stoyanr perhaps you can doublecheck if my assumption is correct here.
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Extensions that have been successfully migrated can now be restored.
```
