### PR TITLE
Ensure `gardener-resource-manager` is highly available

### DIFF
--- a/pkg/operation/botanist/resource_manager.go
+++ b/pkg/operation/botanist/resource_manager.go
@@ -61,7 +61,7 @@ func (b *Botanist) DefaultResourceManager() (resourcemanager.Interface, error) {
 	// MRs (e.g. caused by extension upgrades) that are necessary for completing the hibernation flow.
 	// grm is scaled down later on as part of the HibernateControlPlane step, so we only specify replicas=0 if
 	// the shoot is already hibernated.
-	replicas := int32(1)
+	replicas := int32(3)
 	if b.Shoot.HibernationEnabled && b.Shoot.GetInfo().Status.IsHibernated {
 		replicas = 0
 	}

--- a/pkg/operation/seed/components.go
+++ b/pkg/operation/seed/components.go
@@ -104,7 +104,7 @@ func defaultGardenerResourceManager(c client.Client, imageVector imagevector.Ima
 	}
 	image = &imagevector.Image{Repository: repository, Tag: &tag}
 
-	gardenerResourceManager := resourcemanager.New(c, v1beta1constants.GardenNamespace, image.String(), 1, resourcemanager.Values{
+	gardenerResourceManager := resourcemanager.New(c, v1beta1constants.GardenNamespace, image.String(), 3, resourcemanager.Values{
 		ConcurrentSyncs:                     pointer.Int32(20),
 		MaxConcurrentRootCAPublisherWorkers: pointer.Int32(20),
 		HealthSyncPeriod:                    utils.DurationPtr(time.Minute),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area high-availability
/kind enhancement
/merge squash

**What this PR does / why we need it**:
This PR ensures that `gardener-resource-manager` is highly-available by

- running `3` replicas
- introducing pod anti-affinity
- introducing a `PodDisruptionBudget` with `maxUnavailable=1`.

This is a preparation for activating the newly introduced webhooks (#4817 and #4873).

**Which issue(s) this PR fixes**:
Part of #4878

/invite @BeckerMax 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`gardener-resource-manager` is now deployed in a highly-available way (`3` replicas, pod anti-affinity and a permitted pod disruption of `1`).
```
