### PR TITLE
🛡 Switch shoot components to projected `ServiceAccount` tokens

### DIFF
--- a/charts/shoot-addons/charts/kubernetes-dashboard/templates/deployment-dashboard.yaml
+++ b/charts/shoot-addons/charts/kubernetes-dashboard/templates/deployment-dashboard.yaml
@@ -20,6 +20,9 @@ spec:
     type: RollingUpdate
   template:
     metadata:
+      annotations:
+        # TODO(rfranzke): Remove in a future release.
+        security.gardener.cloud/trigger: rollout
       labels:
         gardener.cloud/role: optional-addon
         origin: gardener

--- a/charts/shoot-addons/charts/kubernetes-dashboard/templates/deployment-metrics-scraper.yaml
+++ b/charts/shoot-addons/charts/kubernetes-dashboard/templates/deployment-metrics-scraper.yaml
@@ -23,6 +23,8 @@ spec:
         origin: gardener
       annotations:
         seccomp.security.alpha.kubernetes.io/pod: 'runtime/default'
+        # TODO(rfranzke): Remove in a future release.
+        security.gardener.cloud/trigger: rollout
     spec:
       containers:
       - name: dashboard-metrics-scraper

--- a/charts/shoot-addons/charts/kubernetes-dashboard/templates/serviceaccount.yaml
+++ b/charts/shoot-addons/charts/kubernetes-dashboard/templates/serviceaccount.yaml
@@ -6,3 +6,4 @@ metadata:
   namespace: {{ include "kubernetes-dashboard.namespace" . }}
   labels:
     k8s-app: kubernetes-dashboard
+automountServiceAccountToken: false

--- a/charts/shoot-addons/charts/nginx-ingress/templates/controller-deployment.yaml
+++ b/charts/shoot-addons/charts/nginx-ingress/templates/controller-deployment.yaml
@@ -28,6 +28,8 @@ spec:
       {{- if .Values.controller.podAnnotations }}
 {{ toYaml .Values.controller.podAnnotations | indent 8}}
       {{- end }}
+        # TODO(rfranzke): Remove in a future release.
+        security.gardener.cloud/trigger: rollout
       labels:
         origin: gardener
         gardener.cloud/role: optional-addon

--- a/charts/shoot-addons/charts/nginx-ingress/templates/serviceaccount.yaml
+++ b/charts/shoot-addons/charts/nginx-ingress/templates/serviceaccount.yaml
@@ -10,4 +10,5 @@ metadata:
     addonmanager.kubernetes.io/mode: Reconcile
   name: {{ template "nginx-ingress.fullname" . }}
   namespace: kube-system
+automountServiceAccountToken: false
 {{- end -}}

--- a/charts/shoot-core/components/charts/apiserver-proxy/templates/apiserver-proxy-serviceaccount.yaml
+++ b/charts/shoot-core/components/charts/apiserver-proxy/templates/apiserver-proxy-serviceaccount.yaml
@@ -6,3 +6,4 @@ metadata:
   labels:
     gardener.cloud/role: system-component
     origin: gardener
+automountServiceAccountToken: false

--- a/charts/shoot-core/components/charts/kube-proxy/templates/_helpers.tpl
+++ b/charts/shoot-core/components/charts/kube-proxy/templates/_helpers.tpl
@@ -88,5 +88,5 @@ conntrack_fix.sh: |
 {{- end -}}
 
 {{- define "kube-proxy.conntrack-fix-script.name" -}}
-kube-proxy-conntrack-fix-script-{{ include "kube-proxy.secret-kubeconfig.data" . | sha256sum | trunc 8 }}
+kube-proxy-conntrack-fix-script-{{ include "kube-proxy.conntrack-fix-script.data" . | sha256sum | trunc 8 }}
 {{- end }}

--- a/charts/shoot-core/components/charts/kube-proxy/templates/kube-proxy-daemonset.yaml
+++ b/charts/shoot-core/components/charts/kube-proxy/templates/kube-proxy-daemonset.yaml
@@ -96,8 +96,6 @@ spec:
         operator: Exists
       hostNetwork: true
       serviceAccountName: kube-proxy
-      # not used - kubeconfig is mounted.
-      automountServiceAccountToken: false
       containers:
       - name: kube-proxy
         image: {{ $pool.kubeProxyImage }}

--- a/charts/shoot-core/components/charts/kube-proxy/templates/kube-proxy-serviceaccount.yaml
+++ b/charts/shoot-core/components/charts/kube-proxy/templates/kube-proxy-serviceaccount.yaml
@@ -3,3 +3,4 @@ kind: ServiceAccount
 metadata:
   name: kube-proxy
   namespace: kube-system
+automountServiceAccountToken: false

--- a/charts/shoot-core/components/charts/kube-proxy/templates/rbac.yaml
+++ b/charts/shoot-core/components/charts/kube-proxy/templates/rbac.yaml
@@ -1,0 +1,14 @@
+# This ClusterRoleBinding is similar to 'system:node-proxier' with the difference that it binds the kube-proxy's
+# ServiceAccount to the `'system:node-proxier` ClusterRole.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: gardener.cloud:target:node-proxier
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:node-proxier
+subjects:
+- kind: ServiceAccount
+  name: kube-proxy
+  namespace: kube-system

--- a/charts/shoot-core/components/charts/kube-proxy/templates/rbac.yaml
+++ b/charts/shoot-core/components/charts/kube-proxy/templates/rbac.yaml
@@ -1,5 +1,5 @@
 # This ClusterRoleBinding is similar to 'system:node-proxier' with the difference that it binds the kube-proxy's
-# ServiceAccount to the `'system:node-proxier` ClusterRole.
+# ServiceAccount to the 'system:node-proxier' ClusterRole.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: kube-system
   labels:
     component: node-exporter
+automountServiceAccountToken: false
 ---
 apiVersion: v1
 kind: Service

--- a/charts/shoot-core/components/charts/node-problem-detector/templates/daemonset.yaml
+++ b/charts/shoot-core/components/charts/node-problem-detector/templates/daemonset.yaml
@@ -25,9 +25,8 @@ spec:
         origin: gardener
         networking.gardener.cloud/to-apiserver: allowed
         networking.gardener.cloud/to-dns: allowed
-      annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ''
 {{- if .Values.annotations }}
+      annotations:
 {{ toYaml .Values.annotations | indent 8 }}
 {{- end }}
     spec:

--- a/charts/shoot-core/components/charts/node-problem-detector/templates/serviceaccount.yaml
+++ b/charts/shoot-core/components/charts/node-problem-detector/templates/serviceaccount.yaml
@@ -7,3 +7,4 @@ metadata:
     helm.sh/chart: {{ include "node-problem-detector.chart" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
   namespace: kube-system
+automountServiceAccountToken: false

--- a/charts/shoot-core/components/charts/nodelocal-dns/templates/daemonset.yaml
+++ b/charts/shoot-core/components/charts/nodelocal-dns/templates/daemonset.yaml
@@ -29,6 +29,8 @@ spec:
 {{ include "node-local-dns.daemonset.annotations" . | indent 8 }}
         prometheus.io/port: "{{ .Values.prometheus.port }}"
         prometheus.io/scrape: "{{ .Values.prometheus.scrape }}"
+        # TODO(rfranzke): Remove in a future release.
+        security.gardener.cloud/trigger: rollout
     spec:
       priorityClassName: system-node-critical
       serviceAccountName: node-local-dns

--- a/charts/shoot-core/components/charts/nodelocal-dns/templates/serviceaccount.yaml
+++ b/charts/shoot-core/components/charts/nodelocal-dns/templates/serviceaccount.yaml
@@ -3,3 +3,4 @@ kind: ServiceAccount
 metadata:
   name: node-local-dns
   namespace: kube-system
+automountServiceAccountToken: false

--- a/pkg/operation/botanist/component/coredns/coredns.go
+++ b/pkg/operation/botanist/component/coredns/coredns.go
@@ -24,7 +24,6 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/kubeapiserver"
-	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -161,6 +160,7 @@ func (c *coreDNS) computeResourcesData() (map[string][]byte, error) {
 				Name:      "coredns",
 				Namespace: metav1.NamespaceSystem,
 			},
+			AutomountServiceAccountToken: pointer.Bool(false),
 		}
 
 		clusterRole = &rbacv1.ClusterRole{
@@ -344,10 +344,8 @@ import custom/*.server
 				},
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
-						Annotations: utils.MergeStringMaps(c.values.PodAnnotations, map[string]string{
-							"scheduler.alpha.kubernetes.io/critical-pod": "",
-						}),
-						Labels: getLabels(),
+						Annotations: c.values.PodAnnotations,
+						Labels:      getLabels(),
 					},
 					Spec: corev1.PodSpec{
 						Affinity: &corev1.Affinity{

--- a/pkg/operation/botanist/component/coredns/coredns_test.go
+++ b/pkg/operation/botanist/component/coredns/coredns_test.go
@@ -86,6 +86,7 @@ var _ = Describe("CoreDNS", func() {
 	Describe("#Deploy", func() {
 		var (
 			serviceAccountYAML = `apiVersion: v1
+automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
   creationTimestamp: null
@@ -278,16 +279,18 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      annotations:
 `
+				if len(podAnnotations) > 0 {
+					out += `      annotations:
+`
+				}
 
 				for k, v := range podAnnotations {
 					out += `        ` + k + `: ` + v + `
 `
 				}
 
-				out += `        scheduler.alpha.kubernetes.io/critical-pod: ""
-      creationTimestamp: null
+				out += `      creationTimestamp: null
       labels:
         gardener.cloud/role: system-component
         k8s-app: kube-dns

--- a/pkg/operation/botanist/component/metricsserver/metrics_server.go
+++ b/pkg/operation/botanist/component/metricsserver/metrics_server.go
@@ -148,6 +148,7 @@ func (m *metricsServer) computeResourcesData() (map[string][]byte, error) {
 				Name:      serviceAccountName,
 				Namespace: metav1.NamespaceSystem,
 			},
+			AutomountServiceAccountToken: pointer.Bool(false),
 		}
 
 		clusterRole = &rbacv1.ClusterRole{
@@ -276,6 +277,10 @@ func (m *metricsServer) computeResourcesData() (map[string][]byte, error) {
 				},
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							// TODO(rfranzke): Remove in a future release.
+							"security.gardener.cloud/trigger": "rollout",
+						},
 						Labels: utils.MergeStringMaps(getLabels(), map[string]string{
 							managedresources.LabelKeyOrigin:                     managedresources.LabelValueGardener,
 							v1beta1constants.GardenRole:                         v1beta1constants.GardenRoleSystemComponent,

--- a/pkg/operation/botanist/component/metricsserver/metrics_server_test.go
+++ b/pkg/operation/botanist/component/metricsserver/metrics_server_test.go
@@ -196,6 +196,7 @@ subjects:
   namespace: kube-system
 `
 		serviceAccountYAML = `apiVersion: v1
+automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
   creationTimestamp: null
@@ -227,6 +228,7 @@ spec:
     metadata:
       annotations:
         ` + references.AnnotationKey(references.KindSecret, secretName) + `: ` + secretName + `
+        security.gardener.cloud/trigger: rollout
       creationTimestamp: null
       labels:
         gardener.cloud/role: system-component
@@ -318,6 +320,7 @@ spec:
     metadata:
       annotations:
         ` + references.AnnotationKey(references.KindSecret, secretName) + `: ` + secretName + `
+        security.gardener.cloud/trigger: rollout
       creationTimestamp: null
       labels:
         gardener.cloud/role: system-component

--- a/pkg/operation/botanist/component/vpnshoot/vpnshoot.go
+++ b/pkg/operation/botanist/component/vpnshoot/vpnshoot.go
@@ -268,6 +268,7 @@ func (v *vpnShoot) computeResourcesData() (map[string][]byte, error) {
 				Namespace: metav1.NamespaceSystem,
 				Labels:    getLabels(),
 			},
+			AutomountServiceAccountToken: pointer.Bool(false),
 		}
 
 		networkPolicy = &networkingv1.NetworkPolicy{
@@ -375,6 +376,10 @@ func (v *vpnShoot) computeResourcesData() (map[string][]byte, error) {
 				},
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							// TODO(rfranzke): Remove in a future release.
+							"security.gardener.cloud/trigger": "rollout",
+						},
 						Labels: map[string]string{
 							v1beta1constants.GardenRole:     v1beta1constants.GardenRoleSystemComponent,
 							v1beta1constants.LabelApp:       labelValue,

--- a/pkg/operation/botanist/component/vpnshoot/vpnshoot_test.go
+++ b/pkg/operation/botanist/component/vpnshoot/vpnshoot_test.go
@@ -177,6 +177,7 @@ spec:
   - Ingress
 `
 			serviceAccountYAML = `apiVersion: v1
+automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
   creationTimestamp: null
@@ -265,7 +266,7 @@ status: {}
 kind: Deployment
 metadata:
   annotations:
-    ` + utils.Indent(getAnnotations(reversedVPNEnabled, secretNameTest, secretNameDHTest, secretNameTLSAuthTest), 4) + ``
+    ` + utils.Indent(getAnnotations(reversedVPNEnabled, secretNameTest, secretNameDHTest, secretNameTLSAuthTest), 4)
 				out += `
   creationTimestamp: null
   labels:
@@ -288,7 +289,8 @@ spec:
   template:
     metadata:
       annotations:
-        ` + utils.Indent(getAnnotations(reversedVPNEnabled, secretNameTest, secretNameDHTest, secretNameTLSAuthTest), 8) + ``
+        ` + utils.Indent(getAnnotations(reversedVPNEnabled, secretNameTest, secretNameDHTest, secretNameTLSAuthTest), 8) + `
+        security.gardener.cloud/trigger: rollout`
 				out += `
       creationTimestamp: null
       labels:
@@ -305,7 +307,7 @@ spec:
         - name: POD_NETWORK
           value: ` + podNetwork + `
         - name: NODE_NETWORK
-          value: ` + nodeNetwork + ``
+          value: ` + nodeNetwork
 				if reversedVPNEnabled {
 					out += `
         - name: ENDPOINT
@@ -313,7 +315,7 @@ spec:
         - name: OPENVPN_PORT
           value: "` + strconv.Itoa(int(openVPNPort)) + `"
         - name: REVERSED_VPN_HEADER
-          value: ` + reversedVPNHeader + ``
+          value: ` + reversedVPNHeader
 				}
 				out += `
         image: ` + image + `
@@ -367,13 +369,13 @@ spec:
       - name: vpn-shoot-tlsauth
         secret:
           defaultMode: 400
-          secretName: ` + secretNameTLSAuthTest + ``
+          secretName: ` + secretNameTLSAuthTest
 				if !reversedVPNEnabled {
 					out += `
       - name: vpn-shoot-dh
         secret:
           defaultMode: 400
-          secretName: ` + secretNameDHTest + ``
+          secretName: ` + secretNameDHTest
 				}
 				out += `
 status: {}

--- a/pkg/operation/botanist/wanted_secrets.go
+++ b/pkg/operation/botanist/wanted_secrets.go
@@ -256,26 +256,6 @@ func (b *Botanist) generateWantedSecretConfigs(basicAuthAPIServer *secrets.Basic
 			SigningCA: certificateAuthorities[v1beta1constants.SecretNameCACluster],
 		},
 
-		// Secret definition for kube-proxy
-		&secrets.ControlPlaneSecretConfig{
-			CertificateSecretConfig: &secrets.CertificateSecretConfig{
-				Name: "kube-proxy",
-
-				CommonName:   user.KubeProxy,
-				Organization: nil,
-				DNSNames:     nil,
-				IPAddresses:  nil,
-
-				CertType:  secrets.ClientCert,
-				SigningCA: certificateAuthorities[v1beta1constants.SecretNameCACluster],
-			},
-
-			KubeConfigRequests: []secrets.KubeConfigRequest{{
-				ClusterName:   b.Shoot.SeedNamespace,
-				APIServerHost: b.Shoot.ComputeOutOfClusterAPIServerAddress(b.APIServerAddress, true),
-			}},
-		},
-
 		// Secret definition for prometheus
 		// TODO(rfranzke): Delete this in a future release once all monitoring configurations of extensions have been
 		// adapted.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement
/merge squash

**What this PR does / why we need it**:
This PR adapts all components deployed by Gardener into the shoot cluster to use projected `ServiceAccount` tokens (instead of the static tokens or even client certificates (in case of `kube-proxy`)).

**Which issue(s) this PR fixes**:
Part of #4660
Part of #4878

**Special notes for your reviewer**:
- We have to trigger a rollout of the pods, hence, there is a change in the `.metadata.annotations` section of the respective pod templates.
-  Note that not all pods use their `ServiceAccount` actively (in those cases it's only added to make `PodSecurityPolicy`s work).
- ✅ ~Depends on #5098 which needs to be merged first, hence, it's in draft state.~

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
All shoot system components deployed by Gardener have been switched to projected `ServiceAccount` tokens (instead of continued usage of static tokens).
```
