### PR TITLE
Adjust the verbosity of the terraformer Pod logs in the terraformer pkg

### DIFF
--- a/extensions/pkg/terraformer/terraformer.go
+++ b/extensions/pkg/terraformer/terraformer.go
@@ -247,18 +247,18 @@ func (t *terraformer) execute(ctx context.Context, command string) error {
 			podLogger.Info("Terraformer pod finished with error")
 
 			if terminationMessage != "" {
-				podLogger.V(1).Info("Termination message of Terraformer pod: " + terminationMessage)
+				podLogger.Info("Termination message of Terraformer pod: " + terminationMessage)
 			} else if ctx.Err() != nil {
-				podLogger.V(1).Info("Context error: " + ctx.Err().Error())
+				podLogger.Info("Context error: " + ctx.Err().Error())
 			} else {
 				// fall back to pod logs as termination message
-				podLogger.V(1).Info("Fetching logs of Terraformer pod as termination message is empty")
+				podLogger.Info("Fetching logs of Terraformer pod as termination message is empty")
 				terminationMessage, err = t.retrievePodLogs(ctx, podLogger, pod)
 				if err != nil {
 					podLogger.Error(err, "Could not retrieve logs of Terraformer pod")
 					return err
 				}
-				podLogger.V(1).Info("Logs of Terraformer pod: " + terminationMessage)
+				podLogger.Info("Logs of Terraformer pod: " + terminationMessage)
 			}
 		}
 


### PR DESCRIPTION
/area ops-productivity usability
/kind bug

This PR (re-)enables the logging in the terraformer pkg to log the output (or at least part of via the terminationMessage) of terraformer Pod run. See https://github.com/gardener/gardener-extension-provider-aws/issues/442 that it is not possible to adjust the logging on extension side to enable exactly these logs.
When I look into terraform related issues, the first thing I am interested in is the output of the initial `terraform apply` run. I usually look for these logs in the provider extension logs (as Shoot can be with `spec.purpose=testing` -> without logging stack; I even doubt that on Shoot creation the logging stack is able to capture logs from the initial `terraform apply` runs).

Fixes #4978

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`github.com/gardener/gardener/extensions/pkg/terraformer` does now log by default the termination message of the Terraformer Pod (or its logs) when the Terraformer Pod finishes with error.
```
