### PR TITLE
Add missing field to v1beta2 VPA

### DIFF
--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/crd-verticalpodautoscalers.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/crd-verticalpodautoscalers.yaml
@@ -72,6 +72,10 @@ spec:
 {{- else -}}
 ---
 # Source: https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
+# For backwards compatibility, the following customizations were performed on the original CRD manifest:
+# - allow nullable status for v1beta2, v1
+# - additional fields for v1beta2:
+#   - .spec.resourcePolicy.containerPolicies[].controlledResources
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -398,6 +402,17 @@ spec:
                             in which case the policy is used by the containers that
                             don't have their own policy specified.
                           type: string
+                        controlledResources:
+                          description: Specifies the type of recommendations that
+                            will be computed (and possibly applied) by VPA. If not
+                            specified, the default of [ResourceCPU, ResourceMemory]
+                            will be used.
+                          items:
+                            description: ResourceName is the name identifying various
+                              resources in a ResourceList.
+                            type: string
+                            enum: ["cpu", "memory"]
+                          type: array
                         maxAllowed:
                           additionalProperties:
                             anyOf:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind api-change
/kind regression
/needs cherry-pick
/priority 1

**What this PR does / why we need it**:
This PR adds `.spec.resourcePolicy.containerPolicies[].controlledResources` to `VerticalPodAutoscaler v1beta2`. This field used to be available when the CRD of version `v1beta1` was deployed (see [here](https://github.com/gardener/gardener/blob/b59f1670ad262416447763acfa99c11e1116a952/charts/seed-bootstrap/charts/vpa/charts/application/templates/crd-verticalpodautoscalers.yaml#L66)).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Field `.spec.resourcePolicy.containerPolicies[].controlledResources` is now available for `VerticalPodAutoscaler v1beta2` objects.
```
