### PR TITLE
Make seed lease/duration configurable

### DIFF
--- a/charts/gardener/gardenlet/charts/runtime/templates/configmap-componentconfig.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/configmap-componentconfig.yaml
@@ -101,6 +101,9 @@ data:
         {{- if .Values.global.gardenlet.config.controllers.seed.leaseResyncSeconds }}
         leaseResyncSeconds: {{ .Values.global.gardenlet.config.controllers.seed.leaseResyncSeconds }}
         {{- end }}
+        {{- if .Values.global.gardenlet.config.controllers.seed.leaseResyncGracePeriod }}
+        leaseResyncGracePeriod: {{ .Values.global.gardenlet.config.controllers.seed.leaseResyncGracePeriod }}
+        {{- end }}
       {{- end }}
       shoot:
         concurrentSyncs: {{ required ".Values.global.gardenlet.config.controllers.shoot.concurrentSyncs is required" .Values.global.gardenlet.config.controllers.shoot.concurrentSyncs }}

--- a/charts/gardener/gardenlet/charts/runtime/templates/configmap-componentconfig.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/configmap-componentconfig.yaml
@@ -95,6 +95,12 @@ data:
       seed:
         concurrentSyncs: {{ required ".Values.global.gardenlet.config.controllers.seed.concurrentSyncs is required" .Values.global.gardenlet.config.controllers.seed.concurrentSyncs }}
         syncPeriod: {{ required ".Values.global.gardenlet.config.controllers.seed.syncPeriod is required" .Values.global.gardenlet.config.controllers.seed.syncPeriod }}
+        {{- if .Values.global.gardenlet.config.controllers.seed.leaseDurationSeconds }}
+        leaseDurationSeconds: {{ .Values.global.gardenlet.config.controllers.seed.leaseDurationSeconds }}
+        {{- end }}
+        {{- if .Values.global.gardenlet.config.controllers.seed.leaseResyncSeconds }}
+        leaseResyncSeconds: {{ .Values.global.gardenlet.config.controllers.seed.leaseResyncSeconds }}
+        {{- end }}
       {{- end }}
       shoot:
         concurrentSyncs: {{ required ".Values.global.gardenlet.config.controllers.shoot.concurrentSyncs is required" .Values.global.gardenlet.config.controllers.shoot.concurrentSyncs }}

--- a/charts/gardener/gardenlet/charts/runtime/templates/configmap-componentconfig.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/configmap-componentconfig.yaml
@@ -95,14 +95,11 @@ data:
       seed:
         concurrentSyncs: {{ required ".Values.global.gardenlet.config.controllers.seed.concurrentSyncs is required" .Values.global.gardenlet.config.controllers.seed.concurrentSyncs }}
         syncPeriod: {{ required ".Values.global.gardenlet.config.controllers.seed.syncPeriod is required" .Values.global.gardenlet.config.controllers.seed.syncPeriod }}
-        {{- if .Values.global.gardenlet.config.controllers.seed.leaseDurationSeconds }}
-        leaseDurationSeconds: {{ .Values.global.gardenlet.config.controllers.seed.leaseDurationSeconds }}
-        {{- end }}
         {{- if .Values.global.gardenlet.config.controllers.seed.leaseResyncSeconds }}
         leaseResyncSeconds: {{ .Values.global.gardenlet.config.controllers.seed.leaseResyncSeconds }}
         {{- end }}
-        {{- if .Values.global.gardenlet.config.controllers.seed.leaseResyncGracePeriod }}
-        leaseResyncGracePeriod: {{ .Values.global.gardenlet.config.controllers.seed.leaseResyncGracePeriod }}
+        {{- if .Values.global.gardenlet.config.controllers.seed.leaseResyncMissThreshold }}
+        leaseResyncMissThreshold: {{ .Values.global.gardenlet.config.controllers.seed.leaseResyncMissThreshold }}
         {{- end }}
       {{- end }}
       shoot:

--- a/charts/gardener/gardenlet/values.yaml
+++ b/charts/gardener/gardenlet/values.yaml
@@ -76,9 +76,8 @@ global:
         seed:
           concurrentSyncs: 5
           syncPeriod: 1m
-        # leaseDurationSeconds: 2
         # leaseResyncSeconds: 2
-        # leaseResyncGracePeriod: 10
+        # leaseResyncMissThreshold: 10
         shoot:
           concurrentSyncs: 20
           syncPeriod: 1h

--- a/charts/gardener/gardenlet/values.yaml
+++ b/charts/gardener/gardenlet/values.yaml
@@ -76,6 +76,8 @@ global:
         seed:
           concurrentSyncs: 5
           syncPeriod: 1m
+        # leaseDurationSeconds: 2
+        # leaseResyncSeconds: 2
         shoot:
           concurrentSyncs: 20
           syncPeriod: 1h

--- a/charts/gardener/gardenlet/values.yaml
+++ b/charts/gardener/gardenlet/values.yaml
@@ -78,6 +78,7 @@ global:
           syncPeriod: 1m
         # leaseDurationSeconds: 2
         # leaseResyncSeconds: 2
+        # leaseResyncGracePeriod: 10
         shoot:
           concurrentSyncs: 20
           syncPeriod: 1h

--- a/cmd/gardenlet/app/gardenlet.go
+++ b/cmd/gardenlet/app/gardenlet.go
@@ -426,7 +426,7 @@ func (g *Gardenlet) Run(ctx context.Context) error {
 	defer controllerCancel()
 
 	// Initialize /healthz manager.
-	healthGracePeriod := time.Duration(*g.Config.Controllers.Shoot.LeaseResyncSeconds*seed.LeaseResyncGracePeriod) * time.Second
+	healthGracePeriod := time.Duration(*g.Config.Controllers.Seed.LeaseResyncSeconds*seed.LeaseResyncGracePeriod) * time.Second
 	g.HealthManager = healthz.NewPeriodicHealthz(clock.RealClock{}, healthGracePeriod)
 
 	if g.CertificateManager != nil {

--- a/cmd/gardenlet/app/gardenlet.go
+++ b/cmd/gardenlet/app/gardenlet.go
@@ -43,7 +43,7 @@ import (
 	"github.com/gardener/gardener/pkg/gardenlet/bootstrap"
 	"github.com/gardener/gardener/pkg/gardenlet/bootstrap/certificate"
 	"github.com/gardener/gardener/pkg/gardenlet/controller"
-	seedcontroller "github.com/gardener/gardener/pkg/gardenlet/controller/seed"
+	"github.com/gardener/gardener/pkg/gardenlet/controller/seed"
 	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 	"github.com/gardener/gardener/pkg/healthz"
 	"github.com/gardener/gardener/pkg/logger"
@@ -426,7 +426,8 @@ func (g *Gardenlet) Run(ctx context.Context) error {
 	defer controllerCancel()
 
 	// Initialize /healthz manager.
-	g.HealthManager = healthz.NewPeriodicHealthz(clock.RealClock{}, seedcontroller.LeaseResyncGracePeriodSeconds*time.Second)
+	healthGracePeriod := time.Duration(*g.Config.Controllers.Shoot.LeaseResyncSeconds*seed.LeaseResyncGracePeriod) * time.Second
+	g.HealthManager = healthz.NewPeriodicHealthz(clock.RealClock{}, healthGracePeriod)
 
 	if g.CertificateManager != nil {
 		g.CertificateManager.ScheduleCertificateRotation(controllerCtx, controllerCancel, g.Recorder)

--- a/cmd/gardenlet/app/gardenlet.go
+++ b/cmd/gardenlet/app/gardenlet.go
@@ -43,7 +43,6 @@ import (
 	"github.com/gardener/gardener/pkg/gardenlet/bootstrap"
 	"github.com/gardener/gardener/pkg/gardenlet/bootstrap/certificate"
 	"github.com/gardener/gardener/pkg/gardenlet/controller"
-	"github.com/gardener/gardener/pkg/gardenlet/controller/seed"
 	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 	"github.com/gardener/gardener/pkg/healthz"
 	"github.com/gardener/gardener/pkg/logger"
@@ -426,7 +425,7 @@ func (g *Gardenlet) Run(ctx context.Context) error {
 	defer controllerCancel()
 
 	// Initialize /healthz manager.
-	healthGracePeriod := time.Duration(*g.Config.Controllers.Seed.LeaseResyncSeconds*seed.LeaseResyncGracePeriod) * time.Second
+	healthGracePeriod := time.Duration((*g.Config.Controllers.Seed.LeaseResyncSeconds)*(*g.Config.Controllers.Seed.LeaseResyncGracePeriod)) * time.Second
 	g.HealthManager = healthz.NewPeriodicHealthz(clock.RealClock{}, healthGracePeriod)
 
 	if g.CertificateManager != nil {

--- a/cmd/gardenlet/app/gardenlet.go
+++ b/cmd/gardenlet/app/gardenlet.go
@@ -425,7 +425,7 @@ func (g *Gardenlet) Run(ctx context.Context) error {
 	defer controllerCancel()
 
 	// Initialize /healthz manager.
-	healthGracePeriod := time.Duration((*g.Config.Controllers.Seed.LeaseResyncSeconds)*(*g.Config.Controllers.Seed.LeaseResyncGracePeriod)) * time.Second
+	healthGracePeriod := time.Duration((*g.Config.Controllers.Seed.LeaseResyncSeconds)*(*g.Config.Controllers.Seed.LeaseResyncMissThreshold)) * time.Second
 	g.HealthManager = healthz.NewPeriodicHealthz(clock.RealClock{}, healthGracePeriod)
 
 	if g.CertificateManager != nil {

--- a/example/20-componentconfig-gardenlet.yaml
+++ b/example/20-componentconfig-gardenlet.yaml
@@ -65,6 +65,7 @@ controllers:
     syncPeriod: 1m
   # leaseDurationSeconds: 2
   # leaseResyncSeconds: 2
+  # leaseResyncGracePeriod: 10
   managedSeed:
     concurrentSyncs: 5
     syncPeriod: 1h

--- a/example/20-componentconfig-gardenlet.yaml
+++ b/example/20-componentconfig-gardenlet.yaml
@@ -63,6 +63,8 @@ controllers:
   seed:
     concurrentSyncs: 5
     syncPeriod: 1m
+  # leaseDurationSeconds: 2
+  # leaseResyncSeconds: 2
   managedSeed:
     concurrentSyncs: 5
     syncPeriod: 1h

--- a/example/20-componentconfig-gardenlet.yaml
+++ b/example/20-componentconfig-gardenlet.yaml
@@ -63,9 +63,8 @@ controllers:
   seed:
     concurrentSyncs: 5
     syncPeriod: 1m
-  # leaseDurationSeconds: 2
   # leaseResyncSeconds: 2
-  # leaseResyncGracePeriod: 10
+  # leaseResyncMissThreshold: 10
   managedSeed:
     concurrentSyncs: 5
     syncPeriod: 1h

--- a/landscaper/pkg/gardenlet/chart/charttest/charttest.go
+++ b/landscaper/pkg/gardenlet/chart/charttest/charttest.go
@@ -655,8 +655,9 @@ func ComputeExpectedGardenletConfiguration(
 				SyncPeriod: &metav1.Duration{
 					Duration: time.Minute,
 				},
-				LeaseDurationSeconds: pointer.Int32(2),
-				LeaseResyncSeconds:   pointer.Int32(2),
+				LeaseDurationSeconds:   pointer.Int32(2),
+				LeaseResyncSeconds:     pointer.Int32(2),
+				LeaseResyncGracePeriod: pointer.Int32(10),
 			},
 			Shoot: &gardenletconfigv1alpha1.ShootControllerConfiguration{
 				ReconcileInMaintenanceOnly: pointer.Bool(false),

--- a/landscaper/pkg/gardenlet/chart/charttest/charttest.go
+++ b/landscaper/pkg/gardenlet/chart/charttest/charttest.go
@@ -655,6 +655,8 @@ func ComputeExpectedGardenletConfiguration(
 				SyncPeriod: &metav1.Duration{
 					Duration: time.Minute,
 				},
+				LeaseDurationSeconds: pointer.Int32(2),
+				LeaseResyncSeconds:   pointer.Int32(2),
 			},
 			Shoot: &gardenletconfigv1alpha1.ShootControllerConfiguration{
 				ReconcileInMaintenanceOnly: pointer.Bool(false),

--- a/landscaper/pkg/gardenlet/chart/charttest/charttest.go
+++ b/landscaper/pkg/gardenlet/chart/charttest/charttest.go
@@ -655,9 +655,8 @@ func ComputeExpectedGardenletConfiguration(
 				SyncPeriod: &metav1.Duration{
 					Duration: time.Minute,
 				},
-				LeaseDurationSeconds:   pointer.Int32(2),
-				LeaseResyncSeconds:     pointer.Int32(2),
-				LeaseResyncGracePeriod: pointer.Int32(10),
+				LeaseResyncSeconds:       pointer.Int32(2),
+				LeaseResyncMissThreshold: pointer.Int32(10),
 			},
 			Shoot: &gardenletconfigv1alpha1.ShootControllerConfiguration{
 				ReconcileInMaintenanceOnly: pointer.Bool(false),

--- a/pkg/gardenlet/apis/config/types.go
+++ b/pkg/gardenlet/apis/config/types.go
@@ -197,16 +197,13 @@ type SeedControllerConfiguration struct {
 	ConcurrentSyncs *int
 	// SyncPeriod is the duration how often the existing resources are reconciled.
 	SyncPeriod *metav1.Duration
-	// LeaseDurationSeconds defines how long the lease is valid (used for Lease.spec.leaseDurationSeconds).
-	// Default: 2s
-	LeaseDurationSeconds *int32
 	// LeaseResyncSeconds defines how often (in seconds) the seed lease is renewed.
 	// Default: 2s
 	LeaseResyncSeconds *int32
-	// LeaseResyncGracePeriod is the amount of missed lease resyncs before the health status
+	// LeaseResyncMissThreshold is the amount of missed lease resyncs before the health status
 	// is changed to false.
 	// Default: 10
-	LeaseResyncGracePeriod *int32
+	LeaseResyncMissThreshold *int32
 }
 
 // ShootControllerConfiguration defines the configuration of the Shoot

--- a/pkg/gardenlet/apis/config/types.go
+++ b/pkg/gardenlet/apis/config/types.go
@@ -224,6 +224,12 @@ type ShootControllerConfiguration struct {
 	// DNSEntryTTLSeconds is the TTL in seconds that is being used for DNS entries when reconciling shoots.
 	// Default: 120s
 	DNSEntryTTLSeconds *int64
+	// LeaseDurationSeconds defines how long the lease is valid (used for Lease.spec.leaseDurationSeconds).
+	//Default : 2s
+	LeaseDurationSeconds *int32
+	// LeaseResyncSeconds defines how often (in seconds) the seed lease is renewed.
+	//Default: 2s
+	LeaseResyncSeconds *int
 }
 
 // ShootCareControllerConfiguration defines the configuration of the ShootCare

--- a/pkg/gardenlet/apis/config/types.go
+++ b/pkg/gardenlet/apis/config/types.go
@@ -197,6 +197,12 @@ type SeedControllerConfiguration struct {
 	ConcurrentSyncs *int
 	// SyncPeriod is the duration how often the existing resources are reconciled.
 	SyncPeriod *metav1.Duration
+	// LeaseDurationSeconds defines how long the lease is valid (used for Lease.spec.leaseDurationSeconds).
+	// Default: 2s
+	LeaseDurationSeconds *int32
+	// LeaseResyncSeconds defines how often (in seconds) the seed lease is renewed.
+	// Default: 2s
+	LeaseResyncSeconds *int32
 }
 
 // ShootControllerConfiguration defines the configuration of the Shoot
@@ -224,12 +230,6 @@ type ShootControllerConfiguration struct {
 	// DNSEntryTTLSeconds is the TTL in seconds that is being used for DNS entries when reconciling shoots.
 	// Default: 120s
 	DNSEntryTTLSeconds *int64
-	// LeaseDurationSeconds defines how long the lease is valid (used for Lease.spec.leaseDurationSeconds).
-	//Default : 2s
-	LeaseDurationSeconds *int32
-	// LeaseResyncSeconds defines how often (in seconds) the seed lease is renewed.
-	//Default: 2s
-	LeaseResyncSeconds *int
 }
 
 // ShootCareControllerConfiguration defines the configuration of the ShootCare

--- a/pkg/gardenlet/apis/config/types.go
+++ b/pkg/gardenlet/apis/config/types.go
@@ -203,6 +203,10 @@ type SeedControllerConfiguration struct {
 	// LeaseResyncSeconds defines how often (in seconds) the seed lease is renewed.
 	// Default: 2s
 	LeaseResyncSeconds *int32
+	// LeaseResyncGracePeriod is the amount of missed lease resyncs before the health status
+	// is changed to false.
+	// Default: 10
+	LeaseResyncGracePeriod *int32
 }
 
 // ShootControllerConfiguration defines the configuration of the Shoot

--- a/pkg/gardenlet/apis/config/v1alpha1/defaults.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/defaults.go
@@ -252,6 +252,10 @@ func SetDefaults_SeedControllerConfiguration(obj *SeedControllerConfiguration) {
 	if obj.LeaseDurationSeconds == nil {
 		obj.LeaseDurationSeconds = pointer.Int32(2)
 	}
+
+	if obj.LeaseResyncGracePeriod == nil {
+		obj.LeaseResyncGracePeriod = pointer.Int32(10)
+	}
 }
 
 // SetDefaults_ShootControllerConfiguration sets defaults for the shoot controller.

--- a/pkg/gardenlet/apis/config/v1alpha1/defaults.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/defaults.go
@@ -244,6 +244,14 @@ func SetDefaults_SeedControllerConfiguration(obj *SeedControllerConfiguration) {
 		v := DefaultControllerSyncPeriod
 		obj.SyncPeriod = &v
 	}
+
+	if obj.LeaseResyncSeconds == nil {
+		obj.LeaseResyncSeconds = pointer.Int32(2)
+	}
+
+	if obj.LeaseDurationSeconds == nil {
+		obj.LeaseDurationSeconds = pointer.Int32(2)
+	}
 }
 
 // SetDefaults_ShootControllerConfiguration sets defaults for the shoot controller.
@@ -275,14 +283,6 @@ func SetDefaults_ShootControllerConfiguration(obj *ShootControllerConfiguration)
 
 	if obj.DNSEntryTTLSeconds == nil {
 		obj.DNSEntryTTLSeconds = pointer.Int64(120)
-	}
-
-	if obj.LeaseResyncSeconds == nil {
-		obj.LeaseResyncSeconds = pointer.Int(2)
-	}
-
-	if obj.LeaseDurationSeconds == nil {
-		obj.LeaseDurationSeconds = pointer.Int32(2)
 	}
 }
 

--- a/pkg/gardenlet/apis/config/v1alpha1/defaults.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/defaults.go
@@ -276,6 +276,14 @@ func SetDefaults_ShootControllerConfiguration(obj *ShootControllerConfiguration)
 	if obj.DNSEntryTTLSeconds == nil {
 		obj.DNSEntryTTLSeconds = pointer.Int64(120)
 	}
+
+	if obj.LeaseResyncSeconds == nil {
+		obj.LeaseResyncSeconds = pointer.Int(2)
+	}
+
+	if obj.LeaseDurationSeconds == nil {
+		obj.LeaseDurationSeconds = pointer.Int32(2)
+	}
 }
 
 // SetDefaults_ShootCareControllerConfiguration sets defaults for the shoot care controller.

--- a/pkg/gardenlet/apis/config/v1alpha1/defaults.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/defaults.go
@@ -249,12 +249,8 @@ func SetDefaults_SeedControllerConfiguration(obj *SeedControllerConfiguration) {
 		obj.LeaseResyncSeconds = pointer.Int32(2)
 	}
 
-	if obj.LeaseDurationSeconds == nil {
-		obj.LeaseDurationSeconds = pointer.Int32(2)
-	}
-
-	if obj.LeaseResyncGracePeriod == nil {
-		obj.LeaseResyncGracePeriod = pointer.Int32(10)
+	if obj.LeaseResyncMissThreshold == nil {
+		obj.LeaseResyncMissThreshold = pointer.Int32(10)
 	}
 }
 

--- a/pkg/gardenlet/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/defaults_test.go
@@ -184,6 +184,23 @@ var _ = Describe("Defaults", func() {
 		})
 	})
 
+	Describe("#SetDefaults_SeedControllerConfiguration", func() {
+		var obj *SeedControllerConfiguration
+
+		BeforeEach(func() {
+			obj = &SeedControllerConfiguration{}
+		})
+
+		It("should default the configuration", func() {
+			SetDefaults_SeedControllerConfiguration(obj)
+
+			Expect(obj.ConcurrentSyncs).To(PointTo(Equal(DefaultControllerConcurrentSyncs)))
+			Expect(obj.SyncPeriod).To(PointTo(Equal(DefaultControllerSyncPeriod)))
+			Expect(obj.LeaseResyncSeconds).To(PointTo(Equal(int32(2))))
+			Expect(obj.LeaseDurationSeconds).To(PointTo(Equal(int32(2))))
+		})
+	})
+
 	Describe("#SetDefaults_ShootControllerConfiguration", func() {
 		var obj *ShootControllerConfiguration
 
@@ -200,8 +217,6 @@ var _ = Describe("Defaults", func() {
 			Expect(obj.ReconcileInMaintenanceOnly).To(PointTo(Equal(false)))
 			Expect(obj.RetryDuration).To(PointTo(Equal(metav1.Duration{Duration: 12 * time.Hour})))
 			Expect(obj.DNSEntryTTLSeconds).To(PointTo(Equal(int64(120))))
-			Expect(obj.LeaseResyncSeconds).To(PointTo(Equal(2)))
-			Expect(obj.LeaseDurationSeconds).To(PointTo(Equal(int32(2))))
 		})
 	})
 

--- a/pkg/gardenlet/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/defaults_test.go
@@ -197,8 +197,7 @@ var _ = Describe("Defaults", func() {
 			Expect(obj.ConcurrentSyncs).To(PointTo(Equal(DefaultControllerConcurrentSyncs)))
 			Expect(obj.SyncPeriod).To(PointTo(Equal(DefaultControllerSyncPeriod)))
 			Expect(obj.LeaseResyncSeconds).To(PointTo(Equal(int32(2))))
-			Expect(obj.LeaseDurationSeconds).To(PointTo(Equal(int32(2))))
-			Expect(obj.LeaseResyncGracePeriod).To(PointTo(Equal(int32(10))))
+			Expect(obj.LeaseResyncMissThreshold).To(PointTo(Equal(int32(10))))
 		})
 	})
 

--- a/pkg/gardenlet/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/defaults_test.go
@@ -198,6 +198,7 @@ var _ = Describe("Defaults", func() {
 			Expect(obj.SyncPeriod).To(PointTo(Equal(DefaultControllerSyncPeriod)))
 			Expect(obj.LeaseResyncSeconds).To(PointTo(Equal(int32(2))))
 			Expect(obj.LeaseDurationSeconds).To(PointTo(Equal(int32(2))))
+			Expect(obj.LeaseResyncGracePeriod).To(PointTo(Equal(int32(10))))
 		})
 	})
 

--- a/pkg/gardenlet/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/defaults_test.go
@@ -200,6 +200,8 @@ var _ = Describe("Defaults", func() {
 			Expect(obj.ReconcileInMaintenanceOnly).To(PointTo(Equal(false)))
 			Expect(obj.RetryDuration).To(PointTo(Equal(metav1.Duration{Duration: 12 * time.Hour})))
 			Expect(obj.DNSEntryTTLSeconds).To(PointTo(Equal(int64(120))))
+			Expect(obj.LeaseResyncSeconds).To(PointTo(Equal(2)))
+			Expect(obj.LeaseDurationSeconds).To(PointTo(Equal(int32(2))))
 		})
 	})
 

--- a/pkg/gardenlet/apis/config/v1alpha1/types.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/types.go
@@ -243,6 +243,14 @@ type SeedControllerConfiguration struct {
 	// SyncPeriod is the duration how often the existing resources are reconciled.
 	// +optional
 	SyncPeriod *metav1.Duration `json:"syncPeriod,omitempty"`
+	// LeaseDurationSeconds defines how long the lease is valid (used for Lease.spec.leaseDurationSeconds).
+	// Defaults to 2
+	// +optional
+	LeaseDurationSeconds *int32 `json:"leaseDurationSeconds,omitempty"`
+	// LeaseResyncSeconds defines how often (in seconds) the seed lease is renewed.
+	// Defaults to 2
+	// +optional
+	LeaseResyncSeconds *int32 `json:"leaseResyncSeconds,omitempty"`
 }
 
 // ShootControllerConfiguration defines the configuration of the Shoot
@@ -277,13 +285,6 @@ type ShootControllerConfiguration struct {
 	// Default: 120s
 	// +optional
 	DNSEntryTTLSeconds *int64 `json:"dnsEntryTTLSeconds,omitempty"`
-
-	//adding the below line for my next task
-	// LeaseDurationSeconds defines how long the lease is valid (used for Lease.spec.leaseDurationSeconds).
-	LeaseDurationSeconds *int32 `json:"leaseDurationSeconds,omitempty" protobuf:"varint,2,opt,name=leaseDurationSeconds"`
-
-	// LeaseResyncSeconds defines how often (in seconds) the seed lease is renewed.
-	LeaseResyncSeconds *int `json:"leaseResyncSeconds,omitempty"`
 }
 
 // ShootCareControllerConfiguration defines the configuration of the ShootCare

--- a/pkg/gardenlet/apis/config/v1alpha1/types.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/types.go
@@ -251,6 +251,11 @@ type SeedControllerConfiguration struct {
 	// Defaults to 2
 	// +optional
 	LeaseResyncSeconds *int32 `json:"leaseResyncSeconds,omitempty"`
+	// LeaseResyncGracePeriod is the amount of missed lease resyncs before the health status
+	// is changed to false.
+	// Defaults to 10
+	// +optional
+	LeaseResyncGracePeriod *int32 `json:"leaseResyncGracePeriod,omitempty"`
 }
 
 // ShootControllerConfiguration defines the configuration of the Shoot

--- a/pkg/gardenlet/apis/config/v1alpha1/types.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/types.go
@@ -277,6 +277,13 @@ type ShootControllerConfiguration struct {
 	// Default: 120s
 	// +optional
 	DNSEntryTTLSeconds *int64 `json:"dnsEntryTTLSeconds,omitempty"`
+
+	//adding the below line for my next task
+	// LeaseDurationSeconds defines how long the lease is valid (used for Lease.spec.leaseDurationSeconds).
+	LeaseDurationSeconds *int32 `json:"leaseDurationSeconds,omitempty" protobuf:"varint,2,opt,name=leaseDurationSeconds"`
+
+	// LeaseResyncSeconds defines how often (in seconds) the seed lease is renewed.
+	LeaseResyncSeconds *int `json:"leaseResyncSeconds,omitempty"`
 }
 
 // ShootCareControllerConfiguration defines the configuration of the ShootCare

--- a/pkg/gardenlet/apis/config/v1alpha1/types.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/types.go
@@ -243,19 +243,15 @@ type SeedControllerConfiguration struct {
 	// SyncPeriod is the duration how often the existing resources are reconciled.
 	// +optional
 	SyncPeriod *metav1.Duration `json:"syncPeriod,omitempty"`
-	// LeaseDurationSeconds defines how long the lease is valid (used for Lease.spec.leaseDurationSeconds).
-	// Defaults to 2
-	// +optional
-	LeaseDurationSeconds *int32 `json:"leaseDurationSeconds,omitempty"`
 	// LeaseResyncSeconds defines how often (in seconds) the seed lease is renewed.
 	// Defaults to 2
 	// +optional
 	LeaseResyncSeconds *int32 `json:"leaseResyncSeconds,omitempty"`
-	// LeaseResyncGracePeriod is the amount of missed lease resyncs before the health status
+	// LeaseResyncMissThreshold is the amount of missed lease resyncs before the health status
 	// is changed to false.
 	// Defaults to 10
 	// +optional
-	LeaseResyncGracePeriod *int32 `json:"leaseResyncGracePeriod,omitempty"`
+	LeaseResyncMissThreshold *int32 `json:"leaseResyncMissThreshold,omitempty"`
 }
 
 // ShootControllerConfiguration defines the configuration of the Shoot

--- a/pkg/gardenlet/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/zz_generated.conversion.go
@@ -1361,6 +1361,8 @@ func Convert_config_SeedConfig_To_v1alpha1_SeedConfig(in *config.SeedConfig, out
 func autoConvert_v1alpha1_SeedControllerConfiguration_To_config_SeedControllerConfiguration(in *SeedControllerConfiguration, out *config.SeedControllerConfiguration, s conversion.Scope) error {
 	out.ConcurrentSyncs = (*int)(unsafe.Pointer(in.ConcurrentSyncs))
 	out.SyncPeriod = (*v1.Duration)(unsafe.Pointer(in.SyncPeriod))
+	out.LeaseDurationSeconds = (*int32)(unsafe.Pointer(in.LeaseDurationSeconds))
+	out.LeaseResyncSeconds = (*int32)(unsafe.Pointer(in.LeaseResyncSeconds))
 	return nil
 }
 
@@ -1372,6 +1374,8 @@ func Convert_v1alpha1_SeedControllerConfiguration_To_config_SeedControllerConfig
 func autoConvert_config_SeedControllerConfiguration_To_v1alpha1_SeedControllerConfiguration(in *config.SeedControllerConfiguration, out *SeedControllerConfiguration, s conversion.Scope) error {
 	out.ConcurrentSyncs = (*int)(unsafe.Pointer(in.ConcurrentSyncs))
 	out.SyncPeriod = (*v1.Duration)(unsafe.Pointer(in.SyncPeriod))
+	out.LeaseDurationSeconds = (*int32)(unsafe.Pointer(in.LeaseDurationSeconds))
+	out.LeaseResyncSeconds = (*int32)(unsafe.Pointer(in.LeaseResyncSeconds))
 	return nil
 }
 

--- a/pkg/gardenlet/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/zz_generated.conversion.go
@@ -1363,6 +1363,7 @@ func autoConvert_v1alpha1_SeedControllerConfiguration_To_config_SeedControllerCo
 	out.SyncPeriod = (*v1.Duration)(unsafe.Pointer(in.SyncPeriod))
 	out.LeaseDurationSeconds = (*int32)(unsafe.Pointer(in.LeaseDurationSeconds))
 	out.LeaseResyncSeconds = (*int32)(unsafe.Pointer(in.LeaseResyncSeconds))
+	out.LeaseResyncGracePeriod = (*int32)(unsafe.Pointer(in.LeaseResyncGracePeriod))
 	return nil
 }
 
@@ -1376,6 +1377,7 @@ func autoConvert_config_SeedControllerConfiguration_To_v1alpha1_SeedControllerCo
 	out.SyncPeriod = (*v1.Duration)(unsafe.Pointer(in.SyncPeriod))
 	out.LeaseDurationSeconds = (*int32)(unsafe.Pointer(in.LeaseDurationSeconds))
 	out.LeaseResyncSeconds = (*int32)(unsafe.Pointer(in.LeaseResyncSeconds))
+	out.LeaseResyncGracePeriod = (*int32)(unsafe.Pointer(in.LeaseResyncGracePeriod))
 	return nil
 }
 

--- a/pkg/gardenlet/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/zz_generated.conversion.go
@@ -1361,9 +1361,8 @@ func Convert_config_SeedConfig_To_v1alpha1_SeedConfig(in *config.SeedConfig, out
 func autoConvert_v1alpha1_SeedControllerConfiguration_To_config_SeedControllerConfiguration(in *SeedControllerConfiguration, out *config.SeedControllerConfiguration, s conversion.Scope) error {
 	out.ConcurrentSyncs = (*int)(unsafe.Pointer(in.ConcurrentSyncs))
 	out.SyncPeriod = (*v1.Duration)(unsafe.Pointer(in.SyncPeriod))
-	out.LeaseDurationSeconds = (*int32)(unsafe.Pointer(in.LeaseDurationSeconds))
 	out.LeaseResyncSeconds = (*int32)(unsafe.Pointer(in.LeaseResyncSeconds))
-	out.LeaseResyncGracePeriod = (*int32)(unsafe.Pointer(in.LeaseResyncGracePeriod))
+	out.LeaseResyncMissThreshold = (*int32)(unsafe.Pointer(in.LeaseResyncMissThreshold))
 	return nil
 }
 
@@ -1375,9 +1374,8 @@ func Convert_v1alpha1_SeedControllerConfiguration_To_config_SeedControllerConfig
 func autoConvert_config_SeedControllerConfiguration_To_v1alpha1_SeedControllerConfiguration(in *config.SeedControllerConfiguration, out *SeedControllerConfiguration, s conversion.Scope) error {
 	out.ConcurrentSyncs = (*int)(unsafe.Pointer(in.ConcurrentSyncs))
 	out.SyncPeriod = (*v1.Duration)(unsafe.Pointer(in.SyncPeriod))
-	out.LeaseDurationSeconds = (*int32)(unsafe.Pointer(in.LeaseDurationSeconds))
 	out.LeaseResyncSeconds = (*int32)(unsafe.Pointer(in.LeaseResyncSeconds))
-	out.LeaseResyncGracePeriod = (*int32)(unsafe.Pointer(in.LeaseResyncGracePeriod))
+	out.LeaseResyncMissThreshold = (*int32)(unsafe.Pointer(in.LeaseResyncMissThreshold))
 	return nil
 }
 

--- a/pkg/gardenlet/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -955,6 +955,11 @@ func (in *SeedControllerConfiguration) DeepCopyInto(out *SeedControllerConfigura
 		*out = new(int32)
 		**out = **in
 	}
+	if in.LeaseResyncGracePeriod != nil {
+		in, out := &in.LeaseResyncGracePeriod, &out.LeaseResyncGracePeriod
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/gardenlet/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -945,6 +945,16 @@ func (in *SeedControllerConfiguration) DeepCopyInto(out *SeedControllerConfigura
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.LeaseDurationSeconds != nil {
+		in, out := &in.LeaseDurationSeconds, &out.LeaseDurationSeconds
+		*out = new(int32)
+		**out = **in
+	}
+	if in.LeaseResyncSeconds != nil {
+		in, out := &in.LeaseResyncSeconds, &out.LeaseResyncSeconds
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/gardenlet/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -945,18 +945,13 @@ func (in *SeedControllerConfiguration) DeepCopyInto(out *SeedControllerConfigura
 		*out = new(v1.Duration)
 		**out = **in
 	}
-	if in.LeaseDurationSeconds != nil {
-		in, out := &in.LeaseDurationSeconds, &out.LeaseDurationSeconds
-		*out = new(int32)
-		**out = **in
-	}
 	if in.LeaseResyncSeconds != nil {
 		in, out := &in.LeaseResyncSeconds, &out.LeaseResyncSeconds
 		*out = new(int32)
 		**out = **in
 	}
-	if in.LeaseResyncGracePeriod != nil {
-		in, out := &in.LeaseResyncGracePeriod, &out.LeaseResyncGracePeriod
+	if in.LeaseResyncMissThreshold != nil {
+		in, out := &in.LeaseResyncMissThreshold, &out.LeaseResyncMissThreshold
 		*out = new(int32)
 		**out = **in
 	}

--- a/pkg/gardenlet/apis/config/zz_generated.deepcopy.go
+++ b/pkg/gardenlet/apis/config/zz_generated.deepcopy.go
@@ -955,6 +955,11 @@ func (in *SeedControllerConfiguration) DeepCopyInto(out *SeedControllerConfigura
 		*out = new(int32)
 		**out = **in
 	}
+	if in.LeaseResyncGracePeriod != nil {
+		in, out := &in.LeaseResyncGracePeriod, &out.LeaseResyncGracePeriod
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/gardenlet/apis/config/zz_generated.deepcopy.go
+++ b/pkg/gardenlet/apis/config/zz_generated.deepcopy.go
@@ -945,6 +945,16 @@ func (in *SeedControllerConfiguration) DeepCopyInto(out *SeedControllerConfigura
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.LeaseDurationSeconds != nil {
+		in, out := &in.LeaseDurationSeconds, &out.LeaseDurationSeconds
+		*out = new(int32)
+		**out = **in
+	}
+	if in.LeaseResyncSeconds != nil {
+		in, out := &in.LeaseResyncSeconds, &out.LeaseResyncSeconds
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/gardenlet/apis/config/zz_generated.deepcopy.go
+++ b/pkg/gardenlet/apis/config/zz_generated.deepcopy.go
@@ -945,18 +945,13 @@ func (in *SeedControllerConfiguration) DeepCopyInto(out *SeedControllerConfigura
 		*out = new(v1.Duration)
 		**out = **in
 	}
-	if in.LeaseDurationSeconds != nil {
-		in, out := &in.LeaseDurationSeconds, &out.LeaseDurationSeconds
-		*out = new(int32)
-		**out = **in
-	}
 	if in.LeaseResyncSeconds != nil {
 		in, out := &in.LeaseResyncSeconds, &out.LeaseResyncSeconds
 		*out = new(int32)
 		**out = **in
 	}
-	if in.LeaseResyncGracePeriod != nil {
-		in, out := &in.LeaseResyncGracePeriod, &out.LeaseResyncGracePeriod
+	if in.LeaseResyncMissThreshold != nil {
+		in, out := &in.LeaseResyncMissThreshold, &out.LeaseResyncMissThreshold
 		*out = new(int32)
 		**out = **in
 	}

--- a/pkg/gardenlet/controller/seed/lease_control.go
+++ b/pkg/gardenlet/controller/seed/lease_control.go
@@ -95,7 +95,7 @@ func (r *leaseReconciler) Reconcile(ctx context.Context, request reconcile.Reque
 		return reconcile.Result{}, err
 	}
 
-	return reconcile.Result{RequeueAfter: time.Duration(*r.config.Controllers.Shoot.LeaseResyncSeconds) * time.Second}, nil
+	return reconcile.Result{RequeueAfter: time.Duration(*r.config.Controllers.Seed.LeaseResyncSeconds) * time.Second}, nil
 }
 
 func (r *leaseReconciler) reconcile(ctx context.Context, gardenClient client.Client, seed *gardencorev1beta1.Seed) error {
@@ -191,7 +191,7 @@ func (r *leaseReconciler) newOrRenewedLease(lease *coordinationv1.Lease, holderI
 	lease.OwnerReferences = []metav1.OwnerReference{ownerReference}
 	lease.Spec = coordinationv1.LeaseSpec{
 		HolderIdentity:       pointer.String(holderIdentity),
-		LeaseDurationSeconds: r.config.Controllers.Shoot.LeaseDurationSeconds,
+		LeaseDurationSeconds: r.config.Controllers.Seed.LeaseDurationSeconds,
 		RenewTime:            &metav1.MicroTime{Time: r.nowFunc().Time},
 	}
 	return lease

--- a/pkg/gardenlet/controller/seed/lease_control.go
+++ b/pkg/gardenlet/controller/seed/lease_control.go
@@ -45,10 +45,6 @@ func (c *Controller) seedLeaseAdd(obj interface{}) {
 	c.seedLeaseQueue.Add(key)
 }
 
-// LeaseResyncGracePeriod is the amount of missed lease resyncs before the health status
-// is changed to false.
-const LeaseResyncGracePeriod = 10
-
 type leaseReconciler struct {
 	clientMap     clientmap.ClientMap
 	logger        logrus.FieldLogger

--- a/pkg/gardenlet/controller/seed/lease_control.go
+++ b/pkg/gardenlet/controller/seed/lease_control.go
@@ -33,6 +33,7 @@ import (
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
+	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	"github.com/gardener/gardener/pkg/healthz"
 )
 
@@ -44,30 +45,26 @@ func (c *Controller) seedLeaseAdd(obj interface{}) {
 	c.seedLeaseQueue.Add(key)
 }
 
-const (
-	// LeaseDurationSeconds defines how long the lease is valid (used for Lease.spec.leaseDurationSeconds).
-	LeaseDurationSeconds = 2
-	// LeaseResyncSeconds defines how often (in seconds) the seed lease is renewed.
-	LeaseResyncSeconds = 2
-	// LeaseResyncGracePeriodSeconds is the grace period for how long the lease may not be resynced before the health status
-	// is changed to false.
-	LeaseResyncGracePeriodSeconds = LeaseResyncSeconds * 10
-)
+// LeaseResyncGracePeriod is the amount of missed lease resyncs before the health status
+// is changed to false.
+const LeaseResyncGracePeriod = 10
 
 type leaseReconciler struct {
 	clientMap     clientmap.ClientMap
 	logger        logrus.FieldLogger
 	healthManager healthz.Manager
 	nowFunc       func() metav1.Time
+	config        *config.GardenletConfiguration
 }
 
 // NewLeaseReconciler creates a new reconciler that periodically renews the gardenlet's lease.
-func NewLeaseReconciler(clientMap clientmap.ClientMap, l logrus.FieldLogger, healthManager healthz.Manager, nowFunc func() metav1.Time) reconcile.Reconciler {
+func NewLeaseReconciler(clientMap clientmap.ClientMap, l logrus.FieldLogger, healthManager healthz.Manager, nowFunc func() metav1.Time, config *config.GardenletConfiguration) reconcile.Reconciler {
 	return &leaseReconciler{
 		clientMap:     clientMap,
 		logger:        l,
 		nowFunc:       nowFunc,
 		healthManager: healthManager,
+		config:        config,
 	}
 }
 
@@ -98,7 +95,7 @@ func (r *leaseReconciler) Reconcile(ctx context.Context, request reconcile.Reque
 		return reconcile.Result{}, err
 	}
 
-	return reconcile.Result{RequeueAfter: LeaseResyncSeconds * time.Second}, nil
+	return reconcile.Result{RequeueAfter: time.Duration(*r.config.Controllers.Shoot.LeaseResyncSeconds) * time.Second}, nil
 }
 
 func (r *leaseReconciler) reconcile(ctx context.Context, gardenClient client.Client, seed *gardencorev1beta1.Seed) error {
@@ -194,7 +191,7 @@ func (r *leaseReconciler) newOrRenewedLease(lease *coordinationv1.Lease, holderI
 	lease.OwnerReferences = []metav1.OwnerReference{ownerReference}
 	lease.Spec = coordinationv1.LeaseSpec{
 		HolderIdentity:       pointer.String(holderIdentity),
-		LeaseDurationSeconds: pointer.Int32(LeaseDurationSeconds),
+		LeaseDurationSeconds: r.config.Controllers.Shoot.LeaseDurationSeconds,
 		RenewTime:            &metav1.MicroTime{Time: r.nowFunc().Time},
 	}
 	return lease

--- a/pkg/gardenlet/controller/seed/lease_control.go
+++ b/pkg/gardenlet/controller/seed/lease_control.go
@@ -187,7 +187,7 @@ func (r *leaseReconciler) newOrRenewedLease(lease *coordinationv1.Lease, holderI
 	lease.OwnerReferences = []metav1.OwnerReference{ownerReference}
 	lease.Spec = coordinationv1.LeaseSpec{
 		HolderIdentity:       pointer.String(holderIdentity),
-		LeaseDurationSeconds: r.config.Controllers.Seed.LeaseDurationSeconds,
+		LeaseDurationSeconds: r.config.Controllers.Seed.LeaseResyncSeconds,
 		RenewTime:            &metav1.MicroTime{Time: r.nowFunc().Time},
 	}
 	return lease

--- a/pkg/gardenlet/controller/seed/lease_control_test.go
+++ b/pkg/gardenlet/controller/seed/lease_control_test.go
@@ -112,8 +112,8 @@ var _ = Describe("LeaseReconciler", func() {
 
 		gardenletConf = &config.GardenletConfiguration{
 			Controllers: &config.GardenletControllerConfiguration{
-				Shoot: &config.ShootControllerConfiguration{
-					LeaseResyncSeconds:   pointer.Int(2),
+				Seed: &config.SeedControllerConfiguration{
+					LeaseResyncSeconds:   pointer.Int32(2),
 					LeaseDurationSeconds: pointer.Int32(2),
 				},
 			},
@@ -170,7 +170,7 @@ var _ = Describe("LeaseReconciler", func() {
 
 	It("reques after the LeaseResync duration successfully", func() {
 		expectedCondition = gardenletReadyCondition()
-		gardenletConf.Controllers.Shoot.LeaseResyncSeconds = pointer.Int(4)
+		gardenletConf.Controllers.Seed.LeaseResyncSeconds = pointer.Int32(4)
 		Expect(reconciler.Reconcile(ctx, request)).To(Equal(reconcile.Result{RequeueAfter: 4 * time.Second}))
 		Expect(healthManager.Get()).To(BeTrue())
 	})
@@ -179,7 +179,7 @@ var _ = Describe("LeaseReconciler", func() {
 		expectedCondition = gardenletReadyCondition()
 		expectedLease.Spec.LeaseDurationSeconds = pointer.Int32(3)
 
-		gardenletConf.Controllers.Shoot.LeaseDurationSeconds = pointer.Int32(3)
+		gardenletConf.Controllers.Seed.LeaseDurationSeconds = pointer.Int32(3)
 		request = reconcile.Request{NamespacedName: client.ObjectKeyFromObject(seed)}
 
 		_, err := reconciler.Reconcile(ctx, request)

--- a/pkg/gardenlet/controller/seed/lease_control_test.go
+++ b/pkg/gardenlet/controller/seed/lease_control_test.go
@@ -168,13 +168,6 @@ var _ = Describe("LeaseReconciler", func() {
 		Expect(healthManager.Get()).To(BeTrue())
 	})
 
-	It("reques after the LeaseResync duration successfully", func() {
-		expectedCondition = gardenletReadyCondition()
-		gardenletConf.Controllers.Seed.LeaseResyncSeconds = pointer.Int32(4)
-		Expect(reconciler.Reconcile(ctx, request)).To(Equal(reconcile.Result{RequeueAfter: 4 * time.Second}))
-		Expect(healthManager.Get()).To(BeTrue())
-	})
-
 	It("should check if LeaseResyncSeconds matches the expectedLease value", func() {
 		expectedCondition = gardenletReadyCondition()
 		expectedLease.Spec.LeaseDurationSeconds = pointer.Int32(3)
@@ -182,8 +175,7 @@ var _ = Describe("LeaseReconciler", func() {
 		gardenletConf.Controllers.Seed.LeaseResyncSeconds = pointer.Int32(3)
 		request = reconcile.Request{NamespacedName: client.ObjectKeyFromObject(seed)}
 
-		_, err := reconciler.Reconcile(ctx, request)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(reconciler.Reconcile(ctx, request)).To(Equal(reconcile.Result{RequeueAfter: 3 * time.Second}))
 		Expect(healthManager.Get()).To(BeTrue())
 	})
 

--- a/pkg/gardenlet/controller/seed/lease_control_test.go
+++ b/pkg/gardenlet/controller/seed/lease_control_test.go
@@ -113,9 +113,8 @@ var _ = Describe("LeaseReconciler", func() {
 		gardenletConf = &config.GardenletConfiguration{
 			Controllers: &config.GardenletControllerConfiguration{
 				Seed: &config.SeedControllerConfiguration{
-					LeaseResyncSeconds:     pointer.Int32(2),
-					LeaseDurationSeconds:   pointer.Int32(2),
-					LeaseResyncGracePeriod: pointer.Int32(10),
+					LeaseResyncSeconds:       pointer.Int32(2),
+					LeaseResyncMissThreshold: pointer.Int32(10),
 				},
 			},
 		}
@@ -176,11 +175,11 @@ var _ = Describe("LeaseReconciler", func() {
 		Expect(healthManager.Get()).To(BeTrue())
 	})
 
-	It("should check if LeaseDurationSeconds matches the expectedLease value", func() {
+	It("should check if LeaseResyncSeconds matches the expectedLease value", func() {
 		expectedCondition = gardenletReadyCondition()
 		expectedLease.Spec.LeaseDurationSeconds = pointer.Int32(3)
 
-		gardenletConf.Controllers.Seed.LeaseDurationSeconds = pointer.Int32(3)
+		gardenletConf.Controllers.Seed.LeaseResyncSeconds = pointer.Int32(3)
 		request = reconcile.Request{NamespacedName: client.ObjectKeyFromObject(seed)}
 
 		_, err := reconciler.Reconcile(ctx, request)

--- a/pkg/gardenlet/controller/seed/lease_control_test.go
+++ b/pkg/gardenlet/controller/seed/lease_control_test.go
@@ -113,8 +113,9 @@ var _ = Describe("LeaseReconciler", func() {
 		gardenletConf = &config.GardenletConfiguration{
 			Controllers: &config.GardenletControllerConfiguration{
 				Seed: &config.SeedControllerConfiguration{
-					LeaseResyncSeconds:   pointer.Int32(2),
-					LeaseDurationSeconds: pointer.Int32(2),
+					LeaseResyncSeconds:     pointer.Int32(2),
+					LeaseDurationSeconds:   pointer.Int32(2),
+					LeaseResyncGracePeriod: pointer.Int32(10),
 				},
 			},
 		}

--- a/pkg/gardenlet/controller/seed/seed.go
+++ b/pkg/gardenlet/controller/seed/seed.go
@@ -82,7 +82,7 @@ func NewSeedController(
 
 	seedController := &Controller{
 		reconciler:      newReconciler(clientMap, recorder, logger.Logger, imageVector, componentImageVectors, identity, clientCertificateExpirationTimestamp, config),
-		leaseReconciler: NewLeaseReconciler(clientMap, logger.Logger, healthManager, metav1.Now),
+		leaseReconciler: NewLeaseReconciler(clientMap, logger.Logger, healthManager, metav1.Now, config),
 
 		// TODO: move this reconciler to controller-manager and let it run once for all Seeds, no Seed specifics required here
 		extensionCheckReconciler: NewExtensionCheckReconciler(clientMap, logger.Logger, metav1.Now),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement

**What this PR does / why we need it**:
Make seed lease/duration period configurable.
**Which issue(s) this PR fixes**:
Fixes #4504

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Two fields `LeaseDurationSeconds` and `LeaseResyncSeconds` added under `SeedControllerConfiguration` to make Seed lease and duration configurable. Both field have default value of 2 seconds.
```
