### PR TITLE
Eliminate client certificate for `kube-state-metrics` and `prometheus`

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/kube-state-metrics-shoot/templates/deployment.yaml
+++ b/charts/seed-monitoring/charts/core/charts/kube-state-metrics-shoot/templates/deployment.yaml
@@ -28,6 +28,7 @@ spec:
         networking.gardener.cloud/to-shoot-apiserver: allowed
         networking.gardener.cloud/from-prometheus: allowed
     spec:
+      automountServiceAccountToken: false
       containers:
       - name: kube-state-metrics
         image: {{ index .Values.images "kube-state-metrics" }}
@@ -36,12 +37,13 @@ spec:
         - /kube-state-metrics
         - --port=8080
         - --telemetry-port=8081
-        - --kubeconfig=/etc/kube-state-metrics/config/kubeconfig
+        - --kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig
         - --namespace=kube-system
         - --collectors=daemonsets,deployments,nodes,pods,statefulsets,verticalpodautoscalers,replicasets
         volumeMounts:
         - name: kubeconfig
-          mountPath: /etc/kube-state-metrics/config
+          mountPath: /var/run/secrets/gardener.cloud/shoot/generic-kubeconfig
+          readOnly: true
         ports:
         - name: metrics
           containerPort: 8080
@@ -64,5 +66,18 @@ spec:
             memory: 32Mi
       volumes:
       - name: kubeconfig
-        secret:
-          secretName: kube-state-metrics
+        projected:
+          defaultMode: 420
+          sources:
+          - secret:
+              items:
+              - key: kubeconfig
+                path: kubeconfig
+              name: generic-token-kubeconfig
+              optional: false
+          - secret:
+              items:
+              - key: token
+                path: token
+              name: shoot-access-kube-state-metrics
+              optional: false

--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/_helpers.tpl
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/_helpers.tpl
@@ -43,16 +43,12 @@ Drops metrics which produce lots of time-series without much gain.
   action: keep
 {{- end -}}
 
-{{- define "prometheus.tls-config.kube-cert-auth" -}}
-ca_file: /etc/prometheus/seed/ca.crt
-cert_file: /etc/prometheus/seed/prometheus.crt
-key_file: /etc/prometheus/seed/prometheus.key
-{{- end -}}
-
-{{- define "prometheus.tls-config.kube-cert-auth-insecure" -}}
-insecure_skip_verify: true
-cert_file: /etc/prometheus/seed/prometheus.crt
-key_file: /etc/prometheus/seed/prometheus.key
+{{- define "prometheus.kube-auth" -}}
+tls_config:
+  ca_file: /etc/prometheus/seed/ca.crt
+authorization:
+  type: Bearer
+  credentials_file: /var/run/secrets/gardener.cloud/shoot/token/token
 {{- end -}}
 
 {{- define "prometheus.alertmanager.namespaces" -}}

--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/blackbox-exporter-config.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/blackbox-exporter-config.yaml
@@ -23,8 +23,7 @@ data:
             Accept: "*/*"
             Accept-Language: "en-US"
           tls_config:
-            ca_file: "/var/run/secrets/blackbox/ca.crt"
-            cert_file: "/var/run/secrets/blackbox/prometheus.crt"
-            key_file: "/var/run/secrets/blackbox/prometheus.key"
+            ca_file: "/var/run/secrets/shoot-ca/ca.crt"
             server_name: {{ .Values.shoot.apiserverServerName }}
+          bearer_token_file: /var/run/secrets/gardener.cloud/shoot/token/token
           preferred_ip_protocol: "ip4"

--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
@@ -98,13 +98,11 @@ data:
     - job_name: kube-kubelet
       honor_labels: false
       scheme: https
-      tls_config:
-{{ include "prometheus.tls-config.kube-cert-auth-insecure" . | indent 8 }}
+{{ include "prometheus.kube-auth" . | indent 6 }}
       kubernetes_sd_configs:
       - role: node
         api_server: https://kube-apiserver:443
-        tls_config:
-{{ include "prometheus.tls-config.kube-cert-auth" . | indent 10 }}
+{{ include "prometheus.kube-auth" . | indent 8 }}
       relabel_configs:
       - source_labels: [ __meta_kubernetes_node_address_InternalIP ]
         target_label: instance
@@ -127,15 +125,11 @@ data:
     - job_name: cadvisor
       honor_labels: false
       scheme: https
-      tls_config:
-        # This is needed because the api server's certificates are not are generated
-        # for a specific pod IP
-{{ include "prometheus.tls-config.kube-cert-auth-insecure" . | indent 8 }}
+{{ include "prometheus.kube-auth" . | indent 6 }}
       kubernetes_sd_configs:
       - role: node
         api_server: https://kube-apiserver:443
-        tls_config:
-{{ include "prometheus.tls-config.kube-cert-auth" . | indent 10 }}
+{{ include "prometheus.kube-auth" . | indent 8 }}
       relabel_configs:
       - action: labelmap
         regex: __meta_kubernetes_node_label_(.+)
@@ -311,15 +305,11 @@ data:
     - job_name: node-local-dns
       honor_labels: false
       scheme: https
-      tls_config:
-        # This is needed because the kubelets' certificates are not are generated
-        # for a specific pod IP
-{{ include "prometheus.tls-config.kube-cert-auth-insecure" . | indent 8 }}
+{{ include "prometheus.kube-auth" . | indent 6 }}
       kubernetes_sd_configs:
       - role: pod
         api_server: https://kube-apiserver:443
-        tls_config:
-{{ include "prometheus.tls-config.kube-cert-auth" . | indent 10 }}
+{{ include "prometheus.kube-auth" . | indent 8 }}
       relabel_configs:
       - source_labels:
         - __meta_kubernetes_pod_name
@@ -346,13 +336,11 @@ data:
       honor_labels: false
       scrape_timeout: 30s
       scheme: https
-      tls_config:
-{{ include "prometheus.tls-config.kube-cert-auth-insecure" . | indent 8 }}
+{{ include "prometheus.kube-auth" . | indent 6 }}
       kubernetes_sd_configs:
       - role: endpoints
         api_server: https://kube-apiserver:443
-        tls_config:
-{{ include "prometheus.tls-config.kube-cert-auth" . | indent 10 }}
+{{ include "prometheus.kube-auth" . | indent 8 }}
       relabel_configs:
       - target_label: type
         replacement: shoot
@@ -380,13 +368,11 @@ data:
     - job_name: kube-proxy
       honor_labels: false
       scheme: https
-      tls_config:
-{{ include "prometheus.tls-config.kube-cert-auth-insecure" . | indent 8 }}
+{{ include "prometheus.kube-auth" . | indent 6 }}
       kubernetes_sd_configs:
       - role: endpoints
         api_server: https://kube-apiserver:443
-        tls_config:
-{{ include "prometheus.tls-config.kube-cert-auth" . | indent 10 }}
+{{ include "prometheus.kube-auth" . | indent 8 }}
       relabel_configs:
       - source_labels:
         - __meta_kubernetes_endpoints_name
@@ -410,15 +396,13 @@ data:
     - job_name: apiserver-proxy
       metrics_path: /metrics
       scheme: https
-      tls_config:
-{{ include "prometheus.tls-config.kube-cert-auth-insecure" . | indent 8 }}
+{{ include "prometheus.kube-auth" . | indent 6 }}
       kubernetes_sd_configs:
       - role: endpoints
         api_server: https://kube-apiserver:443
         namespaces:
           names: [ kube-system ]
-        tls_config:
-{{ include "prometheus.tls-config.kube-cert-auth" . | indent 10 }}
+{{ include "prometheus.kube-auth" . | indent 8 }}
       relabel_configs:
       - target_label: type
         replacement: shoot
@@ -460,8 +444,7 @@ data:
         namespaces:
           names: [ kube-system ]
         api_server: https://kube-apiserver:443
-        tls_config:
-{{ include "prometheus.tls-config.kube-cert-auth" . | indent 10 }}
+{{ include "prometheus.kube-auth" . | indent 8 }}
       relabel_configs:
       - target_label: type
         replacement: seed
@@ -513,15 +496,13 @@ data:
         target:
         - https://kubernetes.default.svc.cluster.local/healthz
       metrics_path: /probe
-      tls_config:
-{{ include "prometheus.tls-config.kube-cert-auth-insecure" . | indent 8 }}
+{{ include "prometheus.kube-auth" . | indent 6 }}
       kubernetes_sd_configs:
       - role: endpoints
         namespaces:
           names: [ kube-system ]
         api_server: https://kube-apiserver:443
-        tls_config:
-{{ include "prometheus.tls-config.kube-cert-auth" . | indent 10 }}
+{{ include "prometheus.kube-auth" . | indent 8 }}
       relabel_configs:
       - target_label: type
         replacement: shoot

--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
@@ -125,9 +125,13 @@ spec:
         - mountPath: /var/prometheus/data
           name: prometheus-db
           subPath: prometheus-
-        # we mount the Shoot cluster's CA and certs
+        # TODO(rfranzke): Delete this in a future release once all monitoring configurations of extensions have been
+        # adapted.
         - mountPath: /etc/prometheus/seed
-          name: prometheus-kubeconfig
+          name: prometheus-client-cert
+        - name: shoot-access
+          mountPath: /var/run/secrets/gardener.cloud/shoot/token
+          readOnly: true
         {{- if hasKey .Values.alerting.auth_type "certificate" }}
         - mountPath: /etc/prometheus/operator
           name: prometheus-remote-am-tls
@@ -152,8 +156,11 @@ spec:
         volumeMounts:
         - name: blackbox-exporter-config-prometheus
           mountPath: /vpn
-        - mountPath: /var/run/secrets/blackbox
-          name: prometheus-kubeconfig
+        - mountPath: /var/run/secrets/shoot-ca
+          name: shoot-ca
+          readOnly: true
+        - name: shoot-access
+          mountPath: /var/run/secrets/gardener.cloud/shoot/token
           readOnly: true
       - name: prometheus-config-reloader
         image: {{ index .Values.images "configmap-reloader" }}
@@ -196,9 +203,14 @@ spec:
       - name: etcd-client-tls
         secret:
           secretName: etcd-client-tls
-      - name: prometheus-kubeconfig
+      # TODO(rfranzke): Delete this in a future release once all monitoring configurations of extensions have been
+      #	adapted.
+      - name: prometheus-client-cert
         secret:
           secretName: prometheus
+      - name: shoot-access
+        secret:
+          secretName: shoot-access-prometheus
       - name: prometheus-kubelet
         secret:
           secretName: prometheus-kubelet

--- a/charts/shoot-core/components/charts/monitoring/charts/kube-state-metrics-shoot/templates/rbac.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/kube-state-metrics-shoot/templates/rbac.yaml
@@ -60,7 +60,6 @@ roleRef:
   kind: ClusterRole
   name: gardener.cloud:monitoring:kube-state-metrics
 subjects:
-- kind: User
-  name: garden.sapcloud.io:monitoring:kube-state-metrics
-- kind: User
-  name: gardener.cloud:monitoring:kube-state-metrics
+- kind: ServiceAccount
+  name: kube-state-metrics
+  namespace: kube-system

--- a/charts/shoot-core/components/charts/monitoring/charts/prometheus-shoot/templates/rbac.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/prometheus-shoot/templates/rbac.yaml
@@ -38,6 +38,10 @@ roleRef:
   kind: ClusterRole
   name: gardener.cloud:monitoring:prometheus
 subjects:
+- kind: ServiceAccount
+  name: prometheus
+  namespace: kube-system
+# TODO(rfranzke): Delete these subjects in a future release once all monitoring configurations of extensions have been adapted.
 - kind: User
   name: garden.sapcloud.io:monitoring:prometheus
 - kind: User

--- a/docs/extensions/logging-and-monitoring.md
+++ b/docs/extensions/logging-and-monitoring.md
@@ -49,8 +49,9 @@ data:
       scheme: https
       tls_config:
         insecure_skip_verify: true
-        cert_file: /etc/prometheus/seed/prometheus.crt
-        key_file: /etc/prometheus/seed/prometheus.key
+      authorization:
+        type: Bearer
+        credentials_file: /var/run/secrets/gardener.cloud/shoot/token/token
       honor_labels: false
       kubernetes_sd_configs:
       - role: endpoints

--- a/pkg/operation/botanist/component/coredns/monitoring.go
+++ b/pkg/operation/botanist/component/coredns/monitoring.go
@@ -79,17 +79,19 @@ var (
 	monitoringScrapeConfig = `job_name: ` + monitoringPrometheusJobName + `
 scheme: https
 tls_config:
-  insecure_skip_verify: true
-  cert_file: /etc/prometheus/seed/prometheus.crt
-  key_file: /etc/prometheus/seed/prometheus.key
+  ca_file: /etc/prometheus/seed/ca.crt
+authorization:
+  type: Bearer
+  credentials_file: /var/run/secrets/gardener.cloud/shoot/token/token
 honor_labels: false
 kubernetes_sd_configs:
 - role: endpoints
   api_server: https://` + v1beta1constants.DeploymentNameKubeAPIServer + `:` + strconv.Itoa(kubeapiserver.Port) + `
   tls_config:
     ca_file: /etc/prometheus/seed/ca.crt
-    cert_file: /etc/prometheus/seed/prometheus.crt
-    key_file: /etc/prometheus/seed/prometheus.key
+  authorization:
+    type: Bearer
+    credentials_file: /var/run/secrets/gardener.cloud/shoot/token/token
 relabel_configs:
 - source_labels:
   - __meta_kubernetes_service_name

--- a/pkg/operation/botanist/component/coredns/monitoring_test.go
+++ b/pkg/operation/botanist/component/coredns/monitoring_test.go
@@ -48,17 +48,19 @@ const (
 	expectedScrapeConfig = `job_name: coredns
 scheme: https
 tls_config:
-  insecure_skip_verify: true
-  cert_file: /etc/prometheus/seed/prometheus.crt
-  key_file: /etc/prometheus/seed/prometheus.key
+  ca_file: /etc/prometheus/seed/ca.crt
+authorization:
+  type: Bearer
+  credentials_file: /var/run/secrets/gardener.cloud/shoot/token/token
 honor_labels: false
 kubernetes_sd_configs:
 - role: endpoints
   api_server: https://kube-apiserver:443
   tls_config:
     ca_file: /etc/prometheus/seed/ca.crt
-    cert_file: /etc/prometheus/seed/prometheus.crt
-    key_file: /etc/prometheus/seed/prometheus.key
+  authorization:
+    type: Bearer
+    credentials_file: /var/run/secrets/gardener.cloud/shoot/token/token
 relabel_configs:
 - source_labels:
   - __meta_kubernetes_service_name

--- a/pkg/operation/botanist/component/kubeapiserver/monitoring.go
+++ b/pkg/operation/botanist/component/kubeapiserver/monitoring.go
@@ -225,8 +225,9 @@ kubernetes_sd_configs:
     names: [{{ .namespace }}]
 tls_config:
   insecure_skip_verify: true
-  cert_file: /etc/prometheus/seed/prometheus.crt
-  key_file: /etc/prometheus/seed/prometheus.key
+authorization:
+  type: Bearer
+  credentials_file: /var/run/secrets/gardener.cloud/shoot/token/token
 relabel_configs:
 - source_labels:
   - __meta_kubernetes_service_name

--- a/pkg/operation/botanist/component/kubeapiserver/monitoring_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/monitoring_test.go
@@ -55,8 +55,9 @@ kubernetes_sd_configs:
     names: [` + testNS + `]
 tls_config:
   insecure_skip_verify: true
-  cert_file: /etc/prometheus/seed/prometheus.crt
-  key_file: /etc/prometheus/seed/prometheus.key
+authorization:
+  type: Bearer
+  credentials_file: /var/run/secrets/gardener.cloud/shoot/token/token
 relabel_configs:
 - source_labels:
   - __meta_kubernetes_service_name

--- a/pkg/operation/botanist/component/kubecontrollermanager/monitoring.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/monitoring.go
@@ -58,8 +58,9 @@ var (
 scheme: https
 tls_config:
   insecure_skip_verify: true
-  cert_file: /etc/prometheus/seed/prometheus.crt
-  key_file: /etc/prometheus/seed/prometheus.key
+authorization:
+  type: Bearer
+  credentials_file: /var/run/secrets/gardener.cloud/shoot/token/token
 honor_labels: false
 scrape_timeout: 15s
 kubernetes_sd_configs:

--- a/pkg/operation/botanist/component/kubecontrollermanager/monitoring_test.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/monitoring_test.go
@@ -60,8 +60,9 @@ const (
 scheme: https
 tls_config:
   insecure_skip_verify: true
-  cert_file: /etc/prometheus/seed/prometheus.crt
-  key_file: /etc/prometheus/seed/prometheus.key
+authorization:
+  type: Bearer
+  credentials_file: /var/run/secrets/gardener.cloud/shoot/token/token
 honor_labels: false
 scrape_timeout: 15s
 kubernetes_sd_configs:

--- a/pkg/operation/botanist/component/kubescheduler/monitoring.go
+++ b/pkg/operation/botanist/component/kubescheduler/monitoring.go
@@ -104,8 +104,9 @@ var (
 scheme: https
 tls_config:
   insecure_skip_verify: true
-  cert_file: /etc/prometheus/seed/prometheus.crt
-  key_file: /etc/prometheus/seed/prometheus.key
+authorization:
+  type: Bearer
+  credentials_file: /var/run/secrets/gardener.cloud/shoot/token/token
 honor_labels: false
 kubernetes_sd_configs:
 - role: endpoints

--- a/pkg/operation/botanist/component/kubescheduler/monitoring_test.go
+++ b/pkg/operation/botanist/component/kubescheduler/monitoring_test.go
@@ -61,8 +61,9 @@ const (
 scheme: https
 tls_config:
   insecure_skip_verify: true
-  cert_file: /etc/prometheus/seed/prometheus.crt
-  key_file: /etc/prometheus/seed/prometheus.key
+authorization:
+  type: Bearer
+  credentials_file: /var/run/secrets/gardener.cloud/shoot/token/token
 honor_labels: false
 kubernetes_sd_configs:
 - role: endpoints

--- a/pkg/operation/botanist/monitoring.go
+++ b/pkg/operation/botanist/monitoring.go
@@ -113,6 +113,7 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 	// Create shoot token secret for kube-state-metrics and prometheus components
 	for _, name := range []string{
 		v1beta1constants.DeploymentNameKubeStateMetricsShoot,
+		v1beta1constants.StatefulSetNamePrometheus,
 	} {
 		if err := gutil.NewShootAccessSecret(name, b.Shoot.SeedNamespace).Reconcile(ctx, b.K8sSeedClient.Client()); err != nil {
 			return err
@@ -343,9 +344,12 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 		}
 	}
 
-	// TODO(rfranzke): Remove in a future release.
-	return kutil.DeleteObject(ctx, b.K8sSeedClient.Client(),
+	return kutil.DeleteObjects(ctx, b.K8sSeedClient.Client(),
+		// TODO(rfranzke): Remove in a future release.
 		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "kube-state-metrics", Namespace: b.Shoot.SeedNamespace}},
+		// TODO(rfranzke): Uncomment this in a future release once all monitoring configurations of extensions have been
+		// adapted.
+		//&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "prometheus", Namespace: b.Shoot.SeedNamespace}},
 	)
 }
 
@@ -597,6 +601,7 @@ func (b *Botanist) DeleteSeedMonitoring(ctx context.Context) error {
 				Name:      "allow-prometheus",
 			},
 		},
+		gutil.NewShootAccessSecret(v1beta1constants.StatefulSetNamePrometheus, b.Shoot.SeedNamespace).Secret,
 		&corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: b.Shoot.SeedNamespace,

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -61,6 +61,7 @@ func (b *Botanist) GenerateAndSaveSecrets(ctx context.Context) error {
 			"kube-scheduler",
 			"kube-controller-manager",
 			"cluster-autoscaler",
+			"kube-state-metrics",
 		} {
 			gardenerResourceDataList.Delete(name)
 		}

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -62,6 +62,9 @@ func (b *Botanist) GenerateAndSaveSecrets(ctx context.Context) error {
 			"kube-controller-manager",
 			"cluster-autoscaler",
 			"kube-state-metrics",
+			// TODO(rfranzke): Uncomment this in a future release once all monitoring configurations of extensions have been
+			// adapted.
+			// "prometheus",
 		} {
 			gardenerResourceDataList.Delete(name)
 		}

--- a/pkg/operation/botanist/wanted_secrets.go
+++ b/pkg/operation/botanist/wanted_secrets.go
@@ -293,26 +293,6 @@ func (b *Botanist) generateWantedSecretConfigs(basicAuthAPIServer *secrets.Basic
 			}},
 		},
 
-		// Secret definition for kube-state-metrics
-		&secrets.ControlPlaneSecretConfig{
-			CertificateSecretConfig: &secrets.CertificateSecretConfig{
-				Name: "kube-state-metrics",
-
-				CommonName:   "gardener.cloud:monitoring:kube-state-metrics",
-				Organization: []string{"gardener.cloud:monitoring"},
-				DNSNames:     nil,
-				IPAddresses:  nil,
-
-				CertType:  secrets.ClientCert,
-				SigningCA: certificateAuthorities[v1beta1constants.SecretNameCACluster],
-			},
-
-			KubeConfigRequests: []secrets.KubeConfigRequest{{
-				ClusterName:   b.Shoot.SeedNamespace,
-				APIServerHost: b.Shoot.ComputeInClusterAPIServerAddress(true),
-			}},
-		},
-
 		// Secret definition for prometheus
 		&secrets.ControlPlaneSecretConfig{
 			CertificateSecretConfig: &secrets.CertificateSecretConfig{

--- a/pkg/operation/botanist/wanted_secrets.go
+++ b/pkg/operation/botanist/wanted_secrets.go
@@ -294,6 +294,8 @@ func (b *Botanist) generateWantedSecretConfigs(basicAuthAPIServer *secrets.Basic
 		},
 
 		// Secret definition for prometheus
+		// TODO(rfranzke): Delete this in a future release once all monitoring configurations of extensions have been
+		// adapted.
 		&secrets.ControlPlaneSecretConfig{
 			CertificateSecretConfig: &secrets.CertificateSecretConfig{
 				Name: "prometheus",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement
/merge squash

**What this PR does / why we need it**:
Similar to #4931, this PR eliminates the client certificate for the `kube-state-metrics` in favor of a token managed by the `TokenRequestor` controller in `gardener-resource-manager`.
`prometheus` has such a token as well, but for backwards-compatibility it also still has access to its client certificate (this will be dropped in the future).

**Which issue(s) this PR fixes**:
Part of #4661
Part of #4878

**Special notes for your reviewer**:
/invite @BeckerMax
/cc @wyb1 @istvanballok 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
`kube-state-metrics` does no longer use a client certificate but an auto-rotated `ServiceAccount` token which is only valid for `12h`. `prometheus` has such a token as well, but for backwards-compatibility it also still has access to its client certificate (this will be dropped in the future).
```
```action developer
The monitoring scrape configurations (particularly the `tls_config` and `authorization` section) of extension controllers must be adapted such that they match the example in https://github.com/gardener/gardener/blob/master/docs/extensions/logging-and-monitoring.md#extensions-monitoring-integration.
```
