### PR TITLE
SeedAuthorizer: Allow gardenlet to delete BackupEntry resources

### DIFF
--- a/pkg/admissioncontroller/webhooks/auth/seed/authorizer.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/authorizer.go
@@ -109,7 +109,7 @@ func (a *authorizer) Authorize(_ context.Context, attrs auth.Attributes) (auth.D
 			)
 		case backupEntryResource:
 			return a.authorize(seedName, graph.VertexTypeBackupEntry, attrs,
-				[]string{"update", "patch"},
+				[]string{"update", "patch", "delete"},
 				[]string{"create", "get", "list", "watch"},
 				[]string{"status"},
 			)

--- a/pkg/admissioncontroller/webhooks/auth/seed/authorizer_test.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/authorizer_test.go
@@ -772,11 +772,10 @@ var _ = Describe("Seed", func() {
 					decision, reason, err := authorizer.Authorize(ctx, attrs)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(decision).To(Equal(auth.DecisionNoOpinion))
-					Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [create get list watch update patch]"))
+					Expect(reason).To(ContainSubstring("only the following verbs are allowed for this resource type: [create get list watch update patch delete]"))
 
 				},
 
-				Entry("delete", "delete"),
 				Entry("deletecollection", "deletecollection"),
 			)
 

--- a/pkg/operation/botanist/component/backupentry/backupentry.go
+++ b/pkg/operation/botanist/component/backupentry/backupentry.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -197,6 +198,16 @@ func (b *backupEntry) reconcile(ctx context.Context, backupEntry *gardencorev1be
 
 // Destroy deletes the BackupEntry resource
 func (b *backupEntry) Destroy(ctx context.Context) error {
+	// SeedAuthorizer will reject a DELETE request to BackupEntry that does not exist with reason 'no relationship found'.
+	// That's why early exit when the BackupEntry does not exist.
+	if err := b.client.Get(ctx, client.ObjectKeyFromObject(b.backupEntry), b.backupEntry); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+
+		return err
+	}
+
 	return kutil.DeleteObject(
 		ctx,
 		b.client,

--- a/pkg/operation/botanist/component/backupentry/backupentry_test.go
+++ b/pkg/operation/botanist/component/backupentry/backupentry_test.go
@@ -292,8 +292,14 @@ var _ = Describe("BackupEntry", func() {
 	})
 
 	Describe("#Destroy", func() {
-		It("should be nil because it's not implemented", func() {
+		It("should not return error when it's not found", func() {
 			Expect(defaultDepWaiter.Destroy(ctx)).To(BeNil())
+		})
+
+		It("should not return error when it's deleted successfully", func() {
+			Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "creating infrastructure succeeds")
+
+			Expect(defaultDepWaiter.Destroy(ctx)).ToNot(HaveOccurred())
 		})
 	})
 


### PR DESCRIPTION
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

After https://github.com/gardener/gardener/pull/4894 the Shoot reconciliation fails with:

```yaml
  lastErrors:
    - description: >-
        task "Destroying source backup entry" failed:
        backupentries.core.gardener.cloud
        "source-shoot--foo--bar--0cbfd2eb-4ec1-428e-a699-b1f0a9078e60" is
        forbidden: User "gardener.cloud:system:seed:aws" cannot delete resource
        "backupentries" in API group "core.gardener.cloud" in the namespace
        "garden-foo": only the following verbs are allowed for this resource
        type: [create get list watch update patch]
      taskID: Destroying source backup entry
      lastUpdateTime: '2021-11-25T09:40:09Z'
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
