### PR TITLE
Fixed broken absolute links

### DIFF
--- a/.github/ISSUE_TEMPLATE/support.md
+++ b/.github/ISSUE_TEMPLATE/support.md
@@ -10,5 +10,5 @@ STOP -- PLEASE READ!
 
 GitHub is not the right place for support requests.
 
-If you're looking for help, please post your question on the [Kubernetes Slack](http://slack.k8s.io/) ([#gardener](https://kubernetes.slack.com/messages/gardener) channel) or join our [weekly meetings](https://github.com/gardener/documentation/blob/master/CONTRIBUTING.md#weekly-meeting).
+If you're looking for help, please post your question on the [Kubernetes Slack](http://slack.k8s.io/) ([#gardener](https://kubernetes.slack.com/messages/gardener) channel) or join our [bi-weekly meetings](https://gardener.cloud/docs/contribute/#bi-weekly-meetings).
 -->

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Alternatively you can use our [garden setup](https://github.com/gardener/garden-
 
 Feedback and contributions are always welcome!
 
-All channels for getting in touch or learning about our project are listed under the [community](https://github.com/gardener/documentation/blob/master/CONTRIBUTING.md#community) section. We are cordially inviting interested parties to join our [bi-weekly meetings](https://github.com/gardener/documentation/blob/master/CONTRIBUTING.md#bi-weekly-meetings).
+All channels for getting in touch or learning about our project are listed under the [community](https://gardener.cloud/docs/contribute/#community) section. We are cordially inviting interested parties to join our [bi-weekly meetings](https://gardener.cloud/docs/contribute/#bi-weekly-meetings).
 
 Please report bugs or suggestions about our Kubernetes clusters as such or the Gardener itself as [GitHub issues](https://github.com/gardener/gardener/issues) or join our [Slack channel #gardener](https://kubernetes.slack.com/messages/gardener) (please invite yourself to the Kubernetes workspace [here](http://slack.k8s.io)).
 

--- a/docs/development/process.md
+++ b/docs/development/process.md
@@ -73,7 +73,7 @@ Usually, the new release is triggered in the beginning of the second week if all
 
 ## Contributing new Features or Fixes
 
-Please refer to the [Gardener contributor guide](https://github.com/gardener/documentation/blob/master/CONTRIBUTING.md).
+Please refer to the [Gardener contributor guide](https://gardener.cloud/docs/contribute/).
 Besides a lot of a general information, it also provides a checklist for newly created pull requests that may help you to prepare your changes for an efficient review process.
 If you are contributing a fix or major improvement, please take care to open cherry-pick PRs to all affected and still supported versions once the change is approved and merged in the `master` branch.
 

--- a/docs/extensions/logging-and-monitoring.md
+++ b/docs/extensions/logging-and-monitoring.md
@@ -188,5 +188,5 @@ If the type of logs exposed in the Grafana instances needs to be changed, it is 
 ## References and additional resources
 
 * [GitHub issue describing the concept](https://github.com/gardener/gardener/issues/1351)
-* [Exemplary implementation (monitoring) for the GCP provider](https://github.com/gardener/gardener-extension-provider-gcp/blob/master/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/configmap-monitoring.yaml)
+* [Exemplary implementation (monitoring) for the GCP provider](https://github.com/gardener/gardener-extension-provider-gcp/blob/master/charts/internal/seed-controlplane/charts/cloud-controller-manager/templates/configmap-observability.yaml)
 * [Exemplary implementation (logging) for the OpenStack provider](https://github.com/gardener/gardener-extension-provider-openstack/blob/master/charts/gardener-extension-provider-openstack/templates/configmap-logging.yaml)

--- a/docs/proposals/README.md
+++ b/docs/proposals/README.md
@@ -22,13 +22,13 @@ Before starting your work and creating a GEP, please take some time to familiari
 general [Gardener Contribution Guidelines](https://gardener.cloud/docs/contribute/).
 
 It is recommended to discuss and outline the motivation of your prospective GEP as a draft with the community before you take the investment of creating the actual GEP. This early briefing supports the understanding for the broad community and leads to a fast feedback for your proposal from the respective experts in the community.
-An appropriate format for this may be the regular [Gardener community meeting](https://github.com/gardener/documentation/blob/master/CONTRIBUTING.md#weekly-meeting).
+An appropriate format for this may be the regular [Gardener community meetings](https://gardener.cloud/docs/contribute/#bi-weekly-meetings).
 
 ## How to file a GEP
 
 GEPs should be created as Markdown `.md` files and are submitted through a GitHub pull request to their current home in [docs/proposals](https://github.com/gardener/gardener/tree/master/docs/proposals). Please use the provided [template](./00-template.md) or follow the structure of existing [GEPs]( https://github.com/gardener/gardener/tree/master/docs/proposals) which makes reviewing easier and faster. Additionally, please link the new GEP in our documentation [index](../README.md#Proposals).
 
-If not already done, please present your GEP in the [regular community meeting](https://github.com/gardener/documentation/blob/master/CONTRIBUTING.md#weekly-meeting) to brief the community about your proposal (we strive for personal communication :) ). Also consider that this may be an important step to raise awareness and understanding for everyone involved.
+If not already done, please present your GEP in the [regular community meetings](https://gardener.cloud/docs/contribute/#bi-weekly-meetings) to brief the community about your proposal (we strive for personal communication :) ). Also consider that this may be an important step to raise awareness and understanding for everyone involved.
 
 The GEP template contains a small set of metadata, which is helpful for keeping track of the enhancement
 in general and especially of who is responsible for implementing and reviewing PRs that are part of


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

**What this PR does / why we need it**:
This PR fixes broken absolute links and removes broken links from the manifest.
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc developer
NONE
```
