### PR TITLE
[release-v1.31] Automated cherry pick of #4714: Increase the kube-rback-proxy and telegraf resources in Loki pod

### DIFF
--- a/charts/seed-bootstrap/charts/loki/templates/hvpa.yaml
+++ b/charts/seed-bootstrap/charts/loki/templates/hvpa.yaml
@@ -76,10 +76,12 @@ spec:
                 cpu: "{{ .Values.hvpa.minAllowed.cpu }}"
             - containerName: curator
               mode: "Off"
+{{- if .Values.rbacSidecarEnabled }}
             - containerName: kube-rbac-proxy
               mode: "Off"
             - containerName: telegraf
               mode: "Off"
+{{- end }}
   weightBasedScalingIntervals:
     - vpaWeight: 100
       startReplicaCount: {{ .Values.replicas }}

--- a/charts/seed-bootstrap/charts/loki/values.yaml
+++ b/charts/seed-bootstrap/charts/loki/values.yaml
@@ -67,18 +67,18 @@ resources:
       memory: 12Mi
   kubeRBACproxy:
     limits:
-      cpu: 20m
-      memory: 30Mi
+      cpu: 60m
+      memory: 50Mi
     requests:
-      cpu: 5m
+      cpu: 30m
       memory: 15Mi 
   telegraf:
     limits:
-      cpu: 5m
-      memory: 50Mi
+      cpu: 15m
+      memory: 100Mi
     requests:
-      cpu: 2m
-      memory: 24Mi
+      cpu: 5m
+      memory: 35Mi
 
 securityContext:
   fsGroup: 10001


### PR DESCRIPTION
/kind/enhancement
/area/logging

Cherry pick of #4714 on release-v1.31.

#4714: Increase the kube-rback-proxy and telegraf resources in Loki pod

**Release Notes:**
```other operator
Increased the `kube-rback-proxy` and `telegraf` container resources in Loki pod to withstand higher resource usage spikes.
```