### PR TITLE
Small enhancements for the test framework

### DIFF
--- a/test/framework/gardener_utils.go
+++ b/test/framework/gardener_utils.go
@@ -61,6 +61,11 @@ func (f *GardenerFramework) GetSeed(ctx context.Context, seedName string) (*gard
 	}
 
 	seedSecretRef := seed.Spec.SecretRef
+	if seedSecretRef == nil {
+		f.Logger.Info("seed does not have secretRef set, skip constructing seed client")
+		return seed, nil, nil
+	}
+
 	seedClient, err := kubernetes.NewClientFromSecret(ctx, f.GardenClient.Client(), seedSecretRef.Namespace, seedSecretRef.Name, kubernetes.WithClientOptions(client.Options{
 		Scheme: kubernetes.SeedScheme,
 	}))

--- a/test/framework/gardenerframework.go
+++ b/test/framework/gardenerframework.go
@@ -19,11 +19,12 @@ import (
 	"flag"
 	"time"
 
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
 )
 
 var gardenerCfg *GardenerConfig
@@ -128,6 +129,9 @@ func mergeGardenerConfig(base, overwrite *GardenerConfig) *GardenerConfig {
 	}
 	if StringSet(overwrite.GardenerKubeconfig) {
 		base.GardenerKubeconfig = overwrite.GardenerKubeconfig
+	}
+	if overwrite.SkipAccessingShoot {
+		base.SkipAccessingShoot = overwrite.SkipAccessingShoot
 	}
 
 	return base

--- a/test/framework/gardenerframework.go
+++ b/test/framework/gardenerframework.go
@@ -33,6 +33,7 @@ type GardenerConfig struct {
 	CommonConfig       *CommonConfig
 	GardenerKubeconfig string
 	ProjectNamespace   string
+	SkipAccessingShoot bool
 }
 
 // GardenerFramework is the gardener test framework that includes functions for working with a gardener instance
@@ -140,6 +141,7 @@ func RegisterGardenerFrameworkFlags() *GardenerConfig {
 
 	flag.StringVar(&newCfg.GardenerKubeconfig, "kubecfg", "", "the path to the kubeconfig  of the garden cluster that will be used for integration tests")
 	flag.StringVar(&newCfg.ProjectNamespace, "project-namespace", "", "specify the gardener project namespace to run tests")
+	flag.BoolVar(&newCfg.SkipAccessingShoot, "skip-accessing-shoot", false, "if set to true then the test does not try to access the shoot via its kubeconfig")
 
 	gardenerCfg = newCfg
 	return gardenerCfg

--- a/test/framework/shootcreationframework.go
+++ b/test/framework/shootcreationframework.go
@@ -393,7 +393,9 @@ func (f *ShootCreationFramework) CreateShoot(ctx context.Context, initializeShoo
 		return nil, err
 	}
 
-	if err := DownloadKubeconfig(ctx, shootFramework.GardenClient, shootFramework.Seed.Spec.SecretRef.Namespace, shootFramework.Seed.Spec.SecretRef.Name, f.Config.seedKubeconfigPath); err != nil {
+	if seedSecretRef := shootFramework.Seed.Spec.SecretRef; seedSecretRef == nil {
+		f.Logger.Info("seed does not have secretRef set, skip constructing seed client")
+	} else if err := DownloadKubeconfig(ctx, shootFramework.GardenClient, shootFramework.Seed.Spec.SecretRef.Namespace, shootFramework.Seed.Spec.SecretRef.Name, f.Config.seedKubeconfigPath); err != nil {
 		f.Logger.Fatalf("Cannot download seed kubeconfig: %s", err.Error())
 		return nil, err
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement
/merge squash

**What this PR does / why we need it**:
This PR lifts the assumption of the test framework that each `Seed` has set `.spec.secretRef` (since this field is optional).
Additionally, it allows to optionally disable the test of accessing the shoot via its ingress. This can be helpful in case the test executor has no network access to this ingress.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
