### PR TITLE
Fix the Shoot networking test when allowPrivilegedContainers=false

### DIFF
--- a/test/framework/resources/templates/network-nginx-daemonset.yaml.tpl
+++ b/test/framework/resources/templates/network-nginx-daemonset.yaml.tpl
@@ -22,3 +22,4 @@ spec:
         name: net-curl
         command: ["sh", "-c"]
         args: ["sleep 300"]
+      serviceAccountName: {{ .name }}

--- a/test/framework/resources/templates/network-nginx-rolebinding-privileged.yaml.tpl
+++ b/test/framework/resources/templates/network-nginx-rolebinding-privileged.yaml.tpl
@@ -1,0 +1,14 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .name }}
+  namespace: {{ .namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: gardener.cloud:psp:privileged
+subjects:
+- kind: ServiceAccount
+  name: {{ .name }}
+  namespace: {{ .namespace }}

--- a/test/framework/resources/templates/network-nginx-serviceaccount.yaml.tpl
+++ b/test/framework/resources/templates/network-nginx-serviceaccount.yaml.tpl
@@ -1,0 +1,6 @@
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .name }}
+  namespace: {{ .namespace }}

--- a/test/framework/resources/templates/templates.go
+++ b/test/framework/resources/templates/templates.go
@@ -18,8 +18,8 @@ const (
 	// SimpleLoadDeploymentName is the name of the simple load deployment template
 	SimpleLoadDeploymentName = "simple-load-deployment.yaml.tpl"
 
-	// NginxDaemonSetName is the name of the nginx deamonset template
-	NginxDaemonSetName = "network-nginx-deamonset.yaml.tpl"
+	// NginxDaemonSetName is the name of the nginx daemonset template
+	NginxDaemonSetName = "network-nginx-daemonset.yaml.tpl"
 
 	// GuestbookAppName is the name if the guestbook app deployment template
 	GuestbookAppName = "guestbook-app.yaml.tpl"

--- a/test/integration/shoots/applications/networking.go
+++ b/test/integration/shoots/applications/networking.go
@@ -45,7 +45,7 @@ import (
 )
 
 const (
-	networkTestTimeout = 1800 * time.Second
+	networkTestTimeout = 30 * time.Minute
 	cleanupTimeout     = 2 * time.Minute
 )
 
@@ -65,10 +65,11 @@ var _ = ginkgo.Describe("Shoot network testing", func() {
 			"namespace": f.Namespace,
 		}
 		ginkgo.By("Deploy the net test daemon set")
-		err := f.RenderAndDeployTemplate(ctx, f.ShootClient, templates.NginxDaemonSetName, templateParams)
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(f.RenderAndDeployTemplate(ctx, f.ShootClient, "network-nginx-serviceaccount.yaml.tpl", templateParams))
+		framework.ExpectNoError(f.RenderAndDeployTemplate(ctx, f.ShootClient, "network-nginx-rolebinding-privileged.yaml.tpl", templateParams))
+		framework.ExpectNoError(f.RenderAndDeployTemplate(ctx, f.ShootClient, templates.NginxDaemonSetName, templateParams))
 
-		err = f.WaitUntilDaemonSetIsRunning(ctx, f.ShootClient.Client(), name, f.Namespace)
+		err := f.WaitUntilDaemonSetIsRunning(ctx, f.ShootClient.Client(), name, f.Namespace)
 		framework.ExpectNoError(err)
 
 		pods := &corev1.PodList{}
@@ -79,24 +80,24 @@ var _ = ginkgo.Describe("Shoot network testing", func() {
 
 		// check if all webservers can be reached from all nodes
 		ginkgo.By("test connectivity to webservers")
-		var res error
+		var allErrs error
 		for _, from := range pods.Items {
 			for _, to := range pods.Items {
 				ginkgo.By(fmt.Sprintf("Testing %s to %s", from.GetName(), to.GetName()))
 				reader, err := podExecutor.Execute(ctx, from.Namespace, from.Name, "net-curl", fmt.Sprintf("curl -L %s:80 --fail -m 10", to.Status.PodIP))
 				if err != nil {
-					res = multierror.Append(res, fmt.Errorf("%s to %s: %w", from.GetName(), to.GetName(), err))
+					allErrs = multierror.Append(allErrs, fmt.Errorf("%s to %s: %w", from.GetName(), to.GetName(), err))
 					continue
 				}
 				data, err := io.ReadAll(reader)
 				if err != nil {
-					f.Logger.Error(err)
+					allErrs = multierror.Append(allErrs, fmt.Errorf("cannot to read the command output: %w", err))
 					continue
 				}
 				f.Logger.Infof("%s to %s: %s", from.GetName(), to.GetName(), data)
 			}
 		}
-		framework.ExpectNoError(err)
+		framework.ExpectNoError(allErrs)
 	}, networkTestTimeout, framework.WithCAfterTest(func(ctx context.Context) {
 		ginkgo.By("cleanup network test daemonset")
 		err := f.ShootClient.Client().Delete(ctx, &appsv1.DaemonSet{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: f.Namespace}})


### PR DESCRIPTION
/area testing quality
/kind bug

Fixes #4898

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
The Shoot networking test does no longer fail against Shoots that do not allow privileged containers (.spec.kubernetes.allowPrivilegedContainers=false).
```
