### PR TITLE
Set terraform v2 as Default

### DIFF
--- a/extensions/pkg/terraformer/config.go
+++ b/extensions/pkg/terraformer/config.go
@@ -76,14 +76,18 @@ func (t *terraformer) SetOwnerRef(owner *metav1.OwnerReference) Terraformer {
 }
 
 // UseV1 configures if it should use flags compatible with terraformer@v1.
-// Deprecated: terraformer v1 deprecated
+// If not specified explicitly, flags compatible with terraformer@v2 will be used.
+//
+// Deprecated: terraformer@v1 is deprecated. Consider switching to terraformer@v2 instead.
 func (t *terraformer) UseV1(v1 bool) Terraformer {
 	t.useV1 = v1
 	return t
 }
 
 // UseV2 configures if it should use flags compatible with terraformer@v2.
-// Deprecated: v2 is set to default version no need to set explicitly
+// TODO (acumino): The func is preserved for backwards compatibility. Remove in a future version.
+//
+// Deprecated: terraformer@v2 is the default version, hence it is no longer needed to specify it explicitly.
 func (t *terraformer) UseV2(v2 bool) Terraformer {
 	return t
 }

--- a/extensions/pkg/terraformer/config.go
+++ b/extensions/pkg/terraformer/config.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -75,9 +75,16 @@ func (t *terraformer) SetOwnerRef(owner *metav1.OwnerReference) Terraformer {
 	return t
 }
 
+// UseV1 configures if it should use flags compatible with terraformer@v1.
+// Deprecated: terraformer v1 deprecated
+func (t *terraformer) UseV1(v1 bool) Terraformer {
+	t.useV1 = v1
+	return t
+}
+
 // UseV2 configures if it should use flags compatible with terraformer@v2.
+// Deprecated: v2 is set to default version no need to set explicitly
 func (t *terraformer) UseV2(v2 bool) Terraformer {
-	t.useV2 = v2
 	return t
 }
 

--- a/extensions/pkg/terraformer/mock/mocks.go
+++ b/extensions/pkg/terraformer/mock/mocks.go
@@ -322,6 +322,20 @@ func (mr *MockTerraformerMockRecorder) SetTerminationGracePeriodSeconds(arg0 int
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTerminationGracePeriodSeconds", reflect.TypeOf((*MockTerraformer)(nil).SetTerminationGracePeriodSeconds), arg0)
 }
 
+// UseV1 mocks base method.
+func (m *MockTerraformer) UseV1(arg0 bool) terraformer.Terraformer {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UseV1", arg0)
+	ret0, _ := ret[0].(terraformer.Terraformer)
+	return ret0
+}
+
+// UseV1 indicates an expected call of UseV1.
+func (mr *MockTerraformerMockRecorder) UseV1(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UseV1", reflect.TypeOf((*MockTerraformer)(nil).UseV1), arg0)
+}
+
 // UseV2 mocks base method.
 func (m *MockTerraformer) UseV2(arg0 bool) terraformer.Terraformer {
 	m.ctrl.T.Helper()

--- a/extensions/pkg/terraformer/terraformer.go
+++ b/extensions/pkg/terraformer/terraformer.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -397,20 +397,19 @@ func (t *terraformer) deployTerraformerPod(ctx context.Context, generateName, co
 }
 
 func (t *terraformer) computeTerraformerCommand(command string) []string {
-	if t.useV2 {
+	if t.useV1 {
 		return []string{
-			"/terraformer",
+			"/terraformer.sh",
 			command,
-			"--zap-log-level=" + t.logLevel,
-			"--configuration-configmap-name=" + t.configName,
-			"--state-configmap-name=" + t.stateName,
-			"--variables-secret-name=" + t.variablesName,
 		}
 	}
-
 	return []string{
-		"/terraformer.sh",
+		"/terraformer",
 		command,
+		"--zap-log-level=" + t.logLevel,
+		"--configuration-configmap-name=" + t.configName,
+		"--state-configmap-name=" + t.stateName,
+		"--variables-secret-name=" + t.variablesName,
 	}
 }
 
@@ -430,7 +429,7 @@ func getTerraformerCommand(pod *corev1.Pod) string {
 func (t *terraformer) env() []corev1.EnvVar {
 	var envVars []corev1.EnvVar
 
-	if !t.useV2 {
+	if t.useV1 {
 		envVars = append(envVars, []corev1.EnvVar{
 			{Name: "MAX_BACKOFF_SEC", Value: "60"},
 			{Name: "MAX_TIME_SEC", Value: "1800"},

--- a/extensions/pkg/terraformer/types.go
+++ b/extensions/pkg/terraformer/types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import (
 )
 
 // terraformer is a struct containing configuration parameters for the Terraform script it acts on.
-// * useV2 indicates if it should use flags compatible with terraformer@v2 (defaults to false)
+// * useV1 indicates if it should use flags compatible with terraformer@v1 (defaults to false)
 // * purpose is a one-word description depicting what the Terraformer does (e.g. 'infrastructure').
 // * namespace is the namespace in which the Terraformer will act.
 // * image is the Docker image name of the Terraformer image.
@@ -47,7 +47,8 @@ import (
 // * deadlineCleaning is the timeout to wait Terraformer Pods to be cleaned up.
 // * deadlinePod is the time to wait apply/destroy Pod to be completed.
 type terraformer struct {
-	useV2 bool
+	// Deprecated: terraformer v1 deprecated
+	useV1 bool
 
 	logger       logr.Logger
 	client       client.Client
@@ -102,6 +103,9 @@ const (
 
 // Terraformer is the Terraformer interface.
 type Terraformer interface {
+	// Deprecated: terraformer v1 deprecated
+	UseV1(bool) Terraformer
+	// Deprecated: v2 is set to default version no need to set explicitly
 	UseV2(bool) Terraformer
 	SetLogLevel(string) Terraformer
 	SetEnvVars(envVars ...corev1.EnvVar) Terraformer

--- a/extensions/pkg/terraformer/types.go
+++ b/extensions/pkg/terraformer/types.go
@@ -47,7 +47,6 @@ import (
 // * deadlineCleaning is the timeout to wait Terraformer Pods to be cleaned up.
 // * deadlinePod is the time to wait apply/destroy Pod to be completed.
 type terraformer struct {
-	// Deprecated: terraformer v1 deprecated
 	useV1 bool
 
 	logger       logr.Logger
@@ -103,9 +102,15 @@ const (
 
 // Terraformer is the Terraformer interface.
 type Terraformer interface {
-	// Deprecated: terraformer v1 deprecated
+	// UseV1 configures if it should use flags compatible with terraformer@v1.
+	// If not specified explicitly, flags compatible with terraformer@v2 will be used.
+	//
+	// Deprecated: terraformer@v1 is deprecated. Consider switching to terraformer@v2 instead.
 	UseV1(bool) Terraformer
-	// Deprecated: v2 is set to default version no need to set explicitly
+	// UseV2 configures if it should use flags compatible with terraformer@v2.
+	// TODO (acumino): The func is preserved for backwards compatibility. Remove in a future version.
+	//
+	// Deprecated: terraformer@v2 is the default version, hence it is no longer needed to specify it explicitly.
 	UseV2(bool) Terraformer
 	SetLogLevel(string) Terraformer
 	SetEnvVars(envVars ...corev1.EnvVar) Terraformer


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
Set the terraformer v2 as Default

**Which issue(s) this PR fixes**:
Fixes #4577
@ialidzhikov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking dependency
The default terraformer version in package `github.com/gardener/gardener/extensions/pkg/terraformer` is now changed to v2. Consumers of this package can still configure the terraformer version using the funcs `UseV1` and `UseV2`(both of these functions are deprecated).
```
