### PR TITLE
Add monitoring config in gardenlet helm chart

### DIFF
--- a/charts/gardener/gardenlet/charts/runtime/templates/configmap-componentconfig.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/configmap-componentconfig.yaml
@@ -181,6 +181,10 @@ data:
     logging:
 {{ toYaml .Values.global.gardenlet.config.logging | indent 6 }}
     {{- end }}
+    {{- if .Values.global.gardenlet.config.monitoring }}
+    monitoring:
+{{ toYaml .Values.global.gardenlet.config.monitoring | indent 6 }}
+    {{- end }}
     {{- if .Values.global.gardenlet.config.sni }}
     sni:
 {{ toYaml .Values.global.gardenlet.config.sni | trim | indent 6 }}

--- a/charts/gardener/gardenlet/values.yaml
+++ b/charts/gardener/gardenlet/values.yaml
@@ -169,3 +169,16 @@ global:
     #   loki:
     #     garden:
     #       priority: 100
+    # monitoring:
+    #   shoot:
+    #     remoteWrite:
+    #       url: https://remoteWriteUrl # remote write URL
+    #       keep: # metrics that should be forwarded to the external write endpoint. If empty all metrics get forwarded
+    #       - kube_pod_container_info
+    #       queueConfig: | # queue_config of prometheus remote write as multiline string
+    #         max_shards: 100
+    #         batch_send_deadline: 20s
+    #         min_backoff: 500ms
+    #         max_backoff: 60s
+    #     externalLabels: # add additional labels to metrics to identify it on the central instance
+    #       additional: label


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:

In PR #4935 I added `monitoring` config to the `gardenletConfig` but i forgot to add this field into the helm chart.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
