### PR TITLE
Enable immediate renewal of gardenlet client cert

### DIFF
--- a/docs/concepts/gardenlet.md
+++ b/docs/concepts/gardenlet.md
@@ -79,8 +79,9 @@ gardenlet configuration to share it with the gardenlet.
 ## Gardenlet Certificate Rotation
 
 The certificate used to authenticate the gardenlet against the API server
-is valid for a year.
-After about 10 months, the gardenlet tries to automatically replace
+has a certain validity based on the configuration of the garden cluster
+(`--cluster-signing-duration` flag of the `kube-controller-manager` (default `1y`)). 
+After about 80% of the validity expired, the gardenlet tries to automatically replace
 the current certificate with a new one (certificate rotation).
 
 To use certificate rotation, you need to specify the secret to store
@@ -95,6 +96,12 @@ using the Bootstrap `kubeconfig`, certificates can be rotated automatically.
 The same control loop in the `gardener-controller-manager` that signs
 the CSRs during the initial TLS Bootstrapping also automatically signs
 the CSR during a certificate rotation.
+
+ℹ️ You can trigger an immediate renewal by annotating the `Secret` in the seed
+cluster stated in the `.gardenClientConnection.kubeconfigSecret` field with
+`gardener.cloud/operation=renew` and restarting the gardenlet. After it booted
+up again, gardenlet will issue a new certificate independent of the remaining
+validity  of the existing one.
 
 ### Rotate Certificate Using Custom `kubeconfig`
 

--- a/pkg/gardenlet/bootstrap/util/util.go
+++ b/pkg/gardenlet/bootstrap/util/util.go
@@ -96,6 +96,7 @@ func UpdateGardenKubeconfigSecret(ctx context.Context, certClientConfig *rest.Co
 	}
 
 	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, seedClient, kubeconfigSecret, func() error {
+		delete(kubeconfigSecret.Annotations, v1beta1constants.GardenerOperation)
 		kubeconfigSecret.Data = map[string][]byte{kubernetes.KubeConfig: kubeconfig}
 		return nil
 	}); err != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
The gardenlet was auto-renewing its client certificate when roughly 80% of the validity expired. However, in some cases operators might want to trigger an immediate renewal. This is now supported by annotating the `Secret` in the seed storing the kubeconfig for communicating with the garden cluster by annotating it with `gardener.cloud/operation=renew` and restarting the gardenlet.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Operators can now explicitly trigger a client certificate renewal for the gardenlets. Please consult [this document](https://github.com/gardener/gardener/blob/master/docs/concepts/gardenlet.md#rotate-certificates-using-bootstrap-kubeconfig) for more information.
```
