### PR TITLE
[release-v1.32] Automated cherry pick of #4709: Fix nil pointer exception during restore phase

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -158,7 +158,7 @@ func (c *Controller) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 		deployOwnerDomainDNSRecord = g.Add(flow.Task{
 			Name:         "Deploying owner domain DNS record",
 			Fn:           flow.TaskFn(botanist.DeployOwnerDNSResources),
-			Dependencies: flow.NewTaskIDs(deployReferencedResources),
+			Dependencies: flow.NewTaskIDs(ensureShootStateExists, deployReferencedResources),
 		})
 		deployInternalDomainDNSRecord = g.Add(flow.Task{
 			Name:         "Deploying internal domain DNS record",

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -556,7 +556,11 @@ func (o *Operation) DeleteShootState(ctx context.Context) error {
 // resource MUST NOT BE MODIFIED (except in test code) since this might interfere with other concurrent reads and writes.
 // To properly update the shootstate resource of this Shoot use SaveGardenerResourceDataInShootState.
 func (o *Operation) GetShootState() *gardencorev1alpha1.ShootState {
-	return o.shootState.Load().(*gardencorev1alpha1.ShootState)
+	shootState, ok := o.shootState.Load().(*gardencorev1alpha1.ShootState)
+	if !ok {
+		return nil
+	}
+	return shootState
 }
 
 // SetShootState sets the shootstate resource of this Shoot in a concurrency safe way.

--- a/pkg/operation/operation_test.go
+++ b/pkg/operation/operation_test.go
@@ -215,6 +215,17 @@ var _ = Describe("operation", func() {
 				Expect(o.DeleteShootState(ctx)).To(Equal(fakeErr))
 			})
 		})
+
+		Describe("#GetShootState", func() {
+			It("should not panic if ShootState was not stored", func() {
+				Expect(o.GetShootState()).To(BeNil())
+			})
+
+			It("should return the correct ShootState", func() {
+				o.SetShootState(shootState)
+				Expect(o.GetShootState()).To(Equal(shootState))
+			})
+		})
 	})
 
 	Describe("#SaveGardenerResourcesInShootState", func() {


### PR DESCRIPTION
/kind/bug
/area/control-plane-migration

Cherry pick of #4709 on release-v1.32.

#4709: Fix nil pointer exception during restore phase

**Release Notes:**
```bugfix operator
Fix a nil pointer exception during control plane migration restore phase that can happen when the `UseDNSRecords` feature gate is enabled.
```