### PR TITLE
Always update timestamp annotation on owner DNSRecord

### DIFF
--- a/pkg/operation/botanist/dnsrecord.go
+++ b/pkg/operation/botanist/dnsrecord.go
@@ -78,11 +78,11 @@ func (b *Botanist) DefaultInternalDNSRecord() extensionsdnsrecord.Interface {
 // DefaultOwnerDNSRecord creates the default deployer for the owner DNSRecord resource.
 func (b *Botanist) DefaultOwnerDNSRecord() extensionsdnsrecord.Interface {
 	values := &extensionsdnsrecord.Values{
-		Name:       b.Shoot.GetInfo().Name + "-" + DNSOwnerName,
-		SecretName: b.Shoot.GetInfo().Name + "-" + DNSInternalName,
-		Namespace:  b.Shoot.SeedNamespace,
-		CreateOnly: true,
-		TTL:        b.Config.Controllers.Shoot.DNSEntryTTLSeconds,
+		Name:          b.Shoot.GetInfo().Name + "-" + DNSOwnerName,
+		SecretName:    b.Shoot.GetInfo().Name + "-" + DNSInternalName,
+		Namespace:     b.Shoot.SeedNamespace,
+		ReconcileOnce: true,
+		TTL:           b.Config.Controllers.Shoot.DNSEntryTTLSeconds,
 	}
 	if b.NeedsInternalDNS() {
 		values.Type = b.Garden.InternalDomain.Provider


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug

**What this PR does / why we need it**:

Always update timestamp annotation on owner DNSRecord to always trigger a watch event for extension controllers.
This is done exactly like for all other extension resources, see https://github.com/gardener/gardener/pull/2290.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/4725

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug was fixed that caused shoot creations to fail at the `Deploying owner domain DNS record` step.
```
