### PR TITLE
Enable `RootCAPublisher` and make `gardener-resource-manager` use a projected `ServiceAccount` token

### DIFF
--- a/pkg/operation/botanist/component/resourcemanager/resource_manager_test.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager_test.go
@@ -61,29 +61,30 @@ var _ = Describe("ResourceManager", func() {
 		replicas        int32 = 1
 
 		// optional configuration
-		clusterIdentity                    = "foo"
-		secretNameKubeconfig               = "kubeconfig-secret"
-		secretNameServer                   = "server-secret"
-		secretMountPathKubeconfig          = "/etc/gardener-resource-manager"
-		secretMountPathServer              = "/etc/gardener-resource-manager-tls"
-		secretMountPathAPIAccess           = "/var/run/secrets/kubernetes.io/serviceaccount"
-		secretChecksumKubeconfig           = "1234"
-		secretChecksumServer               = "5678"
-		secrets                            Secrets
-		alwaysUpdate                             = true
-		concurrentSyncs                    int32 = 20
-		clusterRoleName                          = "gardener-resource-manager-seed"
-		serviceAccountSecretName                 = "sa-secret"
-		healthSyncPeriod                         = time.Minute
-		leaseDuration                            = time.Second * 40
-		maxConcurrentHealthWorkers         int32 = 20
-		maxConcurrentTokenRequestorWorkers int32 = 21
-		renewDeadline                            = time.Second * 10
-		resourceClass                            = "fake-ResourceClass"
-		retryPeriod                              = time.Second * 20
-		syncPeriod                               = time.Second * 80
-		watchedNamespace                         = "fake-ns"
-		targetDisableCache                       = true
+		clusterIdentity                     = "foo"
+		secretNameKubeconfig                = "kubeconfig-secret"
+		secretNameServer                    = "server-secret"
+		secretMountPathKubeconfig           = "/etc/gardener-resource-manager"
+		secretMountPathServer               = "/etc/gardener-resource-manager-tls"
+		secretMountPathAPIAccess            = "/var/run/secrets/kubernetes.io/serviceaccount"
+		secretChecksumKubeconfig            = "1234"
+		secretChecksumServer                = "5678"
+		secrets                             Secrets
+		alwaysUpdate                              = true
+		concurrentSyncs                     int32 = 20
+		clusterRoleName                           = "gardener-resource-manager-seed"
+		serviceAccountSecretName                  = "sa-secret"
+		healthSyncPeriod                          = time.Minute
+		leaseDuration                             = time.Second * 40
+		maxConcurrentHealthWorkers          int32 = 20
+		maxConcurrentTokenRequestorWorkers  int32 = 21
+		maxConcurrentRootCAPublisherWorkers int32 = 22
+		renewDeadline                             = time.Second * 10
+		resourceClass                             = "fake-ResourceClass"
+		retryPeriod                               = time.Second * 20
+		syncPeriod                                = time.Second * 80
+		watchedNamespace                          = "fake-ns"
+		targetDisableCache                        = true
 
 		allowAll                   []rbacv1.PolicyRule
 		allowManagedResources      []rbacv1.PolicyRule
@@ -224,19 +225,20 @@ var _ = Describe("ResourceManager", func() {
 			},
 		}
 		cfg = Values{
-			AlwaysUpdate:                       &alwaysUpdate,
-			ClusterIdentity:                    &clusterIdentity,
-			ConcurrentSyncs:                    &concurrentSyncs,
-			HealthSyncPeriod:                   &healthSyncPeriod,
-			LeaseDuration:                      &leaseDuration,
-			MaxConcurrentHealthWorkers:         &maxConcurrentHealthWorkers,
-			MaxConcurrentTokenRequestorWorkers: &maxConcurrentTokenRequestorWorkers,
-			RenewDeadline:                      &renewDeadline,
-			ResourceClass:                      &resourceClass,
-			RetryPeriod:                        &retryPeriod,
-			SyncPeriod:                         &syncPeriod,
-			TargetDisableCache:                 &targetDisableCache,
-			WatchedNamespace:                   &watchedNamespace,
+			AlwaysUpdate:                        &alwaysUpdate,
+			ClusterIdentity:                     &clusterIdentity,
+			ConcurrentSyncs:                     &concurrentSyncs,
+			HealthSyncPeriod:                    &healthSyncPeriod,
+			LeaseDuration:                       &leaseDuration,
+			MaxConcurrentHealthWorkers:          &maxConcurrentHealthWorkers,
+			MaxConcurrentTokenRequestorWorkers:  &maxConcurrentTokenRequestorWorkers,
+			MaxConcurrentRootCAPublisherWorkers: &maxConcurrentRootCAPublisherWorkers,
+			RenewDeadline:                       &renewDeadline,
+			ResourceClass:                       &resourceClass,
+			RetryPeriod:                         &retryPeriod,
+			SyncPeriod:                          &syncPeriod,
+			TargetDisableCache:                  &targetDisableCache,
+			WatchedNamespace:                    &watchedNamespace,
 		}
 		resourceManager = New(c, deployNamespace, image, replicas, cfg)
 		resourceManager.SetSecrets(secrets)
@@ -248,6 +250,8 @@ var _ = Describe("ResourceManager", func() {
 			fmt.Sprintf("--health-bind-address=:%v", healthPort),
 			fmt.Sprintf("--health-max-concurrent-workers=%v", maxConcurrentHealthWorkers),
 			fmt.Sprintf("--token-requestor-max-concurrent-workers=%v", maxConcurrentTokenRequestorWorkers),
+			fmt.Sprintf("--root-ca-publisher-max-concurrent-workers=%v", maxConcurrentRootCAPublisherWorkers),
+			fmt.Sprintf("--root-ca-file=%s/ca.crt", secretMountPathAPIAccess),
 			fmt.Sprintf("--health-sync-period=%v", healthSyncPeriod),
 			"--leader-election=true",
 			fmt.Sprintf("--leader-election-lease-duration=%v", leaseDuration),
@@ -270,6 +274,8 @@ var _ = Describe("ResourceManager", func() {
 			fmt.Sprintf("--health-bind-address=:%v", healthPort),
 			fmt.Sprintf("--health-max-concurrent-workers=%v", maxConcurrentHealthWorkers),
 			fmt.Sprintf("--token-requestor-max-concurrent-workers=%v", maxConcurrentTokenRequestorWorkers),
+			fmt.Sprintf("--root-ca-publisher-max-concurrent-workers=%v", maxConcurrentRootCAPublisherWorkers),
+			fmt.Sprintf("--root-ca-file=%s/ca.crt", secretMountPathAPIAccess),
 			fmt.Sprintf("--health-sync-period=%v", healthSyncPeriod),
 			"--leader-election=true",
 			fmt.Sprintf("--leader-election-lease-duration=%v", leaseDuration),

--- a/pkg/operation/botanist/resource_manager.go
+++ b/pkg/operation/botanist/resource_manager.go
@@ -45,15 +45,16 @@ func (b *Botanist) DefaultResourceManager() (resourcemanager.Interface, error) {
 	image = &imagevector.Image{Repository: repository, Tag: &tag}
 
 	cfg := resourcemanager.Values{
-		AlwaysUpdate:                       pointer.Bool(true),
-		ClusterIdentity:                    b.Seed.GetInfo().Status.ClusterIdentity,
-		ConcurrentSyncs:                    pointer.Int32(20),
-		HealthSyncPeriod:                   utils.DurationPtr(time.Minute),
-		MaxConcurrentHealthWorkers:         pointer.Int32(10),
-		MaxConcurrentTokenRequestorWorkers: pointer.Int32(10),
-		SyncPeriod:                         utils.DurationPtr(time.Minute),
-		TargetDisableCache:                 pointer.Bool(true),
-		WatchedNamespace:                   pointer.String(b.Shoot.SeedNamespace),
+		AlwaysUpdate:                        pointer.Bool(true),
+		ClusterIdentity:                     b.Seed.GetInfo().Status.ClusterIdentity,
+		ConcurrentSyncs:                     pointer.Int32(20),
+		HealthSyncPeriod:                    utils.DurationPtr(time.Minute),
+		MaxConcurrentHealthWorkers:          pointer.Int32(10),
+		MaxConcurrentTokenRequestorWorkers:  pointer.Int32(10),
+		MaxConcurrentRootCAPublisherWorkers: pointer.Int32(10),
+		SyncPeriod:                          utils.DurationPtr(time.Minute),
+		TargetDisableCache:                  pointer.Bool(true),
+		WatchedNamespace:                    pointer.String(b.Shoot.SeedNamespace),
 	}
 
 	// ensure grm is present during hibernation (if the cluster is not hibernated yet) to reconcile any changes to
@@ -79,6 +80,7 @@ func (b *Botanist) DeployGardenerResourceManager(ctx context.Context) error {
 	b.Shoot.Components.ControlPlane.ResourceManager.SetSecrets(resourcemanager.Secrets{
 		Kubeconfig: component.Secret{Name: resourcemanager.SecretName, Checksum: b.LoadCheckSum(resourcemanager.SecretName)},
 		Server:     component.Secret{Name: resourcemanager.SecretNameServer, Checksum: b.LoadCheckSum(resourcemanager.SecretNameServer)},
+		RootCA:     &component.Secret{Name: v1beta1constants.SecretNameCACluster, Checksum: b.LoadCheckSum(v1beta1constants.SecretNameCACluster)},
 	})
 
 	return b.Shoot.Components.ControlPlane.ResourceManager.Deploy(ctx)

--- a/pkg/operation/botanist/resource_manager_test.go
+++ b/pkg/operation/botanist/resource_manager_test.go
@@ -53,9 +53,11 @@ var _ = Describe("ResourceManager", func() {
 			fakeErr          = fmt.Errorf("fake err")
 			secretName       = "gardener-resource-manager"
 			secretNameServer = "gardener-resource-manager-server"
+			secretNameRootCA = "ca"
 			seedNamespace    = "fake-seed-ns"
 			checksum         = "1234"
 			checksumServer   = "5678"
+			checksumRootCA   = "9012"
 		)
 
 		BeforeEach(func() {
@@ -63,6 +65,7 @@ var _ = Describe("ResourceManager", func() {
 
 			botanist.StoreCheckSum(secretName, checksum)
 			botanist.StoreCheckSum(secretNameServer, checksumServer)
+			botanist.StoreCheckSum(secretNameRootCA, checksumRootCA)
 
 			botanist.Shoot = &shootpkg.Shoot{
 				Components: &shootpkg.Components{
@@ -76,6 +79,7 @@ var _ = Describe("ResourceManager", func() {
 			resourceManager.EXPECT().SetSecrets(resourcemanager.Secrets{
 				Kubeconfig: component.Secret{Name: secretName, Checksum: checksum},
 				Server:     component.Secret{Name: secretNameServer, Checksum: checksumServer},
+				RootCA:     &component.Secret{Name: secretNameRootCA, Checksum: checksumRootCA},
 			})
 		})
 

--- a/pkg/operation/seed/components.go
+++ b/pkg/operation/seed/components.go
@@ -105,10 +105,11 @@ func defaultGardenerResourceManager(c client.Client, imageVector imagevector.Ima
 	image = &imagevector.Image{Repository: repository, Tag: &tag}
 
 	gardenerResourceManager := resourcemanager.New(c, v1beta1constants.GardenNamespace, image.String(), 1, resourcemanager.Values{
-		ConcurrentSyncs:  pointer.Int32(20),
-		HealthSyncPeriod: utils.DurationPtr(time.Minute),
-		ResourceClass:    pointer.String(v1beta1constants.SeedResourceManagerClass),
-		SyncPeriod:       utils.DurationPtr(time.Hour),
+		ConcurrentSyncs:                     pointer.Int32(20),
+		MaxConcurrentRootCAPublisherWorkers: pointer.Int32(20),
+		HealthSyncPeriod:                    utils.DurationPtr(time.Minute),
+		ResourceClass:                       pointer.String(v1beta1constants.SeedResourceManagerClass),
+		SyncPeriod:                          utils.DurationPtr(time.Hour),
 	})
 
 	gardenerResourceManager.SetSecrets(resourcemanager.Secrets{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement
/merge squash

**What this PR does / why we need it**:
This PR activates the `RootCAPublisher` controller in `gardener-resource-manager` (ref #4832) and enables it for both seed and shoot clusters.

Additionally, the `gardener-resource-manager` was switched to use a projected `ServiceAccount` token for accessing the seed cluster's API server. After #4873 is merged it will be able to serve a webhook that injects such projected token volumes into other `Pod`s. However, since itself is "the root" of it, we have to mount such volume explicitly for it.

**Which issue(s) this PR fixes**:
Part of #4878

**Special notes for your reviewer**:
/invite @BeckerMax

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
NONE
```
