### PR TITLE
Fix nil pointer exception during restore phase

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -158,7 +158,7 @@ func (c *Controller) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		deployOwnerDomainDNSRecord = g.Add(flow.Task{
 			Name:         "Deploying owner domain DNS record",
 			Fn:           flow.TaskFn(botanist.DeployOwnerDNSResources),
-			Dependencies: flow.NewTaskIDs(deployReferencedResources),
+			Dependencies: flow.NewTaskIDs(ensureShootStateExists, deployReferencedResources),
 		})
 		deployInternalDomainDNSRecord = g.Add(flow.Task{
 			Name:         "Deploying internal domain DNS record",

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -556,7 +556,11 @@ func (o *Operation) DeleteShootState(ctx context.Context) error {
 // resource MUST NOT BE MODIFIED (except in test code) since this might interfere with other concurrent reads and writes.
 // To properly update the shootstate resource of this Shoot use SaveGardenerResourceDataInShootState.
 func (o *Operation) GetShootState() *gardencorev1alpha1.ShootState {
-	return o.shootState.Load().(*gardencorev1alpha1.ShootState)
+	shootState, ok := o.shootState.Load().(*gardencorev1alpha1.ShootState)
+	if !ok {
+		return nil
+	}
+	return shootState
 }
 
 // SetShootState sets the shootstate resource of this Shoot in a concurrency safe way.

--- a/pkg/operation/operation_test.go
+++ b/pkg/operation/operation_test.go
@@ -215,6 +215,17 @@ var _ = Describe("operation", func() {
 				Expect(o.DeleteShootState(ctx)).To(Equal(fakeErr))
 			})
 		})
+
+		Describe("#GetShootState", func() {
+			It("should not panic if ShootState was not stored", func() {
+				Expect(o.GetShootState()).To(BeNil())
+			})
+
+			It("should return the correct ShootState", func() {
+				o.SetShootState(shootState)
+				Expect(o.GetShootState()).To(Equal(shootState))
+			})
+		})
 	})
 
 	Describe("#SaveGardenerResourcesInShootState", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind bug

**What this PR does / why we need it**:
This PR fixes a nil pointer exception that can happen if the `Deploying owner domain DNS record` step is executed before the `Ensuring that ShootState exists` step when the `UseDNSRecords` feature gate is enabled.

All flow steps that use the ShootState must depend on the `Ensuring that ShootState exists` step during the restore phase. This is now true either implicitly or explicitly.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix a nil pointer exception during control plane migration restore phase that can happen when the `UseDNSRecords` feature gate is enabled.
```
