### PR TITLE
Promote DisallowKubeconfigRotationForShootInDeletion feature gate to beta

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -33,7 +33,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | ReversedVPN | `false` | `Alpha` | `1.22` | |
 | AdminKubeconfigRequest | `false` | `Alpha` | `1.24` | |
 | UseDNSRecords | `false` | `Alpha` | `1.27` | |
-| DisallowKubeconfigRotationForShootInDeletion | `false` | `Alpha` | `1.28` | |
+| DisallowKubeconfigRotationForShootInDeletion | `false` | `Alpha` | `1.28` | `1.31` |
+| DisallowKubeconfigRotationForShootInDeletion | `true` | `Beta` | `1.32` | |
 | RotateSSHKeypairOnMaintenance | `false` | `Alpha` | `1.28` | |
 | DenyInvalidExtensionResources | `false` | `Alpha` | `1.31` | |
 

--- a/hack/local-development/start-apiserver
+++ b/hack/local-development/start-apiserver
@@ -53,7 +53,7 @@ apiserver_flags="
   --feature-gates SeedChange=true \
   --feature-gates AdminKubeconfigRequest=true \
   --feature-gates UseDNSRecords=true \
-  --feature-gates DisallowKubeconfigRotationForShootInDeletion=false \
+  --feature-gates DisallowKubeconfigRotationForShootInDeletion=true \
   --shoot-admin-kubeconfig-max-expiration=1h \
   --enable-admission-plugins=ShootVPAEnabledByDefault \
   --v 2"

--- a/pkg/apiserver/features/features.go
+++ b/pkg/apiserver/features/features.go
@@ -26,7 +26,7 @@ var featureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	features.SeedChange:                                   {Default: false, PreRelease: featuregate.Alpha},
 	features.AdminKubeconfigRequest:                       {Default: false, PreRelease: featuregate.Alpha},
 	features.UseDNSRecords:                                {Default: false, PreRelease: featuregate.Alpha},
-	features.DisallowKubeconfigRotationForShootInDeletion: {Default: false, PreRelease: featuregate.Alpha},
+	features.DisallowKubeconfigRotationForShootInDeletion: {Default: true, PreRelease: featuregate.Beta},
 }
 
 // RegisterFeatureGates registers the feature gates of the Gardener API Server.

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -95,6 +95,7 @@ const (
 	// for shoots that are already in the deletion phase, i.e. `metadata.deletionTimestamp` is set
 	// owner: @vpnachev
 	// alpha: v1.28.0
+	// beta: v1.32.0
 	DisallowKubeconfigRotationForShootInDeletion featuregate.Feature = "DisallowKubeconfigRotationForShootInDeletion"
 
 	// RotateSSHKeypairOnMaintenance enables SSH keypair rotation in the maintenance controller of the gardener-controller-manager.


### PR DESCRIPTION
/kind enhancement

Part of https://github.com/gardener/gardener/issues/4575

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
The `DisallowKubeconfigRotationForShootInDeletion` feature gate in the `gardener-apiserver` has been promoted to beta and is now enabled by default.
```
