### PR TITLE
Clean up 2 types that are no longer used in the Shoot reference control

### DIFF
--- a/pkg/controllermanager/controller/shoot/shoot_reference_control.go
+++ b/pkg/controllermanager/controller/shoot/shoot_reference_control.go
@@ -82,14 +82,7 @@ func shootKubeAPIServerAuditConfigFieldChanged(oldShoot, newShoot *gardencorev1b
 // FinalizerName is the name of the finalizer used for the reference protection.
 const FinalizerName = "gardener.cloud/reference-protection"
 
-// SecretLister fetches secret objects with the given options.
-type SecretLister func(ctx context.Context, secretList *corev1.SecretList, options ...client.ListOption) error
-
-// ConfigMapLister fetches configmap objects with the given options.
-type ConfigMapLister func(ctx context.Context, configMapList *corev1.ConfigMapList, options ...client.ListOption) error
-
 // NewShootReferenceReconciler creates a new instance of a reconciler which checks object references from shoot objects.
-// A special `userSecretLister` serves as an option to retrieve secret objects which are not gardener managed.
 func NewShootReferenceReconciler(l logrus.FieldLogger, gardenClient kubernetes.Interface, config *config.ShootReferenceControllerConfiguration) reconcile.Reconciler {
 	return &shootReferenceReconciler{
 		gardenClient: gardenClient,


### PR DESCRIPTION
/kind cleanup

It seems that after https://github.com/gardener/gardener/pull/3982, these two types are no longer used/needed.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
