### PR TITLE
[release-v1.33] Automated cherry pick of #4950: set include-zones annotation for default domains

### DIFF
--- a/charts/gardener/controlplane/charts/utils-common/templates/_secret-default-domain.yaml
+++ b/charts/gardener/controlplane/charts/utils-common/templates/_secret-default-domain.yaml
@@ -17,6 +17,7 @@ metadata:
     dns.gardener.cloud/domain: {{ ( required ".defaultDomains[].domain is required" $domain.domain ) }}
     {{- if $domain.zone }}
     dns.gardener.cloud/zone: {{ $domain.zone }}
+    dns.gardener.cloud/include-zones: {{ $domain.zone }}
     {{- end }}
 type: Opaque
 data:


### PR DESCRIPTION
/kind/enhancement
/area/control-plane

Cherry pick of #4950 on release-v1.33.

#4950: set include-zones annotation for default domains

**Release Notes:**
```other operator
Set `dns.gardener.cloud/include-zones` annotation for the default domain secret in the Gardener controlplane chart.
```