### PR TITLE
Fix HVPA CRD

### DIFF
--- a/charts/seed-bootstrap/charts/hvpa/templates/hvpa-crd.yaml
+++ b/charts/seed-bootstrap/charts/hvpa/templates/hvpa-crd.yaml
@@ -216,6 +216,7 @@ spec:
                         metadata:
                           description: Metadata of the pods created from this template.
                           type: object
+                          x-kubernetes-preserve-unknown-fields: true
                         spec:
                           description: Spec defines the behavior of a HPA.
                           properties:
@@ -828,6 +829,7 @@ spec:
                         metadata:
                           description: Metadata of the pods created from this template.
                           type: object
+                          x-kubernetes-preserve-unknown-fields: true
                         spec:
                           description: Spec defines the behavior of a VPA.
                           properties:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind regression
/priority 1
/needs cherry-pick

**What this PR does / why we need it**:
Metadata fields for HPA and VPA must have `x-kubernetes-preserve-unknown-fields: true` to retain corresponding information.

**Special notes for your reviewer**:
I will file a PR for the HVPA repo soon, so that the auto generation via `controller-gen` adds this automatically.

/invite @amshuman-kr @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue has been fix that prevented the HVPA to scale target resources adequately.
```
