### PR TITLE
Made forcing tcp upgrade for node local dns configurable.

### DIFF
--- a/charts/shoot-core/components/charts/nodelocal-dns/templates/_helpers.tpl
+++ b/charts/shoot-core/components/charts/nodelocal-dns/templates/_helpers.tpl
@@ -10,7 +10,11 @@ Corefile: |
       loop
       bind {{ .Values.nodeLocal }} {{ .Values.dnsServer }}
       forward . {{ .Values.clusterDNS }} {
+{{- if .Values.forceTcpToClusterDNS }}
               force_tcp
+{{- else }}
+              prefer_udp
+{{- end }}
       }
       prometheus :{{ .Values.prometheus.port }}
       health {{ .Values.nodeLocal }}:8080
@@ -22,7 +26,11 @@ Corefile: |
       loop
       bind {{ .Values.nodeLocal }} {{ .Values.dnsServer }}
       forward . {{ .Values.clusterDNS }} {
+{{- if .Values.forceTcpToClusterDNS }}
               force_tcp
+{{- else }}
+              prefer_udp
+{{- end }}
       }
       prometheus :{{ .Values.prometheus.port }}
       }
@@ -33,7 +41,11 @@ Corefile: |
       loop
       bind {{ .Values.nodeLocal }} {{ .Values.dnsServer }}
       forward . {{ .Values.clusterDNS }} {
+{{- if .Values.forceTcpToClusterDNS }}
               force_tcp
+{{- else }}
+              prefer_udp
+{{- end }}
       }
       prometheus :{{ .Values.prometheus.port }}
       }
@@ -44,7 +56,11 @@ Corefile: |
       loop
       bind {{ .Values.nodeLocal }} {{ .Values.dnsServer }}
       forward . __PILLAR__UPSTREAM__SERVERS__ {
+{{- if .Values.forceTcpToUpstreamDNS }}
               force_tcp
+{{- else }}
+              prefer_udp
+{{- end }}
       }
       prometheus :{{ .Values.prometheus.port }}
       }

--- a/charts/shoot-core/components/charts/nodelocal-dns/values.yaml
+++ b/charts/shoot-core/components/charts/nodelocal-dns/values.yaml
@@ -9,3 +9,5 @@ clusterDNS: __PILLAR__CLUSTER__DNS__
 dnsServer:  ""
 nodeLocal: 169.254.20.10
 domain: cluster.local
+forceTcpToClusterDNS: true
+forceTcpToUpstreamDNS: true

--- a/pkg/apis/core/v1alpha1/constants/types_constants.go
+++ b/pkg/apis/core/v1alpha1/constants/types_constants.go
@@ -226,6 +226,10 @@ const (
 	AnnotationReversedVPN = "alpha.featuregates.shoot.gardener.cloud/reversed-vpn"
 	// AnnotationNodeLocalDNS enables a per node dns cache on the shoot cluster.
 	AnnotationNodeLocalDNS = "alpha.featuregates.shoot.gardener.cloud/node-local-dns"
+	// AnnotationNodeLocalDNSForceTcpToClusterDns enforces upgrade to tcp connections for communication between node local and cluster dns.
+	AnnotationNodeLocalDNSForceTcpToClusterDns = "alpha.featuregates.shoot.gardener.cloud/node-local-dns-force-tcp-to-cluster-dns"
+	// AnnotationNodeLocalDNSForceTcpToUpstreamDns enforces upgrade to tcp connections for communication between node local and upstream dns.
+	AnnotationNodeLocalDNSForceTcpToUpstreamDns = "alpha.featuregates.shoot.gardener.cloud/node-local-dns-force-tcp-to-upstream-dns"
 
 	// OperatingSystemConfigUnitNameKubeletService is a constant for a unit in the operating system config that contains the kubelet service.
 	OperatingSystemConfigUnitNameKubeletService = "kubelet.service"

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -387,6 +387,10 @@ const (
 	AnnotationReversedVPN = "alpha.featuregates.shoot.gardener.cloud/reversed-vpn"
 	// AnnotationNodeLocalDNS enables a per node dns cache on the shoot cluster.
 	AnnotationNodeLocalDNS = "alpha.featuregates.shoot.gardener.cloud/node-local-dns"
+	// AnnotationNodeLocalDNSForceTcpToClusterDns enforces upgrade to tcp connections for communication between node local and cluster dns.
+	AnnotationNodeLocalDNSForceTcpToClusterDns = "alpha.featuregates.shoot.gardener.cloud/node-local-dns-force-tcp-to-cluster-dns"
+	// AnnotationNodeLocalDNSForceTcpToUpstreamDns enforces upgrade to tcp connections for communication between node local and upstream dns.
+	AnnotationNodeLocalDNSForceTcpToUpstreamDns = "alpha.featuregates.shoot.gardener.cloud/node-local-dns-force-tcp-to-upstream-dns"
 
 	// AnnotationShootAPIServerSNIPodInjector is the key for an annotation of a Shoot cluster whose value indicates
 	// if pod injection of 'KUBERNETES_SERVICE_HOST' environment variable should happen for clusters where APIServerSNI

--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/gardener/gardener/charts"
@@ -439,6 +440,17 @@ func (b *Botanist) generateCoreAddonsChart(ctx context.Context) (*chartrenderer.
 	} else {
 		nodeLocalDNSConfig["dnsServer"] = b.Shoot.Networks.CoreDNS.String()
 	}
+
+	nodeLocalDNSForceTcpToClusterDNS := true
+	if forceTcp, err := strconv.ParseBool(b.Shoot.GetInfo().Annotations[v1beta1constants.AnnotationNodeLocalDNSForceTcpToClusterDns]); err == nil {
+		nodeLocalDNSForceTcpToClusterDNS = forceTcp
+	}
+	nodeLocalDNSConfig["forceTcpToClusterDNS"] = nodeLocalDNSForceTcpToClusterDNS
+	nodeLocalDNSForceTcpToUpstreamDNS := true
+	if forceTcp, err := strconv.ParseBool(b.Shoot.GetInfo().Annotations[v1beta1constants.AnnotationNodeLocalDNSForceTcpToUpstreamDns]); err == nil {
+		nodeLocalDNSForceTcpToUpstreamDNS = forceTcp
+	}
+	nodeLocalDNSConfig["forceTcpToUpstreamDNS"] = nodeLocalDNSForceTcpToUpstreamDNS
 
 	nodelocalDNS, err := b.InjectShootShootImages(nodeLocalDNSConfig, charts.ImageNameNodeLocalDns)
 	if err != nil {


### PR DESCRIPTION
In certain scenarios, it might be beneficial to be able to keep upstream dns resolutions
on udp instead of forcing tcp as was the default for node local dns. For example, this
is true if the tcp connection to the upstream dns server is blocked via firewall or it
is simply reacting very slow to tcp requests. The default stays as is, though, i.e. forcing
tcp upgrades for upstream dns requests in the node local dns setup.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
In certain scenarios, it might be beneficial to be able to keep upstream dns resolutions
on udp instead of forcing tcp as was the default for node local dns. For example, this
is true if the tcp connection to the upstream dns server is blocked via firewall or it
is simply reacting very slow to tcp requests.
This pull request makes it possible to configure the enforcement of tcp upgrades for
upstream dns queries via shoot annotations.
The default stays as is, though, i.e. forcing
tcp upgrades for upstream dns requests in the node local dns setup.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Allow users of node-local-dns to switch between udp and tcp for upstream dns queries.
```
