### PR TITLE
Fix helm values for vpa shoot core addon

### DIFF
--- a/charts/shoot-core/components/charts/vertical-pod-autoscaler/charts/application/values.yaml
+++ b/charts/shoot-core/components/charts/vertical-pod-autoscaler/charts/application/values.yaml
@@ -1,1 +1,43 @@
-../../../../../../seed-bootstrap/charts/vpa/charts/application/values.yaml
+global:
+  images:
+    vpa-admission-controller: image-repository:image-tag
+    vpa-recommender: image-repository:image-tag
+    vpa-updater: image-repository:image-tag
+    vpa-exporter: image-repository:image-tag
+
+labels:
+  gardener.cloud/role: vpa
+
+clusterType: shoot
+
+admissionController:
+  replicas: 1
+  enabled: true
+  podAnnotations: {}
+  podLabels: {}
+  enableServiceAccount: true
+  caCert: abcd
+  controlNamespace: abcd
+  port: 10250
+  servicePort: 443
+
+recommender:
+  replicas: 1
+  enabled: true
+  podAnnotations: {}
+  podLabels: {}
+  enableServiceAccount: true
+  interval: 1m0s
+  recommendationMarginFraction: 0.05
+
+updater:
+  replicas: 1
+  enabled: true
+  podAnnotations: {}
+  podLabels: {}
+  enableServiceAccount: true
+  evictAfterOOMThreshold: 48h
+  evictionRateBurst: 1
+  evictionRateLimit: -1
+  evictionTolerance: 1
+  interval: 1m0s

--- a/charts/shoot-core/components/charts/vertical-pod-autoscaler/charts/crds/values.yaml
+++ b/charts/shoot-core/components/charts/vertical-pod-autoscaler/charts/crds/values.yaml
@@ -1,1 +1,2 @@
-../../../../../../seed-bootstrap-crds/charts/vpa/values.yaml
+labels:
+  gardener.cloud/role: vpa

--- a/charts/shoot-core/components/charts/vertical-pod-autoscaler/values.yaml
+++ b/charts/shoot-core/components/charts/vertical-pod-autoscaler/values.yaml
@@ -1,1 +1,0 @@
-../../../../seed-bootstrap/charts/vpa/charts/application/values.yaml

--- a/charts/shoot-core/components/charts/vertical-pod-autoscaler/values.yml
+++ b/charts/shoot-core/components/charts/vertical-pod-autoscaler/values.yml
@@ -1,0 +1,49 @@
+global:
+  images:
+    vpa-admission-controller: image-repository:image-tag
+    vpa-recommender: image-repository:image-tag
+    vpa-updater: image-repository:image-tag
+    vpa-exporter: image-repository:image-tag
+
+
+application:
+  labels:
+    gardener.cloud/role: vpa
+
+  clusterType: shoot
+
+  admissionController:
+    replicas: 1
+    enabled: true
+    podAnnotations: {}
+    podLabels: {}
+    enableServiceAccount: true
+    caCert: abcd
+    controlNamespace: abcd
+    port: 10250
+    servicePort: 443
+
+  recommender:
+    replicas: 1
+    enabled: true
+    podAnnotations: {}
+    podLabels: {}
+    enableServiceAccount: true
+    interval: 1m0s
+    recommendationMarginFraction: 0.05
+
+  updater:
+    replicas: 1
+    enabled: true
+    podAnnotations: {}
+    podLabels: {}
+    enableServiceAccount: true
+    evictAfterOOMThreshold: 48h
+    evictionRateBurst: 1
+    evictionRateLimit: -1
+    evictionTolerance: 1
+    interval: 1m0s
+
+crds:
+  labels:
+    gardener.cloud/role: vpa

--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -296,14 +296,16 @@ func (b *Botanist) generateCoreAddonsChart(ctx context.Context) (*chartrenderer.
 			"enableIPVS": b.Shoot.IPVSEnabled(),
 		}
 		verticalPodAutoscaler = map[string]interface{}{
-			"clusterType": "shoot",
-			"admissionController": map[string]interface{}{
-				"enableServiceAccount": false,
-				"controlNamespace":     b.Shoot.SeedNamespace,
+			"application": map[string]interface{}{
+				"clusterType": "shoot",
+				"admissionController": map[string]interface{}{
+					"enableServiceAccount": false,
+					"controlNamespace":     b.Shoot.SeedNamespace,
+				},
+				"exporter":    map[string]interface{}{"enableServiceAccount": false},
+				"recommender": map[string]interface{}{"enableServiceAccount": false},
+				"updater":     map[string]interface{}{"enableServiceAccount": false},
 			},
-			"exporter":    map[string]interface{}{"enableServiceAccount": false},
-			"recommender": map[string]interface{}{"enableServiceAccount": false},
-			"updater":     map[string]interface{}{"enableServiceAccount": false},
 		}
 
 		shootInfo = map[string]interface{}{
@@ -345,7 +347,7 @@ func (b *Botanist) generateCoreAddonsChart(ctx context.Context) (*chartrenderer.
 	}
 
 	if vpaSecret := b.LoadSecret(common.VPASecretName); vpaSecret != nil {
-		verticalPodAutoscaler["admissionController"].(map[string]interface{})["caCert"] = vpaSecret.Data[secrets.DataKeyCertificateCA]
+		verticalPodAutoscaler["application"].(map[string]interface{})["admissionController"].(map[string]interface{})["caCert"] = vpaSecret.Data[secrets.DataKeyCertificateCA]
 	}
 
 	proxyConfig := b.Shoot.GetInfo().Spec.Kubernetes.KubeProxy


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling control-plane 
/kind bug

**What this PR does / why we need it**:
Fix helm values for vpa shoot core addon.

After the `vertical-pod-autoscaler` chart was split into subcharts with #4537 , the provided values were no
longer taking into account, instead the default ones were used. 

However, the default are suitable for seed clusters and the vpa controllers started failing with missing permissions to work with the respective resources, because the bindings were done for service accounts instead of the client certificates.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/assign @voelzmo 
as this fix is relevant for the v1.33-rc.


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
