### PR TITLE
Fix metrics-server lookup order

### DIFF
--- a/pkg/operation/botanist/component/metricsserver/metrics_server.go
+++ b/pkg/operation/botanist/component/metricsserver/metrics_server.go
@@ -315,7 +315,7 @@ func (m *metricsServer) computeResourcesData() (map[string][]byte, error) {
 								// The kube-apiserver and the kubelet use different CAs, however, the metrics-server assumes the CAs are the same.
 								// We should remove this flag once it is possible to specify the CA of the kubelet.
 								"--kubelet-insecure-tls",
-								"--kubelet-preferred-address-types=Hostname,InternalDNS,InternalIP,ExternalDNS,ExternalIP",
+								"--kubelet-preferred-address-types=InternalIP,InternalDNS,ExternalDNS,ExternalIP,Hostname",
 								fmt.Sprintf("--tls-cert-file=%s/%s", volumeMountPathServer, secrets.DataKeyCertificate),
 								fmt.Sprintf("--tls-private-key-file=%s/%s", volumeMountPathServer, secrets.DataKeyPrivateKey),
 							},

--- a/pkg/operation/botanist/component/metricsserver/metrics_server_test.go
+++ b/pkg/operation/botanist/component/metricsserver/metrics_server_test.go
@@ -245,7 +245,7 @@ spec:
         - --cert-dir=/home/certdir
         - --secure-port=8443
         - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types=Hostname,InternalDNS,InternalIP,ExternalDNS,ExternalIP
+        - --kubelet-preferred-address-types=InternalIP,InternalDNS,ExternalDNS,ExternalIP,Hostname
         - --tls-cert-file=/srv/metrics-server/tls/tls.crt
         - --tls-private-key-file=/srv/metrics-server/tls/tls.key
         image: ` + image + `
@@ -336,7 +336,7 @@ spec:
         - --cert-dir=/home/certdir
         - --secure-port=8443
         - --kubelet-insecure-tls
-        - --kubelet-preferred-address-types=Hostname,InternalDNS,InternalIP,ExternalDNS,ExternalIP
+        - --kubelet-preferred-address-types=InternalIP,InternalDNS,ExternalDNS,ExternalIP,Hostname
         - --tls-cert-file=/srv/metrics-server/tls/tls.crt
         - --tls-private-key-file=/srv/metrics-server/tls/tls.key
         env:


### PR DESCRIPTION
Signed-off-by: vasu1124 <vasu1124@actvirtual.com>

**How to categorize this PR?**
/area control-plane
/kind bug

**What this PR does / why we need it**:
The metrics-server with the current rule will always use `Hostname` to resolve the scraping target. The `Hostname` can only be resolved in infrastructure environments where automatically DNS entries are provisioned. In many environments, like OpenStack, metal, equinix, etc. there is no such DNS entry. 
The setting ensures that the metric-server picks one of the keys (type in the given rule order) from the `node` resource, e.g.
```
  status:
    addresses:
    - address: 10.250.1.161
      type: InternalIP
    - address: shoot--project--name-worker-pool-z1-12345-abcd
      type: Hostname
```
The `type: Hostname` will always be available (no node w/o hostname!), but is not always resolveable. Hence, the metric-server in such cases will always fail to scrape the node.

This PR fixes the rule to choose `InternalIP` first, which should be a correct selection for allmost all environments, and skip to other the alternatives only if that type is not set:
`InternalIP,InternalDNS,ExternalDNS,ExternalIP,Hostname`
 
**Which issue(s) this PR fixes**:
Fixes #4626  #2455 #2019 and probably more

**Special notes for your reviewer**:
We have been arguing over this rule change over many issues (overlayed by a notation/typo fix with/without bracket). 
The proposed rule should be safe. But please run via test matrix.

**Release note**:
```bugfix operator
fix metrics-server for scenarios where address resolution via hostname does not work.
```
