### PR TITLE
Add goleak where applicable, fix one more goroutine leak

### DIFF
--- a/pkg/client/kubernetes/cache/cache.go
+++ b/pkg/client/kubernetes/cache/cache.go
@@ -93,6 +93,11 @@ func (c *aggregator) GetInformerForKind(ctx context.Context, gvk schema.GroupVer
 }
 
 func (c *aggregator) Start(ctx context.Context) error {
+	// NB: this function might leak goroutines, when the context for this aggregator cache is cancelled.
+	// There is no way of waiting for caches to stop, so we there's no point in waiting for the following
+	// goroutines to finish, because there might still be goroutines running under the hood of caches.
+	// However, this is not problematic, as long as the aggregator cache is not in any client set, that might
+	// be invalidated during runtime.
 	for gvk, cache := range c.gvkToCache {
 		go func(gvk schema.GroupVersionKind, cache runtimecache.Cache) {
 			err := cache.Start(ctx)

--- a/pkg/client/kubernetes/cache/cache.go
+++ b/pkg/client/kubernetes/cache/cache.go
@@ -94,7 +94,7 @@ func (c *aggregator) GetInformerForKind(ctx context.Context, gvk schema.GroupVer
 
 func (c *aggregator) Start(ctx context.Context) error {
 	// NB: this function might leak goroutines, when the context for this aggregator cache is cancelled.
-	// There is no way of waiting for caches to stop, so we there's no point in waiting for the following
+	// There is no way of waiting for caches to stop, so there's no point in waiting for the following
 	// goroutines to finish, because there might still be goroutines running under the hood of caches.
 	// However, this is not problematic, as long as the aggregator cache is not in any client set, that might
 	// be invalidated during runtime.

--- a/pkg/controllermanager/controller/controllerregistration/controllerregistration_seed_control_test.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerregistration_seed_control_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"go.uber.org/goleak"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -537,6 +538,16 @@ var _ = Describe("controllerRegistrationReconciler", func() {
 	})
 
 	Describe("#computeKindTypesForShoots", func() {
+		var (
+			ignoreCurrent goleak.Option
+		)
+		BeforeEach(func() {
+			ignoreCurrent = goleak.IgnoreCurrent()
+		})
+		AfterEach(func() {
+			goleak.VerifyNone(GinkgoT(), ignoreCurrent)
+		})
+
 		It("should correctly compute the result for a seed without DNS taint if the feature gate is disabled", func() {
 			defer test.WithFeatureGate(controllermanagerfeatures.FeatureGate, features.UseDNSRecords, false)()
 
@@ -630,7 +641,7 @@ var _ = Describe("controllerRegistrationReconciler", func() {
 		})
 
 		It("should correctly compute types for shoot that has the Seed`s name as status not spec", func() {
-			shootList := []gardencorev1beta1.Shoot{
+			shootList = []gardencorev1beta1.Shoot{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "s4",

--- a/pkg/controllerutils/worker.go
+++ b/pkg/controllerutils/worker.go
@@ -35,7 +35,7 @@ import (
 // added to the wait group when started and marked done when finished.
 // The given context is injected into the `reconciler` if it implements `inject.Stoppable`.
 // Optionally passed inject functions are called with the `reconciler` but potentially returned errors are disregarded.
-func CreateWorker(ctx context.Context, queue workqueue.RateLimitingInterface, resourceType string, reconciler reconcile.Reconciler, waitGroup *sync.WaitGroup, workerCh chan int, injectFn ...inject.Func) {
+func CreateWorker(ctx context.Context, queue workqueue.RateLimitingInterface, resourceType string, reconciler reconcile.Reconciler, waitGroup *sync.WaitGroup, workerCh chan<- int, injectFn ...inject.Func) {
 	fns := append(injectFn, func(i interface{}) error {
 		_, err := inject.StopChannelInto(ctx.Done(), i)
 		return err

--- a/pkg/healthz/periodic_test.go
+++ b/pkg/healthz/periodic_test.go
@@ -50,9 +50,9 @@ var _ = Describe("Periodic", func() {
 
 		Describe("#Start", func() {
 			It("should start the manager", func() {
+				p.Start()
 				defer p.Stop()
 
-				p.Start()
 				Expect(p.Get()).To(BeTrue())
 				Expect(p.timer).NotTo(BeNil())
 				Expect(p.started).To(BeTrue())
@@ -84,15 +84,17 @@ var _ = Describe("Periodic", func() {
 
 		Describe("#Set", func() {
 			It("should correctly set the status to true", func() {
-				defer p.Stop()
 				p.Start()
+				defer p.Stop()
+
 				p.Set(true)
 				Expect(p.Get()).To(BeTrue())
 			})
 
 			It("should correctly set the status to false", func() {
-				defer p.Stop()
 				p.Start()
+				defer p.Stop()
+
 				p.Set(false)
 				Expect(p.Get()).To(BeFalse())
 			})
@@ -113,8 +115,8 @@ var _ = Describe("Periodic", func() {
 			})
 
 			It("should correctly set the status to false after the reset duration", func() {
-				defer p.Stop()
 				p.Start()
+				defer p.Stop()
 
 				Expect(p.Get()).To(BeTrue())
 				fakeClock.Step(resetDuration)
@@ -122,8 +124,8 @@ var _ = Describe("Periodic", func() {
 			})
 
 			It("should correctly reset the timer if status is changed to true", func() {
-				defer p.Stop()
 				p.Start()
+				defer p.Stop()
 
 				Expect(p.Get()).To(BeTrue())
 				fakeClock.Step(resetDuration)

--- a/pkg/utils/flow/progress_reporter_delaying_test.go
+++ b/pkg/utils/flow/progress_reporter_delaying_test.go
@@ -21,11 +21,14 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"go.uber.org/goleak"
 	"k8s.io/apimachinery/pkg/util/clock"
 )
 
 var _ = Describe("ProgressReporterDelaying", func() {
 	It("should behave correctly", func() {
+		defer goleak.VerifyNone(GinkgoT(), goleak.IgnoreCurrent())
+
 		var (
 			ctx           = context.TODO()
 			fakeClock     = clock.NewFakeClock(time.Now())

--- a/pkg/utils/flow/taskfn_test.go
+++ b/pkg/utils/flow/taskfn_test.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package flow_test
+
+import (
+	"context"
+	"errors"
+
+	"github.com/golang/mock/gomock"
+	"github.com/hashicorp/go-multierror"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"go.uber.org/goleak"
+
+	"github.com/gardener/gardener/pkg/utils/flow"
+	mockflow "github.com/gardener/gardener/pkg/utils/flow/mock"
+)
+
+var _ = Describe("task functions", func() {
+	var (
+		ctrl          *gomock.Controller
+		ignoreCurrent goleak.Option
+	)
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+		ignoreCurrent = goleak.IgnoreCurrent()
+	})
+	AfterEach(func() {
+		ctrl.Finish()
+		goleak.VerifyNone(GinkgoT(), ignoreCurrent)
+	})
+
+	Describe("#Parallel", func() {
+		It("should execute the functions in parallel", func() {
+			var (
+				ctx = context.TODO()
+				f1  = mockflow.NewMockTaskFn(ctrl)
+				f2  = mockflow.NewMockTaskFn(ctrl)
+				f3  = mockflow.NewMockTaskFn(ctrl)
+			)
+
+			f1.EXPECT().Do(ctx)
+			f2.EXPECT().Do(ctx)
+			f3.EXPECT().Do(ctx)
+
+			Expect(flow.Parallel(f1.Do, f2.Do, f3.Do)(ctx)).To(Succeed())
+		})
+
+		It("should execute the functions and collect their errors", func() {
+			var (
+				ctx = context.TODO()
+				f1  = mockflow.NewMockTaskFn(ctrl)
+				f2  = mockflow.NewMockTaskFn(ctrl)
+				f3  = mockflow.NewMockTaskFn(ctrl)
+
+				err1 = errors.New("e1")
+				err2 = errors.New("e2")
+			)
+
+			f1.EXPECT().Do(ctx).Return(err1)
+			f2.EXPECT().Do(ctx).Return(err2)
+			f3.EXPECT().Do(ctx)
+
+			err := flow.Parallel(f1.Do, f2.Do, f3.Do)(ctx)
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(BeAssignableToTypeOf(&multierror.Error{}))
+			Expect(err.(*multierror.Error).Errors).To(ConsistOf(err1, err2))
+		})
+	})
+})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness quality
/kind bug

**What this PR does / why we need it**:

Follow up on https://github.com/gardener/gardener/pull/4628 and https://github.com/gardener/gardener/issues/4609#issuecomment-915223191:
- add goleak verification to unit test suites that test code with concurrency (i.e. that start goroutines)
  - unfortunately we are lacking unit tests for some concurrent functions
  - goleak should be used in all new unit tests for concurrent functions from now on
- add a unit test for `flow.ParallelExitOnError` which can currently leak goroutines (the leak has been present since introduction of the func in https://github.com/gardener/gardener/commit/6c7da31077068a51aa752e4daa3a0136d5535a41)
- fix the goroutine leak in `flow.ParallelExitOnError`

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/4609

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Another memory leak in gardenlet has been fixed.
```
