### PR TITLE
Set DenyInvalidExtensionResources feature gate to true for local setup

### DIFF
--- a/example/20-componentconfig-gardenlet.yaml
+++ b/example/20-componentconfig-gardenlet.yaml
@@ -101,6 +101,7 @@ featureGates:
   SeedKubeScheduler: false
   ReversedVPN: false
   UseDNSRecords: true
+  DenyInvalidExtensionResources: true
 # seedConfig:
 #   metadata:
 #     name: my-seed

--- a/hack/local-development/start-seed-admission-controller
+++ b/hack/local-development/start-seed-admission-controller
@@ -26,4 +26,5 @@ GO111MODULE=on \
       -ldflags "$(./hack/get-build-ld-flags.sh)" \
       "$(dirname $0)"/../../cmd/gardener-seed-admission-controller/main.go \
       --kubeconfig="${KUBECONFIG:-$kubeconfig}" \
-      --tls-cert-dir="$(dirname $0)/../../example/seed-admission-controller"
+      --tls-cert-dir="$(dirname $0)/../../example/seed-admission-controller" \
+      --allow-invalid-extension-resources=false


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Set the feature gate `DenyInvalidExtensionResources` to true for the local dev setup so the webhook for the extension resources to work locally:
  - `DenyInvalidExtensionResources` feature gate to true;
  - `--allow-invalid-extension-resources` to false.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

/cc @stoyanr 