### PR TITLE
Prepare switch to logr

### DIFF
--- a/cmd/gardener-admission-controller/app/gardener_admission_controller.go
+++ b/cmd/gardener-admission-controller/app/gardener_admission_controller.go
@@ -228,7 +228,7 @@ func NewGardenerAdmissionControllerCommand() *cobra.Command {
 			cmd.SilenceUsage = true
 			cmd.SilenceErrors = true
 
-			log.Info("Starting " + Name + "...")
+			log.Info("Starting "+Name+"...", "version", version.Get())
 			cmd.Flags().VisitAll(func(flag *pflag.Flag) {
 				log.Info(fmt.Sprintf("FLAG: --%s=%s", flag.Name, flag.Value))
 			})

--- a/cmd/gardener-admission-controller/app/gardener_admission_controller.go
+++ b/cmd/gardener-admission-controller/app/gardener_admission_controller.go
@@ -23,16 +23,13 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/component-base/version"
 	"k8s.io/component-base/version/verflag"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	logzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
+	runtimelog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
@@ -62,6 +59,8 @@ var (
 	configDecoder runtime.Decoder
 
 	gracefulShutdownTimeout = 5 * time.Second
+
+	log = runtimelog.Log
 )
 
 func init() {
@@ -121,8 +120,6 @@ func (o *options) validate() error {
 
 // run runs gardener-admission-controller using the specified options.
 func (o *options) run(ctx context.Context) error {
-	log := logf.Log
-
 	log.Info("Starting Gardener admission controller...", "version", version.Get())
 
 	log.Info("getting rest config")
@@ -177,23 +174,23 @@ func (o *options) run(ctx context.Context) error {
 	log.Info("setting up webhook server")
 	server := mgr.GetWebhookServer()
 
-	namespaceValidationHandler, err := namespacedeletion.New(ctx, logf.Log.WithName(namespacedeletion.HandlerName), mgr.GetCache())
+	namespaceValidationHandler, err := namespacedeletion.New(ctx, runtimelog.Log.WithName(namespacedeletion.HandlerName), mgr.GetCache())
 	if err != nil {
 		return err
 	}
-	seedRestrictionHandler, err := seedrestriction.New(ctx, logf.Log.WithName(seedrestriction.HandlerName), mgr.GetCache())
+	seedRestrictionHandler, err := seedrestriction.New(ctx, runtimelog.Log.WithName(seedrestriction.HandlerName), mgr.GetCache())
 	if err != nil {
 		return err
 	}
-	logSeedAuth := logf.Log.WithName(seedauthorizer.AuthorizerName)
 
+	logSeedAuth := runtimelog.Log.WithName(seedauthorizer.AuthorizerName)
 	server.Register(seedauthorizer.WebhookPath, seedauthorizer.NewHandler(logSeedAuth, seedauthorizer.NewAuthorizer(logSeedAuth, graph)))
 	server.Register(seedrestriction.WebhookPath, &webhook.Admission{Handler: seedRestrictionHandler})
 	server.Register(namespacedeletion.WebhookPath, &webhook.Admission{Handler: namespaceValidationHandler})
-	server.Register(kubeconfigsecret.WebhookPath, &webhook.Admission{Handler: kubeconfigsecret.New(logf.Log.WithName(kubeconfigsecret.HandlerName))})
-	server.Register(resourcesize.WebhookPath, &webhook.Admission{Handler: resourcesize.New(logf.Log.WithName(resourcesize.HandlerName), o.config.Server.ResourceAdmissionConfiguration)})
-	server.Register(auditpolicy.WebhookPath, &webhook.Admission{Handler: auditpolicy.New(logf.Log.WithName(auditpolicy.HandlerName))})
-	server.Register(internaldomainsecret.WebhookPath, &webhook.Admission{Handler: internaldomainsecret.New(logf.Log.WithName(internaldomainsecret.HandlerName))})
+	server.Register(kubeconfigsecret.WebhookPath, &webhook.Admission{Handler: kubeconfigsecret.New(runtimelog.Log.WithName(kubeconfigsecret.HandlerName))})
+	server.Register(resourcesize.WebhookPath, &webhook.Admission{Handler: resourcesize.New(runtimelog.Log.WithName(resourcesize.HandlerName), o.config.Server.ResourceAdmissionConfiguration)})
+	server.Register(auditpolicy.WebhookPath, &webhook.Admission{Handler: auditpolicy.New(runtimelog.Log.WithName(auditpolicy.HandlerName))})
+	server.Register(internaldomainsecret.WebhookPath, &webhook.Admission{Handler: internaldomainsecret.New(runtimelog.Log.WithName(internaldomainsecret.HandlerName))})
 
 	if utils.IsTrue(o.config.Server.EnableDebugHandlers) {
 		log.Info("registering debug handlers")
@@ -211,16 +208,7 @@ func (o *options) run(ctx context.Context) error {
 
 // NewGardenerAdmissionControllerCommand creates a *cobra.Command object with default parameters.
 func NewGardenerAdmissionControllerCommand() *cobra.Command {
-	var (
-		log = logzap.New(logzap.UseDevMode(false), func(opts *logzap.Options) {
-			encCfg := zap.NewProductionEncoderConfig()
-			// overwrite time encoding to human readable format
-			encCfg.EncodeTime = zapcore.ISO8601TimeEncoder
-			opts.Encoder = zapcore.NewJSONEncoder(encCfg)
-		})
-		opts = &options{}
-	)
-	logf.SetLogger(log)
+	opts := &options{}
 
 	cmd := &cobra.Command{
 		Use:   Name,

--- a/cmd/gardener-admission-controller/main.go
+++ b/cmd/gardener-admission-controller/main.go
@@ -20,12 +20,16 @@ import (
 
 	"github.com/gardener/gardener/cmd/gardener-admission-controller/app"
 	"github.com/gardener/gardener/cmd/utils"
+	"github.com/gardener/gardener/pkg/logger"
 
+	runtimelog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 )
 
 func main() {
 	utils.DeduplicateWarnings()
+
+	runtimelog.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON))
 
 	ctx := signals.SetupSignalHandler()
 	if err := app.NewGardenerAdmissionControllerCommand().ExecuteContext(ctx); err != nil {

--- a/cmd/gardener-resource-manager/app/app.go
+++ b/cmd/gardener-resource-manager/app/app.go
@@ -64,7 +64,7 @@ func NewResourceManagerCommand() *cobra.Command {
 			ctx, cancel := context.WithCancel(cmd.Context())
 			defer cancel()
 
-			log.Info("Starting gardener-resource-manager...", "version", version.Get().GitVersion)
+			log.Info("Starting gardener-resource-manager...", "version", version.Get())
 			cmd.Flags().VisitAll(func(flag *pflag.Flag) {
 				log.Info(fmt.Sprintf("FLAG: --%s=%s", flag.Name, flag.Value))
 			})

--- a/cmd/gardener-resource-manager/app/app.go
+++ b/cmd/gardener-resource-manager/app/app.go
@@ -39,12 +39,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
-var log = runtimelog.Log.WithName("gardener-resource-manager")
+var log = runtimelog.Log
 
 // NewResourceManagerCommand creates a new command for running gardener resource manager controllers.
 func NewResourceManagerCommand() *cobra.Command {
-	entryLog := log.WithName("entrypoint")
-
 	managerOpts := &resourcemanagercmd.ManagerOptions{}
 	sourceClientOpts := &resourcemanagercmd.SourceClientOptions{}
 	targetClusterOpts := &resourcemanagercmd.TargetClusterOptions{}
@@ -66,9 +64,9 @@ func NewResourceManagerCommand() *cobra.Command {
 			ctx, cancel := context.WithCancel(cmd.Context())
 			defer cancel()
 
-			entryLog.Info("Starting gardener-resource-manager...", "version", version.Get().GitVersion)
+			log.Info("Starting gardener-resource-manager...", "version", version.Get().GitVersion)
 			cmd.Flags().VisitAll(func(flag *pflag.Flag) {
-				entryLog.Info(fmt.Sprintf("FLAG: --%s=%s", flag.Name, flag.Value))
+				log.Info(fmt.Sprintf("FLAG: --%s=%s", flag.Name, flag.Value))
 			})
 
 			if err := resourcemanagercmd.CompleteAll(
@@ -96,7 +94,7 @@ func NewResourceManagerCommand() *cobra.Command {
 			resourceControllerOpts.Completed().ApplyClassFilter(&secretControllerOpts.Completed().ClassFilter)
 			resourceControllerOpts.Completed().ApplyClassFilter(&healthControllerOpts.Completed().ClassFilter)
 			resourceControllerOpts.Completed().GarbageCollectorActivated = gcControllerOpts.Completed().SyncPeriod > 0
-			if err := resourceControllerOpts.Completed().ApplyDefaultClusterId(ctx, entryLog, sourceClientOpts.Completed().RESTConfig); err != nil {
+			if err := resourceControllerOpts.Completed().ApplyDefaultClusterId(ctx, log, sourceClientOpts.Completed().RESTConfig); err != nil {
 				return err
 			}
 			healthControllerOpts.Completed().TargetCluster = targetClusterOpts.Completed().Cluster
@@ -154,7 +152,7 @@ func NewResourceManagerCommand() *cobra.Command {
 				return err
 
 			case <-cmd.Context().Done():
-				entryLog.Info("Stop signal received, shutting down.")
+				log.Info("Stop signal received, shutting down.")
 				wg.Wait()
 				return nil
 			}

--- a/cmd/gardener-resource-manager/main.go
+++ b/cmd/gardener-resource-manager/main.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/gardener/gardener/cmd/gardener-resource-manager/app"
@@ -34,11 +33,7 @@ func main() {
 		}),
 	)
 
-	zapLogger, err := logger.NewZapLogger("info", "json")
-	if err != nil {
-		panic(fmt.Errorf("failed to init logger: %w", err))
-	}
-	runtimelog.SetLogger(logger.NewZapLogr(zapLogger))
+	runtimelog.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON))
 
 	ctx := signals.SetupSignalHandler()
 

--- a/cmd/gardener-resource-manager/main.go
+++ b/cmd/gardener-resource-manager/main.go
@@ -18,25 +18,19 @@ import (
 	"os"
 
 	"github.com/gardener/gardener/cmd/gardener-resource-manager/app"
+	"github.com/gardener/gardener/cmd/utils"
 	"github.com/gardener/gardener/pkg/logger"
 
-	"k8s.io/client-go/rest"
 	runtimelog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 )
 
 func main() {
-	rest.SetDefaultWarningHandler(
-		rest.NewWarningWriter(os.Stderr, rest.WarningWriterOptions{
-			// only print a given warning the first time we receive it
-			Deduplicate: true,
-		}),
-	)
+	utils.DeduplicateWarnings()
 
 	runtimelog.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON))
 
 	ctx := signals.SetupSignalHandler()
-
 	if err := app.NewResourceManagerCommand().ExecuteContext(ctx); err != nil {
 		runtimelog.Log.Error(err, "error executing the main controller command")
 		os.Exit(1)

--- a/cmd/gardener-scheduler/app/gardener_scheduler.go
+++ b/cmd/gardener-scheduler/app/gardener_scheduler.go
@@ -38,7 +38,7 @@ import (
 	"k8s.io/component-base/version"
 	"k8s.io/component-base/version/verflag"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
-	ctrlruntimelog "sigs.k8s.io/controller-runtime/pkg/log"
+	runtimelog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
@@ -109,17 +109,16 @@ func runCommand(ctx context.Context, opts *Options) error {
 	}
 
 	// Initialize logger
-	zapLogger, err := logger.NewZapLogger(cfg.LogLevel, cfg.LogFormat)
+	log, err := logger.NewZapLogger(cfg.LogLevel, cfg.LogFormat)
 	if err != nil {
 		return fmt.Errorf("failed to init logger: %w", err)
 	}
 
 	// set the logger used by sigs.k8s.io/controller-runtime
-	zapLogr := logger.NewZapLogr(zapLogger)
-	ctrlruntimelog.SetLogger(zapLogr)
+	runtimelog.SetLogger(log)
 
-	zapLogr.Info("Starting Gardener scheduler...", "version", version.Get())
-	zapLogr.Info("Feature Gates", "featureGates", schedulerfeatures.FeatureGate.String())
+	log.Info("Starting Gardener scheduler...", "version", version.Get())
+	log.Info("Feature Gates", "featureGates", schedulerfeatures.FeatureGate.String())
 
 	// Prepare a Kubernetes client object for the Garden cluster which contains all the Clientsets
 	// that can be used to access the Kubernetes API.
@@ -141,7 +140,6 @@ func runCommand(ctx context.Context, opts *Options) error {
 		LeaderElectionID:           cfg.LeaderElection.ResourceName,
 		LeaderElectionNamespace:    cfg.LeaderElection.ResourceNamespace,
 		LeaderElectionResourceLock: cfg.LeaderElection.ResourceLock,
-		Logger:                     zapLogr,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to create controller manager: %w", err)

--- a/cmd/gardener-seed-admission-controller/app/gardener_seed_admission_controller.go
+++ b/cmd/gardener-seed-admission-controller/app/gardener_seed_admission_controller.go
@@ -65,7 +65,7 @@ func NewSeedAdmissionControllerCommand() *cobra.Command {
 
 			cmd.SilenceUsage = true
 
-			log.Info("Starting " + Name + "...")
+			log.Info("Starting "+Name+"...", "version", version.Get())
 			cmd.Flags().VisitAll(func(flag *pflag.Flag) {
 				log.Info(fmt.Sprintf("FLAG: --%s=%s", flag.Name, flag.Value))
 			})
@@ -120,8 +120,6 @@ func (o *Options) validate() error {
 
 // Run runs gardener-seed-admission-controller using the specified options.
 func (o *Options) Run(ctx context.Context) error {
-	log.Info("Starting Gardener Seed admission controller...", "version", version.Get())
-
 	log.Info("getting rest config")
 	restConfig, err := config.GetConfig()
 	if err != nil {

--- a/cmd/gardener-seed-admission-controller/main.go
+++ b/cmd/gardener-seed-admission-controller/main.go
@@ -18,14 +18,18 @@ import (
 	"fmt"
 	"os"
 
+	runtimelog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 
 	"github.com/gardener/gardener/cmd/gardener-seed-admission-controller/app"
 	"github.com/gardener/gardener/cmd/utils"
+	"github.com/gardener/gardener/pkg/logger"
 )
 
 func main() {
 	utils.DeduplicateWarnings()
+
+	runtimelog.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON))
 
 	ctx := signals.SetupSignalHandler()
 	if err := app.NewSeedAdmissionControllerCommand().ExecuteContext(ctx); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/gardener/machine-controller-manager v0.33.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v0.4.0
-	github.com/go-logr/zapr v0.4.0
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/mock v1.6.0
 	github.com/golang/snappy v0.0.4 // indirect

--- a/pkg/logger/zap_test.go
+++ b/pkg/logger/zap_test.go
@@ -15,11 +15,10 @@
 package logger_test
 
 import (
-	. "github.com/gardener/gardener/pkg/logger"
-	"go.uber.org/zap/zapcore"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	. "github.com/gardener/gardener/pkg/logger"
 )
 
 var _ = Describe("zap", func() {
@@ -27,28 +26,29 @@ var _ = Describe("zap", func() {
 		It("should return a pointer to a Logger object ('debug' level)", func() {
 			logger, err := NewZapLogger(DebugLevel, FormatText)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(logger.Core().Enabled(zapcore.DebugLevel)).To(BeTrue())
+			Expect(logger.V(0).Enabled()).To(BeTrue())
+			Expect(logger.V(1).Enabled()).To(BeTrue())
 		})
 
 		It("should return a pointer to a Logger object ('info' level)", func() {
 			logger, err := NewZapLogger(InfoLevel, FormatText)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(logger.Core().Enabled(zapcore.DebugLevel)).To(BeFalse())
-			Expect(logger.Core().Enabled(zapcore.InfoLevel)).To(BeTrue())
+			Expect(logger.V(0).Enabled()).To(BeTrue())
+			Expect(logger.V(1).Enabled()).To(BeFalse())
 		})
 
 		It("should default to 'info' level", func() {
 			logger, err := NewZapLogger("", FormatText)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(logger.Core().Enabled(zapcore.DebugLevel)).To(BeFalse())
-			Expect(logger.Core().Enabled(zapcore.InfoLevel)).To(BeTrue())
+			Expect(logger.V(0).Enabled()).To(BeTrue())
+			Expect(logger.V(1).Enabled()).To(BeFalse())
 		})
 
 		It("should return a pointer to a Logger object ('error' level)", func() {
 			logger, err := NewZapLogger(ErrorLevel, FormatText)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(logger.Core().Enabled(zapcore.InfoLevel)).To(BeFalse())
-			Expect(logger.Core().Enabled(zapcore.ErrorLevel)).To(BeTrue())
+			Expect(logger.V(0).Enabled()).To(BeFalse())
+			Expect(logger.V(1).Enabled()).To(BeFalse())
 		})
 
 		It("should reject invalid log level", func() {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -130,7 +130,6 @@ github.com/ghodss/yaml
 ## explicit
 github.com/go-logr/logr
 # github.com/go-logr/zapr v0.4.0
-## explicit
 github.com/go-logr/zapr
 # github.com/go-openapi/jsonpointer v0.19.5
 github.com/go-openapi/jsonpointer


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:

Cleans up some logging helpers and stuff to prepare the switch from `logrus` to `logr`.
Now, we reuse the helpers from c-r to their full potential and drop custom coding that does the same.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/4251

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
None
```
