### PR TITLE
Made Shoot.Kubernetes.KubeProxy.Enabled mutable again as the extensions can now deal with it.

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -420,16 +420,6 @@ func validateKubeProxyUpdate(newConfig, oldConfig *core.KubeProxyConfig, version
 	if ok, _ := versionutils.CheckVersionMeetsConstraint(version, "< 1.16"); ok {
 		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newMode, oldMode, fldPath.Child("mode"))...)
 	}
-	// The enabled flag is immutable for now to ensure that the networking extensions have time to adapt to it.
-	newEnabled := true
-	oldEnabled := true
-	if newConfig != nil && newConfig.Enabled != nil {
-		newEnabled = *newConfig.Enabled
-	}
-	if oldConfig != nil && oldConfig.Enabled != nil {
-		oldEnabled = *oldConfig.Enabled
-	}
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newEnabled, oldEnabled, fldPath.Child("enabled"))...)
 	return allErrs
 }
 

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -1866,7 +1866,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Expect(errorList).To(BeEmpty())
 			})
 
-			It("should fail when kube-proxy is switched off", func() {
+			It("should not fail when kube-proxy is switched off", func() {
 				kubernetesConfig := core.KubernetesConfig{}
 				disabled := false
 				config := core.KubeProxyConfig{
@@ -1884,12 +1884,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 
 				errorList := ValidateShootSpecUpdate(&shoot.Spec, &oldShoot.Spec, metav1.ObjectMeta{}, field.NewPath("spec"))
 
-				Expect(errorList).ToNot(BeEmpty())
-				Expect(errorList).To(ConsistOfFields(Fields{
-					"Type":   Equal(field.ErrorTypeInvalid),
-					"Field":  Equal("spec.kubernetes.kubeProxy.enabled"),
-					"Detail": Equal(`field is immutable`),
-				}))
+				Expect(errorList).To(BeEmpty())
 			})
 		})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind cleanup

**What this PR does / why we need it**:
The pull request enables the mutability of the Shoot.Spec.Kubernetes.KubeProxy.Enabled flag as the networking provider can now both deal with it.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Kube-proxy can now be enabled/disabled for clusters by setting the Shoot.Spec.Kubernetes.KubeProxy.Enabled flag accordingly. The change might be rejected by the used networking provider depending on the cluster configuration.
Please ensure that the networking provider extensions you use have at least v1.20.1 (calico) or v1.6.0 (cilium).
```
