### PR TITLE
Fix managed seed condition 'SeedRegistered' to not update its timestamps on each reconciliation

### DIFF
--- a/pkg/gardenlet/controller/managedseed/managedseed_actuator_test.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_actuator_test.go
@@ -16,6 +16,7 @@ package managedseed
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 
 	"github.com/gardener/gardener/charts"
@@ -616,6 +617,7 @@ var _ = Describe("Actuator", func() {
 				expectCreateSeedSecrets()
 				recorder.EXPECT().Eventf(managedSeed, corev1.EventTypeNormal, gardencorev1beta1.EventReconciling, "Creating or updating seed %s", name)
 				expectCreateSeed()
+				expectGetSeed(true)
 
 				status, wait, err := actuator.Reconcile(ctx, managedSeed)
 				Expect(err).ToNot(HaveOccurred())
@@ -626,9 +628,10 @@ var _ = Describe("Actuator", func() {
 						"Reason": Equal(gardencorev1beta1.EventReconciled),
 					}),
 					MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(seedmanagementv1alpha1.ManagedSeedSeedRegistered),
-						"Status": Equal(gardencorev1beta1.ConditionTrue),
-						"Reason": Equal(gardencorev1beta1.EventReconciled),
+						"Type":    Equal(seedmanagementv1alpha1.ManagedSeedSeedRegistered),
+						"Status":  Equal(gardencorev1beta1.ConditionTrue),
+						"Reason":  Equal(gardencorev1beta1.EventReconciled),
+						"Message": Equal(fmt.Sprintf("Seed %s has been created.", name)),
 					}),
 				))
 				Expect(wait).To(Equal(false))
@@ -652,6 +655,7 @@ var _ = Describe("Actuator", func() {
 				expectPrepareGardenClientConnection()
 				expectGetGardenletChartValues(true)
 				expectApplyGardenletChart()
+				expectGetSeed(true)
 
 				status, wait, err := actuator.Reconcile(ctx, managedSeed)
 				Expect(err).ToNot(HaveOccurred())
@@ -662,9 +666,10 @@ var _ = Describe("Actuator", func() {
 						"Reason": Equal(gardencorev1beta1.EventReconciled),
 					}),
 					MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(seedmanagementv1alpha1.ManagedSeedSeedRegistered),
-						"Status": Equal(gardencorev1beta1.ConditionTrue),
-						"Reason": Equal(gardencorev1beta1.EventReconciled),
+						"Type":    Equal(seedmanagementv1alpha1.ManagedSeedSeedRegistered),
+						"Status":  Equal(gardencorev1beta1.ConditionTrue),
+						"Reason":  Equal(gardencorev1beta1.EventReconciled),
+						"Message": Equal(fmt.Sprintf("Seed %s has been created.", name)),
 					}),
 				))
 				Expect(wait).To(Equal(false))
@@ -683,6 +688,7 @@ var _ = Describe("Actuator", func() {
 				expectMergeWithParent()
 				expectGetGardenletChartValues(false)
 				expectApplyGardenletChart()
+				expectGetSeed(true)
 
 				status, wait, err := actuator.Reconcile(ctx, managedSeed)
 				Expect(err).ToNot(HaveOccurred())
@@ -693,9 +699,10 @@ var _ = Describe("Actuator", func() {
 						"Reason": Equal(gardencorev1beta1.EventReconciled),
 					}),
 					MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(seedmanagementv1alpha1.ManagedSeedSeedRegistered),
-						"Status": Equal(gardencorev1beta1.ConditionTrue),
-						"Reason": Equal(gardencorev1beta1.EventReconciled),
+						"Type":    Equal(seedmanagementv1alpha1.ManagedSeedSeedRegistered),
+						"Status":  Equal(gardencorev1beta1.ConditionTrue),
+						"Reason":  Equal(gardencorev1beta1.EventReconciled),
+						"Message": Equal(fmt.Sprintf("Seed %s has been created.", name)),
 					}),
 				))
 				Expect(wait).To(Equal(false))
@@ -723,9 +730,10 @@ var _ = Describe("Actuator", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(status.Conditions).To(ConsistOf(
 					MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(seedmanagementv1alpha1.ManagedSeedSeedRegistered),
-						"Status": Equal(gardencorev1beta1.ConditionFalse),
-						"Reason": Equal(gardencorev1beta1.EventDeleting),
+						"Type":    Equal(seedmanagementv1alpha1.ManagedSeedSeedRegistered),
+						"Status":  Equal(gardencorev1beta1.ConditionProgressing),
+						"Reason":  Equal(gardencorev1beta1.EventDeleting),
+						"Message": Equal(fmt.Sprintf("Seed %s is in deletion.s", name)),
 					}),
 				))
 				Expect(wait).To(Equal(false))
@@ -743,9 +751,10 @@ var _ = Describe("Actuator", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(status.Conditions).To(ConsistOf(
 					MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(seedmanagementv1alpha1.ManagedSeedSeedRegistered),
-						"Status": Equal(gardencorev1beta1.ConditionFalse),
-						"Reason": Equal(gardencorev1beta1.EventDeleting),
+						"Type":    Equal(seedmanagementv1alpha1.ManagedSeedSeedRegistered),
+						"Status":  Equal(gardencorev1beta1.ConditionFalse),
+						"Reason":  Equal(gardencorev1beta1.EventDeleted),
+						"Message": Equal(fmt.Sprintf("Seed %s has been deleted.", name)),
 					}),
 				))
 				Expect(wait).To(Equal(true))
@@ -764,9 +773,10 @@ var _ = Describe("Actuator", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(status.Conditions).To(ConsistOf(
 					MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(seedmanagementv1alpha1.ManagedSeedSeedRegistered),
-						"Status": Equal(gardencorev1beta1.ConditionFalse),
-						"Reason": Equal(gardencorev1beta1.EventDeleting),
+						"Type":    Equal(seedmanagementv1alpha1.ManagedSeedSeedRegistered),
+						"Status":  Equal(gardencorev1beta1.ConditionFalse),
+						"Reason":  Equal(gardencorev1beta1.EventDeleted),
+						"Message": Equal(fmt.Sprintf("Seed %s has been deleted.", name)),
 					}),
 				))
 				Expect(wait).To(Equal(true))
@@ -808,9 +818,10 @@ var _ = Describe("Actuator", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(status.Conditions).To(ConsistOf(
 					MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(seedmanagementv1alpha1.ManagedSeedSeedRegistered),
-						"Status": Equal(gardencorev1beta1.ConditionFalse),
-						"Reason": Equal(gardencorev1beta1.EventDeleting),
+						"Type":    Equal(seedmanagementv1alpha1.ManagedSeedSeedRegistered),
+						"Status":  Equal(gardencorev1beta1.ConditionProgressing),
+						"Reason":  Equal(gardencorev1beta1.EventDeleting),
+						"Message": Equal(fmt.Sprintf("Seed %s is in deletion.s", name)),
 					}),
 				))
 				Expect(wait).To(Equal(false))
@@ -831,9 +842,10 @@ var _ = Describe("Actuator", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(status.Conditions).To(ConsistOf(
 					MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(seedmanagementv1alpha1.ManagedSeedSeedRegistered),
-						"Status": Equal(gardencorev1beta1.ConditionFalse),
-						"Reason": Equal(gardencorev1beta1.EventDeleting),
+						"Type":    Equal(seedmanagementv1alpha1.ManagedSeedSeedRegistered),
+						"Status":  Equal(gardencorev1beta1.ConditionFalse),
+						"Reason":  Equal(gardencorev1beta1.EventDeleted),
+						"Message": Equal(fmt.Sprintf("Seed %s has been deleted.", name)),
 					}),
 				))
 				Expect(wait).To(Equal(true))
@@ -852,9 +864,10 @@ var _ = Describe("Actuator", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(status.Conditions).To(ConsistOf(
 					MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(seedmanagementv1alpha1.ManagedSeedSeedRegistered),
-						"Status": Equal(gardencorev1beta1.ConditionFalse),
-						"Reason": Equal(gardencorev1beta1.EventDeleting),
+						"Type":    Equal(seedmanagementv1alpha1.ManagedSeedSeedRegistered),
+						"Status":  Equal(gardencorev1beta1.ConditionFalse),
+						"Reason":  Equal(gardencorev1beta1.EventDeleted),
+						"Message": Equal(fmt.Sprintf("Seed %s has been deleted.", name)),
 					}),
 				))
 				Expect(wait).To(Equal(true))
@@ -874,9 +887,10 @@ var _ = Describe("Actuator", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(status.Conditions).To(ConsistOf(
 					MatchFields(IgnoreExtras, Fields{
-						"Type":   Equal(seedmanagementv1alpha1.ManagedSeedSeedRegistered),
-						"Status": Equal(gardencorev1beta1.ConditionFalse),
-						"Reason": Equal(gardencorev1beta1.EventDeleting),
+						"Type":    Equal(seedmanagementv1alpha1.ManagedSeedSeedRegistered),
+						"Status":  Equal(gardencorev1beta1.ConditionFalse),
+						"Reason":  Equal(gardencorev1beta1.EventDeleted),
+						"Message": Equal(fmt.Sprintf("Seed %s has been deleted.", name)),
 					}),
 				))
 				Expect(wait).To(Equal(true))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug

**What this PR does / why we need it**:
Now the timestamps of managed seed condition `SeedRegistered` are updated only when there is actually a change in the condition message. Previously, `updateCondition` function was setting the condition to `Progressing` state on the in-memory resource, however this change was never pushed to the API. The following `updateCondition` was setting the condition back to `True` and this again triggers the timestamps to be updated. However, watching only the resource from the API, the only change is the timestamps.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
A bug in the managedseed actuator, that was updating the conditions only in the in-memory resource, is now fixed.
```
