### PR TITLE
Enable secrets cache for GCM

### DIFF
--- a/cmd/gardenlet/app/gardenlet.go
+++ b/cmd/gardenlet/app/gardenlet.go
@@ -318,11 +318,8 @@ func NewGardenlet(ctx context.Context, cfg *config.GardenletConfiguration) (*Gar
 			&corev1.ConfigMap{},
 			&corev1.Event{},
 			&eventsv1.Event{},
-		)
-
-	if seedConfig := cfg.SeedConfig; seedConfig != nil {
-		gardenClientMapBuilder = gardenClientMapBuilder.ForSeed(seedConfig.Name)
-	}
+		).
+		ForSeed(cfg.SeedConfig.Name)
 
 	seedClientMapBuilder := clientmapbuilder.NewSeedClientMapBuilder().
 		WithClientConnectionConfig(&cfg.SeedClientConnection.ClientConnectionConfiguration)

--- a/cmd/gardenlet/app/gardenlet.go
+++ b/cmd/gardenlet/app/gardenlet.go
@@ -148,18 +148,16 @@ func (o *Options) validate(args []string) error {
 }
 
 func run(ctx context.Context, o *Options) error {
-	if len(o.ConfigFile) > 0 {
-		c, err := o.loadConfigFromFile(o.ConfigFile)
-		if err != nil {
-			return fmt.Errorf("unable to read the configuration file: %w", err)
-		}
-
-		if errs := configvalidation.ValidateGardenletConfiguration(c, nil, false); len(errs) > 0 {
-			return fmt.Errorf("errors validating the configuration: %+v", errs)
-		}
-
-		o.config = c
+	c, err := o.loadConfigFromFile(o.ConfigFile)
+	if err != nil {
+		return fmt.Errorf("unable to read the configuration file: %w", err)
 	}
+
+	if errs := configvalidation.ValidateGardenletConfiguration(c, nil, false); len(errs) > 0 {
+		return fmt.Errorf("errors validating the configuration: %+v", errs)
+	}
+
+	o.config = c
 
 	// Add feature flags
 	if err := gardenletfeatures.FeatureGate.SetFromMap(o.config.FeatureGates); err != nil {

--- a/pkg/client/kubernetes/clientmap/internal/garden_clientmap.go
+++ b/pkg/client/kubernetes/clientmap/internal/garden_clientmap.go
@@ -71,8 +71,8 @@ func (f *GardenClientSetFactory) NewClientSet(_ context.Context, k clientmap.Cli
 		kubernetes.WithUncached(f.UncachedObjects...),
 	}
 
-	// Use multi-namespaced caches for Secrets which only consider seed namespaces
-	// because Gardenlet is not permitted to open a watch for Secrets on any other namespace.
+	// Use multi-namespaced caches for Secrets which only consider the seed namespace.
+	// Gardenlet is not permitted to open a watch for Secrets on any other namespace.
 	if seedName := f.SeedName; len(seedName) > 0 {
 		configFns = append(configFns, kubernetes.WithNewCacheFunc(
 			kubernetes.AggregatorCacheFunc(
@@ -83,11 +83,6 @@ func (f *GardenClientSetFactory) NewClientSet(_ context.Context, k clientmap.Cli
 				kubernetes.GardenScheme,
 			),
 		))
-	} else {
-		// We need to disable caching for Secrets if Gardenlet is potentially responsible for multiple seeds
-		// because we cannot (yet) handle seed additions/removals dynamically for the Garden client at runtime.
-		// https://github.com/gardener/gardener/pull/3700#discussion_r593070505
-		configFns = append(configFns, kubernetes.WithUncached(&corev1.Secret{}))
 	}
 
 	return NewClientSetWithConfig(configFns...)

--- a/pkg/client/kubernetes/clientmap/internal/garden_clientmap_test.go
+++ b/pkg/client/kubernetes/clientmap/internal/garden_clientmap_test.go
@@ -82,7 +82,6 @@ var _ = Describe("GardenClientMap", func() {
 					kubernetes.WithRESTConfig(restConfig),
 					kubernetes.WithClientOptions(client.Options{Scheme: kubernetes.GardenScheme}),
 					kubernetes.WithUncached(&corev1.ConfigMap{}),
-					kubernetes.WithUncached(&corev1.Secret{}),
 				))
 				return fakeCS, nil
 			}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement

**What this PR does / why we need it**:
This PR enables the cache for `Secret`s when GCM constructs the garden client. Earlier, Gardenlet was able to handle multiple seeds (before https://github.com/gardener/gardener/pull/4306) which required us to disable the `Secret`s cache entirely.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The Gardener-Controller-Manager now also caches `Secret` objects if the `CachedRuntimeClients` feature gate is enabled.
```
