### PR TITLE
[GEP-17] Let destination gardenlet determine that operation should be restore

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control_migrate.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_migrate.go
@@ -38,7 +38,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -62,7 +61,7 @@ func (r *shootReconciler) prepareShootForMigration(ctx context.Context, logger l
 		return reconcile.Result{}, nil
 	}
 
-	r.recorder.Event(shoot, corev1.EventTypeNormal, gardencorev1beta1.EventPrepareMigration, "Prepare Shoot cluster for migration")
+	r.recorder.Event(shoot, corev1.EventTypeNormal, gardencorev1beta1.EventPrepareMigration, "Preparing Shoot cluster for migration")
 	shootNamespace := shootpkg.ComputeTechnicalID(project.Name, shoot)
 	if err = r.updateShootStatusOperationStart(ctx, gardenClient.Client(), shoot, shootNamespace, gardencorev1beta1.LastOperationTypeMigrate); err != nil {
 		return reconcile.Result{}, err
@@ -70,7 +69,7 @@ func (r *shootReconciler) prepareShootForMigration(ctx context.Context, logger l
 
 	o, operationErr := r.initializeOperation(ctx, logger, gardenClient, shoot, project, cloudProfile, seed)
 	if operationErr != nil {
-		updateErr := r.patchShootStatusOperationError(ctx, gardenClient.Client(), shoot, fmt.Sprintf("Could not initialize a new operation for preparation of Shoot Control Plane migration: %s", operationErr.Error()), gardencorev1beta1.LastOperationTypeMigrate, lastErrorsOperationInitializationFailure(shoot.Status.LastErrors, operationErr)...)
+		updateErr := r.patchShootStatusOperationError(ctx, gardenClient.Client(), shoot, fmt.Sprintf("Could not initialize a new operation for Shoot cluster preparation for migration: %s", operationErr.Error()), gardencorev1beta1.LastOperationTypeMigrate, lastErrorsOperationInitializationFailure(shoot.Status.LastErrors, operationErr)...)
 		return reconcile.Result{}, utilerrors.WithSuppressed(operationErr, updateErr)
 	}
 	// At this point the migration is allowed, hence, check if the seed is up-to-date, then sync the Cluster resource
@@ -79,7 +78,7 @@ func (r *shootReconciler) prepareShootForMigration(ctx context.Context, logger l
 		return patchShootStatusAndRequeueOnSyncError(ctx, gardenClient.Client(), shoot, logger, err)
 	}
 
-	if flowErr := r.runPrepareShootControlPlaneMigration(ctx, o); flowErr != nil {
+	if flowErr := r.runPrepareShootForMigrationFlow(ctx, o); flowErr != nil {
 		r.recorder.Event(shoot, corev1.EventTypeWarning, gardencorev1beta1.EventMigrationPreparationFailed, flowErr.Description)
 		updateErr := r.patchShootStatusOperationError(ctx, gardenClient.Client(), shoot, flowErr.Description, gardencorev1beta1.LastOperationTypeMigrate, flowErr.LastErrors...)
 		return reconcile.Result{}, utilerrors.WithSuppressed(errors.New(flowErr.Description), updateErr)
@@ -88,7 +87,7 @@ func (r *shootReconciler) prepareShootForMigration(ctx context.Context, logger l
 	return r.finalizeShootPrepareForMigration(ctx, gardenClient.Client(), shoot, o)
 }
 
-func (r *shootReconciler) runPrepareShootControlPlaneMigration(ctx context.Context, o *operation.Operation) *gardencorev1beta1helper.WrappedLastErrors {
+func (r *shootReconciler) runPrepareShootForMigrationFlow(ctx context.Context, o *operation.Operation) *gardencorev1beta1helper.WrappedLastErrors {
 	var (
 		botanist                     *botanistpkg.Botanist
 		err                          error
@@ -103,7 +102,7 @@ func (r *shootReconciler) runPrepareShootControlPlaneMigration(ctx context.Conte
 		}
 	}
 
-	errorContext := utilerrors.NewErrorContext("Shoot's control plane preparation for migration", tasksWithErrors)
+	errorContext := utilerrors.NewErrorContext("Shoot cluster preparation for migration", tasksWithErrors)
 
 	err = utilerrors.HandleErrors(errorContext,
 		func(errorID string) error {
@@ -172,7 +171,7 @@ func (r *shootReconciler) runPrepareShootControlPlaneMigration(ctx context.Conte
 		defaultTimeout          = 10 * time.Minute
 		defaultInterval         = 5 * time.Second
 
-		g = flow.NewGraph("Shoot's control plane preparation for migration")
+		g = flow.NewGraph("Shoot cluster preparation for migration")
 
 		ensureShootStateExists = g.Add(flow.Task{
 			Name: "Ensuring that ShootState exists",
@@ -304,7 +303,7 @@ func (r *shootReconciler) runPrepareShootControlPlaneMigration(ctx context.Conte
 			Dependencies: flow.NewTaskIDs(waitUntilAPIServerDeleted),
 		})
 		migrateBackupEntryInGarden = g.Add(flow.Task{
-			Name:         "Migrate BackupEntry to new seed",
+			Name:         "Migrating BackupEntry to new seed",
 			Fn:           botanist.Shoot.Components.BackupEntry.Migrate,
 			Dependencies: flow.NewTaskIDs(createETCDSnapshot),
 		})
@@ -343,11 +342,11 @@ func (r *shootReconciler) runPrepareShootControlPlaneMigration(ctx context.Conte
 		ErrorContext:     errorContext,
 		ErrorCleaner:     o.CleanShootTaskError,
 	}); err != nil {
-		o.Logger.Errorf("Failed to prepare Shoot %q for migration: %+v", o.Shoot.GetInfo().Name, err)
+		o.Logger.Errorf("Failed to prepare Shoot cluster %q for migration: %+v", o.Shoot.GetInfo().Name, err)
 		return gardencorev1beta1helper.NewWrappedLastErrors(gardencorev1beta1helper.FormatLastErrDescription(err), flow.Errors(err))
 	}
 
-	o.Logger.Infof("Successfully prepared Shoot's control plane for migration %q", o.Shoot.GetInfo().Name)
+	o.Logger.Infof("Successfully prepared Shoot cluster %q for migration", o.Shoot.GetInfo().Name)
 	return nil
 }
 
@@ -367,19 +366,10 @@ func (r *shootReconciler) finalizeShootPrepareForMigration(ctx context.Context, 
 		return reconcile.Result{}, err
 	}
 
-	r.recorder.Event(shoot, corev1.EventTypeNormal, gardencorev1beta1.EventMigrationPrepared, "Shoot Control Plane prepared for migration, successfully")
-
-	statusPatch := client.MergeFrom(shoot.DeepCopy())
-	shoot.Status.RetryCycleStartTime = nil
-	shoot.Status.SeedName = nil
-	shoot.Status.LastErrors = nil
-	shoot.Status.LastOperation = &gardencorev1beta1.LastOperation{
-		Type:           gardencorev1beta1.LastOperationTypeRestore,
-		State:          gardencorev1beta1.LastOperationStatePending,
-		Progress:       0,
-		Description:    "Shoot cluster state has been successfully prepared for migration.",
-		LastUpdateTime: metav1.Now(),
+	r.recorder.Event(shoot, corev1.EventTypeNormal, gardencorev1beta1.EventMigrationPrepared, "Prepared Shoot cluster for migration")
+	if err := r.patchShootStatusOperationSuccess(ctx, gardenClient, shoot, o.Shoot.SeedNamespace, nil, gardencorev1beta1.LastOperationTypeMigrate); err != nil {
+		return reconcile.Result{}, err
 	}
 
-	return reconcile.Result{}, gardenClient.Status().Patch(ctx, shoot, statusPatch)
+	return reconcile.Result{}, nil
 }

--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -27,17 +27,19 @@ import (
 	"github.com/gardener/gardener/pkg/operation"
 	botanistpkg "github.com/gardener/gardener/pkg/operation/botanist"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
+	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/errors"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	retryutils "github.com/gardener/gardener/pkg/utils/retry"
 )
 
-// runReconcileShootFlow reconciles the Shoot cluster's state.
+// runReconcileShootFlow reconciles the Shoot cluster.
 // It receives an Operation object <o> which stores the Shoot object.
-func (r *shootReconciler) runReconcileShootFlow(ctx context.Context, o *operation.Operation) *gardencorev1beta1helper.WrappedLastErrors {
+func (r *shootReconciler) runReconcileShootFlow(ctx context.Context, o *operation.Operation, operationType gardencorev1beta1.LastOperationType) *gardencorev1beta1helper.WrappedLastErrors {
 	// We create the botanists (which will do the actual work).
 	var (
+		isRestoring             = operationType == gardencorev1beta1.LastOperationTypeRestore
 		botanist                *botanistpkg.Botanist
 		tasksWithErrors         []string
 		isCopyOfBackupsRequired bool
@@ -50,7 +52,7 @@ func (r *shootReconciler) runReconcileShootFlow(ctx context.Context, o *operatio
 		}
 	}
 
-	errorContext := errors.NewErrorContext("Shoot cluster reconciliation", tasksWithErrors)
+	errorContext := errors.NewErrorContext(fmt.Sprintf("Shoot cluster %s", utils.IifString(isRestoring, "restoration", "reconciliation")), tasksWithErrors)
 
 	err = errors.HandleErrors(errorContext,
 		func(errorID string) error {
@@ -91,7 +93,7 @@ func (r *shootReconciler) runReconcileShootFlow(ctx context.Context, o *operatio
 		sniPhase                       = botanist.Shoot.Components.ControlPlane.KubeAPIServerSNIPhase
 		requestControlPlanePodsRestart = controllerutils.HasTask(o.Shoot.GetInfo().Annotations, v1beta1constants.ShootTaskRestartControlPlanePods)
 
-		g                      = flow.NewGraph("Shoot cluster reconciliation")
+		g                      = flow.NewGraph(fmt.Sprintf("Shoot cluster %s", utils.IifString(isRestoring, "restoration", "reconciliation")))
 		ensureShootStateExists = g.Add(flow.Task{
 			Name: "Ensuring that ShootState exists",
 			Fn:   flow.TaskFn(botanist.EnsureShootStateExists).RetryUntilTimeout(defaultInterval, defaultTimeout),
@@ -404,7 +406,7 @@ func (r *shootReconciler) runReconcileShootFlow(ctx context.Context, o *operatio
 			Dependencies: flow.NewTaskIDs(deployNetwork),
 		})
 		_ = g.Add(flow.Task{
-			Name:         "Deploying shoot cluster-identity",
+			Name:         "Deploying shoot cluster identity",
 			Fn:           flow.TaskFn(botanist.DeployClusterIdentity).RetryUntilTimeout(defaultInterval, defaultTimeout).SkipIf(o.Shoot.HibernationEnabled),
 			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, ensureShootClusterIdentity, waitUntilOperatingSystemConfigReady),
 		})
@@ -555,7 +557,7 @@ func (r *shootReconciler) runReconcileShootFlow(ctx context.Context, o *operatio
 			Dependencies: flow.NewTaskIDs(deployExtensionResources),
 		})
 		deleteStaleExtensionResources = g.Add(flow.Task{
-			Name:         "Delete stale extension resources",
+			Name:         "Deleting stale extension resources",
 			Fn:           flow.TaskFn(botanist.Shoot.Components.Extensions.Extension.DeleteStaleResources).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(initializeShootClients),
 		})
@@ -575,7 +577,7 @@ func (r *shootReconciler) runReconcileShootFlow(ctx context.Context, o *operatio
 			Dependencies: flow.NewTaskIDs(deployContainerRuntimeResources),
 		})
 		deleteStaleContainerRuntimeResources = g.Add(flow.Task{
-			Name:         "Delete stale container runtime resources",
+			Name:         "Deleting stale container runtime resources",
 			Fn:           flow.TaskFn(botanist.Shoot.Components.Extensions.ContainerRuntime.DeleteStaleResources).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(initializeShootClients),
 		})
@@ -585,7 +587,7 @@ func (r *shootReconciler) runReconcileShootFlow(ctx context.Context, o *operatio
 			Dependencies: flow.NewTaskIDs(deleteStaleContainerRuntimeResources),
 		})
 		_ = g.Add(flow.Task{
-			Name: "Restart control plane pods",
+			Name: "Restarting control plane pods",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				if err := botanist.RestartControlPlanePods(ctx); err != nil {
 					return err
@@ -609,7 +611,7 @@ func (r *shootReconciler) runReconcileShootFlow(ctx context.Context, o *operatio
 		ErrorContext:     errorContext,
 		ErrorCleaner:     o.CleanShootTaskError,
 	}); err != nil {
-		o.Logger.Errorf("Failed to reconcile Shoot %q: %+v", o.Shoot.GetInfo().Name, err)
+		o.Logger.Errorf("Failed to %s Shoot cluster %q: %+v", utils.IifString(isRestoring, "restore", "reconcile"), o.Shoot.GetInfo().Name, err)
 		return gardencorev1beta1helper.NewWrappedLastErrors(gardencorev1beta1helper.FormatLastErrDescription(err), flow.Errors(err))
 	}
 
@@ -621,7 +623,7 @@ func (r *shootReconciler) runReconcileShootFlow(ctx context.Context, o *operatio
 		}
 	}
 
-	o.Logger.Infof("Successfully reconciled Shoot %q", o.Shoot.GetInfo().Name)
+	o.Logger.Infof("Successfully %s Shoot cluster %q", utils.IifString(isRestoring, "restored", "reconciled"), o.Shoot.GetInfo().Name)
 	return nil
 }
 

--- a/pkg/registry/core/shoot/strategy.go
+++ b/pkg/registry/core/shoot/strategy.go
@@ -162,8 +162,8 @@ func (shootStatusStrategy) PrepareForUpdate(ctx context.Context, obj, old runtim
 	oldShoot := old.(*core.Shoot)
 	newShoot.Spec = oldShoot.Spec
 
-	if lastOperation := newShoot.Status.LastOperation; lastOperation != nil && lastOperation.Type == core.LastOperationTypeRestore &&
-		lastOperation.State == core.LastOperationStatePending {
+	if lastOperation := newShoot.Status.LastOperation; lastOperation != nil && lastOperation.Type == core.LastOperationTypeMigrate &&
+		lastOperation.State == core.LastOperationStateSucceeded {
 		newShoot.Generation = oldShoot.Generation + 1
 	}
 }

--- a/pkg/utils/miscellaneous.go
+++ b/pkg/utils/miscellaneous.go
@@ -157,3 +157,12 @@ func ShallowCopyMapStringInterface(values map[string]interface{}) map[string]int
 	}
 	return copiedValues
 }
+
+// IifString returns onTrue if the condition is true, and onFalse otherwise.
+// It is similar to the ternary operator (?:) and the IIF function (see https://en.wikipedia.org/wiki/IIf) in other languages.
+func IifString(condition bool, onTrue, onFalse string) string {
+	if condition {
+		return onTrue
+	}
+	return onFalse
+}

--- a/pkg/utils/miscellaneous_test.go
+++ b/pkg/utils/miscellaneous_test.go
@@ -110,4 +110,12 @@ baz`, spaces)).To(Equal(`foo
 			Expect(v["bar"].(map[string]interface{})["baz"]).To(Equal("bang"))
 		})
 	})
+
+	DescribeTable("#IifString",
+		func(condition bool, expectation string) {
+			Expect(IifString(condition, "true", "false")).To(Equal(expectation))
+		},
+		Entry("condition is true", true, "true"),
+		Entry("condition is false", false, "false"),
+	)
 })


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane-migration
/kind enhancement

**What this PR does / why we need it**:
* As a preparation for introducing the control plane migration "bad case" fallback logic, lets the destination `gardenlet` determine that the operation should be `restore` when the current last operation is `Migrate Succeeded`.
* Improves migration flow messages to ensure consistent terminology and correct phrasing.
* Also improves reconciliation and deletion flow messages to ensure that they are accurate (differentiating between "reconcile" and "restore") and consistent (always using the same phrasing).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```other operator
NONE
```
