### PR TITLE
Make `cloud-config-downloader` script robust to updates as it runs

### DIFF
--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/downloader/downloader_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/downloader/downloader_test.go
@@ -213,8 +213,13 @@ ExecStart=/var/lib/cloud-config-downloader/download-cloud-config.sh
 [Install]
 WantedBy=multi-user.target`
 
-	ccdScript = `#!/bin/bash -eu
+	ccdScript = `#!/bin/bash
 
+set -o errexit
+set -o nounset
+set -o pipefail
+
+{
 SECRET_NAME="` + ccdSecretName + `"
 
 PATH_CLOUDCONFIG_DOWNLOADER_SERVER="/var/lib/cloud-config-downloader/credentials/server"
@@ -240,5 +245,8 @@ echo "$CHECKSUM" > "$PATH_CLOUDCONFIG_CHECKSUM"
 
 SCRIPT="$(echo "$SECRET" | sed -rn 's/  script: (.*)/\1/p')"
 echo "$SCRIPT" | base64 -d | bash
+
+exit $?
+}
 `
 )

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/downloader/templates/scripts/download-cloud-config.tpl.sh
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/downloader/templates/scripts/download-cloud-config.tpl.sh
@@ -1,5 +1,10 @@
-#!/bin/bash -eu
+#!/bin/bash
 
+set -o errexit
+set -o nounset
+set -o pipefail
+
+{
 SECRET_NAME="{{ .secretName }}"
 
 PATH_CLOUDCONFIG_DOWNLOADER_SERVER="{{ .pathCredentialsServer }}"
@@ -25,3 +30,6 @@ echo "$CHECKSUM" > "$PATH_CLOUDCONFIG_CHECKSUM"
 
 SCRIPT="$(echo "$SECRET" | sed -rn 's/  {{ .dataKeyScript }}: (.*)/\1/p')"
 echo "$SCRIPT" | base64 -d | bash
+
+exit $?
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug

**What this PR does / why we need it**:
This PR makes the `cloud-config-downloader` script robust about being changed as it runs. Since the script updates itself we could get into dangerous situations, basically see

- https://stackoverflow.com/questions/2285403/how-to-make-shell-scripts-robust-to-source-being-changed-as-they-run/2358432#2358432
- https://stackoverflow.com/questions/3398258/edit-shell-script-while-its-running

**Special notes for your reviewer**:
/invite @danielfoehrKn @timebertt 
/milestone v1.37

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
