### PR TITLE
Fix users RBAC deffinition

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
@@ -53,7 +53,7 @@ rules:
   - apiservices
   verbs:
   - '*'
-- apiGroup:
+- apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions
@@ -171,7 +171,7 @@ rules:
   - get
   - list
   - watch
-- apiGroup:
+- apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions


### PR DESCRIPTION
**How to categorize this PR?**
/kind bug

**What this PR does / why we need it**:
#4636 has introduced a bug in the users RBACs and the gardener chart is failing to be deployed with error like
```
error validating data: ValidationError(ClusterRole.rules[6]): unknown field "apiGroup" in io.k8s.api.rbac.v1.PolicyRule; if you choose to ignore these errors, turn validation off with --validate=false
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
