### PR TITLE
Fix format data device

### DIFF
--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/executor_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/executor_test.go
@@ -162,10 +162,30 @@ mkdir -p "/var/lib/cloud-config-downloader/downloads" "/var/lib/kubelet" "$PATH_
 		kubeletDataVolumePart = `function format-data-device() {
   LABEL=KUBEDEV
   if ! blkid --label $LABEL >/dev/null; then
-    DEVICES=$(lsblk -dbsnP -o NAME,PARTTYPE,FSTYPE,SIZE)
-    MATCHING_DEVICES=$(echo "$DEVICES" | grep 'PARTTYPE="".*FSTYPE="".*SIZE="` + *kubeletDataVolumeSize + `"')
+    DISK_DEVICES=$(lsblk -dbsnP -o NAME,PARTTYPE,FSTYPE,SIZE,PATH,TYPE | grep 'TYPE="disk"')
+    while IFS= read -r line; do
+      MATCHING_DEVICE_CANDIDATE=$(echo "$line" | grep 'PARTTYPE="".*FSTYPE="".*SIZE="` + *kubeletDataVolumeSize + `"')
+      if [ -z "$MATCHING_DEVICE_CANDIDATE" ]; then
+        continue
+      fi
+
+      # Skip device if it's already mounted.
+      DEVICE_NAME=$(echo "$MATCHING_DEVICE_CANDIDATE" | cut -f2 -d\")
+      DEVICE_MOUNTS=$(lsblk -dbsnP -o NAME,MOUNTPOINT,TYPE | grep -e "^NAME=\"$DEVICE_NAME.*\".*TYPE=\"part\"$")
+      if echo "$DEVICE_MOUNTS" | awk '{print $2}' | grep "MOUNTPOINT=\"\/.*\"" > /dev/null; then
+        continue
+      fi
+
+      TARGET_DEVICE_NAME="$DEVICE_NAME"
+      break
+    done <<< "$DISK_DEVICES"
+
+    if [ -z "$TARGET_DEVICE_NAME" ]; then
+      echo "No kubelet data device not found"
+      return
+    fi
+
     echo "Matching kubelet data device by size : ` + *kubeletDataVolumeSize + `"
-    TARGET_DEVICE_NAME=$(echo "$MATCHING_DEVICES" | head -n1 | cut -f2 -d\")
     echo "detected kubelet data device $TARGET_DEVICE_NAME"
     mkfs.ext4 -L $LABEL -O quota -E lazy_itable_init=0,lazy_journal_init=0,quotatype=usrquota:grpquota:prjquota  /dev/$TARGET_DEVICE_NAME
     echo "formatted and labeled data device $TARGET_DEVICE_NAME"

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/templates/scripts/execute-cloud-config.tpl.sh
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/templates/scripts/execute-cloud-config.tpl.sh
@@ -21,10 +21,30 @@ mkdir -p "{{ .pathDownloadsDirectory }}" "{{ .pathKubeletDirectory }}" "$PATH_HY
 function format-data-device() {
   LABEL=KUBEDEV
   if ! blkid --label $LABEL >/dev/null; then
-    DEVICES=$(lsblk -dbsnP -o NAME,PARTTYPE,FSTYPE,SIZE)
-    MATCHING_DEVICES=$(echo "$DEVICES" | grep 'PARTTYPE="".*FSTYPE="".*SIZE="{{ .kubeletDataVolume.size }}"')
+    DISK_DEVICES=$(lsblk -dbsnP -o NAME,PARTTYPE,FSTYPE,SIZE,PATH,TYPE | grep 'TYPE="disk"')
+    while IFS= read -r line; do
+      MATCHING_DEVICE_CANDIDATE=$(echo "$line" | grep 'PARTTYPE="".*FSTYPE="".*SIZE="{{ .kubeletDataVolume.size }}"')
+      if [ -z "$MATCHING_DEVICE_CANDIDATE" ]; then
+        continue
+      fi
+
+      # Skip device if it's already mounted.
+      DEVICE_NAME=$(echo "$MATCHING_DEVICE_CANDIDATE" | cut -f2 -d\")
+      DEVICE_MOUNTS=$(lsblk -dbsnP -o NAME,MOUNTPOINT,TYPE | grep -e "^NAME=\"$DEVICE_NAME.*\".*TYPE=\"part\"$")
+      if echo "$DEVICE_MOUNTS" | awk '{print $2}' | grep "MOUNTPOINT=\"\/.*\"" > /dev/null; then
+        continue
+      fi
+
+      TARGET_DEVICE_NAME="$DEVICE_NAME"
+      break
+    done <<< "$DISK_DEVICES"
+
+    if [ -z "$TARGET_DEVICE_NAME" ]; then
+      echo "No kubelet data device not found"
+      return
+    fi
+
     echo "Matching kubelet data device by size : {{ .kubeletDataVolume.size }}"
-    TARGET_DEVICE_NAME=$(echo "$MATCHING_DEVICES" | head -n1 | cut -f2 -d\")
     echo "detected kubelet data device $TARGET_DEVICE_NAME"
     mkfs.ext4 -L $LABEL -O quota -E lazy_itable_init=0,lazy_journal_init=0,quotatype=usrquota:grpquota:prjquota  /dev/$TARGET_DEVICE_NAME
     echo "formatted and labeled data device $TARGET_DEVICE_NAME"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind bug

**What this PR does / why we need it**:
This PR fixes an issue that caused a data disk of a worker node not to be formatted and eventually prevented the node from joining the cluster. It happened when the boot disk and the data disk were configured with the same disk space:

```
volume:
          type: pd-standard
          size: 50Gi
        dataVolumes:
          - name: kubelet-dir
            type: pd-standard
            size: 50Gi
        kubeletDataVolumeName: kubelet-dir
```

The fix only consideres devices w/o mount points as potential candidates. Hence, a boot device (actively mounted) will not be picked even if it is as of the same size.

/invite @guydaichs 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
An issue has been fixed which caused a worker node with a configured data disk not to get ready. This issue only happened if the data disk was of the same size as the boot disk.
```
