### PR TITLE
Enhance `TokenRequestor` to be able to sync tokens to a `Secret` in the target cluster

### DIFF
--- a/docs/concepts/resource-manager.md
+++ b/docs/concepts/resource-manager.md
@@ -432,13 +432,12 @@ serviceaccount.resources.gardener.cloud/token-expiration-duration: 6h
 
 It automatically renews once 80% of the lifetime is reached or after `24h`.
 
-If the `Secret` is annotated with
+Optionally, the controller can also populate the token into a `Secret` in the target cluster. This can be requested by annotating the `Secret` in the source cluster with
 
 ```yaml
-serviceaccount.resources.gardener.cloud/skip-deletion: "true"
+token-requestor.resources.gardener.cloud/target-secret-name: "foo"
+token-requestor.resources.gardener.cloud/target-secret-namespace: "bar"
 ```
-
-then the respective `ServiceAccount` will not be deleted when the `Secret` is deleted.
 
 ## Webhooks
 

--- a/example/resource-manager/30-secret-tokenrequestor.yaml
+++ b/example/resource-manager/30-secret-tokenrequestor.yaml
@@ -9,8 +9,14 @@ metadata:
     # used for authorization by the token
     serviceaccount.resources.gardener.cloud/name: kube-scheduler
     serviceaccount.resources.gardener.cloud/namespace: kube-system
+
     # configure the expiration duration of the token. Defaults to 12h
     # serviceaccount.resources.gardener.cloud/token-expiration-duration: 12h
+
+    # name and namespace of a Secret in the target cluster to which the token
+    # should be synced (instead of this one)
+    # token-requestor.resources.gardener.cloud/target-secret-name: kube-scheduler
+    # token-requestor.resources.gardener.cloud/target-secret-namespace: kube-system
   labels:
     # the token-requestor will only act upon secrets with this label
     resources.gardener.cloud/purpose: token-requestor

--- a/hack/local-development/start-resource-manager
+++ b/hack/local-development/start-resource-manager
@@ -32,4 +32,6 @@ GO111MODULE=on \
 	    --sync-period=60s \
 	    --max-concurrent-workers=10 \
 	    --health-sync-period=60s \
-	    --health-max-concurrent-workers=10
+	    --health-max-concurrent-workers=10 \
+	    --token-requestor-max-concurrent-workers=10 \
+	    --token-invalidator-max-concurrent-workers=10

--- a/pkg/apis/resources/v1alpha1/types.go
+++ b/pkg/apis/resources/v1alpha1/types.go
@@ -54,20 +54,35 @@ const (
 	// for the invalidation of the static ServiceAccount token.
 	StaticTokenConsider = "token-invalidator.resources.gardener.cloud/consider"
 
-	// ResourceManagerPurpose is a constant for the key in a label describing the purpose of the respective object reconciled by the resource manager.
+	// TokenRequestorTargetSecretName is a constant for an annotation on a Secret which indicates that the token requestor
+	// shall sync the token to a secret in the target cluster with the given name.
+	TokenRequestorTargetSecretName = "token-requestor.resources.gardener.cloud/target-secret-name"
+	// TokenRequestorTargetSecretNamespace is a constant for an annotation on a Secret which indicates that the token
+	// requestor shall sync the token to a secret in the target cluster with the given namespace.
+	TokenRequestorTargetSecretNamespace = "token-requestor.resources.gardener.cloud/target-secret-namespace"
+
+	// ResourceManagerPurpose is a constant for the key in a label describing the purpose of the respective object
+	// reconciled by the resource manager.
 	ResourceManagerPurpose = "resources.gardener.cloud/purpose"
-	// LabelPurposeTokenRequest is a constant for a label value indicating that this secret should be reconciled by the token-requestor.
+	// LabelPurposeTokenRequest is a constant for a label value indicating that this secret should be reconciled by the
+	// token-requestor.
 	LabelPurposeTokenRequest = "token-requestor"
-	// LabelPurposeTokenInvalidation is a constant for a label value indicating that this secret should be considered by the token-invalidator.
+	// LabelPurposeTokenInvalidation is a constant for a label value indicating that this secret should be considered by
+	// the token-invalidator.
 	LabelPurposeTokenInvalidation = "token-invalidator"
-	// ServiceAccountName is the key of an annotation of a secret whose value contains the service account name
+
+	// ServiceAccountName is the key of an annotation of a secret whose value contains the service account name.
 	ServiceAccountName = "serviceaccount.resources.gardener.cloud/name"
-	// ServiceAccountNamespace is the key of an annotation of a secret whose value contains the service account namespace
+	// ServiceAccountNamespace is the key of an annotation of a secret whose value contains the service account
+	// namespace.
 	ServiceAccountNamespace = "serviceaccount.resources.gardener.cloud/namespace"
-	// ServiceAccountTokenExpirationDuration is the key of an annotation of a secret whose value contains the expiration duration of the token created
+	// ServiceAccountTokenExpirationDuration is the key of an annotation of a secret whose value contains the expiration
+	// duration of the token created.
 	ServiceAccountTokenExpirationDuration = "serviceaccount.resources.gardener.cloud/token-expiration-duration"
-	// ServiceAccountTokenRenewTimestamp is the key of an annotation of a secret whose value contains the timestamp when the token needs to be renewed
+	// ServiceAccountTokenRenewTimestamp is the key of an annotation of a secret whose value contains the timestamp when
+	// the token needs to be renewed.
 	ServiceAccountTokenRenewTimestamp = "serviceaccount.resources.gardener.cloud/token-renew-timestamp"
+
 	// DataKeyToken is the data key whose value contains a service account token.
 	DataKeyToken = "token"
 	// DataKeyKubeconfig is the data key whose value contains a kubeconfig with a service account token.

--- a/pkg/resourcemanager/controller/tokenrequestor/reconciler_test.go
+++ b/pkg/resourcemanager/controller/tokenrequestor/reconciler_test.go
@@ -195,7 +195,7 @@ var _ = Describe("Reconciler", func() {
 
 			Expect(sourceClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
 			Expect(secret.Data).NotTo(HaveKey("token"))
-			Expect(secret.Annotations).NotTo(HaveKeyWithValue("serviceaccount.resources.gardener.cloud/token-renew-timestamp", fakeNow.Add(expectedRenewDuration).Format(time.RFC3339)))
+			Expect(secret.Annotations).To(HaveKeyWithValue("serviceaccount.resources.gardener.cloud/token-renew-timestamp", fakeNow.Add(expectedRenewDuration).Format(time.RFC3339)))
 
 			Expect(targetClient.Get(ctx, client.ObjectKeyFromObject(serviceAccount), serviceAccount)).To(Succeed())
 			Expect(serviceAccount.AutomountServiceAccountToken).To(PointTo(BeFalse()))
@@ -209,7 +209,6 @@ var _ = Describe("Reconciler", func() {
 
 			Expect(targetClient.Get(ctx, client.ObjectKeyFromObject(targetSecret), targetSecret)).To(Succeed())
 			Expect(targetSecret.Data).To(HaveKeyWithValue("token", []byte(token)))
-			Expect(targetSecret.Annotations).To(HaveKeyWithValue("serviceaccount.resources.gardener.cloud/token-renew-timestamp", fakeNow.Add(expectedRenewDuration).Format(time.RFC3339)))
 		})
 
 		It("should create a new service account, generate a new token and requeue, and create the target secret in the next reconciliation", func() {
@@ -249,11 +248,10 @@ var _ = Describe("Reconciler", func() {
 
 			Expect(targetClient.Get(ctx, client.ObjectKeyFromObject(targetSecret), targetSecret)).To(Succeed())
 			Expect(targetSecret.Data).To(HaveKeyWithValue("token", []byte(token)))
-			Expect(targetSecret.Annotations).To(HaveKeyWithValue("serviceaccount.resources.gardener.cloud/token-renew-timestamp", fakeNow.Add(expectedRenewDuration).Format(time.RFC3339)))
 
 			Expect(sourceClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
 			Expect(secret.Data).NotTo(HaveKey("token"))
-			Expect(secret.Annotations).NotTo(HaveKeyWithValue("serviceaccount.resources.gardener.cloud/token-renew-timestamp", fakeNow.Add(expectedRenewDuration).Format(time.RFC3339)))
+			Expect(secret.Annotations).To(HaveKeyWithValue("serviceaccount.resources.gardener.cloud/token-renew-timestamp", fakeNow.Add(expectedRenewDuration).Format(time.RFC3339)))
 		})
 
 		It("should fail when the provided kubeconfig cannot be decoded", func() {

--- a/pkg/utils/gardener/shoot.go
+++ b/pkg/utils/gardener/shoot.go
@@ -224,6 +224,8 @@ type ShootAccessSecret struct {
 
 	tokenExpirationDuration string
 	kubeconfig              *clientcmdv1.Config
+	targetSecretName        string
+	targetSecretNamespace   string
 }
 
 // NewShootAccessSecret returns a new ShootAccessSecret object and initializes it with an empty corev1.Secret object
@@ -275,6 +277,13 @@ func (s *ShootAccessSecret) WithKubeconfig(kubeconfigRaw *clientcmdv1.Config) *S
 	return s
 }
 
+// WithTargetSecret sets the kubeconfig field of the ShootAccessSecret.
+func (s *ShootAccessSecret) WithTargetSecret(name, namespace string) *ShootAccessSecret {
+	s.targetSecretName = name
+	s.targetSecretNamespace = namespace
+	return s
+}
+
 // Reconcile creates or patches the given shoot access secret. Based on the struct configuration, it adds the required
 // annotations for the token requestor controller of gardener-resource-manager.
 func (s *ShootAccessSecret) Reconcile(ctx context.Context, c client.Client) error {
@@ -286,6 +295,14 @@ func (s *ShootAccessSecret) Reconcile(ctx context.Context, c client.Client) erro
 
 		if s.tokenExpirationDuration != "" {
 			metav1.SetMetaDataAnnotation(&s.Secret.ObjectMeta, resourcesv1alpha1.ServiceAccountTokenExpirationDuration, s.tokenExpirationDuration)
+		}
+
+		if s.targetSecretName != "" {
+			metav1.SetMetaDataAnnotation(&s.Secret.ObjectMeta, resourcesv1alpha1.TokenRequestorTargetSecretName, s.targetSecretName)
+		}
+
+		if s.targetSecretNamespace != "" {
+			metav1.SetMetaDataAnnotation(&s.Secret.ObjectMeta, resourcesv1alpha1.TokenRequestorTargetSecretNamespace, s.targetSecretNamespace)
 		}
 
 		if s.kubeconfig == nil {

--- a/pkg/utils/gardener/shoot_test.go
+++ b/pkg/utils/gardener/shoot_test.go
@@ -388,6 +388,15 @@ var _ = Describe("Shoot", func() {
 						validate()
 						Expect(shootAccessSecret.Secret.Data).To(HaveKeyWithValue("kubeconfig", kubeconfigRaw))
 					})
+
+					It("should work w/ target secret", func() {
+						targetSecretName, targetSecretNamespace := "tname", "tnamespace"
+
+						shootAccessSecret.WithTargetSecret(targetSecretName, targetSecretNamespace)
+						validate()
+						Expect(shootAccessSecret.Secret.Annotations).To(HaveKeyWithValue("token-requestor.resources.gardener.cloud/target-secret-name", targetSecretName))
+						Expect(shootAccessSecret.Secret.Annotations).To(HaveKeyWithValue("token-requestor.resources.gardener.cloud/target-secret-namespace", targetSecretNamespace))
+					})
 				})
 
 				Context("update", func() {
@@ -452,6 +461,15 @@ var _ = Describe("Shoot", func() {
 
 						validate()
 						Expect(shootAccessSecret.Secret.Data).NotTo(HaveKey("token"))
+					})
+
+					It("should work w/ target secret", func() {
+						targetSecretName, targetSecretNamespace := "tname", "tnamespace"
+
+						shootAccessSecret.WithTargetSecret(targetSecretName, targetSecretNamespace)
+						validate()
+						Expect(shootAccessSecret.Secret.Annotations).To(HaveKeyWithValue("token-requestor.resources.gardener.cloud/target-secret-name", targetSecretName))
+						Expect(shootAccessSecret.Secret.Annotations).To(HaveKeyWithValue("token-requestor.resources.gardener.cloud/target-secret-namespace", targetSecretNamespace))
 					})
 				})
 			})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
The `TokenRequestor` controller (part of `gardener-resource-manager`) can now optionally sync the tokens into a `Secret` in the target cluster (instead of in the source cluster). This can be controlled via the new `token-requestor.resources.gardener.cloud/target-secret-name{space}` annotations on the `Secret` in the source cluster.

**Which issue(s) this PR fixes**:
Part of #4661
Part of #4878

**Special notes for your reviewer**:
This is a prerequisite for adapting the `cloud-config-downloader` and `promtail` components as part of #4661.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
The `TokenRequestor` controller (part of `gardener-resource-manager`) can now optionally sync the tokens into a `Secret` in the target cluster (see [this document](https://github.com/gardener/gardener/blob/master/docs/concepts/resource-manager.md#tokenrequestor) for more information).
```
