### PR TITLE
Provide ip address of local node to vpn-seed-server so that the readiness/liveness probes can be removed from the log output.

### DIFF
--- a/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server.go
+++ b/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server.go
@@ -370,6 +370,14 @@ func (v *vpnSeedServer) Deploy(ctx context.Context) error {
 									Name:  "POD_NETWORK",
 									Value: v.podNetwork,
 								},
+								{
+									Name: "LOCAL_NODE_IP",
+									ValueFrom: &corev1.EnvVarSource{
+										FieldRef: &corev1.ObjectFieldSelector{
+											FieldPath: "status.hostIP",
+										},
+									},
+								},
 							},
 							ReadinessProbe: &corev1.Probe{
 								Handler: corev1.Handler{

--- a/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server_test.go
+++ b/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server_test.go
@@ -320,6 +320,14 @@ admin:
 											Name:  "POD_NETWORK",
 											Value: podNetwork,
 										},
+										{
+											Name: "LOCAL_NODE_IP",
+											ValueFrom: &corev1.EnvVarSource{
+												FieldRef: &corev1.ObjectFieldSelector{
+													FieldPath: "status.hostIP",
+												},
+											},
+										},
 									},
 									ReadinessProbe: &corev1.Probe{
 										Handler: corev1.Handler{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Provide ip address of local node to vpn-seed-server so that the readiness/liveness probes can be removed from the log output.
The readiness/liveness probes clutter the log output. Removing them makes it easier
to reason about what is actually going on.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:
This works in conjunction with https://github.com/gardener/vpn2/pull/7

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Removed log output of readiness/liveness probes from vpn-seed-server log.
```
