### PR TITLE
Retry hyperkube preload if it failed

### DIFF
--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/executor_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/executor_test.go
@@ -221,15 +221,36 @@ fi
 
 echo "Checking whether we need to preload a new hyperkube image..."
 if [[ "$LAST_DOWNLOADED_HYPERKUBE_IMAGE" != "` + hyperkubeImage.String() + `" ]]; then
+  if ! /usr/bin/docker info &> /dev/null ; then
+    echo "docker daemon is not available, cannot preload hyperkube image"
+    exit 1
+  fi
+
   echo "Preloading hyperkube image (` + hyperkubeImage.String() + `) because last downloaded image ($LAST_DOWNLOADED_HYPERKUBE_IMAGE) is outdated"
-  /usr/bin/docker pull "` + hyperkubeImage.String() + `"
+  if ! /usr/bin/docker pull "` + hyperkubeImage.String() + `" ; then
+    echo "hyperkube image preload failed"
+    exit 1
+  fi
+
+  # append image reference checksum to copied filenames in order to easily check if copying the binaries succeeded
+  hyperkubeImageSHA="7eb590a802776879e4db84c42ec60a2bd2094659ed3773252753287b880912fb"
 
   echo "Starting temporary hyperkube container to copy binaries to host"` +
 		copyKubernetesBinariesFn(hyperkubeImage) + `
-  chmod +x "$PATH_HYPERKUBE_DOWNLOADS/kubelet"
-  chmod +x "$PATH_HYPERKUBE_DOWNLOADS/kubectl"
+  chmod +x "$PATH_HYPERKUBE_DOWNLOADS/kubelet-$hyperkubeImageSHA"
+  chmod +x "$PATH_HYPERKUBE_DOWNLOADS/kubectl-$hyperkubeImageSHA"
 
-  echo "` + hyperkubeImage.String() + `" > "$PATH_LAST_DOWNLOADED_HYPERKUBE_IMAGE"
+  if ! [ -f "$PATH_HYPERKUBE_DOWNLOADS/kubelet-$hyperkubeImageSHA" -a -f "$PATH_HYPERKUBE_DOWNLOADS/kubectl-$hyperkubeImageSHA" ]; then
+    echo "extracting kubernetes binaries from hyperkube image failed"
+    exit 1
+  fi
+
+  # only write to $PATH_LAST_DOWNLOADED_HYPERKUBE_IMAGE if copy operation succeeded
+  # this is done to retry failed operations on the execution
+  mv "$PATH_HYPERKUBE_DOWNLOADS/kubelet-$hyperkubeImageSHA" "$PATH_HYPERKUBE_DOWNLOADS/kubelet" && \
+    mv "$PATH_HYPERKUBE_DOWNLOADS/kubectl-$hyperkubeImageSHA" "$PATH_HYPERKUBE_DOWNLOADS/kubectl" && \
+    echo "` + hyperkubeImage.String() + `" > "$PATH_LAST_DOWNLOADED_HYPERKUBE_IMAGE"
+
   LAST_DOWNLOADED_HYPERKUBE_IMAGE="$(cat "$PATH_LAST_DOWNLOADED_HYPERKUBE_IMAGE")"
 else
   echo "No need to preload new hyperkube image because binaries for $LAST_DOWNLOADED_HYPERKUBE_IMAGE were found in $PATH_HYPERKUBE_DOWNLOADS"
@@ -380,21 +401,21 @@ date +%s > "$PATH_EXECUTION_LAST_DATE"
 
 func copyKubernetesBinariesFromHyperkubeImageForVersionsLess117(hyperkubeImage *imagevector.Image) string {
 	return `
-  /usr/bin/docker run --rm -v "$PATH_HYPERKUBE_DOWNLOADS":"$PATH_HYPERKUBE_DOWNLOADS":rw "` + hyperkubeImage.String() + `" /bin/sh -c "cp /usr/local/bin/kubelet $PATH_HYPERKUBE_DOWNLOADS"
-  /usr/bin/docker run --rm -v "$PATH_HYPERKUBE_DOWNLOADS":"$PATH_HYPERKUBE_DOWNLOADS":rw "` + hyperkubeImage.String() + `" /bin/sh -c "cp /usr/local/bin/kubectl $PATH_HYPERKUBE_DOWNLOADS"`
+  /usr/bin/docker run --rm -v "$PATH_HYPERKUBE_DOWNLOADS":"$PATH_HYPERKUBE_DOWNLOADS":rw "` + hyperkubeImage.String() + `" /bin/sh -c "cp /usr/local/bin/kubelet $PATH_HYPERKUBE_DOWNLOADS/kubelet-$hyperkubeImageSHA"
+  /usr/bin/docker run --rm -v "$PATH_HYPERKUBE_DOWNLOADS":"$PATH_HYPERKUBE_DOWNLOADS":rw "` + hyperkubeImage.String() + `" /bin/sh -c "cp /usr/local/bin/kubectl $PATH_HYPERKUBE_DOWNLOADS/kubectl-$hyperkubeImageSHA"`
 }
 
 func copyKubernetesBinariesFromHyperkubeImageForVersionsLess119(hyperkubeImage *imagevector.Image) string {
 	return `
-  /usr/bin/docker run --rm -v "$PATH_HYPERKUBE_DOWNLOADS":"$PATH_HYPERKUBE_DOWNLOADS":rw --entrypoint /bin/sh "` + hyperkubeImage.String() + `" -c "cp /usr/local/bin/kubelet $PATH_HYPERKUBE_DOWNLOADS"
-  /usr/bin/docker run --rm -v "$PATH_HYPERKUBE_DOWNLOADS":"$PATH_HYPERKUBE_DOWNLOADS":rw --entrypoint /bin/sh "` + hyperkubeImage.String() + `" -c "cp /usr/local/bin/kubectl $PATH_HYPERKUBE_DOWNLOADS"`
+  /usr/bin/docker run --rm -v "$PATH_HYPERKUBE_DOWNLOADS":"$PATH_HYPERKUBE_DOWNLOADS":rw --entrypoint /bin/sh "` + hyperkubeImage.String() + `" -c "cp /usr/local/bin/kubelet $PATH_HYPERKUBE_DOWNLOADS/kubelet-$hyperkubeImageSHA"
+  /usr/bin/docker run --rm -v "$PATH_HYPERKUBE_DOWNLOADS":"$PATH_HYPERKUBE_DOWNLOADS":rw --entrypoint /bin/sh "` + hyperkubeImage.String() + `" -c "cp /usr/local/bin/kubectl $PATH_HYPERKUBE_DOWNLOADS/kubectl-$hyperkubeImageSHA"`
 }
 
 func copyKubernetesBinariesFromHyperkubeImageForVersionsGreaterEqual119(hyperkubeImage *imagevector.Image) string {
 	return `
   HYPERKUBE_CONTAINER_ID="$(/usr/bin/docker run --rm -d -v "$PATH_HYPERKUBE_DOWNLOADS":"$PATH_HYPERKUBE_DOWNLOADS":rw "` + hyperkubeImage.String() + `")"
-  /usr/bin/docker cp   "$HYPERKUBE_CONTAINER_ID":/kubelet "$PATH_HYPERKUBE_DOWNLOADS"
-  /usr/bin/docker cp   "$HYPERKUBE_CONTAINER_ID":/kubectl "$PATH_HYPERKUBE_DOWNLOADS"
+  /usr/bin/docker cp   "$HYPERKUBE_CONTAINER_ID":/kubelet "$PATH_HYPERKUBE_DOWNLOADS/kubelet-$hyperkubeImageSHA"
+  /usr/bin/docker cp   "$HYPERKUBE_CONTAINER_ID":/kubectl "$PATH_HYPERKUBE_DOWNLOADS/kubectl-$hyperkubeImageSHA"
   /usr/bin/docker stop "$HYPERKUBE_CONTAINER_ID"`
 }
 

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/executor_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/executor_test.go
@@ -413,10 +413,11 @@ func copyKubernetesBinariesFromHyperkubeImageForVersionsLess119(hyperkubeImage *
 
 func copyKubernetesBinariesFromHyperkubeImageForVersionsGreaterEqual119(hyperkubeImage *imagevector.Image) string {
 	return `
-  HYPERKUBE_CONTAINER_ID="$(/usr/bin/docker run --rm -d -v "$PATH_HYPERKUBE_DOWNLOADS":"$PATH_HYPERKUBE_DOWNLOADS":rw "` + hyperkubeImage.String() + `")"
+  HYPERKUBE_CONTAINER_ID="$(/usr/bin/docker run -d -v "$PATH_HYPERKUBE_DOWNLOADS":"$PATH_HYPERKUBE_DOWNLOADS":rw "` + hyperkubeImage.String() + `")"
   /usr/bin/docker cp   "$HYPERKUBE_CONTAINER_ID":/kubelet "$PATH_HYPERKUBE_DOWNLOADS/kubelet-$hyperkubeImageSHA"
   /usr/bin/docker cp   "$HYPERKUBE_CONTAINER_ID":/kubectl "$PATH_HYPERKUBE_DOWNLOADS/kubectl-$hyperkubeImageSHA"
-  /usr/bin/docker stop "$HYPERKUBE_CONTAINER_ID"`
+  /usr/bin/docker stop "$HYPERKUBE_CONTAINER_ID"
+  /usr/bin/docker rm "$HYPERKUBE_CONTAINER_ID"`
 }
 
 const scriptCopyKubernetesBinary = `#!/bin/bash -eu

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/templates/scripts/execute-cloud-config.tpl.sh
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/templates/scripts/execute-cloud-config.tpl.sh
@@ -102,10 +102,11 @@ if [[ "$LAST_DOWNLOADED_HYPERKUBE_IMAGE" != "{{ .hyperkubeImage }}" ]]; then
   {{ .pathDockerBinary }} run --rm -v "$PATH_HYPERKUBE_DOWNLOADS":"$PATH_HYPERKUBE_DOWNLOADS":rw --entrypoint /bin/sh "{{ .hyperkubeImage }}" -c "cp /usr/local/bin/kubelet $PATH_HYPERKUBE_DOWNLOADS/kubelet-$hyperkubeImageSHA"
   {{ .pathDockerBinary }} run --rm -v "$PATH_HYPERKUBE_DOWNLOADS":"$PATH_HYPERKUBE_DOWNLOADS":rw --entrypoint /bin/sh "{{ .hyperkubeImage }}" -c "cp /usr/local/bin/kubectl $PATH_HYPERKUBE_DOWNLOADS/kubectl-$hyperkubeImageSHA"
 {{- else }}
-  HYPERKUBE_CONTAINER_ID="$({{ .pathDockerBinary }} run --rm -d -v "$PATH_HYPERKUBE_DOWNLOADS":"$PATH_HYPERKUBE_DOWNLOADS":rw "{{ .hyperkubeImage }}")"
+  HYPERKUBE_CONTAINER_ID="$({{ .pathDockerBinary }} run -d -v "$PATH_HYPERKUBE_DOWNLOADS":"$PATH_HYPERKUBE_DOWNLOADS":rw "{{ .hyperkubeImage }}")"
   {{ .pathDockerBinary }} cp   "$HYPERKUBE_CONTAINER_ID":/kubelet "$PATH_HYPERKUBE_DOWNLOADS/kubelet-$hyperkubeImageSHA"
   {{ .pathDockerBinary }} cp   "$HYPERKUBE_CONTAINER_ID":/kubectl "$PATH_HYPERKUBE_DOWNLOADS/kubectl-$hyperkubeImageSHA"
   {{ .pathDockerBinary }} stop "$HYPERKUBE_CONTAINER_ID"
+  {{ .pathDockerBinary }} rm "$HYPERKUBE_CONTAINER_ID"
 {{- end }}
   chmod +x "$PATH_HYPERKUBE_DOWNLOADS/kubelet-$hyperkubeImageSHA"
   chmod +x "$PATH_HYPERKUBE_DOWNLOADS/kubectl-$hyperkubeImageSHA"

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/templates/scripts/execute-cloud-config.tpl.sh
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/templates/scripts/execute-cloud-config.tpl.sh
@@ -79,27 +79,48 @@ fi
 
 echo "Checking whether we need to preload a new hyperkube image..."
 if [[ "$LAST_DOWNLOADED_HYPERKUBE_IMAGE" != "{{ .hyperkubeImage }}" ]]; then
+  if ! {{ .pathDockerBinary }} info &> /dev/null ; then
+    echo "docker daemon is not available, cannot preload hyperkube image"
+    exit 1
+  fi
+
   echo "Preloading hyperkube image ({{ .hyperkubeImage }}) because last downloaded image ($LAST_DOWNLOADED_HYPERKUBE_IMAGE) is outdated"
-  {{ .pathDockerBinary }} pull "{{ .hyperkubeImage }}"
+  if ! {{ .pathDockerBinary }} pull "{{ .hyperkubeImage }}" ; then
+    echo "hyperkube image preload failed"
+    exit 1
+  fi
+
+  # append image reference checksum to copied filenames in order to easily check if copying the binaries succeeded
+  hyperkubeImageSHA="{{ .hyperkubeImage | sha256sum }}"
 
   echo "Starting temporary hyperkube container to copy binaries to host"
 
 {{- if semverCompare "< 1.17" .kubernetesVersion }}
-  {{ .pathDockerBinary }} run --rm -v "$PATH_HYPERKUBE_DOWNLOADS":"$PATH_HYPERKUBE_DOWNLOADS":rw "{{ .hyperkubeImage }}" /bin/sh -c "cp /usr/local/bin/kubelet $PATH_HYPERKUBE_DOWNLOADS"
-  {{ .pathDockerBinary }} run --rm -v "$PATH_HYPERKUBE_DOWNLOADS":"$PATH_HYPERKUBE_DOWNLOADS":rw "{{ .hyperkubeImage }}" /bin/sh -c "cp /usr/local/bin/kubectl $PATH_HYPERKUBE_DOWNLOADS"
+  {{ .pathDockerBinary }} run --rm -v "$PATH_HYPERKUBE_DOWNLOADS":"$PATH_HYPERKUBE_DOWNLOADS":rw "{{ .hyperkubeImage }}" /bin/sh -c "cp /usr/local/bin/kubelet $PATH_HYPERKUBE_DOWNLOADS/kubelet-$hyperkubeImageSHA"
+  {{ .pathDockerBinary }} run --rm -v "$PATH_HYPERKUBE_DOWNLOADS":"$PATH_HYPERKUBE_DOWNLOADS":rw "{{ .hyperkubeImage }}" /bin/sh -c "cp /usr/local/bin/kubectl $PATH_HYPERKUBE_DOWNLOADS/kubectl-$hyperkubeImageSHA"
 {{- else if semverCompare "< 1.19" .kubernetesVersion }}
-  {{ .pathDockerBinary }} run --rm -v "$PATH_HYPERKUBE_DOWNLOADS":"$PATH_HYPERKUBE_DOWNLOADS":rw --entrypoint /bin/sh "{{ .hyperkubeImage }}" -c "cp /usr/local/bin/kubelet $PATH_HYPERKUBE_DOWNLOADS"
-  {{ .pathDockerBinary }} run --rm -v "$PATH_HYPERKUBE_DOWNLOADS":"$PATH_HYPERKUBE_DOWNLOADS":rw --entrypoint /bin/sh "{{ .hyperkubeImage }}" -c "cp /usr/local/bin/kubectl $PATH_HYPERKUBE_DOWNLOADS"
+  {{ .pathDockerBinary }} run --rm -v "$PATH_HYPERKUBE_DOWNLOADS":"$PATH_HYPERKUBE_DOWNLOADS":rw --entrypoint /bin/sh "{{ .hyperkubeImage }}" -c "cp /usr/local/bin/kubelet $PATH_HYPERKUBE_DOWNLOADS/kubelet-$hyperkubeImageSHA"
+  {{ .pathDockerBinary }} run --rm -v "$PATH_HYPERKUBE_DOWNLOADS":"$PATH_HYPERKUBE_DOWNLOADS":rw --entrypoint /bin/sh "{{ .hyperkubeImage }}" -c "cp /usr/local/bin/kubectl $PATH_HYPERKUBE_DOWNLOADS/kubectl-$hyperkubeImageSHA"
 {{- else }}
   HYPERKUBE_CONTAINER_ID="$({{ .pathDockerBinary }} run --rm -d -v "$PATH_HYPERKUBE_DOWNLOADS":"$PATH_HYPERKUBE_DOWNLOADS":rw "{{ .hyperkubeImage }}")"
-  {{ .pathDockerBinary }} cp   "$HYPERKUBE_CONTAINER_ID":/kubelet "$PATH_HYPERKUBE_DOWNLOADS"
-  {{ .pathDockerBinary }} cp   "$HYPERKUBE_CONTAINER_ID":/kubectl "$PATH_HYPERKUBE_DOWNLOADS"
+  {{ .pathDockerBinary }} cp   "$HYPERKUBE_CONTAINER_ID":/kubelet "$PATH_HYPERKUBE_DOWNLOADS/kubelet-$hyperkubeImageSHA"
+  {{ .pathDockerBinary }} cp   "$HYPERKUBE_CONTAINER_ID":/kubectl "$PATH_HYPERKUBE_DOWNLOADS/kubectl-$hyperkubeImageSHA"
   {{ .pathDockerBinary }} stop "$HYPERKUBE_CONTAINER_ID"
 {{- end }}
-  chmod +x "$PATH_HYPERKUBE_DOWNLOADS/kubelet"
-  chmod +x "$PATH_HYPERKUBE_DOWNLOADS/kubectl"
+  chmod +x "$PATH_HYPERKUBE_DOWNLOADS/kubelet-$hyperkubeImageSHA"
+  chmod +x "$PATH_HYPERKUBE_DOWNLOADS/kubectl-$hyperkubeImageSHA"
 
-  echo "{{ .hyperkubeImage }}" > "$PATH_LAST_DOWNLOADED_HYPERKUBE_IMAGE"
+  if ! [ -f "$PATH_HYPERKUBE_DOWNLOADS/kubelet-$hyperkubeImageSHA" -a -f "$PATH_HYPERKUBE_DOWNLOADS/kubectl-$hyperkubeImageSHA" ]; then
+    echo "extracting kubernetes binaries from hyperkube image failed"
+    exit 1
+  fi
+
+  # only write to $PATH_LAST_DOWNLOADED_HYPERKUBE_IMAGE if copy operation succeeded
+  # this is done to retry failed operations on the execution
+  mv "$PATH_HYPERKUBE_DOWNLOADS/kubelet-$hyperkubeImageSHA" "$PATH_HYPERKUBE_DOWNLOADS/kubelet" && \
+    mv "$PATH_HYPERKUBE_DOWNLOADS/kubectl-$hyperkubeImageSHA" "$PATH_HYPERKUBE_DOWNLOADS/kubectl" && \
+    echo "{{ .hyperkubeImage }}" > "$PATH_LAST_DOWNLOADED_HYPERKUBE_IMAGE"
+
   LAST_DOWNLOADED_HYPERKUBE_IMAGE="$(cat "$PATH_LAST_DOWNLOADED_HYPERKUBE_IMAGE")"
 else
   echo "No need to preload new hyperkube image because binaries for $LAST_DOWNLOADED_HYPERKUBE_IMAGE were found in $PATH_HYPERKUBE_DOWNLOADS"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug

**What this PR does / why we need it**:

Previously, the cloud-config script didn't retry pulling the hyperkube image if it failed once (e.g. docker daemon unavailable), because it still wrote the image tag to `$PATH_LAST_DOWNLOADED_HYPERKUBE_IMAGE`. On the next run, it simply thought the binaries were already successfully downloaded.

This PR enhances the script to only write the file if the entire operation was actually successful. By this, failed operations are retried.

The PR also replaces `docker run --rm -d` with a `docker run -d` and proper `docker rm`.
`docker run --rm -d` doesn't make much sense, if the container process doesn't terminate (like `sleep`, which is the entrypoint of our hyperkube image). `run --rm -d` is also not supported on similar CLIs like `nerdctl`, which we want to use for provider-local, so this will make our lives easier.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/5001

**Special notes for your reviewer**:
/squash

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
The node bootstrapping mechanism has been enhanced to retry failed hyperkube preload operations.
```
