### PR TITLE
[release-v1.31] Automated cherry pick of #4676: Fix ingress class handling

### DIFF
--- a/charts/seed-bootstrap/charts/loki/templates/kube-rbac-proxy-ingress.yaml
+++ b/charts/seed-bootstrap/charts/loki/templates/kube-rbac-proxy-ingress.yaml
@@ -3,7 +3,7 @@ apiVersion: {{ include "ingressversion" . }}
 kind: Ingress
 metadata:
   annotations:
-{{- if semverCompare "<= 1.21.x" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare "< 1.22-0" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/ingress.class: {{ .Values.ingress.class }}
 {{- end }}
     nginx.ingress.kubernetes.io/configuration-snippet: "proxy_set_header X-Scope-OrgID operator;"
@@ -12,7 +12,7 @@ metadata:
   labels:
 {{ toYaml .Values.labels | indent 4 }}
 spec:
-{{- if semverCompare ">= 1.22" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">= 1.22-0" .Capabilities.KubeVersion.GitVersion }}
   ingressClassName: {{ .Values.ingress.class }}
 {{- end }}
   tls:

--- a/charts/seed-bootstrap/charts/nginx-ingress/templates/_helpers.tpl
+++ b/charts/seed-bootstrap/charts/nginx-ingress/templates/_helpers.tpl
@@ -9,7 +9,7 @@ nginx-ingress-controller-{{ include "nginx-ingress.config.data" . | sha256sum | 
 {{- end }}
 
 {{- define "nginx-ingress.class" -}}
-{{- if semverCompare ">= 1.22" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">= 1.22-0" .Capabilities.KubeVersion.GitVersion -}}
 k8s.io/{{ .Values.global.ingressClass }}
 {{- else -}}
 {{ .Values.global.ingressClass }}

--- a/charts/seed-bootstrap/charts/nginx-ingress/templates/controller-deployment.yaml
+++ b/charts/seed-bootstrap/charts/nginx-ingress/templates/controller-deployment.yaml
@@ -61,7 +61,7 @@ spec:
             - --publish-service=garden/nginx-ingress-controller
             - --election-id=ingress-controller-seed-leader
             - --ingress-class={{ .Values.global.ingressClass }}
-            {{- if semverCompare ">= 1.22" .Capabilities.KubeVersion.GitVersion -}}
+            {{- if semverCompare ">= 1.22-0" .Capabilities.KubeVersion.GitVersion -}}
             - --controller-class={{ include "nginx-ingress.class" . }}
             {{- end }}
             - --update-status=true

--- a/charts/seed-bootstrap/charts/nginx-ingress/templates/ingressclass.yaml
+++ b/charts/seed-bootstrap/charts/nginx-ingress/templates/ingressclass.yaml
@@ -1,4 +1,4 @@
-{{- if semverCompare ">= 1.22" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">= 1.22-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:

--- a/charts/seed-bootstrap/templates/aggregate-prometheus/ingress.yaml
+++ b/charts/seed-bootstrap/templates/aggregate-prometheus/ingress.yaml
@@ -2,7 +2,7 @@ apiVersion: {{ include "ingressversion" . }}
 kind: Ingress
 metadata:
   annotations:
-{{- if semverCompare "<= 1.21.x" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare "< 1.22-0" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/ingress.class: {{ .Values.global.ingressClass }}
 {{- end }}
     nginx.ingress.kubernetes.io/auth-realm: Authentication Required
@@ -11,7 +11,7 @@ metadata:
   name: aggregate-prometheus
   namespace: {{ .Release.Namespace }}
 spec:
-{{- if semverCompare ">= 1.22" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">= 1.22-0" .Capabilities.KubeVersion.GitVersion }}
   ingressClassName: {{ .Values.global.ingressClass }}
 {{- end }}
   tls:

--- a/charts/seed-bootstrap/templates/grafana/ingress.yaml
+++ b/charts/seed-bootstrap/templates/grafana/ingress.yaml
@@ -2,7 +2,7 @@ apiVersion: {{ include "ingressversion" . }}
 kind: Ingress
 metadata:
   annotations:
-{{- if semverCompare "<= 1.21.x" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare "< 1.22-0" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/ingress.class: {{ .Values.global.ingressClass }}
 {{- end }}
     nginx.ingress.kubernetes.io/auth-realm: Authentication Required
@@ -11,7 +11,7 @@ metadata:
   name: grafana
   namespace: {{ .Release.Namespace }}
 spec:
-{{- if semverCompare ">= 1.22" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">= 1.22-0" .Capabilities.KubeVersion.GitVersion }}
   ingressClassName: {{ .Values.global.ingressClass }}
 {{- end }}
   tls:

--- a/charts/seed-monitoring/charts/alertmanager/templates/ingress.yaml
+++ b/charts/seed-monitoring/charts/alertmanager/templates/ingress.yaml
@@ -2,7 +2,7 @@ apiVersion: {{ include "ingressversion" . }}
 kind: Ingress
 metadata:
   annotations:
-{{- if semverCompare "<= 1.21.x" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare "< 1.22-0" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/ingress.class: {{ .Values.ingress.class }}
 {{- end }}
     nginx.ingress.kubernetes.io/auth-realm: Authentication Required
@@ -11,7 +11,7 @@ metadata:
   name: {{ .Chart.Name }}
   namespace: {{ .Release.Namespace }}
 spec:
-{{- if semverCompare ">= 1.22" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">= 1.22-0" .Capabilities.KubeVersion.GitVersion }}
   ingressClassName: {{ .Values.ingress.class }}
 {{- end }}
   tls:

--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/ingress.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/ingress.yaml
@@ -2,7 +2,7 @@ apiVersion: {{ include "ingressversion" . }}
 kind: Ingress
 metadata:
   annotations:
-{{- if semverCompare "<= 1.21.x" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare "< 1.22-0" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/ingress.class: {{ .Values.ingress.class }}
 {{- end }}
     nginx.ingress.kubernetes.io/auth-realm: Authentication Required
@@ -11,7 +11,7 @@ metadata:
   name: {{ .Chart.Name }}
   namespace: {{ .Release.Namespace }}
 spec:
-{{- if semverCompare ">= 1.22" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">= 1.22-0" .Capabilities.KubeVersion.GitVersion }}
   ingressClassName: {{ .Values.ingress.class }}
 {{- end }}
   tls:

--- a/charts/seed-monitoring/charts/grafana/templates/grafana-ingress.yaml
+++ b/charts/seed-monitoring/charts/grafana/templates/grafana-ingress.yaml
@@ -2,7 +2,7 @@ apiVersion: {{ include "ingressversion" . }}
 kind: Ingress
 metadata:
   annotations:
-{{- if semverCompare "<= 1.21.x" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare "< 1.22-0" .Capabilities.KubeVersion.GitVersion }}
     kubernetes.io/ingress.class: {{ .Values.ingress.class }}
 {{- end }}
     nginx.ingress.kubernetes.io/auth-realm: Authentication Required
@@ -19,7 +19,7 @@ metadata:
     component: grafana
     role: {{ .Values.role }}
 spec:
-{{- if semverCompare ">= 1.22" .Capabilities.KubeVersion.GitVersion }}
+{{- if semverCompare ">= 1.22-0" .Capabilities.KubeVersion.GitVersion }}
   ingressClassName: {{ .Values.ingress.class }}
 {{- end }}
   tls:


### PR DESCRIPTION
/kind/bug
/area/control-plane

Cherry pick of #4676 on release-v1.31.

#4676: Fix ingress class handling

**Release Notes:**
```bugfix operator
A bug has been fixed that did not add the required ingress class in some seed clusters that are not Gardener managed.
```