### PR TITLE
[release-v1.31] Automated cherry pick of #4656: Add missing field to v1beta2 VPA

### DIFF
--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/crd-verticalpodautoscalers.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/crd-verticalpodautoscalers.yaml
@@ -72,6 +72,10 @@ spec:
 {{- else -}}
 ---
 # Source: https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
+# For backwards compatibility, the following customizations were performed on the original CRD manifest:
+# - allow nullable status for v1beta2, v1
+# - additional fields for v1beta2:
+#   - .spec.resourcePolicy.containerPolicies[].controlledResources
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -398,6 +402,17 @@ spec:
                             in which case the policy is used by the containers that
                             don't have their own policy specified.
                           type: string
+                        controlledResources:
+                          description: Specifies the type of recommendations that
+                            will be computed (and possibly applied) by VPA. If not
+                            specified, the default of [ResourceCPU, ResourceMemory]
+                            will be used.
+                          items:
+                            description: ResourceName is the name identifying various
+                              resources in a ResourceList.
+                            type: string
+                            enum: ["cpu", "memory"]
+                          type: array
                         maxAllowed:
                           additionalProperties:
                             anyOf:


### PR DESCRIPTION
/kind/api-change
/kind/regression
/area/auto-scaling

Cherry pick of #4656 on release-v1.31.

#4656: Add missing field to v1beta2 VPA

**Release Notes:**
```bugfix user
Field `.spec.resourcePolicy.containerPolicies[].controlledResources` is now available for `VerticalPodAutoscaler v1beta2` objects.
```