### PR TITLE
Remove the "garden.sapcloud.io/role" label from several control plane components (2)

### DIFF
--- a/charts/seed-bootstrap/charts/loki/templates/statefulset.yaml
+++ b/charts/seed-bootstrap/charts/loki/templates/statefulset.yaml
@@ -21,7 +21,6 @@ spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      garden.sapcloud.io/role: logging
 {{ toYaml .Values.labels | indent 6 }}
   template:
     metadata:
@@ -31,7 +30,6 @@ spec:
         networking.gardener.cloud/to-dns: allowed
         networking.gardener.cloud/to-shoot-apiserver: allowed
 {{- end}}
-        garden.sapcloud.io/role: logging
 {{ toYaml .Values.labels | indent 8 }}
       annotations:
 {{ include "loki.statefulset.annotations" . | indent 8 }}

--- a/charts/seed-monitoring/charts/alertmanager/templates/alertmanager.yaml
+++ b/charts/seed-monitoring/charts/alertmanager/templates/alertmanager.yaml
@@ -56,7 +56,6 @@ spec:
     metadata:
       labels:
         gardener.cloud/role: monitoring
-        garden.sapcloud.io/role: monitoring
         component: alertmanager
         role: monitoring
         networking.gardener.cloud/to-dns: allowed

--- a/charts/seed-monitoring/charts/core/charts/kube-state-metrics-shoot/templates/deployment.yaml
+++ b/charts/seed-monitoring/charts/core/charts/kube-state-metrics-shoot/templates/deployment.yaml
@@ -22,7 +22,6 @@ spec:
     metadata:
       labels:
         gardener.cloud/role: monitoring
-        garden.sapcloud.io/role: monitoring
         component: kube-state-metrics
         type: shoot
         networking.gardener.cloud/to-dns: allowed

--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
@@ -54,7 +54,6 @@ spec:
 {{- end }}
       labels:
         gardener.cloud/role: monitoring
-        garden.sapcloud.io/role: monitoring
         app: prometheus
         role: monitoring
         networking.gardener.cloud/to-dns: allowed

--- a/charts/seed-monitoring/charts/grafana/templates/grafana-deployment.yaml
+++ b/charts/seed-monitoring/charts/grafana/templates/grafana-deployment.yaml
@@ -28,7 +28,6 @@ spec:
 {{ include "grafana.deployment.annotations" . | indent 8 }}
       labels:
         gardener.cloud/role: monitoring
-        garden.sapcloud.io/role: monitoring
         component: grafana
         networking.gardener.cloud/to-dns: allowed
         role: {{ .Values.role }}

--- a/pkg/operation/botanist/component/kubeapiserver/deployment.go
+++ b/pkg/operation/botanist/component/kubeapiserver/deployment.go
@@ -152,7 +152,6 @@ func (k *kubeAPIServer) reconcileDeployment(
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: k.computePodAnnotations(),
 					Labels: utils.MergeStringMaps(GetLabels(), map[string]string{
-						v1beta1constants.DeprecatedGardenRole:                v1beta1constants.GardenRoleControlPlane,
 						v1beta1constants.LabelNetworkPolicyToDNS:             v1beta1constants.LabelNetworkPolicyAllowed,
 						v1beta1constants.LabelNetworkPolicyToPublicNetworks:  v1beta1constants.LabelNetworkPolicyAllowed,
 						v1beta1constants.LabelNetworkPolicyToPrivateNetworks: v1beta1constants.LabelNetworkPolicyAllowed,

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
@@ -1455,7 +1455,6 @@ rules:
 						"reference.resources.gardener.cloud/configmap-d4419cd4": "audit-policy-config-f5b578b4",
 					}))
 					Expect(deployment.Spec.Template.Labels).To(Equal(map[string]string{
-						"garden.sapcloud.io/role":          "controlplane",
 						"gardener.cloud/role":              "controlplane",
 						"app":                              "kubernetes",
 						"role":                             "apiserver",

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -388,12 +388,12 @@ func DeleteGrafanaByRole(ctx context.Context, k8sClient kubernetes.Interface, na
 	return nil
 }
 
-// DeleteDeploymentsHavingDeprecatedRoleLabelKey deletes the Deployments with the passed object keys if
-// the corresponding Deployment .spec.selector contains the deprecated "garden.sapcloud.io/role" label key.
-func DeleteDeploymentsHavingDeprecatedRoleLabelKey(ctx context.Context, c client.Client, keys []client.ObjectKey) error {
+// DeleteStatefulSetsHavingDeprecatedRoleLabelKey deletes the StatefulSets with the passed object keys if
+// the corresponding StatefulSet .spec.selector contains the deprecated "garden.sapcloud.io/role" label key.
+func DeleteStatefulSetsHavingDeprecatedRoleLabelKey(ctx context.Context, c client.Client, keys []client.ObjectKey) error {
 	for _, key := range keys {
-		deployment := &appsv1.Deployment{}
-		if err := c.Get(ctx, key, deployment); err != nil {
+		sts := &appsv1.StatefulSet{}
+		if err := c.Get(ctx, key, sts); err != nil {
 			if apierrors.IsNotFound(err) {
 				continue
 			}
@@ -401,12 +401,12 @@ func DeleteDeploymentsHavingDeprecatedRoleLabelKey(ctx context.Context, c client
 			return err
 		}
 
-		if _, ok := deployment.Spec.Selector.MatchLabels[v1beta1constants.DeprecatedGardenRole]; ok {
-			if err := c.Delete(ctx, deployment); client.IgnoreNotFound(err) != nil {
+		if _, ok := sts.Spec.Selector.MatchLabels[v1beta1constants.DeprecatedGardenRole]; ok {
+			if err := c.Delete(ctx, sts); client.IgnoreNotFound(err) != nil {
 				return err
 			}
 
-			if err := kutil.WaitUntilResourceDeleted(ctx, c, deployment, 2*time.Second); err != nil {
+			if err := kutil.WaitUntilResourceDeleted(ctx, c, sts, 2*time.Second); err != nil {
 				return err
 			}
 		}

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -950,6 +950,18 @@ func RunReconcileSeedFlow(
 		return err
 	}
 
+	// .spec.selector of a StatefulSet is immutable. If StatefulSet's .spec.selector contains
+	// the deprecated role label key, we delete it and let it to be re-created below with the chart apply.
+	// TODO (ialidzhikov): remove in a future version
+	if loggingEnabled {
+		stsKeys := []client.ObjectKey{
+			kutil.Key(v1beta1constants.GardenNamespace, v1beta1constants.StatefulSetNameLoki),
+		}
+		if err := common.DeleteStatefulSetsHavingDeprecatedRoleLabelKey(ctx, seedClient, stsKeys); err != nil {
+			return err
+		}
+	}
+
 	values := kubernetes.Values(map[string]interface{}{
 		"priorityClassName": v1beta1constants.PriorityClassNameShootControlPlane,
 		"global": map[string]interface{}{


### PR DESCRIPTION
/kind cleanup
/merge squash

Second part of https://github.com/gardener/gardener/pull/4768

Ref #1649

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
gardenlet does no longer maintain the deprecated `garden.sapcloud.io/role` label key in the control plane Pod labels. Before upgrading this this version of Gardener, make sure that you first upgraded to at least Gardener v1.31.0.
```
