### PR TITLE
Fixes cluster-autoscaler started with missing flags after cp migration

### DIFF
--- a/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
@@ -90,7 +90,9 @@ func (a *genericActuator) Restore(ctx context.Context, worker *extensionsv1alpha
 		return fmt.Errorf("failed to restore the machine deployment config: %w", err)
 	}
 
-	return nil
+	// Finally reconcile the worker so that the machine-controller-manager gets scaled up and OwnerReferences between
+	// machinedeployments, machinesets and machines are added properly.
+	return a.Reconcile(ctx, worker, cluster)
 }
 
 func (a *genericActuator) addStateToMachineDeployment(worker *extensionsv1alpha1.Worker, wantedMachineDeployments workercontroller.MachineDeployments) error {

--- a/extensions/pkg/controller/worker/reconciler.go
+++ b/extensions/pkg/controller/worker/reconciler.go
@@ -229,7 +229,7 @@ func (r *reconciler) restore(ctx context.Context, logger logr.Logger, worker *ex
 	}
 
 	// requeue to trigger reconciliation
-	return reconcile.Result{Requeue: true}, nil
+	return reconcile.Result{}, nil
 }
 
 func isWorkerMigrated(worker *extensionsv1alpha1.Worker) bool {

--- a/extensions/pkg/controller/worker/reconciler_test.go
+++ b/extensions/pkg/controller/worker/reconciler_test.go
@@ -169,7 +169,7 @@ var _ = Describe("Worker Reconcile", func() {
 			want:    reconcile.Result{},
 			wantErr: false,
 		}),
-		Entry("test migrate when operrationAnnotation Migrate occurs", &test{
+		Entry("test migrate when operationAnnotation Migrate occurs", &test{
 			fields: fields{
 				logger:          logger,
 				actuator:        newMockActuator("migrate", nil),
@@ -185,7 +185,7 @@ var _ = Describe("Worker Reconcile", func() {
 			want:    reconcile.Result{},
 			wantErr: false,
 		}),
-		Entry("test error during migrate when operrationAnnotation Migrate occurs", &test{
+		Entry("test error during migrate when operationAnnotation Migrate occurs", &test{
 			fields: fields{
 				logger:          logger,
 				actuator:        newMockActuator("migrate", errors.New("test")),
@@ -265,7 +265,7 @@ var _ = Describe("Worker Reconcile", func() {
 			want:    reconcile.Result{},
 			wantErr: true,
 		}),
-		Entry("test restore when operrationAnnotation Restore occurs", &test{
+		Entry("test restore when operationAnnotation Restore occurs", &test{
 			fields: fields{
 				logger:          logger,
 				actuator:        newMockActuator("restore", nil),
@@ -278,10 +278,10 @@ var _ = Describe("Worker Reconcile", func() {
 					getCluster()).Build(),
 			},
 			args:    arguments,
-			want:    reconcile.Result{Requeue: true},
+			want:    reconcile.Result{},
 			wantErr: false,
 		}),
-		Entry("test error restore when operrationAnnotation Restore occurs", &test{
+		Entry("test error restore when operationAnnotation Restore occurs", &test{
 			fields: fields{
 				logger:          logger,
 				actuator:        newMockActuator("restore", errors.New("test")),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind bug

**What this PR does / why we need it**:
With this PR the cluster-autoscaler is always started with the required flags for nodes:
```
    - --nodes=2:5:shoot--mig--migration1.shoot--mig--migration1-worker-oc3sx-z1
    - --nodes=3:5:shoot--mig--migration1.shoot--mig--migration1-worker-das32-z1
```

Previously these flags could be omitted as `gardenlet` checks the status of the Worker resource for machine deployments to construct the flags. Since the worker resource can get in a ready state after it was restored but before being requeued for a reconciliation the machine deployments can be missing from the status when `gardenlet` looks for them.
This PR basically removes the requeue at the end of the restore operation and will directly reconcile the resource after the restore logic has finished. 

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixes an issue that could cause the `cluster-autoscaler` to be started without `--nodes` during the restore phase of control plane migration.
```
