### PR TITLE
kube-apiserver: Adapted initial delay seconds of livenessProbe to livez-grace-period

### DIFF
--- a/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
+++ b/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml
@@ -194,7 +194,11 @@ spec:
               value: Bearer {{ .Values.probeCredentials }}
           successThreshold: 1
           failureThreshold: 3
+          {{- if semverCompare ">= 1.16" .Values.kubernetesVersion }}
+          initialDelaySeconds: 60
+          {{- else }}
           initialDelaySeconds: 15
+          {{- end }}
           periodSeconds: 10
           timeoutSeconds: 15
         readinessProbe:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind cleanup

**What this PR does / why we need it**:
This pull request adapts the initial delay of the kube-apiservers liveness probe to the grace period of the livez endpoint defined in the kube-apiserver args.  

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
Relates to  https://github.com/gardener/gardener/blob/7145aa25f9523945ec7bfbd257ec9101176ade4c/charts/seed-controlplane/charts/kube-apiserver/templates/deployment.yaml#L142

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Liveness probe of kube-apiserver is now adapted to the grace period of the /livez endpoint.
```
