### PR TITLE
Fixes nil ptr exception if an `etcd.Status.Etcd` field is not set

### DIFF
--- a/pkg/operation/botanist/component/etcd/etcd.go
+++ b/pkg/operation/botanist/component/etcd/etcd.go
@@ -195,7 +195,7 @@ func (e *etcd) Deploy(ctx context.Context) error {
 	}
 
 	stsName := e.etcd.Name
-	if foundEtcd && existingEtcd.Status.Etcd.Name != "" {
+	if foundEtcd && existingEtcd.Status.Etcd != nil && existingEtcd.Status.Etcd.Name != "" {
 		stsName = existingEtcd.Status.Etcd.Name
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
During shoot creation, if the deployment of the etcd component is retried due to a minor error (In the `RetryUntilTimeout()` func) a nil pointer exception is thrown because the `etcd.Status.Etcd` field is not populated by the etcd-druid yet.
The same can happen during shoot creation if the `etcd-druid` is stuck in a crashloop backoff or is not running for some other reason.

**Which issue(s) this PR fixes**:
Fixes #4964

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
  Fixes a nil pointer exception during shoot creation that can occur when deploying the `etcd-main` and `etcd-events` `Etcd` resources if their `etcd.Status.Etcd` fields are not set by the etcd-druid fast enough.
```
