### PR TITLE
Ensure owner DNSRecords are optional

### DIFF
--- a/extensions/pkg/controller/backupentry/reconciler.go
+++ b/extensions/pkg/controller/backupentry/reconciler.go
@@ -100,7 +100,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	operationType := gardencorev1beta1helper.ComputeOperationType(be.ObjectMeta, be.Status.LastOperation)
 
-	if cluster != nil && operationType != gardencorev1beta1.LastOperationTypeMigrate {
+	if cluster != nil && cluster.Shoot != nil && operationType != gardencorev1beta1.LastOperationTypeMigrate {
 		key := "backupentry:" + be.Name
 		ok, watchdogCtx, cleanup, err := common.GetOwnerCheckResultAndContext(ctx, r.client, shootTechnicalID, cluster.Shoot.Name, key)
 		if err != nil {

--- a/extensions/pkg/controller/containerruntime/reconciler.go
+++ b/extensions/pkg/controller/containerruntime/reconciler.go
@@ -102,7 +102,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	operationType := gardencorev1beta1helper.ComputeOperationType(cr.ObjectMeta, cr.Status.LastOperation)
 
-	if operationType != gardencorev1beta1.LastOperationTypeMigrate {
+	if cluster.Shoot != nil && operationType != gardencorev1beta1.LastOperationTypeMigrate {
 		key := "containerruntime:" + kutil.ObjectName(cr)
 		ok, watchdogCtx, cleanup, err := common.GetOwnerCheckResultAndContext(ctx, r.client, cr.Namespace, cluster.Shoot.Name, key)
 		if err != nil {

--- a/extensions/pkg/controller/controlplane/reconciler.go
+++ b/extensions/pkg/controller/controlplane/reconciler.go
@@ -101,7 +101,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	operationType := gardencorev1beta1helper.ComputeOperationType(cp.ObjectMeta, cp.Status.LastOperation)
 
-	if operationType != gardencorev1beta1.LastOperationTypeMigrate {
+	if cluster.Shoot != nil && operationType != gardencorev1beta1.LastOperationTypeMigrate {
 		key := "controlplane:" + kutil.ObjectName(cp)
 		ok, watchdogCtx, cleanup, err := common.GetOwnerCheckResultAndContext(ctx, r.client, cp.Namespace, cluster.Shoot.Name, key)
 		if err != nil {

--- a/extensions/pkg/controller/dnsrecord/reconciler.go
+++ b/extensions/pkg/controller/dnsrecord/reconciler.go
@@ -103,7 +103,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	operationType := gardencorev1beta1helper.ComputeOperationType(dns.ObjectMeta, dns.Status.LastOperation)
 
-	if cluster != nil && dns.Name != cluster.Shoot.Name+"-"+botanist.DNSOwnerName && operationType != gardencorev1beta1.LastOperationTypeMigrate {
+	if cluster != nil && cluster.Shoot != nil && dns.Name != cluster.Shoot.Name+"-"+botanist.DNSOwnerName && operationType != gardencorev1beta1.LastOperationTypeMigrate {
 		key := "dnsrecord:" + kutil.ObjectName(dns)
 		ok, watchdogCtx, cleanup, err := common.GetOwnerCheckResultAndContext(ctx, r.client, dns.Namespace, cluster.Shoot.Name, key)
 		if err != nil {

--- a/extensions/pkg/controller/extension/reconciler.go
+++ b/extensions/pkg/controller/extension/reconciler.go
@@ -189,7 +189,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	operationType := gardencorev1beta1helper.ComputeOperationType(ex.ObjectMeta, ex.Status.LastOperation)
 
-	if operationType != gardencorev1beta1.LastOperationTypeMigrate {
+	if cluster.Shoot != nil && operationType != gardencorev1beta1.LastOperationTypeMigrate {
 		key := "extension:" + kutil.ObjectName(ex)
 		ok, watchdogCtx, cleanup, err := common.GetOwnerCheckResultAndContext(ctx, r.client, ex.Namespace, cluster.Shoot.Name, key)
 		if err != nil {

--- a/extensions/pkg/controller/infrastructure/reconciler.go
+++ b/extensions/pkg/controller/infrastructure/reconciler.go
@@ -105,7 +105,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	operationType := gardencorev1beta1helper.ComputeOperationType(infrastructure.ObjectMeta, infrastructure.Status.LastOperation)
 
-	if operationType != gardencorev1beta1.LastOperationTypeMigrate {
+	if cluster.Shoot != nil && operationType != gardencorev1beta1.LastOperationTypeMigrate {
 		key := "infrastructure:" + kutil.ObjectName(infrastructure)
 		ok, watchdogCtx, cleanup, err := common.GetOwnerCheckResultAndContext(ctx, r.client, infrastructure.Namespace, cluster.Shoot.Name, key)
 		if err != nil {

--- a/extensions/pkg/controller/network/reconciler.go
+++ b/extensions/pkg/controller/network/reconciler.go
@@ -97,7 +97,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	operationType := gardencorev1beta1helper.ComputeOperationType(network.ObjectMeta, network.Status.LastOperation)
 
-	if operationType != gardencorev1beta1.LastOperationTypeMigrate {
+	if cluster.Shoot != nil && operationType != gardencorev1beta1.LastOperationTypeMigrate {
 		key := "network:" + kutil.ObjectName(network)
 		ok, watchdogCtx, cleanup, err := common.GetOwnerCheckResultAndContext(ctx, r.client, network.Namespace, cluster.Shoot.Name, key)
 		if err != nil {

--- a/extensions/pkg/controller/operatingsystemconfig/reconciler.go
+++ b/extensions/pkg/controller/operatingsystemconfig/reconciler.go
@@ -111,7 +111,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	operationType := gardencorev1beta1helper.ComputeOperationType(osc.ObjectMeta, osc.Status.LastOperation)
 
-	if operationType != gardencorev1beta1.LastOperationTypeMigrate {
+	if cluster.Shoot != nil && operationType != gardencorev1beta1.LastOperationTypeMigrate {
 		key := "operatingsystemconfig:" + kutil.ObjectName(osc)
 		ok, watchdogCtx, cleanup, err := common.GetOwnerCheckResultAndContext(ctx, r.client, osc.Namespace, cluster.Shoot.Name, key)
 		if err != nil {

--- a/extensions/pkg/controller/worker/reconciler.go
+++ b/extensions/pkg/controller/worker/reconciler.go
@@ -99,7 +99,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	operationType := gardencorev1beta1helper.ComputeOperationType(worker.ObjectMeta, worker.Status.LastOperation)
 
-	if operationType != gardencorev1beta1.LastOperationTypeMigrate {
+	if cluster.Shoot != nil && operationType != gardencorev1beta1.LastOperationTypeMigrate {
 		key := "worker:" + kutil.ObjectName(worker)
 		ok, watchdogCtx, cleanup, err := r.watchdogManager.GetResultAndContext(ctx, r.client, worker.Namespace, cluster.Shoot.Name, key)
 		if err != nil {

--- a/pkg/extensions/owner.go
+++ b/pkg/extensions/owner.go
@@ -20,6 +20,7 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -27,7 +28,7 @@ import (
 // If the owner DNSRecord resource is not found, it returns empty strings.
 func GetOwnerNameAndID(ctx context.Context, c client.Client, namespace, shootName string) (string, string, error) {
 	dns := &extensionsv1alpha1.DNSRecord{}
-	if err := c.Get(ctx, kutil.Key(namespace, shootName+"-owner"), dns); client.IgnoreNotFound(err) != nil {
+	if err := c.Get(ctx, kutil.Key(namespace, shootName+"-owner"), dns); client.IgnoreNotFound(err) != nil && !meta.IsNoMatchError(err) {
 		return "", "", err
 	}
 

--- a/pkg/extensions/owner_test.go
+++ b/pkg/extensions/owner_test.go
@@ -27,6 +27,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -95,6 +96,15 @@ var _ = Describe("owner", func() {
 
 		It("should return empty owner name and ID if the owner DNSRecord is not found", func() {
 			expectGetDNSRecord(apierrors.NewNotFound(schema.GroupResource{}, dnsName))
+
+			name, id, err := GetOwnerNameAndID(ctx, c, namespace, shootName)
+			Expect(err).To(Not(HaveOccurred()))
+			Expect(name).To(BeEmpty())
+			Expect(id).To(BeEmpty())
+		})
+
+		It("should return empty owner name and ID if the DNSRecord kind could not be matched", func() {
+			expectGetDNSRecord(&meta.NoKindMatchError{})
 
 			name, id, err := GetOwnerNameAndID(ctx, c, namespace, shootName)
 			Expect(err).To(Not(HaveOccurred()))


### PR DESCRIPTION
**How to categorize this PR?**

/area robustness
/kind bug

**What this PR does / why we need it**:
Ensure owner `DNSRecord` resources are optional and the owner check watchdogs are disabled without any failures in either of the following cases:
* The `Shoot` field in the `Cluster` resource is `nil`.
* The `dnsrecords` CRD is not present and getting the owner `DNSRecord` fails with "no matches for kind" error.

See the discussions in https://github.com/gardener/gardener-extension-provider-aws/pull/424.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```other operator
Creating owner check watchdogs will no longer fail if the `Shoot` field in the `Cluster` resource is nil or the `dnsrecords` CRD is not present.
```
