### PR TITLE
`ExtensionValidator` only triggers if spec changed

### DIFF
--- a/plugin/pkg/global/extensionvalidation/admission_test.go
+++ b/plugin/pkg/global/extensionvalidation/admission_test.go
@@ -106,6 +106,11 @@ var _ = Describe("ExtensionValidator", func() {
 
 			Expect(err).To(HaveOccurred())
 		})
+
+		It("should do nothing because the spec has not changed", func() {
+			attrs := admission.NewAttributesRecord(backupBucket, backupBucket, core.Kind("BackupBucket").WithVersion("version"), backupBucket.Namespace, backupBucket.Name, core.Resource("backupbuckets").WithVersion("version"), "", admission.Update, &metav1.DeleteOptions{}, false, nil)
+			Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
+		})
 	})
 
 	Context("BackupEntry", func() {
@@ -171,6 +176,11 @@ var _ = Describe("ExtensionValidator", func() {
 			err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 			Expect(err).To(HaveOccurred())
+		})
+
+		It("should do nothing because the spec has not changed", func() {
+			attrs := admission.NewAttributesRecord(backupEntry, backupEntry, core.Kind("BackupEntry").WithVersion("version"), backupEntry.Namespace, backupEntry.Name, core.Resource("backupentries").WithVersion("version"), "", admission.Update, &metav1.DeleteOptions{}, false, nil)
+			Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
 		})
 	})
 
@@ -260,6 +270,11 @@ var _ = Describe("ExtensionValidator", func() {
 			err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 			Expect(err).To(HaveOccurred())
+		})
+
+		It("should do nothing because the spec has not changed", func() {
+			attrs := admission.NewAttributesRecord(seed, seed, core.Kind("Seed").WithVersion("version"), seed.Namespace, seed.Name, core.Resource("seeds").WithVersion("version"), "", admission.Update, &metav1.DeleteOptions{}, false, nil)
+			Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
 		})
 	})
 
@@ -363,6 +378,11 @@ var _ = Describe("ExtensionValidator", func() {
 			err := admissionHandler.Validate(context.TODO(), attrs, nil)
 
 			Expect(err).To(HaveOccurred())
+		})
+
+		It("should do nothing because the spec has not changed", func() {
+			attrs := admission.NewAttributesRecord(shoot, shoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.DeleteOptions{}, false, nil)
+			Expect(admissionHandler.Validate(context.TODO(), attrs, nil)).To(Succeed())
 		})
 	})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
Similar to other admission plugins and hence as a best practice, we should only perform the validation for referenced extension types in the `ExtensionValidator` when a resource was newly created or when its specification was changed.

Without this change, it could happen that the gardenlet cannot remove its finalizer from the `Seed` resource in case the used `ControllerRegistration`s were deleted as well (since the plugin would complain that the referenced extension types are not registered).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The validation whether referenced extension types are actually registered in the system is now only performed when a resource is newly created or when its `spec` section has changed.
```
