### PR TITLE
Expose a metric on frequent container restarts in the seed

### DIFF
--- a/charts/seed-bootstrap/prometheus-rules/recording-rules.rules.yaml
+++ b/charts/seed-bootstrap/prometheus-rules/recording-rules.rules.yaml
@@ -225,6 +225,10 @@ groups:
   - record: seed:kube_pod_container_status_restarts_total:sum_by_container
     expr: sum(kube_pod_container_status_restarts_total) by (container)
 
+  # Recording rules for container restart count per gardener or extension namespace
+  - record: seed:kube_pod_container_status_restarts_total:max_by_namespace
+    expr: max by(namespace) (increase(kube_pod_container_status_restarts_total{namespace=~"garden|extension.+"}[1h]))
+
   # Recording rules for deployment spec replicas per deployment
   - record: seed:kube_deployment_spec_replicas:sum_by_deployment
     expr: sum(kube_deployment_spec_replicas) by (deployment)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

Expose a metric on frequent container restarts in the seed.
This metric can be federated into the garden soil cluster to
emit alerts when a garden system component or extension is
restarting frequently.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Expose a metric on frequent container restarts in the seed
```
