### PR TITLE
[release-v1.35] Automated cherry pick of #5016: Adjust the verbosity of the terraformer Pod logs in the terraformer pkg

### DIFF
--- a/extensions/pkg/terraformer/terraformer.go
+++ b/extensions/pkg/terraformer/terraformer.go
@@ -247,18 +247,18 @@ func (t *terraformer) execute(ctx context.Context, command string) error {
 			podLogger.Info("Terraformer pod finished with error")
 
 			if terminationMessage != "" {
-				podLogger.V(1).Info("Termination message of Terraformer pod: " + terminationMessage)
+				podLogger.Info("Termination message of Terraformer pod: " + terminationMessage)
 			} else if ctx.Err() != nil {
-				podLogger.V(1).Info("Context error: " + ctx.Err().Error())
+				podLogger.Info("Context error: " + ctx.Err().Error())
 			} else {
 				// fall back to pod logs as termination message
-				podLogger.V(1).Info("Fetching logs of Terraformer pod as termination message is empty")
+				podLogger.Info("Fetching logs of Terraformer pod as termination message is empty")
 				terminationMessage, err = t.retrievePodLogs(ctx, podLogger, pod)
 				if err != nil {
 					podLogger.Error(err, "Could not retrieve logs of Terraformer pod")
 					return err
 				}
-				podLogger.V(1).Info("Logs of Terraformer pod: " + terminationMessage)
+				podLogger.Info("Logs of Terraformer pod: " + terminationMessage)
 			}
 		}
 


### PR DESCRIPTION
/kind/bug
/area/ops-productivity
/area/usability

Cherry pick of #5016 on release-v1.35.

#5016: Adjust the verbosity of the terraformer Pod logs in the terraformer pkg

**Release Notes:**
```other operator
`github.com/gardener/gardener/extensions/pkg/terraformer` does now log by default the termination message of the Terraformer Pod (or its logs) when the Terraformer Pod finishes with error.
```