### PR TITLE
Temporarily skip the Shoot maintenance test suite

### DIFF
--- a/test/integration/envtest/shootmaintenance/maintenance_suite_test.go
+++ b/test/integration/envtest/shootmaintenance/maintenance_suite_test.go
@@ -37,7 +37,11 @@ import (
 	"github.com/gardener/gardener/test/framework"
 )
 
+// TODO: This test suite is disabled because of a known flake in the test (https://github.com/gardener/gardener/issues/4944).
+// Enable the test suite again after fixing the flake.
+
 func TestShootMaintenance(t *testing.T) {
+	t.Skipf("Temporarily skipping the test suite because of known flake...")
 	controllermanagerfeatures.RegisterFeatureGates()
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Shoot Maintenance Controller Integration Test Suite")


### PR DESCRIPTION
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

Temporarily skip the Shoot maintenance test suite until the known flake (https://github.com/gardener/gardener/issues/4944) is fixed.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
