### PR TITLE
Ensure proper extension controller cleanup when seed is deleted

### DIFF
--- a/pkg/controllermanager/controller/controllerregistration/seed_control.go
+++ b/pkg/controllermanager/controller/controllerregistration/seed_control.go
@@ -53,7 +53,10 @@ func (c *Controller) seedUpdate(oldObj, newObj interface{}) {
 		return
 	}
 
-	c.seedAdd(newObj, !apiequality.Semantic.DeepEqual(oldObject.Spec.DNS.Provider, newObject.Spec.DNS.Provider))
+	enqueue := !apiequality.Semantic.DeepEqual(oldObject.Spec.DNS.Provider, newObject.Spec.DNS.Provider) ||
+		newObject.DeletionTimestamp != nil
+
+	c.seedAdd(newObj, enqueue)
 }
 
 func (c *Controller) seedDelete(obj interface{}) {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
Earlier, when a `Seed` was deleted (`deletionTimestamp` was set), the controller did not enqueue it to the `controllerRegistrationSeedQueue` queue (on update, it only enqueued when the DNS provider was changed).
This could led to `ControllerInstallation` not being deleted for such seeds, remaining in the system until (through whatever other trigger) the seed gets enqueued to `controllerRegistrationSeedQueue` later.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed which could prevent proper deletion of `ControllerInstallation`s when a `Seed` was marked for deletion.
```
