### PR TITLE
Fixed a couple of panels in the istio mesh dashboard and exposed the istio http metrics.

### DIFF
--- a/charts/istio/istio-ingress/templates/envoy-filter.yaml
+++ b/charts/istio/istio-ingress/templates/envoy-filter.yaml
@@ -202,6 +202,167 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
+  name: stats-filter-1.9
+  namespace: {{ .Release.Namespace }}
+spec:
+  configPatches:
+    - applyTo: HTTP_FILTER
+      match:
+        context: GATEWAY
+        proxy:
+          proxyVersion: '^1\.9.*'
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.filters.network.http_connection_manager"
+              subFilter:
+                name: "envoy.filters.http.router"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: istio.stats
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+            value:
+              config:
+                root_id: stats_outbound
+                configuration:
+                  "@type": "type.googleapis.com/google.protobuf.StringValue"
+                  value: |
+                    {
+                    }
+                vm_config:
+                  vm_id: stats_outbound
+                  runtime: envoy.wasm.runtime.null
+                  code:
+                    local:
+                      inline_string: envoy.wasm.stats
+
+---
+
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: metadata-exchange-1.9
+  namespace: {{ .Release.Namespace }}
+spec:
+  configPatches:
+    - applyTo: HTTP_FILTER
+      match:
+        context: GATEWAY
+        proxy:
+          proxyVersion: '^1\.9.*'
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.filters.network.http_connection_manager"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: istio.metadata_exchange
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+            value:
+              config:
+                configuration:
+                  "@type": "type.googleapis.com/google.protobuf.StringValue"
+                  value: |
+                    {}
+                vm_config:
+                  runtime: envoy.wasm.runtime.null
+                  code:
+                    local:
+                      inline_string: envoy.wasm.metadata_exchange
+
+---
+
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: stats-filter-1.10
+  namespace: {{ .Release.Namespace }}
+spec:
+  configPatches:
+    - applyTo: HTTP_FILTER
+      match:
+        context: GATEWAY
+        proxy:
+          proxyVersion: '^1\.10.*'
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.filters.network.http_connection_manager"
+              subFilter:
+                name: "envoy.filters.http.router"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: istio.stats
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+            value:
+              config:
+                root_id: stats_outbound
+                configuration:
+                  "@type": "type.googleapis.com/google.protobuf.StringValue"
+                  value: |
+                    {
+                      "debug": "false",
+                      "stat_prefix": "istio",
+                      "disable_host_header_fallback": true
+                    }
+                vm_config:
+                  vm_id: stats_outbound
+                  runtime: envoy.wasm.runtime.null
+                  code:
+                    local:
+                      inline_string: envoy.wasm.stats
+
+---
+
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: metadata-exchange-1.10
+  namespace: {{ .Release.Namespace }}
+spec:
+  configPatches:
+    - applyTo: HTTP_FILTER
+      match:
+        context: GATEWAY
+        proxy:
+          proxyVersion: '^1\.10.*'
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.filters.network.http_connection_manager"
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: istio.metadata_exchange
+          typed_config:
+            "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+            type_url: type.googleapis.com/envoy.extensions.filters.http.wasm.v3.Wasm
+            value:
+              config:
+                configuration:
+                  "@type": "type.googleapis.com/google.protobuf.StringValue"
+                  value: |
+                    {}
+                vm_config:
+                  runtime: envoy.wasm.runtime.null
+                  code:
+                    local:
+                      inline_string: envoy.wasm.metadata_exchange
+
+---
+
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
   name: http-connect-listener
   namespace: {{ .Release.Namespace }}
 spec:

--- a/charts/seed-bootstrap/dashboards/istio/istio-mesh-dashboard.json
+++ b/charts/seed-bootstrap/dashboards/istio/istio-mesh-dashboard.json
@@ -81,13 +81,13 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(istio_tcp_received_bytes_total{destination_service_name=~\"$tcp_service\"})",
+          "expr": "sum(istio_tcp_received_bytes_total{destination_service=~\"$tcp_service\"})",
           "interval": "",
           "legendFormat": "Received",
           "refId": "A"
         },
         {
-          "expr": "sum(istio_tcp_sent_bytes_total{destination_service_name=~\"$tcp_service\"})",
+          "expr": "sum(istio_tcp_sent_bytes_total{destination_service=~\"$tcp_service\"})",
           "interval": "",
           "legendFormat": "Send",
           "refId": "B"
@@ -471,7 +471,7 @@
           "tableColumn": "",
           "targets": [
             {
-              "expr": "avg(galley_istio_networking_virtualservices)",
+              "expr": "max(pilot_k8s_cfg_events{type=\"VirtualService\", event=\"add\"}) - (max(pilot_k8s_cfg_events{type=\"VirtualService\", event=\"delete\"}) or max(up * 0))",
               "format": "time_series",
               "intervalFactor": 1,
               "refId": "A"
@@ -559,7 +559,7 @@
           "tableColumn": "",
           "targets": [
             {
-              "expr": "avg(galley_istio_networking_destinationrules)",
+              "expr": "max(pilot_k8s_cfg_events{type=\"DestinationRule\", event=\"add\"}) - (max(pilot_k8s_cfg_events{type=\"DestinationRule\", event=\"delete\"}) or max(up * 0))",
               "format": "time_series",
               "intervalFactor": 1,
               "refId": "A"
@@ -647,7 +647,7 @@
           "tableColumn": "",
           "targets": [
             {
-              "expr": "avg(galley_istio_networking_gateways)",
+              "expr": "max(pilot_k8s_cfg_events{type=\"Gateway\", event=\"add\"}) - (max(pilot_k8s_cfg_events{type=\"Gateway\", event=\"delete\"}) or max(up * 0))",
               "format": "time_series",
               "intervalFactor": 1,
               "refId": "A"
@@ -735,7 +735,7 @@
           "tableColumn": "",
           "targets": [
             {
-              "expr": "avg(galley_istio_authentication_meshpolicies)",
+              "expr": "max(pilot_k8s_cfg_events{type=\"WorkloadEntry\", event=\"add\"}) - (max(pilot_k8s_cfg_events{type=\"WorkloadEntry\", event=\"delete\"}) or max(up * 0))",
               "format": "time_series",
               "hide": false,
               "intervalFactor": 1,
@@ -745,7 +745,7 @@
           "thresholds": "",
           "timeFrom": null,
           "timeShift": null,
-          "title": "Authentication Mesh Policies",
+          "title": "Workload Entries",
           "type": "singlestat",
           "valueFontSize": "80%",
           "valueMaps": [
@@ -839,7 +839,7 @@
           "tableColumn": "",
           "targets": [
             {
-              "expr": "round(sum(irate(istio_requests_total{reporter=\"destination\"}[$__rate_interval])), 0.001)",
+              "expr": "round(sum(irate(istio_requests_total{reporter=\"source\"}[$__rate_interval])), 0.001)",
               "intervalFactor": 1,
               "refId": "A",
               "step": 4
@@ -925,7 +925,7 @@
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(rate(istio_requests_total{reporter=\"destination\", response_code!~\"5.*\"}[$__rate_interval])) / sum(rate(istio_requests_total{reporter=\"destination\"}[$__rate_interval]))",
+              "expr": "sum(rate(istio_requests_total{reporter=\"source\", response_code!~\"5.*\"}[$__rate_interval])) / sum(rate(istio_requests_total{reporter=\"source\"}[$__rate_interval]))",
               "format": "time_series",
               "intervalFactor": 1,
               "refId": "A",
@@ -1012,7 +1012,7 @@
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(irate(istio_requests_total{reporter=\"destination\", response_code=~\"4.*\"}[$__rate_interval])) ",
+              "expr": "sum(irate(istio_requests_total{reporter=\"source\", response_code=~\"4.*\"}[$__rate_interval])) ",
               "format": "time_series",
               "intervalFactor": 1,
               "refId": "A",
@@ -1099,7 +1099,7 @@
           "tableColumn": "",
           "targets": [
             {
-              "expr": "sum(irate(istio_requests_total{reporter=\"destination\", response_code=~\"5.*\"}[$__rate_interval])) ",
+              "expr": "sum(irate(istio_requests_total{reporter=\"source\", response_code=~\"5.*\"}[$__rate_interval])) ",
               "format": "time_series",
               "intervalFactor": 1,
               "refId": "A",
@@ -1326,7 +1326,7 @@
           ],
           "targets": [
             {
-              "expr": "label_join(sum(rate(istio_requests_total{reporter=\"destination\", response_code=\"200\"}[$__rate_interval])) by (destination_workload, destination_workload_namespace, destination_service), \"destination_workload_var\", \".\", \"destination_workload\", \"destination_workload_namespace\")",
+              "expr": "label_join(sum(rate(istio_requests_total{reporter=\"source\", response_code=\"200\"}[$__rate_interval])) by (destination_workload, destination_workload_namespace, destination_service), \"destination_workload_var\", \".\", \"destination_workload\", \"destination_workload_namespace\")",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -1335,7 +1335,7 @@
               "refId": "A"
             },
             {
-              "expr": "label_join((histogram_quantile(0.50, sum(rate(istio_request_duration_milliseconds_bucket{reporter=\"destination\"}[$__rate_interval])) by (le, destination_workload, destination_workload_namespace)) / 1000) or histogram_quantile(0.50, sum(rate(istio_request_duration_seconds_bucket{reporter=\"destination\"}[$__rate_interval])) by (le, destination_workload, destination_workload_namespace)), \"destination_workload_var\", \".\", \"destination_workload\", \"destination_workload_namespace\")",
+              "expr": "label_join((histogram_quantile(0.50, sum(rate(istio_request_duration_milliseconds_bucket{reporter=\"source\"}[$__rate_interval])) by (le, destination_workload, destination_workload_namespace)) / 1000) or histogram_quantile(0.50, sum(rate(istio_request_duration_seconds_bucket{reporter=\"source\"}[$__rate_interval])) by (le, destination_workload, destination_workload_namespace)), \"destination_workload_var\", \".\", \"destination_workload\", \"destination_workload_namespace\")",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -1344,7 +1344,7 @@
               "refId": "B"
             },
             {
-              "expr": "label_join((histogram_quantile(0.90, sum(rate(istio_request_duration_milliseconds_bucket{reporter=\"destination\"}[$__rate_interval])) by (le, destination_workload, destination_workload_namespace)) / 1000) or histogram_quantile(0.90, sum(rate(istio_request_duration_seconds_bucket{reporter=\"destination\"}[$__rate_interval])) by (le, destination_workload, destination_workload_namespace)), \"destination_workload_var\", \".\", \"destination_workload\", \"destination_workload_namespace\")",
+              "expr": "label_join((histogram_quantile(0.90, sum(rate(istio_request_duration_milliseconds_bucket{reporter=\"source\"}[$__rate_interval])) by (le, destination_workload, destination_workload_namespace)) / 1000) or histogram_quantile(0.90, sum(rate(istio_request_duration_seconds_bucket{reporter=\"source\"}[$__rate_interval])) by (le, destination_workload, destination_workload_namespace)), \"destination_workload_var\", \".\", \"destination_workload\", \"destination_workload_namespace\")",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -1353,7 +1353,7 @@
               "refId": "D"
             },
             {
-              "expr": "label_join((histogram_quantile(0.99, sum(rate(istio_request_duration_milliseconds_bucket{reporter=\"destination\"}[$__rate_interval])) by (le, destination_workload, destination_workload_namespace)) / 1000) or histogram_quantile(0.99, sum(rate(istio_request_duration_seconds_bucket{reporter=\"destination\"}[$__rate_interval])) by (le, destination_workload, destination_workload_namespace)), \"destination_workload_var\", \".\", \"destination_workload\", \"destination_workload_namespace\")",
+              "expr": "label_join((histogram_quantile(0.99, sum(rate(istio_request_duration_milliseconds_bucket{reporter=\"source\"}[$__rate_interval])) by (le, destination_workload, destination_workload_namespace)) / 1000) or histogram_quantile(0.99, sum(rate(istio_request_duration_seconds_bucket{reporter=\"source\"}[$__rate_interval])) by (le, destination_workload, destination_workload_namespace)), \"destination_workload_var\", \".\", \"destination_workload\", \"destination_workload_namespace\")",
               "format": "table",
               "hide": false,
               "instant": true,
@@ -1362,7 +1362,7 @@
               "refId": "E"
             },
             {
-              "expr": "label_join((sum(rate(istio_requests_total{reporter=\"destination\", response_code!~\"5.*\"}[$__rate_interval])) by (destination_workload, destination_workload_namespace) / sum(rate(istio_requests_total{reporter=\"destination\"}[$__rate_interval])) by (destination_workload, destination_workload_namespace)), \"destination_workload_var\", \".\", \"destination_workload\", \"destination_workload_namespace\")",
+              "expr": "label_join((sum(rate(istio_requests_total{reporter=\"source\", response_code!~\"5.*\"}[$__rate_interval])) by (destination_workload, destination_workload_namespace) / sum(rate(istio_requests_total{reporter=\"source\"}[$__rate_interval])) by (destination_workload, destination_workload_namespace)), \"destination_workload_var\", \".\", \"destination_workload\", \"destination_workload_namespace\")",
               "format": "table",
               "hide": false,
               "instant": true,

--- a/charts/seed-bootstrap/values.yaml
+++ b/charts/seed-bootstrap/values.yaml
@@ -260,10 +260,6 @@ allowedMetrics:
   - prometheus_target_scrapes_sample_out_of_order_total
 
   istiod:
-  - galley_istio_authentication_meshpolicies
-  - galley_istio_networking_destinationrules
-  - galley_istio_networking_gateways
-  - galley_istio_networking_virtualservices
   - galley_validation_failed
   - galley_validation_passed
   - go_goroutines
@@ -277,6 +273,7 @@ allowedMetrics:
   - pilot_conflict_outbound_listener_http_over_current_tcp
   - pilot_conflict_outbound_listener_tcp_over_current_http
   - pilot_conflict_outbound_listener_tcp_over_current_tcp
+  - pilot_k8s_cfg_events
   - pilot_proxy_convergence_time_bucket
   - pilot_proxy_convergence_time_bucket
   - pilot_services


### PR DESCRIPTION
Some of the used performance counters were removed from istio quite some time ago.
Apparently, nobody noticed the failing dashboards. Now, at least the dashboards
for virtual services, destination rules and gateways should work again.
Furthermore, a dashboard with a resource that is no longer available was replaced
with workload entries, which we currently do not use.
There were also a couple of panels with incorrect reporter values and one panel
with incorrect tag names.
Last but not least, the additional envoy filters expose the http metrics of istio
so that corresponding dashboards also receive values. The data is currently only
relevant for the reversed-vpn as the apiserver connections go through tcp.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Fixed a couple of panels in the istio mesh dashboard.
Some of the used performance counters were removed from istio quite some time ago.
Apparently, nobody noticed the failing dashboards. Now, at least the dashboards
for virtual services, destination rules and gateways should work again.
Furthermore, a dashboard with a resource that is no longer available was replaced
with workload entries, which we currently do not use.
There were also a couple of panels with incorrect reporter values and one panel
with incorrect tag names.
Last but not least, the additional envoy filters expose the http metrics of istio
so that corresponding dashboards also receive values. The data is currently only
relevant for the reversed-vpn as the apiserver connections go through tcp.
**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fixed several panels and corresponding metric ingestion in the istio mesh dashboard.
```
