### PR TITLE
Fix antiaffinity terms in gardener charts

### DIFF
--- a/charts/gardener/controlplane/charts/runtime/templates/admission-controller/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/admission-controller/deployment.yaml
@@ -42,17 +42,19 @@ spec:
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - gardener
-              - key: role
-                operator: In
-                values:
-                - admission-controller
-            topologyKey: kubernetes.io/hostname
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - gardener
+                - key: role
+                  operator: In
+                  values:
+                  - admission-controller
+              topologyKey: kubernetes.io/hostname
+            weight: 1
       {{- end }}
       containers:
       - name: gardener-admission-controller

--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
@@ -61,17 +61,19 @@ spec:
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - gardener
-              - key: role
-                operator: In
-                values:
-                - apiserver
-            topologyKey: kubernetes.io/hostname
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - gardener
+                - key: role
+                  operator: In
+                  values:
+                  - apiserver
+              topologyKey: kubernetes.io/hostname
+            weight: 1
       {{- end }}
       containers:
       - name: gardener-apiserver

--- a/charts/gardener/controlplane/charts/runtime/templates/controller-manager/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/controller-manager/deployment.yaml
@@ -48,17 +48,19 @@ spec:
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - gardener
-              - key: role
-                operator: In
-                values:
-                - controller-manager
-            topologyKey: kubernetes.io/hostname
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - gardener
+                - key: role
+                  operator: In
+                  values:
+                  - controller-manager
+              topologyKey: kubernetes.io/hostname
+            weight: 1
       {{- end }}
       containers:
       - name: gardener-controller-manager

--- a/charts/gardener/controlplane/charts/runtime/templates/scheduler/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/scheduler/deployment.yaml
@@ -41,17 +41,19 @@ spec:
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - labelSelector:
-              matchExpressions:
-              - key: app
-                operator: In
-                values:
-                - gardener
-              - key: role
-                operator: In
-                values:
-                - scheduler
-            topologyKey: kubernetes.io/hostname
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - gardener
+                - key: role
+                  operator: In
+                  values:
+                  - scheduler
+              topologyKey: kubernetes.io/hostname
+            weight: 1
       {{- end }}
       containers:
       - name: gardener-scheduler


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug

**What this PR does / why we need it**:

Follow-up on #5000 

**Which issue(s) this PR fixes**:
```
Deployment.apps "gardener-admission-controller" is invalid: [spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight: Invalid value: 0: must be in the range 1-100, spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.topologyKey: Required value: can not be empty, spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.topologyKey: Invalid value: "": name part must be non-empty, spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.topologyKey: Invalid value: "": name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')]
```

**Special notes for your reviewer**:

/milestone v1.36
