### PR TITLE
Use 720h instead of 30d for KCM flags

### DIFF
--- a/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager.go
@@ -472,9 +472,9 @@ func (k *kubeControllerManager) computeCommand(port int32) []string {
 	)
 
 	if version.ConstraintK8sGreaterEqual119.Check(k.version) {
-		command = append(command, "--cluster-signing-duration=30d")
+		command = append(command, "--cluster-signing-duration=720h")
 	} else {
-		command = append(command, "--experimental-cluster-signing-duration=30d")
+		command = append(command, "--experimental-cluster-signing-duration=720h")
 	}
 
 	command = append(command,

--- a/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager_test.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager_test.go
@@ -818,9 +818,9 @@ func commandForKubernetesVersion(
 	)
 
 	if k8sVersionGreaterEqual119, _ := versionutils.CompareVersions(version, ">=", "1.19"); k8sVersionGreaterEqual119 {
-		command = append(command, "--cluster-signing-duration=30d")
+		command = append(command, "--cluster-signing-duration=720h")
 	} else {
-		command = append(command, "--experimental-cluster-signing-duration=30d")
+		command = append(command, "--experimental-cluster-signing-duration=720h")
 	}
 
 	command = append(command,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
Introduced with #5096, it seems not all Kubernetes versions can cater with `30d` as value...

```
Error: invalid argument "30d" for "--cluster-signing-duration" flag: time: unknown unit "d" in duration "30d"
```

Let's use `720h` instead to be on the safe side.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
