### PR TITLE
Fix recreation of vpn-shoot secret

### DIFF
--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -39,7 +39,6 @@ import (
 	secretutils "github.com/gardener/gardener/pkg/utils/secrets"
 
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientcmdlatest "k8s.io/client-go/tools/clientcmd/api/latest"
@@ -85,11 +84,7 @@ func (b *Botanist) GenerateAndSaveSecrets(ctx context.Context) error {
 				// Delete existing VPN-related secrets which were not signed with the newly introduced ca-vpn so that
 				// they get regenerated.
 				// TODO(rfranzke): Remove in a future version.
-				if err := b.K8sSeedClient.Client().Get(ctx, kutil.Key(b.Shoot.SeedNamespace, v1beta1constants.SecretNameCAVPN), &corev1.Secret{}); err != nil {
-					if !apierrors.IsNotFound(err) {
-						return err
-					}
-
+				if gardenerResourceDataList.Get(v1beta1constants.SecretNameCAVPN) == nil {
 					if err := b.cleanupTunnelSecrets(ctx, &gardenerResourceDataList,
 						vpnseedserver.DeploymentName,
 						kubeapiserver.SecretNameHTTPProxy,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind bug

**What this PR does / why we need it**:
When the `ReversedVPN` feature gate is enabled, the CA for the VPN connection is retrieved from the `ShootState` instead of the shoot's namespace in the seed. With this the VPN connection secrets will only be recreated if the CA isn't present in the `ShootState`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @timebertt 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```