### PR TITLE
Promote `DisallowKubeconfigRotationForShootInDeletion` feature gate to GA

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -34,8 +34,6 @@ The following tables are a summary of the feature gates that you can set on diff
 | ReversedVPN | `false` | `Alpha` | `1.22` | |
 | AdminKubeconfigRequest | `false` | `Alpha` | `1.24` | |
 | UseDNSRecords | `false` | `Alpha` | `1.27` | |
-| DisallowKubeconfigRotationForShootInDeletion | `false` | `Alpha` | `1.28` | `1.31` |
-| DisallowKubeconfigRotationForShootInDeletion | `true` | `Beta` | `1.32` | |
 | RotateSSHKeypairOnMaintenance | `false` | `Alpha` | `1.28` | |
 | DenyInvalidExtensionResources | `false` | `Alpha` | `1.31` | |
 
@@ -51,6 +49,9 @@ The following tables are a summary of the feature gates that you can set on diff
 | MountHostCADirectories | `true` | `Beta` | `1.26` | `1.27` |
 | MountHostCADirectories | `true` | `GA` | `1.27` | |
 | MountHostCADirectories | | `Removed` | `1.30` | |
+| DisallowKubeconfigRotationForShootInDeletion | `false` | `Alpha` | `1.28` | `1.31` |
+| DisallowKubeconfigRotationForShootInDeletion | `true` | `Beta` | `1.32` | `1.35` |
+| DisallowKubeconfigRotationForShootInDeletion | `true` | `GA` | `1.36` | |
 
 ## Using a feature
 

--- a/docs/usage/shoot_operations.md
+++ b/docs/usage/shoot_operations.md
@@ -36,7 +36,7 @@ kubectl -n garden-<project-name> annotate shoot <shoot-name> gardener.cloud/oper
 ## Rotate kubeconfig credentials
 
 Annotate the shoot with `gardener.cloud/operation=rotate-kubeconfig-credentials` to make the `gardenlet` exchange the credentials in your shoot cluster's kubeconfig.
-This operation is not allowed for shoot clusters that are already in deletion if the feature gate `DisallowKubeconfigRotationForShootInDeletion` is enabled.
+This operation is not allowed for shoot clusters that are already in deletion.
 Please note that only the token (and basic auth password, if enabled) are exchanged. The cluster CAs remain the same.
 
 ```bash

--- a/hack/local-development/start-apiserver
+++ b/hack/local-development/start-apiserver
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+# Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -53,7 +53,6 @@ apiserver_flags="
   --feature-gates SeedChange=true \
   --feature-gates AdminKubeconfigRequest=true \
   --feature-gates UseDNSRecords=true \
-  --feature-gates DisallowKubeconfigRotationForShootInDeletion=true \
   --shoot-admin-kubeconfig-max-expiration=1h \
   --enable-admission-plugins=ShootVPAEnabledByDefault \
   --v 2"

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -147,11 +147,6 @@ func ValidateShootObjectMetaUpdate(newMeta, oldMeta metav1.ObjectMeta, fldPath *
 
 // validateShootKubeconfigRotation validates that shoot in deletion cannot rotate its kubeconfig.
 func validateShootKubeconfigRotation(newMeta, oldMeta metav1.ObjectMeta, fldPath *field.Path) field.ErrorList {
-	// if the feature gate `DisallowKubeconfigRotationForShootInDeletion` is disabled, allow kubeconfig rotation
-	if !utilfeature.DefaultFeatureGate.Enabled(features.DisallowKubeconfigRotationForShootInDeletion) {
-		return field.ErrorList{}
-	}
-
 	if newMeta.DeletionTimestamp == nil {
 		return field.ErrorList{}
 	}

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -2210,9 +2210,8 @@ var _ = Describe("Shoot Validation Tests", func() {
 		})
 
 		Describe("kubeconfig rotation", func() {
-			DescribeTable("DisallowKubeconfigRotationForShootInDeletion=true",
+			DescribeTable("DisallowKubeconfigRotationForShootInDeletion",
 				func(oldAnnotations, newAnnotations map[string]string, newSetDeletionTimestamp, expectedError bool) {
-					defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.DisallowKubeconfigRotationForShootInDeletion, true)()
 					now := metav1.NewTime(time.Now())
 					newShoot := prepareShootForUpdate(shoot)
 					if oldAnnotations != nil {
@@ -2245,34 +2244,6 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Entry("should allow update request for cluster in deletion with already requested kubeconfig rotation", map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials", "foo": "bar"}, true, false),
 				Entry("should not allow kubeconfig rotation for cluster in deletion", nil, map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, true, true),
 				Entry("should not allow kubeconfig rotation for cluster in deletion with already requested operation", map[string]string{"gardener.cloud/operation": "some-other-operation"}, map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, true, true),
-			)
-
-			DescribeTable("DisallowKubeconfigRotationForShootInDeletion=false",
-				func(oldAnnotations, newAnnotations map[string]string, newSetDeletionTimestamp bool) {
-					defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.DisallowKubeconfigRotationForShootInDeletion, false)()
-					now := metav1.NewTime(time.Now())
-					newShoot := prepareShootForUpdate(shoot)
-					if oldAnnotations != nil {
-						shoot.Annotations = oldAnnotations
-					}
-
-					if newSetDeletionTimestamp {
-						newShoot.DeletionTimestamp = &now
-					}
-					newShoot.Annotations = newAnnotations
-
-					errorList := ValidateShootObjectMetaUpdate(newShoot.ObjectMeta, shoot.ObjectMeta, field.NewPath("metadata"))
-
-					Expect(errorList).To(HaveLen(0))
-				},
-				Entry("should allow kubeconfig rotation for cluster not in deletion", nil, map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, false),
-				Entry("should allow reconcile operation for cluster in deletion", nil, map[string]string{"gardener.cloud/operation": "reconcile"}, true),
-				Entry("should allow any annotations for cluster in deletion", nil, map[string]string{"foo": "bar"}, true),
-				Entry("should allow other update request for cluster in deletion and already requested kubeconfig rotation operation", map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, map[string]string{"gardener.cloud/operation": "reconcile"}, true),
-				Entry("should allow any annotations for cluster in deletion with already requested kubeconfig rotation", map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, map[string]string{"foo": "bar"}, true),
-				Entry("should allow update request for cluster in deletion with already requested kubeconfig rotation", map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials", "foo": "bar"}, true),
-				Entry("should allow kubeconfig rotation for cluster in deletion", nil, map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, true),
-				Entry("should allow kubeconfig rotation for cluster in deletion with already requested operation", map[string]string{"gardener.cloud/operation": "some-other-operation"}, map[string]string{"gardener.cloud/operation": "rotate-kubeconfig-credentials"}, true),
 			)
 		})
 	})

--- a/pkg/apiserver/features/features.go
+++ b/pkg/apiserver/features/features.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ var featureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	features.SeedChange:                                   {Default: false, PreRelease: featuregate.Alpha},
 	features.AdminKubeconfigRequest:                       {Default: false, PreRelease: featuregate.Alpha},
 	features.UseDNSRecords:                                {Default: false, PreRelease: featuregate.Alpha},
-	features.DisallowKubeconfigRotationForShootInDeletion: {Default: true, PreRelease: featuregate.Beta},
+	features.DisallowKubeconfigRotationForShootInDeletion: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // TODO (@acumino): remove DisallowKubeconfigRotationForShootInDeletion in v1.38.
 }
 
 // RegisterFeatureGates registers the feature gates of the Gardener API Server.

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -97,6 +97,7 @@ const (
 	// owner: @vpnachev
 	// alpha: v1.28.0
 	// beta: v1.32.0
+	// GA: v1.36.0
 	DisallowKubeconfigRotationForShootInDeletion featuregate.Feature = "DisallowKubeconfigRotationForShootInDeletion"
 
 	// RotateSSHKeypairOnMaintenance enables SSH keypair rotation in the maintenance controller of the gardener-controller-manager.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**Which issue(s) this PR fixes**:
Part of #4575
@ialidzhikov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `DisallowKubeconfigRotationForShootInDeletion` feature gate in the `gardener-apiserver` has been promoted to GA.
```
