### PR TITLE
Fix Shoot deletion on Seeds with non-tolerated taints

### DIFF
--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -163,7 +163,6 @@ func (v *ValidateShoot) Admit(ctx context.Context, a admission.Attributes, o adm
 
 	if a.GetOperation() == admission.Delete {
 		shoot, convertIsSuccessful = a.GetOldObject().(*core.Shoot)
-		oldShoot = shoot
 	} else {
 		shoot, convertIsSuccessful = a.GetObject().(*core.Shoot)
 	}
@@ -295,6 +294,10 @@ func (c *validationContext) validateProjectMembership(a admission.Attributes) er
 }
 
 func (c *validationContext) validateScheduling(a admission.Attributes, shootLister corelisters.ShootLister, seedLister corelisters.SeedLister) error {
+	if a.GetOperation() == admission.Delete {
+		return nil
+	}
+
 	var (
 		shootIsBeingScheduled          = c.oldShoot.Spec.SeedName == nil && c.shoot.Spec.SeedName != nil
 		shootIsBeingRescheduled        = c.oldShoot.Spec.SeedName != nil && c.shoot.Spec.SeedName != nil && *c.shoot.Spec.SeedName != *c.oldShoot.Spec.SeedName

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -301,7 +301,7 @@ func (c *validationContext) validateScheduling(a admission.Attributes, shootList
 	var (
 		shootIsBeingScheduled          = c.oldShoot.Spec.SeedName == nil && c.shoot.Spec.SeedName != nil
 		shootIsBeingRescheduled        = c.oldShoot.Spec.SeedName != nil && c.shoot.Spec.SeedName != nil && *c.shoot.Spec.SeedName != *c.oldShoot.Spec.SeedName
-		mustCheckSchedulingConstraints = shootIsBeingScheduled || shootIsBeingRescheduled
+		mustCheckSchedulingConstraints = (shootIsBeingScheduled || shootIsBeingRescheduled) && a.GetOperation() != admission.Delete
 	)
 
 	if mustCheckSchedulingConstraints {

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -163,11 +163,7 @@ func (v *ValidateShoot) Admit(ctx context.Context, a admission.Attributes, o adm
 
 	if a.GetOperation() == admission.Delete {
 		shoot, convertIsSuccessful = a.GetOldObject().(*core.Shoot)
-		old, ok := a.GetOldObject().(*core.Shoot)
-		if !ok {
-			return apierrors.NewInternalError(errors.New("could not convert old resource into Shoot object"))
-		}
-		oldShoot = old
+		oldShoot = shoot
 	} else {
 		shoot, convertIsSuccessful = a.GetObject().(*core.Shoot)
 	}

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -163,6 +163,11 @@ func (v *ValidateShoot) Admit(ctx context.Context, a admission.Attributes, o adm
 
 	if a.GetOperation() == admission.Delete {
 		shoot, convertIsSuccessful = a.GetOldObject().(*core.Shoot)
+		old, ok := a.GetOldObject().(*core.Shoot)
+		if !ok {
+			return apierrors.NewInternalError(errors.New("could not convert old resource into Shoot object"))
+		}
+		oldShoot = old
 	} else {
 		shoot, convertIsSuccessful = a.GetObject().(*core.Shoot)
 	}

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -301,7 +301,7 @@ func (c *validationContext) validateScheduling(a admission.Attributes, shootList
 	var (
 		shootIsBeingScheduled          = c.oldShoot.Spec.SeedName == nil && c.shoot.Spec.SeedName != nil
 		shootIsBeingRescheduled        = c.oldShoot.Spec.SeedName != nil && c.shoot.Spec.SeedName != nil && *c.shoot.Spec.SeedName != *c.oldShoot.Spec.SeedName
-		mustCheckSchedulingConstraints = (shootIsBeingScheduled || shootIsBeingRescheduled) && a.GetOperation() != admission.Delete
+		mustCheckSchedulingConstraints = shootIsBeingScheduled || shootIsBeingRescheduled
 	)
 
 	if mustCheckSchedulingConstraints {

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -925,7 +925,7 @@ var _ = Describe("validator", func() {
 						Expect(coreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&project)).To(Succeed())
 						Expect(coreInformerFactory.Core().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
 						Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
-						attrs := admission.NewAttributesRecord(&shoot, &shoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Delete, &metav1.UpdateOptions{}, false, nil)
+						attrs := admission.NewAttributesRecord(nil, &shoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Delete, &metav1.UpdateOptions{}, false, nil)
 
 						err := admissionHandler.Admit(context.TODO(), attrs, nil)
 						Expect(err).ToNot(HaveOccurred())

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -904,6 +904,17 @@ var _ = Describe("validator", func() {
 						err := admissionHandler.Admit(context.TODO(), attrs, nil)
 						Expect(err).ToNot(HaveOccurred())
 					})
+
+					It("delete should pass even if the Seed specified in shoot manifest has non-tolerated taints", func() {
+						seed.Spec.Taints = []core.SeedTaint{{Key: core.SeedTaintProtected}}
+						Expect(coreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&project)).To(Succeed())
+						Expect(coreInformerFactory.Core().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
+						Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+						attrs := admission.NewAttributesRecord(&shoot, &shoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Delete, &metav1.UpdateOptions{}, false, nil)
+
+						err := admissionHandler.Admit(context.TODO(), attrs, nil)
+						Expect(err).ToNot(HaveOccurred())
+					})
 				})
 
 				Context("seed capacity", func() {

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -882,8 +882,10 @@ var _ = Describe("validator", func() {
 
 					It("update should pass because the Seed stays the same, even if it has non-tolerated taints", func() {
 						oldShoot.Spec.SeedName = pointer.String("seed")
-						shoot.Spec.Provider.Workers[0].Maximum = 10
 						seed.Spec.Taints = []core.SeedTaint{{Key: core.SeedTaintProtected}}
+
+						// Modify the Shoot spec to avoid an early exit optimization during the admission
+						shoot.Spec.Provider.Workers[0].Maximum = 10
 
 						Expect(coreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&project)).To(Succeed())
 						Expect(coreInformerFactory.Core().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -1020,6 +1020,31 @@ var _ = Describe("validator", func() {
 						err := admissionHandler.Admit(context.TODO(), attrs, nil)
 						Expect(err).To(MatchError(ContainSubstring("already has the maximum number of shoots scheduled on it")))
 					})
+
+					It("should allow Shoot deletion even though seed's allocatable capacity is exhausted / over exhausted", func() {
+						seed.Status.Allocatable = corev1.ResourceList{"shoots": allocatableShoots}
+
+						otherShoot := shoot.DeepCopy()
+						otherShoot.Name = "other-shoot-1"
+						otherShoot.Spec.SeedName = &seedName
+						Expect(coreInformerFactory.Core().InternalVersion().Shoots().Informer().GetStore().Add(otherShoot)).To(Succeed())
+
+						otherShoot = shoot.DeepCopy()
+						otherShoot.Name = "other-shoot-2"
+						otherShoot.Spec.SeedName = &seedName
+						Expect(coreInformerFactory.Core().InternalVersion().Shoots().Informer().GetStore().Add(otherShoot)).To(Succeed())
+
+						// admission for DELETION uses the old Shoot object
+						oldShoot.Spec.SeedName = &seedName
+
+						Expect(coreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&project)).To(Succeed())
+						Expect(coreInformerFactory.Core().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
+						Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+						attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Delete, &metav1.DeleteOptions{}, false, nil)
+
+						err := admissionHandler.Admit(context.TODO(), attrs, nil)
+						Expect(err).ToNot(HaveOccurred())
+					})
 				})
 			})
 

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -868,6 +868,7 @@ var _ = Describe("validator", func() {
 					})
 
 					It("update should fail because the new Seed specified in shoot manifest has non-tolerated taints", func() {
+						oldShoot.Spec.SeedName = pointer.String("old-seed")
 						seed.Spec.Taints = []core.SeedTaint{{Key: core.SeedTaintProtected}}
 
 						Expect(coreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&project)).To(Succeed())
@@ -877,6 +878,20 @@ var _ = Describe("validator", func() {
 
 						err := admissionHandler.Admit(context.TODO(), attrs, nil)
 						Expect(err).To(HaveOccurred())
+					})
+
+					It("update should pass because the Seed stays the same, even if it has non-tolerated taints", func() {
+						oldShoot.Spec.SeedName = pointer.String("seed")
+						shoot.Spec.Provider.Workers[0].Maximum = 10
+						seed.Spec.Taints = []core.SeedTaint{{Key: core.SeedTaintProtected}}
+
+						Expect(coreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&project)).To(Succeed())
+						Expect(coreInformerFactory.Core().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
+						Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+						attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+
+						err := admissionHandler.Admit(context.TODO(), attrs, nil)
+						Expect(err).ToNot(HaveOccurred())
 					})
 
 					It("create should pass because shoot tolerates all taints of the seed", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
With the changes done in #4521, we started to use the variable `oldShoot` inside `validateScheduling` to decide if looking at taints is necessary – even in the `action.Delete` scenario. Previously, this decision was explicitly filtered by looking at the action itself. Turns out `oldShoot` wasn't populated in the `action.Delete` case.

We now have the same 3 lines in the `delete` and `update` case – should we even extract this?

**Which issue(s) this PR fixes**:
Fixes #4889

**Special notes for your reviewer**:
Tested with local dev setup in addition to unit-test.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed a bug which prevented Shoot deletion on Seeds with non-tolerated taints.
```
