### PR TITLE
Eliminate client certificate for `vpa-{admission-controller,recommender,updater}`

### DIFF
--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/_helpers.tpl
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/_helpers.tpl
@@ -1,0 +1,7 @@
+{{- define "vpa.rbac-name-infix" -}}
+{{- if eq .Values.clusterType "shoot" -}}
+target
+{{- else -}}
+{{ .Values.clusterType }}{{/* TODO: Rename this to "source" once the VPA Helm charts gets refactored into a Golang component. */}}
+{{- end -}}
+{{- end -}}

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrole-actor.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrole-actor.yaml
@@ -3,7 +3,7 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
 metadata:
-  name: gardener.cloud:vpa:{{ .Values.clusterType }}:actor
+  name: gardener.cloud:vpa:{{ include "vpa.rbac-name-infix" . }}:actor
   labels:
   {{ toYaml .Values.labels | indent 4 }}
 rules:

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrole-admission-controller.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrole-admission-controller.yaml
@@ -3,7 +3,7 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
 metadata:
-  name: gardener.cloud:vpa:{{ .Values.clusterType }}:admission-controller
+  name: gardener.cloud:vpa:{{ include "vpa.rbac-name-infix" . }}:admission-controller
   labels:
   {{ toYaml .Values.labels | indent 4 }}
 rules:

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrole-checkpointer.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrole-checkpointer.yaml
@@ -3,7 +3,7 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
 metadata:
-  name: gardener.cloud:vpa:{{ .Values.clusterType }}:checkpoint-actor
+  name: gardener.cloud:vpa:{{ include "vpa.rbac-name-infix" . }}:checkpoint-actor
   labels:
   {{ toYaml .Values.labels | indent 4 }}
 rules:

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrole-recommender.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrole-recommender.yaml
@@ -3,7 +3,7 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
 metadata:
-  name: gardener.cloud:vpa:{{ .Values.clusterType }}:metrics-reader
+  name: gardener.cloud:vpa:{{ include "vpa.rbac-name-infix" . }}:metrics-reader
   labels:
   {{ toYaml .Values.labels | indent 4 }}
 rules:

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrole-target-reader.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrole-target-reader.yaml
@@ -3,7 +3,7 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
 metadata:
-  name: gardener.cloud:vpa:{{ .Values.clusterType }}:target-reader
+  name: gardener.cloud:vpa:{{ include "vpa.rbac-name-infix" . }}:target-reader
   labels:
   {{ toYaml .Values.labels | indent 4 }}
 rules:

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrole-updater-evictioner.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrole-updater-evictioner.yaml
@@ -3,7 +3,7 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
 metadata:
-  name: gardener.cloud:vpa:{{ .Values.clusterType }}:evictioner
+  name: gardener.cloud:vpa:{{ include "vpa.rbac-name-infix" . }}:evictioner
   labels:
   {{ toYaml .Values.labels | indent 4 }}
 rules:

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-actor.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-actor.yaml
@@ -2,7 +2,7 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRoleBinding
 metadata:
-  name: gardener.cloud:vpa:{{ .Values.clusterType }}:actor
+  name: gardener.cloud:vpa:{{ include "vpa.rbac-name-infix" . }}:actor
   labels:
   {{ toYaml .Values.labels | indent 4 }}
   annotations:
@@ -10,7 +10,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: gardener.cloud:vpa:{{ .Values.clusterType }}:actor
+  name: gardener.cloud:vpa:{{ include "vpa.rbac-name-infix" . }}:actor
 {{- if or .Values.recommender.enabled .Values.updater.enabled }}
 subjects:
 {{- if .Values.recommender.enabled }}

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-actor.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-actor.yaml
@@ -19,9 +19,9 @@ subjects:
   name: vpa-recommender
   namespace: {{ .Release.Namespace }}
 {{- else }}
-- apiGroup: rbac.authorization.k8s.io
-  kind: User
-  name: gardener.cloud:vpa:recommender
+- kind: ServiceAccount
+  name: vpa-recommender
+  namespace: kube-system
 {{- end }}
 {{- end }}
 {{- if .Values.updater.enabled }}
@@ -30,9 +30,9 @@ subjects:
   name: vpa-updater
   namespace: {{ .Release.Namespace }}
 {{- else }}
-- apiGroup: rbac.authorization.k8s.io
-  kind: User
-  name: gardener.cloud:vpa:updater
+- kind: ServiceAccount
+  name: vpa-updater
+  namespace: kube-system
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-actor.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-actor.yaml
@@ -14,24 +14,20 @@ roleRef:
 {{- if or .Values.recommender.enabled .Values.updater.enabled }}
 subjects:
 {{- if .Values.recommender.enabled }}
-{{- if .Values.recommender.enableServiceAccount }}
 - kind: ServiceAccount
   name: vpa-recommender
+{{- if .Values.recommender.createServiceAccount }}
   namespace: {{ .Release.Namespace }}
 {{- else }}
-- kind: ServiceAccount
-  name: vpa-recommender
   namespace: kube-system
 {{- end }}
 {{- end }}
 {{- if .Values.updater.enabled }}
-{{- if .Values.updater.enableServiceAccount }}
 - kind: ServiceAccount
   name: vpa-updater
+{{- if .Values.updater.createServiceAccount }}
   namespace: {{ .Release.Namespace }}
 {{- else }}
-- kind: ServiceAccount
-  name: vpa-updater
   namespace: kube-system
 {{- end }}
 {{- end }}

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-admission-controller.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-admission-controller.yaml
@@ -18,8 +18,8 @@ subjects:
   name: vpa-admission-controller
   namespace: {{ .Release.Namespace }}
 {{- else }}
-- apiGroup: rbac.authorization.k8s.io
-  kind: User
-  name: gardener.cloud:vpa:admission-controller
+- kind: ServiceAccount
+  name: vpa-admission-controller
+  namespace: kube-system
 {{- end }}
 {{- end }}

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-admission-controller.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-admission-controller.yaml
@@ -2,7 +2,7 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRoleBinding
 metadata:
-  name: gardener.cloud:vpa:{{ .Values.clusterType }}:admission-controller
+  name: gardener.cloud:vpa:{{ include "vpa.rbac-name-infix" . }}:admission-controller
   labels:
   {{ toYaml .Values.labels | indent 4 }}
   annotations:
@@ -10,7 +10,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: gardener.cloud:vpa:{{ .Values.clusterType }}:admission-controller
+  name: gardener.cloud:vpa:{{ include "vpa.rbac-name-infix" . }}:admission-controller
 {{- if .Values.admissionController.enabled }}
 subjects:
 - kind: ServiceAccount

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-admission-controller.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-admission-controller.yaml
@@ -13,13 +13,11 @@ roleRef:
   name: gardener.cloud:vpa:{{ .Values.clusterType }}:admission-controller
 {{- if .Values.admissionController.enabled }}
 subjects:
-{{- if .Values.admissionController.enableServiceAccount }}
 - kind: ServiceAccount
   name: vpa-admission-controller
+{{- if .Values.admissionController.createServiceAccount }}
   namespace: {{ .Release.Namespace }}
 {{- else }}
-- kind: ServiceAccount
-  name: vpa-admission-controller
   namespace: kube-system
 {{- end }}
 {{- end }}

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-checkpointer.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-checkpointer.yaml
@@ -2,7 +2,7 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRoleBinding
 metadata:
-  name: gardener.cloud:vpa:{{ .Values.clusterType }}:checkpoint-actor
+  name: gardener.cloud:vpa:{{ include "vpa.rbac-name-infix" . }}:checkpoint-actor
   labels:
   {{ toYaml .Values.labels | indent 4 }}
   annotations:
@@ -10,7 +10,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: gardener.cloud:vpa:{{ .Values.clusterType }}:checkpoint-actor
+  name: gardener.cloud:vpa:{{ include "vpa.rbac-name-infix" . }}:checkpoint-actor
 {{- if .Values.recommender.enabled }}
 subjects:
 - kind: ServiceAccount

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-checkpointer.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-checkpointer.yaml
@@ -13,13 +13,11 @@ roleRef:
   name: gardener.cloud:vpa:{{ .Values.clusterType }}:checkpoint-actor
 {{- if .Values.recommender.enabled }}
 subjects:
-{{- if .Values.recommender.enableServiceAccount }}
 - kind: ServiceAccount
   name: vpa-recommender
+{{- if .Values.recommender.createServiceAccount }}
   namespace: {{ .Release.Namespace }}
 {{- else }}
-- kind: ServiceAccount
-  name: vpa-recommender
   namespace: kube-system
 {{- end }}
 {{- end }}

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-checkpointer.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-checkpointer.yaml
@@ -18,8 +18,8 @@ subjects:
   name: vpa-recommender
   namespace: {{ .Release.Namespace }}
 {{- else }}
-- apiGroup: rbac.authorization.k8s.io
-  kind: User
-  name: gardener.cloud:vpa:recommender
+- kind: ServiceAccount
+  name: vpa-recommender
+  namespace: kube-system
 {{- end }}
 {{- end }}

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-recommender.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-recommender.yaml
@@ -13,13 +13,11 @@ roleRef:
   name: gardener.cloud:vpa:{{ .Values.clusterType }}:metrics-reader
 {{- if .Values.recommender.enabled }}
 subjects:
-{{- if .Values.recommender.enableServiceAccount }}
 - kind: ServiceAccount
   name: vpa-recommender
+{{- if .Values.recommender.createServiceAccount }}
   namespace: {{ .Release.Namespace }}
 {{- else }}
-- kind: ServiceAccount
-  name: vpa-recommender
   namespace: kube-system
 {{- end }}
 {{- end }}

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-recommender.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-recommender.yaml
@@ -2,7 +2,7 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRoleBinding
 metadata:
-  name: gardener.cloud:vpa:{{ .Values.clusterType }}:metrics-reader
+  name: gardener.cloud:vpa:{{ include "vpa.rbac-name-infix" . }}:metrics-reader
   labels:
   {{ toYaml .Values.labels | indent 4 }}
   annotations:
@@ -10,7 +10,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: gardener.cloud:vpa:{{ .Values.clusterType }}:metrics-reader
+  name: gardener.cloud:vpa:{{ include "vpa.rbac-name-infix" . }}:metrics-reader
 {{- if .Values.recommender.enabled }}
 subjects:
 - kind: ServiceAccount

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-recommender.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-recommender.yaml
@@ -18,8 +18,8 @@ subjects:
   name: vpa-recommender
   namespace: {{ .Release.Namespace }}
 {{- else }}
-- apiGroup: rbac.authorization.k8s.io
-  kind: User
-  name: gardener.cloud:vpa:recommender
+- kind: ServiceAccount
+  name: vpa-recommender
+  namespace: kube-system
 {{- end }}
 {{- end }}

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-target-reader.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-target-reader.yaml
@@ -14,35 +14,29 @@ roleRef:
 {{- if or .Values.admissionController.enabled .Values.recommender.enabled .Values.updater.enabled }}
 subjects:
 {{- if .Values.recommender.enabled }}
-{{- if .Values.recommender.enableServiceAccount }}
 - kind: ServiceAccount
   name: vpa-recommender
+{{- if .Values.recommender.createServiceAccount }}
   namespace: {{ .Release.Namespace }}
 {{- else }}
-- kind: ServiceAccount
-  name: vpa-recommender
   namespace: kube-system
 {{- end }}
 {{- end }}
 {{- if .Values.admissionController.enabled }}
-{{- if .Values.admissionController.enableServiceAccount }}
 - kind: ServiceAccount
   name: vpa-admission-controller
+{{- if .Values.admissionController.createServiceAccount }}
   namespace: {{ .Release.Namespace }}
 {{- else }}
-- kind: ServiceAccount
-  name: vpa-admission-controller
   namespace: kube-system
 {{- end }}
 {{- end }}
 {{- if .Values.updater.enabled }}
-{{- if .Values.updater.enableServiceAccount }}
 - kind: ServiceAccount
   name: vpa-updater
+{{- if .Values.updater.createServiceAccount }}
   namespace: {{ .Release.Namespace }}
 {{- else }}
-- kind: ServiceAccount
-  name: vpa-updater
   namespace: kube-system
 {{- end }}
 {{- end }}

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-target-reader.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-target-reader.yaml
@@ -2,7 +2,7 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRoleBinding
 metadata:
-  name: gardener.cloud:vpa:{{ .Values.clusterType }}:target-reader
+  name: gardener.cloud:vpa:{{ include "vpa.rbac-name-infix" . }}:target-reader
   labels:
   {{ toYaml .Values.labels | indent 4 }}
   annotations:
@@ -10,7 +10,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: gardener.cloud:vpa:{{ .Values.clusterType }}:target-reader
+  name: gardener.cloud:vpa:{{ include "vpa.rbac-name-infix" . }}:target-reader
 {{- if or .Values.admissionController.enabled .Values.recommender.enabled .Values.updater.enabled }}
 subjects:
 {{- if .Values.recommender.enabled }}

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-target-reader.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-target-reader.yaml
@@ -19,9 +19,9 @@ subjects:
   name: vpa-recommender
   namespace: {{ .Release.Namespace }}
 {{- else }}
-- apiGroup: rbac.authorization.k8s.io
-  kind: User
-  name: gardener.cloud:vpa:recommender
+- kind: ServiceAccount
+  name: vpa-recommender
+  namespace: kube-system
 {{- end }}
 {{- end }}
 {{- if .Values.admissionController.enabled }}
@@ -30,9 +30,9 @@ subjects:
   name: vpa-admission-controller
   namespace: {{ .Release.Namespace }}
 {{- else }}
-- apiGroup: rbac.authorization.k8s.io
-  kind: User
-  name: gardener.cloud:vpa:admission-controller
+- kind: ServiceAccount
+  name: vpa-admission-controller
+  namespace: kube-system
 {{- end }}
 {{- end }}
 {{- if .Values.updater.enabled }}
@@ -41,9 +41,9 @@ subjects:
   name: vpa-updater
   namespace: {{ .Release.Namespace }}
 {{- else }}
-- apiGroup: rbac.authorization.k8s.io
-  kind: User
-  name: gardener.cloud:vpa:updater
+- kind: ServiceAccount
+  name: vpa-updater
+  namespace: kube-system
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-updater-evictioner.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-updater-evictioner.yaml
@@ -2,7 +2,7 @@
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRoleBinding
 metadata:
-  name: gardener.cloud:vpa:{{ .Values.clusterType }}:evictioner
+  name: gardener.cloud:vpa:{{ include "vpa.rbac-name-infix" . }}:evictioner
   labels:
   {{ toYaml .Values.labels | indent 4 }}
   annotations:
@@ -10,7 +10,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: gardener.cloud:vpa:{{ .Values.clusterType }}:evictioner
+  name: gardener.cloud:vpa:{{ include "vpa.rbac-name-infix" . }}:evictioner
 {{- if .Values.updater.enabled }}
 subjects:
 - kind: ServiceAccount

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-updater-evictioner.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-updater-evictioner.yaml
@@ -18,8 +18,8 @@ subjects:
   name: vpa-updater
   namespace: {{ .Release.Namespace }}
 {{- else }}
-- apiGroup: rbac.authorization.k8s.io
-  kind: User
-  name: gardener.cloud:vpa:updater
+- kind: ServiceAccount
+  name: vpa-updater
+  namespace: kube-system
 {{- end }}
 {{- end }}

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-updater-evictioner.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-updater-evictioner.yaml
@@ -13,13 +13,11 @@ roleRef:
   name: gardener.cloud:vpa:{{ .Values.clusterType }}:evictioner
 {{- if .Values.updater.enabled }}
 subjects:
-{{- if .Values.updater.enableServiceAccount }}
 - kind: ServiceAccount
   name: vpa-updater
+{{- if .Values.updater.createServiceAccount }}
   namespace: {{ .Release.Namespace }}
 {{- else }}
-- kind: ServiceAccount
-  name: vpa-updater
   namespace: kube-system
 {{- end }}
 {{- end }}

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/serviceaccount-admission-controller.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/serviceaccount-admission-controller.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.admissionController.enabled .Values.admissionController.enableServiceAccount }}
+{{- if and .Values.admissionController.enabled .Values.admissionController.createServiceAccount }}
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/serviceaccount-recommender.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/serviceaccount-recommender.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.recommender.enabled .Values.recommender.enableServiceAccount }}
+{{- if and .Values.recommender.enabled .Values.recommender.createServiceAccount }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/serviceaccount-updater.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/serviceaccount-updater.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.updater.enabled .Values.updater.enableServiceAccount }}
+{{- if and .Values.updater.enabled .Values.updater.createServiceAccount }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-admission-controller.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-admission-controller.yaml
@@ -68,7 +68,7 @@ spec:
             mountPath: "/etc/tls-certs"
             readOnly: true
 {{- if not .Values.admissionController.enableServiceAccount }}
-          - name: vpa-admission-controller
+          - name: shoot-access
             mountPath: /var/run/secrets/kubernetes.io/serviceaccount
             readOnly: true
 {{- end }}
@@ -86,8 +86,19 @@ spec:
           secret:
             secretName: vpa-tls-certs
 {{- if not .Values.admissionController.enableServiceAccount }}
-        - name: vpa-admission-controller
-          secret:
-            secretName: vpa-admission-controller
+        - name: shoot-access
+          projected:
+            defaultMode: 420
+            sources:
+            - secret:
+                items:
+                - key: ca.crt
+                  path: ca.crt
+                name: ca
+            - secret:
+                items:
+                - key: token
+                  path: token
+                name: shoot-access-vpa-admission-controller
 {{- end }}
 {{- end }}

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-admission-controller.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-admission-controller.yaml
@@ -31,7 +31,7 @@ spec:
 {{ toYaml .Values.admissionController.podLabels | indent 8 }}
 {{- end }}
     spec:
-{{- if .Values.admissionController.enableServiceAccount }}
+{{- if .Values.admissionController.createServiceAccount }}
       serviceAccountName: vpa-admission-controller
 {{- else }}
       automountServiceAccountToken: false
@@ -52,7 +52,7 @@ spec:
         image: {{ index .Values.global.images "vpa-admission-controller" }}
         imagePullPolicy: IfNotPresent
         env:
-{{- if not .Values.admissionController.enableServiceAccount }}
+{{- if not .Values.admissionController.createServiceAccount }}
         - name: KUBERNETES_SERVICE_HOST
           value: kube-apiserver
         - name: KUBERNETES_SERVICE_PORT
@@ -67,7 +67,7 @@ spec:
           - name: vpa-tls-certs
             mountPath: "/etc/tls-certs"
             readOnly: true
-{{- if not .Values.admissionController.enableServiceAccount }}
+{{- if not .Values.admissionController.createServiceAccount }}
           - name: shoot-access
             mountPath: /var/run/secrets/kubernetes.io/serviceaccount
             readOnly: true
@@ -85,7 +85,7 @@ spec:
         - name: vpa-tls-certs
           secret:
             secretName: vpa-tls-certs
-{{- if not .Values.admissionController.enableServiceAccount }}
+{{- if not .Values.admissionController.createServiceAccount }}
         - name: shoot-access
           projected:
             defaultMode: 420

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-recommender.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-recommender.yaml
@@ -31,7 +31,7 @@ spec:
 {{ toYaml .Values.admissionController.podLabels | indent 8 }}
 {{- end }}
     spec:
-{{- if .Values.recommender.enableServiceAccount }}
+{{- if .Values.recommender.createServiceAccount }}
       serviceAccountName: vpa-recommender
 {{- else }}
       automountServiceAccountToken: false
@@ -48,7 +48,7 @@ spec:
         - --pod-recommendation-min-memory-mb=10
         - --recommendation-margin-fraction={{ .Values.recommender.recommendationMarginFraction }}
         - --recommender-interval={{ .Values.recommender.interval }}
-{{- if not .Values.recommender.enableServiceAccount }}
+{{- if not .Values.recommender.createServiceAccount }}
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: kube-apiserver
@@ -69,7 +69,7 @@ spec:
             memory: 200Mi
         ports:
         - containerPort: 8080
-{{- if not .Values.recommender.enableServiceAccount }}
+{{- if not .Values.recommender.createServiceAccount }}
       volumes:
       - name: shoot-access
         projected:

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-recommender.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-recommender.yaml
@@ -55,7 +55,7 @@ spec:
         - name: KUBERNETES_SERVICE_PORT
           value: "443"
         volumeMounts:
-        - name: vpa-recommender
+        - name: shoot-access
           mountPath: /var/run/secrets/kubernetes.io/serviceaccount
           readOnly: true
 {{- end }}
@@ -71,8 +71,19 @@ spec:
         - containerPort: 8080
 {{- if not .Values.recommender.enableServiceAccount }}
       volumes:
-      - name: vpa-recommender
-        secret:
-          secretName: vpa-recommender
+      - name: shoot-access
+        projected:
+          defaultMode: 420
+          sources:
+          - secret:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: ca
+          - secret:
+              items:
+              - key: token
+                path: token
+              name: shoot-access-vpa-recommender
 {{- end }}
 {{- end }}

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-updater.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-updater.yaml
@@ -65,7 +65,7 @@ spec:
 {{- end }}
 {{- if not .Values.updater.enableServiceAccount }}
         volumeMounts:
-        - name: vpa-updater
+        - name: shoot-access
           mountPath: /var/run/secrets/kubernetes.io/serviceaccount
           readOnly: true
 {{- end }}
@@ -80,8 +80,19 @@ spec:
         - containerPort: 8080
 {{- if not .Values.updater.enableServiceAccount }}
       volumes:
-      - name: vpa-updater
-        secret:
-          secretName: vpa-updater
+      - name: shoot-access
+        projected:
+          defaultMode: 420
+          sources:
+          - secret:
+              items:
+              - key: ca.crt
+                path: ca.crt
+              name: ca
+          - secret:
+              items:
+              - key: token
+                path: token
+              name: shoot-access-vpa-updater
 {{- end }}
 {{- end }}

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-updater.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-updater.yaml
@@ -30,7 +30,7 @@ spec:
 {{ toYaml .Values.updater.podLabels | indent 8 }}
 {{- end }}
     spec:
-{{- if .Values.updater.enableServiceAccount }}
+{{- if .Values.updater.createServiceAccount }}
       serviceAccountName: vpa-updater
 {{- else }}
       automountServiceAccountToken: false
@@ -50,7 +50,7 @@ spec:
         - --updater-interval={{ .Values.updater.interval }}
         - --stderrthreshold=info
         - --v=2
-{{- if not .Values.updater.enableServiceAccount }}
+{{- if not .Values.updater.createServiceAccount }}
         env:
         - name: KUBERNETES_SERVICE_HOST
           value: kube-apiserver
@@ -63,7 +63,7 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
 {{- end }}
-{{- if not .Values.updater.enableServiceAccount }}
+{{- if not .Values.updater.createServiceAccount }}
         volumeMounts:
         - name: shoot-access
           mountPath: /var/run/secrets/kubernetes.io/serviceaccount
@@ -78,7 +78,7 @@ spec:
             memory: 200Mi
         ports:
         - containerPort: 8080
-{{- if not .Values.updater.enableServiceAccount }}
+{{- if not .Values.updater.createServiceAccount }}
       volumes:
       - name: shoot-access
         projected:

--- a/charts/seed-bootstrap/charts/vpa/values.yaml
+++ b/charts/seed-bootstrap/charts/vpa/values.yaml
@@ -15,7 +15,7 @@ admissionController:
   enabled: true
   podAnnotations: {}
   podLabels: {}
-  enableServiceAccount: true
+  createServiceAccount: true
   caCert: abcd
   controlNamespace: abcd
   port: 10250
@@ -26,7 +26,7 @@ recommender:
   enabled: true
   podAnnotations: {}
   podLabels: {}
-  enableServiceAccount: true
+  createServiceAccount: true
   interval: 1m0s
   recommendationMarginFraction: 0.05
 
@@ -35,7 +35,7 @@ updater:
   enabled: true
   podAnnotations: {}
   podLabels: {}
-  enableServiceAccount: true
+  createServiceAccount: true
   evictAfterOOMThreshold: 48h
   evictionRateBurst: 1
   evictionRateLimit: -1

--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -303,12 +303,12 @@ func (b *Botanist) generateCoreAddonsChart(ctx context.Context) (*chartrenderer.
 			"application": map[string]interface{}{
 				"clusterType": "shoot",
 				"admissionController": map[string]interface{}{
-					"enableServiceAccount": false,
+					"createServiceAccount": false,
 					"controlNamespace":     b.Shoot.SeedNamespace,
 				},
-				"exporter":    map[string]interface{}{"enableServiceAccount": false},
-				"recommender": map[string]interface{}{"enableServiceAccount": false},
-				"updater":     map[string]interface{}{"enableServiceAccount": false},
+				"exporter":    map[string]interface{}{"createServiceAccount": false},
+				"recommender": map[string]interface{}{"createServiceAccount": false},
+				"updater":     map[string]interface{}{"createServiceAccount": false},
 			},
 		}
 

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -69,7 +69,7 @@ func (b *Botanist) DeployVerticalPodAutoscaler(ctx context.Context) error {
 			"podLabels": utils.MergeMaps(podLabels, map[string]interface{}{
 				v1beta1constants.LabelNetworkPolicyFromShootAPIServer: "allowed",
 			}),
-			"enableServiceAccount": false,
+			"createServiceAccount": false,
 		}
 		exporter = map[string]interface{}{
 			"enabled":  false,
@@ -81,7 +81,7 @@ func (b *Botanist) DeployVerticalPodAutoscaler(ctx context.Context) error {
 				"checksum/secret-vpa-recommender": b.LoadCheckSum("vpa-recommender"),
 			},
 			"podLabels":                    podLabels,
-			"enableServiceAccount":         false,
+			"createServiceAccount":         false,
 			"recommendationMarginFraction": gardencorev1beta1.DefaultRecommendationMarginFraction,
 			"interval":                     gardencorev1beta1.DefaultRecommenderInterval,
 		}
@@ -91,7 +91,7 @@ func (b *Botanist) DeployVerticalPodAutoscaler(ctx context.Context) error {
 				"checksum/secret-vpa-updater": b.LoadCheckSum("vpa-updater"),
 			},
 			"podLabels":              podLabels,
-			"enableServiceAccount":   false,
+			"createServiceAccount":   false,
 			"evictAfterOOMThreshold": gardencorev1beta1.DefaultEvictAfterOOMThreshold,
 			"evictionRateBurst":      gardencorev1beta1.DefaultEvictionRateBurst,
 			"evictionRateLimit":      gardencorev1beta1.DefaultEvictionRateLimit,

--- a/pkg/operation/botanist/wanted_secrets.go
+++ b/pkg/operation/botanist/wanted_secrets.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/gardener/gardener/charts"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/dependencywatchdog"
@@ -84,12 +83,6 @@ func (b *Botanist) wantedCertificateAuthorities() map[string]*secrets.Certificat
 	return wantedCertificateAuthorities
 }
 
-var vpaSecrets = map[string]string{
-	charts.ImageNameVpaAdmissionController: common.VpaAdmissionControllerName,
-	charts.ImageNameVpaRecommender:         common.VpaRecommenderName,
-	charts.ImageNameVpaUpdater:             common.VpaUpdaterName,
-}
-
 func (b *Botanist) generateStaticTokenConfig() *secrets.StaticTokenSecretConfig {
 	staticTokenConfig := &secrets.StaticTokenSecretConfig{
 		Name: kubeapiserver.SecretNameStaticToken,
@@ -104,15 +97,6 @@ func (b *Botanist) generateStaticTokenConfig() *secrets.StaticTokenSecretConfig 
 				UserID:   common.KubeAPIServerHealthCheck,
 			},
 		},
-	}
-
-	if b.Shoot.WantsVerticalPodAutoscaler {
-		for secretName, username := range vpaSecrets {
-			staticTokenConfig.Tokens[secretName] = secrets.TokenConfig{
-				Username: username,
-				UserID:   secretName,
-			}
-		}
 	}
 
 	if b.isShootNodeLoggingEnabled() {

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -89,15 +89,6 @@ const (
 	// RegistrationSpecHash is a constant for a label on `ControllerInstallation`s (similar to `pod-template-hash` on `Pod`s).
 	RegistrationSpecHash = "registration-spec-hash"
 
-	// VpaAdmissionControllerName is the name of the vpa-admission-controller name.
-	VpaAdmissionControllerName = "gardener.cloud:vpa:admission-controller"
-	// VpaRecommenderName is the name of the vpa-recommender name.
-	VpaRecommenderName = "gardener.cloud:vpa:recommender"
-	// VpaUpdaterName is the name of the vpa-updater name.
-	VpaUpdaterName = "gardener.cloud:vpa:updater"
-	// VpaExporterName is the name of the vpa-exporter name.
-	VpaExporterName = "gardener.cloud:vpa:exporter"
-
 	// IstioNamespace is the istio-system namespace
 	IstioNamespace = "istio-system"
 

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -25,6 +25,7 @@ import (
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
+	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
 	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
@@ -165,11 +166,15 @@ func DeleteVpa(ctx context.Context, c client.Client, namespace string, isShoot b
 
 	if isShoot {
 		resources = append(resources,
+			gutil.NewShootAccessSecret(v1beta1constants.DeploymentNameVPAAdmissionController, namespace).Secret,
+			gutil.NewShootAccessSecret(v1beta1constants.DeploymentNameVPARecommender, namespace).Secret,
+			gutil.NewShootAccessSecret(v1beta1constants.DeploymentNameVPAUpdater, namespace).Secret,
+			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: VPASecretName, Namespace: namespace}},
+			&networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "allow-kube-apiserver-to-vpa-admission-controller", Namespace: namespace}},
+			// TODO(rfranzke): Remove in a future release.
 			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "vpa-admission-controller", Namespace: namespace}},
 			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "vpa-recommender", Namespace: namespace}},
-			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: VPASecretName, Namespace: namespace}},
 			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "vpa-updater", Namespace: namespace}},
-			&networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "allow-kube-apiserver-to-vpa-admission-controller", Namespace: namespace}},
 		)
 	} else {
 		resources = append(resources,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement
/merge squash

**What this PR does / why we need it**:
Similar to #4931, this PR eliminates the client certificate for `vpa-{admission-controller,recommender,updater}` in favor of a token managed by the `TokenRequestor` controller in `gardener-resource-manager`.

**Which issue(s) this PR fixes**:
Part of #4661
Part of #4878

**Special notes for your reviewer**:
/invite @BeckerMax

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
`vpa-{admission-controller,recommender,updater}` do no longer use a client certificate but an auto-rotated `ServiceAccount` token which is only valid for `12h`.
```