### PR TITLE
Fix owner DNSRecords stuck in states different from `Succeeded`

### DIFF
--- a/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord.go
+++ b/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"time"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -174,11 +175,18 @@ func (c *dnsRecord) deploy(ctx context.Context, operation string) (extensionsv1a
 				return nil, err
 			}
 		} else {
-			// DNSRecord already exists, just update the timestamp annotation.
-			// If the object is still annotated with the operation annotation (e.g. not reconciled yet) this will send a watch
-			// event to the extension controller triggering a new reconciliation.
 			patch := client.MergeFrom(c.dnsRecord.DeepCopy())
-			metav1.SetMetaDataAnnotation(&c.dnsRecord.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
+			if c.dnsRecord.Status.LastOperation != nil &&
+				c.dnsRecord.Status.LastOperation.Type == gardencorev1beta1.LastOperationTypeCreate &&
+				c.dnsRecord.Status.LastOperation.State != gardencorev1beta1.LastOperationStateSucceeded {
+				// If the DNSRecord is in Create but not yet Succeeded, reconcile it again.
+				_ = mutateFn()
+			} else {
+				// Otherwise, just update the timestamp annotation.
+				// If the object is still annotated with the operation annotation (e.g. not reconciled yet) this will send a watch
+				// event to the extension controller triggering a new reconciliation.
+				metav1.SetMetaDataAnnotation(&c.dnsRecord.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
+			}
 			if err := c.client.Patch(ctx, c.dnsRecord, patch); err != nil {
 				return nil, err
 			}

--- a/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord.go
+++ b/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord.go
@@ -176,10 +176,8 @@ func (c *dnsRecord) deploy(ctx context.Context, operation string) (extensionsv1a
 			}
 		} else {
 			patch := client.MergeFrom(c.dnsRecord.DeepCopy())
-			if c.dnsRecord.Status.LastOperation != nil &&
-				c.dnsRecord.Status.LastOperation.Type == gardencorev1beta1.LastOperationTypeCreate &&
-				c.dnsRecord.Status.LastOperation.State != gardencorev1beta1.LastOperationStateSucceeded {
-				// If the DNSRecord is in Create but not yet Succeeded, reconcile it again.
+			if c.dnsRecord.Status.LastOperation != nil && c.dnsRecord.Status.LastOperation.State != gardencorev1beta1.LastOperationStateSucceeded {
+				// If the DNSRecord is not yet Succeeded, reconcile it again.
 				_ = mutateFn()
 			} else {
 				// Otherwise, just update the timestamp annotation.

--- a/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord_test.go
+++ b/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord_test.go
@@ -246,7 +246,7 @@ var _ = Describe("DNSRecord", func() {
 			}))
 		})
 
-		It("should deploy the DNSRecord resource if ReconcileOnce is true and the DNSRecord is in Create / Error", func() {
+		It("should deploy the DNSRecord resource if ReconcileOnce is true and the DNSRecord is not Succeeded", func() {
 			values.ReconcileOnce = true
 			dnsRecord = dnsrecord.New(log, c, values, dnsrecord.DefaultInterval, dnsrecord.DefaultSevereThreshold, dnsrecord.DefaultTimeout)
 
@@ -255,7 +255,6 @@ var _ = Describe("DNSRecord", func() {
 			metav1.SetMetaDataAnnotation(&existingDNS.ObjectMeta, v1beta1constants.GardenerTimestamp, now.UTC().Add(-time.Second).String())
 			existingDNS.Spec.Zone = pointer.String("other-zone")
 			existingDNS.Status.LastOperation = &gardencorev1beta1.LastOperation{
-				Type:  gardencorev1beta1.LastOperationTypeCreate,
 				State: gardencorev1beta1.LastOperationStateError,
 			}
 			Expect(c.Create(ctx, existingDNS)).To(Succeed())
@@ -283,7 +282,6 @@ var _ = Describe("DNSRecord", func() {
 				Status: extensionsv1alpha1.DNSRecordStatus{
 					DefaultStatus: extensionsv1alpha1.DefaultStatus{
 						LastOperation: &gardencorev1beta1.LastOperation{
-							Type:  gardencorev1beta1.LastOperationTypeCreate,
 							State: gardencorev1beta1.LastOperationStateError,
 						},
 					},


### PR DESCRIPTION
**How to categorize this PR?**

/area robustness
/kind bug

**What this PR does / why we need it**:
Fixes a bug that causes owner `DNSRecord` resources to be never reconciled again after they are in an `Error` state (or any other state different from `Succeeded` that persists for some time).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```bugfix user
Fixed a bug that caused owner `DNSRecord` resources to be never reconciled again after they are in an `Error` state.
```
