### PR TITLE
Replace extensions.NewGardenDecoder by kubernetes.GardenCodec

### DIFF
--- a/extensions/pkg/controller/cluster.go
+++ b/extensions/pkg/controller/cluster.go
@@ -20,8 +20,6 @@ import "github.com/gardener/gardener/pkg/extensions"
 type Cluster = extensions.Cluster
 
 var (
-	// NewGardenDecoder returns a new Garden API decoder.
-	NewGardenDecoder = extensions.NewGardenDecoder
 	// GetCluster tries to read Gardener's Cluster extension resource in the given namespace.
 	GetCluster = extensions.GetCluster
 	// CloudProfileFromCluster returns the CloudProfile resource inside the Cluster resource.

--- a/extensions/pkg/controller/csimigration/controller.go
+++ b/extensions/pkg/controller/csimigration/controller.go
@@ -15,7 +15,6 @@
 package csimigration
 
 import (
-	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	extensionspredicate "github.com/gardener/gardener/extensions/pkg/predicate"
 
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
@@ -67,10 +66,9 @@ func Add(mgr manager.Manager, args AddArgs) error {
 	}
 
 	var (
-		decoder           = extensionscontroller.NewGardenDecoder()
 		defaultPredicates = []predicate.Predicate{
-			extensionspredicate.ClusterShootProviderType(decoder, args.Type),
-			extensionspredicate.ClusterShootKubernetesVersionForCSIMigrationAtLeast(decoder, args.CSIMigrationKubernetesVersion),
+			extensionspredicate.ClusterShootProviderType(args.Type),
+			extensionspredicate.ClusterShootKubernetesVersionForCSIMigrationAtLeast(args.CSIMigrationKubernetesVersion),
 			ClusterCSIMigrationControllerNotFinished(),
 		}
 	)

--- a/extensions/pkg/controller/csimigration/reconciler.go
+++ b/extensions/pkg/controller/csimigration/reconciler.go
@@ -32,7 +32,6 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -45,8 +44,7 @@ const RequeueAfter = time.Minute
 type reconciler struct {
 	logger logr.Logger
 
-	client  client.Client
-	decoder runtime.Decoder
+	client client.Client
 
 	csiMigrationKubernetesVersion       string
 	storageClassNameToLegacyProvisioner map[string]string
@@ -57,7 +55,6 @@ type reconciler struct {
 func NewReconciler(csiMigrationKubernetesVersion string, storageClassNameToLegacyProvisioner map[string]string) reconcile.Reconciler {
 	return &reconciler{
 		logger:                              log.Log.WithName(ControllerName),
-		decoder:                             extensionscontroller.NewGardenDecoder(),
 		csiMigrationKubernetesVersion:       csiMigrationKubernetesVersion,
 		storageClassNameToLegacyProvisioner: storageClassNameToLegacyProvisioner,
 	}
@@ -77,7 +74,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, err
 	}
 
-	shoot, err := extensionscontroller.ShootFromCluster(r.decoder, cluster)
+	shoot, err := extensionscontroller.ShootFromCluster(cluster)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/extensions/pkg/predicate/predicate.go
+++ b/extensions/pkg/predicate/predicate.go
@@ -29,7 +29,6 @@ import (
 	"github.com/gardener/gardener/pkg/utils/version"
 
 	"github.com/go-logr/logr"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
@@ -180,7 +179,7 @@ func HasPurpose(purpose extensionsv1alpha1.Purpose) predicate.Predicate {
 }
 
 // ClusterShootProviderType is a predicate for the provider type of the shoot in the cluster resource.
-func ClusterShootProviderType(decoder runtime.Decoder, providerType string) predicate.Predicate {
+func ClusterShootProviderType(providerType string) predicate.Predicate {
 	f := func(obj client.Object) bool {
 		if obj == nil {
 			return false
@@ -191,7 +190,7 @@ func ClusterShootProviderType(decoder runtime.Decoder, providerType string) pred
 			return false
 		}
 
-		shoot, err := extensionscontroller.ShootFromCluster(decoder, cluster)
+		shoot, err := extensionscontroller.ShootFromCluster(cluster)
 		if err != nil {
 			return false
 		}
@@ -247,7 +246,7 @@ func GardenCoreProviderType(providerType string) predicate.Predicate {
 }
 
 // ClusterShootKubernetesVersionForCSIMigrationAtLeast is a predicate for the kubernetes version of the shoot in the cluster resource.
-func ClusterShootKubernetesVersionForCSIMigrationAtLeast(decoder runtime.Decoder, kubernetesVersion string) predicate.Predicate {
+func ClusterShootKubernetesVersionForCSIMigrationAtLeast(kubernetesVersion string) predicate.Predicate {
 	f := func(obj client.Object) bool {
 		if obj == nil {
 			return false
@@ -258,7 +257,7 @@ func ClusterShootKubernetesVersionForCSIMigrationAtLeast(decoder runtime.Decoder
 			return false
 		}
 
-		shoot, err := extensionscontroller.ShootFromCluster(decoder, cluster)
+		shoot, err := extensionscontroller.ShootFromCluster(cluster)
 		if err != nil {
 			return false
 		}

--- a/extensions/pkg/predicate/predicate_test.go
+++ b/extensions/pkg/predicate/predicate_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"encoding/json"
 
-	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
@@ -113,15 +112,9 @@ var _ = Describe("Predicate", func() {
 	)
 
 	Describe("#ClusterShootProviderType", func() {
-		var decoder runtime.Decoder
-
-		BeforeEach(func() {
-			decoder = extensionscontroller.NewGardenDecoder()
-		})
-
 		It("should match the type", func() {
 			var (
-				predicate                                           = ClusterShootProviderType(decoder, extensionType)
+				predicate                                           = ClusterShootProviderType(extensionType)
 				createEvent, updateEvent, deleteEvent, genericEvent = computeEvents(extensionType, version, nil)
 			)
 
@@ -133,7 +126,7 @@ var _ = Describe("Predicate", func() {
 
 		It("should not match the type", func() {
 			var (
-				predicate                                           = ClusterShootProviderType(decoder, extensionType)
+				predicate                                           = ClusterShootProviderType(extensionType)
 				createEvent, updateEvent, deleteEvent, genericEvent = computeEvents("other-extension-type", version, nil)
 			)
 
@@ -145,15 +138,9 @@ var _ = Describe("Predicate", func() {
 	})
 
 	Describe("#ClusterShootKubernetesVersionForCSIMigrationAtLeast", func() {
-		var decoder runtime.Decoder
-
-		BeforeEach(func() {
-			decoder = extensionscontroller.NewGardenDecoder()
-		})
-
 		It("should match the minimum kubernetes version", func() {
 			var (
-				predicate                                           = ClusterShootKubernetesVersionForCSIMigrationAtLeast(decoder, version)
+				predicate                                           = ClusterShootKubernetesVersionForCSIMigrationAtLeast(version)
 				createEvent, updateEvent, deleteEvent, genericEvent = computeEvents(extensionType, version, nil)
 			)
 
@@ -165,7 +152,7 @@ var _ = Describe("Predicate", func() {
 
 		It("should not match the minimum kubernetes version", func() {
 			var (
-				predicate                                           = ClusterShootKubernetesVersionForCSIMigrationAtLeast(decoder, version)
+				predicate                                           = ClusterShootKubernetesVersionForCSIMigrationAtLeast(version)
 				createEvent, updateEvent, deleteEvent, genericEvent = computeEvents(extensionType, "1.17", nil)
 			)
 
@@ -177,7 +164,7 @@ var _ = Describe("Predicate", func() {
 
 		It("should not match minimum kubernetes version due to overwrite", func() {
 			var (
-				predicate                                           = ClusterShootKubernetesVersionForCSIMigrationAtLeast(decoder, version)
+				predicate                                           = ClusterShootKubernetesVersionForCSIMigrationAtLeast(version)
 				createEvent, updateEvent, deleteEvent, genericEvent = computeEvents(extensionType, "1.17", pointer.String("1.17"))
 			)
 

--- a/pkg/client/kubernetes/types.go
+++ b/pkg/client/kubernetes/types.go
@@ -19,7 +19,6 @@ import (
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
-	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
 	istionetworkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	istionetworkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
@@ -43,6 +42,7 @@ import (
 	gardenercoreinstall "github.com/gardener/gardener/pkg/apis/core/install"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	gardenoperationsinstall "github.com/gardener/gardener/pkg/apis/operations/install"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	gardenseedmanagementinstall "github.com/gardener/gardener/pkg/apis/seedmanagement/install"
 	gardensettingsinstall "github.com/gardener/gardener/pkg/apis/settings/install"
 	"github.com/gardener/gardener/pkg/chartrenderer"
@@ -68,6 +68,9 @@ var (
 		client.PropagationPolicy(metav1.DeletePropagationBackground),
 		client.GracePeriodSeconds(0),
 	}
+
+	// GardenCodec is a codec factory using the Garden scheme.
+	GardenCodec = serializer.NewCodecFactory(GardenScheme)
 
 	// SeedSerializer is a YAML serializer using the Seed scheme.
 	SeedSerializer = json.NewSerializerWithOptions(json.DefaultMetaFactory, SeedScheme, SeedScheme, json.SerializerOptions{Yaml: true, Pretty: false, Strict: false})

--- a/pkg/gardenlet/controller/extensions/shootstate_control.go
+++ b/pkg/gardenlet/controller/extensions/shootstate_control.go
@@ -48,7 +48,6 @@ type ShootStateControl struct {
 	seedClient      kubernetes.Interface
 	log             *logrus.Logger
 	recorder        record.EventRecorder
-	decoder         runtime.Decoder
 }
 
 // NewShootStateControl creates a new instance of ShootStateControl.
@@ -58,7 +57,6 @@ func NewShootStateControl(k8sGardenClient, seedClient kubernetes.Interface, log 
 		seedClient:      seedClient,
 		log:             log,
 		recorder:        recorder,
-		decoder:         extensions.NewGardenDecoder(),
 	}
 }
 
@@ -254,7 +252,7 @@ func (s *ShootStateControl) getClusterFromRequest(ctx context.Context, req recon
 }
 
 func (s *ShootStateControl) getShootStateFromCluster(ctx context.Context, cluster *extensionsv1alpha1.Cluster) (*gardencorev1alpha1.ShootState, error) {
-	shoot, err := extensions.ShootFromCluster(s.decoder, cluster)
+	shoot, err := extensions.ShootFromCluster(cluster)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind technical-debt cleanup

**What this PR does / why we need it**:

Before, `extensions.{CloudProfile,Seed,Shoot}FromCluster` decoded objects
into their internal version and converted them back to v1beta1 afterwards,
although the Cluster resource already contains the objects in v1beta1.
Also, they used a `UniversalDecoder` which performs defaulting, which is
actually undesirable.
`UniversalDeserializer` does not perform defaulting and conversion, it just
decodes into the given version, which is exactly what we want right now.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other dependency
`extensions.NewGardenDecoder` has been removed in favor of `kubernetes.GardenCodec`.
```
