### PR TITLE
Add `unknown` status label value

### DIFF
--- a/pkg/controllermanager/controller/managedseedset/managedseedset_replica_test.go
+++ b/pkg/controllermanager/controller/managedseedset/managedseedset_replica_test.go
@@ -279,6 +279,8 @@ var _ = Describe("Replica", func() {
 			shoot(nil, "", "", operationshoot.StatusProgressing, false), operationshoot.StatusProgressing),
 		Entry("should return unhealthy",
 			shoot(nil, "", "", operationshoot.StatusUnhealthy, false), operationshoot.StatusUnhealthy),
+		Entry("should return unknown",
+			shoot(nil, "", "", operationshoot.StatusUnknown, false), operationshoot.StatusUnknown),
 	)
 
 	DescribeTable("#IsDeletable",

--- a/pkg/operation/shoot/status.go
+++ b/pkg/operation/shoot/status.go
@@ -31,13 +31,16 @@ const (
 	StatusProgressing Status = "progressing"
 	// StatusUnhealthy indicates that a shoot is considered unhealthy.
 	StatusUnhealthy Status = "unhealthy"
+	// StatusUnknown indicates that the shoot health status is not known.
+	StatusUnknown Status = "unknown"
 )
 
 var (
 	shootStatusValues = map[Status]int{
 		StatusHealthy:     3,
 		StatusProgressing: 2,
-		StatusUnhealthy:   1,
+		StatusUnknown:     1,
+		StatusUnhealthy:   0,
 	}
 )
 
@@ -66,6 +69,8 @@ func ConditionStatusToStatus(status gardencorev1beta1.ConditionStatus) Status {
 		return StatusHealthy
 	case gardencorev1beta1.ConditionProgressing:
 		return StatusProgressing
+	case gardencorev1beta1.ConditionUnknown:
+		return StatusUnknown
 	}
 	return StatusUnhealthy
 }

--- a/pkg/operation/shoot/status_test.go
+++ b/pkg/operation/shoot/status_test.go
@@ -31,9 +31,13 @@ var _ = Describe("Shoot Utils", func() {
 			},
 			Entry("healthy - healthy", StatusHealthy, StatusHealthy, StatusHealthy),
 			Entry("healthy - progressing", StatusHealthy, StatusProgressing, StatusProgressing),
+			Entry("healthy - unknown", StatusHealthy, StatusUnknown, StatusUnknown),
 			Entry("healthy - unhealthy", StatusHealthy, StatusUnhealthy, StatusUnhealthy),
 			Entry("progressing - progressing", StatusProgressing, StatusProgressing, StatusProgressing),
+			Entry("progressing - unknown", StatusProgressing, StatusUnknown, StatusUnknown),
 			Entry("progressing - unhealthy", StatusProgressing, StatusUnhealthy, StatusUnhealthy),
+			Entry("unknown - unknown", StatusUnknown, StatusUnknown, StatusUnknown),
+			Entry("unknown - unhealthy", StatusUnknown, StatusUnhealthy, StatusUnhealthy),
 			Entry("unhealthy - unhealthy", StatusUnhealthy, StatusUnhealthy, StatusUnhealthy),
 		)
 
@@ -43,7 +47,7 @@ var _ = Describe("Shoot Utils", func() {
 			},
 			Entry("ConditionTrue", gardencorev1beta1.ConditionTrue, StatusHealthy),
 			Entry("ConditionProgressing", gardencorev1beta1.ConditionProgressing, StatusProgressing),
-			Entry("ConditionUnknown", gardencorev1beta1.ConditionUnknown, StatusUnhealthy),
+			Entry("ConditionUnknown", gardencorev1beta1.ConditionUnknown, StatusUnknown),
 			Entry("ConditionFalse", gardencorev1beta1.ConditionFalse, StatusUnhealthy),
 		)
 
@@ -63,7 +67,7 @@ var _ = Describe("Shoot Utils", func() {
 				{Status: gardencorev1beta1.ConditionTrue},
 				{Status: gardencorev1beta1.ConditionProgressing},
 				{Status: gardencorev1beta1.ConditionUnknown},
-			}, StatusUnhealthy),
+			}, StatusUnknown),
 			Entry("false condition", []gardencorev1beta1.Condition{
 				{Status: gardencorev1beta1.ConditionTrue},
 				{Status: gardencorev1beta1.ConditionProgressing},
@@ -104,6 +108,8 @@ var _ = Describe("Shoot Utils", func() {
 				&gardencorev1beta1.LastOperation{State: gardencorev1beta1.LastOperationStateError}, nil, nil, StatusUnhealthy),
 			Entry("lastOperation.State is LastOperationStateSucceeded with healthy conditions",
 				&gardencorev1beta1.LastOperation{State: gardencorev1beta1.LastOperationStateSucceeded}, nil, nil, StatusHealthy),
+			Entry("lastOperation.State is LastOperationStateSucceeded with unknown conditions",
+				&gardencorev1beta1.LastOperation{State: gardencorev1beta1.LastOperationStateSucceeded}, nil, []gardencorev1beta1.Condition{{Status: gardencorev1beta1.ConditionUnknown}}, StatusUnknown),
 			Entry("lastOperation.State is LastOperationStateSucceeded with unhealthy conditions",
 				&gardencorev1beta1.LastOperation{State: gardencorev1beta1.LastOperationStateSucceeded}, nil, []gardencorev1beta1.Condition{{Status: gardencorev1beta1.ConditionFalse}}, StatusUnhealthy),
 			Entry("lastOperation.Type is LastOperationTypeCreate and lastOperation.State is LastOperationStateSucceeded with unhealthy conditions",


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Introduces a new shoot status label `unknown` that corresponds to `Unknown` conditions.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
* The `unknown` status is treated as better than `unhealthy`, but worse than `progressing`, meaning that if any condition is `Unknown`, the shoot status is also downgraded to `unknown`, unless it should be `unhealthy` based on the status of other conditions, last operation, or last errors. 

**Release note**:

```feature operator
A new shoot status label value `unknown` that corresponds to `Unknown` conditions has been introduced.
```
