### PR TITLE
Fix linting complains

### DIFF
--- a/pkg/operation/botanist/component/coredns/coredns.go
+++ b/pkg/operation/botanist/component/coredns/coredns.go
@@ -75,6 +75,7 @@ type Interface interface {
 	SetPodAnnotations(map[string]string)
 }
 
+// Values is a set of configuration values for the coredns component.
 type Values struct {
 	// APIServerHost is the host of the kube-apiserver.
 	APIServerHost *string

--- a/pkg/utils/secrets/certificates.go
+++ b/pkg/utils/secrets/certificates.go
@@ -37,6 +37,7 @@ import (
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
+// CertType is a string alias for certificate types.
 type CertType string
 
 const (


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
`make check` on `master` is currently failing with:

```
$ make check
> Check
Executing golangci-lint
pkg/utils/secrets/certificates.go:40:6: exported: exported type CertType should have comment or be unexported (revive)
type CertType string
     ^
pkg/operation/botanist/component/coredns/coredns.go:78:6: exported: exported type Values should have comment or be unexported (revive)
type Values struct {
     ^
make: *** [check] Error 1
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
