### PR TITLE
Drop support for "ambiguous" gardenlets in `Seed{Authorizer,Restriction}`

### DIFF
--- a/docs/deployment/gardenlet_api_access.md
+++ b/docs/deployment/gardenlet_api_access.md
@@ -112,14 +112,12 @@ As mentioned earlier, it's the authorizer's job to evaluate API requests and ret
 - `DecisionDeny`: The request is denied, further configured authorizers won't be consulted.
 - `DecisionNoOpinion`: A decision cannot be made, further configured authorizers will be consulted.
 
-For backwards compatibility, no requests are denied at the moment, so that an ambiguous request is still deferred to a subsequent authorizer like RBAC.
+For backwards compatibility, no requests are denied at the moment, so that they are still deferred to a subsequent authorizer like RBAC.
+Though, this might change in the future.
 
 First, the `SeedAuthorizer` extracts the `Seed` name from the API request. This requires a proper TLS certificate the `gardenlet` uses to contact the API server and is automatically given if [TLS bootstrapping](../concepts/gardenlet.md#TLS-Bootstrapping) is used.
 Concretely, the authorizer checks the certificate for name `gardener.cloud:system:seed:<seed-name>` and group `gardener.cloud:system:seeds`.
-In cases this information is missing e.g., when a custom Kubeconfig is used, the authorizer cannot make any decision.
-Likewise, if `gardenlet` is responsible for more than one `Seed`, the name in the mentioned TLS certificate is `gardener.cloud:system:seed:<ambiguous>` and a definite decision cannot be made as well.
-The authorizer immediately returns with `DecisionNoOpinion` for all ambiguous cases which means that the request is neither allowed nor denied and further configured authorizers (e.g. RBAC) will be contacted.
-Thus, RBAC is still a considerable option to restrict the `gardenlet`'s access permission if the above explained preconditions are not given.
+In cases where this information is missing e.g., when a custom Kubeconfig is used, the authorizer cannot make any decision. Thus, RBAC is still a considerable option to restrict the `gardenlet`'s access permission if the above explained preconditions are not given.
 
 With the `Seed` name at hand, the authorizer checks for an **existing path** from the resource that a request is being made for to the `Seed` belonging to the `gardenlet`. Take a look at the [Implementation Details](#implementation-details) section for more information.
 

--- a/pkg/admissioncontroller/seedidentity/identity.go
+++ b/pkg/admissioncontroller/seedidentity/identity.go
@@ -26,7 +26,7 @@ import (
 )
 
 // FromUserInfoInterface returns the seed name and a boolean indicating whether the provided user has the
-// gardener.cloud:system:seeds group. If the seed name is ambiguous then an empty string will be returned.
+// gardener.cloud:system:seeds group.
 func FromUserInfoInterface(u user.Info) (string, bool) {
 	if u == nil {
 		return "", false
@@ -41,9 +41,12 @@ func FromUserInfoInterface(u user.Info) (string, bool) {
 		return "", false
 	}
 
-	var seedName string
-	if suffix := strings.TrimPrefix(userName, v1beta1constants.SeedUserNamePrefix); suffix != v1beta1constants.SeedUserNameSuffixAmbiguous {
-		seedName = suffix
+	seedName := strings.TrimPrefix(userName, v1beta1constants.SeedUserNamePrefix)
+	if seedName == "" ||
+		// Do no longer consider "ambiguous" gardenlets as valid users.
+		// TODO(rfranzke): Drop this in a future version.
+		seedName == "<ambiguous>" {
+		return "", false
 	}
 
 	return seedName, true

--- a/pkg/admissioncontroller/seedidentity/identity_test.go
+++ b/pkg/admissioncontroller/seedidentity/identity_test.go
@@ -41,7 +41,7 @@ var _ = Describe("identity", func() {
 		Entry("user name prefix but no groups", &user.DefaultInfo{Name: "gardener.cloud:system:seed:foo"}, "", false),
 		Entry("user name prefix but seed group not present", &user.DefaultInfo{Name: "gardener.cloud:system:seed:foo", Groups: []string{"bar"}}, "", false),
 		Entry("user name prefix and seed group", &user.DefaultInfo{Name: "gardener.cloud:system:seed:foo", Groups: []string{"gardener.cloud:system:seeds"}}, "foo", true),
-		Entry("user name prefix and seed group (ambiguous)", &user.DefaultInfo{Name: "gardener.cloud:system:seed:<ambiguous>", Groups: []string{"gardener.cloud:system:seeds"}}, "", true),
+		Entry("user name prefix and seed group (ambiguous)", &user.DefaultInfo{Name: "gardener.cloud:system:seed:<ambiguous>", Groups: []string{"gardener.cloud:system:seeds"}}, "", false),
 	)
 
 	DescribeTable("#FromAuthenticationV1UserInfo",
@@ -56,7 +56,7 @@ var _ = Describe("identity", func() {
 		Entry("user name prefix but no groups", authenticationv1.UserInfo{Username: "gardener.cloud:system:seed:foo"}, "", false),
 		Entry("user name prefix but seed group not present", authenticationv1.UserInfo{Username: "gardener.cloud:system:seed:foo", Groups: []string{"bar"}}, "", false),
 		Entry("user name prefix and seed group", authenticationv1.UserInfo{Username: "gardener.cloud:system:seed:foo", Groups: []string{"gardener.cloud:system:seeds"}}, "foo", true),
-		Entry("user name prefix and seed group (ambiguous)", authenticationv1.UserInfo{Username: "gardener.cloud:system:seed:<ambiguous>", Groups: []string{"gardener.cloud:system:seeds"}}, "", true),
+		Entry("user name prefix and seed group (ambiguous)", authenticationv1.UserInfo{Username: "gardener.cloud:system:seed:<ambiguous>", Groups: []string{"gardener.cloud:system:seeds"}}, "", false),
 	)
 
 	DescribeTable("#FromCertificateSigningRequest",
@@ -71,6 +71,6 @@ var _ = Describe("identity", func() {
 		Entry("user name prefix but no groups", &x509.CertificateRequest{Subject: pkix.Name{CommonName: "gardener.cloud:system:seed:foo"}}, "", false),
 		Entry("user name prefix but seed group not present", &x509.CertificateRequest{Subject: pkix.Name{CommonName: "gardener.cloud:system:seed:foo", Organization: []string{"bar"}}}, "", false),
 		Entry("user name prefix and seed group", &x509.CertificateRequest{Subject: pkix.Name{CommonName: "gardener.cloud:system:seed:foo", Organization: []string{"gardener.cloud:system:seeds"}}}, "foo", true),
-		Entry("user name prefix and seed group (ambiguous)", &x509.CertificateRequest{Subject: pkix.Name{CommonName: "gardener.cloud:system:seed:<ambiguous>", Organization: []string{"gardener.cloud:system:seeds"}}}, "", true),
+		Entry("user name prefix and seed group (ambiguous)", &x509.CertificateRequest{Subject: pkix.Name{CommonName: "gardener.cloud:system:seed:<ambiguous>", Organization: []string{"gardener.cloud:system:seeds"}}}, "", false),
 	)
 })

--- a/pkg/admissioncontroller/webhooks/admission/seedrestriction/admission.go
+++ b/pkg/admissioncontroller/webhooks/admission/seedrestriction/admission.go
@@ -152,10 +152,6 @@ func (h *handler) admitBackupBucket(ctx context.Context, seedName string, reques
 		return h.admit(seedName, backupBucket.Spec.SeedName)
 
 	case admissionv1.Delete:
-		// Allow request if seed name is not known (ambiguous case).
-		if seedName == "" {
-			return admission.Allowed("")
-		}
 		// If a gardenlet tries to delete a BackupBucket then it may only be allowed if the name is equal to the UID of
 		// the gardenlet's seed.
 		seed := &gardencorev1beta1.Seed{}
@@ -470,11 +466,6 @@ func (h *handler) admitShootState(ctx context.Context, seedName string, request 
 }
 
 func (h *handler) admit(seedName string, seedNamesForObject ...*string) admission.Response {
-	// Allow request if seed name is not known (ambiguous case).
-	if seedName == "" {
-		return admission.Allowed("")
-	}
-
 	// Allow request if one of the seed names for the object matches the seed name of the requesting user.
 	for _, seedNameForObject := range seedNamesForObject {
 		if seedNameForObject != nil && *seedNameForObject == seedName {

--- a/pkg/admissioncontroller/webhooks/admission/seedrestriction/admission_test.go
+++ b/pkg/admissioncontroller/webhooks/admission/seedrestriction/admission_test.go
@@ -69,8 +69,8 @@ var _ = Describe("handler", func() {
 		request admission.Request
 		encoder runtime.Encoder
 
-		seedName                string
-		seedUser, ambiguousUser authenticationv1.UserInfo
+		seedName string
+		seedUser authenticationv1.UserInfo
 
 		responseAllowed = admission.Response{
 			AdmissionResponse: admissionv1.AdmissionResponse{
@@ -104,10 +104,6 @@ var _ = Describe("handler", func() {
 		seedName = "seed"
 		seedUser = authenticationv1.UserInfo{
 			Username: fmt.Sprintf("%s%s", v1beta1constants.SeedUserNamePrefix, seedName),
-			Groups:   []string{v1beta1constants.SeedsGroup},
-		}
-		ambiguousUser = authenticationv1.UserInfo{
-			Username: fmt.Sprintf("%s%s", v1beta1constants.SeedUserNamePrefix, v1beta1constants.SeedUserNameSuffixAmbiguous),
 			Groups:   []string{v1beta1constants.SeedsGroup},
 		}
 	})
@@ -227,28 +223,6 @@ var _ = Describe("handler", func() {
 
 					Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
 				})
-
-				It("should allow the request because seed name is ambiguous (spec)", func() {
-					request.UserInfo = ambiguousUser
-
-					mockCache.EXPECT().Get(ctx, kutil.Key(namespace, name), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot) error {
-						(&gardencorev1beta1.Shoot{Spec: gardencorev1beta1.ShootSpec{SeedName: pointer.String("some-different-seed")}}).DeepCopyInto(obj)
-						return nil
-					})
-
-					Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
-				})
-
-				It("should allow the request because seed name is ambiguous (status)", func() {
-					request.UserInfo = ambiguousUser
-
-					mockCache.EXPECT().Get(ctx, kutil.Key(namespace, name), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot) error {
-						(&gardencorev1beta1.Shoot{Status: gardencorev1beta1.ShootStatus{SeedName: pointer.String("some-different-seed")}}).DeepCopyInto(obj)
-						return nil
-					})
-
-					Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
-				})
 			})
 		})
 
@@ -340,20 +314,6 @@ var _ = Describe("handler", func() {
 
 					Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
 				})
-
-				It("should allow the request because seed name is ambiguous", func() {
-					request.UserInfo = ambiguousUser
-
-					objData, err := runtime.Encode(encoder, &gardencorev1beta1.BackupBucket{
-						Spec: gardencorev1beta1.BackupBucketSpec{
-							SeedName: pointer.String("some-different-seed"),
-						},
-					})
-					Expect(err).NotTo(HaveOccurred())
-					request.Object.Raw = objData
-
-					Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
-				})
 			})
 
 			Context("when operation is delete", func() {
@@ -398,17 +358,6 @@ var _ = Describe("handler", func() {
 
 					mockCache.EXPECT().Get(ctx, kutil.Key(seedName), gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Seed) error {
 						(&gardencorev1beta1.Seed{ObjectMeta: metav1.ObjectMeta{UID: types.UID(uid)}}).DeepCopyInto(obj)
-						return nil
-					})
-
-					Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
-				})
-
-				It("should allow the request because seed name is ambiguous", func() {
-					request.UserInfo = ambiguousUser
-
-					mockCache.EXPECT().Get(ctx, kutil.Key(seedName), gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Seed) error {
-						(&gardencorev1beta1.Seed{ObjectMeta: metav1.ObjectMeta{UID: "1234"}}).DeepCopyInto(obj)
 						return nil
 					})
 
@@ -525,33 +474,6 @@ var _ = Describe("handler", func() {
 
 					Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
 				})
-
-				DescribeTable("should allow the request because seed name is ambiguous",
-					func(seedNameInBackupEntry, seedNameInBackupBucket *string) {
-						request.UserInfo = ambiguousUser
-
-						objData, err := runtime.Encode(encoder, &gardencorev1beta1.BackupEntry{
-							Spec: gardencorev1beta1.BackupEntrySpec{
-								BucketName: bucketName,
-								SeedName:   seedNameInBackupEntry,
-							},
-						})
-						Expect(err).NotTo(HaveOccurred())
-						request.Object.Raw = objData
-
-						mockCache.EXPECT().Get(ctx, kutil.Key(bucketName), gomock.AssignableToTypeOf(&gardencorev1beta1.BackupBucket{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.BackupBucket) error {
-							(&gardencorev1beta1.BackupBucket{Spec: gardencorev1beta1.BackupBucketSpec{SeedName: seedNameInBackupBucket}}).DeepCopyInto(obj)
-							return nil
-						})
-
-						Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
-					},
-
-					Entry("seed name nil", nil, nil),
-					Entry("seed name is different", pointer.String("some-different-seed"), nil),
-					Entry("seed name is equal but bucket's seed name is nil", &seedName, nil),
-					Entry("seed name is equal but bucket's seed name is different", &seedName, pointer.String("some-different-seed")),
-				)
 			})
 		})
 
@@ -612,20 +534,6 @@ var _ = Describe("handler", func() {
 					objData, err := runtime.Encode(encoder, &gardenoperationsv1alpha1.Bastion{
 						Spec: gardenoperationsv1alpha1.BastionSpec{
 							SeedName: &seedName,
-						},
-					})
-					Expect(err).NotTo(HaveOccurred())
-					request.Object.Raw = objData
-
-					Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
-				})
-
-				It("should allow the request because seed name is ambiguous", func() {
-					request.UserInfo = ambiguousUser
-
-					objData, err := runtime.Encode(encoder, &gardenoperationsv1alpha1.Bastion{
-						Spec: gardenoperationsv1alpha1.BastionSpec{
-							SeedName: pointer.String("some-different-seed"),
 						},
 					})
 					Expect(err).NotTo(HaveOccurred())
@@ -706,14 +614,6 @@ var _ = Describe("handler", func() {
 
 					Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
 				})
-
-				It("should allow the request because seed name is ambiguous", func() {
-					request.Name = "some-different-seed"
-					request.Namespace = "gardener-system-seed-lease"
-					request.UserInfo = ambiguousUser
-
-					Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
-				})
 			})
 		})
 
@@ -757,13 +657,6 @@ var _ = Describe("handler", func() {
 
 					It("should allow the request because seed name matches", func() {
 						request.Name = seedName
-
-						Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
-					})
-
-					It("should allow the request because seed name is ambiguous", func() {
-						request.UserInfo = ambiguousUser
-						request.Name = "some-different-seed"
 
 						Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
 					})
@@ -1140,44 +1033,6 @@ BkEao/FEz4eQuV5atSD0S78+aF4BriEtWKKjXECTCxMuqcA24vGOgHIrEbKd7zSC
 
 						Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
 					})
-
-					It("should allow the request because seed name is ambiguous", func() {
-						objData, err := runtime.Encode(encoder, &certificatesv1beta1.CertificateSigningRequest{
-							TypeMeta: metav1.TypeMeta{
-								APIVersion: certificatesv1beta1.SchemeGroupVersion.String(),
-								Kind:       "CertificateSigningRequest",
-							},
-							Spec: certificatesv1beta1.CertificateSigningRequestSpec{
-								Request: []byte(`-----BEGIN CERTIFICATE REQUEST-----
-MIIClzCCAX8CAQAwUjEkMCIGA1UEChMbZ2FyZGVuZXIuY2xvdWQ6c3lzdGVtOnNl
-ZWRzMSowKAYDVQQDEyFnYXJkZW5lci5jbG91ZDpzeXN0ZW06c2VlZDpteXNlZWQw
-ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCzNgJWhogJrCSzAhKKmHkJ
-FuooKAbxpWRGDOe5DiB8jPdgCoRCkZYnF7D9x9cDzliljA9IeBad3P3E9oegtSV/
-sXFJYqb+lRuhJQ5oo2eBC6WRg+Oxglp+n7o7xt0bO7JHS977mqNrqsJ1d1FnJHTB
-MPHPxqoqkgIbdW4t219ckSA20aWzC3PU7I7+Z9OD+YfuuYgzkWG541XyBBKVSD2w
-Ix2yGu6zrslqZ1eVBZ4IoxpWrQNmLSMFQVnABThyEUi0U1eVtW0vPNwSnBf0mufX
-Z0PpqAIPVjr64Z4s3HHml2GSu64iOxaG5wwb9qIPcdyFaQCep/sFh7kq1KjNI1Ql
-AgMBAAGgADANBgkqhkiG9w0BAQsFAAOCAQEAb+meLvm7dgHpzhu0XQ39w41FgpTv
-S7p78ABFwzDNcP1NwfrEUft0T/rUwPiMlN9zve2rRicaZX5Z7Bol/newejsu8H5z
-OdotvtKjE7zBCMzwnXZwO/0pA0cuUFcAy50DPcr35gdGjGlzV9ogO+HPKPTieS3n
-TRVg+MWlcLqCjALr9Y4N39DOzf4/SJts8AZJJ+lyyxnY3XIPXx7SdADwNWC8BX0U
-OK8CwMwN3iiBQ4redVeMK7LU1unV899q/PWB+NXFcKVr+Grm/Kom5VxuhXSzcHEp
-yO57qEcJqG1cB7iSchFuCSTuDBbZlN0fXgn4YjiWZyb4l3BDp3rm4iJImA==
------END CERTIFICATE REQUEST-----`),
-								Usages: []certificatesv1beta1.KeyUsage{
-									certificatesv1beta1.UsageKeyEncipherment,
-									certificatesv1beta1.UsageDigitalSignature,
-									certificatesv1beta1.UsageClientAuth,
-								},
-							},
-						})
-						Expect(err).NotTo(HaveOccurred())
-						request.Object.Raw = objData
-
-						request.UserInfo = ambiguousUser
-
-						Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
-					})
 				})
 
 				Context("v1", func() {
@@ -1307,44 +1162,6 @@ BkEao/FEz4eQuV5atSD0S78+aF4BriEtWKKjXECTCxMuqcA24vGOgHIrEbKd7zSC
 
 						Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
 					})
-
-					It("should allow the request because seed name is ambiguous", func() {
-						objData, err := runtime.Encode(encoder, &certificatesv1.CertificateSigningRequest{
-							TypeMeta: metav1.TypeMeta{
-								APIVersion: certificatesv1.SchemeGroupVersion.String(),
-								Kind:       "CertificateSigningRequest",
-							},
-							Spec: certificatesv1.CertificateSigningRequestSpec{
-								Request: []byte(`-----BEGIN CERTIFICATE REQUEST-----
-MIIClzCCAX8CAQAwUjEkMCIGA1UEChMbZ2FyZGVuZXIuY2xvdWQ6c3lzdGVtOnNl
-ZWRzMSowKAYDVQQDEyFnYXJkZW5lci5jbG91ZDpzeXN0ZW06c2VlZDpteXNlZWQw
-ggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCzNgJWhogJrCSzAhKKmHkJ
-FuooKAbxpWRGDOe5DiB8jPdgCoRCkZYnF7D9x9cDzliljA9IeBad3P3E9oegtSV/
-sXFJYqb+lRuhJQ5oo2eBC6WRg+Oxglp+n7o7xt0bO7JHS977mqNrqsJ1d1FnJHTB
-MPHPxqoqkgIbdW4t219ckSA20aWzC3PU7I7+Z9OD+YfuuYgzkWG541XyBBKVSD2w
-Ix2yGu6zrslqZ1eVBZ4IoxpWrQNmLSMFQVnABThyEUi0U1eVtW0vPNwSnBf0mufX
-Z0PpqAIPVjr64Z4s3HHml2GSu64iOxaG5wwb9qIPcdyFaQCep/sFh7kq1KjNI1Ql
-AgMBAAGgADANBgkqhkiG9w0BAQsFAAOCAQEAb+meLvm7dgHpzhu0XQ39w41FgpTv
-S7p78ABFwzDNcP1NwfrEUft0T/rUwPiMlN9zve2rRicaZX5Z7Bol/newejsu8H5z
-OdotvtKjE7zBCMzwnXZwO/0pA0cuUFcAy50DPcr35gdGjGlzV9ogO+HPKPTieS3n
-TRVg+MWlcLqCjALr9Y4N39DOzf4/SJts8AZJJ+lyyxnY3XIPXx7SdADwNWC8BX0U
-OK8CwMwN3iiBQ4redVeMK7LU1unV899q/PWB+NXFcKVr+Grm/Kom5VxuhXSzcHEp
-yO57qEcJqG1cB7iSchFuCSTuDBbZlN0fXgn4YjiWZyb4l3BDp3rm4iJImA==
------END CERTIFICATE REQUEST-----`),
-								Usages: []certificatesv1.KeyUsage{
-									certificatesv1.UsageKeyEncipherment,
-									certificatesv1.UsageDigitalSignature,
-									certificatesv1.UsageClientAuth,
-								},
-							},
-						})
-						Expect(err).NotTo(HaveOccurred())
-						request.Object.Raw = objData
-
-						request.UserInfo = ambiguousUser
-
-						Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
-					})
 				})
 			})
 		})
@@ -1461,17 +1278,6 @@ yO57qEcJqG1cB7iSchFuCSTuDBbZlN0fXgn4YjiWZyb4l3BDp3rm4iJImA==
 
 						Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
 					})
-
-					It("should allow because the user is ambiguous", func() {
-						request.UserInfo = ambiguousUser
-
-						mockCache.EXPECT().Get(ctx, kutil.Key(name), gomock.AssignableToTypeOf(&gardencorev1beta1.BackupBucket{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.BackupBucket) error {
-							(&gardencorev1beta1.BackupBucket{Spec: gardencorev1beta1.BackupBucketSpec{SeedName: pointer.String("some-different-seed")}}).DeepCopyInto(obj)
-							return nil
-						})
-
-						Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
-					})
 				})
 
 				Context("shoot-related project secret", func() {
@@ -1528,17 +1334,6 @@ yO57qEcJqG1cB7iSchFuCSTuDBbZlN0fXgn4YjiWZyb4l3BDp3rm4iJImA==
 						It("should allow because the related shoot does belong to gardenlet's seed", func() {
 							mockCache.EXPECT().Get(ctx, kutil.Key(namespace, name), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot) error {
 								(&gardencorev1beta1.Shoot{Spec: gardencorev1beta1.ShootSpec{SeedName: &seedName}}).DeepCopyInto(obj)
-								return nil
-							})
-
-							Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
-						})
-
-						It("should allow because the user is ambiguous", func() {
-							request.UserInfo = ambiguousUser
-
-							mockCache.EXPECT().Get(ctx, kutil.Key(namespace, name), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot) error {
-								(&gardencorev1beta1.Shoot{Spec: gardencorev1beta1.ShootSpec{SeedName: pointer.String("some-different-seed")}}).DeepCopyInto(obj)
 								return nil
 							})
 
@@ -1805,44 +1600,7 @@ yO57qEcJqG1cB7iSchFuCSTuDBbZlN0fXgn4YjiWZyb4l3BDp3rm4iJImA==
 						Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
 					})
 
-					It("should allow if the seed does not yet exist (ambiguous case)", func() {
-						request.UserInfo = ambiguousUser
-						shoot.Spec.SeedName = pointer.String("some-other-seed")
-
-						mockCache.EXPECT().Get(ctx, kutil.Key(managedSeedNamespace, managedSeedName), gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeed{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *seedmanagementv1alpha1.ManagedSeed) error {
-							managedSeed.DeepCopyInto(obj)
-							return nil
-						})
-						mockCache.EXPECT().Get(ctx, kutil.Key(managedSeedNamespace, shootName), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot) error {
-							shoot.DeepCopyInto(obj)
-							return nil
-						})
-						mockCache.EXPECT().Get(ctx, kutil.Key(managedSeedName), gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
-
-						Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
-					})
-
 					It("should allow if the seed does exist but client cert is expired", func() {
-						mockCache.EXPECT().Get(ctx, kutil.Key(managedSeedNamespace, managedSeedName), gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeed{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *seedmanagementv1alpha1.ManagedSeed) error {
-							managedSeed.DeepCopyInto(obj)
-							return nil
-						})
-						mockCache.EXPECT().Get(ctx, kutil.Key(managedSeedNamespace, shootName), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot) error {
-							shoot.DeepCopyInto(obj)
-							return nil
-						})
-						mockCache.EXPECT().Get(ctx, kutil.Key(managedSeedName), gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Seed) error {
-							(&gardencorev1beta1.Seed{Status: gardencorev1beta1.SeedStatus{ClientCertificateExpirationTimestamp: &metav1.Time{Time: time.Now().Add(-time.Hour)}}}).DeepCopyInto(obj)
-							return nil
-						})
-
-						Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
-					})
-
-					It("should allow if the seed does exist but client cert is expired (ambiguous case)", func() {
-						request.UserInfo = ambiguousUser
-						shoot.Spec.SeedName = pointer.String("some-other-seed")
-
 						mockCache.EXPECT().Get(ctx, kutil.Key(managedSeedNamespace, managedSeedName), gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeed{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *seedmanagementv1alpha1.ManagedSeed) error {
 							managedSeed.DeepCopyInto(obj)
 							return nil
@@ -2094,72 +1852,6 @@ yO57qEcJqG1cB7iSchFuCSTuDBbZlN0fXgn4YjiWZyb4l3BDp3rm4iJImA==
 						})
 
 						Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
-					})
-
-					Context("ambiguous user", func() {
-						BeforeEach(func() {
-							request.UserInfo = ambiguousUser
-						})
-
-						It("should allow because the secret is referenced in a managedseed's `.seedTemplate.spec.secretRef`", func() {
-							var (
-								secretName      = "secret-foo"
-								secretNamespace = "secret-bar"
-							)
-
-							request.Namespace = secretNamespace
-							request.Name = secretName
-							managedSeeds[0].Spec.SeedTemplate.Spec.SecretRef = &corev1.SecretReference{
-								Name:      secretName,
-								Namespace: secretNamespace,
-							}
-
-							mockCache.EXPECT().List(ctx, gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeedList{})).DoAndReturn(func(ctx context.Context, list *seedmanagementv1alpha1.ManagedSeedList, opts ...client.ListOption) error {
-								(&seedmanagementv1alpha1.ManagedSeedList{Items: managedSeeds}).DeepCopyInto(list)
-								return nil
-							})
-							mockCache.EXPECT().Get(ctx, kutil.Key(managedSeed1Namespace, shoot1.Name), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot) error {
-								shoot1.DeepCopyInto(obj)
-								return nil
-							})
-							mockCache.EXPECT().Get(ctx, kutil.Key(managedSeed1Namespace, shoot2.Name), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot) error {
-								shoot2.DeepCopyInto(obj)
-								return nil
-							})
-
-							Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
-						})
-
-						It("should allow because the secret is referenced in a managedseed's `.seedTemplate.spec.backup.secretRef`", func() {
-							var (
-								secretName      = "secret-bar"
-								secretNamespace = "secret-foo"
-							)
-
-							request.Namespace = secretNamespace
-							request.Name = secretName
-							managedSeeds[0].Spec.SeedTemplate.Spec.Backup = &gardencorev1beta1.SeedBackup{
-								SecretRef: corev1.SecretReference{
-									Name:      secretName,
-									Namespace: secretNamespace,
-								},
-							}
-
-							mockCache.EXPECT().List(ctx, gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeedList{})).DoAndReturn(func(ctx context.Context, list *seedmanagementv1alpha1.ManagedSeedList, opts ...client.ListOption) error {
-								(&seedmanagementv1alpha1.ManagedSeedList{Items: managedSeeds}).DeepCopyInto(list)
-								return nil
-							})
-							mockCache.EXPECT().Get(ctx, kutil.Key(managedSeed1Namespace, shoot1.Name), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot) error {
-								shoot1.DeepCopyInto(obj)
-								return nil
-							})
-							mockCache.EXPECT().Get(ctx, kutil.Key(managedSeed1Namespace, shoot2.Name), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot) error {
-								shoot2.DeepCopyInto(obj)
-								return nil
-							})
-
-							Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
-						})
 					})
 				})
 			})
@@ -2421,44 +2113,7 @@ yO57qEcJqG1cB7iSchFuCSTuDBbZlN0fXgn4YjiWZyb4l3BDp3rm4iJImA==
 							Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
 						})
 
-						It("should allow if the seed does not yet exist (ambiguous case)", func() {
-							request.UserInfo = ambiguousUser
-							shoot.Spec.SeedName = pointer.String("some-other-seed")
-
-							mockCache.EXPECT().Get(ctx, kutil.Key(managedSeedNamespace, managedSeedName), gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeed{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *seedmanagementv1alpha1.ManagedSeed) error {
-								managedSeed.DeepCopyInto(obj)
-								return nil
-							})
-							mockCache.EXPECT().Get(ctx, kutil.Key(managedSeedNamespace, shootName), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot) error {
-								shoot.DeepCopyInto(obj)
-								return nil
-							})
-							mockCache.EXPECT().Get(ctx, kutil.Key(managedSeedName), gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
-
-							Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
-						})
-
 						It("should allow if the seed does exist but client cert is expired", func() {
-							mockCache.EXPECT().Get(ctx, kutil.Key(managedSeedNamespace, managedSeedName), gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeed{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *seedmanagementv1alpha1.ManagedSeed) error {
-								managedSeed.DeepCopyInto(obj)
-								return nil
-							})
-							mockCache.EXPECT().Get(ctx, kutil.Key(managedSeedNamespace, shootName), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot) error {
-								shoot.DeepCopyInto(obj)
-								return nil
-							})
-							mockCache.EXPECT().Get(ctx, kutil.Key(managedSeedName), gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Seed) error {
-								(&gardencorev1beta1.Seed{Status: gardencorev1beta1.SeedStatus{ClientCertificateExpirationTimestamp: &metav1.Time{Time: time.Now().Add(-time.Hour)}}}).DeepCopyInto(obj)
-								return nil
-							})
-
-							Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
-						})
-
-						It("should allow if the seed does exist but client cert is expired (ambiguous case)", func() {
-							request.UserInfo = ambiguousUser
-							shoot.Spec.SeedName = pointer.String("some-other-seed")
-
 							mockCache.EXPECT().Get(ctx, kutil.Key(managedSeedNamespace, managedSeedName), gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeed{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *seedmanagementv1alpha1.ManagedSeed) error {
 								managedSeed.DeepCopyInto(obj)
 								return nil
@@ -2690,44 +2345,7 @@ yO57qEcJqG1cB7iSchFuCSTuDBbZlN0fXgn4YjiWZyb4l3BDp3rm4iJImA==
 						Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
 					})
 
-					It("should allow if the seed does not yet exist (ambiguous case)", func() {
-						request.UserInfo = ambiguousUser
-						shoot.Spec.SeedName = pointer.String("some-other-seed")
-
-						mockCache.EXPECT().Get(ctx, kutil.Key(managedSeedNamespace, managedSeedName), gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeed{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *seedmanagementv1alpha1.ManagedSeed) error {
-							managedSeed.DeepCopyInto(obj)
-							return nil
-						})
-						mockCache.EXPECT().Get(ctx, kutil.Key(managedSeedNamespace, shootName), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot) error {
-							shoot.DeepCopyInto(obj)
-							return nil
-						})
-						mockCache.EXPECT().Get(ctx, kutil.Key(managedSeedName), gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
-
-						Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
-					})
-
 					It("should allow if the seed does exist but client cert is expired", func() {
-						mockCache.EXPECT().Get(ctx, kutil.Key(managedSeedNamespace, managedSeedName), gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeed{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *seedmanagementv1alpha1.ManagedSeed) error {
-							managedSeed.DeepCopyInto(obj)
-							return nil
-						})
-						mockCache.EXPECT().Get(ctx, kutil.Key(managedSeedNamespace, shootName), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot) error {
-							shoot.DeepCopyInto(obj)
-							return nil
-						})
-						mockCache.EXPECT().Get(ctx, kutil.Key(managedSeedName), gomock.AssignableToTypeOf(&gardencorev1beta1.Seed{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Seed) error {
-							(&gardencorev1beta1.Seed{Status: gardencorev1beta1.SeedStatus{ClientCertificateExpirationTimestamp: &metav1.Time{Time: time.Now().Add(-time.Hour)}}}).DeepCopyInto(obj)
-							return nil
-						})
-
-						Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
-					})
-
-					It("should allow if the seed does exist but client cert is expired (ambiguous case)", func() {
-						request.UserInfo = ambiguousUser
-						shoot.Spec.SeedName = pointer.String("some-other-seed")
-
 						mockCache.EXPECT().Get(ctx, kutil.Key(managedSeedNamespace, managedSeedName), gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeed{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *seedmanagementv1alpha1.ManagedSeed) error {
 							managedSeed.DeepCopyInto(obj)
 							return nil

--- a/pkg/admissioncontroller/webhooks/auth/seed/authorizer.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/authorizer.go
@@ -202,15 +202,12 @@ func (a *authorizer) Authorize(_ context.Context, attrs auth.Attributes) (auth.D
 
 func (a *authorizer) authorizeClusterRoleBinding(seedName string, attrs auth.Attributes) (auth.Decision, string, error) {
 	// Allow gardenlet to delete its cluster role binding after bootstrapping (in this case, there is no `Seed` resource
-	// in the system yet, so we can't rely on the graph). Ambiguous gardenlets can delete all relevant cluster role
-	// bindings.
+	// in the system yet, so we can't rely on the graph).
 	if attrs.GetVerb() == "delete" &&
 		strings.HasPrefix(attrs.GetName(), bootstraputil.ClusterRoleBindingNamePrefix) {
 
 		managedSeedNamespace, managedSeedName := bootstraputil.MetadataFromClusterRoleBindingName(attrs.GetName())
-		if seedName == "" ||
-			(managedSeedNamespace == v1beta1constants.GardenNamespace && managedSeedName == seedName) {
-
+		if managedSeedNamespace == v1beta1constants.GardenNamespace && managedSeedName == seedName {
 			return auth.DecisionAllow, "", nil
 		}
 	}
@@ -272,22 +269,17 @@ func (a *authorizer) authorizeNamespace(seedName string, attrs auth.Attributes) 
 }
 
 func (a *authorizer) authorizeSecret(seedName string, attrs auth.Attributes) (auth.Decision, string, error) {
-	// Allow gardenlets to get/list/watch secrets in their seed-<name> namespaces. Allow ambiguous gardenlets to
-	// get/list/watch secrets secrets in all seed-* namespaces.
-	if utils.ValueExists(attrs.GetVerb(), []string{"get", "list", "watch"}) &&
-		((seedName != "" && attrs.GetNamespace() == gutil.ComputeGardenNamespace(seedName)) ||
-			(seedName == "" && strings.HasPrefix(attrs.GetNamespace(), gutil.SeedNamespaceNamePrefix))) {
-
+	// Allow gardenlets to get/list/watch secrets in their seed-<name> namespaces.
+	if utils.ValueExists(attrs.GetVerb(), []string{"get", "list", "watch"}) && attrs.GetNamespace() == gutil.ComputeGardenNamespace(seedName) {
 		return auth.DecisionAllow, "", nil
 	}
 
 	// Allow gardenlet to delete its bootstrap token (in this case, there is no `Seed` resource in the system yet, so
-	// we can't rely on the graph). Ambiguous gardenlets can delete all bootstrap tokens.
+	// we can't rely on the graph).
 	if (attrs.GetVerb() == "delete" &&
 		attrs.GetNamespace() == metav1.NamespaceSystem &&
 		strings.HasPrefix(attrs.GetName(), bootstraptokenapi.BootstrapTokenSecretPrefix)) &&
-		(seedName == "" ||
-			(attrs.GetName() == bootstraptokenapi.BootstrapTokenSecretPrefix+bootstraputil.TokenID(metav1.ObjectMeta{Name: seedName, Namespace: v1beta1constants.GardenNamespace}))) {
+		(attrs.GetName() == bootstraptokenapi.BootstrapTokenSecretPrefix+bootstraputil.TokenID(metav1.ObjectMeta{Name: seedName, Namespace: v1beta1constants.GardenNamespace})) {
 
 		return auth.DecisionAllow, "", nil
 	}
@@ -301,12 +293,11 @@ func (a *authorizer) authorizeSecret(seedName string, attrs auth.Attributes) (au
 
 func (a *authorizer) authorizeServiceAccount(seedName string, attrs auth.Attributes) (auth.Decision, string, error) {
 	// Allow gardenlet to delete its service account after bootstrapping (in this case, there is no `Seed` resource in
-	// the system yet, so we can't rely on the graph). Ambiguous gardenlets can delete all relevant service accounts.
+	// the system yet, so we can't rely on the graph).
 	if attrs.GetVerb() == "delete" &&
 		attrs.GetNamespace() == v1beta1constants.GardenNamespace &&
 		strings.HasPrefix(attrs.GetName(), bootstraputil.ServiceAccountNamePrefix) &&
-		(seedName == "" ||
-			strings.TrimPrefix(attrs.GetName(), bootstraputil.ServiceAccountNamePrefix) == seedName) {
+		strings.TrimPrefix(attrs.GetName(), bootstraputil.ServiceAccountNamePrefix) == seedName {
 
 		return auth.DecisionAllow, "", nil
 	}
@@ -360,11 +351,6 @@ func (a *authorizer) hasPathFrom(seedName string, fromType graph.VertexType, att
 	if len(attrs.GetName()) == 0 {
 		a.logger.Info(fmt.Sprintf("SEED DENY: '%s' %#v", seedName, attrs))
 		return auth.DecisionNoOpinion, "No Object name found", nil
-	}
-
-	// Allow request if seed name is not known because a target seed cannot be used to find a path.
-	if seedName == "" {
-		return auth.DecisionAllow, "", nil
 	}
 
 	// If the request is made for a namespace then the attributes.Namespace field is not empty. It contains the name of

--- a/pkg/admissioncontroller/webhooks/auth/seed/authorizer_test.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/authorizer_test.go
@@ -53,8 +53,8 @@ var _ = Describe("Seed", func() {
 		graph      *mockgraph.MockInterface
 		authorizer auth.Authorizer
 
-		seedName                string
-		seedUser, ambiguousUser user.Info
+		seedName string
+		seedUser user.Info
 	)
 
 	BeforeEach(func() {
@@ -68,10 +68,6 @@ var _ = Describe("Seed", func() {
 		seedName = "seed"
 		seedUser = &user.DefaultInfo{
 			Name:   fmt.Sprintf("%s%s", v1beta1constants.SeedUserNamePrefix, seedName),
-			Groups: []string{v1beta1constants.SeedsGroup},
-		}
-		ambiguousUser = &user.DefaultInfo{
-			Name:   fmt.Sprintf("%s%s", v1beta1constants.SeedUserNamePrefix, v1beta1constants.SeedUserNameSuffixAmbiguous),
 			Groups: []string{v1beta1constants.SeedsGroup},
 		}
 	})
@@ -193,16 +189,6 @@ var _ = Describe("Seed", func() {
 				Expect(decision).To(Equal(auth.DecisionNoOpinion))
 				Expect(reason).To(ContainSubstring("No Object name found"))
 			})
-
-			It("should allow because seed name is ambiguous", func() {
-				attrs.User = ambiguousUser
-
-				decision, reason, err := authorizer.Authorize(ctx, attrs)
-
-				Expect(err).NotTo(HaveOccurred())
-				Expect(decision).To(Equal(auth.DecisionAllow))
-				Expect(reason).To(BeEmpty())
-			})
 		})
 
 		Context("when requested for ConfigMaps", func() {
@@ -284,16 +270,6 @@ var _ = Describe("Seed", func() {
 				Expect(decision).To(Equal(auth.DecisionNoOpinion))
 				Expect(reason).To(ContainSubstring("No Object name found"))
 			})
-
-			It("should allow because seed name is ambiguous", func() {
-				attrs.User = ambiguousUser
-
-				decision, reason, err := authorizer.Authorize(ctx, attrs)
-
-				Expect(err).NotTo(HaveOccurred())
-				Expect(decision).To(Equal(auth.DecisionAllow))
-				Expect(reason).To(BeEmpty())
-			})
 		})
 
 		Context("when requested for SecretBindings", func() {
@@ -363,16 +339,6 @@ var _ = Describe("Seed", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(decision).To(Equal(auth.DecisionNoOpinion))
 				Expect(reason).To(ContainSubstring("No Object name found"))
-			})
-
-			It("should allow because seed name is ambiguous", func() {
-				attrs.User = ambiguousUser
-
-				decision, reason, err := authorizer.Authorize(ctx, attrs)
-
-				Expect(err).NotTo(HaveOccurred())
-				Expect(decision).To(Equal(auth.DecisionAllow))
-				Expect(reason).To(BeEmpty())
 			})
 		})
 
@@ -475,16 +441,6 @@ var _ = Describe("Seed", func() {
 				Expect(decision).To(Equal(auth.DecisionNoOpinion))
 				Expect(reason).To(ContainSubstring("No Object name found"))
 			})
-
-			It("should allow because seed name is ambiguous", func() {
-				attrs.User = ambiguousUser
-
-				decision, reason, err := authorizer.Authorize(ctx, attrs)
-
-				Expect(err).NotTo(HaveOccurred())
-				Expect(decision).To(Equal(auth.DecisionAllow))
-				Expect(reason).To(BeEmpty())
-			})
 		})
 
 		Context("when requested for Namespaces", func() {
@@ -565,16 +521,6 @@ var _ = Describe("Seed", func() {
 				Expect(decision).To(Equal(auth.DecisionNoOpinion))
 				Expect(reason).To(ContainSubstring("No Object name found"))
 			})
-
-			It("should allow because seed name is ambiguous", func() {
-				attrs.User = ambiguousUser
-
-				decision, reason, err := authorizer.Authorize(ctx, attrs)
-
-				Expect(err).NotTo(HaveOccurred())
-				Expect(decision).To(Equal(auth.DecisionAllow))
-				Expect(reason).To(BeEmpty())
-			})
 		})
 
 		Context("when requested for Projects", func() {
@@ -643,16 +589,6 @@ var _ = Describe("Seed", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(decision).To(Equal(auth.DecisionNoOpinion))
 				Expect(reason).To(ContainSubstring("No Object name found"))
-			})
-
-			It("should allow because seed name is ambiguous", func() {
-				attrs.User = ambiguousUser
-
-				decision, reason, err := authorizer.Authorize(ctx, attrs)
-
-				Expect(err).NotTo(HaveOccurred())
-				Expect(decision).To(Equal(auth.DecisionAllow))
-				Expect(reason).To(BeEmpty())
 			})
 		})
 
@@ -750,16 +686,6 @@ var _ = Describe("Seed", func() {
 				Entry("update w/ subresource", "update", "status"),
 				Entry("delete", "delete", ""),
 			)
-
-			It("should allow because seed name is ambiguous", func() {
-				attrs.User = ambiguousUser
-
-				decision, reason, err := authorizer.Authorize(ctx, attrs)
-
-				Expect(err).NotTo(HaveOccurred())
-				Expect(decision).To(Equal(auth.DecisionAllow))
-				Expect(reason).To(BeEmpty())
-			})
 		})
 
 		Context("when requested for BackupEntries", func() {
@@ -853,16 +779,6 @@ var _ = Describe("Seed", func() {
 				Entry("update w/o subresource", "update", ""),
 				Entry("update w/ subresource", "update", "status"),
 			)
-
-			It("should allow because seed name is ambiguous", func() {
-				attrs.User = ambiguousUser
-
-				decision, reason, err := authorizer.Authorize(ctx, attrs)
-
-				Expect(err).NotTo(HaveOccurred())
-				Expect(decision).To(Equal(auth.DecisionAllow))
-				Expect(reason).To(BeEmpty())
-			})
 		})
 
 		Context("when requested for ExposureClasses", func() {
@@ -931,16 +847,6 @@ var _ = Describe("Seed", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(decision).To(Equal(auth.DecisionNoOpinion))
 				Expect(reason).To(ContainSubstring("No Object name found"))
-			})
-
-			It("should allow because seed name is ambiguous", func() {
-				attrs.User = ambiguousUser
-
-				decision, reason, err := authorizer.Authorize(ctx, attrs)
-
-				Expect(err).NotTo(HaveOccurred())
-				Expect(decision).To(Equal(auth.DecisionAllow))
-				Expect(reason).To(BeEmpty())
 			})
 		})
 
@@ -1026,16 +932,6 @@ var _ = Describe("Seed", func() {
 				Entry("update w/o subresource", "update", ""),
 				Entry("update w/ subresource", "update", "status"),
 			)
-
-			It("should allow because seed name is ambiguous", func() {
-				attrs.User = ambiguousUser
-
-				decision, reason, err := authorizer.Authorize(ctx, attrs)
-
-				Expect(err).NotTo(HaveOccurred())
-				Expect(decision).To(Equal(auth.DecisionAllow))
-				Expect(reason).To(BeEmpty())
-			})
 		})
 
 		Context("when requested for ManagedSeeds", func() {
@@ -1120,16 +1016,6 @@ var _ = Describe("Seed", func() {
 				Entry("update w/o subresource", "update", ""),
 				Entry("update w/ subresource", "update", "status"),
 			)
-
-			It("should allow because seed name is ambiguous", func() {
-				attrs.User = ambiguousUser
-
-				decision, reason, err := authorizer.Authorize(ctx, attrs)
-
-				Expect(err).NotTo(HaveOccurred())
-				Expect(decision).To(Equal(auth.DecisionAllow))
-				Expect(reason).To(BeEmpty())
-			})
 		})
 
 		Context("when requested for ControllerInstallations", func() {
@@ -1213,16 +1099,6 @@ var _ = Describe("Seed", func() {
 				Entry("update w/o subresource", "update", ""),
 				Entry("update w/ subresource", "update", "status"),
 			)
-
-			It("should allow because seed name is ambiguous", func() {
-				attrs.User = ambiguousUser
-
-				decision, reason, err := authorizer.Authorize(ctx, attrs)
-
-				Expect(err).NotTo(HaveOccurred())
-				Expect(decision).To(Equal(auth.DecisionAllow))
-				Expect(reason).To(BeEmpty())
-			})
 		})
 
 		Context("when requested for corev1.Events", func() {
@@ -1430,16 +1306,6 @@ var _ = Describe("Seed", func() {
 				Entry("get", "get"),
 				Entry("update", "update"),
 			)
-
-			It("should allow because seed name is ambiguous", func() {
-				attrs.User = ambiguousUser
-
-				decision, reason, err := authorizer.Authorize(ctx, attrs)
-
-				Expect(err).NotTo(HaveOccurred())
-				Expect(decision).To(Equal(auth.DecisionAllow))
-				Expect(reason).To(BeEmpty())
-			})
 		})
 
 		Context("when requested for Shoots", func() {
@@ -1524,16 +1390,6 @@ var _ = Describe("Seed", func() {
 				Entry("update w/o subresource", "update", ""),
 				Entry("update w/ subresource", "update", "status"),
 			)
-
-			It("should allow because seed name is ambiguous", func() {
-				attrs.User = ambiguousUser
-
-				decision, reason, err := authorizer.Authorize(ctx, attrs)
-
-				Expect(err).NotTo(HaveOccurred())
-				Expect(decision).To(Equal(auth.DecisionAllow))
-				Expect(reason).To(BeEmpty())
-			})
 		})
 
 		Context("when requested for Seeds", func() {
@@ -1589,16 +1445,6 @@ var _ = Describe("Seed", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(decision).To(Equal(auth.DecisionNoOpinion))
 				Expect(reason).To(ContainSubstring("only the following subresources are allowed for this resource type: [status]"))
-			})
-
-			It("should allow because seed name is ambiguous", func() {
-				attrs.User = ambiguousUser
-
-				decision, reason, err := authorizer.Authorize(ctx, attrs)
-
-				Expect(err).NotTo(HaveOccurred())
-				Expect(decision).To(Equal(auth.DecisionAllow))
-				Expect(reason).To(BeEmpty())
 			})
 		})
 
@@ -1661,16 +1507,6 @@ var _ = Describe("Seed", func() {
 				Expect(decision).To(Equal(auth.DecisionNoOpinion))
 				Expect(reason).To(ContainSubstring("only the following subresources are allowed for this resource type: []"))
 			})
-
-			It("should allow because seed name is ambiguous", func() {
-				attrs.User = ambiguousUser
-
-				decision, reason, err := authorizer.Authorize(ctx, attrs)
-
-				Expect(err).NotTo(HaveOccurred())
-				Expect(decision).To(Equal(auth.DecisionAllow))
-				Expect(reason).To(BeEmpty())
-			})
 		})
 
 		Context("when requested for ControllerDeployments", func() {
@@ -1718,16 +1554,6 @@ var _ = Describe("Seed", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(decision).To(Equal(auth.DecisionNoOpinion))
 				Expect(reason).To(ContainSubstring("only the following subresources are allowed for this resource type: []"))
-			})
-
-			It("should allow because seed name is ambiguous", func() {
-				attrs.User = ambiguousUser
-
-				decision, reason, err := authorizer.Authorize(ctx, attrs)
-
-				Expect(err).NotTo(HaveOccurred())
-				Expect(decision).To(Equal(auth.DecisionAllow))
-				Expect(reason).To(BeEmpty())
 			})
 
 			DescribeTable("should return correct result if path exists",
@@ -1834,16 +1660,6 @@ var _ = Describe("Seed", func() {
 				Entry("get", "get", ""),
 				Entry("get with subresource", "get", "seedclient"),
 			)
-
-			It("should allow because seed name is ambiguous", func() {
-				attrs.User = ambiguousUser
-
-				decision, reason, err := authorizer.Authorize(ctx, attrs)
-
-				Expect(err).NotTo(HaveOccurred())
-				Expect(decision).To(Equal(auth.DecisionAllow))
-				Expect(reason).To(BeEmpty())
-			})
 		})
 
 		Context("when requested for Secrets", func() {
@@ -1881,39 +1697,10 @@ var _ = Describe("Seed", func() {
 				Entry("watch", "watch"),
 			)
 
-			DescribeTable("should allow without consulting the graph because verb is get, list, or watch in the seed's namespace when user is ambiguous",
-				func(verb string) {
-					attrs.User = ambiguousUser
-					attrs.Namespace = "seed-foobar"
-					attrs.Verb = verb
-
-					decision, reason, err := authorizer.Authorize(ctx, attrs)
-					Expect(err).NotTo(HaveOccurred())
-					Expect(decision).To(Equal(auth.DecisionAllow))
-					Expect(reason).To(BeEmpty())
-				},
-
-				Entry("get", "get"),
-				Entry("list", "list"),
-				Entry("watch", "watch"),
-			)
-
 			It("should allow to delete the gardenlet's bootstrap tokens without consulting the graph", func() {
 				attrs.Verb = "delete"
 				attrs.Namespace = "kube-system"
 				attrs.Name = "bootstrap-token-" + bootstraputil.TokenID(metav1.ObjectMeta{Name: seedName, Namespace: v1beta1constants.GardenNamespace})
-
-				decision, reason, err := authorizer.Authorize(ctx, attrs)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(decision).To(Equal(auth.DecisionAllow))
-				Expect(reason).To(BeEmpty())
-			})
-
-			It("should allow to delete any bootstrap tokens without consulting the graph when user is ambiguous", func() {
-				attrs.User = ambiguousUser
-				attrs.Verb = "delete"
-				attrs.Namespace = "kube-system"
-				attrs.Name = "bootstrap-token-anythingcanbehere"
 
 				decision, reason, err := authorizer.Authorize(ctx, attrs)
 				Expect(err).NotTo(HaveOccurred())
@@ -1995,16 +1782,6 @@ var _ = Describe("Seed", func() {
 				Entry("update", "update"),
 				Entry("delete", "delete"),
 			)
-
-			It("should allow because seed name is ambiguous", func() {
-				attrs.User = ambiguousUser
-
-				decision, reason, err := authorizer.Authorize(ctx, attrs)
-
-				Expect(err).NotTo(HaveOccurred())
-				Expect(decision).To(Equal(auth.DecisionAllow))
-				Expect(reason).To(BeEmpty())
-			})
 		})
 
 		Context("when requested for ClusterRoleBindings", func() {
@@ -2028,17 +1805,6 @@ var _ = Describe("Seed", func() {
 			It("should allow to delete the gardenlet's bootstrap cluster role binding without consulting the graph", func() {
 				attrs.Verb = "delete"
 				attrs.Name = "gardener.cloud:system:seed-bootstrapper:garden:" + seedName
-
-				decision, reason, err := authorizer.Authorize(ctx, attrs)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(decision).To(Equal(auth.DecisionAllow))
-				Expect(reason).To(BeEmpty())
-			})
-
-			It("should allow to delete any bootstrap cluster role binding without consulting the graph when user is ambiguous", func() {
-				attrs.User = ambiguousUser
-				attrs.Verb = "delete"
-				attrs.Name = "gardener.cloud:system:seed-bootstrapper:garden:anythingcanbehere"
 
 				decision, reason, err := authorizer.Authorize(ctx, attrs)
 				Expect(err).NotTo(HaveOccurred())
@@ -2111,16 +1877,6 @@ var _ = Describe("Seed", func() {
 				Expect(decision).To(Equal(auth.DecisionNoOpinion))
 				Expect(reason).To(ContainSubstring("No Object name found"))
 			})
-
-			It("should allow because seed name is ambiguous", func() {
-				attrs.User = ambiguousUser
-
-				decision, reason, err := authorizer.Authorize(ctx, attrs)
-
-				Expect(err).NotTo(HaveOccurred())
-				Expect(decision).To(Equal(auth.DecisionAllow))
-				Expect(reason).To(BeEmpty())
-			})
 		})
 
 		Context("when requested for ServiceAccounts", func() {
@@ -2146,18 +1902,6 @@ var _ = Describe("Seed", func() {
 				attrs.Verb = "delete"
 				attrs.Namespace = "garden"
 				attrs.Name = "gardenlet-bootstrap-" + seedName
-
-				decision, reason, err := authorizer.Authorize(ctx, attrs)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(decision).To(Equal(auth.DecisionAllow))
-				Expect(reason).To(BeEmpty())
-			})
-
-			It("should allow to delete any bootstrap service account without consulting the graph when user is ambiguous", func() {
-				attrs.User = ambiguousUser
-				attrs.Verb = "delete"
-				attrs.Namespace = "garden"
-				attrs.Name = "gardenlet-bootstrap-anythingcanbehere"
 
 				decision, reason, err := authorizer.Authorize(ctx, attrs)
 				Expect(err).NotTo(HaveOccurred())
@@ -2229,16 +1973,6 @@ var _ = Describe("Seed", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(decision).To(Equal(auth.DecisionNoOpinion))
 				Expect(reason).To(ContainSubstring("No Object name found"))
-			})
-
-			It("should allow because seed name is ambiguous", func() {
-				attrs.User = ambiguousUser
-
-				decision, reason, err := authorizer.Authorize(ctx, attrs)
-
-				Expect(err).NotTo(HaveOccurred())
-				Expect(decision).To(Equal(auth.DecisionAllow))
-				Expect(reason).To(BeEmpty())
 			})
 		})
 	})

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -481,8 +481,6 @@ const (
 	SeedsGroup = "gardener.cloud:system:seeds"
 	// SeedUserNamePrefix is the identity user name prefix for gardenlets when authenticating to the API server.
 	SeedUserNamePrefix = "gardener.cloud:system:seed:"
-	// SeedUserNameSuffixAmbiguous is the default seed name in case the gardenlet config.SeedConfig is not set
-	SeedUserNameSuffixAmbiguous = "<ambiguous>"
 
 	// ProjectName is the key of a label on namespaces whose value holds the project name.
 	ProjectName = "project.gardener.cloud/name"

--- a/pkg/gardenlet/bootstrap/util/util.go
+++ b/pkg/gardenlet/bootstrap/util/util.go
@@ -57,7 +57,7 @@ func GetSeedName(seedConfig *config.SeedConfig) string {
 	if seedConfig != nil {
 		return seedConfig.Name
 	}
-	return v1beta1constants.SeedUserNameSuffixAmbiguous
+	return ""
 }
 
 // GetTargetClusterName returns the target cluster of the gardenlet based on the SeedClientConnection.

--- a/pkg/gardenlet/bootstrap/util/util_test.go
+++ b/pkg/gardenlet/bootstrap/util/util_test.go
@@ -369,11 +369,6 @@ var _ = Describe("Util", func() {
 			})
 			Expect(result).To(Equal("test-name"))
 		})
-
-		It("should return the default name", func() {
-			result := GetSeedName(nil)
-			Expect(result).To(Equal("<ambiguous>"))
-		})
 	})
 
 	Describe("GetTargetClusterName", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement
/merge squash

**What this PR does / why we need it**:
After #4078 gardenlets can only be responsible for exactly one seed, so there is no need to keep the special handling for "ambiguous gardenlet"s in the seed authorizer anymore (ref https://github.com/gardener/gardener/blob/master/docs/deployment/gardenlet_api_access.md#authorizer-decisions). Let's drop this code.

**Which issue(s) this PR fixes**:
Fixes #5090

**Special notes for your reviewer**:
/invite @timuthy 
~This is in draft state until #5086 is merged.~

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```action operator
The [`SeedAuthorizer` and `SeedRestriction` features](https://github.com/gardener/gardener/blob/master/docs/deployment/gardenlet_api_access.md) do no longer support "ambiguous" gardenlets (i.e., gardenlets responsible for multiple seed clusters) since this feature was dropped already with Gardener v1.27. In case you have activated these features then you have to make sure that you deploy a dedicated gardenlet per seed cluster and that they don't use a client certificate with the (now removed) `gardener.cloud:system:seeds:<ambiguous>` common name before updating to this Gardener version. [This document](https://github.com/gardener/gardener/blob/master/docs/concepts/gardenlet.md#rotate-certificates-using-bootstrap-kubeconfig) describes how to make the gardenlet regenerate its client certificate after you have reconfigured it.
```
