### PR TITLE
Eliminate references of `gardener/gardener/extensions` from packages in `gardener/gardener/pkg`

### DIFF
--- a/extensions/pkg/controller/backupbucket/reconciler.go
+++ b/extensions/pkg/controller/backupbucket/reconciler.go
@@ -109,8 +109,8 @@ func (r *reconciler) reconcile(ctx context.Context, bb *extensionsv1alpha1.Backu
 
 	r.logger.Info("Starting the reconciliation of backupbucket", "backupbucket", kutil.ObjectName(bb))
 	if err := r.actuator.Reconcile(ctx, bb); err != nil {
-		_ = r.statusUpdater.Error(ctx, bb, extensionscontroller.ReconcileErrCauseOrErr(err), operationType, "Error reconciling backupbucket")
-		return extensionscontroller.ReconcileErr(err)
+		_ = r.statusUpdater.Error(ctx, bb, reconcilerutils.ReconcileErrCauseOrErr(err), operationType, "Error reconciling backupbucket")
+		return reconcilerutils.ReconcileErr(err)
 	}
 
 	if err := r.statusUpdater.Success(ctx, bb, operationType, "Successfully reconciled backupbucket"); err != nil {
@@ -133,8 +133,8 @@ func (r *reconciler) delete(ctx context.Context, bb *extensionsv1alpha1.BackupBu
 
 	r.logger.Info("Starting the deletion of backupbucket", "backupbucket", kutil.ObjectName(bb))
 	if err := r.actuator.Delete(ctx, bb); err != nil {
-		_ = r.statusUpdater.Error(ctx, bb, extensionscontroller.ReconcileErrCauseOrErr(err), operationType, "Error deleting backupbucket")
-		return extensionscontroller.ReconcileErr(err)
+		_ = r.statusUpdater.Error(ctx, bb, reconcilerutils.ReconcileErrCauseOrErr(err), operationType, "Error deleting backupbucket")
+		return reconcilerutils.ReconcileErr(err)
 	}
 
 	if err := r.statusUpdater.Success(ctx, bb, operationType, "Successfully deleted backupbucket"); err != nil {

--- a/extensions/pkg/controller/backupentry/genericactuator/actuator.go
+++ b/extensions/pkg/controller/backupentry/genericactuator/actuator.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 
 	"github.com/gardener/gardener/extensions/pkg/controller/backupentry"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -83,7 +84,7 @@ func (a *actuator) deployEtcdBackupSecret(ctx context.Context, be *extensionsv1a
 	}
 
 	backupSecretData := backupSecret.DeepCopy().Data
-	backupSecretData[DataKeyBackupBucketName] = []byte(be.Spec.BucketName)
+	backupSecretData[v1beta1constants.DataKeyBackupBucketName] = []byte(be.Spec.BucketName)
 	etcdSecretData, err := a.backupEntryDelegate.GetETCDSecretData(ctx, be, backupSecretData)
 	if err != nil {
 		return err
@@ -91,7 +92,7 @@ func (a *actuator) deployEtcdBackupSecret(ctx context.Context, be *extensionsv1a
 
 	etcdSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      BackupSecretName,
+			Name:      v1beta1constants.BackupSecretName,
 			Namespace: shootTechnicalID,
 		},
 	}

--- a/extensions/pkg/controller/backupentry/genericactuator/actuator_test.go
+++ b/extensions/pkg/controller/backupentry/genericactuator/actuator_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/gardener/gardener/extensions/pkg/controller/backupentry"
 	"github.com/gardener/gardener/extensions/pkg/controller/backupentry/genericactuator"
 	mockgenericactuator "github.com/gardener/gardener/extensions/pkg/controller/backupentry/genericactuator/mock"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 
 	"github.com/golang/mock/gomock"
@@ -79,11 +80,11 @@ var _ = Describe("Actuator", func() {
 			"foo":        []byte("bar"),
 		}
 
-		etcdBackupSecretKey = client.ObjectKey{Namespace: shootTechnicalID, Name: genericactuator.BackupSecretName}
+		etcdBackupSecretKey = client.ObjectKey{Namespace: shootTechnicalID, Name: v1beta1constants.BackupSecretName}
 		etcdBackupSecret    = &corev1.Secret{
 			TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:            genericactuator.BackupSecretName,
+				Name:            v1beta1constants.BackupSecretName,
 				Namespace:       shootTechnicalID,
 				ResourceVersion: "1",
 			},

--- a/extensions/pkg/controller/backupentry/genericactuator/types.go
+++ b/extensions/pkg/controller/backupentry/genericactuator/types.go
@@ -20,13 +20,6 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 )
 
-const (
-	// BackupSecretName is the name of secret having credentials for etcd backups.
-	BackupSecretName string = "etcd-backup"
-	// DataKeyBackupBucketName is the name of a data key whose value contains the backup bucket name.
-	DataKeyBackupBucketName string = "bucketName"
-)
-
 // BackupEntryDelegate preforms provider specific operation with BackupBucket resources.
 type BackupEntryDelegate interface {
 	// Delete deletes the BackupBucket.

--- a/extensions/pkg/controller/backupentry/reconciler.go
+++ b/extensions/pkg/controller/backupentry/reconciler.go
@@ -148,8 +148,8 @@ func (r *reconciler) reconcile(ctx context.Context, be *extensionsv1alpha1.Backu
 
 	r.logger.Info("Starting the reconciliation of backupentry", "backupentry", kutil.ObjectName(be))
 	if err := r.actuator.Reconcile(ctx, be); err != nil {
-		_ = r.statusUpdater.Error(ctx, be, extensionscontroller.ReconcileErrCauseOrErr(err), operationType, "Error reconciling backupentry")
-		return extensionscontroller.ReconcileErr(err)
+		_ = r.statusUpdater.Error(ctx, be, reconcilerutils.ReconcileErrCauseOrErr(err), operationType, "Error reconciling backupentry")
+		return reconcilerutils.ReconcileErr(err)
 	}
 
 	if err := r.statusUpdater.Success(ctx, be, operationType, "Successfully reconciled backupentry"); err != nil {
@@ -178,8 +178,8 @@ func (r *reconciler) restore(ctx context.Context, be *extensionsv1alpha1.BackupE
 
 	r.logger.Info("Starting the restoration of backupentry", "backupentry", kutil.ObjectName(be))
 	if err := r.actuator.Restore(ctx, be); err != nil {
-		_ = r.statusUpdater.Error(ctx, be, extensionscontroller.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeRestore, "Error restoring backupentry")
-		return extensionscontroller.ReconcileErr(err)
+		_ = r.statusUpdater.Error(ctx, be, reconcilerutils.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeRestore, "Error restoring backupentry")
+		return reconcilerutils.ReconcileErr(err)
 	}
 
 	if err := r.statusUpdater.Success(ctx, be, gardencorev1beta1.LastOperationTypeRestore, "Successfully restored backupentry"); err != nil {
@@ -221,8 +221,8 @@ func (r *reconciler) delete(ctx context.Context, be *extensionsv1alpha1.BackupEn
 	}
 
 	if err := r.actuator.Delete(ctx, be); err != nil {
-		_ = r.statusUpdater.Error(ctx, be, extensionscontroller.ReconcileErrCauseOrErr(err), operationType, "Error deleting backupentry")
-		return extensionscontroller.ReconcileErr(err)
+		_ = r.statusUpdater.Error(ctx, be, reconcilerutils.ReconcileErrCauseOrErr(err), operationType, "Error deleting backupentry")
+		return reconcilerutils.ReconcileErr(err)
 	}
 
 	if err := r.statusUpdater.Success(ctx, be, operationType, "Successfully deleted backupentry"); err != nil {
@@ -248,8 +248,8 @@ func (r *reconciler) migrate(ctx context.Context, be *extensionsv1alpha1.BackupE
 
 	r.logger.Info("Starting the migration of backupentry", "backupentry", kutil.ObjectName(be))
 	if err := r.actuator.Migrate(ctx, be); err != nil {
-		_ = r.statusUpdater.Error(ctx, be, extensionscontroller.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeMigrate, "Error migrating backupentry")
-		return extensionscontroller.ReconcileErr(err)
+		_ = r.statusUpdater.Error(ctx, be, reconcilerutils.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeMigrate, "Error migrating backupentry")
+		return reconcilerutils.ReconcileErr(err)
 	}
 
 	if err := r.statusUpdater.Success(ctx, be, gardencorev1beta1.LastOperationTypeMigrate, "Successfully migrated backupentry"); err != nil {

--- a/extensions/pkg/controller/bastion/reconciler.go
+++ b/extensions/pkg/controller/bastion/reconciler.go
@@ -109,8 +109,8 @@ func (r *reconciler) reconcile(ctx context.Context, bastion *extensionsv1alpha1.
 
 	r.logger.Info("Starting the reconciliation of bastion", "bastion", kutil.ObjectName(bastion))
 	if err := r.actuator.Reconcile(ctx, bastion, cluster); err != nil {
-		_ = r.statusUpdater.Error(ctx, bastion, extensionscontroller.ReconcileErrCauseOrErr(err), operationType, "Error reconciling bastion")
-		return extensionscontroller.ReconcileErr(err)
+		_ = r.statusUpdater.Error(ctx, bastion, reconcilerutils.ReconcileErrCauseOrErr(err), operationType, "Error reconciling bastion")
+		return reconcilerutils.ReconcileErr(err)
 	}
 
 	if err := r.statusUpdater.Success(ctx, bastion, operationType, "Successfully reconciled bastion"); err != nil {
@@ -134,8 +134,8 @@ func (r *reconciler) delete(ctx context.Context, bastion *extensionsv1alpha1.Bas
 	r.logger.Info("Starting the deletion of bastion", "bastion", kutil.ObjectName(bastion))
 
 	if err := r.actuator.Delete(ctx, bastion, cluster); err != nil {
-		_ = r.statusUpdater.Error(ctx, bastion, extensionscontroller.ReconcileErrCauseOrErr(err), operationType, "Error deleting bastion")
-		return extensionscontroller.ReconcileErr(err)
+		_ = r.statusUpdater.Error(ctx, bastion, reconcilerutils.ReconcileErrCauseOrErr(err), operationType, "Error deleting bastion")
+		return reconcilerutils.ReconcileErr(err)
 	}
 
 	if err := r.statusUpdater.Success(ctx, bastion, operationType, "Successfully reconciled bastion"); err != nil {

--- a/extensions/pkg/controller/containerruntime/reconciler.go
+++ b/extensions/pkg/controller/containerruntime/reconciler.go
@@ -141,8 +141,8 @@ func (r *reconciler) reconcile(ctx context.Context, cr *extensionsv1alpha1.Conta
 	}
 
 	if err := r.actuator.Reconcile(ctx, cr, cluster); err != nil {
-		_ = r.statusUpdater.Error(ctx, cr, extensionscontroller.ReconcileErrCauseOrErr(err), operationType, "Error reconciling containerruntime")
-		return extensionscontroller.ReconcileErr(err)
+		_ = r.statusUpdater.Error(ctx, cr, reconcilerutils.ReconcileErrCauseOrErr(err), operationType, "Error reconciling containerruntime")
+		return reconcilerutils.ReconcileErr(err)
 	}
 
 	if err := r.statusUpdater.Success(ctx, cr, operationType, "Successfully reconciled containerruntime"); err != nil {
@@ -162,8 +162,8 @@ func (r *reconciler) restore(ctx context.Context, cr *extensionsv1alpha1.Contain
 	}
 
 	if err := r.actuator.Restore(ctx, cr, cluster); err != nil {
-		_ = r.statusUpdater.Error(ctx, cr, extensionscontroller.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeRestore, "Error restoring containerruntime")
-		return extensionscontroller.ReconcileErr(err)
+		_ = r.statusUpdater.Error(ctx, cr, reconcilerutils.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeRestore, "Error restoring containerruntime")
+		return reconcilerutils.ReconcileErr(err)
 	}
 
 	if err := r.statusUpdater.Success(ctx, cr, gardencorev1beta1.LastOperationTypeRestore, "Successfully restored containerruntime"); err != nil {
@@ -188,8 +188,8 @@ func (r *reconciler) delete(ctx context.Context, cr *extensionsv1alpha1.Containe
 	}
 
 	if err := r.actuator.Delete(ctx, cr, cluster); err != nil {
-		_ = r.statusUpdater.Error(ctx, cr, extensionscontroller.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeDelete, "Error deleting containerruntime")
-		return extensionscontroller.ReconcileErr(err)
+		_ = r.statusUpdater.Error(ctx, cr, reconcilerutils.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeDelete, "Error deleting containerruntime")
+		return reconcilerutils.ReconcileErr(err)
 	}
 
 	if err := r.statusUpdater.Success(ctx, cr, gardencorev1beta1.LastOperationTypeDelete, "Successfully deleted containerruntime"); err != nil {
@@ -210,8 +210,8 @@ func (r *reconciler) migrate(ctx context.Context, cr *extensionsv1alpha1.Contain
 	}
 
 	if err := r.actuator.Migrate(ctx, cr, cluster); err != nil {
-		_ = r.statusUpdater.Error(ctx, cr, extensionscontroller.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeMigrate, "Error migrating containerruntime")
-		return extensionscontroller.ReconcileErr(err)
+		_ = r.statusUpdater.Error(ctx, cr, reconcilerutils.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeMigrate, "Error migrating containerruntime")
+		return reconcilerutils.ReconcileErr(err)
 	}
 
 	if err := r.statusUpdater.Success(ctx, cr, gardencorev1beta1.LastOperationTypeMigrate, "Successfully migrated containerruntime"); err != nil {

--- a/extensions/pkg/controller/controlplane/reconciler.go
+++ b/extensions/pkg/controller/controlplane/reconciler.go
@@ -142,8 +142,8 @@ func (r *reconciler) reconcile(ctx context.Context, cp *extensionsv1alpha1.Contr
 	r.logger.Info("Starting the reconciliation of controlplane", "controlplane", kutil.ObjectName(cp))
 	requeue, err := r.actuator.Reconcile(ctx, cp, cluster)
 	if err != nil {
-		_ = r.statusUpdater.Error(ctx, cp, extensionscontroller.ReconcileErrCauseOrErr(err), operationType, "Error reconciling controlplane")
-		return extensionscontroller.ReconcileErr(err)
+		_ = r.statusUpdater.Error(ctx, cp, reconcilerutils.ReconcileErrCauseOrErr(err), operationType, "Error reconciling controlplane")
+		return reconcilerutils.ReconcileErr(err)
 	}
 
 	if err := r.statusUpdater.Success(ctx, cp, operationType, "Successfully reconciled controlplane"); err != nil {
@@ -168,8 +168,8 @@ func (r *reconciler) restore(ctx context.Context, cp *extensionsv1alpha1.Control
 	r.logger.Info("Starting the restoration of controlplane", "controlplane", kutil.ObjectName(cp))
 	requeue, err := r.actuator.Restore(ctx, cp, cluster)
 	if err != nil {
-		_ = r.statusUpdater.Error(ctx, cp, extensionscontroller.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeRestore, "Error restoring controlplane")
-		return extensionscontroller.ReconcileErr(err)
+		_ = r.statusUpdater.Error(ctx, cp, reconcilerutils.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeRestore, "Error restoring controlplane")
+		return reconcilerutils.ReconcileErr(err)
 	}
 
 	if err := r.statusUpdater.Success(ctx, cp, gardencorev1beta1.LastOperationTypeRestore, "Successfully restored controlplane"); err != nil {
@@ -194,8 +194,8 @@ func (r *reconciler) migrate(ctx context.Context, cp *extensionsv1alpha1.Control
 
 	r.logger.Info("Starting the migration of controlplane", "controlplane", kutil.ObjectName(cp))
 	if err := r.actuator.Migrate(ctx, cp, cluster); err != nil {
-		_ = r.statusUpdater.Error(ctx, cp, extensionscontroller.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeMigrate, "Error migrating controlplane")
-		return extensionscontroller.ReconcileErr(err)
+		_ = r.statusUpdater.Error(ctx, cp, reconcilerutils.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeMigrate, "Error migrating controlplane")
+		return reconcilerutils.ReconcileErr(err)
 	}
 
 	if err := r.statusUpdater.Success(ctx, cp, gardencorev1beta1.LastOperationTypeMigrate, "Successfully migrated controlplane"); err != nil {
@@ -227,8 +227,8 @@ func (r *reconciler) delete(ctx context.Context, cp *extensionsv1alpha1.ControlP
 
 	r.logger.Info("Starting the deletion of controlplane", "controlplane", kutil.ObjectName(cp))
 	if err := r.actuator.Delete(ctx, cp, cluster); err != nil {
-		_ = r.statusUpdater.Error(ctx, cp, extensionscontroller.ReconcileErrCauseOrErr(err), operationType, "Error deleting controlplane")
-		return extensionscontroller.ReconcileErr(err)
+		_ = r.statusUpdater.Error(ctx, cp, reconcilerutils.ReconcileErrCauseOrErr(err), operationType, "Error deleting controlplane")
+		return reconcilerutils.ReconcileErr(err)
 	}
 
 	if err := r.statusUpdater.Success(ctx, cp, operationType, "Successfully deleted controlplane"); err != nil {

--- a/extensions/pkg/controller/dnsrecord/reconciler.go
+++ b/extensions/pkg/controller/dnsrecord/reconciler.go
@@ -143,8 +143,8 @@ func (r *reconciler) reconcile(ctx context.Context, dns *extensionsv1alpha1.DNSR
 
 	r.logger.Info("Starting the reconciliation of dnsrecord", "dnsrecord", kutil.ObjectName(dns))
 	if err := r.actuator.Reconcile(ctx, dns, cluster); err != nil {
-		_ = r.statusUpdater.Error(ctx, dns, extensionscontroller.ReconcileErrCauseOrErr(err), operationType, "Error reconciling dnsrecord")
-		return extensionscontroller.ReconcileErr(err)
+		_ = r.statusUpdater.Error(ctx, dns, reconcilerutils.ReconcileErrCauseOrErr(err), operationType, "Error reconciling dnsrecord")
+		return reconcilerutils.ReconcileErr(err)
 	}
 
 	if err := r.statusUpdater.Success(ctx, dns, operationType, "Successfully reconciled dnsrecord"); err != nil {
@@ -165,8 +165,8 @@ func (r *reconciler) restore(ctx context.Context, dns *extensionsv1alpha1.DNSRec
 
 	r.logger.Info("Starting the restoration of dnsrecord", "dnsrecord", kutil.ObjectName(dns))
 	if err := r.actuator.Restore(ctx, dns, cluster); err != nil {
-		_ = r.statusUpdater.Error(ctx, dns, extensionscontroller.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeRestore, "Error restoring dnsrecord")
-		return extensionscontroller.ReconcileErr(err)
+		_ = r.statusUpdater.Error(ctx, dns, reconcilerutils.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeRestore, "Error restoring dnsrecord")
+		return reconcilerutils.ReconcileErr(err)
 	}
 
 	if err := r.statusUpdater.Success(ctx, dns, gardencorev1beta1.LastOperationTypeRestore, "Successfully restored dnsrecord"); err != nil {
@@ -187,8 +187,8 @@ func (r *reconciler) migrate(ctx context.Context, dns *extensionsv1alpha1.DNSRec
 
 	r.logger.Info("Starting the migration of dnsrecord", "dnsrecord", kutil.ObjectName(dns))
 	if err := r.actuator.Migrate(ctx, dns, cluster); err != nil {
-		_ = r.statusUpdater.Error(ctx, dns, extensionscontroller.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeMigrate, "Error migrating dnsrecord")
-		return extensionscontroller.ReconcileErr(err)
+		_ = r.statusUpdater.Error(ctx, dns, reconcilerutils.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeMigrate, "Error migrating dnsrecord")
+		return reconcilerutils.ReconcileErr(err)
 	}
 
 	if err := r.statusUpdater.Success(ctx, dns, gardencorev1beta1.LastOperationTypeMigrate, "Successfully migrated dnsrecord"); err != nil {
@@ -220,8 +220,8 @@ func (r *reconciler) delete(ctx context.Context, dns *extensionsv1alpha1.DNSReco
 
 	r.logger.Info("Starting the deletion of dnsrecord", "dnsrecord", kutil.ObjectName(dns))
 	if err := r.actuator.Delete(ctx, dns, cluster); err != nil {
-		_ = r.statusUpdater.Error(ctx, dns, extensionscontroller.ReconcileErrCauseOrErr(err), operationType, "Error deleting dnsrecord")
-		return extensionscontroller.ReconcileErr(err)
+		_ = r.statusUpdater.Error(ctx, dns, reconcilerutils.ReconcileErrCauseOrErr(err), operationType, "Error deleting dnsrecord")
+		return reconcilerutils.ReconcileErr(err)
 	}
 
 	if err := r.statusUpdater.Success(ctx, dns, operationType, "Successfully deleted dnsrecord"); err != nil {

--- a/extensions/pkg/controller/extension/reconciler.go
+++ b/extensions/pkg/controller/extension/reconciler.go
@@ -153,8 +153,8 @@ func (r *reconciler) reconcile(ctx context.Context, ex *extensionsv1alpha1.Exten
 
 	r.logger.Info("Starting the reconciliation of extension", "extension", kutil.ObjectName(ex))
 	if err := r.actuator.Reconcile(ctx, ex); err != nil {
-		_ = r.statusUpdater.Error(ctx, ex, extensionscontroller.ReconcileErrCauseOrErr(err), operationType, "Error reconciling extension")
-		return extensionscontroller.ReconcileErr(err)
+		_ = r.statusUpdater.Error(ctx, ex, reconcilerutils.ReconcileErrCauseOrErr(err), operationType, "Error reconciling extension")
+		return reconcilerutils.ReconcileErr(err)
 	}
 
 	if err := r.statusUpdater.Success(ctx, ex, operationType, "Successfully reconciled extension"); err != nil {
@@ -176,8 +176,8 @@ func (r *reconciler) delete(ctx context.Context, ex *extensionsv1alpha1.Extensio
 
 	r.logger.Info("Starting the deletion of extension", "extension", kutil.ObjectName(ex))
 	if err := r.actuator.Delete(ctx, ex); err != nil {
-		_ = r.statusUpdater.Error(ctx, ex, extensionscontroller.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeDelete, "Error deleting the extension")
-		return extensionscontroller.ReconcileErr(err)
+		_ = r.statusUpdater.Error(ctx, ex, reconcilerutils.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeDelete, "Error deleting the extension")
+		return reconcilerutils.ReconcileErr(err)
 	}
 
 	if err := r.statusUpdater.Success(ctx, ex, gardencorev1beta1.LastOperationTypeDelete, "Successfully deleted the extension"); err != nil {
@@ -202,8 +202,8 @@ func (r *reconciler) restore(ctx context.Context, ex *extensionsv1alpha1.Extensi
 
 	r.logger.Info("Starting the restoration of extension", "extension", kutil.ObjectName(ex))
 	if err := r.actuator.Restore(ctx, ex); err != nil {
-		_ = r.statusUpdater.Error(ctx, ex, extensionscontroller.ReconcileErrCauseOrErr(err), operationType, "Unable to restore Extension resource")
-		return extensionscontroller.ReconcileErr(err)
+		_ = r.statusUpdater.Error(ctx, ex, reconcilerutils.ReconcileErrCauseOrErr(err), operationType, "Unable to restore Extension resource")
+		return reconcilerutils.ReconcileErr(err)
 	}
 
 	if err := r.statusUpdater.Success(ctx, ex, operationType, "Successfully restored Extension resource"); err != nil {
@@ -224,8 +224,8 @@ func (r *reconciler) migrate(ctx context.Context, ex *extensionsv1alpha1.Extensi
 
 	r.logger.Info("Starting the migration of extension", "extension", kutil.ObjectName(ex))
 	if err := r.actuator.Migrate(ctx, ex); err != nil {
-		_ = r.statusUpdater.Error(ctx, ex, extensionscontroller.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeMigrate, "Error migrating Extension resource")
-		return extensionscontroller.ReconcileErr(err)
+		_ = r.statusUpdater.Error(ctx, ex, reconcilerutils.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeMigrate, "Error migrating Extension resource")
+		return reconcilerutils.ReconcileErr(err)
 	}
 
 	if err := r.statusUpdater.Success(ctx, ex, gardencorev1beta1.LastOperationTypeMigrate, "Successfully migrated Extension resource"); err != nil {

--- a/extensions/pkg/controller/infrastructure/reconciler.go
+++ b/extensions/pkg/controller/infrastructure/reconciler.go
@@ -150,8 +150,8 @@ func (r *reconciler) reconcile(ctx context.Context, logger logr.Logger, infrastr
 
 	logger.Info("Starting the reconciliation of infrastructure", "infrastructure", kutil.ObjectName(infrastructure))
 	if err := r.actuator.Reconcile(ctx, infrastructure, cluster); err != nil {
-		_ = r.statusUpdater.Error(ctx, infrastructure, extensionscontroller.ReconcileErrCauseOrErr(err), operationType, "Error reconciling infrastructure")
-		return extensionscontroller.ReconcileErr(err)
+		_ = r.statusUpdater.Error(ctx, infrastructure, reconcilerutils.ReconcileErrCauseOrErr(err), operationType, "Error reconciling infrastructure")
+		return reconcilerutils.ReconcileErr(err)
 	}
 
 	if err := r.statusUpdater.Success(ctx, infrastructure, operationType, "Successfully reconciled infrastructure"); err != nil {
@@ -172,8 +172,8 @@ func (r *reconciler) delete(ctx context.Context, logger logr.Logger, infrastruct
 	}
 
 	if err := r.actuator.Delete(ctx, infrastructure, cluster); err != nil {
-		_ = r.statusUpdater.Error(ctx, infrastructure, extensionscontroller.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeDelete, "Error deleting infrastructure")
-		return extensionscontroller.ReconcileErr(err)
+		_ = r.statusUpdater.Error(ctx, infrastructure, reconcilerutils.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeDelete, "Error deleting infrastructure")
+		return reconcilerutils.ReconcileErr(err)
 	}
 
 	if err := r.statusUpdater.Success(ctx, infrastructure, gardencorev1beta1.LastOperationTypeDelete, "Successfully deleted infrastructure"); err != nil {
@@ -190,8 +190,8 @@ func (r *reconciler) migrate(ctx context.Context, logger logr.Logger, infrastruc
 	}
 
 	if err := r.actuator.Migrate(ctx, infrastructure, cluster); err != nil {
-		_ = r.statusUpdater.Error(ctx, infrastructure, extensionscontroller.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeMigrate, "Error migrating infrastructure")
-		return extensionscontroller.ReconcileErr(err)
+		_ = r.statusUpdater.Error(ctx, infrastructure, reconcilerutils.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeMigrate, "Error migrating infrastructure")
+		return reconcilerutils.ReconcileErr(err)
 	}
 
 	if err := r.statusUpdater.Success(ctx, infrastructure, gardencorev1beta1.LastOperationTypeMigrate, "Successfully migrated infrastructure"); err != nil {
@@ -225,8 +225,8 @@ func (r *reconciler) restore(ctx context.Context, logger logr.Logger, infrastruc
 	}
 
 	if err := r.actuator.Restore(ctx, infrastructure, cluster); err != nil {
-		_ = r.statusUpdater.Error(ctx, infrastructure, extensionscontroller.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeRestore, "Error restoring infrastructure")
-		return extensionscontroller.ReconcileErr(err)
+		_ = r.statusUpdater.Error(ctx, infrastructure, reconcilerutils.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeRestore, "Error restoring infrastructure")
+		return reconcilerutils.ReconcileErr(err)
 	}
 
 	if err := r.removeAnnotation(ctx, logger, infrastructure); err != nil {

--- a/extensions/pkg/controller/network/reconciler.go
+++ b/extensions/pkg/controller/network/reconciler.go
@@ -137,8 +137,8 @@ func (r *reconciler) reconcile(ctx context.Context, network *extensionsv1alpha1.
 
 	r.logger.Info("Starting the reconciliation of network", "network", kutil.ObjectName(network))
 	if err := r.actuator.Reconcile(ctx, network, cluster); err != nil {
-		_ = r.statusUpdater.Error(ctx, network, extensionscontroller.ReconcileErrCauseOrErr(err), operationType, "Error reconciling network")
-		return extensionscontroller.ReconcileErr(err)
+		_ = r.statusUpdater.Error(ctx, network, reconcilerutils.ReconcileErrCauseOrErr(err), operationType, "Error reconciling network")
+		return reconcilerutils.ReconcileErr(err)
 	}
 
 	if err := r.statusUpdater.Success(ctx, network, operationType, "Successfully reconciled network"); err != nil {
@@ -158,8 +158,8 @@ func (r *reconciler) restore(ctx context.Context, network *extensionsv1alpha1.Ne
 	}
 
 	if err := r.actuator.Restore(ctx, network, cluster); err != nil {
-		_ = r.statusUpdater.Error(ctx, network, extensionscontroller.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeRestore, "Error restoring network")
-		return extensionscontroller.ReconcileErr(err)
+		_ = r.statusUpdater.Error(ctx, network, reconcilerutils.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeRestore, "Error restoring network")
+		return reconcilerutils.ReconcileErr(err)
 	}
 
 	if err := r.statusUpdater.Success(ctx, network, gardencorev1beta1.LastOperationTypeRestore, "Successfully restored network"); err != nil {
@@ -185,8 +185,8 @@ func (r *reconciler) delete(ctx context.Context, network *extensionsv1alpha1.Net
 
 	r.logger.Info("Starting the deletion of network", "network", kutil.ObjectName(network))
 	if err := r.actuator.Delete(ctx, network, cluster); err != nil {
-		_ = r.statusUpdater.Error(ctx, network, extensionscontroller.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeDelete, "Error deleting network")
-		return extensionscontroller.ReconcileErr(err)
+		_ = r.statusUpdater.Error(ctx, network, reconcilerutils.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeDelete, "Error deleting network")
+		return reconcilerutils.ReconcileErr(err)
 	}
 
 	if err := r.statusUpdater.Success(ctx, network, gardencorev1beta1.LastOperationTypeDelete, "Successfully deleted network"); err != nil {
@@ -207,8 +207,8 @@ func (r *reconciler) migrate(ctx context.Context, network *extensionsv1alpha1.Ne
 	}
 
 	if err := r.actuator.Migrate(ctx, network, cluster); err != nil {
-		_ = r.statusUpdater.Error(ctx, network, extensionscontroller.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeMigrate, "Error migrating network")
-		return extensionscontroller.ReconcileErr(err)
+		_ = r.statusUpdater.Error(ctx, network, reconcilerutils.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeMigrate, "Error migrating network")
+		return reconcilerutils.ReconcileErr(err)
 	}
 
 	if err := r.statusUpdater.Success(ctx, network, gardencorev1beta1.LastOperationTypeMigrate, "Successfully migrated network"); err != nil {

--- a/extensions/pkg/controller/operatingsystemconfig/oscommon/actuator/actuator_util.go
+++ b/extensions/pkg/controller/operatingsystemconfig/oscommon/actuator/actuator_util.go
@@ -17,9 +17,9 @@ package actuator
 import (
 	"context"
 
-	"github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig/oscommon/cloudinit"
 	commonosgenerator "github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig/oscommon/generator"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	extensionsv1alpha1helper "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1/helper"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
 	corev1 "k8s.io/api/core/v1"
@@ -69,7 +69,7 @@ func DataForFileContent(ctx context.Context, c client.Client, namespace string, 
 		if len(inline.Encoding) == 0 {
 			return []byte(inline.Data), nil
 		}
-		return cloudinit.Decode(inline.Encoding, []byte(inline.Data))
+		return extensionsv1alpha1helper.Decode(inline.Encoding, []byte(inline.Data))
 	}
 
 	secret := &corev1.Secret{}

--- a/extensions/pkg/controller/operatingsystemconfig/oscommon/cloudinit/cloudinit.go
+++ b/extensions/pkg/controller/operatingsystemconfig/oscommon/cloudinit/cloudinit.go
@@ -20,24 +20,14 @@ import (
 	"encoding/base64"
 	"fmt"
 	"io"
+
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 )
 
-// FileCodecID is the id of a FileCodec for cloud-init scripts.
-type FileCodecID string
-
-const (
-	// B64FileCodecID is the base64 file codec id.
-	B64FileCodecID FileCodecID = "b64"
-	// GZIPFileCodecID is the gzip file codec id.
-	GZIPFileCodecID FileCodecID = "gzip"
-	// GZIPB64FileCodecID is the gzip combined with base64 codec id.
-	GZIPB64FileCodecID FileCodecID = "gzip+b64"
-)
-
-var validFileCodecIDs = map[FileCodecID]struct{}{
-	B64FileCodecID:     {},
-	GZIPFileCodecID:    {},
-	GZIPB64FileCodecID: {},
+var validFileCodecIDs = map[extensionsv1alpha1.FileCodecID]struct{}{
+	extensionsv1alpha1.B64FileCodecID:     {},
+	extensionsv1alpha1.GZIPFileCodecID:    {},
+	extensionsv1alpha1.GZIPB64FileCodecID: {},
 }
 
 // FileCodec is a codec to en- and decode data in cloud-init scripts with.j
@@ -93,21 +83,21 @@ func (gzipFileCodec) Decode(data []byte) ([]byte, error) {
 }
 
 // ParseFileCodecID tries to parse a string into a FileCodecID.
-func ParseFileCodecID(s string) (FileCodecID, error) {
-	id := FileCodecID(s)
+func ParseFileCodecID(s string) (extensionsv1alpha1.FileCodecID, error) {
+	id := extensionsv1alpha1.FileCodecID(s)
 	if _, ok := validFileCodecIDs[id]; !ok {
 		return id, fmt.Errorf("invalid file codec id %q", id)
 	}
 	return id, nil
 }
 
-var fileCodecIDToFileCodec = map[FileCodecID]FileCodec{
-	B64FileCodecID:  B64FileCodec,
-	GZIPFileCodecID: GZIPFileCodec,
+var fileCodecIDToFileCodec = map[extensionsv1alpha1.FileCodecID]FileCodec{
+	extensionsv1alpha1.B64FileCodecID:  B64FileCodec,
+	extensionsv1alpha1.GZIPFileCodecID: GZIPFileCodec,
 }
 
 // FileCodecForID retrieves the FileCodec for the given FileCodecID.
-func FileCodecForID(id FileCodecID) FileCodec {
+func FileCodecForID(id extensionsv1alpha1.FileCodecID) FileCodec {
 	return fileCodecIDToFileCodec[id]
 }
 

--- a/extensions/pkg/controller/operatingsystemconfig/reconciler.go
+++ b/extensions/pkg/controller/operatingsystemconfig/reconciler.go
@@ -152,21 +152,21 @@ func (r *reconciler) reconcile(ctx context.Context, osc *extensionsv1alpha1.Oper
 	r.logger.Info("Starting the reconciliation of operatingsystemconfig", "operatingsystemconfig", kutil.ObjectName(osc))
 	userData, command, units, err := r.actuator.Reconcile(ctx, osc)
 	if err != nil {
-		_ = r.statusUpdater.Error(ctx, osc, extensionscontroller.ReconcileErrCauseOrErr(err), operationType, "Error reconciling operatingsystemconfig")
-		return extensionscontroller.ReconcileErr(err)
+		_ = r.statusUpdater.Error(ctx, osc, reconcilerutils.ReconcileErrCauseOrErr(err), operationType, "Error reconciling operatingsystemconfig")
+		return reconcilerutils.ReconcileErr(err)
 	}
 
 	secret, err := r.reconcileOSCResultSecret(ctx, osc, userData)
 	if err != nil {
-		_ = r.statusUpdater.Error(ctx, osc, extensionscontroller.ReconcileErrCauseOrErr(err), operationType, "Could not apply secret for generated cloud config")
-		return extensionscontroller.ReconcileErr(err)
+		_ = r.statusUpdater.Error(ctx, osc, reconcilerutils.ReconcileErrCauseOrErr(err), operationType, "Could not apply secret for generated cloud config")
+		return reconcilerutils.ReconcileErr(err)
 	}
 
 	patch := client.MergeFrom(osc.DeepCopy())
 	setOSCStatus(osc, secret, command, units)
 	if err := r.client.Status().Patch(ctx, osc, patch); err != nil {
-		_ = r.statusUpdater.Error(ctx, osc, extensionscontroller.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeRestore, "Could not update units and secret ref.")
-		return extensionscontroller.ReconcileErr(err)
+		_ = r.statusUpdater.Error(ctx, osc, reconcilerutils.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeRestore, "Could not update units and secret ref.")
+		return reconcilerutils.ReconcileErr(err)
 	}
 	if err := r.statusUpdater.Success(ctx, osc, operationType, "Successfully reconciled operatingsystemconfig"); err != nil {
 		return reconcile.Result{}, err
@@ -187,21 +187,21 @@ func (r *reconciler) restore(ctx context.Context, osc *extensionsv1alpha1.Operat
 	r.logger.Info("Starting the restoration of operatingsystemconfig", "operatingsystemconfig", kutil.ObjectName(osc))
 	userData, command, units, err := r.actuator.Restore(ctx, osc)
 	if err != nil {
-		_ = r.statusUpdater.Error(ctx, osc, extensionscontroller.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeRestore, "Error restoring operatingsystemconfig")
-		return extensionscontroller.ReconcileErr(err)
+		_ = r.statusUpdater.Error(ctx, osc, reconcilerutils.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeRestore, "Error restoring operatingsystemconfig")
+		return reconcilerutils.ReconcileErr(err)
 	}
 
 	secret, err := r.reconcileOSCResultSecret(ctx, osc, userData)
 	if err != nil {
-		_ = r.statusUpdater.Error(ctx, osc, extensionscontroller.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeRestore, "Could not apply secret for generated cloud config")
-		return extensionscontroller.ReconcileErr(err)
+		_ = r.statusUpdater.Error(ctx, osc, reconcilerutils.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeRestore, "Could not apply secret for generated cloud config")
+		return reconcilerutils.ReconcileErr(err)
 	}
 
 	patch := client.MergeFrom(osc.DeepCopy())
 	setOSCStatus(osc, secret, command, units)
 	if err := r.client.Status().Patch(ctx, osc, patch); err != nil {
-		_ = r.statusUpdater.Error(ctx, osc, extensionscontroller.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeRestore, "Could not update units and secret ref.")
-		return extensionscontroller.ReconcileErr(err)
+		_ = r.statusUpdater.Error(ctx, osc, reconcilerutils.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeRestore, "Could not update units and secret ref.")
+		return reconcilerutils.ReconcileErr(err)
 	}
 
 	if err := r.statusUpdater.Success(ctx, osc, gardencorev1beta1.LastOperationTypeRestore, "Successfully restored operatingsystemconfig"); err != nil {
@@ -227,8 +227,8 @@ func (r *reconciler) delete(ctx context.Context, osc *extensionsv1alpha1.Operati
 
 	r.logger.Info("Starting the deletion of operatingsystemconfig", "operatingsystemconfig", kutil.ObjectName(osc))
 	if err := r.actuator.Delete(ctx, osc); err != nil {
-		_ = r.statusUpdater.Error(ctx, osc, extensionscontroller.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeDelete, "Error deleting operatingsystemconfig")
-		return extensionscontroller.ReconcileErr(err)
+		_ = r.statusUpdater.Error(ctx, osc, reconcilerutils.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeDelete, "Error deleting operatingsystemconfig")
+		return reconcilerutils.ReconcileErr(err)
 	}
 
 	if err := r.statusUpdater.Success(ctx, osc, gardencorev1beta1.LastOperationTypeDelete, "Successfully deleted operatingsystemconfig"); err != nil {
@@ -255,8 +255,8 @@ func (r *reconciler) migrate(ctx context.Context, osc *extensionsv1alpha1.Operat
 
 	r.logger.Info("Starting the migration of operatingsystemconfig", "operatingsystemconfig", kutil.ObjectName(osc))
 	if err := r.actuator.Migrate(ctx, osc); err != nil {
-		_ = r.statusUpdater.Error(ctx, osc, extensionscontroller.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeMigrate, "Error migrating operatingsystemconfig")
-		return extensionscontroller.ReconcileErr(err)
+		_ = r.statusUpdater.Error(ctx, osc, reconcilerutils.ReconcileErrCauseOrErr(err), gardencorev1beta1.LastOperationTypeMigrate, "Error migrating operatingsystemconfig")
+		return reconcilerutils.ReconcileErr(err)
 	}
 
 	if err := r.statusUpdater.Success(ctx, osc, gardencorev1beta1.LastOperationTypeMigrate, "Successfully migrated operatingsystemconfig"); err != nil {

--- a/extensions/pkg/controller/utils.go
+++ b/extensions/pkg/controller/utils.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"reflect"
 
-	controllererror "github.com/gardener/gardener/extensions/pkg/controller/error"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
@@ -37,7 +36,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 var (
@@ -57,32 +55,6 @@ var (
 
 func init() {
 	utilruntime.Must(AddToScheme(ExtensionsScheme))
-}
-
-// ReconcileErr returns a reconcile.Result or an error, depending on whether the error is a
-// RequeueAfterError or not.
-func ReconcileErr(err error) (reconcile.Result, error) {
-	if requeueAfter, ok := err.(*controllererror.RequeueAfterError); ok {
-		return reconcile.Result{Requeue: true, RequeueAfter: requeueAfter.RequeueAfter}, nil
-	}
-	return reconcile.Result{}, err
-}
-
-// ReconcileErrCause returns the cause in case the error is an RequeueAfterError. Otherwise,
-// it returns the input error.
-func ReconcileErrCause(err error) error {
-	if requeueAfter, ok := err.(*controllererror.RequeueAfterError); ok {
-		return requeueAfter.Cause
-	}
-	return err
-}
-
-// ReconcileErrCauseOrErr returns the cause of the error or the error if the cause is nil.
-func ReconcileErrCauseOrErr(err error) error {
-	if cause := ReconcileErrCause(err); cause != nil {
-		return cause
-	}
-	return err
 }
 
 // AddToManagerBuilder aggregates various AddToManager functions.

--- a/extensions/pkg/controller/worker/reconciler.go
+++ b/extensions/pkg/controller/worker/reconciler.go
@@ -148,7 +148,7 @@ func (r *reconciler) migrate(ctx context.Context, logger logr.Logger, worker *ex
 	logger.Info("Starting the migration of worker", "worker", kutil.ObjectName(worker))
 	if err := r.actuator.Migrate(ctx, worker, cluster); err != nil {
 		_ = r.statusUpdater.Error(ctx, worker, err, gardencorev1beta1.LastOperationTypeMigrate, "Error migrating worker")
-		return extensionscontroller.ReconcileErr(err)
+		return reconcilerutils.ReconcileErr(err)
 	}
 
 	if err := r.statusUpdater.Success(ctx, worker, gardencorev1beta1.LastOperationTypeMigrate, "Successfully migrate worker"); err != nil {
@@ -179,7 +179,7 @@ func (r *reconciler) delete(ctx context.Context, logger logr.Logger, worker *ext
 	logger.Info("Starting the deletion of worker", "worker", kutil.ObjectName(worker))
 	if err := r.actuator.Delete(ctx, worker, cluster); err != nil {
 		_ = r.statusUpdater.Error(ctx, worker, err, gardencorev1beta1.LastOperationTypeDelete, "Error deleting worker")
-		return extensionscontroller.ReconcileErr(err)
+		return reconcilerutils.ReconcileErr(err)
 	}
 
 	if err := r.statusUpdater.Success(ctx, worker, gardencorev1beta1.LastOperationTypeDelete, "Successfully deleted worker"); err != nil {
@@ -200,7 +200,7 @@ func (r *reconciler) reconcile(ctx context.Context, logger logr.Logger, worker *
 	logger.Info("Starting the reconciliation of worker", "worker", kutil.ObjectName(worker))
 	if err := r.actuator.Reconcile(ctx, worker, cluster); err != nil {
 		_ = r.statusUpdater.Error(ctx, worker, err, operationType, "Error reconciling worker")
-		return extensionscontroller.ReconcileErr(err)
+		return reconcilerutils.ReconcileErr(err)
 	}
 
 	if err := r.statusUpdater.Success(ctx, worker, operationType, "Successfully reconciled worker"); err != nil {
@@ -218,7 +218,7 @@ func (r *reconciler) restore(ctx context.Context, logger logr.Logger, worker *ex
 	logger.Info("Starting the restoration of worker", "worker", kutil.ObjectName(worker))
 	if err := r.actuator.Restore(ctx, worker, cluster); err != nil {
 		_ = r.statusUpdater.Error(ctx, worker, err, gardencorev1beta1.LastOperationTypeRestore, "Error restoring worker")
-		return extensionscontroller.ReconcileErr(err)
+		return reconcilerutils.ReconcileErr(err)
 	}
 
 	if err := r.statusUpdater.Success(ctx, worker, gardencorev1beta1.LastOperationTypeRestore, "Successfully reconciled worker"); err != nil {

--- a/extensions/pkg/controller/worker/state_reconciler.go
+++ b/extensions/pkg/controller/worker/state_reconciler.go
@@ -17,10 +17,10 @@ package worker
 import (
 	"context"
 
-	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	errorutils "github.com/gardener/gardener/pkg/controllerutils/reconciler"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -85,7 +85,7 @@ func (r *stateReconciler) Reconcile(ctx context.Context, request reconcile.Reque
 	if err := r.actuator.Reconcile(ctx, worker); err != nil {
 		msg := "Error updating worker state"
 		logger.Error(err, msg)
-		return extensionscontroller.ReconcileErr(err)
+		return errorutils.ReconcileErr(err)
 	}
 
 	msg := "Successfully updated worker state"

--- a/extensions/pkg/webhook/controlplane/genericmutator/mutator.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/mutator.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig/oscommon/cloudinit"
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	gcontext "github.com/gardener/gardener/extensions/pkg/webhook/context"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
@@ -396,7 +395,7 @@ func (m *mutator) ensureKubeletCloudProviderConfig(ctx context.Context, gctx gco
 
 	// Encode cloud provider config into inline content
 	var fci *extensionsv1alpha1.FileContentInline
-	if fci, err = m.fciCodec.Encode([]byte(s), string(cloudinit.B64FileCodecID)); err != nil {
+	if fci, err = m.fciCodec.Encode([]byte(s), string(extensionsv1alpha1.B64FileCodecID)); err != nil {
 		return fmt.Errorf("could not encode kubelet cloud provider config: %w", err)
 	}
 

--- a/hack/api-reference/extensions.md
+++ b/hack/api-reference/extensions.md
@@ -2959,6 +2959,11 @@ FileContent
 </tr>
 </tbody>
 </table>
+<h3 id="extensions.gardener.cloud/v1alpha1.FileCodecID">FileCodecID
+(<code>string</code> alias)</p></h3>
+<p>
+<p>FileCodecID is the id of a FileCodec for cloud-init scripts.</p>
+</p>
 <h3 id="extensions.gardener.cloud/v1alpha1.FileContent">FileContent
 </h3>
 <p>

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -479,6 +479,11 @@ const (
 
 	// DefaultVpnRange is the default network range for the vpn between seed and shoot cluster.
 	DefaultVpnRange = "192.168.123.0/24"
+
+	// BackupSecretName is the name of secret having credentials for etcd backups.
+	BackupSecretName string = "etcd-backup"
+	// DataKeyBackupBucketName is the name of a data key whose value contains the backup bucket name.
+	DataKeyBackupBucketName string = "bucketName"
 )
 
 // ControlPlaneSecretRoles contains all role values used for control plane secrets synced to the Garden cluster.

--- a/pkg/apis/extensions/v1alpha1/helper/filecodec.go
+++ b/pkg/apis/extensions/v1alpha1/helper/filecodec.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package cloudinit
+package helper
 
 import (
 	"bytes"

--- a/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
+++ b/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
@@ -234,3 +234,15 @@ const (
 
 // ContainerDRuntimeContainersBinFolder is the folder where Container Runtime binaries should be saved for ContainerD usage
 const ContainerDRuntimeContainersBinFolder = "/var/bin/containerruntimes"
+
+// FileCodecID is the id of a FileCodec for cloud-init scripts.
+type FileCodecID string
+
+const (
+	// B64FileCodecID is the base64 file codec id.
+	B64FileCodecID FileCodecID = "b64"
+	// GZIPFileCodecID is the gzip file codec id.
+	GZIPFileCodecID FileCodecID = "gzip"
+	// GZIPB64FileCodecID is the gzip combined with base64 codec id.
+	GZIPB64FileCodecID FileCodecID = "gzip+b64"
+)

--- a/pkg/apis/extensions/validation/operatingsystemconfig.go
+++ b/pkg/apis/extensions/validation/operatingsystemconfig.go
@@ -15,7 +15,6 @@
 package validation
 
 import (
-	"github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig/oscommon/cloudinit"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils"
 
@@ -124,7 +123,7 @@ func ValidateFiles(files []extensionsv1alpha1.File, fldPath *field.Path) field.E
 				allErrs = append(allErrs, field.Required(idxPath.Child("content", "secretRef", "dataKey"), "field is required"))
 			}
 		case file.Content.Inline != nil:
-			encodings := []string{"", string(cloudinit.B64FileCodecID), string(cloudinit.GZIPFileCodecID), string(cloudinit.GZIPB64FileCodecID)}
+			encodings := []string{"", string(extensionsv1alpha1.B64FileCodecID), string(extensionsv1alpha1.GZIPFileCodecID), string(extensionsv1alpha1.GZIPB64FileCodecID)}
 			if !utils.ValueExists(file.Content.Inline.Encoding, encodings) {
 				allErrs = append(allErrs, field.NotSupported(idxPath.Child("content", "inline", "encoding"), file.Content.Inline.Encoding, encodings))
 			}

--- a/pkg/controllerutils/reconciler/reconcile.go
+++ b/pkg/controllerutils/reconciler/reconcile.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2011 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reconciler
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+// ReconcileErr returns a reconcile.Result or an error, depending on whether the error is a
+// RequeueAfterError or not.
+func ReconcileErr(err error) (reconcile.Result, error) {
+	if requeueAfter, ok := err.(*RequeueAfterError); ok {
+		return reconcile.Result{Requeue: true, RequeueAfter: requeueAfter.RequeueAfter}, nil
+	}
+	return reconcile.Result{}, err
+}
+
+// ReconcileErrCause returns the cause in case the error is an RequeueAfterError. Otherwise,
+// it returns the input error.
+func ReconcileErrCause(err error) error {
+	if requeueAfter, ok := err.(*RequeueAfterError); ok {
+		return requeueAfter.Cause
+	}
+	return err
+}
+
+// ReconcileErrCauseOrErr returns the cause of the error or the error if the cause is nil.
+func ReconcileErrCauseOrErr(err error) error {
+	if cause := ReconcileErrCause(err); cause != nil {
+		return cause
+	}
+	return err
+}

--- a/pkg/controllerutils/reconciler/reconcile_test.go
+++ b/pkg/controllerutils/reconciler/reconcile_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reconciler_test
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/gardener/gardener/pkg/controllerutils/reconciler"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+var _ = Describe("Reconcile", func() {
+	var (
+		fakeErr           = fmt.Errorf("fake")
+		cause             = fmt.Errorf("cause")
+		requeueAfter      = time.Hour
+		requeueAfterError = &RequeueAfterError{Cause: cause, RequeueAfter: requeueAfter}
+	)
+
+	Describe("#ReconcileErr", func() {
+		It("should return the correct result if it's no RequeueAfterError", func() {
+			res, err := ReconcileErr(fakeErr)
+			Expect(err).To(MatchError(fakeErr))
+			Expect(res).To(Equal(reconcile.Result{}))
+		})
+
+		It("should return the correct result if it's a RequeueAfterError", func() {
+			res, err := ReconcileErr(requeueAfterError)
+			Expect(err).To(BeNil())
+			Expect(res).To(Equal(reconcile.Result{Requeue: true, RequeueAfter: requeueAfter}))
+		})
+	})
+
+	Describe("#ReconcileErrCause", func() {
+		It("should return the correct result if it's no RequeueAfterError", func() {
+			Expect(ReconcileErrCause(fakeErr)).To(MatchError(fakeErr))
+		})
+
+		It("should return the correct result if it's a RequeueAfterError", func() {
+			Expect(ReconcileErrCause(requeueAfterError)).To(Equal(cause))
+		})
+	})
+
+	Describe("#ReconcileErrCauseOrErr", func() {
+		It("should return the correct result if it's no RequeueAfterError", func() {
+			Expect(ReconcileErrCauseOrErr(fakeErr)).To(MatchError(fakeErr))
+		})
+
+		It("should return the correct result if it's a RequeueAfterError", func() {
+			Expect(ReconcileErrCauseOrErr(requeueAfterError)).To(Equal(cause))
+		})
+	})
+})

--- a/pkg/controllerutils/reconciler/reconciler_suite_test.go
+++ b/pkg/controllerutils/reconciler/reconciler_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reconciler_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestReconciler(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ControllerUtils Reconciler Suite")
+}

--- a/pkg/controllerutils/reconciler/requeue.go
+++ b/pkg/controllerutils/reconciler/requeue.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package error
+package reconciler
 
 import (
 	"fmt"

--- a/pkg/controllerutils/reconciler/requeue_test.go
+++ b/pkg/controllerutils/reconciler/requeue_test.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reconciler_test
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/gardener/gardener/pkg/controllerutils/reconciler"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Requeue", func() {
+	var (
+		cause        = fmt.Errorf("cause")
+		requeueAfter = time.Hour
+	)
+
+	DescribeTable("#Error",
+		func(err *RequeueAfterError, expectedMsg string) {
+			Expect(err.Error()).To(Equal(expectedMsg))
+		},
+
+		Entry("w/o cause", &RequeueAfterError{RequeueAfter: requeueAfter}, "requeue in "+requeueAfter.String()),
+		Entry("w/ cause", &RequeueAfterError{Cause: cause, RequeueAfter: requeueAfter}, "requeue in "+requeueAfter.String()+" due to "+cause.Error()),
+	)
+})

--- a/pkg/gardenlet/controller/bastion/bastion_reconciler.go
+++ b/pkg/gardenlet/controller/bastion/bastion_reconciler.go
@@ -20,8 +20,6 @@ import (
 	"fmt"
 	"time"
 
-	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
-	ctrlerror "github.com/gardener/gardener/extensions/pkg/controller/error"
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	gardencorev1alpha1helper "github.com/gardener/gardener/pkg/apis/core/v1alpha1/helper"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -31,6 +29,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
 	"github.com/gardener/gardener/pkg/controllerutils"
+	reconciler2 "github.com/gardener/gardener/pkg/controllerutils/reconciler"
 	"github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -112,11 +111,11 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		err = r.reconcileBastion(ctx, logger, gardenClient.Client(), seedClient.Client(), bastion, &shoot)
 	}
 
-	if cause := extensionscontroller.ReconcileErrCause(err); cause != nil {
+	if cause := reconciler2.ReconcileErrCause(err); cause != nil {
 		logger.Errorf("Reconciling failed: %v", cause)
 	}
 
-	return extensionscontroller.ReconcileErr(err)
+	return reconciler2.ReconcileErr(err)
 }
 
 func (r *reconciler) reconcileBastion(
@@ -232,7 +231,7 @@ func (r *reconciler) cleanupBastion(
 	}
 
 	// cleanup is now triggered on the seed, requeue to wait for it to happen
-	return &ctrlerror.RequeueAfterError{
+	return &reconciler2.RequeueAfterError{
 		RequeueAfter: 5 * time.Second,
 		Cause:        errors.New("bastion extension cleanup has not completed yet"),
 	}

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/utils/filecontentinlinecodec.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/utils/filecontentinlinecodec.go
@@ -17,8 +17,8 @@ package utils
 import (
 	"fmt"
 
-	"github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig/oscommon/cloudinit"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	extensionsv1alpha1helper "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1/helper"
 )
 
 // FileContentInlineCodec contains methods for encoding and decoding byte slices
@@ -78,13 +78,13 @@ func (c *fileContentInlineCodec) Decode(fci *extensionsv1alpha1.FileContentInlin
 	return data, nil
 }
 
-func getFileCodec(encoding string) (cloudinit.FileCodec, error) {
+func getFileCodec(encoding string) (extensionsv1alpha1helper.FileCodec, error) {
 	if encoding == "" {
 		return nil, nil
 	}
-	fileCodecID, err := cloudinit.ParseFileCodecID(encoding)
+	fileCodecID, err := extensionsv1alpha1helper.ParseFileCodecID(encoding)
 	if err != nil {
 		return nil, fmt.Errorf("could not parse file codec ID '%s': %w", encoding, err)
 	}
-	return cloudinit.FileCodecForID(fileCodecID), nil
+	return extensionsv1alpha1helper.FileCodecForID(fileCodecID), nil
 }

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/utils/filecontentinlinecodec_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/utils/filecontentinlinecodec_test.go
@@ -15,7 +15,6 @@
 package utils
 
 import (
-	"github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig/oscommon/cloudinit"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 
 	. "github.com/onsi/ginkgo"
@@ -29,7 +28,7 @@ kind: KubeletConfiguration
 `)
 
 		fileContent = &extensionsv1alpha1.FileContentInline{
-			Encoding: string(cloudinit.B64FileCodecID),
+			Encoding: "b64",
 			Data:     `YXBpVmVyc2lvbjoga3ViZWxldC5jb25maWcuazhzLmlvL3YxYmV0YTEKa2luZDogS3ViZWxldENvbmZpZ3VyYXRpb24K`,
 		}
 	)
@@ -40,7 +39,7 @@ kind: KubeletConfiguration
 			c := NewFileContentInlineCodec()
 
 			// Call Encode and check result
-			fci, err := c.Encode(data, string(cloudinit.B64FileCodecID))
+			fci, err := c.Encode(data, "b64")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(fci).To(Equal(fileContent))
 		})

--- a/pkg/operation/botanist/etcd.go
+++ b/pkg/operation/botanist/etcd.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"hash/crc32"
 
-	"github.com/gardener/gardener/extensions/pkg/controller/backupentry/genericactuator"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
@@ -93,7 +92,7 @@ func (b *Botanist) DeployEtcd(ctx context.Context) error {
 
 	if b.Seed.GetInfo().Spec.Backup != nil {
 		secret := &corev1.Secret{}
-		if err := b.K8sSeedClient.Client().Get(ctx, kutil.Key(b.Shoot.SeedNamespace, genericactuator.BackupSecretName), secret); err != nil {
+		if err := b.K8sSeedClient.Client().Get(ctx, kutil.Key(b.Shoot.SeedNamespace, v1beta1constants.BackupSecretName), secret); err != nil {
 			return err
 		}
 
@@ -104,9 +103,9 @@ func (b *Botanist) DeployEtcd(ctx context.Context) error {
 
 		b.Shoot.Components.ControlPlane.EtcdMain.SetBackupConfig(&etcd.BackupConfig{
 			Provider:             b.Seed.GetInfo().Spec.Backup.Provider,
-			SecretRefName:        genericactuator.BackupSecretName,
+			SecretRefName:        v1beta1constants.BackupSecretName,
 			Prefix:               b.Shoot.BackupEntryName,
-			Container:            string(secret.Data[genericactuator.DataKeyBackupBucketName]),
+			Container:            string(secret.Data[v1beta1constants.DataKeyBackupBucketName]),
 			FullSnapshotSchedule: snapshotSchedule,
 		})
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR eliminates all references of `gardener/gardener/extensions` from packages in `gardener/gardener/pkg`, following up on https://github.com/gardener/gardener/pull/4860#issuecomment-946423892.

/cc @timebertt 

**Special notes for your reviewer**:
- ~✅ Based on #4860 which should be merged first~
- ~Only the last four commits are relevant (the others belong to #4860)~

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking developer
The `github.com/gardener/gardener/extensions/pkg/controller.{ReconcileErr,ReconcileErrCause,ReconcileErrCauseOrErr} functions have been moved to `github.com/gardener/gardener/pkg/controllerutils/reconciler`.
```
