### PR TITLE
Add workaround for projected service account tokens

### DIFF
--- a/pkg/resourcemanager/webhook/projectedtokenmount/handler.go
+++ b/pkg/resourcemanager/webhook/projectedtokenmount/handler.go
@@ -95,6 +95,21 @@ func (h *handler) Handle(ctx context.Context, req admission.Request) admission.R
 		pod.Spec.Containers[i].VolumeMounts = append(pod.Spec.Containers[i].VolumeMounts, getVolumeMount())
 	}
 
+	// Workaround https://github.com/kubernetes/kubernetes/issues/82573 - this got fixed with
+	// https://github.com/kubernetes/kubernetes/pull/89193 starting with Kubernetes 1.19, however, we don't know to
+	// which node the newly created Pod gets scheduled (it could be that the API server is already running on 1.19 while
+	// the kubelets are still on 1.18). Hence, let's just unconditionally add this and remove this coding again once we
+	// drop support for seed and shoot clusters < 1.19.
+	{
+		if pod.Spec.SecurityContext == nil {
+			pod.Spec.SecurityContext = &corev1.PodSecurityContext{}
+		}
+
+		if pod.Spec.SecurityContext.FSGroup == nil {
+			pod.Spec.SecurityContext.FSGroup = pointer.Int64(65534)
+		}
+	}
+
 	marshaledPod, err := json.Marshal(pod)
 	if err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)

--- a/pkg/resourcemanager/webhook/projectedtokenmount/handler_test.go
+++ b/pkg/resourcemanager/webhook/projectedtokenmount/handler_test.go
@@ -255,6 +255,13 @@ var _ = Describe("Handler", func() {
 				Expect(response.Patches).To(ConsistOf(
 					jsonpatch.JsonPatchOperation{
 						Operation: "add",
+						Path:      "/spec/securityContext",
+						Value: map[string]interface{}{
+							"fsGroup": float64(65534),
+						},
+					},
+					jsonpatch.JsonPatchOperation{
+						Operation: "add",
 						Path:      "/spec/volumes",
 						Value: []interface{}{
 							map[string]interface{}{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bugfix

**What this PR does / why we need it**:
Without this we pretty much run into https://github.com/kubernetes/kubernetes/issues/82573 for clusters < 1.19.

**Special notes for your reviewer**:
/cc @danielfoehrKn - this should go into the upcoming v1.37 release
/milestone v1.37

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
