### PR TITLE
Remove the "garden.sapcloud.io/role" label from several control plane components (1)

### DIFF
--- a/pkg/operation/botanist/component/clusterautoscaler/cluster_autoscaler.go
+++ b/pkg/operation/botanist/component/clusterautoscaler/cluster_autoscaler.go
@@ -176,7 +176,6 @@ func (c *clusterAutoscaler) Deploy(ctx context.Context) error {
 				},
 				Labels: utils.MergeStringMaps(getLabels(), map[string]string{
 					v1beta1constants.GardenRole:                         v1beta1constants.GardenRoleControlPlane,
-					v1beta1constants.DeprecatedGardenRole:               v1beta1constants.GardenRoleControlPlane,
 					v1beta1constants.LabelNetworkPolicyToDNS:            v1beta1constants.LabelNetworkPolicyAllowed,
 					v1beta1constants.LabelNetworkPolicyToShootAPIServer: v1beta1constants.LabelNetworkPolicyAllowed,
 					v1beta1constants.LabelNetworkPolicyToSeedAPIServer:  v1beta1constants.LabelNetworkPolicyAllowed,

--- a/pkg/operation/botanist/component/clusterautoscaler/cluster_autoscaler_test.go
+++ b/pkg/operation/botanist/component/clusterautoscaler/cluster_autoscaler_test.go
@@ -252,7 +252,6 @@ var _ = Describe("ClusterAutoscaler", func() {
 								"app":                              "kubernetes",
 								"role":                             "cluster-autoscaler",
 								"gardener.cloud/role":              "controlplane",
-								"garden.sapcloud.io/role":          "controlplane",
 								"networking.gardener.cloud/to-dns": "allowed",
 								"networking.gardener.cloud/to-seed-apiserver":  "allowed",
 								"networking.gardener.cloud/to-shoot-apiserver": "allowed",

--- a/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager.go
@@ -213,7 +213,6 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 				},
 				Labels: utils.MergeStringMaps(getLabels(), map[string]string{
 					v1beta1constants.GardenRole:                         v1beta1constants.GardenRoleControlPlane,
-					v1beta1constants.DeprecatedGardenRole:               v1beta1constants.GardenRoleControlPlane,
 					v1beta1constants.LabelPodMaintenanceRestart:         "true",
 					v1beta1constants.LabelNetworkPolicyToDNS:            v1beta1constants.LabelNetworkPolicyAllowed,
 					v1beta1constants.LabelNetworkPolicyToShootAPIServer: v1beta1constants.LabelNetworkPolicyAllowed,

--- a/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager_test.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager_test.go
@@ -419,7 +419,6 @@ var _ = Describe("KubeControllerManager", func() {
 										"app":                                "kubernetes",
 										"role":                               "controller-manager",
 										"gardener.cloud/role":                "controlplane",
-										"garden.sapcloud.io/role":            "controlplane",
 										"maintenance.gardener.cloud/restart": "true",
 										"networking.gardener.cloud/to-dns":   "allowed",
 										"networking.gardener.cloud/to-shoot-apiserver": "allowed",

--- a/pkg/operation/botanist/component/kubescheduler/kube_scheduler.go
+++ b/pkg/operation/botanist/component/kubescheduler/kube_scheduler.go
@@ -183,7 +183,6 @@ func (k *kubeScheduler) Deploy(ctx context.Context) error {
 				},
 				Labels: utils.MergeStringMaps(getLabels(), map[string]string{
 					v1beta1constants.GardenRole:                         v1beta1constants.GardenRoleControlPlane,
-					v1beta1constants.DeprecatedGardenRole:               v1beta1constants.GardenRoleControlPlane,
 					v1beta1constants.LabelPodMaintenanceRestart:         "true",
 					v1beta1constants.LabelNetworkPolicyToDNS:            v1beta1constants.LabelNetworkPolicyAllowed,
 					v1beta1constants.LabelNetworkPolicyToShootAPIServer: v1beta1constants.LabelNetworkPolicyAllowed,

--- a/pkg/operation/botanist/component/kubescheduler/kube_scheduler_test.go
+++ b/pkg/operation/botanist/component/kubescheduler/kube_scheduler_test.go
@@ -177,7 +177,6 @@ var _ = Describe("KubeScheduler", func() {
 								"app":                                "kubernetes",
 								"role":                               "scheduler",
 								"gardener.cloud/role":                "controlplane",
-								"garden.sapcloud.io/role":            "controlplane",
 								"maintenance.gardener.cloud/restart": "true",
 								"networking.gardener.cloud/to-dns":   "allowed",
 								"networking.gardener.cloud/to-shoot-apiserver": "allowed",

--- a/pkg/operation/botanist/component/resourcemanager/resource_manager.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager.go
@@ -443,14 +443,6 @@ func (r *resourceManager) ensureDeployment(ctx context.Context) error {
 			}
 		}
 
-		// TODO(beckermax) remove in a future version
-		// Leave garden.sapcloud.io/role in controlplane pods for compatibility reasons
-		if v, ok := deployment.Labels[v1beta1constants.GardenRole]; ok && v == v1beta1constants.GardenRoleControlPlane {
-			deployment.Spec.Template.ObjectMeta.Labels = utils.MergeStringMaps(deployment.Spec.Template.ObjectMeta.Labels, map[string]string{
-				v1beta1constants.DeprecatedGardenRole: v1beta1constants.GardenRoleControlPlane,
-			})
-		}
-
 		return nil
 	})
 	return err

--- a/pkg/operation/botanist/component/resourcemanager/resource_manager_test.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager_test.go
@@ -300,7 +300,6 @@ var _ = Describe("ResourceManager", func() {
 							"networking.gardener.cloud/to-shoot-apiserver": "allowed",
 							v1beta1constants.GardenRole:                    v1beta1constants.GardenRoleControlPlane,
 							v1beta1constants.LabelApp:                      "gardener-resource-manager",
-							v1beta1constants.DeprecatedGardenRole:          v1beta1constants.GardenRoleControlPlane,
 						},
 					},
 					Spec: corev1.PodSpec{
@@ -637,7 +636,6 @@ var _ = Describe("ResourceManager", func() {
 				delete(service.ObjectMeta.Labels, v1beta1constants.GardenRole)
 				delete(deployment.ObjectMeta.Labels, v1beta1constants.GardenRole)
 				delete(deployment.Spec.Template.ObjectMeta.Labels, v1beta1constants.GardenRole)
-				delete(deployment.Spec.Template.ObjectMeta.Labels, v1beta1constants.DeprecatedGardenRole)
 				delete(vpa.ObjectMeta.Labels, v1beta1constants.GardenRole)
 				// Remove networking label from deployment template
 				delete(deployment.Spec.Template.Labels, "networking.gardener.cloud/to-dns")


### PR DESCRIPTION
/kind cleanup
/merge squash

As the last part of https://github.com/gardener/gardener/issues/1649, we can now remove the deprecated "garden.sapcloud.io/role" label key from the control plane Pods (since longtime the control plane Pods are already maintaining both "gardener.cloud/role" and "garden.sapcloud.io/role").

This PR adapts the kube-controller-manager, kube-scheduler, gardener-resource-manager and cluster-autoscaler Pod templates.
My plan is to follow up with similar PRs for kube-apiserver, monitoring components and logging components.

Ref https://github.com/gardener/gardener/issues/1649

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
