### PR TITLE
Fix broken master

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control_migrate.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_migrate.go
@@ -55,7 +55,7 @@ func (r *shootReconciler) prepareShootForMigration(ctx context.Context, logger l
 	if failed || ignored {
 		if syncErr := r.syncClusterResourceToSeed(ctx, shoot, project, cloudProfile, seed); syncErr != nil {
 			logger.WithError(syncErr).Infof("Not allowed to update Shoot with error, trying to sync Cluster resource again")
-			updateErr := r.patchShootStatusOperationError(ctx, gardenClient.Client(), nil, shoot, syncErr.Error(), gardencorev1beta1.LastOperationTypeMigrate, shoot.Status.LastErrors...)
+			updateErr := r.patchShootStatusOperationError(ctx, gardenClient.Client(), shoot, syncErr.Error(), gardencorev1beta1.LastOperationTypeMigrate, shoot.Status.LastErrors...)
 			return reconcile.Result{}, utilerrors.WithSuppressed(syncErr, updateErr)
 		}
 		logger.Info("Shoot is failed or ignored")


### PR DESCRIPTION
Master is broken after merging https://github.com/gardener/gardener/pull/4963 and https://github.com/gardener/gardener/pull/4883 concurrently.

From https://concourse.ci.gardener.cloud/teams/gardener/pipelines/gardener-master/jobs/master-head-update-job/builds/227#L617989ee:195:
```
> Check
Executing golangci-lint
pkg/gardenlet/controller/shoot/shoot_control_migrate.go:58:151: too many arguments in call to r.patchShootStatusOperationError (typecheck)
			updateErr := r.patchShootStatusOperationError(ctx, gardenClient.Client(), nil, shoot, syncErr.Error(), gardencorev1beta1.LastOperationTypeMigrate, shoot.Status.LastErrors...)
			                                                                                                                                                   ^
make: *** [Makefile:186: check] Error 1
```

cc @vpnachev @plkokanov 