### PR TITLE
Deploy `gardener-resource-manager` in the same version like `gardenlet`

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -11,6 +11,9 @@ images:
 - name: gardener-seed-admission-controller
   sourceRepository: github.com/gardener/gardener
   repository: eu.gcr.io/gardener-project/gardener/seed-admission-controller
+- name: gardener-resource-manager
+  sourceRepository: github.com/gardener/gardener
+  repository: eu.gcr.io/gardener-project/gardener/resource-manager
 
 # Seed bootstrap
 - name: pause-container
@@ -28,10 +31,6 @@ images:
   sourceRepository: github.com/gardener/etcd-druid
   repository: eu.gcr.io/gardener-project/gardener/etcd-druid
   tag: "v0.5.2"
-- name: gardener-resource-manager
-  sourceRepository: github.com/gardener/gardener-resource-manager
-  repository: eu.gcr.io/gardener-project/gardener/gardener-resource-manager
-  tag: "v0.25.1"
 - name: dependency-watchdog
   sourceRepository: github.com/gardener/dependency-watchdog
   repository: eu.gcr.io/gardener-project/gardener/dependency-watchdog

--- a/pkg/operation/botanist/resource_manager.go
+++ b/pkg/operation/botanist/resource_manager.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
+	"k8s.io/component-base/version"
 	"k8s.io/utils/pointer"
 )
 
@@ -36,6 +37,12 @@ func (b *Botanist) DefaultResourceManager() (resourcemanager.Interface, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	repository, tag := image.String(), version.Get().GitVersion
+	if image.Tag != nil {
+		repository, tag = image.Repository, *image.Tag
+	}
+	image = &imagevector.Image{Repository: repository, Tag: &tag}
 
 	cfg := resourcemanager.Values{
 		AlwaysUpdate:               pointer.Bool(true),

--- a/pkg/operation/seed/components.go
+++ b/pkg/operation/seed/components.go
@@ -96,6 +96,12 @@ func defaultGardenerResourceManager(c client.Client, seedVersion string, imageVe
 		return nil, err
 	}
 
+	repository, tag := image.String(), version.Get().GitVersion
+	if image.Tag != nil {
+		repository, tag = image.Repository, *image.Tag
+	}
+	image = &imagevector.Image{Repository: repository, Tag: &tag}
+
 	return resourcemanager.New(c, v1beta1constants.GardenNamespace, image.String(), 1, resourcemanager.Values{
 		ConcurrentSyncs:  pointer.Int32(20),
 		HealthSyncPeriod: utils.DurationPtr(time.Minute),

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -420,7 +420,6 @@ func RunReconcileSeedFlow(
 			charts.ImageNameLokiCurator,
 			charts.ImageNameFluentBit,
 			charts.ImageNameFluentBitPluginInstaller,
-			charts.ImageNameGardenerResourceManager,
 			charts.ImageNameGrafana,
 			charts.ImageNamePauseContainer,
 			charts.ImageNamePrometheus,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
After #4757, we should make sure that GRM is deployed in the same version like gardenlet, similar to how it's done for GSAC.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
