### PR TITLE
Remove ext-authz-server when ManagedIstio is disabled

### DIFF
--- a/pkg/operation/seed/components.go
+++ b/pkg/operation/seed/components.go
@@ -43,6 +43,7 @@ import (
 	scalerapi "github.com/gardener/dependency-watchdog/pkg/scaler/api"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/component-base/version"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -241,7 +242,9 @@ func defaultExternalAuthzServer(
 		return extAuthServer, nil
 	}
 
-	vpnSeedDeployments := &appsv1.DeploymentList{}
+	vpnSeedDeployments := &metav1.PartialObjectMetadataList{}
+	vpnSeedDeployments.SetGroupVersionKind(appsv1.SchemeGroupVersion.WithKind("DeploymentList"))
+
 	if err := c.List(ctx, vpnSeedDeployments, client.MatchingLabels(map[string]string{v1beta1constants.LabelApp: v1beta1constants.DeploymentNameVPNSeedServer}), client.Limit(1)); err != nil {
 		return nil, err
 	}

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -1091,7 +1091,7 @@ func runCreateSeedFlow(
 	if err != nil {
 		return err
 	}
-	extAuthzServer, err := defaultExternalAuthzServer(seedClient, kubernetesVersion.String(), imageVector)
+	extAuthzServer, err := defaultExternalAuthzServer(ctx, seedClient, kubernetesVersion.String(), imageVector)
 	if err != nil {
 		return err
 	}
@@ -1155,7 +1155,7 @@ func runCreateSeedFlow(
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Deploying external authz server",
-			Fn:           flow.TaskFn(extAuthzServer.Deploy).DoIf(gardenletfeatures.FeatureGate.Enabled(features.ManagedIstio)),
+			Fn:           extAuthzServer.Deploy,
 			Dependencies: flow.NewTaskIDs(deployResourceManager),
 		})
 	)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Addition to #4991 so that the `ext-authz-server` is eventually removed if the `ManagedIstio` feature gate is turned off.

**Special notes for your reviewer**:
/invite @ScheererJ 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The external authentication server (required for reversed VPN tunnel) is now being cleaned-up if the `ManagedIstio` feature gate is turned off.
```
