### PR TITLE
issue#386 call inject func of mutator to inject client/decoder/apirea…

### DIFF
--- a/extensions/pkg/webhook/handler.go
+++ b/extensions/pkg/webhook/handler.go
@@ -54,6 +54,7 @@ func NewBuilder(mgr manager.Manager, logger logr.Logger) *HandlerBuilder {
 
 // WithMutator adds the given mutator for the given types to the HandlerBuilder.
 func (b *HandlerBuilder) WithMutator(mutator Mutator, types ...client.Object) *HandlerBuilder {
+	mutator = hybridMutator(mutator)
 	b.mutatorMap[mutator] = append(b.mutatorMap[mutator], types...)
 
 	return b


### PR DESCRIPTION
**How to categorize this PR?**
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
The k8s client is needed when we want to some complex logic in admission for mutation. For example, I need to get cloudprofile from client to check whether image is owned by alicloud or a customized image. If customized image is used for worker group, we can enable encrypted disk for worker by default. 
For more detail, you can check this PR https://github.com/gardener/gardener-extension-provider-alicloud/pull/392 
After this PR is merged, I can implement InjectSchema/InjectClient/InjectAPIReader in mutator of extension
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
```other developer

```
