### PR TITLE
Remove references to alicloud specific coreos and ubuntu os extensions

### DIFF
--- a/extensions/README.md
+++ b/extensions/README.md
@@ -34,11 +34,9 @@ Check out these repositories for implementations of the Gardener Extension contr
 ### Operating System
 
 - [CoreOS/FlatCar](https://github.com/gardener/gardener-extension-os-coreos)
-- [CoreOS/FlatCar (Alicloud)](https://github.com/gardener/gardener-extension-os-coreos-alicloud)
 - [GardenLinux](https://github.com/gardener/gardener-extension-os-gardenlinux)
 - [Debian/Ubuntu (MetalStack)](https://github.com/metal-stack/os-metal-extension)
 - [Ubuntu](https://github.com/gardener/gardener-extension-os-ubuntu)
-- [Ubuntu (Alicloud)](https://github.com/gardener/gardener-extension-os-ubuntu-alicloud)
 - [SuSE CHost](https://github.com/gardener/gardener-extension-os-suse-chost)
 
 ### Container Runtime


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind cleanup

**What this PR does / why we need it**:
Remove references to alicloud specific coreos and ubuntu os extensions that have been deprecated and transferred to gardener attic org.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
