### PR TITLE
Extract and collect error codes from ManagedResources

### DIFF
--- a/pkg/apis/core/v1beta1/helper/errors.go
+++ b/pkg/apis/core/v1beta1/helper/errors.go
@@ -146,6 +146,62 @@ func ExtractErrorCodes(err error) []gardencorev1beta1.ErrorCode {
 	return codes
 }
 
+var _ error = (*MultiErrorWithCodes)(nil)
+
+// MultiErrorWithCodes is a struct that contains multiple errors and `ErrorCodes`s.
+type MultiErrorWithCodes struct {
+	errors      []error
+	errorFormat func(errs []error) string
+
+	errorCodeStr sets.String
+	codes        []gardencorev1beta1.ErrorCode
+}
+
+// NewMultiErrorWithCodes returns a new instance of `MultiErrorWithCodes`.
+func NewMultiErrorWithCodes(errorFormat func(errs []error) string) *MultiErrorWithCodes {
+	return &MultiErrorWithCodes{
+		errorFormat:  errorFormat,
+		errorCodeStr: sets.NewString(),
+	}
+}
+
+// Append appends the given error to the `MultiErrorWithCodes`.
+func (m *MultiErrorWithCodes) Append(err error) {
+	for _, code := range ExtractErrorCodes(err) {
+		if m.errorCodeStr.Has(string(code)) {
+			continue
+		}
+		m.errorCodeStr.Insert(string(code))
+		m.codes = append(m.codes, code)
+	}
+
+	m.errors = append(m.errors, err)
+}
+
+// Codes returns all underlying `gardencorev1beta1.ErrorCode` codes.
+func (m *MultiErrorWithCodes) Codes() []gardencorev1beta1.ErrorCode {
+	if m.codes == nil {
+		return nil
+	}
+
+	cp := make([]gardencorev1beta1.ErrorCode, len(m.codes))
+	copy(cp, m.codes)
+	return cp
+}
+
+// ErrorOrNil returns nil if no underlying errors are given.
+func (m *MultiErrorWithCodes) ErrorOrNil() error {
+	if len(m.errors) == 0 {
+		return nil
+	}
+	return m
+}
+
+// Error implements the error interface.
+func (m *MultiErrorWithCodes) Error() string {
+	return m.errorFormat(m.errors)
+}
+
 // FormatLastErrDescription formats the error message string for the last occurred error.
 func FormatLastErrDescription(err error) string {
 	errString := err.Error()

--- a/pkg/apis/core/v1beta1/helper/errors.go
+++ b/pkg/apis/core/v1beta1/helper/errors.go
@@ -148,7 +148,7 @@ func ExtractErrorCodes(err error) []gardencorev1beta1.ErrorCode {
 
 var _ error = (*MultiErrorWithCodes)(nil)
 
-// MultiErrorWithCodes is a struct that contains multiple errors and `ErrorCodes`s.
+// MultiErrorWithCodes is a struct that contains multiple errors and ErrorCodes.
 type MultiErrorWithCodes struct {
 	errors      []error
 	errorFormat func(errs []error) string

--- a/pkg/gardenlet/controller/shoot/shoot_control_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_delete.go
@@ -388,7 +388,7 @@ func (r *shootReconciler) runDeleteShootFlow(ctx context.Context, o *operation.O
 		})
 		cleanShootNamespaces = g.Add(flow.Task{
 			Name:         "Cleaning shoot namespaces",
-			Fn:           flow.TaskFn(botanist. CleanShootNamespaces).Timeout(10 * time.Minute).DoIf(cleanupShootResources),
+			Fn:           flow.TaskFn(botanist.CleanShootNamespaces).Timeout(10 * time.Minute).DoIf(cleanupShootResources),
 			Dependencies: flow.NewTaskIDs(cleanKubernetesResources),
 		})
 		destroyNetwork = g.Add(flow.Task{

--- a/pkg/gardenlet/controller/shoot/shoot_control_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_delete.go
@@ -388,7 +388,7 @@ func (r *shootReconciler) runDeleteShootFlow(ctx context.Context, o *operation.O
 		})
 		cleanShootNamespaces = g.Add(flow.Task{
 			Name:         "Cleaning shoot namespaces",
-			Fn:           flow.TaskFn(botanist.CleanShootNamespaces).Timeout(10 * time.Minute).DoIf(cleanupShootResources),
+			Fn:           flow.TaskFn(botanist. CleanShootNamespaces).Timeout(10 * time.Minute).DoIf(cleanupShootResources),
 			Dependencies: flow.NewTaskIDs(cleanKubernetesResources),
 		})
 		destroyNetwork = g.Add(flow.Task{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR makes the `WaitUntilManagedResourcesDeleted` to detect and extract error codes from the `ManagedResources` that is stuck in deletion.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The error code detection has been enhanced for `ManagedResource` objects that are stuck when a shoot is deleted. This enables Gardener to assign the corresponding error code(s) to the shoot object.
```
