### PR TITLE
Add gardener step which checks the docforge manifest

### DIFF
--- a/.ci/verify
+++ b/.ci/verify
@@ -42,7 +42,7 @@ if [ $use_cache = yes ] ; then
   done
 
   # run test instead of test-cov to speed-up PR verification as `-cover` flag is not "cacheable"
-  make check-generate verify
+  make check-generate verify check-docforge
 
   echo "> moving all cached dirs back to concourse cache dir"
   for cache in "${cache_dirs[@]}" ; do

--- a/Makefile
+++ b/Makefile
@@ -224,6 +224,10 @@ test-cov-clean:
 test-prometheus: $(PROMTOOL)
 	@./hack/test-prometheus.sh
 
+.PHONY: check-docforge
+check-docforge: $(DOCFORGE)
+	@./hack/check-docforge.sh
+
 .PHONY: verify
 verify: check format test test-integration test-prometheus
 

--- a/hack/check-docforge.sh
+++ b/hack/check-docforge.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+docCommitHash="12922abea4c5afa207cc9c09b18414cd2348890c"
+
+echo "> Check Docforge Manifest"
+repoPath=${1-"$(readlink -f $(dirname ${0})/..)"}
+manifestPath=${2-"${repoPath}/.docforge/manifest.yaml"}
+diffDirs=${3-".docforge/;docs/"}
+repoName=${4-"gardener"}
+useToken=${5-false}
+
+tmpDir=$(mktemp -d)
+function cleanup {
+    rm -rf "$tmpDir"
+}
+trap cleanup EXIT ERR INT TERM
+
+curl https://raw.githubusercontent.com/gardener/documentation/${docCommitHash}/.ci/check-manifest --output ${tmpDir}/check-manifest-script.sh && chmod +x ${tmpDir}/check-manifest-script.sh
+curl https://raw.githubusercontent.com/gardener/documentation/${docCommitHash}/.ci/check-manifest-config --output ${tmpDir}/manifest-config
+scriptPath="${tmpDir}/check-manifest-script.sh"
+configPath="${tmpDir}/manifest-config"
+
+${scriptPath} --repo-path ${repoPath} --repo-name ${repoName} --use-token ${useToken} --manifest-path ${manifestPath} --diff-dirs ${diffDirs} --config-path ${configPath}

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -22,6 +22,7 @@
 HACK_PKG_PATH              := $(shell go list -tags tools -f '{{ .Dir }}' github.com/gardener/gardener/hack)
 TOOLS_BIN_DIR              := $(TOOLS_DIR)/bin
 CONTROLLER_GEN             := $(TOOLS_BIN_DIR)/controller-gen
+DOCFORGE                   := $(TOOLS_BIN_DIR)/docforge
 GEN_CRD_API_REFERENCE_DOCS := $(TOOLS_BIN_DIR)/gen-crd-api-reference-docs
 GOIMPORTS                  := $(TOOLS_BIN_DIR)/goimports
 GOLANGCI_LINT              := $(TOOLS_BIN_DIR)/golangci-lint
@@ -39,6 +40,7 @@ YQ                         := $(TOOLS_BIN_DIR)/yq
 GOLANGCI_LINT_VERSION ?= v1.42.1
 HELM_VERSION ?= v3.5.4
 YQ_VERSION ?= v4.9.6
+DOCFORGE_VERSION ?= v0.21.0
 
 export TOOLS_BIN_DIR := $(TOOLS_BIN_DIR)
 export PATH := $(abspath $(TOOLS_BIN_DIR)):$(PATH)
@@ -110,3 +112,7 @@ $(YAML2JSON): go.mod
 $(YQ): $(call tool_version_file,$(YQ),$(YQ_VERSION))
 	curl -L -o $(YQ) https://github.com/mikefarah/yq/releases/download/$(YQ_VERSION)/yq_$(shell uname -s | tr '[:upper:]' '[:lower:]')_$(shell uname -m | sed 's/x86_64/amd64/')
 	chmod +x $(YQ)
+
+$(DOCFORGE): $(call tool_version_file,$(DOCFORGE),$(DOCFORGE_VERSION))
+	curl -L -o $(DOCFORGE) https://github.com/gardener/docforge/releases/download/$(DOCFORGE_VERSION)/docforge-$(shell uname -s | tr '[:upper:]' '[:lower:]')-$(shell uname -m | sed 's/x86_64/amd64/')
+	chmod +x $(DOCFORGE)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
Add gardener step which checks the docforge manifest and the documentation related to it.
The step can be triggered separately with `make check-docforge` command.
Also it is attached to the `verify` and `verify-extended` steps and this mean that it will be executed on each PR. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@rfranzke 
@timebertt 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
New `check-docforge` step will be executed on each PR in the CI/CD
```
