### PR TITLE
Eliminate client certificate for `kube-rbac-proxy`

### DIFF
--- a/charts/seed-bootstrap/charts/loki/templates/serviceaccount.yaml
+++ b/charts/seed-bootstrap/charts/loki/templates/serviceaccount.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  labels:
-{{ toYaml .Values.labels | indent 4 }}
-  annotations:
-{{ toYaml .Values.annotations | indent 4 }}
-  name: loki
-  namespace: {{ .Release.Namespace }}

--- a/charts/seed-bootstrap/charts/loki/templates/statefulset.yaml
+++ b/charts/seed-bootstrap/charts/loki/templates/statefulset.yaml
@@ -33,11 +33,8 @@ spec:
 {{ toYaml .Values.labels | indent 8 }}
       annotations:
 {{ include "loki.statefulset.annotations" . | indent 8 }}
-{{- if .Values.rbacSidecarEnabled }}
-        checksum/kube-rbac-proxy-kubeconfig: {{ .Values.kubeRBACProxyKubeconfigCheckSum }}
-{{- end }}
     spec:
-      serviceAccountName: loki
+      automountServiceAccountToken: false
       securityContext:
         fsGroup: 10001
       priorityClassName: {{ .Values.priorityClass.name }}
@@ -48,7 +45,7 @@ spec:
           args:
           - --insecure-listen-address=0.0.0.0:{{ .Values.kubeRBACProxy.port }}
           - --upstream=http://127.0.0.1:3100/
-          - --kubeconfig=/kubeconfig/kubeconfig
+          - --kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig
           - --logtostderr=true
           - --v=6
           resources:
@@ -59,7 +56,8 @@ spec:
             protocol: TCP
           volumeMounts:
             - name: kubeconfig
-              mountPath: /kubeconfig
+              mountPath: /var/run/secrets/gardener.cloud/shoot/generic-kubeconfig
+              readOnly: true
           securityContext:
             runAsNonRoot: true
             runAsUser: 65532
@@ -148,8 +146,21 @@ spec:
             name: {{ include "loki.config.name" . }}
 {{- if .Values.rbacSidecarEnabled }}
         - name: kubeconfig
-          secret:
-            secretName: kube-rbac-proxy-kubeconfig
+          projected:
+            defaultMode: 420
+            sources:
+            - secret:
+                items:
+                - key: kubeconfig
+                  path: kubeconfig
+                name: generic-token-kubeconfig
+                optional: false
+            - secret:
+                items:
+                - key: token
+                  path: token
+                name: shoot-access-kube-rbac-proxy
+                optional: false
         - name: telegraf-config-volume
           configMap:
             name: {{ include "telegraf.config.name" . }}

--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -95,11 +95,6 @@ func (r *shootReconciler) runReconcileShootFlow(ctx context.Context, o *operatio
 			Name: "Deploying Shoot namespace in Seed",
 			Fn:   flow.TaskFn(botanist.DeploySeedNamespace).RetryUntilTimeout(defaultInterval, defaultTimeout),
 		})
-		deployLokiRBACProxy = g.Add(flow.Task{
-			Name:         "Deploying kube-rbac-proxy in Shoot",
-			Fn:           flow.TaskFn(botanist.Shoot.Components.Logging.ShootRBACProxy.Deploy).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			Dependencies: flow.NewTaskIDs(),
-		})
 		ensureShootClusterIdentity = g.Add(flow.Task{
 			Name:         "Ensuring Shoot cluster identity",
 			Fn:           flow.TaskFn(botanist.EnsureShootClusterIdentity).RetryUntilTimeout(defaultInterval, defaultTimeout),
@@ -153,7 +148,7 @@ func (r *shootReconciler) runReconcileShootFlow(ctx context.Context, o *operatio
 		deploySeedLogging = g.Add(flow.Task{
 			Name:         "Deploying shoot logging stack in Seed",
 			Fn:           flow.TaskFn(botanist.DeploySeedLogging).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			Dependencies: flow.NewTaskIDs(deployNamespace, deployLokiRBACProxy, deploySecrets),
+			Dependencies: flow.NewTaskIDs(deployNamespace, deploySecrets),
 		})
 		deployReferencedResources = g.Add(flow.Task{
 			Name:         "Deploying referenced resources",
@@ -336,7 +331,7 @@ func (r *shootReconciler) runReconcileShootFlow(ctx context.Context, o *operatio
 		deployOperatingSystemConfig = g.Add(flow.Task{
 			Name:         "Deploying operating system specific configuration for shoot workers",
 			Fn:           flow.TaskFn(botanist.DeployOperatingSystemConfig).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			Dependencies: flow.NewTaskIDs(deployReferencedResources, waitUntilInfrastructureReady, waitUntilControlPlaneReady, deployLokiRBACProxy),
+			Dependencies: flow.NewTaskIDs(deployReferencedResources, waitUntilInfrastructureReady, waitUntilControlPlaneReady),
 		})
 		waitUntilOperatingSystemConfigReady = g.Add(flow.Task{
 			Name:         "Waiting until operating system configurations for worker nodes have been reconciled",

--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -163,10 +163,9 @@ func New(ctx context.Context, o *operation.Operation) (*Botanist, error) {
 	}
 
 	// Logging
-	o.Shoot.Components.Logging.ShootRBACProxy, err = logging.NewKubeRBACProxy(&logging.KubeRBACProxyOptions{
-		Client:                    b.K8sSeedClient.Client(),
-		Namespace:                 b.Shoot.SeedNamespace,
-		IsShootNodeLoggingEnabled: b.isShootNodeLoggingEnabled(),
+	o.Shoot.Components.Logging.ShootRBACProxy, err = logging.NewKubeRBACProxy(&logging.Values{
+		Client:    b.K8sSeedClient.Client(),
+		Namespace: b.Shoot.SeedNamespace,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -310,10 +310,6 @@ func (b *Botanist) rotateKubeconfigSecrets(ctx context.Context, gardenerResource
 		common.KubecfgSecretName,
 	}
 
-	if b.isShootNodeLoggingEnabled() {
-		secrets = append(secrets, logging.SecretNameLokiKubeRBACProxyKubeconfig)
-	}
-
 	if err := b.deleteSecrets(ctx, gardenerResourceDataList, secrets...); err != nil {
 		return err
 	}

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -25,7 +25,6 @@ import (
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	"github.com/gardener/gardener/pkg/operation/botanist/component/logging"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
 	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
@@ -201,15 +200,6 @@ func DeleteVpa(ctx context.Context, c client.Client, namespace string, isShoot b
 	return nil
 }
 
-// DeleteShootLoggingStack deletes all shoot resource of the logging stack in the given namespace.
-func DeleteShootLoggingStack(ctx context.Context, k8sClient client.Client, namespace string) error {
-	if err := DeleteLoki(ctx, k8sClient, namespace); err != nil {
-		return err
-	}
-
-	return DeleteShootNodeLoggingStack(ctx, k8sClient, namespace)
-}
-
 // DeleteLoki  deletes all resources of the Loki in a given namespace.
 func DeleteLoki(ctx context.Context, k8sClient client.Client, namespace string) error {
 	resources := []client.Object{
@@ -218,24 +208,10 @@ func DeleteLoki(ctx context.Context, k8sClient client.Client, namespace string) 
 		&hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "loki", Namespace: namespace}},
 		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "loki-config", Namespace: namespace}},
 		&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "loki", Namespace: namespace}},
-		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "loki", Namespace: namespace}},
 		&appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "loki", Namespace: namespace}},
 		&corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "loki-loki-0", Namespace: namespace}},
 	}
 
-	return kutil.DeleteObjects(ctx, k8sClient, resources...)
-}
-
-// DeleteShootNodeLoggingStack deletes all shoot resource of the shoot-node logging stack in the given namespace.
-func DeleteShootNodeLoggingStack(ctx context.Context, k8sClient client.Client, namespace string) error {
-	resources := []client.Object{
-		&extensionsv1beta1.Ingress{ObjectMeta: metav1.ObjectMeta{Name: "loki", Namespace: namespace}},
-		&networkingv1.Ingress{ObjectMeta: metav1.ObjectMeta{Name: "loki", Namespace: namespace}},
-		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: logging.SecretNameLokiKubeRBACProxyKubeconfig, Namespace: namespace}},
-		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: LokiTLS, Namespace: namespace}},
-		&networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "allow-from-prometheus-to-loki-telegraf", Namespace: namespace}},
-		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "telegraf-config", Namespace: namespace}},
-	}
 	return kutil.DeleteObjects(ctx, k8sClient, resources...)
 }
 

--- a/pkg/operation/common/utils_test.go
+++ b/pkg/operation/common/utils_test.go
@@ -21,7 +21,6 @@ import (
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
-	"github.com/gardener/gardener/pkg/operation/botanist/component/logging"
 	. "github.com/gardener/gardener/pkg/operation/common"
 
 	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
@@ -30,7 +29,6 @@ import (
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	networkingv1 "k8s.io/api/networking/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
@@ -319,7 +317,6 @@ var _ = Describe("common", func() {
 			&hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "loki", Namespace: v1beta1constants.GardenNamespace}},
 			&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "loki-config", Namespace: v1beta1constants.GardenNamespace}},
 			&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "loki", Namespace: v1beta1constants.GardenNamespace}},
-			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "loki", Namespace: v1beta1constants.GardenNamespace}},
 			&appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "loki", Namespace: v1beta1constants.GardenNamespace}},
 			&corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "loki-loki-0", Namespace: v1beta1constants.GardenNamespace}},
 		}
@@ -341,52 +338,6 @@ var _ = Describe("common", func() {
 			}
 
 			err := DeleteSeedLoggingStack(ctx, c)
-			Expect(err).ToNot(HaveOccurred())
-		})
-	})
-
-	Describe("#DeleteShootLoggingStack", func() {
-		var (
-			ctrl *gomock.Controller
-			c    *mockclient.MockClient
-			ctx  context.Context
-		)
-
-		resources := []client.Object{
-			//shoot components
-			&networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "allow-loki", Namespace: v1beta1constants.GardenNamespace}},
-			&networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "allow-to-loki", Namespace: v1beta1constants.GardenNamespace}},
-			&hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "loki", Namespace: v1beta1constants.GardenNamespace}},
-			&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "loki-config", Namespace: v1beta1constants.GardenNamespace}},
-			&corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: "loki", Namespace: v1beta1constants.GardenNamespace}},
-			&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "loki", Namespace: v1beta1constants.GardenNamespace}},
-			&appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: "loki", Namespace: v1beta1constants.GardenNamespace}},
-			&corev1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: "loki-loki-0", Namespace: v1beta1constants.GardenNamespace}},
-			&networkingv1.Ingress{ObjectMeta: metav1.ObjectMeta{Name: "loki", Namespace: v1beta1constants.GardenNamespace}},
-			&extensionsv1beta1.Ingress{ObjectMeta: metav1.ObjectMeta{Name: "loki", Namespace: v1beta1constants.GardenNamespace}},
-			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: logging.SecretNameLokiKubeRBACProxyKubeconfig, Namespace: v1beta1constants.GardenNamespace}},
-			&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: LokiTLS, Namespace: v1beta1constants.GardenNamespace}},
-			&networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "allow-from-prometheus-to-loki-telegraf", Namespace: v1beta1constants.GardenNamespace}},
-			&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "telegraf-config", Namespace: v1beta1constants.GardenNamespace}},
-		}
-
-		BeforeEach(func() {
-			ctrl = gomock.NewController(GinkgoT())
-			c = mockclient.NewMockClient(ctrl)
-
-			ctx = context.TODO()
-		})
-
-		AfterEach(func() {
-			ctrl.Finish()
-		})
-
-		It("should delete all shoot logging stack components", func() {
-			for _, resource := range resources {
-				c.EXPECT().Delete(ctx, resource)
-			}
-
-			err := DeleteShootLoggingStack(ctx, c, v1beta1constants.GardenNamespace)
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement
/merge squash

**What this PR does / why we need it**:
Similar to #4931, this PR eliminates the client certificate for the `kube-rbac-proxy` in favor of a token managed by the `TokenRequestor` controller in `gardener-resource-manager`.

**Which issue(s) this PR fixes**:
Part of #4661
Part of #4878

**Special notes for your reviewer**:
/invite @BeckerMax
/cc @vlvasilev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
`kube-rbac-proxy` does no longer use a client certificate but an auto-rotated `ServiceAccount` token which is only valid for `12h`.
```