### PR TITLE
Fix flaky envtests

### DIFF
--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -33,4 +33,7 @@ echo "using envtest tools installed at '$KUBEBUILDER_ASSETS'"
 echo "> Integration Tests"
 
 export KUBEBUILDER_CONTROLPLANE_START_TIMEOUT=2m
+export GOMEGA_DEFAULT_EVENTUALLY_TIMEOUT=5s
+export GOMEGA_DEFAULT_EVENTUALLY_POLLING_INTERVAL=200ms
+
 GO111MODULE=on go test -timeout=5m -mod=vendor $@ | grep -v 'no test files'

--- a/test/integration/envtest/resourcemanager/tokenrequestor/tokenrequestor_test.go
+++ b/test/integration/envtest/resourcemanager/tokenrequestor/tokenrequestor_test.go
@@ -19,13 +19,11 @@ import (
 
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	clientcmdlatest "k8s.io/client-go/tools/clientcmd/api/latest"
 	clientcmdv1 "k8s.io/client-go/tools/clientcmd/api/v1"
@@ -123,7 +121,7 @@ var _ = Describe("TokenRequestor tests", func() {
 
 		AfterEach(func() {
 			var newClient client.Client
-			newClient, err = client.New(newRestConfig, client.Options{Scheme: kubernetesscheme.Scheme})
+			newClient, err = client.New(newRestConfig, client.Options{Mapper: testClient.RESTMapper()})
 			Expect(err).ToNot(HaveOccurred())
 
 			Eventually(func() error {

--- a/test/integration/envtest/seedadmissioncontroller/extensioncrds_test.go
+++ b/test/integration/envtest/seedadmissioncontroller/extensioncrds_test.go
@@ -17,7 +17,6 @@ package seedadmissioncontroller_test
 import (
 	"context"
 	"fmt"
-	"time"
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
@@ -115,7 +114,7 @@ var _ = Describe("Extension CRDs Webhook Handler", func() {
 				}
 			}
 			return true
-		}, 5*time.Second, 200*time.Millisecond).Should(BeTrue())
+		}).Should(BeTrue())
 	})
 
 	objectID := func(obj client.Object) string {
@@ -126,34 +125,34 @@ var _ = Describe("Extension CRDs Webhook Handler", func() {
 		Eventually(func() string {
 			err := c.Delete(ctx, obj)
 			return string(apierrors.ReasonForError(err))
-		}, 5*time.Second, 200*time.Millisecond).Should(ContainSubstring("annotation to delete"), objectID(obj))
+		}).Should(ContainSubstring("annotation to delete"), objectID(obj))
 	}
 
 	testDeleteCollectionUnconfirmed := func(ctx context.Context, obj client.Object) {
 		Eventually(func() string {
 			err := c.DeleteAllOf(ctx, obj, client.InNamespace(obj.GetNamespace()))
 			return string(apierrors.ReasonForError(err))
-		}, 5*time.Second, 200*time.Millisecond).Should(ContainSubstring("annotation to delete"), objectID(obj))
+		}).Should(ContainSubstring("annotation to delete"), objectID(obj))
 	}
 
 	testDeletionConfirmed := func(ctx context.Context, obj client.Object) {
 		Eventually(func() error {
 			return c.Delete(ctx, obj)
-		}, 5*time.Second, 200*time.Millisecond).ShouldNot(HaveOccurred(), objectID(obj))
+		}).ShouldNot(HaveOccurred(), objectID(obj))
 		Eventually(func() bool {
 			err := c.Get(ctx, client.ObjectKeyFromObject(obj), obj)
 			return apierrors.IsNotFound(err) || meta.IsNoMatchError(err)
-		}, 5*time.Second, 200*time.Millisecond).Should(BeTrue(), objectID(obj))
+		}).Should(BeTrue(), objectID(obj))
 	}
 
 	testDeleteCollectionConfirmed := func(ctx context.Context, obj client.Object) {
 		Eventually(func() error {
 			return c.DeleteAllOf(ctx, obj, client.InNamespace(obj.GetNamespace()))
-		}, 5*time.Second, 200*time.Millisecond).ShouldNot(HaveOccurred(), objectID(obj))
+		}).ShouldNot(HaveOccurred(), objectID(obj))
 		Eventually(func() bool {
 			err := c.Get(ctx, client.ObjectKeyFromObject(obj), obj)
 			return apierrors.IsNotFound(err) || meta.IsNoMatchError(err)
-		}, 5*time.Second, 200*time.Millisecond).Should(BeTrue(), objectID(obj))
+		}).Should(BeTrue(), objectID(obj))
 	}
 
 	Context("extension resources", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
This PR fixes flakes in the `TokenRequestor` test like this: https://concourse.ci.gardener.cloud/teams/gardener/pipelines/gardener-master/jobs/master-head-update-job/builds/203

```
• Failure in Spec Teardown (AfterEach) [1.050 seconds]
TokenRequestor tests
/go/src/github.com/gardener/gardener/test/integration/envtest/resourcemanager/tokenrequestor/tokenrequestor_test.go:35
  it should be able to authenticate
  /go/src/github.com/gardener/gardener/test/integration/envtest/resourcemanager/tokenrequestor/tokenrequestor_test.go:121
    should be able to authenticate with the created token [AfterEach]
    /go/src/github.com/gardener/gardener/test/integration/envtest/resourcemanager/tokenrequestor/tokenrequestor_test.go:134

    Timed out after 1.001s.
    Expected
        <*meta.NoKindMatchError | 0xc00031e280>: {
            GroupKind: {
                Group: "",
                Kind: "ServiceAccount",
            },
            SearchedVersions: ["v1"],
        }
    to be Forbidden error

    /go/src/github.com/gardener/gardener/test/integration/envtest/resourcemanager/tokenrequestor/tokenrequestor_test.go:131
```

by reusing the `RESTMapper` from the existing `testClient`. This way, no discovery call is made with new the client and the `ServiceAccount` kind is known immediately.

In addition, to better cater with CPU-throttling in our CI environment, the global GOMEGA values are overwritten (default timeout is `1s`).

/squash

**Which issue(s) this PR fixes**:
Fixes #4970

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
