### PR TITLE
Capture a metric for a persistent volume issue

### DIFF
--- a/charts/seed-bootstrap/charts/kube-state-metrics/templates/deployment.yaml
+++ b/charts/seed-bootstrap/charts/kube-state-metrics/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
         - /kube-state-metrics
         - --port=8080
         - --telemetry-port=8081
-        - --collectors=deployments,pods,statefulsets,nodes,horizontalpodautoscalers,replicasets
+        - --collectors=deployments,pods,statefulsets,nodes,horizontalpodautoscalers,persistentvolumeclaims,replicasets
         ports:
         - name: metrics
           containerPort: 8080

--- a/charts/seed-bootstrap/prometheus-rules/recording-rules.rules.yaml
+++ b/charts/seed-bootstrap/prometheus-rules/recording-rules.rules.yaml
@@ -1,6 +1,11 @@
 groups:
 - name: recording-rules.rules
   rules:
+
+  # detect an issue when the persistent volume is not mounted properly, and instead the local disk is used
+  - record: seed:persistentvolume:inconsistent_size
+    expr: abs(1 - kubelet_volume_stats_capacity_bytes / on(namespace, persistentvolumeclaim) kube_persistentvolumeclaim_resource_requests_storage_bytes) > 0.05
+
   # Recording rules for the sum of the usage per container
   - record: seed:container_cpu_usage_seconds_total:sum_by_container
     expr: sum(rate(container_cpu_usage_seconds_total[5m])) by (container)

--- a/charts/seed-bootstrap/values.yaml
+++ b/charts/seed-bootstrap/values.yaml
@@ -148,6 +148,7 @@ allowedMetrics:
   - process_open_fds
 
   kubeStateMetrics:
+  - kube_persistentvolumeclaim_resource_requests_storage_bytes
   - kube_daemonset_metadata_generation
   - kube_daemonset_status_current_number_scheduled
   - kube_daemonset_status_desired_number_scheduled


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

We observed that sometimes persistent volumes are not mounted properly
and the local disk is used instead. To detect that situation, we compare
2 metrics:
- the size of the persistent volume claim, as exposed by kube-state-metrics
- the size of the mounted volume, as exposed by the kubelet

Due to the overhead of the filesystem, they are not exactly the same
(filesystem capacity is about 2% less than the raw disk capacity).

We expose these metrics for federation in the garden cluster, where an
alert could be defined to notify the operators.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Expose a metric for inconsistent persistent volume sizes
```
