### PR TITLE
Extend CRD for DNSOwner with DNSActivation fields

### DIFF
--- a/pkg/operation/botanist/component/extensions/crds/templates/crd-dnsowner.tpl.yaml
+++ b/pkg/operation/botanist/component/extensions/crds/templates/crd-dnsowner.tpl.yaml
@@ -51,6 +51,18 @@ spec:
                 active:
                   description: state of the ownerid for the DNS controller observing entry using this owner id (default:true)
                   type: boolean
+                dnsActivation:
+                  description: Optional activation info for controlling the owner activation remotely via DNS TXT record
+                  properties:
+                    dnsName:
+                      description: DNS name for controlling the owner activation remotely via DNS TXT record
+                      type: string
+                    value:
+                      description: Optional value for the DNS activation record used to activate this owner The default is the id of the cluster used to read the owner object
+                      type: string
+                  required:
+                    - dnsName
+                  type: object
                 ownerId:
                   description: owner id used to tag entries in external DNS system
                   type: string
@@ -63,6 +75,9 @@ spec:
               type: object
             status:
               properties:
+                active:
+                  description: state of the ownerid for the DNS controller observing entry using this owner id
+                  type: boolean
                 entries:
                   description: Entry statistic for this owner id
                   properties:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind enhancement

**What this PR does / why we need it**:
The `DNSOwner` will support "DNSActivation" with the next release containing PR https://github.com/gardener/external-dns-management/pull/192.
This allows to activate/deactivate the shoot's `DNSEntries` in the controlplane namespace of the seed generated by the shoot-dns-service using the owner DNS record.
As the `CustomResourceDefinition` of the `DNSOwner` is managed by Gardener, the CRD needs to updated here.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Extend `DNSOwner` CRD with `DNSActivation` fields
```
