### PR TITLE
Extend the load integration test to check for teneants logs

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -229,7 +229,7 @@ images:
 - name: fluent-bit-plugin-installer
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/fluent-bit-to-loki
-  tag: "v0.37.2"
+  tag: "v0.38.0"
 - name: loki
   sourceRepository: github.com/grafana/loki
   repository: grafana/loki
@@ -237,7 +237,7 @@ images:
 - name: loki-curator
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/loki-curator
-  tag: "v0.37.2"
+  tag: "v0.38.0"
 - name: kube-rbac-proxy
   sourceRepository: github.com/brancz/kube-rbac-proxy
   repository: quay.io/brancz/kube-rbac-proxy
@@ -249,7 +249,7 @@ images:
 - name: telegraf
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/telegraf-iptables
-  tag: "v0.37.2"
+  tag: "v0.38.0"
 
 # VPA
 - name: vpa-admission-controller

--- a/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-daemonset.yaml
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-daemonset.yaml
@@ -91,10 +91,10 @@ spec:
           periodSeconds: 10
         livenessProbe:
           httpGet:
-            path: /
-            port: 2020
+            path: /healthz
+            port: 2021
           initialDelaySeconds: 90
-          periodSeconds: 10
+          periodSeconds: 300
         volumeMounts:
         - name: config-dir
           mountPath: /fluent-bit/etc

--- a/test/integration/shoots/logging/utils.go
+++ b/test/integration/shoots/logging/utils.go
@@ -244,3 +244,11 @@ func newPodAntiAffinity(matchLabels map[string]string) *corev1.PodAntiAffinity {
 		},
 	}
 }
+
+func newGardenNamespace(namespace string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namespace,
+		},
+	}
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
With this PR the logging load integration test checks for tenants logs.
Also, the gardener fluent-bit-to-loki version is upgraded to v0.38.0 which supports `health` probe.
The gardener fluent-bit-to-loki `concurrent map interaction and write` issue is fixed.
The memory consumption of the plugin is decreased by avoiding unnecessary runtime.Extension deserilizations.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Logging load integration test checks also for tenants logs.
```
```other developer github.com/gardener/logging #116 @vlvasilev
The gardener fluent-bit-to-loki output plugin has a health probe. 
```
```other operator github.com/gardener/logging #115 @vlvasilev
Remove the redundant runtime.Extension deserilizations in the gardener fluent-bit-to-loki output plugin.
```
```other operator github.com/gardener/logging #114 @vlvasilev
The gardener fluent-bit-to-loki `concurrent map interaction and write` issue is fixed.
```