### PR TITLE
Add auto-replacement of user facing certificates

### DIFF
--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -113,6 +113,9 @@ const (
 	// EndUserCrtValidity is the time period a user facing certificate is valid.
 	EndUserCrtValidity = 730 * 24 * time.Hour // ~2 years, see https://support.apple.com/en-us/HT210176
 
+	// CrtRenewalWindow is the time window in which certificates are supposed to be replaced before they expire.
+	CrtRenewalWindow = 30 * 24 * time.Hour
+
 	// ShootDNSIngressName is a constant for the DNS resources used for the shoot ingress addon.
 	ShootDNSIngressName = "ingress"
 
@@ -129,3 +132,12 @@ const (
 	// NodeLocalIPVSAddress is the IPv4 address used by node local dns when IPVS is used.
 	NodeLocalIPVSAddress = "169.254.20.10"
 )
+
+// IngressTLSSecretNames are the secrets which contain operator or user facing x509 certificates.
+// These are usually exposed via an `Ingress` in the shoot control plane.
+var IngressTLSSecretNames = []string{
+	AlertManagerTLS,
+	GrafanaTLS,
+	PrometheusTLS,
+	LokiTLS,
+}

--- a/pkg/utils/secrets/certificates.go
+++ b/pkg/utils/secrets/certificates.go
@@ -484,3 +484,16 @@ func SelfGenerateTLSServerCertificate(name string, dnsNames []string, ips []net.
 
 	return certificate, caCertificate, tempDir, nil
 }
+
+// CertificateIsExpired returns `true` if the given certificate is expired.
+// The given `renewalWindow` lets the certificate expire earlier.
+func CertificateIsExpired(cert []byte, renewalWindow time.Duration) (bool, error) {
+	now := NowFunc()
+
+	x509, err := utils.DecodeCertificate(cert)
+	if err != nil {
+		return false, err
+	}
+
+	return now.After(x509.NotAfter.Add(-renewalWindow)), nil
+}

--- a/pkg/utils/secrets/types.go
+++ b/pkg/utils/secrets/types.go
@@ -14,7 +14,11 @@
 
 package secrets
 
-import "github.com/gardener/gardener/pkg/utils/infodata"
+import (
+	"time"
+
+	"github.com/gardener/gardener/pkg/utils/infodata"
+)
 
 // ConfigInterface define functions needed for generating a specific secret.
 type ConfigInterface interface {
@@ -33,3 +37,7 @@ type DataInterface interface {
 	// SecretData computes the data map which can be used in a Kubernetes secret.
 	SecretData() map[string][]byte
 }
+
+// NowFunc is a function returning the current time.
+// Exposed for testing.
+var NowFunc = time.Now


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
This PR adds the automatic replacement of user facing x509 certificates `30 days` before they expire.

**Which issue(s) this PR fixes**:
Fixes #1684

**Special notes for your reviewer**:
We are already very opinionated when creating certificates, e.g. fixed validity duration and key length. Hence, I decided to set the renewal time window to `30 days` as this is the default for other community projects like [Cert-Manager](cert-manager.io).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Certificates for Alertmanager, Grafana, Loki and Prometheus are now automatically renewed in a time windows of 30 days before they expire.
```
