### PR TITLE
enable to allow certain AuthInfo fields

### DIFF
--- a/pkg/client/kubernetes/client.go
+++ b/pkg/client/kubernetes/client.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/gardener/gardener/pkg/utils"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -47,8 +48,22 @@ var (
 	UseCachedRuntimeClients = false
 )
 
-// KubeConfig is the key to the kubeconfig
-const KubeConfig = "kubeconfig"
+const (
+	// KubeConfig is the key to the kubeconfig
+	KubeConfig = "kubeconfig"
+	// AuthClientCertificate references the AuthInfo.ClientCertificate field of a kubeconfig
+	AuthClientCertificate = "client-certificate"
+	// AuthClientKey references the AuthInfo.ClientKey field of a kubeconfig
+	AuthClientKey = "client-key"
+	// AuthTokenFile references the AuthInfo.Tokenfile field of a kubeconfig
+	AuthTokenFile = "tokenFile"
+	// AuthImpersonate references the AuthInfo.Impersonate field of a kubeconfig
+	AuthImpersonate = "act-as"
+	// AuthProvider references the AuthInfo.AuthProvider field of a kubeconfig
+	AuthProvider = "auth-provider"
+	// AuthExec references the AuthInfo.Exec field of a kubeconfig
+	AuthExec = "exec"
+)
 
 func init() {
 	// enable protobuf for Gardener API for controller-runtime clients
@@ -80,16 +95,13 @@ func NewClientFromFile(masterURL, kubeconfigPath string, fns ...ConfigFunc) (Int
 		&clientcmd.ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{Server: masterURL}},
 	)
 
-	if err := validateClientConfig(clientConfig); err != nil {
-		return nil, err
-	}
-
 	config, err := clientConfig.ClientConfig()
 	if err != nil {
 		return nil, err
 	}
 
-	opts := append([]ConfigFunc{WithRESTConfig(config)}, fns...)
+	opts := append([]ConfigFunc{WithRESTConfig(config), WithClientConfig(clientConfig)}, fns...)
+
 	return NewWithConfig(opts...)
 }
 
@@ -142,7 +154,7 @@ func RESTConfigFromClientConnectionConfiguration(cfg *componentbaseconfig.Client
 			&clientcmd.ConfigOverrides{ClusterInfo: clientcmdapi.Cluster{Server: ""}},
 		)
 
-		if err := validateClientConfig(clientConfig); err != nil {
+		if err := validateClientConfig(clientConfig, nil); err != nil {
 			return nil, err
 		}
 
@@ -174,7 +186,7 @@ func RESTConfigFromKubeconfig(kubeconfig []byte) (*rest.Config, error) {
 		return nil, err
 	}
 
-	if err := validateClientConfig(clientConfig); err != nil {
+	if err := validateClientConfig(clientConfig, nil); err != nil {
 		return nil, err
 	}
 
@@ -185,35 +197,44 @@ func RESTConfigFromKubeconfig(kubeconfig []byte) (*rest.Config, error) {
 	return restConfig, nil
 }
 
-func validateClientConfig(clientConfig clientcmd.ClientConfig) error {
+func validateClientConfig(clientConfig clientcmd.ClientConfig, allowedFields []string) error {
+	if clientConfig == nil {
+		return nil
+	}
+
 	rawConfig, err := clientConfig.RawConfig()
 	if err != nil {
 		return err
 	}
-	return ValidateConfig(rawConfig)
+	return ValidateConfigWithAllowList(rawConfig, allowedFields)
 }
 
 // ValidateConfig validates that the auth info of a given kubeconfig doesn't have unsupported fields.
 func ValidateConfig(config clientcmdapi.Config) error {
+	return ValidateConfigWithAllowList(config, nil)
+}
+
+// ValidateConfigWithAllowList validates that the auth info of a given kubeconfig doesn't have unsupported fields. It takes an additional list of allowed fields.
+func ValidateConfigWithAllowList(config clientcmdapi.Config, allowedFields []string) error {
 	validFields := []string{"client-certificate-data", "client-key-data", "token", "username", "password"}
+	validFields = append(validFields, allowedFields...)
 
 	for user, authInfo := range config.AuthInfos {
 		switch {
-		case authInfo.ClientCertificate != "":
+		case authInfo.ClientCertificate != "" && !utils.ValueExists(AuthClientCertificate, validFields):
 			return fmt.Errorf("client certificate files are not supported (user %q), these are the valid fields: %+v", user, validFields)
-		case authInfo.ClientKey != "":
+		case authInfo.ClientKey != "" && !utils.ValueExists(AuthClientKey, validFields):
 			return fmt.Errorf("client key files are not supported (user %q), these are the valid fields: %+v", user, validFields)
-		case authInfo.TokenFile != "":
+		case authInfo.TokenFile != "" && !utils.ValueExists(AuthTokenFile, validFields):
 			return fmt.Errorf("token files are not supported (user %q), these are the valid fields: %+v", user, validFields)
-		case authInfo.Impersonate != "" || len(authInfo.ImpersonateGroups) > 0:
+		case (authInfo.Impersonate != "" || len(authInfo.ImpersonateGroups) > 0) && !utils.ValueExists(AuthImpersonate, validFields):
 			return fmt.Errorf("impersonation is not supported, these are the valid fields: %+v", validFields)
-		case authInfo.AuthProvider != nil && len(authInfo.AuthProvider.Config) > 0:
+		case (authInfo.AuthProvider != nil && len(authInfo.AuthProvider.Config) > 0) && !utils.ValueExists(AuthProvider, validFields):
 			return fmt.Errorf("auth provider configurations are not supported (user %q), these are the valid fields: %+v", user, validFields)
-		case authInfo.Exec != nil:
+		case authInfo.Exec != nil && !utils.ValueExists(AuthExec, validFields):
 			return fmt.Errorf("exec configurations are not supported (user %q), these are the valid fields: %+v", user, validFields)
 		}
 	}
-
 	return nil
 }
 
@@ -256,6 +277,10 @@ func NewWithConfig(fns ...ConfigFunc) (Interface, error) {
 }
 
 func newClientSet(conf *Config) (Interface, error) {
+	if err := validateClientConfig(conf.clientConfig, conf.allowedUserFields); err != nil {
+		return nil, err
+	}
+
 	if err := setConfigDefaults(conf); err != nil {
 		return nil, err
 	}

--- a/pkg/client/kubernetes/client_test.go
+++ b/pkg/client/kubernetes/client_test.go
@@ -15,15 +15,15 @@
 package kubernetes_test
 
 import (
-	"fmt"
-
 	"github.com/gardener/gardener/pkg/client/kubernetes"
+
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	gomegatypes "github.com/onsi/gomega/types"
+
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
-
-const impersonateGroup = "act-as-group"
 
 var _ = Describe("Client", func() {
 
@@ -31,8 +31,6 @@ var _ = Describe("Client", func() {
 		authInfo clientcmdapi.AuthInfo
 		config   clientcmdapi.Config
 	)
-
-	fieldsToTest := []string{kubernetes.AuthTokenFile, kubernetes.AuthImpersonate, impersonateGroup, kubernetes.AuthExec, kubernetes.AuthProvider, kubernetes.AuthClientCertificate, kubernetes.AuthClientKey}
 
 	BeforeEach(func() {
 		authInfo = clientcmdapi.AuthInfo{}
@@ -43,83 +41,271 @@ var _ = Describe("Client", func() {
 		}
 	})
 
-	Context("ValidateConfig", func() {
-		It("An empty Kubeconfig should with be validated successfully", func() {
+	Describe("#ValidateConfig", func() {
+		It("should not return an error for an empty kubeconfig", func() {
 			err := kubernetes.ValidateConfig(config)
 			Expect(err).ToNot(HaveOccurred())
 		})
-		It("A Kubeconfig with a valid field should with be validated successfully", func() {
+
+		It("should not return an error for a kubeconfig with valid field", func() {
 			config.AuthInfos["test"].Token = "test"
 
 			err := kubernetes.ValidateConfig(config)
 			Expect(err).ToNot(HaveOccurred())
 		})
-		for _, field := range fieldsToTest {
-			It(fmt.Sprintf("A kubeconfig with %s should be validated properly", field), func() {
-				switch field {
-				case kubernetes.AuthProvider:
-					config.AuthInfos["test"].AuthProvider = &clientcmdapi.AuthProviderConfig{Config: map[string]string{"provider": "test"}}
-				case kubernetes.AuthExec:
-					config.AuthInfos["test"].Exec = &clientcmdapi.ExecConfig{Command: "/bin/test"}
-				case kubernetes.AuthTokenFile:
-					config.AuthInfos["test"].TokenFile = "test"
-				case kubernetes.AuthImpersonate:
-					config.AuthInfos["test"].Impersonate = "test"
-				case impersonateGroup:
-					config.AuthInfos["test"].ImpersonateGroups = []string{"test"}
-				case kubernetes.AuthClientKey:
-					config.AuthInfos["test"].ClientKey = "test"
-				case kubernetes.AuthClientCertificate:
-					config.AuthInfos["test"].ClientCertificate = "test"
-				}
+
+		DescribeTable("kubeconfig shoud be validated properly",
+			func(config clientcmdapi.Config, matcher gomegatypes.GomegaMatcher) {
 				err := kubernetes.ValidateConfig(config)
-				Expect(err).To(HaveOccurred())
-			})
-		}
+
+				Expect(err).To(matcher)
+			},
+			Entry("auth-provider",
+				clientcmdapi.Config{
+					AuthInfos: map[string]*clientcmdapi.AuthInfo{
+						"test": {
+							AuthProvider: &clientcmdapi.AuthProviderConfig{Config: map[string]string{"provider": "test"}},
+						},
+					},
+				},
+				HaveOccurred(),
+			),
+			Entry("exec",
+				clientcmdapi.Config{
+					AuthInfos: map[string]*clientcmdapi.AuthInfo{
+						"test": {
+							Exec: &clientcmdapi.ExecConfig{Command: "/bin/test"},
+						},
+					},
+				},
+				HaveOccurred(),
+			),
+			Entry("tokenFile",
+				clientcmdapi.Config{
+					AuthInfos: map[string]*clientcmdapi.AuthInfo{
+						"test": {
+							TokenFile: "test",
+						},
+					},
+				},
+				HaveOccurred(),
+			),
+			Entry("act-as",
+				clientcmdapi.Config{
+					AuthInfos: map[string]*clientcmdapi.AuthInfo{
+						"test": {
+							Impersonate: "test",
+						},
+					},
+				},
+				HaveOccurred(),
+			),
+			Entry("act-as-group",
+				clientcmdapi.Config{
+					AuthInfos: map[string]*clientcmdapi.AuthInfo{
+						"test": {
+							ImpersonateGroups: []string{"test"},
+						},
+					},
+				},
+				HaveOccurred(),
+			),
+			Entry("client-key",
+				clientcmdapi.Config{
+					AuthInfos: map[string]*clientcmdapi.AuthInfo{
+						"test": {
+							ClientKey: "test",
+						},
+					},
+				},
+				HaveOccurred(),
+			),
+			Entry("client-certificate",
+				clientcmdapi.Config{
+					AuthInfos: map[string]*clientcmdapi.AuthInfo{
+						"test": {
+							ClientCertificate: "test",
+						},
+					},
+				},
+				HaveOccurred(),
+			),
+		)
 	})
 
-	Context("ValidateConfigWithAllowList", func() {
-		It("An empty Kubeconfig should with be validated successfully", func() {
+	Describe("#ValidateConfigWithAllowList", func() {
+		It("should not return an error for an empty kubeconfig", func() {
 			err := kubernetes.ValidateConfigWithAllowList(config, nil)
 			Expect(err).ToNot(HaveOccurred())
 		})
-		It("A Kubeconfig with valid fields should with be validated successfully", func() {
+
+		It("should not return an error for a kubeconfig with valid field", func() {
 			config.AuthInfos["test"].Token = "test"
 
 			err := kubernetes.ValidateConfigWithAllowList(config, nil)
 			Expect(err).ToNot(HaveOccurred())
 		})
-		for _, field := range fieldsToTest {
-			It(fmt.Sprintf("A kubeconfig with %s should be validated properly", field), func() {
-				var allowedFields []string
-				switch field {
-				case kubernetes.AuthProvider:
-					allowedFields = append(allowedFields, kubernetes.AuthProvider)
-					config.AuthInfos["test"].AuthProvider = &clientcmdapi.AuthProviderConfig{Config: map[string]string{"provider": "test"}}
-				case kubernetes.AuthExec:
-					allowedFields = append(allowedFields, kubernetes.AuthExec)
-					config.AuthInfos["test"].Exec = &clientcmdapi.ExecConfig{Command: "/bin/test"}
-				case kubernetes.AuthTokenFile:
-					allowedFields = append(allowedFields, kubernetes.AuthTokenFile)
-					config.AuthInfos["test"].TokenFile = "test"
-				case kubernetes.AuthImpersonate:
-					allowedFields = append(allowedFields, kubernetes.AuthImpersonate)
-					config.AuthInfos["test"].Impersonate = "test"
-				case impersonateGroup:
-					allowedFields = append(allowedFields, kubernetes.AuthImpersonate)
-					config.AuthInfos["test"].ImpersonateGroups = []string{"test"}
-				case kubernetes.AuthClientKey:
-					allowedFields = append(allowedFields, kubernetes.AuthClientKey)
-					config.AuthInfos["test"].ClientKey = "test"
-				case kubernetes.AuthClientCertificate:
-					allowedFields = append(allowedFields, kubernetes.AuthClientCertificate)
-					config.AuthInfos["test"].ClientCertificate = "test"
-				}
+
+		DescribeTable("kubeconfig should be validated properly",
+			func(config clientcmdapi.Config, allowedFields []string, matcher gomegatypes.GomegaMatcher) {
 				err := kubernetes.ValidateConfigWithAllowList(config, allowedFields)
-				Expect(err).ToNot(HaveOccurred())
-				err = kubernetes.ValidateConfigWithAllowList(config, nil)
-				Expect(err).To(HaveOccurred())
-			})
-		}
+
+				Expect(err).To(matcher)
+			},
+			Entry("reject auth-provider",
+				clientcmdapi.Config{
+					AuthInfos: map[string]*clientcmdapi.AuthInfo{
+						"test": {
+							AuthProvider: &clientcmdapi.AuthProviderConfig{Config: map[string]string{"provider": "test"}},
+						},
+					},
+				},
+				nil,
+				HaveOccurred(),
+			),
+			Entry("accept auth-provider",
+				clientcmdapi.Config{
+					AuthInfos: map[string]*clientcmdapi.AuthInfo{
+						"test": {
+							AuthProvider: &clientcmdapi.AuthProviderConfig{Config: map[string]string{"provider": "test"}},
+						},
+					},
+				},
+				[]string{kubernetes.AuthProvider},
+				Not(HaveOccurred()),
+			),
+			Entry("reject exec",
+				clientcmdapi.Config{
+					AuthInfos: map[string]*clientcmdapi.AuthInfo{
+						"test": {
+							Exec: &clientcmdapi.ExecConfig{Command: "/bin/test"},
+						},
+					},
+				},
+				nil,
+				HaveOccurred(),
+			),
+			Entry("accept exec",
+				clientcmdapi.Config{
+					AuthInfos: map[string]*clientcmdapi.AuthInfo{
+						"test": {
+							Exec: &clientcmdapi.ExecConfig{Command: "/bin/test"},
+						},
+					},
+				},
+				[]string{kubernetes.AuthExec},
+				Not(HaveOccurred()),
+			),
+			Entry("reject tokenFile",
+				clientcmdapi.Config{
+					AuthInfos: map[string]*clientcmdapi.AuthInfo{
+						"test": {
+							TokenFile: "test",
+						},
+					},
+				},
+				nil,
+				HaveOccurred(),
+			),
+			Entry("accept tokenFile",
+				clientcmdapi.Config{
+					AuthInfos: map[string]*clientcmdapi.AuthInfo{
+						"test": {
+							TokenFile: "test",
+						},
+					},
+				},
+				[]string{kubernetes.AuthTokenFile},
+				Not(HaveOccurred()),
+			),
+			Entry("reject act-as",
+				clientcmdapi.Config{
+					AuthInfos: map[string]*clientcmdapi.AuthInfo{
+						"test": {
+							Impersonate: "test",
+						},
+					},
+				},
+				nil,
+				HaveOccurred(),
+			),
+			Entry("accept act-as",
+				clientcmdapi.Config{
+					AuthInfos: map[string]*clientcmdapi.AuthInfo{
+						"test": {
+							Impersonate: "test",
+						},
+					},
+				},
+				[]string{kubernetes.AuthImpersonate},
+				Not(HaveOccurred()),
+			),
+			Entry("reject act-as-group",
+				clientcmdapi.Config{
+					AuthInfos: map[string]*clientcmdapi.AuthInfo{
+						"test": {
+							ImpersonateGroups: []string{"test"},
+						},
+					},
+				},
+				nil,
+				HaveOccurred(),
+			),
+			Entry("accept act-as-group",
+				clientcmdapi.Config{
+					AuthInfos: map[string]*clientcmdapi.AuthInfo{
+						"test": {
+							ImpersonateGroups: []string{"test"},
+						},
+					},
+				},
+				[]string{kubernetes.AuthImpersonate},
+				Not(HaveOccurred()),
+			),
+			Entry("reject client-key",
+				clientcmdapi.Config{
+					AuthInfos: map[string]*clientcmdapi.AuthInfo{
+						"test": {
+							ClientKey: "test",
+						},
+					},
+				},
+				nil,
+				HaveOccurred(),
+			),
+			Entry("accept client-key",
+				clientcmdapi.Config{
+					AuthInfos: map[string]*clientcmdapi.AuthInfo{
+						"test": {
+							ClientKey: "test",
+						},
+					},
+				},
+				[]string{kubernetes.AuthClientKey},
+				Not(HaveOccurred()),
+			),
+			Entry("reject client-certificate",
+				clientcmdapi.Config{
+					AuthInfos: map[string]*clientcmdapi.AuthInfo{
+						"test": {
+							ClientCertificate: "test",
+						},
+					},
+				},
+				[]string{""},
+				HaveOccurred(),
+			),
+			Entry("accept client-certificate",
+				clientcmdapi.Config{
+					AuthInfos: map[string]*clientcmdapi.AuthInfo{
+						"test": {
+							ClientCertificate: "test",
+						},
+					},
+				},
+				[]string{kubernetes.AuthClientCertificate},
+				Not(HaveOccurred()),
+			),
+		)
 	})
 })

--- a/pkg/client/kubernetes/client_test.go
+++ b/pkg/client/kubernetes/client_test.go
@@ -1,0 +1,125 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kubernetes_test
+
+import (
+	"fmt"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
+)
+
+const impersonateGroup = "act-as-group"
+
+var _ = Describe("Client", func() {
+
+	var (
+		authInfo clientcmdapi.AuthInfo
+		config   clientcmdapi.Config
+	)
+
+	fieldsToTest := []string{kubernetes.AuthTokenFile, kubernetes.AuthImpersonate, impersonateGroup, kubernetes.AuthExec, kubernetes.AuthProvider, kubernetes.AuthClientCertificate, kubernetes.AuthClientKey}
+
+	BeforeEach(func() {
+		authInfo = clientcmdapi.AuthInfo{}
+		config = clientcmdapi.Config{
+			AuthInfos: map[string]*clientcmdapi.AuthInfo{
+				"test": &authInfo,
+			},
+		}
+	})
+
+	Context("ValidateConfig", func() {
+		It("An empty Kubeconfig should with be validated successfully", func() {
+			err := kubernetes.ValidateConfig(config)
+			Expect(err).ToNot(HaveOccurred())
+		})
+		It("A Kubeconfig with a valid field should with be validated successfully", func() {
+			config.AuthInfos["test"].Token = "test"
+
+			err := kubernetes.ValidateConfig(config)
+			Expect(err).ToNot(HaveOccurred())
+		})
+		for _, field := range fieldsToTest {
+			It(fmt.Sprintf("A kubeconfig with %s should be validated properly", field), func() {
+				switch field {
+				case kubernetes.AuthProvider:
+					config.AuthInfos["test"].AuthProvider = &clientcmdapi.AuthProviderConfig{Config: map[string]string{"provider": "test"}}
+				case kubernetes.AuthExec:
+					config.AuthInfos["test"].Exec = &clientcmdapi.ExecConfig{Command: "/bin/test"}
+				case kubernetes.AuthTokenFile:
+					config.AuthInfos["test"].TokenFile = "test"
+				case kubernetes.AuthImpersonate:
+					config.AuthInfos["test"].Impersonate = "test"
+				case impersonateGroup:
+					config.AuthInfos["test"].ImpersonateGroups = []string{"test"}
+				case kubernetes.AuthClientKey:
+					config.AuthInfos["test"].ClientKey = "test"
+				case kubernetes.AuthClientCertificate:
+					config.AuthInfos["test"].ClientCertificate = "test"
+				}
+				err := kubernetes.ValidateConfig(config)
+				Expect(err).To(HaveOccurred())
+			})
+		}
+	})
+
+	Context("ValidateConfigWithAllowList", func() {
+		It("An empty Kubeconfig should with be validated successfully", func() {
+			err := kubernetes.ValidateConfigWithAllowList(config, nil)
+			Expect(err).ToNot(HaveOccurred())
+		})
+		It("A Kubeconfig with valid fields should with be validated successfully", func() {
+			config.AuthInfos["test"].Token = "test"
+
+			err := kubernetes.ValidateConfigWithAllowList(config, nil)
+			Expect(err).ToNot(HaveOccurred())
+		})
+		for _, field := range fieldsToTest {
+			It(fmt.Sprintf("A kubeconfig with %s should be validated properly", field), func() {
+				var allowedFields []string
+				switch field {
+				case kubernetes.AuthProvider:
+					allowedFields = append(allowedFields, kubernetes.AuthProvider)
+					config.AuthInfos["test"].AuthProvider = &clientcmdapi.AuthProviderConfig{Config: map[string]string{"provider": "test"}}
+				case kubernetes.AuthExec:
+					allowedFields = append(allowedFields, kubernetes.AuthExec)
+					config.AuthInfos["test"].Exec = &clientcmdapi.ExecConfig{Command: "/bin/test"}
+				case kubernetes.AuthTokenFile:
+					allowedFields = append(allowedFields, kubernetes.AuthTokenFile)
+					config.AuthInfos["test"].TokenFile = "test"
+				case kubernetes.AuthImpersonate:
+					allowedFields = append(allowedFields, kubernetes.AuthImpersonate)
+					config.AuthInfos["test"].Impersonate = "test"
+				case impersonateGroup:
+					allowedFields = append(allowedFields, kubernetes.AuthImpersonate)
+					config.AuthInfos["test"].ImpersonateGroups = []string{"test"}
+				case kubernetes.AuthClientKey:
+					allowedFields = append(allowedFields, kubernetes.AuthClientKey)
+					config.AuthInfos["test"].ClientKey = "test"
+				case kubernetes.AuthClientCertificate:
+					allowedFields = append(allowedFields, kubernetes.AuthClientCertificate)
+					config.AuthInfos["test"].ClientCertificate = "test"
+				}
+				err := kubernetes.ValidateConfigWithAllowList(config, allowedFields)
+				Expect(err).ToNot(HaveOccurred())
+				err = kubernetes.ValidateConfigWithAllowList(config, nil)
+				Expect(err).To(HaveOccurred())
+			})
+		}
+	})
+})

--- a/pkg/client/kubernetes/options.go
+++ b/pkg/client/kubernetes/options.go
@@ -18,9 +18,8 @@ import (
 	"errors"
 	"time"
 
-	"k8s.io/client-go/tools/clientcmd"
-
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 	baseconfig "k8s.io/component-base/config"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/client/kubernetes/options.go
+++ b/pkg/client/kubernetes/options.go
@@ -18,6 +18,8 @@ import (
 	"errors"
 	"time"
 
+	"k8s.io/client-go/tools/clientcmd"
+
 	"k8s.io/client-go/rest"
 	baseconfig "k8s.io/component-base/config"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
@@ -26,12 +28,14 @@ import (
 
 // Config carries options for new ClientSets.
 type Config struct {
-	newRuntimeCache cache.NewCacheFunc
-	clientOptions   client.Options
-	restConfig      *rest.Config
-	cacheResync     *time.Duration
-	disableCache    bool
-	uncachedObjects []client.Object
+	newRuntimeCache   cache.NewCacheFunc
+	clientOptions     client.Options
+	restConfig        *rest.Config
+	cacheResync       *time.Duration
+	disableCache      bool
+	uncachedObjects   []client.Object
+	allowedUserFields []string
+	clientConfig      clientcmd.ClientConfig
 }
 
 // NewConfig returns a new Config with an empty REST config to allow testing ConfigFuncs without exporting
@@ -106,6 +110,22 @@ func WithUncached(objs ...client.Object) ConfigFunc {
 func WithNewCacheFunc(fn cache.NewCacheFunc) ConfigFunc {
 	return func(config *Config) error {
 		config.newRuntimeCache = fn
+		return nil
+	}
+}
+
+// WithAllowedUserFields allows to specify additional kubeconfig.user fields allowed during validation.
+func WithAllowedUserFields(allowedUserFields []string) ConfigFunc {
+	return func(config *Config) error {
+		config.allowedUserFields = allowedUserFields
+		return nil
+	}
+}
+
+// WithClientConfig adds a ClientConfig for validation at a later stage.
+func WithClientConfig(clientConfig clientcmd.ClientConfig) ConfigFunc {
+	return func(config *Config) error {
+		config.clientConfig = clientConfig
 		return nil
 	}
 }

--- a/test/framework/gardenerframework.go
+++ b/test/framework/gardenerframework.go
@@ -90,6 +90,7 @@ func (f *GardenerFramework) BeforeEach() {
 		client.Options{
 			Scheme: kubernetes.GardenScheme,
 		}),
+		kubernetes.WithAllowedUserFields([]string{kubernetes.AuthTokenFile}),
 	)
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	f.GardenClient = gardenClient


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
Testmachinery will support the use of kubeconfigs with a `tokenFile` in combination with OpenIDConnect (https://github.com/gardener/test-infra/pull/379). The Gardener test framework will be invoked with a kubeconfig provided via the TestRun. 

However, the client used in the Gardener test framework denies the usage of a `tokenFile`.

This PR enables the validation to be parameterized with additionally allowed fields and expands the the test framework to allow a `tokenFile`. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```
NONE
```
