### PR TITLE
Refactor shoot controller to reconcile.Reconciler

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_care_control_test.go
+++ b/pkg/gardenlet/controller/shoot/shoot_care_control_test.go
@@ -315,14 +315,14 @@ var _ = Describe("Shoot Care Control", func() {
 					revertFns = append(revertFns,
 						test.WithVars(&NewHealthCheck,
 							healthCheckFunc(func(cond []gardencorev1beta1.Condition) []gardencorev1beta1.Condition {
-								copy := append(cond[:0:0], cond...)
-								return copy
+								conditionsCopy := append(cond[:0:0], cond...)
+								return conditionsCopy
 							}),
 						),
 						test.WithVars(&NewConstraintCheck,
 							constraintCheckFunc(func(constr []gardencorev1beta1.Condition) []gardencorev1beta1.Condition {
-								copy := append(constr[:0:0], constr...)
-								return copy
+								constraintsCopy := append(constr[:0:0], constr...)
+								return constraintsCopy
 							}),
 						),
 					)
@@ -680,7 +680,7 @@ func healthCheckFunc(fn resultingConditionFunc) NewHealthCheckFunc {
 
 type resultingConstraintFunc func(cond []gardencorev1beta1.Condition) []gardencorev1beta1.Condition
 
-func (c resultingConstraintFunc) Check(ctx context.Context, constraints []gardencorev1beta1.Condition) []gardencorev1beta1.Condition {
+func (c resultingConstraintFunc) Check(_ context.Context, constraints []gardencorev1beta1.Condition) []gardencorev1beta1.Condition {
 	return c(constraints)
 }
 
@@ -765,6 +765,6 @@ type failingPatchClient struct {
 	client.Client
 }
 
-func (c failingPatchClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+func (c failingPatchClient) Patch(context.Context, client.Object, client.Patch, ...client.PatchOption) error {
 	return c.err
 }

--- a/pkg/gardenlet/controller/shoot/shoot_control_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_delete.go
@@ -507,7 +507,7 @@ func (r *shootReconciler) runDeleteShootFlow(ctx context.Context, o *operation.O
 
 		destroyIngressDomainDNSRecord = g.Add(flow.Task{
 			Name:         "Destroying nginx ingress DNS record",
-			Fn:           flow.TaskFn(botanist.DestroyIngressDNSResources),
+			Fn:           botanist.DestroyIngressDNSResources,
 			Dependencies: flow.NewTaskIDs(syncPointCleaned),
 		})
 		destroyInfrastructure = g.Add(flow.Task{
@@ -522,7 +522,7 @@ func (r *shootReconciler) runDeleteShootFlow(ctx context.Context, o *operation.O
 		})
 		destroyExternalDomainDNSRecord = g.Add(flow.Task{
 			Name:         "Destroying external domain DNS record",
-			Fn:           flow.TaskFn(botanist.DestroyExternalDNSResources),
+			Fn:           botanist.DestroyExternalDNSResources,
 			Dependencies: flow.NewTaskIDs(syncPointCleaned, deleteKubeAPIServer),
 		})
 		deleteGrafana = g.Add(flow.Task{
@@ -544,17 +544,17 @@ func (r *shootReconciler) runDeleteShootFlow(ctx context.Context, o *operation.O
 
 		destroyInternalDomainDNSRecord = g.Add(flow.Task{
 			Name:         "Destroying internal domain DNS record",
-			Fn:           flow.TaskFn(botanist.DestroyInternalDNSResources),
+			Fn:           botanist.DestroyInternalDNSResources,
 			Dependencies: flow.NewTaskIDs(syncPoint),
 		})
 		destroyOwnerDomainDNSRecord = g.Add(flow.Task{
 			Name:         "Destroying owner domain DNS record",
-			Fn:           flow.TaskFn(botanist.DestroyOwnerDNSResources),
+			Fn:           botanist.DestroyOwnerDNSResources,
 			Dependencies: flow.NewTaskIDs(syncPoint),
 		})
 		deleteDNSProviders = g.Add(flow.Task{
 			Name:         "Deleting additional DNS providers",
-			Fn:           flow.TaskFn(botanist.DeleteDNSProviders),
+			Fn:           botanist.DeleteDNSProviders,
 			Dependencies: flow.NewTaskIDs(destroyInternalDomainDNSRecord, destroyOwnerDomainDNSRecord),
 		})
 		destroyReferencedResources = g.Add(flow.Task{

--- a/pkg/gardenlet/controller/shoot/shoot_control_migrate.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_migrate.go
@@ -156,7 +156,7 @@ func (r *shootReconciler) runPrepareShootControlPlaneMigration(ctx context.Conte
 		})
 		generateSecrets = g.Add(flow.Task{
 			Name:         "Generating secrets and saving them into ShootState",
-			Fn:           flow.TaskFn(botanist.GenerateAndSaveSecrets),
+			Fn:           botanist.GenerateAndSaveSecrets,
 			Dependencies: flow.NewTaskIDs(ensureShootStateExists),
 		})
 		deploySecrets = g.Add(flow.Task{
@@ -226,7 +226,7 @@ func (r *shootReconciler) runPrepareShootControlPlaneMigration(ctx context.Conte
 		})
 		deleteAllManagedResourcesFromShootNamespace = g.Add(flow.Task{
 			Name:         "Deleting all Managed Resources from the Shoot's namespace",
-			Fn:           flow.TaskFn(botanist.DeleteAllManagedResourcesObjects),
+			Fn:           botanist.DeleteAllManagedResourcesObjects,
 			Dependencies: flow.NewTaskIDs(keepManagedResourcesObjectsInShoot, ensureResourceManagerScaledUp),
 		})
 		waitForManagedResourcesDeletion = g.Add(flow.Task{
@@ -241,27 +241,27 @@ func (r *shootReconciler) runPrepareShootControlPlaneMigration(ctx context.Conte
 		})
 		waitUntilAPIServerDeleted = g.Add(flow.Task{
 			Name:         "Waiting until kube-apiserver doesn't exist",
-			Fn:           flow.TaskFn(botanist.Shoot.Components.ControlPlane.KubeAPIServer.WaitCleanup),
+			Fn:           botanist.Shoot.Components.ControlPlane.KubeAPIServer.WaitCleanup,
 			Dependencies: flow.NewTaskIDs(prepareKubeAPIServerForMigration),
 		})
 		migrateIngressDNSRecord = g.Add(flow.Task{
 			Name:         "Migrating nginx ingress DNS record",
-			Fn:           flow.TaskFn(botanist.MigrateIngressDNSResources),
+			Fn:           botanist.MigrateIngressDNSResources,
 			Dependencies: flow.NewTaskIDs(waitUntilAPIServerDeleted),
 		})
 		migrateExternalDNSRecord = g.Add(flow.Task{
 			Name:         "Migrating external domain DNS record",
-			Fn:           flow.TaskFn(botanist.MigrateExternalDNSResources),
+			Fn:           botanist.MigrateExternalDNSResources,
 			Dependencies: flow.NewTaskIDs(waitUntilAPIServerDeleted),
 		})
 		migrateInternalDNSRecord = g.Add(flow.Task{
 			Name:         "Migrating internal domain DNS record",
-			Fn:           flow.TaskFn(botanist.MigrateInternalDNSResources),
+			Fn:           botanist.MigrateInternalDNSResources,
 			Dependencies: flow.NewTaskIDs(waitUntilAPIServerDeleted),
 		})
 		migrateOwnerDNSRecord = g.Add(flow.Task{
 			Name:         "Migrating owner domain DNS record",
-			Fn:           flow.TaskFn(botanist.MigrateOwnerDNSResources),
+			Fn:           botanist.MigrateOwnerDNSResources,
 			Dependencies: flow.NewTaskIDs(waitUntilAPIServerDeleted),
 		})
 		destroyDNSRecords = g.Add(flow.Task{
@@ -271,7 +271,7 @@ func (r *shootReconciler) runPrepareShootControlPlaneMigration(ctx context.Conte
 		})
 		destroyDNSProviders = g.Add(flow.Task{
 			Name:         "Deleting DNS providers",
-			Fn:           flow.TaskFn(botanist.DeleteDNSProviders),
+			Fn:           botanist.DeleteDNSProviders,
 			Dependencies: flow.NewTaskIDs(migrateIngressDNSRecord, migrateExternalDNSRecord, migrateInternalDNSRecord, migrateOwnerDNSRecord),
 		})
 		createETCDSnapshot = g.Add(flow.Task{
@@ -286,12 +286,12 @@ func (r *shootReconciler) runPrepareShootControlPlaneMigration(ctx context.Conte
 		})
 		migrateBackupEntryInGarden = g.Add(flow.Task{
 			Name:         "Migrate BackupEntry to new seed",
-			Fn:           flow.TaskFn(botanist.Shoot.Components.BackupEntry.Migrate),
+			Fn:           botanist.Shoot.Components.BackupEntry.Migrate,
 			Dependencies: flow.NewTaskIDs(createETCDSnapshot),
 		})
 		waitUntilBackupEntryInGardenMigrated = g.Add(flow.Task{
 			Name:         "Waiting for BackupEntry to be migrated to new seed",
-			Fn:           flow.TaskFn(botanist.Shoot.Components.BackupEntry.WaitMigrate),
+			Fn:           botanist.Shoot.Components.BackupEntry.WaitMigrate,
 			Dependencies: flow.NewTaskIDs(migrateBackupEntryInGarden),
 		})
 		deleteNamespace = g.Add(flow.Task{

--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -131,7 +131,7 @@ func (r *shootReconciler) runReconcileShootFlow(ctx context.Context, o *operatio
 		})
 		generateSecrets = g.Add(flow.Task{
 			Name: "Generating secrets and saving them into ShootState",
-			Fn:   flow.TaskFn(botanist.GenerateAndSaveSecrets),
+			Fn:   botanist.GenerateAndSaveSecrets,
 			Dependencies: func() flow.TaskIDs {
 				taskIDs := flow.NewTaskIDs(deployNamespace, ensureShootStateExists)
 				if !dnsEnabled && !o.Shoot.HibernationEnabled {
@@ -142,7 +142,7 @@ func (r *shootReconciler) runReconcileShootFlow(ctx context.Context, o *operatio
 		})
 		deploySecrets = g.Add(flow.Task{
 			Name:         "Deploying Shoot certificates / keys",
-			Fn:           flow.TaskFn(botanist.DeploySecrets),
+			Fn:           botanist.DeploySecrets,
 			Dependencies: flow.NewTaskIDs(deployNamespace, generateSecrets, ensureShootStateExists),
 		})
 		deploySeedLogging = g.Add(flow.Task{
@@ -157,7 +157,7 @@ func (r *shootReconciler) runReconcileShootFlow(ctx context.Context, o *operatio
 		})
 		deployOwnerDomainDNSRecord = g.Add(flow.Task{
 			Name:         "Deploying owner domain DNS record",
-			Fn:           flow.TaskFn(botanist.DeployOwnerDNSResources),
+			Fn:           botanist.DeployOwnerDNSResources,
 			Dependencies: flow.NewTaskIDs(ensureShootStateExists, deployReferencedResources),
 		})
 		deployInternalDomainDNSRecord = g.Add(flow.Task{
@@ -238,17 +238,17 @@ func (r *shootReconciler) runReconcileShootFlow(ctx context.Context, o *operatio
 		})
 		generateEncryptionConfigurationMetaData = g.Add(flow.Task{
 			Name:         "Generating etcd encryption configuration",
-			Fn:           flow.TaskFn(botanist.GenerateEncryptionConfiguration),
+			Fn:           botanist.GenerateEncryptionConfiguration,
 			Dependencies: flow.NewTaskIDs(deployNamespace, ensureShootStateExists),
 		})
 		persistETCDEncryptionConfiguration = g.Add(flow.Task{
 			Name:         "Persisting etcd encryption configuration in ShootState",
-			Fn:           flow.TaskFn(botanist.PersistEncryptionConfiguration),
+			Fn:           botanist.PersistEncryptionConfiguration,
 			Dependencies: flow.NewTaskIDs(deployNamespace, ensureShootStateExists, generateEncryptionConfigurationMetaData),
 		})
 		createOrUpdateETCDEncryptionConfiguration = g.Add(flow.Task{
 			Name:         "Applying etcd encryption configuration",
-			Fn:           flow.TaskFn(botanist.ApplyEncryptionConfiguration),
+			Fn:           botanist.ApplyEncryptionConfiguration,
 			Dependencies: flow.NewTaskIDs(deployNamespace, ensureShootStateExists, generateEncryptionConfigurationMetaData, persistETCDEncryptionConfiguration),
 		})
 		deployKubeAPIServer = g.Add(flow.Task{

--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -35,7 +35,7 @@ import (
 
 // runReconcileShootFlow reconciles the Shoot cluster's state.
 // It receives an Operation object <o> which stores the Shoot object.
-func (c *Controller) runReconcileShootFlow(ctx context.Context, o *operation.Operation) *gardencorev1beta1helper.WrappedLastErrors {
+func (r *shootReconciler) runReconcileShootFlow(ctx context.Context, o *operation.Operation) *gardencorev1beta1helper.WrappedLastErrors {
 	// We create the botanists (which will do the actual work).
 	var (
 		botanist        *botanistpkg.Botanist
@@ -550,7 +550,7 @@ func (c *Controller) runReconcileShootFlow(ctx context.Context, o *operation.Ope
 
 	if err := f.Run(ctx, flow.Opts{
 		Logger:           o.Logger,
-		ProgressReporter: c.newProgressReporter(o.ReportShootProgress),
+		ProgressReporter: r.newProgressReporter(o.ReportShootProgress),
 		ErrorContext:     errorContext,
 		ErrorCleaner:     o.CleanShootTaskErrorAndUpdateStatusLabel,
 	}); err != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:

Refactor shoot controller to `reconcile.Reconciler` and cleanup some linter warnings.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/4251

**Special notes for your reviewer**:

/squash

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
