### PR TITLE
Fix naming error in Scheduler doc

### DIFF
--- a/docs/concepts/scheduler.md
+++ b/docs/concepts/scheduler.md
@@ -108,4 +108,4 @@ In case the scheduler fails to find a suitable seed, the operation is being retr
 
 ## Current Limitation / Future Plans
 
-- Azure has unfortunately a geographically non-hierarchical naming pattern and does not start with the continent. This is the reason why we will exchange the implementation of the `MinimalRegion` strategy with a more suitable one in the future.
+- Azure has unfortunately a geographically non-hierarchical naming pattern and does not start with the continent. This is the reason why we will exchange the implementation of the `MinimalDistance` strategy with a more suitable one in the future.


### PR DESCRIPTION
Replace non-existent strategy `MinimalRegion` with `MinimalDistance` in _Current Limitations_ section of the _Gardener Scheduler_ documentation.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind cleanup

**What this PR does / why we need it**:
It's kind of embarrassing to even open this PR, but it really tripped me up when I read of `MinimalRegion` as a scheduler strategy. I think it's supposed to say `MinimalDistance`?
 
**Which issue(s) this PR fixes**:
None that I know of, but it felt it was a bit overkill to raise one for this...

**Special notes for your reviewer**:
First contribution here, hope I didn't violate any contribution guidelines with it :D

**Release note**:
NONE
