### PR TITLE
Drop references to `extensions` from `pkg/operation`

### DIFF
--- a/extensions/pkg/controller/backupentry/genericactuator/actuator.go
+++ b/extensions/pkg/controller/backupentry/genericactuator/actuator.go
@@ -116,8 +116,8 @@ func (a *actuator) deleteEtcdBackupSecret(ctx context.Context, secretName string
 
 func emptyEtcdBackupSecret(backupEntryName string) *corev1.Secret {
 	secretName := v1beta1constants.BackupSecretName
-	if strings.HasPrefix(backupEntryName, backupentry.SourcePrefix) {
-		secretName = fmt.Sprintf("%s-%s", backupentry.SourcePrefix, v1beta1constants.BackupSecretName)
+	if strings.HasPrefix(backupEntryName, v1beta1constants.BackupSourcePrefix) {
+		secretName = fmt.Sprintf("%s-%s", v1beta1constants.BackupSourcePrefix, v1beta1constants.BackupSecretName)
 	}
 	shootTechnicalID, _ := backupentry.ExtractShootDetailsFromBackupEntryName(backupEntryName)
 

--- a/extensions/pkg/controller/backupentry/util.go
+++ b/extensions/pkg/controller/backupentry/util.go
@@ -17,14 +17,13 @@ package backupentry
 import (
 	"fmt"
 	"strings"
-)
 
-// SourcePrefix is the prefix for names of resources related to source backupentries when copying backups.
-const SourcePrefix = "source"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+)
 
 // ExtractShootDetailsFromBackupEntryName returns Shoot resource technicalID its UID from provided <backupEntryName>.
 func ExtractShootDetailsFromBackupEntryName(backupEntryName string) (shootTechnicalID, shootUID string) {
-	backupEntryName = strings.TrimPrefix(backupEntryName, fmt.Sprintf("%s-", SourcePrefix))
+	backupEntryName = strings.TrimPrefix(backupEntryName, fmt.Sprintf("%s-", v1beta1constants.BackupSourcePrefix))
 	tokens := strings.Split(backupEntryName, "--")
 	shootUID = tokens[len(tokens)-1]
 	shootTechnicalID = strings.TrimSuffix(backupEntryName, "--"+shootUID)

--- a/extensions/pkg/controller/backupentry/util_test.go
+++ b/extensions/pkg/controller/backupentry/util_test.go
@@ -23,7 +23,6 @@ import (
 )
 
 var _ = Describe("Util", func() {
-
 	DescribeTable("#ExtractShootDetailsFromBackupEntryName",
 		func(backupEntryName, expectedShootTechnicalID, expectedShootUID string) {
 			shootTechnicalID, shootUID := ExtractShootDetailsFromBackupEntryName(backupEntryName)

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -504,6 +504,8 @@ const (
 	BackupSecretName string = "etcd-backup"
 	// DataKeyBackupBucketName is the name of a data key whose value contains the backup bucket name.
 	DataKeyBackupBucketName string = "bucketName"
+	// BackupSourcePrefix is the prefix for names of resources related to source backupentries when copying backups.
+	BackupSourcePrefix = "source"
 
 	// GardenerAudience is the identifier for Gardener controllers when interacting with the API Server
 	GardenerAudience = "gardener"

--- a/pkg/operation/botanist/backupentry.go
+++ b/pkg/operation/botanist/backupentry.go
@@ -18,11 +18,12 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/gardener/gardener/extensions/pkg/controller/backupentry"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/features"
 	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 	corebackupentry "github.com/gardener/gardener/pkg/operation/botanist/component/backupentry"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -69,7 +70,7 @@ func (b *Botanist) SourceBackupEntry() corebackupentry.Interface {
 		b.K8sGardenClient.Client(),
 		&corebackupentry.Values{
 			Namespace:      b.Shoot.GetInfo().Namespace,
-			Name:           fmt.Sprintf("%s-%s", backupentry.SourcePrefix, b.Shoot.BackupEntryName),
+			Name:           fmt.Sprintf("%s-%s", v1beta1constants.BackupSourcePrefix, b.Shoot.BackupEntryName),
 			ShootPurpose:   b.Shoot.GetInfo().Spec.Purpose,
 			OwnerReference: ownerRef,
 			SeedName:       b.Shoot.GetInfo().Spec.SeedName,

--- a/pkg/operation/botanist/etcdcopybackupstask.go
+++ b/pkg/operation/botanist/etcdcopybackupstask.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/gardener/gardener/extensions/pkg/controller/backupentry"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/etcdcopybackupstask"
@@ -55,12 +54,12 @@ func (b *Botanist) DeployEtcdCopyBackupsTask(ctx context.Context) error {
 		return err
 	}
 
-	sourceBackupEntryName := fmt.Sprintf("%s-%s", backupentry.SourcePrefix, b.Shoot.BackupEntryName)
+	sourceBackupEntryName := fmt.Sprintf("%s-%s", v1beta1constants.BackupSourcePrefix, b.Shoot.BackupEntryName)
 	sourceBackupEntry := &extensionsv1alpha1.BackupEntry{}
 	if err := b.K8sSeedClient.Client().Get(ctx, kutil.Key(sourceBackupEntryName), sourceBackupEntry); err != nil {
 		return err
 	}
-	sourceSecretName := fmt.Sprintf("%s-%s", backupentry.SourcePrefix, v1beta1constants.BackupSecretName)
+	sourceSecretName := fmt.Sprintf("%s-%s", v1beta1constants.BackupSourcePrefix, v1beta1constants.BackupSecretName)
 	sourceSecret := &corev1.Secret{}
 	if err := b.K8sSeedClient.Client().Get(ctx, kutil.Key(b.Shoot.SeedNamespace, sourceSecretName), sourceSecret); err != nil {
 		return err


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR drops the references to the `extensions` package from the `pkg/operation` package. This allows to make its build context more slim and prevents potential cyclic dependencies. Similar to #4880.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
