### PR TITLE
Exclude noisy typecheck linter errors

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -31,6 +31,9 @@ issues:
   - unexported-return # exported func .* returns unexported type .*, which can be annoying to use
   - indent-error-flow # if block ends with a return statement, so drop this else and outdent its block
   - "exported: (type|func) name will be used as .* by other packages, and that stutters;"
+  # typecheck:
+  - "undeclared name: `.*`"
+  - "\".*\" imported but not used"
   exclude-rules:
   - linters:
     - staticcheck


### PR DESCRIPTION
**How to categorize this PR?**

/area dev-productivity
/kind bug

**What this PR does / why we need it**:
Excludes noisy `typecheck` linter errors. In some situations when there are actual compiler errors, a large amount of such "bogus" typecheck errors is displayed that obscure the real issue and confuse the developer.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This issue seems to be related to the recent update of `golangci-lint` that probably included also a `typecheck` update.

With this change, if there are indeed undefined names or unused imports, `golangci-lint` will not complain, but `go vet` will report the errors, so `make check` will still fail.

**Release note**:

```other operator
NONE
```
