### PR TITLE
Refactor CIDR validation library to properly handle overlaps

### DIFF
--- a/pkg/apis/core/validation/seed.go
+++ b/pkg/apis/core/validation/seed.go
@@ -112,11 +112,10 @@ func ValidateSeedSpec(seedSpec *core.SeedSpec, fldPath *field.Path, inTemplate b
 	}
 
 	allErrs = append(allErrs, cidrvalidation.ValidateCIDRParse(networks...)...)
-	allErrs = append(allErrs, cidrvalidation.ValidateCIDROverlap(networks, networks, false)...)
+	allErrs = append(allErrs, cidrvalidation.ValidateCIDROverlap(networks, false)...)
 
-	vpnDefaultRanges := []cidrvalidation.CIDR{cidrvalidation.NewCIDR(v1beta1constants.DefaultVpnRange, field.NewPath(""))}
-	allErrs = append(allErrs, cidrvalidation.ValidateCIDROverlap(vpnDefaultRanges, networks, false)...)
-	allErrs = append(allErrs, cidrvalidation.ValidateCIDROverlap(networks, vpnDefaultRanges, false)...)
+	vpnDefaultRanges := cidrvalidation.NewCIDR(v1beta1constants.DefaultVpnRange, field.NewPath(""))
+	allErrs = append(allErrs, vpnDefaultRanges.ValidateNotOverlap(networks...)...)
 
 	if seedSpec.Backup != nil {
 		if len(seedSpec.Backup.Provider) == 0 {

--- a/pkg/apis/core/validation/seed_test.go
+++ b/pkg/apis/core/validation/seed_test.go
@@ -286,33 +286,35 @@ var _ = Describe("Seed Validation Tests", func() {
 			errorList := ValidateSeed(seed)
 
 			Expect(errorList).To(ConsistOfFields(Fields{
-				"Type":   Equal(field.ErrorTypeInvalid),
-				"Field":  Equal("spec.networks.pods"),
-				"Detail": Equal(`must not be a subset of "spec.networks.nodes" ("10.0.0.0/8")`),
+				"Type":     Equal(field.ErrorTypeInvalid),
+				"Field":    Equal("spec.networks.nodes"),
+				"BadValue": Equal("10.0.0.0/8"),
+				"Detail":   Equal("must not overlap with \"spec.networks.pods\" (\"10.0.1.0/24\")"),
 			}, Fields{
-				"Type":   Equal(field.ErrorTypeInvalid),
-				"Field":  Equal("spec.networks.services"),
-				"Detail": Equal(`must not be a subset of "spec.networks.nodes" ("10.0.0.0/8")`),
-			}, Fields{
-				"Type":   Equal(field.ErrorTypeInvalid),
-				"Field":  Equal("spec.networks.shootDefaults.pods"),
-				"Detail": Equal(`must not be a subset of "spec.networks.nodes" ("10.0.0.0/8")`),
-			}, Fields{
-				"Type":   Equal(field.ErrorTypeInvalid),
-				"Field":  Equal("spec.networks.shootDefaults.services"),
-				"Detail": Equal(`must not be a subset of "spec.networks.nodes" ("10.0.0.0/8")`),
-			}, Fields{
-				"Type":   Equal(field.ErrorTypeInvalid),
-				"Field":  Equal("spec.networks.services"),
-				"Detail": Equal(`must not be a subset of "spec.networks.pods" ("10.0.1.0/24")`),
+				"Type":     Equal(field.ErrorTypeInvalid),
+				"Field":    Equal("spec.networks.nodes"),
+				"BadValue": Equal("10.0.0.0/8"),
+				"Detail":   Equal("must not overlap with \"spec.networks.services\" (\"10.0.1.64/26\")"),
 			}, Fields{
 				"Type":   Equal(field.ErrorTypeInvalid),
 				"Field":  Equal("spec.networks.shootDefaults.pods"),
-				"Detail": Equal(`must not be a subset of "spec.networks.pods" ("10.0.1.0/24")`),
+				"Detail": Equal(`must not overlap with "spec.networks.nodes" ("10.0.0.0/8")`),
 			}, Fields{
 				"Type":   Equal(field.ErrorTypeInvalid),
 				"Field":  Equal("spec.networks.shootDefaults.services"),
-				"Detail": Equal(`must not be a subset of "spec.networks.pods" ("10.0.1.0/24")`),
+				"Detail": Equal(`must not overlap with "spec.networks.nodes" ("10.0.0.0/8")`),
+			}, Fields{
+				"Type":   Equal(field.ErrorTypeInvalid),
+				"Field":  Equal("spec.networks.services"),
+				"Detail": Equal(`must not overlap with "spec.networks.pods" ("10.0.1.0/24")`),
+			}, Fields{
+				"Type":   Equal(field.ErrorTypeInvalid),
+				"Field":  Equal("spec.networks.shootDefaults.pods"),
+				"Detail": Equal(`must not overlap with "spec.networks.pods" ("10.0.1.0/24")`),
+			}, Fields{
+				"Type":   Equal(field.ErrorTypeInvalid),
+				"Field":  Equal("spec.networks.shootDefaults.services"),
+				"Detail": Equal(`must not overlap with "spec.networks.pods" ("10.0.1.0/24")`),
 			}))
 		})
 
@@ -341,27 +343,23 @@ var _ = Describe("Seed Validation Tests", func() {
 			Expect(errorList).To(ConsistOfFields(Fields{
 				"Type":   Equal(field.ErrorTypeInvalid),
 				"Field":  Equal("spec.networks.pods"),
-				"Detail": Equal(`must not be a subset of "[]" ("192.168.123.0/24")`),
+				"Detail": Equal(`must not overlap with "[]" ("192.168.123.0/24")`),
 			}, Fields{
 				"Type":   Equal(field.ErrorTypeInvalid),
 				"Field":  Equal("spec.networks.services"),
-				"Detail": Equal(`must not be a subset of "[]" ("192.168.123.0/24")`),
+				"Detail": Equal(`must not overlap with "[]" ("192.168.123.0/24")`),
 			}, Fields{
 				"Type":   Equal(field.ErrorTypeInvalid),
 				"Field":  Equal("spec.networks.nodes"),
-				"Detail": Equal(`must not be a subset of "[]" ("192.168.123.0/24")`),
+				"Detail": Equal(`must not overlap with "[]" ("192.168.123.0/24")`),
 			}, Fields{
 				"Type":   Equal(field.ErrorTypeInvalid),
 				"Field":  Equal("spec.networks.shootDefaults.pods"),
-				"Detail": Equal(`must not be a subset of "[]" ("192.168.123.0/24")`),
+				"Detail": Equal(`must not overlap with "[]" ("192.168.123.0/24")`),
 			}, Fields{
 				"Type":   Equal(field.ErrorTypeInvalid),
 				"Field":  Equal("spec.networks.shootDefaults.services"),
-				"Detail": Equal(`must not be a subset of "[]" ("192.168.123.0/24")`),
-			}, Fields{
-				"Type":   Equal(field.ErrorTypeInvalid),
-				"Field":  Equal("[]"),
-				"Detail": Equal(`must not be a subset of "spec.networks.nodes" ("192.168.123.0/27")`),
+				"Detail": Equal(`must not overlap with "[]" ("192.168.123.0/24")`),
 			}))
 		})
 
@@ -374,11 +372,7 @@ var _ = Describe("Seed Validation Tests", func() {
 			Expect(errorList).To(ConsistOfFields(Fields{
 				"Type":   Equal(field.ErrorTypeInvalid),
 				"Field":  Equal("spec.networks.services"),
-				"Detail": Equal(`must not be a subset of "[]" ("192.168.123.0/24")`),
-			}, Fields{
-				"Type":   Equal(field.ErrorTypeInvalid),
-				"Field":  Equal("[]"),
-				"Detail": Equal(`must not be a subset of "spec.networks.services" ("192.168.123.0/24")`),
+				"Detail": Equal(`must not overlap with "[]" ("192.168.123.0/24")`),
 			}))
 		})
 
@@ -390,8 +384,8 @@ var _ = Describe("Seed Validation Tests", func() {
 
 			Expect(errorList).To(ConsistOfFields(Fields{
 				"Type":   Equal(field.ErrorTypeInvalid),
-				"Field":  Equal("[]"),
-				"Detail": Equal(`must not be a subset of "spec.networks.pods" ("192.168.0.0/16")`),
+				"Field":  Equal("spec.networks.pods"),
+				"Detail": Equal(`must not overlap with "[]" ("192.168.123.0/24")`),
 			}))
 		})
 

--- a/pkg/apis/extensions/validation/network.go
+++ b/pkg/apis/extensions/validation/network.go
@@ -66,7 +66,7 @@ func ValidateNetworkSpec(spec *extensionsv1alpha1.NetworkSpec, fldPath *field.Pa
 	}
 
 	allErrs = append(allErrs, cidrvalidation.ValidateCIDRParse(cidrs...)...)
-	allErrs = append(allErrs, cidrvalidation.ValidateCIDROverlap(cidrs, cidrs, false)...)
+	allErrs = append(allErrs, cidrvalidation.ValidateCIDROverlap(cidrs, false)...)
 
 	return allErrs
 }

--- a/pkg/apis/extensions/validation/network_test.go
+++ b/pkg/apis/extensions/validation/network_test.go
@@ -92,9 +92,6 @@ var _ = Describe("Network validation tests", func() {
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeInvalid),
-				"Field": Equal("spec.podCIDR"),
-			})), PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeInvalid),
 				"Field": Equal("spec.serviceCIDR"),
 			}))))
 		})

--- a/pkg/utils/validation/cidr/cidr.go
+++ b/pkg/utils/validation/cidr/cidr.go
@@ -31,8 +31,8 @@ type CIDR interface {
 	GetIPNet() *net.IPNet
 	// Parse checks if CIDR parses
 	Parse() bool
-	// ValidateNotSubset returns errors if subsets overlap with CIDR. This is the inverse operation of ValidateOverlap.
-	ValidateNotSubset(subsets ...CIDR) field.ErrorList
+	// ValidateNotOverlap returns errors if subsets overlap with CIDR. This is the inverse operation of ValidateOverlap.
+	ValidateNotOverlap(subsets ...CIDR) field.ErrorList
 	// ValidateParse returns errors CIDR can't be parsed.
 	ValidateParse() field.ErrorList
 	// ValidateSubset returns errors if subsets is not a subset.
@@ -82,14 +82,18 @@ func (c *cidrPath) ValidateOverlap(subsets ...CIDR) field.ErrorList {
 		if subset == nil || c == subset || !subset.Parse() {
 			continue
 		}
-		if !c.net.Contains(subset.GetIPNet().IP) && !subset.GetIPNet().Contains(c.net.IP) {
-			allErrs = append(allErrs, field.Invalid(subset.GetFieldPath(), subset.GetCIDR(), fmt.Sprintf("must overlap with %q (%q)", c.fieldPath.String(), c.cidr)))
+
+		// continue if CIDRs overlap.
+		if c.net.Contains(subset.GetIPNet().IP) || subset.GetIPNet().Contains(c.net.IP) {
+			continue
 		}
+
+		allErrs = append(allErrs, field.Invalid(subset.GetFieldPath(), subset.GetCIDR(), fmt.Sprintf("must overlap with %q (%q)", c.fieldPath.String(), c.cidr)))
 	}
 	return allErrs
 }
 
-func (c *cidrPath) ValidateNotSubset(subsets ...CIDR) field.ErrorList {
+func (c *cidrPath) ValidateNotOverlap(subsets ...CIDR) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if c.ParseError != nil {
 		return allErrs
@@ -98,9 +102,13 @@ func (c *cidrPath) ValidateNotSubset(subsets ...CIDR) field.ErrorList {
 		if subset == nil || c == subset || !subset.Parse() {
 			continue
 		}
-		if c.net.Contains(subset.GetIPNet().IP) || subset.GetIPNet().Contains(c.net.IP) {
-			allErrs = append(allErrs, field.Invalid(subset.GetFieldPath(), subset.GetCIDR(), fmt.Sprintf("must not be a subset of %q (%q)", c.fieldPath.String(), c.cidr)))
+
+		// continue if CIDRs do not overlap.
+		if !c.net.Contains(subset.GetIPNet().IP) && !subset.GetIPNet().Contains(c.net.IP) {
+			continue
 		}
+
+		allErrs = append(allErrs, field.Invalid(subset.GetFieldPath(), subset.GetCIDR(), fmt.Sprintf("must not overlap with %q (%q)", c.fieldPath.String(), c.cidr)))
 	}
 	return allErrs
 }

--- a/pkg/utils/validation/cidr/cidr_test.go
+++ b/pkg/utils/validation/cidr/cidr_test.go
@@ -102,25 +102,25 @@ var _ = Describe("cidr", func() {
 			})
 		})
 
-		Context("ValidateNotSubset", func() {
+		Context("ValidateNotOverlap", func() {
 			It("should not be a subset", func() {
 				cdr := NewCIDR(validGardenCIDR, path)
 				other := NewCIDR(string("2.2.2.2/32"), path)
 
-				Expect(cdr.ValidateNotSubset(other)).To(BeEmpty())
+				Expect(cdr.ValidateNotOverlap(other)).To(BeEmpty())
 			})
 
 			It("should ignore nil values", func() {
 				cdr := NewCIDR(validGardenCIDR, path)
 
-				Expect(cdr.ValidateNotSubset(nil)).To(BeEmpty())
+				Expect(cdr.ValidateNotOverlap(nil)).To(BeEmpty())
 			})
 
 			It("should ignore when parse error", func() {
 				cdr := NewCIDR(invalidGardenCIDR, path)
 				other := NewCIDR(string("2.2.2.2/32"), path)
 
-				Expect(cdr.ValidateNotSubset(other)).To(BeEmpty())
+				Expect(cdr.ValidateNotOverlap(other)).To(BeEmpty())
 			})
 
 			It("should return a nil FieldPath", func() {
@@ -129,11 +129,24 @@ var _ = Describe("cidr", func() {
 				badPath := field.NewPath("bad")
 				other := NewCIDR(badCIDR, badPath)
 
-				Expect(cdr.ValidateNotSubset(other)).To(ConsistOfFields(Fields{
+				Expect(cdr.ValidateNotOverlap(other)).To(ConsistOfFields(Fields{
 					"Type":     Equal(field.ErrorTypeInvalid),
 					"Field":    Equal(badPath.String()),
 					"BadValue": Equal(badCIDR),
-					"Detail":   Equal(`must not be a subset of "foo" ("10.0.0.0/8")`),
+					"Detail":   Equal(`must not overlap with "foo" ("10.0.0.0/8")`),
+				}))
+			})
+
+			It("should return an error if CIDRs are the same", func() {
+				cdr := NewCIDR(validGardenCIDR, path)
+				badPath := field.NewPath("bad")
+				bad := NewCIDR(validGardenCIDR, badPath)
+
+				Expect(cdr.ValidateNotOverlap(bad)).To(ConsistOfFields(Fields{
+					"Type":     Equal(field.ErrorTypeInvalid),
+					"Field":    Equal(badPath.String()),
+					"BadValue": Equal(validGardenCIDR),
+					"Detail":   Equal(`must not overlap with "foo" ("10.0.0.0/8")`),
 				}))
 			})
 
@@ -143,11 +156,11 @@ var _ = Describe("cidr", func() {
 				badPath := field.NewPath("bad")
 				bad := NewCIDR(badCIDR, badPath)
 
-				Expect(cdr.ValidateNotSubset(bad)).To(ConsistOfFields(Fields{
+				Expect(cdr.ValidateNotOverlap(bad)).To(ConsistOfFields(Fields{
 					"Type":     Equal(field.ErrorTypeInvalid),
 					"Field":    Equal(badPath.String()),
 					"BadValue": Equal(badCIDR),
-					"Detail":   Equal(`must not be a subset of "foo" ("10.1.0.0/16")`),
+					"Detail":   Equal(`must not overlap with "foo" ("10.1.0.0/16")`),
 				}))
 			})
 		})
@@ -319,25 +332,25 @@ var _ = Describe("cidr", func() {
 			})
 		})
 
-		Context("ValidateNotSubset", func() {
+		Context("ValidateNotOverlap", func() {
 			It("should not be a subset", func() {
 				cdr := NewCIDR(validGardenCIDR, path)
 				other := NewCIDR(string("3001:0db8:85a3::1/128"), path)
 
-				Expect(cdr.ValidateNotSubset(other)).To(BeEmpty())
+				Expect(cdr.ValidateNotOverlap(other)).To(BeEmpty())
 			})
 
 			It("should ignore nil values", func() {
 				cdr := NewCIDR(validGardenCIDR, path)
 
-				Expect(cdr.ValidateNotSubset(nil)).To(BeEmpty())
+				Expect(cdr.ValidateNotOverlap(nil)).To(BeEmpty())
 			})
 
 			It("should ignore when parse error", func() {
 				cdr := NewCIDR(invalidGardenCIDR, path)
 				other := NewCIDR(string("3001:0db8:85a3::1/128"), path)
 
-				Expect(cdr.ValidateNotSubset(other)).To(BeEmpty())
+				Expect(cdr.ValidateNotOverlap(other)).To(BeEmpty())
 			})
 
 			It("should return a nil FieldPath", func() {
@@ -346,11 +359,11 @@ var _ = Describe("cidr", func() {
 				badPath := field.NewPath("bad")
 				other := NewCIDR(badCIDR, badPath)
 
-				Expect(cdr.ValidateNotSubset(other)).To(ConsistOfFields(Fields{
+				Expect(cdr.ValidateNotOverlap(other)).To(ConsistOfFields(Fields{
 					"Type":     Equal(field.ErrorTypeInvalid),
 					"Field":    Equal(badPath.String()),
 					"BadValue": Equal(badCIDR),
-					"Detail":   Equal(`must not be a subset of "foo" ("2001:0db8:85a3::/104")`),
+					"Detail":   Equal(`must not overlap with "foo" ("2001:0db8:85a3::/104")`),
 				}))
 			})
 
@@ -360,11 +373,11 @@ var _ = Describe("cidr", func() {
 				badPath := field.NewPath("bad")
 				other := NewCIDR(badCIDR, badPath)
 
-				Expect(cdr.ValidateNotSubset(other)).To(ConsistOfFields(Fields{
+				Expect(cdr.ValidateNotOverlap(other)).To(ConsistOfFields(Fields{
 					"Type":     Equal(field.ErrorTypeInvalid),
 					"Field":    Equal(badPath.String()),
 					"BadValue": Equal(badCIDR),
-					"Detail":   Equal(`must not be a subset of "foo" ("2001:0db8::/16")`),
+					"Detail":   Equal(`must not overlap with "foo" ("2001:0db8::/16")`),
 				}))
 			})
 		})

--- a/pkg/utils/validation/cidr/disjoint.go
+++ b/pkg/utils/validation/cidr/disjoint.go
@@ -16,10 +16,10 @@ package cidr
 
 import (
 	"fmt"
-	"net"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 // ValidateNetworkDisjointedness validates that the given <seedNetworks> and <k8sNetworks> are disjoint.
@@ -72,7 +72,7 @@ func ValidateNetworkDisjointedness(fldPath *field.Path, shootNodes, shootPods, s
 
 // NetworksIntersect returns true if the given network CIDRs intersect.
 func NetworksIntersect(cidr1, cidr2 string) bool {
-	_, net1, err1 := net.ParseCIDR(cidr1)
-	_, net2, err2 := net.ParseCIDR(cidr2)
-	return err1 != nil || err2 != nil || net2.Contains(net1.IP) || net1.Contains(net2.IP)
+	c1 := NewCIDR(cidr1, field.NewPath(""))
+	c2 := NewCIDR(cidr2, field.NewPath(""))
+	return c1.ValidateOverlap(c2).ToAggregate() == nil
 }

--- a/pkg/utils/validation/cidr/helper.go
+++ b/pkg/utils/validation/cidr/helper.go
@@ -32,15 +32,17 @@ func ValidateCIDRParse(cidrPaths ...CIDR) (allErrs field.ErrorList) {
 }
 
 // ValidateCIDROverlap validates that the provided CIDRs do not overlap.
-func ValidateCIDROverlap(leftPaths, rightPaths []CIDR, overlap bool) (allErrs field.ErrorList) {
-	for _, left := range leftPaths {
-		if left == nil {
+func ValidateCIDROverlap(paths []CIDR, overlap bool) field.ErrorList {
+	allErrs := field.ErrorList{}
+	for i := 0; i < len(paths)-1; i++ {
+		if paths[i] == nil {
 			continue
 		}
+
 		if overlap {
-			allErrs = append(allErrs, left.ValidateOverlap(rightPaths...)...)
+			allErrs = append(allErrs, paths[i].ValidateOverlap(paths[i+1:]...)...)
 		} else {
-			allErrs = append(allErrs, left.ValidateNotSubset(rightPaths...)...)
+			allErrs = append(allErrs, paths[i].ValidateNotOverlap(paths[i+1:]...)...)
 		}
 	}
 	return allErrs

--- a/pkg/utils/validation/cidr/helper.go
+++ b/pkg/utils/validation/cidr/helper.go
@@ -38,7 +38,7 @@ func ValidateCIDROverlap(leftPaths, rightPaths []CIDR, overlap bool) (allErrs fi
 			continue
 		}
 		if overlap {
-			allErrs = append(allErrs, left.ValidateSubset(rightPaths...)...)
+			allErrs = append(allErrs, left.ValidateOverlap(rightPaths...)...)
 		} else {
 			allErrs = append(allErrs, left.ValidateNotSubset(rightPaths...)...)
 		}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
This is an addition to https://github.com/gardener/gardener/pull/4810 to refactor the CIDR validation library with the following changes:
+ add `validateOverlap` method
+ rename `validateNotSubset` to `validateNotOverlap` to reflect it's actual use.
+ refactor `ValidateCIDROverlap`
+ update tests

Lets look at one of the changes in  `pkg/apis/core/validation/seed.go` to explain the motivation for this change:
```
	allErrs = append(allErrs, cidrvalidation.ValidateCIDROverlap(vpnDefaultRanges, networks, false)...)
	allErrs = append(allErrs, cidrvalidation.ValidateCIDROverlap(networks, vpnDefaultRanges, false)...)
```
You can see that `ValidateCIDROverlap` (internally just calling `ValidateNotSubset`) does neither validate for proper subsets, not for proper cidr overlap. That is with why it needs to be called 2 times (with the arguments swapping places) meaning that the use of the function neither matches its name nor it's intended use.

The new refactoring of `validateNotOverlap` properly handles case where the argument is a subset, same or superset of the CIDR it tests against. 

This was also the reason for _NxN_ patterns existed like:
```
allErrs = append(allErrs, cidrvalidation.ValidateCIDROverlap(networks, networks, false)...)
```

The `ValidateCIDROverlap` now only takes an array of CIDRs and performs the check in a "factorial-like" fashion. That is why certain test cases had to be adapted to account for the removal of the bidirectional tests (e.g. when testing for no overlap between pod and service CIDRs, it is no longer necessary to test if service CIDR is disjoint with pods).

The rename of the `validateNotSubset` was done to accommodate for its actual behaviour and to reflect the "breaking" behavior of this change. The change in `ValidateCIDROverlap` to use internally the `ValidateOverlap` is certainly more lenient therefore no action should be necessary.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking developer
`pkg/utils/validation/cidr` package has been changed to properly detect CIDR overlaps. Please make sure to adapt your use of the library when revendoring.
- `CIDR.ValidateNotSubset` have been replaced by `CIDR.ValidateNotOverlap`. `CIDR.ValidateNotOverlap` is stricter as it does not allow its subject to be a superset or subset of the CIDRs it tests against (previously only the superset condition was checked).
```
