### PR TITLE
Eliminate client certificate for `kube-controller-manager` and `cluster-autoscaler`

### DIFF
--- a/pkg/operation/botanist/clusterautoscaler.go
+++ b/pkg/operation/botanist/clusterautoscaler.go
@@ -18,7 +18,6 @@ import (
 	"context"
 
 	"github.com/gardener/gardener/charts"
-	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/clusterautoscaler"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 )
@@ -42,9 +41,6 @@ func (b *Botanist) DefaultClusterAutoscaler() (clusterautoscaler.Interface, erro
 // DeployClusterAutoscaler deploys the Kubernetes cluster-autoscaler.
 func (b *Botanist) DeployClusterAutoscaler(ctx context.Context) error {
 	if b.Shoot.WantsClusterAutoscaler {
-		b.Shoot.Components.ControlPlane.ClusterAutoscaler.SetSecrets(clusterautoscaler.Secrets{
-			Kubeconfig: component.Secret{Name: clusterautoscaler.SecretName, Checksum: b.LoadCheckSum(clusterautoscaler.SecretName)},
-		})
 		b.Shoot.Components.ControlPlane.ClusterAutoscaler.SetNamespaceUID(b.SeedNamespaceObject.UID)
 		b.Shoot.Components.ControlPlane.ClusterAutoscaler.SetMachineDeployments(b.Shoot.Components.Extensions.Worker.MachineDeployments())
 

--- a/pkg/operation/botanist/clusterautoscaler_test.go
+++ b/pkg/operation/botanist/clusterautoscaler_test.go
@@ -23,8 +23,6 @@ import (
 	mockkubernetes "github.com/gardener/gardener/pkg/client/kubernetes/mock"
 	"github.com/gardener/gardener/pkg/operation"
 	. "github.com/gardener/gardener/pkg/operation/botanist"
-	"github.com/gardener/gardener/pkg/operation/botanist/component"
-	"github.com/gardener/gardener/pkg/operation/botanist/component/clusterautoscaler"
 	mockclusterautoscaler "github.com/gardener/gardener/pkg/operation/botanist/component/clusterautoscaler/mock"
 	mockworker "github.com/gardener/gardener/pkg/operation/botanist/component/extensions/worker/mock"
 	shootpkg "github.com/gardener/gardener/pkg/operation/shoot"
@@ -90,8 +88,6 @@ var _ = Describe("ClusterAutoscaler", func() {
 
 			ctx                = context.TODO()
 			fakeErr            = fmt.Errorf("fake err")
-			secretName         = "cluster-autoscaler"
-			checksum           = "1234"
 			namespaceUID       = types.UID("5678")
 			machineDeployments = []extensionsv1alpha1.MachineDeployment{{}}
 		)
@@ -100,7 +96,6 @@ var _ = Describe("ClusterAutoscaler", func() {
 			clusterAutoscaler = mockclusterautoscaler.NewMockInterface(ctrl)
 			worker = mockworker.NewMockInterface(ctrl)
 
-			botanist.StoreCheckSum(secretName, checksum)
 			botanist.SeedNamespaceObject = &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
 					UID: namespaceUID,
@@ -122,9 +117,6 @@ var _ = Describe("ClusterAutoscaler", func() {
 			BeforeEach(func() {
 				botanist.Shoot.WantsClusterAutoscaler = true
 
-				clusterAutoscaler.EXPECT().SetSecrets(clusterautoscaler.Secrets{
-					Kubeconfig: component.Secret{Name: secretName, Checksum: checksum},
-				})
 				clusterAutoscaler.EXPECT().SetNamespaceUID(namespaceUID)
 				worker.EXPECT().MachineDeployments().Return(machineDeployments)
 				clusterAutoscaler.EXPECT().SetMachineDeployments(machineDeployments)

--- a/pkg/operation/botanist/component/clusterautoscaler/mock/mocks.go
+++ b/pkg/operation/botanist/component/clusterautoscaler/mock/mocks.go
@@ -9,7 +9,6 @@ import (
 	reflect "reflect"
 
 	v1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	clusterautoscaler "github.com/gardener/gardener/pkg/operation/botanist/component/clusterautoscaler"
 	gomock "github.com/golang/mock/gomock"
 	types "k8s.io/apimachinery/pkg/types"
 )
@@ -117,18 +116,6 @@ func (m *MockInterface) SetNamespaceUID(arg0 types.UID) {
 func (mr *MockInterfaceMockRecorder) SetNamespaceUID(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetNamespaceUID", reflect.TypeOf((*MockInterface)(nil).SetNamespaceUID), arg0)
-}
-
-// SetSecrets mocks base method.
-func (m *MockInterface) SetSecrets(arg0 clusterautoscaler.Secrets) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetSecrets", arg0)
-}
-
-// SetSecrets indicates an expected call of SetSecrets.
-func (mr *MockInterfaceMockRecorder) SetSecrets(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSecrets", reflect.TypeOf((*MockInterface)(nil).SetSecrets), arg0)
 }
 
 // Wait mocks base method.

--- a/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager.go
@@ -23,16 +23,18 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/utils"
+	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 	"github.com/gardener/gardener/pkg/utils/secrets"
 	"github.com/gardener/gardener/pkg/utils/version"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	"github.com/Masterminds/semver"
-	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
@@ -53,8 +55,6 @@ const (
 	ServiceName   = "kube-controller-manager"
 	containerName = v1beta1constants.DeploymentNameKubeControllerManager
 
-	// SecretName is a constant for the secret name for the kube-controller-manager's kubeconfig secret.
-	SecretName = "kube-controller-manager"
 	// SecretNameServer is the name of the kube-controller-manager server certificate secret.
 	SecretNameServer = "kube-controller-manager-server"
 
@@ -67,8 +67,6 @@ const (
 	volumeMountPathCA = "/srv/kubernetes/ca"
 	// volumeMountPathServiceAccountKey is the volume mount path for the service account key that is a PEM-encoded private RSA or ECDSA key used to sign service account tokens.
 	volumeMountPathServiceAccountKey = "/srv/kubernetes/service-account-key"
-	// volumeMountPathKubeconfig is the volume mount path for the kubeconfig which can be used by the kube-controller-manager to communicate with the kube-apiserver.
-	volumeMountPathKubeconfig = "/var/lib/kube-controller-manager"
 	// volumeMountPathServer is the volume mount path for the x509 TLS server certificate and key for the HTTPS server inside the kube-controller-manager (which is used for metrics and health checks).
 	volumeMountPathServer = "/var/lib/kube-controller-manager-server"
 
@@ -140,9 +138,6 @@ type kubeControllerManager struct {
 }
 
 func (k *kubeControllerManager) Deploy(ctx context.Context) error {
-	if k.secrets.Kubeconfig.Name == "" || k.secrets.Kubeconfig.Checksum == "" {
-		return fmt.Errorf("missing kubeconfig secret information")
-	}
 	if k.secrets.Server.Name == "" || k.secrets.Server.Checksum == "" {
 		return fmt.Errorf("missing server secret information")
 	}
@@ -154,10 +149,11 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 	}
 
 	var (
-		vpa        = k.emptyVPA()
-		hvpa       = k.emptyHVPA()
-		service    = k.emptyService()
-		deployment = k.emptyDeployment()
+		vpa               = k.emptyVPA()
+		hvpa              = k.emptyHVPA()
+		service           = k.emptyService()
+		shootAccessSecret = k.newShootAccessSecret()
+		deployment        = k.emptyDeployment()
 
 		port              int32 = 10257
 		probeURIScheme          = corev1.URISchemeHTTPS
@@ -196,6 +192,10 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 		return err
 	}
 
+	if err := shootAccessSecret.Reconcile(ctx, k.seedClient); err != nil {
+		return err
+	}
+
 	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, k.seedClient, deployment, func() error {
 		deployment.Labels = utils.MergeStringMaps(getLabels(), map[string]string{
 			v1beta1constants.GardenRole: v1beta1constants.GardenRoleControlPlane,
@@ -208,7 +208,6 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 				Annotations: map[string]string{
 					"checksum/secret-" + k.secrets.CA.Name:                k.secrets.CA.Checksum,
 					"checksum/secret-" + k.secrets.ServiceAccountKey.Name: k.secrets.ServiceAccountKey.Checksum,
-					"checksum/secret-" + k.secrets.Kubeconfig.Name:        k.secrets.Kubeconfig.Checksum,
 					"checksum/secret-" + k.secrets.Server.Name:            k.secrets.Server.Checksum,
 				},
 				Labels: utils.MergeStringMaps(getLabels(), map[string]string{
@@ -220,6 +219,7 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 				}),
 			},
 			Spec: corev1.PodSpec{
+				AutomountServiceAccountToken: pointer.Bool(false),
 				Containers: []corev1.Container{
 					{
 						Name:            containerName,
@@ -258,10 +258,6 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 								MountPath: volumeMountPathServiceAccountKey,
 							},
 							{
-								Name:      k.secrets.Kubeconfig.Name,
-								MountPath: volumeMountPathKubeconfig,
-							},
-							{
 								Name:      k.secrets.Server.Name,
 								MountPath: volumeMountPathServer,
 							},
@@ -286,14 +282,6 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 						},
 					},
 					{
-						Name: k.secrets.Kubeconfig.Name,
-						VolumeSource: corev1.VolumeSource{
-							Secret: &corev1.SecretVolumeSource{
-								SecretName: k.secrets.Kubeconfig.Name,
-							},
-						},
-					},
-					{
 						Name: k.secrets.Server.Name,
 						VolumeSource: corev1.VolumeSource{
 							Secret: &corev1.SecretVolumeSource{
@@ -304,6 +292,8 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 				},
 			},
 		}
+
+		utilruntime.Must(gutil.InjectGenericKubeconfig(deployment, shootAccessSecret.Secret.Name))
 		return nil
 	}); err != nil {
 		return err
@@ -401,14 +391,16 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 		}
 	}
 
-	// create managed resource that deploys resources to the Shoot API Server
-	return k.deployShootManagedResource(ctx)
+	if err := k.reconcileShootResources(ctx, shootAccessSecret.ServiceAccountName); err != nil {
+		return err
+	}
+
+	// TODO(rfranzke): Remove in a future release.
+	return kutil.DeleteObject(ctx, k.seedClient, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "kube-controller-manager", Namespace: k.namespace}})
 }
 
-func (k *kubeControllerManager) SetSecrets(secrets Secrets) { k.secrets = secrets }
-func (k *kubeControllerManager) SetShootClient(c client.Client) {
-	k.shootClient = c
-}
+func (k *kubeControllerManager) SetSecrets(secrets Secrets)      { k.secrets = secrets }
+func (k *kubeControllerManager) SetShootClient(c client.Client)  { k.shootClient = c }
 func (k *kubeControllerManager) SetReplicaCount(replicas int32)  { k.replicas = replicas }
 func (k *kubeControllerManager) Destroy(_ context.Context) error { return nil }
 
@@ -426,6 +418,10 @@ func (k *kubeControllerManager) emptyService() *corev1.Service {
 
 func (k *kubeControllerManager) emptyDeployment() *appsv1.Deployment {
 	return &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameKubeControllerManager, Namespace: k.namespace}}
+}
+
+func (k *kubeControllerManager) newShootAccessSecret() *gutil.ShootAccessSecret {
+	return gutil.NewShootAccessSecret(v1beta1constants.DeploymentNameKubeControllerManager, k.namespace)
 }
 
 func (k *kubeControllerManager) emptyManagedResource() *resourcesv1alpha1.ManagedResource {
@@ -459,6 +455,9 @@ func (k *kubeControllerManager) computeCommand(port int32) []string {
 		"--allocate-node-cidrs=true",
 		"--attach-detach-reconcile-sync-period=1m0s",
 		"--controllers=*,bootstrapsigner,tokencleaner",
+		"--authentication-kubeconfig="+gutil.PathGenericKubeconfig,
+		"--authorization-kubeconfig="+gutil.PathGenericKubeconfig,
+		"--kubeconfig="+gutil.PathGenericKubeconfig,
 	)
 
 	if k.config.NodeCIDRMaskSize != nil {
@@ -504,7 +503,6 @@ func (k *kubeControllerManager) computeCommand(port int32) []string {
 	command = append(command,
 		fmt.Sprintf("--horizontal-pod-autoscaler-sync-period=%s", defaultHorizontalPodAutoscalerConfig.SyncPeriod.Duration.String()),
 		fmt.Sprintf("--horizontal-pod-autoscaler-tolerance=%v", *defaultHorizontalPodAutoscalerConfig.Tolerance),
-		fmt.Sprintf("--kubeconfig=%s/%s", volumeMountPathKubeconfig, secrets.DataKeyKubeconfig),
 		"--leader-elect=true",
 		fmt.Sprintf("--node-monitor-grace-period=%s", nodeMonitorGracePeriod.Duration),
 		fmt.Sprintf("--pod-eviction-timeout=%s", podEvictionTimeout.Duration),
@@ -516,8 +514,6 @@ func (k *kubeControllerManager) computeCommand(port int32) []string {
 		fmt.Sprintf("--horizontal-pod-autoscaler-downscale-stabilization=%s", defaultHorizontalPodAutoscalerConfig.DownscaleStabilization.Duration.String()),
 		fmt.Sprintf("--horizontal-pod-autoscaler-initial-readiness-delay=%s", defaultHorizontalPodAutoscalerConfig.InitialReadinessDelay.Duration.String()),
 		fmt.Sprintf("--horizontal-pod-autoscaler-cpu-initialization-period=%s", defaultHorizontalPodAutoscalerConfig.CPUInitializationPeriod.Duration.String()),
-		fmt.Sprintf("--authentication-kubeconfig=%s/%s", volumeMountPathKubeconfig, secrets.DataKeyKubeconfig),
-		fmt.Sprintf("--authorization-kubeconfig=%s/%s", volumeMountPathKubeconfig, secrets.DataKeyKubeconfig),
 		fmt.Sprintf("--tls-cert-file=%s/%s", volumeMountPathServer, secrets.ControlPlaneSecretDataKeyCertificatePEM(SecretNameServer)),
 		fmt.Sprintf("--tls-private-key-file=%s/%s", volumeMountPathServer, secrets.ControlPlaneSecretDataKeyPrivateKey(SecretNameServer)),
 		fmt.Sprintf("--tls-cipher-suites=%s", strings.Join(kutil.TLSCipherSuites(k.version), ",")),
@@ -590,8 +586,6 @@ func (k *kubeControllerManager) computeResourceRequirements(ctx context.Context)
 
 // Secrets is collection of secrets for the kube-controller-manager.
 type Secrets struct {
-	// Kubeconfig is a secret that contains a kubeconfig which can be used by the kube-controller-manager to communicate with the kube-apiserver.
-	Kubeconfig component.Secret
 	// Server is a secret containing a x509 TLS server certificate and key for the HTTPS server inside the kube-controller-manager (which is used for metrics and health checks).
 	Server component.Secret
 	// CA is a secret containing a root CA x509 certificate and key that is used for the flags.

--- a/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager_test.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager_test.go
@@ -22,17 +22,17 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/logger"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	. "github.com/gardener/gardener/pkg/operation/botanist/component/kubecontrollermanager"
+	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
-	"github.com/gardener/gardener/pkg/utils/managedresources"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
 
 	"github.com/Masterminds/semver"
-	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
@@ -92,14 +92,15 @@ var _ = Describe("KubeControllerManager", func() {
 		}
 
 		// checksums
-		secretChecksumKubeconfig        = "1234"
 		secretChecksumServer            = "5678"
 		secretChecksumCA                = "1234"
 		secretChecksumServiceAccountKey = "1234"
 
-		vpaName             = "kube-controller-manager-vpa"
-		hvpaName            = "kube-controller-manager"
-		managedResourceName = "shoot-core-kube-controller-manager"
+		vpaName                   = "kube-controller-manager-vpa"
+		hvpaName                  = "kube-controller-manager"
+		secretName                = "shoot-access-kube-controller-manager"
+		managedResourceName       = "shoot-core-kube-controller-manager"
+		managedResourceSecretName = "managedresource-shoot-core-kube-controller-manager"
 	)
 
 	BeforeEach(func() {
@@ -128,28 +129,21 @@ var _ = Describe("KubeControllerManager", func() {
 			})
 
 			Context("missing secret information", func() {
-				It("should return an error because the kubeconfig secret information is not provided", func() {
-					Expect(kubeControllerManager.Deploy(ctx)).To(MatchError(ContainSubstring("missing kubeconfig secret information")))
-				})
-
 				It("should return an error because the server secret information is not provided", func() {
-					kubeControllerManager.SetSecrets(Secrets{Kubeconfig: component.Secret{Name: "kube-controller-manager", Checksum: secretChecksumKubeconfig}})
 					Expect(kubeControllerManager.Deploy(ctx)).To(MatchError(ContainSubstring("missing server secret information")))
 				})
 
 				It("should return an error because the CA secret information is not provided", func() {
 					kubeControllerManager.SetSecrets(Secrets{
-						Kubeconfig: component.Secret{Name: "kube-controller-manager", Checksum: secretChecksumKubeconfig},
-						Server:     component.Secret{Name: "kube-controller-manager-server", Checksum: secretChecksumServer},
+						Server: component.Secret{Name: "kube-controller-manager-server", Checksum: secretChecksumServer},
 					})
 					Expect(kubeControllerManager.Deploy(ctx)).To(MatchError(ContainSubstring("missing CA secret information")))
 				})
 
 				It("should return an error because the ServiceAccountKey secret information is not provided", func() {
 					kubeControllerManager.SetSecrets(Secrets{
-						Kubeconfig: component.Secret{Name: "kube-controller-manager", Checksum: secretChecksumKubeconfig},
-						Server:     component.Secret{Name: "kube-controller-manager-server", Checksum: secretChecksumServer},
-						CA:         component.Secret{Name: "ca", Checksum: secretChecksumCA},
+						Server: component.Secret{Name: "kube-controller-manager-server", Checksum: secretChecksumServer},
+						CA:     component.Secret{Name: "ca", Checksum: secretChecksumCA},
 					})
 					Expect(kubeControllerManager.Deploy(ctx)).To(MatchError(ContainSubstring("missing ServiceAccountKey secret information")))
 				})
@@ -157,7 +151,6 @@ var _ = Describe("KubeControllerManager", func() {
 			Context("secret information available", func() {
 				BeforeEach(func() {
 					kubeControllerManager.SetSecrets(Secrets{
-						Kubeconfig:        component.Secret{Name: "kube-controller-manager", Checksum: secretChecksumKubeconfig},
 						Server:            component.Secret{Name: "kube-controller-manager-server", Checksum: secretChecksumServer},
 						CA:                component.Secret{Name: "ca", Checksum: secretChecksumCA},
 						ServiceAccountKey: component.Secret{Name: "service-account-key", Checksum: secretChecksumServiceAccountKey},
@@ -173,10 +166,23 @@ var _ = Describe("KubeControllerManager", func() {
 					Expect(kubeControllerManager.Deploy(ctx)).To(MatchError(fakeErr))
 				})
 
+				It("should fail when the secret cannot be created", func() {
+					gomock.InOrder(
+						c.EXPECT().Get(ctx, kutil.Key(namespace, ServiceName), gomock.AssignableToTypeOf(&corev1.Service{})),
+						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Service{}), gomock.Any()),
+						c.EXPECT().Get(ctx, kutil.Key(namespace, secretName), gomock.AssignableToTypeOf(&corev1.Secret{})),
+						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()).Return(fakeErr),
+					)
+
+					Expect(kubeControllerManager.Deploy(ctx)).To(MatchError(fakeErr))
+				})
+
 				It("should fail because the deployment cannot be created", func() {
 					gomock.InOrder(
 						c.EXPECT().Get(ctx, kutil.Key(namespace, ServiceName), gomock.AssignableToTypeOf(&corev1.Service{})),
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Service{}), gomock.Any()),
+						c.EXPECT().Get(ctx, kutil.Key(namespace, secretName), gomock.AssignableToTypeOf(&corev1.Secret{})),
+						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()),
 						c.EXPECT().Get(ctx, kutil.Key(namespace, v1beta1constants.DeploymentNameKubeControllerManager), gomock.AssignableToTypeOf(&appsv1.Deployment{})),
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&appsv1.Deployment{}), gomock.Any()).Return(fakeErr),
 					)
@@ -188,6 +194,8 @@ var _ = Describe("KubeControllerManager", func() {
 					gomock.InOrder(
 						c.EXPECT().Get(ctx, kutil.Key(namespace, ServiceName), gomock.AssignableToTypeOf(&corev1.Service{})),
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Service{}), gomock.Any()),
+						c.EXPECT().Get(ctx, kutil.Key(namespace, secretName), gomock.AssignableToTypeOf(&corev1.Secret{})),
+						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()),
 						c.EXPECT().Get(ctx, kutil.Key(namespace, v1beta1constants.DeploymentNameKubeControllerManager), gomock.AssignableToTypeOf(&appsv1.Deployment{})),
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&appsv1.Deployment{}), gomock.Any()),
 						c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: hvpaName, Namespace: namespace}}).Return(fakeErr),
@@ -200,6 +208,8 @@ var _ = Describe("KubeControllerManager", func() {
 					gomock.InOrder(
 						c.EXPECT().Get(ctx, kutil.Key(namespace, ServiceName), gomock.AssignableToTypeOf(&corev1.Service{})),
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Service{}), gomock.Any()),
+						c.EXPECT().Get(ctx, kutil.Key(namespace, secretName), gomock.AssignableToTypeOf(&corev1.Secret{})),
+						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()),
 						c.EXPECT().Get(ctx, kutil.Key(namespace, v1beta1constants.DeploymentNameKubeControllerManager), gomock.AssignableToTypeOf(&appsv1.Deployment{})),
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&appsv1.Deployment{}), gomock.Any()),
 						c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: hvpaName, Namespace: namespace}}),
@@ -210,32 +220,60 @@ var _ = Describe("KubeControllerManager", func() {
 					Expect(kubeControllerManager.Deploy(ctx)).To(MatchError(fakeErr))
 				})
 
-				It("should fail because the managed resource cannot be deleted", func() {
+				It("should fail because the managed resource secret cannot be created", func() {
 					gomock.InOrder(
 						c.EXPECT().Get(ctx, kutil.Key(namespace, ServiceName), gomock.AssignableToTypeOf(&corev1.Service{})),
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Service{}), gomock.Any()),
+						c.EXPECT().Get(ctx, kutil.Key(namespace, secretName), gomock.AssignableToTypeOf(&corev1.Secret{})),
+						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()),
 						c.EXPECT().Get(ctx, kutil.Key(namespace, v1beta1constants.DeploymentNameKubeControllerManager), gomock.AssignableToTypeOf(&appsv1.Deployment{})),
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&appsv1.Deployment{}), gomock.Any()),
 						c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: hvpaName, Namespace: namespace}}),
 						c.EXPECT().Get(ctx, kutil.Key(namespace, vpaName), gomock.AssignableToTypeOf(&autoscalingv1beta2.VerticalPodAutoscaler{})),
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&autoscalingv1beta2.VerticalPodAutoscaler{}), gomock.Any()),
-						c.EXPECT().Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: managedResourceName, Namespace: namespace}}).Return(fakeErr),
+						c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceSecretName), gomock.AssignableToTypeOf(&corev1.Secret{})),
+						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()).Return(fakeErr),
 					)
 
 					Expect(kubeControllerManager.Deploy(ctx)).To(MatchError(fakeErr))
 				})
 
-				It("should fail because the managed resource secret cannot be deleted", func() {
+				It("should fail because the managed resource cannot be created", func() {
 					gomock.InOrder(
 						c.EXPECT().Get(ctx, kutil.Key(namespace, ServiceName), gomock.AssignableToTypeOf(&corev1.Service{})),
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Service{}), gomock.Any()),
+						c.EXPECT().Get(ctx, kutil.Key(namespace, secretName), gomock.AssignableToTypeOf(&corev1.Secret{})),
+						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()),
 						c.EXPECT().Get(ctx, kutil.Key(namespace, v1beta1constants.DeploymentNameKubeControllerManager), gomock.AssignableToTypeOf(&appsv1.Deployment{})),
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&appsv1.Deployment{}), gomock.Any()),
 						c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: hvpaName, Namespace: namespace}}),
 						c.EXPECT().Get(ctx, kutil.Key(namespace, vpaName), gomock.AssignableToTypeOf(&autoscalingv1beta2.VerticalPodAutoscaler{})),
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&autoscalingv1beta2.VerticalPodAutoscaler{}), gomock.Any()),
-						c.EXPECT().Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: managedResourceName, Namespace: namespace}}),
-						c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: managedresources.SecretName(managedResourceName, true), Namespace: namespace}}).Return(fakeErr),
+						c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceSecretName), gomock.AssignableToTypeOf(&corev1.Secret{})),
+						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()),
+						c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceName), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
+						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{}), gomock.Any()).Return(fakeErr),
+					)
+
+					Expect(kubeControllerManager.Deploy(ctx)).To(MatchError(fakeErr))
+				})
+
+				It("should fail because the legacy secret cannot be deleted", func() {
+					gomock.InOrder(
+						c.EXPECT().Get(ctx, kutil.Key(namespace, ServiceName), gomock.AssignableToTypeOf(&corev1.Service{})),
+						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Service{}), gomock.Any()),
+						c.EXPECT().Get(ctx, kutil.Key(namespace, secretName), gomock.AssignableToTypeOf(&corev1.Secret{})),
+						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()),
+						c.EXPECT().Get(ctx, kutil.Key(namespace, v1beta1constants.DeploymentNameKubeControllerManager), gomock.AssignableToTypeOf(&appsv1.Deployment{})),
+						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&appsv1.Deployment{}), gomock.Any()),
+						c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: hvpaName, Namespace: namespace}}),
+						c.EXPECT().Get(ctx, kutil.Key(namespace, vpaName), gomock.AssignableToTypeOf(&autoscalingv1beta2.VerticalPodAutoscaler{})),
+						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&autoscalingv1beta2.VerticalPodAutoscaler{}), gomock.Any()),
+						c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceSecretName), gomock.AssignableToTypeOf(&corev1.Secret{})),
+						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()),
+						c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceName), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
+						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{}), gomock.Any()),
+						c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "kube-controller-manager"}}).Return(fakeErr),
 					)
 
 					Expect(kubeControllerManager.Deploy(ctx)).To(MatchError(fakeErr))
@@ -267,6 +305,21 @@ var _ = Describe("KubeControllerManager", func() {
 							}},
 						},
 					},
+				}
+
+				secret = &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      secretName,
+						Namespace: namespace,
+						Annotations: map[string]string{
+							"serviceaccount.resources.gardener.cloud/name":      "kube-controller-manager",
+							"serviceaccount.resources.gardener.cloud/namespace": "kube-system",
+						},
+						Labels: map[string]string{
+							"resources.gardener.cloud/purpose": "token-requestor",
+						},
+					},
+					Type: corev1.SecretTypeOpaque,
 				}
 
 				hvpaUpdateModeAuto = hvpav1alpha1.UpdateModeAuto
@@ -388,7 +441,7 @@ var _ = Describe("KubeControllerManager", func() {
 
 				replicas      int32 = 1
 				deploymentFor       = func(version string, config *gardencorev1beta1.KubeControllerManagerConfig) *appsv1.Deployment {
-					return &appsv1.Deployment{
+					deploy := &appsv1.Deployment{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      v1beta1constants.DeploymentNameKubeControllerManager,
 							Namespace: namespace,
@@ -412,7 +465,6 @@ var _ = Describe("KubeControllerManager", func() {
 									Annotations: map[string]string{
 										"checksum/secret-ca":                             secretChecksumCA,
 										"checksum/secret-service-account-key":            secretChecksumServiceAccountKey,
-										"checksum/secret-kube-controller-manager":        secretChecksumKubeconfig,
 										"checksum/secret-kube-controller-manager-server": secretChecksumServer,
 									},
 									Labels: map[string]string{
@@ -426,6 +478,7 @@ var _ = Describe("KubeControllerManager", func() {
 									},
 								},
 								Spec: corev1.PodSpec{
+									AutomountServiceAccountToken: pointer.Bool(false),
 									Containers: []corev1.Container{
 										{
 											Name:            "kube-controller-manager",
@@ -473,10 +526,6 @@ var _ = Describe("KubeControllerManager", func() {
 													MountPath: "/srv/kubernetes/service-account-key",
 												},
 												{
-													Name:      "kube-controller-manager",
-													MountPath: "/var/lib/kube-controller-manager",
-												},
-												{
 													Name:      "kube-controller-manager-server",
 													MountPath: "/var/lib/kube-controller-manager-server",
 												},
@@ -501,14 +550,6 @@ var _ = Describe("KubeControllerManager", func() {
 											},
 										},
 										{
-											Name: "kube-controller-manager",
-											VolumeSource: corev1.VolumeSource{
-												Secret: &corev1.SecretVolumeSource{
-													SecretName: "kube-controller-manager",
-												},
-											},
-										},
-										{
 											Name: "kube-controller-manager-server",
 											VolumeSource: corev1.VolumeSource{
 												Secret: &corev1.SecretVolumeSource{
@@ -521,6 +562,48 @@ var _ = Describe("KubeControllerManager", func() {
 							},
 						},
 					}
+
+					Expect(gutil.InjectGenericKubeconfig(deploy, secret.Name)).To(Succeed())
+					return deploy
+				}
+
+				clusterRoleBindingYAML = `apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  creationTimestamp: null
+  name: gardener.cloud:target:kube-controller-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:kube-controller-manager
+subjects:
+- kind: ServiceAccount
+  name: kube-controller-manager
+  namespace: kube-system
+`
+				managedResourceSecret = &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      managedResourceSecretName,
+						Namespace: namespace,
+					},
+					Type: corev1.SecretTypeOpaque,
+					Data: map[string][]byte{
+						"clusterrolebinding____gardener.cloud_target_kube-controller-manager.yaml": []byte(clusterRoleBindingYAML),
+					},
+				}
+				managedResource = &resourcesv1alpha1.ManagedResource{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      managedResourceName,
+						Namespace: namespace,
+						Labels:    map[string]string{"origin": "gardener"},
+					},
+					Spec: resourcesv1alpha1.ManagedResourceSpec{
+						SecretRefs: []corev1.LocalObjectReference{
+							{Name: managedResourceSecretName},
+						},
+						InjectLabels: map[string]string{"shoot.gardener.cloud/no-cleanup": "true"},
+						KeepObjects:  pointer.Bool(false),
+					},
 				}
 
 				emptyConfig                = &gardencorev1beta1.KubeControllerManagerConfig{}
@@ -559,7 +642,6 @@ var _ = Describe("KubeControllerManager", func() {
 					)
 
 					kubeControllerManager.SetSecrets(Secrets{
-						Kubeconfig:        component.Secret{Name: "kube-controller-manager", Checksum: secretChecksumKubeconfig},
 						Server:            component.Secret{Name: "kube-controller-manager-server", Checksum: secretChecksumServer},
 						CA:                component.Secret{Name: "ca", Checksum: secretChecksumCA},
 						ServiceAccountKey: component.Secret{Name: "service-account-key", Checksum: secretChecksumServiceAccountKey},
@@ -576,6 +658,11 @@ var _ = Describe("KubeControllerManager", func() {
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Service{}), gomock.Any()).
 							Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 								Expect(obj).To(DeepEqual(serviceFor(version)))
+							}),
+						c.EXPECT().Get(ctx, kutil.Key(namespace, secretName), gomock.AssignableToTypeOf(&corev1.Secret{})),
+						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()).
+							Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
+								Expect(obj).To(DeepEqual(secret))
 							}),
 						c.EXPECT().Get(ctx, kutil.Key(namespace, v1beta1constants.DeploymentNameKubeControllerManager), gomock.AssignableToTypeOf(&appsv1.Deployment{})),
 						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&appsv1.Deployment{}), gomock.Any()).
@@ -605,8 +692,18 @@ var _ = Describe("KubeControllerManager", func() {
 					}
 
 					gomock.InOrder(
-						c.EXPECT().Delete(ctx, &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: managedResourceName, Namespace: namespace}}),
-						c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: managedresources.SecretName(managedResourceName, true), Namespace: namespace}}),
+						c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceSecretName), gomock.AssignableToTypeOf(&corev1.Secret{})),
+						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).
+							Do(func(ctx context.Context, obj client.Object, _ ...client.UpdateOption) {
+								Expect(obj).To(DeepEqual(managedResourceSecret))
+							}),
+						c.EXPECT().Get(ctx, kutil.Key(namespace, managedResourceName), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
+						c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).
+							Do(func(ctx context.Context, obj client.Object, _ ...client.UpdateOption) {
+								Expect(obj).To(DeepEqual(managedResource))
+							}),
+
+						c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "kube-controller-manager", Namespace: namespace}}),
 					)
 
 					Expect(kubeControllerManager.Deploy(ctx)).To(Succeed())
@@ -704,6 +801,9 @@ func commandForKubernetesVersion(
 		"--allocate-node-cidrs=true",
 		"--attach-detach-reconcile-sync-period=1m0s",
 		"--controllers=*,bootstrapsigner,tokencleaner",
+		"--authentication-kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig",
+		"--authorization-kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig",
+		"--kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig",
 	)
 
 	if nodeCIDRMaskSize != nil {
@@ -749,7 +849,6 @@ func commandForKubernetesVersion(
 	command = append(command,
 		fmt.Sprintf("--horizontal-pod-autoscaler-sync-period=%s", horizontalPodAutoscalerConfig.SyncPeriod.Duration.String()),
 		fmt.Sprintf("--horizontal-pod-autoscaler-tolerance=%v", *horizontalPodAutoscalerConfig.Tolerance),
-		"--kubeconfig=/var/lib/kube-controller-manager/kubeconfig",
 		"--leader-elect=true",
 		fmt.Sprintf("--node-monitor-grace-period=%s", nodeMonitorGracePeriodSetting),
 		fmt.Sprintf("--pod-eviction-timeout=%s", podEvictionTimeoutSetting),
@@ -761,8 +860,6 @@ func commandForKubernetesVersion(
 		fmt.Sprintf("--horizontal-pod-autoscaler-downscale-stabilization=%s", horizontalPodAutoscalerConfig.DownscaleStabilization.Duration.String()),
 		fmt.Sprintf("--horizontal-pod-autoscaler-initial-readiness-delay=%s", horizontalPodAutoscalerConfig.InitialReadinessDelay.Duration.String()),
 		fmt.Sprintf("--horizontal-pod-autoscaler-cpu-initialization-period=%s", horizontalPodAutoscalerConfig.CPUInitializationPeriod.Duration.String()),
-		"--authentication-kubeconfig=/var/lib/kube-controller-manager/kubeconfig",
-		"--authorization-kubeconfig=/var/lib/kube-controller-manager/kubeconfig",
 		"--tls-cert-file=/var/lib/kube-controller-manager-server/kube-controller-manager-server.crt",
 		"--tls-private-key-file=/var/lib/kube-controller-manager-server/kube-controller-manager-server.key",
 		"--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA,TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",

--- a/pkg/operation/botanist/component/kubecontrollermanager/shoot_resources.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/shoot_resources.go
@@ -17,14 +17,38 @@ package kubecontrollermanager
 import (
 	"context"
 
-	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/managedresources"
+
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func (k *kubeControllerManager) deployShootManagedResource(ctx context.Context) error {
-	return kutil.DeleteObjects(
-		ctx,
-		k.seedClient,
-		k.emptyManagedResource(),
-		k.emptyManagedResourceSecret(),
+func (k *kubeControllerManager) reconcileShootResources(ctx context.Context, serviceAccountName string) error {
+	var (
+		registry = managedresources.NewRegistry(kubernetes.ShootScheme, kubernetes.ShootCodec, kubernetes.ShootSerializer)
+
+		clusterRoleBinding = &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "gardener.cloud:target:kube-controller-manager",
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: rbacv1.GroupName,
+				Kind:     "ClusterRole",
+				Name:     "system:kube-controller-manager",
+			},
+			Subjects: []rbacv1.Subject{{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      serviceAccountName,
+				Namespace: metav1.NamespaceSystem,
+			}},
+		}
 	)
+
+	data, err := registry.AddAllAndSerialize(clusterRoleBinding)
+	if err != nil {
+		return err
+	}
+
+	return managedresources.CreateForShoot(ctx, k.seedClient, k.namespace, managedResourceName, false, data)
 }

--- a/pkg/operation/botanist/component/kubescheduler/kube_scheduler_test.go
+++ b/pkg/operation/botanist/component/kubescheduler/kube_scheduler_test.go
@@ -19,8 +19,6 @@ import (
 	"fmt"
 	"strconv"
 
-	gutil "github.com/gardener/gardener/pkg/utils/gardener"
-
 	"github.com/Masterminds/semver"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
@@ -42,6 +40,7 @@ import (
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	. "github.com/gardener/gardener/pkg/operation/botanist/component/kubescheduler"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
+	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"

--- a/pkg/operation/botanist/kubecontrollermanager.go
+++ b/pkg/operation/botanist/kubecontrollermanager.go
@@ -76,7 +76,6 @@ func (b *Botanist) DeployKubeControllerManager(ctx context.Context) error {
 	b.Shoot.Components.ControlPlane.KubeControllerManager.SetSecrets(kubecontrollermanager.Secrets{
 		CA:                component.Secret{Name: v1beta1constants.SecretNameCACluster, Checksum: b.LoadCheckSum(v1beta1constants.SecretNameCACluster)},
 		ServiceAccountKey: component.Secret{Name: v1beta1constants.SecretNameServiceAccountKey, Checksum: b.LoadCheckSum(v1beta1constants.SecretNameServiceAccountKey)},
-		Kubeconfig:        component.Secret{Name: kubecontrollermanager.SecretName, Checksum: b.LoadCheckSum(kubecontrollermanager.SecretName)},
 		Server:            component.Secret{Name: kubecontrollermanager.SecretNameServer, Checksum: b.LoadCheckSum(kubecontrollermanager.SecretNameServer)},
 	})
 

--- a/pkg/operation/botanist/kubecontrollermanager_test.go
+++ b/pkg/operation/botanist/kubecontrollermanager_test.go
@@ -98,16 +98,13 @@ var _ = Describe("KubeControllerManager", func() {
 		var (
 			kubeControllerManager *mockkubecontrollermanager.MockInterface
 
-			secretName                  = "kube-controller-manager"
 			secretNameServer            = "kube-controller-manager-server"
 			secretNameCA                = "ca"
 			secretNameServiceAccountKey = "service-account-key"
-			checksum                    = "12"
 			checksumServer              = "34"
 			checksumCA                  = "56"
 			checksumServiceAccountKey   = "78"
 			secrets                     = kubecontrollermanager.Secrets{
-				Kubeconfig:        component.Secret{Name: secretName, Checksum: checksum},
 				Server:            component.Secret{Name: secretNameServer, Checksum: checksumServer},
 				CA:                component.Secret{Name: secretNameCA, Checksum: checksumCA},
 				ServiceAccountKey: component.Secret{Name: secretNameServiceAccountKey, Checksum: checksumServiceAccountKey},
@@ -118,7 +115,6 @@ var _ = Describe("KubeControllerManager", func() {
 			kubeControllerManager = mockkubecontrollermanager.NewMockInterface(ctrl)
 
 			botanist.K8sSeedClient = kubernetesClient
-			botanist.StoreCheckSum(secretName, checksum)
 			botanist.StoreCheckSum(secretNameServer, checksumServer)
 			botanist.StoreCheckSum(secretNameCA, checksumCA)
 			botanist.StoreCheckSum(secretNameServiceAccountKey, checksumServiceAccountKey)

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -60,6 +60,7 @@ func (b *Botanist) GenerateAndSaveSecrets(ctx context.Context) error {
 		// TODO(rfranzke): Remove in a future version.
 		for _, name := range []string{
 			"kube-scheduler",
+			"kube-controller-manager",
 		} {
 			gardenerResourceDataList.Delete(name)
 		}

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -61,6 +61,7 @@ func (b *Botanist) GenerateAndSaveSecrets(ctx context.Context) error {
 		for _, name := range []string{
 			"kube-scheduler",
 			"kube-controller-manager",
+			"cluster-autoscaler",
 		} {
 			gardenerResourceDataList.Delete(name)
 		}

--- a/pkg/operation/botanist/wanted_secrets.go
+++ b/pkg/operation/botanist/wanted_secrets.go
@@ -21,7 +21,6 @@ import (
 	"github.com/gardener/gardener/charts"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	"github.com/gardener/gardener/pkg/operation/botanist/component/clusterautoscaler"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/dependencywatchdog"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/etcd"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig/downloader"
@@ -243,26 +242,6 @@ func (b *Botanist) generateWantedSecretConfigs(basicAuthAPIServer *secrets.Basic
 				CertType:  secrets.ServerCert,
 				SigningCA: certificateAuthorities[v1beta1constants.SecretNameCACluster],
 			},
-		},
-
-		// Secret definition for cluster-autoscaler
-		&secrets.ControlPlaneSecretConfig{
-			CertificateSecretConfig: &secrets.CertificateSecretConfig{
-				Name: clusterautoscaler.SecretName,
-
-				CommonName:   clusterautoscaler.UserName,
-				Organization: nil,
-				DNSNames:     nil,
-				IPAddresses:  nil,
-
-				CertType:  secrets.ClientCert,
-				SigningCA: certificateAuthorities[v1beta1constants.SecretNameCACluster],
-			},
-
-			KubeConfigRequests: []secrets.KubeConfigRequest{{
-				ClusterName:   b.Shoot.SeedNamespace,
-				APIServerHost: b.Shoot.ComputeInClusterAPIServerAddress(true),
-			}},
 		},
 
 		// Secret definition for gardener-resource-manager

--- a/pkg/operation/botanist/wanted_secrets.go
+++ b/pkg/operation/botanist/wanted_secrets.go
@@ -215,25 +215,6 @@ func (b *Botanist) generateWantedSecretConfigs(basicAuthAPIServer *secrets.Basic
 			},
 		},
 
-		// Secret definition for kube-controller-manager
-		&secrets.ControlPlaneSecretConfig{
-			CertificateSecretConfig: &secrets.CertificateSecretConfig{
-				Name: kubecontrollermanager.SecretName,
-
-				CommonName:   user.KubeControllerManager,
-				Organization: nil,
-				DNSNames:     nil,
-				IPAddresses:  nil,
-
-				CertType:  secrets.ClientCert,
-				SigningCA: certificateAuthorities[v1beta1constants.SecretNameCACluster],
-			},
-			KubeConfigRequests: []secrets.KubeConfigRequest{{
-				ClusterName:   b.Shoot.SeedNamespace,
-				APIServerHost: b.Shoot.ComputeInClusterAPIServerAddress(true),
-			}},
-		},
-
 		// Secret definition for kube-controller-manager server
 		&secrets.ControlPlaneSecretConfig{
 			CertificateSecretConfig: &secrets.CertificateSecretConfig{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement
/merge squash

**What this PR does / why we need it**:
Similar to #4931, this PR eliminates the client certificate for the `kube-controller-manager` and `cluster-autoscaler` in favor of a token managed by the `TokenRequestor` controller in `gardener-resource-manager`.

**Which issue(s) this PR fixes**:
Part of #4661
Part of #4878

**Special notes for your reviewer**:
/invite @BeckerMax

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
`kube-controller-manager` and `cluster-autoscaler` do no longer use a client certificate but an auto-rotated `ServiceAccount` token which is only valid for `12h`.
```
