### PR TITLE
Modify documentation manifest

### DIFF
--- a/.docforge/manifest.yaml
+++ b/.docforge/manifest.yaml
@@ -1,6 +1,73 @@
-nodesSelector:
-  path: https://github.com/gardener/gardener/tree/master/docs    
+{{- $vers := Split .versions "," -}}
+{{ $defaultBranch := (index $vers 0) }}
+structure:
+- name: _index.md
+  source: https://github.com/gardener/gardener/blob/{{$defaultBranch}}/README.md
+- name: concepts
+  properties:
+    frontmatter:
+      title: Concepts
+      weight: 1
+  nodes:
+  - nodesSelector:
+      path: https://github.com/gardener/gardener/tree/{{$defaultBranch}}/docs/concepts
+- name: deployment
+  properties:
+    frontmatter:
+      title: Deployment
+      weight: 2
+  nodes:
+  - nodesSelector:
+      path: https://github.com/gardener/gardener/tree/{{$defaultBranch}}/docs/deployment
+- name: development
+  properties:
+    frontmatter:
+      title: Development
+      weight: 3
+  nodes:
+  - nodesSelector:
+      path: https://github.com/gardener/gardener/tree/{{$defaultBranch}}/docs/development
+- name: extensions
+  properties:
+    frontmatter:
+      title: Extensions
+      weight: 4
+  nodes:
+  - nodesSelector:
+      path: https://github.com/gardener/gardener/tree/{{$defaultBranch}}/docs/extensions
+- name: monitoring
+  properties:
+    frontmatter:
+      title: Monitoring
+      weight: 5
+  nodes:
+  - nodesSelector:
+      path: https://github.com/gardener/gardener/tree/{{$defaultBranch}}/docs/monitoring
+- name: proposals
+  properties:
+    frontmatter:
+      title: Proposals
+      weight: 6
+  nodes:
+  - nodesSelector:
+      path: https://github.com/gardener/gardener/tree/{{$defaultBranch}}/docs/proposals
+- name: testing
+  properties:
+    frontmatter:
+      title: Testing
+      weight: 7
+  nodes:
+  - nodesSelector:
+      path: https://github.com/gardener/gardener/tree/{{$defaultBranch}}/docs/testing
+- name: usage
+  properties:
+    frontmatter:
+      title: Usage
+      weight: 8
+  nodes:
+  - nodesSelector:
+      path: https://github.com/gardener/gardener/tree/{{$defaultBranch}}/docs/usage
 links:
   downloads:
     scope:
-      gardener/gardener/(blob|raw)/(.*)/docs: ~
+      "gardener/gardener/(blob|raw)/(.*)/docs": ~


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
This PR modifies the docs manifest. Now can be listed particular directories, which will be attached to the website.
Also it uses the new docforge feature, where the default branch will be dynamically taken. This means that if in the future the default branch is changed from `master` to `main` for example, the documentation together with all relative links will continue to work.

**Possible configurations**:
1. Adding/removing directories
2. The weight of each section can be changed. The weight property represents the order of the sections.
3. In the frontmatter could be added also `description` property. The description will be shown in the website.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
None
```
