### PR TITLE
Make the linter fail on missing or wrong doc comments

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -10,12 +10,30 @@ run:
 
   skip-files:
   - ".*\\.pb\\.go$"
+  - "zz_generated\\..*\\.go$"
+  - "openapi_generated\\.go$"
 
 linters:
   disable:
   - unused
+  enable:
+  - golint
 
 issues:
+  exclude-use-default: false
+  exclude:
+  # errcheck: Almost all programs ignore errors on these functions and in most cases it's ok
+  - Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*printf?|os\.(Un)?Setenv). is not checked
+  # golint:
+  - (don't use underscores in Go names;|don't use an underscore in package name)
+  - ((var|const|struct field) `.*` should be `.*`|func .* should be .*)
+  - a blank import should be only in a main or test package, or have a comment justifying it
+  - should not use dot imports
+  - package comment should be of the form
+  - type name will be used as .* by other packages, and that stutters;
+  - exported func .* returns unexported type .*, which can be annoying to use
+  - "`if` block ends with a `return` statement, so drop this `else` and outdent its block"
+  - if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary)
   exclude-rules:
   - linters:
     - staticcheck

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -17,23 +17,20 @@ linters:
   disable:
   - unused
   enable:
-  - golint
+  - revive
 
 issues:
   exclude-use-default: false
   exclude:
   # errcheck: Almost all programs ignore errors on these functions and in most cases it's ok
   - Error return value of .((os\.)?std(out|err)\..*|.*Close|.*Flush|os\.Remove(All)?|.*printf?|os\.(Un)?Setenv). is not checked
-  # golint:
-  - (don't use underscores in Go names;|don't use an underscore in package name)
-  - ((var|const|struct field) `.*` should be `.*`|func .* should be .*)
-  - a blank import should be only in a main or test package, or have a comment justifying it
-  - should not use dot imports
-  - package comment should be of the form
-  - (type|func) name will be used as .* by other packages, and that stutters;
-  - exported func .* returns unexported type .*, which can be annoying to use
-  - "`if` block ends with a `return` statement, so drop this `else` and outdent its block"
-  - if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary)
+  # revive:
+  - var-naming # ((var|const|struct field|func) .* should be .*
+  - dot-imports # should not use dot imports
+  - package-comments # package comment should be of the form
+  - unexported-return # exported func .* returns unexported type .*, which can be annoying to use
+  - indent-error-flow # if block ends with a return statement, so drop this else and outdent its block
+  - "exported: (type|func) name will be used as .* by other packages, and that stutters;"
   exclude-rules:
   - linters:
     - staticcheck

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -30,7 +30,7 @@ issues:
   - a blank import should be only in a main or test package, or have a comment justifying it
   - should not use dot imports
   - package comment should be of the form
-  - type name will be used as .* by other packages, and that stutters;
+  - (type|func) name will be used as .* by other packages, and that stutters;
   - exported func .* returns unexported type .*, which can be annoying to use
   - "`if` block ends with a `return` statement, so drop this `else` and outdent its block"
   - if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary)

--- a/extensions/pkg/controller/common/context.go
+++ b/extensions/pkg/controller/common/context.go
@@ -34,7 +34,7 @@ type ClientContext struct {
 	client  client.Client
 }
 
-// NewClientConntext offers the possibility to create a ClientContext without injection.
+// NewClientContext offers the possibility to create a ClientContext without injection.
 func NewClientContext(client client.Client, scheme *runtime.Scheme, decoder runtime.Decoder) ClientContext {
 	if decoder == nil && scheme != nil {
 		decoder = serializer.NewCodecFactory(scheme, serializer.EnableStrict).UniversalDecoder()

--- a/extensions/pkg/controller/healthcheck/actuator.go
+++ b/extensions/pkg/controller/healthcheck/actuator.go
@@ -50,7 +50,7 @@ import (
 // For example: func() extensionsv1alpha1.Object {return &extensionsv1alpha1.Worker{}}
 type GetExtensionObjectFunc = func() extensionsv1alpha1.Object
 
-// GetExtensionObjectFunc returns the extension object that should be registered with the health check controller. Has to be a List.
+// GetExtensionObjectListFunc returns the extension object list that should be registered with the health check controller.
 // For example: func() client.ObjectList { return &extensionsv1alpha1.WorkerList{} }
 type GetExtensionObjectListFunc = func() client.ObjectList
 

--- a/extensions/pkg/controller/healthcheck/config/types.go
+++ b/extensions/pkg/controller/healthcheck/config/types.go
@@ -16,6 +16,7 @@ package config
 
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+// HealthCheckConfig contains the health check controller configuration.
 type HealthCheckConfig struct {
 	// SyncPeriod is the duration how often the existing resources are reconciled (how
 	// often the health check of Shoot clusters is performed (only if no operation is

--- a/extensions/pkg/controller/healthcheck/config/v1alpha1/types.go
+++ b/extensions/pkg/controller/healthcheck/config/v1alpha1/types.go
@@ -16,6 +16,7 @@ package v1alpha1
 
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+// HealthCheckConfig contains the health check controller configuration.
 type HealthCheckConfig struct {
 	// SyncPeriod is the duration how often the existing resources are reconciled (how
 	// often the health check of Shoot clusters is performed (only if no operation is

--- a/extensions/pkg/controller/healthcheck/controller.go
+++ b/extensions/pkg/controller/healthcheck/controller.go
@@ -131,6 +131,7 @@ func (a *AddArgs) RegisterExtension(getExtensionObjFunc GetExtensionObjectFunc, 
 	return nil
 }
 
+// GetExtensionGroupVersionKind returns the schema.GroupVersionKind of the registered extension of this AddArgs.
 func (a *AddArgs) GetExtensionGroupVersionKind() schema.GroupVersionKind {
 	return a.registeredExtension.groupVersionKind
 }

--- a/extensions/pkg/controller/healthcheck/general/daemonset.go
+++ b/extensions/pkg/controller/healthcheck/general/daemonset.go
@@ -43,15 +43,15 @@ type DaemonSetHealthChecker struct {
 type DaemonSetCheckType string
 
 const (
-	DaemonSetCheckTypeSeed  DaemonSetCheckType = "Seed"
-	DaemonSetCheckTypeShoot DaemonSetCheckType = "Shoot"
+	daemonSetCheckTypeSeed  DaemonSetCheckType = "Seed"
+	daemonSetCheckTypeShoot DaemonSetCheckType = "Shoot"
 )
 
 // NewSeedDaemonSetHealthChecker is a healthCheck function to check DaemonSets
 func NewSeedDaemonSetHealthChecker(name string) healthcheck.HealthCheck {
 	return &DaemonSetHealthChecker{
 		name:      name,
-		checkType: DaemonSetCheckTypeSeed,
+		checkType: daemonSetCheckTypeSeed,
 	}
 }
 
@@ -59,7 +59,7 @@ func NewSeedDaemonSetHealthChecker(name string) healthcheck.HealthCheck {
 func NewShootDaemonSetHealthChecker(name string) healthcheck.HealthCheck {
 	return &DaemonSetHealthChecker{
 		name:      name,
-		checkType: DaemonSetCheckTypeShoot,
+		checkType: daemonSetCheckTypeShoot,
 	}
 }
 
@@ -88,7 +88,7 @@ func (healthChecker *DaemonSetHealthChecker) DeepCopy() healthcheck.HealthCheck 
 func (healthChecker *DaemonSetHealthChecker) Check(ctx context.Context, request types.NamespacedName) (*healthcheck.SingleCheckResult, error) {
 	daemonSet := &appsv1.DaemonSet{}
 	var err error
-	if healthChecker.checkType == DaemonSetCheckTypeSeed {
+	if healthChecker.checkType == daemonSetCheckTypeSeed {
 		err = healthChecker.seedClient.Get(ctx, client.ObjectKey{Namespace: request.Namespace, Name: healthChecker.name}, daemonSet)
 	} else {
 		err = healthChecker.shootClient.Get(ctx, client.ObjectKey{Namespace: request.Namespace, Name: healthChecker.name}, daemonSet)

--- a/extensions/pkg/controller/healthcheck/general/deployment.go
+++ b/extensions/pkg/controller/healthcheck/general/deployment.go
@@ -43,15 +43,15 @@ type DeploymentHealthChecker struct {
 type DeploymentCheckType string
 
 const (
-	DeploymentCheckTypeSeed  DeploymentCheckType = "Seed"
-	DeploymentCheckTypeShoot DeploymentCheckType = "Shoot"
+	deploymentCheckTypeSeed  DeploymentCheckType = "Seed"
+	deploymentCheckTypeShoot DeploymentCheckType = "Shoot"
 )
 
 // NewSeedDeploymentHealthChecker is a healthCheck function to check Deployments in the Seed cluster
 func NewSeedDeploymentHealthChecker(deploymentName string) healthcheck.HealthCheck {
 	return &DeploymentHealthChecker{
 		name:      deploymentName,
-		checkType: DeploymentCheckTypeSeed,
+		checkType: deploymentCheckTypeSeed,
 	}
 }
 
@@ -59,7 +59,7 @@ func NewSeedDeploymentHealthChecker(deploymentName string) healthcheck.HealthChe
 func NewShootDeploymentHealthChecker(deploymentName string) healthcheck.HealthCheck {
 	return &DeploymentHealthChecker{
 		name:      deploymentName,
-		checkType: DeploymentCheckTypeShoot,
+		checkType: deploymentCheckTypeShoot,
 	}
 }
 
@@ -89,7 +89,7 @@ func (healthChecker *DeploymentHealthChecker) Check(ctx context.Context, request
 	deployment := &appsv1.Deployment{}
 
 	var err error
-	if healthChecker.checkType == DeploymentCheckTypeSeed {
+	if healthChecker.checkType == deploymentCheckTypeSeed {
 		err = healthChecker.seedClient.Get(ctx, client.ObjectKey{Namespace: request.Namespace, Name: healthChecker.name}, deployment)
 	} else {
 		err = healthChecker.shootClient.Get(ctx, client.ObjectKey{Namespace: request.Namespace, Name: healthChecker.name}, deployment)

--- a/extensions/pkg/controller/healthcheck/general/statefulsets.go
+++ b/extensions/pkg/controller/healthcheck/general/statefulsets.go
@@ -43,15 +43,15 @@ type StatefulSetHealthChecker struct {
 type StatefulSetCheckType string
 
 const (
-	StatefulSetCheckTypeSeed  StatefulSetCheckType = "Seed"
-	StatefulSetCheckTypeShoot StatefulSetCheckType = "Shoot"
+	statefulSetCheckTypeSeed  StatefulSetCheckType = "Seed"
+	statefulSetCheckTypeShoot StatefulSetCheckType = "Shoot"
 )
 
 // NewSeedStatefulSetChecker is a healthCheck function to check StatefulSets
 func NewSeedStatefulSetChecker(name string) healthcheck.HealthCheck {
 	return &StatefulSetHealthChecker{
 		name:      name,
-		checkType: StatefulSetCheckTypeSeed,
+		checkType: statefulSetCheckTypeSeed,
 	}
 }
 
@@ -59,7 +59,7 @@ func NewSeedStatefulSetChecker(name string) healthcheck.HealthCheck {
 func NewShootStatefulSetChecker(name string) healthcheck.HealthCheck {
 	return &StatefulSetHealthChecker{
 		name:      name,
-		checkType: StatefulSetCheckTypeShoot,
+		checkType: statefulSetCheckTypeShoot,
 	}
 }
 
@@ -89,7 +89,7 @@ func (healthChecker *StatefulSetHealthChecker) Check(ctx context.Context, reques
 	statefulSet := &appsv1.StatefulSet{}
 
 	var err error
-	if healthChecker.checkType == StatefulSetCheckTypeSeed {
+	if healthChecker.checkType == statefulSetCheckTypeSeed {
 		err = healthChecker.seedClient.Get(ctx, client.ObjectKey{Namespace: request.Namespace, Name: healthChecker.name}, statefulSet)
 	} else {
 		err = healthChecker.shootClient.Get(ctx, client.ObjectKey{Namespace: request.Namespace, Name: healthChecker.name}, statefulSet)

--- a/extensions/pkg/controller/healthcheck/healtcheck_actuator.go
+++ b/extensions/pkg/controller/healthcheck/healtcheck_actuator.go
@@ -61,17 +61,20 @@ func NewActuator(provider, extensionKind string, getExtensionObjFunc GetExtensio
 	}
 }
 
+// InjectScheme injects the given runtime.Scheme into this Actuator.
 func (a *Actuator) InjectScheme(scheme *runtime.Scheme) error {
 	a.scheme = scheme
 	a.decoder = serializer.NewCodecFactory(a.scheme).UniversalDecoder()
 	return nil
 }
 
+// InjectClient injects the given client.Client into this Actuator.
 func (a *Actuator) InjectClient(client client.Client) error {
 	a.seedClient = client
 	return nil
 }
 
+// InjectConfig injects the given rest.Config into this Actuator.
 func (a *Actuator) InjectConfig(config *rest.Config) error {
 	a.restConfig = config
 	return nil

--- a/extensions/pkg/controller/healthcheck/inject.go
+++ b/extensions/pkg/controller/healthcheck/inject.go
@@ -24,7 +24,7 @@ type ShootClient interface {
 	InjectShootClient(client.Client)
 }
 
-// ShootClient is an interface to be used to receive a seed client.
+// SeedClient is an interface to be used to receive a seed client.
 type SeedClient interface {
 	// InjectSeedClient injects the seed client
 	InjectSeedClient(client.Client)

--- a/extensions/pkg/controller/operatingsystemconfig/controller.go
+++ b/extensions/pkg/controller/operatingsystemconfig/controller.go
@@ -79,9 +79,5 @@ func add(mgr manager.Manager, options controller.Options, predicates []predicate
 		return err
 	}
 
-	if err := ctrl.Watch(&source.Kind{Type: &extensionsv1alpha1.OperatingSystemConfig{}}, &handler.EnqueueRequestForObject{}, predicates...); err != nil {
-		return err
-	}
-
-	return nil
+	return ctrl.Watch(&source.Kind{Type: &extensionsv1alpha1.OperatingSystemConfig{}}, &handler.EnqueueRequestForObject{}, predicates...)
 }

--- a/extensions/pkg/webhook/controlplane/genericmutator/mutator.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/mutator.go
@@ -270,11 +270,7 @@ func (m *mutator) mutateOperatingSystemConfig(ctx context.Context, gctx gcontext
 		return err
 	}
 
-	if err := m.ensurer.EnsureAdditionalUnits(ctx, gctx, &osc.Spec.Units, oldUnits); err != nil {
-		return err
-	}
-
-	return nil
+	return m.ensurer.EnsureAdditionalUnits(ctx, gctx, &osc.Spec.Units, oldUnits)
 }
 
 func (m *mutator) ensureKubeletServiceUnitContent(ctx context.Context, gctx gcontext.GardenContext, content, oldContent *string) error {

--- a/extensions/pkg/webhook/controlplane/genericmutator/mutator.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/mutator.go
@@ -373,6 +373,7 @@ func (m *mutator) ensureKubernetesGeneralConfiguration(ctx context.Context, gctx
 	return nil
 }
 
+// CloudProviderConfigPath is the path to the cloudprovider.conf kubelet configuration file.
 const CloudProviderConfigPath = "/var/lib/kubelet/cloudprovider.conf"
 
 func (m *mutator) ensureKubeletCloudProviderConfig(ctx context.Context, gctx gcontext.GardenContext, osc *extensionsv1alpha1.OperatingSystemConfig) error {

--- a/extensions/pkg/webhook/network/mutator.go
+++ b/extensions/pkg/webhook/network/mutator.go
@@ -25,6 +25,7 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 )
 
+// MutateFn is a function that validates and if needed mutates the given extensionsv1alpha1.Network.
 type MutateFn func(new, old *extensionsv1alpha1.Network) error
 
 // NewMutator creates a new network mutator.

--- a/extensions/pkg/webhook/registration.go
+++ b/extensions/pkg/webhook/registration.go
@@ -35,7 +35,7 @@ import (
 const (
 	// NamePrefix is the prefix used for {Valida,Muta}tingWebhookConfigurations of extensions.
 	NamePrefix = "gardener-extension-"
-	// NameSuffixShoots is the suffix used for {Valida,Muta}tingWebhookConfigurations of extensions targeting a shoot.
+	// NameSuffixShoot is the suffix used for {Valida,Muta}tingWebhookConfigurations of extensions targeting a shoot.
 	NameSuffixShoot = "-shoot"
 )
 

--- a/extensions/pkg/webhook/shoot/shoot.go
+++ b/extensions/pkg/webhook/shoot/shoot.go
@@ -46,7 +46,7 @@ type Args struct {
 	MutatorWithShootClient extensionswebhook.MutatorWithShootClient
 }
 
-// Add creates a new webhook with the shoot as target cluster.
+// New creates a new webhook with the shoot as target cluster.
 func New(mgr manager.Manager, args Args) (*extensionswebhook.Webhook, error) {
 	logger.Info("Creating webhook", "name", WebhookName)
 

--- a/extensions/pkg/webhook/webhook.go
+++ b/extensions/pkg/webhook/webhook.go
@@ -50,6 +50,7 @@ type Webhook struct {
 	Selector *metav1.LabelSelector
 }
 
+// Args contains Webhook creation arguments.
 type Args struct {
 	Provider   string
 	Name       string

--- a/extensions/test/e2e/framework/networkpolicies/generators/networkpolicies.go
+++ b/extensions/test/e2e/framework/networkpolicies/generators/networkpolicies.go
@@ -52,6 +52,7 @@ type cloudAwarePackage struct {
 	cloud networkpolicies.CloudAware
 }
 
+// NewPackages returns a function that returns generator.Packages for the given generator context and arguments.
 func NewPackages(cloud networkpolicies.CloudAware) func(p *generator.Context, arguments *args.GeneratorArgs) generator.Packages {
 	return (&cloudAwarePackage{cloud: cloud}).Packages
 }

--- a/extensions/test/integration/healthcheck/healthcheck_operation.go
+++ b/extensions/test/integration/healthcheck/healthcheck_operation.go
@@ -153,10 +153,12 @@ func TestHealthCheckWithManagedResource(ctx context.Context, timeout time.Durati
 	}, healthConditionType, gardencorev1beta1.ConditionFalse, healthcheck.ReasonUnsuccessful)
 }
 
+// ControlPlaneHealthCheckDeleteSeedDeployment is a convenience function to delete the given deployment and check the control plane resource condition.
 func ControlPlaneHealthCheckDeleteSeedDeployment(ctx context.Context, f *framework.ShootFramework, controlPlaneName, deploymentName string, healthConditionType gardencorev1beta1.ConditionType) error {
 	return deleteSeedDeploymentCheck(ctx, f, extensionsv1alpha1.SchemeGroupVersion.WithKind(extensionsv1alpha1.ControlPlaneResource), controlPlaneName, deploymentName, healthConditionType)
 }
 
+// WorkerHealthCheckDeleteSeedDeployment is a convenience function to delete the given deployment and check the worker resource condition.
 func WorkerHealthCheckDeleteSeedDeployment(ctx context.Context, f *framework.ShootFramework, controlPlaneName, deploymentName string, healthConditionType gardencorev1beta1.ConditionType) error {
 	return deleteSeedDeploymentCheck(ctx, f, extensionsv1alpha1.SchemeGroupVersion.WithKind(extensionsv1alpha1.WorkerResource), controlPlaneName, deploymentName, healthConditionType)
 }
@@ -188,6 +190,7 @@ func deleteSeedDeploymentCheck(ctx context.Context, f *framework.ShootFramework,
 	}, healthConditionType, gardencorev1beta1.ConditionUnknown, gardencorev1beta1.ConditionCheckError)
 }
 
+// MachineDeletionHealthCheck is a convenience function to delete the first machine and check the worker resource condition.
 func MachineDeletionHealthCheck(ctx context.Context, f *framework.ShootFramework) error {
 	var err error
 	machineList := machinev1alpha1.MachineList{}

--- a/hack/api-reference/core.md
+++ b/hack/api-reference/core.md
@@ -736,6 +736,7 @@ ControllerRegistrationDeployment
 <h3 id="core.gardener.cloud/v1beta1.Plant">Plant
 </h3>
 <p>
+<p>Plant represents an external kubernetes cluster.</p>
 </p>
 <table>
 <thead>
@@ -1021,6 +1022,7 @@ ProjectStatus
 <h3 id="core.gardener.cloud/v1beta1.Quota">Quota
 </h3>
 <p>
+<p>Quota represents a quota on resources consumed by shoot clusters either per project or per provider secret.</p>
 </p>
 <table>
 <thead>
@@ -1124,6 +1126,7 @@ Kubernetes core/v1.ObjectReference
 <h3 id="core.gardener.cloud/v1beta1.SecretBinding">SecretBinding
 </h3>
 <p>
+<p>SecretBinding represents a binding to a secret in the same or another namespace.</p>
 </p>
 <table>
 <thead>
@@ -1402,6 +1405,7 @@ SeedStatus
 <h3 id="core.gardener.cloud/v1beta1.Shoot">Shoot
 </h3>
 <p>
+<p>Shoot represents a Shoot cluster created and managed by Gardener.</p>
 </p>
 <table>
 <thead>
@@ -3284,6 +3288,7 @@ not a default domain is used.</p>
 <a href="#core.gardener.cloud/v1beta1.SeedDNSProvider">SeedDNSProvider</a>)
 </p>
 <p>
+<p>DNSIncludeExclude contains information about which domains shall be included/excluded.</p>
 </p>
 <table>
 <thead>
@@ -3302,7 +3307,7 @@ not a default domain is used.</p>
 </td>
 <td>
 <em>(Optional)</em>
-<p>Include is a list of resources that shall be included.</p>
+<p>Include is a list of domains that shall be included.</p>
 </td>
 </tr>
 <tr>
@@ -3314,7 +3319,7 @@ not a default domain is used.</p>
 </td>
 <td>
 <em>(Optional)</em>
-<p>Exclude is a list of resources that shall be excluded.</p>
+<p>Exclude is a list of domains that shall be excluded.</p>
 </td>
 </tr>
 </tbody>

--- a/hack/api-reference/extensions.md
+++ b/hack/api-reference/extensions.md
@@ -1983,7 +1983,7 @@ Kubernetes core/v1.LoadBalancerIngress
 <a href="#extensions.gardener.cloud/v1alpha1.OperatingSystemConfigSpec">OperatingSystemConfigSpec</a>)
 </p>
 <p>
-<p>CRI config is a structure contains configurations of the CRI library</p>
+<p>CRIConfig contains configurations of the CRI library.</p>
 </p>
 <table>
 <thead>
@@ -2024,7 +2024,7 @@ CRIName
 <a href="#extensions.gardener.cloud/v1alpha1.OperatingSystemConfigStatus">OperatingSystemConfigStatus</a>)
 </p>
 <p>
-<p>CloudConfig is a structure for containing the generated output for the given operating system
+<p>CloudConfig contains the generated output for the given operating system
 config spec. It contains a reference to a secret as the result may contain confidential data.</p>
 </p>
 <table>
@@ -2212,6 +2212,7 @@ DefaultStatus
 <a href="#extensions.gardener.cloud/v1alpha1.ContainerRuntimeSpec">ContainerRuntimeSpec</a>)
 </p>
 <p>
+<p>ContainerRuntimeWorkerPool identifies a Shoot worker pool by its name and selector.</p>
 </p>
 <table>
 <thead>
@@ -3419,7 +3420,7 @@ DefaultStatus
 <a href="#extensions.gardener.cloud/v1alpha1.OperatingSystemConfigSpec">OperatingSystemConfigSpec</a>)
 </p>
 <p>
-<p>OperatingSystemConfigPurpose  is a string alias.</p>
+<p>OperatingSystemConfigPurpose is a string alias.</p>
 </p>
 <h3 id="extensions.gardener.cloud/v1alpha1.OperatingSystemConfigSpec">OperatingSystemConfigSpec
 </h3>

--- a/landscaper/pkg/gardenlet/apis/imports/v1alpha1/conversions.go
+++ b/landscaper/pkg/gardenlet/apis/imports/v1alpha1/conversions.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:golint
+//nolint:revive
 package v1alpha1
 
 import (

--- a/landscaper/pkg/gardenlet/apis/imports/v1alpha1/conversions.go
+++ b/landscaper/pkg/gardenlet/apis/imports/v1alpha1/conversions.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//nolint:golint
 package v1alpha1
 
 import (

--- a/pkg/apis/authentication/v1alpha1/defaults.go
+++ b/pkg/apis/authentication/v1alpha1/defaults.go
@@ -24,6 +24,7 @@ func addDefaultingFuncs(scheme *runtime.Scheme) error {
 	return RegisterDefaults(scheme)
 }
 
+// SetDefaults_AdminKubeconfigRequestSpec sets default values for AdminKubeconfigRequestSpec objects.
 func SetDefaults_AdminKubeconfigRequestSpec(obj *AdminKubeconfigRequestSpec) {
 	if obj.ExpirationSeconds == nil {
 		hour := int64(60 * 60)

--- a/pkg/apis/core/types_quota.go
+++ b/pkg/apis/core/types_quota.go
@@ -22,6 +22,7 @@ import (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// Quota represents a quota on resources consumed by shoot clusters either per project or per provider secret.
 type Quota struct {
 	metav1.TypeMeta
 	// Standard object metadata.

--- a/pkg/apis/core/types_secretbinding.go
+++ b/pkg/apis/core/types_secretbinding.go
@@ -22,6 +22,7 @@ import (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// SecretBinding represents a binding to a secret in the same or another namespace.
 type SecretBinding struct {
 	metav1.TypeMeta
 	// Standard object metadata.

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -934,8 +934,10 @@ type CRI struct {
 type CRIName string
 
 const (
+	// CRINameContainerD is a constant for ContainerD CRI name.
 	CRINameContainerD CRIName = "containerd"
-	CRINameDocker     CRIName = "docker"
+	// CRINameDocker is a constant for Docker CRI name.
+	CRINameDocker CRIName = "docker"
 )
 
 // ContainerRuntime contains information about worker's available container runtime

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -29,6 +29,7 @@ import (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// Shoot represents a Shoot cluster created and managed by Gardener.
 type Shoot struct {
 	metav1.TypeMeta
 	// Standard object metadata.
@@ -225,10 +226,11 @@ type DNSProvider struct {
 	Zones *DNSIncludeExclude
 }
 
+// DNSIncludeExclude contains information about which domains shall be included/excluded.
 type DNSIncludeExclude struct {
-	// Include is a list of resources that shall be included.
+	// Include is a list of domains that shall be included.
 	Include []string
-	// Exclude is a list of resources that shall be excluded.
+	// Exclude is a list of domains that shall be excluded.
 	Exclude []string
 }
 

--- a/pkg/apis/core/v1alpha1/conversions.go
+++ b/pkg/apis/core/v1alpha1/conversions.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:golint
+//nolint:revive
 package v1alpha1
 
 import (

--- a/pkg/apis/core/v1alpha1/conversions.go
+++ b/pkg/apis/core/v1alpha1/conversions.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//nolint:golint
 package v1alpha1
 
 import (

--- a/pkg/apis/core/v1alpha1/generated.proto
+++ b/pkg/apis/core/v1alpha1/generated.proto
@@ -558,12 +558,13 @@ message DNS {
   repeated DNSProvider providers = 2;
 }
 
+// DNSIncludeExclude contains information about which domains shall be included/excluded.
 message DNSIncludeExclude {
-  // Include is a list of resources that shall be included.
+  // Include is a list of domains that shall be included.
   // +optional
   repeated string include = 1;
 
-  // Exclude is a list of resources that shall be excluded.
+  // Exclude is a list of domains that shall be excluded.
   // +optional
   repeated string exclude = 2;
 }
@@ -1489,6 +1490,7 @@ message OpenIDConnectClientAuthentication {
   optional string secret = 2;
 }
 
+// Plant represents an external kubernetes cluster.
 message Plant {
   // Standard object metadata.
   // +optional
@@ -1683,6 +1685,7 @@ message Provider {
   repeated Worker workers = 4;
 }
 
+// Quota represents a quota on resources consumed by shoot clusters either per project or per provider secret.
 message Quota {
   // Standard object metadata.
   // +optional
@@ -1757,6 +1760,7 @@ message ResourceWatchCacheSize {
   optional int32 size = 3;
 }
 
+// SecretBinding represents a binding to a secret in the same or another namespace.
 message SecretBinding {
   // Standard object metadata.
   // +optional
@@ -2071,6 +2075,7 @@ message ServiceAccountConfig {
   optional k8s.io.api.core.v1.LocalObjectReference signingKeySecretName = 2;
 }
 
+// Shoot represents a Shoot cluster created and managed by Gardener.
 message Shoot {
   // Standard object metadata.
   // +optional

--- a/pkg/apis/core/v1alpha1/helper/helper.go
+++ b/pkg/apis/core/v1alpha1/helper/helper.go
@@ -204,6 +204,7 @@ func TaintsHave(taints []gardencorev1alpha1.SeedTaint, key string) bool {
 	return false
 }
 
+// ShootedSeed contains the configuration of a shooted seed.
 type ShootedSeed struct {
 	DisableDNS                     *bool
 	DisableCapacityReservation     *bool
@@ -219,11 +220,13 @@ type ShootedSeed struct {
 	WithSecretRef                  bool
 }
 
+// ShootedSeedAPIServer contains the configuration of a shooted seed API server.
 type ShootedSeedAPIServer struct {
 	Replicas   *int32
 	Autoscaler *ShootedSeedAPIServerAutoscaler
 }
 
+// ShootedSeedAPIServerAutoscaler contains the configuration of a shooted seed API server autoscaler.
 type ShootedSeedAPIServerAutoscaler struct {
 	MinReplicas *int32
 	MaxReplicas int32

--- a/pkg/apis/core/v1alpha1/types_plant.go
+++ b/pkg/apis/core/v1alpha1/types_plant.go
@@ -22,6 +22,7 @@ import (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// Plant represents an external kubernetes cluster.
 type Plant struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object metadata.

--- a/pkg/apis/core/v1alpha1/types_quota.go
+++ b/pkg/apis/core/v1alpha1/types_quota.go
@@ -22,6 +22,7 @@ import (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// Quota represents a quota on resources consumed by shoot clusters either per project or per provider secret.
 type Quota struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object metadata.

--- a/pkg/apis/core/v1alpha1/types_secretbinding.go
+++ b/pkg/apis/core/v1alpha1/types_secretbinding.go
@@ -22,6 +22,7 @@ import (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// SecretBinding represents a binding to a secret in the same or another namespace.
 type SecretBinding struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object metadata.

--- a/pkg/apis/core/v1alpha1/types_shoot.go
+++ b/pkg/apis/core/v1alpha1/types_shoot.go
@@ -1164,8 +1164,10 @@ type CRI struct {
 type CRIName string
 
 const (
+	// CRINameContainerD is a constant for ContainerD CRI name.
 	CRINameContainerD CRIName = "containerd"
-	CRINameDocker     CRIName = "docker"
+	// CRINameDocker is a constant for Docker CRI name.
+	CRINameDocker CRIName = "docker"
 )
 
 // ContainerRuntime contains information about worker's available container runtime

--- a/pkg/apis/core/v1alpha1/types_shoot.go
+++ b/pkg/apis/core/v1alpha1/types_shoot.go
@@ -30,6 +30,7 @@ import (
 // +genclient:method=CreateAdminKubeconfigRequest,verb=create,subresource=adminkubeconfig,input=github.com/gardener/gardener/pkg/apis/authentication/v1alpha1.AdminKubeconfigRequest,result=github.com/gardener/gardener/pkg/apis/authentication/v1alpha1.AdminKubeconfigRequest
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// Shoot represents a Shoot cluster created and managed by Gardener.
 type Shoot struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object metadata.
@@ -263,11 +264,12 @@ type DNSProvider struct {
 	Zones *DNSIncludeExclude `json:"zones,omitempty" protobuf:"bytes,5,opt,name=zones"`
 }
 
+// DNSIncludeExclude contains information about which domains shall be included/excluded.
 type DNSIncludeExclude struct {
-	// Include is a list of resources that shall be included.
+	// Include is a list of domains that shall be included.
 	// +optional
 	Include []string `json:"include,omitempty" protobuf:"bytes,1,rep,name=include"`
-	// Exclude is a list of resources that shall be excluded.
+	// Exclude is a list of domains that shall be excluded.
 	// +optional
 	Exclude []string `json:"exclude,omitempty" protobuf:"bytes,2,rep,name=exclude"`
 }

--- a/pkg/apis/core/v1beta1/conversions.go
+++ b/pkg/apis/core/v1beta1/conversions.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:golint
+//nolint:revive
 package v1beta1
 
 import (

--- a/pkg/apis/core/v1beta1/conversions.go
+++ b/pkg/apis/core/v1beta1/conversions.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//nolint:golint
 package v1beta1
 
 import (

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -559,12 +559,13 @@ message DNS {
   repeated DNSProvider providers = 2;
 }
 
+// DNSIncludeExclude contains information about which domains shall be included/excluded.
 message DNSIncludeExclude {
-  // Include is a list of resources that shall be included.
+  // Include is a list of domains that shall be included.
   // +optional
   repeated string include = 1;
 
-  // Exclude is a list of resources that shall be excluded.
+  // Exclude is a list of domains that shall be excluded.
   // +optional
   repeated string exclude = 2;
 }
@@ -1401,6 +1402,7 @@ message OpenIDConnectClientAuthentication {
   optional string secret = 2;
 }
 
+// Plant represents an external kubernetes cluster.
 message Plant {
   // Standard object metadata.
   // +optional
@@ -1595,6 +1597,7 @@ message Provider {
   repeated Worker workers = 4;
 }
 
+// Quota represents a quota on resources consumed by shoot clusters either per project or per provider secret.
 message Quota {
   // Standard object metadata.
   // +optional
@@ -1661,6 +1664,7 @@ message ResourceWatchCacheSize {
   optional int32 size = 3;
 }
 
+// SecretBinding represents a binding to a secret in the same or another namespace.
 message SecretBinding {
   // Standard object metadata.
   // +optional
@@ -1995,6 +1999,7 @@ message ServiceAccountConfig {
   optional k8s.io.api.core.v1.LocalObjectReference signingKeySecretName = 2;
 }
 
+// Shoot represents a Shoot cluster created and managed by Gardener.
 message Shoot {
   // Standard object metadata.
   // +optional

--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -249,6 +249,7 @@ func TaintsAreTolerated(taints []gardencorev1beta1.SeedTaint, tolerations []gard
 	return true
 }
 
+// ShootedSeed contains the configuration of a shooted seed.
 type ShootedSeed struct {
 	DisableDNS                      *bool
 	DisableCapacityReservation      *bool
@@ -269,16 +270,19 @@ type ShootedSeed struct {
 	Resources                       *ShootedSeedResources
 }
 
+// ShootedSeedAPIServer contains the configuration of a shooted seed API server.
 type ShootedSeedAPIServer struct {
 	Replicas   *int32
 	Autoscaler *ShootedSeedAPIServerAutoscaler
 }
 
+// ShootedSeedAPIServerAutoscaler contains the configuration of a shooted seed API server autoscaler.
 type ShootedSeedAPIServerAutoscaler struct {
 	MinReplicas *int32
 	MaxReplicas int32
 }
 
+// ShootedSeedResources contains the resources capacity and reserved values of a shooted seed.
 type ShootedSeedResources struct {
 	Capacity corev1.ResourceList
 	Reserved corev1.ResourceList
@@ -1016,6 +1020,7 @@ func FindPrimaryDNSProvider(providers []gardencorev1beta1.DNSProvider) *gardenco
 	return nil
 }
 
+// VersionPredicate is a function that evaluates a condition on the given versions.
 type VersionPredicate func(expirableVersion gardencorev1beta1.ExpirableVersion, version *semver.Version) (bool, error)
 
 // GetKubernetesVersionForPatchUpdate finds the latest Kubernetes patch version for its minor version in the <cloudProfile> compared

--- a/pkg/apis/core/v1beta1/types_plant.go
+++ b/pkg/apis/core/v1beta1/types_plant.go
@@ -22,6 +22,7 @@ import (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// Plant represents an external kubernetes cluster.
 type Plant struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object metadata.

--- a/pkg/apis/core/v1beta1/types_quota.go
+++ b/pkg/apis/core/v1beta1/types_quota.go
@@ -22,6 +22,7 @@ import (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// Quota represents a quota on resources consumed by shoot clusters either per project or per provider secret.
 type Quota struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object metadata.

--- a/pkg/apis/core/v1beta1/types_secretbinding.go
+++ b/pkg/apis/core/v1beta1/types_secretbinding.go
@@ -22,6 +22,7 @@ import (
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// SecretBinding represents a binding to a secret in the same or another namespace.
 type SecretBinding struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object metadata.

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -30,6 +30,7 @@ import (
 // +genclient:method=CreateAdminKubeconfigRequest,verb=create,subresource=adminkubeconfig,input=github.com/gardener/gardener/pkg/apis/authentication/v1alpha1.AdminKubeconfigRequest,result=github.com/gardener/gardener/pkg/apis/authentication/v1alpha1.AdminKubeconfigRequest
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// Shoot represents a Shoot cluster created and managed by Gardener.
 type Shoot struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard object metadata.
@@ -275,11 +276,12 @@ type DNSProvider struct {
 	Zones *DNSIncludeExclude `json:"zones,omitempty" protobuf:"bytes,5,opt,name=zones"`
 }
 
+// DNSIncludeExclude contains information about which domains shall be included/excluded.
 type DNSIncludeExclude struct {
-	// Include is a list of resources that shall be included.
+	// Include is a list of domains that shall be included.
 	// +optional
 	Include []string `json:"include,omitempty" protobuf:"bytes,1,rep,name=include"`
-	// Exclude is a list of resources that shall be excluded.
+	// Exclude is a list of domains that shall be excluded.
 	// +optional
 	Exclude []string `json:"exclude,omitempty" protobuf:"bytes,2,rep,name=exclude"`
 }

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -1176,8 +1176,10 @@ type CRI struct {
 type CRIName string
 
 const (
+	// CRINameContainerD is a constant for ContainerD CRI name.
 	CRINameContainerD CRIName = "containerd"
-	CRINameDocker     CRIName = "docker"
+	// CRINameDocker is a constant for Docker CRI name.
+	CRINameDocker CRIName = "docker"
 )
 
 // ContainerRuntime contains information about worker's available container runtime

--- a/pkg/apis/extensions/register.go
+++ b/pkg/apis/extensions/register.go
@@ -15,5 +15,6 @@
 package extensions
 
 const (
+	// GroupName is the name of the extensions API group.
 	GroupName = "extensions.gardener.cloud"
 )

--- a/pkg/apis/extensions/v1alpha1/helper/helper.go
+++ b/pkg/apis/extensions/v1alpha1/helper/helper.go
@@ -35,9 +35,8 @@ func ClusterAutoscalerRequired(pools []extensionsv1alpha1.WorkerPool) bool {
 func GetDNSRecordType(address string) extensionsv1alpha1.DNSRecordType {
 	if ip := net.ParseIP(address); ip != nil && ip.To4() != nil {
 		return extensionsv1alpha1.DNSRecordTypeA
-	} else {
-		return extensionsv1alpha1.DNSRecordTypeCNAME
 	}
+	return extensionsv1alpha1.DNSRecordTypeCNAME
 }
 
 // GetDNSRecordTTL returns the value of the given ttl, or 120 if nil.

--- a/pkg/apis/extensions/v1alpha1/register.go
+++ b/pkg/apis/extensions/v1alpha1/register.go
@@ -36,8 +36,10 @@ func Resource(resource string) schema.GroupResource {
 }
 
 var (
+	// SchemeBuilder is a new Scheme Builder which registers our API.
 	SchemeBuilder = runtime.NewSchemeBuilder(addKnownTypes)
-	AddToScheme   = SchemeBuilder.AddToScheme
+	// AddToScheme is a reference to the Scheme Builder's AddToScheme function.
+	AddToScheme = SchemeBuilder.AddToScheme
 )
 
 // Adds the list of known types to Scheme.

--- a/pkg/apis/extensions/v1alpha1/types_containerruntime.go
+++ b/pkg/apis/extensions/v1alpha1/types_containerruntime.go
@@ -79,6 +79,7 @@ type ContainerRuntimeSpec struct {
 	DefaultSpec `json:",inline"`
 }
 
+// ContainerRuntimeWorkerPool identifies a Shoot worker pool by its name and selector.
 type ContainerRuntimeWorkerPool struct {
 	// Name specifies the name of the worker pool the container runtime should be available for.
 	Name string `json:"name"`

--- a/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
+++ b/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
@@ -191,14 +191,14 @@ type OperatingSystemConfigStatus struct {
 	Units []string `json:"units,omitempty"`
 }
 
-// CloudConfig is a structure for containing the generated output for the given operating system
+// CloudConfig contains the generated output for the given operating system
 // config spec. It contains a reference to a secret as the result may contain confidential data.
 type CloudConfig struct {
 	// SecretRef is a reference to a secret that contains the actual result of the generated cloud config.
 	SecretRef corev1.SecretReference `json:"secretRef"`
 }
 
-// OperatingSystemConfigPurpose  is a string alias.
+// OperatingSystemConfigPurpose is a string alias.
 type OperatingSystemConfigPurpose string
 
 const (
@@ -216,7 +216,7 @@ const (
 	OperatingSystemConfigSecretDataKey = "cloud_config"
 )
 
-// CRI config is a structure contains configurations of the CRI library
+// CRIConfig contains configurations of the CRI library.
 type CRIConfig struct {
 	// Name is a mandatory string containing the name of the CRI library. Supported values are `docker` and `containerd`.
 	Name CRIName `json:"name"`

--- a/pkg/apis/operations/v1alpha1/conversions.go
+++ b/pkg/apis/operations/v1alpha1/conversions.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//nolint:revive
 package v1alpha1
 
 import (

--- a/pkg/apis/seedmanagement/v1alpha1/conversions.go
+++ b/pkg/apis/seedmanagement/v1alpha1/conversions.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:golint
+//nolint:revive
 package v1alpha1
 
 import (

--- a/pkg/apis/seedmanagement/v1alpha1/conversions.go
+++ b/pkg/apis/seedmanagement/v1alpha1/conversions.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//nolint:golint
 package v1alpha1
 
 import (

--- a/pkg/apis/seedmanagement/validation/managedseedset.go
+++ b/pkg/apis/seedmanagement/validation/managedseedset.go
@@ -60,7 +60,7 @@ func ValidateManagedSeedSetUpdate(newManagedSeedSet, oldManagedSeedSet *seedmana
 	return allErrs
 }
 
-// ValidateManagedSeedStatusUpdate validates a ManagedSeedSet object before a status update.
+// ValidateManagedSeedSetStatusUpdate validates a ManagedSeedSet object before a status update.
 func ValidateManagedSeedSetStatusUpdate(newManagedSeedSet, oldManagedSeedSet *seedmanagement.ManagedSeedSet) field.ErrorList {
 	allErrs := field.ErrorList{}
 

--- a/pkg/apiserver/apiserver.go
+++ b/pkg/apiserver/apiserver.go
@@ -27,10 +27,12 @@ import (
 	genericapiserver "k8s.io/apiserver/pkg/server"
 )
 
+// ExtraConfig contains non-generic Gardener API server configuration.
 type ExtraConfig struct {
 	AdminKubeconfigMaxExpiration time.Duration
 }
 
+// Config contains Gardener API server configuration.
 type Config struct {
 	GenericConfig *genericapiserver.RecommendedConfig
 	ExtraConfig   ExtraConfig
@@ -46,6 +48,7 @@ type completedConfig struct {
 	ExtraConfig   *ExtraConfig
 }
 
+// CompletedConfig contains completed Gardener API server configuration.
 type CompletedConfig struct {
 	*completedConfig
 }

--- a/pkg/client/kubernetes/chartoptions.go
+++ b/pkg/client/kubernetes/chartoptions.go
@@ -108,6 +108,7 @@ type DeleteOptions struct {
 // TolerateErrorFunc is a function for which err is tolerated.
 type TolerateErrorFunc func(err error) bool
 
+// MutateDeleteOptions applies this configuration to the given delete options.
 func (t TolerateErrorFunc) MutateDeleteOptions(opts *DeleteOptions) {
 	if opts.TolerateErrorFuncs == nil {
 		opts.TolerateErrorFuncs = []TolerateErrorFunc{}
@@ -116,6 +117,7 @@ func (t TolerateErrorFunc) MutateDeleteOptions(opts *DeleteOptions) {
 	opts.TolerateErrorFuncs = append(opts.TolerateErrorFuncs, t)
 }
 
+// MutateDeleteManifestOptions applies this configuration to the given delete manifest options.
 func (t TolerateErrorFunc) MutateDeleteManifestOptions(opts *DeleteManifestOptions) {
 	if opts.TolerateErrorFuncs == nil {
 		opts.TolerateErrorFuncs = []TolerateErrorFunc{}

--- a/pkg/client/kubernetes/clientmap/builder/plant_builder.go
+++ b/pkg/client/kubernetes/clientmap/builder/plant_builder.go
@@ -53,7 +53,7 @@ func (b *PlantClientMapBuilder) WithGardenClientMap(clientMap clientmap.ClientMa
 	return b
 }
 
-// WithGardenClientMap sets the ClientSet that should be used as the Garden client.
+// WithGardenClientSet sets the ClientSet that should be used as the Garden client.
 func (b *PlantClientMapBuilder) WithGardenClientSet(clientSet kubernetes.Interface) *PlantClientMapBuilder {
 	b.gardenClientFunc = func(ctx context.Context) (kubernetes.Interface, error) {
 		return clientSet, nil

--- a/pkg/client/kubernetes/clientmap/builder/shoot_builder.go
+++ b/pkg/client/kubernetes/clientmap/builder/shoot_builder.go
@@ -56,7 +56,7 @@ func (b *ShootClientMapBuilder) WithGardenClientMap(clientMap clientmap.ClientMa
 	return b
 }
 
-// WithGardenClientMap sets the ClientSet that should be used as the Garden client.
+// WithGardenClientSet sets the ClientSet that should be used as the Garden client.
 func (b *ShootClientMapBuilder) WithGardenClientSet(clientSet kubernetes.Interface) *ShootClientMapBuilder {
 	b.gardenClientFunc = func(ctx context.Context) (kubernetes.Interface, error) {
 		return clientSet, nil

--- a/pkg/client/kubernetes/clientmap/internal/garden_clientmap.go
+++ b/pkg/client/kubernetes/clientmap/internal/garden_clientmap.go
@@ -96,6 +96,7 @@ func (f *GardenClientSetFactory) NewClientSet(_ context.Context, k clientmap.Cli
 // GardenClientSetKey is a ClientSetKey for the garden cluster.
 type GardenClientSetKey struct{}
 
+// Key returns the string representation of the ClientSetKey.
 func (k GardenClientSetKey) Key() string {
 	return "garden"
 }

--- a/pkg/client/kubernetes/clientmap/internal/plant_clientmap.go
+++ b/pkg/client/kubernetes/clientmap/internal/plant_clientmap.go
@@ -109,6 +109,7 @@ type PlantClientSetKey struct {
 	Namespace, Name string
 }
 
+// Key returns the string representation of the ClientSetKey.
 func (k PlantClientSetKey) Key() string {
 	return k.Namespace + "/" + k.Name
 }

--- a/pkg/client/kubernetes/clientmap/internal/seed_clientmap.go
+++ b/pkg/client/kubernetes/clientmap/internal/seed_clientmap.go
@@ -71,6 +71,7 @@ func (f *SeedClientSetFactory) NewClientSet(ctx context.Context, k clientmap.Cli
 // SeedClientSetKey is a ClientSetKey for a Seed cluster.
 type SeedClientSetKey string
 
+// Key returns the string representation of the ClientSetKey.
 func (k SeedClientSetKey) Key() string {
 	return string(k)
 }

--- a/pkg/client/kubernetes/clientmap/internal/shoot_clientmap.go
+++ b/pkg/client/kubernetes/clientmap/internal/shoot_clientmap.go
@@ -209,6 +209,7 @@ type ShootClientSetKey struct {
 	Namespace, Name string
 }
 
+// Key returns the string representation of the ClientSetKey.
 func (k ShootClientSetKey) Key() string {
 	return k.Namespace + "/" + k.Name
 }

--- a/pkg/client/kubernetes/manifestoptions.go
+++ b/pkg/client/kubernetes/manifestoptions.go
@@ -16,11 +16,11 @@ package kubernetes
 
 // DeleteManifestOption is some configuration that modifies options for a delete request.
 type DeleteManifestOption interface {
-	// MutateDeleteOptions applies this configuration to the given delete options.
+	// MutateDeleteManifestOptions applies this configuration to the given delete options.
 	MutateDeleteManifestOptions(opts *DeleteManifestOptions)
 }
 
-// DeleteOptions contains options for delete requests
+// DeleteManifestOptions contains options for delete requests.
 type DeleteManifestOptions struct {
 	// TolerateErrorFuncs are functions for which errors are tolerated.
 	TolerateErrorFuncs []TolerateErrorFunc

--- a/pkg/client/kubernetes/test/fake_kubernetes.go
+++ b/pkg/client/kubernetes/test/fake_kubernetes.go
@@ -48,6 +48,7 @@ func NewClientSetWithFakedServerVersion(kubernetes kubernetesclientset.Interface
 	}
 }
 
+// Discovery returns the discovery interface of this client set.
 func (c *ClientSet) Discovery() discovery.DiscoveryInterface {
 	return c.DiscoveryInterface
 }

--- a/pkg/client/kubernetes/test/options_matchers.go
+++ b/pkg/client/kubernetes/test/options_matchers.go
@@ -59,7 +59,7 @@ type configFuncMatcher struct {
 
 func (m *configFuncMatcher) Match(actual interface{}) (success bool, err error) {
 	if m.expected == nil {
-		return false, fmt.Errorf("Refusing to compare <nil> to <nil>.\nBe explicit and use BeNil() instead.  This is to avoid mistakes where both sides of an assertion are erroneously uninitialized.") //nolint:golint
+		return false, fmt.Errorf("Refusing to compare <nil> to <nil>.\nBe explicit and use BeNil() instead.  This is to avoid mistakes where both sides of an assertion are erroneously uninitialized.") //nolint:revive
 	}
 	if actual == nil {
 		return false, nil

--- a/pkg/client/kubernetes/test/options_matchers.go
+++ b/pkg/client/kubernetes/test/options_matchers.go
@@ -59,7 +59,7 @@ type configFuncMatcher struct {
 
 func (m *configFuncMatcher) Match(actual interface{}) (success bool, err error) {
 	if m.expected == nil {
-		return false, fmt.Errorf("Refusing to compare <nil> to <nil>.\nBe explicit and use BeNil() instead.  This is to avoid mistakes where both sides of an assertion are erroneously uninitialized.")
+		return false, fmt.Errorf("Refusing to compare <nil> to <nil>.\nBe explicit and use BeNil() instead.  This is to avoid mistakes where both sides of an assertion are erroneously uninitialized.") //nolint:golint
 	}
 	if actual == nil {
 		return false, nil

--- a/pkg/controllermanager/apis/config/v1alpha1/conversions.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/conversions.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:golint
+//nolint:revive
 package v1alpha1
 
 import (

--- a/pkg/controllermanager/apis/config/v1alpha1/conversions.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/conversions.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//nolint:golint
 package v1alpha1
 
 import (
@@ -25,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 )
 
-// Convert_v1alpha1_QuotaConfiguration_To_config_QuotaConfiguration converts the external QuotaConfiguration version to the internal one.
 func Convert_v1alpha1_QuotaConfiguration_To_config_QuotaConfiguration(in *QuotaConfiguration, out *config.QuotaConfiguration, s conversion.Scope) error {
 	err := autoConvert_v1alpha1_QuotaConfiguration_To_config_QuotaConfiguration(in, out, s)
 	if err != nil {

--- a/pkg/controllermanager/controller/managedseedset/managedseedset_replica.go
+++ b/pkg/controllermanager/controller/managedseedset/managedseedset_replica.go
@@ -284,10 +284,7 @@ func (r *replica) RetryShoot(ctx context.Context, c client.Client) error {
 	if r.shoot == nil {
 		return nil
 	}
-	if err := kutil.SetAnnotationAndUpdate(ctx, c, r.shoot, v1beta1constants.GardenerOperation, v1beta1constants.ShootOperationRetry); err != nil {
-		return err
-	}
-	return nil
+	return kutil.SetAnnotationAndUpdate(ctx, c, r.shoot, v1beta1constants.GardenerOperation, v1beta1constants.ShootOperationRetry)
 }
 
 func shootReconcileSucceeded(shoot *gardencorev1beta1.Shoot) bool {

--- a/pkg/gardenlet/apis/config/types.go
+++ b/pkg/gardenlet/apis/config/types.go
@@ -419,7 +419,7 @@ type ExposureClassHandler struct {
 	SNI *SNI
 }
 
-// LoadBalancerService contains configuration which is used to configure the underlying
+// LoadBalancerServiceConfig contains configuration which is used to configure the underlying
 // load balancer to apply the control plane endpoint exposure strategy.
 type LoadBalancerServiceConfig struct {
 	// Annotations is a key value map to annotate the underlying load balancer services.

--- a/pkg/gardenlet/apis/config/v1alpha1/conversions.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/conversions.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//nolint:golint
+//nolint:revive
 package v1alpha1
 
 import (

--- a/pkg/gardenlet/apis/config/v1alpha1/conversions.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/conversions.go
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//nolint:golint
 package v1alpha1
 
 import (

--- a/pkg/gardenlet/apis/config/v1alpha1/types.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/types.go
@@ -499,7 +499,7 @@ type ExposureClassHandler struct {
 	SNI *SNI `json:"sni,omitempty"`
 }
 
-// LoadBalancerService contains configuration which is used to configure the underlying
+// LoadBalancerServiceConfig contains configuration which is used to configure the underlying
 // load balancer to apply the control plane endpoint exposure strategy.
 type LoadBalancerServiceConfig struct {
 	// Annotations is a key value map to annotate the underlying load balancer services.

--- a/pkg/gardenlet/bootstrap/certificate/certificate_rotation.go
+++ b/pkg/gardenlet/bootstrap/certificate/certificate_rotation.go
@@ -59,7 +59,7 @@ type Manager struct {
 	seedName               string
 }
 
-// NewCertificateRotation creates a certificate manager that can be used to rotate gardenlet's client certificate for the Garden cluster
+// NewCertificateManager creates a certificate manager that can be used to rotate gardenlet's client certificate for the Garden cluster
 func NewCertificateManager(clientMap clientmap.ClientMap, seedClient client.Client, config *config.GardenletConfiguration) *Manager {
 	seedName := bootstraputil.GetSeedName(config.SeedConfig)
 	gardenletTargetClusterName := bootstraputil.GetTargetClusterName(config.SeedClientConnection)

--- a/pkg/gardenlet/controller/networkpolicy/helper/helper.go
+++ b/pkg/gardenlet/controller/networkpolicy/helper/helper.go
@@ -29,6 +29,8 @@ import (
 	"github.com/gardener/gardener/pkg/controllerutils"
 )
 
+// AllowToSeedAPIServer is the name of the Network Policy that allows egress to the Seed's Kubernetes API Server
+// endpoints in the default namespace.
 const AllowToSeedAPIServer = "allow-to-seed-apiserver"
 
 // GetEgressRules creates Network Policy egress rules from endpoint subsets.

--- a/pkg/gardenlet/controller/networkpolicy/hostnameresolver/resolver.go
+++ b/pkg/gardenlet/controller/networkpolicy/hostnameresolver/resolver.go
@@ -127,7 +127,7 @@ func (l *resolver) Start(stopCtx context.Context) {
 	}
 }
 
-// Resolved returns a slice of resolved ip addresses.
+// Subset returns a slice of resolved ip addresses.
 func (l *resolver) Subset() []corev1.EndpointSubset {
 	l.lock.RLock()
 	defer l.lock.RUnlock()
@@ -207,6 +207,7 @@ func CreateForCluster(client kubernetes.Interface, logger logrus.FieldLogger) (P
 	return NewNoOpProvider(), nil
 }
 
+// NewNoOpProvider returns a no-op Provider.
 func NewNoOpProvider() Provider { return &noOpResover{} }
 
 // HasSynced always returns true.
@@ -215,7 +216,7 @@ func (*noOpResover) HasSynced() bool { return true }
 // Start does nothing.
 func (*noOpResover) Start(_ context.Context) {}
 
-// Resolved returns a slice of resolved ip addresses.
+// Subset returns an empty slice.
 func (*noOpResover) Subset() []corev1.EndpointSubset { return []corev1.EndpointSubset{} }
 
 // WithCallback does nothing.

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -2422,11 +2422,12 @@ func schema_pkg_apis_core_v1alpha1_DNSIncludeExclude(ref common.ReferenceCallbac
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "DNSIncludeExclude contains information about which domains shall be included/excluded.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"include": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Include is a list of resources that shall be included.",
+							Description: "Include is a list of domains that shall be included.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -2441,7 +2442,7 @@ func schema_pkg_apis_core_v1alpha1_DNSIncludeExclude(ref common.ReferenceCallbac
 					},
 					"exclude": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Exclude is a list of resources that shall be excluded.",
+							Description: "Exclude is a list of domains that shall be excluded.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -4762,7 +4763,8 @@ func schema_pkg_apis_core_v1alpha1_Plant(ref common.ReferenceCallback) common.Op
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "Plant represents an external kubernetes cluster.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {
 						SchemaProps: spec.SchemaProps{
@@ -5347,7 +5349,8 @@ func schema_pkg_apis_core_v1alpha1_Quota(ref common.ReferenceCallback) common.Op
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "Quota represents a quota on resources consumed by shoot clusters either per project or per provider secret.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {
 						SchemaProps: spec.SchemaProps{
@@ -5628,7 +5631,8 @@ func schema_pkg_apis_core_v1alpha1_SecretBinding(ref common.ReferenceCallback) c
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "SecretBinding represents a binding to a secret in the same or another namespace.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {
 						SchemaProps: spec.SchemaProps{
@@ -6543,7 +6547,8 @@ func schema_pkg_apis_core_v1alpha1_Shoot(ref common.ReferenceCallback) common.Op
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "Shoot represents a Shoot cluster created and managed by Gardener.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {
 						SchemaProps: spec.SchemaProps{
@@ -9417,11 +9422,12 @@ func schema_pkg_apis_core_v1beta1_DNSIncludeExclude(ref common.ReferenceCallback
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "DNSIncludeExclude contains information about which domains shall be included/excluded.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"include": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Include is a list of resources that shall be included.",
+							Description: "Include is a list of domains that shall be included.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -9436,7 +9442,7 @@ func schema_pkg_apis_core_v1beta1_DNSIncludeExclude(ref common.ReferenceCallback
 					},
 					"exclude": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Exclude is a list of resources that shall be excluded.",
+							Description: "Exclude is a list of domains that shall be excluded.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -11471,7 +11477,8 @@ func schema_pkg_apis_core_v1beta1_Plant(ref common.ReferenceCallback) common.Ope
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "Plant represents an external kubernetes cluster.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {
 						SchemaProps: spec.SchemaProps{
@@ -12056,7 +12063,8 @@ func schema_pkg_apis_core_v1beta1_Quota(ref common.ReferenceCallback) common.Ope
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "Quota represents a quota on resources consumed by shoot clusters either per project or per provider secret.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {
 						SchemaProps: spec.SchemaProps{
@@ -12291,7 +12299,8 @@ func schema_pkg_apis_core_v1beta1_SecretBinding(ref common.ReferenceCallback) co
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "SecretBinding represents a binding to a secret in the same or another namespace.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {
 						SchemaProps: spec.SchemaProps{
@@ -13265,7 +13274,8 @@ func schema_pkg_apis_core_v1beta1_Shoot(ref common.ReferenceCallback) common.Ope
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Type: []string{"object"},
+				Description: "Shoot represents a Shoot cluster created and managed by Gardener.",
+				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"kind": {
 						SchemaProps: spec.SchemaProps{

--- a/pkg/operation/botanist/component/dependencywatchdog/dependency_watchdog.go
+++ b/pkg/operation/botanist/component/dependencywatchdog/dependency_watchdog.go
@@ -59,6 +59,7 @@ const (
 	configFileName  = "dep-config.yaml"
 )
 
+// Values contains dependency-watchdog values.
 type Values struct {
 	Role Role
 	ValuesEndpoint
@@ -66,10 +67,12 @@ type Values struct {
 	Image string
 }
 
+// ValuesEndpoint contains the service dependants of dependency-watchdog.
 type ValuesEndpoint struct {
 	ServiceDependants restarterapi.ServiceDependants
 }
 
+// ValuesProbe contains the probe dependants list of dependency-watchdog.
 type ValuesProbe struct {
 	ProbeDependantsList scalerapi.ProbeDependantsList
 }

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/promtail/component.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/promtail/component.go
@@ -33,15 +33,15 @@ const (
 	// PathPromtailAuthToken is the path for the promtail authentication token,
 	// which is used to auth agains the Loki sidecar proxy.
 	PathPromtailAuthToken = PathPromtailDirectory + "/auth-token"
-	// PathPromtailConfig is the path for the promtail's configuration file
+	// PathPromtailConfig is the path for the promtail's configuration file.
 	PathPromtailConfig = v1beta1constants.OperatingSystemConfigFilePathPromtailConfig
 	// PathPromtailCACert is the path for the loki-tls certificate authority.
 	PathPromtailCACert = PathPromtailDirectory + "/ca.crt"
-	// PromtailServerPort is the promtail listening port
+	// PromtailServerPort is the promtail listening port.
 	PromtailServerPort = 3001
-	// PromtailPositionFile is the path for storing the scraped file offsets
+	// PromtailPositionFile is the path for storing the scraped file offsets.
 	PromtailPositionFile = "/var/log/positions.yaml"
-	// PathSetActiveJournalFileScript
+	// PathSetActiveJournalFileScript is the path for the active journal file script.
 	PathSetActiveJournalFileScript = PathPromtailDirectory + "/scripts/set_active_journal_file.sh"
 )
 

--- a/pkg/operation/botanist/component/phase.go
+++ b/pkg/operation/botanist/component/phase.go
@@ -24,7 +24,7 @@ const (
 	PhaseEnabled
 	// PhaseDisabled is when a component was disabled before and it's still disabled.
 	PhaseDisabled
-	// PhaseEnabled is when a component was disabled before, but it's being activated.
+	// PhaseEnabling is when a component was disabled before, but it's being activated.
 	PhaseEnabling
 	// PhaseDisabling is when a component was enabled before, but it's being disabled.
 	PhaseDisabling

--- a/pkg/operation/botanist/component/projectrbac/projectrbac.go
+++ b/pkg/operation/botanist/component/projectrbac/projectrbac.go
@@ -46,12 +46,13 @@ const (
 	nameProjectViewer = "gardener.cloud:system:project-viewer"
 )
 
+// Interface extends component.Deployer with a function to delete stale extension roles resources.
 type Interface interface {
 	component.Deployer
 	DeleteStaleExtensionRolesResources(context.Context) error
 }
 
-// New creates a new instance of DeployWaiter for the RBAC resources required to interact with Projects.
+// New creates a new instance of Interface for the RBAC resources required to interact with Projects.
 func New(client client.Client, project *gardencorev1beta1.Project) (Interface, error) {
 	if project.Spec.Namespace == nil {
 		return nil, fmt.Errorf("cannot create Interface for a project with `.spec.namespace=nil`")

--- a/pkg/operation/botanist/component/projectrbac/projectrbac.go
+++ b/pkg/operation/botanist/component/projectrbac/projectrbac.go
@@ -36,14 +36,14 @@ import (
 )
 
 const (
-	NamePrefixSpecificProjectAdmin      = "gardener.cloud:system:project:"
-	NamePrefixSpecificProjectMember     = "gardener.cloud:system:project-member:"
-	NamePrefixSpecificProjectUAM        = "gardener.cloud:system:project-uam:"
-	NamePrefixSpecificProjectViewer     = "gardener.cloud:system:project-viewer:"
-	NamePrefixSpecificProjectExtensions = "gardener.cloud:extension:project:"
+	namePrefixSpecificProjectAdmin      = "gardener.cloud:system:project:"
+	namePrefixSpecificProjectMember     = "gardener.cloud:system:project-member:"
+	namePrefixSpecificProjectUAM        = "gardener.cloud:system:project-uam:"
+	namePrefixSpecificProjectViewer     = "gardener.cloud:system:project-viewer:"
+	namePrefixSpecificProjectExtensions = "gardener.cloud:extension:project:"
 
-	NameProjectMember = "gardener.cloud:system:project-member"
-	NameProjectViewer = "gardener.cloud:system:project-viewer"
+	nameProjectMember = "gardener.cloud:system:project-member"
+	nameProjectViewer = "gardener.cloud:system:project-viewer"
 )
 
 type Interface interface {
@@ -108,7 +108,7 @@ func (p *projectRBAC) Deploy(ctx context.Context) error {
 		func(ctx context.Context) error {
 			return p.reconcileResources(
 				ctx,
-				NamePrefixSpecificProjectAdmin+p.project.Name,
+				namePrefixSpecificProjectAdmin+p.project.Name,
 				true,
 				nil,
 				nil,
@@ -135,7 +135,7 @@ func (p *projectRBAC) Deploy(ctx context.Context) error {
 		func(ctx context.Context) error {
 			return p.reconcileResources(
 				ctx,
-				NamePrefixSpecificProjectUAM+p.project.Name,
+				namePrefixSpecificProjectUAM+p.project.Name,
 				true,
 				nil,
 				nil,
@@ -156,9 +156,9 @@ func (p *projectRBAC) Deploy(ctx context.Context) error {
 		func(ctx context.Context) error {
 			return p.reconcileResources(
 				ctx,
-				NamePrefixSpecificProjectMember+p.project.Name,
+				namePrefixSpecificProjectMember+p.project.Name,
 				true,
-				pointer.String(NameProjectMember),
+				pointer.String(nameProjectMember),
 				nil,
 				members,
 				nil,
@@ -183,9 +183,9 @@ func (p *projectRBAC) Deploy(ctx context.Context) error {
 		func(ctx context.Context) error {
 			return p.reconcileResources(
 				ctx,
-				NamePrefixSpecificProjectViewer+p.project.Name,
+				namePrefixSpecificProjectViewer+p.project.Name,
 				true,
-				pointer.String(NameProjectViewer),
+				pointer.String(nameProjectViewer),
 				nil,
 				viewers,
 				nil,
@@ -210,7 +210,7 @@ func (p *projectRBAC) Deploy(ctx context.Context) error {
 	// project extension roles resources
 	for _, roleName := range extensionRolesNames.List() {
 		var (
-			name            = fmt.Sprintf("%s%s:%s", NamePrefixSpecificProjectExtensions, p.project.Name, roleName)
+			name            = fmt.Sprintf("%s%s:%s", namePrefixSpecificProjectExtensions, p.project.Name, roleName)
 			subjects        = extensionRolesNameToSubjects[roleName]
 			aggregationRule = &rbacv1.AggregationRule{
 				ClusterRoleSelectors: []metav1.LabelSelector{
@@ -305,19 +305,19 @@ func (p *projectRBAC) Destroy(ctx context.Context) error {
 	}
 
 	return kutil.DeleteObjects(ctx, p.client,
-		emptyClusterRole(NamePrefixSpecificProjectAdmin+p.project.Name),
-		emptyClusterRoleBinding(NamePrefixSpecificProjectAdmin+p.project.Name),
+		emptyClusterRole(namePrefixSpecificProjectAdmin+p.project.Name),
+		emptyClusterRoleBinding(namePrefixSpecificProjectAdmin+p.project.Name),
 
-		emptyClusterRole(NamePrefixSpecificProjectUAM+p.project.Name),
-		emptyClusterRoleBinding(NamePrefixSpecificProjectUAM+p.project.Name),
+		emptyClusterRole(namePrefixSpecificProjectUAM+p.project.Name),
+		emptyClusterRoleBinding(namePrefixSpecificProjectUAM+p.project.Name),
 
-		emptyClusterRole(NamePrefixSpecificProjectMember+p.project.Name),
-		emptyClusterRoleBinding(NamePrefixSpecificProjectMember+p.project.Name),
-		emptyRoleBinding(NameProjectMember, *p.project.Spec.Namespace),
+		emptyClusterRole(namePrefixSpecificProjectMember+p.project.Name),
+		emptyClusterRoleBinding(namePrefixSpecificProjectMember+p.project.Name),
+		emptyRoleBinding(nameProjectMember, *p.project.Spec.Namespace),
 
-		emptyClusterRole(NamePrefixSpecificProjectViewer+p.project.Name),
-		emptyClusterRoleBinding(NamePrefixSpecificProjectViewer+p.project.Name),
-		emptyRoleBinding(NameProjectViewer, *p.project.Spec.Namespace),
+		emptyClusterRole(namePrefixSpecificProjectViewer+p.project.Name),
+		emptyClusterRoleBinding(namePrefixSpecificProjectViewer+p.project.Name),
+		emptyRoleBinding(nameProjectViewer, *p.project.Spec.Namespace),
 	)
 }
 
@@ -369,7 +369,7 @@ func (p *projectRBAC) getExtensionRolesResourceLabels() map[string]string {
 }
 
 func getExtensionRoleNameFromRBAC(resourceName, projectName string) string {
-	return strings.TrimPrefix(resourceName, NamePrefixSpecificProjectExtensions+projectName+":")
+	return strings.TrimPrefix(resourceName, namePrefixSpecificProjectExtensions+projectName+":")
 }
 
 func getExtensionRoleNameFromRole(role string) string {

--- a/pkg/operation/botanist/component/resourcemanager/logging.go
+++ b/pkg/operation/botanist/component/resourcemanager/logging.go
@@ -44,7 +44,7 @@ const (
 `
 )
 
-// LoggingConfiguration returns a fluent-bit parser and filters for the gardener-resource-manager logs.
+// CentralLoggingConfiguration returns a fluent-bit parser and filters for the gardener-resource-manager logs.
 func CentralLoggingConfiguration() (component.CentralLoggingConfig, error) {
 	return component.CentralLoggingConfig{Filters: loggingFilters, Parsers: loggingParser}, nil
 }

--- a/pkg/operation/botanist/dns.go
+++ b/pkg/operation/botanist/dns.go
@@ -495,11 +495,7 @@ func (d dnsRestoreDeployer) Deploy(ctx context.Context) error {
 	}
 
 	// Wait for the entry to become ready
-	if err := d.entry.Wait(ctx); err != nil {
-		return err
-	}
-
-	return nil
+	return d.entry.Wait(ctx)
 }
 
 func (d dnsRestoreDeployer) Destroy(_ context.Context) error { return nil }

--- a/pkg/operation/botanist/kubeapiserver.go
+++ b/pkg/operation/botanist/kubeapiserver.go
@@ -172,11 +172,7 @@ func (b *Botanist) WakeUpKubeAPIServer(ctx context.Context) error {
 	if err := kubernetes.ScaleDeployment(ctx, b.K8sSeedClient.Client(), kutil.Key(b.Shoot.SeedNamespace, v1beta1constants.DeploymentNameKubeAPIServer), 1); err != nil {
 		return err
 	}
-	if err := b.Shoot.Components.ControlPlane.KubeAPIServer.Wait(ctx); err != nil {
-		return err
-	}
-
-	return nil
+	return b.Shoot.Components.ControlPlane.KubeAPIServer.Wait(ctx)
 }
 
 // ScaleKubeAPIServerToOne scales kube-apiserver replicas to one.

--- a/pkg/operation/botanist/monitoring.go
+++ b/pkg/operation/botanist/monitoring.go
@@ -45,7 +45,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// DeploySeedMonitoring will install the Helm release "seed-monitoring" in the Seed clusters. It comprises components
+// DeploySeedMonitoring installs the Helm release "seed-monitoring" in the Seed clusters. It comprises components
 // to monitor the Shoot cluster whose control plane runs in the Seed cluster.
 func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 	if b.Shoot.Purpose == gardencorev1beta1.ShootPurposeTesting {
@@ -294,6 +294,7 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 	return nil
 }
 
+// DeploySeedGrafana deploys the grafana charts to the Seed cluster.
 func (b *Botanist) DeploySeedGrafana(ctx context.Context) error {
 	if b.Shoot.Purpose == gardencorev1beta1.ShootPurposeTesting {
 		return b.DeleteGrafana(ctx)

--- a/pkg/operation/care/constraints.go
+++ b/pkg/operation/care/constraints.go
@@ -77,7 +77,7 @@ func NewConstraint(op *operation.Operation, shootClientInit ShootClientInit) *Co
 	}
 }
 
-// ConstraintsChecks conducts the constraints checks on all the given constraints.
+// Check checks all given constraints.
 func (c *Constraint) Check(
 	ctx context.Context,
 	constraints []gardencorev1beta1.Condition,

--- a/pkg/operation/care/health.go
+++ b/pkg/operation/care/health.go
@@ -59,6 +59,7 @@ type Health struct {
 	logger logrus.FieldLogger
 }
 
+// ShootClientInit is a function that initializes a kubernetes client for a Shoot.
 type ShootClientInit func() (kubernetes.Interface, bool, error)
 
 // NewHealth creates a new Health instance with the given parameters.

--- a/pkg/operation/care/health_check_test.go
+++ b/pkg/operation/care/health_check_test.go
@@ -410,7 +410,7 @@ var _ = Describe("health check", func() {
 			)
 
 			if !upToDate {
-				mr.Generation += 1
+				mr.Generation++
 			}
 
 			mr.Status.Conditions = conditions

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -531,6 +531,7 @@ func (o *Operation) EnsureShootStateExists(ctx context.Context) error {
 	return err
 }
 
+// DeleteShootState deletes the ShootState resource for the corresponding shoot.
 func (o *Operation) DeleteShootState(ctx context.Context) error {
 	shootState := &gardencorev1alpha1.ShootState{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -412,10 +412,7 @@ func (s *Shoot) GetMaxNodeCount() int32 {
 // controller has generated a nodes network then this CIDR will take priority. Otherwise, the nodes network
 // CIDR specified in the shoot will be returned (if possible). If no CIDR was specified then nil is returned.
 func (s *Shoot) GetNodeNetwork() *string {
-	if val := s.GetInfo().Spec.Networking.Nodes; val != nil {
-		return val
-	}
-	return nil
+	return s.GetInfo().Spec.Networking.Nodes
 }
 
 // GetReplicas returns the given <wokenUp> number if the shoot is not hibernated, or zero otherwise.

--- a/pkg/utils/errors/unwrap.go
+++ b/pkg/utils/errors/unwrap.go
@@ -20,7 +20,7 @@ type causer interface {
 	Cause() error
 }
 
-// Unwraps and returns the root error. Multiple wrappings either via `fmt.Errorf` or via `causer` implementations are properly taken into account.
+// Unwrap unwraps and returns the root error. Multiple wrappings either via `fmt.Errorf` or via `causer` implementations are properly taken into account.
 func Unwrap(err error) error {
 	var cdone, udone bool
 

--- a/pkg/utils/imagevector/imagevector_validation_test.go
+++ b/pkg/utils/imagevector/imagevector_validation_test.go
@@ -124,8 +124,5 @@ func write(w io.Writer, imageVector ImageVector) error {
 		Images: imageVector,
 	}
 
-	if err := yaml.NewEncoder(w).Encode(&vector); err != nil {
-		return err
-	}
-	return nil
+	return yaml.NewEncoder(w).Encode(&vector)
 }

--- a/pkg/utils/test/options.go
+++ b/pkg/utils/test/options.go
@@ -19,7 +19,9 @@ import (
 	"strings"
 )
 
+// Flag is a flag that can be represented as a slice of strings.
 type Flag interface {
+	// Slice returns a representation of this Flag as a slice of strings.
 	Slice() []string
 }
 
@@ -70,18 +72,22 @@ func (f *stringSliceFlag) Slice() []string {
 	return []string{keyToFlag(f.key), strings.Join(f.value, ",")}
 }
 
+// IntFlag returns a Flag with the given key and integer value.
 func IntFlag(key string, value int) Flag {
 	return &intFlag{key, value}
 }
 
+// StringFlag returns a Flag with the given key and string value.
 func StringFlag(key, value string) Flag {
 	return &stringFlag{key, value}
 }
 
+// BoolFlag returns a Flag with the given key and boolean value.
 func BoolFlag(key string, value bool) Flag {
 	return &boolFlag{key, value}
 }
 
+// StringSliceFlag returns a flag with the given key and string slice value.
 func StringSliceFlag(key string, value ...string) Flag {
 	return &stringSliceFlag{key, value}
 }

--- a/pkg/utils/values.go
+++ b/pkg/utils/values.go
@@ -82,10 +82,7 @@ func convert(x, y interface{}) error {
 	if err != nil {
 		return err
 	}
-	if err := json.Unmarshal(jsonBytes, y); err != nil {
-		return err
-	}
-	return nil
+	return json.Unmarshal(jsonBytes, y)
 }
 
 // getFromValues returns the element at the specified location in the given values (either map or slice),

--- a/plugin/pkg/global/customverbauthorizer/admission.go
+++ b/plugin/pkg/global/customverbauthorizer/admission.go
@@ -40,7 +40,7 @@ const (
 	// CustomVerbModifyProjectTolerationsWhitelist is a constant for the custom verb that allows modifying the
 	// `.spec.tolerations.whitelist` field in `Project` resources.
 	CustomVerbModifyProjectTolerationsWhitelist = "modify-spec-tolerations-whitelist"
-	// CustomVerbProjectUserAccessManagement is a constant for the custom verb that allows to manage human users or
+	// CustomVerbProjectManageMembers is a constant for the custom verb that allows to manage human users or
 	// groups subjects in the `.spec.members` field in `Project` resources.
 	CustomVerbProjectManageMembers = "manage-members"
 )

--- a/plugin/pkg/global/deletionconfirmation/admission.go
+++ b/plugin/pkg/global/deletionconfirmation/admission.go
@@ -109,7 +109,7 @@ func (d *DeletionConfirmation) SetExternalCoreInformerFactory(f externalcoreinfo
 	readyFuncs = append(readyFuncs, shootStateInformer.Informer().HasSynced)
 }
 
-// SetCoreClientset gets the clientset from the Kubernetes client.
+// SetInternalCoreClientset gets the clientset from the Kubernetes client.
 func (d *DeletionConfirmation) SetInternalCoreClientset(c internalversion.Interface) {
 	d.gardenCoreClient = c
 }

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -288,7 +288,7 @@ var _ = Describe("validator", func() {
 			It("update should pass because the Seed has new non-tolerated taints that were added after the shoot was scheduled to it", func() {
 				seed.Spec.Taints = []core.SeedTaint{{Key: core.SeedTaintProtected}}
 				oldShoot.Spec.SeedName = shoot.Spec.SeedName
-				shoot.Spec.Provider.Workers[0].Maximum += 1
+				shoot.Spec.Provider.Workers[0].Maximum++
 
 				Expect(coreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&project)).To(Succeed())
 				Expect(coreInformerFactory.Core().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())

--- a/test/framework/common.go
+++ b/test/framework/common.go
@@ -38,7 +38,7 @@ const (
 	// testmachinery provided kubeconfigs.
 	TestMachineryKubeconfigsPathEnvVarName = "TM_KUBECONFIG_PATH"
 
-	// TestMachineryTestRunEnvVarName is the name of the environment variable that holds the testrun ID.
+	// TestMachineryTestRunIDEnvVarName is the name of the environment variable that holds the testrun ID.
 	TestMachineryTestRunIDEnvVarName = "TM_TESTRUN_ID"
 
 	// SeedTaintTestRun is the taint used to limit shoots that can be scheduled on a seed to shoots created by the same testrun.

--- a/test/framework/dump.go
+++ b/test/framework/dump.go
@@ -228,6 +228,7 @@ func (f *GardenerFramework) dumpGardenerExtension(extension v1alpha1.Object) {
 	}
 }
 
+// DumpLogsForPodsWithLabelsInNamespace prints the logs of pods in the given namespace selected by the given list options.
 func (f *CommonFramework) DumpLogsForPodsWithLabelsInNamespace(ctx context.Context, ctxIdentifier string, k8sClient kubernetes.Interface, namespace string, opts ...client.ListOption) error {
 	pods := &corev1.PodList{}
 	opts = append(opts, client.InNamespace(namespace))
@@ -244,6 +245,7 @@ func (f *CommonFramework) DumpLogsForPodsWithLabelsInNamespace(ctx context.Conte
 	return result
 }
 
+// DumpLogsForPodInNamespace prints the logs of the pod with the given namespace and name.
 func (f *CommonFramework) DumpLogsForPodInNamespace(ctx context.Context, ctxIdentifier string, k8sClient kubernetes.Interface, podNamespace, podName string) error {
 	f.Logger.Infof("%s [NAMESPACE %s] [POD %s] [LOGS]", ctxIdentifier, podNamespace, podName)
 	podIf := k8sClient.Kubernetes().CoreV1().Pods(podNamespace)

--- a/test/framework/gardener_utils.go
+++ b/test/framework/gardener_utils.go
@@ -685,7 +685,7 @@ func (f *GardenerFramework) WaitForManagedSeedToBeCreated(ctx context.Context, m
 	})
 }
 
-// DeleteSeed deletes the given managed seed and waits for it to be deleted.
+// DeleteManagedSeed deletes the given managed seed and waits for it to be deleted.
 func (f *GardenerFramework) DeleteManagedSeed(ctx context.Context, managedSeed *seedmanagementv1alpha1.ManagedSeed) error {
 	// Delete the managed seed
 	err := retry.UntilTimeout(ctx, 20*time.Second, 5*time.Minute, func(ctx context.Context) (done bool, err error) {

--- a/test/framework/gardener_utils.go
+++ b/test/framework/gardener_utils.go
@@ -355,11 +355,7 @@ func (f *GardenerFramework) AnnotateShoot(ctx context.Context, shoot *gardencore
 		metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, annotationKey, annotationValue)
 	}
 
-	if err := f.GardenClient.Client().Patch(ctx, shoot, patch); err != nil {
-		return err
-	}
-
-	return nil
+	return f.GardenClient.Client().Patch(ctx, shoot, patch)
 }
 
 // RemoveShootAnnotation removes an annotation with key <annotationKey> from a shoot object

--- a/test/framework/landscaper/commonframework.go
+++ b/test/framework/landscaper/commonframework.go
@@ -245,7 +245,7 @@ func (f *CommonFrameworkLandscaper) waitForInstallationToBeCreated(ctx context.C
 	})
 }
 
-// DeleteSeed deletes the given installation and waits for it to be deleted.
+// DeleteInstallation deletes the given installation and waits for it to be deleted.
 func (f *CommonFrameworkLandscaper) DeleteInstallation(ctx context.Context, name string) error {
 	installation := &landscaperv1alpha1.Installation{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/framework/landscaper/commonframework.go
+++ b/test/framework/landscaper/commonframework.go
@@ -373,8 +373,5 @@ func (f *CommonFrameworkLandscaper) CreateTargetWithKubeconfig(ctx context.Conte
 		},
 	}
 
-	if err := f.LandscaperClient.Create(ctx, seedCluster); err != nil {
-		return err
-	}
-	return nil
+	return f.LandscaperClient.Create(ctx, seedCluster)
 }

--- a/test/framework/landscaper/commonframework.go
+++ b/test/framework/landscaper/commonframework.go
@@ -174,6 +174,7 @@ func mergeLandscaperCommonConfig(base, overwrite *LandscaperCommonConfig) *Lands
 	return base
 }
 
+// GetInstallation creates and returns a landscaperv1alpha1.Installation for the given name.
 func (f *CommonFrameworkLandscaper) GetInstallation(name string) *landscaperv1alpha1.Installation {
 	name = fmt.Sprintf("%s-%s", name, f.ResourceSuffix)
 

--- a/test/framework/landscaper/gardenletframework.go
+++ b/test/framework/landscaper/gardenletframework.go
@@ -74,7 +74,7 @@ type GardenletFramework struct {
 	ComponentConfiguration *configv1alpha1.GardenletConfiguration
 }
 
-// LandscaperCommonConfig is the configuration for the landscaper
+// GardenletConfig is the configuration of the gardenlet landscaper component.
 type GardenletConfig struct {
 	SeedKubeconfigPath             string
 	ImageVectorOverwrite           *string
@@ -84,7 +84,7 @@ type GardenletConfig struct {
 	LandscaperCommonConfig         *LandscaperCommonConfig
 }
 
-// NewManagedSeedFramework creates a new managed seed framework.
+// NewGardenletFramework creates a new GardenletFramework.
 func NewGardenletFramework(cfg *GardenletConfig) *GardenletFramework {
 	var gardenerConfig *GardenerConfig
 	if cfg != nil {

--- a/test/framework/landscaper/gardenletframework.go
+++ b/test/framework/landscaper/gardenletframework.go
@@ -244,11 +244,7 @@ func (f *GardenletFramework) createGardenletLandscaperConfig(ctx context.Context
 		dataImportComponentConfiguration: string(re),
 	}
 
-	if err := f.CreateConfigMap(ctx, cmNameGardenletLandscaperConfig, data); err != nil {
-		return err
-	}
-
-	return nil
+	return f.CreateConfigMap(ctx, cmNameGardenletLandscaperConfig, data)
 }
 
 // CreateInstallation creates an Installation CRD in the landscaper cluster

--- a/test/framework/shootcreationframework.go
+++ b/test/framework/shootcreationframework.go
@@ -429,11 +429,7 @@ func (f *ShootCreationFramework) InitializeShootWithFlags(ctx context.Context) e
 		return err
 	}
 
-	if err = setShootWorkerSettings(shootObject, f.Config, cloudProfile); err != nil {
-		return err
-	}
-
-	return nil
+	return setShootWorkerSettings(shootObject, f.Config, cloudProfile)
 }
 
 // newShootFramework creates a new ShootFramework with the Shoot created by the ShootCreationFramework

--- a/test/framework/shootcreationframework.go
+++ b/test/framework/shootcreationframework.go
@@ -348,6 +348,7 @@ func RegisterShootCreationFrameworkFlags() *ShootCreationConfig {
 	return shootCreationCfg
 }
 
+// CreateShoot creates a shoot using this framework's configuration.
 func (f *ShootCreationFramework) CreateShoot(ctx context.Context, initializeShootWithFlags, waitUntilShootIsReconciled bool) (*gardencorev1beta1.Shoot, error) {
 	if initializeShootWithFlags {
 		if err := f.InitializeShootWithFlags(ctx); err != nil {
@@ -398,6 +399,7 @@ func (f *ShootCreationFramework) CreateShoot(ctx context.Context, initializeShoo
 	return f.Shoot, nil
 }
 
+// InitializeShootWithFlags initializes a shoot to be created by this framework.
 func (f *ShootCreationFramework) InitializeShootWithFlags(ctx context.Context) error {
 	// if running in test machinery, test will be executed from root of the project
 	if !FileExists(fmt.Sprintf(".%s", f.Config.shootYamlPath)) {

--- a/test/framework/shootmigrationtest.go
+++ b/test/framework/shootmigrationtest.go
@@ -183,7 +183,7 @@ func (t *ShootMigrationTest) PopulateAfterMigrationComparisonElements(ctx contex
 	return
 }
 
-// CompareElementsAfterMigration compares the Machine details, Node names and Pod statuses before and after migration and returns error if there are diferences.
+// CompareElementsAfterMigration compares the Machine details, Node names and Pod statuses before and after migration and returns error if there are differences.
 func (t *ShootMigrationTest) CompareElementsAfterMigration() error {
 	if !reflect.DeepEqual(t.ComparisonElementsBeforeMigration.MachineNames, t.ComparisonElementsAfterMigration.MachineNames) {
 		return fmt.Errorf("initial Machines %s, do not match after-migrate Machines %s", t.ComparisonElementsBeforeMigration.MachineNames, t.ComparisonElementsAfterMigration.MachineNames)
@@ -201,8 +201,8 @@ func (t *ShootMigrationTest) CompareElementsAfterMigration() error {
 	return nil
 }
 
-// Check the timestamp of all objects that the resource-manager creates in the Shoot cluster.
-// The timestamp should not be after the ShootMigrationTest.MigrationTime
+// CheckObjectsTimestamp checks the timestamp of all objects that the resource-manager creates in the Shoot cluster.
+// The timestamp should not be after ShootMigrationTest.MigrationTime.
 func (t *ShootMigrationTest) CheckObjectsTimestamp(ctx context.Context, mrExcludeList, resourcesWithGeneratedName []string) error {
 	mrList := &resourcesv1alpha1.ManagedResourceList{}
 	if err := t.TargetSeedClient.Client().List(

--- a/test/framework/test_options.go
+++ b/test/framework/test_options.go
@@ -115,7 +115,7 @@ func WithAfterTests(funcs ...func()) TestOption {
 	return afterTests(funcs)
 }
 
-// WithAfterTests adds contextified functions to the current test that are called
+// WithCAfterTest adds contextified functions to the current test that are called
 // when the test has finished
 func WithCAfterTest(body func(ctx context.Context), timeout time.Duration) TestOption {
 	return &cAfterTestOption{

--- a/test/framework/worker_utils.go
+++ b/test/framework/worker_utils.go
@@ -80,10 +80,7 @@ func SetupShootWorker(shoot *gardencorev1beta1.Shoot, cloudProfile *gardencorev1
 	// clear current workers
 	shoot.Spec.Provider.Workers = []gardencorev1beta1.Worker{}
 
-	if err := AddWorker(shoot, cloudProfile, cloudProfile.Spec.MachineImages[0], workerZone); err != nil {
-		return err
-	}
-	return nil
+	return AddWorker(shoot, cloudProfile, cloudProfile.Spec.MachineImages[0], workerZone)
 }
 
 // AddWorker adds a valid default worker to the shoot for the given machineImage and CloudProfile.

--- a/test/system/complete_reconcile/gardener_reconcile_test.go
+++ b/test/system/complete_reconcile/gardener_reconcile_test.go
@@ -83,7 +83,7 @@ var _ = Describe("Shoot reconciliation testing", func() {
 			}
 
 			if reconciledShoots != len(shoots.Items) {
-				err := fmt.Errorf("Reconciled %d of %d shoots. Waiting ...", reconciledShoots, len(shoots.Items)) //nolint:golint
+				err := fmt.Errorf("Reconciled %d of %d shoots. Waiting ...", reconciledShoots, len(shoots.Items)) //nolint:revive
 				f.Logger.Info(err.Error())
 				return retry.MinorError(err)
 			}

--- a/test/system/complete_reconcile/gardener_reconcile_test.go
+++ b/test/system/complete_reconcile/gardener_reconcile_test.go
@@ -83,7 +83,7 @@ var _ = Describe("Shoot reconciliation testing", func() {
 			}
 
 			if reconciledShoots != len(shoots.Items) {
-				err := fmt.Errorf("Reconciled %d of %d shoots. Waiting ...", reconciledShoots, len(shoots.Items))
+				err := fmt.Errorf("Reconciled %d of %d shoots. Waiting ...", reconciledShoots, len(shoots.Items)) //nolint:golint
 				f.Logger.Info(err.Error())
 				return retry.MinorError(err)
 			}

--- a/test/system/shoot_cp_migration/migrate_test.go
+++ b/test/system/shoot_cp_migration/migrate_test.go
@@ -241,11 +241,7 @@ func afterMigration(ctx context.Context, t *ShootMigrationTest, guestBookApp app
 	guestBookApp.Cleanup(ctx)
 
 	ginkgo.By("Checking timestamps of all resources...")
-	if err := t.CheckObjectsTimestamp(ctx, strings.Split(*mrExcludeList, ","), strings.Split(*resourcesWithGeneratedName, ",")); err != nil {
-		return err
-	}
-
-	return nil
+	return t.CheckObjectsTimestamp(ctx, strings.Split(*mrExcludeList, ","), strings.Split(*resourcesWithGeneratedName, ","))
 }
 
 func initGuestBookTest(ctx context.Context, t *ShootMigrationTest) (*applications.GuestBookTest, error) {

--- a/test/system/shoot_cp_migration/migrate_test.go
+++ b/test/system/shoot_cp_migration/migrate_test.go
@@ -142,19 +142,20 @@ func initShootAndClient(ctx context.Context, t *ShootMigrationTest) (err error) 
 func initSeedsAndClients(ctx context.Context, t *ShootMigrationTest) error {
 	t.Config.SourceSeedName = *t.Shoot.Spec.SeedName
 
-	if seed, seedClient, err := t.GardenerFramework.GetSeed(ctx, t.Config.TargetSeedName); err != nil {
+	seed, seedClient, err := t.GardenerFramework.GetSeed(ctx, t.Config.TargetSeedName)
+	if err != nil {
 		return err
-	} else {
-		t.TargetSeedClient = seedClient
-		t.TargetSeed = seed
 	}
+	t.TargetSeedClient = seedClient
+	t.TargetSeed = seed
 
-	if seed, seedClient, err := t.GardenerFramework.GetSeed(ctx, t.Config.SourceSeedName); err != nil {
+	seed, seedClient, err = t.GardenerFramework.GetSeed(ctx, t.Config.SourceSeedName)
+	if err != nil {
 		return err
-	} else {
-		t.SourceSeedClient = seedClient
-		t.SourceSeed = seed
 	}
+	t.SourceSeedClient = seedClient
+	t.SourceSeed = seed
+
 	return nil
 }
 


### PR DESCRIPTION
**How to categorize this PR?**

/area quality, dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Makes the linter fail on missing or wrong doc comments and a few other common style errors, and fixes all such issues that already exist.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Making the linter fail on missing or wrong doc comments and a few other common style errors consists of enabling `revive` in the `golangci-lint` configuration and excluding certain `revive` errors that we are perhaps not interested in. 

I have fixed the following `revive` errors (as regexes that could be included in the `golangci-lint` configuration if desired):
```
- "exported: comment on exported (var|const|type|method|function) .* should be of the form "
- "exported: exported (var|const|type|method|function) .* should have comment or be unexported"
- receiver-naming # receiver name .* should be consistent with previous receiver name .* for .*
- error-strings # error strings should not be capitalized or end with punctuation or a newline
- increment-decrement # should replace .* \+= 1 with .*\+\+
- if-return # redundant if \.\.\.; err != nil check, just return error instead
```

I have disabled the following `revive` errors via the `golangci-lint` configuration:
```
- var-naming # ((var|const|struct field|func) .* should be .*
- dot-imports # should not use dot imports
- package-comments # package comment should be of the form
- unexported-return # exported func .* returns unexported type .*, which can be annoying to use
- indent-error-flow # if block ends with a return statement, so drop this else and outdent its block
- "exported: (type|func) name will be used as .* by other packages, and that stutters;"
```

See also https://github.com/gardener/gardener-extension-provider-gcp/pull/319.
  
**Release note**:

```other developer
Missing or wrong doc comments and a few other common style errors will now be reported by the linter.
```
