### PR TITLE
Fix removal of error codes from conditions

### DIFF
--- a/pkg/apis/core/v1alpha1/helper/condition_builder.go
+++ b/pkg/apis/core/v1alpha1/helper/condition_builder.go
@@ -101,6 +101,7 @@ func (b *defaultConditionBuilder) WithNowFunc(now func() metav1.Time) ConditionB
 // If OldCondition is provided:
 // - Any changes to status set the `LastTransitionTime`
 // - Any updates to the message, reason or the codes cause set `LastUpdateTime` to the current time.
+// - The error codes will not be transferred from the old to the new condition
 func (b *defaultConditionBuilder) Build() (new gardencorev1alpha1.Condition, updated bool) {
 	var (
 		now       = b.nowFunc()
@@ -137,11 +138,7 @@ func (b *defaultConditionBuilder) Build() (new gardencorev1alpha1.Condition, upd
 		new.Message = "The condition has been initialized but its semantic check has not been performed yet."
 	}
 
-	if b.codes != nil {
-		new.Codes = b.codes
-	} else if b.codes == nil && b.old.Codes == nil {
-		new.Codes = nil
-	}
+	new.Codes = b.codes
 
 	if new.Status != b.old.Status {
 		new.LastTransitionTime = now

--- a/pkg/apis/core/v1alpha1/helper/condition_builder_test.go
+++ b/pkg/apis/core/v1alpha1/helper/condition_builder_test.go
@@ -210,6 +210,7 @@ var _ = Describe("Builder", func() {
 						Message:            fubarMessage,
 						Codes:              codes,
 					}).
+					WithCodes(codes...).
 					Build()
 			})
 
@@ -226,6 +227,38 @@ var _ = Describe("Builder", func() {
 					Reason:             bazReason,
 					Message:            fubarMessage,
 					Codes:              codes,
+				}))
+			})
+		})
+
+		Context("Clear error codes", func() {
+			JustBeforeEach(func() {
+				result, updated = bldr.
+					WithNowFunc(defaultTimeFunc).
+					WithOldCondition(gardencorev1alpha1.Condition{
+						Type:               conditionType,
+						Status:             fooStatus,
+						LastTransitionTime: metav1.NewTime(time.Unix(10, 0)),
+						LastUpdateTime:     metav1.NewTime(time.Unix(11, 0)),
+						Reason:             bazReason,
+						Message:            fubarMessage,
+						Codes:              codes,
+					}).
+					Build()
+			})
+
+			It("should mark the result as updated", func() {
+				Expect(updated).To(BeTrue())
+			})
+
+			It("should return correct result", func() {
+				Expect(result).To(Equal(gardencorev1alpha1.Condition{
+					Type:               conditionType,
+					Status:             fooStatus,
+					LastTransitionTime: metav1.NewTime(time.Unix(10, 0)),
+					LastUpdateTime:     defaultTime,
+					Reason:             bazReason,
+					Message:            fubarMessage,
 				}))
 			})
 		})
@@ -371,6 +404,7 @@ var _ = Describe("Builder", func() {
 						Message:            fubarMessage,
 						Codes:              []gardencorev1alpha1.ErrorCode{gardencorev1alpha1.ErrorInfraQuotaExceeded},
 					}).
+					WithCodes([]gardencorev1alpha1.ErrorCode{gardencorev1alpha1.ErrorInfraQuotaExceeded}...).
 					Build()
 
 				Expect(result.LastUpdateTime).To(Equal(metav1.NewTime(time.Unix(11, 0))))

--- a/pkg/apis/core/v1alpha1/helper/helper_test.go
+++ b/pkg/apis/core/v1alpha1/helper/helper_test.go
@@ -154,6 +154,29 @@ var _ = Describe("helper", func() {
 					"LastUpdateTime":     Equal(testTime),
 				}),
 			),
+			Entry("clear codes",
+				gardencorev1alpha1.Condition{
+					Type:               "type",
+					Status:             gardencorev1alpha1.ConditionTrue,
+					Reason:             "reason",
+					Message:            "message",
+					LastTransitionTime: testTime,
+					LastUpdateTime:     testTime,
+					Codes:              []gardencorev1alpha1.ErrorCode{gardencorev1alpha1.ErrorInfraQuotaExceeded},
+				},
+				gardencorev1alpha1.ConditionTrue,
+				"reason",
+				"message",
+				nil,
+				MatchFields(IgnoreExtras, Fields{
+					"Status":             Equal(gardencorev1alpha1.ConditionTrue),
+					"Reason":             Equal("reason"),
+					"Message":            Equal("message"),
+					"LastTransitionTime": Equal(testTime),
+					"LastUpdateTime":     Satisfy(afterTestTime),
+					"Codes":              BeEmpty(),
+				}),
+			),
 		)
 
 		Describe("#MergeConditions", func() {

--- a/pkg/apis/core/v1beta1/helper/condition_builder.go
+++ b/pkg/apis/core/v1beta1/helper/condition_builder.go
@@ -101,6 +101,7 @@ func (b *defaultConditionBuilder) WithNowFunc(now func() metav1.Time) ConditionB
 // If OldCondition is provided:
 // - Any changes to status set the `LastTransitionTime`
 // - Any updates to the message, reason or the codes cause set `LastUpdateTime` to the current time.
+// - The error codes will not be transferred from the old to the new condition
 func (b *defaultConditionBuilder) Build() (new gardencorev1beta1.Condition, updated bool) {
 	var (
 		now       = b.nowFunc()
@@ -137,11 +138,7 @@ func (b *defaultConditionBuilder) Build() (new gardencorev1beta1.Condition, upda
 		new.Message = "The condition has been initialized but its semantic check has not been performed yet."
 	}
 
-	if b.codes != nil {
-		new.Codes = b.codes
-	} else if b.codes == nil && b.old.Codes == nil {
-		new.Codes = nil
-	}
+	new.Codes = b.codes
 
 	if new.Status != b.old.Status {
 		new.LastTransitionTime = now

--- a/pkg/apis/core/v1beta1/helper/condition_builder_test.go
+++ b/pkg/apis/core/v1beta1/helper/condition_builder_test.go
@@ -210,6 +210,7 @@ var _ = Describe("Builder", func() {
 						Message:            fubarMessage,
 						Codes:              codes,
 					}).
+					WithCodes(codes...).
 					Build()
 			})
 
@@ -226,6 +227,38 @@ var _ = Describe("Builder", func() {
 					Reason:             bazReason,
 					Message:            fubarMessage,
 					Codes:              codes,
+				}))
+			})
+		})
+
+		Context("Clear error codes", func() {
+			JustBeforeEach(func() {
+				result, updated = bldr.
+					WithNowFunc(defaultTimeFunc).
+					WithOldCondition(gardencorev1beta1.Condition{
+						Type:               conditionType,
+						Status:             fooStatus,
+						LastTransitionTime: metav1.NewTime(time.Unix(10, 0)),
+						LastUpdateTime:     metav1.NewTime(time.Unix(11, 0)),
+						Reason:             bazReason,
+						Message:            fubarMessage,
+						Codes:              codes,
+					}).
+					Build()
+			})
+
+			It("should mark the result as updated", func() {
+				Expect(updated).To(BeTrue())
+			})
+
+			It("should return correct result", func() {
+				Expect(result).To(Equal(gardencorev1beta1.Condition{
+					Type:               conditionType,
+					Status:             fooStatus,
+					LastTransitionTime: metav1.NewTime(time.Unix(10, 0)),
+					LastUpdateTime:     defaultTime,
+					Reason:             bazReason,
+					Message:            fubarMessage,
 				}))
 			})
 		})
@@ -371,6 +404,7 @@ var _ = Describe("Builder", func() {
 						Message:            fubarMessage,
 						Codes:              []gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorInfraQuotaExceeded},
 					}).
+					WithCodes([]gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorInfraQuotaExceeded}...).
 					Build()
 
 				Expect(result.LastUpdateTime).To(Equal(metav1.NewTime(time.Unix(11, 0))))

--- a/pkg/apis/core/v1beta1/helper/helper_test.go
+++ b/pkg/apis/core/v1beta1/helper/helper_test.go
@@ -161,6 +161,29 @@ var _ = Describe("helper", func() {
 					"LastUpdateTime":     Equal(testTime),
 				}),
 			),
+			Entry("clear codes",
+				gardencorev1beta1.Condition{
+					Type:               "type",
+					Status:             gardencorev1beta1.ConditionTrue,
+					Reason:             "reason",
+					Message:            "message",
+					LastTransitionTime: testTime,
+					LastUpdateTime:     testTime,
+					Codes:              []gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorInfraQuotaExceeded},
+				},
+				gardencorev1beta1.ConditionTrue,
+				"reason",
+				"message",
+				nil,
+				MatchFields(IgnoreExtras, Fields{
+					"Status":             Equal(gardencorev1beta1.ConditionTrue),
+					"Reason":             Equal("reason"),
+					"Message":            Equal("message"),
+					"LastTransitionTime": Equal(testTime),
+					"LastUpdateTime":     Satisfy(afterTestTime),
+					"Codes":              BeEmpty(),
+				}),
+			),
 		)
 
 		Describe("#MergeConditions", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
The ConditionBuilder will now clean the error codes from the old condition provided with `WithOldCondition()` if no error codes are added with the `WithCondition()` function.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
While looking at the code I could not understand what the exact intent was with the error codes. In the unit tests and the ConditionBuillder code it is assumed that if the old condition has error codes, they will be kept. However, in code that makes use of the ConditionBuilder it is assumed that if `WithOldCondition()` is called and `WithCodes()` is not used or it is used with an empty argument list that the error codes will not be transferred from the old condition to the new one.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Error codes are now removed from `gardencorev1beta1.Condition` created with the `ConditionBuilder` if `ConditionBuilder.WithOldCondition(oldCondition)` is used to initialize the condition, but error codes are not provided with `ConditionBuilder.WithCodes(codes...)`
```