### PR TITLE
Add script which checks the docforge manifest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -186,6 +186,10 @@ check: $(GOIMPORTS) $(GOLANGCI_LINT) $(HELM)
 	@hack/check.sh --golangci-lint-config=./.golangci.yaml ./cmd/... ./extensions/... ./pkg/... ./plugin/... ./test/...
 	@hack/check-charts.sh ./charts
 
+.PHONY: check-manifest
+check-manifest:
+	@hack/check-manifest.sh .docforge/ docs/
+
 .PHONY: generate
 generate: $(CONTROLLER_GEN) $(GEN_CRD_API_REFERENCE_DOCS) $(GOIMPORTS) $(GO_TO_PROTOBUF) $(MOCKGEN) $(OPENAPI_GEN) $(PROTOC_GEN_GOGO) $(YAML2JSON)
 	@hack/update-protobuf.sh

--- a/hack/check-manifest-config
+++ b/hack/check-manifest-config
@@ -1,0 +1,2 @@
+resourceMappings:
+  "https://github.com/gardener/gardener": "REPO_PATH"

--- a/hack/check-manifest.sh
+++ b/hack/check-manifest.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# For the check-manifest step the following environment variables are used:
+# GIT_OAUTH_TOKEN - used for fetch the content from Github
+# CHECKED_DIRS - the directories which will be checked for diff against origin/master. If Diff exists then the checks will be triggered.
+# otherwise the script will exist with status code 0
+set -e
+
+if [[ $(uname) == 'Darwin' ]]; then
+  READLINK_BIN="greadlink"
+else
+  READLINK_BIN="readlink"
+fi
+
+repoPath="$(${READLINK_BIN} -f $(dirname ${0})/..)"
+manifestPath="${repoPath}/.docforge/manifest.yaml"
+configPath="${repoPath}/hack/check-manifest-config"
+
+cd ${repoPath}
+diffExist=false
+
+for arg in "$@"; do
+  diff=$(git diff origin/master --name-only | grep "^${arg}" || true)
+  if [[ ! -z "${diff}" ]] ; then
+    diffExist=true
+    break
+  fi
+done
+
+if [[ "${diffExist}" = false ]] ; then
+    echo "There is no diff in the checked directories so the script exits successfully"
+    exit 0
+fi
+
+getGitHubToken() {
+  # Check if gardener-ci is available (in local setup)
+  command -v gardener-ci >/dev/null && gardenci="true" || gardenci=""
+  if [[ $gardenci == "true" ]]; then
+    # Get a (round-robin) random technical GitHub user credentials
+    technicalUser=$(gardener-ci config model_element --cfg-type github --cfg-name "${1}" --key credentials | sed -e "s/^GithubCredentials //" -e "s/'/\"/g")
+    if [[ -n "${technicalUser}" ]]; then
+      # get auth token and strip lead/trail quotes
+      authToken=$(sed -e 's/"//g' <<<$(jq -n '$c.authToken' --argjson c "$technicalUser"))
+      # get username and strip lead/trail quotes
+      username=$(sed -e 's/"//g' <<<$(jq -n '$c.username' --argjson c "$technicalUser"))
+      echo "${username}:${authToken}"
+    fi
+  fi
+}
+
+GIT_OAUTH_TOKEN=${GIT_OAUTH_TOKEN:-$(getGitHubToken github_com)}
+test $GIT_OAUTH_TOKEN
+
+
+# Set config file
+tmpConfigPath="tmp-config"
+sed -e "s@REPO_PATH@${repoPath}@g" ${configPath} > ${tmpConfigPath}
+export DOCFORGECONFIG=${tmpConfigPath}
+
+echo "Running docforge command..."
+docforge \
+  -f ${manifestPath} \
+  -d tmp \
+  --github-oauth-token $GIT_OAUTH_TOKEN \
+  --hugo \
+  --use-git=true \
+  --dry-run
+
+rm -rf ${tmpConfigPath}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
Add script which checks if the manifest in the repo can be processed by the docforge.

The script will call `docforge` only if there is a PR with a change in `.docforge` or `docs` directories, otherwise the script will exit with status code 0.

This script will be added in the `pipeline_definition` as a PR step.

After 1-2weeks experimental period we can also make it as a required step.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@dimitar-kostadinov @Kostov6 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc developer
A new `check-manifest` step will be triggered on each PR which will check if the manifest file can be processed by docforge
```
