### PR TITLE
Introduce dedicated CA for `ReversedVPN` components

### DIFF
--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -30,6 +30,9 @@ const (
 	// SecretNameCAMetricsServer is a constant for the name of a Kubernetes secret object that contains the CA
 	// certificate of the metrics-server of a shoot cluster.
 	SecretNameCAMetricsServer = "ca-metrics-server"
+	// SecretNameCAVPN is a constant for the name of a Kubernetes secret object that contains the CA
+	// certificate of the VPN components of a shoot cluster.
+	SecretNameCAVPN = "ca-vpn"
 	// SecretNameCloudProvider is a constant for the name of a Kubernetes secret object that contains the provider
 	// specific credentials that shall be used to create/delete the shoot.
 	SecretNameCloudProvider = "cloudprovider"

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -34,9 +34,11 @@ import (
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/secrets"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -65,6 +67,23 @@ func (b *Botanist) GenerateAndSaveSecrets(ctx context.Context) error {
 			if b.Shoot.ReversedVPNEnabled {
 				if err := b.cleanupTunnelSecrets(ctx, &gardenerResourceDataList, kubeapiserver.SecretNameVPNSeed, kubeapiserver.SecretNameVPNSeedTLSAuth, "vpn-shoot"); err != nil {
 					return err
+				}
+
+				// Delete existing VPN-related secrets which were not signed with the newly introduced ca-vpn so that
+				// they get regenerated.
+				// TODO(rfranzke): Remove in a future version.
+				if err := b.K8sSeedClient.Client().Get(ctx, kutil.Key(b.Shoot.SeedNamespace, v1beta1constants.SecretNameCAVPN), &corev1.Secret{}); err != nil {
+					if !apierrors.IsNotFound(err) {
+						return err
+					}
+
+					if err := b.cleanupTunnelSecrets(ctx, &gardenerResourceDataList,
+						vpnseedserver.DeploymentName,
+						kubeapiserver.SecretNameHTTPProxy,
+						vpnseedserver.VpnShootSecretName,
+					); err != nil {
+						return err
+					}
 				}
 			} else {
 				if err := b.cleanupTunnelSecrets(ctx, &gardenerResourceDataList, vpnseedserver.DeploymentName, vpnseedserver.VpnShootSecretName, vpnseedserver.VpnSeedServerTLSAuth); err != nil {

--- a/pkg/operation/botanist/wanted_secrets.go
+++ b/pkg/operation/botanist/wanted_secrets.go
@@ -75,6 +75,11 @@ func (b *Botanist) wantedCertificateAuthorities() map[string]*secrets.Certificat
 			CommonName: "metrics-server",
 			CertType:   secrets.CACert,
 		},
+		v1beta1constants.SecretNameCAVPN: {
+			Name:       v1beta1constants.SecretNameCAVPN,
+			CommonName: "vpn",
+			CertType:   secrets.CACert,
+		},
 	}
 
 	return wantedCertificateAuthorities
@@ -693,7 +698,7 @@ func (b *Botanist) generateWantedSecretConfigs(basicAuthAPIServer *secrets.Basic
 				Name:       vpnseedserver.VpnShootSecretName,
 				CommonName: "vpn-shoot-client",
 				CertType:   secrets.ClientCert,
-				SigningCA:  certificateAuthorities[v1beta1constants.SecretNameCACluster],
+				SigningCA:  certificateAuthorities[v1beta1constants.SecretNameCAVPN],
 			},
 
 			// Secret definition for vpn-seed-server (OpenVPN server side)
@@ -702,7 +707,7 @@ func (b *Botanist) generateWantedSecretConfigs(basicAuthAPIServer *secrets.Basic
 				CommonName: "vpn-seed-server",
 				DNSNames:   kubernetes.DNSNamesForService(vpnseedserver.ServiceName, b.Shoot.SeedNamespace),
 				CertType:   secrets.ServerCert,
-				SigningCA:  certificateAuthorities[v1beta1constants.SecretNameCACluster],
+				SigningCA:  certificateAuthorities[v1beta1constants.SecretNameCAVPN],
 			},
 
 			&secrets.VPNTLSAuthConfig{
@@ -714,7 +719,7 @@ func (b *Botanist) generateWantedSecretConfigs(basicAuthAPIServer *secrets.Basic
 				Name:       kubeapiserver.SecretNameHTTPProxy,
 				CommonName: "kube-apiserver-http-proxy",
 				CertType:   secrets.ClientCert,
-				SigningCA:  certificateAuthorities[v1beta1constants.SecretNameCACluster],
+				SigningCA:  certificateAuthorities[v1beta1constants.SecretNameCAVPN],
 			},
 		)
 	} else {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
This PR introduces a dedicated CA for the components related to the reversed VPN tunnel. There is no need to use the cluster CA to sign the certificates.

This makes such client certificates unable from authenticating against the cluster's API server.

Before:

```
$ curl https://api.my-example-shoot-cluster.com --cacert <(k -n shoot--foo--bar get secret vpn-shoot-client -o json | jq -r '.data["ca.crt"]' | base64 -d) --cert <(k -n shoot--foo--bar get secret vpn-shoot-client -o json | jq -r '.data["tls.crt"]' | base64 -d) --key <(k -n shoot--foo--bar get secret vpn-shoot-client -o json | jq -r '.data["tls.key"]' | base64 -d)
{
  "kind": "Status",
  "apiVersion": "v1",
  "metadata": {

  },
  "status": "Failure",
  "message": "forbidden: User \"vpn-shoot-client\" cannot get path \"/\"",
  "reason": "Forbidden",
  "details": {

  },
  "code": 403
}
```

After:

```
$ curl https://api.my-example-shoot-cluster.com --cacert <(k -n shoot--foo--bar get secret vpn-shoot-client -o json | jq -r '.data["ca.crt"]' | base64 -d) --cert <(k -n shoot--foo--bar get secret vpn-shoot-client -o json | jq -r '.data["tls.crt"]' | base64 -d) --key <(k -n shoot--foo--bar get secret vpn-shoot-client -o json | jq -r '.data["tls.key"]' | base64 -d)
curl: (60) SSL certificate problem: unable to get local issuer certificate
More details here: https://curl.haxx.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the web page mentioned above.
```

and when using the correct CA:

```
$ curl https://api.my-example-shoot-cluster.com --cacert <(k -n shoot--foo--bar get secret ca -o json | jq -r '.data["ca.crt"]' | base64 -d) --cert <(k -n shoot--foo--bar get secret vpn-shoot-client -o json | jq -r '.data["tls.crt"]' | base64 -d) --key <(k -n shoot--foo--bar get secret vpn-shoot-client -o json | jq -r '.data["tls.key"]' | base64 -d)
{
  "kind": "Status",
  "apiVersion": "v1",
  "metadata": {

  },
  "status": "Failure",
  "message": "Unauthorized",
  "reason": "Unauthorized",
  "code": 401
}
```

**Special notes for your reviewer**:
The certificates for the components related to the "legacy" VPN tunnel are kept as is since the `vpn-seed` needs to communicate with the `kube-apiserver` to figure out the load balancer ingress for the `vpn-shoot` `Service` in the `kube-system` namespace of shoot clusters. I don't think it makes sense to invest here since our goal is to promote `ReversedVPN` to make it the default, eventually remove the feature gate and drop the legacy VPN solution entirely.

/invite @ScheererJ @DockToFuture 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
There is now a new, dedicated certificate authority (`ca-vpn`) for the components related to the reversed VPN feature for shoot clusters.
```
