### PR TITLE
Introduce annotation to allow skipping the infrastructure cleanup sleep step

### DIFF
--- a/docs/usage/shoot_cleanup.md
+++ b/docs/usage/shoot_cleanup.md
@@ -24,14 +24,14 @@ It is possible to override the finalization grace periods via annotations on the
 ⚠️ If `"0"` is provided then all resources are finalized immediately without waiting for any graceful deletion.
 Please be aware that this might lead to orphaned infrastructure artefacts.
 
-## Infrastructure Cleanup Grace Period
+## Infrastructure Cleanup Wait Period
 
 After all above cleanup steps have been performed and the `Infrastructure` extension resource has been deleted the gardenlet waits for a certain duration to allow controllers to properly cleanup infrastructure resources.
 
 By default, this duration is set to `5m`. Only after this time has passed the shoot deletion flow continues with the entire tear-down of the remaining control plane components (including `kube-apiserver`s, etc.).
 
-It is also possible to override this grace period via an annotations on the `Shoot`:
+It is also possible to override this wait period via an annotations on the `Shoot`:
 
-- `shoot.gardener.cloud/cleanup-infrastructure-resources-grace-period-seconds`
+- `shoot.gardener.cloud/infrastructure-cleanup-wait-period-seconds`
 
-> ℹ️️ All provided grace period values larger than the above mentioned defaults are ignored.
+> ℹ️️ All provided period values larger than the above mentioned defaults are ignored.

--- a/docs/usage/shoot_cleanup.md
+++ b/docs/usage/shoot_cleanup.md
@@ -24,4 +24,14 @@ It is possible to override the finalization grace periods via annotations on the
 ⚠️ If `"0"` is provided then all resources are finalized immediately without waiting for any graceful deletion.
 Please be aware that this might lead to orphaned infrastructure artefacts.
 
-ℹ️️ All grace period values larger than the above mentioned defaults are ignored.
+## Infrastructure Cleanup Grace Period
+
+After all above cleanup steps have been performed and the `Infrastructure` extension resource has been deleted the gardenlet waits for a certain duration to allow controllers to properly cleanup infrastructure resources.
+
+By default, this duration is set to `5m`. Only after this time has passed the shoot deletion flow continues with the entire tear-down of the remaining control plane components (including `kube-apiserver`s, etc.).
+
+It is also possible to override this grace period via an annotations on the `Shoot`:
+
+- `shoot.gardener.cloud/cleanup-infrastructure-resources-grace-period-seconds`
+
+> ℹ️️ All provided grace period values larger than the above mentioned defaults are ignored.

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -388,6 +388,11 @@ const (
 	// namespaces' step. Concretely, after the specified seconds, all the finalizers of the affected resources are
 	// forcefully removed.
 	AnnotationShootCleanupNamespaceResourcesFinalizeGracePeriodSeconds = "shoot.gardener.cloud/cleanup-namespaces-finalize-grace-period-seconds"
+	// AnnotationShootCleanupInfrastructureResourceGracePeriodSeconds is a key for an annotation on a Shoot
+	// resource that declares the grace period in seconds for waiting for infrastructure resources cleanup. Concretely,
+	// Gardener will wait for the specified time after the Infrastructure extension object has been deleted to allow
+	// controllers to gracefully cleanup everything (default behaviour is 300s).
+	AnnotationShootCleanupInfrastructureResourceGracePeriodSeconds = "shoot.gardener.cloud/cleanup-infrastructure-resources-grace-period-seconds"
 	// AnnotationReversedVPN moves the vpn-server to the seed.
 	AnnotationReversedVPN = "alpha.featuregates.shoot.gardener.cloud/reversed-vpn"
 	// AnnotationNodeLocalDNS enables a per node dns cache on the shoot cluster.

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -388,11 +388,11 @@ const (
 	// namespaces' step. Concretely, after the specified seconds, all the finalizers of the affected resources are
 	// forcefully removed.
 	AnnotationShootCleanupNamespaceResourcesFinalizeGracePeriodSeconds = "shoot.gardener.cloud/cleanup-namespaces-finalize-grace-period-seconds"
-	// AnnotationShootCleanupInfrastructureResourceGracePeriodSeconds is a key for an annotation on a Shoot
-	// resource that declares the grace period in seconds for waiting for infrastructure resources cleanup. Concretely,
+	// AnnotationShootInfrastructureCleanupWaitPeriodSeconds is a key for an annotation on a Shoot
+	// resource that declares the wait period in seconds for infrastructure resources cleanup. Concretely,
 	// Gardener will wait for the specified time after the Infrastructure extension object has been deleted to allow
 	// controllers to gracefully cleanup everything (default behaviour is 300s).
-	AnnotationShootCleanupInfrastructureResourceGracePeriodSeconds = "shoot.gardener.cloud/cleanup-infrastructure-resources-grace-period-seconds"
+	AnnotationShootInfrastructureCleanupWaitPeriodSeconds = "shoot.gardener.cloud/infrastructure-cleanup-wait-period-seconds"
 	// AnnotationReversedVPN moves the vpn-server to the seed.
 	AnnotationReversedVPN = "alpha.featuregates.shoot.gardener.cloud/reversed-vpn"
 	// AnnotationNodeLocalDNS enables a per node dns cache on the shoot cluster.

--- a/pkg/gardenlet/controller/shoot/shoot_control_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_delete.go
@@ -17,6 +17,7 @@ package shoot
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -460,7 +461,20 @@ func (r *shootReconciler) runDeleteShootFlow(ctx context.Context, o *operation.O
 		timeForInfrastructureResourceCleanup = g.Add(flow.Task{
 			Name: "Waiting until time for infrastructure resource cleanup has elapsed",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
-				ctx, cancel := context.WithTimeout(ctx, 5*time.Minute)
+				waitFor := 5 * time.Minute
+
+				if v, ok := botanist.Shoot.GetInfo().Annotations[v1beta1constants.AnnotationShootCleanupInfrastructureResourceGracePeriodSeconds]; ok {
+					seconds, err := strconv.Atoi(v)
+					if err != nil {
+						return err
+					}
+
+					if newWaitFor := time.Duration(seconds) * time.Second; newWaitFor < waitFor {
+						waitFor = newWaitFor
+					}
+				}
+
+				ctx, cancel := context.WithTimeout(ctx, waitFor)
 				defer cancel()
 
 				<-ctx.Done()

--- a/pkg/gardenlet/controller/shoot/shoot_control_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_delete.go
@@ -463,7 +463,7 @@ func (r *shootReconciler) runDeleteShootFlow(ctx context.Context, o *operation.O
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				waitFor := 5 * time.Minute
 
-				if v, ok := botanist.Shoot.GetInfo().Annotations[v1beta1constants.AnnotationShootCleanupInfrastructureResourceGracePeriodSeconds]; ok {
+				if v, ok := botanist.Shoot.GetInfo().Annotations[v1beta1constants.AnnotationShootInfrastructureCleanupWaitPeriodSeconds]; ok {
 					seconds, err := strconv.Atoi(v)
 					if err != nil {
 						return err


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
Today, it is hard-coded that Gardener waits for `5m` during the shoot deletion. This cannot be influenced or disabled.
With this PR, similar to #4212, it is possible to overwrite this duration by annotating the `Shoot` with `shoot.gardener.cloud/cleanup-infrastructure-resources-grace-period-seconds`.

Prerequisite for #5024

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
It's now possible to override the grace periods for the infrastructure cleanup wait step in the shoot deletion by specifying the `shoot.gardener.cloud/cleanup-infrastructure-resources-grace-period-seconds` annotation on the `Shoot` (default behaviour: `"300"`). Please be aware that overriding this value might lead to orphaned infrastructure artifacts.
```