### PR TITLE
Reject new Shoots with internal apiVersion in infrastructureConfig

### DIFF
--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -601,15 +601,24 @@ func (c *validationContext) validateAPIVersionForRawExtensions() field.ErrorList
 	}
 
 	for i, worker := range c.shoot.Spec.Provider.Workers {
-		if worker.ProviderConfig == nil {
+		if worker.Machine.Image.ProviderConfig == nil {
 			continue
 		}
 		// we ignore any errors while trying to parse the GVK from the RawExtension, because we don't actually want to validate against the Scheme (k8s doesn't know about the extension's GVK anyways)
 		// and the RawExtension could contain arbitrary json. However, *if* the RawExtension is a k8s-like object, we want to ensure that only external APIs can be used.
-		_, gvk, _ := serializer.NewCodecFactory(kubernetesscheme.Scheme).UniversalDecoder(corev1.SchemeGroupVersion).Decode(worker.ProviderConfig.Raw, nil, nil)
+		_, gvk, _ := serializer.NewCodecFactory(kubernetesscheme.Scheme).UniversalDecoder(corev1.SchemeGroupVersion).Decode(worker.Machine.Image.ProviderConfig.Raw, nil, nil)
 		if gvk.Version == runtime.APIVersionInternal {
-			allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "provider", "workers").Index(i).Child("providerConfig"), gvk, "must not use apiVersion 'internal'"))
+			allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "provider", "workers").Index(i).Child("machine", "image", "providerConfig"), gvk, "must not use apiVersion 'internal'"))
 		}
+		//if worker.ProviderConfig == nil {
+		//	continue
+		//}
+		//// we ignore any errors while trying to parse the GVK from the RawExtension, because we don't actually want to validate against the Scheme (k8s doesn't know about the extension's GVK anyways)
+		//// and the RawExtension could contain arbitrary json. However, *if* the RawExtension is a k8s-like object, we want to ensure that only external APIs can be used.
+		//_, gvk, _ := serializer.NewCodecFactory(kubernetesscheme.Scheme).UniversalDecoder(corev1.SchemeGroupVersion).Decode(worker.ProviderConfig.Raw, nil, nil)
+		//if gvk.Version == runtime.APIVersionInternal {
+		//	allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "provider", "workers").Index(i).Child("providerConfig"), gvk, "must not use apiVersion 'internal'"))
+		//}
 	}
 	return allErrs
 }

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -582,6 +582,9 @@ func (c *validationContext) validateProvider(a admission.Attributes) field.Error
 }
 
 func (c *validationContext) validateAPIVersionForRawExtension(path *field.Path, extension *runtime.RawExtension) *field.Error {
+	if extension == nil {
+		return nil
+	}
 	// we ignore any errors while trying to parse the GVK from the RawExtension, because we don't actually want to validate against the Scheme (k8s doesn't know about the extension's GVK anyways)
 	// and the RawExtension could contain arbitrary json. However, *if* the RawExtension is a k8s-like object, we want to ensure that only external APIs can be used.
 	_, gvk, _ := serializer.NewCodecFactory(kubernetesscheme.Scheme).UniversalDecoder(corev1.SchemeGroupVersion).Decode(extension.Raw, nil, nil)

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -548,6 +548,11 @@ func (c *validationContext) validateProvider(a admission.Attributes) field.Error
 		if err != nil {
 			allErrs = append(allErrs, err)
 		}
+
+		err = c.validateAPIVersionForRawExtension(path.Child("controlPlaneConfig"), c.shoot.Spec.Provider.ControlPlaneConfig)
+		if err != nil {
+			allErrs = append(allErrs, err)
+		}
 	}
 
 	for i, worker := range c.shoot.Spec.Provider.Workers {

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -601,24 +601,38 @@ func (c *validationContext) validateAPIVersionForRawExtensions() field.ErrorList
 	}
 
 	for i, worker := range c.shoot.Spec.Provider.Workers {
-		if worker.Machine.Image.ProviderConfig == nil {
-			continue
+		if worker.ProviderConfig != nil {
+
+			// we ignore any errors while trying to parse the GVK from the RawExtension, because we don't actually want to validate against the Scheme (k8s doesn't know about the extension's GVK anyways)
+			// and the RawExtension could contain arbitrary json. However, *if* the RawExtension is a k8s-like object, we want to ensure that only external APIs can be used.
+			_, gvk, _ := serializer.NewCodecFactory(kubernetesscheme.Scheme).UniversalDecoder(corev1.SchemeGroupVersion).Decode(worker.ProviderConfig.Raw, nil, nil)
+			if gvk.Version == runtime.APIVersionInternal {
+				allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "provider", "workers").Index(i).Child("providerConfig"), gvk, "must not use apiVersion 'internal'"))
+			}
 		}
-		// we ignore any errors while trying to parse the GVK from the RawExtension, because we don't actually want to validate against the Scheme (k8s doesn't know about the extension's GVK anyways)
-		// and the RawExtension could contain arbitrary json. However, *if* the RawExtension is a k8s-like object, we want to ensure that only external APIs can be used.
-		_, gvk, _ := serializer.NewCodecFactory(kubernetesscheme.Scheme).UniversalDecoder(corev1.SchemeGroupVersion).Decode(worker.Machine.Image.ProviderConfig.Raw, nil, nil)
-		if gvk.Version == runtime.APIVersionInternal {
-			allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "provider", "workers").Index(i).Child("machine", "image", "providerConfig"), gvk, "must not use apiVersion 'internal'"))
+		if worker.Machine.Image.ProviderConfig != nil {
+
+			// we ignore any errors while trying to parse the GVK from the RawExtension, because we don't actually want to validate against the Scheme (k8s doesn't know about the extension's GVK anyways)
+			// and the RawExtension could contain arbitrary json. However, *if* the RawExtension is a k8s-like object, we want to ensure that only external APIs can be used.
+			_, gvk, _ := serializer.NewCodecFactory(kubernetesscheme.Scheme).UniversalDecoder(corev1.SchemeGroupVersion).Decode(worker.Machine.Image.ProviderConfig.Raw, nil, nil)
+			if gvk.Version == runtime.APIVersionInternal {
+				allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "provider", "workers").Index(i).Child("machine", "image", "providerConfig"), gvk, "must not use apiVersion 'internal'"))
+			}
 		}
-		//if worker.ProviderConfig == nil {
-		//	continue
-		//}
-		//// we ignore any errors while trying to parse the GVK from the RawExtension, because we don't actually want to validate against the Scheme (k8s doesn't know about the extension's GVK anyways)
-		//// and the RawExtension could contain arbitrary json. However, *if* the RawExtension is a k8s-like object, we want to ensure that only external APIs can be used.
-		//_, gvk, _ := serializer.NewCodecFactory(kubernetesscheme.Scheme).UniversalDecoder(corev1.SchemeGroupVersion).Decode(worker.ProviderConfig.Raw, nil, nil)
-		//if gvk.Version == runtime.APIVersionInternal {
-		//	allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "provider", "workers").Index(i).Child("providerConfig"), gvk, "must not use apiVersion 'internal'"))
-		//}
+		if worker.CRI != nil && worker.CRI.ContainerRuntimes != nil {
+			for j, cr := range worker.CRI.ContainerRuntimes {
+				if cr.ProviderConfig == nil {
+					continue
+				}
+				// we ignore any errors while trying to parse the GVK from the RawExtension, because we don't actually want to validate against the Scheme (k8s doesn't know about the extension's GVK anyways)
+				// and the RawExtension could contain arbitrary json. However, *if* the RawExtension is a k8s-like object, we want to ensure that only external APIs can be used.
+				_, gvk, _ := serializer.NewCodecFactory(kubernetesscheme.Scheme).UniversalDecoder(corev1.SchemeGroupVersion).Decode(cr.ProviderConfig.Raw, nil, nil)
+				if gvk.Version == runtime.APIVersionInternal {
+					allErrs = append(allErrs, field.Invalid(field.NewPath("spec", "provider", "workers").Index(i).Child("cri", "containerRuntimes").Index(j).Child("providerConfig"), gvk, "must not use apiVersion 'internal'"))
+				}
+			}
+		}
+
 	}
 	return allErrs
 }

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -553,6 +553,11 @@ func (c *validationContext) validateProvider(a admission.Attributes) field.Error
 		if err != nil {
 			allErrs = append(allErrs, err)
 		}
+
+		err = c.validateAPIVersionForRawExtension(path.Child("networkConfig"), c.shoot.Spec.Networking.ProviderConfig)
+		if err != nil {
+			allErrs = append(allErrs, err)
+		}
 	}
 
 	for i, worker := range c.shoot.Spec.Provider.Workers {

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -2142,26 +2142,26 @@ var _ = Describe("validator", func() {
 				BeforeEach(func() {
 					shoot.Spec.Provider.InfrastructureConfig = &runtime.RawExtension{
 						Raw: []byte(`{
-"kind": "InfrastructureConfig",
-"apiVersion": "azure.provider.extensions.gardener.cloud/__internal",
-"networks": {"vnet": {"cidr": "10.250.0.0/16"}}
-}`),
+						"kind": "InfrastructureConfig",
+						"apiVersion": "azure.provider.extensions.gardener.cloud/__internal",
+						"key": "value"
+						}`),
 					}
 
 					shoot.Spec.Provider.ControlPlaneConfig = &runtime.RawExtension{
 						Raw: []byte(`{
-"apiVersion": "aws.provider.extensions.gardener.cloud/__internal",
-"kind": "ControlPlaneConfig",
-"cloudControllerManager": {"featureGates": { "CustomResourceValidation": true}},
-"storage": {"managedDefaultClass": false}}`),
+						"apiVersion": "aws.provider.extensions.gardener.cloud/__internal",
+						"kind": "ControlPlaneConfig",
+						"key": "value"
+						}`),
 					}
 
 					shoot.Spec.Networking.ProviderConfig = &runtime.RawExtension{
 						Raw: []byte(`{
-"apiVersion": "calico.networking.extensions.gardener.cloud/__internal",
-"kind": "NetworkConfig",
-"backend": "bird",
-"ipam": {"type": "host-local", "cidr": "usePodCIDR"}}`)}
+						"apiVersion": "calico.networking.extensions.gardener.cloud/__internal",
+						"kind": "NetworkConfig",
+						"key": "value"
+						}`)}
 
 					shoot.Spec.Provider.Workers = append(shoot.Spec.Provider.Workers, core.Worker{
 						Name: "worker-with-invalid-providerConfig",
@@ -2170,11 +2170,12 @@ var _ = Describe("validator", func() {
 							Image: &core.ShootMachineImage{
 								Name:    validMachineImageName,
 								Version: "0.0.1",
-								ProviderConfig: &runtime.RawExtension{Raw: []byte(`{
-					"apiVersion": "memoryone-chost.os.extensions.gardener.cloud/__internal",
-					"kind": "OperatingSystemConfiguration",
-					"memoryTopology": "3",
-					"systemMemory": "7x"}`)},
+								ProviderConfig: &runtime.RawExtension{
+									Raw: []byte(`{
+									"apiVersion": "memoryone-chost.os.extensions.gardener.cloud/__internal",
+									"kind": "OperatingSystemConfiguration",
+									"key": "value"
+									}`)},
 							},
 						},
 						CRI: &core.CRI{
@@ -2182,10 +2183,12 @@ var _ = Describe("validator", func() {
 							ContainerRuntimes: []core.ContainerRuntime{
 								{
 									Type: "test-cr",
-									ProviderConfig: &runtime.RawExtension{Raw: []byte(`{
-									"apiVersion": "some.api/__internal",
-									"kind": "ContainerRuntimeConfig",
-									"some-key": "some-value"}`)},
+									ProviderConfig: &runtime.RawExtension{
+										Raw: []byte(`{
+										"apiVersion": "some.api/__internal",
+										"kind": "ContainerRuntimeConfig",
+										"some-key": "some-value"
+										}`)},
 								},
 							},
 						},
@@ -2197,12 +2200,12 @@ var _ = Describe("validator", func() {
 							Type:       &volumeType,
 						},
 						Zones: []string{"europe-a"},
-						ProviderConfig: &runtime.RawExtension{Raw: []byte(`{
-"apiVersion": "aws.provider.extensions.gardener.cloud/__internal",
-"kind": "WorkerConfig",
-"volume": {"iops": 10000},
-"dataVolumes": [{"name": "kubelet-dir", "snapshotID": "snap-13234"}],
-"iamInstanceProfile": {"name": "my-profile", "arn": "my-instance-profile-arn"}}`)},
+						ProviderConfig: &runtime.RawExtension{
+							Raw: []byte(`{
+							"apiVersion": "aws.provider.extensions.gardener.cloud/__internal",
+							"kind": "WorkerConfig",
+							"key": "value"
+							}`)},
 					})
 				})
 
@@ -2243,53 +2246,55 @@ var _ = Describe("validator", func() {
 				It("admits new clusters using other apiVersion than 'internal'", func() {
 					shoot.Spec.Provider.InfrastructureConfig = &runtime.RawExtension{
 						Raw: []byte(`{
-"kind": "InfrastructureConfig",
-"apiVersion": "azure.provider.extensions.gardener.cloud/v1",
-"networks": {"vnet": {"cidr": "10.250.0.0/16"}}
-}`),
+						"kind": "InfrastructureConfig",
+						"apiVersion": "azure.provider.extensions.gardener.cloud/v1",
+						"key": "value"
+						}`),
 					}
 
 					shoot.Spec.Provider.ControlPlaneConfig = &runtime.RawExtension{
 						Raw: []byte(`{
-"apiVersion": "aws.provider.extensions.gardener.cloud/v1alpha1",
-"kind": "ControlPlaneConfig",
-"cloudControllerManager": {"featureGates": { "CustomResourceValidation": true}},
-"storage": {"managedDefaultClass": false}}`),
+						"apiVersion": "aws.provider.extensions.gardener.cloud/v1alpha1",
+						"kind": "ControlPlaneConfig",
+						"key": "value"
+						}`),
 					}
 
 					shoot.Spec.Networking.ProviderConfig = &runtime.RawExtension{
 						Raw: []byte(`{
-"apiVersion": "calico.networking.extensions.gardener.cloud/v1alpha1",
-"kind": "NetworkConfig",
-"backend": "bird",
-"ipam": {"type": "host-local", "cidr": "usePodCIDR"}}`)}
+						"apiVersion": "calico.networking.extensions.gardener.cloud/v1alpha1",
+						"kind": "NetworkConfig",
+						"key": "value"
+						}`)}
 
 					shoot.Spec.Provider.Workers[1].Machine.Image = &core.ShootMachineImage{
 						Name:    validMachineImageName,
 						Version: "0.0.1",
 						ProviderConfig: &runtime.RawExtension{Raw: []byte(`{
-					"apiVersion": "memoryone-chost.os.extensions.gardener.cloud/v1alpha1",
-					"kind": "OperatingSystemConfiguration",
-					"memoryTopology": "3",
-					"systemMemory": "7x"}`)},
+						"apiVersion": "memoryone-chost.os.extensions.gardener.cloud/v1alpha1",
+						"kind": "OperatingSystemConfiguration",
+						"key": "value"
+						}`)},
 					}
 
-					shoot.Spec.Provider.Workers[1].ProviderConfig = &runtime.RawExtension{Raw: []byte(`{
-"apiVersion": "aws.provider.extensions.gardener.cloud/v1alpha1",
-"kind": "WorkerConfig",
-"volume": {"iops": 10000},
-"dataVolumes": [{"name": "kubelet-dir", "snapshotID": "snap-13234"}],
-"iamInstanceProfile": {"name": "my-profile", "arn": "my-instance-profile-arn"}}`)}
+					shoot.Spec.Provider.Workers[1].ProviderConfig = &runtime.RawExtension{
+						Raw: []byte(`{
+						"apiVersion": "aws.provider.extensions.gardener.cloud/v1alpha1",
+						"kind": "WorkerConfig",
+						"key": "value"
+						}`)}
 
 					shoot.Spec.Provider.Workers[1].CRI = &core.CRI{
 						Name: core.CRINameContainerD,
 						ContainerRuntimes: []core.ContainerRuntime{
 							{
 								Type: "test-cr",
-								ProviderConfig: &runtime.RawExtension{Raw: []byte(`{
+								ProviderConfig: &runtime.RawExtension{
+									Raw: []byte(`{
 									"apiVersion": "some.api/v1alpha1",
 									"kind": "ContainerRuntimeConfig",
-									"some-key": "some-value"}`)},
+									"key": "value"
+									}`)},
 							},
 						},
 					}
@@ -2307,10 +2312,8 @@ var _ = Describe("validator", func() {
 			It("allows RawExtensions to contain arbitrary json blobs", func() {
 				shoot.Spec.Provider.InfrastructureConfig = &runtime.RawExtension{
 					Raw: []byte(`{
-"this": "is",
-"valid": "json",
-"key": {"object": {"objectKey": 1337}}
-}`),
+					"key": "value"
+					}`),
 				}
 
 				Expect(coreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&project)).To(Succeed())
@@ -2326,10 +2329,8 @@ var _ = Describe("validator", func() {
 			It("doesn't throw an error when the passed json is invalid", func() {
 				shoot.Spec.Provider.InfrastructureConfig = &runtime.RawExtension{
 					Raw: []byte(`{
-"this": "is",
-invalid: "json",
-"key": {"object": {"objectKey": 1337}}
-}`),
+					"key": invalid-value
+					}`),
 				}
 
 				Expect(coreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&project)).To(Succeed())

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -2142,8 +2142,14 @@ var _ = Describe("validator", func() {
 "cloudControllerManager": {"featureGates": { "CustomResourceValidation": true}},
 "storage": {"managedDefaultClass": false}}`),
 					}
-				})
 
+					shoot.Spec.Networking.ProviderConfig = &runtime.RawExtension{
+						Raw: []byte(`{
+"apiVersion": "calico.networking.extensions.gardener.cloud/__internal",
+"kind": "NetworkConfig",
+"backend": "bird",
+"ipam": {"type": "host-local", "cidr": "usePodCIDR"}}`)}
+				})
 				It("ensures new clusters cannot use the apiVersion 'internal'", func() {
 					Expect(coreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&project)).To(Succeed())
 					Expect(coreInformerFactory.Core().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
@@ -2155,6 +2161,7 @@ var _ = Describe("validator", func() {
 					Expect(err).To(BeForbiddenError())
 					Expect(err.Error()).To(ContainSubstring("Kind=InfrastructureConfig: must not use apiVersion 'internal'"))
 					Expect(err.Error()).To(ContainSubstring("Kind=ControlPlaneConfig: must not use apiVersion 'internal'"))
+					Expect(err.Error()).To(ContainSubstring("Kind=NetworkConfig: must not use apiVersion 'internal'"))
 				})
 
 				// TODO (voelzmo): remove this test and the associated production code once we gave owners of existing Shoots a nice grace period to move away from 'internal' apiVersion
@@ -2190,6 +2197,13 @@ var _ = Describe("validator", func() {
 "cloudControllerManager": {"featureGates": { "CustomResourceValidation": true}},
 "storage": {"managedDefaultClass": false}}`),
 					}
+
+					shoot.Spec.Networking.ProviderConfig = &runtime.RawExtension{
+						Raw: []byte(`{
+"apiVersion": "calico.networking.extensions.gardener.cloud/v1alpha1",
+"kind": "NetworkConfig",
+"backend": "bird",
+"ipam": {"type": "host-local", "cidr": "usePodCIDR"}}`)}
 					Expect(coreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&project)).To(Succeed())
 					Expect(coreInformerFactory.Core().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
 					Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -214,6 +214,9 @@ var _ = Describe("validator", func() {
 								Name: "worker-name",
 								Machine: core.Machine{
 									Type: "machine-type-1",
+									Image: &core.ShootMachineImage{
+										Name: validMachineImageName,
+									},
 								},
 								Minimum: 1,
 								Maximum: 1,
@@ -1364,7 +1367,7 @@ var _ = Describe("validator", func() {
 				var (
 					classificationPreview = core.ClassificationPreview
 
-					imageName1 = "some-image"
+					imageName1 = validMachineImageName
 					imageName2 = "other-image"
 
 					expiredVersion          = "1.1.1"
@@ -2150,25 +2153,15 @@ var _ = Describe("validator", func() {
 "backend": "bird",
 "ipam": {"type": "host-local", "cidr": "usePodCIDR"}}`)}
 
-					// TODO: this is actually image-specific providerconfig. WorkerConfig can be found here https://github.com/gardener/gardener-extension-provider-aws/blob/master/example/30-worker.yaml#L113-L123
-					shoot.Spec.Provider.Workers = append(shoot.Spec.Provider.Workers, core.Worker{
-						Name: "worker-with-internal-providerConfig",
-						Machine: core.Machine{
-							Type: "machine-type-1",
-						},
-						Minimum: 1,
-						Maximum: 1,
-						Volume: &core.Volume{
-							VolumeSize: "40Gi",
-							Type:       &volumeType,
-						},
-						Zones: []string{"europe-a"},
+					shoot.Spec.Provider.Workers[0].Machine.Image = &core.ShootMachineImage{
+						Name:    validMachineImageName,
+						Version: "0.0.1",
 						ProviderConfig: &runtime.RawExtension{Raw: []byte(`{
-"apiVersion": "memoryone-chost.os.extensions.gardener.cloud/__internal",
-"kind": "OperatingSystemConfiguration",
-"memoryTopology": "3",
-"systemMemory": "7x"}`)},
-					})
+					"apiVersion": "memoryone-chost.os.extensions.gardener.cloud/__internal",
+					"kind": "OperatingSystemConfiguration",
+					"memoryTopology": "3",
+					"systemMemory": "7x"}`)},
+					}
 				})
 				It("ensures new clusters cannot use the apiVersion 'internal'", func() {
 					Expect(coreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&project)).To(Succeed())
@@ -2225,23 +2218,15 @@ var _ = Describe("validator", func() {
 "kind": "NetworkConfig",
 "backend": "bird",
 "ipam": {"type": "host-local", "cidr": "usePodCIDR"}}`)}
-					shoot.Spec.Provider.Workers[1] = core.Worker{
-						Name: "worker-with-internal-providerConfig",
-						Machine: core.Machine{
-							Type: "machine-type-1",
-						},
-						Minimum: 1,
-						Maximum: 1,
-						Volume: &core.Volume{
-							VolumeSize: "40Gi",
-							Type:       &volumeType,
-						},
-						Zones: []string{"europe-a"},
+
+					shoot.Spec.Provider.Workers[0].Machine.Image = &core.ShootMachineImage{
+						Name:    validMachineImageName,
+						Version: "0.0.1",
 						ProviderConfig: &runtime.RawExtension{Raw: []byte(`{
-"apiVersion": "memoryone-chost.os.extensions.gardener.cloud/v1alpha1",
-"kind": "OperatingSystemConfiguration",
-"memoryTopology": "3",
-"systemMemory": "7x"}`)},
+					"apiVersion": "memoryone-chost.os.extensions.gardener.cloud/v1alpha1",
+					"kind": "OperatingSystemConfiguration",
+					"memoryTopology": "3",
+					"systemMemory": "7x"}`)},
 					}
 					Expect(coreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&project)).To(Succeed())
 					Expect(coreInformerFactory.Core().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
New Shoots which specify `__internal` as apiVersion for their InfrastructureConfig are rejected. Updates to existing Shoots are still allowed for compatibility reasons.

**Which issue(s) this PR fixes**:
Fixes #4874

**Special notes for your reviewer**:
A similar issue seems to exist for ControlPlaneConfig, should I be adding a new PR with similar change?

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
New Shoots can no longer specify `__internal` for the apiVersion in their InfrastructureConfig. For compatibility reasons, existing Shoots with this configuration can still be updated.
```
