### PR TITLE
Prefix DNSRecord secret names to avoid collisions

### DIFF
--- a/docs/extensions/dnsrecord.md
+++ b/docs/extensions/dnsrecord.md
@@ -57,7 +57,7 @@ Optionally, the `DNSRecord` resource may contain also the following information:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: dnsrecord-external
+  name: dnsrecord-bar-external
   namespace: shoot--foo--bar
 type: Opaque
 data:
@@ -71,7 +71,7 @@ metadata:
 spec:
   type: aws-route53
   secretRef:
-    name: dnsrecord-external
+    name: dnsrecord-bar-external
     namespace: shoot--foo--bar
 # region: eu-west-1
 # zone: ZFOO

--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -458,7 +458,7 @@ func (r *shootReconciler) runReconcileShootFlow(ctx context.Context, o *operatio
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Cleaning up orphaned DNSRecord secrets",
-			Fn:           flow.TaskFn(botanist.CleanupOrphanedDNSRecordSecrets),
+			Fn:           flow.TaskFn(botanist.CleanupOrphanedDNSRecordSecrets).DoIf(!o.Shoot.HibernationEnabled),
 			Dependencies: flow.NewTaskIDs(deployInternalDomainDNSRecord, deployExternalDomainDNSRecord, deployOwnerDomainDNSRecord, deployIngressDomainDNSRecord),
 		})
 		_ = g.Add(flow.Task{

--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -457,6 +457,11 @@ func (r *shootReconciler) runReconcileShootFlow(ctx context.Context, o *operatio
 			Dependencies: flow.NewTaskIDs(nginxLBReady),
 		})
 		_ = g.Add(flow.Task{
+			Name:         "Cleaning up orphaned DNSRecord secrets",
+			Fn:           flow.TaskFn(botanist.CleanupOrphanedDNSRecordSecrets),
+			Dependencies: flow.NewTaskIDs(deployInternalDomainDNSRecord, deployExternalDomainDNSRecord, deployOwnerDomainDNSRecord, deployIngressDomainDNSRecord)})
+
+		_ = g.Add(flow.Task{
 			Name:         "Deploying additional DNS providers",
 			Fn:           flow.TaskFn(botanist.DeployAdditionalDNSProviders).DoIf(!o.Shoot.HibernationEnabled),
 			Dependencies: flow.NewTaskIDs(deployInternalDomainDNSRecord, deployExternalDomainDNSRecord, deployIngressDomainDNSRecord, deployOwnerDomainDNSRecord),

--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -459,8 +459,8 @@ func (r *shootReconciler) runReconcileShootFlow(ctx context.Context, o *operatio
 		_ = g.Add(flow.Task{
 			Name:         "Cleaning up orphaned DNSRecord secrets",
 			Fn:           flow.TaskFn(botanist.CleanupOrphanedDNSRecordSecrets),
-			Dependencies: flow.NewTaskIDs(deployInternalDomainDNSRecord, deployExternalDomainDNSRecord, deployOwnerDomainDNSRecord, deployIngressDomainDNSRecord)})
-
+			Dependencies: flow.NewTaskIDs(deployInternalDomainDNSRecord, deployExternalDomainDNSRecord, deployOwnerDomainDNSRecord, deployIngressDomainDNSRecord)
+		})
 		_ = g.Add(flow.Task{
 			Name:         "Deploying additional DNS providers",
 			Fn:           flow.TaskFn(botanist.DeployAdditionalDNSProviders).DoIf(!o.Shoot.HibernationEnabled),

--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -459,7 +459,7 @@ func (r *shootReconciler) runReconcileShootFlow(ctx context.Context, o *operatio
 		_ = g.Add(flow.Task{
 			Name:         "Cleaning up orphaned DNSRecord secrets",
 			Fn:           flow.TaskFn(botanist.CleanupOrphanedDNSRecordSecrets),
-			Dependencies: flow.NewTaskIDs(deployInternalDomainDNSRecord, deployExternalDomainDNSRecord, deployOwnerDomainDNSRecord, deployIngressDomainDNSRecord)
+			Dependencies: flow.NewTaskIDs(deployInternalDomainDNSRecord, deployExternalDomainDNSRecord, deployOwnerDomainDNSRecord, deployIngressDomainDNSRecord),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Deploying additional DNS providers",

--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -141,7 +141,7 @@ func (b *Botanist) NeedsIngressDNS() bool {
 func (b *Botanist) DefaultIngressDNSRecord() extensionsdnsrecord.Interface {
 	values := &extensionsdnsrecord.Values{
 		Name:       b.Shoot.GetInfo().Name + "-" + common.ShootDNSIngressName,
-		SecretName: "dnsrecord-" + b.Shoot.GetInfo().Name + "-" + DNSExternalName,
+		SecretName: DNSRecordSecretPrefix + "-" + b.Shoot.GetInfo().Name + "-" + DNSExternalName,
 		Namespace:  b.Shoot.SeedNamespace,
 		TTL:        b.Config.Controllers.Shoot.DNSEntryTTLSeconds,
 	}

--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -141,7 +141,7 @@ func (b *Botanist) NeedsIngressDNS() bool {
 func (b *Botanist) DefaultIngressDNSRecord() extensionsdnsrecord.Interface {
 	values := &extensionsdnsrecord.Values{
 		Name:       b.Shoot.GetInfo().Name + "-" + common.ShootDNSIngressName,
-		SecretName: b.Shoot.GetInfo().Name + "-" + DNSExternalName,
+		SecretName: "dnsrecord-" + b.Shoot.GetInfo().Name + "-" + DNSExternalName,
 		Namespace:  b.Shoot.SeedNamespace,
 		TTL:        b.Config.Controllers.Shoot.DNSEntryTTLSeconds,
 	}

--- a/pkg/operation/botanist/addons_test.go
+++ b/pkg/operation/botanist/addons_test.go
@@ -287,7 +287,7 @@ var _ = Describe("addons", func() {
 						Type: externalProvider,
 					},
 					SecretRef: corev1.SecretReference{
-						Name:      shootName + "-" + DNSExternalName,
+						Name:      "dnsrecord-" + shootName + "-" + DNSExternalName,
 						Namespace: seedNamespace,
 					},
 					Zone:       pointer.String(externalZone),
@@ -299,7 +299,7 @@ var _ = Describe("addons", func() {
 			}))
 
 			secret := &corev1.Secret{}
-			err = client.Get(ctx, types.NamespacedName{Name: shootName + "-" + DNSExternalName, Namespace: seedNamespace}, secret)
+			err = client.Get(ctx, types.NamespacedName{Name: "dnsrecord-" + shootName + "-" + DNSExternalName, Namespace: seedNamespace}, secret)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(secret).To(DeepDerivativeEqual(&corev1.Secret{
 				TypeMeta: metav1.TypeMeta{
@@ -307,7 +307,7 @@ var _ = Describe("addons", func() {
 					APIVersion: "v1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:            shootName + "-" + DNSExternalName,
+					Name:            "dnsrecord-" + shootName + "-" + DNSExternalName,
 					Namespace:       seedNamespace,
 					ResourceVersion: "1",
 				},

--- a/pkg/operation/botanist/addons_test.go
+++ b/pkg/operation/botanist/addons_test.go
@@ -58,7 +58,9 @@ import (
 var _ = Describe("addons", func() {
 
 	var (
-		ctrl *gomock.Controller
+		shootName     = "testShoot"
+		seedNamespace = "shoot--foo--bar"
+		ctrl          *gomock.Controller
 
 		scheme *runtime.Scheme
 		client client.Client

--- a/pkg/operation/botanist/addons_test.go
+++ b/pkg/operation/botanist/addons_test.go
@@ -287,7 +287,7 @@ var _ = Describe("addons", func() {
 						Type: externalProvider,
 					},
 					SecretRef: corev1.SecretReference{
-						Name:      "dnsrecord-" + shootName + "-" + DNSExternalName,
+						Name:      DNSRecordSecretPrefix + "-" + shootName + "-" + DNSExternalName,
 						Namespace: seedNamespace,
 					},
 					Zone:       pointer.String(externalZone),
@@ -299,7 +299,7 @@ var _ = Describe("addons", func() {
 			}))
 
 			secret := &corev1.Secret{}
-			err = client.Get(ctx, types.NamespacedName{Name: "dnsrecord-" + shootName + "-" + DNSExternalName, Namespace: seedNamespace}, secret)
+			err = client.Get(ctx, types.NamespacedName{Name: DNSRecordSecretPrefix + "-" + shootName + "-" + DNSExternalName, Namespace: seedNamespace}, secret)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(secret).To(DeepDerivativeEqual(&corev1.Secret{
 				TypeMeta: metav1.TypeMeta{
@@ -307,7 +307,7 @@ var _ = Describe("addons", func() {
 					APIVersion: "v1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:            "dnsrecord-" + shootName + "-" + DNSExternalName,
+					Name:            DNSRecordSecretPrefix + "-" + shootName + "-" + DNSExternalName,
 					Namespace:       seedNamespace,
 					ResourceVersion: "1",
 				},

--- a/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord.go
+++ b/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord.go
@@ -64,10 +64,9 @@ type Values struct {
 	Name string
 	// SecretName is the name of the secret referenced by the DNSRecord resource.
 	SecretName string
-	// ReconcileOnValueChangeOnly specifies that the DNSRecord resource should only be created and only reconciled when Values are changed.
-	// If Values didn't change, it is still updated with the timestamp annotation on Deploy.
-	// This mode is used for owner DNS records to avoid competing reconciliations during controlplane migrations.
-	ReconcileOnValueChangeOnly bool
+	// ReconcileOnChange specifies that the DNSRecord resource should only be reconciled when first created or if its desired state has changed compared to the current one.
+	// This mode is used for owner DNS records to avoid competing reconciliations during the control plane migration "bad case" scenario.
+	ReconcileOnChange bool
 	// Type is the type of the DNSRecord provider.
 	Type string
 	// SecretData is the secret data of the DNSRecord (containing provider credentials, etc.)
@@ -165,7 +164,7 @@ func (c *dnsRecord) deploy(ctx context.Context, operation string) (extensionsv1a
 		return nil
 	}
 
-	if c.values.ReconcileOnValueChangeOnly {
+	if c.values.ReconcileOnChange {
 		if err := c.client.Get(ctx, client.ObjectKeyFromObject(c.dnsRecord), c.dnsRecord); err != nil {
 			if !apierrors.IsNotFound(err) {
 				return nil, err

--- a/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord.go
+++ b/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord.go
@@ -182,6 +182,7 @@ func (c *dnsRecord) deploy(ctx context.Context, operation string) (extensionsv1a
 				// If the DNSRecord is not yet Succeeded, reconcile it again.
 				_ = mutateFn()
 			} else {
+				// TODO (voelzmo) remove this when all DNSRecord secrets have migrated to a prefixed version
 				// Check if we need to migrate the referenced secret
 				if !strings.HasPrefix(c.dnsRecord.Spec.SecretRef.Name, "dnsrecord-") {
 					c.dnsRecord.Spec.SecretRef.Name = fmt.Sprintf("dnsrecord-%s", c.dnsRecord.Spec.SecretRef.Name)

--- a/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord.go
+++ b/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord.go
@@ -180,7 +180,7 @@ func (c *dnsRecord) deploy(ctx context.Context, operation string) (extensionsv1a
 			if c.dnsRecord.Status.LastOperation != nil && c.dnsRecord.Status.LastOperation.State != gardencorev1beta1.LastOperationStateSucceeded {
 				// If the DNSRecord is not yet Succeeded, reconcile it again.
 				_ = mutateFn()
-			} else if c.ValuesHaveChanged() {
+			} else if c.valuesDontMatchDNSRecord() {
 				_ = mutateFn()
 			} else {
 				// Otherwise, just update the timestamp annotation.
@@ -279,7 +279,7 @@ func (c *dnsRecord) SetValues(values []string) {
 	c.values.Values = values
 }
 
-func (c *dnsRecord) ValuesHaveChanged() bool {
+func (c *dnsRecord) valuesDontMatchDNSRecord() bool {
 	return c.values.SecretName != c.dnsRecord.Spec.SecretRef.Name ||
 		!pointer.StringEqual(c.values.Zone, c.dnsRecord.Spec.Zone) ||
 		c.values.DNSName != c.dnsRecord.Spec.Name ||

--- a/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord.go
+++ b/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord.go
@@ -62,10 +62,10 @@ type Values struct {
 	Name string
 	// SecretName is the name of the secret referenced by the DNSRecord resource.
 	SecretName string
-	// ReconcileOnce specifies that the DNSRecord resource should only be created and never reconciled after that again.
-	// However, on Deploy it is still updated with the timestamp annotation.
-	// This mode is used for owner DNS records.
-	ReconcileOnce bool
+	// ReconcileOnValueChangeOnly specifies that the DNSRecord resource should only be created and only reconciled when Values are changed.
+	// If Values didn't change, it is still updated with the timestamp annotation on Deploy.
+	// This mode is used for owner DNS records to avoid competing reconciliations during controlplane migrations.
+	ReconcileOnValueChangeOnly bool
 	// Type is the type of the DNSRecord provider.
 	Type string
 	// SecretData is the secret data of the DNSRecord (containing provider credentials, etc.)
@@ -163,7 +163,7 @@ func (c *dnsRecord) deploy(ctx context.Context, operation string) (extensionsv1a
 		return nil
 	}
 
-	if c.values.ReconcileOnce {
+	if c.values.ReconcileOnValueChangeOnly {
 		if err := c.client.Get(ctx, client.ObjectKeyFromObject(c.dnsRecord), c.dnsRecord); err != nil {
 			if !apierrors.IsNotFound(err) {
 				return nil, err

--- a/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord.go
+++ b/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord.go
@@ -23,6 +23,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
@@ -281,9 +282,9 @@ func (c *dnsRecord) SetValues(values []string) {
 
 func (c *dnsRecord) ValuesHaveChanged() bool {
 	return c.values.DNSName != c.dnsRecord.Spec.Name ||
-		*c.values.Zone != *c.dnsRecord.Spec.Zone ||
+		!pointer.StringEqual(c.values.Zone, c.dnsRecord.Spec.Zone) ||
 		c.values.RecordType != c.dnsRecord.Spec.RecordType ||
-		*c.values.TTL != *c.dnsRecord.Spec.TTL ||
+		!pointer.Int64Equal(c.values.TTL, c.dnsRecord.Spec.TTL) ||
 		!reflect.DeepEqual(c.values.Values, c.dnsRecord.Spec.Values) ||
 		c.secret.Name != c.dnsRecord.Spec.SecretRef.Name ||
 		c.values.Type != c.dnsRecord.Spec.Type

--- a/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord.go
+++ b/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord.go
@@ -282,7 +282,6 @@ func (c *dnsRecord) SetValues(values []string) {
 func (c *dnsRecord) valuesDontMatchDNSRecord() bool {
 	return c.values.SecretName != c.dnsRecord.Spec.SecretRef.Name ||
 		!pointer.StringEqual(c.values.Zone, c.dnsRecord.Spec.Zone) ||
-		c.values.DNSName != c.dnsRecord.Spec.Name ||
 		!reflect.DeepEqual(c.values.Values, c.dnsRecord.Spec.Values) ||
 		!pointer.Int64Equal(c.values.TTL, c.dnsRecord.Spec.TTL)
 }

--- a/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord.go
+++ b/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord.go
@@ -32,7 +32,6 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/extensions"
-	"github.com/gardener/gardener/pkg/operation/botanist"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 )
 
@@ -185,8 +184,8 @@ func (c *dnsRecord) deploy(ctx context.Context, operation string) (extensionsv1a
 			} else {
 				// TODO (voelzmo) remove this when all DNSRecord secrets have migrated to a prefixed version
 				// Check if we need to migrate the referenced secret
-				if !strings.HasPrefix(c.dnsRecord.Spec.SecretRef.Name, botanist.DNSRecordSecretPrefix) {
-					c.dnsRecord.Spec.SecretRef.Name = fmt.Sprintf("%s-%s", botanist.DNSRecordSecretPrefix, c.dnsRecord.Spec.SecretRef.Name)
+				if !strings.HasPrefix(c.dnsRecord.Spec.SecretRef.Name, "dnsrecord-") {
+					c.dnsRecord.Spec.SecretRef.Name = fmt.Sprintf("dnsrecord-%s", c.dnsRecord.Spec.SecretRef.Name)
 				}
 				// Otherwise, just update the timestamp annotation.
 				// If the object is still annotated with the operation annotation (e.g. not reconciled yet) this will send a watch

--- a/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord.go
+++ b/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord.go
@@ -185,8 +185,8 @@ func (c *dnsRecord) deploy(ctx context.Context, operation string) (extensionsv1a
 			} else {
 				// TODO (voelzmo) remove this when all DNSRecord secrets have migrated to a prefixed version
 				// Check if we need to migrate the referenced secret
-				if !strings.HasPrefix(c.dnsRecord.Spec.SecretRef.Name, "dnsrecord-") {
-					c.dnsRecord.Spec.SecretRef.Name = fmt.Sprintf("dnsrecord-%s", c.dnsRecord.Spec.SecretRef.Name)
+				if !strings.HasPrefix(c.dnsRecord.Spec.SecretRef.Name, botanist.DNSRecordSecretPrefix) {
+					c.dnsRecord.Spec.SecretRef.Name = fmt.Sprintf("%s-%s", botanist.DNSRecordSecretPrefix, c.dnsRecord.Spec.SecretRef.Name)
 				}
 				// Otherwise, just update the timestamp annotation.
 				// If the object is still annotated with the operation annotation (e.g. not reconciled yet) this will send a watch

--- a/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord.go
+++ b/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord.go
@@ -281,11 +281,9 @@ func (c *dnsRecord) SetValues(values []string) {
 }
 
 func (c *dnsRecord) ValuesHaveChanged() bool {
-	return c.values.DNSName != c.dnsRecord.Spec.Name ||
+	return c.values.SecretName != c.dnsRecord.Spec.SecretRef.Name ||
 		!pointer.StringEqual(c.values.Zone, c.dnsRecord.Spec.Zone) ||
-		c.values.RecordType != c.dnsRecord.Spec.RecordType ||
-		!pointer.Int64Equal(c.values.TTL, c.dnsRecord.Spec.TTL) ||
+		c.values.DNSName != c.dnsRecord.Spec.Name ||
 		!reflect.DeepEqual(c.values.Values, c.dnsRecord.Spec.Values) ||
-		c.secret.Name != c.dnsRecord.Spec.SecretRef.Name ||
-		c.values.Type != c.dnsRecord.Spec.Type
+		!pointer.Int64Equal(c.values.TTL, c.dnsRecord.Spec.TTL)
 }

--- a/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord.go
+++ b/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 	"time"
 
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -28,10 +27,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/extensions"
+	"github.com/gardener/gardener/pkg/operation/botanist"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 )
 

--- a/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord.go
+++ b/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord.go
@@ -16,8 +16,6 @@ package dnsrecord
 
 import (
 	"context"
-	"fmt"
-	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -182,10 +180,11 @@ func (c *dnsRecord) deploy(ctx context.Context, operation string) (extensionsv1a
 				// If the DNSRecord is not yet Succeeded, reconcile it again.
 				_ = mutateFn()
 			} else {
-				// TODO (voelzmo) remove this when all DNSRecord secrets have migrated to a prefixed version
+				// TODO (voelzmo): remove this when all DNSRecord secrets have migrated to a prefixed version
 				// Check if we need to migrate the referenced secret
-				if !strings.HasPrefix(c.dnsRecord.Spec.SecretRef.Name, "dnsrecord-") {
-					c.dnsRecord.Spec.SecretRef.Name = fmt.Sprintf("dnsrecord-%s", c.dnsRecord.Spec.SecretRef.Name)
+				if c.dnsRecord.Spec.SecretRef.Name != c.secret.Name {
+					metav1.SetMetaDataAnnotation(&c.dnsRecord.ObjectMeta, v1beta1constants.GardenerOperation, operation)
+					c.dnsRecord.Spec.SecretRef.Name = c.secret.Name
 				}
 				// Otherwise, just update the timestamp annotation.
 				// If the object is still annotated with the operation annotation (e.g. not reconciled yet) this will send a watch

--- a/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord.go
+++ b/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord.go
@@ -16,6 +16,8 @@ package dnsrecord
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -180,6 +182,10 @@ func (c *dnsRecord) deploy(ctx context.Context, operation string) (extensionsv1a
 				// If the DNSRecord is not yet Succeeded, reconcile it again.
 				_ = mutateFn()
 			} else {
+				// Check if we need to migrate the referenced secret
+				if !strings.HasPrefix(c.dnsRecord.Spec.SecretRef.Name, "dnsrecord-") {
+					c.dnsRecord.Spec.SecretRef.Name = fmt.Sprintf("dnsrecord-%s", c.dnsRecord.Spec.SecretRef.Name)
+				}
 				// Otherwise, just update the timestamp annotation.
 				// If the object is still annotated with the operation annotation (e.g. not reconciled yet) this will send a watch
 				// event to the extension controller triggering a new reconciliation.

--- a/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord_test.go
+++ b/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord_test.go
@@ -50,7 +50,6 @@ import (
 const (
 	name                = "foo"
 	namespace           = "shoot--foo--bar"
-	secretName          = "testsecret"
 	extensionType       = "provider"
 	zone                = "zone"
 	dnsName             = "foo.bar.external.example.com"
@@ -60,7 +59,8 @@ const (
 
 var _ = Describe("DNSRecord", func() {
 	var (
-		ctrl *gomock.Controller
+		secretName string
+		ctrl       *gomock.Controller
 
 		c client.Client
 
@@ -81,6 +81,7 @@ var _ = Describe("DNSRecord", func() {
 	)
 
 	BeforeEach(func() {
+		secretName = "dnsrecord-testsecret"
 		ctrl = gomock.NewController(GinkgoT())
 
 		scheme := runtime.NewScheme()
@@ -102,6 +103,9 @@ var _ = Describe("DNSRecord", func() {
 			Values:     []string{address},
 			TTL:        pointer.Int64(ttl),
 		}
+	})
+
+	JustBeforeEach(func() {
 		dnsRecord = dnsrecord.New(log, c, values, dnsrecord.DefaultInterval, dnsrecord.DefaultSevereThreshold, dnsrecord.DefaultTimeout)
 
 		dns = &extensionsv1alpha1.DNSRecord{

--- a/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord_test.go
+++ b/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord_test.go
@@ -373,48 +373,6 @@ var _ = Describe("DNSRecord", func() {
 				})
 			})
 			Context("when dnsrecord values change", func() {
-				It("should reconcile when DNSName changes", func() {
-					delete(dns.Annotations, v1beta1constants.GardenerOperation)
-					// set old timestamp (e.g. added on creation / earlier Deploy call)
-					metav1.SetMetaDataAnnotation(&dns.ObjectMeta, v1beta1constants.GardenerTimestamp, now.UTC().Add(-time.Second).String())
-					Expect(c.Create(ctx, dns)).To(Succeed())
-
-					values.DNSName = "new-dnsname"
-					Expect(dnsRecord.Deploy(ctx)).To(Succeed())
-
-					deployedDNS := &extensionsv1alpha1.DNSRecord{}
-					err := c.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, deployedDNS)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(deployedDNS).To(DeepEqual(&extensionsv1alpha1.DNSRecord{
-						TypeMeta: metav1.TypeMeta{
-							APIVersion: extensionsv1alpha1.SchemeGroupVersion.String(),
-							Kind:       extensionsv1alpha1.DNSRecordResource,
-						},
-						ObjectMeta: metav1.ObjectMeta{
-							Name:            name,
-							Namespace:       namespace,
-							ResourceVersion: "2",
-							Annotations: map[string]string{
-								v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
-								v1beta1constants.GardenerTimestamp: now.UTC().String(),
-							},
-						},
-						Spec: extensionsv1alpha1.DNSRecordSpec{
-							DefaultSpec: extensionsv1alpha1.DefaultSpec{
-								Type: extensionType,
-							},
-							SecretRef: corev1.SecretReference{
-								Name:      secretName,
-								Namespace: namespace,
-							},
-							Zone:       pointer.String(zone),
-							Name:       "new-dnsname",
-							RecordType: extensionsv1alpha1.DNSRecordTypeA,
-							Values:     []string{address},
-							TTL:        pointer.Int64(ttl),
-						},
-					}))
-				})
 				It("should reconcile when zone changes", func() {
 					delete(dns.Annotations, v1beta1constants.GardenerOperation)
 					// set old timestamp (e.g. added on creation / earlier Deploy call)
@@ -457,13 +415,13 @@ var _ = Describe("DNSRecord", func() {
 						},
 					}))
 				})
-				It("should reconcile when RecordType changes", func() {
+				It("should reconcile when DNSName changes", func() {
 					delete(dns.Annotations, v1beta1constants.GardenerOperation)
 					// set old timestamp (e.g. added on creation / earlier Deploy call)
 					metav1.SetMetaDataAnnotation(&dns.ObjectMeta, v1beta1constants.GardenerTimestamp, now.UTC().Add(-time.Second).String())
 					Expect(c.Create(ctx, dns)).To(Succeed())
 
-					values.RecordType = extensionsv1alpha1.DNSRecordTypeTXT
+					values.DNSName = "new-dnsname"
 					Expect(dnsRecord.Deploy(ctx)).To(Succeed())
 
 					deployedDNS := &extensionsv1alpha1.DNSRecord{}
@@ -492,91 +450,7 @@ var _ = Describe("DNSRecord", func() {
 								Namespace: namespace,
 							},
 							Zone:       pointer.String(zone),
-							Name:       dnsName,
-							RecordType: extensionsv1alpha1.DNSRecordTypeTXT,
-							Values:     []string{address},
-							TTL:        pointer.Int64(ttl),
-						},
-					}))
-				})
-				It("should reconcile when TTL changes", func() {
-					delete(dns.Annotations, v1beta1constants.GardenerOperation)
-					// set old timestamp (e.g. added on creation / earlier Deploy call)
-					metav1.SetMetaDataAnnotation(&dns.ObjectMeta, v1beta1constants.GardenerTimestamp, now.UTC().Add(-time.Second).String())
-					Expect(c.Create(ctx, dns)).To(Succeed())
-
-					values.TTL = pointer.Int64(1337)
-					Expect(dnsRecord.Deploy(ctx)).To(Succeed())
-
-					deployedDNS := &extensionsv1alpha1.DNSRecord{}
-					err := c.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, deployedDNS)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(deployedDNS).To(DeepEqual(&extensionsv1alpha1.DNSRecord{
-						TypeMeta: metav1.TypeMeta{
-							APIVersion: extensionsv1alpha1.SchemeGroupVersion.String(),
-							Kind:       extensionsv1alpha1.DNSRecordResource,
-						},
-						ObjectMeta: metav1.ObjectMeta{
-							Name:            name,
-							Namespace:       namespace,
-							ResourceVersion: "2",
-							Annotations: map[string]string{
-								v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
-								v1beta1constants.GardenerTimestamp: now.UTC().String(),
-							},
-						},
-						Spec: extensionsv1alpha1.DNSRecordSpec{
-							DefaultSpec: extensionsv1alpha1.DefaultSpec{
-								Type: extensionType,
-							},
-							SecretRef: corev1.SecretReference{
-								Name:      secretName,
-								Namespace: namespace,
-							},
-							Zone:       pointer.String(zone),
-							Name:       dnsName,
-							RecordType: extensionsv1alpha1.DNSRecordTypeA,
-							Values:     []string{address},
-							TTL:        pointer.Int64(1337),
-						},
-					}))
-				})
-				It("should reconcile when Provider Type changes", func() {
-					delete(dns.Annotations, v1beta1constants.GardenerOperation)
-					// set old timestamp (e.g. added on creation / earlier Deploy call)
-					metav1.SetMetaDataAnnotation(&dns.ObjectMeta, v1beta1constants.GardenerTimestamp, now.UTC().Add(-time.Second).String())
-					Expect(c.Create(ctx, dns)).To(Succeed())
-
-					values.Type = "new-provider"
-					Expect(dnsRecord.Deploy(ctx)).To(Succeed())
-
-					deployedDNS := &extensionsv1alpha1.DNSRecord{}
-					err := c.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, deployedDNS)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(deployedDNS).To(DeepEqual(&extensionsv1alpha1.DNSRecord{
-						TypeMeta: metav1.TypeMeta{
-							APIVersion: extensionsv1alpha1.SchemeGroupVersion.String(),
-							Kind:       extensionsv1alpha1.DNSRecordResource,
-						},
-						ObjectMeta: metav1.ObjectMeta{
-							Name:            name,
-							Namespace:       namespace,
-							ResourceVersion: "2",
-							Annotations: map[string]string{
-								v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
-								v1beta1constants.GardenerTimestamp: now.UTC().String(),
-							},
-						},
-						Spec: extensionsv1alpha1.DNSRecordSpec{
-							DefaultSpec: extensionsv1alpha1.DefaultSpec{
-								Type: "new-provider",
-							},
-							SecretRef: corev1.SecretReference{
-								Name:      secretName,
-								Namespace: namespace,
-							},
-							Zone:       pointer.String(zone),
-							Name:       dnsName,
+							Name:       "new-dnsname",
 							RecordType: extensionsv1alpha1.DNSRecordTypeA,
 							Values:     []string{address},
 							TTL:        pointer.Int64(ttl),
@@ -622,6 +496,48 @@ var _ = Describe("DNSRecord", func() {
 							RecordType: extensionsv1alpha1.DNSRecordTypeA,
 							Values:     []string{"8.8.8.8"},
 							TTL:        pointer.Int64(ttl),
+						},
+					}))
+				})
+				It("should reconcile when TTL changes", func() {
+					delete(dns.Annotations, v1beta1constants.GardenerOperation)
+					// set old timestamp (e.g. added on creation / earlier Deploy call)
+					metav1.SetMetaDataAnnotation(&dns.ObjectMeta, v1beta1constants.GardenerTimestamp, now.UTC().Add(-time.Second).String())
+					Expect(c.Create(ctx, dns)).To(Succeed())
+
+					values.TTL = pointer.Int64(1337)
+					Expect(dnsRecord.Deploy(ctx)).To(Succeed())
+
+					deployedDNS := &extensionsv1alpha1.DNSRecord{}
+					err := c.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, deployedDNS)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(deployedDNS).To(DeepEqual(&extensionsv1alpha1.DNSRecord{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: extensionsv1alpha1.SchemeGroupVersion.String(),
+							Kind:       extensionsv1alpha1.DNSRecordResource,
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:            name,
+							Namespace:       namespace,
+							ResourceVersion: "2",
+							Annotations: map[string]string{
+								v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
+								v1beta1constants.GardenerTimestamp: now.UTC().String(),
+							},
+						},
+						Spec: extensionsv1alpha1.DNSRecordSpec{
+							DefaultSpec: extensionsv1alpha1.DefaultSpec{
+								Type: extensionType,
+							},
+							SecretRef: corev1.SecretReference{
+								Name:      secretName,
+								Namespace: namespace,
+							},
+							Zone:       pointer.String(zone),
+							Name:       dnsName,
+							RecordType: extensionsv1alpha1.DNSRecordTypeA,
+							Values:     []string{address},
+							TTL:        pointer.Int64(1337),
 						},
 					}))
 				})

--- a/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord_test.go
+++ b/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord_test.go
@@ -244,7 +244,7 @@ var _ = Describe("DNSRecord", func() {
 				expectedDNSRecord.ResourceVersion = "2"
 			})
 
-			It("should deploy the DNSRecord resource if ReconcileOnChange is true and the DNSRecord is not found", func() {
+			It("should deploy the DNSRecord resource if the DNSRecord is not found", func() {
 				expectedDNSRecord.ResourceVersion = "1"
 
 				Expect(dnsRecord.Deploy(ctx)).To(Succeed())
@@ -255,7 +255,7 @@ var _ = Describe("DNSRecord", func() {
 				Expect(deployedDNS).To(DeepEqual(expectedDNSRecord))
 			})
 
-			It("should deploy the DNSRecord resource if ReconcileOnChange is true and the DNSRecord is not Succeeded", func() {
+			It("should deploy the DNSRecord resource if the DNSRecord is not Succeeded", func() {
 				existingDNS := dns.DeepCopy()
 				delete(existingDNS.Annotations, v1beta1constants.GardenerOperation)
 				metav1.SetMetaDataAnnotation(&existingDNS.ObjectMeta, v1beta1constants.GardenerTimestamp, now.UTC().Add(-time.Second).String())
@@ -280,7 +280,7 @@ var _ = Describe("DNSRecord", func() {
 				Expect(deployedDNS).To(DeepEqual(expectedDNSRecord))
 			})
 
-			It("should only update the timestamp annotation if ReconcileOnChange is true and the DNSRecord exists with the same values", func() {
+			It("should only update the timestamp annotation if the DNSRecord exists with the same values", func() {
 				delete(dns.Annotations, v1beta1constants.GardenerOperation)
 				// set old timestamp (e.g. added on creation / earlier Deploy call)
 				metav1.SetMetaDataAnnotation(&dns.ObjectMeta, v1beta1constants.GardenerTimestamp, now.UTC().Add(-time.Second).String())
@@ -298,7 +298,7 @@ var _ = Describe("DNSRecord", func() {
 				Expect(deployedDNS).To(DeepEqual(expectedDNSRecord))
 			})
 
-			table.DescribeTable("DNSRecord is reconciled when desired values differ from actual values", func(modifyValues func(), modifyExpected func()) {
+			table.DescribeTable("should reconcile the DNSRecord if desired values differ from current state", func(modifyValues func(), modifyExpected func()) {
 				delete(dns.Annotations, v1beta1constants.GardenerOperation)
 				// set old timestamp (e.g. added on creation / earlier Deploy call)
 				metav1.SetMetaDataAnnotation(&dns.ObjectMeta, v1beta1constants.GardenerTimestamp, now.UTC().Add(-time.Second).String())

--- a/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord_test.go
+++ b/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord_test.go
@@ -626,6 +626,54 @@ var _ = Describe("DNSRecord", func() {
 					}))
 				})
 			})
+
+			Context("when zone is nil", func() {
+				BeforeEach(func() {
+					values.Zone = nil
+				})
+
+				It("should not fail", func() {
+					delete(dns.Annotations, v1beta1constants.GardenerOperation)
+					// set old timestamp (e.g. added on creation / earlier Deploy call)
+					metav1.SetMetaDataAnnotation(&dns.ObjectMeta, v1beta1constants.GardenerTimestamp, now.UTC().Add(-time.Second).String())
+					Expect(c.Create(ctx, dns)).To(Succeed())
+
+					Expect(dnsRecord.Deploy(ctx)).To(Succeed())
+
+					deployedDNS := &extensionsv1alpha1.DNSRecord{}
+					err := c.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, deployedDNS)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(deployedDNS).To(DeepEqual(&extensionsv1alpha1.DNSRecord{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: extensionsv1alpha1.SchemeGroupVersion.String(),
+							Kind:       extensionsv1alpha1.DNSRecordResource,
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:            name,
+							Namespace:       namespace,
+							ResourceVersion: "2",
+							Annotations: map[string]string{
+								v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
+								v1beta1constants.GardenerTimestamp: now.UTC().String(),
+							},
+						},
+						Spec: extensionsv1alpha1.DNSRecordSpec{
+							DefaultSpec: extensionsv1alpha1.DefaultSpec{
+								Type: extensionType,
+							},
+							SecretRef: corev1.SecretReference{
+								Name:      secretName,
+								Namespace: namespace,
+							},
+							Zone:       nil,
+							Name:       dnsName,
+							RecordType: extensionsv1alpha1.DNSRecordTypeA,
+							Values:     []string{address},
+							TTL:        pointer.Int64(ttl),
+						},
+					}))
+				})
+			})
 		})
 
 	})

--- a/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord_test.go
+++ b/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord_test.go
@@ -223,8 +223,8 @@ var _ = Describe("DNSRecord", func() {
 			Expect(dnsRecord.Deploy(ctx)).To(MatchError(testErr))
 		})
 
-		It("should deploy the DNSRecord resource if ReconcileOnce is true and the DNSRecord is not found", func() {
-			values.ReconcileOnce = true
+		It("should deploy the DNSRecord resource if ReconcileOnValueChangeOnly is true and the DNSRecord is not found", func() {
+			values.ReconcileOnValueChangeOnly = true
 			dnsRecord = dnsrecord.New(log, c, values, dnsrecord.DefaultInterval, dnsrecord.DefaultSevereThreshold, dnsrecord.DefaultTimeout)
 
 			Expect(dnsRecord.Deploy(ctx)).To(Succeed())
@@ -250,8 +250,8 @@ var _ = Describe("DNSRecord", func() {
 			}))
 		})
 
-		It("should deploy the DNSRecord resource if ReconcileOnce is true and the DNSRecord is not Succeeded", func() {
-			values.ReconcileOnce = true
+		It("should deploy the DNSRecord resource if ReconcileOnValueChangeOnly is true and the DNSRecord is not Succeeded", func() {
+			values.ReconcileOnValueChangeOnly = true
 			dnsRecord = dnsrecord.New(log, c, values, dnsrecord.DefaultInterval, dnsrecord.DefaultSevereThreshold, dnsrecord.DefaultTimeout)
 
 			existingDNS := dns.DeepCopy()
@@ -293,8 +293,8 @@ var _ = Describe("DNSRecord", func() {
 			}))
 		})
 
-		It("should update the timestamp annotation if ReconcileOnce is true and the DNSRecord is found", func() {
-			values.ReconcileOnce = true
+		It("should update the timestamp annotation if ReconcileOnValueChangeOnly is true and the DNSRecord is found", func() {
+			values.ReconcileOnValueChangeOnly = true
 			dnsRecord = dnsrecord.New(log, c, values, dnsrecord.DefaultInterval, dnsrecord.DefaultSevereThreshold, dnsrecord.DefaultTimeout)
 			delete(dns.Annotations, v1beta1constants.GardenerOperation)
 			// set old timestamp (e.g. added on creation / earlier Deploy call)
@@ -329,8 +329,8 @@ var _ = Describe("DNSRecord", func() {
 				secretName = "testsecret"
 			})
 
-			It("should prefix the referenced secret of existing DNSRecords with 'dnsrecord-' when ReconcileOnce is true", func() {
-				values.ReconcileOnce = true
+			It("should prefix the referenced secret of existing DNSRecords with 'dnsrecord-' when ReconcileOnValueChangeOnly is true", func() {
+				values.ReconcileOnValueChangeOnly = true
 				dnsRecord = dnsrecord.New(log, c, values, dnsrecord.DefaultInterval, dnsrecord.DefaultSevereThreshold, dnsrecord.DefaultTimeout)
 				delete(dns.Annotations, v1beta1constants.GardenerOperation)
 				// set old timestamp (e.g. added on creation / earlier Deploy call)

--- a/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord_test.go
+++ b/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord_test.go
@@ -221,11 +221,11 @@ var _ = Describe("DNSRecord", func() {
 			Expect(dnsRecord.Deploy(ctx)).To(MatchError(testErr))
 		})
 
-		Context("When ReconcileOnValueChangeOnly is true", func() {
+		Context("When ReconcileOnChange is true", func() {
 			var expectedDNSRecord *extensionsv1alpha1.DNSRecord
 
 			BeforeEach(func() {
-				values.ReconcileOnValueChangeOnly = true
+				values.ReconcileOnChange = true
 
 				expectedDNSRecord = &extensionsv1alpha1.DNSRecord{
 					TypeMeta: metav1.TypeMeta{
@@ -244,7 +244,7 @@ var _ = Describe("DNSRecord", func() {
 				expectedDNSRecord.ResourceVersion = "2"
 			})
 
-			It("should deploy the DNSRecord resource if ReconcileOnValueChangeOnly is true and the DNSRecord is not found", func() {
+			It("should deploy the DNSRecord resource if ReconcileOnChange is true and the DNSRecord is not found", func() {
 				expectedDNSRecord.ResourceVersion = "1"
 
 				Expect(dnsRecord.Deploy(ctx)).To(Succeed())
@@ -255,7 +255,7 @@ var _ = Describe("DNSRecord", func() {
 				Expect(deployedDNS).To(DeepEqual(expectedDNSRecord))
 			})
 
-			It("should deploy the DNSRecord resource if ReconcileOnValueChangeOnly is true and the DNSRecord is not Succeeded", func() {
+			It("should deploy the DNSRecord resource if ReconcileOnChange is true and the DNSRecord is not Succeeded", func() {
 				existingDNS := dns.DeepCopy()
 				delete(existingDNS.Annotations, v1beta1constants.GardenerOperation)
 				metav1.SetMetaDataAnnotation(&existingDNS.ObjectMeta, v1beta1constants.GardenerTimestamp, now.UTC().Add(-time.Second).String())
@@ -280,7 +280,7 @@ var _ = Describe("DNSRecord", func() {
 				Expect(deployedDNS).To(DeepEqual(expectedDNSRecord))
 			})
 
-			It("should only update the timestamp annotation if ReconcileOnValueChangeOnly is true and the DNSRecord exists with the same values", func() {
+			It("should only update the timestamp annotation if ReconcileOnChange is true and the DNSRecord exists with the same values", func() {
 				delete(dns.Annotations, v1beta1constants.GardenerOperation)
 				// set old timestamp (e.g. added on creation / earlier Deploy call)
 				metav1.SetMetaDataAnnotation(&dns.ObjectMeta, v1beta1constants.GardenerTimestamp, now.UTC().Add(-time.Second).String())

--- a/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord_test.go
+++ b/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord_test.go
@@ -316,8 +316,7 @@ var _ = Describe("DNSRecord", func() {
 			},
 				table.Entry("secretName changes", func() { values.SecretName = "new-secret-name" }, func() { expectedDNSRecord.Spec.SecretRef.Name = "new-secret-name" }),
 				table.Entry("zone changes", func() { values.Zone = pointer.String("new-zone") }, func() { expectedDNSRecord.Spec.Zone = pointer.String("new-zone") }),
-				table.Entry("DNSName changes", func() { values.DNSName = "new-dnsname" }, func() { expectedDNSRecord.Spec.Name = "new-dnsname" }),
-				table.Entry("DNSNameRecord values change", func() { values.Values = []string{"8.8.8.8"} }, func() { expectedDNSRecord.Spec.Values = []string{"8.8.8.8"} }),
+				table.Entry("values changes", func() { values.Values = []string{"8.8.8.8"} }, func() { expectedDNSRecord.Spec.Values = []string{"8.8.8.8"} }),
 				table.Entry("TTL changes", func() { values.TTL = pointer.Int64(1337) }, func() { expectedDNSRecord.Spec.TTL = pointer.Int64(1337) }),
 				table.Entry("zone is nil", func() { values.Zone = nil }, func() { expectedDNSRecord.Spec.Zone = nil }),
 			)

--- a/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord_test.go
+++ b/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord_test.go
@@ -323,7 +323,7 @@ var _ = Describe("DNSRecord", func() {
 			}))
 		})
 
-		// TODO (voelzmo) remove this when all DNSRecord secrets have migrated to a prefixed version
+		// TODO (voelzmo): remove this when all DNSRecord secrets have migrated to a prefixed version
 		Context("when the referenced secret is not prefixed with 'dnsrecord-' yet", func() {
 			BeforeEach(func() {
 				secretName = "testsecret"
@@ -337,6 +337,7 @@ var _ = Describe("DNSRecord", func() {
 				metav1.SetMetaDataAnnotation(&dns.ObjectMeta, v1beta1constants.GardenerTimestamp, now.UTC().Add(-time.Second).String())
 				Expect(c.Create(ctx, dns)).To(Succeed())
 
+				values.SecretName = "dnsrecord-testsecret"
 				Expect(dnsRecord.Deploy(ctx)).To(Succeed())
 
 				deployedDNS := &extensionsv1alpha1.DNSRecord{}
@@ -352,6 +353,7 @@ var _ = Describe("DNSRecord", func() {
 						Namespace:       namespace,
 						ResourceVersion: "2",
 						Annotations: map[string]string{
+							v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
 							v1beta1constants.GardenerTimestamp: now.UTC().String(),
 						},
 					},

--- a/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord_test.go
+++ b/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord_test.go
@@ -323,6 +323,7 @@ var _ = Describe("DNSRecord", func() {
 			}))
 		})
 
+		// TODO (voelzmo) remove this when all DNSRecord secrets have migrated to a prefixed version
 		Context("when the referenced secret is not prefixed with 'dnsrecord-' yet", func() {
 			BeforeEach(func() {
 				secretName = "testsecret"

--- a/pkg/operation/botanist/dns.go
+++ b/pkg/operation/botanist/dns.go
@@ -48,6 +48,8 @@ const (
 	DNSProviderRoleAdditional = "managed-dns-provider"
 	// DNSRealmAnnotation is the annotation key for restricting provider access for shoot DNS entries
 	DNSRealmAnnotation = "dns.gardener.cloud/realms"
+	// DNSRecordSecretPrefix is a constant for prefixing secrets referenced by DNSRecords
+	DNSRecordSecretPrefix = "dnsrecord"
 )
 
 // DeployExternalDNS deploys the external DNSOwner, DNSProvider, and DNSEntry resources.

--- a/pkg/operation/botanist/dnsrecord.go
+++ b/pkg/operation/botanist/dnsrecord.go
@@ -27,7 +27,7 @@ import (
 func (b *Botanist) DefaultExternalDNSRecord() extensionsdnsrecord.Interface {
 	values := &extensionsdnsrecord.Values{
 		Name:       b.Shoot.GetInfo().Name + "-" + DNSExternalName,
-		SecretName: b.Shoot.GetInfo().Name + "-" + DNSExternalName,
+		SecretName: "dnsrecord-" + b.Shoot.GetInfo().Name + "-" + DNSExternalName,
 		Namespace:  b.Shoot.SeedNamespace,
 		TTL:        b.Config.Controllers.Shoot.DNSEntryTTLSeconds,
 	}
@@ -53,7 +53,7 @@ func (b *Botanist) DefaultExternalDNSRecord() extensionsdnsrecord.Interface {
 func (b *Botanist) DefaultInternalDNSRecord() extensionsdnsrecord.Interface {
 	values := &extensionsdnsrecord.Values{
 		Name:       b.Shoot.GetInfo().Name + "-" + DNSInternalName,
-		SecretName: b.Shoot.GetInfo().Name + "-" + DNSInternalName,
+		SecretName: "dnsrecord-" + b.Shoot.GetInfo().Name + "-" + DNSInternalName,
 		Namespace:  b.Shoot.SeedNamespace,
 		TTL:        b.Config.Controllers.Shoot.DNSEntryTTLSeconds,
 	}
@@ -79,7 +79,7 @@ func (b *Botanist) DefaultInternalDNSRecord() extensionsdnsrecord.Interface {
 func (b *Botanist) DefaultOwnerDNSRecord() extensionsdnsrecord.Interface {
 	values := &extensionsdnsrecord.Values{
 		Name:          b.Shoot.GetInfo().Name + "-" + DNSOwnerName,
-		SecretName:    b.Shoot.GetInfo().Name + "-" + DNSInternalName,
+		SecretName:    "dnsrecord-" + b.Shoot.GetInfo().Name + "-" + DNSInternalName,
 		Namespace:     b.Shoot.SeedNamespace,
 		ReconcileOnce: true,
 		TTL:           b.Config.Controllers.Shoot.DNSEntryTTLSeconds,

--- a/pkg/operation/botanist/dnsrecord.go
+++ b/pkg/operation/botanist/dnsrecord.go
@@ -212,9 +212,9 @@ func (b *Botanist) deployOrRestoreDNSRecord(ctx context.Context, dnsRecord compo
 	return dnsRecord.Deploy(ctx)
 }
 
-// TODO (voelzmo) remove this when all DNSRecord secrets have migrated to a prefixed version
 // CleanupOrphanedDNSRecordSecrets cleans up secrets related to DNSRecords which may be orphaned after introducing the 'dnsrecord-' prefix
 func (b *Botanist) CleanupOrphanedDNSRecordSecrets(ctx context.Context) error {
+	// TODO (voelzmo) remove this when all DNSRecord secrets have migrated to a prefixed version
 	var err error
 	shootName := b.Shoot.GetInfo().Name
 	if shootName != "gardener" {

--- a/pkg/operation/botanist/dnsrecord.go
+++ b/pkg/operation/botanist/dnsrecord.go
@@ -214,7 +214,7 @@ func (b *Botanist) deployOrRestoreDNSRecord(ctx context.Context, dnsRecord compo
 
 // CleanupOrphanedDNSRecordSecrets cleans up secrets related to DNSRecords which may be orphaned after introducing the 'dnsrecord-' prefix
 func (b *Botanist) CleanupOrphanedDNSRecordSecrets(ctx context.Context) error {
-	// TODO (voelzmo) remove this when all DNSRecord secrets have migrated to a prefixed version
+	// TODO (voelzmo): remove this when all DNSRecord secrets have migrated to a prefixed version
 	var err error
 	shootName := b.Shoot.GetInfo().Name
 	if shootName != "gardener" {

--- a/pkg/operation/botanist/dnsrecord.go
+++ b/pkg/operation/botanist/dnsrecord.go
@@ -83,11 +83,11 @@ func (b *Botanist) DefaultInternalDNSRecord() extensionsdnsrecord.Interface {
 // DefaultOwnerDNSRecord creates the default deployer for the owner DNSRecord resource.
 func (b *Botanist) DefaultOwnerDNSRecord() extensionsdnsrecord.Interface {
 	values := &extensionsdnsrecord.Values{
-		Name:          b.Shoot.GetInfo().Name + "-" + DNSOwnerName,
-		SecretName:    DNSRecordSecretPrefix + "-" + b.Shoot.GetInfo().Name + "-" + DNSInternalName,
-		Namespace:     b.Shoot.SeedNamespace,
-		ReconcileOnce: true,
-		TTL:           b.Config.Controllers.Shoot.DNSEntryTTLSeconds,
+		Name:                       b.Shoot.GetInfo().Name + "-" + DNSOwnerName,
+		SecretName:                 DNSRecordSecretPrefix + "-" + b.Shoot.GetInfo().Name + "-" + DNSInternalName,
+		Namespace:                  b.Shoot.SeedNamespace,
+		ReconcileOnValueChangeOnly: true,
+		TTL:                        b.Config.Controllers.Shoot.DNSEntryTTLSeconds,
 	}
 	if b.NeedsInternalDNS() {
 		values.Type = b.Garden.InternalDomain.Provider

--- a/pkg/operation/botanist/dnsrecord.go
+++ b/pkg/operation/botanist/dnsrecord.go
@@ -212,6 +212,7 @@ func (b *Botanist) deployOrRestoreDNSRecord(ctx context.Context, dnsRecord compo
 	return dnsRecord.Deploy(ctx)
 }
 
+// TODO (voelzmo) remove this when all DNSRecord secrets have migrated to a prefixed version
 // CleanupOrphanedDNSRecordSecrets cleans up secrets related to DNSRecords which may be orphaned after introducing the 'dnsrecord-' prefix
 func (b *Botanist) CleanupOrphanedDNSRecordSecrets(ctx context.Context) error {
 	var err error

--- a/pkg/operation/botanist/dnsrecord.go
+++ b/pkg/operation/botanist/dnsrecord.go
@@ -83,11 +83,11 @@ func (b *Botanist) DefaultInternalDNSRecord() extensionsdnsrecord.Interface {
 // DefaultOwnerDNSRecord creates the default deployer for the owner DNSRecord resource.
 func (b *Botanist) DefaultOwnerDNSRecord() extensionsdnsrecord.Interface {
 	values := &extensionsdnsrecord.Values{
-		Name:                       b.Shoot.GetInfo().Name + "-" + DNSOwnerName,
-		SecretName:                 DNSRecordSecretPrefix + "-" + b.Shoot.GetInfo().Name + "-" + DNSInternalName,
-		Namespace:                  b.Shoot.SeedNamespace,
-		ReconcileOnValueChangeOnly: true,
-		TTL:                        b.Config.Controllers.Shoot.DNSEntryTTLSeconds,
+		Name:              b.Shoot.GetInfo().Name + "-" + DNSOwnerName,
+		SecretName:        DNSRecordSecretPrefix + "-" + b.Shoot.GetInfo().Name + "-" + DNSInternalName,
+		Namespace:         b.Shoot.SeedNamespace,
+		ReconcileOnChange: true,
+		TTL:               b.Config.Controllers.Shoot.DNSEntryTTLSeconds,
 	}
 	if b.NeedsInternalDNS() {
 		values.Type = b.Garden.InternalDomain.Provider

--- a/pkg/operation/botanist/dnsrecord.go
+++ b/pkg/operation/botanist/dnsrecord.go
@@ -30,7 +30,7 @@ import (
 func (b *Botanist) DefaultExternalDNSRecord() extensionsdnsrecord.Interface {
 	values := &extensionsdnsrecord.Values{
 		Name:       b.Shoot.GetInfo().Name + "-" + DNSExternalName,
-		SecretName: "dnsrecord-" + b.Shoot.GetInfo().Name + "-" + DNSExternalName,
+		SecretName: DNSRecordSecretPrefix + "-" + b.Shoot.GetInfo().Name + "-" + DNSExternalName,
 		Namespace:  b.Shoot.SeedNamespace,
 		TTL:        b.Config.Controllers.Shoot.DNSEntryTTLSeconds,
 	}
@@ -56,7 +56,7 @@ func (b *Botanist) DefaultExternalDNSRecord() extensionsdnsrecord.Interface {
 func (b *Botanist) DefaultInternalDNSRecord() extensionsdnsrecord.Interface {
 	values := &extensionsdnsrecord.Values{
 		Name:       b.Shoot.GetInfo().Name + "-" + DNSInternalName,
-		SecretName: "dnsrecord-" + b.Shoot.GetInfo().Name + "-" + DNSInternalName,
+		SecretName: DNSRecordSecretPrefix + "-" + b.Shoot.GetInfo().Name + "-" + DNSInternalName,
 		Namespace:  b.Shoot.SeedNamespace,
 		TTL:        b.Config.Controllers.Shoot.DNSEntryTTLSeconds,
 	}
@@ -82,7 +82,7 @@ func (b *Botanist) DefaultInternalDNSRecord() extensionsdnsrecord.Interface {
 func (b *Botanist) DefaultOwnerDNSRecord() extensionsdnsrecord.Interface {
 	values := &extensionsdnsrecord.Values{
 		Name:          b.Shoot.GetInfo().Name + "-" + DNSOwnerName,
-		SecretName:    "dnsrecord-" + b.Shoot.GetInfo().Name + "-" + DNSInternalName,
+		SecretName:    DNSRecordSecretPrefix + "-" + b.Shoot.GetInfo().Name + "-" + DNSInternalName,
 		Namespace:     b.Shoot.SeedNamespace,
 		ReconcileOnce: true,
 		TTL:           b.Config.Controllers.Shoot.DNSEntryTTLSeconds,

--- a/pkg/operation/botanist/dnsrecord.go
+++ b/pkg/operation/botanist/dnsrecord.go
@@ -214,11 +214,15 @@ func (b *Botanist) deployOrRestoreDNSRecord(ctx context.Context, dnsRecord compo
 
 // CleanupOrphanedDNSRecordSecrets cleans up secrets related to DNSRecords which may be orphaned after introducing the 'dnsrecord-' prefix
 func (b *Botanist) CleanupOrphanedDNSRecordSecrets(ctx context.Context) error {
-	err := b.K8sSeedClient.Client().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: b.Shoot.GetInfo().Name + "-" + DNSInternalName, Namespace: b.Shoot.SeedNamespace}})
-	if client.IgnoreNotFound(err) != nil {
-		return fmt.Errorf("could not clean up orphaned internal DNSRecord secret: %w", err)
+	var err error
+	shootName := b.Shoot.GetInfo().Name
+	if shootName != "gardener" {
+		err = b.K8sSeedClient.Client().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: shootName + "-" + DNSInternalName, Namespace: b.Shoot.SeedNamespace}})
+		if client.IgnoreNotFound(err) != nil {
+			return fmt.Errorf("could not clean up orphaned internal DNSRecord secret: %w", err)
+		}
 	}
-	err = b.K8sSeedClient.Client().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: b.Shoot.GetInfo().Name + "-" + DNSExternalName, Namespace: b.Shoot.SeedNamespace}})
+	err = b.K8sSeedClient.Client().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: shootName + "-" + DNSExternalName, Namespace: b.Shoot.SeedNamespace}})
 	if client.IgnoreNotFound(err) != nil {
 		return fmt.Errorf("could not clean up orphaned external DNSRecord secret: %w", err)
 	}

--- a/pkg/operation/botanist/dnsrecord.go
+++ b/pkg/operation/botanist/dnsrecord.go
@@ -19,6 +19,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
@@ -212,11 +213,11 @@ func (b *Botanist) deployOrRestoreDNSRecord(ctx context.Context, dnsRecord compo
 
 // CleanupOrphanedDNSRecordSecrets cleans up secrets related to DNSRecords which may be orphaned after introducing the 'dnsrecord-' prefix
 func (b *Botanist) CleanupOrphanedDNSRecordSecrets(ctx context.Context) error {
-	err := b.K8sSeedClient.Client().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: b.Shoot.GetInfo().Name + "-" + DNSInternalName, Namespace: b.Shoot.SeedNamespace}})
+	err := client.IgnoreNotFound(b.K8sSeedClient.Client().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: b.Shoot.GetInfo().Name + "-" + DNSInternalName, Namespace: b.Shoot.SeedNamespace}}))
 	if err != nil {
 		return err
 	}
-	err = b.K8sSeedClient.Client().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: b.Shoot.GetInfo().Name + "-" + DNSExternalName, Namespace: b.Shoot.SeedNamespace}})
+	err = client.IgnoreNotFound(b.K8sSeedClient.Client().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: b.Shoot.GetInfo().Name + "-" + DNSExternalName, Namespace: b.Shoot.SeedNamespace}}))
 	if err != nil {
 		return err
 	}

--- a/pkg/operation/botanist/dnsrecord_test.go
+++ b/pkg/operation/botanist/dnsrecord_test.go
@@ -200,7 +200,7 @@ var _ = Describe("dnsrecord", func() {
 						Type: externalProvider,
 					},
 					SecretRef: corev1.SecretReference{
-						Name:      "dnsrecord-" + shootName + "-" + DNSExternalName,
+						Name:      DNSRecordSecretPrefix + "-" + shootName + "-" + DNSExternalName,
 						Namespace: seedNamespace,
 					},
 					Zone:       pointer.String(externalZone),
@@ -212,7 +212,7 @@ var _ = Describe("dnsrecord", func() {
 			}))
 
 			secret := &corev1.Secret{}
-			err = c.Get(ctx, types.NamespacedName{Name: "dnsrecord-" + shootName + "-" + DNSExternalName, Namespace: seedNamespace}, secret)
+			err = c.Get(ctx, types.NamespacedName{Name: DNSRecordSecretPrefix + "-" + shootName + "-" + DNSExternalName, Namespace: seedNamespace}, secret)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(secret).To(DeepDerivativeEqual(&corev1.Secret{
 				TypeMeta: metav1.TypeMeta{
@@ -220,7 +220,7 @@ var _ = Describe("dnsrecord", func() {
 					APIVersion: "v1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:            "dnsrecord-" + shootName + "-" + DNSExternalName,
+					Name:            DNSRecordSecretPrefix + "-" + shootName + "-" + DNSExternalName,
 					Namespace:       seedNamespace,
 					ResourceVersion: "1",
 				},
@@ -262,7 +262,7 @@ var _ = Describe("dnsrecord", func() {
 						Type: internalProvider,
 					},
 					SecretRef: corev1.SecretReference{
-						Name:      "dnsrecord-" + shootName + "-" + DNSInternalName,
+						Name:      DNSRecordSecretPrefix + "-" + shootName + "-" + DNSInternalName,
 						Namespace: seedNamespace,
 					},
 					Zone:       pointer.String(internalZone),
@@ -274,7 +274,7 @@ var _ = Describe("dnsrecord", func() {
 			}))
 
 			secret := &corev1.Secret{}
-			err = c.Get(ctx, types.NamespacedName{Name: "dnsrecord-" + shootName + "-" + DNSInternalName, Namespace: seedNamespace}, secret)
+			err = c.Get(ctx, types.NamespacedName{Name: DNSRecordSecretPrefix + "-" + shootName + "-" + DNSInternalName, Namespace: seedNamespace}, secret)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(secret).To(DeepDerivativeEqual(&corev1.Secret{
 				TypeMeta: metav1.TypeMeta{
@@ -282,7 +282,7 @@ var _ = Describe("dnsrecord", func() {
 					APIVersion: "v1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:            "dnsrecord-" + shootName + "-" + DNSInternalName,
+					Name:            DNSRecordSecretPrefix + "-" + shootName + "-" + DNSInternalName,
 					Namespace:       seedNamespace,
 					ResourceVersion: "1",
 				},
@@ -467,7 +467,7 @@ var _ = Describe("dnsrecord", func() {
 		BeforeEach(func() {
 			// create an internal secret which is not prefixed with 'dnsrecord-' and is of the form '<shootName>-internal'
 			orphanedInternalSecret = &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("%s-internal", shootName),
+				Name:      shootName + "-" + DNSInternalName,
 				Namespace: seedNamespace,
 			}}
 			err := c.Create(ctx, orphanedInternalSecret)
@@ -475,7 +475,7 @@ var _ = Describe("dnsrecord", func() {
 
 			// create a regular internal secret which is prefixed with 'dnsrecord-'
 			regularInternalSecret = &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("dnsrecord-%s-internal", shootName),
+				Name:      DNSRecordSecretPrefix + "-" + shootName + "-" + DNSInternalName,
 				Namespace: seedNamespace,
 			}}
 			err = c.Create(ctx, regularInternalSecret)
@@ -483,7 +483,7 @@ var _ = Describe("dnsrecord", func() {
 
 			// create an internal secret which is not prefixed with 'dnsrecord-' and is of the form '<shootName>-internal'
 			orphanedExternalSecret = &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("%s-external", shootName),
+				Name:      shootName + "-" + DNSExternalName,
 				Namespace: seedNamespace,
 			}}
 			err = c.Create(ctx, orphanedExternalSecret)
@@ -491,7 +491,7 @@ var _ = Describe("dnsrecord", func() {
 
 			// create a regular internal secret which is prefixed with 'dnsrecord-'
 			regularExternalSecret = &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("dnsrecord-%s-external", shootName),
+				Name:      DNSRecordSecretPrefix + "-" + shootName + "-" + DNSExternalName,
 				Namespace: seedNamespace,
 			}}
 			err = c.Create(ctx, regularExternalSecret)

--- a/pkg/operation/botanist/dnsrecord_test.go
+++ b/pkg/operation/botanist/dnsrecord_test.go
@@ -516,6 +516,24 @@ var _ = Describe("dnsrecord", func() {
 			Expect(externalSecret).To(DeepDerivativeEqual(regularExternalSecret))
 		})
 
+		Context("When the Shoot name is 'gardener'", func() {
+			BeforeEach(func() {
+				shootName = "gardener"
+				seedNamespace = "shoot--gardener--bar"
+			})
+
+			It("should clean up the external orphaned secret, but keep the internal orphaned secret", func() {
+
+				Expect(b.CleanupOrphanedDNSRecordSecrets(ctx)).To(Succeed())
+				Expect(c.Get(ctx, client.ObjectKey{Name: orphanedExternalSecret.Name, Namespace: seedNamespace}, &corev1.Secret{})).To(BeNotFoundError())
+
+				internalSecret := &corev1.Secret{}
+				Expect(c.Get(ctx, client.ObjectKey{Name: orphanedInternalSecret.Name, Namespace: seedNamespace}, internalSecret)).To(Succeed())
+				Expect(internalSecret).To(DeepDerivativeEqual(orphanedInternalSecret))
+
+			})
+		})
+
 		It("should not fail the clean up of orphaned Secret when there are none", func() {
 			Expect(b.CleanupOrphanedDNSRecordSecrets(ctx)).To(Succeed())
 			Expect(c.Get(ctx, client.ObjectKey{Name: orphanedExternalSecret.Name, Namespace: seedNamespace}, &corev1.Secret{})).To(BeNotFoundError())

--- a/pkg/operation/botanist/dnsrecord_test.go
+++ b/pkg/operation/botanist/dnsrecord_test.go
@@ -200,7 +200,7 @@ var _ = Describe("dnsrecord", func() {
 						Type: externalProvider,
 					},
 					SecretRef: corev1.SecretReference{
-						Name:      shootName + "-" + DNSExternalName,
+						Name:      "dnsrecord-" + shootName + "-" + DNSExternalName,
 						Namespace: seedNamespace,
 					},
 					Zone:       pointer.String(externalZone),
@@ -212,7 +212,7 @@ var _ = Describe("dnsrecord", func() {
 			}))
 
 			secret := &corev1.Secret{}
-			err = client.Get(ctx, types.NamespacedName{Name: shootName + "-" + DNSExternalName, Namespace: seedNamespace}, secret)
+			err = client.Get(ctx, types.NamespacedName{Name: "dnsrecord-" + shootName + "-" + DNSExternalName, Namespace: seedNamespace}, secret)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(secret).To(DeepDerivativeEqual(&corev1.Secret{
 				TypeMeta: metav1.TypeMeta{
@@ -220,7 +220,7 @@ var _ = Describe("dnsrecord", func() {
 					APIVersion: "v1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:            shootName + "-" + DNSExternalName,
+					Name:            "dnsrecord-" + shootName + "-" + DNSExternalName,
 					Namespace:       seedNamespace,
 					ResourceVersion: "1",
 				},
@@ -262,7 +262,7 @@ var _ = Describe("dnsrecord", func() {
 						Type: internalProvider,
 					},
 					SecretRef: corev1.SecretReference{
-						Name:      shootName + "-" + DNSInternalName,
+						Name:      "dnsrecord-" + shootName + "-" + DNSInternalName,
 						Namespace: seedNamespace,
 					},
 					Zone:       pointer.String(internalZone),
@@ -274,7 +274,7 @@ var _ = Describe("dnsrecord", func() {
 			}))
 
 			secret := &corev1.Secret{}
-			err = client.Get(ctx, types.NamespacedName{Name: shootName + "-" + DNSInternalName, Namespace: seedNamespace}, secret)
+			err = client.Get(ctx, types.NamespacedName{Name: "dnsrecord-" + shootName + "-" + DNSInternalName, Namespace: seedNamespace}, secret)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(secret).To(DeepDerivativeEqual(&corev1.Secret{
 				TypeMeta: metav1.TypeMeta{
@@ -282,7 +282,7 @@ var _ = Describe("dnsrecord", func() {
 					APIVersion: "v1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:            shootName + "-" + DNSInternalName,
+					Name:            "dnsrecord-" + shootName + "-" + DNSInternalName,
 					Namespace:       seedNamespace,
 					ResourceVersion: "1",
 				},

--- a/pkg/operation/botanist/dnsrecord_test.go
+++ b/pkg/operation/botanist/dnsrecord_test.go
@@ -461,6 +461,7 @@ var _ = Describe("dnsrecord", func() {
 		})
 	})
 
+	// TODO (voelzmo) remove this when all DNSRecord secrets have migrated to a prefixed version
 	Describe("#CleanupOrphanedDNSRecordSecrets", func() {
 		var orphanedInternalSecret *corev1.Secret
 		var regularInternalSecret *corev1.Secret

--- a/pkg/operation/botanist/dnsrecord_test.go
+++ b/pkg/operation/botanist/dnsrecord_test.go
@@ -75,7 +75,7 @@ var _ = Describe("dnsrecord", func() {
 		ctrl *gomock.Controller
 
 		scheme *runtime.Scheme
-		client client.Client
+		c      client.Client
 
 		externalDNSRecord *mockdnsrecord.MockInterface
 		internalDNSRecord *mockdnsrecord.MockInterface
@@ -95,7 +95,7 @@ var _ = Describe("dnsrecord", func() {
 		scheme = runtime.NewScheme()
 		Expect(extensionsv1alpha1.AddToScheme(scheme)).NotTo(HaveOccurred())
 		Expect(corev1.AddToScheme(scheme)).NotTo(HaveOccurred())
-		client = fake.NewClientBuilder().WithScheme(scheme).Build()
+		c = fake.NewClientBuilder().WithScheme(scheme).Build()
 
 		externalDNSRecord = mockdnsrecord.NewMockInterface(ctrl)
 		internalDNSRecord = mockdnsrecord.NewMockInterface(ctrl)
@@ -154,11 +154,11 @@ var _ = Describe("dnsrecord", func() {
 		})
 
 		renderer := cr.NewWithServerVersion(&version.Info{})
-		chartApplier := kubernetes.NewChartApplier(renderer, kubernetes.NewApplier(client, meta.NewDefaultRESTMapper([]schema.GroupVersion{})))
+		chartApplier := kubernetes.NewChartApplier(renderer, kubernetes.NewApplier(c, meta.NewDefaultRESTMapper([]schema.GroupVersion{})))
 		Expect(chartApplier).NotTo(BeNil(), "should return chart applier")
 
 		b.K8sSeedClient = fakeclientset.NewClientSetBuilder().
-			WithClient(client).
+			WithClient(c).
 			WithChartApplier(chartApplier).
 			Build()
 
@@ -172,14 +172,14 @@ var _ = Describe("dnsrecord", func() {
 
 	Context("DefaultExternalDNSRecord", func() {
 		It("should create a component that creates the DNSRecord and its secret on Deploy", func() {
-			c := b.DefaultExternalDNSRecord()
-			c.SetRecordType(extensionsv1alpha1.DNSRecordTypeA)
-			c.SetValues([]string{address})
+			r := b.DefaultExternalDNSRecord()
+			r.SetRecordType(extensionsv1alpha1.DNSRecordTypeA)
+			r.SetValues([]string{address})
 
-			Expect(c.Deploy(ctx)).ToNot(HaveOccurred())
+			Expect(r.Deploy(ctx)).ToNot(HaveOccurred())
 
 			dnsRecord := &extensionsv1alpha1.DNSRecord{}
-			err := client.Get(ctx, types.NamespacedName{Name: shootName + "-" + DNSExternalName, Namespace: seedNamespace}, dnsRecord)
+			err := c.Get(ctx, types.NamespacedName{Name: shootName + "-" + DNSExternalName, Namespace: seedNamespace}, dnsRecord)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(dnsRecord).To(DeepDerivativeEqual(&extensionsv1alpha1.DNSRecord{
 				TypeMeta: metav1.TypeMeta{
@@ -212,7 +212,7 @@ var _ = Describe("dnsrecord", func() {
 			}))
 
 			secret := &corev1.Secret{}
-			err = client.Get(ctx, types.NamespacedName{Name: "dnsrecord-" + shootName + "-" + DNSExternalName, Namespace: seedNamespace}, secret)
+			err = c.Get(ctx, types.NamespacedName{Name: "dnsrecord-" + shootName + "-" + DNSExternalName, Namespace: seedNamespace}, secret)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(secret).To(DeepDerivativeEqual(&corev1.Secret{
 				TypeMeta: metav1.TypeMeta{
@@ -234,14 +234,14 @@ var _ = Describe("dnsrecord", func() {
 
 	Context("DefaultInternalDNSRecord", func() {
 		It("should create a component that creates the DNSRecord and its secret on Deploy", func() {
-			c := b.DefaultInternalDNSRecord()
-			c.SetRecordType(extensionsv1alpha1.DNSRecordTypeA)
-			c.SetValues([]string{address})
+			r := b.DefaultInternalDNSRecord()
+			r.SetRecordType(extensionsv1alpha1.DNSRecordTypeA)
+			r.SetValues([]string{address})
 
-			Expect(c.Deploy(ctx)).ToNot(HaveOccurred())
+			Expect(r.Deploy(ctx)).ToNot(HaveOccurred())
 
 			dnsRecord := &extensionsv1alpha1.DNSRecord{}
-			err := client.Get(ctx, types.NamespacedName{Name: shootName + "-" + DNSInternalName, Namespace: seedNamespace}, dnsRecord)
+			err := c.Get(ctx, types.NamespacedName{Name: shootName + "-" + DNSInternalName, Namespace: seedNamespace}, dnsRecord)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(dnsRecord).To(DeepDerivativeEqual(&extensionsv1alpha1.DNSRecord{
 				TypeMeta: metav1.TypeMeta{
@@ -274,7 +274,7 @@ var _ = Describe("dnsrecord", func() {
 			}))
 
 			secret := &corev1.Secret{}
-			err = client.Get(ctx, types.NamespacedName{Name: "dnsrecord-" + shootName + "-" + DNSInternalName, Namespace: seedNamespace}, secret)
+			err = c.Get(ctx, types.NamespacedName{Name: "dnsrecord-" + shootName + "-" + DNSInternalName, Namespace: seedNamespace}, secret)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(secret).To(DeepDerivativeEqual(&corev1.Secret{
 				TypeMeta: metav1.TypeMeta{

--- a/pkg/operation/botanist/dnsrecord_test.go
+++ b/pkg/operation/botanist/dnsrecord_test.go
@@ -461,12 +461,14 @@ var _ = Describe("dnsrecord", func() {
 		})
 	})
 
-	// TODO (voelzmo) remove this when all DNSRecord secrets have migrated to a prefixed version
+	// TODO (voelzmo): remove this when all DNSRecord secrets have migrated to a prefixed version
 	Describe("#CleanupOrphanedDNSRecordSecrets", func() {
-		var orphanedInternalSecret *corev1.Secret
-		var regularInternalSecret *corev1.Secret
-		var orphanedExternalSecret *corev1.Secret
-		var regularExternalSecret *corev1.Secret
+		var (
+			orphanedInternalSecret *corev1.Secret
+			regularInternalSecret  *corev1.Secret
+			orphanedExternalSecret *corev1.Secret
+			regularExternalSecret  *corev1.Secret
+		)
 
 		JustBeforeEach(func() {
 			// create an internal secret which is not prefixed with 'dnsrecord-' and is of the form '<shootName>-internal'
@@ -485,7 +487,7 @@ var _ = Describe("dnsrecord", func() {
 			err = c.Create(ctx, regularInternalSecret)
 			Expect(err).ToNot(HaveOccurred())
 
-			// create an internal secret which is not prefixed with 'dnsrecord-' and is of the form '<shootName>-internal'
+			// create an external secret which is not prefixed with 'dnsrecord-' and is of the form '<shootName>-external'
 			orphanedExternalSecret = &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
 				Name:      shootName + "-" + DNSExternalName,
 				Namespace: seedNamespace,
@@ -493,7 +495,7 @@ var _ = Describe("dnsrecord", func() {
 			err = c.Create(ctx, orphanedExternalSecret)
 			Expect(err).ToNot(HaveOccurred())
 
-			// create a regular internal secret which is prefixed with 'dnsrecord-'
+			// create a regular external secret which is prefixed with 'dnsrecord-'
 			regularExternalSecret = &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
 				Name:      DNSRecordSecretPrefix + "-" + shootName + "-" + DNSExternalName,
 				Namespace: seedNamespace,
@@ -524,14 +526,12 @@ var _ = Describe("dnsrecord", func() {
 			})
 
 			It("should clean up the external orphaned secret, but keep the internal orphaned secret", func() {
-
 				Expect(b.CleanupOrphanedDNSRecordSecrets(ctx)).To(Succeed())
 				Expect(c.Get(ctx, client.ObjectKey{Name: orphanedExternalSecret.Name, Namespace: seedNamespace}, &corev1.Secret{})).To(BeNotFoundError())
 
 				internalSecret := &corev1.Secret{}
 				Expect(c.Get(ctx, client.ObjectKey{Name: orphanedInternalSecret.Name, Namespace: seedNamespace}, internalSecret)).To(Succeed())
 				Expect(internalSecret).To(DeepDerivativeEqual(orphanedInternalSecret))
-
 			})
 		})
 
@@ -539,7 +539,6 @@ var _ = Describe("dnsrecord", func() {
 			Expect(b.CleanupOrphanedDNSRecordSecrets(ctx)).To(Succeed())
 			Expect(c.Get(ctx, client.ObjectKey{Name: orphanedExternalSecret.Name, Namespace: seedNamespace}, &corev1.Secret{})).To(BeNotFoundError())
 			Expect(b.CleanupOrphanedDNSRecordSecrets(ctx)).To(Succeed())
-
 		})
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
When a shoot with name `gardener` is created, the secret for the internal DNSRecord was created as `gardener-internal`. This had a collision with the secret containing the information how to reach the apiserver, which is also called `gardener-internal`. This PR prefixes the dnsrecord related secrets with `dnsrecord-` and therefore avoids the name collision.

**Which issue(s) this PR fixes**:
Fixes #4895

**Special notes for your reviewer**:
There could be other ways on how to change the name. This change keeps the shoot's name and adds a dnsrecord prefix, allowing to easier understanding where these secrets come from.


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bug user
Fixed a bug which didn't allow Shoots with the name 'gardener' to be created succesfully.
```
