### PR TITLE
Fix make test-integration for bash 3

### DIFF
--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -27,8 +27,7 @@ if ! command -v setup-envtest &> /dev/null ; then
 fi
 
 # --use-env allows overwriting the envtest tools path via the KUBEBUILDER_ASSETS env var just like it was before
-setup-envtest use --use-env -p env ${ENVTEST_K8S_VERSION}
-source <(setup-envtest use --use-env -p env ${ENVTEST_K8S_VERSION})
+export KUBEBUILDER_ASSETS="$(setup-envtest use --use-env -p path ${ENVTEST_K8S_VERSION})"
 echo "using envtest tools installed at '$KUBEBUILDER_ASSETS'"
 
 echo "> Integration Tests"


### PR DESCRIPTION
/area dev-productivity
/kind bug

Fixes https://github.com/gardener/gardener/issues/4558

Snitched the change from https://github.com/kubernetes-sigs/controller-runtime/blob/0cce21be79d95701d5491816a4098dafd7fe107a/hack/check-everything.sh#L40

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
`make test-integration` works with bash version 3 now.
```
