### PR TITLE
Enhance HA-settings for gardener controlplane

### DIFF
--- a/charts/gardener/controlplane/charts/runtime/templates/admission-controller/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/admission-controller/deployment.yaml
@@ -41,7 +41,7 @@ spec:
       {{- if gt (int .Values.global.admission.replicaCount) 1 }}
       affinity:
         podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
+          preferredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchExpressions:
               - key: app

--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
@@ -60,7 +60,7 @@ spec:
       {{- if or .Values.global.apiserver.hvpa.enabled (gt (int .Values.global.apiserver.replicaCount) 1) }}
       affinity:
         podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
+          preferredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchExpressions:
               - key: app

--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
@@ -57,7 +57,7 @@ spec:
       {{- if not .Values.global.apiserver.kubeconfig }}
       serviceAccountName: {{ required ".Values.global.apiserver.serviceAccountName is required" .Values.global.apiserver.serviceAccountName }}
       {{- end }}
-      {{- if gt (int .Values.global.apiserver.replicaCount) 1 }}
+      {{- if or .Values.global.apiserver.hvpa.enabled (gt (int .Values.global.apiserver.replicaCount) 1) }}
       affinity:
         podAntiAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/poddisruptionbudget.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/poddisruptionbudget.yaml
@@ -1,4 +1,4 @@
-{{- if gt (int .Values.global.apiserver.replicaCount) 1 }}
+{{- if or .Values.global.apiserver.hvpa.enabled (gt (int .Values.global.apiserver.replicaCount) 1) }}
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:

--- a/charts/gardener/controlplane/charts/runtime/templates/controller-manager/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/controller-manager/deployment.yaml
@@ -47,7 +47,7 @@ spec:
       {{- if gt (int .Values.global.controller.replicaCount) 1 }}
       affinity:
         podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
+          preferredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchExpressions:
               - key: app

--- a/charts/gardener/controlplane/charts/runtime/templates/scheduler/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/scheduler/deployment.yaml
@@ -40,7 +40,7 @@ spec:
       {{- if gt (int .Values.global.scheduler.replicaCount) 1 }}
       affinity:
         podAntiAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
+          preferredDuringSchedulingIgnoredDuringExecution:
           - labelSelector:
               matchExpressions:
               - key: app

--- a/charts/gardener/controlplane/values.yaml
+++ b/charts/gardener/controlplane/values.yaml
@@ -260,7 +260,7 @@ global:
   # Gardener admission controller configuration values
   admission:
     enabled: true
-    replicaCount: 1
+    replicaCount: 3
     serviceAccountName: gardener-admission-controller
     image:
       repository: eu.gcr.io/gardener-project/gardener/admission-controller


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area high-availability quality
/kind enhancement

**What this PR does / why we need it**:

Enhance HA-settings for gardener controlplane:
- Admission controller is deployed in HA-mode by default (replicas=3) -> will add PDB and antiAffinity (otherwise missing)
- API server: make sure pdb/antiaffinity are added when using hvpa (replicas is set to 1, which will cause missing PDB and antiAffinity)
- Switch to soft antiaffinity (hard antiaffinity might block rolling updates on restricted clusters, also allow running stuff on smaller clusters)

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
HA-settings in the Gardener Control Plane chart have been enhanced.
```
