### PR TITLE
Deflake newly introduced flaky unit test

### DIFF
--- a/pkg/controllermanager/controller/controllerregistration/controllerregistration_seed_control_test.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerregistration_seed_control_test.go
@@ -881,26 +881,15 @@ var _ = Describe("controllerRegistrationReconciler", func() {
 			})
 
 			It("should return an error when needed controller installation is being deleted", func() {
-				installation3 := controllerInstallation3.DeepCopy()
-				installation3.DeletionTimestamp = &now
+				installation2 := controllerInstallation2.DeepCopy()
+				installation2.DeletionTimestamp = &now
 				var (
-					wantedControllerRegistrations  = sets.NewString(controllerRegistration2.Name, controllerRegistration3.Name)
+					wantedControllerRegistrations  = sets.NewString(controllerRegistration2.Name)
 					registrationNameToInstallation = map[string]*gardencorev1beta1.ControllerInstallation{
 						controllerRegistration1.Name: controllerInstallation1,
-						controllerRegistration2.Name: controllerInstallation2,
-						controllerRegistration3.Name: installation3,
+						controllerRegistration2.Name: installation2,
 					}
 				)
-
-				installation2 := controllerInstallation2.DeepCopy()
-				installation2.Labels = map[string]string{
-					common.ControllerDeploymentHash: "d37bba62f222c81b",
-					common.RegistrationSpecHash:     "61ca93a1782c5fa3",
-					common.SeedSpecHash:             "a5e0943b25bc6cab",
-				}
-
-				k8sClient.EXPECT().Get(ctx, kutil.Key(controllerInstallation2.Name), gomock.AssignableToTypeOf(&gardencorev1beta1.ControllerInstallation{}))
-				k8sClient.EXPECT().Patch(ctx, installation2, gomock.Any())
 
 				err := deployNeededInstallations(ctx, nopLogger, k8sClient, seedWithShootDNSEnabled, wantedControllerRegistrations, controllerRegistrations, registrationNameToInstallation)
 


### PR DESCRIPTION
/area testing
/kind flake

#4718 introduced a new unit test that is currently flaky (ref https://concourse.ci.gardener.cloud/teams/gardener/pipelines/gardener-master/jobs/master-head-update-job/builds/74). The reason is that a `set.String` is passed to the `deployNeededInstallations` func and the func uses `UnsortedList` of this `set.String`. The doc string of `UnsortedList` is 
```
// UnsortedList returns the slice with contents in random order.
```

So right now it can be the case that the `deployNeededInstallations` deploys first the ControllerInstallation that errors and in this case the test fail that there are no calls to mock expectations related to the successful ControllerInstallation deployment.
As this test is about testing ControllerInstallation which deployment is expected to cause error, it is enough to remove the ControllerInstallation that is expected to be deployed successfully as part of this test.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
