### PR TITLE
Ignore loki sts healthcheck if loki is disabled

### DIFF
--- a/pkg/operation/care/checker.go
+++ b/pkg/operation/care/checker.go
@@ -496,10 +496,11 @@ func (b *HealthChecker) CheckMonitoringControlPlane(
 func (b *HealthChecker) CheckLoggingControlPlane(
 	namespace string,
 	isTestingShoot bool,
+	lokiEnabled bool,
 	condition gardencorev1beta1.Condition,
 	statefulSetLister kutil.StatefulSetLister,
 ) (*gardencorev1beta1.Condition, error) {
-	if isTestingShoot {
+	if isTestingShoot || !lokiEnabled {
 		return nil, nil
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind bug

**What this PR does / why we need it**:
I added in #4949 the possibility to disable loki in gardenletConfiguration. Unfortunately I didn't see that there is a health check which fails now, because the `loki` statefulset doesn't exists.

**Which issue(s) this PR fixes**:
Related  #4949 


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix failing health check if loki is disabled in gardenlet configuration
```
