### PR TITLE
Disable parallel execution of update-codegen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,7 @@ check: $(GOIMPORTS) $(GOLANGCI_LINT) $(HELM)
 .PHONY: generate
 generate: $(CONTROLLER_GEN) $(GEN_CRD_API_REFERENCE_DOCS) $(GOIMPORTS) $(GO_TO_PROTOBUF) $(MOCKGEN) $(OPENAPI_GEN) $(PROTOC_GEN_GOGO) $(YAML2JSON)
 	@hack/update-protobuf.sh
-	@hack/update-codegen.sh --parallel
+	@hack/update-codegen.sh
 	@hack/generate-parallel.sh charts cmd example extensions pkg plugin landscaper test
 	@hack/generate-monitoring-docs.sh
 

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -381,7 +381,7 @@ if [[ $# -gt 0 && "$1" == "--parallel" ]]; then
     scheduler_groups \
     gardenlet_groups \
     shoottolerationrestriction_groups \
-    landscapergardenlet_groups
+    landscapergardenlet_groups \
     landscapercontrolplane_groups
 else
   authentication_groups


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
We sporadically saw errors when running check-generate
locally or in pipelines. Appearance of those errors correlate
with the time we introduced parallelisation for `make generate`.

When looking at the logs of a failing run we can see that the first
error appears when running update-codegen.sh. Consequently, this
removes the parallel execution in this script.

We were not able to consistently reproduce this issue to find the exact
root cause.

Workaround for: https://github.com/gardener/gardener/issues/4570

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Parts of `make-generate` are no longer executed in parallel.
```

/invite @stoyanr 
