### PR TITLE
Improvements during machine drains

### DIFF
--- a/example/gardener-local/kind/kubeconfig
+++ b/example/gardener-local/kind/kubeconfig
@@ -1,0 +1,3 @@
+apiVersion: v1
+kind: Config
+preferences: {}

--- a/extensions/pkg/controller/healthcheck/healtcheck_actuator.go
+++ b/extensions/pkg/controller/healthcheck/healtcheck_actuator.go
@@ -246,6 +246,7 @@ func (a *Actuator) ExecuteHealthCheckFunctions(ctx context.Context, request type
 					details.WriteString(fmt.Sprintf("%d) %s ", index+1, ensureTrailingDot(check.detail)))
 				}
 
+				// take only the lowest threshold per condition type to not hide any failed checks
 				if check.threshold != nil && (threshold == nil || *threshold > *check.threshold) {
 					threshold = check.threshold
 				}

--- a/extensions/pkg/controller/healthcheck/worker/helpers.go
+++ b/extensions/pkg/controller/healthcheck/worker/helpers.go
@@ -16,12 +16,16 @@ package worker
 
 import (
 	"fmt"
+	"math"
 	"strings"
+	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardencorev1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var (
@@ -37,6 +41,10 @@ var (
 		machinev1alpha1.MachineDeploymentReplicaFailure,
 		machinev1alpha1.MachineDeploymentFrozen,
 	}
+
+	// NowFunc is a function returning the current time.
+	// Exposed for testing.
+	NowFunc = time.Now
 )
 
 // CheckMachineDeployment checks whether the given MachineDeployment is healthy.
@@ -103,11 +111,15 @@ func checkNodesScalingUp(machineList *machinev1alpha1.MachineList, readyNodes, d
 		return gardencorev1beta1.ConditionFalse, fmt.Errorf("not enough machine objects created yet (%d/%d)", machineObjects, desiredMachines)
 	}
 
-	var pendingMachines, erroneousMachines int
+	var pendingMachines, erroneousMachines, terminatingMachines int
 	for _, machine := range machineList.Items {
 		switch machine.Status.CurrentStatus.Phase {
 		case machinev1alpha1.MachineRunning, machinev1alpha1.MachineAvailable:
 			// machine is already running fine
+			continue
+		case machinev1alpha1.MachineTerminating:
+			// terminating machines are not handled by this check. This is to avoid showing terminating/draining machines during a rolling update as erroneous.
+			terminatingMachines++
 			continue
 		case machinev1alpha1.MachinePending, "": // https://github.com/gardener/machine-controller-manager/issues/466
 			// machine is in the process of being created
@@ -119,18 +131,18 @@ func checkNodesScalingUp(machineList *machinev1alpha1.MachineList, readyNodes, d
 	}
 
 	if erroneousMachines > 0 {
-		return gardencorev1beta1.ConditionFalse, fmt.Errorf("%s erroneous", cosmeticMachineMessage(erroneousMachines))
+		return gardencorev1beta1.ConditionFalse, fmt.Errorf("%s erroneous", cosmeticNodeMessage(erroneousMachines))
 	}
 	if pendingMachines == 0 {
 		return gardencorev1beta1.ConditionFalse, fmt.Errorf("not enough ready worker nodes registered in the cluster (%d/%d)", readyNodes, desiredMachines)
 	}
 
-	return gardencorev1beta1.ConditionProgressing, fmt.Errorf("%s provisioning and should join the cluster soon", cosmeticMachineMessage(pendingMachines))
+	return gardencorev1beta1.ConditionProgressing, fmt.Errorf("%s provisioning and should join the cluster soon", cosmeticNodeMessage(pendingMachines))
 }
 
-func checkNodesScalingDown(machineList *machinev1alpha1.MachineList, nodeList *corev1.NodeList, registeredNodes, desiredMachines int) (gardencorev1beta1.ConditionStatus, error) {
+func checkNodesScalingDown(machineList *machinev1alpha1.MachineList, nodeList *corev1.NodeList, registeredNodes, desiredMachines int, machineDrainTimeoutThreshold *int) (gardencorev1beta1.ConditionStatus, *time.Duration, error) {
 	if registeredNodes == desiredMachines {
-		return gardencorev1beta1.ConditionTrue, nil
+		return gardencorev1beta1.ConditionTrue, nil, nil
 	}
 
 	// Check if all nodes that are cordoned map to machines with a deletion timestamp. This might be the case during
@@ -142,26 +154,121 @@ func checkNodesScalingDown(machineList *machinev1alpha1.MachineList, nodeList *c
 		}
 	}
 
-	var cordonedNodes int
+	// NOTE: The drain window is defined as the machineDrainTimeout on the Worker Pool * machineDrainTimeoutThreshold (e.g 0.8)
+	// The machineDrainTimeoutThreshold is specific to the extension
+	var (
+		// Machines of worker pool not defining a machineDrainTimeout
+		cordonedNodesWithoutCustomDrainTimeout int
+		// Machines not exceeding the worker pool's machineDrainTimeout.
+		cordonedNodesWithinCustomDrainWindow int
+		// Machines that failed to be drained during the drain window. This causes the health check to fail.
+		// The machines are drained as soon as the whole duration defined in the worker pool's machineDrainTimeout is expired.
+		cordonedNodesExceedingCustomDrainWindow int
+		// Threshold that marks this health check as progressing
+		scaleDownProgressingThresholdNotExceeded = defaultScaleDownProgressingThreshold
+		// Threshold that marks this health check as failed. The overall health check in the Shoot might still be shown as progressing.
+		scaleDownProgressingThresholdExceeded = defaultScaleDownProgressingThreshold
+
+		minDurationUntilDrainWindowExpires        time.Duration
+		nameNextWorkerPoolWithExpiringDrainWindow string
+
+		nameWorkerPoolWithAlreadyExpiringDrainWindow string
+		nextForceDeletionTime                        time.Time
+		minDurationTillForceDeletion                 time.Duration
+	)
+
 	for _, node := range nodeList.Items {
 		if node.Spec.Unschedulable {
 			machine, ok := nodeNameToMachine[node.Name]
 			if !ok {
-				return gardencorev1beta1.ConditionFalse, fmt.Errorf("machine object for cordoned node %q not found", node.Name)
+				return gardencorev1beta1.ConditionFalse, nil, fmt.Errorf("machine object for cordoned node %q not found", node.Name)
 			}
 			if machine.DeletionTimestamp == nil {
-				return gardencorev1beta1.ConditionFalse, fmt.Errorf("cordoned node %q found but corresponding machine object does not have a deletion timestamp", node.Name)
+				return gardencorev1beta1.ConditionFalse, nil, fmt.Errorf("cordoned node %q found but corresponding machine object does not have a deletion timestamp", node.Name)
 			}
-			cordonedNodes++
+
+			// Only count as a condoned node when exceeds drain threshold
+			// this check is done here and not on a higher level, as it is a relative value based on
+			// the machine's individual drain timeout
+			if machine.Spec.MachineConfiguration != nil &&
+				machine.Spec.MachineConfiguration.MachineDrainTimeout != nil &&
+				machineDrainTimeoutThreshold != nil {
+				exceeded, progressingThresholdBasedOnMachineDrainTimeout, durationTillExpiration := ThresholdIsExceeded(machine.DeletionTimestamp, *machine.Spec.MachineDrainTimeout, *machineDrainTimeoutThreshold)
+
+				if !exceeded {
+					cordonedNodesWithinCustomDrainWindow++
+
+					// Remember the highest threshold. This is for the case that no nodes exceed the machineDrainTimeoutThreshold!
+					// Reason: we know in that case that all cordoned machines respect the threshold for the custom MachineDrainTimeout => we have to return a threshold that marks this check as progressing, not failed.
+					// If a scaleDownProgressingThreshold lower than the highest threshold for any machine is returned, it causes a failing health check because the
+					// LastTransitionTime on the ExtensionResource for the EveryNodeReady condition is older.
+					if progressingThresholdBasedOnMachineDrainTimeout > scaleDownProgressingThresholdNotExceeded {
+						scaleDownProgressingThresholdNotExceeded = progressingThresholdBasedOnMachineDrainTimeout
+					}
+
+					// to have a useful error message on the extension resource, also remember the time until the next drain window expires
+					if minDurationUntilDrainWindowExpires == 0 || durationTillExpiration < minDurationUntilDrainWindowExpires {
+						minDurationUntilDrainWindowExpires = durationTillExpiration
+						nameNextWorkerPoolWithExpiringDrainWindow = machine.Spec.NodeTemplateSpec.Labels[gardencorev1beta1constants.LabelWorkerPool]
+					}
+
+					continue
+				}
+
+				// Remember the lowest threshold. This is for the case that at least the machine of one node exceeds the machineDrainTimeoutThreshold!
+				// we have to return a threshold that marks this check as failed, not progressing.
+				// This also overwrites the defaultScaleDownProgressingThreshold if the MachineDrainTimeout of the current machine is lower than that
+				// (otherwise, we might never see an error for a machine whose timeout is lower than the defaultScaleDownProgressingThreshold).
+				if progressingThresholdBasedOnMachineDrainTimeout < scaleDownProgressingThresholdExceeded {
+					scaleDownProgressingThresholdExceeded = progressingThresholdBasedOnMachineDrainTimeout
+				}
+
+				// calculate the time when the MCM will force drain the machine
+				// this is important information for the Shoot owner and operator and should be visible in the Shoot's readiness conditions
+				forceDeletionTime, durationTillForceDeletion := GetDurationTillForceDeletion(machine.DeletionTimestamp, *machine.Spec.MachineDrainTimeout)
+
+				if minDurationTillForceDeletion == 0 || durationTillForceDeletion < minDurationTillForceDeletion {
+					minDurationTillForceDeletion = durationTillForceDeletion
+					nextForceDeletionTime = forceDeletionTime
+					nameWorkerPoolWithAlreadyExpiringDrainWindow = machine.Spec.NodeTemplateSpec.Labels[gardencorev1beta1constants.LabelWorkerPool]
+				}
+
+				cordonedNodesExceedingCustomDrainWindow++
+				continue
+			}
+
+			cordonedNodesWithoutCustomDrainTimeout++
 		}
 	}
 
-	// If there are still more nodes than desired then report an error.
-	if registeredNodes-cordonedNodes != desiredMachines {
-		return gardencorev1beta1.ConditionFalse, fmt.Errorf("too many worker nodes are registered. Exceeding maximum desired machine count (%d/%d)", registeredNodes, desiredMachines)
+	// All good: there are no nodes without a machineDrainTimeout and there are no cordoned nodes whose machines exceed the machineDrainTimeoutThreshold.
+	// Return a threshold that does not mark this test as failed.
+	if cordonedNodesWithoutCustomDrainTimeout == 0 && cordonedNodesExceedingCustomDrainWindow == 0 && cordonedNodesWithinCustomDrainWindow > 0 {
+		return gardencorev1beta1.ConditionProgressing, &scaleDownProgressingThresholdNotExceeded, fmt.Errorf("%s waiting to be drained from pods. The %s within the regular drain window. The Shoot's next drain window targets worker pool %q and ends in %s", cosmeticNodeMessage(cordonedNodesWithinCustomDrainWindow), cosmeticNodeMessageNoCount(cordonedNodesWithinCustomDrainWindow), nameNextWorkerPoolWithExpiringDrainWindow, minDurationUntilDrainWindowExpires.Round(time.Second).String())
 	}
 
-	return gardencorev1beta1.ConditionProgressing, fmt.Errorf("%s waiting to be completely drained from pods. If this persists, check your pod disruption budgets and pending finalizers. Please note, that nodes that fail to be drained will be deleted automatically", cosmeticMachineMessage(cordonedNodes))
+	// There are no nodes without a machineDrainTimeout but there are cordoned nodes whose machines exceed the MachineDrainTimeout.
+	if cordonedNodesWithoutCustomDrainTimeout == 0 && cordonedNodesExceedingCustomDrainWindow > 0 {
+		if time.Now().UTC().Before(nextForceDeletionTime) {
+			return gardencorev1beta1.ConditionFalse, nil, fmt.Errorf("%s failed to be drained from pods within the regular drain window. Please note, that nodes of worker pool %q are forcefully terminated at %s (in %s)", cosmeticNodeSingularPlural(cordonedNodesExceedingCustomDrainWindow), nameWorkerPoolWithAlreadyExpiringDrainWindow, nextForceDeletionTime.Round(time.Second).String(), minDurationTillForceDeletion.Round(time.Second).String())
+		}
+		return gardencorev1beta1.ConditionFalse, nil, fmt.Errorf("%s failed to be drained from pods within the regular drain window. Please note, that nodes of worker pool %q are forcefully terminated since %s", cosmeticNodeSingularPlural(cordonedNodesExceedingCustomDrainWindow), nameWorkerPoolWithAlreadyExpiringDrainWindow, nextForceDeletionTime.Round(time.Second).String())
+	}
+
+	totalCordonedNodes := cordonedNodesWithoutCustomDrainTimeout + cordonedNodesExceedingCustomDrainWindow + cordonedNodesWithinCustomDrainWindow
+
+	// There are too many registered node, but no machine is currently being drained.
+	if totalCordonedNodes == 0 && registeredNodes > desiredMachines {
+		return gardencorev1beta1.ConditionFalse, nil, fmt.Errorf("too many worker nodes are registered. Exceeding maximum desired machine count (%d/%d)", registeredNodes, desiredMachines)
+	}
+
+	// If there are still more nodes than desired then report an error.
+	if registeredNodes-totalCordonedNodes > desiredMachines {
+		return gardencorev1beta1.ConditionFalse, nil, fmt.Errorf("too many worker nodes are registered. Exceeding maximum desired machine count (%d/%d). Additionally, %s waiting to be completely drained from pods", registeredNodes, desiredMachines, cosmeticNodeMessage(totalCordonedNodes))
+	}
+
+	// Either no machineDrainTimeoutThreshold was defined (Status: progressing or failed), or the machineDrainTimeoutThreshold of at least one machine is exceeded (Status: failed)
+	return gardencorev1beta1.ConditionProgressing, &scaleDownProgressingThresholdExceeded, fmt.Errorf("%s waiting to be drained from pods. If this persists, check your pod disruption budgets and pending finalizers. Please note, that nodes which fail to be drained are forcefully terminated", cosmeticNodeMessage(totalCordonedNodes))
 }
 
 func getDesiredMachineCount(machineDeployments []machinev1alpha1.MachineDeployment) int {
@@ -194,9 +301,44 @@ func requiredConditionMissing(conditionType machinev1alpha1.MachineDeploymentCon
 	return fmt.Errorf("condition %q is missing", conditionType)
 }
 
-func cosmeticMachineMessage(numberOfMachines int) string {
-	if numberOfMachines == 1 {
-		return fmt.Sprintf("%d machine is", numberOfMachines)
+func cosmeticNodeMessage(numberOfNodes int) string {
+	if numberOfNodes == 1 {
+		return fmt.Sprintf("%d node is", numberOfNodes)
 	}
-	return fmt.Sprintf("%d machines are", numberOfMachines)
+	return fmt.Sprintf("%d nodes are", numberOfNodes)
+}
+
+func cosmeticNodeSingularPlural(numberOfNodes int) string {
+	if numberOfNodes == 1 {
+		return fmt.Sprintf("%d node", numberOfNodes)
+	}
+	return fmt.Sprintf("%d nodes", numberOfNodes)
+}
+
+func cosmeticNodeMessageNoCount(numberOfNodes int) string {
+	if numberOfNodes == 1 {
+		return "node is"
+	}
+	return "nodes are"
+}
+
+// ThresholdIsExceeded returns
+// - true in case the given thresholdPercentage is exceeded.
+// - the threshold based on the given thresholdPercentage.
+// - the duration until the threshold is exceeded, or the duration the threshold is already exceeded
+func ThresholdIsExceeded(base *metav1.Time, duration metav1.Duration, thresholdPercentage int) (bool, time.Duration, time.Duration) {
+	elapsedValidity := NowFunc().UTC().Sub(base.Time.UTC()).Seconds()
+	var validityThreshold = duration.Seconds() * (float64(thresholdPercentage) / 100)
+
+	return elapsedValidity > validityThreshold, time.Duration(int64(validityThreshold)) * time.Second, time.Duration(int64(math.Abs(elapsedValidity-validityThreshold))) * time.Second
+}
+
+// GetDurationTillForceDeletion calculates the time when a machine is force deleted by the MCM given the deletion timestamp
+// of the machine and the machineDrainTimeout
+// returns
+// - the UTC time when the force deletion takes place
+// - the time until force deletion
+func GetDurationTillForceDeletion(machineDeletionTimestamp *metav1.Time, drainTimeout metav1.Duration) (time.Time, time.Duration) {
+	forceDeletionTime := machineDeletionTimestamp.Time.UTC().Add(drainTimeout.Duration)
+	return forceDeletionTime, forceDeletionTime.Sub(time.Now().UTC())
 }

--- a/pkg/operation/botanist/component/extensions/worker/worker_test.go
+++ b/pkg/operation/botanist/component/extensions/worker/worker_test.go
@@ -40,7 +40,6 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -108,37 +107,6 @@ var _ = Describe("Worker", func() {
 		worker2MachineImageVersion       = "worker2machineimagev1"
 		worker2UserData                  = []byte("bootstrap-me-now")
 
-		machineTypes = []gardencorev1beta1.MachineType{
-			{
-				Name:   worker1MachineType,
-				CPU:    resource.MustParse("4"),
-				GPU:    resource.MustParse("1"),
-				Memory: resource.MustParse("256Gi"),
-			},
-			{
-				Name:   worker2MachineType,
-				CPU:    resource.MustParse("16"),
-				GPU:    resource.MustParse("0"),
-				Memory: resource.MustParse("512Gi"),
-			},
-		}
-
-		workerPool1NodeTemplate = &extensionsv1alpha1.NodeTemplate{
-			Capacity: corev1.ResourceList{
-				"cpu":    machineTypes[0].CPU,
-				"gpu":    machineTypes[0].GPU,
-				"memory": machineTypes[0].Memory,
-			},
-		}
-
-		workerPool2NodeTemplate = &extensionsv1alpha1.NodeTemplate{
-			Capacity: corev1.ResourceList{
-				"cpu":    machineTypes[1].CPU,
-				"gpu":    machineTypes[1].GPU,
-				"memory": machineTypes[1].Memory,
-			},
-		}
-
 		w, empty *extensionsv1alpha1.Worker
 		wSpec    extensionsv1alpha1.WorkerSpec
 
@@ -161,7 +129,6 @@ var _ = Describe("Worker", func() {
 			Type:                         extensionType,
 			Region:                       region,
 			KubernetesVersion:            kubernetesVersion,
-			MachineTypes:                 machineTypes,
 			SSHPublicKey:                 sshPublicKey,
 			InfrastructureProviderStatus: infrastructureProviderStatus,
 			WorkerNameToOperatingSystemConfigsMap: map[string]*operatingsystemconfig.OperatingSystemConfigs{
@@ -301,7 +268,6 @@ var _ = Describe("Worker", func() {
 					KubernetesVersion:                pointer.String(kubernetesVersion.String()),
 					Zones:                            []string{worker1Zone1, worker1Zone2},
 					MachineControllerManagerSettings: worker1MCMSettings,
-					NodeTemplate:                     workerPool1NodeTemplate,
 				},
 				{
 					Name:           worker2Name,
@@ -322,7 +288,6 @@ var _ = Describe("Worker", func() {
 					},
 					KubernetesVersion: &workerKubernetesVersion,
 					UserData:          worker2UserData,
-					NodeTemplate:      workerPool2NodeTemplate,
 				},
 			},
 		}
@@ -343,7 +308,6 @@ var _ = Describe("Worker", func() {
 			Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
 
 			obj := &extensionsv1alpha1.Worker{}
-
 			err := c.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, obj)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -362,53 +326,6 @@ var _ = Describe("Worker", func() {
 					ResourceVersion: "1",
 				},
 				Spec: wSpec,
-			}))
-		})
-		It("should initialize nodeTemplate when it exists for pool in worker resource, but absent in cloudProfile", func() {
-			defer test.WithVars(&worker.TimeNow, mockNow.Do)()
-			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
-
-			newValues := *values
-			newValues.Workers = []gardencorev1beta1.Worker{
-				values.Workers[1],
-			}
-			newValues.MachineTypes = []gardencorev1beta1.MachineType{}
-
-			expectedWorkerSpec := wSpec.DeepCopy()
-			expectedWorkerSpec.Pools = []extensionsv1alpha1.WorkerPool{
-				wSpec.Pools[1],
-			}
-
-			existingWorker := w.DeepCopy()
-			existingWorker.Spec.Pools = []extensionsv1alpha1.WorkerPool{
-				wSpec.Pools[1],
-			}
-
-			Expect(c.Create(ctx, existingWorker)).To(Succeed(), "creating worker succeeds")
-
-			defaultDepWaiter = worker.New(log, c, &newValues, time.Millisecond, 250*time.Millisecond, 500*time.Millisecond)
-			Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
-
-			obj := &extensionsv1alpha1.Worker{}
-
-			err := c.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, obj)
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(obj).To(DeepEqual(&extensionsv1alpha1.Worker{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: extensionsv1alpha1.SchemeGroupVersion.String(),
-					Kind:       extensionsv1alpha1.WorkerResource,
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      name,
-					Namespace: namespace,
-					Annotations: map[string]string{
-						"gardener.cloud/operation": "reconcile",
-						"gardener.cloud/timestamp": now.UTC().String(),
-					},
-					ResourceVersion: "2",
-				},
-				Spec: *expectedWorkerSpec,
 			}))
 		})
 	})
@@ -556,7 +473,7 @@ var _ = Describe("Worker", func() {
 			mc.EXPECT().Status().Return(mc)
 
 			mc.EXPECT().Get(ctx, client.ObjectKeyFromObject(empty), gomock.AssignableToTypeOf(empty)).
-				Return(apierrors.NewNotFound(extensionsv1alpha1.Resource("workers"), name)).AnyTimes()
+				Return(apierrors.NewNotFound(extensionsv1alpha1.Resource("workers"), name))
 
 			// deploy with wait-for-state annotation
 			obj := w.DeepCopy()


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/kind enhancement

**What this PR does / why we need it**:

Shoot reconciliation respects custom machineDrainTimeout
 - the time the Gardenlet waits for the worker to be reconciled is adjusted if a node pool configures a custom machine drain timeout. This avoids unnecessary reconciles and running into backoffs.
 - Minor caveat: The first reconciliation assumes that no rolling update is in progress using the default timeout, as the provider extension has not yet updated the Worker's `RollingUpdate` condition. This can lead to at maximum 2 reconciliations during a drain operation (before it was n * default timeout of 10 minutes, not considering backoff).

Fix errors in machine health checks 
 - do not hide drain operations when deleting a worker pool.
 - do not wrongly label `terminating` machines as `erroneous` during rolling update scenarios.
 - Do not cause failing (but progressing) health checks for machines that are drained within their machine drain timeout specified in the [Shoot resource for each worker pool](https://github.com/gardener/gardener/blob/83acd9e3f2cce4fd04a597282170a06ec1d335b2/example/90-shoot.yaml#L121)

Improve health check messages during drain operations
- Add health check information about the next worker pool regular drain window (based on the `machineDrainTimeout` and an extension-specific threshold)
- After the health check window expired, inform about the next force termination time + duration


**Which issue(s) this PR fixes**:
Fixes #4726 4726

**Special notes for your reviewer**:

I have tried to test all worker pool scenarios:
- For one and multiple Worker pools: scale up, scale down, drain without custom drain timeout, drain with custom drain timeout where pods block the drain
- Rolling updates of 1 or more worker pools
- Deletion of a worker pool

You can use this pod to simulate workload that fails to drain for an hour without having a misconfigured PDB

```
apiVersion: v1
kind: Pod
metadata:
  name: nodrain
spec:
  containers:
    - command:
        - sleep
        - "10000000"
      image: eu.gcr.io/gardener-project/gardener/ops-toolbelt
      imagePullPolicy: Always
      name: dummy
      resources: {}
      stdin: true
      terminationMessagePath: /dev/termination-log
      terminationMessagePolicy: File
      lifecycle:
        preStop:
          exec:
            command: [ "/bin/sh","-c","sleep 3600" ]
  priority: 0
  terminationGracePeriodSeconds: 7200
  restartPolicy: Always
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
 The gardenlet respects node pool-specific machine drain timeouts to reduce reconciliations.
```
```other operator
 Healthcheck messages have been improved for machine drain operations.
```
```other operator
Machines that are drained within their machine drain timeout cause `Progressing` health checks. Machines that fail to be drained within their machine drain timeout cause failed health checks.
```