### PR TITLE
Seed monitoring enhancement

### DIFF
--- a/charts/seed-bootstrap/charts/monitoring/templates/config.yaml
+++ b/charts/seed-bootstrap/charts/monitoring/templates/config.yaml
@@ -68,6 +68,28 @@ data:
         - prometheus-web.garden.svc
       metric_relabel_configs:
 {{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.cadvisor | indent 6 }}
+
+    - job_name: kube-state-metrics
+      # Service is used, because we only care about metric from one kube-state-metrics instance
+      # and not multiple in HA setup
+      kubernetes_sd_configs:
+      - role: service
+        namespaces:
+          names: [ garden ]
+      relabel_configs:
+      - source_labels: [ __meta_kubernetes_service_label_component ]
+        regex: kube-state-metrics
+        action: keep
+      - source_labels: [ __meta_kubernetes_service_port_name ]
+        regex: metrics
+        action: keep
+      - target_label: instance
+        replacement: kube-state-metrics
+      metric_relabel_configs:
+      - source_labels: [ namespace ]
+        regex: shoot-.+
+        action: drop
+
     - job_name: prometheus
       static_configs:
       - targets: [ localhost:9090 ]

--- a/charts/seed-bootstrap/charts/monitoring/templates/config.yaml
+++ b/charts/seed-bootstrap/charts/monitoring/templates/config.yaml
@@ -68,3 +68,6 @@ data:
         - prometheus-web.garden.svc
       metric_relabel_configs:
 {{ include "prometheus.keep-metrics.metric-relabel-config" .Values.allowedMetrics.cadvisor | indent 6 }}
+    - job_name: prometheus
+      static_configs:
+      - targets: [ localhost:9090 ]

--- a/charts/seed-bootstrap/charts/monitoring/templates/config.yaml
+++ b/charts/seed-bootstrap/charts/monitoring/templates/config.yaml
@@ -62,6 +62,7 @@ data:
         - '{job="cadvisor",namespace=~"extension-(.+)"}'
         - '{job="cadvisor",namespace="garden"}'
         - '{job="cadvisor",namespace=~"istio-(.+)"}'
+        - '{job="cadvisor",namespace="kube-system"}'
       static_configs:
       - targets:
         - prometheus-web.garden.svc

--- a/charts/seed-bootstrap/charts/monitoring/templates/config.yaml
+++ b/charts/seed-bootstrap/charts/monitoring/templates/config.yaml
@@ -32,6 +32,9 @@ data:
         regex: __meta_kubernetes_pod_label_(.+)
 
     - job_name: garden
+      scheme: https
+      tls_config:
+        insecure_skip_verify: true
       kubernetes_sd_configs:
       - role: pod
       relabel_configs:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement
/kind bug

**What this PR does / why we need it**:

- Fixes an issue when scraping the gardenlet. Https is now used instead of http. Original PR #4560. Partial fix for #2815 

- Add kube-state-metrics metrics to the seed-prometheus #4683

- Seed prometheus scrapes itself for meta information

**Which issue(s) this PR fixes**:
 Fixes #4683

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixes an issue when scraping the gardenlet. Https is now used instead of http.
```
```other operator
Add kube-state-metrics metrics to the seed-prometheus
```
```other operator
Seed prometheus scrapes itself for meta information
```
