### PR TITLE
Upgrade fluent-bit-to-loki plugin to version 0.37.1 

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -229,7 +229,7 @@ images:
 - name: fluent-bit-plugin-installer
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/fluent-bit-to-loki
-  tag: "v0.36.2"
+  tag: "v0.37.1"
 - name: loki
   sourceRepository: github.com/grafana/loki
   repository: grafana/loki
@@ -237,7 +237,7 @@ images:
 - name: loki-curator
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/loki-curator
-  tag: "v0.36.2"
+  tag: "v0.37.1"
 - name: kube-rbac-proxy
   sourceRepository: github.com/brancz/kube-rbac-proxy
   repository: quay.io/brancz/kube-rbac-proxy
@@ -249,7 +249,7 @@ images:
 - name: telegraf
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/telegraf-iptables
-  tag: "v0.36.2"
+  tag: "v0.37.1"
 
 # VPA
 - name: vpa-admission-controller

--- a/charts/seed-bootstrap/charts/fluent-bit/templates/_helpers.tpl
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/_helpers.tpl
@@ -8,6 +8,7 @@ input.conf: |-
 {{- include "input.conf" . }}
 
 filter-kubernetes.conf: |-
+  # Lua filter to add the tag into the record
   [FILTER]
       Name                lua
       Match               kubernetes.*
@@ -178,16 +179,6 @@ filter-kubernetes.conf: |-
 {{- toString .Values.additionalFilters | indent 2 }}
 {{- end }}
 
-  [FILTER]
-      Name record_modifier
-      Match {{ .Values.exposedComponentsTagPrefix }}.*
-      Record gardenuser user
-
-  [FILTER]
-      Name                rewrite_tag
-      Match               {{ .Values.exposedComponentsTagPrefix }}.*
-      Rule                $tag ^.+? kubernetes.$TAG false
-      Emitter_Name        re_emitted-reversed-rewrite-tag
   # Scripts
   [FILTER]
       Name                lua

--- a/test/framework/resources/templates/logger-app.yaml.tpl
+++ b/test/framework/resources/templates/logger-app.yaml.tpl
@@ -51,7 +51,20 @@ spec:
 {{ else }}
           value: 0s
 {{- end }}
+        resources:
+          limits:
+            cpu: 8m
+            memory: 20Mi
+          requests:
+            cpu: 4m
+            memory: 3Mi
       securityContext:
         fsGroup: 65532
         runAsUser: 65532
         runAsNonRoot: true
+{{ if .NodeName }}
+      nodeName: {{ .NodeName }}
+{{- end }}
+{{ if .NodeSelector }}
+      nodeSelector: {{ .NodeSelector }}
+{{- end }}

--- a/test/framework/shoot_utils.go
+++ b/test/framework/shoot_utils.go
@@ -47,11 +47,8 @@ func (f *ShootFramework) ShootKubeconfigSecretName() string {
 }
 
 // GetLokiLogs gets logs from the last 1 hour for <key>, <value> from the loki instance in <lokiNamespace>
-func (f *ShootFramework) GetLokiLogs(ctx context.Context, tenant, lokiNamespace, key, value string, client kubernetes.Interface) (*SearchResponse, error) {
-	lokiLabels := labels.SelectorFromSet(labels.Set(map[string]string{
-		"app":  lokiLogging,
-		"role": "logging",
-	}))
+func (f *ShootFramework) GetLokiLogs(ctx context.Context, lokiLabels map[string]string, tenant, lokiNamespace, key, value string, client kubernetes.Interface) (*SearchResponse, error) {
+	lokiLabelsSelector := labels.SelectorFromSet(labels.Set(lokiLabels))
 
 	if tenant == "" {
 		tenant = "fake"
@@ -64,7 +61,7 @@ func (f *ShootFramework) GetLokiLogs(ctx context.Context, tenant, lokiNamespace,
 	var reader io.Reader
 	err := retry.Until(ctx, defaultPollInterval, func(ctx context.Context) (bool, error) {
 		var err error
-		reader, err = PodExecByLabel(ctx, lokiLabels, lokiLogging, command, lokiNamespace, client)
+		reader, err = PodExecByLabel(ctx, lokiLabelsSelector, lokiLogging, command, lokiNamespace, client)
 
 		if err != nil {
 			f.Logger.Warn(err)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
With this PR we upgrade the version of the gardener fluent-bit-to-loki plugin to 0.37.1 version.
This version introduces two features.
1. In the output configuration we can specify the destinations of the logs based on the Shoot state.
By default when a shoot is in a `creation` state the logs are sent to both central and shoot Loki.
The same applies when the shoot is in a `deletion` state.
2. A reserved stream label `__gardener_multitenant_id__ ` is introduced.
The plugin searches the key/value entry in the log record, then extracts it and adds it as a stream label.
At the end of processing just before the logs are about to be sent the label is removed and the value is parsed in order to retrieve all of the tenants which have to receive the logs. The tenants are semicolons separated.

Also, the Gardenlet is modified to detect `rewrite_tag` filters from the extension and to translate them into a `modify` filter which adds  `"__gardener_multitenant_id__":"operator;user"` into the logs. The embedded `rewrite_tag` filter also is removed and replaced with `modify` one.
This change was done because when an extension component logs are exposed to the end-user we just replicated them and then we used to have separated plugin instances for them. Then, the plugin instances for both `operator` and `user` tenant was united but because we have already used a `rewrite_tag` filter the logic of re-emitting the logs was the same. And since we start to increase the number of exposed components the repetition of logs has grown bigger and bigger.

The logging integration tests are modified accordingly to the new plugin version(0.37.1)

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->

```feature operator  https://github.com/gardener/logging/pull/109 @vlvasilev
 Logs can be spread across Shoot control-plane Loki and central Loki base on the Shoot state.
```
```feature operator  https://github.com/gardener/logging/pull/110 @vlvasilev 
A reserved Loki stream label `__gardener_multitenant_id__` is introduced to specify multiple tenants separated by semicolon.
```
```other operator
Adapt the logging integration tests to use the gardener fluent-bit-to-loki plugin version 0.37.1
```