### PR TITLE
Ensure KCM ClusterRoleBinding is not deleted too early

### DIFF
--- a/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager_test.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager_test.go
@@ -602,7 +602,7 @@ subjects:
 							{Name: managedResourceSecretName},
 						},
 						InjectLabels: map[string]string{"shoot.gardener.cloud/no-cleanup": "true"},
-						KeepObjects:  pointer.Bool(false),
+						KeepObjects:  pointer.Bool(true),
 					},
 				}
 

--- a/pkg/operation/botanist/component/kubecontrollermanager/shoot_resources.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/shoot_resources.go
@@ -50,5 +50,5 @@ func (k *kubeControllerManager) reconcileShootResources(ctx context.Context, ser
 		return err
 	}
 
-	return managedresources.CreateForShoot(ctx, k.seedClient, k.namespace, managedResourceName, false, data)
+	return managedresources.CreateForShoot(ctx, k.seedClient, k.namespace, managedResourceName, true, data)
 }


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind bug

**What this PR does / why we need it**:
Ensures that the KCM `ClusterRoleBinding` is not deleted too early from the shoot. When this happens, KCM starts crashing with `configmaps "extension-apiserver-authentication" is forbidden: User "system:serviceaccount:kube-system:kube-controller-manager" cannot get resource "configmaps" in API group "" in the namespace "kube-system"`, and deletion of other managed resources may fail since KCM is not there to remove the `foregroundDeletion` finalizers from various resources.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This PR fixes the issue using the simplest possible approach, by setting `keep=true` on the KCM MR. There is perhaps a "better" (but slightly more complex) way to fix this by splitting managed resources into 2 priority groups. 

**Release note**:

```other operator
NONE
```
