### PR TITLE
Enable lameduck in CoreDNS health check

### DIFF
--- a/pkg/operation/botanist/component/coredns/coredns.go
+++ b/pkg/operation/botanist/component/coredns/coredns.go
@@ -216,7 +216,9 @@ func (c *coreDNS) computeResourcesData() (map[string][]byte, error) {
   log . {
       class error
   }
-  health
+  health {
+      lameduck 15s
+  }
   ready
   kubernetes ` + c.values.ClusterDomain + ` in-addr.arpa ip6.arpa {
       pods insecure

--- a/pkg/operation/botanist/component/coredns/coredns_test.go
+++ b/pkg/operation/botanist/component/coredns/coredns_test.go
@@ -146,7 +146,9 @@ data:
       log . {
           class error
       }
-      health
+      health {
+          lameduck 15s
+      }
       ready
       kubernetes ` + clusterDomain + ` in-addr.arpa ip6.arpa {
           pods insecure


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area high-availability ops-productivity networking
/kind enhancement

**What this PR does / why we need it**:
Enable lameduck in CoreDNS health. This way the coredns will not be shutdown immediately on SIGTERM, instead
- the replica will be removed from the endpoints of the service, also the readiness probe will start failing, but the liveness will still succeed
- the clients with established connections will keep working, but no new connections will be accepted


Basically, this should do something similar to `preStop` hook that sleeps for 15 seconds, but due to the fact that coredns image is very minimal, such hook cannot be implemented. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The CoreDNS health plugin is now configured with `lameduck` of 15 seconds. This way, when a coredns replica is being shut down, it will keep serving the currently established clients for up to 15 seconds so that they can reconnect to some of the other replicas. More info about the `lameduck` can be found [here](https://coredns.io/plugins/health/).
```
