### PR TITLE
Skip moving generated CRDs when prefix is empty

### DIFF
--- a/hack/generate-seed-crds.sh
+++ b/hack/generate-seed-crds.sh
@@ -72,7 +72,10 @@ generate_group () {
   controller-gen crd paths="$package_path" output:crd:dir="$output_dir" output:stdout
 
   while IFS= read -r crd; do
-    mv "$crd" "$output_dir/$file_name_prefix$(basename $crd)"
+    crd_out="$output_dir/$file_name_prefix$(basename $crd)"
+    if [ "$crd" != "$crd_out" ]; then
+      mv "$crd" "$crd_out"
+    fi
   done < <(ls "$output_dir/${group}"_*.yaml)
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
This PR fixes a minor issue with the `generate-seed-crds.sh` script that occurs when an empty prefix is given:

```
mv: '/tmp/build/a94a8fe5/pull-request-gardener.etcd-druid-pr.master/config/crd/bases/druid.gardener.cloud_etcdcopybackupstasks.yaml' and '/tmp/build/a94a8fe5/pull-request-gardener.etcd-druid-pr.master/config/crd/bases/druid.gardener.cloud_etcdcopybackupstasks.yaml' are the same file
```

**Special notes for your reviewer**:
Originally, I tried to use `mv -f` but did not succeed in a `golang` container.

/cc @timebertt 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
A bug has been fixed which caused issues when `hack/generate-seed-crds.sh` was called with an empty `<file-name-prefix>`.
```
