### PR TITLE
Fix broken links in the extensions API reference

### DIFF
--- a/hack/api-reference/extensions-config.json
+++ b/hack/api-reference/extensions-config.json
@@ -16,8 +16,8 @@
             "docsURLTemplate": "https://godoc.org/k8s.io/apimachinery/pkg/util/intstr#IntOrString"
         },
         {
-            "typeMatchPrefix": "^github\\.com/gardener/gardener/pkg/apis/core/",
-            "docsURLTemplate": "../core.md#core.gardener.cloud/v1alpha1.{{.TypeIdentifier}}"
+            "typeMatchPrefix": "^github\\.com/gardener/gardener/pkg/apis/core/v1beta1",
+            "docsURLTemplate": "./core.md#core.gardener.cloud/v1beta1.{{.TypeIdentifier}}"
         },
         {
             "typeMatchPrefix": "^k8s\\.io/(api|apimachinery/pkg/apis)/",

--- a/hack/api-reference/extensions.md
+++ b/hack/api-reference/extensions.md
@@ -2712,7 +2712,7 @@ k8s.io/apimachinery/pkg/runtime.RawExtension
 <td>
 <code>conditions</code></br>
 <em>
-<a href="../core.md#core.gardener.cloud/v1alpha1.Condition">
+<a href="./core.md#core.gardener.cloud/v1beta1.Condition">
 []github.com/gardener/gardener/pkg/apis/core/v1beta1.Condition
 </a>
 </em>
@@ -2726,7 +2726,7 @@ k8s.io/apimachinery/pkg/runtime.RawExtension
 <td>
 <code>lastError</code></br>
 <em>
-<a href="../core.md#core.gardener.cloud/v1alpha1.LastError">
+<a href="./core.md#core.gardener.cloud/v1beta1.LastError">
 github.com/gardener/gardener/pkg/apis/core/v1beta1.LastError
 </a>
 </em>
@@ -2740,7 +2740,7 @@ github.com/gardener/gardener/pkg/apis/core/v1beta1.LastError
 <td>
 <code>lastOperation</code></br>
 <em>
-<a href="../core.md#core.gardener.cloud/v1alpha1.LastOperation">
+<a href="./core.md#core.gardener.cloud/v1beta1.LastOperation">
 github.com/gardener/gardener/pkg/apis/core/v1beta1.LastOperation
 </a>
 </em>
@@ -2779,7 +2779,7 @@ k8s.io/apimachinery/pkg/runtime.RawExtension
 <td>
 <code>resources</code></br>
 <em>
-<a href="../core.md#core.gardener.cloud/v1alpha1.NamedResourceReference">
+<a href="./core.md#core.gardener.cloud/v1beta1.NamedResourceReference">
 []github.com/gardener/gardener/pkg/apis/core/v1beta1.NamedResourceReference
 </a>
 </em>
@@ -3993,7 +3993,7 @@ string
 <td>
 <code>machineControllerManager</code></br>
 <em>
-<a href="../core.md#core.gardener.cloud/v1alpha1.MachineControllerManagerSettings">
+<a href="./core.md#core.gardener.cloud/v1beta1.MachineControllerManagerSettings">
 github.com/gardener/gardener/pkg/apis/core/v1beta1.MachineControllerManagerSettings
 </a>
 </em>


### PR DESCRIPTION
/area documentation

@Kristian-ZH noticed that even after https://github.com/gardener/gardener/pull/4678 there are still broken links in the extensions API reference:

```
W1004 06:56:34.656804      48 content_processor.go:242] failed to validate absolute link for ../core.md#core.gardener.cloud/v1alpha1.Condition from source https://github.com/gardener/gardener/blob/master/hack/api-reference/extensions.md: resource "https://github.com/gardener/gardener/blob/master/hack/core.md#core.gardener.cloud/v1alpha1.Condition" not found
W1004 06:56:34.656876      48 content_processor.go:242] failed to validate absolute link for ../core.md#core.gardener.cloud/v1alpha1.LastError from source https://github.com/gardener/gardener/blob/master/hack/api-reference/extensions.md: resource "https://github.com/gardener/gardener/blob/master/hack/core.md#core.gardener.cloud/v1alpha1.LastError" not found
W1004 06:56:34.656952      48 content_processor.go:242] failed to validate absolute link for ../core.md#core.gardener.cloud/v1alpha1.LastOperation from source https://github.com/gardener/gardener/blob/master/hack/api-reference/extensions.md: resource "https://github.com/gardener/gardener/blob/master/hack/core.md#core.gardener.cloud/v1alpha1.LastOperation" not found
W1004 06:56:34.684061      48 content_processor.go:242] failed to validate absolute link for ../core.md#core.gardener.cloud/v1alpha1.NamedResourceReference from source https://github.com/gardener/gardener/blob/master/hack/api-reference/extensions.md: resource "https://github.com/gardener/gardener/blob/master/hack/core.md#core.gardener.cloud/v1alpha1.NamedResourceReference" not found
W1004 06:56:35.008112      48 content_processor.go:242] failed to validate absolute link for ../core.md#core.gardener.cloud/v1alpha1.MachineControllerManagerSettings from source https://github.com/gardener/gardener/blob/master/hack/api-reference/extensions.md: resource "https://github.com/gardener/gardener/blob/master/hack/core.md#core.gardener.cloud/v1alpha1.MachineControllerManagerSettings" not found
```

This PR fixes the broken links.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
