### PR TITLE
Enhancements for condition builder

### DIFF
--- a/pkg/apis/core/v1beta1/helper/condition_builder_test.go
+++ b/pkg/apis/core/v1beta1/helper/condition_builder_test.go
@@ -129,27 +129,73 @@ var _ = Describe("Builder", func() {
 		})
 
 		Context("#WithReason", func() {
-			JustBeforeEach(func() {
+			DescribeTable("New condition", func(reason *string, expectedReason string) {
+				if reason != nil {
+					bldr.WithReason(*reason)
+				}
+
 				result, updated = bldr.
 					WithNowFunc(defaultTimeFunc).
-					WithReason(bazReason).
 					Build()
-			})
 
-			It("should mark the result as updated", func() {
 				Expect(updated).To(BeTrue())
-			})
 
-			It("should return correct result", func() {
 				Expect(result).To(Equal(gardencorev1beta1.Condition{
 					Type:               conditionType,
 					Status:             unknowStatus,
 					LastTransitionTime: defaultTime,
 					LastUpdateTime:     defaultTime,
-					Reason:             bazReason,
+					Reason:             expectedReason,
 					Message:            unitializedMessage,
 				}))
-			})
+			},
+				Entry("reason is not set", nil, initializedReason),
+				Entry("empty reason is set", pointer.String(""), unspecifiedReason),
+				Entry("reason is set", pointer.StringPtr(bazReason), bazReason),
+			)
+
+			DescribeTable("With old condition", func(reason *string, previousReason, expectedReason string) {
+				lastUpdateTime := metav1.NewTime(time.Unix(11, 0))
+
+				if reason != nil {
+					bldr.WithReason(*reason)
+				}
+
+				result, updated = bldr.
+					WithNowFunc(defaultTimeFunc).
+					WithOldCondition(gardencorev1beta1.Condition{
+						Type:               conditionType,
+						Status:             fooStatus,
+						LastTransitionTime: metav1.NewTime(time.Unix(10, 0)),
+						LastUpdateTime:     lastUpdateTime,
+						Reason:             previousReason,
+						Message:            fubarMessage,
+						Codes:              codes,
+					}).
+					WithCodes(codes...).
+					Build()
+
+				if reason != nil && *reason != previousReason || previousReason == "" {
+					Expect(updated).To(BeTrue())
+					lastUpdateTime = defaultTime
+				}
+
+				Expect(result).To(Equal(gardencorev1beta1.Condition{
+					Type:               conditionType,
+					Status:             fooStatus,
+					LastTransitionTime: metav1.NewTime(time.Unix(10, 0)),
+					LastUpdateTime:     lastUpdateTime,
+					Reason:             expectedReason,
+					Message:            fubarMessage,
+					Codes:              codes,
+				}))
+			},
+				Entry("reason is not set", nil, bazReason, bazReason),
+				Entry("reason was previously empty", nil, "", initializedReason),
+				Entry("empty reason is set", pointer.String(""), bazReason, unspecifiedReason),
+				Entry("message is the same", pointer.StringPtr("ReasonA"), "ReasonA", "ReasonA"),
+				Entry("message changed", pointer.StringPtr("ReasonA"), bazReason, "ReasonA"),
+			)
 		})
 
 		Context("#WithMessage", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR adds some improvements to the condition builder. Earlier, when an empty (`""`) `reason` or `message` was passed, the respective fields in the condition did not change.
For instance, if there had been a failed condition earlier which was then updated to an successful condition result w/o specifying a `message`, the condition eventually contained a positive result (`status: "True"`) with an error message:

```
 - lastTransitionTime: "2021-11-16T07:43:19Z"
    lastUpdateTime: "2021-11-16T07:43:19Z"
    message: 'could not deploy gardenlet into shoot garden/seed1: admission
      webhook "seed-restriction.gardener.cloud" denied the request: managed seed garden/seed1
      is already bootstrapped'
    reason: Reconciled
    status: "True"
    type: SeedRegistered
```

Now, an empty `message` is set to `No message given.` and an empty `reason` is set to `Unspecified`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The condition handling was improved in Gardener which sometimes resulted in conditions having outdated `reason`s or `message`s.
```
