### PR TITLE
Enhanced the usage doc for NodeLocalDNS

### DIFF
--- a/docs/usage/node-local-dns.md
+++ b/docs/usage/node-local-dns.md
@@ -31,6 +31,9 @@ All that needs to be done to enable the usage of the `node-local-dns` feature is
 It is worth noting that: 
 
 - When migrating from IPVS to IPTables, existing pods will continue to leverage the node-local-dns cache. 
-- When migrating from IPtables to IPVS, only newer pods will be switched to the node-local-dns cache. 
+- When migrating from IPtables to IPVS, only newer pods will be switched to the node-local-dns cache.
+- The annotation will take effect during the next shoot reconciliation. This happens automatically once per day in the maintenance period (unless you have disabled it). 
+- During the reconfiguration of the node-local-dns there might be a short disruption in terms of domain name resolution depending on the setup. Usually, dns requests are repeated for some time as udp is an unreliable protocol, but that strictly depends on the application/way the domain name resolution happens. It is recommended to let the shoot be reconciled during the next maintenance period. 
+- If a short DNS outage is not a big issue, you can [trigger reconciliation](./shoot_operations.md#immediate-reconciliation) directly after setting the annotation.
 
 For more information about `node-local-dns` please refer to the [KEP](https://github.com/kubernetes/enhancements/blob/master/keps/sig-network/1024-nodelocal-cache-dns/README.md) or to the [usage documentation](https://kubernetes.io/docs/tasks/administer-cluster/nodelocaldns/). 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/area ops-productivity
/area networking
/kind cleanup

**What this PR does / why we need it**:
Enhanced the usage document for `NodeLocalDNS` with explanation on effects during shoot reconciliation  and recommendation for the same. The current usage doesn't touch upon these aspects and having this information can enable the consumer of the feature make an informed decision. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@ScheererJ - The wording is taken from your recent recommendation to one of the consumer of the feature. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc user
The usage document for NodeLocalDNS is now enhanced with explanation on effects during shoot reconciliation  and recommendation for the same.
```
