### PR TITLE
Clean up `VolumeSnapshots` and `VolumeSnapshotContents`

### DIFF
--- a/docs/usage/shoot_cleanup.md
+++ b/docs/usage/shoot_cleanup.md
@@ -12,6 +12,7 @@ Some resources are deleted with a grace period, and all resources are forcefully
 1. All `APIService`s and `CustomResourceDefinition`s are deleted with a `5m` grace period. Forceful finalization happens after `1h`.
 1. All `CronJob`s, `DaemonSet`s, `Deployment`s, `Ingress`s, `Job`s, `Pod`s, `ReplicaSet`s, `ReplicationController`s, `Service`s, `StatefulSet`s, `PersistentVolumeClaim`s are deleted with a `5m` grace period. Forceful finalization happens after `5m`.
    > If the `Shoot` is annotated with `shoot.gardener.cloud/skip-cleanup=true` then only `Service`s and `PersistentVolumeClaim`s are considered.
+1. All `VolumeSnapshot`s and `VolumeSnapshotContent`s are deleted with a `5m` grace period. Forceful finalization happens after `1h`.
 1. All `Namespace`s  are deleted without any grace period. Forceful finalization happens after `5m`.
 
 It is possible to override the finalization grace periods via annotations on the `Shoot`:

--- a/pkg/client/kubernetes/types.go
+++ b/pkg/client/kubernetes/types.go
@@ -20,6 +20,7 @@ import (
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
+	volumesnapshotv1beta1 "github.com/kubernetes-csi/external-snapshotter/v2/pkg/apis/volumesnapshot/v1beta1"
 	istionetworkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	istionetworkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	apiextensionsscheme "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
@@ -123,6 +124,7 @@ func init() {
 		apiregistrationscheme.AddToScheme,
 		autoscalingv1beta2.AddToScheme,
 		metricsv1beta1.AddToScheme,
+		volumesnapshotv1beta1.AddToScheme,
 	)
 	utilruntime.Must(shootSchemeBuilder.AddToScheme(ShootScheme))
 

--- a/pkg/operation/botanist/cleanup.go
+++ b/pkg/operation/botanist/cleanup.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gardener/gardener/pkg/utils/retry"
 	"github.com/gardener/gardener/pkg/utils/version"
 
+	volumesnapshotv1beta1 "github.com/kubernetes-csi/external-snapshotter/v2/pkg/apis/volumesnapshot/v1beta1"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -156,6 +157,12 @@ var (
 	// PersistentVolumeClaimCleanOption is the delete selector for PersistentVolumeClaims.
 	PersistentVolumeClaimCleanOption = utilclient.ListWith{&NoCleanupPreventionListOption}
 
+	// VolumeSnapshotCleanOption is the delete selector for VolumeSnapshots.
+	VolumeSnapshotCleanOption = utilclient.ListWith{&NoCleanupPreventionListOption}
+
+	// VolumeSnapshotContentCleanOption is the delete selector for VolumeSnapshotContents.
+	VolumeSnapshotContentCleanOption = utilclient.ListWith{&NoCleanupPreventionListOption}
+
 	// NamespaceErrorToleration are the errors to be tolerated during deletion.
 	NamespaceErrorToleration = utilclient.TolerateErrors{apierrors.IsConflict}
 )
@@ -203,10 +210,9 @@ func (b *Botanist) CleanWebhooks(ctx context.Context) error {
 // CleanExtendedAPIs removes API extensions like CRDs and API services from the Shoot cluster.
 func (b *Botanist) CleanExtendedAPIs(ctx context.Context) error {
 	var (
-		c           = b.K8sShootClient.Client()
-		ensurer     = utilclient.GoneBeforeEnsurer(b.Shoot.GetInfo().GetDeletionTimestamp().Time)
-		defaultOps  = utilclient.NewCleanOps(utilclient.DefaultCleaner(), ensurer)
-		crdCleanOps = utilclient.NewCleanOps(utilclient.DefaultCleaner(), ensurer)
+		c       = b.K8sShootClient.Client()
+		ensurer = utilclient.GoneBeforeEnsurer(b.Shoot.GetInfo().GetDeletionTimestamp().Time)
+		ops     = utilclient.NewCleanOps(utilclient.DefaultCleaner(), ensurer)
 	)
 
 	cleanOptions, err := b.getCleanOptions(GracePeriodFiveMinutes, FinalizeAfterOneHour, v1beta1constants.AnnotationShootCleanupExtendedAPIsFinalizeGracePeriodSeconds, 0.1)
@@ -221,8 +227,8 @@ func (b *Botanist) CleanExtendedAPIs(ctx context.Context) error {
 	}
 
 	return flow.Parallel(
-		cleanResourceFn(defaultOps, c, &apiregistrationv1.APIServiceList{}, APIServiceCleanOption, cleanOptions),
-		cleanResourceFn(crdCleanOps, c, crdList, CustomResourceDefinitionCleanOption, cleanOptions),
+		cleanResourceFn(ops, c, &apiregistrationv1.APIServiceList{}, APIServiceCleanOption, cleanOptions),
+		cleanResourceFn(ops, c, crdList, CustomResourceDefinitionCleanOption, cleanOptions),
 	)(ctx)
 }
 
@@ -246,6 +252,8 @@ func (b *Botanist) CleanKubernetesResources(ctx context.Context) error {
 		return flow.Parallel(
 			cleanResourceFn(ops, c, &corev1.ServiceList{}, ServiceCleanOption, cleanOptions),
 			cleanResourceFn(ops, c, &corev1.PersistentVolumeClaimList{}, PersistentVolumeClaimCleanOption, cleanOptions),
+			cleanResourceFn(ops, c, &volumesnapshotv1beta1.VolumeSnapshotList{}, VolumeSnapshotContentCleanOption, cleanOptions),
+			cleanResourceFn(ops, c, &volumesnapshotv1beta1.VolumeSnapshotContentList{}, VolumeSnapshotContentCleanOption, cleanOptions),
 		)(ctx)
 	}
 
@@ -266,6 +274,10 @@ func (b *Botanist) CleanKubernetesResources(ctx context.Context) error {
 		cleanResourceFn(ops, c, &corev1.ServiceList{}, ServiceCleanOption, cleanOptions),
 		cleanResourceFn(ops, c, &appsv1.StatefulSetList{}, StatefulSetCleanOption, cleanOptions),
 		cleanResourceFn(ops, c, &corev1.PersistentVolumeClaimList{}, PersistentVolumeClaimCleanOption, cleanOptions),
+		// Cleaning up VolumeSnapshots can take a longer time if many snapshots were taken.
+		// Hence, we only finalize these objects after 1h.
+		cleanResourceFn(ops, c, &volumesnapshotv1beta1.VolumeSnapshotList{}, VolumeSnapshotContentCleanOption, FinalizeAfterOneHour),
+		cleanResourceFn(ops, c, &volumesnapshotv1beta1.VolumeSnapshotContentList{}, VolumeSnapshotContentCleanOption, FinalizeAfterOneHour),
 	)(ctx)
 }
 

--- a/pkg/operation/botanist/cleanup.go
+++ b/pkg/operation/botanist/cleanup.go
@@ -186,7 +186,7 @@ func (b *Botanist) CleanWebhooks(ctx context.Context) error {
 	var (
 		c       = b.K8sShootClient.Client()
 		ensurer = utilclient.GoneBeforeEnsurer(b.Shoot.GetInfo().GetDeletionTimestamp().Time)
-		ops     = utilclient.NewCleanOps(utilclient.DefaultCleaner(), ensurer)
+		ops     = utilclient.NewCleanOps(ensurer, utilclient.DefaultCleaner())
 	)
 
 	cleanOptions, err := b.getCleanOptions(GracePeriodFiveMinutes, FinalizeAfterFiveMinutes, v1beta1constants.AnnotationShootCleanupWebhooksFinalizeGracePeriodSeconds, 1)
@@ -212,7 +212,7 @@ func (b *Botanist) CleanExtendedAPIs(ctx context.Context) error {
 	var (
 		c       = b.K8sShootClient.Client()
 		ensurer = utilclient.GoneBeforeEnsurer(b.Shoot.GetInfo().GetDeletionTimestamp().Time)
-		ops     = utilclient.NewCleanOps(utilclient.DefaultCleaner(), ensurer)
+		ops     = utilclient.NewCleanOps(ensurer, utilclient.DefaultCleaner())
 	)
 
 	cleanOptions, err := b.getCleanOptions(GracePeriodFiveMinutes, FinalizeAfterOneHour, v1beta1constants.AnnotationShootCleanupExtendedAPIsFinalizeGracePeriodSeconds, 0.1)
@@ -240,8 +240,9 @@ func (b *Botanist) CleanKubernetesResources(ctx context.Context) error {
 	var (
 		c                  = b.K8sShootClient.Client()
 		ensurer            = utilclient.GoneBeforeEnsurer(b.Shoot.GetInfo().GetDeletionTimestamp().Time)
-		ops                = utilclient.NewCleanOps(utilclient.DefaultCleaner(), ensurer)
-		snapshotContentOps = utilclient.NewCleanOps(utilclient.NewVolumeSnapshotContentCleaner(), ensurer)
+		cleaner            = utilclient.DefaultCleaner()
+		ops                = utilclient.NewCleanOps(ensurer, cleaner)
+		snapshotContentOps = utilclient.NewCleanOps(ensurer, cleaner, utilclient.DefaultVolumeSnapshotContentCleaner())
 	)
 
 	cleanOptions, err := b.getCleanOptions(GracePeriodFiveMinutes, FinalizeAfterFiveMinutes, v1beta1constants.AnnotationShootCleanupKubernetesResourcesFinalizeGracePeriodSeconds, 1)
@@ -249,7 +250,7 @@ func (b *Botanist) CleanKubernetesResources(ctx context.Context) error {
 		return err
 	}
 
-	snapshotCleanOptions, err := b.getCleanOptions(ZeroGracePeriod, FinalizeAfterOneHour, v1beta1constants.AnnotationShootCleanupKubernetesResourcesFinalizeGracePeriodSeconds, 1)
+	snapshotCleanOptions, err := b.getCleanOptions(GracePeriodFiveMinutes, FinalizeAfterOneHour, v1beta1constants.AnnotationShootCleanupKubernetesResourcesFinalizeGracePeriodSeconds, 0.5)
 	if err != nil {
 		return err
 	}
@@ -293,7 +294,7 @@ func (b *Botanist) CleanShootNamespaces(ctx context.Context) error {
 	var (
 		c                 = b.K8sShootClient.Client()
 		namespaceCleaner  = utilclient.NewNamespaceCleaner(b.K8sShootClient.Kubernetes().CoreV1().Namespaces())
-		namespaceCleanOps = utilclient.NewCleanOps(namespaceCleaner, utilclient.DefaultGoneEnsurer())
+		namespaceCleanOps = utilclient.NewCleanOps(utilclient.DefaultGoneEnsurer(), namespaceCleaner)
 	)
 
 	cleanOptions, err := b.getCleanOptions(ZeroGracePeriod, FinalizeAfterFiveMinutes, v1beta1constants.AnnotationShootCleanupNamespaceResourcesFinalizeGracePeriodSeconds, 0)

--- a/pkg/operation/botanist/cleanup.go
+++ b/pkg/operation/botanist/cleanup.go
@@ -248,6 +248,11 @@ func (b *Botanist) CleanKubernetesResources(ctx context.Context) error {
 		return err
 	}
 
+	snapshotCleanOptions, err := b.getCleanOptions(ZeroGracePeriod, FinalizeAfterOneHour, v1beta1constants.AnnotationShootCleanupKubernetesResourcesFinalizeGracePeriodSeconds, 1)
+	if err != nil {
+		return err
+	}
+
 	if metav1.HasAnnotation(b.Shoot.GetInfo().ObjectMeta, v1beta1constants.AnnotationShootSkipCleanup) {
 		return flow.Parallel(
 			cleanResourceFn(ops, c, &corev1.ServiceList{}, ServiceCleanOption, cleanOptions),
@@ -276,8 +281,8 @@ func (b *Botanist) CleanKubernetesResources(ctx context.Context) error {
 		cleanResourceFn(ops, c, &corev1.PersistentVolumeClaimList{}, PersistentVolumeClaimCleanOption, cleanOptions),
 		// Cleaning up VolumeSnapshots can take a longer time if many snapshots were taken.
 		// Hence, we only finalize these objects after 1h.
-		cleanResourceFn(ops, c, &volumesnapshotv1beta1.VolumeSnapshotList{}, VolumeSnapshotContentCleanOption, FinalizeAfterOneHour),
-		cleanResourceFn(ops, c, &volumesnapshotv1beta1.VolumeSnapshotContentList{}, VolumeSnapshotContentCleanOption, FinalizeAfterOneHour),
+		cleanResourceFn(ops, c, &volumesnapshotv1beta1.VolumeSnapshotList{}, VolumeSnapshotContentCleanOption, snapshotCleanOptions),
+		cleanResourceFn(ops, c, &volumesnapshotv1beta1.VolumeSnapshotContentList{}, VolumeSnapshotContentCleanOption, snapshotCleanOptions),
 	)(ctx)
 }
 

--- a/pkg/utils/kubernetes/client/client.go
+++ b/pkg/utils/kubernetes/client/client.go
@@ -264,7 +264,7 @@ func (v *volumeSnapshotContentCleaner) triggerVolumeSnapshotDeletion(ctx context
 		obj.SetAnnotations(make(map[string]string))
 	}
 
-	// annVolumeSnapshotBeingDeleted triggers the CSI side-care to delete the snapshot on the infrastructure.
+	// annVolumeSnapshotBeingDeleted triggers the CSI sidecar to delete the snapshot on the infrastructure.
 	// annVolumeSnapshotBeingCreated must not exist if we want the controller to delete the snapshot.
 	// See https://github.com/kubernetes-csi/external-snapshotter/blob/138d310e5d2d102fcf90df96d7a8aaf6690ce76e/pkg/sidecar-controller/snapshot_controller.go#L563
 	obj.GetAnnotations()[annVolumeSnapshotBeingDeleted] = "yes"

--- a/pkg/utils/kubernetes/client/client.go
+++ b/pkg/utils/kubernetes/client/client.go
@@ -415,7 +415,7 @@ func cleanCollectionAction(
 }
 
 type cleanerOps struct {
-	Cleaner
+	cleaners []Cleaner
 	GoneEnsurer
 }
 
@@ -425,19 +425,21 @@ func (o *cleanerOps) CleanAndEnsureGone(ctx context.Context, c client.Client, ob
 	cleanOptions := &CleanOptions{}
 	cleanOptions.ApplyOptions(opts)
 
-	if err := o.Clean(ctx, c, obj, opts...); err != nil {
-		return err
+	for _, cle := range o.cleaners {
+		if err := cle.Clean(ctx, c, obj, opts...); err != nil {
+			return err
+		}
 	}
 
 	return o.EnsureGone(ctx, c, obj, cleanOptions.ListOptions...)
 }
 
 // NewCleanOps instantiates new CleanOps with the given Cleaner and GoneEnsurer.
-func NewCleanOps(cleaner Cleaner, ensurer GoneEnsurer) CleanOps {
+func NewCleanOps(ensurer GoneEnsurer, cleaner ...Cleaner) CleanOps {
 	return &cleanerOps{cleaner, ensurer}
 }
 
-var defaultCleanerOps = NewCleanOps(DefaultCleaner(), DefaultGoneEnsurer())
+var defaultCleanerOps = NewCleanOps(DefaultGoneEnsurer(), DefaultCleaner())
 
 // DefaultCleanOps are the default CleanOps.
 func DefaultCleanOps() CleanOps {

--- a/pkg/utils/kubernetes/client/client_test.go
+++ b/pkg/utils/kubernetes/client/client_test.go
@@ -581,7 +581,7 @@ var _ = Describe("Cleaner", func() {
 		BeforeEach(func() {
 			cleaner = mockutilclient.NewMockCleaner(ctrl)
 			ensurer = mockutilclient.NewMockGoneEnsurer(ctrl)
-			o = NewCleanOps(cleaner, ensurer)
+			o = NewCleanOps(ensurer, cleaner)
 		})
 
 		Describe("CleanAndEnsureGone", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR enhances Gardener's clean-up logic to also include `VolumeSnapshots` and `VolumeSnapshotContents`. As opposed to other resources, those are only forcefully cleaned up after `1h` because deleting snapshots can take a while depending on the number of snapshots which were taken before.

However, `5m` (default) after the `VolumeSnapshotConent` has been deleted for the first time, an annotation `snapshot.storage.kubernetes.io/volumesnapshot-being-deleted=yes` is added to the affected object. It triggers a more or less forceful but graceful deletion through the CSI snapshotter, i.e. the snapshot in the infrastructure is deleted as well as the `VolumeSnapshotConent` if the previous step succeeded. The `snapshot.storage.kubernetes.io/volumesnapshot-being-created` annotation is removed likewise to not block the deletion flow.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Gardener now cleans up `VolumeSnapshots` and `VolumeSnapshotContents` during cluster deletion. These resources are forcefully deleted after a `1h` grace period which eventually lead to leaked snapshots on the cloud provider side. Hence, if the CSI-Snapshotter cannot delete affected snapshots successfully for `1h`, operators/shoot-owners have to purge them manually.
```
