### PR TITLE
[release-v1.32] Automated cherry pick of #4756: Always update timestamp annotation on owner DNSRecord

### DIFF
--- a/pkg/operation/botanist/dnsrecord.go
+++ b/pkg/operation/botanist/dnsrecord.go
@@ -78,11 +78,11 @@ func (b *Botanist) DefaultInternalDNSRecord() extensionsdnsrecord.Interface {
 // DefaultOwnerDNSRecord creates the default deployer for the owner DNSRecord resource.
 func (b *Botanist) DefaultOwnerDNSRecord() extensionsdnsrecord.Interface {
 	values := &extensionsdnsrecord.Values{
-		Name:       b.Shoot.GetInfo().Name + "-" + DNSOwnerName,
-		SecretName: b.Shoot.GetInfo().Name + "-" + DNSInternalName,
-		Namespace:  b.Shoot.SeedNamespace,
-		CreateOnly: true,
-		TTL:        b.Config.Controllers.Shoot.DNSEntryTTLSeconds,
+		Name:          b.Shoot.GetInfo().Name + "-" + DNSOwnerName,
+		SecretName:    b.Shoot.GetInfo().Name + "-" + DNSInternalName,
+		Namespace:     b.Shoot.SeedNamespace,
+		ReconcileOnce: true,
+		TTL:           b.Config.Controllers.Shoot.DNSEntryTTLSeconds,
 	}
 	if b.NeedsInternalDNS() {
 		values.Type = b.Garden.InternalDomain.Provider


### PR DESCRIPTION
/kind/bug
/area/robustness

Cherry pick of #4756 on release-v1.32.

#4756: Always update timestamp annotation on owner DNSRecord

**Release Notes:**
```bugfix user
A bug was fixed that caused shoot creations to fail at the `Deploying owner domain DNS record` step.
```