### PR TITLE
Increase infrastructure reconciliation wait timeout

### DIFF
--- a/pkg/operation/botanist/component/extensions/infrastructure/infrastructure.go
+++ b/pkg/operation/botanist/component/extensions/infrastructure/infrastructure.go
@@ -34,9 +34,9 @@ import (
 
 const (
 	// DefaultInterval is the default interval for retry operations.
-	DefaultInterval = 5 * time.Second
+	DefaultInterval = 10 * time.Second
 	// DefaultSevereThreshold is the default threshold until an error reported by another component is treated as 'severe'.
-	DefaultSevereThreshold = 30 * time.Second
+	DefaultSevereThreshold = 3 * time.Minute
 	// DefaultTimeout is the default timeout and defines how long Gardener should wait
 	// for a successful reconciliation of an infrastructure resource.
 	DefaultTimeout = 10 * time.Minute


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind technical-debt

**What this PR does / why we need it**:

Infrastructure creation, even on fast cloud providers like AWS, can take > 2 minutes.
The low`DefaultSevereThreshold ` timeout of 30 s  causes the infra component to return a not retry-able error after 30 seconds. This causes the whole reconciliation to restart.

Why is that a problem
- causes around 4 extra reconciliations for each Shoot creation (up until the infrastructure flow)
- Retrying a failed shoot with a previously incorrect Infrastructure config will probably lead to a failed Shoot again as the infrastructure does not complete within 30 seconds and failed shoots are not retried. This is annoying as the retry annotation has to be set again, even though the `infrastructure` CRD is successful.



In addition, the check period is increased from 5 to 10 seconds to reduce API requests and log cluttering.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The Gardenlet wait timeout for infrastructure reconciliation has been increased from 30 seconds to 3 minutes. This should reduce unnecessary reconciliations and improve the UX when updating the infrastructure of failed Shoots to a valid configuration.
```
