### PR TITLE
Fix few warnings on API reference generation

### DIFF
--- a/hack/api-reference/seedmanagement-config.json
+++ b/hack/api-reference/seedmanagement-config.json
@@ -8,6 +8,14 @@
     ],
     "externalPackages": [
         {
+            "typeMatchPrefix": "^k8s\\.io/apimachinery/pkg/runtime\\.RawExtension$",
+            "docsURLTemplate": "https://godoc.org/k8s.io/apimachinery/pkg/runtime#RawExtension"
+        },
+        {
+            "typeMatchPrefix": "^github\\.com/gardener/gardener/pkg/apis/core/v1beta1",
+            "docsURLTemplate": "./core.md#core.gardener.cloud/v1beta1.{{.TypeIdentifier}}"
+        },
+        {
             "typeMatchPrefix": "^k8s\\.io/(api|apimachinery/pkg/apis)/",
             "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
         }

--- a/hack/api-reference/seedmanagement.md
+++ b/hack/api-reference/seedmanagement.md
@@ -93,7 +93,9 @@ Shoot
 <td>
 <code>seedTemplate</code></br>
 <em>
+<a href="./core.md#core.gardener.cloud/v1beta1.SeedTemplate">
 github.com/gardener/gardener/pkg/apis/core/v1beta1.SeedTemplate
+</a>
 </em>
 </td>
 <td>
@@ -242,7 +244,9 @@ Each ManagedSeed created / updated by the ManagedSeedSet will fulfill this templ
 <td>
 <code>shootTemplate</code></br>
 <em>
+<a href="./core.md#core.gardener.cloud/v1beta1.ShootTemplate">
 github.com/gardener/gardener/pkg/apis/core/v1beta1.ShootTemplate
+</a>
 </em>
 </td>
 <td>
@@ -343,7 +347,9 @@ the image, etc.</p>
 <td>
 <code>config</code></br>
 <em>
+<a href="https://godoc.org/k8s.io/apimachinery/pkg/runtime#RawExtension">
 k8s.io/apimachinery/pkg/runtime.RawExtension
+</a>
 </em>
 </td>
 <td>
@@ -663,7 +669,9 @@ Each ManagedSeed created / updated by the ManagedSeedSet will fulfill this templ
 <td>
 <code>shootTemplate</code></br>
 <em>
+<a href="./core.md#core.gardener.cloud/v1beta1.ShootTemplate">
 github.com/gardener/gardener/pkg/apis/core/v1beta1.ShootTemplate
+</a>
 </em>
 </td>
 <td>
@@ -830,7 +838,9 @@ newest ControllerRevision.</p>
 <td>
 <code>conditions</code></br>
 <em>
+<a href="./core.md#core.gardener.cloud/v1beta1.Condition">
 []github.com/gardener/gardener/pkg/apis/core/v1beta1.Condition
+</a>
 </em>
 </td>
 <td>
@@ -891,7 +901,9 @@ Shoot
 <td>
 <code>seedTemplate</code></br>
 <em>
+<a href="./core.md#core.gardener.cloud/v1beta1.SeedTemplate">
 github.com/gardener/gardener/pkg/apis/core/v1beta1.SeedTemplate
+</a>
 </em>
 </td>
 <td>
@@ -939,7 +951,9 @@ with the given deployment parameters and GardenletConfiguration.</p>
 <td>
 <code>conditions</code></br>
 <em>
+<a href="./core.md#core.gardener.cloud/v1beta1.Condition">
 []github.com/gardener/gardener/pkg/apis/core/v1beta1.Condition
+</a>
 </em>
 </td>
 <td>
@@ -1027,7 +1041,9 @@ Shoot
 <td>
 <code>seedTemplate</code></br>
 <em>
+<a href="./core.md#core.gardener.cloud/v1beta1.SeedTemplate">
 github.com/gardener/gardener/pkg/apis/core/v1beta1.SeedTemplate
+</a>
 </em>
 </td>
 <td>


### PR DESCRIPTION
/area documentation
/kind enhancement

Currently `make generate-sequential` yields the following warnings while generating the API reference for the seedmanagement:

```
I1006 14:13:57.806416   15029 main.go:229] using package=github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1
W1006 14:13:57.935732   15029 main.go:423] not found external link source for type github.com/gardener/gardener/pkg/apis/core/v1beta1.SeedTemplate
W1006 14:13:57.936879   15029 main.go:423] not found external link source for type github.com/gardener/gardener/pkg/apis/core/v1beta1.ShootTemplate
W1006 14:13:57.937229   15029 main.go:423] not found external link source for type k8s.io/apimachinery/pkg/runtime.RawExtension
W1006 14:13:57.940018   15029 main.go:423] not found external link source for type github.com/gardener/gardener/pkg/apis/core/v1beta1.ShootTemplate
W1006 14:13:57.940384   15029 main.go:423] not found external link source for type github.com/gardener/gardener/pkg/apis/core/v1beta1.Condition
W1006 14:13:57.940681   15029 main.go:423] not found external link source for type github.com/gardener/gardener/pkg/apis/core/v1beta1.SeedTemplate
W1006 14:13:57.940830   15029 main.go:423] not found external link source for type github.com/gardener/gardener/pkg/apis/core/v1beta1.Condition
W1006 14:13:57.941306   15029 main.go:423] not found external link source for type github.com/gardener/gardener/pkg/apis/core/v1beta1.SeedTemplate
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
