### PR TITLE
Update shoot_autoscaling.md

### DIFF
--- a/docs/usage/shoot_autoscaling.md
+++ b/docs/usage/shoot_autoscaling.md
@@ -20,7 +20,7 @@ The `Shoot` API allows to configure a few flags of the `cluster-autoscaler`:
 * `.spec.kubernetes.clusterAutoscaler.ScaleDownDelayAfterDelete` defines how long after node deletion that scale down evaluation resumes (defaults to `ScanInterval`).
 * `.spec.kubernetes.clusterAutoscaler.ScaleDownDelayAfterFailure` defines how long after scale down failure that scale down evaluation resumes (default: `3m`).
 * `.spec.kubernetes.clusterAutoscaler.ScaleDownUnneededTime` defines how long a node should be unneeded before it is eligible for scale down (default: `30m`).
-* `.spec.kubernetes.clusterAutoscaler.ScaleDownUtilizationThreshold` defines the threshold in % under which a node is being removed (default: `50`).
+* `.spec.kubernetes.clusterAutoscaler.ScaleDownUtilizationThreshold` defines the threshold under which a node is being removed (default: `0.5`).
 * `.spec.kubernetes.clusterAutoscaler.ScanInterval` defines how often cluster is reevaluated for scale up or down (default: `10s`). 
 
 ## Vertical Pod Auto-Scaling

--- a/docs/usage/shoot_autoscaling.md
+++ b/docs/usage/shoot_autoscaling.md
@@ -20,7 +20,7 @@ The `Shoot` API allows to configure a few flags of the `cluster-autoscaler`:
 * `.spec.kubernetes.clusterAutoscaler.ScaleDownDelayAfterDelete` defines how long after node deletion that scale down evaluation resumes (defaults to `ScanInterval`).
 * `.spec.kubernetes.clusterAutoscaler.ScaleDownDelayAfterFailure` defines how long after scale down failure that scale down evaluation resumes (default: `3m`).
 * `.spec.kubernetes.clusterAutoscaler.ScaleDownUnneededTime` defines how long a node should be unneeded before it is eligible for scale down (default: `30m`).
-* `.spec.kubernetes.clusterAutoscaler.ScaleDownUtilizationThreshold` defines the threshold in % under which a node is being removed.
+* `.spec.kubernetes.clusterAutoscaler.ScaleDownUtilizationThreshold` defines the threshold in % under which a node is being removed (default: `50`).
 * `.spec.kubernetes.clusterAutoscaler.ScanInterval` defines how often cluster is reevaluated for scale up or down (default: `10s`). 
 
 ## Vertical Pod Auto-Scaling


### PR DESCRIPTION
added the default value for `ScaleDownUtilizationThreshold`

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation

**What this PR does / why we need it**:
adds default value for `ScaleDownUtilizationThreshold`
