### PR TITLE
[CPM IT]  Adding seed-taint-testrun-value property

### DIFF
--- a/.test-defs/MigrateShoot.yaml
+++ b/.test-defs/MigrateShoot.yaml
@@ -17,4 +17,5 @@ spec:
     -kubecfg="$TM_KUBECONFIG_PATH/gardener.config"
     -mr-exclude-list="$MR_EXCLUDE_LIST"
     -resources-with-generated-name="$RESOURCES_WITH_GENERATED_NAME"
+    -add-test-run-taint="$ADD_TEST_RUN_TAINT"
   image: eu.gcr.io/gardener-project/3rd/golang:1.17.3

--- a/test/system/shoot_cp_migration/migrate_test.go
+++ b/test/system/shoot_cp_migration/migrate_test.go
@@ -51,6 +51,7 @@ var (
 	shootNamespace             *string
 	mrExcludeList              *string
 	resourcesWithGeneratedName *string
+	addTestRunTaint            *string
 	gardenerConfig             *GardenerConfig
 )
 
@@ -61,14 +62,16 @@ func init() {
 	shootNamespace = flag.String("shoot-namespace", "", "namespace of the shoot")
 	mrExcludeList = flag.String("mr-exclude-list", "", "comma-separated values of the ManagedResources that will be exlude during the 'CreationTimestamp' check")
 	resourcesWithGeneratedName = flag.String("resources-with-generated-name", "", "comma-separated names of resources deployed via managed resources that get their name generated during reconciliation and will be excluded during the 'CreationTimestamp' check")
+	addTestRunTaint = flag.String("add-test-run-taint", "", "if this property is set to 'true' the 'test.gardener.cloud/test-run' taint with the value of the 'TM_TESTRUN_ID' environment variable, will be applied to the shoot")
 }
 
 var _ = ginkgo.Describe("Shoot migration testing", func() {
 	f := NewGardenerFramework(gardenerConfig)
 	t := NewShootMigrationTest(f, &ShootMigrationConfig{
-		ShootName:      *shootName,
-		ShootNamespace: *shootNamespace,
-		TargetSeedName: *targetSeedName,
+		ShootName:       *shootName,
+		ShootNamespace:  *shootNamespace,
+		TargetSeedName:  *targetSeedName,
+		AddTestRunTaint: *addTestRunTaint,
 	})
 	guestBookApp := applications.GuestBookTest{}
 	testSecret := &corev1.Secret{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind enhancement

**What this PR does / why we need it**:
This PR adds `seed-taint-testrun-value` property that will enable to set the value for the `test.gardener.cloud/test-run`. With the current implementation for that value the environment variable `TM_TESTRUN_ID`. This is limiting as it requires that the seed is also tainted the same way and with the same `TM_TESTRUN_ID` as value.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
