### PR TITLE
Adds nodeTemplate to worker CRD

### DIFF
--- a/pkg/operation/botanist/component/extensions/crds/templates/crd-worker.tpl.yaml
+++ b/pkg/operation/botanist/component/extensions/crds/templates/crd-worker.tpl.yaml
@@ -181,6 +181,23 @@ spec:
                       name:
                         description: Name is the name of this worker pool.
                         type: string
+                      nodeTemplate:
+                        description: NodeTemplate contains resource information of the
+                          machine which is used by Cluster Autoscaler to generate nodeTemplate
+                          during scaling a nodeGroup from zero
+                        properties:
+                          capacity:
+                            additionalProperties:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            description: Capacity represents the expected Node capacity.
+                            type: object
+                        required:
+                        - capacity
+                        type: object
                       providerConfig:
                         description: ProviderConfig is a provider specific configuration
                           for the worker pool.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind bug

**What this PR does / why we need it**:
Adds nodeTemplate fields to worker CRD . It was not added as a part of [this](https://github.com/gardener/gardener/pull/4980) PR.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
