### PR TITLE
[GEP-17] Ensure final full snapshot is created and waited for while copying backups

### DIFF
--- a/pkg/operation/botanist/component/etcd/etcd.go
+++ b/pkg/operation/botanist/component/etcd/etcd.go
@@ -588,7 +588,7 @@ func (e *etcd) Snapshot(ctx context.Context, podExecutor kubernetes.PodExecutor)
 		podsList.Items[0].GetName(),
 		containerNameBackupRestore,
 		"/bin/sh",
-		fmt.Sprintf("curl -k https://etcd-%s-local:%d/snapshot/full", e.role, PortBackupRestore),
+		fmt.Sprintf("curl -k https://etcd-%s-local:%d/snapshot/full?final=true", e.role, PortBackupRestore),
 	)
 	return err
 }

--- a/pkg/operation/botanist/component/etcd/etcd_test.go
+++ b/pkg/operation/botanist/component/etcd/etcd_test.go
@@ -1174,7 +1174,7 @@ var _ = Describe("Etcd", func() {
 					podName,
 					"backup-restore",
 					"/bin/sh",
-					"curl -k https://etcd-"+testRole+"-local:8080/snapshot/full",
+					"curl -k https://etcd-"+testRole+"-local:8080/snapshot/full?final=true",
 				)
 
 				Expect(etcd.Snapshot(ctx, podExecutor)).To(Succeed())
@@ -1260,7 +1260,7 @@ var _ = Describe("Etcd", func() {
 					podName,
 					"backup-restore",
 					"/bin/sh",
-					"curl -k https://etcd-"+testRole+"-local:8080/snapshot/full",
+					"curl -k https://etcd-"+testRole+"-local:8080/snapshot/full?final=true",
 				).Return(nil, fakeErr)
 
 				Expect(etcd.Snapshot(ctx, podExecutor)).To(MatchError(fakeErr))

--- a/pkg/operation/botanist/component/etcdcopybackupstask/etcdcopybackupstask.go
+++ b/pkg/operation/botanist/component/etcdcopybackupstask/etcdcopybackupstask.go
@@ -38,6 +38,9 @@ const (
 	// DefaultTimeout is the default timeout and defines how long Gardener should wait
 	// for a successful reconciliation of an EtcdCopyBackupsTasks resource.
 	DefaultTimeout = 5 * time.Minute
+
+	// DefaultWaitForFinalSnapshotTimeout is the default timeout for waiting for a final full snapshot.
+	DefaultWaitForFinalSnapshotTimeout = 30 * time.Minute
 )
 
 // Interface contains functions to manage EtcdCopyBackupsTasks.
@@ -63,6 +66,8 @@ type Values struct {
 	MaxBackups *uint32
 	// MaxBackupAge is the maximum age in days that a backup must have in order to be copied.
 	MaxBackupAge *uint32
+	// WaitForFinalSnapshot defines the parameters for waiting for a final full snapshot before copying backups.
+	WaitForFinalSnapshot *druidv1alpha1.WaitForFinalSnapshotSpec
 }
 
 type etcdCopyBackupsTask struct {
@@ -108,6 +113,7 @@ func (e *etcdCopyBackupsTask) Deploy(ctx context.Context) error {
 	e.task.Spec.MaxBackups = e.values.MaxBackups
 	e.task.Spec.SourceStore = e.values.SourceStore
 	e.task.Spec.TargetStore = e.values.TargetStore
+	e.task.Spec.WaitForFinalSnapshot = e.values.WaitForFinalSnapshot
 	return e.client.Create(ctx, e.task)
 }
 

--- a/pkg/operation/botanist/etcdcopybackupstask.go
+++ b/pkg/operation/botanist/etcdcopybackupstask.go
@@ -23,6 +23,7 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/etcdcopybackupstask"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -39,6 +40,10 @@ func (b *Botanist) DefaultEtcdCopyBackupsTask() etcdcopybackupstask.Interface {
 		&etcdcopybackupstask.Values{
 			Name:      b.Shoot.GetInfo().Name,
 			Namespace: b.Shoot.SeedNamespace,
+			WaitForFinalSnapshot: &druidv1alpha1.WaitForFinalSnapshotSpec{
+				Enabled: true,
+				Timeout: &metav1.Duration{Duration: etcdcopybackupstask.DefaultWaitForFinalSnapshotTimeout},
+			},
 		},
 		etcdcopybackupstask.DefaultInterval,
 		etcdcopybackupstask.DefaultSevereThreshold,

--- a/pkg/operation/botanist/etcdcopybackupstask_test.go
+++ b/pkg/operation/botanist/etcdcopybackupstask_test.go
@@ -109,6 +109,10 @@ var _ = Describe("EtcdCopyBackupsTask", func() {
 				expectedValues: Equal(&etcdcopybackupstask.Values{
 					Name:      botanist.Shoot.GetInfo().Name,
 					Namespace: botanist.Shoot.SeedNamespace,
+					WaitForFinalSnapshot: &druidv1alpha1.WaitForFinalSnapshotSpec{
+						Enabled: true,
+						Timeout: &metav1.Duration{Duration: etcdcopybackupstask.DefaultWaitForFinalSnapshotTimeout},
+					},
 				}),
 				expectedWaitInterval:       Equal(etcdcopybackupstask.DefaultInterval),
 				expectedWaitSevereTreshold: Equal(etcdcopybackupstask.DefaultSevereThreshold),


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane-migration
/kind enhancement

**What this PR does / why we need it**:
Ensures that the final full snapshot is created and waited upon while copying backups for control plane migration "good case" and "bad case" scenarios.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
* The logic to "fallback" to the bad case scenario (detecting that the migration in the source seed has repeatedly failed or is unable to be executed) is not yet introduced, this will be done in a future PR.
* It's nevertheless possible to test the "bad case" scenario by manually commenting out the actual migration execution.

**Release note**:

```other operator
A final full snapshot is created and waited upon while copying backups for control plane migration "good case" and "bad case" scenarios.
```
