### PR TITLE
Fix worker validation to allow updating the worker type

### DIFF
--- a/pkg/apis/extensions/validation/worker.go
+++ b/pkg/apis/extensions/validation/worker.go
@@ -102,7 +102,6 @@ func ValidateWorkerSpecUpdate(new, old *extensionsv1alpha1.WorkerSpec, deletionT
 		return allErrs
 	}
 
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Type, old.Type, fldPath.Child("type"))...)
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Region, old.Region, fldPath.Child("region"))...)
 
 	return allErrs

--- a/pkg/apis/extensions/validation/worker_test.go
+++ b/pkg/apis/extensions/validation/worker_test.go
@@ -132,24 +132,21 @@ var _ = Describe("Worker validation tests", func() {
 			}))))
 		})
 
-		It("should prevent updating the type and region", func() {
+		It("should prevent updating the region", func() {
 			newWorker := prepareWorkerForUpdate(worker)
-			newWorker.Spec.Type = "changed-type"
 			newWorker.Spec.Region = "changed-region"
 
 			errorList := ValidateWorkerUpdate(newWorker, worker)
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeInvalid),
-				"Field": Equal("spec.type"),
-			})), PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeInvalid),
 				"Field": Equal("spec.region"),
 			}))))
 		})
 
-		It("should allow updating the name of the referenced secret, the infrastructure provider status, the ssh public key, or the worker pools", func() {
+		It("should allow updating the type, the name of the referenced secret, the infrastructure provider status, the ssh public key, or the worker pools", func() {
 			newWorker := prepareWorkerForUpdate(worker)
+			newWorker.Spec.Type = "changed-type"
 			newWorker.Spec.SecretRef.Name = "changed-secretref-name"
 			newWorker.Spec.InfrastructureProviderStatus = nil
 			newWorker.Spec.SSHPublicKey = []byte("other-key")


### PR DESCRIPTION
**How to categorize this PR?**

/area quality, ops-productivity
/kind bug

**What this PR does / why we need it**:
Fixes the validation of `Worker` extension resources to allow updating the `spec.type` field.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```other operator
The validation of `Worker` extension resources will now allow updating the `spec.type` field.
```
