### PR TITLE
[release-v1.32] Automated cherry pick of #4706: Seed monitoring enhancement

### DIFF
--- a/charts/seed-bootstrap/charts/monitoring/templates/config.yaml
+++ b/charts/seed-bootstrap/charts/monitoring/templates/config.yaml
@@ -32,6 +32,9 @@ data:
         regex: __meta_kubernetes_pod_label_(.+)
 
     - job_name: garden
+      scheme: https
+      tls_config:
+        insecure_skip_verify: true
       kubernetes_sd_configs:
       - role: pod
       relabel_configs:


### PR DESCRIPTION
/kind/bug
/kind/enhancement
/area/monitoring

Cherry pick of #4706 on release-v1.32.

#4706: Seed monitoring enhancement

**Release Notes:**
```other operator
Fixes an issue when scraping the gardenlet. Https is now used instead of http.
```
