### PR TITLE
Activate ReversedVPN feature gate for local development

### DIFF
--- a/example/20-componentconfig-gardenlet.yaml
+++ b/example/20-componentconfig-gardenlet.yaml
@@ -101,7 +101,7 @@ featureGates:
   APIServerSNI: true
   CachedRuntimeClients: true
   SeedKubeScheduler: false
-  ReversedVPN: false
+  ReversedVPN: true
   UseDNSRecords: true
   DenyInvalidExtensionResources: true
 # seedConfig:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area cost networking
/kind enhancement

**What this PR does / why we need it**:
The tunnel based on `ReversedVPN` is planned to be come the default solution. After the recent improvements it is more stable, hence, let's activate it for local development to (a) get more experience with it and (b) save costs.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy developer
The `ReversedVPN` feature gate is now activated by default for local development.
```
