### PR TITLE
document rotation of cloudprovider secret

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -40,6 +40,7 @@
 * [Reversed Cluster VPN](usage/reversed-vpn-tunnel.md)
 * [Seed Bootstrapping](usage/seed_bootstrapping.md)
 * [Seed Settings](usage/seed_settings.md)
+* [Secrets and Rotation](usage/secrets_rotation.md)
 * [Shoot cluster purposes](usage/shoot_purposes.md)
 * [Shoot Kubernetes and Operating System Versioning](usage/shoot_versions.md)
 * [Shoot Networking](usage/shoot_networking.md)

--- a/docs/usage/secrets_rotation.md
+++ b/docs/usage/secrets_rotation.md
@@ -8,12 +8,13 @@
 
 *Usage*: Authenticate gardener and kubernetes components for infrastructure operations
 
+*Description*: Gardener uses the cloudprovider secret to interact with the infrastructure when setting up shoot networks or security groups via the [terraformer](https://github.com/gardener/terraformer). It is also used by the [cloud-controller-manager](https://kubernetes.io/docs/concepts/architecture/cloud-controller/) of your Shoot to communicate with the infrastructure for example to create Loadbalancer services, routes or retrieve information about Node objects.
+Depending on the cloudprovider the format of the secret differs. Please consult the example above and respective infrastructure extension documentation for the concrete layout.
+
+To put it in use a cloudprovider secret is bound to one more namespaces (and therefore projects) using a [SecretBinding](https://github.com/gardener/gardener/blob/master/example/80-secretbinding.yaml). For Shoots created in those projects the secret is synced to the shoot namespace in the seed cluster.
+
 *Rotation*: Rotating the cloudprovider secret requires multiple steps:
 
 1. Either create the new secret in the garden cluster and add a secretBinding or edit the current secret.
-2. :warning: Wait until all Shoots using the secret are reconciled before you deactivate the old secret! Otherwise the shoots will no longer function.
-3. After you are sure all Shoots using the secret are reconciled you can go ahead and deactivate the old secret in your infrastructure provider.
-
-*Description*: Gardener uses the cloudprovider secret to interact with the infrastructure when setting up shoot networks or security groups via the [terraformer](https://github.com/gardener/terraformer). It is also used by the cloud-controller-manager of your Shoot for example to create VMs. Depending on the cloudprovider the format of the secret differs. Please consult the example above and respective infrastructure extension documentation for the concrete layout. 
-
-To put it in use a cloudprovider secret is bound to one more namespaces (and therefore projects) using a [SecretBinding](https://github.com/gardener/gardener/blob/master/example/80-secretbinding.yaml). For Shoots created in those projects the secret is synced to the shoot namespace in the seed cluster.
+2. :warning: Wait until all Shoots using the secret are reconciled before you disable the old secret in your infrastructure account! Otherwise the shoots will no longer function.
+3. After you are sure all Shoots using the secret are reconciled you can go ahead and deactivate the old secret in your infrastructure account.

--- a/docs/usage/secrets_rotation.md
+++ b/docs/usage/secrets_rotation.md
@@ -11,10 +11,10 @@
 *Description*: Gardener uses the cloudprovider secret to interact with the infrastructure when setting up shoot networks or security groups via the [terraformer](https://github.com/gardener/terraformer). It is also used by the [cloud-controller-manager](https://kubernetes.io/docs/concepts/architecture/cloud-controller/) of your Shoot to communicate with the infrastructure for example to create Loadbalancer services, routes or retrieve information about Node objects.
 Depending on the cloudprovider the format of the secret differs. Please consult the example above and respective infrastructure extension documentation for the concrete layout.
 
-To put it in use a cloudprovider secret is bound to one more namespaces (and therefore projects) using a [SecretBinding](https://github.com/gardener/gardener/blob/master/example/80-secretbinding.yaml). For Shoots created in those projects the secret is synced to the shoot namespace in the seed cluster.
+To put it in use, a cloudprovider secret is bound to one more namespaces (and therefore projects) using a [SecretBinding](https://github.com/gardener/gardener/blob/master/example/80-secretbinding.yaml). For Shoots created in those projects the secret is synced to the shoot namespace in the seed cluster.
 
 *Rotation*: Rotating the cloudprovider secret requires multiple steps:
 
-1. Either create the new secret in the garden cluster and add a secretBinding or edit the current secret.
+1. Update the data keys in the secret.
 2. :warning: Wait until all Shoots using the secret are reconciled before you disable the old secret in your infrastructure account! Otherwise the shoots will no longer function.
-3. After you are sure all Shoots using the secret are reconciled you can go ahead and deactivate the old secret in your infrastructure account.
+3. After all Shoots using the secret were reconciled you can go ahead and deactivate the old secret in your infrastructure account.

--- a/docs/usage/secrets_rotation.md
+++ b/docs/usage/secrets_rotation.md
@@ -1,0 +1,19 @@
+# Secrets and rotation
+
+## List of secrets
+
+**Cloudprovider Secret**
+
+*Example*: https://github.com/gardener/gardener/blob/master/example/70-secret-provider.yaml
+
+*Usage*: Authenticate gardener and kubernetes components for infrastructure operations
+
+*Rotation*: Rotating the cloudprovider secret requires multiple steps:
+
+1. Either create the new secret in the garden cluster and add a secretBinding or edit the current secret.
+2. :warning: Wait until all Shoots using the secret are reconciled before you deactivate the old secret! Otherwise the shoots will no longer function.
+3. After you are sure all Shoots using the secret are reconciled you can go ahead and deactivate the old secret in your infrastructure provider.
+
+*Description*: Gardener uses the cloudprovider secret to interact with the infrastructure when setting up shoot networks or security groups via the [terraformer](https://github.com/gardener/terraformer). It is also used by the cloud-controller-manager of your Shoot for example to create VMs. Depending on the cloudprovider the format of the secret differs. Please consult the example above and respective infrastructure extension documentation for the concrete layout. 
+
+To put it in use a cloudprovider secret is bound to one more namespaces (and therefore projects) using a [SecretBinding](https://github.com/gardener/gardener/blob/master/example/80-secretbinding.yaml). For Shoots created in those projects the secret is synced to the shoot namespace in the seed cluster.


### PR DESCRIPTION
**How to categorize this PR?**

/area documentation
 
**What this PR does / why we need it**:
See https://github.com/gardener/gardener/issues/4630

I thought we could start a page where we list relevant secrets and how to rotate them. Especially, as we plan to invest more in the topic of secret rotation we are going to need a place for documenting that.

**Note for reviewer**:

The doc reflects my current understanding which might be incomplete or partially incorrect, if this is the case even regarding minor corrections please comment. Thanks!

```other operator
[add documentation](https://github.com/gardener/gardener/blob/master/docs/usage/secrets_rotation.md#user-provided-secrets) on rotation of cloud provider secret
```
