### PR TITLE
Promote CachedRuntimeClients feature gate to beta

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -27,7 +27,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | ManagedIstio | `true` | `Beta` | `1.19` | |
 | APIServerSNI | `false` | `Alpha` | `1.7` | `1.18` |
 | APIServerSNI | `true` | `Beta` | `1.19` | |
-| CachedRuntimeClients | `false` | `Alpha` | `1.7` | |
+| CachedRuntimeClients | `false` | `Alpha` | `1.7` | `1.33` |
+| CachedRuntimeClients | `true` | `Beta` | `1.34` | |
 | SeedChange | `false` | `Alpha` | `1.12` | |
 | SeedKubeScheduler | `false` | `Alpha` | `1.15` | |
 | ReversedVPN | `false` | `Alpha` | `1.22` | |

--- a/docs/development/kubernetes-clients.md
+++ b/docs/development/kubernetes-clients.md
@@ -185,10 +185,11 @@ This means, that if you read the same object from different cache implementation
 
 By default, the `client.Client` created by a controller-runtime `Manager` is a `DelegatingClient`. It delegates `Get` and `List` calls to a `Cache` and all other calls to a client, that talks directly to the API server. Exceptions are requests with `*unstructured.Unstructured` objects and object kinds that were configured to be excluded from the cache in the `DelegatingClient`.
 
-> ℹ️ Currently, the controller-runtime client contained in Gardener's client collection (`kubernetes.Interface.Client()`) is not cached and does not use the cache contained in the client set (`kubernetes.Interface.Cache()`). This means, the client always reads directly from the API server, but you can intentionally read from the cache if desired.
->
-> If the `CachedRuntimeClients` feature gate is enabled, `Client()` returns a `DelegatingClient` that uses the cache returned from `Cache()` under the hood. This means, all `Client()` usages should be ready for cached clients and should be able to cater with stale cache reads.
-> See [gardener/gardener#2822](https://github.com/gardener/gardener/issues/2822) for details on the graduation progress.
+> ℹ️
+> If the `CachedRuntimeClients` feature gate is enabled (enabled by default starting from `v1.34`), `kubernetes.Interface.Client()` returns a `DelegatingClient` that uses the cache returned from `kubernetes.Interface.Cache()` under the hood. This means, all `Client()` usages need to be ready for cached clients and should be able to cater with stale cache reads.
+> See [gardener/gardener#2822](https://github.com/gardener/gardener/issues/2822) for details on the graduation progress to beta.
+> 
+> If the feature gate is explicitly disabled, the controller-runtime client (`kubernetes.Interface.Client()`) is not cached and does not use the cache contained in the client set (`kubernetes.Interface.Cache()`). This means, the client always reads directly from the API server, but you can intentionally read from the cache if desired.
 
 _Important characteristics of cached controller-runtime clients:_
 

--- a/pkg/client/kubernetes/client.go
+++ b/pkg/client/kubernetes/client.go
@@ -40,9 +40,10 @@ import (
 )
 
 var (
-	// UseCachedRuntimeClients is a flag for enabling cached controller-runtime clients (defaults to false).
-	// If enabled, the client returned by Interface.Client() will be backed by a cache, otherwise it will talk directly
-	// to the API server.
+	// UseCachedRuntimeClients is a flag for enabling cached controller-runtime clients. The CachedRuntimeClients feature
+	// gate (enabled by default sinde v1.34) causes this flag to be set to true.
+	// If enabled, the client returned by Interface.Client() will be backed by Interface.Cache(), otherwise it will talk
+	// directly to the API server.
 	UseCachedRuntimeClients = false
 )
 

--- a/pkg/controllermanager/features/features.go
+++ b/pkg/controllermanager/features/features.go
@@ -25,7 +25,7 @@ var (
 	// FeatureGate is a shared global FeatureGate for Gardener Controller Manager flags.
 	FeatureGate  = featuregate.NewFeatureGate()
 	featureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-		features.CachedRuntimeClients:          {Default: false, PreRelease: featuregate.Alpha},
+		features.CachedRuntimeClients:          {Default: true, PreRelease: featuregate.Beta},
 		features.UseDNSRecords:                 {Default: false, PreRelease: featuregate.Alpha},
 		features.RotateSSHKeypairOnMaintenance: {Default: false, PreRelease: featuregate.Alpha},
 	}

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -61,8 +61,9 @@ const (
 
 	// CachedRuntimeClients enables a cache in the controller-runtime clients, that Gardener uses.
 	// If disabled all controller-runtime clients will directly talk to the API server instead of relying on a cache.
-	// owner @tim-ebert
+	// owner @timebertt
 	// alpha: v1.7.0
+	// beta: v1.34.0
 	CachedRuntimeClients featuregate.Feature = "CachedRuntimeClients"
 
 	// SeedChange enables updating the `spec.seedName` field during shoot validation from a non-empty value

--- a/pkg/gardenlet/features/features.go
+++ b/pkg/gardenlet/features/features.go
@@ -30,7 +30,7 @@ var (
 		features.HVPAForShootedSeed:            {Default: false, PreRelease: featuregate.Alpha},
 		features.ManagedIstio:                  {Default: true, PreRelease: featuregate.Beta},
 		features.APIServerSNI:                  {Default: true, PreRelease: featuregate.Beta},
-		features.CachedRuntimeClients:          {Default: false, PreRelease: featuregate.Alpha},
+		features.CachedRuntimeClients:          {Default: true, PreRelease: featuregate.Beta},
 		features.SeedKubeScheduler:             {Default: false, PreRelease: featuregate.Alpha},
 		features.ReversedVPN:                   {Default: false, PreRelease: featuregate.Alpha},
 		features.UseDNSRecords:                 {Default: false, PreRelease: featuregate.Alpha},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement

**What this PR does / why we need it**:

All required steps for graduating the `CachedRuntimeClients` feature gate to beta have been completed (https://github.com/gardener/gardener/issues/2822) and we have been running it successfully in one of our internal landscapes with about 3k enduser clusters since about 6 weeks.
Hence, we now promote the feature gate to beta.

**Which issue(s) this PR fixes**:
Closes https://github.com/gardener/gardener/issues/2822

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The `CachedRuntimeClients` feature gate is promoted to beta and now enabled by default.
```
