### PR TITLE
GAC's seed restriction webhook uses 'Equivalent' match policy

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/validatingwebhook-admission-controller.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/validatingwebhook-admission-controller.yaml
@@ -100,7 +100,7 @@ webhooks:
   - apiGroups:
     - ""
     apiVersions:
-    - "*"
+    - v1
     operations:
     - CREATE
     resources:
@@ -109,7 +109,7 @@ webhooks:
   - apiGroups:
     - rbac.authorization.k8s.io
     apiVersions:
-    - "*"
+    - v1
     operations:
     - CREATE
     resources:
@@ -117,7 +117,7 @@ webhooks:
   - apiGroups:
     - coordination.k8s.io
     apiVersions:
-    - "*"
+    - v1
     operations:
     - CREATE
     resources:
@@ -125,7 +125,7 @@ webhooks:
   - apiGroups:
     - certificates.k8s.io
     apiVersions:
-    - "*"
+    - v1beta1
     operations:
     - CREATE
     resources:
@@ -133,7 +133,7 @@ webhooks:
   - apiGroups:
     - core.gardener.cloud
     apiVersions:
-    - "*"
+    - v1beta1
     operations:
     - CREATE
     resources:
@@ -142,7 +142,7 @@ webhooks:
   - apiGroups:
     - core.gardener.cloud
     apiVersions:
-    - "*"
+    - v1beta1
     operations:
     - CREATE
     - DELETE
@@ -151,7 +151,7 @@ webhooks:
   - apiGroups:
     - operations.gardener.cloud
     apiVersions:
-    - "*"
+    - v1alpha1
     operations:
     - CREATE
     resources:
@@ -159,7 +159,7 @@ webhooks:
   - apiGroups:
     - core.gardener.cloud
     apiVersions:
-    - "*"
+    - v1beta1
     operations:
     - CREATE
     - UPDATE
@@ -167,6 +167,7 @@ webhooks:
     resources:
     - seeds
   failurePolicy: Fail
+  matchPolicy: Equivalent
   clientConfig:
     {{- if .Values.global.deployment.virtualGarden.enabled }}
     url: https://gardener-admission-controller.garden/webhooks/admission/seedrestriction

--- a/hack/local-development/dev-setup-register-gardener
+++ b/hack/local-development/dev-setup-register-gardener
@@ -367,7 +367,7 @@ $ADMISSION_CONTROLLER_PORT_STRING
   - apiGroups:
     - ""
     apiVersions:
-    - "*"
+    - v1
     operations:
     - CREATE
     resources:
@@ -376,7 +376,7 @@ $ADMISSION_CONTROLLER_PORT_STRING
   - apiGroups:
     - rbac.authorization.k8s.io
     apiVersions:
-    - "*"
+    - v1
     operations:
     - CREATE
     resources:
@@ -384,7 +384,7 @@ $ADMISSION_CONTROLLER_PORT_STRING
   - apiGroups:
     - coordination.k8s.io
     apiVersions:
-    - "*"
+    - v1
     operations:
     - CREATE
     resources:
@@ -392,12 +392,13 @@ $ADMISSION_CONTROLLER_PORT_STRING
   - apiGroups:
     - certificates.k8s.io
     apiVersions:
-    - "*"
+    - v1beta1
     operations:
     - CREATE
     resources:
     - certificatesigningrequests
   failurePolicy: Fail
+  matchPolicy: Equivalent
   clientConfig:
     service:
       namespace: garden
@@ -412,7 +413,7 @@ $ADMISSION_CONTROLLER_PORT_STRING
   - apiGroups:
     - core.gardener.cloud
     apiVersions:
-    - "*"
+    - v1beta1
     operations:
     - CREATE
     resources:
@@ -421,7 +422,7 @@ $ADMISSION_CONTROLLER_PORT_STRING
   - apiGroups:
     - core.gardener.cloud
     apiVersions:
-    - "*"
+    - v1beta1
     operations:
     - CREATE
     - DELETE
@@ -430,7 +431,7 @@ $ADMISSION_CONTROLLER_PORT_STRING
   - apiGroups:
     - operations.gardener.cloud
     apiVersions:
-    - "*"
+    - v1alpha1
     operations:
     - CREATE
     resources:
@@ -438,7 +439,7 @@ $ADMISSION_CONTROLLER_PORT_STRING
   - apiGroups:
     - core.gardener.cloud
     apiVersions:
-    - "*"
+    - v1beta1
     operations:
     - CREATE
     - UPDATE
@@ -446,6 +447,7 @@ $ADMISSION_CONTROLLER_PORT_STRING
     resources:
     - seeds
   failurePolicy: Fail
+  matchPolicy: Equivalent
   clientConfig:
     url: https://127.0.0.1:$ADMISSION_CONTROLLER_SECURE_PORT/webhooks/admission/seedrestriction
     caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSURZRENDQWtpZ0F3SUJBZ0lVYWEyY0ZPL0NTVnJ2cThPLzBnZXVNdFhMT3NJd0RRWUpLb1pJaHZjTkFRRUwKQlFBd1NERUxNQWtHQTFVRUJoTUNWVk14Q3pBSkJnTlZCQWdUQWtOQk1SWXdGQVlEVlFRSEV3MVRZVzRnUm5KaApibU5wYzJOdk1SUXdFZ1lEVlFRREV3dGxlR0Z0Y0d4bExtNWxkREFlRncweE9EQTRNVFl5TURNeU1EQmFGdzB5Ck16QTRNVFV5TURNeU1EQmFNRWd4Q3pBSkJnTlZCQVlUQWxWVE1Rc3dDUVlEVlFRSUV3SkRRVEVXTUJRR0ExVUUKQnhNTlUyRnVJRVp5WVc1amFYTmpiekVVTUJJR0ExVUVBeE1MWlhoaGJYQnNaUzV1WlhRd2dnRWlNQTBHQ1NxRwpTSWIzRFFFQkFRVUFBNElCRHdBd2dnRUtBb0lCQVFDNUM4L3ZoWHVFeWQwZlQ2YmxIcGtrbERiY251ckQ0SzZTCmJGaGRMWmVHQ0krdktXMzRPdEFzOFNwQXZrSmsxL0FPZ0ZsZFBGaTdGYThZbWdKQ3piR255bEZxcXJhd2RCaEgKdFZZeENBZTE0dTJTZGlxMXNPZ3VyRHRRM0doK0V1NXUrUDBsMTZ5MGR5UXhsNGREdHdIZno0anJOVmFkbldEYwpULytQUHNkNDZpMCtjT1loa0RrN1I1NEV1Rysxa1hha0c0c1hWcEt5MVRNd295bnJCVmg0MkwzYnNrcXJWbnBUCitnY0F6Q3RvaWE4WFJKL2pob3NjWHRSMHIxdEtpM2cxSjRxQTd1WDRJOXJUc2dPQmNrMGV4SlBSZ0Vtd3VPNUYKc1o0NEU4TUlveCtGVkg5TkRUY0JkSVQ5NVhVbGNhbkhKK1Baa1JVWFp5c2lNOWxuSWpCakFnTUJBQUdqUWpCQQpNQTRHQTFVZER3RUIvd1FFQXdJQkJqQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01CMEdBMVVkRGdRV0JCUVVKVTJJCmlDcll0dEhoTmhqNWh3c1FJK01JbGpBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQVRlOTNldkVBSThtZGlwZG0KanBGQjkrMFczQzJrTzEvQ3RCdWpOM1B2ZWc5OGxVOXBrS2lVOVdRL3orYlpEV3pUeklTdlYzMk9WSkNtUVN6cgpWRFJUMDNjbGpQaUJYOW9GNTc3TTE2TzNacnZQV3QxUXo2WHptYk9hdjVidkJXaTlpVWRMSEptOHA2Q0RIS1lYCklEZXdsVUg4K0FGaU10d0xlcjRRZFdRUnkrMGlOZG5YQjhCYnZ3QmxhcU1oUlphancyaW83eUdaZ3FXVmI5cnkKNlRsNnF1ZVpaazJOeUszSURtbTdhMWV4TFhQUjh2U2QyUUI2YlNCTVI3NXAvRm1jVkN1VzY0MlRZTnEwUW9VcwpXOXlUM3YxcHhRZlhraTZWTGQ3L3Y4QnhwTlEzazFWM01LWGlLOEIwOEdzRDZJa2s5R2dNVmNkWDRaQmVtWmYzCjBjVUQyUT09Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
The `seedrestriction` webhook of the `gardener-admission-controller`'s `ValidatingWebhookConfiguration` in the garden cluster is using the `Exact` policy and specifies `*` for the API versions of the intercepted objects, however, the code doesn't support all API versions.

Concretely, I encountered the following error using a garden cluster of Kubernetes v1.19: 

```
{"certificate-rotation":"seed: foo, target cluster: in cluster","level":"error","msg":"certificate rotation failed: cannot create certificate signing request: admission webhook \"seed-restriction.gardener.cloud\" denied the request: unable to decode certificates.k8s.io/v1, Kind=CertificateSigningRequest into *v1beta1.CertificateSigningRequest","time":"2021-09-14T12:54:17Z"}
```

In 1.19, the `CertificateSigningRequest` API was promoted to `v1` (https://github.com/kubernetes/kubernetes/pull/91685), however, GAC always tries to decode the object into `v1beta1` (https://github.com/gardener/gardener/blob/f5353762715d0aa5b3e5ded07f044cf431374193/pkg/admissioncontroller/webhooks/admission/seedrestriction/admission.go#L212-L215).

Using the `Equivalent` match policy and explicitly specifying the supported API versions makes the `kube-apiserver` auto-converting the objects before consulting admission webhooks, see https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#matching-requests-matchpolicy. 

Related to #4616

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed which prevented renewing gardenlet's client certificates for Garden clusters using Kubernetes v1.19 or higher.
```
