### PR TITLE
Removes reconciliation of controlplane with deletion timestamp

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_delete.go
@@ -650,10 +650,11 @@ func needsControlPlaneDeployment(ctx context.Context, o *operation.Operation, ku
 	if err != nil {
 		return false, err
 	}
+
 	// treat `ControlPlane` in deletion as if it is already gone. If it is marked for deletion, we also shouldn't wait
 	// for it to be reconciled, as it can potentially block the whole deletion flow (deletion depends on other control
 	// plane components like kcm and grm) which are scaled up later in the flow
-	if (!exists || markedForDeletion) && !kubeAPIServerDeploymentFound {
+	if !exists && !kubeAPIServerDeploymentFound || markedForDeletion {
 		return false, nil
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane ops-productivity robustness
/kind bug

**What this PR does / why we need it**:
When a Shoot is deleted and the corresponding `extensions.gardener.cloud/v1alpha1.ControlPlane` resource already has a `.metadata.deletionTimestamp` it will not be redeployed if the deletion flow is restarted. However, if the `extensions.gardener.cloud/v1alpha1.ControlPlane` resource is already gone, but the kube-apiserver deployment still exists, it will be redeployed because some providers require an injection of a `cloud-provider-config` secret (which is managed by the `ControlPlane`) in the kube-apiserver deployment. If that secret is missing and the `Infrastructure` resource still exists, the shoot deletion flow can get stuck on [this step](https://github.com/gardener/gardener/blob/acc2dc4f9b0f8fe39115e1af7ad22c247dbf9f83/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go#L266) if the kube-apiserver pods are restarted for some reaosn.

**Which issue(s) this PR fixes**:
Fixes #4724

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
When a Shoot is deleted and the corresponding `extensions.gardener.cloud/v1alpha1.ControlPlane` resource already has a `.metadata.deletionTimestamp` it will not be redeployed if the deletion flow is restarted.
```
