### PR TITLE
Do not consider GRM webhooks in constraints check

### DIFF
--- a/pkg/operation/botanist/component/resourcemanager/resource_manager.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager.go
@@ -61,6 +61,8 @@ const (
 	SecretName = "gardener-resource-manager"
 	// SecretNameServer is the name of the gardener-resource-manager server certificate secret.
 	SecretNameServer = "gardener-resource-manager-server"
+	// LabelValue is a constant for the value of the 'app' label on Kubernetes resources.
+	LabelValue = "gardener-resource-manager"
 
 	// UserName is the name that should be used for the secret that the gardener resource manager uses to
 	// authenticate itself with the kube-apiserver (e.g., the common name in its client certificate).
@@ -986,7 +988,7 @@ func (r *resourceManager) getNetworkPolicyLabels() map[string]string {
 
 func appLabel() map[string]string {
 	return map[string]string{
-		v1beta1constants.LabelApp: "gardener-resource-manager",
+		v1beta1constants.LabelApp: LabelValue,
 	}
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind bug

**What this PR does / why we need it**:
Without this PR, a `Shoot`'s constraints would look as follows:

```yaml
    constraints:
    - lastTransitionTime: "2021-11-23T08:54:35Z"
      lastUpdateTime: "2021-11-23T08:53:07Z"
      message: 'MutatingWebhookConfiguration "gardener-resource-manager-shoot" is
        problematic: webhook "projected-token-mount.resources.gardener.cloud" with
        failurePolicy "Fail" and 10s timeout might prevent worker nodes from properly
        joining the shoot cluster'
      reason: ProblematicWebhooks
      status: "False"
      type: HibernationPossible
    - lastTransitionTime: "2021-11-23T08:54:35Z"
      lastUpdateTime: "2021-11-23T08:53:07Z"
      message: 'MutatingWebhookConfiguration "gardener-resource-manager-shoot" is
        problematic: webhook "projected-token-mount.resources.gardener.cloud" with
        failurePolicy "Fail" and 10s timeout might prevent worker nodes from properly
        joining the shoot cluster'
      reason: ProblematicWebhooks
      status: "False"
      type: MaintenancePreconditionsSatisfied
```

This PR fixes this by excluding Gardener-managed webhooks from these checks.

**Special notes for your reviewer**:
/invite @stoyanr 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
