### PR TITLE
Destroy the source BackupEntry only during restore phase

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -253,7 +253,7 @@ func (r *shootReconciler) runReconcileShootFlow(ctx context.Context, o *operatio
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Destroying source backup entry",
-			Fn:           flow.TaskFn(botanist.Shoot.Components.SourceBackupEntry.Destroy).DoIf(allowBackup),
+			Fn:           flow.TaskFn(botanist.DestroySourceBackupEntry).DoIf(allowBackup),
 			Dependencies: flow.NewTaskIDs(deployETCD),
 		})
 		waitUntilEtcdReady = g.Add(flow.Task{

--- a/pkg/operation/botanist/backupentry_test.go
+++ b/pkg/operation/botanist/backupentry_test.go
@@ -1,0 +1,140 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package botanist_test
+
+import (
+	"context"
+
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/features"
+	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
+	"github.com/gardener/gardener/pkg/operation"
+	. "github.com/gardener/gardener/pkg/operation/botanist"
+	mockbackupentry "github.com/gardener/gardener/pkg/operation/botanist/component/backupentry/mock"
+	"github.com/gardener/gardener/pkg/operation/seed"
+	shootpkg "github.com/gardener/gardener/pkg/operation/shoot"
+	"github.com/gardener/gardener/pkg/utils/test"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("BackupEntry", func() {
+
+	var (
+		ctrl *gomock.Controller
+		ctx  = context.TODO()
+
+		botanist          *Botanist
+		sourceBackupEntry *mockbackupentry.MockInterface
+	)
+
+	BeforeEach(func() {
+		ctrl = gomock.NewController(GinkgoT())
+
+		sourceBackupEntry = mockbackupentry.NewMockInterface(ctrl)
+		botanist = &Botanist{
+			Operation: &operation.Operation{
+				Shoot: &shootpkg.Shoot{
+					Components: &shootpkg.Components{
+						SourceBackupEntry: sourceBackupEntry,
+					},
+				},
+			},
+		}
+
+		botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bar",
+				Namespace: "foo",
+			},
+			Status: gardencorev1beta1.ShootStatus{
+				LastOperation: &gardencorev1beta1.LastOperation{
+					Type: v1beta1.LastOperationTypeRestore,
+				},
+			},
+		})
+		botanist.Seed = &seed.Seed{}
+		botanist.Seed.SetInfo(&gardencorev1beta1.Seed{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "seed",
+				Namespace: "garden",
+			},
+			Spec: gardencorev1beta1.SeedSpec{
+				Backup: &gardencorev1beta1.SeedBackup{
+					Provider: "gcp",
+				},
+			},
+		})
+	})
+
+	AfterEach(func() {
+		ctrl.Finish()
+	})
+
+	Describe("#DestroySourceBackupEntry", func() {
+
+		It("shouldn't destroy the SourceBackupEntry component when CopyEtcdBackupsDuringControlPlaneMigration=false", func() {
+			defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.CopyEtcdBackupsDuringControlPlaneMigration, false)()
+
+			Expect(botanist.DestroySourceBackupEntry(ctx)).To(Succeed())
+		})
+
+		It("shouldn't destroy the SourceBackupEntry component when Seed backup is not enabled", func() {
+			defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.CopyEtcdBackupsDuringControlPlaneMigration, true)()
+
+			botanist.Seed.SetInfo(&gardencorev1beta1.Seed{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "seed",
+					Namespace: "garden",
+				},
+				Spec: gardencorev1beta1.SeedSpec{
+					Backup: nil,
+				},
+			})
+
+			Expect(botanist.DestroySourceBackupEntry(ctx)).To(Succeed())
+		})
+
+		It("shouldn't destroy the SourceBackupEntry component when Shoot is not in restore phase", func() {
+			defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.CopyEtcdBackupsDuringControlPlaneMigration, true)()
+
+			botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bar",
+					Namespace: "foo",
+				},
+				Status: gardencorev1beta1.ShootStatus{
+					LastOperation: &gardencorev1beta1.LastOperation{
+						Type: v1beta1.LastOperationTypeReconcile,
+					},
+				},
+			})
+
+			Expect(botanist.DestroySourceBackupEntry(ctx)).To(Succeed())
+		})
+
+		It("should destroy the SourceBackupEntry component", func() {
+			defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.CopyEtcdBackupsDuringControlPlaneMigration, true)()
+
+			sourceBackupEntry.EXPECT().Destroy(ctx)
+
+			Expect(botanist.DestroySourceBackupEntry(ctx)).To(Succeed())
+		})
+	})
+})

--- a/pkg/operation/botanist/migration_test.go
+++ b/pkg/operation/botanist/migration_test.go
@@ -24,7 +24,7 @@ import (
 	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 	"github.com/gardener/gardener/pkg/operation"
 	. "github.com/gardener/gardener/pkg/operation/botanist"
-	mockbackupntry "github.com/gardener/gardener/pkg/operation/botanist/component/backupentry/mock"
+	mockbackupentry "github.com/gardener/gardener/pkg/operation/botanist/component/backupentry/mock"
 	mocketcd "github.com/gardener/gardener/pkg/operation/botanist/component/etcd/mock"
 	mockcontainerruntime "github.com/gardener/gardener/pkg/operation/botanist/component/extensions/containerruntime/mock"
 	mockcontrolplane "github.com/gardener/gardener/pkg/operation/botanist/component/extensions/controlplane/mock"
@@ -192,8 +192,8 @@ var _ = Describe("migration", func() {
 	Describe("#IsCopyOfBackupsRequired", func() {
 		var (
 			etcdMain          *mocketcd.MockInterface
-			backupEntry       *mockbackupntry.MockInterface
-			sourceBackupEntry *mockbackupntry.MockInterface
+			backupEntry       *mockbackupentry.MockInterface
+			sourceBackupEntry *mockbackupentry.MockInterface
 			fakeErr           = errors.New("Fake error")
 		)
 
@@ -224,8 +224,8 @@ var _ = Describe("migration", func() {
 			})
 
 			etcdMain = mocketcd.NewMockInterface(ctrl)
-			backupEntry = mockbackupntry.NewMockInterface(ctrl)
-			sourceBackupEntry = mockbackupntry.NewMockInterface(ctrl)
+			backupEntry = mockbackupentry.NewMockInterface(ctrl)
+			sourceBackupEntry = mockbackupentry.NewMockInterface(ctrl)
 			botanist.Shoot.Components.ControlPlane = &shootpkg.ControlPlane{
 				EtcdMain: etcdMain,
 			}


### PR DESCRIPTION
/area quality
/kind bug

Running `Destroying source backup entry` task with SeedAuthorizer enabled is causing issues - see https://github.com/gardener/gardener/pull/5066.

@plkokanov suggested that we should rather run the `Destroying source backup entry` task when the current operation is restore and when the CopyEtcdBackupsDuringControlPlaneMigration feature gate is enabled.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
