### PR TITLE
[release-v1.35] Automated cherry pick of #4991: Allow seed bootstrap to succeed even with feature gate managed istio is disabled.

### DIFF
--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -1144,7 +1144,7 @@ func runCreateSeedFlow(
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Deploying external authz server",
-			Fn:           extAuthzServer.Deploy,
+			Fn:           flow.TaskFn(extAuthzServer.Deploy).DoIf(gardenletfeatures.FeatureGate.Enabled(features.ManagedIstio)),
 			Dependencies: flow.NewTaskIDs(deployResourceManager),
 		})
 	)


### PR DESCRIPTION
/kind/bug
/area/networking

Cherry pick of #4991 on release-v1.35.

#4991: Allow seed bootstrap to succeed even with feature gate managed istio is disabled.

**Release Notes:**
```bugfix operator
An issue causing seed bootstrap to fail when the `ManagedIstio` feature gate is disabled is now fixed.
```