### PR TITLE
Fix few more warnings on API reference generation

### DIFF
--- a/hack/api-reference/operations-config.json
+++ b/hack/api-reference/operations-config.json
@@ -8,6 +8,10 @@
     ],
     "externalPackages": [
         {
+            "typeMatchPrefix": "^github\\.com/gardener/gardener/pkg/apis/core/v1alpha1",
+            "docsURLTemplate": "./core.md#core.gardener.cloud/v1alpha1.{{.TypeIdentifier}}"
+        },
+        {
             "typeMatchPrefix": "^k8s\\.io/(api|apimachinery/pkg/apis)/",
             "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
         }

--- a/hack/api-reference/operations.md
+++ b/hack/api-reference/operations.md
@@ -300,7 +300,9 @@ Kubernetes core/v1.LoadBalancerIngress
 <td>
 <code>conditions</code></br>
 <em>
+<a href="./core.md#core.gardener.cloud/v1alpha1.Condition">
 []github.com/gardener/gardener/pkg/apis/core/v1alpha1.Condition
+</a>
 </em>
 </td>
 <td>

--- a/hack/api-reference/resources-config.json
+++ b/hack/api-reference/resources-config.json
@@ -8,6 +8,10 @@
     ],
     "externalPackages": [
         {
+            "typeMatchPrefix": "^github\\.com/gardener/gardener/pkg/apis/core/v1beta1",
+            "docsURLTemplate": "./core.md#core.gardener.cloud/v1beta1.{{.TypeIdentifier}}"
+        },
+        {
             "typeMatchPrefix": "^k8s\\.io/(api|apimachinery/pkg/apis)/",
             "docsURLTemplate": "https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.19/#{{lower .TypeIdentifier}}-{{arrIndex .PackageSegments -1}}-{{arrIndex .PackageSegments -2}}"
         }

--- a/hack/api-reference/resources.md
+++ b/hack/api-reference/resources.md
@@ -308,7 +308,9 @@ resource, should also be deleted when the corresponding StatefulSet is deleted (
 <td>
 <code>conditions</code></br>
 <em>
+<a href="./core.md#core.gardener.cloud/v1beta1.Condition">
 []github.com/gardener/gardener/pkg/apis/core/v1beta1.Condition
+</a>
 </em>
 </td>
 <td>


### PR DESCRIPTION
/area documentation
/kind enhancement

By chance, I noticed 2 more warnings on API reference generation:

```
I1014 15:30:32.765223    3904 main.go:229] using package=github.com/gardener/gardener/pkg/apis/operations/v1alpha1
W1014 15:30:32.823804    3904 main.go:423] not found external link source for type github.com/gardener/gardener/pkg/apis/core/v1alpha1.Condition

I1014 15:30:34.377312    3906 main.go:229] using package=github.com/gardener/gardener/pkg/apis/resources/v1alpha1
W1014 15:30:34.432646    3906 main.go:423] not found external link source for type github.com/gardener/gardener/pkg/apis/core/v1beta1.Condition
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
