### PR TITLE
Fix deletion of shoots with invalid DNS provider credentials

### DIFF
--- a/pkg/operation/botanist/dns.go
+++ b/pkg/operation/botanist/dns.go
@@ -372,9 +372,14 @@ func (b *Botanist) APIServerSNIPodMutatorEnabled() bool {
 
 // DeployAdditionalDNSProviders deploys all additional DNS providers in the shoot namespace of the seed.
 func (b *Botanist) DeployAdditionalDNSProviders(ctx context.Context) error {
-	fns := make([]flow.TaskFn, 0, len(b.Shoot.Components.Extensions.DNS.AdditionalProviders))
+	return b.DeployDNSProviders(ctx, b.Shoot.Components.Extensions.DNS.AdditionalProviders)
+}
 
-	for _, v := range b.Shoot.Components.Extensions.DNS.AdditionalProviders {
+// DeployDNSProviders deploys the specified DNS providers in the shoot namespace of the seed.
+func (b *Botanist) DeployDNSProviders(ctx context.Context, dnsProviders map[string]component.DeployWaiter) error {
+	fns := make([]flow.TaskFn, 0, len(dnsProviders))
+
+	for _, v := range dnsProviders {
 		dnsProvider := v
 		fns = append(fns, func(ctx context.Context) error {
 			return component.OpWaiter(dnsProvider).Deploy(ctx)

--- a/pkg/utils/kubernetes/object.go
+++ b/pkg/utils/kubernetes/object.go
@@ -24,6 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -38,6 +39,15 @@ func ObjectName(obj client.Object) string {
 		return obj.GetName()
 	}
 	return client.ObjectKeyFromObject(obj).String()
+}
+
+// ParseObjectName parses the given object name (in the format <namespace>/<name>) to its constituent namespace and name.
+// If the given object name is not namespaced, an empty namespace is returned.
+func ParseObjectName(objectName string) (string, string) {
+	if parts := strings.Split(objectName, string(types.Separator)); len(parts) == 2 {
+		return parts[0], parts[1]
+	}
+	return "", objectName
 }
 
 // DeleteObjects deletes a list of Kubernetes objects.

--- a/pkg/utils/kubernetes/object_test.go
+++ b/pkg/utils/kubernetes/object_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/hashicorp/go-multierror"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -57,6 +58,18 @@ var _ = Describe("Object", func() {
 	AfterEach(func() {
 		ctrl.Finish()
 	})
+
+	DescribeTable("#ParseObjectName",
+		func(objectName, expectedNamespace, expectedName string) {
+			namespace, name := ParseObjectName(objectName)
+			Expect(namespace).To(Equal(expectedNamespace))
+			Expect(name).To(Equal(expectedName))
+		},
+		Entry("namespaced name", "foo/bar", "foo", "bar"),
+		Entry("non-namespaced name", "foo", "", "foo"),
+		Entry("non-namespaced name with a separator", "/foo", "", "foo"),
+		Entry("empty name", "", "", ""),
+	)
 
 	Describe("#DeleteObjects", func() {
 		It("should fail because an object fails to delete", func() {


### PR DESCRIPTION
**How to categorize this PR?**

/area networking
/kind bug

**What this PR does / why we need it**:
Fixes deletion of shoots with invalid DNS provider credentials by avoiding the deployment of additional DNS providers in the deletion flow for which there are no `DNSEntry` resources with non-empty `Status.Targets` in the shoot namespace (for example, if the `DNSProvider` has never been created successfully in the first place). 

Note that if there are `DNSEntry` resources with non-empty `Status.Targets` for a `DNSProvider` it will still be deployed and the shoot deletion will still fail if this fails (e.g. due to invalid credentials). In such situations, it is mandatory to fix the credentials (or whatever error is preventing the successful `DNSProvider` deployment) in order to ensure that actual DNS records will be deleted.

**Which issue(s) this PR fixes**:
Fixes #4778

**Special notes for your reviewer**:

**Release note**:

```bugfix user
It should now be possible to delete shoots with invalid DNS provider credentials if there are no DNSEntry resources with non-empty `Status.Targets` for the corresponding provider in the shoot namespace.
```
