### PR TITLE
Log feature gates on gardener-apiserver startup

### DIFF
--- a/cmd/gardener-admission-controller/app/gardener_admission_controller.go
+++ b/cmd/gardener-admission-controller/app/gardener_admission_controller.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/component-base/version"
 	"k8s.io/component-base/version/verflag"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -121,6 +122,8 @@ func (o *options) validate() error {
 // run runs gardener-admission-controller using the specified options.
 func (o *options) run(ctx context.Context) error {
 	log := logf.Log
+
+	log.Info("Starting Gardener admission controller...", "version", version.Get())
 
 	log.Info("getting rest config")
 	if kubeconfig := os.Getenv("KUBECONFIG"); kubeconfig != "" {

--- a/cmd/gardener-apiserver/app/gardener_apiserver.go
+++ b/cmd/gardener-apiserver/app/gardener_apiserver.go
@@ -40,6 +40,7 @@ import (
 	seedmanagementinformer "github.com/gardener/gardener/pkg/client/seedmanagement/informers/externalversions"
 	settingsclientset "github.com/gardener/gardener/pkg/client/settings/clientset/versioned"
 	settingsinformer "github.com/gardener/gardener/pkg/client/settings/informers/externalversions"
+	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/openapi"
 
 	"github.com/spf13/cobra"
@@ -247,6 +248,11 @@ func (o *Options) config(kubeAPIServerConfig *rest.Config, kubeClient *kubernete
 
 // Run runs gardener-apiserver with the given Options.
 func (o *Options) Run(ctx context.Context) error {
+	logger := logger.NewLogger("", "")
+	logger.Info("Starting Gardener API server...")
+	logger.Infof("Version: %+v", version.Get())
+	logger.Infof("Feature Gates: %s", utilfeature.DefaultFeatureGate)
+
 	// Create clientset for the native Kubernetes API group
 	// Use remote kubeconfig file (if set) or in-cluster config to create a new Kubernetes client for the native Kubernetes API groups
 	kubeAPIServerConfig, err := clientcmd.BuildConfigFromFlags("", o.Recommended.CoreAPI.CoreAPIKubeconfigPath)

--- a/cmd/gardener-controller-manager/app/gardener_controller_manager.go
+++ b/cmd/gardener-controller-manager/app/gardener_controller_manager.go
@@ -47,6 +47,7 @@ import (
 	kubernetesclientset "k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/leaderelection"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/component-base/version"
 	"k8s.io/component-base/version/verflag"
 )
 
@@ -206,6 +207,7 @@ func NewGardener(ctx context.Context, cfg *config.ControllerManagerConfiguration
 	// Initialize logger
 	logger := logger.NewLogger(cfg.LogLevel, cfg.LogFormat)
 	logger.Info("Starting Gardener controller manager...")
+	logger.Infof("Version: %+v", version.Get())
 	logger.Infof("Feature Gates: %s", controllermanagerfeatures.FeatureGate.String())
 
 	if flag := flag.Lookup("v"); flag != nil {

--- a/cmd/gardener-scheduler/app/gardener_scheduler.go
+++ b/cmd/gardener-scheduler/app/gardener_scheduler.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"k8s.io/component-base/version"
 	"k8s.io/component-base/version/verflag"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	ctrlruntimelog "sigs.k8s.io/controller-runtime/pkg/log"
@@ -117,7 +118,8 @@ func runCommand(ctx context.Context, opts *Options) error {
 	zapLogr := logger.NewZapLogr(zapLogger)
 	ctrlruntimelog.SetLogger(zapLogr)
 
-	zapLogr.Info("Starting Gardener scheduler ...", "features", schedulerfeatures.FeatureGate.String())
+	zapLogr.Info("Starting Gardener scheduler...", "version", version.Get())
+	zapLogr.Info("Feature Gates", "featureGates", schedulerfeatures.FeatureGate.String())
 
 	// Prepare a Kubernetes client object for the Garden cluster which contains all the Clientsets
 	// that can be used to access the Kubernetes API.

--- a/cmd/gardener-seed-admission-controller/app/gardener_seed_admission_controller.go
+++ b/cmd/gardener-seed-admission-controller/app/gardener_seed_admission_controller.go
@@ -24,6 +24,7 @@ import (
 	"github.com/spf13/pflag"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
+	"k8s.io/component-base/version"
 	"k8s.io/component-base/version/verflag"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -131,6 +132,8 @@ func (o *Options) validate() error {
 // Run runs gardener-seed-admission-controller using the specified options.
 func (o *Options) Run(ctx context.Context) error {
 	log := logf.Log
+
+	log.Info("Starting Gardener Seed admission controller...", "version", version.Get())
 
 	log.Info("getting rest config")
 	restConfig, err := config.GetConfig()

--- a/cmd/gardenlet/app/gardenlet.go
+++ b/cmd/gardenlet/app/gardenlet.go
@@ -240,6 +240,7 @@ func NewGardenlet(ctx context.Context, cfg *config.GardenletConfiguration) (*Gar
 	// Initialize logger
 	logger := logger.NewLogger(*cfg.LogLevel, *cfg.LogFormat)
 	logger.Info("Starting Gardenlet...")
+	logger.Infof("Version: %+v", version.Get())
 	logger.Infof("Feature Gates: %s", gardenletfeatures.FeatureGate.String())
 
 	if flag := flag.Lookup("v"); flag != nil {


### PR DESCRIPTION
/area ops-productivity usability
/kind enhancement

Fixes #4579

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
