### PR TITLE
fix pdb for reversed-vpn-auth-server

### DIFF
--- a/pkg/operation/botanist/component/extauthzserver/external_authz_server.go
+++ b/pkg/operation/botanist/component/extauthzserver/external_authz_server.go
@@ -255,12 +255,7 @@ func (a *authServer) Deploy(ctx context.Context) error {
 
 	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, a.client, pdb, func() error {
 		maxUnavailable := intstr.FromInt(1)
-
-		pdb.ObjectMeta = metav1.ObjectMeta{
-			Name:      DeploymentName + "-pdb",
-			Namespace: a.namespace,
-			Labels:    getLabels(),
-		}
+		pdb.Labels = getLabels()
 		pdb.Spec.MaxUnavailable = &maxUnavailable
 		pdb.Spec.Selector = &metav1.LabelSelector{
 			MatchLabels: getLabels(),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Fix pdb for reversed-vpn-auth-server. With object metadata set it will run into `metadata.resourceVersion: Invalid value: 0x0` when trying to update the resource.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
none
```
