### PR TITLE
Reduce validity of certificates issued via `CertificateSigningRequest`s from `1y` to `30d`

### DIFF
--- a/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager.go
@@ -469,6 +469,15 @@ func (k *kubeControllerManager) computeCommand(port int32) []string {
 		fmt.Sprintf("--cluster-name=%s", k.namespace),
 		fmt.Sprintf("--cluster-signing-cert-file=%s/%s", volumeMountPathCA, secrets.DataKeyCertificateCA),
 		fmt.Sprintf("--cluster-signing-key-file=%s/%s", volumeMountPathCA, secrets.DataKeyPrivateKeyCA),
+	)
+
+	if version.ConstraintK8sGreaterEqual119.Check(k.version) {
+		command = append(command, "--cluster-signing-duration=30d")
+	} else {
+		command = append(command, "--experimental-cluster-signing-duration=30d")
+	}
+
+	command = append(command,
 		"--concurrent-deployment-syncs=50",
 		"--concurrent-endpoint-syncs=15",
 		"--concurrent-gc-syncs=30",

--- a/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager_test.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager_test.go
@@ -815,6 +815,15 @@ func commandForKubernetesVersion(
 		fmt.Sprintf("--cluster-name=%s", clusterName),
 		"--cluster-signing-cert-file=/srv/kubernetes/ca/ca.crt",
 		"--cluster-signing-key-file=/srv/kubernetes/ca/ca.key",
+	)
+
+	if k8sVersionGreaterEqual119, _ := versionutils.CompareVersions(version, ">=", "1.19"); k8sVersionGreaterEqual119 {
+		command = append(command, "--cluster-signing-duration=30d")
+	} else {
+		command = append(command, "--experimental-cluster-signing-duration=30d")
+	}
+
+	command = append(command,
 		"--concurrent-deployment-syncs=50",
 		"--concurrent-endpoint-syncs=15",
 		"--concurrent-gc-syncs=30",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
This PR sets the `--{experimental-}cluster-signing-duration` flag to `30d` for KCM of shoot clusters. This will effectively reduce the validity of certificates issued via `CertificateSigningRequest`s from `1y` to `30d`, including those for the kubelets running on the shoot worker nodes.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
In order to reduce the validity of client certificates used by `kubelet`s running on the worker nodes of shoot clusters, the  expiration duration for certificates issued via `CertificateSigningRequest`s has been reduced from `1y` to `30d`. A custom expiration duration per `CertificateSigningRequest` can be set via the `.spec.expirationSeconds` fields (available from Kubernetes v1.22).
```
