### PR TITLE
set include-zones annotation for default domains

### DIFF
--- a/charts/gardener/controlplane/charts/utils-common/templates/_secret-default-domain.yaml
+++ b/charts/gardener/controlplane/charts/utils-common/templates/_secret-default-domain.yaml
@@ -17,6 +17,7 @@ metadata:
     dns.gardener.cloud/domain: {{ ( required ".defaultDomains[].domain is required" $domain.domain ) }}
     {{- if $domain.zone }}
     dns.gardener.cloud/zone: {{ $domain.zone }}
+    dns.gardener.cloud/include-zones: {{ $domain.zone }}
     {{- end }}
 type: Opaque
 data:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
The default `external` `DNSProvider` only specifies the included domain currently. Depending on which hosted zones are available in the account used by this `DNSProvider`, the external-dns extension may not be able to choose the zone unambiguously and shoot creation fails with "Error while waiting for DNSProvider shoot--foo--bar/external to become ready: state Error: overlapping zones ...".

As the correct zone is typically already set for the `DNSRecord` feature, the zone ID can be specified with setting the `dns.gardener.cloud/include-zones` annotation in the default domain secret to select the zone unambiguously.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Set `dns.gardener.cloud/include-zones` annotation for the default domain secret in the Gardener controlplane chart.
```
