### PR TITLE
Increase the kube-rback-proxy and telegraf resources in Loki pod

### DIFF
--- a/charts/seed-bootstrap/charts/loki/templates/hvpa.yaml
+++ b/charts/seed-bootstrap/charts/loki/templates/hvpa.yaml
@@ -76,10 +76,12 @@ spec:
                 cpu: "{{ .Values.hvpa.minAllowed.cpu }}"
             - containerName: curator
               mode: "Off"
+{{- if .Values.rbacSidecarEnabled }}
             - containerName: kube-rbac-proxy
               mode: "Off"
             - containerName: telegraf
               mode: "Off"
+{{- end }}
   weightBasedScalingIntervals:
     - vpaWeight: 100
       startReplicaCount: {{ .Values.replicas }}

--- a/charts/seed-bootstrap/charts/loki/values.yaml
+++ b/charts/seed-bootstrap/charts/loki/values.yaml
@@ -65,18 +65,18 @@ resources:
       memory: 12Mi
   kubeRBACproxy:
     limits:
-      cpu: 20m
-      memory: 30Mi
+      cpu: 60m
+      memory: 50Mi
     requests:
-      cpu: 5m
+      cpu: 30m
       memory: 15Mi 
   telegraf:
     limits:
-      cpu: 5m
-      memory: 50Mi
+      cpu: 15m
+      memory: 100Mi
     requests:
-      cpu: 2m
-      memory: 24Mi
+      cpu: 5m
+      memory: 35Mi
 
 securityContext:
   fsGroup: 10001


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
Increase the kube-rback-proxy and telegraf resources in Loki pod

**Which issue(s) this PR fixes**:
Fixes #4735

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Increased the `kube-rback-proxy` and `telegraf` container resources in Loki pod to withstand higher resource usage spikes.
```
