### PR TITLE
Fix CSR approval in GCM for v1 API version

### DIFF
--- a/pkg/controllermanager/controller/certificatesigningrequest/csr_autoapprove_control.go
+++ b/pkg/controllermanager/controller/certificatesigningrequest/csr_autoapprove_control.go
@@ -35,6 +35,7 @@ import (
 	authorizationv1 "k8s.io/api/authorization/v1"
 	certificatesv1 "k8s.io/api/certificates/v1"
 	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -114,6 +115,7 @@ func (r *csrReconciler) Reconcile(ctx context.Context, request reconcile.Request
 				Type:    certificatesv1.CertificateApproved,
 				Reason:  "AutoApproved",
 				Message: "Auto approving gardenlet client certificate after SubjectAccessReview.",
+				Status:  v1.ConditionTrue,
 			})
 			_, err := r.gardenClient.Kubernetes().CertificatesV1().CertificateSigningRequests().UpdateApproval(ctx, csrV1.Name, csrV1, kubernetes.DefaultUpdateOptions())
 			return err


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness ops-productivity
/kind bug
/priority 1

**What this PR does / why we need it**:
Fix CSR approval in GCM for v1 API version by populating the mandatory condition field `Status`.

**Which issue(s) this PR fixes**:
Fixes #4688 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
