### PR TITLE
Add missing GRM network policy and network policy labels

### DIFF
--- a/pkg/operation/botanist/component/resourcemanager/resource_manager_test.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager_test.go
@@ -37,6 +37,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -98,6 +99,8 @@ var _ = Describe("ResourceManager", func() {
 		matchPolicy                                = admissionregistrationv1.Exact
 		sideEffect                                 = admissionregistrationv1.SideEffectClassNone
 		caBundle                                   = []byte("ca-bundle")
+		networkPolicyProtocol                      = corev1.ProtocolTCP
+		networkPolicyPort                          = intstr.FromInt(serverPort)
 
 		allowAll                     []rbacv1.PolicyRule
 		allowManagedResources        []rbacv1.PolicyRule
@@ -118,6 +121,7 @@ var _ = Describe("ResourceManager", func() {
 		mutatingWebhookConfiguration *admissionregistrationv1.MutatingWebhookConfiguration
 		managedResourceSecret        *corev1.Secret
 		managedResource              *resourcesv1alpha1.ManagedResource
+		networkPolicy                *networkingv1.NetworkPolicy
 	)
 
 	BeforeEach(func() {
@@ -352,6 +356,7 @@ var _ = Describe("ResourceManager", func() {
 							"networking.gardener.cloud/to-dns":                    "allowed",
 							"networking.gardener.cloud/to-seed-apiserver":         "allowed",
 							"networking.gardener.cloud/to-shoot-apiserver":        "allowed",
+							"networking.gardener.cloud/from-shoot-apiserver":      "allowed",
 							v1beta1constants.GardenRole:                           v1beta1constants.GardenRoleControlPlane,
 							v1beta1constants.LabelApp:                             "gardener-resource-manager",
 						},
@@ -717,6 +722,41 @@ webhooks:
 				KeepObjects:  pointer.Bool(false),
 			},
 		}
+		networkPolicy = &networkingv1.NetworkPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "allow-kube-apiserver-to-gardener-resource-manager",
+				Namespace: deployNamespace,
+				Labels:    defaultLabels,
+				Annotations: map[string]string{
+					v1beta1constants.GardenerDescription: "Allows Egress from shoot's kube-apiserver pods to gardener-resource-manager pods.",
+				},
+			},
+			Spec: networkingv1.NetworkPolicySpec{
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						v1beta1constants.LabelApp:   v1beta1constants.LabelKubernetes,
+						v1beta1constants.LabelRole:  v1beta1constants.LabelAPIServer,
+						v1beta1constants.GardenRole: v1beta1constants.GardenRoleControlPlane,
+					},
+				},
+				Egress: []networkingv1.NetworkPolicyEgressRule{{
+					To: []networkingv1.NetworkPolicyPeer{{
+						PodSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								v1beta1constants.LabelApp: "gardener-resource-manager",
+							},
+						},
+					}},
+					Ports: []networkingv1.NetworkPolicyPort{{
+						Protocol: &networkPolicyProtocol,
+						Port:     &networkPolicyPort,
+					}},
+				}},
+				PolicyTypes: []networkingv1.PolicyType{
+					networkingv1.PolicyTypeEgress,
+				},
+			},
+		}
 	})
 
 	AfterEach(func() {
@@ -780,6 +820,11 @@ webhooks:
 					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 						Expect(obj).To(DeepEqual(managedResource))
 					}),
+					c.EXPECT().Get(ctx, kutil.Key(deployNamespace, "allow-kube-apiserver-to-gardener-resource-manager"), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
+					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()).
+						Do(func(ctx context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
+							Expect(obj).To(DeepEqual(networkPolicy))
+						}),
 				)
 				Expect(resourceManager.Deploy(ctx)).To(Succeed())
 			})
@@ -1034,6 +1079,11 @@ webhooks:
 					c.EXPECT().Update(ctx, gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Do(func(ctx context.Context, obj client.Object, opts ...client.UpdateOption) {
 						Expect(obj).To(DeepEqual(managedResource))
 					}),
+					c.EXPECT().Get(ctx, kutil.Key(deployNamespace, "allow-kube-apiserver-to-gardener-resource-manager"), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
+					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()).
+						Do(func(ctx context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
+							Expect(obj).To(DeepEqual(networkPolicy))
+						}),
 				)
 				Expect(resourceManager.Deploy(ctx)).To(Succeed())
 			})
@@ -1087,6 +1137,7 @@ webhooks:
 				delete(deployment.Spec.Template.Labels, "networking.gardener.cloud/to-dns")
 				delete(deployment.Spec.Template.Labels, "networking.gardener.cloud/to-seed-apiserver")
 				delete(deployment.Spec.Template.Labels, "networking.gardener.cloud/to-shoot-apiserver")
+				delete(deployment.Spec.Template.Labels, "networking.gardener.cloud/from-shoot-apiserver")
 
 				secrets.Kubeconfig.Name, secrets.Kubeconfig.Checksum = "", ""
 				cfg.TargetDiffersFromSourceCluster = false


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind bug

**What this PR does / why we need it**:
Fixes connectivity issues between `kube-apiserver` and `gardener-resource-manager` pods after GRM webhooks were enabled with #5002 by adding the missing `NetworkPolicy` resource and network policy labels on GRM pods.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```other operator
NONE
```
