### PR TITLE
Disable by default ShootCoreAddonRestarter in the gardener chart

### DIFF
--- a/charts/gardener/controlplane/values.yaml
+++ b/charts/gardener/controlplane/values.yaml
@@ -383,7 +383,7 @@ global:
         shootMaintenance:
           concurrentSyncs: 5
           enableShootControlPlaneRestarter: true
-          enableShootCoreAddonRestarter: true
+          enableShootCoreAddonRestarter: false
         shootQuota:
           concurrentSyncs: 5
           syncPeriod: 60m


### PR DESCRIPTION
**What this PR does / why we need it**:
Disable by default ShootCoreAddonRestarter in the gardener chart

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `ShootCoreAddonRestarter` is now disabled by default in the gardener controlplane chart.
```
