### PR TITLE
Enable `TokenRequestor` and eliminate client certificate for `kube-scheduler`

### DIFF
--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -56,6 +56,10 @@ const (
 	// for the shoot API server instead the DNS name or load balancer address.
 	SecretNameGardenerInternal = "gardener-internal"
 
+	// SecretNameGenericTokenKubeconfig is a constant for the name of the kubeconfig used by the shoot controlplane
+	// components to authenticate against the shoot Kubernetes API server.
+	SecretNameGenericTokenKubeconfig = "generic-token-kubeconfig"
+
 	// SecretPrefixGeneratedBackupBucket is a constant for the prefix of a secret name in the garden cluster related to
 	// BackpuBuckets.
 	SecretPrefixGeneratedBackupBucket = "generated-bucket-"

--- a/pkg/apis/resources/v1alpha1/types.go
+++ b/pkg/apis/resources/v1alpha1/types.go
@@ -66,8 +66,6 @@ const (
 	ServiceAccountTokenExpirationDuration = "serviceaccount.resources.gardener.cloud/token-expiration-duration"
 	// ServiceAccountTokenRenewTimestamp is the key of an annotation of a secret whose value contains the timestamp when the token needs to be renewed
 	ServiceAccountTokenRenewTimestamp = "serviceaccount.resources.gardener.cloud/token-renew-timestamp"
-	// ServiceAccountSkipDeletion is the key of an annotation of a secret whose value contains whether the serviceaccount referenced by this secret should be deleted
-	ServiceAccountSkipDeletion = "serviceaccount.resources.gardener.cloud/skip-deletion"
 	// DataKeyToken is the data key whose value contains a service account token.
 	DataKeyToken = "token"
 	// DataKeyKubeconfig is the data key whose value contains a kubeconfig with a service account token.

--- a/pkg/operation/botanist/component/resourcemanager/resource_manager.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager.go
@@ -157,6 +157,8 @@ type Values struct {
 	LeaseDuration *time.Duration
 	// MaxConcurrentHealthWorkers configures the number of worker threads for concurrent health reconciliation of resources
 	MaxConcurrentHealthWorkers *int32
+	// MaxConcurrentTokenRequestorWorkers configures the number of worker threads for concurrent token requestor reconciliations
+	MaxConcurrentTokenRequestorWorkers *int32
 	// RenewDeadline configures the renew deadline for leader election
 	RenewDeadline *time.Duration
 	// ResourceClass is used to filter resource resources
@@ -491,6 +493,9 @@ func (r *resourceManager) computeCommand() []string {
 	cmd = append(cmd, fmt.Sprintf("--health-bind-address=:%v", healthPort))
 	if r.values.MaxConcurrentHealthWorkers != nil {
 		cmd = append(cmd, fmt.Sprintf("--health-max-concurrent-workers=%d", *r.values.MaxConcurrentHealthWorkers))
+	}
+	if r.values.MaxConcurrentTokenRequestorWorkers != nil {
+		cmd = append(cmd, fmt.Sprintf("--token-requestor-max-concurrent-workers=%d", *r.values.MaxConcurrentTokenRequestorWorkers))
 	}
 	if r.values.HealthSyncPeriod != nil {
 		cmd = append(cmd, fmt.Sprintf("--health-sync-period=%s", *r.values.HealthSyncPeriod))

--- a/pkg/operation/botanist/component/resourcemanager/resource_manager_test.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager_test.go
@@ -61,26 +61,27 @@ var _ = Describe("ResourceManager", func() {
 		replicas        int32 = 1
 
 		// optional configuration
-		clusterIdentity            = "foo"
-		secretNameKubeconfig       = "kubeconfig-secret"
-		secretNameServer           = "server-secret"
-		secretMountPathKubeconfig  = "/etc/gardener-resource-manager"
-		secretMountPathServer      = "/etc/gardener-resource-manager-tls"
-		secretChecksumKubeconfig   = "1234"
-		secretChecksumServer       = "5678"
-		secrets                    Secrets
-		alwaysUpdate                     = true
-		concurrentSyncs            int32 = 20
-		clusterRoleName                  = "gardener-resource-manager-seed"
-		healthSyncPeriod                 = time.Minute
-		leaseDuration                    = time.Second * 40
-		maxConcurrentHealthWorkers int32 = 20
-		renewDeadline                    = time.Second * 10
-		resourceClass                    = "fake-ResourceClass"
-		retryPeriod                      = time.Second * 20
-		syncPeriod                       = time.Second * 80
-		targetDisableCache               = true
-		watchedNamespace                 = "fake-ns"
+		clusterIdentity                    = "foo"
+		secretNameKubeconfig               = "kubeconfig-secret"
+		secretNameServer                   = "server-secret"
+		secretMountPathKubeconfig          = "/etc/gardener-resource-manager"
+		secretMountPathServer              = "/etc/gardener-resource-manager-tls"
+		secretChecksumKubeconfig           = "1234"
+		secretChecksumServer               = "5678"
+		secrets                            Secrets
+		alwaysUpdate                             = true
+		concurrentSyncs                    int32 = 20
+		clusterRoleName                          = "gardener-resource-manager-seed"
+		healthSyncPeriod                         = time.Minute
+		leaseDuration                            = time.Second * 40
+		maxConcurrentHealthWorkers         int32 = 20
+		maxConcurrentTokenRequestorWorkers int32 = 21
+		renewDeadline                            = time.Second * 10
+		resourceClass                            = "fake-ResourceClass"
+		retryPeriod                              = time.Second * 20
+		syncPeriod                               = time.Second * 80
+		targetDisableCache                       = true
+		watchedNamespace                         = "fake-ns"
 
 		allowAll                   []rbacv1.PolicyRule
 		allowManagedResources      []rbacv1.PolicyRule
@@ -221,18 +222,19 @@ var _ = Describe("ResourceManager", func() {
 			},
 		}
 		cfg = Values{
-			AlwaysUpdate:               &alwaysUpdate,
-			ClusterIdentity:            &clusterIdentity,
-			ConcurrentSyncs:            &concurrentSyncs,
-			HealthSyncPeriod:           &healthSyncPeriod,
-			LeaseDuration:              &leaseDuration,
-			MaxConcurrentHealthWorkers: &maxConcurrentHealthWorkers,
-			RenewDeadline:              &renewDeadline,
-			ResourceClass:              &resourceClass,
-			RetryPeriod:                &retryPeriod,
-			SyncPeriod:                 &syncPeriod,
-			TargetDisableCache:         &targetDisableCache,
-			WatchedNamespace:           &watchedNamespace,
+			AlwaysUpdate:                       &alwaysUpdate,
+			ClusterIdentity:                    &clusterIdentity,
+			ConcurrentSyncs:                    &concurrentSyncs,
+			HealthSyncPeriod:                   &healthSyncPeriod,
+			LeaseDuration:                      &leaseDuration,
+			MaxConcurrentHealthWorkers:         &maxConcurrentHealthWorkers,
+			MaxConcurrentTokenRequestorWorkers: &maxConcurrentTokenRequestorWorkers,
+			RenewDeadline:                      &renewDeadline,
+			ResourceClass:                      &resourceClass,
+			RetryPeriod:                        &retryPeriod,
+			SyncPeriod:                         &syncPeriod,
+			TargetDisableCache:                 &targetDisableCache,
+			WatchedNamespace:                   &watchedNamespace,
 		}
 		resourceManager = New(c, deployNamespace, image, replicas, cfg)
 		resourceManager.SetSecrets(secrets)
@@ -243,6 +245,7 @@ var _ = Describe("ResourceManager", func() {
 			"--garbage-collector-sync-period=12h",
 			fmt.Sprintf("--health-bind-address=:%v", healthPort),
 			fmt.Sprintf("--health-max-concurrent-workers=%v", maxConcurrentHealthWorkers),
+			fmt.Sprintf("--token-requestor-max-concurrent-workers=%v", maxConcurrentTokenRequestorWorkers),
 			fmt.Sprintf("--health-sync-period=%v", healthSyncPeriod),
 			"--leader-election=true",
 			fmt.Sprintf("--leader-election-lease-duration=%v", leaseDuration),
@@ -264,6 +267,7 @@ var _ = Describe("ResourceManager", func() {
 			"--garbage-collector-sync-period=12h",
 			fmt.Sprintf("--health-bind-address=:%v", healthPort),
 			fmt.Sprintf("--health-max-concurrent-workers=%v", maxConcurrentHealthWorkers),
+			fmt.Sprintf("--token-requestor-max-concurrent-workers=%v", maxConcurrentTokenRequestorWorkers),
 			fmt.Sprintf("--health-sync-period=%v", healthSyncPeriod),
 			"--leader-election=true",
 			fmt.Sprintf("--leader-election-lease-duration=%v", leaseDuration),

--- a/pkg/operation/botanist/kubescheduler.go
+++ b/pkg/operation/botanist/kubescheduler.go
@@ -43,8 +43,7 @@ func (b *Botanist) DefaultKubeScheduler() (kubescheduler.Interface, error) {
 // DeployKubeScheduler deploys the Kubernetes scheduler.
 func (b *Botanist) DeployKubeScheduler(ctx context.Context) error {
 	b.Shoot.Components.ControlPlane.KubeScheduler.SetSecrets(kubescheduler.Secrets{
-		Kubeconfig: component.Secret{Name: kubescheduler.SecretName, Checksum: b.LoadCheckSum(kubescheduler.SecretName)},
-		Server:     component.Secret{Name: kubescheduler.SecretNameServer, Checksum: b.LoadCheckSum(kubescheduler.SecretNameServer)},
+		Server: component.Secret{Name: kubescheduler.SecretNameServer, Checksum: b.LoadCheckSum(kubescheduler.SecretNameServer)},
 	})
 
 	return b.Shoot.Components.ControlPlane.KubeScheduler.Deploy(ctx)

--- a/pkg/operation/botanist/kubescheduler_test.go
+++ b/pkg/operation/botanist/kubescheduler_test.go
@@ -84,16 +84,13 @@ var _ = Describe("KubeScheduler", func() {
 
 			ctx              = context.TODO()
 			fakeErr          = fmt.Errorf("fake err")
-			secretName       = "kube-scheduler"
 			secretNameServer = "kube-scheduler-server"
-			checksum         = "1234"
 			checksumServer   = "5678"
 		)
 
 		BeforeEach(func() {
 			kubeScheduler = mockkubescheduler.NewMockInterface(ctrl)
 
-			botanist.StoreCheckSum(secretName, checksum)
 			botanist.StoreCheckSum(secretNameServer, checksumServer)
 			botanist.Shoot = &shootpkg.Shoot{
 				Components: &shootpkg.Components{
@@ -104,8 +101,7 @@ var _ = Describe("KubeScheduler", func() {
 			}
 
 			kubeScheduler.EXPECT().SetSecrets(kubescheduler.Secrets{
-				Kubeconfig: component.Secret{Name: secretName, Checksum: checksum},
-				Server:     component.Secret{Name: secretNameServer, Checksum: checksumServer},
+				Server: component.Secret{Name: secretNameServer, Checksum: checksumServer},
 			})
 		})
 

--- a/pkg/operation/botanist/resource_manager.go
+++ b/pkg/operation/botanist/resource_manager.go
@@ -45,14 +45,15 @@ func (b *Botanist) DefaultResourceManager() (resourcemanager.Interface, error) {
 	image = &imagevector.Image{Repository: repository, Tag: &tag}
 
 	cfg := resourcemanager.Values{
-		AlwaysUpdate:               pointer.Bool(true),
-		ClusterIdentity:            b.Seed.GetInfo().Status.ClusterIdentity,
-		ConcurrentSyncs:            pointer.Int32(20),
-		HealthSyncPeriod:           utils.DurationPtr(time.Minute),
-		MaxConcurrentHealthWorkers: pointer.Int32(10),
-		SyncPeriod:                 utils.DurationPtr(time.Minute),
-		TargetDisableCache:         pointer.Bool(true),
-		WatchedNamespace:           pointer.String(b.Shoot.SeedNamespace),
+		AlwaysUpdate:                       pointer.Bool(true),
+		ClusterIdentity:                    b.Seed.GetInfo().Status.ClusterIdentity,
+		ConcurrentSyncs:                    pointer.Int32(20),
+		HealthSyncPeriod:                   utils.DurationPtr(time.Minute),
+		MaxConcurrentHealthWorkers:         pointer.Int32(10),
+		MaxConcurrentTokenRequestorWorkers: pointer.Int32(10),
+		SyncPeriod:                         utils.DurationPtr(time.Minute),
+		TargetDisableCache:                 pointer.Bool(true),
+		WatchedNamespace:                   pointer.String(b.Shoot.SeedNamespace),
 	}
 
 	// ensure grm is present during hibernation (if the cluster is not hibernated yet) to reconcile any changes to

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -54,6 +54,15 @@ import (
 func (b *Botanist) GenerateAndSaveSecrets(ctx context.Context) error {
 	return b.SaveGardenerResourceDataInShootState(ctx, func(gardenerResourceData *[]gardencorev1alpha1.GardenerResourceData) error {
 		gardenerResourceDataList := gardencorev1alpha1helper.GardenerResourceDataList(*gardenerResourceData)
+
+		// Remove legacy secrets from ShootState.
+		// TODO(rfranzke): Remove in a future version.
+		for _, name := range []string{
+			"kube-scheduler",
+		} {
+			gardenerResourceDataList.Delete(name)
+		}
+
 		switch b.Shoot.GetInfo().Annotations[v1beta1constants.GardenerOperation] {
 		case v1beta1constants.ShootOperationRotateKubeconfigCredentials:
 			if err := b.rotateKubeconfigSecrets(ctx, &gardenerResourceDataList); err != nil {

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -34,10 +34,15 @@ import (
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/secrets"
+	secretutils "github.com/gardener/gardener/pkg/utils/secrets"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientcmdlatest "k8s.io/client-go/tools/clientcmd/api/latest"
+	clientcmdv1 "k8s.io/client-go/tools/clientcmd/api/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -185,7 +190,33 @@ func (b *Botanist) DeploySecrets(ctx context.Context) error {
 		b.ControlPlaneWildcardCert = certSecret
 	}
 
-	return nil
+	return b.reconcileGenericKubeconfigSecret(ctx)
+}
+
+func (b *Botanist) reconcileGenericKubeconfigSecret(ctx context.Context) error {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      v1beta1constants.SecretNameGenericTokenKubeconfig,
+			Namespace: b.Shoot.SeedNamespace,
+		},
+	}
+
+	kubeconfig, err := runtime.Encode(clientcmdlatest.Codec, kutil.NewKubeconfig(
+		b.Shoot.SeedNamespace,
+		b.Shoot.ComputeInClusterAPIServerAddress(true),
+		b.LoadSecret(v1beta1constants.SecretNameCACluster).Data[secretutils.DataKeyCertificateCA],
+		clientcmdv1.AuthInfo{TokenFile: gutil.PathShootToken},
+	))
+	if err != nil {
+		return err
+	}
+
+	_, err = controllerutils.CreateOrGetAndMergePatch(ctx, b.K8sSeedClient.Client(), secret, func() error {
+		secret.Type = corev1.SecretTypeOpaque
+		secret.Data = map[string][]byte{secretutils.DataKeyKubeconfig: kubeconfig}
+		return nil
+	})
+	return err
 }
 
 // DeployCloudProviderSecret creates or updates the cloud provider secret in the Shoot namespace
@@ -302,7 +333,7 @@ func (b *Botanist) deleteBasicAuthDependantSecrets(ctx context.Context, gardener
 	return b.deleteSecrets(ctx, gardenerResourceDataList, kubeapiserver.SecretNameBasicAuth, common.KubecfgSecretName)
 }
 
-func (b *Botanist) storeAPIServerHealthCheckToken(staticToken *secrets.StaticToken) error {
+func (b *Botanist) storeAPIServerHealthCheckToken(staticToken *secretutils.StaticToken) error {
 	kubeAPIServerHealthCheckToken, err := staticToken.GetTokenForUsername(common.KubeAPIServerHealthCheck)
 	if err != nil {
 		return err
@@ -312,7 +343,7 @@ func (b *Botanist) storeAPIServerHealthCheckToken(staticToken *secrets.StaticTok
 	return nil
 }
 
-func (b *Botanist) storePromtailRBACAuthToken(staticToken *secrets.StaticToken) error {
+func (b *Botanist) storePromtailRBACAuthToken(staticToken *secretutils.StaticToken) error {
 	promtailRBACAuthToken, err := staticToken.GetTokenForUsername(logging.PromtailRBACName)
 	if err != nil {
 		return err
@@ -322,7 +353,7 @@ func (b *Botanist) storePromtailRBACAuthToken(staticToken *secrets.StaticToken) 
 	return nil
 }
 
-func (b *Botanist) storeStaticTokenAsSecrets(ctx context.Context, staticToken *secrets.StaticToken, caCert []byte, secretNameToUsername map[string]string) error {
+func (b *Botanist) storeStaticTokenAsSecrets(ctx context.Context, staticToken *secretutils.StaticToken, caCert []byte, secretNameToUsername map[string]string) error {
 	for secretName, username := range secretNameToUsername {
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -339,8 +370,8 @@ func (b *Botanist) storeStaticTokenAsSecrets(ctx context.Context, staticToken *s
 
 		if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, b.K8sSeedClient.Client(), secret, func() error {
 			secret.Data = map[string][]byte{
-				secrets.DataKeyToken:         []byte(token.Token),
-				secrets.DataKeyCertificateCA: caCert,
+				secretutils.DataKeyToken:         []byte(token.Token),
+				secretutils.DataKeyCertificateCA: caCert,
 			}
 			return nil
 		}); err != nil {
@@ -362,12 +393,12 @@ func getExpiredCerts(gardenerResourceDataList gardencorev1alpha1helper.GardenerR
 			continue
 		}
 
-		certObj := &secrets.CertificateJSONData{}
+		certObj := &secretutils.CertificateJSONData{}
 		if err := json.Unmarshal(data.Data.Raw, certObj); err != nil {
 			return nil, err
 		}
 
-		expired, err := secrets.CertificateIsExpired(certObj.Certificate, renewalWindow)
+		expired, err := secretutils.CertificateIsExpired(certObj.Certificate, renewalWindow)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/operation/botanist/wanted_secrets.go
+++ b/pkg/operation/botanist/wanted_secrets.go
@@ -244,26 +244,6 @@ func (b *Botanist) generateWantedSecretConfigs(basicAuthAPIServer *secrets.Basic
 			},
 		},
 
-		// Secret definition for kube-scheduler
-		&secrets.ControlPlaneSecretConfig{
-			CertificateSecretConfig: &secrets.CertificateSecretConfig{
-				Name: kubescheduler.SecretName,
-
-				CommonName:   user.KubeScheduler,
-				Organization: nil,
-				DNSNames:     nil,
-				IPAddresses:  nil,
-
-				CertType:  secrets.ClientCert,
-				SigningCA: certificateAuthorities[v1beta1constants.SecretNameCACluster],
-			},
-
-			KubeConfigRequests: []secrets.KubeConfigRequest{{
-				ClusterName:   b.Shoot.SeedNamespace,
-				APIServerHost: b.Shoot.ComputeInClusterAPIServerAddress(true),
-			}},
-		},
-
 		// Secret definition for kube-scheduler server
 		&secrets.ControlPlaneSecretConfig{
 			CertificateSecretConfig: &secrets.CertificateSecretConfig{

--- a/pkg/utils/gardener/shoot.go
+++ b/pkg/utils/gardener/shoot.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils"
 )
 
@@ -188,3 +189,10 @@ func IsShootProjectSecret(secretName string) (string, bool) {
 
 	return "", false
 }
+
+const (
+	// VolumeMountPathGenericKubeconfig is a constant for the path to which the generic shoot kubeconfig will be mounted.
+	VolumeMountPathGenericKubeconfig = "/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig"
+	// PathShootToken is a constant for the path at which the shoot token file is accessible.
+	PathShootToken = VolumeMountPathGenericKubeconfig + "/" + resourcesv1alpha1.DataKeyToken
+)

--- a/pkg/utils/gardener/shoot.go
+++ b/pkg/utils/gardener/shoot.go
@@ -15,17 +15,32 @@
 package gardener
 
 import (
+	"context"
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
+	appsv1beta1 "k8s.io/api/apps/v1beta1"
+	appsv1beta2 "k8s.io/api/apps/v1beta2"
+	batchv1 "k8s.io/api/batch/v1"
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientcmdlatest "k8s.io/client-go/tools/clientcmd/api/latest"
+	clientcmdv1 "k8s.io/client-go/tools/clientcmd/api/v1"
 	"k8s.io/component-base/version"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/utils"
+	"github.com/gardener/gardener/pkg/utils/secrets"
 )
 
 // RespectShootSyncPeriodOverwrite checks whether to respect the sync period overwrite of a Shoot or not.
@@ -191,8 +206,215 @@ func IsShootProjectSecret(secretName string) (string, bool) {
 }
 
 const (
+	// SecretNamePrefixShootAccess is the prefix of all secrets containing credentials for accessing shoot clusters.
+	SecretNamePrefixShootAccess = "shoot-access-"
 	// VolumeMountPathGenericKubeconfig is a constant for the path to which the generic shoot kubeconfig will be mounted.
 	VolumeMountPathGenericKubeconfig = "/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig"
 	// PathShootToken is a constant for the path at which the shoot token file is accessible.
 	PathShootToken = VolumeMountPathGenericKubeconfig + "/" + resourcesv1alpha1.DataKeyToken
+	// PathGenericKubeconfig is a constant for the path at which the kubeconfig file is accessible.
+	PathGenericKubeconfig = VolumeMountPathGenericKubeconfig + "/" + secrets.DataKeyKubeconfig
 )
+
+// ShootAccessSecret contains settings for a shoot access secret consumed by a component communicating with a shoot API
+// server.
+type ShootAccessSecret struct {
+	Secret             *corev1.Secret
+	ServiceAccountName string
+
+	tokenExpirationDuration string
+	kubeconfig              *clientcmdv1.Config
+}
+
+// NewShootAccessSecret returns a new ShootAccessSecret object and initializes it with an empty corev1.Secret object
+// with for the given name and namespace. If not already done, the name will be prefixed with the
+// SecretNamePrefixShootAccess. The ServiceAccountName field will be defaulted with the name.
+func NewShootAccessSecret(name, namespace string) *ShootAccessSecret {
+	if !strings.HasPrefix(name, SecretNamePrefixShootAccess) {
+		name = SecretNamePrefixShootAccess + name
+	}
+
+	return &ShootAccessSecret{
+		Secret: &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+		},
+		ServiceAccountName: strings.TrimPrefix(name, SecretNamePrefixShootAccess),
+	}
+}
+
+// WithNameOverride sets the ObjectMeta.Name field of the *corev1.Secret inside the ShootAccessSecret.
+func (s *ShootAccessSecret) WithNameOverride(name string) *ShootAccessSecret {
+	s.Secret.Name = name
+	return s
+}
+
+// WithNamespaceOverride sets the ObjectMeta.Namespace field of the *corev1.Secret inside the ShootAccessSecret.
+func (s *ShootAccessSecret) WithNamespaceOverride(namespace string) *ShootAccessSecret {
+	s.Secret.Namespace = namespace
+	return s
+}
+
+// WithServiceAccountName sets the ServiceAccountName field of the ShootAccessSecret.
+func (s *ShootAccessSecret) WithServiceAccountName(name string) *ShootAccessSecret {
+	s.ServiceAccountName = name
+	return s
+}
+
+// WithTokenExpirationDuration sets the tokenExpirationDuration field of the ShootAccessSecret.
+func (s *ShootAccessSecret) WithTokenExpirationDuration(duration string) *ShootAccessSecret {
+	s.tokenExpirationDuration = duration
+	return s
+}
+
+// WithKubeconfig sets the kubeconfig field of the ShootAccessSecret.
+func (s *ShootAccessSecret) WithKubeconfig(kubeconfigRaw *clientcmdv1.Config) *ShootAccessSecret {
+	s.kubeconfig = kubeconfigRaw
+	return s
+}
+
+// Reconcile creates or patches the given shoot access secret. Based on the struct configuration, it adds the required
+// annotations for the token requestor controller of gardener-resource-manager.
+func (s *ShootAccessSecret) Reconcile(ctx context.Context, c client.Client) error {
+	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, c, s.Secret, func() error {
+		s.Secret.Type = corev1.SecretTypeOpaque
+		metav1.SetMetaDataLabel(&s.Secret.ObjectMeta, resourcesv1alpha1.ResourceManagerPurpose, resourcesv1alpha1.LabelPurposeTokenRequest)
+		metav1.SetMetaDataAnnotation(&s.Secret.ObjectMeta, resourcesv1alpha1.ServiceAccountName, s.ServiceAccountName)
+		metav1.SetMetaDataAnnotation(&s.Secret.ObjectMeta, resourcesv1alpha1.ServiceAccountNamespace, metav1.NamespaceSystem)
+
+		if s.tokenExpirationDuration != "" {
+			metav1.SetMetaDataAnnotation(&s.Secret.ObjectMeta, resourcesv1alpha1.ServiceAccountTokenExpirationDuration, s.tokenExpirationDuration)
+		}
+
+		if s.kubeconfig == nil {
+			delete(s.Secret.Data, resourcesv1alpha1.DataKeyKubeconfig)
+		} else {
+			delete(s.Secret.Data, resourcesv1alpha1.DataKeyToken)
+
+			if kubeconfigRaw, ok := s.Secret.Data[resourcesv1alpha1.DataKeyKubeconfig]; ok {
+				existingKubeconfig := &clientcmdv1.Config{}
+				if _, _, err := clientcmdlatest.Codec.Decode(kubeconfigRaw, nil, existingKubeconfig); err != nil {
+					return err
+				}
+				s.kubeconfig.AuthInfos = existingKubeconfig.AuthInfos
+			}
+
+			kubeconfigRaw, err := runtime.Encode(clientcmdlatest.Codec, s.kubeconfig)
+			if err != nil {
+				return err
+			}
+
+			if s.Secret.Data == nil {
+				s.Secret.Data = make(map[string][]byte, 1)
+			}
+
+			s.Secret.Data[resourcesv1alpha1.DataKeyKubeconfig] = kubeconfigRaw
+		}
+
+		return nil
+	})
+	return err
+}
+
+// InjectGenericKubeconfig injects the volumes and volume mounts for the generic shoot kubeconfig into the provided
+// object. The access secret name must be the name of a secret containing a JWT token which should be used by the
+// kubeconfig. If the object has multiple containers then the default is to inject it into all of them. If it should
+// only be done for a selection of containers then their respective names must be provided.
+func InjectGenericKubeconfig(obj runtime.Object, accessSecretName string, containerNames ...string) error {
+	switch o := obj.(type) {
+	case *corev1.Pod:
+		injectGenericKubeconfig(&o.Spec, accessSecretName, containerNames...)
+
+	case *appsv1.Deployment:
+		injectGenericKubeconfig(&o.Spec.Template.Spec, accessSecretName, containerNames...)
+
+	case *appsv1beta2.Deployment:
+		injectGenericKubeconfig(&o.Spec.Template.Spec, accessSecretName, containerNames...)
+
+	case *appsv1beta1.Deployment:
+		injectGenericKubeconfig(&o.Spec.Template.Spec, accessSecretName, containerNames...)
+
+	case *appsv1.StatefulSet:
+		injectGenericKubeconfig(&o.Spec.Template.Spec, accessSecretName, containerNames...)
+
+	case *appsv1beta2.StatefulSet:
+		injectGenericKubeconfig(&o.Spec.Template.Spec, accessSecretName, containerNames...)
+
+	case *appsv1beta1.StatefulSet:
+		injectGenericKubeconfig(&o.Spec.Template.Spec, accessSecretName, containerNames...)
+
+	case *appsv1.DaemonSet:
+		injectGenericKubeconfig(&o.Spec.Template.Spec, accessSecretName, containerNames...)
+
+	case *appsv1beta2.DaemonSet:
+		injectGenericKubeconfig(&o.Spec.Template.Spec, accessSecretName, containerNames...)
+
+	case *batchv1.Job:
+		injectGenericKubeconfig(&o.Spec.Template.Spec, accessSecretName, containerNames...)
+
+	case *batchv1.CronJob:
+		injectGenericKubeconfig(&o.Spec.JobTemplate.Spec.Template.Spec, accessSecretName, containerNames...)
+
+	case *batchv1beta1.CronJob:
+		injectGenericKubeconfig(&o.Spec.JobTemplate.Spec.Template.Spec, accessSecretName, containerNames...)
+
+	default:
+		return fmt.Errorf("unhandled object type %T", obj)
+	}
+
+	return nil
+}
+
+func injectGenericKubeconfig(podSpec *corev1.PodSpec, accessSecretName string, containerNames ...string) {
+	var (
+		volume = corev1.Volume{
+			Name: "kubeconfig",
+			VolumeSource: corev1.VolumeSource{
+				Projected: &corev1.ProjectedVolumeSource{
+					DefaultMode: pointer.Int32(420),
+					Sources: []corev1.VolumeProjection{
+						{
+							Secret: &corev1.SecretProjection{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: v1beta1constants.SecretNameGenericTokenKubeconfig,
+								},
+								Items: []corev1.KeyToPath{{
+									Key:  secrets.DataKeyKubeconfig,
+									Path: secrets.DataKeyKubeconfig,
+								}},
+								Optional: pointer.Bool(false),
+							},
+						},
+						{
+							Secret: &corev1.SecretProjection{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: accessSecretName,
+								},
+								Items: []corev1.KeyToPath{{
+									Key:  resourcesv1alpha1.DataKeyToken,
+									Path: resourcesv1alpha1.DataKeyToken,
+								}},
+								Optional: pointer.Bool(false),
+							},
+						},
+					},
+				},
+			},
+		}
+
+		volumeMount = corev1.VolumeMount{
+			Name:      volume.Name,
+			MountPath: VolumeMountPathGenericKubeconfig,
+			ReadOnly:  true,
+		}
+	)
+
+	podSpec.Volumes = append(podSpec.Volumes, volume)
+	for i, container := range podSpec.Containers {
+		if len(containerNames) == 0 || utils.ValueExists(container.Name, containerNames) {
+			podSpec.Containers[i].VolumeMounts = append(podSpec.Containers[i].VolumeMounts, volumeMount)
+		}
+	}
+}

--- a/pkg/utils/kubernetes/kubernetes.go
+++ b/pkg/utils/kubernetes/kubernetes.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/duration"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
+	clientcmdv1 "k8s.io/client-go/tools/clientcmd/api/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
@@ -630,4 +631,29 @@ func CertificatesV1beta1UsagesToCertificatesV1Usages(usages []certificatesv1beta
 		out = append(out, certificatesv1.KeyUsage(u))
 	}
 	return out
+}
+
+// NewKubeconfig returns a new kubeconfig structure.
+func NewKubeconfig(contextName, server string, caCert []byte, authInfo clientcmdv1.AuthInfo) *clientcmdv1.Config {
+	return &clientcmdv1.Config{
+		CurrentContext: contextName,
+		Clusters: []clientcmdv1.NamedCluster{{
+			Name: contextName,
+			Cluster: clientcmdv1.Cluster{
+				Server:                   `https://` + server,
+				CertificateAuthorityData: caCert,
+			},
+		}},
+		AuthInfos: []clientcmdv1.NamedAuthInfo{{
+			Name:     contextName,
+			AuthInfo: authInfo,
+		}},
+		Contexts: []clientcmdv1.NamedContext{{
+			Name: contextName,
+			Context: clientcmdv1.Context{
+				Cluster:  contextName,
+				AuthInfo: contextName,
+			},
+		}},
+	}
 }

--- a/pkg/utils/kubernetes/kubernetes_test.go
+++ b/pkg/utils/kubernetes/kubernetes_test.go
@@ -52,6 +52,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/rest"
 	fakerestclient "k8s.io/client-go/rest/fake"
+	clientcmdv1 "k8s.io/client-go/tools/clientcmd/api/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -1561,6 +1562,39 @@ var _ = Describe("kubernetes", func() {
 				certificatesv1.UsageOCSPSigning,
 				certificatesv1.UsageMicrosoftSGC,
 				certificatesv1.UsageNetscapeSGC,
+			}))
+		})
+	})
+
+	Describe("#NewKubeconfig", func() {
+		var (
+			contextName = "context"
+			server      = "server"
+			caCert      = []byte("ca crt")
+			authInfo    = clientcmdv1.AuthInfo{Token: "foo"}
+		)
+
+		It("should return the expected kubeconfig", func() {
+			Expect(NewKubeconfig(contextName, server, caCert, authInfo)).To(Equal(&clientcmdv1.Config{
+				CurrentContext: contextName,
+				Clusters: []clientcmdv1.NamedCluster{{
+					Name: contextName,
+					Cluster: clientcmdv1.Cluster{
+						Server:                   `https://` + server,
+						CertificateAuthorityData: caCert,
+					},
+				}},
+				AuthInfos: []clientcmdv1.NamedAuthInfo{{
+					Name:     contextName,
+					AuthInfo: authInfo,
+				}},
+				Contexts: []clientcmdv1.NamedContext{{
+					Name: contextName,
+					Context: clientcmdv1.Context{
+						Cluster:  contextName,
+						AuthInfo: contextName,
+					},
+				}},
 			}))
 		})
 	})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement
/merge squash

**What this PR does / why we need it**:
This PR activates the `TokenRequestor` controller in `gardener-resource-manager` (ref #4867) and eliminates the client certificate for the `kube-scheduler` in favor of a token managed by this controller.

**Which issue(s) this PR fixes**:
Part of #4661
Part of #4878

**Special notes for your reviewer**:
/invite @BeckerMax @timebertt 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
`kube-scheduler` does no longer use a client certificate but an auto-rotated `ServiceAccount` token which is only valid for `12h`.
```
