### PR TITLE
Increase the cental Loki storage to 100Gi

### DIFF
--- a/docs/deployment/configuring_logging.md
+++ b/docs/deployment/configuring_logging.md
@@ -80,3 +80,23 @@ logging:
   loki:
     enabled: false
 ```
+
+# Configuring central Loki storage capacity
+
+By default, the central Loki has 100Gi of storage capacity.
+To overwrite the current central Loki storage capacity, the `logging.loki.garden.storage` setting in the gardenlet's component configuration should be altered.
+If you need to increase it you can do so without loosing the current data by specifying higher capacity. Doing so, the Loki's `PersistentVolume` capacity will be increased instead of deleting the current PV.
+However, if you specify less capacity then the `PersistentVolume` will be delete and with it the logs, too.
+
+```yaml
+featureGates:
+  Logging: true
+logging:
+  fluentBit:
+    output: |-
+      [Output]
+          ...
+  loki:
+    garden:
+      storage: "200Gi"
+```

--- a/example/20-componentconfig-gardenlet.yaml
+++ b/example/20-componentconfig-gardenlet.yaml
@@ -132,6 +132,7 @@ featureGates:
 #     enabled: true
 #     garden:
 #       priority: 100
+#       storage: "100Gi"
 #   shootNodeLogging:
 #     shootPurposes:
 #     - "development"

--- a/pkg/gardenlet/apis/config/types.go
+++ b/pkg/gardenlet/apis/config/types.go
@@ -19,6 +19,7 @@ import (
 	gardencore "github.com/gardener/gardener/pkg/apis/core"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	componentbaseconfig "k8s.io/component-base/config"
 	"k8s.io/klog"
@@ -374,6 +375,8 @@ type Loki struct {
 type GardenLoki struct {
 	// Priority is the priority value for the Loki
 	Priority *int32
+	// Storage is the disk storage capacity of the central Loki
+	Storage *resource.Quantity
 }
 
 // ShootNodeLogging contains configuration for the shoot node logging.

--- a/pkg/gardenlet/apis/config/v1alpha1/types.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/types.go
@@ -20,6 +20,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"k8s.io/klog"
@@ -457,7 +458,11 @@ type Loki struct {
 // GardenLoki contains configuration for the Loki in garden namespace.
 type GardenLoki struct {
 	// Priority is the priority value for the Loki
+	// +optional
 	Priority *int `json:"priority,omitempty" yaml:"priority,omitempty"`
+	// Storage is the disk storage capacity of the central Loki
+	// +optional
+	Storage *resource.Quantity `json:"storage,omitempty" yaml:"storage,omitempty"`
 }
 
 // ShootNodeLogging contains configuration for the shoot node logging.

--- a/pkg/gardenlet/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/zz_generated.conversion.go
@@ -28,6 +28,7 @@ import (
 	v1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	config "github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	corev1 "k8s.io/api/core/v1"
+	resource "k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -842,6 +843,7 @@ func autoConvert_v1alpha1_GardenLoki_To_config_GardenLoki(in *GardenLoki, out *c
 	} else {
 		out.Priority = nil
 	}
+	out.Storage = (*resource.Quantity)(unsafe.Pointer(in.Storage))
 	return nil
 }
 
@@ -858,6 +860,7 @@ func autoConvert_config_GardenLoki_To_v1alpha1_GardenLoki(in *config.GardenLoki,
 	} else {
 		out.Priority = nil
 	}
+	out.Storage = (*resource.Quantity)(unsafe.Pointer(in.Storage))
 	return nil
 }
 

--- a/pkg/gardenlet/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -431,6 +431,11 @@ func (in *GardenLoki) DeepCopyInto(out *GardenLoki) {
 		*out = new(int)
 		**out = **in
 	}
+	if in.Storage != nil {
+		in, out := &in.Storage, &out.Storage
+		x := (*in).DeepCopy()
+		*out = &x
+	}
 	return
 }
 

--- a/pkg/gardenlet/apis/config/zz_generated.deepcopy.go
+++ b/pkg/gardenlet/apis/config/zz_generated.deepcopy.go
@@ -431,6 +431,11 @@ func (in *GardenLoki) DeepCopyInto(out *GardenLoki) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.Storage != nil {
+		in, out := &in.Storage, &out.Storage
+		x := (*in).DeepCopy()
+		*out = &x
+	}
 	return
 }
 

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -516,6 +516,7 @@ func RunReconcileSeedFlow(
 		parsers                           = strings.Builder{}
 		fluentBitConfigurationsOverwrites = map[string]interface{}{}
 		lokiValues                        = map[string]interface{}{}
+		centralLokiStorage                = resource.MustParse("100Gi")
 	)
 
 	lokiValues["enabled"] = loggingEnabled
@@ -527,79 +528,95 @@ func RunReconcileSeedFlow(
 		return err
 	}
 
-	// check if loki disabled in gardenlet config
-	if loggingConfig != nil &&
-		loggingConfig.Loki != nil &&
-		loggingConfig.Loki.Enabled != nil &&
-		!*loggingConfig.Loki.Enabled {
-		lokiValues["enabled"] = false
-		if err := common.DeleteLoki(ctx, seedClient, gardenNamespace.Name); err != nil {
-			return err
-		}
-	}
-
 	if loggingEnabled {
-		lokiValues["authEnabled"] = false
-
 		lokiVpa := &autoscalingv1beta2.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: "loki-vpa", Namespace: v1beta1constants.GardenNamespace}}
 		if err := seedClient.Delete(ctx, lokiVpa); client.IgnoreNotFound(err) != nil && !meta.IsNoMatchError(err) {
 			return err
 		}
 
-		if conf.Logging != nil && conf.Logging.Loki != nil && conf.Logging.Loki.Garden != nil &&
-			conf.Logging.Loki.Garden.Priority != nil {
-			priority := *conf.Logging.Loki.Garden.Priority
-			if err := deletePriorityClassIfValueNotTheSame(ctx, seedClient, common.GardenLokiPriorityClassName, priority); err != nil {
+		// check if loki disabled in gardenlet config
+		if loggingConfig != nil &&
+			loggingConfig.Loki != nil &&
+			loggingConfig.Loki.Enabled != nil &&
+			!*loggingConfig.Loki.Enabled {
+			lokiValues["enabled"] = false
+			if err := common.DeleteLoki(ctx, seedClient, gardenNamespace.Name); err != nil {
 				return err
-			}
-			lokiValues["priorityClass"] = map[string]interface{}{
-				"value": priority,
-				"name":  common.GardenLokiPriorityClassName,
 			}
 		} else {
-			pc := &schedulingv1.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: common.GardenLokiPriorityClassName}}
-			if err := seedClient.Delete(ctx, pc); client.IgnoreNotFound(err) != nil {
-				return err
+			lokiValues["authEnabled"] = false
+			if loggingConfig != nil && loggingConfig.Loki != nil && loggingConfig.Loki.Garden != nil && loggingConfig.Loki.Garden.Storage != nil {
+				centralLokiStorage = *loggingConfig.Loki.Garden.Storage
 			}
-		}
+			lokiValues["storage"] = centralLokiStorage
 
-		if hvpaEnabled {
-			shootInfo := &corev1.ConfigMap{}
-			maintenanceBegin := "220000-0000"
-			maintenanceEnd := "230000-0000"
-			if err := seedClient.Get(ctx, kutil.Key(metav1.NamespaceSystem, "shoot-info"), shootInfo); err != nil {
-				if !apierrors.IsNotFound(err) {
-					return err
-				}
-			} else {
-				shootMaintenanceBegin, err := utils.ParseMaintenanceTime(shootInfo.Data["maintenanceBegin"])
-				if err != nil {
-					return err
-				}
-				maintenanceBegin = shootMaintenanceBegin.Add(1, 0, 0).Formatted()
-
-				shootMaintenanceEnd, err := utils.ParseMaintenanceTime(shootInfo.Data["maintenanceEnd"])
-				if err != nil {
-					return err
-				}
-				maintenanceEnd = shootMaintenanceEnd.Add(1, 0, 0).Formatted()
-			}
-
-			lokiValues["hvpa"] = map[string]interface{}{
-				"enabled": true,
-				"maintenanceTimeWindow": map[string]interface{}{
-					"begin": maintenanceBegin,
-					"end":   maintenanceEnd,
-				},
-			}
-
-			currentResources, err := kutil.GetContainerResourcesInStatefulSet(ctx, seedClient, kutil.Key(v1beta1constants.GardenNamespace, "loki"))
+			update, err := updatePVCIfStorageNotTheSame(ctx, seedClient, "loki-loki-0", centralLokiStorage)
 			if err != nil {
 				return err
 			}
-			if len(currentResources) != 0 && currentResources["loki"] != nil {
-				lokiValues["resources"] = map[string]interface{}{
-					"loki": currentResources["loki"],
+			// Only if there was an updated PVC we have to delete the current loki StatefulSet
+			if update {
+				lokiSts := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.StatefulSetNameLoki, Namespace: v1beta1constants.GardenNamespace}}
+				if err := client.IgnoreNotFound(seedClient.Delete(ctx, lokiSts)); err != nil {
+					return err
+				}
+			}
+
+			if hvpaEnabled {
+				shootInfo := &corev1.ConfigMap{}
+				maintenanceBegin := "220000-0000"
+				maintenanceEnd := "230000-0000"
+				if err := seedClient.Get(ctx, kutil.Key(metav1.NamespaceSystem, "shoot-info"), shootInfo); err != nil {
+					if !apierrors.IsNotFound(err) {
+						return err
+					}
+				} else {
+					shootMaintenanceBegin, err := utils.ParseMaintenanceTime(shootInfo.Data["maintenanceBegin"])
+					if err != nil {
+						return err
+					}
+					maintenanceBegin = shootMaintenanceBegin.Add(1, 0, 0).Formatted()
+
+					shootMaintenanceEnd, err := utils.ParseMaintenanceTime(shootInfo.Data["maintenanceEnd"])
+					if err != nil {
+						return err
+					}
+					maintenanceEnd = shootMaintenanceEnd.Add(1, 0, 0).Formatted()
+				}
+
+				lokiValues["hvpa"] = map[string]interface{}{
+					"enabled": true,
+					"maintenanceTimeWindow": map[string]interface{}{
+						"begin": maintenanceBegin,
+						"end":   maintenanceEnd,
+					},
+				}
+
+				currentResources, err := kutil.GetContainerResourcesInStatefulSet(ctx, seedClient, kutil.Key(v1beta1constants.GardenNamespace, v1beta1constants.StatefulSetNameLoki))
+				if err != nil {
+					return err
+				}
+				if len(currentResources) != 0 && currentResources[v1beta1constants.StatefulSetNameLoki] != nil {
+					lokiValues["resources"] = map[string]interface{}{
+						v1beta1constants.StatefulSetNameLoki: currentResources[v1beta1constants.StatefulSetNameLoki],
+					}
+				}
+			}
+
+			if conf.Logging != nil && conf.Logging.Loki != nil && conf.Logging.Loki.Garden != nil &&
+				conf.Logging.Loki.Garden.Priority != nil {
+				priority := *conf.Logging.Loki.Garden.Priority
+				if err := deletePriorityClassIfValueNotTheSame(ctx, seedClient, common.GardenLokiPriorityClassName, priority); err != nil {
+					return err
+				}
+				lokiValues["priorityClass"] = map[string]interface{}{
+					"value": priority,
+					"name":  common.GardenLokiPriorityClassName,
+				}
+			} else {
+				pc := &schedulingv1.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: common.GardenLokiPriorityClassName}}
+				if err := seedClient.Delete(ctx, pc); client.IgnoreNotFound(err) != nil {
+					return err
 				}
 			}
 		}
@@ -1850,4 +1867,37 @@ func cleanupOrphanExposureClassHandlerResources(ctx context.Context, c client.Cl
 	}
 
 	return nil
+}
+
+// updatePVCIfStorageNotTheSame updates the PVC if passed storage value is not the same as the current one.
+// If there was a successful update it will retun true as result.
+// Caution: If the passed storage capacity is less than the current one the existing PVC and its PV will be deleted.
+func updatePVCIfStorageNotTheSame(ctx context.Context, k8sClient client.Client, pvcName string, quantityToCompare resource.Quantity) (bool, error) {
+	pvc := &corev1.PersistentVolumeClaim{}
+	if err := k8sClient.Get(ctx, kutil.Key(v1beta1constants.GardenNamespace, pvcName), pvc); err != nil {
+		return false, client.IgnoreNotFound(err)
+	}
+
+	switch quantityToCompare.Cmp(*pvc.Spec.Resources.Requests.Storage()) {
+	case 0:
+		return false, nil
+	case 1:
+		// json merge patch
+		patch := client.MergeFrom(pvc.DeepCopy())
+		pvc.Spec.Resources.Requests = corev1.ResourceList{
+			corev1.ResourceStorage: quantityToCompare,
+		}
+		if err := k8sClient.Patch(ctx, pvc, patch); err != nil {
+			return false, err
+		}
+		return true, nil
+	case -1:
+		if err := k8sClient.Delete(ctx, pvc); err != nil {
+			return false, client.IgnoreNotFound(err)
+		}
+		return true, nil
+	default:
+		// This should never happen
+		return false, fmt.Errorf("Unknow result comparing PVC %s storage value %v with %v", pvcName, pvc.Spec.Resources.Requests.Storage(), quantityToCompare)
+	}
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
With this PR the central Loki storage capacity is increased from 30Gi to 100Gi and it is configurable via `Gadenlet` configuration. Since we start to store the logs from shoots in `Creating` and `Deleting` states we started lacking storage capacity or inodes. By increasing the Loki PV size we provide more space and more inode without deleting the existing logs. In case the central Loki instances of different landscapes need more storage it can be simply increased via the `gardenlet` configuration.
In case we set lower storage capacity the current central Loki PVCs and their PVs will be deleted with the logs.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
