### PR TITLE
Remove bootstraptoken file from original osc

### DIFF
--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -604,13 +604,13 @@ func (d *deployer) deploy(ctx context.Context, operation string) (extensionsv1al
 
 		if ccdUnitContent != nil {
 			// We do not want to overwrite a valid Bootstraptoken with the tokenPlaceholder
-			for i, file := range downloaderFiles {
-				if file.Path == downloader.PathBootstrapToken {
-					downloaderFiles = append(downloaderFiles[:i], downloaderFiles[i+1:]...)
-					break
+			for _, downloaderFile := range downloaderFiles {
+				if downloaderFile.Path == downloader.PathBootstrapToken {
+					continue
 				}
+				files = append(files, downloaderFile)
 			}
-			files = append(files, downloaderFiles...)
+
 			files = append(files, extensionsv1alpha1.File{
 				Path:        "/etc/systemd/system/" + downloader.UnitName,
 				Permissions: pointer.Int32(0644),

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -603,6 +603,13 @@ func (d *deployer) deploy(ctx context.Context, operation string) (extensionsv1al
 		}
 
 		if ccdUnitContent != nil {
+			// We do not want to overwrite a valid Bootstraptoken with the tokenPlaceholder
+			for i, file := range downloaderFiles {
+				if file.Path == downloader.PathBootstrapToken {
+					downloaderFiles = append(downloaderFiles[:i], downloaderFiles[i+1:]...)
+					break
+				}
+			}
 			files = append(files, downloaderFiles...)
 			files = append(files, extensionsv1alpha1.File{
 				Path:        "/etc/systemd/system/" + downloader.UnitName,


### PR DESCRIPTION
Without this change the original osc contains all files and units from the downloader osc. This means that a valid bootstraptoken (replaced by the MCM in the userData) will be overwritten with a token placeholder when the cloud-config is downloaded.

This becomes relevant in debugging scenarios where the node did not start up correctly (for whatever reason). Then the bootstrap token is overwritten and the node can never join. Also it adds confusion when debugging the node as it seems the token placeholder was never replaced.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area quality
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The bootstrap-token placeholder will no longer be present in the original operatingsystemconfig
```
