### PR TITLE
Fix minor bugs w.r.t. deleting no longer referenced immutable `ConfigMap`s/`Secret`s

### DIFF
--- a/pkg/operation/botanist/logging.go
+++ b/pkg/operation/botanist/logging.go
@@ -21,12 +21,16 @@ import (
 
 	"github.com/gardener/gardener/charts"
 	gardencore "github.com/gardener/gardener/pkg/apis/core"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/features"
 	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/logging"
 	"github.com/gardener/gardener/pkg/operation/common"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // DeploySeedLogging will install the Helm release "seed-bootstrap/charts/loki" in the Seed clusters.
@@ -98,7 +102,15 @@ func (b *Botanist) DeploySeedLogging(ctx context.Context) error {
 		}
 	}
 
-	return b.K8sSeedClient.ChartApplier().Apply(ctx, filepath.Join(charts.Path, "seed-bootstrap", "charts", "loki"), b.Shoot.SeedNamespace, fmt.Sprintf("%s-logging", b.Shoot.SeedNamespace), kubernetes.Values(lokiValues))
+	if err := b.K8sSeedClient.ChartApplier().Apply(ctx, filepath.Join(charts.Path, "seed-bootstrap", "charts", "loki"), b.Shoot.SeedNamespace, fmt.Sprintf("%s-logging", b.Shoot.SeedNamespace), kubernetes.Values(lokiValues)); err != nil {
+		return err
+	}
+
+	// TODO(rfranzke): Remove in a future release.
+	return kutil.DeleteObjects(ctx, b.K8sSeedClient.Client(),
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: v1beta1constants.GardenNamespace, Name: "loki-config"}},
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: v1beta1constants.GardenNamespace, Name: "telegraf-config"}},
+	)
 }
 
 func (b *Botanist) isShootNodeLoggingEnabled() bool {

--- a/pkg/operation/botanist/monitoring.go
+++ b/pkg/operation/botanist/monitoring.go
@@ -485,9 +485,12 @@ func (b *Botanist) deployGrafanaCharts(ctx context.Context, role, dashboards, ba
 
 	// TODO(rfranzke): Remove in a future release.
 	return kutil.DeleteObjects(ctx, b.K8sSeedClient.Client(),
-		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: b.Shoot.SeedNamespace, Name: "grafana-dashboard-providers"}},
-		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: b.Shoot.SeedNamespace, Name: "grafana-datasources"}},
-		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: b.Shoot.SeedNamespace, Name: "grafana-dashboards"}},
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: b.Shoot.SeedNamespace, Name: "grafana-operators-dashboard-providers"}},
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: b.Shoot.SeedNamespace, Name: "grafana-operators-datasources"}},
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: b.Shoot.SeedNamespace, Name: "grafana-operators-dashboards"}},
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: b.Shoot.SeedNamespace, Name: "grafana-users-dashboard-providers"}},
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: b.Shoot.SeedNamespace, Name: "grafana-users-datasources"}},
+		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: b.Shoot.SeedNamespace, Name: "grafana-users-dashboards"}},
 	)
 }
 

--- a/pkg/resourcemanager/controller/garbagecollector/references/references.go
+++ b/pkg/resourcemanager/controller/garbagecollector/references/references.go
@@ -88,64 +88,64 @@ func InjectAnnotations(obj runtime.Object, additional ...string) error {
 	switch o := obj.(type) {
 	case *corev1.Pod:
 		referenceAnnotations := computeAnnotations(o.Spec, additional...)
-		o.Annotations = utils.MergeStringMaps(o.Annotations, referenceAnnotations)
+		o.Annotations = mergeAnnotations(o.Annotations, referenceAnnotations)
 
 	case *appsv1.Deployment:
 		referenceAnnotations := computeAnnotations(o.Spec.Template.Spec, additional...)
-		o.Annotations = utils.MergeStringMaps(o.Annotations, referenceAnnotations)
-		o.Spec.Template.Annotations = utils.MergeStringMaps(o.Spec.Template.Annotations, referenceAnnotations)
+		o.Annotations = mergeAnnotations(o.Annotations, referenceAnnotations)
+		o.Spec.Template.Annotations = mergeAnnotations(o.Spec.Template.Annotations, referenceAnnotations)
 
 	case *appsv1beta2.Deployment:
 		referenceAnnotations := computeAnnotations(o.Spec.Template.Spec, additional...)
-		o.Annotations = utils.MergeStringMaps(o.Annotations, referenceAnnotations)
-		o.Spec.Template.Annotations = utils.MergeStringMaps(o.Spec.Template.Annotations, referenceAnnotations)
+		o.Annotations = mergeAnnotations(o.Annotations, referenceAnnotations)
+		o.Spec.Template.Annotations = mergeAnnotations(o.Spec.Template.Annotations, referenceAnnotations)
 
 	case *appsv1beta1.Deployment:
 		referenceAnnotations := computeAnnotations(o.Spec.Template.Spec, additional...)
-		o.Annotations = utils.MergeStringMaps(o.Annotations, referenceAnnotations)
-		o.Spec.Template.Annotations = utils.MergeStringMaps(o.Spec.Template.Annotations, referenceAnnotations)
+		o.Annotations = mergeAnnotations(o.Annotations, referenceAnnotations)
+		o.Spec.Template.Annotations = mergeAnnotations(o.Spec.Template.Annotations, referenceAnnotations)
 
 	case *appsv1.StatefulSet:
 		referenceAnnotations := computeAnnotations(o.Spec.Template.Spec, additional...)
-		o.Annotations = utils.MergeStringMaps(o.Annotations, referenceAnnotations)
-		o.Spec.Template.Annotations = utils.MergeStringMaps(o.Spec.Template.Annotations, referenceAnnotations)
+		o.Annotations = mergeAnnotations(o.Annotations, referenceAnnotations)
+		o.Spec.Template.Annotations = mergeAnnotations(o.Spec.Template.Annotations, referenceAnnotations)
 
 	case *appsv1beta2.StatefulSet:
 		referenceAnnotations := computeAnnotations(o.Spec.Template.Spec, additional...)
-		o.Annotations = utils.MergeStringMaps(o.Annotations, referenceAnnotations)
-		o.Spec.Template.Annotations = utils.MergeStringMaps(o.Spec.Template.Annotations, referenceAnnotations)
+		o.Annotations = mergeAnnotations(o.Annotations, referenceAnnotations)
+		o.Spec.Template.Annotations = mergeAnnotations(o.Spec.Template.Annotations, referenceAnnotations)
 
 	case *appsv1beta1.StatefulSet:
 		referenceAnnotations := computeAnnotations(o.Spec.Template.Spec, additional...)
-		o.Annotations = utils.MergeStringMaps(o.Annotations, referenceAnnotations)
-		o.Spec.Template.Annotations = utils.MergeStringMaps(o.Spec.Template.Annotations, referenceAnnotations)
+		o.Annotations = mergeAnnotations(o.Annotations, referenceAnnotations)
+		o.Spec.Template.Annotations = mergeAnnotations(o.Spec.Template.Annotations, referenceAnnotations)
 
 	case *appsv1.DaemonSet:
 		referenceAnnotations := computeAnnotations(o.Spec.Template.Spec, additional...)
-		o.Annotations = utils.MergeStringMaps(o.Annotations, referenceAnnotations)
-		o.Spec.Template.Annotations = utils.MergeStringMaps(o.Spec.Template.Annotations, referenceAnnotations)
+		o.Annotations = mergeAnnotations(o.Annotations, referenceAnnotations)
+		o.Spec.Template.Annotations = mergeAnnotations(o.Spec.Template.Annotations, referenceAnnotations)
 
 	case *appsv1beta2.DaemonSet:
 		referenceAnnotations := computeAnnotations(o.Spec.Template.Spec, additional...)
-		o.Annotations = utils.MergeStringMaps(o.Annotations, referenceAnnotations)
-		o.Spec.Template.Annotations = utils.MergeStringMaps(o.Spec.Template.Annotations, referenceAnnotations)
+		o.Annotations = mergeAnnotations(o.Annotations, referenceAnnotations)
+		o.Spec.Template.Annotations = mergeAnnotations(o.Spec.Template.Annotations, referenceAnnotations)
 
 	case *batchv1.Job:
 		referenceAnnotations := computeAnnotations(o.Spec.Template.Spec, additional...)
-		o.Annotations = utils.MergeStringMaps(o.Annotations, referenceAnnotations)
-		o.Spec.Template.Annotations = utils.MergeStringMaps(o.Spec.Template.Annotations, referenceAnnotations)
+		o.Annotations = mergeAnnotations(o.Annotations, referenceAnnotations)
+		o.Spec.Template.Annotations = mergeAnnotations(o.Spec.Template.Annotations, referenceAnnotations)
 
 	case *batchv1.CronJob:
 		referenceAnnotations := computeAnnotations(o.Spec.JobTemplate.Spec.Template.Spec, additional...)
-		o.Annotations = utils.MergeStringMaps(o.Annotations, referenceAnnotations)
-		o.Spec.JobTemplate.Annotations = utils.MergeStringMaps(o.Spec.JobTemplate.Annotations, referenceAnnotations)
-		o.Spec.JobTemplate.Spec.Template.Annotations = utils.MergeStringMaps(o.Spec.JobTemplate.Spec.Template.Annotations, referenceAnnotations)
+		o.Annotations = mergeAnnotations(o.Annotations, referenceAnnotations)
+		o.Spec.JobTemplate.Annotations = mergeAnnotations(o.Spec.JobTemplate.Annotations, referenceAnnotations)
+		o.Spec.JobTemplate.Spec.Template.Annotations = mergeAnnotations(o.Spec.JobTemplate.Spec.Template.Annotations, referenceAnnotations)
 
 	case *batchv1beta1.CronJob:
 		referenceAnnotations := computeAnnotations(o.Spec.JobTemplate.Spec.Template.Spec, additional...)
-		o.Annotations = utils.MergeStringMaps(o.Annotations, referenceAnnotations)
-		o.Spec.JobTemplate.Annotations = utils.MergeStringMaps(o.Spec.JobTemplate.Annotations, referenceAnnotations)
-		o.Spec.JobTemplate.Spec.Template.Annotations = utils.MergeStringMaps(o.Spec.JobTemplate.Spec.Template.Annotations, referenceAnnotations)
+		o.Annotations = mergeAnnotations(o.Annotations, referenceAnnotations)
+		o.Spec.JobTemplate.Annotations = mergeAnnotations(o.Spec.JobTemplate.Annotations, referenceAnnotations)
+		o.Spec.JobTemplate.Spec.Template.Annotations = mergeAnnotations(o.Spec.JobTemplate.Spec.Template.Annotations, referenceAnnotations)
 
 	default:
 		return fmt.Errorf("unhandled object type %T", obj)
@@ -194,4 +194,17 @@ func computeAnnotations(spec corev1.PodSpec, additional ...string) map[string]st
 	}
 
 	return out
+}
+
+func mergeAnnotations(oldAnnotations, newAnnotations map[string]string) map[string]string {
+	// Remove all existing annotations with the AnnotationKeyPrefix to make sure that no longer referenced resources
+	// do not remain in the annotations.
+	old := make(map[string]string, len(oldAnnotations))
+	for k, v := range oldAnnotations {
+		if !strings.HasPrefix(k, AnnotationKeyPrefix) {
+			old[k] = v
+		}
+	}
+
+	return utils.MergeStringMaps(old, newAnnotations)
 }

--- a/pkg/resourcemanager/controller/garbagecollector/references/references_test.go
+++ b/pkg/resourcemanager/controller/garbagecollector/references/references_test.go
@@ -76,6 +76,8 @@ var _ = Describe("References", func() {
 
 			annotations = map[string]string{
 				"some-existing": "annotation",
+				"reference.resources.gardener.cloud/configmap-1234567": "cm0",
+				"reference.resources.gardener.cloud/secret-1234567":    "secret0",
 			}
 			podSpec = corev1.PodSpec{
 				Containers: []corev1.Container{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
This PR contains three commits to fix the following aspects:

- Introduced with https://github.com/gardener/gardener/pull/4528/commits/fe7f8a9cf54a3cc8f8e3ebd5dc88ffc54ac3c8c5, 71d219f makes sure the correct legacy Grafana `ConfigMap`s are deleted.
- Introduced with https://github.com/gardener/gardener/pull/4528/commits/66a8e7e44b7fffae78bc8273b06cab6f12a9a930, 
1d74e23 makes sure that the legacy loki `ConfigMap`s are also deleted in shoot namespaces (not only in the `garden` namespace).
- Introduced with https://github.com/gardener/gardener-resource-manager/pull/127/commits/78a20b0056f4d087682290746f35d5e47334708c, dced8ae makes sure that existing resource reference annotations are removed before injecting the new resource reference annotations.

**Special notes for your reviewer**:
Thanks to @timebertt for bringing this to my attention!
/squash

For reference, this was an exemplary shoot namespace that shows a couple of `ConfigMap`s that should have been deleted but still exist:

```
NAME                                             DATA   AGE    GARBAGE-COLLECTABLE-REFERENCE
audit-policy-config-8f919704                     1      38d    true
audit-policy-config-f5b578b4                     1      9d     true
etcd-bootstrap-8b40db                            1      136d
etcd-bootstrap-cfca71                            1      136d
grafana-operators-dashboard-providers            1      136d
grafana-operators-dashboard-providers-acaa2b61   1      38d    true
grafana-operators-dashboards                     30     136d
grafana-operators-dashboards-56c32a19            24     27d    true
grafana-operators-datasources                    1      136d
grafana-operators-datasources-4af3d2bd           1      38d    true
grafana-users-dashboard-providers                1      136d
grafana-users-dashboard-providers-acaa2b61       1      38d    true
grafana-users-dashboards                         16     136d
grafana-users-dashboards-acca85d1                13     27d    true
grafana-users-datasources                        1      136d
grafana-users-datasources-4af3d2bd               1      38d    true
kube-apiserver-admission-config-00775eae         1      38d    true
kube-apiserver-admission-config-e38ff146         1      9d     true
kube-scheduler-config-86e20cfa                   1      38d    true
loki-config                                      2      136d
loki-config-6cac1d4c                             2      38d    true
telegraf-config                                  2      50d
telegraf-config-147526e0                         2      38d    true
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed which caused some of no longer referenced immutable `ConfigMap`s/`Secret`s in shoot namespaces in seed clusters not to be deleted.
```
