### PR TITLE
Fix indentation for extensions dashboards

### DIFF
--- a/charts/seed-monitoring/charts/grafana/templates/_helpers.tpl
+++ b/charts/seed-monitoring/charts/grafana/templates/_helpers.tpl
@@ -82,7 +82,7 @@ grafana-{{ .Values.role }}-datasources-{{ include "grafana.datasources.data" . |
 {{ end }}
 {{ end }}
 {{- if .Values.extensions.dashboards }}
-{{- toString .Values.extensions.dashboards | indent 2 }}
+{{- toString .Values.extensions.dashboards }}
 {{ end }}
 {{- end -}}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area monitoring
/kind bug

**What this PR does / why we need it**:
All extensions dashboards are not visible anymore in Grafana for both operators and users.
The bug is a wrong indent in the template.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
For an old shoot, you can verify in the control plane namespace that all extensions dashboards are missing since some time:

```bash
$ k get cm | grep dashboards
grafana-operators-dashboards                     30     88d
grafana-operators-dashboards-46adb4b0            24     15d
grafana-users-dashboards                         16     88d
grafana-users-dashboards-574117d5                13     15d
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix indentation for extensions Grafana dashboards
```
