### PR TITLE
Enhance SeedAuthorizer to allow `DELETE` requests if resource does not exist in the system

### DIFF
--- a/pkg/admissioncontroller/webhooks/auth/seed/authorizer.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/authorizer.go
@@ -374,6 +374,12 @@ func (a *authorizer) hasPathFrom(seedName string, fromType graph.VertexType, att
 		namespace = ""
 	}
 
+	// If the vertex does not exist in the graph (i.e., the resource does not exist in the system) then we allow the
+	// request.
+	if attrs.GetVerb() == "delete" && !a.graph.HasVertex(fromType, namespace, attrs.GetName()) {
+		return auth.DecisionAllow, "", nil
+	}
+
 	if !a.graph.HasPathFrom(fromType, namespace, attrs.GetName(), graph.VertexTypeSeed, "", seedName) {
 		a.logger.Info(fmt.Sprintf("SEED DENY: '%s' %#v", seedName, attrs))
 		return auth.DecisionNoOpinion, fmt.Sprintf("no relationship found between seed '%s' and this object", seedName), nil

--- a/pkg/admissioncontroller/webhooks/auth/seed/authorizer.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/authorizer.go
@@ -103,8 +103,8 @@ func (a *authorizer) Authorize(_ context.Context, attrs auth.Attributes) (auth.D
 		switch requestResource {
 		case backupBucketResource:
 			return a.authorize(seedName, graph.VertexTypeBackupBucket, attrs,
-				[]string{"update", "patch"},
-				[]string{"create", "delete", "get", "list", "watch"},
+				[]string{"update", "patch", "delete"},
+				[]string{"create", "get", "list", "watch"},
 				[]string{"status"},
 			)
 		case backupEntryResource:

--- a/pkg/admissioncontroller/webhooks/auth/seed/authorizer_test.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/authorizer_test.go
@@ -674,7 +674,7 @@ var _ = Describe("Seed", func() {
 				}
 			})
 
-			DescribeTable("should allow without consulting the graph because verb is get, list, watch, create, delete",
+			DescribeTable("should allow without consulting the graph because verb is get, list, watch, create",
 				func(verb string) {
 					attrs.Verb = verb
 

--- a/pkg/admissioncontroller/webhooks/auth/seed/authorizer_test.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/authorizer_test.go
@@ -404,9 +404,23 @@ var _ = Describe("Seed", func() {
 				Expect(reason).To(BeEmpty())
 			})
 
+			It("should allow when verb is delete and resource does not exist", func() {
+				attrs.Verb = "delete"
+
+				graph.EXPECT().HasVertex(graphpkg.VertexTypeShootState, namespace, name).Return(false)
+				decision, reason, err := authorizer.Authorize(ctx, attrs)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(decision).To(Equal(auth.DecisionAllow))
+				Expect(reason).To(BeEmpty())
+			})
+
 			DescribeTable("should return correct result if path exists",
 				func(verb string) {
 					attrs.Verb = verb
+
+					if verb == "delete" {
+						graph.EXPECT().HasVertex(graphpkg.VertexTypeShootState, namespace, name).Return(true).Times(2)
+					}
 
 					graph.EXPECT().HasPathFrom(graphpkg.VertexTypeShootState, namespace, name, graphpkg.VertexTypeSeed, "", seedName).Return(true)
 					decision, reason, err := authorizer.Authorize(ctx, attrs)
@@ -786,6 +800,16 @@ var _ = Describe("Seed", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(decision).To(Equal(auth.DecisionNoOpinion))
 				Expect(reason).To(ContainSubstring("only the following subresources are allowed for this resource type: [status]"))
+			})
+
+			It("should allow when verb is delete and resource does not exist", func() {
+				attrs.Verb = "delete"
+
+				graph.EXPECT().HasVertex(graphpkg.VertexTypeBackupEntry, namespace, name).Return(false)
+				decision, reason, err := authorizer.Authorize(ctx, attrs)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(decision).To(Equal(auth.DecisionAllow))
+				Expect(reason).To(BeEmpty())
 			})
 
 			DescribeTable("should return correct result if path exists",
@@ -1917,9 +1941,23 @@ var _ = Describe("Seed", func() {
 				Expect(reason).To(ContainSubstring("only the following subresources are allowed for this resource type: []"))
 			})
 
+			It("should allow when verb is delete and resource does not exist", func() {
+				attrs.Verb = "delete"
+
+				graph.EXPECT().HasVertex(graphpkg.VertexTypeSecret, namespace, name).Return(false)
+				decision, reason, err := authorizer.Authorize(ctx, attrs)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(decision).To(Equal(auth.DecisionAllow))
+				Expect(reason).To(BeEmpty())
+			})
+
 			DescribeTable("should return correct result if path exists",
 				func(verb string) {
 					attrs.Verb = verb
+
+					if verb == "delete" {
+						graph.EXPECT().HasVertex(graphpkg.VertexTypeSecret, namespace, name).Return(true).Times(2)
+					}
 
 					graph.EXPECT().HasPathFrom(graphpkg.VertexTypeSecret, namespace, name, graphpkg.VertexTypeSeed, "", seedName).Return(true)
 					decision, reason, err := authorizer.Authorize(ctx, attrs)

--- a/pkg/admissioncontroller/webhooks/auth/seed/graph/graph.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/graph/graph.go
@@ -40,6 +40,8 @@ import (
 type Interface interface {
 	// Setup registers the event handler functions for the various resource types.
 	Setup(ctx context.Context, c cache.Cache) error
+	// HasVertex returns true when the given vertex exists in the graph.
+	HasVertex(vertexType VertexType, vertexNamespace, vertexName string) bool
 	// HasPathFrom returns true when there is a path from <from> to <to>.
 	HasPathFrom(fromType VertexType, fromNamespace, fromName string, toType VertexType, toNamespace, toName string) bool
 }
@@ -102,6 +104,11 @@ func (g *graph) Setup(ctx context.Context, c cache.Cache) error {
 	}
 
 	return nil
+}
+
+func (g *graph) HasVertex(vertexType VertexType, vertexNamespace, vertexName string) bool {
+	_, ok := g.getVertex(vertexType, vertexNamespace, vertexName)
+	return ok
 }
 
 func (g *graph) HasPathFrom(fromType VertexType, fromNamespace, fromName string, toType VertexType, toNamespace, toName string) bool {

--- a/pkg/admissioncontroller/webhooks/auth/seed/graph/graph_test.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/graph/graph_test.go
@@ -300,6 +300,17 @@ yO57qEcJqG1cB7iSchFuCSTuDBbZlN0fXgn4YjiWZyb4l3BDp3rm4iJImA==
 		}
 	})
 
+	Describe("#HasVertex", func() {
+		It("should return false", func() {
+			Expect(graph.HasVertex(VertexTypeSeed, seed1.Namespace, seed1.Name)).To(BeFalse())
+		})
+
+		It("should return true", func() {
+			fakeInformerSeed.Add(seed1)
+			Expect(graph.HasVertex(VertexTypeSeed, seed1.Namespace, seed1.Name)).To(BeTrue())
+		})
+	})
+
 	It("should behave as expected for gardencorev1beta1.Seed", func() {
 		By("add")
 		fakeInformerSeed.Add(seed1)

--- a/pkg/admissioncontroller/webhooks/auth/seed/graph/mock/mocks.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/graph/mock/mocks.go
@@ -50,6 +50,20 @@ func (mr *MockInterfaceMockRecorder) HasPathFrom(arg0, arg1, arg2, arg3, arg4, a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasPathFrom", reflect.TypeOf((*MockInterface)(nil).HasPathFrom), arg0, arg1, arg2, arg3, arg4, arg5)
 }
 
+// HasVertex mocks base method.
+func (m *MockInterface) HasVertex(arg0 graph.VertexType, arg1, arg2 string) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasVertex", arg0, arg1, arg2)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// HasVertex indicates an expected call of HasVertex.
+func (mr *MockInterfaceMockRecorder) HasVertex(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasVertex", reflect.TypeOf((*MockInterface)(nil).HasVertex), arg0, arg1, arg2)
+}
+
 // Setup mocks base method.
 func (m *MockInterface) Setup(arg0 context.Context, arg1 cache.Cache) error {
 	m.ctrl.T.Helper()

--- a/pkg/operation/botanist/component/backupentry/backupentry.go
+++ b/pkg/operation/botanist/component/backupentry/backupentry.go
@@ -28,7 +28,6 @@ import (
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -198,16 +197,6 @@ func (b *backupEntry) reconcile(ctx context.Context, backupEntry *gardencorev1be
 
 // Destroy deletes the BackupEntry resource
 func (b *backupEntry) Destroy(ctx context.Context) error {
-	// SeedAuthorizer will reject a DELETE request to BackupEntry that does not exist with reason 'no relationship found'.
-	// That's why early exit when the BackupEntry does not exist.
-	if err := b.client.Get(ctx, client.ObjectKeyFromObject(b.backupEntry), b.backupEntry); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil
-		}
-
-		return err
-	}
-
 	return kutil.DeleteObject(
 		ctx,
 		b.client,

--- a/pkg/operation/botanist/component/backupentry/backupentry_test.go
+++ b/pkg/operation/botanist/component/backupentry/backupentry_test.go
@@ -297,7 +297,7 @@ var _ = Describe("BackupEntry", func() {
 		})
 
 		It("should not return error when it's deleted successfully", func() {
-			Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "creating infrastructure succeeds")
+			Expect(c.Create(ctx, expected)).To(Succeed(), "creating BackupEntry succeeds")
 			Expect(defaultDepWaiter.Destroy(ctx)).To(Succeed())
 		})
 	})

--- a/pkg/operation/botanist/component/backupentry/backupentry_test.go
+++ b/pkg/operation/botanist/component/backupentry/backupentry_test.go
@@ -293,13 +293,12 @@ var _ = Describe("BackupEntry", func() {
 
 	Describe("#Destroy", func() {
 		It("should not return error when it's not found", func() {
-			Expect(defaultDepWaiter.Destroy(ctx)).To(BeNil())
+			Expect(defaultDepWaiter.Destroy(ctx)).To(Succeed())
 		})
 
 		It("should not return error when it's deleted successfully", func() {
 			Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "creating infrastructure succeeds")
-
-			Expect(defaultDepWaiter.Destroy(ctx)).ToNot(HaveOccurred())
+			Expect(defaultDepWaiter.Destroy(ctx)).To(Succeed())
 		})
 	})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement
/squash

**What this PR does / why we need it**:
With this PR, the SeedAuthorizer is enhanced to allow `DELETE` requests if resource does not exist in the system. This is to prevent special client handling (as introduced in https://github.com/gardener/gardener/pull/5066, for example) which anyways would not necessarily work in all cases.

Hence, apart from above, the PR reverts such special handling that was introduced in the `backupentry` component.

Additionally, unconditional `DELETE`s are no longer allowed for `BackupBucket`s (which only were introduced to work around #5083).

**Which issue(s) this PR fixes**:
Fixes #5082
Fixes #5083

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug in the SeedAuthorizer has been fixed which allowed gardenlets to unconditionally delete `BackupBucket`s.
```
```improvement developer
The SeedAuthorizer does now allow `DELETE` requests if the resource does not exist in the system.
```
