### PR TITLE
`ControllerRegistration` controller shouldn't hang when there is no internal domain secret

### DIFF
--- a/pkg/controllermanager/controller/controllerregistration/controllerregistration_seed_control.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerregistration_seed_control.go
@@ -103,7 +103,7 @@ func (r *controllerRegistrationSeedReconciler) Reconcile(ctx context.Context, re
 		return reconcile.Result{}, err
 	}
 
-	secrets, err := gardenpkg.ReadGardenSecrets(ctx, r.gardenClient.Client(), gutil.ComputeGardenNamespace(seed.Name), logger)
+	secrets, err := gardenpkg.ReadGardenSecrets(ctx, r.gardenClient.Client(), gutil.ComputeGardenNamespace(seed.Name), logger, false)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/gardenlet/controller/seed/seed_control.go
+++ b/pkg/gardenlet/controller/seed/seed_control.go
@@ -311,7 +311,7 @@ func (r *reconciler) reconcile(ctx context.Context, gardenClient client.Client, 
 		return err
 	}
 
-	gardenSecrets, err := garden.ReadGardenSecrets(ctx, gardenClient, gutil.ComputeGardenNamespace(seed.Name), log)
+	gardenSecrets, err := garden.ReadGardenSecrets(ctx, gardenClient, gutil.ComputeGardenNamespace(seed.Name), log, true)
 	if err != nil {
 		conditionSeedBootstrapped = gardencorev1beta1helper.UpdatedCondition(conditionSeedBootstrapped, gardencorev1beta1.ConditionFalse, "GardenSecretsError", err.Error())
 		_ = r.patchSeedStatus(ctx, gardenClient, log, seed, seedKubernetesVersion, capacity, allocatable, conditionSeedBootstrapped)

--- a/pkg/gardenlet/controller/shoot/shoot_care_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_care_control.go
@@ -269,7 +269,7 @@ func (r *careReconciler) care(ctx context.Context, gardenClientSet kubernetes.In
 
 	// Only read Garden secrets once because we don't rely on up-to-date secrets for health checks.
 	if r.gardenSecrets == nil {
-		secrets, err := garden.ReadGardenSecrets(careCtx, gardenClient, gutil.ComputeGardenNamespace(*shoot.Spec.SeedName), log)
+		secrets, err := garden.ReadGardenSecrets(careCtx, gardenClient, gutil.ComputeGardenNamespace(*shoot.Spec.SeedName), log, true)
 		if err != nil {
 			return fmt.Errorf("error reading Garden secrets: %w", err)
 		}

--- a/pkg/gardenlet/controller/shoot/shoot_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control.go
@@ -298,7 +298,7 @@ func shouldPrepareShootForMigration(shoot *gardencorev1beta1.Shoot) bool {
 const taskID = "initializeOperation"
 
 func (r *shootReconciler) initializeOperation(ctx context.Context, logger logrus.FieldLogger, gardenClient kubernetes.Interface, shoot *gardencorev1beta1.Shoot, project *gardencorev1beta1.Project, cloudProfile *gardencorev1beta1.CloudProfile, seed *gardencorev1beta1.Seed) (*operation.Operation, error) {
-	gardenSecrets, err := garden.ReadGardenSecrets(ctx, gardenClient.Client(), gutil.ComputeGardenNamespace(seed.Name), logger)
+	gardenSecrets, err := garden.ReadGardenSecrets(ctx, gardenClient.Client(), gutil.ComputeGardenNamespace(seed.Name), logger, true)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operation/garden/garden.go
+++ b/pkg/operation/garden/garden.go
@@ -170,7 +170,7 @@ var gardenRoleReq = utils.MustNewRequirement(v1beta1constants.GardenRole, select
 
 // ReadGardenSecrets reads the Kubernetes Secrets from the Garden cluster which are independent of Shoot clusters.
 // The Secret objects are stored on the Controller in order to pass them to created Garden objects later.
-func ReadGardenSecrets(ctx context.Context, c client.Reader, namespace string, log logrus.FieldLogger) (map[string]*corev1.Secret, error) {
+func ReadGardenSecrets(ctx context.Context, c client.Reader, namespace string, log logrus.FieldLogger, enforceInternalDomainSecret bool) (map[string]*corev1.Secret, error) {
 	var (
 		logInfo                             []string
 		secretsMap                          = make(map[string]*corev1.Secret)
@@ -273,7 +273,7 @@ func ReadGardenSecrets(ctx context.Context, c client.Reader, namespace string, l
 		// is used in all kubeconfigs. With that we have a robust endpoint stable against underlying ip/hostname changes.
 		// And there can only be one of this internal domain secret because otherwise the gardener would not know which
 		// domain it should use.
-		if numberOfInternalDomainSecrets == 0 {
+		if enforceInternalDomainSecret && numberOfInternalDomainSecrets == 0 {
 			return nil, fmt.Errorf("need an internal domain secret but found none")
 		}
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
When all `Shoot`s are deleted in a system and the internal domain secret is deleted before the last `ControllerRegistration` then the controller gets into a never ending hanging state since it cannot find any internal domain secret.
This PR fixes this issue.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed which caused the `gardener-controller-manager` to hang forever in case the internal domain secret got deleted before the last `ControllerRegistration`.
```
