### PR TITLE
Add technical-id/cluster-id of the shoot cluster to the worker labels

### DIFF
--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -433,6 +433,10 @@ const (
 	LabelWorkerPoolDeprecated = "worker.garden.sapcloud.io/group"
 	// LabelWorkerPoolSystemComponents is a constant that indicates whether the worker pool should host system components
 	LabelWorkerPoolSystemComponents = "worker.gardener.cloud/system-components"
+	// LabelWorkerTechnicalID is a constant for a label that indicates the technical id this worker belongs to
+	LabelWorkerTechnicalID = "worker.gardener.cloud/technical-id"
+	// LabelWorkerClusterID is a constant for a label that indicates the cluster id this worker belongs to
+	LabelWorkerClusterID = "worker.gardener.cloud/cluster-id"
 
 	// EventResourceReferenced indicates that the resource deletion is in waiting mode because the resource is still
 	// being referenced by at least one other resource (e.g. a SecretBinding is still referenced by a Shoot)

--- a/pkg/operation/botanist/component/extensions/worker/worker.go
+++ b/pkg/operation/botanist/component/extensions/worker/worker.go
@@ -71,6 +71,10 @@ type Values struct {
 	Type string
 	// Region is the region of the shoot.
 	Region string
+	// TechnicalID of the cluster this worker belongs to
+	TechnicalID string
+	// Cluster uuid this worker belongs to
+	ClusterID string
 	// Workers is the list of worker pools.
 	Workers []gardencorev1beta1.Worker
 	// KubernetesVersion is the Kubernetes version of the cluster for which the worker nodes shall be created.
@@ -168,6 +172,8 @@ func (w *worker) deploy(ctx context.Context, operation string) (extensionsv1alph
 		// worker pool name labels
 		labels[v1beta1constants.LabelWorkerPool] = workerPool.Name
 		labels[v1beta1constants.LabelWorkerPoolDeprecated] = workerPool.Name
+		labels[v1beta1constants.LabelWorkerTechnicalID] = w.values.TechnicalID
+		labels[v1beta1constants.LabelWorkerClusterID] = w.values.ClusterID
 
 		// add CRI labels selected by the RuntimeClass
 		if workerPool.CRI != nil {

--- a/pkg/operation/botanist/component/extensions/worker/worker_test.go
+++ b/pkg/operation/botanist/component/extensions/worker/worker_test.go
@@ -63,6 +63,8 @@ var _ = Describe("Worker", func() {
 		namespace                    = "testnamespace"
 		extensionType                = "some-type"
 		region                       = "local"
+		technicalID                  = "shoot--test--somecluster"
+		clusterID                    = "a47edb90-fa63-4b65-984e-4968ab0864f6"
 		sshPublicKey                 = []byte("very-public")
 		kubernetesVersion            = semver.MustParse("1.15.5")
 		infrastructureProviderStatus = &runtime.RawExtension{Raw: []byte(`{"baz":"foo"}`)}
@@ -126,6 +128,8 @@ var _ = Describe("Worker", func() {
 			Namespace:                    namespace,
 			Type:                         extensionType,
 			Region:                       region,
+			TechnicalID:                  technicalID,
+			ClusterID:                    clusterID,
 			KubernetesVersion:            kubernetesVersion,
 			SSHPublicKey:                 sshPublicKey,
 			InfrastructureProviderStatus: infrastructureProviderStatus,
@@ -231,10 +235,12 @@ var _ = Describe("Worker", func() {
 					MaxUnavailable: worker1MaxUnavailable,
 					Annotations:    worker1Annotations,
 					Labels: utils.MergeStringMaps(worker1Labels, map[string]string{
-						"node.kubernetes.io/role":         "node",
-						"worker.gardener.cloud/pool":      worker1Name,
-						"worker.garden.sapcloud.io/group": worker1Name,
-						"worker.gardener.cloud/cri-name":  string(worker1CRIName),
+						"node.kubernetes.io/role":                                                   "node",
+						"worker.gardener.cloud/pool":                                                worker1Name,
+						"worker.gardener.cloud/technical-id":                                        technicalID,
+						"worker.gardener.cloud/cluster-id":                                          clusterID,
+						"worker.garden.sapcloud.io/group":                                           worker1Name,
+						"worker.gardener.cloud/cri-name":                                            string(worker1CRIName),
 						"containerruntime.worker.gardener.cloud/" + worker1CRIContainerRuntime1Type: "true",
 					}),
 					Taints:      worker1Taints,
@@ -273,6 +279,8 @@ var _ = Describe("Worker", func() {
 						"node.kubernetes.io/role":                 "node",
 						"worker.gardener.cloud/system-components": "true",
 						"worker.gardener.cloud/pool":              worker2Name,
+						"worker.gardener.cloud/technical-id":      technicalID,
+						"worker.gardener.cloud/cluster-id":        clusterID,
 						"worker.garden.sapcloud.io/group":         worker2Name,
 					},
 					MachineType: worker2MachineType,

--- a/pkg/operation/botanist/worker.go
+++ b/pkg/operation/botanist/worker.go
@@ -43,6 +43,8 @@ func (b *Botanist) DefaultWorker() worker.Interface {
 			Name:              b.Shoot.GetInfo().Name,
 			Type:              b.Shoot.GetInfo().Spec.Provider.Type,
 			Region:            b.Shoot.GetInfo().Spec.Region,
+			TechnicalID:       b.Shoot.GetInfo().Status.TechnicalID,
+			ClusterID:         string(b.Shoot.GetInfo().Status.UID),
 			Workers:           b.Shoot.GetInfo().Spec.Provider.Workers,
 			KubernetesVersion: b.Shoot.KubernetesVersion,
 		},


### PR DESCRIPTION
Worker now get the label:
* `worker.gardener.cloud/technical-id`
*  `worker.gardener.cloud/cluster-id`
containing the technical-id and uid of the Shoot Cluster the node belongs to.

**How to categorize this PR?**

/area control-plane
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This allows a easier identification of the cluster and tagging of outgoing data like
log files.


**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Nodes now have a labels for technical id and uid of the shoot cluster they belong to.
```
