### PR TITLE
Use `certificates.k8s.io/v1.CertificateSigningRequests` if available

### DIFF
--- a/pkg/admissioncontroller/webhooks/auth/seed/authorizer.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/authorizer.go
@@ -31,7 +31,7 @@ import (
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 
 	"github.com/go-logr/logr"
-	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
+	certificatesv1 "k8s.io/api/certificates/v1"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
 	eventsv1 "k8s.io/api/events/v1"
@@ -66,7 +66,7 @@ var (
 	backupBucketResource              = gardencorev1beta1.Resource("backupbuckets")
 	backupEntryResource               = gardencorev1beta1.Resource("backupentries")
 	bastionResource                   = gardenoperationsv1alpha1.Resource("bastions")
-	certificateSigningRequestResource = certificatesv1beta1.Resource("certificatesigningrequests")
+	certificateSigningRequestResource = certificatesv1.Resource("certificatesigningrequests")
 	cloudProfileResource              = gardencorev1beta1.Resource("cloudprofiles")
 	clusterRoleBindingResource        = rbacv1.Resource("clusterrolebindings")
 	configMapResource                 = corev1.Resource("configmaps")

--- a/pkg/admissioncontroller/webhooks/auth/seed/graph/graph_test.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/graph/graph_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/onsi/gomega/matchers"
 	gomegatypes "github.com/onsi/gomega/types"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
-	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
+	certificatesv1 "k8s.io/api/certificates/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -106,7 +106,7 @@ var _ = Describe("graph", func() {
 		managedSeed1SecretRef              = corev1.SecretReference{Namespace: "ms1secret2", Name: "ms1secret2"}
 
 		seedNameInCSR = "myseed"
-		csr1          *certificatesv1beta1.CertificateSigningRequest
+		csr1          *certificatesv1.CertificateSigningRequest
 
 		serviceAccount1Secret1 = "sa1secret1"
 		serviceAccount1Secret2 = "sa1secret2"
@@ -133,17 +133,17 @@ var _ = Describe("graph", func() {
 		fakeInformers = &informertest.FakeInformers{
 			Scheme: scheme,
 			InformersByGVK: map[schema.GroupVersionKind]toolscache.SharedIndexInformer{
-				gardencorev1beta1.SchemeGroupVersion.WithKind("Seed"):                        fakeInformerSeed,
-				gardencorev1beta1.SchemeGroupVersion.WithKind("Shoot"):                       fakeInformerShoot,
-				gardencorev1beta1.SchemeGroupVersion.WithKind("Project"):                     fakeInformerProject,
-				gardencorev1beta1.SchemeGroupVersion.WithKind("BackupBucket"):                fakeInformerBackupBucket,
-				gardencorev1beta1.SchemeGroupVersion.WithKind("BackupEntry"):                 fakeInformerBackupEntry,
-				gardenoperationsv1alpha1.SchemeGroupVersion.WithKind("Bastion"):              fakeInformerBastion,
-				gardencorev1beta1.SchemeGroupVersion.WithKind("SecretBinding"):               fakeInformerSecretBinding,
-				gardencorev1beta1.SchemeGroupVersion.WithKind("ControllerInstallation"):      fakeInformerControllerInstallation,
-				seedmanagementv1alpha1.SchemeGroupVersion.WithKind("ManagedSeed"):            fakeInformerManagedSeed,
-				certificatesv1beta1.SchemeGroupVersion.WithKind("CertificateSigningRequest"): fakeInformerCertificateSigningRequest,
-				corev1.SchemeGroupVersion.WithKind("ServiceAccount"):                         fakeInformerServiceAccount,
+				gardencorev1beta1.SchemeGroupVersion.WithKind("Seed"):                   fakeInformerSeed,
+				gardencorev1beta1.SchemeGroupVersion.WithKind("Shoot"):                  fakeInformerShoot,
+				gardencorev1beta1.SchemeGroupVersion.WithKind("Project"):                fakeInformerProject,
+				gardencorev1beta1.SchemeGroupVersion.WithKind("BackupBucket"):           fakeInformerBackupBucket,
+				gardencorev1beta1.SchemeGroupVersion.WithKind("BackupEntry"):            fakeInformerBackupEntry,
+				gardenoperationsv1alpha1.SchemeGroupVersion.WithKind("Bastion"):         fakeInformerBastion,
+				gardencorev1beta1.SchemeGroupVersion.WithKind("SecretBinding"):          fakeInformerSecretBinding,
+				gardencorev1beta1.SchemeGroupVersion.WithKind("ControllerInstallation"): fakeInformerControllerInstallation,
+				seedmanagementv1alpha1.SchemeGroupVersion.WithKind("ManagedSeed"):       fakeInformerManagedSeed,
+				certificatesv1.SchemeGroupVersion.WithKind("CertificateSigningRequest"): fakeInformerCertificateSigningRequest,
+				corev1.SchemeGroupVersion.WithKind("ServiceAccount"):                    fakeInformerServiceAccount,
 			},
 		}
 
@@ -263,9 +263,9 @@ var _ = Describe("graph", func() {
 			},
 		}
 
-		csr1 = &certificatesv1beta1.CertificateSigningRequest{
+		csr1 = &certificatesv1.CertificateSigningRequest{
 			ObjectMeta: metav1.ObjectMeta{Name: "csr1"},
-			Spec: certificatesv1beta1.CertificateSigningRequestSpec{
+			Spec: certificatesv1.CertificateSigningRequestSpec{
 				Request: []byte(`-----BEGIN CERTIFICATE REQUEST-----
 MIIClzCCAX8CAQAwUjEkMCIGA1UEChMbZ2FyZGVuZXIuY2xvdWQ6c3lzdGVtOnNl
 ZWRzMSowKAYDVQQDEyFnYXJkZW5lci5jbG91ZDpzeXN0ZW06c2VlZDpteXNlZWQw
@@ -282,10 +282,10 @@ TRVg+MWlcLqCjALr9Y4N39DOzf4/SJts8AZJJ+lyyxnY3XIPXx7SdADwNWC8BX0U
 OK8CwMwN3iiBQ4redVeMK7LU1unV899q/PWB+NXFcKVr+Grm/Kom5VxuhXSzcHEp
 yO57qEcJqG1cB7iSchFuCSTuDBbZlN0fXgn4YjiWZyb4l3BDp3rm4iJImA==
 -----END CERTIFICATE REQUEST-----`),
-				Usages: []certificatesv1beta1.KeyUsage{
-					certificatesv1beta1.UsageKeyEncipherment,
-					certificatesv1beta1.UsageDigitalSignature,
-					certificatesv1beta1.UsageClientAuth,
+				Usages: []certificatesv1.KeyUsage{
+					certificatesv1.UsageKeyEncipherment,
+					certificatesv1.UsageDigitalSignature,
+					certificatesv1.UsageClientAuth,
 				},
 			},
 		}
@@ -959,7 +959,7 @@ yO57qEcJqG1cB7iSchFuCSTuDBbZlN0fXgn4YjiWZyb4l3BDp3rm4iJImA==
 		Expect(graph.HasPathFrom(VertexTypeSecret, managedSeedBootstrapTokenNamespace, managedSeedBootstrapTokenName, VertexTypeManagedSeed, managedSeed1.Namespace, managedSeed1.Name)).To(BeFalse())
 	})
 
-	It("should behave as expected for certificatesv1beta1.CertificateSigningRequest", func() {
+	It("should behave as expected for certificatesv1.CertificateSigningRequest", func() {
 		By("add")
 		fakeInformerCertificateSigningRequest.Add(csr1)
 		Expect(graph.graph.Nodes().Len()).To(Equal(2))

--- a/pkg/controllermanager/controller/certificatesigningrequest/certificatesigningrequest.go
+++ b/pkg/controllermanager/controller/certificatesigningrequest/certificatesigningrequest.go
@@ -61,7 +61,10 @@ func NewCSRController(
 		return nil, err
 	}
 
-	var csrInformer ctrlruntimecache.Informer
+	var (
+		csrInformer            ctrlruntimecache.Informer
+		certificatesAPIVersion = "v1"
+	)
 
 	csrInformer, err = gardenClient.Cache().GetInformer(ctx, &certificatesv1.CertificateSigningRequest{})
 	if err != nil {
@@ -74,10 +77,11 @@ func NewCSRController(
 		if err != nil {
 			return nil, fmt.Errorf("failed to get CSR Informer: %w", err)
 		}
+		certificatesAPIVersion = "v1beta1"
 	}
 
 	csrController := &Controller{
-		reconciler: NewCSRReconciler(logger.Logger, gardenClient),
+		reconciler: NewCSRReconciler(logger.Logger, gardenClient, certificatesAPIVersion),
 		csrQueue:   workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "CertificateSigningRequest"),
 		workerCh:   make(chan int),
 	}

--- a/pkg/gardenlet/bootstrap/certificate/certificate.go
+++ b/pkg/gardenlet/bootstrap/certificate/certificate.go
@@ -154,7 +154,7 @@ func waitForCertificate(ctx context.Context, client kubernetesclientset.Interfac
 			return retry.Ok()
 		}
 
-		// fall back to v1beta1
+		// fallback to v1beta1
 		if csr, err := client.CertificatesV1beta1().CertificateSigningRequests().Get(ctx, reqName, metav1.GetOptions{}); err == nil {
 			if csr.UID != reqUID {
 				return retry.SevereError(fmt.Errorf("csr %q changed UIDs", csr.Name))

--- a/pkg/utils/gardener/seed.go
+++ b/pkg/utils/gardener/seed.go
@@ -20,8 +20,7 @@ import (
 	"strings"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-
-	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
+	certificatesv1 "k8s.io/api/certificates/v1"
 )
 
 const (
@@ -45,7 +44,7 @@ func ComputeSeedName(seedNamespaceName string) string {
 
 // IsSeedClientCert returns true when the given CSR and usages match the requirements for a client certificate for a
 // seed.
-func IsSeedClientCert(x509cr *x509.CertificateRequest, usages []certificatesv1beta1.KeyUsage) bool {
+func IsSeedClientCert(x509cr *x509.CertificateRequest, usages []certificatesv1.KeyUsage) bool {
 	if !reflect.DeepEqual([]string{v1beta1constants.SeedsGroup}, x509cr.Subject.Organization) {
 		return false
 	}
@@ -54,10 +53,10 @@ func IsSeedClientCert(x509cr *x509.CertificateRequest, usages []certificatesv1be
 		return false
 	}
 
-	if !hasExactUsages(usages, []certificatesv1beta1.KeyUsage{
-		certificatesv1beta1.UsageKeyEncipherment,
-		certificatesv1beta1.UsageDigitalSignature,
-		certificatesv1beta1.UsageClientAuth,
+	if !hasExactUsages(usages, []certificatesv1.KeyUsage{
+		certificatesv1.UsageKeyEncipherment,
+		certificatesv1.UsageDigitalSignature,
+		certificatesv1.UsageClientAuth,
 	}) {
 		return false
 	}
@@ -65,12 +64,12 @@ func IsSeedClientCert(x509cr *x509.CertificateRequest, usages []certificatesv1be
 	return strings.HasPrefix(x509cr.Subject.CommonName, v1beta1constants.SeedUserNamePrefix)
 }
 
-func hasExactUsages(usages, requiredUsages []certificatesv1beta1.KeyUsage) bool {
+func hasExactUsages(usages, requiredUsages []certificatesv1.KeyUsage) bool {
 	if len(requiredUsages) != len(usages) {
 		return false
 	}
 
-	usageMap := map[certificatesv1beta1.KeyUsage]struct{}{}
+	usageMap := map[certificatesv1.KeyUsage]struct{}{}
 	for _, u := range usages {
 		usageMap[u] = struct{}{}
 	}

--- a/pkg/utils/gardener/seed_test.go
+++ b/pkg/utils/gardener/seed_test.go
@@ -25,7 +25,7 @@ import (
 	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
-	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
+	certificatesv1 "k8s.io/api/certificates/v1"
 )
 
 var _ = Describe("utils", func() {
@@ -56,7 +56,7 @@ var _ = Describe("utils", func() {
 	)
 
 	DescribeTable("#IsSeedClientCert",
-		func(x509cr *x509.CertificateRequest, usages []certificatesv1beta1.KeyUsage, matcher gomegatypes.GomegaMatcher) {
+		func(x509cr *x509.CertificateRequest, usages []certificatesv1.KeyUsage, matcher gomegatypes.GomegaMatcher) {
 			Expect(IsSeedClientCert(x509cr, usages)).To(matcher)
 		},
 
@@ -65,7 +65,7 @@ var _ = Describe("utils", func() {
 		Entry("email addresses given", &x509.CertificateRequest{Subject: pkix.Name{Organization: []string{"gardener.cloud:system:seeds"}}, EmailAddresses: []string{"foo"}}, nil, BeFalse()),
 		Entry("ip addresses given", &x509.CertificateRequest{Subject: pkix.Name{Organization: []string{"gardener.cloud:system:seeds"}}, IPAddresses: []net.IP{{}}}, nil, BeFalse()),
 		Entry("usages do not match", &x509.CertificateRequest{Subject: pkix.Name{Organization: []string{"gardener.cloud:system:seeds"}}}, nil, BeFalse()),
-		Entry("common name does not match", &x509.CertificateRequest{Subject: pkix.Name{Organization: []string{"gardener.cloud:system:seeds"}}}, []certificatesv1beta1.KeyUsage{certificatesv1beta1.UsageKeyEncipherment, certificatesv1beta1.UsageDigitalSignature, certificatesv1beta1.UsageClientAuth}, BeFalse()),
-		Entry("everything matches", &x509.CertificateRequest{Subject: pkix.Name{Organization: []string{"gardener.cloud:system:seeds"}, CommonName: "gardener.cloud:system:seed:foo"}}, []certificatesv1beta1.KeyUsage{certificatesv1beta1.UsageKeyEncipherment, certificatesv1beta1.UsageDigitalSignature, certificatesv1beta1.UsageClientAuth}, BeTrue()),
+		Entry("common name does not match", &x509.CertificateRequest{Subject: pkix.Name{Organization: []string{"gardener.cloud:system:seeds"}}}, []certificatesv1.KeyUsage{certificatesv1.UsageKeyEncipherment, certificatesv1.UsageDigitalSignature, certificatesv1.UsageClientAuth}, BeFalse()),
+		Entry("everything matches", &x509.CertificateRequest{Subject: pkix.Name{Organization: []string{"gardener.cloud:system:seeds"}, CommonName: "gardener.cloud:system:seed:foo"}}, []certificatesv1.KeyUsage{certificatesv1.UsageKeyEncipherment, certificatesv1.UsageDigitalSignature, certificatesv1.UsageClientAuth}, BeTrue()),
 	)
 })

--- a/pkg/utils/kubernetes/kubernetes.go
+++ b/pkg/utils/kubernetes/kubernetes.go
@@ -28,6 +28,8 @@ import (
 
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
+	certificatesv1 "k8s.io/api/certificates/v1"
+	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -613,4 +615,13 @@ func IgnoreAlreadyExists(err error) error {
 		return nil
 	}
 	return err
+}
+
+// CertificatesV1beta1UsagesToCertificatesV1Usages converts []certificatesv1beta1.KeyUsage to []certificatesv1.KeyUsage.
+func CertificatesV1beta1UsagesToCertificatesV1Usages(usages []certificatesv1beta1.KeyUsage) []certificatesv1.KeyUsage {
+	var out []certificatesv1.KeyUsage
+	for _, u := range usages {
+		out = append(out, certificatesv1.KeyUsage(u))
+	}
+	return out
 }

--- a/pkg/utils/kubernetes/kubernetes_test.go
+++ b/pkg/utils/kubernetes/kubernetes_test.go
@@ -40,6 +40,8 @@ import (
 	gomegatypes "github.com/onsi/gomega/types"
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
+	certificatesv1 "k8s.io/api/certificates/v1"
+	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -1497,5 +1499,59 @@ var _ = Describe("kubernetes", func() {
 			Entry("w/  container name, logs of current  container", []corev1.ContainerStatus{{}, {Name: containerName, State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{}}}}, containerName, false),
 			Entry("w/  container name, logs of previous container", []corev1.ContainerStatus{{}, {Name: containerName, State: corev1.ContainerState{Running: &corev1.ContainerStateRunning{}}}}, containerName, true),
 		)
+	})
+
+	Describe("#CertificatesV1beta1UsagesToCertificatesV1Usages", func() {
+		It("should correctly convert", func() {
+			Expect(CertificatesV1beta1UsagesToCertificatesV1Usages([]certificatesv1beta1.KeyUsage{
+				certificatesv1beta1.UsageSigning,
+				certificatesv1beta1.UsageDigitalSignature,
+				certificatesv1beta1.UsageContentCommitment,
+				certificatesv1beta1.UsageKeyEncipherment,
+				certificatesv1beta1.UsageKeyAgreement,
+				certificatesv1beta1.UsageDataEncipherment,
+				certificatesv1beta1.UsageCertSign,
+				certificatesv1beta1.UsageCRLSign,
+				certificatesv1beta1.UsageEncipherOnly,
+				certificatesv1beta1.UsageDecipherOnly,
+				certificatesv1beta1.UsageAny,
+				certificatesv1beta1.UsageServerAuth,
+				certificatesv1beta1.UsageClientAuth,
+				certificatesv1beta1.UsageCodeSigning,
+				certificatesv1beta1.UsageEmailProtection,
+				certificatesv1beta1.UsageSMIME,
+				certificatesv1beta1.UsageIPsecEndSystem,
+				certificatesv1beta1.UsageIPsecTunnel,
+				certificatesv1beta1.UsageIPsecUser,
+				certificatesv1beta1.UsageTimestamping,
+				certificatesv1beta1.UsageOCSPSigning,
+				certificatesv1beta1.UsageMicrosoftSGC,
+				certificatesv1beta1.UsageNetscapeSGC,
+			})).To(Equal([]certificatesv1.KeyUsage{
+				certificatesv1.UsageSigning,
+				certificatesv1.UsageDigitalSignature,
+				certificatesv1.UsageContentCommitment,
+				certificatesv1.UsageKeyEncipherment,
+				certificatesv1.UsageKeyAgreement,
+				certificatesv1.UsageDataEncipherment,
+				certificatesv1.UsageCertSign,
+				certificatesv1.UsageCRLSign,
+				certificatesv1.UsageEncipherOnly,
+				certificatesv1.UsageDecipherOnly,
+				certificatesv1.UsageAny,
+				certificatesv1.UsageServerAuth,
+				certificatesv1.UsageClientAuth,
+				certificatesv1.UsageCodeSigning,
+				certificatesv1.UsageEmailProtection,
+				certificatesv1.UsageSMIME,
+				certificatesv1.UsageIPsecEndSystem,
+				certificatesv1.UsageIPsecTunnel,
+				certificatesv1.UsageIPsecUser,
+				certificatesv1.UsageTimestamping,
+				certificatesv1.UsageOCSPSigning,
+				certificatesv1.UsageMicrosoftSGC,
+				certificatesv1.UsageNetscapeSGC,
+			}))
+		})
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:
The `gardener-{admission-controller,controller-manager}` components now prefer using the `certificates.k8s.io/v1` API if available. Earlier, they were using `v1beta1` which made it impossible to use them with a garden cluster of Kubernetes v1.22 or higher.

/cc @timuthy 
/squash

**Which issue(s) this PR fixes**:
Fixes #4616

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The `gardener-{admission-controller,controller-manager}` components now prefer using the `certificates.k8s.io/v1` API if available.
```
