### PR TITLE
Temporarily skip Root CA Controller Integration Test Suite

### DIFF
--- a/test/integration/envtest/resourcemanager/rootcapublisher/publisher_suite_test.go
+++ b/test/integration/envtest/resourcemanager/rootcapublisher/publisher_suite_test.go
@@ -32,7 +32,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
+// TODO: This test suite is disabled because of a known flake in the test.
+// Enable the test suite again after fixing the flake.
+
 func TestRootCAPublisher(t *testing.T) {
+	t.Skipf("Temporarily skipping the test suite because of known flake...")
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Root CA Controller Integration Test Suite")
 }


### PR DESCRIPTION
/area testing
/kind flake

Temporarily skip the `RootCAPublisher` test suite until the known flake (see #4970) is fixed.

**Release note**:

```other operator
NONE
```
