### PR TITLE
Fix API server address in cloud-config-download for shoots with disabled DNS

### DIFF
--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/mock/mocks.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/mock/mocks.go
@@ -106,6 +106,18 @@ func (mr *MockInterfaceMockRecorder) Restore(arg0, arg1 interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Restore", reflect.TypeOf((*MockInterface)(nil).Restore), arg0, arg1)
 }
 
+// SetAPIServerAdress mocks base method.
+func (m *MockInterface) SetAPIServerAdress(arg0 string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetAPIServerAdress", arg0)
+}
+
+// SetAPIServerAdress indicates an expected call of SetAPIServerAdress.
+func (mr *MockInterfaceMockRecorder) SetAPIServerAdress(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAPIServerAdress", reflect.TypeOf((*MockInterface)(nil).SetAPIServerAdress), arg0)
+}
+
 // SetCABundle mocks base method.
 func (m *MockInterface) SetCABundle(arg0 *string) {
 	m.ctrl.T.Helper()

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/mock/mocks.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/mock/mocks.go
@@ -106,16 +106,16 @@ func (mr *MockInterfaceMockRecorder) Restore(arg0, arg1 interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Restore", reflect.TypeOf((*MockInterface)(nil).Restore), arg0, arg1)
 }
 
-// SetAPIServerAdress mocks base method.
-func (m *MockInterface) SetAPIServerAdress(arg0 string) {
+// SetAPIServerURL mocks base method.
+func (m *MockInterface) SetAPIServerURL(arg0 string) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetAPIServerAdress", arg0)
+	m.ctrl.Call(m, "SetAPIServerURL", arg0)
 }
 
-// SetAPIServerAdress indicates an expected call of SetAPIServerAdress.
-func (mr *MockInterfaceMockRecorder) SetAPIServerAdress(arg0 interface{}) *gomock.Call {
+// SetAPIServerURL indicates an expected call of SetAPIServerURL.
+func (mr *MockInterfaceMockRecorder) SetAPIServerURL(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAPIServerAdress", reflect.TypeOf((*MockInterface)(nil).SetAPIServerAdress), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetAPIServerURL", reflect.TypeOf((*MockInterface)(nil).SetAPIServerURL), arg0)
 }
 
 // SetCABundle mocks base method.

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -66,8 +66,8 @@ type Interface interface {
 	DeleteStaleResources(context.Context) error
 	// WaitCleanupStaleResources waits until all unused OperatingSystemConfig resources are cleaned up.
 	WaitCleanupStaleResources(context.Context) error
-	// SetAPIServerAdress sets the APIServerURL value.
-	SetAPIServerAdress(string)
+	// SetAPIServerURL sets the APIServerURL value.
+	SetAPIServerURL(string)
 	// SetCABundle sets the CABundle value.
 	SetCABundle(*string)
 	// SetKubeletCACertificate sets the KubeletCACertificate value.
@@ -400,9 +400,9 @@ func (o *operatingSystemConfig) forEachWorkerPoolAndPurposeTaskFn(fn func(contex
 	return fns
 }
 
-// SetAPIServerAdress sets the APIServerURL value.
-func (o *operatingSystemConfig) SetAPIServerAdress(address string) {
-	o.values.APIServerURL = address
+// SetAPIServerURL sets the APIServerURL value.
+func (o *operatingSystemConfig) SetAPIServerURL(apiServerURL string) {
+	o.values.APIServerURL = apiServerURL
 }
 
 // SetCABundle sets the CABundle value.

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -66,6 +66,8 @@ type Interface interface {
 	DeleteStaleResources(context.Context) error
 	// WaitCleanupStaleResources waits until all unused OperatingSystemConfig resources are cleaned up.
 	WaitCleanupStaleResources(context.Context) error
+	// SetAPIServerAdress sets the APIServerURL value.
+	SetAPIServerAdress(string)
 	// SetCABundle sets the CABundle value.
 	SetCABundle(*string)
 	// SetKubeletCACertificate sets the KubeletCACertificate value.
@@ -396,6 +398,11 @@ func (o *operatingSystemConfig) forEachWorkerPoolAndPurposeTaskFn(fn func(contex
 	})
 
 	return fns
+}
+
+// SetAPIServerAdress sets the APIServerURL value.
+func (o *operatingSystemConfig) SetAPIServerAdress(address string) {
+	o.values.APIServerURL = address
 }
 
 // SetCABundle sets the CABundle value.

--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -63,9 +63,6 @@ func (b *Botanist) DefaultOperatingSystemConfig() (operatingsystemconfig.Interfa
 			Namespace:         b.Shoot.SeedNamespace,
 			KubernetesVersion: b.Shoot.KubernetesVersion,
 			Workers:           b.Shoot.GetInfo().Spec.Provider.Workers,
-			DownloaderValues: operatingsystemconfig.DownloaderValues{
-				APIServerURL: fmt.Sprintf("https://%s", b.Shoot.ComputeOutOfClusterAPIServerAddress(b.APIServerAddress, true)),
-			},
 			OriginalValues: operatingsystemconfig.OriginalValues{
 				ClusterDNSAddress:       clusterDNSAddress,
 				ClusterDomain:           gardencorev1beta1.DefaultDomain,
@@ -84,6 +81,7 @@ func (b *Botanist) DefaultOperatingSystemConfig() (operatingsystemconfig.Interfa
 // DeployOperatingSystemConfig deploys the OperatingSystemConfig custom resource and triggers the restore operation in
 // case the Shoot is in the restore phase of the control plane migration.
 func (b *Botanist) DeployOperatingSystemConfig(ctx context.Context) error {
+	b.Shoot.Components.Extensions.OperatingSystemConfig.SetAPIServerAdress(fmt.Sprintf("https://%s", b.Shoot.ComputeOutOfClusterAPIServerAddress(b.APIServerAddress, true)))
 	b.Shoot.Components.Extensions.OperatingSystemConfig.SetCABundle(b.getOperatingSystemConfigCABundle())
 	b.Shoot.Components.Extensions.OperatingSystemConfig.SetKubeletCACertificate(string(b.LoadSecret(v1beta1constants.SecretNameCAKubelet).Data[secrets.DataKeyCertificateCA]))
 

--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -81,7 +81,7 @@ func (b *Botanist) DefaultOperatingSystemConfig() (operatingsystemconfig.Interfa
 // DeployOperatingSystemConfig deploys the OperatingSystemConfig custom resource and triggers the restore operation in
 // case the Shoot is in the restore phase of the control plane migration.
 func (b *Botanist) DeployOperatingSystemConfig(ctx context.Context) error {
-	b.Shoot.Components.Extensions.OperatingSystemConfig.SetAPIServerAdress(fmt.Sprintf("https://%s", b.Shoot.ComputeOutOfClusterAPIServerAddress(b.APIServerAddress, true)))
+	b.Shoot.Components.Extensions.OperatingSystemConfig.SetAPIServerURL(fmt.Sprintf("https://%s", b.Shoot.ComputeOutOfClusterAPIServerAddress(b.APIServerAddress, true)))
 	b.Shoot.Components.Extensions.OperatingSystemConfig.SetCABundle(b.getOperatingSystemConfigCABundle())
 	b.Shoot.Components.Extensions.OperatingSystemConfig.SetKubeletCACertificate(string(b.LoadSecret(v1beta1constants.SecretNameCAKubelet).Data[secrets.DataKeyCertificateCA]))
 

--- a/pkg/operation/botanist/operatingsystemconfig_test.go
+++ b/pkg/operation/botanist/operatingsystemconfig_test.go
@@ -118,7 +118,7 @@ var _ = Describe("operatingsystemconfig", func() {
 			It("should deploy successfully (DisableDNS=true)", func() {
 				botanist.Shoot.DisableDNS = true
 
-				operatingSystemConfig.EXPECT().SetAPIServerAdress(fmt.Sprintf("https://%s", apiServerAddress))
+				operatingSystemConfig.EXPECT().SetAPIServerURL(fmt.Sprintf("https://%s", apiServerAddress))
 				operatingSystemConfig.EXPECT().SetCABundle(pointer.String("\n" + string(ca)))
 				operatingSystemConfig.EXPECT().SetKubeletCACertificate(string(caKubelet))
 				operatingSystemConfig.EXPECT().SetSSHPublicKeys([]string{string(sshPublicKey), string(sshPublicKeyOld)})
@@ -130,7 +130,7 @@ var _ = Describe("operatingsystemconfig", func() {
 
 		Context("deploy", func() {
 			BeforeEach(func() {
-				operatingSystemConfig.EXPECT().SetAPIServerAdress(fmt.Sprintf("https://api.%s", shootDomain))
+				operatingSystemConfig.EXPECT().SetAPIServerURL(fmt.Sprintf("https://api.%s", shootDomain))
 				operatingSystemConfig.EXPECT().SetKubeletCACertificate(string(caKubelet))
 				operatingSystemConfig.EXPECT().SetSSHPublicKeys([]string{string(sshPublicKey), string(sshPublicKeyOld)})
 			})
@@ -196,7 +196,7 @@ var _ = Describe("operatingsystemconfig", func() {
 
 		Context("restore", func() {
 			BeforeEach(func() {
-				operatingSystemConfig.EXPECT().SetAPIServerAdress(fmt.Sprintf("https://api.%s", shootDomain))
+				operatingSystemConfig.EXPECT().SetAPIServerURL(fmt.Sprintf("https://api.%s", shootDomain))
 				operatingSystemConfig.EXPECT().SetKubeletCACertificate(string(caKubelet))
 				operatingSystemConfig.EXPECT().SetSSHPublicKeys([]string{string(sshPublicKey), string(sshPublicKeyOld)})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability robustness
/kind bug

**What this PR does / why we need it**:

If shoot DNS is disabled, the API server address is not known when the OSC component is instantiated.
With this PR, `ComputeOutOfClusterAPIServerAddress` is called during `DeployOperatingSystemConfig`, when the API server address is known.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/4968

**Special notes for your reviewer**:

Probably broken since https://github.com/gardener/gardener/pull/3454, see https://github.com/gardener/gardener/pull/3454/files#diff-78a67ae80f891c299fbd162c192ef1fe19663c5db0bef7e1a42bb04eb70a6335R68
/invite @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fixed a bug in the node bootstrapping for shoots without DNS records.
```
