### PR TITLE
[release-v1.31] Automated cherry pick of #4663: Fix migration of extension resources

### DIFF
--- a/extensions/pkg/controller/backupentry/reconciler.go
+++ b/extensions/pkg/controller/backupentry/reconciler.go
@@ -99,15 +99,11 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	operationType := gardencorev1beta1helper.ComputeOperationType(be.ObjectMeta, be.Status.LastOperation)
 
 	switch {
+	case extensionscontroller.ShouldSkipOperation(operationType, be):
+		return reconcile.Result{}, nil
 	case operationType == gardencorev1beta1.LastOperationTypeMigrate:
-		if extensionscontroller.IsMigrated(be) {
-			return reconcile.Result{}, nil
-		}
 		return r.migrate(ctx, be)
 	case be.DeletionTimestamp != nil:
-		if extensionscontroller.IsMigrated(be) {
-			return reconcile.Result{}, nil
-		}
 		return r.delete(ctx, be)
 	case operationType == gardencorev1beta1.LastOperationTypeRestore:
 		return r.restore(ctx, be)

--- a/extensions/pkg/controller/containerruntime/reconciler.go
+++ b/extensions/pkg/controller/containerruntime/reconciler.go
@@ -100,15 +100,11 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	operationType := gardencorev1beta1helper.ComputeOperationType(cr.ObjectMeta, cr.Status.LastOperation)
 
 	switch {
+	case extensionscontroller.ShouldSkipOperation(operationType, cr):
+		return reconcile.Result{}, nil
 	case operationType == gardencorev1beta1.LastOperationTypeMigrate:
-		if extensionscontroller.IsMigrated(cr) {
-			return reconcile.Result{}, nil
-		}
 		return r.migrate(ctx, cr, cluster)
 	case cr.DeletionTimestamp != nil:
-		if extensionscontroller.IsMigrated(cr) {
-			return reconcile.Result{}, nil
-		}
 		return r.delete(ctx, cr, cluster)
 	case operationType == gardencorev1beta1.LastOperationTypeRestore:
 		return r.restore(ctx, cr, cluster)

--- a/extensions/pkg/controller/controlplane/reconciler.go
+++ b/extensions/pkg/controller/controlplane/reconciler.go
@@ -100,15 +100,11 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	operationType := gardencorev1beta1helper.ComputeOperationType(cp.ObjectMeta, cp.Status.LastOperation)
 
 	switch {
+	case extensionscontroller.ShouldSkipOperation(operationType, cp):
+		return reconcile.Result{}, nil
 	case operationType == gardencorev1beta1.LastOperationTypeMigrate:
-		if extensionscontroller.IsMigrated(cp) {
-			return reconcile.Result{}, nil
-		}
 		return r.migrate(ctx, cp, cluster)
 	case cp.DeletionTimestamp != nil:
-		if extensionscontroller.IsMigrated(cp) {
-			return reconcile.Result{}, nil
-		}
 		return r.delete(ctx, cp, cluster)
 	case operationType == gardencorev1beta1.LastOperationTypeRestore:
 		return r.restore(ctx, cp, cluster)

--- a/extensions/pkg/controller/dnsrecord/reconciler.go
+++ b/extensions/pkg/controller/dnsrecord/reconciler.go
@@ -101,15 +101,11 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	operationType := gardencorev1beta1helper.ComputeOperationType(dns.ObjectMeta, dns.Status.LastOperation)
 
 	switch {
+	case extensionscontroller.ShouldSkipOperation(operationType, dns):
+		return reconcile.Result{}, nil
 	case operationType == gardencorev1beta1.LastOperationTypeMigrate:
-		if extensionscontroller.IsMigrated(dns) {
-			return reconcile.Result{}, nil
-		}
 		return r.migrate(ctx, dns, cluster)
 	case dns.DeletionTimestamp != nil:
-		if extensionscontroller.IsMigrated(dns) {
-			return reconcile.Result{}, nil
-		}
 		return r.delete(ctx, dns, cluster)
 	case operationType == gardencorev1beta1.LastOperationTypeRestore:
 		return r.restore(ctx, dns, cluster)

--- a/extensions/pkg/controller/extension/reconciler.go
+++ b/extensions/pkg/controller/extension/reconciler.go
@@ -188,15 +188,11 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	operationType := gardencorev1beta1helper.ComputeOperationType(ex.ObjectMeta, ex.Status.LastOperation)
 
 	switch {
+	case extensionscontroller.ShouldSkipOperation(operationType, ex):
+		return reconcile.Result{}, nil
 	case operationType == gardencorev1beta1.LastOperationTypeMigrate:
-		if extensionscontroller.IsMigrated(ex) {
-			return reconcile.Result{}, nil
-		}
 		return r.migrate(ctx, ex)
 	case ex.DeletionTimestamp != nil:
-		if extensionscontroller.IsMigrated(ex) {
-			return reconcile.Result{}, nil
-		}
 		return r.delete(ctx, ex)
 	case operationType == gardencorev1beta1.LastOperationTypeRestore:
 		return r.restore(ctx, ex, operationType)

--- a/extensions/pkg/controller/infrastructure/reconciler.go
+++ b/extensions/pkg/controller/infrastructure/reconciler.go
@@ -105,15 +105,11 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	operationType := gardencorev1beta1helper.ComputeOperationType(infrastructure.ObjectMeta, infrastructure.Status.LastOperation)
 
 	switch {
+	case extensionscontroller.ShouldSkipOperation(operationType, infrastructure):
+		return reconcile.Result{}, nil
 	case operationType == gardencorev1beta1.LastOperationTypeMigrate:
-		if extensionscontroller.IsMigrated(infrastructure) {
-			return reconcile.Result{}, nil
-		}
 		return r.migrate(ctx, logger.WithValues("operation", "migrate"), infrastructure, cluster)
 	case infrastructure.DeletionTimestamp != nil:
-		if extensionscontroller.IsMigrated(infrastructure) {
-			return reconcile.Result{}, nil
-		}
 		return r.delete(ctx, logger.WithValues("operation", "delete"), infrastructure, cluster)
 	case operationType == gardencorev1beta1.LastOperationTypeRestore:
 		return r.restore(ctx, logger.WithValues("operation", "restore"), infrastructure, cluster)

--- a/extensions/pkg/controller/network/reconciler.go
+++ b/extensions/pkg/controller/network/reconciler.go
@@ -96,15 +96,11 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	operationType := gardencorev1beta1helper.ComputeOperationType(network.ObjectMeta, network.Status.LastOperation)
 
 	switch {
+	case extensionscontroller.ShouldSkipOperation(operationType, network):
+		return reconcile.Result{}, nil
 	case operationType == gardencorev1beta1.LastOperationTypeMigrate:
-		if extensionscontroller.IsMigrated(network) {
-			return reconcile.Result{}, nil
-		}
 		return r.migrate(ctx, network, cluster)
 	case network.DeletionTimestamp != nil:
-		if extensionscontroller.IsMigrated(network) {
-			return reconcile.Result{}, nil
-		}
 		return r.delete(ctx, network, cluster)
 	case operationType == gardencorev1beta1.LastOperationTypeRestore:
 		return r.restore(ctx, network, cluster)

--- a/extensions/pkg/controller/operatingsystemconfig/reconciler.go
+++ b/extensions/pkg/controller/operatingsystemconfig/reconciler.go
@@ -110,15 +110,11 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	operationType := gardencorev1beta1helper.ComputeOperationType(osc.ObjectMeta, osc.Status.LastOperation)
 
 	switch {
+	case extensionscontroller.ShouldSkipOperation(operationType, osc):
+		return reconcile.Result{}, nil
 	case operationType == gardencorev1beta1.LastOperationTypeMigrate:
-		if extensionscontroller.IsMigrated(osc) {
-			return reconcile.Result{}, nil
-		}
 		return r.migrate(ctx, osc)
 	case osc.DeletionTimestamp != nil:
-		if extensionscontroller.IsMigrated(osc) {
-			return reconcile.Result{}, nil
-		}
 		return r.delete(ctx, osc)
 	case operationType == gardencorev1beta1.LastOperationTypeRestore:
 		return r.restore(ctx, osc)

--- a/extensions/pkg/controller/utils.go
+++ b/extensions/pkg/controller/utils.go
@@ -185,6 +185,11 @@ func IsMigrated(obj extensionsv1alpha1.Object) bool {
 		lastOp.State == gardencorev1beta1.LastOperationStateSucceeded
 }
 
+// ShouldSkipOperation checks if the current operation should be skipped depending on the lastOperation of the extension object.
+func ShouldSkipOperation(operationType gardencorev1beta1.LastOperationType, obj extensionsv1alpha1.Object) bool {
+	return operationType != gardencorev1beta1.LastOperationTypeMigrate && operationType != gardencorev1beta1.LastOperationTypeRestore && IsMigrated(obj)
+}
+
 // GetObjectByReference gets an object by the given reference, in the given namespace.
 // If the object kind doesn't match the given reference kind this will result in an error.
 func GetObjectByReference(ctx context.Context, c client.Client, ref *autoscalingv1.CrossVersionObjectReference, namespace string, obj client.Object) error {

--- a/extensions/pkg/controller/utils_test.go
+++ b/extensions/pkg/controller/utils_test.go
@@ -180,6 +180,128 @@ var _ = Describe("Utils", func() {
 		})
 	})
 
+	Describe("#ShouldSkipOperation", func() {
+		var (
+			worker *extensionsv1alpha1.Worker
+		)
+
+		BeforeEach(func() {
+			worker = &extensionsv1alpha1.Worker{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Worker",
+					APIVersion: "TestApi",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-worker",
+					Namespace: "test-namespace",
+				},
+			}
+		})
+
+		Context("reconcile operation", func() {
+			var (
+				operationType = gardencorev1beta1.LastOperationTypeReconcile
+			)
+
+			It("should return false when lastOperation is missing", func() {
+				Expect(controller.ShouldSkipOperation(operationType, worker)).To(BeFalse())
+			})
+
+			It("should return true when lastOperation is migrate and succeeded", func() {
+				worker.Status.LastOperation = &gardencorev1beta1.LastOperation{
+					Type:  gardencorev1beta1.LastOperationTypeMigrate,
+					State: gardencorev1beta1.LastOperationStateSucceeded,
+				}
+				Expect(controller.ShouldSkipOperation(operationType, worker)).To(BeTrue())
+			})
+
+			It("should return false when lastOperation is not migrate", func() {
+				worker.Status.LastOperation = &gardencorev1beta1.LastOperation{
+					Type: gardencorev1beta1.LastOperationTypeRestore,
+				}
+				Expect(controller.ShouldSkipOperation(operationType, worker)).To(BeFalse())
+			})
+		})
+
+		Context("restore operation", func() {
+			var (
+				operationType = gardencorev1beta1.LastOperationTypeRestore
+			)
+
+			It("should return false when lastOperation is missing", func() {
+				Expect(controller.ShouldSkipOperation(operationType, worker)).To(BeFalse())
+			})
+
+			It("should return false when lastOperation is migrate and succeeded", func() {
+				worker.Status.LastOperation = &gardencorev1beta1.LastOperation{
+					Type:  gardencorev1beta1.LastOperationTypeMigrate,
+					State: gardencorev1beta1.LastOperationStateSucceeded,
+				}
+				Expect(controller.ShouldSkipOperation(operationType, worker)).To(BeFalse())
+			})
+
+			It("should return false when lastOperation is not migrate", func() {
+				worker.Status.LastOperation = &gardencorev1beta1.LastOperation{
+					Type:  gardencorev1beta1.LastOperationTypeReconcile,
+					State: gardencorev1beta1.LastOperationStateSucceeded,
+				}
+				Expect(controller.ShouldSkipOperation(operationType, worker)).To(BeFalse())
+			})
+		})
+
+		Context("delete operation", func() {
+			var (
+				operationType = gardencorev1beta1.LastOperationTypeDelete
+			)
+
+			It("should return false when lastOperation is missing", func() {
+				Expect(controller.ShouldSkipOperation(operationType, worker)).To(BeFalse())
+			})
+
+			It("should return true when lastOperation is migrate and succeeded", func() {
+				worker.Status.LastOperation = &gardencorev1beta1.LastOperation{
+					Type:  gardencorev1beta1.LastOperationTypeMigrate,
+					State: gardencorev1beta1.LastOperationStateSucceeded,
+				}
+				Expect(controller.ShouldSkipOperation(operationType, worker)).To(BeTrue())
+			})
+
+			It("should return false when lastOperation is not migrate", func() {
+				worker.Status.LastOperation = &gardencorev1beta1.LastOperation{
+					Type:  gardencorev1beta1.LastOperationTypeReconcile,
+					State: gardencorev1beta1.LastOperationStateSucceeded,
+				}
+				Expect(controller.ShouldSkipOperation(operationType, worker)).To(BeFalse())
+			})
+		})
+
+		Context("migrate operation", func() {
+			var (
+				operationType = gardencorev1beta1.LastOperationTypeRestore
+			)
+
+			It("should return false when lastOperation is missing", func() {
+				Expect(controller.ShouldSkipOperation(operationType, worker)).To(BeFalse())
+			})
+
+			It("should return false when lastOperation is migrate and succeeded", func() {
+				worker.Status.LastOperation = &gardencorev1beta1.LastOperation{
+					Type:  gardencorev1beta1.LastOperationTypeMigrate,
+					State: gardencorev1beta1.LastOperationStateSucceeded,
+				}
+				Expect(controller.ShouldSkipOperation(operationType, worker)).To(BeFalse())
+			})
+
+			It("should return false when lastOperation is not migrate", func() {
+				worker.Status.LastOperation = &gardencorev1beta1.LastOperation{
+					Type:  gardencorev1beta1.LastOperationTypeReconcile,
+					State: gardencorev1beta1.LastOperationStateSucceeded,
+				}
+				Expect(controller.ShouldSkipOperation(operationType, worker)).To(BeFalse())
+			})
+		})
+	})
+
 	Describe("#IsMigrated", func() {
 		var (
 			worker *extensionsv1alpha1.Worker

--- a/extensions/pkg/controller/worker/reconciler.go
+++ b/extensions/pkg/controller/worker/reconciler.go
@@ -97,15 +97,11 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	operationType := gardencorev1beta1helper.ComputeOperationType(worker.ObjectMeta, worker.Status.LastOperation)
 
 	switch {
+	case extensionscontroller.ShouldSkipOperation(operationType, worker):
+		return reconcile.Result{}, nil
 	case operationType == gardencorev1beta1.LastOperationTypeMigrate:
-		if extensionscontroller.IsMigrated(worker) {
-			return reconcile.Result{}, nil
-		}
 		return r.migrate(ctx, logger.WithValues("operation", "migrate"), worker, cluster)
 	case worker.DeletionTimestamp != nil:
-		if extensionscontroller.IsMigrated(worker) {
-			return reconcile.Result{}, nil
-		}
 		return r.delete(ctx, logger.WithValues("operation", "delete"), worker, cluster)
 	case operationType == gardencorev1beta1.LastOperationTypeRestore:
 		return r.restore(ctx, logger.WithValues("operation", "restore"), worker, cluster)


### PR DESCRIPTION
/kind/bug
/area/control-plane-migration

Cherry pick of #4663 on release-v1.31.

#4663: Fix migration of extension resources

**Release Notes:**
```other dependency
If a resource has been successfully migrated, following reconcile operations are properly skipped, whereas migrate operations can be performed.
```