### PR TITLE
Add docforge manifest aliases to api-reference

### DIFF
--- a/.docforge/manifest.yaml
+++ b/.docforge/manifest.yaml
@@ -8,6 +8,7 @@ structure:
     frontmatter:
       title: API Reference
       weight: 1
+      aliases: "/api-reference/"
   nodes:
   - nodesSelector:
       path: https://github.com/gardener/gardener/tree/{{$defaultBranch}}/docs/api-reference


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
Create redirect from `/api-reference/` to `/docs/gardener/api-reference` in the website.
In this way the old bookmarks will continue to work.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
None
```
