### PR TITLE
Move `pkg/resourcemanager/manager` to `pkg/utils/managedresources/builder`

### DIFF
--- a/pkg/utils/managedresources/builder/managedresources.go
+++ b/pkg/utils/managedresources/builder/managedresources.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package manager
+package builder
 
 import (
 	"context"
@@ -31,7 +31,7 @@ type ManagedResource struct {
 	resource *resourcesv1alpha1.ManagedResource
 }
 
-// NewManagedResource creates a new manager for a ManagedResource.
+// NewManagedResource creates a new builder for a ManagedResource.
 func NewManagedResource(client client.Client) *ManagedResource {
 	return &ManagedResource{
 		client:   client,

--- a/pkg/utils/managedresources/builder/manager_suite_test.go
+++ b/pkg/utils/managedresources/builder/manager_suite_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package manager_test
+package builder_test
 
 import (
 	"testing"

--- a/pkg/utils/managedresources/builder/resourcemanager_test.go
+++ b/pkg/utils/managedresources/builder/resourcemanager_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package manager
+package builder
 
 import (
 	"context"

--- a/pkg/utils/managedresources/builder/secrets.go
+++ b/pkg/utils/managedresources/builder/secrets.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package manager
+package builder
 
 import (
 	"context"
@@ -31,7 +31,7 @@ type Secret struct {
 	secret    *corev1.Secret
 }
 
-// NewSecret creates a new manager for a secret.
+// NewSecret creates a new builder for a secret.
 func NewSecret(client client.Client) *Secret {
 	return &Secret{
 		client:    client,

--- a/pkg/utils/managedresources/managedresources.go
+++ b/pkg/utils/managedresources/managedresources.go
@@ -118,7 +118,7 @@ func Create(ctx context.Context, client client.Client, namespace, name string, s
 	return deployManagedResource(ctx, secret, managedResource)
 }
 
-// CreateForSeed deploys a ManagedResource CR for the seed's gardener-resource-builder.
+// CreateForSeed deploys a ManagedResource CR for the seed's gardener-resource-manager.
 func CreateForSeed(ctx context.Context, client client.Client, namespace, name string, keepObjects bool, data map[string][]byte) error {
 	var (
 		secretName, secret = NewSecret(client, namespace, name, data, true)
@@ -128,7 +128,7 @@ func CreateForSeed(ctx context.Context, client client.Client, namespace, name st
 	return deployManagedResource(ctx, secret, managedResource)
 }
 
-// CreateForShoot deploys a ManagedResource CR for the shoot's gardener-resource-builder.
+// CreateForShoot deploys a ManagedResource CR for the shoot's gardener-resource-manager.
 func CreateForShoot(ctx context.Context, client client.Client, namespace, name string, keepObjects bool, data map[string][]byte) error {
 	var (
 		secretName, secret = NewSecret(client, namespace, name, data, true)
@@ -234,7 +234,7 @@ func SetKeepObjects(ctx context.Context, c client.Writer, namespace, name string
 	return nil
 }
 
-// RenderChartAndCreate renders a chart and creates a ManagedResource for the gardener-resource-builder
+// RenderChartAndCreate renders a chart and creates a ManagedResource for the gardener-resource-manager
 // out of the results.
 func RenderChartAndCreate(ctx context.Context, namespace string, name string, secretNameWithPrefix bool, client client.Client, chartRenderer chartrenderer.Interface, chart chart.Interface, values map[string]interface{}, imageVector imagevector.ImageVector, chartNamespace string, version string, withNoCleanupLabel bool, forceOverwriteAnnotations bool) error {
 	chartName, data, err := chart.Render(chartRenderer, chartNamespace, imageVector, version, version, values)

--- a/pkg/utils/managedresources/managedresources.go
+++ b/pkg/utils/managedresources/managedresources.go
@@ -28,7 +28,7 @@ import (
 	"github.com/gardener/gardener/pkg/utils/retry"
 
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
-	"github.com/gardener/gardener/pkg/resourcemanager/manager"
+	"github.com/gardener/gardener/pkg/utils/managedresources/builder"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/utils/pointer"
@@ -54,9 +54,8 @@ func SecretName(name string, withPrefix bool) string {
 }
 
 // New initiates a new ManagedResource object which can be reconciled.
-func New(client client.Client, namespace, name, class string, keepObjects *bool, labels, injectedLabels map[string]string, forceOverwriteAnnotations *bool) *manager.ManagedResource {
-	mr := manager.
-		NewManagedResource(client).
+func New(client client.Client, namespace, name, class string, keepObjects *bool, labels, injectedLabels map[string]string, forceOverwriteAnnotations *bool) *builder.ManagedResource {
+	mr := builder.NewManagedResource(client).
 		WithNamespacedName(namespace, name).
 		WithClass(class).
 		WithLabels(labels).
@@ -73,7 +72,7 @@ func New(client client.Client, namespace, name, class string, keepObjects *bool,
 }
 
 // NewForShoot constructs a new ManagedResource object for the shoot's Gardener-Resource-Manager.
-func NewForShoot(c client.Client, namespace, name string, keepObjects bool) *manager.ManagedResource {
+func NewForShoot(c client.Client, namespace, name string, keepObjects bool) *builder.ManagedResource {
 	var (
 		injectedLabels = map[string]string{v1beta1constants.ShootNoCleanup: "true"}
 		labels         = map[string]string{LabelKeyOrigin: LabelValueGardener}
@@ -83,15 +82,14 @@ func NewForShoot(c client.Client, namespace, name string, keepObjects bool) *man
 }
 
 // NewForSeed constructs a new ManagedResource object for the seed's Gardener-Resource-Manager.
-func NewForSeed(c client.Client, namespace, name string, keepObjects bool) *manager.ManagedResource {
+func NewForSeed(c client.Client, namespace, name string, keepObjects bool) *builder.ManagedResource {
 	return New(c, namespace, name, v1beta1constants.SeedResourceManagerClass, &keepObjects, nil, nil, nil)
 }
 
 // NewSecret initiates a new Secret object which can be reconciled.
-func NewSecret(client client.Client, namespace, name string, data map[string][]byte, secretNameWithPrefix bool) (string, *manager.Secret) {
+func NewSecret(client client.Client, namespace, name string, data map[string][]byte, secretNameWithPrefix bool) (string, *builder.Secret) {
 	secretName := SecretName(name, secretNameWithPrefix)
-	return secretName, manager.
-		NewSecret(client).
+	return secretName, builder.NewSecret(client).
 		WithNamespacedName(namespace, secretName).
 		WithKeyValues(data)
 }
@@ -120,7 +118,7 @@ func Create(ctx context.Context, client client.Client, namespace, name string, s
 	return deployManagedResource(ctx, secret, managedResource)
 }
 
-// CreateForSeed deploys a ManagedResource CR for the seed's gardener-resource-manager.
+// CreateForSeed deploys a ManagedResource CR for the seed's gardener-resource-builder.
 func CreateForSeed(ctx context.Context, client client.Client, namespace, name string, keepObjects bool, data map[string][]byte) error {
 	var (
 		secretName, secret = NewSecret(client, namespace, name, data, true)
@@ -130,7 +128,7 @@ func CreateForSeed(ctx context.Context, client client.Client, namespace, name st
 	return deployManagedResource(ctx, secret, managedResource)
 }
 
-// CreateForShoot deploys a ManagedResource CR for the shoot's gardener-resource-manager.
+// CreateForShoot deploys a ManagedResource CR for the shoot's gardener-resource-builder.
 func CreateForShoot(ctx context.Context, client client.Client, namespace, name string, keepObjects bool, data map[string][]byte) error {
 	var (
 		secretName, secret = NewSecret(client, namespace, name, data, true)
@@ -140,7 +138,7 @@ func CreateForShoot(ctx context.Context, client client.Client, namespace, name s
 	return deployManagedResource(ctx, secret, managedResource)
 }
 
-func deployManagedResource(ctx context.Context, secret *manager.Secret, managedResource *manager.ManagedResource) error {
+func deployManagedResource(ctx context.Context, secret *builder.Secret, managedResource *builder.ManagedResource) error {
 	if err := secret.Reconcile(ctx); err != nil {
 		return fmt.Errorf("could not create or update secret of managed resources: %w", err)
 	}
@@ -156,15 +154,13 @@ func deployManagedResource(ctx context.Context, secret *manager.Secret, managedR
 func Delete(ctx context.Context, client client.Client, namespace string, name string, secretNameWithPrefix bool) error {
 	secretName := SecretName(name, secretNameWithPrefix)
 
-	if err := manager.
-		NewManagedResource(client).
+	if err := builder.NewManagedResource(client).
 		WithNamespacedName(namespace, name).
 		Delete(ctx); err != nil {
 		return fmt.Errorf("could not delete managed resource '%s/%s': %w", namespace, name, err)
 	}
 
-	if err := manager.
-		NewSecret(client).
+	if err := builder.NewSecret(client).
 		WithNamespacedName(namespace, secretName).
 		Delete(ctx); err != nil {
 		return fmt.Errorf("could not delete secret '%s/%s' of managed resource: %w", namespace, secretName, err)
@@ -238,7 +234,7 @@ func SetKeepObjects(ctx context.Context, c client.Writer, namespace, name string
 	return nil
 }
 
-// RenderChartAndCreate renders a chart and creates a ManagedResource for the gardener-resource-manager
+// RenderChartAndCreate renders a chart and creates a ManagedResource for the gardener-resource-builder
 // out of the results.
 func RenderChartAndCreate(ctx context.Context, namespace string, name string, secretNameWithPrefix bool, client client.Client, chartRenderer chartrenderer.Interface, chart chart.Interface, values map[string]interface{}, imageVector imagevector.ImageVector, chartNamespace string, version string, withNoCleanupLabel bool, forceOverwriteAnnotations bool) error {
 	chartName, data, err := chart.Render(chartRenderer, chartNamespace, imageVector, version, version, values)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Similar to #4860, this is a follow-up of https://github.com/gardener/gardener/pull/4757, namely https://github.com/gardener/gardener/pull/4757#discussion_r721988334.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking developer
The package `pkg/resourcemanager/manager` was moved to `pkg/utils/managedresources/builder`.
```
