### PR TITLE
Optimize finalizer addition

### DIFF
--- a/pkg/controllermanager/controller/cloudprofile/cloudprofile_control_test.go
+++ b/pkg/controllermanager/controller/cloudprofile/cloudprofile_control_test.go
@@ -193,7 +193,7 @@ var _ = Describe("Controller", func() {
 				errToReturn := apierrors.NewNotFound(schema.GroupResource{}, cloudProfileName)
 
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
-					Expect(patch.Data(o)).To(BeEquivalentTo(fmt.Sprintf(`{"metadata":{"finalizers":["%s"],"resourceVersion":"42"}}`, finalizerName)))
+					Expect(patch.Data(o)).To(BeEquivalentTo(fmt.Sprintf(`{"metadata":{"finalizers":["%s"]}}`, finalizerName)))
 					return errToReturn
 				})
 
@@ -204,7 +204,7 @@ var _ = Describe("Controller", func() {
 
 			It("should ensure the finalizer (no error)", func() {
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.CloudProfile{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
-					Expect(patch.Data(o)).To(BeEquivalentTo(fmt.Sprintf(`{"metadata":{"finalizers":["%s"],"resourceVersion":"42"}}`, finalizerName)))
+					Expect(patch.Data(o)).To(BeEquivalentTo(fmt.Sprintf(`{"metadata":{"finalizers":["%s"]}}`, finalizerName)))
 					return nil
 				})
 

--- a/pkg/controllermanager/controller/controllerdeployment/controllerdeployment_control.go
+++ b/pkg/controllermanager/controller/controllerdeployment/controllerdeployment_control.go
@@ -90,5 +90,9 @@ func (c *controllerDeploymentReconciler) Reconcile(ctx context.Context, req reco
 		return reconcile.Result{}, controllerutils.PatchRemoveFinalizers(ctx, c.gardenClient, controllerDeployment, FinalizerName)
 	}
 
-	return reconcile.Result{}, controllerutils.PatchAddFinalizers(ctx, c.gardenClient, controllerDeployment, FinalizerName)
+	if !controllerutil.ContainsFinalizer(controllerDeployment, FinalizerName) {
+		return reconcile.Result{}, controllerutils.StrategicMergePatchAddFinalizers(ctx, c.gardenClient, controllerDeployment, FinalizerName)
+	}
+
+	return reconcile.Result{}, nil
 }

--- a/pkg/controllermanager/controller/controllerdeployment/controllerdeployment_control_test.go
+++ b/pkg/controllermanager/controller/controllerdeployment/controllerdeployment_control_test.go
@@ -192,7 +192,7 @@ var _ = Describe("Controller", func() {
 				errToReturn := apierrors.NewNotFound(schema.GroupResource{}, controllerDeploymentName)
 
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerDeployment{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
-					Expect(patch.Data(o)).To(BeEquivalentTo(fmt.Sprintf(`{"metadata":{"finalizers":["%s"],"resourceVersion":"42"}}`, finalizerName)))
+					Expect(patch.Data(o)).To(BeEquivalentTo(fmt.Sprintf(`{"metadata":{"finalizers":["%s"]}}`, finalizerName)))
 					return errToReturn
 				})
 
@@ -203,7 +203,7 @@ var _ = Describe("Controller", func() {
 
 			It("should ensure the finalizer (no error)", func() {
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerDeployment{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
-					Expect(patch.Data(o)).To(BeEquivalentTo(fmt.Sprintf(`{"metadata":{"finalizers":["%s"],"resourceVersion":"42"}}`, finalizerName)))
+					Expect(patch.Data(o)).To(BeEquivalentTo(fmt.Sprintf(`{"metadata":{"finalizers":["%s"]}}`, finalizerName)))
 					return nil
 				})
 

--- a/pkg/controllermanager/controller/controllerregistration/controllerregistration_control.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerregistration_control.go
@@ -93,5 +93,9 @@ func (r *controllerRegistrationReconciler) Reconcile(ctx context.Context, reques
 		return reconcile.Result{}, controllerutils.PatchRemoveFinalizers(ctx, r.gardenClient, controllerRegistration, FinalizerName)
 	}
 
-	return reconcile.Result{}, controllerutils.PatchAddFinalizers(ctx, r.gardenClient, controllerRegistration, FinalizerName)
+	if !controllerutil.ContainsFinalizer(controllerRegistration, FinalizerName) {
+		return reconcile.Result{}, controllerutils.StrategicMergePatchAddFinalizers(ctx, r.gardenClient, controllerRegistration, FinalizerName)
+	}
+
+	return reconcile.Result{}, nil
 }

--- a/pkg/controllermanager/controller/controllerregistration/controllerregistration_control_test.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerregistration_control_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -34,6 +33,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/logger"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 var _ = Describe("Controller", func() {
@@ -250,7 +250,7 @@ var _ = Describe("Controller", func() {
 				errToReturn := apierrors.NewNotFound(schema.GroupResource{}, controllerRegistrationName)
 
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerRegistration{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
-					Expect(patch.Data(o)).To(BeEquivalentTo(fmt.Sprintf(`{"metadata":{"finalizers":["%s"],"resourceVersion":"42"}}`, finalizerName)))
+					Expect(patch.Data(o)).To(BeEquivalentTo(fmt.Sprintf(`{"metadata":{"finalizers":["%s"]}}`, finalizerName)))
 					return errToReturn
 				})
 
@@ -261,7 +261,7 @@ var _ = Describe("Controller", func() {
 
 			It("should ensure the finalizer (no error)", func() {
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerRegistration{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
-					Expect(patch.Data(o)).To(BeEquivalentTo(fmt.Sprintf(`{"metadata":{"finalizers":["%s"],"resourceVersion":"42"}}`, finalizerName)))
+					Expect(patch.Data(o)).To(BeEquivalentTo(fmt.Sprintf(`{"metadata":{"finalizers":["%s"]}}`, finalizerName)))
 					return nil
 				})
 

--- a/pkg/controllermanager/controller/controllerregistration/seed_control.go
+++ b/pkg/controllermanager/controller/controllerregistration/seed_control.go
@@ -108,5 +108,9 @@ func (r *seedReconciler) Reconcile(ctx context.Context, request reconcile.Reques
 		return reconcile.Result{}, controllerutils.PatchRemoveFinalizers(ctx, r.gardenClient, seed, FinalizerName)
 	}
 
-	return reconcile.Result{}, controllerutils.PatchAddFinalizers(ctx, r.gardenClient, seed, FinalizerName)
+	if !controllerutil.ContainsFinalizer(seed, FinalizerName) {
+		return reconcile.Result{}, controllerutils.StrategicMergePatchAddFinalizers(ctx, r.gardenClient, seed, FinalizerName)
+	}
+
+	return reconcile.Result{}, nil
 }

--- a/pkg/controllermanager/controller/controllerregistration/seed_control_test.go
+++ b/pkg/controllermanager/controller/controllerregistration/seed_control_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -34,6 +33,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/logger"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 var _ = Describe("Controller", func() {
@@ -222,7 +222,7 @@ var _ = Describe("seedReconciler", func() {
 				errToReturn := apierrors.NewNotFound(schema.GroupResource{}, seedName)
 
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
-					Expect(patch.Data(o)).To(BeEquivalentTo(fmt.Sprintf(`{"metadata":{"finalizers":["%s"],"resourceVersion":"42"}}`, finalizerName)))
+					Expect(patch.Data(o)).To(BeEquivalentTo(fmt.Sprintf(`{"metadata":{"finalizers":["%s"]}}`, finalizerName)))
 					return errToReturn
 				})
 
@@ -233,7 +233,7 @@ var _ = Describe("seedReconciler", func() {
 
 			It("should ensure the finalizer (no error)", func() {
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
-					Expect(patch.Data(o)).To(BeEquivalentTo(fmt.Sprintf(`{"metadata":{"finalizers":["%s"],"resourceVersion":"42"}}`, finalizerName)))
+					Expect(patch.Data(o)).To(BeEquivalentTo(fmt.Sprintf(`{"metadata":{"finalizers":["%s"]}}`, finalizerName)))
 					return nil
 				})
 

--- a/pkg/controllermanager/controller/managedseedset/managedseedset_reconciler.go
+++ b/pkg/controllermanager/controller/managedseedset/managedseedset_reconciler.go
@@ -75,9 +75,11 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 func (r *reconciler) reconcile(ctx context.Context, set *seedmanagementv1alpha1.ManagedSeedSet) (result reconcile.Result, err error) {
 	// Ensure gardener finalizer
-	r.getLogger(set).Debug("Ensuring finalizer")
-	if err := controllerutils.PatchAddFinalizers(ctx, r.gardenClient.Client(), set, gardencorev1beta1.GardenerName); err != nil {
-		return reconcile.Result{}, fmt.Errorf("could not ensure gardener finalizer: %w", err)
+	if !controllerutil.ContainsFinalizer(set, gardencorev1beta1.GardenerName) {
+		r.getLogger(set).Debug("Ensuring finalizer")
+		if err := controllerutils.StrategicMergePatchAddFinalizers(ctx, r.gardenClient.Client(), set, gardencorev1beta1.GardenerName); err != nil {
+			return reconcile.Result{}, fmt.Errorf("could not ensure gardener finalizer: %w", err)
+		}
 	}
 
 	var status *seedmanagementv1alpha1.ManagedSeedSetStatus

--- a/pkg/controllermanager/controller/managedseedset/managedseedset_reconciler.go
+++ b/pkg/controllermanager/controller/managedseedset/managedseedset_reconciler.go
@@ -76,7 +76,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 func (r *reconciler) reconcile(ctx context.Context, set *seedmanagementv1alpha1.ManagedSeedSet) (result reconcile.Result, err error) {
 	// Ensure gardener finalizer
 	if !controllerutil.ContainsFinalizer(set, gardencorev1beta1.GardenerName) {
-		r.getLogger(set).Debug("Ensuring finalizer")
+		r.getLogger(set).Debug("Adding finalizer")
 		if err := controllerutils.StrategicMergePatchAddFinalizers(ctx, r.gardenClient.Client(), set, gardencorev1beta1.GardenerName); err != nil {
 			return reconcile.Result{}, fmt.Errorf("could not ensure gardener finalizer: %w", err)
 		}

--- a/pkg/controllermanager/controller/shoot/shoot_reference_control.go
+++ b/pkg/controllermanager/controller/shoot/shoot_reference_control.go
@@ -154,7 +154,7 @@ func (r *shootReferenceReconciler) reconcileShootReferences(ctx context.Context,
 	// Manage finalizers on shoot.
 	hasFinalizer := controllerutil.ContainsFinalizer(shoot, FinalizerName)
 	if needsFinalizer && !hasFinalizer {
-		return controllerutils.PatchAddFinalizers(ctx, r.gardenClient.Client(), shoot, FinalizerName)
+		return controllerutils.StrategicMergePatchAddFinalizers(ctx, r.gardenClient.Client(), shoot, FinalizerName)
 	}
 	if !needsFinalizer && hasFinalizer {
 		return controllerutils.PatchRemoveFinalizers(ctx, r.gardenClient.Client(), shoot, FinalizerName)
@@ -188,7 +188,7 @@ func (r *shootReferenceReconciler) handleReferencedSecrets(ctx context.Context, 
 			if controllerutil.ContainsFinalizer(secret, FinalizerName) {
 				return nil
 			}
-			return controllerutils.PatchAddFinalizers(ctx, c, secret, FinalizerName)
+			return controllerutils.StrategicMergePatchAddFinalizers(ctx, c, secret, FinalizerName)
 		})
 	}
 	err := flow.Parallel(fns...)(ctx)
@@ -208,7 +208,7 @@ func (r *shootReferenceReconciler) handleReferencedConfigMap(ctx context.Context
 				return true, nil
 			}
 
-			return true, controllerutils.PatchAddFinalizers(ctx, c, configMap, FinalizerName)
+			return true, controllerutils.StrategicMergePatchAddFinalizers(ctx, c, configMap, FinalizerName)
 		}
 	}
 

--- a/pkg/controllerutils/finalizers.go
+++ b/pkg/controllerutils/finalizers.go
@@ -23,23 +23,23 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// PatchAddFinalizers adds the given finalizers to the object via a patch request.
+// PatchAddFinalizers adds the given finalizers to the object via a merge patch request with optimistic locking.
 func PatchAddFinalizers(ctx context.Context, writer client.Writer, obj client.Object, finalizers ...string) error {
-	return patchFinalizers(ctx, writer, obj, controllerutil.AddFinalizer, finalizers...)
+	return patchFinalizers(ctx, writer, obj, mergeFromWithOptimisticLock, controllerutil.AddFinalizer, finalizers...)
 }
 
-// PatchRemoveFinalizers removes the given finalizers from the object via a patch request.
+// PatchRemoveFinalizers removes the given finalizers from the object via a merge patch request with optimistic locking.
 func PatchRemoveFinalizers(ctx context.Context, writer client.Writer, obj client.Object, finalizers ...string) error {
-	return patchFinalizers(ctx, writer, obj, controllerutil.RemoveFinalizer, finalizers...)
+	return patchFinalizers(ctx, writer, obj, mergeFromWithOptimisticLock, controllerutil.RemoveFinalizer, finalizers...)
 }
 
-func patchFinalizers(ctx context.Context, writer client.Writer, obj client.Object, mutate func(client.Object, string), finalizers ...string) error {
+func patchFinalizers(ctx context.Context, writer client.Writer, obj client.Object, patchFunc patchFn, mutate func(client.Object, string), finalizers ...string) error {
 	beforePatch := obj.DeepCopyObject().(client.Object)
 	for _, finalizer := range finalizers {
 		mutate(obj, finalizer)
 	}
 
-	return writer.Patch(ctx, obj, client.MergeFromWithOptions(beforePatch, client.MergeFromWithOptimisticLock{}))
+	return writer.Patch(ctx, obj, patchFunc(beforePatch))
 }
 
 // EnsureFinalizer ensures that a finalizer of the given name is set on the given object with exponential backoff.
@@ -75,7 +75,7 @@ func tryPatchFinalizers(ctx context.Context, reader client.Reader, writer client
 			return err
 		}
 
-		return patchFinalizers(ctx, writer, obj, mutate, finalizer)
+		return patchFinalizers(ctx, writer, obj, mergeFromWithOptimisticLock, mutate, finalizer)
 	})
 }
 
@@ -91,5 +91,5 @@ func tryPatchObject(ctx context.Context, reader client.Reader, writer client.Wri
 func patchObject(ctx context.Context, writer client.Writer, obj client.Object, mutate func(client.Object)) error {
 	beforePatch := obj.DeepCopyObject().(client.Object)
 	mutate(obj)
-	return writer.Patch(ctx, obj, client.MergeFromWithOptions(beforePatch, client.MergeFromWithOptimisticLock{}))
+	return writer.Patch(ctx, obj, mergeFromWithOptimisticLock(beforePatch))
 }

--- a/pkg/gardenlet/controller/backupentry/backup_entry_reconciler.go
+++ b/pkg/gardenlet/controller/backupentry/backup_entry_reconciler.go
@@ -110,7 +110,7 @@ func (r *reconciler) reconcileBackupEntry(ctx context.Context, gardenClient kube
 	backupEntryLogger := logger.NewFieldLogger(r.logger, "backupentry", kutil.ObjectName(backupEntry))
 
 	if !controllerutil.ContainsFinalizer(backupEntry, gardencorev1beta1.GardenerName) {
-		if err := controllerutils.PatchAddFinalizers(ctx, gardenClient.Client(), backupEntry, gardencorev1beta1.GardenerName); err != nil {
+		if err := controllerutils.StrategicMergePatchAddFinalizers(ctx, gardenClient.Client(), backupEntry, gardencorev1beta1.GardenerName); err != nil {
 			backupEntryLogger.Errorf("Failed to ensure gardener finalizer on backupentry: %+v", err)
 			return reconcile.Result{}, err
 		}

--- a/pkg/gardenlet/controller/bastion/bastion_reconciler.go
+++ b/pkg/gardenlet/controller/bastion/bastion_reconciler.go
@@ -131,7 +131,7 @@ func (r *reconciler) reconcileBastion(
 
 	// ensure finalizer is set
 	if !controllerutil.ContainsFinalizer(bastion, finalizerName) {
-		if err := controllerutils.PatchAddFinalizers(ctx, gardenClient, bastion, finalizerName); err != nil {
+		if err := controllerutils.StrategicMergePatchAddFinalizers(ctx, gardenClient, bastion, finalizerName); err != nil {
 			return fmt.Errorf("failed ensure %q finalizer on bastion: %w", finalizerName, err)
 		}
 		// the patch above already triggers a reconcile, so we can stop here

--- a/pkg/gardenlet/controller/managedseed/managedseed_reconciler.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_reconciler.go
@@ -71,7 +71,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 func (r *reconciler) reconcile(ctx context.Context, ms *seedmanagementv1alpha1.ManagedSeed) (result reconcile.Result, err error) {
 	// Ensure gardener finalizer
 	if !controllerutil.ContainsFinalizer(ms, gardencorev1beta1.GardenerName) {
-		r.getLogger(ms).Debug("Ensuring finalizer")
+		r.getLogger(ms).Debug("Adding finalizer")
 		if err := controllerutils.StrategicMergePatchAddFinalizers(ctx, r.gardenClient.Client(), ms, gardencorev1beta1.GardenerName); err != nil {
 			return reconcile.Result{}, fmt.Errorf("could not ensure gardener finalizer: %w", err)
 		}

--- a/pkg/gardenlet/controller/managedseed/managedseed_reconciler.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_reconciler.go
@@ -70,9 +70,11 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 func (r *reconciler) reconcile(ctx context.Context, ms *seedmanagementv1alpha1.ManagedSeed) (result reconcile.Result, err error) {
 	// Ensure gardener finalizer
-	r.getLogger(ms).Debug("Ensuring finalizer")
-	if err := controllerutils.PatchAddFinalizers(ctx, r.gardenClient.Client(), ms, gardencorev1beta1.GardenerName); err != nil {
-		return reconcile.Result{}, fmt.Errorf("could not ensure gardener finalizer: %w", err)
+	if !controllerutil.ContainsFinalizer(ms, gardencorev1beta1.GardenerName) {
+		r.getLogger(ms).Debug("Ensuring finalizer")
+		if err := controllerutils.StrategicMergePatchAddFinalizers(ctx, r.gardenClient.Client(), ms, gardencorev1beta1.GardenerName); err != nil {
+			return reconcile.Result{}, fmt.Errorf("could not ensure gardener finalizer: %w", err)
+		}
 	}
 
 	var status *seedmanagementv1alpha1.ManagedSeedStatus

--- a/pkg/gardenlet/controller/shoot/shoot_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control.go
@@ -427,7 +427,7 @@ func (c *Controller) reconcileShoot(ctx context.Context, logger logrus.FieldLogg
 	)
 
 	if !controllerutil.ContainsFinalizer(shoot, gardencorev1beta1.GardenerName) {
-		if err := controllerutils.PatchAddFinalizers(ctx, gardenClient.Client(), shoot.DeepCopy(), gardencorev1beta1.GardenerName); err != nil {
+		if err := controllerutils.StrategicMergePatchAddFinalizers(ctx, gardenClient.Client(), shoot, gardencorev1beta1.GardenerName); err != nil {
 			return reconcile.Result{}, fmt.Errorf("could not add finalizer to Shoot: %s", err.Error())
 		}
 		return reconcile.Result{}, nil


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement

**What this PR does / why we need it**:

This PR optimizes how gardener adds finalizers on k-api and g-api resources:
- switch to strategic merge patch for adding finalizers to make use of the `merge` directive on `metadata.finalizers` and run without optimistic locking
- don't patch object if finalizer is already present

The goal is to minimize conflicts, especially on the start of reconciliations.
In our dev landscape, I observed the following numbers of conflicts caused by finalizer addition from the logs of gardener-controller-manager and gardenlet over 6 hours:
```
$ cat /tmp/conflicts-gardenlet | grep -i 'finalizer' | sed -E 's/^.*Operation cannot be fulfilled on ([^ ]*).*$/\1/' | sort | uniq -c
     10 backupentries.core.gardener.cloud
     53 shoots.core.gardener.cloud
$ cat /tmp/conflicts-gcm | grep -i 'finalizer' | sed -E 's/^.*Operation cannot be fulfilled on ([^ ]*).*$/\1/' | sort | uniq -c
   1432 plants.core.gardener.cloud
```

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2822

**Special notes for your reviewer**:
/squash

Note the comment on `StrategicMergePatchAddFinalizers`:

> we can't do the same for removing finalizers, because removing the last finalizer results in the following patch: `{"metadata":{"finalizers":null}}` which is not safe to issue without optimistic locking.
> Also, `$deleteFromPrimitiveList` is not idempotent, see https://github.com/kubernetes/kubernetes/issues/105146.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
