### PR TITLE
Keep `watch_cache_capacity` and go runtime metrics

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
@@ -100,6 +100,8 @@ allowedMetrics:
   - process_open_fds
   - watch_cache_capacity_increase_total
   - watch_cache_capacity_decrease_total
+  - watch_cache_capacity
+  - go_.+
   kubeProxy:
   - kubeproxy_network_programming_duration_seconds_bucket
   - kubeproxy_network_programming_duration_seconds_count


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

Keep `watch_cache_capacity` and go runtime metrics of kube-apiserver.

Since kubernetes 1.19, the API server watch caches are dynamically sized.
We already have metrics and dashboards for the increase/decrease of the watch cache sizes, but not for the actual current watch cache size.
Note, that the `watch_cache_capacity` metric is only available starting from k8s 1.21: https://github.com/kubernetes/kubernetes/pull/96904

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

We should also add a dashboard panel based on that metric.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
