### PR TITLE
Adds list of resources with generated names to ignore after cp migration integration tests

### DIFF
--- a/.test-defs/MigrateShoot.yaml
+++ b/.test-defs/MigrateShoot.yaml
@@ -16,4 +16,5 @@ spec:
     -shoot-namespace=$PROJECT_NAMESPACE
     -kubecfg="$TM_KUBECONFIG_PATH/gardener.config"
     -mr-exclude-list="$MR_EXCLUDE_LIST"
+    -resources-with-generated-name="$RESOURCES_WITH_GENERATED_NAME"
   image: eu.gcr.io/gardener-project/3rd/golang:1.16.7

--- a/test/framework/shootmigrationtest.go
+++ b/test/framework/shootmigrationtest.go
@@ -203,7 +203,7 @@ func (t *ShootMigrationTest) CompareElementsAfterMigration() error {
 
 // Check the timestamp of all objects that the resource-manager creates in the Shoot cluster.
 // The timestamp should not be after the ShootMigrationTest.MigrationTime
-func (t *ShootMigrationTest) CheckObjectsTimestamp(ctx context.Context, mrExcludeList []string) error {
+func (t *ShootMigrationTest) CheckObjectsTimestamp(ctx context.Context, mrExcludeList, resourcesWithGeneratedName []string) error {
 	mrList := &resourcesv1alpha1.ManagedResourceList{}
 	if err := t.TargetSeedClient.Client().List(
 		ctx,
@@ -218,6 +218,11 @@ func (t *ShootMigrationTest) CheckObjectsTimestamp(ctx context.Context, mrExclud
 			if !utils.ValueExists(mr.GetName(), mrExcludeList) {
 				t.GardenerFramework.Logger.Infof("=== Managed Resource: %s/%s ===", mr.Namespace, mr.Name)
 				for _, r := range mr.Status.Resources {
+					nameWithoutSHA256Sum := r.Name[:len(r.Name)-9]
+					if utils.ValueExists(nameWithoutSHA256Sum, resourcesWithGeneratedName) {
+						continue
+					}
+
 					obj := &unstructured.Unstructured{}
 					obj.SetAPIVersion(r.APIVersion)
 					obj.SetKind(r.Kind)

--- a/test/system/shoot_cp_migration/migrate_test.go
+++ b/test/system/shoot_cp_migration/migrate_test.go
@@ -46,11 +46,12 @@ const (
 )
 
 var (
-	targetSeedName *string
-	shootName      *string
-	shootNamespace *string
-	mrExcludeList  *string
-	gardenerConfig *GardenerConfig
+	targetSeedName             *string
+	shootName                  *string
+	shootNamespace             *string
+	mrExcludeList              *string
+	resourcesWithGeneratedName *string
+	gardenerConfig             *GardenerConfig
 )
 
 func init() {
@@ -59,6 +60,7 @@ func init() {
 	shootName = flag.String("shoot-name", "", "name of the shoot")
 	shootNamespace = flag.String("shoot-namespace", "", "namespace of the shoot")
 	mrExcludeList = flag.String("mr-exclude-list", "", "comma-separated values of the ManagedResources that will be exlude during the 'CreationTimestamp' check")
+	resourcesWithGeneratedName = flag.String("resources-with-generated-name", "", "comma-separated names of resources deployed via managed resources that get their name generated during reconciliation and will be excluded during the 'CreationTimestamp' check")
 }
 
 var _ = ginkgo.Describe("Shoot migration testing", func() {
@@ -238,7 +240,7 @@ func afterMigration(ctx context.Context, t *ShootMigrationTest, guestBookApp app
 	guestBookApp.Cleanup(ctx)
 
 	ginkgo.By("Checking timestamps of all resources...")
-	if err := t.CheckObjectsTimestamp(ctx, strings.Split(*mrExcludeList, ",")); err != nil {
+	if err := t.CheckObjectsTimestamp(ctx, strings.Split(*mrExcludeList, ","), strings.Split(*resourcesWithGeneratedName, ",")); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/area test
/kind enhancement

**What this PR does / why we need it**:
Adds an additional option to the integration tests in which resources that are deployed as part of a `ManagedResource` can be listed. The actual names of the resources that should be added to the list have a sha256 sum appended to their names when they are created during reconciliation, e.g.: `apiserver-proxy-config-4a8878b6`. In that specific case the `resources-with-generated-name` option would just contain `apiserver-proxy-config`
Since this sha256 sum depends on the content of the resource (which can change when the control plane is migrated to a new seed) the resources will be recreated and [this check](https://github.com/gardener/gardener/blob/15b45a994678652d3bdefc5bc50982bb1b84beef/test/system/shoot_cp_migration/migrate_test.go#L241) will fail. The resources listed in `resources-with-generated-name` will be excluded from this check.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
One other approach I considered is to add an additional label in the charts of the specific resources that have a sha256 sum appended to their name. But this means that they would have a label only required by the integration tests. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
