### PR TITLE
Allow seed bootstrap to succeed even with feature gate managed istio is disabled.

### DIFF
--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -1155,7 +1155,7 @@ func runCreateSeedFlow(
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Deploying external authz server",
-			Fn:           extAuthzServer.Deploy,
+			Fn:           flow.TaskFn(extAuthzServer.Deploy).DoIf(gardenletfeatures.FeatureGate.Enabled(features.ManagedIstio)),
 			Dependencies: flow.NewTaskIDs(deployResourceManager),
 		})
 	)


### PR DESCRIPTION
The external authorization server for the authorization of reversed vpn connections
was always deployed regardless if managed istio was enabled. This caused issues
when the custom resource definitions of istio were missing due to managed istio
being disabled.

Co-authored-by: Sebastian Stauch <sebastian.stauch@sap.com>

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
The external authorization server for the authorization of reversed vpn connections
was always deployed regardless if managed istio was enabled. This caused issues
when the custom resource definitions of istio were missing due to managed istio
being disabled.
Now, the external authorization server is only deployed if managed istio is enabled.

**Which issue(s) this PR fixes**:
Fixes #4985 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing seed bootstrap to fail when the `ManagedIstio` feature gate is disabled is now fixed.
```
