### PR TITLE
Relax VPA validation

### DIFF
--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/crd-verticalpodautoscalers.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/crd-verticalpodautoscalers.yaml
@@ -71,11 +71,9 @@ spec:
                           enum: ["cpu", "memory"]
 {{- else -}}
 ---
-# Source: https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/deploy/vpa-v1-crd-gen.yaml
-# For backwards compatibility, the following customizations were performed on the original CRD manifest:
-# - allow nullable status for v1beta2, v1
-# - additional fields for v1beta2:
-#   - .spec.resourcePolicy.containerPolicies[].controlledResources
+# For backwards compatibility it's not possible to take the community based VPA definition since it tightens
+# the validation too much. Instead, the CRD needs to retain and permit unknown fields as it used to be with
+# the `v1beta1` CRD version.
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -96,512 +94,100 @@ spec:
     singular: verticalpodautoscaler
   scope: Namespaced
   versions:
-  - additionalPrinterColumns:
-    - jsonPath: .spec.updatePolicy.updateMode
-      name: Mode
-      type: string
-    - jsonPath: .status.recommendation.containerRecommendations[0].target.cpu
-      name: CPU
-      type: string
-    - jsonPath: .status.recommendation.containerRecommendations[0].target.memory
-      name: Mem
-      type: string
-    - jsonPath: .status.conditions[?(@.type=='RecommendationProvided')].status
-      name: Provided
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
-    name: v1
+  - name: v1
     schema:
       openAPIV3Schema:
-        description: VerticalPodAutoscaler is the configuration for a vertical pod
-          autoscaler, which automatically manages pod resources based on historical
-          and real time resource utilization.
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
         properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
           spec:
-            description: 'Specification of the behavior of the autoscaler. More info:
-              https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status.'
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+            required: []
             properties:
-              resourcePolicy:
-                description: Controls how the autoscaler computes recommended resources.
-                  The resource policy may be used to set constraints on the recommendations
-                  for individual containers. If not specified, the autoscaler computes
-                  recommended resources for all containers in the pod, without additional
-                  constraints.
-                properties:
-                  containerPolicies:
-                    description: Per-container resource policies.
-                    items:
-                      description: ContainerResourcePolicy controls how autoscaler
-                        computes the recommended resources for a specific container.
-                      properties:
-                        containerName:
-                          description: Name of the container or DefaultContainerResourcePolicy,
-                            in which case the policy is used by the containers that
-                            don't have their own policy specified.
-                          type: string
-                        controlledResources:
-                          description: Specifies the type of recommendations that
-                            will be computed (and possibly applied) by VPA. If not
-                            specified, the default of [ResourceCPU, ResourceMemory]
-                            will be used.
-                          items:
-                            description: ResourceName is the name identifying various
-                              resources in a ResourceList.
-                            type: string
-                          type: array
-                        controlledValues:
-                          description: Specifies which resource values should be controlled.
-                            The default is "RequestsAndLimits".
-                          enum:
-                          - RequestsAndLimits
-                          - RequestsOnly
-                          type: string
-                        maxAllowed:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: Specifies the maximum amount of resources that
-                            will be recommended for the container. The default is
-                            no maximum.
-                          type: object
-                        minAllowed:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: Specifies the minimal amount of resources that
-                            will be recommended for the container. The default is
-                            no minimum.
-                          type: object
-                        mode:
-                          description: Whether autoscaler is enabled for the container.
-                            The default is "Auto".
-                          enum:
-                          - Auto
-                          - "Off"
-                          type: string
-                      type: object
-                    type: array
-                type: object
               targetRef:
-                description: TargetRef points to the controller managing the set of
-                  pods for the autoscaler to control - e.g. Deployment, StatefulSet.
-                  VerticalPodAutoscaler can be targeted at controller implementing
-                  scale subresource (the pod set is retrieved from the controller's
-                  ScaleStatus) or some well known controllers (e.g. for DaemonSet
-                  the pod set is read from the controller's spec). If VerticalPodAutoscaler
-                  cannot use specified target it will report ConfigUnsupported condition.
-                  Note that VerticalPodAutoscaler does not require full implementation
-                  of scale subresource - it will not use it to modify the replica
-                  count. The only thing retrieved is a label selector matching pods
-                  grouped by the target resource.
-                properties:
-                  apiVersion:
-                    description: API version of the referent
-                    type: string
-                  kind:
-                    description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
-                    type: string
-                  name:
-                    description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
-                    type: string
-                required:
-                - kind
-                - name
                 type: object
+                x-kubernetes-preserve-unknown-fields: true
               updatePolicy:
-                description: Describes the rules on how changes are applied to the
-                  pods. If not specified, all fields in the `PodUpdatePolicy` are
-                  set to their default values.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
                 properties:
                   updateMode:
-                    description: Controls when autoscaler applies changes to the pod
-                      resources. The default is 'Auto'.
-                    enum:
-                    - "Off"
-                    - Initial
-                    - Recreate
-                    - Auto
                     type: string
+              resourcePolicy:
                 type: object
-            required:
-            - targetRef
-            type: object
-          status:
-            description: Current information about the autoscaler.
-            properties:
-              conditions:
-                description: Conditions is the set of conditions required for this
-                  autoscaler to scale its target, and indicates whether or not those
-                  conditions are met.
-                items:
-                  description: VerticalPodAutoscalerCondition describes the state
-                    of a VerticalPodAutoscaler at a certain point.
-                  properties:
-                    lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another
-                      format: date-time
-                      type: string
-                    message:
-                      description: message is a human-readable explanation containing
-                        details about the transition
-                      type: string
-                    reason:
-                      description: reason is the reason for the condition's last transition.
-                      type: string
-                    status:
-                      description: status is the status of the condition (True, False,
-                        Unknown)
-                      type: string
-                    type:
-                      description: type describes the current condition
-                      type: string
-                  required:
-                  - status
-                  - type
-                  type: object
-                type: array
-              recommendation:
-                description: The most recently computed amount of resources recommended
-                  by the autoscaler for the controlled pods.
+                x-kubernetes-preserve-unknown-fields: true
                 properties:
-                  containerRecommendations:
-                    description: Resources recommended by the autoscaler for each
-                      container.
+                  containerPolicies:
+                    type: array
                     items:
-                      description: RecommendedContainerResources is the recommendation
-                        of resources computed by autoscaler for a specific container.
-                        Respects the container resource policy if present in the spec.
-                        In particular the recommendation is not produced for containers
-                        with `ContainerScalingMode` set to 'Off'.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
                       properties:
                         containerName:
-                          description: Name of the container.
                           type: string
-                        lowerBound:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: Minimum recommended amount of resources. Observes
-                            ContainerResourcePolicy. This amount is not guaranteed
-                            to be sufficient for the application to operate in a stable
-                            way, however running with less resources is likely to
-                            have significant impact on performance/availability.
+                        mode:
+                          type: string
+                          enum: ["Auto", "Off"]
+                        minAllowed:
                           type: object
-                        target:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: Recommended amount of resources. Observes ContainerResourcePolicy.
+                          x-kubernetes-preserve-unknown-fields: true
+                        maxAllowed:
                           type: object
-                        uncappedTarget:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: The most recent recommended resources target
-                            computed by the autoscaler for the controlled pods, based
-                            only on actual resource usage, not taking into account
-                            the ContainerResourcePolicy. May differ from the Recommendation
-                            if the actual resource usage causes the target to violate
-                            the ContainerResourcePolicy (lower than MinAllowed or
-                            higher that MaxAllowed). Used only as status indication,
-                            will not affect actual resource assignment.
-                          type: object
-                        upperBound:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: Maximum recommended amount of resources. Observes
-                            ContainerResourcePolicy. Any resources allocated beyond
-                            this value are likely wasted. This value may be larger
-                            than the maximum amount of application is actually capable
-                            of consuming.
-                          type: object
-                      required:
-                      - target
-                      type: object
-                    type: array
-                type: object
-            type: object
-            nullable: true
-        required:
-        - spec
-        type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        controlledResources:
+                          type: array
+                          items:
+                            type: string
+                            enum: ["cpu", "memory"]
     served: true
     storage: true
   - name: v1beta2
     schema:
       openAPIV3Schema:
-        description: VerticalPodAutoscaler is the configuration for a vertical pod
-          autoscaler, which automatically manages pod resources based on historical
-          and real time resource utilization.
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
         properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
-              of an object. Servers should convert recognized schemas to the latest
-              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
-              object represents. Servers may infer this from the endpoint the client
-              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
           spec:
-            description: 'Specification of the behavior of the autoscaler. More info:
-              https://git.k8s.io/community/contributors/devel/api-conventions.md#spec-and-status.'
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+            required: []
             properties:
-              resourcePolicy:
-                description: Controls how the autoscaler computes recommended resources.
-                  The resource policy may be used to set constraints on the recommendations
-                  for individual containers. If not specified, the autoscaler computes
-                  recommended resources for all containers in the pod, without additional
-                  constraints.
-                properties:
-                  containerPolicies:
-                    description: Per-container resource policies.
-                    items:
-                      description: ContainerResourcePolicy controls how autoscaler
-                        computes the recommended resources for a specific container.
-                      properties:
-                        containerName:
-                          description: Name of the container or DefaultContainerResourcePolicy,
-                            in which case the policy is used by the containers that
-                            don't have their own policy specified.
-                          type: string
-                        controlledResources:
-                          description: Specifies the type of recommendations that
-                            will be computed (and possibly applied) by VPA. If not
-                            specified, the default of [ResourceCPU, ResourceMemory]
-                            will be used.
-                          items:
-                            description: ResourceName is the name identifying various
-                              resources in a ResourceList.
-                            type: string
-                            enum: ["cpu", "memory"]
-                          type: array
-                        maxAllowed:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: Specifies the maximum amount of resources that
-                            will be recommended for the container. The default is
-                            no maximum.
-                          type: object
-                        minAllowed:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: Specifies the minimal amount of resources that
-                            will be recommended for the container. The default is
-                            no minimum.
-                          type: object
-                        mode:
-                          description: Whether autoscaler is enabled for the container.
-                            The default is "Auto".
-                          enum:
-                          - Auto
-                          - "Off"
-                          type: string
-                      type: object
-                    type: array
-                type: object
               targetRef:
-                description: TargetRef points to the controller managing the set of
-                  pods for the autoscaler to control - e.g. Deployment, StatefulSet.
-                  VerticalPodAutoscaler can be targeted at controller implementing
-                  scale subresource (the pod set is retrieved from the controller's
-                  ScaleStatus) or some well known controllers (e.g. for DaemonSet
-                  the pod set is read from the controller's spec). If VerticalPodAutoscaler
-                  cannot use specified target it will report ConfigUnsupported condition.
-                  Note that VerticalPodAutoscaler does not require full implementation
-                  of scale subresource - it will not use it to modify the replica
-                  count. The only thing retrieved is a label selector matching pods
-                  grouped by the target resource.
-                properties:
-                  apiVersion:
-                    description: API version of the referent
-                    type: string
-                  kind:
-                    description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"'
-                    type: string
-                  name:
-                    description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
-                    type: string
-                required:
-                - kind
-                - name
                 type: object
+                x-kubernetes-preserve-unknown-fields: true
               updatePolicy:
-                description: Describes the rules on how changes are applied to the
-                  pods. If not specified, all fields in the `PodUpdatePolicy` are
-                  set to their default values.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
                 properties:
                   updateMode:
-                    description: Controls when autoscaler applies changes to the pod
-                      resources. The default is 'Auto'.
-                    enum:
-                    - "Off"
-                    - Initial
-                    - Recreate
-                    - Auto
                     type: string
+              resourcePolicy:
                 type: object
-            required:
-            - targetRef
-            type: object
-          status:
-            description: Current information about the autoscaler.
-            properties:
-              conditions:
-                description: Conditions is the set of conditions required for this
-                  autoscaler to scale its target, and indicates whether or not those
-                  conditions are met.
-                items:
-                  description: VerticalPodAutoscalerCondition describes the state
-                    of a VerticalPodAutoscaler at a certain point.
-                  properties:
-                    lastTransitionTime:
-                      description: lastTransitionTime is the last time the condition
-                        transitioned from one status to another
-                      format: date-time
-                      type: string
-                    message:
-                      description: message is a human-readable explanation containing
-                        details about the transition
-                      type: string
-                    reason:
-                      description: reason is the reason for the condition's last transition.
-                      type: string
-                    status:
-                      description: status is the status of the condition (True, False,
-                        Unknown)
-                      type: string
-                    type:
-                      description: type describes the current condition
-                      type: string
-                  required:
-                  - status
-                  - type
-                  type: object
-                type: array
-              recommendation:
-                description: The most recently computed amount of resources recommended
-                  by the autoscaler for the controlled pods.
+                x-kubernetes-preserve-unknown-fields: true
                 properties:
-                  containerRecommendations:
-                    description: Resources recommended by the autoscaler for each
-                      container.
+                  containerPolicies:
+                    type: array
                     items:
-                      description: RecommendedContainerResources is the recommendation
-                        of resources computed by autoscaler for a specific container.
-                        Respects the container resource policy if present in the spec.
-                        In particular the recommendation is not produced for containers
-                        with `ContainerScalingMode` set to 'Off'.
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
                       properties:
                         containerName:
-                          description: Name of the container.
                           type: string
-                        lowerBound:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: Minimum recommended amount of resources. Observes
-                            ContainerResourcePolicy. This amount is not guaranteed
-                            to be sufficient for the application to operate in a stable
-                            way, however running with less resources is likely to
-                            have significant impact on performance/availability.
+                        mode:
+                          type: string
+                          enum: ["Auto", "Off"]
+                        minAllowed:
                           type: object
-                        target:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: Recommended amount of resources. Observes ContainerResourcePolicy.
+                          x-kubernetes-preserve-unknown-fields: true
+                        maxAllowed:
                           type: object
-                        uncappedTarget:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: The most recent recommended resources target
-                            computed by the autoscaler for the controlled pods, based
-                            only on actual resource usage, not taking into account
-                            the ContainerResourcePolicy. May differ from the Recommendation
-                            if the actual resource usage causes the target to violate
-                            the ContainerResourcePolicy (lower than MinAllowed or
-                            higher that MaxAllowed). Used only as status indication,
-                            will not affect actual resource assignment.
-                          type: object
-                        upperBound:
-                          additionalProperties:
-                            anyOf:
-                            - type: integer
-                            - type: string
-                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                            x-kubernetes-int-or-string: true
-                          description: Maximum recommended amount of resources. Observes
-                            ContainerResourcePolicy. Any resources allocated beyond
-                            this value are likely wasted. This value may be larger
-                            than the maximum amount of application is actually capable
-                            of consuming.
-                          type: object
-                      required:
-                      - target
-                      type: object
-                    type: array
-                type: object
-            type: object
-            nullable: true
-        required:
-        - spec
-        type: object
+                          x-kubernetes-preserve-unknown-fields: true
+                        controlledResources:
+                          type: array
+                          items:
+                            type: string
+                            enum: ["cpu", "memory"]
     served: true
     storage: false
 {{- end }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind api-change
/needs cherry-pick

**What this PR does / why we need it**:
This PR relaxes the VPA validation further. With https://github.com/gardener/gardener/pull/4562 we transitioned to `v1` CRDs which involves a tighter validation, especially if unknown fields are involved. With this change, we go back to the compatibility level of the `v1beta1` CRD. This turned out to be an inevitable step to unblock users who applied "broken" VPA objects before.

**Special notes for your reviewer**:
/cc @ialidzhikov @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
VPA validation has been relaxed further through the corresponding CRD. Unknown fields are now kept instead of resulting in validation errors.
```
