### PR TITLE
Several enhancements for the integration test framework

### DIFF
--- a/test/framework/shoot_utils.go
+++ b/test/framework/shoot_utils.go
@@ -278,6 +278,11 @@ func setShootNetworkingSettings(shoot *gardencorev1beta1.Shoot, cfg *ShootCreati
 		shoot.Spec.DNS = &gardencorev1beta1.DNS{Domain: &cfg.externalDomain}
 		clearDNS = false
 	}
+
+	if StringSet(cfg.networkingType) {
+		shoot.Spec.Networking.Type = cfg.networkingType
+	}
+
 	if StringSet(cfg.networkingPods) {
 		shoot.Spec.Networking.Pods = &cfg.networkingPods
 	}

--- a/test/framework/shootcreationframework.go
+++ b/test/framework/shootcreationframework.go
@@ -151,12 +151,10 @@ func validateShootCreationConfig(cfg *ShootCreationConfig) {
 		cfg.allowPrivilegedContainers = &parsedBool
 	}
 
-	if !StringSet(cfg.infrastructureProviderConfig) {
-		ginkgo.Fail(fmt.Sprintf("you need to specify the filepath to the infrastructureProviderConfig for the provider '%s'", cfg.shootProviderType))
-	}
-
-	if !FileExists(cfg.infrastructureProviderConfig) {
-		ginkgo.Fail(fmt.Sprintf("path to the infrastructureProviderConfig of the Shoot is invalid: %s", cfg.infrastructureProviderConfig))
+	if StringSet(cfg.infrastructureProviderConfig) {
+		if !FileExists(cfg.infrastructureProviderConfig) {
+			ginkgo.Fail(fmt.Sprintf("you need to specify the filepath to the infrastructureProviderConfig for the provider '%s'", cfg.shootProviderType))
+		}
 	}
 
 	if StringSet(cfg.controlPlaneProviderConfig) {

--- a/test/framework/shootcreationframework.go
+++ b/test/framework/shootcreationframework.go
@@ -407,8 +407,12 @@ func (f *ShootCreationFramework) CreateShoot(ctx context.Context, initializeShoo
 func (f *ShootCreationFramework) InitializeShootWithFlags(ctx context.Context) error {
 	// if running in test machinery, test will be executed from root of the project
 	if !FileExists(fmt.Sprintf(".%s", f.Config.shootYamlPath)) {
-		// locally, we need find the example shoot
-		f.Config.shootYamlPath = filepath.Join(f.TemplatesDir, f.Config.shootYamlPath)
+		path := f.Config.shootYamlPath
+		if !filepath.IsAbs(f.Config.shootYamlPath) {
+			// locally, we need find the example shoot
+			path = filepath.Join(f.TemplatesDir, f.Config.shootYamlPath)
+		}
+		f.Config.shootYamlPath = path
 		if !FileExists(f.Config.shootYamlPath) {
 			return fmt.Errorf("shoot template should exist")
 		}

--- a/test/framework/shootcreationframework.go
+++ b/test/framework/shootcreationframework.go
@@ -48,6 +48,7 @@ type ShootCreationConfig struct {
 	shootK8sVersion               string
 	externalDomain                string
 	workerZone                    string
+	networkingType                string
 	networkingPods                string
 	networkingServices            string
 	networkingNodes               string
@@ -252,6 +253,10 @@ func mergeShootCreationConfig(base, overwrite *ShootCreationConfig) *ShootCreati
 		base.workerZone = overwrite.workerZone
 	}
 
+	if StringSet(overwrite.networkingType) {
+		base.networkingType = overwrite.networkingType
+	}
+
 	if StringSet(overwrite.networkingPods) {
 		base.networkingPods = overwrite.networkingPods
 	}
@@ -325,6 +330,7 @@ func RegisterShootCreationFrameworkFlags() *ShootCreationConfig {
 	flag.StringVar(&newCfg.shootK8sVersion, "k8s-version", "", "kubernetes version to use for the shoot.")
 	flag.StringVar(&newCfg.externalDomain, "external-domain", "", "external domain to use for the shoot. If not set, will use the default domain.")
 	flag.StringVar(&newCfg.workerZone, "worker-zone", "", "zone to use for every worker of the shoot.")
+	flag.StringVar(&newCfg.networkingType, "networking-type", "calico", "the spec.networking.type to use for this shoot. Optional. Defaults to calico.")
 	flag.StringVar(&newCfg.networkingPods, "networking-pods", "", "the spec.networking.pods to use for this shoot. Optional.")
 	flag.StringVar(&newCfg.networkingServices, "networking-services", "", "the spec.networking.services to use for this shoot. Optional.")
 	flag.StringVar(&newCfg.networkingNodes, "networking-nodes", "", "the spec.networking.nodes to use for this shoot. Optional.")

--- a/test/framework/worker_utils.go
+++ b/test/framework/worker_utils.go
@@ -101,10 +101,7 @@ func AddWorker(shoot *gardencorev1beta1.Shoot, cloudProfile *gardencorev1beta1.C
 		},
 	})
 
-	if machineType.Storage == nil {
-		if len(cloudProfile.Spec.VolumeTypes) == 0 {
-			return fmt.Errorf("no VolumeTypes configured in the Cloudprofile '%s'", cloudProfile.Name)
-		}
+	if machineType.Storage == nil && len(cloudProfile.Spec.VolumeTypes) > 0 {
 		shoot.Spec.Provider.Workers[0].Volume = &gardencorev1beta1.Volume{
 			Type:       &cloudProfile.Spec.VolumeTypes[0].Name,
 			VolumeSize: "35Gi",

--- a/test/framework/worker_utils.go
+++ b/test/framework/worker_utils.go
@@ -23,19 +23,6 @@ import (
 	"github.com/gardener/gardener/pkg/utils"
 )
 
-// AddWorkerForName adds a valid worker to the shoot for the given machine image name. Returns an error if the machine image cannot be found in the CloudProfile.
-func AddWorkerForName(shoot *gardencorev1beta1.Shoot, cloudProfile *gardencorev1beta1.CloudProfile, machineImageName *string, workerZone string) error {
-	found, image, err := helper.DetermineMachineImageForName(cloudProfile, *machineImageName)
-	if err != nil {
-		return err
-	}
-	if !found {
-		return fmt.Errorf("could not find machine image '%s' in CloudProfile '%s'", *machineImageName, cloudProfile.Name)
-	}
-
-	return AddWorker(shoot, cloudProfile, image, workerZone)
-}
-
 // setShootWorkerSettings sets the Shoot's worker settings from the given config
 func setShootWorkerSettings(shoot *gardencorev1beta1.Shoot, cfg *ShootCreationConfig, cloudProfile *gardencorev1beta1.CloudProfile) error {
 	if StringSet(cfg.workersConfig) {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
This PR contains several enhancements for the integration test framework:

- Drop wrong assumptions about
  - `.spec.provider.infrastructureConfig` being required in the `Shoot`
  - `.spec.volumeTypes` being required in the `CloudProfile` when the machine type does not specify `.storage`
  - the file provided via the `-shoot-template-path` to be part of the `templates` directory
- Make `.spec.networking.type` configurable (was hard-coded to `calico`)
- Drop dead/unused code

Prerequisite for #5024

/invite @dguendisch 
/squash

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
