### PR TITLE
Generate unique OSC resources per machine image name

### DIFF
--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -335,7 +335,7 @@ func (o *operatingSystemConfig) forEachWorkerPoolAndPurpose(fn func(*extensionsv
 			extensionsv1alpha1.OperatingSystemConfigPurposeProvision,
 			extensionsv1alpha1.OperatingSystemConfigPurposeReconcile,
 		} {
-			oscName := Key(worker.Name, o.values.KubernetesVersion) + purposeToKeySuffix(purpose)
+			oscName := Key(worker.Name, o.values.KubernetesVersion) + keySuffix(worker.Machine.Image.Name, purpose)
 
 			osc, ok := o.oscs[oscName]
 			if !ok {
@@ -625,12 +625,12 @@ func Key(workerName string, kubernetesVersion *semver.Version) string {
 	return fmt.Sprintf("cloud-config-%s-%s", workerName, utils.ComputeSHA256Hex([]byte(kubernetesMajorMinorVersion))[:5])
 }
 
-func purposeToKeySuffix(purpose extensionsv1alpha1.OperatingSystemConfigPurpose) string {
+func keySuffix(machineImageName string, purpose extensionsv1alpha1.OperatingSystemConfigPurpose) string {
 	switch purpose {
 	case extensionsv1alpha1.OperatingSystemConfigPurposeProvision:
-		return "-downloader"
+		return "-" + machineImageName + "-downloader"
 	case extensionsv1alpha1.OperatingSystemConfigPurposeReconcile:
-		return "-original"
+		return "-" + machineImageName + "-original"
 	}
 	return ""
 }

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
@@ -219,7 +219,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 
 				oscDownloader := &extensionsv1alpha1.OperatingSystemConfig{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "cloud-config-" + worker.Name + "-77ac3-downloader",
+						Name:      "cloud-config-" + worker.Name + "-77ac3-" + worker.Machine.Image.Name + "-downloader",
 						Namespace: namespace,
 						Annotations: map[string]string{
 							v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
@@ -240,7 +240,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 
 				oscOriginal := &extensionsv1alpha1.OperatingSystemConfig{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "cloud-config-" + worker.Name + "-77ac3-original",
+						Name:      "cloud-config-" + worker.Name + "-77ac3-" + worker.Machine.Image.Name + "-original",
 						Namespace: namespace,
 						Annotations: map[string]string{
 							v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
@@ -317,13 +317,13 @@ var _ = Describe("OperatingSystemConfig", func() {
 				for _, worker := range workers {
 					extensions = append(extensions,
 						gardencorev1alpha1.ExtensionResourceState{
-							Name:    pointer.String("cloud-config-" + worker.Name + "-77ac3-downloader"),
+							Name:    pointer.String("cloud-config-" + worker.Name + "-77ac3-" + worker.Machine.Image.Name + "-downloader"),
 							Kind:    extensionsv1alpha1.OperatingSystemConfigResource,
 							Purpose: pointer.String(string(extensionsv1alpha1.OperatingSystemConfigPurposeProvision)),
 							State:   &runtime.RawExtension{Raw: stateDownloader},
 						},
 						gardencorev1alpha1.ExtensionResourceState{
-							Name:    pointer.String("cloud-config-" + worker.Name + "-77ac3-original"),
+							Name:    pointer.String("cloud-config-" + worker.Name + "-77ac3-" + worker.Machine.Image.Name + "-original"),
 							Kind:    extensionsv1alpha1.OperatingSystemConfigResource,
 							Purpose: pointer.String(string(extensionsv1alpha1.OperatingSystemConfigPurposeReconcile)),
 							State:   &runtime.RawExtension{Raw: stateOriginal},
@@ -564,37 +564,37 @@ var _ = Describe("OperatingSystemConfig", func() {
 				Expect(defaultDepWaiter.WorkerNameToOperatingSystemConfigsMap()).To(Equal(map[string]*OperatingSystemConfigs{
 					worker1Name: {
 						Downloader: Data{
-							Content: "foobar-cloud-config-" + worker1Name + "-77ac3-downloader",
-							Command: pointer.String("foo-cloud-config-" + worker1Name + "-77ac3-downloader"),
+							Content: "foobar-cloud-config-" + worker1Name + "-77ac3-type1-downloader",
+							Command: pointer.String("foo-cloud-config-" + worker1Name + "-77ac3-type1-downloader"),
 							Units: []string{
-								"bar-cloud-config-" + worker1Name + "-77ac3-downloader",
-								"baz-cloud-config-" + worker1Name + "-77ac3-downloader",
+								"bar-cloud-config-" + worker1Name + "-77ac3-type1-downloader",
+								"baz-cloud-config-" + worker1Name + "-77ac3-type1-downloader",
 							},
 						},
 						Original: Data{
-							Content: "foobar-cloud-config-" + worker1Name + "-77ac3-original",
-							Command: pointer.String("foo-cloud-config-" + worker1Name + "-77ac3-original"),
+							Content: "foobar-cloud-config-" + worker1Name + "-77ac3-type1-original",
+							Command: pointer.String("foo-cloud-config-" + worker1Name + "-77ac3-type1-original"),
 							Units: []string{
-								"bar-cloud-config-" + worker1Name + "-77ac3-original",
-								"baz-cloud-config-" + worker1Name + "-77ac3-original",
+								"bar-cloud-config-" + worker1Name + "-77ac3-type1-original",
+								"baz-cloud-config-" + worker1Name + "-77ac3-type1-original",
 							},
 						},
 					},
 					worker2Name: {
 						Downloader: Data{
-							Content: "foobar-cloud-config-" + worker2Name + "-77ac3-downloader",
-							Command: pointer.String("foo-cloud-config-" + worker2Name + "-77ac3-downloader"),
+							Content: "foobar-cloud-config-" + worker2Name + "-77ac3-type2-downloader",
+							Command: pointer.String("foo-cloud-config-" + worker2Name + "-77ac3-type2-downloader"),
 							Units: []string{
-								"bar-cloud-config-" + worker2Name + "-77ac3-downloader",
-								"baz-cloud-config-" + worker2Name + "-77ac3-downloader",
+								"bar-cloud-config-" + worker2Name + "-77ac3-type2-downloader",
+								"baz-cloud-config-" + worker2Name + "-77ac3-type2-downloader",
 							},
 						},
 						Original: Data{
-							Content: "foobar-cloud-config-" + worker2Name + "-77ac3-original",
-							Command: pointer.String("foo-cloud-config-" + worker2Name + "-77ac3-original"),
+							Content: "foobar-cloud-config-" + worker2Name + "-77ac3-type2-original",
+							Command: pointer.String("foo-cloud-config-" + worker2Name + "-77ac3-type2-original"),
 							Units: []string{
-								"bar-cloud-config-" + worker2Name + "-77ac3-original",
-								"baz-cloud-config-" + worker2Name + "-77ac3-original",
+								"bar-cloud-config-" + worker2Name + "-77ac3-type2-original",
+								"baz-cloud-config-" + worker2Name + "-77ac3-type2-original",
 							},
 						},
 					},


### PR DESCRIPTION
**How to categorize this PR?**

/area quality, ops-productivity
/kind bug

**What this PR does / why we need it**:
Causes `gardenlet` to generate unique `OperatingSystemConfig` resources per machine image name. This is needed because the machine image name is the `spec.type` of the OSC resource, and this field is immutable, similarly to `spec.type` fields of all other extension resources. With the `DenyInvalidExtensionResources` feature gate enabled (see #4499), attempting to change the `machine.image.name` field of one of the workers of an existing shoot would result in validation errors similar to:

```
"{\"level\":\"info\",\"ts\":\"2021-09-14T09:12:21.536Z\",\"logger\":\"extension_resources\",\"msg\":\"Invalid extension resource detected\",\"operation\":\"UPDATE\",\"error\":\"OperatingSystemConfig.extensions.gardener.cloud \"shoot--core--d066080sd2/cloud-config-worker-uq358-c8518-original\" is invalid: spec.type: Invalid value: \"ubuntu\": field is immutable\"}\n"
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Another option for addressing this issue would have been to change the validation in order to no longer treat the `spec.type` field as immutable. This would work (if the feature gate is disabled, it actually works by updating the existing OSC resource). However, this would be inconsistent with all other extension resources, and therefore the solution proposed here should be preferred.

**Release note**:

```other operator
gardenlet now generates unique OSC resources per machine image name in order to avoid validation errors.
```
