### PR TITLE
Allow object selector for extensions webhooks

### DIFF
--- a/extensions/pkg/webhook/registration.go
+++ b/extensions/pkg/webhook/registration.go
@@ -66,6 +66,7 @@ func RegisterWebhooks(ctx context.Context, mgr manager.Manager, namespace, provi
 			AdmissionReviewVersions: []string{"v1", "v1beta1"},
 			Name:                    fmt.Sprintf("%s.%s.extensions.gardener.cloud", webhook.Name, strings.TrimPrefix(providerName, "provider-")),
 			NamespaceSelector:       webhook.Selector,
+			ObjectSelector:          webhook.ObjectSelector,
 			Rules:                   rules,
 			SideEffects:             &sideEffects,
 			TimeoutSeconds:          pointer.Int32(10),

--- a/extensions/pkg/webhook/webhook.go
+++ b/extensions/pkg/webhook/webhook.go
@@ -39,15 +39,16 @@ const (
 
 // Webhook is the specification of a webhook.
 type Webhook struct {
-	Name     string
-	Kind     string
-	Provider string
-	Path     string
-	Target   string
-	Types    []client.Object
-	Webhook  *admission.Webhook
-	Handler  http.Handler
-	Selector *metav1.LabelSelector
+	Name           string
+	Kind           string
+	Provider       string
+	Path           string
+	Target         string
+	Types          []client.Object
+	Webhook        *admission.Webhook
+	Handler        http.Handler
+	Selector       *metav1.LabelSelector
+	ObjectSelector *metav1.LabelSelector
 }
 
 // Args contains Webhook creation arguments.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
It is now possible to provide an `ObjectSelector` when registering an extension webhook by configuring `github.com/gardener/gardener/extensions/pkg/webhook.Webhook`.

Prerequisite for #5024

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
It is now possible to provide an `ObjectSelector` when registering an extension webhook by configuring `github.com/gardener/gardener/extensions/pkg/webhook.Webhook`.
```
