### PR TITLE
Bump envtest binaries to v1.22

### DIFF
--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-ENVTEST_K8S_VERSION=${ENVTEST_K8S_VERSION:-"1.20"}
+ENVTEST_K8S_VERSION=${ENVTEST_K8S_VERSION:-"1.22"}
 
 echo "> Installing envtest tools@${ENVTEST_K8S_VERSION} with setup-envtest if necessary"
 if ! command -v setup-envtest &> /dev/null ; then


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

Bump envtest binaries to v1.22 to make use of disabled etcd fsync in envtests.

Quick comparison on my machine:
Before:
```
$ make test-integration
> Installing envtest tools@1.20 with setup-envtest if necessary
using envtest tools installed at '/Users/timebertt/Library/Application Support/io.kubebuilder.envtest/k8s/1.20.2-darwin-amd64'
> Integration Tests
ok  	github.com/gardener/gardener/extensions/test/integration/envtest/backupbucket	47.720s
ok  	github.com/gardener/gardener/test/integration/envtest/envtest	30.591s
ok  	github.com/gardener/gardener/test/integration/envtest/seedadmissioncontroller	33.503s
ok  	github.com/gardener/gardener/test/integration/envtest/shootretry	32.240s
```

After:
```
$ make test-integration
> Installing envtest tools@1.22 with setup-envtest if necessary
using envtest tools installed at '/Users/d067603/Library/Application Support/io.kubebuilder.envtest/k8s/1.22.0-darwin-amd64'
> Integration Tests
ok  	github.com/gardener/gardener/extensions/test/integration/envtest/backupbucket	31.206s
ok  	github.com/gardener/gardener/test/integration/envtest/envtest	14.243s
ok  	github.com/gardener/gardener/test/integration/envtest/seedadmissioncontroller	13.674s
ok  	github.com/gardener/gardener/test/integration/envtest/shootretry	14.426s
```

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/4772

**Special notes for your reviewer**:

This is a breaking change for extensions, as they need to update the CRDs that are added during integration tests.
E.g. this test will start failing: https://github.com/gardener/gardener-extension-provider-aws/blob/51d2a020b218c16d4dbc1f0a197c9a83bae9f48e/test/integration/dnsrecord/dnsrecord_test.go#L110-L122
Ref https://github.com/gardener/gardener-extension-provider-aws/issues/430

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Envtest binaries have been upgraded to version v1.22. By this, we disable etcd fsync in envtests which speeds up test execution by not writing etcd data to disk.
```
```breaking dependencies
Envtest binaries have been upgraded to version v1.22. Please ensure to update your CRD and Webhook manifests to API versions supported in v1.22. You can consult [this guide](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22) for help on the migration.
```
