### PR TITLE
Fix ingress class handling

### DIFF
--- a/charts/seed-bootstrap/charts/loki/templates/kube-rbac-proxy-ingress.yaml
+++ b/charts/seed-bootstrap/charts/loki/templates/kube-rbac-proxy-ingress.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ include "ingressversion" . }}
 kind: Ingress
 metadata:
   annotations:
-{{- if semverCompare "<= 1.21.x" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare "< 1.22-0" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/ingress.class: {{ .Values.ingress.class }}
 {{- end }}
     nginx.ingress.kubernetes.io/configuration-snippet: "proxy_set_header X-Scope-OrgID operator;"
@@ -12,7 +12,7 @@ metadata:
   labels:
 {{ toYaml .Values.labels | indent 4 }}
 spec:
-{{- if semverCompare ">= 1.22" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">= 1.22-0" .Capabilities.KubeVersion.GitVersion }}
   ingressClassName: {{ .Values.ingress.class }}
 {{- end }}
   tls:

--- a/charts/seed-bootstrap/charts/nginx-ingress/templates/_helpers.tpl
+++ b/charts/seed-bootstrap/charts/nginx-ingress/templates/_helpers.tpl
@@ -9,7 +9,7 @@ nginx-ingress-controller-{{ include "nginx-ingress.config.data" . | sha256sum | 
 {{- end }}
 
 {{- define "nginx-ingress.class" -}}
-{{- if semverCompare ">= 1.22" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">= 1.22-0" .Capabilities.KubeVersion.GitVersion -}}
 k8s.io/{{ .Values.global.ingressClass }}
 {{- else -}}
 {{ .Values.global.ingressClass }}

--- a/charts/seed-bootstrap/charts/nginx-ingress/templates/controller-deployment.yaml
+++ b/charts/seed-bootstrap/charts/nginx-ingress/templates/controller-deployment.yaml
@@ -61,7 +61,7 @@ spec:
             - --publish-service=garden/nginx-ingress-controller
             - --election-id=ingress-controller-seed-leader
             - --ingress-class={{ .Values.global.ingressClass }}
-            {{- if semverCompare ">= 1.22" .Capabilities.KubeVersion.GitVersion -}}
+            {{- if semverCompare ">= 1.22-0" .Capabilities.KubeVersion.GitVersion -}}
             - --controller-class={{ include "nginx-ingress.class" . }}
             {{- end }}
             - --update-status=true

--- a/charts/seed-bootstrap/charts/nginx-ingress/templates/ingressclass.yaml
+++ b/charts/seed-bootstrap/charts/nginx-ingress/templates/ingressclass.yaml
@@ -1,4 +1,4 @@
-{{- if semverCompare ">= 1.22" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">= 1.22-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:

--- a/charts/seed-bootstrap/templates/aggregate-prometheus/ingress.yaml
+++ b/charts/seed-bootstrap/templates/aggregate-prometheus/ingress.yaml
@@ -2,7 +2,7 @@ apiVersion: {{ include "ingressversion" . }}
 kind: Ingress
 metadata:
   annotations:
-{{- if semverCompare "<= 1.21.x" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare "< 1.22-0" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/ingress.class: {{ .Values.global.ingressClass }}
 {{- end }}
     nginx.ingress.kubernetes.io/auth-realm: Authentication Required
@@ -11,7 +11,7 @@ metadata:
   name: aggregate-prometheus
   namespace: {{ .Release.Namespace }}
 spec:
-{{- if semverCompare ">= 1.22" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">= 1.22-0" .Capabilities.KubeVersion.GitVersion }}
   ingressClassName: {{ .Values.global.ingressClass }}
 {{- end }}
   tls:

--- a/charts/seed-bootstrap/templates/grafana/ingress.yaml
+++ b/charts/seed-bootstrap/templates/grafana/ingress.yaml
@@ -2,7 +2,7 @@ apiVersion: {{ include "ingressversion" . }}
 kind: Ingress
 metadata:
   annotations:
-{{- if semverCompare "<= 1.21.x" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare "< 1.22-0" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/ingress.class: {{ .Values.global.ingressClass }}
 {{- end }}
     nginx.ingress.kubernetes.io/auth-realm: Authentication Required
@@ -11,7 +11,7 @@ metadata:
   name: grafana
   namespace: {{ .Release.Namespace }}
 spec:
-{{- if semverCompare ">= 1.22" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">= 1.22-0" .Capabilities.KubeVersion.GitVersion }}
   ingressClassName: {{ .Values.global.ingressClass }}
 {{- end }}
   tls:

--- a/charts/seed-monitoring/charts/alertmanager/templates/ingress.yaml
+++ b/charts/seed-monitoring/charts/alertmanager/templates/ingress.yaml
@@ -2,7 +2,7 @@ apiVersion: {{ include "ingressversion" . }}
 kind: Ingress
 metadata:
   annotations:
-{{- if semverCompare "<= 1.21.x" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare "< 1.22-0" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/ingress.class: {{ .Values.ingress.class }}
 {{- end }}
     nginx.ingress.kubernetes.io/auth-realm: Authentication Required
@@ -11,7 +11,7 @@ metadata:
   name: {{ .Chart.Name }}
   namespace: {{ .Release.Namespace }}
 spec:
-{{- if semverCompare ">= 1.22" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">= 1.22-0" .Capabilities.KubeVersion.GitVersion }}
   ingressClassName: {{ .Values.ingress.class }}
 {{- end }}
   tls:

--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/ingress.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/ingress.yaml
@@ -2,7 +2,7 @@ apiVersion: {{ include "ingressversion" . }}
 kind: Ingress
 metadata:
   annotations:
-{{- if semverCompare "<= 1.21.x" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare "< 1.22-0" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/ingress.class: {{ .Values.ingress.class }}
 {{- end }}
     nginx.ingress.kubernetes.io/auth-realm: Authentication Required
@@ -11,7 +11,7 @@ metadata:
   name: {{ .Chart.Name }}
   namespace: {{ .Release.Namespace }}
 spec:
-{{- if semverCompare ">= 1.22" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">= 1.22-0" .Capabilities.KubeVersion.GitVersion }}
   ingressClassName: {{ .Values.ingress.class }}
 {{- end }}
   tls:

--- a/charts/seed-monitoring/charts/grafana/templates/grafana-ingress.yaml
+++ b/charts/seed-monitoring/charts/grafana/templates/grafana-ingress.yaml
@@ -2,7 +2,7 @@ apiVersion: {{ include "ingressversion" . }}
 kind: Ingress
 metadata:
   annotations:
-{{- if semverCompare "<= 1.21.x" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare "< 1.22-0" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/ingress.class: {{ .Values.ingress.class }}
 {{- end }}
     nginx.ingress.kubernetes.io/auth-realm: Authentication Required
@@ -19,7 +19,7 @@ metadata:
     component: grafana
     role: {{ .Values.role }}
 spec:
-{{- if semverCompare ">= 1.22" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">= 1.22-0" .Capabilities.KubeVersion.GitVersion }}
   ingressClassName: {{ .Values.ingress.class }}
 {{- end }}
   tls:

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -881,7 +881,10 @@ func RunReconcileSeedFlow(
 		}
 	}
 
-	ingressClass := computeNginxIngressClass(seed, kubernetesVersion)
+	ingressClass, err := computeNginxIngressClass(seed, kubernetesVersion)
+	if err != nil {
+		return err
+	}
 
 	values := kubernetes.Values(map[string]interface{}{
 		"priorityClassName": v1beta1constants.PriorityClassNameShootControlPlane,
@@ -1599,7 +1602,14 @@ func migrateIngressClassForShootIngresses(ctx context.Context, gardenClient, see
 }
 
 func switchIngressClass(ctx context.Context, seedClient client.Client, ingressKey types.NamespacedName, newClass string, kubernetesVersion *semver.Version) error {
-	if versionutils.ConstraintK8sLessEqual121.Check(kubernetesVersion) {
+	// We need to use `versionutils.CompareVersions` because this function normalizes the seed version first.
+	// This is especially necessary if the seed cluster is a non Gardener managed cluster and thus might have some
+	// custom version suffix.
+	lessEqual121, err := versionutils.CompareVersions(kubernetesVersion.String(), "<=", "1.21.x")
+	if err != nil {
+		return err
+	}
+	if lessEqual121 {
 		ingress := &extensionsv1beta1.Ingress{}
 
 		if err := seedClient.Get(ctx, ingressKey, ingress); err != nil {
@@ -1646,15 +1656,24 @@ func computeNginxIngress(seed *Seed) map[string]interface{} {
 	return values
 }
 
-func computeNginxIngressClass(seed *Seed, kubernetesVersion *semver.Version) string {
+func computeNginxIngressClass(seed *Seed, kubernetesVersion *semver.Version) (string, error) {
 	managed := managedIngress(seed)
-	if managed && versionutils.ConstraintK8sGreaterEqual122.Check(kubernetesVersion) {
-		return v1beta1constants.SeedNginxIngressClass122
+
+	// We need to use `versionutils.CompareVersions` because this function normalizes the seed version first.
+	// This is especially necessary if the seed cluster is a non Gardener managed cluster and thus might have some
+	// custom version suffix.
+	greaterEqual122, err := versionutils.CompareVersions(kubernetesVersion.String(), ">=", "1.22")
+	if err != nil {
+		return "", err
+	}
+
+	if managed && greaterEqual122 {
+		return v1beta1constants.SeedNginxIngressClass122, nil
 	}
 	if managed {
-		return v1beta1constants.SeedNginxIngressClass
+		return v1beta1constants.SeedNginxIngressClass, nil
 	}
-	return v1beta1constants.ShootNginxIngressClass
+	return v1beta1constants.ShootNginxIngressClass, nil
 }
 
 func deleteIngressController(ctx context.Context, c client.Client) error {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug
/needs cherry-pick

**What this PR does / why we need it**:
This PR improves the handling for rendered Ingress resource which are deployed to seed clusters.
Seeds can be non Gardener managed clusters and might contain a custom version suffix (`v1.19.12-some-suffix`).
With such a version, the version switches in the Helm charts did not work reliably.

**Special notes for your reviewer**:
/cc @mliepold @dguendisch 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed that did not add the required ingress class in some seed clusters that are not Gardener managed.
```
