### PR TITLE
Eliminate `Try{Update,Patch}*`

### DIFF
--- a/extensions/pkg/controller/backupentry/reconciler.go
+++ b/extensions/pkg/controller/backupentry/reconciler.go
@@ -265,7 +265,7 @@ func (r *reconciler) migrate(ctx context.Context, be *extensionsv1alpha1.BackupE
 	}
 
 	r.logger.Info("Removing all finalizers", "backupentry", kutil.ObjectName(be))
-	if err := extensionscontroller.DeleteAllFinalizers(ctx, r.client, be); err != nil {
+	if err := controllerutils.RemoveAllFinalizers(ctx, r.client, r.client, be); err != nil {
 		return reconcile.Result{}, fmt.Errorf("error removing all finalizers from backupentry: %+v", err)
 	}
 

--- a/extensions/pkg/controller/containerruntime/reconciler.go
+++ b/extensions/pkg/controller/containerruntime/reconciler.go
@@ -219,7 +219,7 @@ func (r *reconciler) migrate(ctx context.Context, cr *extensionsv1alpha1.Contain
 	}
 
 	r.logger.Info("Removing all finalizers", "containerruntime", kutil.ObjectName(cr))
-	if err := extensionscontroller.DeleteAllFinalizers(ctx, r.client, cr); err != nil {
+	if err := controllerutils.RemoveAllFinalizers(ctx, r.client, r.client, cr); err != nil {
 		return reconcile.Result{}, fmt.Errorf("error removing finalizers from the containerruntime: %+v", err)
 	}
 

--- a/extensions/pkg/controller/controlplane/reconciler.go
+++ b/extensions/pkg/controller/controlplane/reconciler.go
@@ -203,7 +203,7 @@ func (r *reconciler) migrate(ctx context.Context, cp *extensionsv1alpha1.Control
 	}
 
 	r.logger.Info("Removing all finalizers.", "controlplane", kutil.ObjectName(cp))
-	if err := extensionscontroller.DeleteAllFinalizers(ctx, r.client, cp); err != nil {
+	if err := controllerutils.RemoveAllFinalizers(ctx, r.client, r.client, cp); err != nil {
 		return reconcile.Result{}, fmt.Errorf("error removing finalizers from controlplane: %+v", err)
 	}
 

--- a/extensions/pkg/controller/dnsrecord/reconciler.go
+++ b/extensions/pkg/controller/dnsrecord/reconciler.go
@@ -196,7 +196,7 @@ func (r *reconciler) migrate(ctx context.Context, dns *extensionsv1alpha1.DNSRec
 	}
 
 	r.logger.Info("Removing all finalizers", "dnsrecord", kutil.ObjectName(dns))
-	if err := extensionscontroller.DeleteAllFinalizers(ctx, r.client, dns); err != nil {
+	if err := controllerutils.RemoveAllFinalizers(ctx, r.client, r.client, dns); err != nil {
 		return reconcile.Result{}, fmt.Errorf("error removing finalizers from dnsrecord: %+v", err)
 	}
 

--- a/extensions/pkg/controller/extension/reconciler.go
+++ b/extensions/pkg/controller/extension/reconciler.go
@@ -233,7 +233,7 @@ func (r *reconciler) migrate(ctx context.Context, ex *extensionsv1alpha1.Extensi
 	}
 
 	r.logger.Info("Removing all finalizers", "extension", kutil.ObjectName(ex))
-	if err := extensionscontroller.DeleteAllFinalizers(ctx, r.client, ex); err != nil {
+	if err := controllerutils.RemoveAllFinalizers(ctx, r.client, r.client, ex); err != nil {
 		return reconcile.Result{}, fmt.Errorf("error removing finalizers from extension: %+v", err)
 	}
 

--- a/extensions/pkg/controller/healthcheck/reconciler.go
+++ b/extensions/pkg/controller/healthcheck/reconciler.go
@@ -23,7 +23,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -36,7 +35,6 @@ import (
 	gardenv1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	"github.com/gardener/gardener/pkg/controllerutils"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
@@ -268,19 +266,17 @@ type condition struct {
 }
 
 func (r *reconciler) updateExtensionConditions(ctx context.Context, extension extensionsv1alpha1.Object, conditions ...condition) error {
-	return controllerutils.TryPatchStatus(ctx, retry.DefaultBackoff, r.client, extension, func() error {
-		for _, cond := range conditions {
-			now := metav1.Now()
-			if c := gardencorev1beta1helper.GetCondition(extension.GetExtensionStatus().GetConditions(), gardencorev1beta1.ConditionType(cond.healthConditionType)); c != nil {
-				cond.builder.WithOldCondition(*c)
-			}
-			updatedCondition, _ := cond.builder.WithNowFunc(func() metav1.Time { return now }).Build()
-			// always update - the Gardenlet expects a recent health check
-			updatedCondition.LastUpdateTime = now
-			extension.GetExtensionStatus().SetConditions(gardencorev1beta1helper.MergeConditions(extension.GetExtensionStatus().GetConditions(), updatedCondition))
+	for _, cond := range conditions {
+		now := metav1.Now()
+		if c := gardencorev1beta1helper.GetCondition(extension.GetExtensionStatus().GetConditions(), gardencorev1beta1.ConditionType(cond.healthConditionType)); c != nil {
+			cond.builder.WithOldCondition(*c)
 		}
-		return nil
-	})
+		updatedCondition, _ := cond.builder.WithNowFunc(func() metav1.Time { return now }).Build()
+		// always update - the Gardenlet expects a recent health check
+		updatedCondition.LastUpdateTime = now
+		extension.GetExtensionStatus().SetConditions(gardencorev1beta1helper.MergeConditions(extension.GetExtensionStatus().GetConditions(), updatedCondition))
+	}
+	return r.client.Status().Update(ctx, extension)
 }
 
 func (r *reconciler) resultWithRequeue() reconcile.Result {

--- a/extensions/pkg/controller/network/reconciler.go
+++ b/extensions/pkg/controller/network/reconciler.go
@@ -216,7 +216,7 @@ func (r *reconciler) migrate(ctx context.Context, network *extensionsv1alpha1.Ne
 	}
 
 	r.logger.Info("Removing all finalizers", "network", kutil.ObjectName(network))
-	if err := extensionscontroller.DeleteAllFinalizers(ctx, r.client, network); err != nil {
+	if err := controllerutils.RemoveAllFinalizers(ctx, r.client, r.client, network); err != nil {
 		return reconcile.Result{}, fmt.Errorf("error removing finalizers from the network: %+v", err)
 	}
 

--- a/extensions/pkg/controller/operatingsystemconfig/reconciler.go
+++ b/extensions/pkg/controller/operatingsystemconfig/reconciler.go
@@ -264,8 +264,8 @@ func (r *reconciler) migrate(ctx context.Context, osc *extensionsv1alpha1.Operat
 	}
 
 	r.logger.Info("Removing finalizer.", "osc", osc.Name)
-	if err := extensionscontroller.DeleteAllFinalizers(ctx, r.client, osc); err != nil {
-		return reconcile.Result{}, fmt.Errorf("Error removing all finalizers from operatingsystemconfig: %+v", err)
+	if err := controllerutils.RemoveAllFinalizers(ctx, r.client, r.client, osc); err != nil {
+		return reconcile.Result{}, fmt.Errorf("error removing all finalizers from operatingsystemconfig: %+v", err)
 	}
 
 	if err := extensionscontroller.RemoveAnnotation(ctx, r.client, osc, v1beta1constants.GardenerOperation); err != nil {

--- a/extensions/pkg/controller/utils.go
+++ b/extensions/pkg/controller/utils.go
@@ -24,7 +24,6 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
-	"github.com/gardener/gardener/pkg/controllerutils"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
 	"github.com/Masterminds/semver"
@@ -34,7 +33,6 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -83,14 +81,6 @@ func (a *AddToManagerBuilder) AddToManager(m manager.Manager) error {
 		}
 	}
 	return nil
-}
-
-// DeleteAllFinalizers removes all finalizers from the object and issues an  update.
-func DeleteAllFinalizers(ctx context.Context, client client.Client, obj client.Object) error {
-	return controllerutils.TryUpdate(ctx, retry.DefaultBackoff, client, obj, func() error {
-		obj.SetFinalizers(nil)
-		return nil
-	})
 }
 
 // GetSecretByReference returns the Secret object matching the given SecretReference.

--- a/extensions/pkg/controller/worker/genericactuator/actuator.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator.go
@@ -255,8 +255,8 @@ func (a *genericActuator) shallowDeleteMachineClassSecrets(ctx context.Context, 
 	// Delete the finalizers to all secrets which were used for machine classes that do not exist anymore.
 	for _, secret := range secretList.Items {
 		if !wantedMachineDeployments.HasSecret(secret.Name) {
-			if err := extensionscontroller.DeleteAllFinalizers(ctx, a.client, &secret); err != nil {
-				return fmt.Errorf("Error removing finalizer from MachineClassSecret: %s/%s: %w", secret.Namespace, secret.Name, err)
+			if err := controllerutils.RemoveAllFinalizers(ctx, a.client, a.client, &secret); err != nil {
+				return fmt.Errorf("error removing finalizer from MachineClassSecret: %s/%s: %w", secret.Namespace, secret.Name, err)
 			}
 			if err := a.client.Delete(ctx, &secret); err != nil {
 				return err
@@ -322,7 +322,7 @@ func (a *genericActuator) shallowDeleteAllObjects(ctx context.Context, logger lo
 
 	return meta.EachListItem(objectList, func(obj runtime.Object) error {
 		object := obj.(client.Object)
-		if err := extensionscontroller.DeleteAllFinalizers(ctx, a.client, object); err != nil {
+		if err := controllerutils.RemoveAllFinalizers(ctx, a.client, a.client, object); err != nil {
 			return err
 		}
 		if err := a.client.Delete(ctx, object); client.IgnoreNotFound(err) != nil {

--- a/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
@@ -22,14 +22,12 @@ import (
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	workercontroller "github.com/gardener/gardener/extensions/pkg/controller/worker"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	"github.com/gardener/gardener/pkg/controllerutils"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
@@ -133,12 +131,8 @@ func (a *genericActuator) restoreMachineSetsAndMachines(ctx context.Context, log
 				return err
 			}
 
-			if err := controllerutils.TryPatchStatus(ctx, retry.DefaultBackoff, a.client, newMachine, func() error {
-				newMachine.Status = machine.Status
-				return nil
-			}); err != nil {
-				return err
-			}
+			newMachine.Status = machine.Status
+			return a.client.Status().Update(ctx, newMachine)
 		}
 	}
 

--- a/pkg/controllerutils/patch_test.go
+++ b/pkg/controllerutils/patch_test.go
@@ -16,13 +16,9 @@ package controllerutils
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
-	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/test"
 
 	"github.com/golang/mock/gomock"
@@ -35,9 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	corescheme "k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -229,46 +223,4 @@ var _ = Describe("Patch", func() {
 		Describe("#CreateOrGetAndMergePatch", func() { testSuite(CreateOrGetAndMergePatch, types.MergePatchType) })
 		Describe("#CreateOrGetAndStrategicMergePatch", func() { testSuite(CreateOrGetAndStrategicMergePatch, types.StrategicMergePatchType) })
 	})
-
-	Describe("#TryPatch", func() {
-		It("should set state to obj, when conflict occurs", func() {
-			s := runtime.NewScheme()
-			Expect(extensionsv1alpha1.AddToScheme(s)).NotTo(HaveOccurred())
-			objInFakeClient := newInfraObj()
-			objInFakeClient.SetResourceVersion("1")
-			objInFakeClient.Status.Conditions = []v1beta1.Condition{
-				{Type: "Health", Reason: "reason", Message: "messages", Status: "status", LastUpdateTime: metav1.Now()},
-			}
-
-			c := fake.NewClientBuilder().WithScheme(s).WithObjects(objInFakeClient).Build()
-			infraObj := objInFakeClient.DeepCopy()
-			transform := func() error {
-				infraState, _ := json.Marshal(state{"someState"})
-				infraObj.GetExtensionStatus().SetState(&runtime.RawExtension{Raw: infraState})
-				return nil
-			}
-
-			u := &conflictErrManager{
-				conflictsBeforeUpdate: 2,
-				client:                c,
-			}
-
-			tryPatchErr := tryPatch(context.Background(), retry.DefaultRetry, c, infraObj, u.patchFunc, transform)
-			Expect(tryPatchErr).NotTo(HaveOccurred())
-
-			objFromFakeClient := &extensionsv1alpha1.Infrastructure{}
-			err := c.Get(context.Background(), kutil.Key("infraNamespace", "infraName"), objFromFakeClient)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(objFromFakeClient).To(Equal(infraObj))
-		})
-	})
 })
-
-func (c *conflictErrManager) patchFunc(ctx context.Context, obj client.Object, patch client.Patch, o ...client.PatchOption) error {
-	if c.conflictsBeforeUpdate == c.conflictsOccured {
-		return c.client.Status().Patch(ctx, obj, patch, o...)
-	}
-
-	c.conflictsOccured++
-	return apierrors.NewConflict(schema.GroupResource{}, "", nil)
-}

--- a/pkg/controllerutils/update.go
+++ b/pkg/controllerutils/update.go
@@ -83,15 +83,6 @@ func TypedCreateOrUpdate(ctx context.Context, c client.Client, scheme *runtime.S
 	return controllerutil.OperationResultUpdated, c.Update(ctx, obj)
 }
 
-// TryUpdate tries to apply the given transformation function onto the given object, and to update it afterwards.
-// It retries the update with an exponential backoff.
-// Deprecated: This function is deprecated and will be removed in a future version. Please don't consider using it.
-// See https://github.com/gardener/gardener/blob/master/docs/development/kubernetes-clients.md#dont-retry-on-conflict
-// for more information.
-func TryUpdate(ctx context.Context, backoff wait.Backoff, c client.Client, obj client.Object, transform func() error) error {
-	return tryUpdate(ctx, backoff, c, obj, c.Update, transform)
-}
-
 // TryUpdateStatus tries to apply the given transformation function onto the given object, and to update its
 // status afterwards. It retries the status update with an exponential backoff.
 // Deprecated: This function is deprecated and will be removed in a future version. Please don't consider using it.

--- a/pkg/controllerutils/update.go
+++ b/pkg/controllerutils/update.go
@@ -17,14 +17,11 @@ package controllerutils
 import (
 	"context"
 	"fmt"
-	"reflect"
-	"time"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -81,71 +78,4 @@ func TypedCreateOrUpdate(ctx context.Context, c client.Client, scheme *runtime.S
 	}
 
 	return controllerutil.OperationResultUpdated, c.Update(ctx, obj)
-}
-
-// TryUpdateStatus tries to apply the given transformation function onto the given object, and to update its
-// status afterwards. It retries the status update with an exponential backoff.
-// Deprecated: This function is deprecated and will be removed in a future version. Please don't consider using it.
-// See https://github.com/gardener/gardener/blob/master/docs/development/kubernetes-clients.md#dont-retry-on-conflict
-// for more information.
-func TryUpdateStatus(ctx context.Context, backoff wait.Backoff, c client.Client, obj client.Object, transform func() error) error {
-	return tryUpdate(ctx, backoff, c, obj, c.Status().Update, transform)
-}
-
-func tryUpdate(ctx context.Context, backoff wait.Backoff, c client.Client, obj client.Object, updateFunc func(context.Context, client.Object, ...client.UpdateOption) error, transform func() error) error {
-	resetCopy := obj.DeepCopyObject()
-	return exponentialBackoff(ctx, backoff, func() (bool, error) {
-		if err := c.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
-			return false, err
-		}
-
-		beforeTransform := obj.DeepCopyObject()
-		if err := transform(); err != nil {
-			return false, err
-		}
-
-		if reflect.DeepEqual(obj, beforeTransform) {
-			return true, nil
-		}
-
-		if err := updateFunc(ctx, obj); err != nil {
-			if apierrors.IsConflict(err) {
-				// In case of a conflict we are resetting the obj to its original version, as it was
-				// passed to the function, to ensure that, on the next iteration the
-				// equality check of the obj recieved from the server and the object after
-				// its transformation would be valid. Otherwise the obj would be with mutated
-				// fields in result of the transform function from previous iteration.
-				reflect.ValueOf(obj).Elem().Set(reflect.ValueOf(resetCopy).Elem())
-				return false, nil
-			}
-			return false, err
-		}
-		return true, nil
-	})
-}
-
-func exponentialBackoff(ctx context.Context, backoff wait.Backoff, condition wait.ConditionFunc) error {
-	duration := backoff.Duration
-
-	for i := 0; i < backoff.Steps; i++ {
-		if ok, err := condition(); err != nil || ok {
-			return err
-		}
-
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-			adjusted := duration
-			if backoff.Jitter > 0.0 {
-				adjusted = wait.Jitter(duration, backoff.Jitter)
-			}
-			time.Sleep(adjusted)
-			duration = time.Duration(float64(duration) * backoff.Factor)
-		}
-
-		i++
-	}
-
-	return wait.ErrWaitTimeout
 }

--- a/pkg/controllerutils/update_test.go
+++ b/pkg/controllerutils/update_test.go
@@ -12,16 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package controllerutils
+package controllerutils_test
 
 import (
 	"context"
-	"encoding/json"
 
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	. "github.com/gardener/gardener/pkg/controllerutils"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
-	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 
 	"github.com/golang/mock/gomock"
@@ -36,10 +33,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	autoscalerv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
 	"k8s.io/client-go/kubernetes/scheme"
-	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
@@ -304,63 +299,3 @@ var _ = Describe("utils", func() {
 		})
 	})
 })
-
-var _ = Describe("#tryUpdate", func() {
-	It("should set state to obj, when conflict occurs", func() {
-		s := runtime.NewScheme()
-		Expect(extensionsv1alpha1.AddToScheme(s)).NotTo(HaveOccurred())
-		objInFakeClient := newInfraObj()
-		objInFakeClient.Status.Conditions = []gardencorev1beta1.Condition{
-			{Type: "Health", Reason: "reason", Message: "messages", Status: "status", LastUpdateTime: metav1.Now()},
-		}
-
-		c := fake.NewClientBuilder().WithScheme(s).WithObjects(objInFakeClient).Build()
-		infraObj := newInfraObj()
-		transform := func() error {
-			infraState, _ := json.Marshal(state{"someState"})
-			infraObj.GetExtensionStatus().SetState(&runtime.RawExtension{Raw: infraState})
-			return nil
-		}
-
-		u := &conflictErrManager{
-			conflictsBeforeUpdate: 2,
-			client:                c,
-		}
-
-		tryUpdateErr := tryUpdate(context.TODO(), retry.DefaultRetry, c, infraObj, u.updateFunc, transform)
-		Expect(tryUpdateErr).NotTo(HaveOccurred())
-
-		objFromFakeClient := &extensionsv1alpha1.Infrastructure{}
-		err := c.Get(context.TODO(), kutil.Key("infraNamespace", "infraName"), objFromFakeClient)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(objFromFakeClient).To(Equal(infraObj))
-	})
-})
-
-type state struct {
-	Name string `json:"name"`
-}
-
-func newInfraObj() *extensionsv1alpha1.Infrastructure {
-	return &extensionsv1alpha1.Infrastructure{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "infraName",
-			Namespace: "infraNamespace",
-		},
-	}
-}
-
-type conflictErrManager struct {
-	conflictsBeforeUpdate int
-	conflictsOccured      int
-	client                client.Client
-}
-
-func (c *conflictErrManager) updateFunc(ctx context.Context, obj client.Object, o ...client.UpdateOption) error {
-	if c.conflictsBeforeUpdate == c.conflictsOccured {
-		return c.client.Status().Update(ctx, obj, o...)
-	}
-
-	c.conflictsOccured++
-	return apierrors.NewConflict(schema.GroupResource{}, "", nil)
-}

--- a/pkg/utils/test/test.go
+++ b/pkg/utils/test/test.go
@@ -20,7 +20,6 @@ import (
 	"os"
 	"reflect"
 
-	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 	"github.com/golang/mock/gomock"
 	"github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -29,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
 // WithVar sets the given var to the src value and returns a function to revert to the original state.
@@ -182,7 +182,7 @@ func WithTempFile(dir, pattern string, content []byte, fileName *string) func() 
 }
 
 // EXPECTPatch is a helper function for a GoMock call expecting a patch with the mock client.
-func EXPECTPatch(ctx context.Context, c *mockclient.MockClient, expectedObj, mergeFrom client.Object, patchType types.PatchType, rets ...interface{}) *gomock.Call {
+func EXPECTPatch(ctx interface{}, c *mockclient.MockClient, expectedObj, mergeFrom client.Object, patchType types.PatchType, rets ...interface{}) *gomock.Call {
 	var expectedPatch client.Patch
 
 	switch patchType {
@@ -197,12 +197,12 @@ func EXPECTPatch(ctx context.Context, c *mockclient.MockClient, expectedObj, mer
 
 // EXPECTPatchWithOptimisticLock is a helper function for a GoMock call with the mock client
 // expecting a merge patch with optimistic lock.
-func EXPECTPatchWithOptimisticLock(ctx context.Context, c *mockclient.MockClient, expectedObj, mergeFrom client.Object, rets ...interface{}) *gomock.Call {
+func EXPECTPatchWithOptimisticLock(ctx interface{}, c *mockclient.MockClient, expectedObj, mergeFrom client.Object, rets ...interface{}) *gomock.Call {
 	expectedPatch := client.MergeFromWithOptions(mergeFrom, client.MergeFromWithOptimisticLock{})
 	return expectPatch(ctx, c, expectedObj, expectedPatch, rets...)
 }
 
-func expectPatch(ctx context.Context, c *mockclient.MockClient, expectedObj client.Object, expectedPatch client.Patch, rets ...interface{}) *gomock.Call {
+func expectPatch(ctx interface{}, c *mockclient.MockClient, expectedObj client.Object, expectedPatch client.Patch, rets ...interface{}) *gomock.Call {
 	expectedData, expectedErr := expectedPatch.Data(expectedObj)
 	Expect(expectedErr).To(BeNil())
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability quality
/kind cleanup

**What this PR does / why we need it**:

Follow-up on https://github.com/gardener/gardener/pull/4757#discussion_r722007081.
Completely eliminate `Try{Update,Patch}*` from our codebase (extensions library and resource-manager).
ref https://github.com/gardener/gardener/blob/master/docs/development/kubernetes-clients.md#dont-retry-on-conflict

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2414

**Special notes for your reviewer**:

✅ needs to be tested e2e (incl. vendoring some provider extension and testing that as well): ref https://github.com/gardener/gardener-extension-provider-aws/pull/464

/squash

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking dependency
The deprecated functions `pkg/controllerutils.Try{Patch,Update}` and friends have been removed. Please switch to the usual client methods for updating/patching without `RetryOnConflict`-semantics. See https://github.com/gardener/gardener/blob/master/docs/development/kubernetes-clients.md#dont-retry-on-conflict for more details on why their usage was discouraged.
```
```breaking dependency
The `extensions/pkg/controller.DeleteAllFinalizers` function has been removed. You can use `pkg/controllerutils.RemoveAllFinalizers` instead.
```
