### PR TITLE
Fix race condition in WaitCleanup

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -506,7 +506,7 @@ func (c *Controller) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Waiting until stale extension resources are deleted",
-			Fn:           flow.TaskFn(botanist.Shoot.Components.Extensions.Extension.WaitCleanup).SkipIf(o.Shoot.HibernationEnabled),
+			Fn:           flow.TaskFn(botanist.Shoot.Components.Extensions.Extension.WaitCleanupStaleResources).SkipIf(o.Shoot.HibernationEnabled),
 			Dependencies: flow.NewTaskIDs(deleteStaleExtensionResources),
 		})
 		deployContainerRuntimeResources = g.Add(flow.Task{

--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -335,7 +335,7 @@ func (c *Controller) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Waiting until stale operating system config resources are deleted",
-			Fn:           flow.TaskFn(botanist.Shoot.Components.Extensions.OperatingSystemConfig.WaitCleanup).SkipIf(o.Shoot.HibernationEnabled),
+			Fn:           flow.TaskFn(botanist.Shoot.Components.Extensions.OperatingSystemConfig.WaitCleanupStaleResources).SkipIf(o.Shoot.HibernationEnabled),
 			Dependencies: flow.NewTaskIDs(deleteStaleOperatingSystemConfigResources),
 		})
 		deployGardenerResourceManager = g.Add(flow.Task{

--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -519,15 +519,15 @@ func (c *Controller) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 			Fn:           botanist.Shoot.Components.Extensions.ContainerRuntime.Wait,
 			Dependencies: flow.NewTaskIDs(deployContainerRuntimeResources),
 		})
-		deleteStaleResources = g.Add(flow.Task{
+		deleteStaleContainerRuntimeResources = g.Add(flow.Task{
 			Name:         "Delete stale container runtime resources",
 			Fn:           flow.TaskFn(botanist.Shoot.Components.Extensions.ContainerRuntime.DeleteStaleResources).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(initializeShootClients),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Waiting until stale container runtime resources are deleted",
-			Fn:           flow.TaskFn(botanist.Shoot.Components.Extensions.ContainerRuntime.WaitCleanup).SkipIf(o.Shoot.HibernationEnabled),
-			Dependencies: flow.NewTaskIDs(deleteStaleResources),
+			Fn:           flow.TaskFn(botanist.Shoot.Components.Extensions.ContainerRuntime.WaitCleanupStaleResources).SkipIf(o.Shoot.HibernationEnabled),
+			Dependencies: flow.NewTaskIDs(deleteStaleContainerRuntimeResources),
 		})
 		_ = g.Add(flow.Task{
 			Name: "Restart control plane pods",

--- a/pkg/operation/botanist/component/extensions/containerruntime/mock/mocks.go
+++ b/pkg/operation/botanist/component/extensions/containerruntime/mock/mocks.go
@@ -133,6 +133,20 @@ func (mr *MockInterfaceMockRecorder) WaitCleanup(arg0 interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitCleanup", reflect.TypeOf((*MockInterface)(nil).WaitCleanup), arg0)
 }
 
+// WaitCleanupStaleResources mocks base method.
+func (m *MockInterface) WaitCleanupStaleResources(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitCleanupStaleResources", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WaitCleanupStaleResources indicates an expected call of WaitCleanupStaleResources.
+func (mr *MockInterfaceMockRecorder) WaitCleanupStaleResources(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitCleanupStaleResources", reflect.TypeOf((*MockInterface)(nil).WaitCleanupStaleResources), arg0)
+}
+
 // WaitMigrate mocks base method.
 func (m *MockInterface) WaitMigrate(arg0 context.Context) error {
 	m.ctrl.T.Helper()

--- a/pkg/operation/botanist/component/extensions/extension/mock/mocks.go
+++ b/pkg/operation/botanist/component/extensions/extension/mock/mocks.go
@@ -148,6 +148,20 @@ func (mr *MockInterfaceMockRecorder) WaitCleanup(arg0 interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitCleanup", reflect.TypeOf((*MockInterface)(nil).WaitCleanup), arg0)
 }
 
+// WaitCleanupStaleResources mocks base method.
+func (m *MockInterface) WaitCleanupStaleResources(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitCleanupStaleResources", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WaitCleanupStaleResources indicates an expected call of WaitCleanupStaleResources.
+func (mr *MockInterfaceMockRecorder) WaitCleanupStaleResources(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitCleanupStaleResources", reflect.TypeOf((*MockInterface)(nil).WaitCleanupStaleResources), arg0)
+}
+
 // WaitMigrate mocks base method.
 func (m *MockInterface) WaitMigrate(arg0 context.Context) error {
 	m.ctrl.T.Helper()

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/mock/mocks.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/mock/mocks.go
@@ -194,6 +194,20 @@ func (mr *MockInterfaceMockRecorder) WaitCleanup(arg0 interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitCleanup", reflect.TypeOf((*MockInterface)(nil).WaitCleanup), arg0)
 }
 
+// WaitCleanupStaleResources mocks base method.
+func (m *MockInterface) WaitCleanupStaleResources(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitCleanupStaleResources", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WaitCleanupStaleResources indicates an expected call of WaitCleanupStaleResources.
+func (mr *MockInterfaceMockRecorder) WaitCleanupStaleResources(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitCleanupStaleResources", reflect.TypeOf((*MockInterface)(nil).WaitCleanupStaleResources), arg0)
+}
+
 // WaitMigrate mocks base method.
 func (m *MockInterface) WaitMigrate(arg0 context.Context) error {
 	m.ctrl.T.Helper()

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
@@ -643,20 +643,13 @@ var _ = Describe("OperatingSystemConfig", func() {
 		})
 
 		Describe("#WaitCleanup", func() {
-			It("should not return error when resources are removed", func() {
+			It("should not return error if all resources are gone", func() {
 				Expect(defaultDepWaiter.WaitCleanup(ctx)).To(Succeed())
 			})
 
-			It("should not return error if resources exist but they don't have deletionTimestamp", func() {
+			It("should return error if resources still exist", func() {
 				Expect(c.Create(ctx, expected[0])).To(Succeed())
-				Expect(defaultDepWaiter.WaitCleanup(ctx)).To(Succeed())
-			})
-
-			It("should return error if resources with deletionTimestamp still exist", func() {
-				timeNow := metav1.Now()
-				expected[0].DeletionTimestamp = &timeNow
-				Expect(c.Create(ctx, expected[0])).To(Succeed())
-				Expect(defaultDepWaiter.WaitCleanup(ctx)).To(MatchError(ContainSubstring("is still present")))
+				Expect(defaultDepWaiter.WaitCleanup(ctx)).To(MatchError(ContainSubstring("OperatingSystemConfig test-namespace/cloud-config-worker1-77ac3-type1-downloader is still present")))
 			})
 		})
 
@@ -748,6 +741,25 @@ var _ = Describe("OperatingSystemConfig", func() {
 				for _, item := range oscList.Items {
 					Expect(item.Spec.Type).ToNot(Equal(newType))
 				}
+			})
+		})
+
+		Describe("#WaitCleanupStaleResources", func() {
+			It("should not return error if all resources are gone", func() {
+				Expect(defaultDepWaiter.WaitCleanupStaleResources(ctx)).To(Succeed())
+			})
+
+			It("should not return error if wanted resources exist", func() {
+				Expect(c.Create(ctx, expected[0])).To(Succeed())
+				Expect(defaultDepWaiter.WaitCleanupStaleResources(ctx)).To(Succeed())
+			})
+
+			It("should return error if stale resources still exist", func() {
+				staleOSC := expected[0].DeepCopy()
+				staleOSC.Name = "new-name"
+				Expect(c.Create(ctx, staleOSC)).To(Succeed(), "creating stale OSC succeeds")
+
+				Expect(defaultDepWaiter.WaitCleanupStaleResources(ctx)).To(MatchError(ContainSubstring("OperatingSystemConfig test-namespace/new-name is still present")))
 			})
 		})
 	})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug

**What this PR does / why we need it**:

This PR fixes a race in the `WaitCleanup` logic of Extension, OSC and ContainerRuntime components, that can occur if the `CachedRuntimeClients` feature gate is enabled.
`WaitCleanup` is now split into `WaitCleanup` (waits for all resources to be deleted, e.g. in delete flow) and `WaitCleanupStaleResources` (only waits for unwanted resources to be deleted, i.e. after a call to `DeleteStaleResources` in the reconcile flow).
See the linked issue and commit messages for more details. 

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/4648

**Special notes for your reviewer**:

Thanks @timuthy for your input on the solution.
/squash

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A race in gardenlet has been fixed, that caused gardenlet not to wait for `Extension` and other resources to be deleted if the `CachedRuntimeClients` feature gate is enabled.
```
