### PR TITLE
Fix migration of extension resources

### DIFF
--- a/extensions/pkg/controller/backupentry/reconciler.go
+++ b/extensions/pkg/controller/backupentry/reconciler.go
@@ -99,15 +99,11 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	operationType := gardencorev1beta1helper.ComputeOperationType(be.ObjectMeta, be.Status.LastOperation)
 
 	switch {
+	case extensionscontroller.ShouldSkipOperation(operationType, be):
+		return reconcile.Result{}, nil
 	case operationType == gardencorev1beta1.LastOperationTypeMigrate:
-		if extensionscontroller.IsMigrated(be) {
-			return reconcile.Result{}, nil
-		}
 		return r.migrate(ctx, be)
 	case be.DeletionTimestamp != nil:
-		if extensionscontroller.IsMigrated(be) {
-			return reconcile.Result{}, nil
-		}
 		return r.delete(ctx, be)
 	case operationType == gardencorev1beta1.LastOperationTypeRestore:
 		return r.restore(ctx, be)

--- a/extensions/pkg/controller/containerruntime/reconciler.go
+++ b/extensions/pkg/controller/containerruntime/reconciler.go
@@ -100,15 +100,11 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	operationType := gardencorev1beta1helper.ComputeOperationType(cr.ObjectMeta, cr.Status.LastOperation)
 
 	switch {
+	case extensionscontroller.ShouldSkipOperation(operationType, cr):
+		return reconcile.Result{}, nil
 	case operationType == gardencorev1beta1.LastOperationTypeMigrate:
-		if extensionscontroller.IsMigrated(cr) {
-			return reconcile.Result{}, nil
-		}
 		return r.migrate(ctx, cr, cluster)
 	case cr.DeletionTimestamp != nil:
-		if extensionscontroller.IsMigrated(cr) {
-			return reconcile.Result{}, nil
-		}
 		return r.delete(ctx, cr, cluster)
 	case operationType == gardencorev1beta1.LastOperationTypeRestore:
 		return r.restore(ctx, cr, cluster)

--- a/extensions/pkg/controller/controlplane/reconciler.go
+++ b/extensions/pkg/controller/controlplane/reconciler.go
@@ -100,15 +100,11 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	operationType := gardencorev1beta1helper.ComputeOperationType(cp.ObjectMeta, cp.Status.LastOperation)
 
 	switch {
+	case extensionscontroller.ShouldSkipOperation(operationType, cp):
+		return reconcile.Result{}, nil
 	case operationType == gardencorev1beta1.LastOperationTypeMigrate:
-		if extensionscontroller.IsMigrated(cp) {
-			return reconcile.Result{}, nil
-		}
 		return r.migrate(ctx, cp, cluster)
 	case cp.DeletionTimestamp != nil:
-		if extensionscontroller.IsMigrated(cp) {
-			return reconcile.Result{}, nil
-		}
 		return r.delete(ctx, cp, cluster)
 	case operationType == gardencorev1beta1.LastOperationTypeRestore:
 		return r.restore(ctx, cp, cluster)

--- a/extensions/pkg/controller/dnsrecord/reconciler.go
+++ b/extensions/pkg/controller/dnsrecord/reconciler.go
@@ -101,15 +101,11 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	operationType := gardencorev1beta1helper.ComputeOperationType(dns.ObjectMeta, dns.Status.LastOperation)
 
 	switch {
+	case extensionscontroller.ShouldSkipOperation(operationType, dns):
+		return reconcile.Result{}, nil
 	case operationType == gardencorev1beta1.LastOperationTypeMigrate:
-		if extensionscontroller.IsMigrated(dns) {
-			return reconcile.Result{}, nil
-		}
 		return r.migrate(ctx, dns, cluster)
 	case dns.DeletionTimestamp != nil:
-		if extensionscontroller.IsMigrated(dns) {
-			return reconcile.Result{}, nil
-		}
 		return r.delete(ctx, dns, cluster)
 	case operationType == gardencorev1beta1.LastOperationTypeRestore:
 		return r.restore(ctx, dns, cluster)

--- a/extensions/pkg/controller/extension/reconciler.go
+++ b/extensions/pkg/controller/extension/reconciler.go
@@ -188,15 +188,11 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	operationType := gardencorev1beta1helper.ComputeOperationType(ex.ObjectMeta, ex.Status.LastOperation)
 
 	switch {
+	case extensionscontroller.ShouldSkipOperation(operationType, ex):
+		return reconcile.Result{}, nil
 	case operationType == gardencorev1beta1.LastOperationTypeMigrate:
-		if extensionscontroller.IsMigrated(ex) {
-			return reconcile.Result{}, nil
-		}
 		return r.migrate(ctx, ex)
 	case ex.DeletionTimestamp != nil:
-		if extensionscontroller.IsMigrated(ex) {
-			return reconcile.Result{}, nil
-		}
 		return r.delete(ctx, ex)
 	case operationType == gardencorev1beta1.LastOperationTypeRestore:
 		return r.restore(ctx, ex, operationType)

--- a/extensions/pkg/controller/infrastructure/reconciler.go
+++ b/extensions/pkg/controller/infrastructure/reconciler.go
@@ -105,15 +105,11 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	operationType := gardencorev1beta1helper.ComputeOperationType(infrastructure.ObjectMeta, infrastructure.Status.LastOperation)
 
 	switch {
+	case extensionscontroller.ShouldSkipOperation(operationType, infrastructure):
+		return reconcile.Result{}, nil
 	case operationType == gardencorev1beta1.LastOperationTypeMigrate:
-		if extensionscontroller.IsMigrated(infrastructure) {
-			return reconcile.Result{}, nil
-		}
 		return r.migrate(ctx, logger.WithValues("operation", "migrate"), infrastructure, cluster)
 	case infrastructure.DeletionTimestamp != nil:
-		if extensionscontroller.IsMigrated(infrastructure) {
-			return reconcile.Result{}, nil
-		}
 		return r.delete(ctx, logger.WithValues("operation", "delete"), infrastructure, cluster)
 	case operationType == gardencorev1beta1.LastOperationTypeRestore:
 		return r.restore(ctx, logger.WithValues("operation", "restore"), infrastructure, cluster)

--- a/extensions/pkg/controller/network/reconciler.go
+++ b/extensions/pkg/controller/network/reconciler.go
@@ -96,15 +96,11 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	operationType := gardencorev1beta1helper.ComputeOperationType(network.ObjectMeta, network.Status.LastOperation)
 
 	switch {
+	case extensionscontroller.ShouldSkipOperation(operationType, network):
+		return reconcile.Result{}, nil
 	case operationType == gardencorev1beta1.LastOperationTypeMigrate:
-		if extensionscontroller.IsMigrated(network) {
-			return reconcile.Result{}, nil
-		}
 		return r.migrate(ctx, network, cluster)
 	case network.DeletionTimestamp != nil:
-		if extensionscontroller.IsMigrated(network) {
-			return reconcile.Result{}, nil
-		}
 		return r.delete(ctx, network, cluster)
 	case operationType == gardencorev1beta1.LastOperationTypeRestore:
 		return r.restore(ctx, network, cluster)

--- a/extensions/pkg/controller/operatingsystemconfig/reconciler.go
+++ b/extensions/pkg/controller/operatingsystemconfig/reconciler.go
@@ -110,15 +110,11 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	operationType := gardencorev1beta1helper.ComputeOperationType(osc.ObjectMeta, osc.Status.LastOperation)
 
 	switch {
+	case extensionscontroller.ShouldSkipOperation(operationType, osc):
+		return reconcile.Result{}, nil
 	case operationType == gardencorev1beta1.LastOperationTypeMigrate:
-		if extensionscontroller.IsMigrated(osc) {
-			return reconcile.Result{}, nil
-		}
 		return r.migrate(ctx, osc)
 	case osc.DeletionTimestamp != nil:
-		if extensionscontroller.IsMigrated(osc) {
-			return reconcile.Result{}, nil
-		}
 		return r.delete(ctx, osc)
 	case operationType == gardencorev1beta1.LastOperationTypeRestore:
 		return r.restore(ctx, osc)

--- a/extensions/pkg/controller/utils.go
+++ b/extensions/pkg/controller/utils.go
@@ -185,6 +185,11 @@ func IsMigrated(obj extensionsv1alpha1.Object) bool {
 		lastOp.State == gardencorev1beta1.LastOperationStateSucceeded
 }
 
+// ShouldSkipOperation checks if the current operation should be skipped depending on the lastOperation of the extension object.
+func ShouldSkipOperation(operationType gardencorev1beta1.LastOperationType, obj extensionsv1alpha1.Object) bool {
+	return operationType != gardencorev1beta1.LastOperationTypeMigrate && operationType != gardencorev1beta1.LastOperationTypeRestore && IsMigrated(obj)
+}
+
 // GetObjectByReference gets an object by the given reference, in the given namespace.
 // If the object kind doesn't match the given reference kind this will result in an error.
 func GetObjectByReference(ctx context.Context, c client.Client, ref *autoscalingv1.CrossVersionObjectReference, namespace string, obj client.Object) error {

--- a/extensions/pkg/controller/utils_test.go
+++ b/extensions/pkg/controller/utils_test.go
@@ -180,6 +180,128 @@ var _ = Describe("Utils", func() {
 		})
 	})
 
+	Describe("#ShouldSkipOperation", func() {
+		var (
+			worker *extensionsv1alpha1.Worker
+		)
+
+		BeforeEach(func() {
+			worker = &extensionsv1alpha1.Worker{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Worker",
+					APIVersion: "TestApi",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-worker",
+					Namespace: "test-namespace",
+				},
+			}
+		})
+
+		Context("reconcile operation", func() {
+			var (
+				operationType = gardencorev1beta1.LastOperationTypeReconcile
+			)
+
+			It("should return false when lastOperation is missing", func() {
+				Expect(controller.ShouldSkipOperation(operationType, worker)).To(BeFalse())
+			})
+
+			It("should return true when lastOperation is migrate and succeeded", func() {
+				worker.Status.LastOperation = &gardencorev1beta1.LastOperation{
+					Type:  gardencorev1beta1.LastOperationTypeMigrate,
+					State: gardencorev1beta1.LastOperationStateSucceeded,
+				}
+				Expect(controller.ShouldSkipOperation(operationType, worker)).To(BeTrue())
+			})
+
+			It("should return false when lastOperation is not migrate", func() {
+				worker.Status.LastOperation = &gardencorev1beta1.LastOperation{
+					Type: gardencorev1beta1.LastOperationTypeRestore,
+				}
+				Expect(controller.ShouldSkipOperation(operationType, worker)).To(BeFalse())
+			})
+		})
+
+		Context("restore operation", func() {
+			var (
+				operationType = gardencorev1beta1.LastOperationTypeRestore
+			)
+
+			It("should return false when lastOperation is missing", func() {
+				Expect(controller.ShouldSkipOperation(operationType, worker)).To(BeFalse())
+			})
+
+			It("should return false when lastOperation is migrate and succeeded", func() {
+				worker.Status.LastOperation = &gardencorev1beta1.LastOperation{
+					Type:  gardencorev1beta1.LastOperationTypeMigrate,
+					State: gardencorev1beta1.LastOperationStateSucceeded,
+				}
+				Expect(controller.ShouldSkipOperation(operationType, worker)).To(BeFalse())
+			})
+
+			It("should return false when lastOperation is not migrate", func() {
+				worker.Status.LastOperation = &gardencorev1beta1.LastOperation{
+					Type:  gardencorev1beta1.LastOperationTypeReconcile,
+					State: gardencorev1beta1.LastOperationStateSucceeded,
+				}
+				Expect(controller.ShouldSkipOperation(operationType, worker)).To(BeFalse())
+			})
+		})
+
+		Context("delete operation", func() {
+			var (
+				operationType = gardencorev1beta1.LastOperationTypeDelete
+			)
+
+			It("should return false when lastOperation is missing", func() {
+				Expect(controller.ShouldSkipOperation(operationType, worker)).To(BeFalse())
+			})
+
+			It("should return true when lastOperation is migrate and succeeded", func() {
+				worker.Status.LastOperation = &gardencorev1beta1.LastOperation{
+					Type:  gardencorev1beta1.LastOperationTypeMigrate,
+					State: gardencorev1beta1.LastOperationStateSucceeded,
+				}
+				Expect(controller.ShouldSkipOperation(operationType, worker)).To(BeTrue())
+			})
+
+			It("should return false when lastOperation is not migrate", func() {
+				worker.Status.LastOperation = &gardencorev1beta1.LastOperation{
+					Type:  gardencorev1beta1.LastOperationTypeReconcile,
+					State: gardencorev1beta1.LastOperationStateSucceeded,
+				}
+				Expect(controller.ShouldSkipOperation(operationType, worker)).To(BeFalse())
+			})
+		})
+
+		Context("migrate operation", func() {
+			var (
+				operationType = gardencorev1beta1.LastOperationTypeRestore
+			)
+
+			It("should return false when lastOperation is missing", func() {
+				Expect(controller.ShouldSkipOperation(operationType, worker)).To(BeFalse())
+			})
+
+			It("should return false when lastOperation is migrate and succeeded", func() {
+				worker.Status.LastOperation = &gardencorev1beta1.LastOperation{
+					Type:  gardencorev1beta1.LastOperationTypeMigrate,
+					State: gardencorev1beta1.LastOperationStateSucceeded,
+				}
+				Expect(controller.ShouldSkipOperation(operationType, worker)).To(BeFalse())
+			})
+
+			It("should return false when lastOperation is not migrate", func() {
+				worker.Status.LastOperation = &gardencorev1beta1.LastOperation{
+					Type:  gardencorev1beta1.LastOperationTypeReconcile,
+					State: gardencorev1beta1.LastOperationStateSucceeded,
+				}
+				Expect(controller.ShouldSkipOperation(operationType, worker)).To(BeFalse())
+			})
+		})
+	})
+
 	Describe("#IsMigrated", func() {
 		var (
 			worker *extensionsv1alpha1.Worker

--- a/extensions/pkg/controller/worker/reconciler.go
+++ b/extensions/pkg/controller/worker/reconciler.go
@@ -97,15 +97,11 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	operationType := gardencorev1beta1helper.ComputeOperationType(worker.ObjectMeta, worker.Status.LastOperation)
 
 	switch {
+	case extensionscontroller.ShouldSkipOperation(operationType, worker):
+		return reconcile.Result{}, nil
 	case operationType == gardencorev1beta1.LastOperationTypeMigrate:
-		if extensionscontroller.IsMigrated(worker) {
-			return reconcile.Result{}, nil
-		}
 		return r.migrate(ctx, logger.WithValues("operation", "migrate"), worker, cluster)
 	case worker.DeletionTimestamp != nil:
-		if extensionscontroller.IsMigrated(worker) {
-			return reconcile.Result{}, nil
-		}
 		return r.delete(ctx, logger.WithValues("operation", "delete"), worker, cluster)
 	case operationType == gardencorev1beta1.LastOperationTypeRestore:
 		return r.restore(ctx, logger.WithValues("operation", "restore"), worker, cluster)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind bug

**What this PR does / why we need it**:
This PR makes it possible to perform migrate and restore operations, and to skip delete and reconcile operations for extension resources that have already been migrated successfully.

Previously the reconcile operation was incorrectly not skipped for successfully migrated resources. This caused a problem since the resource is requeued during the migrate operation because of updates and the `gardener.cloud/operation=migrate` annotation being present on the resource. A reconciliation gets automatically triggered after the migrate and this redeploys artefacts related to the extension resource.

The migrate operation is allowed for resources that are already successfully migrated since the finalizers are removed only after the status of the resource is updated to successful and the `gardener.cloud/operation=migrate` operation annotation is removed after the finalizers are successfully deleted. Previously if the deletion of the finalizers fails for any reason and the operation is restarted, the resource can never be deleted as the operation annotation is never removed and since the controller considers that the migrate operation is successful it would get skipped. 

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other dependency
If a resource has been successfully migrated, following reconcile operations are properly skipped, whereas migrate operations can be performed.
```
