### PR TITLE
Add gardenlet version skew information

### DIFF
--- a/docs/concepts/gardenlet.md
+++ b/docs/concepts/gardenlet.md
@@ -248,6 +248,10 @@ into all of your seeds (if they aren’t managed, as mentioned earlier).
 
 More information: [Deploy a Gardenlet](../deployment/deploy_gardenlet.md) for all instructions.
 
+## Gardenlet Allowed Version Skew
+
+The gardenlet version should always match the Gardener control plane version and may be at most (e.g. during the update of an installation) one minor version behind (never ahead).
+
 ## Related Links
 
 [Gardener Architecture](https://github.com/gardener/documentation/wiki/Architecture)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds information about the allowed version skew between the gardenlet and the Gardener control plane.

**Which issue(s) this PR fixes**:
It doesn't fix, but covers one aspect of #4916. Please decide whether you like the information to be de-central (like in this PR for the gardenlet) or you'd rather like to reject this PR and instead go for a central document like https://kubernetes.io/releases/version-skew-policy.

**Release note**:
```doc operator
The allowed version skew between gardenlet and the Gardener control plane is now documented (at most one minor version behind, never ahead).
```

cc @rfranzke 