### PR TITLE
Update Nginx Ingress

### DIFF
--- a/charts/gardener/gardenlet/charts/runtime/templates/clusterrole-gardenlet.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/clusterrole-gardenlet.yaml
@@ -280,6 +280,7 @@ rules:
   - networking.k8s.io
   resources:
   - ingresses
+  - ingressclasses
   verbs:
   - create
   - delete

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -190,8 +190,13 @@ images:
 - name: nginx-ingress-controller
   sourceRepository: github.com/kubernetes/ingress-nginx
   repository: k8s.gcr.io/ingress-nginx/controller
-  tag: "v0.41.2"
-  targetVersion: ">= 1.20"
+  tag: "v0.49.0"
+  targetVersion: ">= 1.20, < 1.22"
+- name: nginx-ingress-controller
+  sourceRepository: github.com/kubernetes/ingress-nginx
+  repository: k8s.gcr.io/ingress-nginx/controller
+  tag: "v1.0.0"
+  targetVersion: ">= 1.22"
 - name: nginx-ingress-controller-seed
   sourceRepository: github.com/kubernetes/ingress-nginx
   repository: k8s.gcr.io/ingress-nginx/controller

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -195,7 +195,13 @@ images:
 - name: nginx-ingress-controller-seed
   sourceRepository: github.com/kubernetes/ingress-nginx
   repository: k8s.gcr.io/ingress-nginx/controller
-  tag: "v0.41.2"
+  tag: "v0.49.0"
+  targetVersion: "< 1.22"
+- name: nginx-ingress-controller-seed
+  sourceRepository: github.com/kubernetes/ingress-nginx
+  repository: k8s.gcr.io/ingress-nginx/controller
+  tag: "v1.0.0"
+  targetVersion: ">= 1.22"
 - name: ingress-default-backend
   sourceRepository: github.com/gardener/ingress-default-backend
   repository: eu.gcr.io/gardener-project/gardener/ingress-default-backend

--- a/charts/seed-bootstrap/charts/loki/templates/kube-rbac-proxy-ingress.yaml
+++ b/charts/seed-bootstrap/charts/loki/templates/kube-rbac-proxy-ingress.yaml
@@ -3,13 +3,18 @@ apiVersion: {{ include "ingressversion" . }}
 kind: Ingress
 metadata:
   annotations:
+{{- if semverCompare "<= 1.21.x" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/ingress.class: {{ .Values.ingress.class }}
+{{- end }}
     nginx.ingress.kubernetes.io/configuration-snippet: "proxy_set_header X-Scope-OrgID operator;"
   name: loki
   namespace: {{ .Release.Namespace }}
   labels:
 {{ toYaml .Values.labels | indent 4 }}
 spec:
+{{- if semverCompare ">= 1.22" .Capabilities.KubeVersion.GitVersion }}
+  ingressClassName: {{ .Values.ingress.class }}
+{{- end }}
   tls:
   {{- range .Values.ingress.hosts }}
   - secretName: {{ required ".secretName is required" .secretName }}

--- a/charts/seed-bootstrap/charts/nginx-ingress/templates/_helpers.tpl
+++ b/charts/seed-bootstrap/charts/nginx-ingress/templates/_helpers.tpl
@@ -7,3 +7,11 @@
 {{- define "nginx-ingress.config.name" -}}
 nginx-ingress-controller-{{ include "nginx-ingress.config.data" . | sha256sum | trunc 8 }}
 {{- end }}
+
+{{- define "nginx-ingress.class" -}}
+{{- if semverCompare ">= 1.22" .Capabilities.KubeVersion.GitVersion -}}
+k8s.io/{{ .Values.global.ingressClass }}
+{{- else -}}
+{{ .Values.global.ingressClass }}
+{{- end }}
+{{- end }}

--- a/charts/seed-bootstrap/charts/nginx-ingress/templates/controller-deployment.yaml
+++ b/charts/seed-bootstrap/charts/nginx-ingress/templates/controller-deployment.yaml
@@ -61,6 +61,9 @@ spec:
             - --publish-service=garden/nginx-ingress-controller
             - --election-id=ingress-controller-seed-leader
             - --ingress-class={{ .Values.global.ingressClass }}
+            {{- if semverCompare ">= 1.22" .Capabilities.KubeVersion.GitVersion -}}
+            - --controller-class={{ include "nginx-ingress.class" . }}
+            {{- end }}
             - --update-status=true
             - --annotations-prefix=nginx.ingress.kubernetes.io
             - --configmap=garden/{{ include "nginx-ingress.config.name" . }}

--- a/charts/seed-bootstrap/charts/nginx-ingress/templates/ingressclass.yaml
+++ b/charts/seed-bootstrap/charts/nginx-ingress/templates/ingressclass.yaml
@@ -1,0 +1,11 @@
+{{- if semverCompare ">= 1.22" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  labels:
+    app: nginx-ingress
+    component: "controller"
+  name: {{ .Values.global.ingressClass }}
+spec:
+  controller: {{ include "nginx-ingress.class" . }}
+{{- end }}

--- a/charts/seed-bootstrap/charts/nginx-ingress/values.yaml
+++ b/charts/seed-bootstrap/charts/nginx-ingress/values.yaml
@@ -1,4 +1,5 @@
 global:
+  ingressClass: "seed-nginx"
   images:
     nginx-ingress-controller-seed: image-repository:image-tag
     ingress-default-backend: image-repository:image-tag

--- a/charts/seed-bootstrap/templates/aggregate-prometheus/ingress.yaml
+++ b/charts/seed-bootstrap/templates/aggregate-prometheus/ingress.yaml
@@ -2,13 +2,18 @@ apiVersion: {{ include "ingressversion" . }}
 kind: Ingress
 metadata:
   annotations:
+{{- if semverCompare "<= 1.21.x" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/ingress.class: {{ .Values.global.ingressClass }}
+{{- end }}
     nginx.ingress.kubernetes.io/auth-realm: Authentication Required
     nginx.ingress.kubernetes.io/auth-secret: aggregate-prometheus-basic-auth
     nginx.ingress.kubernetes.io/auth-type: basic
   name: aggregate-prometheus
   namespace: {{ .Release.Namespace }}
 spec:
+{{- if semverCompare ">= 1.22" .Capabilities.KubeVersion.GitVersion }}
+  ingressClassName: {{ .Values.global.ingressClass }}
+{{- end }}
   tls:
   - secretName: {{ .Values.aggregatePrometheus.secretName }}
     hosts:

--- a/charts/seed-bootstrap/templates/grafana/ingress.yaml
+++ b/charts/seed-bootstrap/templates/grafana/ingress.yaml
@@ -2,13 +2,18 @@ apiVersion: {{ include "ingressversion" . }}
 kind: Ingress
 metadata:
   annotations:
+{{- if semverCompare "<= 1.21.x" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/ingress.class: {{ .Values.global.ingressClass }}
+{{- end }}
     nginx.ingress.kubernetes.io/auth-realm: Authentication Required
     nginx.ingress.kubernetes.io/auth-secret: grafana-basic-auth
     nginx.ingress.kubernetes.io/auth-type: basic
   name: grafana
   namespace: {{ .Release.Namespace }}
 spec:
+{{- if semverCompare ">= 1.22" .Capabilities.KubeVersion.GitVersion }}
+  ingressClassName: {{ .Values.global.ingressClass }}
+{{- end }}
   tls:
   - secretName: {{ .Values.grafana.secretName }}
     hosts:

--- a/charts/seed-monitoring/charts/alertmanager/templates/ingress.yaml
+++ b/charts/seed-monitoring/charts/alertmanager/templates/ingress.yaml
@@ -2,13 +2,18 @@ apiVersion: {{ include "ingressversion" . }}
 kind: Ingress
 metadata:
   annotations:
+{{- if semverCompare "<= 1.21.x" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/ingress.class: {{ .Values.ingress.class }}
+{{- end }}
     nginx.ingress.kubernetes.io/auth-realm: Authentication Required
     nginx.ingress.kubernetes.io/auth-secret: {{ .Chart.Name }}-basic-auth
     nginx.ingress.kubernetes.io/auth-type: basic
   name: {{ .Chart.Name }}
   namespace: {{ .Release.Namespace }}
 spec:
+{{- if semverCompare ">= 1.22" .Capabilities.KubeVersion.GitVersion }}
+  ingressClassName: {{ .Values.ingress.class }}
+{{- end }}
   tls:
   {{- range .Values.ingress.hosts }}
   - secretName: {{ required ".secretName is required" .secretName }}

--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/ingress.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/ingress.yaml
@@ -2,13 +2,18 @@ apiVersion: {{ include "ingressversion" . }}
 kind: Ingress
 metadata:
   annotations:
+{{- if semverCompare "<= 1.21.x" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/ingress.class: {{ .Values.ingress.class }}
+{{- end }}
     nginx.ingress.kubernetes.io/auth-realm: Authentication Required
     nginx.ingress.kubernetes.io/auth-secret: {{ .Chart.Name }}-basic-auth
     nginx.ingress.kubernetes.io/auth-type: basic
   name: {{ .Chart.Name }}
   namespace: {{ .Release.Namespace }}
 spec:
+{{- if semverCompare ">= 1.22" .Capabilities.KubeVersion.GitVersion }}
+  ingressClassName: {{ .Values.ingress.class }}
+{{- end }}
   tls:
   {{- range .Values.ingress.hosts }}
   - secretName: {{ required ".secretName is required" .secretName }}

--- a/charts/seed-monitoring/charts/grafana/templates/grafana-ingress.yaml
+++ b/charts/seed-monitoring/charts/grafana/templates/grafana-ingress.yaml
@@ -2,7 +2,9 @@ apiVersion: {{ include "ingressversion" . }}
 kind: Ingress
 metadata:
   annotations:
+{{- if semverCompare "<= 1.21.x" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/ingress.class: {{ .Values.ingress.class }}
+{{- end }}
     nginx.ingress.kubernetes.io/auth-realm: Authentication Required
     nginx.ingress.kubernetes.io/auth-secret: grafana-{{ .Values.role }}-basic-auth
     nginx.ingress.kubernetes.io/auth-type: basic
@@ -17,6 +19,9 @@ metadata:
     component: grafana
     role: {{ .Values.role }}
 spec:
+{{- if semverCompare ">= 1.22" .Capabilities.KubeVersion.GitVersion }}
+  ingressClassName: {{ .Values.ingress.class }}
+{{- end }}
   tls:
   {{- range .Values.ingress.hosts }}
   - secretName: {{ required ".secretName is required" .secretName }}

--- a/charts/shoot-addons/charts/nginx-ingress/templates/_helpers.tpl
+++ b/charts/shoot-addons/charts/nginx-ingress/templates/_helpers.tpl
@@ -47,3 +47,11 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $name := default .Chart.Name .Values.nameOverride -}}
 {{- printf "%s-%s-%s" .Release.Name $name .Values.defaultBackend.name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{- define "nginx-ingress.class" -}}
+{{- if semverCompare ">= 1.22" .Capabilities.KubeVersion.GitVersion -}}
+k8s.io/{{ .Values.controller.ingressClass }}
+{{- else -}}
+{{ .Values.controller.ingressClass }}
+{{- end }}
+{{- end }}

--- a/charts/shoot-addons/charts/nginx-ingress/templates/controller-deployment.yaml
+++ b/charts/shoot-addons/charts/nginx-ingress/templates/controller-deployment.yaml
@@ -48,6 +48,10 @@ spec:
           - --publish-service={{ template "nginx-ingress.controller.publishServicePath" . }}
           {{- end }}
           - --election-id={{ .Values.controller.electionID }}
+          {{- if semverCompare ">= 1.22" .Capabilities.KubeVersion.GitVersion }}
+          - --watch-ingress-without-class=true
+          - --controller-class={{ include "nginx-ingress.class" . }}
+          {{- end }}
           - --ingress-class={{ .Values.controller.ingressClass }}
           - --update-status=true
           - --annotations-prefix=nginx.ingress.kubernetes.io

--- a/charts/shoot-addons/charts/nginx-ingress/templates/ingressclass.yaml
+++ b/charts/shoot-addons/charts/nginx-ingress/templates/ingressclass.yaml
@@ -1,0 +1,16 @@
+{{- if semverCompare ">= 1.22" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  annotations:
+    ingressclass.kubernetes.io/is-default-class: true
+  labels:
+    origin: gardener
+    gardener.cloud/role: optional-addon
+    app: {{ template "nginx-ingress.name" . }}
+    component: "{{ .Values.controller.name }}"
+    release: {{ .Release.Name }}
+  name: {{ .Values.controller.ingressClass }}
+spec:
+  controller: {{ include "nginx-ingress.class" . }}
+{{- end }}

--- a/landscaper/pkg/gardenlet/chart/charttest/charttest.go
+++ b/landscaper/pkg/gardenlet/chart/charttest/charttest.go
@@ -301,7 +301,7 @@ func getGardenletClusterRole(labels map[string]string) *rbacv1.ClusterRole {
 			},
 			{
 				APIGroups: []string{"extensions", "networking.k8s.io"},
-				Resources: []string{"ingresses"},
+				Resources: []string{"ingresses", "ingressclasses"},
 				Verbs:     []string{"create", "delete", "deletecollection", "get", "list", "watch", "patch", "update"},
 			},
 			{

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -448,6 +448,8 @@ const (
 
 	// SeedNginxIngressClass defines the ingress class for the seed nginx ingress controller
 	SeedNginxIngressClass = "nginx-gardener"
+	// SeedNginxIngressClass122 defines the ingress class for the seed nginx ingress controller for K8s >= 1.22
+	SeedNginxIngressClass122 = "nginx-ingress-gardener"
 	// IngressKindNginx defines nginx as kind as managed Seed ingress
 	IngressKindNginx = "nginx"
 	// ShootNginxIngressClass defines the ingress class for the seed nginx ingress controller

--- a/pkg/operation/botanist/logging.go
+++ b/pkg/operation/botanist/logging.go
@@ -56,11 +56,16 @@ func (b *Botanist) DeploySeedLogging(ctx context.Context) error {
 		hvpaEnabled = gardenletfeatures.FeatureGate.Enabled(features.HVPAForShootedSeed)
 	}
 
+	ingressClass, err := getIngressClass(b.Seed.GetInfo())
+	if err != nil {
+		return err
+	}
+
 	if b.isShootNodeLoggingEnabled() {
 		lokiValues["rbacSidecarEnabled"] = true
 		lokiValues["kubeRBACProxyKubeconfigCheckSum"] = b.LoadCheckSum(logging.SecretNameLokiKubeRBACProxyKubeconfig)
 		lokiValues["ingress"] = map[string]interface{}{
-			"class": getIngressClass(b.Seed.GetInfo().Spec.Ingress),
+			"class": ingressClass,
 			"hosts": []map[string]interface{}{
 				{
 					"hostName":    b.ComputeLokiHost(),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/topology seed shoot
/kind enhancement

**What this PR does / why we need it**:
This PR updates Nginx Ingress Controllers to `v0.49.0` (Kubernetes 1.20, 1.21), `v1.0.0` (Kubernetes >= 1.22) for shoot clusters and `v0.49.0` (Kubernetes 1.18, 1.19, 1.20, 1.21), `v1.0.0` (Kubernetes >= 1.22) for seed clusters (managed ingress feature).

**Which issue(s) this PR fixes**:
Fixes #4271
Parts of #4363

**Special notes for your reviewer**:
I used the best practices described in this document: https://kubernetes.github.io/ingress-nginx/#faq-migration-to-apiversion-networkingk8siov1

Additionally, I checked the following functionalities:
* ✅ Test `v0.49.0` with Kubernetes `v1.21.3` shoot cluster
* ✅ Test `v1.0.0` with Kubernetes `v1.22.1` by upgrading an existing shoot cluster
* ✅ Test `v0.49.0` with Kubernetes `v1.21.3` seed cluster
* ✅ Test `v1.0.0` with Kubernetes `v1.22.1` seed cluster by upgrading it
* ✅ Migrated a `v1.22.1` seed cluster from using the shoot addon Nginx to the seed managed Nginx feature

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The NGINX Ingress Controller has been updated to `v0.49.0` for seed clusters running Kubernetes 1.18, 1.19, 1.20, 1.21. For seed clusters running Kubernetes >= 1.22 NGINX Ingress Controller `v1.0.0` is used.
```

```feature user
The NGINX Ingress Controller addon has been updated to `v0.49.0` for shoot clusters running Kubernetes 1.20, 1.21. For shoot clusters running Kubernetes >= 1.22 NGINX Ingress Controller `v1.0.0` is used. Please have a detailed look at this [FAQ document](https://kubernetes.github.io/ingress-nginx/#faq-migration-to-apiversion-networkingk8siov1) which explains the most important ingress changes when updating to NGINX Ingress Controller `v1.0.0`.
```