### PR TITLE
[release-v1.30] Automated cherry pick of #4619: Fix gardenlet metrics

### DIFF
--- a/pkg/gardenlet/controller/networkpolicy/controller.go
+++ b/pkg/gardenlet/controller/networkpolicy/controller.go
@@ -198,9 +198,9 @@ func (c *Controller) RunningWorkers() int {
 
 // CollectMetrics implements gardenmetrics.ControllerMetricsCollector interface
 func (c *Controller) CollectMetrics(ch chan<- prometheus.Metric) {
-	metric, err := prometheus.NewConstMetric(gardenlet.ControllerWorkerSum, prometheus.GaugeValue, float64(c.RunningWorkers()), "extensions")
+	metric, err := prometheus.NewConstMetric(gardenlet.ControllerWorkerSum, prometheus.GaugeValue, float64(c.RunningWorkers()), "networkpolicy")
 	if err != nil {
-		gardenlet.ScrapeFailures.With(prometheus.Labels{"kind": "extensions-controller"}).Inc()
+		gardenlet.ScrapeFailures.With(prometheus.Labels{"kind": "networkpolicy-controller"}).Inc()
 		return
 	}
 	ch <- metric


### PR DESCRIPTION
/kind/bug
/area/monitoring

Cherry pick of #4619 on release-v1.30.

#4619: Fix gardenlet metrics

**Release Notes:**
```bugfix operator
Fix an issue where the gardenlet no longer exposed metrics
```