### PR TITLE
[release-v1.29] Automated cherry pick of #4629: Fix format data device

### DIFF
--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/executor_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/executor_test.go
@@ -162,10 +162,30 @@ mkdir -p "/var/lib/cloud-config-downloader/downloads" "/var/lib/kubelet" "$PATH_
 		kubeletDataVolumePart = `function format-data-device() {
   LABEL=KUBEDEV
   if ! blkid --label $LABEL >/dev/null; then
-    DEVICES=$(lsblk -dbsnP -o NAME,PARTTYPE,FSTYPE,SIZE)
-    MATCHING_DEVICES=$(echo "$DEVICES" | grep 'PARTTYPE="".*FSTYPE="".*SIZE="` + *kubeletDataVolumeSize + `"')
+    DISK_DEVICES=$(lsblk -dbsnP -o NAME,PARTTYPE,FSTYPE,SIZE,PATH,TYPE | grep 'TYPE="disk"')
+    while IFS= read -r line; do
+      MATCHING_DEVICE_CANDIDATE=$(echo "$line" | grep 'PARTTYPE="".*FSTYPE="".*SIZE="` + *kubeletDataVolumeSize + `"')
+      if [ -z "$MATCHING_DEVICE_CANDIDATE" ]; then
+        continue
+      fi
+
+      # Skip device if it's already mounted.
+      DEVICE_NAME=$(echo "$MATCHING_DEVICE_CANDIDATE" | cut -f2 -d\")
+      DEVICE_MOUNTS=$(lsblk -dbsnP -o NAME,MOUNTPOINT,TYPE | grep -e "^NAME=\"$DEVICE_NAME.*\".*TYPE=\"part\"$")
+      if echo "$DEVICE_MOUNTS" | awk '{print $2}' | grep "MOUNTPOINT=\"\/.*\"" > /dev/null; then
+        continue
+      fi
+
+      TARGET_DEVICE_NAME="$DEVICE_NAME"
+      break
+    done <<< "$DISK_DEVICES"
+
+    if [ -z "$TARGET_DEVICE_NAME" ]; then
+      echo "No kubelet data device not found"
+      return
+    fi
+
     echo "Matching kubelet data device by size : ` + *kubeletDataVolumeSize + `"
-    TARGET_DEVICE_NAME=$(echo "$MATCHING_DEVICES" | head -n1 | cut -f2 -d\")
     echo "detected kubelet data device $TARGET_DEVICE_NAME"
     mkfs.ext4 -L $LABEL -O quota -E lazy_itable_init=0,lazy_journal_init=0,quotatype=usrquota:grpquota:prjquota  /dev/$TARGET_DEVICE_NAME
     echo "formatted and labeled data device $TARGET_DEVICE_NAME"

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/templates/scripts/execute-cloud-config.tpl.sh
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/templates/scripts/execute-cloud-config.tpl.sh
@@ -21,10 +21,30 @@ mkdir -p "{{ .pathDownloadsDirectory }}" "{{ .pathKubeletDirectory }}" "$PATH_HY
 function format-data-device() {
   LABEL=KUBEDEV
   if ! blkid --label $LABEL >/dev/null; then
-    DEVICES=$(lsblk -dbsnP -o NAME,PARTTYPE,FSTYPE,SIZE)
-    MATCHING_DEVICES=$(echo "$DEVICES" | grep 'PARTTYPE="".*FSTYPE="".*SIZE="{{ .kubeletDataVolume.size }}"')
+    DISK_DEVICES=$(lsblk -dbsnP -o NAME,PARTTYPE,FSTYPE,SIZE,PATH,TYPE | grep 'TYPE="disk"')
+    while IFS= read -r line; do
+      MATCHING_DEVICE_CANDIDATE=$(echo "$line" | grep 'PARTTYPE="".*FSTYPE="".*SIZE="{{ .kubeletDataVolume.size }}"')
+      if [ -z "$MATCHING_DEVICE_CANDIDATE" ]; then
+        continue
+      fi
+
+      # Skip device if it's already mounted.
+      DEVICE_NAME=$(echo "$MATCHING_DEVICE_CANDIDATE" | cut -f2 -d\")
+      DEVICE_MOUNTS=$(lsblk -dbsnP -o NAME,MOUNTPOINT,TYPE | grep -e "^NAME=\"$DEVICE_NAME.*\".*TYPE=\"part\"$")
+      if echo "$DEVICE_MOUNTS" | awk '{print $2}' | grep "MOUNTPOINT=\"\/.*\"" > /dev/null; then
+        continue
+      fi
+
+      TARGET_DEVICE_NAME="$DEVICE_NAME"
+      break
+    done <<< "$DISK_DEVICES"
+
+    if [ -z "$TARGET_DEVICE_NAME" ]; then
+      echo "No kubelet data device not found"
+      return
+    fi
+
     echo "Matching kubelet data device by size : {{ .kubeletDataVolume.size }}"
-    TARGET_DEVICE_NAME=$(echo "$MATCHING_DEVICES" | head -n1 | cut -f2 -d\")
     echo "detected kubelet data device $TARGET_DEVICE_NAME"
     mkfs.ext4 -L $LABEL -O quota -E lazy_itable_init=0,lazy_journal_init=0,quotatype=usrquota:grpquota:prjquota  /dev/$TARGET_DEVICE_NAME
     echo "formatted and labeled data device $TARGET_DEVICE_NAME"


### PR DESCRIPTION
/kind/bug
/area/os

Cherry pick of #4629 on release-v1.29.

#4629: Fix format data device

**Release Notes:**
```bugfix user
An issue has been fixed which caused a worker node with a configured data disk not to get ready. This issue only happened if the data disk was of the same size as the boot disk.
```