### PR TITLE
Adding documentation for stale projects

### DIFF
--- a/docs/usage/projects.md
+++ b/docs/usage/projects.md
@@ -89,3 +89,7 @@ All newly created projects will only bind the owner to the `uam` role.
 The owner can still grant the `uam` role to other members if desired.
 For projects created before Gardener v1.8 the Gardener Controller Manager will migrate all projects to also assign the `uam` role to all `admin` members (to not break existing use-cases). The corresponding migration logic is present in Gardener Controller Manager from v1.8 to v1.13.
 The project owner can gradually remove these roles if desired. 
+
+## Stale Projects
+
+When a project is not actively used for some period of time the project is marked as "stale". This is done by controller called "Stale Projects Reconciler". Once the project is marked as stale there is a time frame in which if not used it will be deleted by that controller. More detailed information can be found [here](../concepts/controller-manager.md#stale-projects-reconciler).


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
Documentation regarding the stale projects is missing in https://github.com/gardener/gardener/blob/master/docs/usage/projects.md. It would be better to include some details there of better UX.
**Which issue(s) this PR fixes**:
Fixes #4416 
**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
