### PR TITLE
[release-v1.32] Automated cherry pick of #4707: add missing 'sideEffects' field to validatingwebhookconfiguration

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/validatingwebhook-admission-controller.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/validatingwebhook-admission-controller.yaml
@@ -30,6 +30,7 @@ webhooks:
       path: /webhooks/validate-namespace-deletion
     {{- end }}
     caBundle: {{ required ".Values.global.admission.config.server.https.tls.caBundle is required" (b64enc .Values.global.admission.config.server.https.tls.caBundle) }}
+  sideEffects: None
 - name: validate-kubeconfig-secrets.gardener.cloud
   admissionReviewVersions: ["v1", "v1beta1"]
   timeoutSeconds: 10


### PR DESCRIPTION
/kind/bug
/area/control-plane

Cherry pick of #4707 on release-v1.32.

#4707: add missing 'sideEffects' field to validatingwebhookconfiguration

**Release Notes:**
```bugfix operator
Added a missing `sideEffects` field to the ValidatingWebhookConfiguration template in the Gardener control plane helm chart.
```