### PR TITLE
Fix GSAC's deletion protection

### DIFF
--- a/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller.go
+++ b/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller.go
@@ -29,7 +29,6 @@ import (
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	"github.com/gardener/gardener/pkg/seedadmissioncontroller/webhooks/admission/extensioncrds"
 	"github.com/gardener/gardener/pkg/seedadmissioncontroller/webhooks/admission/extensionresources"
-	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 
@@ -347,7 +346,7 @@ func GetValidatingWebhookConfig(caBundle []byte, webhookClientService *corev1.Se
 			FailurePolicy:     &failurePolicy,
 			NamespaceSelector: &metav1.LabelSelector{},
 			ObjectSelector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{gutil.DeletionProtected: "true"},
+				MatchLabels: extensioncrds.ObjectSelector,
 			},
 			ClientConfig: admissionregistrationv1.WebhookClientConfig{
 				CABundle: caBundle,

--- a/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller.go
+++ b/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller.go
@@ -134,6 +134,7 @@ func (g *gardenerSeedAdmissionController) Deploy(ctx context.Context) error {
 						"bastions",
 						"containerruntimes",
 						"controlplanes",
+						"dnsrecords",
 						"extensions",
 						"infrastructures",
 						"networks",

--- a/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller_test.go
+++ b/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller_test.go
@@ -92,6 +92,7 @@ rules:
   - bastions
   - containerruntimes
   - controlplanes
+  - dnsrecords
   - extensions
   - infrastructures
   - networks

--- a/pkg/seedadmissioncontroller/webhooks/admission/request.go
+++ b/pkg/seedadmissioncontroller/webhooks/admission/request.go
@@ -25,7 +25,8 @@ import (
 )
 
 // ExtractRequestObject extracts the object in the admission request and returns it.
-func ExtractRequestObject(ctx context.Context, reader client.Reader, decoder *admission.Decoder, request admission.Request) (runtime.Object, error) {
+// The given `ListOption` is used to list affected objects in case of a `DELETECOLLECTION` request.
+func ExtractRequestObject(ctx context.Context, reader client.Reader, decoder *admission.Decoder, request admission.Request, listOp client.ListOption) (runtime.Object, error) {
 	var (
 		obj runtime.Object
 		err error
@@ -38,7 +39,7 @@ func ExtractRequestObject(ctx context.Context, reader client.Reader, decoder *ad
 		o := &unstructured.UnstructuredList{}
 		o.SetAPIVersion(request.Kind.Group + "/" + request.Kind.Version)
 		o.SetKind(request.Kind.Kind + "List")
-		err = reader.List(ctx, o, client.InNamespace(request.Namespace))
+		err = reader.List(ctx, o, listOp)
 		obj = o
 
 	case request.OldObject.Raw != nil:

--- a/pkg/seedadmissioncontroller/webhooks/admission/request.go
+++ b/pkg/seedadmissioncontroller/webhooks/admission/request.go
@@ -16,13 +16,12 @@ package admission
 
 import (
 	"context"
+	"fmt"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
-
-	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 // ExtractRequestObject extracts the object in the admission request and returns it.
@@ -33,6 +32,15 @@ func ExtractRequestObject(ctx context.Context, reader client.Reader, decoder *ad
 	)
 
 	switch {
+	// DELETECOLLECTION requests don't contain the entire object list.
+	// Lookup all existing objects of that gvk.
+	case request.Name == "":
+		o := &unstructured.UnstructuredList{}
+		o.SetAPIVersion(request.Kind.Group + "/" + request.Kind.Version)
+		o.SetKind(request.Kind.Kind + "List")
+		err = reader.List(ctx, o, client.InNamespace(request.Namespace))
+		obj = o
+
 	case request.OldObject.Raw != nil:
 		obj = &unstructured.Unstructured{}
 		err = decoder.DecodeRaw(request.OldObject, obj)
@@ -41,22 +49,8 @@ func ExtractRequestObject(ctx context.Context, reader client.Reader, decoder *ad
 		obj = &unstructured.Unstructured{}
 		err = decoder.DecodeRaw(request.Object, obj)
 
-	// DELETECOLLECTION request, lookup all existing objects of that gvk
-	case request.Name == "":
-		o := &unstructured.UnstructuredList{}
-		o.SetAPIVersion(request.Kind.Group + "/" + request.Kind.Version)
-		o.SetKind(request.Kind.Kind + "List")
-		err = reader.List(ctx, o, client.InNamespace(request.Namespace))
-		obj = o
-
-	// Older Kubernetes versions don't provide the object neither in OldObject nor in the Object field. In this case
-	// we have to look it up ourselves.
 	default:
-		o := &unstructured.Unstructured{}
-		o.SetAPIVersion(request.Kind.Group + "/" + request.Kind.Version)
-		o.SetKind(request.Kind.Kind)
-		err = reader.Get(ctx, kutil.Key(request.Namespace, request.Name), o)
-		obj = o
+		err = fmt.Errorf("no object found in admission request")
 	}
 
 	return obj, err

--- a/pkg/seedadmissioncontroller/webhooks/admission/request_test.go
+++ b/pkg/seedadmissioncontroller/webhooks/admission/request_test.go
@@ -77,7 +77,7 @@ var _ = Describe("admission", func() {
 			It("should return an error because the old object cannot be decoded", func() {
 				request.OldObject = runtime.RawExtension{Raw: []byte("foo")}
 
-				_, err := ExtractRequestObject(ctx, c, decoder, request)
+				_, err := ExtractRequestObject(ctx, c, decoder, request, nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("invalid character"))
 			})
@@ -88,7 +88,7 @@ var _ = Describe("admission", func() {
 
 				request.OldObject = runtime.RawExtension{Raw: objJSON}
 
-				result, err := ExtractRequestObject(ctx, c, decoder, request)
+				result, err := ExtractRequestObject(ctx, c, decoder, request, nil)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result.GetObjectKind().GroupVersionKind().Kind).To(Equal(resource.Resource))
 			})
@@ -108,7 +108,7 @@ var _ = Describe("admission", func() {
 			It("should return an error because the new object cannot be decoded", func() {
 				request.Object = runtime.RawExtension{Raw: []byte("foo")}
 
-				_, err := ExtractRequestObject(ctx, c, decoder, request)
+				_, err := ExtractRequestObject(ctx, c, decoder, request, nil)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("invalid character"))
 			})
@@ -119,7 +119,7 @@ var _ = Describe("admission", func() {
 
 				request.Object = runtime.RawExtension{Raw: objJSON}
 
-				result, err := ExtractRequestObject(ctx, c, decoder, request)
+				result, err := ExtractRequestObject(ctx, c, decoder, request, nil)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result.GetObjectKind().GroupVersionKind().Kind).To(Equal(resource.Resource))
 			})
@@ -140,7 +140,7 @@ var _ = Describe("admission", func() {
 			})
 
 			It("should return an error because the GET call failed", func() {
-				_, err := ExtractRequestObject(ctx, c, decoder, request)
+				_, err := ExtractRequestObject(ctx, c, decoder, request, nil)
 				Expect(err).Should(MatchError("no object found in admission request"))
 			})
 		})
@@ -170,7 +170,7 @@ var _ = Describe("admission", func() {
 
 				c.EXPECT().List(ctx, obj, listOp).Return(fakeErr)
 
-				_, err := ExtractRequestObject(ctx, c, decoder, request)
+				_, err := ExtractRequestObject(ctx, c, decoder, request, listOp)
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(Equal(err))
 			})
@@ -188,7 +188,7 @@ var _ = Describe("admission", func() {
 					return nil
 				})
 
-				result, err := ExtractRequestObject(ctx, c, decoder, request)
+				result, err := ExtractRequestObject(ctx, c, decoder, request, listOp)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result.GetObjectKind().GroupVersionKind().Kind).To(Equal("List"))
 			})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug

**What this PR does / why we need it**:
This PR fixes several issues in the Gardener Seed Admission Controller, concretely in the `extension_crds` handler and deployment:
1. GSAC `ClusterRole` didn't contain permissions to get or list `DNSRecords`.
2. The handler never tried to list resources in the `DELETECOLLECTION` case because Kube-Apiserver always fills `request.OldObject` (with one object), so the `case request.Name == ""` was never considered.
3. In case of a `CustomResourceDefinition` deletion, GSAC must not list all objects but only those with `gardener.cloud/deletion-protected: true`.

**Special notes for your reviewer**:
The `GET` case has also been removed from ` pkg/seedadmissioncontroller/webhooks/admission/request.go` because with the range of supported K8s versions for seeds (>= 1.18) this has become irrelevant.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Several issues have been fixed in the `Gardener-Seed-Admission-Controller` when `DELETECOLLECTION` requests are sent to the admission webhook.
```
