### PR TITLE
Ensure KCM MR is not deleted too early via priority labels

### DIFF
--- a/pkg/operation/botanist/component/clusterautoscaler/cluster_autoscaler_test.go
+++ b/pkg/operation/botanist/component/clusterautoscaler/cluster_autoscaler_test.go
@@ -471,7 +471,7 @@ subjects:
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      managedResourceName,
 				Namespace: namespace,
-				Labels:    map[string]string{"origin": "gardener"},
+				Labels:    map[string]string{"origin": "gardener", "priority": "normal"},
 			},
 			Spec: resourcesv1alpha1.ManagedResourceSpec{
 				SecretRefs: []corev1.LocalObjectReference{

--- a/pkg/operation/botanist/component/clusteridentity/clusteridentity_test.go
+++ b/pkg/operation/botanist/component/clusteridentity/clusteridentity_test.go
@@ -85,7 +85,7 @@ metadata:
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      managedResourceName,
 				Namespace: namespace,
-				Labels:    map[string]string{"origin": "gardener"},
+				Labels:    map[string]string{"origin": "gardener", "priority": "normal"},
 			},
 			Spec: resourcesv1alpha1.ManagedResourceSpec{
 				SecretRefs: []corev1.LocalObjectReference{

--- a/pkg/operation/botanist/component/coredns/coredns_test.go
+++ b/pkg/operation/botanist/component/coredns/coredns_test.go
@@ -458,7 +458,7 @@ status:
 					Name:            managedResource.Name,
 					Namespace:       managedResource.Namespace,
 					ResourceVersion: "1",
-					Labels:          map[string]string{"origin": "gardener"},
+					Labels:          map[string]string{"origin": "gardener", "priority": "normal"},
 				},
 				Spec: resourcesv1alpha1.ManagedResourceSpec{
 					InjectLabels: map[string]string{"shoot.gardener.cloud/no-cleanup": "true"},

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
@@ -1055,7 +1055,8 @@ subjects:
 							Namespace:       managedResource.Namespace,
 							ResourceVersion: "1",
 							Labels: map[string]string{
-								"origin": "gardener",
+								"origin":   "gardener",
+								"priority": "normal",
 							},
 						},
 						Spec: resourcesv1alpha1.ManagedResourceSpec{

--- a/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager_test.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager_test.go
@@ -595,14 +595,14 @@ subjects:
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      managedResourceName,
 						Namespace: namespace,
-						Labels:    map[string]string{"origin": "gardener"},
+						Labels:    map[string]string{"origin": "gardener", "priority": "high"},
 					},
 					Spec: resourcesv1alpha1.ManagedResourceSpec{
 						SecretRefs: []corev1.LocalObjectReference{
 							{Name: managedResourceSecretName},
 						},
 						InjectLabels: map[string]string{"shoot.gardener.cloud/no-cleanup": "true"},
-						KeepObjects:  pointer.Bool(true),
+						KeepObjects:  pointer.Bool(false),
 					},
 				}
 

--- a/pkg/operation/botanist/component/kubecontrollermanager/shoot_resources.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/shoot_resources.go
@@ -50,5 +50,5 @@ func (k *kubeControllerManager) reconcileShootResources(ctx context.Context, ser
 		return err
 	}
 
-	return managedresources.CreateForShoot(ctx, k.seedClient, k.namespace, managedResourceName, true, data)
+	return managedresources.CreateForShootWithPriority(ctx, k.seedClient, k.namespace, managedResourceName, false, managedresources.LabelValueHigh, data)
 }

--- a/pkg/operation/botanist/component/kubescheduler/kube_scheduler_test.go
+++ b/pkg/operation/botanist/component/kubescheduler/kube_scheduler_test.go
@@ -317,7 +317,7 @@ subjects:
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      managedResourceName,
 				Namespace: namespace,
-				Labels:    map[string]string{"origin": "gardener"},
+				Labels:    map[string]string{"origin": "gardener", "priority": "normal"},
 			},
 			Spec: resourcesv1alpha1.ManagedResourceSpec{
 				SecretRefs: []corev1.LocalObjectReference{

--- a/pkg/operation/botanist/component/logging/kube_rbac_proxy_test.go
+++ b/pkg/operation/botanist/component/logging/kube_rbac_proxy_test.go
@@ -277,7 +277,8 @@ var _ = Describe("KubeRBACProxy", func() {
 						Name:      managedResourceName,
 						Namespace: namespace,
 						Labels: map[string]string{
-							"origin": "gardener",
+							"origin":   "gardener",
+							"priority": "normal",
 						},
 					},
 					Spec: resourcesv1alpha1.ManagedResourceSpec{

--- a/pkg/operation/botanist/component/metricsserver/metrics_server_test.go
+++ b/pkg/operation/botanist/component/metricsserver/metrics_server_test.go
@@ -424,7 +424,7 @@ status: {}
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      managedResourceName,
 				Namespace: namespace,
-				Labels:    map[string]string{"origin": "gardener"},
+				Labels:    map[string]string{"origin": "gardener", "priority": "normal"},
 			},
 			Spec: resourcesv1alpha1.ManagedResourceSpec{
 				SecretRefs: []corev1.LocalObjectReference{

--- a/pkg/operation/botanist/component/namespaces/namespaces_test.go
+++ b/pkg/operation/botanist/component/namespaces/namespaces_test.go
@@ -82,7 +82,7 @@ status: {}
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      managedResourceName,
 				Namespace: namespace,
-				Labels:    map[string]string{"origin": "gardener"},
+				Labels:    map[string]string{"origin": "gardener", "priority": "normal"},
 			},
 			Spec: resourcesv1alpha1.ManagedResourceSpec{
 				SecretRefs: []corev1.LocalObjectReference{

--- a/pkg/operation/botanist/component/resourcemanager/resource_manager_test.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager_test.go
@@ -712,7 +712,7 @@ webhooks:
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "shoot-core-gardener-resource-manager",
 				Namespace: deployNamespace,
-				Labels:    map[string]string{"origin": "gardener"},
+				Labels:    map[string]string{"origin": "gardener", "priority": "normal"},
 			},
 			Spec: resourcesv1alpha1.ManagedResourceSpec{
 				SecretRefs: []corev1.LocalObjectReference{

--- a/pkg/operation/botanist/operatingsystemconfig_test.go
+++ b/pkg/operation/botanist/operatingsystemconfig_test.go
@@ -421,7 +421,7 @@ metadata:
 									Expect(obj.ObjectMeta).To(Equal(metav1.ObjectMeta{
 										Name:      "shoot-cloud-config-execution",
 										Namespace: namespace,
-										Labels:    map[string]string{"origin": "gardener"},
+										Labels:    map[string]string{"origin": "gardener", "priority": "normal"},
 									}))
 									Expect(obj.Spec.SecretRefs).To(ConsistOf(
 										corev1.LocalObjectReference{Name: "managedresource-shoot-cloud-config-execution-" + worker1Name},

--- a/pkg/utils/managedresources/managedresources_test.go
+++ b/pkg/utils/managedresources/managedresources_test.go
@@ -106,7 +106,7 @@ var _ = Describe("managedresources", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      name,
 						Namespace: namespace,
-						Labels:    map[string]string{"origin": "gardener"},
+						Labels:    map[string]string{"origin": "gardener", "priority": "normal"},
 					},
 					Spec: resourcesv1alpha1.ManagedResourceSpec{
 						SecretRefs:   []corev1.LocalObjectReference{{Name: "managedresource-" + name}},


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind bug

**What this PR does / why we need it**:
Ensures that the KCM `ManagedResource` containing its `ClusterRoleBinding` is not deleted too early from the shoot. When this happens, KCM starts crashing with `configmaps "extension-apiserver-authentication" is forbidden: User "system:serviceaccount:kube-system:kube-controller-manager" cannot get resource "configmaps" in API group "" in the namespace "kube-system"`, and deletion of other managed resources may fail since KCM is not there to remove the `foregroundDeletion` finalizers from various resources.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This PR is an alternative to #5062 (and therefore undoes its changes). Instead of fixing the issue by setting `keep=true` on the KCM MR, it splits all managed resources into 2 groups with `normal` and `high` priority based on a `priority` label. The MRs from the `high` priority group are deleted later in the flow (after the control plane is deleted, since the `csi-driver-node` daemon set may also use `foregroundDeletion` finalizers), when it's safe to do so.

This has the following advantages:
* No resources are artificially kept in the shoot just to resolve ordering issues.
* If there are other MRs in the future that may need to be deleted later, they could simply be labeled with `high` priority.

It also has the obvious disadvantage that it's a bit more complex, so we should judge the value of the above sufficiently high to justify it.

**Release note**:

```other operator
NONE
```
