### PR TITLE
Move gardener related docs from g/documentation to g/g

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,7 @@
 * [Dockershim removal](usage/docker-shim-removal.md)
 * [ExposureClasses](usage/exposureclasses.md)
 * [Gardener configuration and usage](usage/configuration.md)
+* [Hibernate a Cluster](usage/shoot_hibernate.md)
 * [`ManagedIstio` feature](usage/istio.md)
 * [Network Policies in the Shoot Cluster](usage/shoot_network_policies.md)
 * [`NodeLocalDNS` feature](usage/node-local-dns.md)

--- a/docs/usage/shoot_hibernate.md
+++ b/docs/usage/shoot_hibernate.md
@@ -1,0 +1,50 @@
+---
+title: Hibernate a Cluster
+level: beginner
+category: Operation
+scope: operator
+tags: ["task"]
+publishdate: 2020-11-19
+---
+# Hibernate a Cluster
+
+Clusters are only needed 24 hours a day if they run productive workload. So whenever you do development in a cluster, or just use it for tests or demo purposes, you can save much money if you scale-down your Kubernetes resources whenever you don't need them. However, scaling them down manually can become time-consuming the more resources you have. 
+
+Gardener offers a clever way to automatically scale-down all resources to zero: cluster hibernation. You can either hibernate a cluster by pushing a button or by defining a hibernation schedule.
+
+> To save costs, it's recommended to define a hibernation schedule before the creation of a cluster. You can hibernate your cluster or wake up your cluster manually even if there's a schedule for its hibernation.
+
+- [What is hibernated?](#what-is-hibernated)
+- [What isn’t affected by the hibernation?](#what-isnt-affected-by-the-hibernation)
+- [Hibernate your cluster manually](#hibernate-your-cluster-manually)
+- [Wake up your cluster manually](#wake-up-your-cluster-manually)
+- [Create a schedule to hibernate your cluster](#create-a-schedule-to-hibernate-your-cluster)
+
+
+## What is hibernated?
+
+When a cluster is hibernated, Gardener scales down worker nodes and the cluster's control plane to free resources at the IaaS provider. This affects:
+
+* Your workload, for example, pods, deployments, custom resources.
+* The virtual machines running your workload.
+* The resources of the control plane of your cluster.
+
+## What isn’t affected by the hibernation?
+
+To scale up everything where it was before hibernation, Gardener doesn’t delete state-related information, that is, information stored in persistent volumes. The cluster state as persistent in `etcd` is also preserved.
+
+## Hibernate your cluster manually
+
+To hibernate your cluster you can run the following `kubectl` command:
+```
+$ kubectl patch shoot -n $NAMESPACE $SHOOT_NAME -p '{"spec":{"hibernation":{"enabled": true}}}'
+```
+
+## Wake up your cluster manually
+
+To wake up your cluster you can run the following `kubectl` command:
+```
+$ kubectl patch shoot -n $NAMESPACE $SHOOT_NAME -p '{"spec":{"hibernation":{"enabled": false}}}'
+```
+
+**Hibernation schedule is also supported. More details can be found [here](../../pkg/apis/core/v1beta1/types_shoot.go#L335-L348)**


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
Our plan is to move all the documentation from gardener/documentation repo to the repo it belongs.
In this way we will leave in the documentation repo only pages like: blogs, adopters, community
All other documents will be transferred to the related repos and will be maintained from the repo's maintainers.
The next step will be to link the documentation folder directly from the repos (The idea behind docforge).

Please review this PR and give me your feedback if there is a files you do not recognise as gardener specific.

I will open this PR as DRAFT, because currently the relative links will not work. Once I receive your approval with this change, I will fix them and will mark the PR as ready for review.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@n-boshnakov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
None
```
