### PR TITLE
Fix typo in local dev setup start script

### DIFF
--- a/hack/local-development/local-garden/start.sh
+++ b/hack/local-development/local-garden/start.sh
@@ -32,7 +32,7 @@ $(dirname $0)/run-kube-etcd $LOCAL_GARDEN_LABEL
 $(dirname $0)/run-kube-apiserver $LOCAL_GARDEN_LABEL $ACTIVATE_SEEDAUTHORIZER
 $(dirname $0)/run-kube-controller-manager $LOCAL_GARDEN_LABEL
 
-echo "# This etcd will be used to storge gardener resources (e.g., seeds, shoots)"
+echo "# This etcd will be used to store gardener resources (e.g., seeds, shoots)"
 $(dirname $0)/run-gardener-etcd $LOCAL_GARDEN_LABEL
 
 for i in 1..10; do


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
Fix typo in local dev setup start script.


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
