### PR TITLE
ManagedSeed: Do not add the Shoot cloud provider credentials into the Seed kubeconfig Secret

### DIFF
--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -1324,8 +1324,8 @@ Kubernetes core/v1.SecretReference
 </td>
 <td>
 <em>(Optional)</em>
-<p>SecretRef is a reference to a Secret object containing the Kubeconfig and the cloud provider credentials for
-the account the Seed cluster has been deployed to.</p>
+<p>SecretRef is a reference to a Secret object containing the Kubeconfig of the Kubernetes
+cluster to be registered as Seed.</p>
 </td>
 </tr>
 <tr>
@@ -8028,8 +8028,8 @@ Kubernetes core/v1.SecretReference
 </td>
 <td>
 <em>(Optional)</em>
-<p>SecretRef is a reference to a Secret object containing the Kubeconfig and the cloud provider credentials for
-the account the Seed cluster has been deployed to.</p>
+<p>SecretRef is a reference to a Secret object containing the Kubeconfig of the Kubernetes
+cluster to be registered as Seed.</p>
 </td>
 </tr>
 <tr>
@@ -8370,8 +8370,8 @@ Kubernetes core/v1.SecretReference
 </td>
 <td>
 <em>(Optional)</em>
-<p>SecretRef is a reference to a Secret object containing the Kubeconfig and the cloud provider credentials for
-the account the Seed cluster has been deployed to.</p>
+<p>SecretRef is a reference to a Secret object containing the Kubeconfig of the Kubernetes
+cluster to be registered as Seed.</p>
 </td>
 </tr>
 <tr>

--- a/pkg/apis/core/types_seed.go
+++ b/pkg/apis/core/types_seed.go
@@ -68,8 +68,8 @@ type SeedSpec struct {
 	Networks SeedNetworks
 	// Provider defines the provider type and region for this Seed cluster.
 	Provider SeedProvider
-	// SecretRef is a reference to a Secret object containing the Kubeconfig and the cloud provider credentials for
-	// the account the Seed cluster has been deployed to.
+	// SecretRef is a reference to a Secret object containing the Kubeconfig of the Kubernetes
+	// cluster to be registered as Seed.
 	SecretRef *corev1.SecretReference
 	// Settings contains certain settings for this seed cluster.
 	Settings *SeedSettings

--- a/pkg/apis/core/v1alpha1/generated.proto
+++ b/pkg/apis/core/v1alpha1/generated.proto
@@ -2026,8 +2026,8 @@ message SeedSpec {
   // Provider defines the provider type and region for this Seed cluster.
   optional SeedProvider provider = 5;
 
-  // SecretRef is a reference to a Secret object containing the Kubeconfig and the cloud provider credentials for
-  // the account the Seed cluster has been deployed to.
+  // SecretRef is a reference to a Secret object containing the Kubeconfig of the Kubernetes
+  // cluster to be registered as Seed.
   // +optional
   optional k8s.io.api.core.v1.SecretReference secretRef = 6;
 

--- a/pkg/apis/core/v1alpha1/types_seed.go
+++ b/pkg/apis/core/v1alpha1/types_seed.go
@@ -66,8 +66,8 @@ type SeedSpec struct {
 	Networks SeedNetworks `json:"networks" protobuf:"bytes,4,opt,name=networks"`
 	// Provider defines the provider type and region for this Seed cluster.
 	Provider SeedProvider `json:"provider" protobuf:"bytes,5,opt,name=provider"`
-	// SecretRef is a reference to a Secret object containing the Kubeconfig and the cloud provider credentials for
-	// the account the Seed cluster has been deployed to.
+	// SecretRef is a reference to a Secret object containing the Kubeconfig of the Kubernetes
+	// cluster to be registered as Seed.
 	// +optional
 	SecretRef *corev1.SecretReference `json:"secretRef,omitempty" protobuf:"bytes,6,opt,name=secretRef"`
 	// Taints describes taints on the seed.

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -1928,8 +1928,8 @@ message SeedSpec {
   // Provider defines the provider type and region for this Seed cluster.
   optional SeedProvider provider = 4;
 
-  // SecretRef is a reference to a Secret object containing the Kubeconfig and the cloud provider credentials for
-  // the account the Seed cluster has been deployed to.
+  // SecretRef is a reference to a Secret object containing the Kubeconfig of the Kubernetes
+  // cluster to be registered as Seed.
   // +optional
   optional k8s.io.api.core.v1.SecretReference secretRef = 5;
 

--- a/pkg/apis/core/v1beta1/types_seed.go
+++ b/pkg/apis/core/v1beta1/types_seed.go
@@ -72,8 +72,8 @@ type SeedSpec struct {
 	Networks SeedNetworks `json:"networks" protobuf:"bytes,3,opt,name=networks"`
 	// Provider defines the provider type and region for this Seed cluster.
 	Provider SeedProvider `json:"provider" protobuf:"bytes,4,opt,name=provider"`
-	// SecretRef is a reference to a Secret object containing the Kubeconfig and the cloud provider credentials for
-	// the account the Seed cluster has been deployed to.
+	// SecretRef is a reference to a Secret object containing the Kubeconfig of the Kubernetes
+	// cluster to be registered as Seed.
 	// +optional
 	SecretRef *corev1.SecretReference `json:"secretRef,omitempty" protobuf:"bytes,5,opt,name=secretRef"`
 	// Taints describes taints on the seed.

--- a/pkg/gardenlet/controller/managedseed/managedseed_actuator.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_actuator.go
@@ -488,10 +488,6 @@ func (a *actuator) createOrUpdateSeedSecrets(ctx context.Context, spec *gardenco
 			return err
 		}
 
-		// Initialize seed secret data
-		data := shootSecret.Data
-		data[kubernetes.KubeConfig] = shootKubeconfigSecret.Data[kubernetes.KubeConfig]
-
 		// Create or update seed secret
 		secret := &corev1.Secret{
 			ObjectMeta: kutil.ObjectMeta(spec.SecretRef.Namespace, spec.SecretRef.Name),
@@ -501,7 +497,9 @@ func (a *actuator) createOrUpdateSeedSecrets(ctx context.Context, spec *gardenco
 				*metav1.NewControllerRef(managedSeed, seedmanagementv1alpha1.SchemeGroupVersion.WithKind("ManagedSeed")),
 			}
 			secret.Type = corev1.SecretTypeOpaque
-			secret.Data = data
+			secret.Data = map[string][]byte{
+				kubernetes.KubeConfig: shootKubeconfigSecret.Data[kubernetes.KubeConfig],
+			}
 			return nil
 		}); err != nil {
 			return err

--- a/pkg/gardenlet/controller/managedseed/managedseed_actuator_test.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_actuator_test.go
@@ -263,7 +263,6 @@ var _ = Describe("Actuator", func() {
 				},
 			},
 			Data: map[string][]byte{
-				"foo":        []byte("bar"),
 				"kubeconfig": []byte("kubeconfig"),
 			},
 			Type: corev1.SecretTypeOpaque,

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -6428,7 +6428,7 @@ func schema_pkg_apis_core_v1alpha1_SeedSpec(ref common.ReferenceCallback) common
 					},
 					"secretRef": {
 						SchemaProps: spec.SchemaProps{
-							Description: "SecretRef is a reference to a Secret object containing the Kubeconfig and the cloud provider credentials for the account the Seed cluster has been deployed to.",
+							Description: "SecretRef is a reference to a Secret object containing the Kubeconfig of the Kubernetes cluster to be registered as Seed.",
 							Ref:         ref("k8s.io/api/core/v1.SecretReference"),
 						},
 					},
@@ -13234,7 +13234,7 @@ func schema_pkg_apis_core_v1beta1_SeedSpec(ref common.ReferenceCallback) common.
 					},
 					"secretRef": {
 						SchemaProps: spec.SchemaProps{
-							Description: "SecretRef is a reference to a Secret object containing the Kubeconfig and the cloud provider credentials for the account the Seed cluster has been deployed to.",
+							Description: "SecretRef is a reference to a Secret object containing the Kubeconfig of the Kubernetes cluster to be registered as Seed.",
 							Ref:         ref("k8s.io/api/core/v1.SecretReference"),
 						},
 					},


### PR DESCRIPTION
/area documentation
/area control-plane
/kind cleanup

I am not aware of cloud provider credentials that should be passed with Seed `spec.secretRef` field. The backup cloud provider credentials are passed via `spec.backup.secretRef`. To me it seems like the doc string is outdated. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The ManagedSeed controller does no longer add the Shoot cloud provider credentials into the Seed kubeconfig Secret (Seed `.spec.secretRef`).
```
