### PR TITLE
Fix flaky test in `gardeneraccess` component

### DIFF
--- a/pkg/operation/botanist/component/gardeneraccess/access.go
+++ b/pkg/operation/botanist/component/gardeneraccess/access.go
@@ -69,19 +69,24 @@ type Values struct {
 	caCertificate []byte
 }
 
+type accessNameToServer struct {
+	name   string
+	server string
+}
+
 func (g *gardener) Deploy(ctx context.Context) error {
 	var (
-		accessNameToServer = map[string]string{
-			v1beta1constants.SecretNameGardener:         g.values.ServerOutOfCluster,
-			v1beta1constants.SecretNameGardenerInternal: g.values.ServerInCluster,
+		accessNamesToServers = []accessNameToServer{
+			{v1beta1constants.SecretNameGardener, g.values.ServerOutOfCluster},
+			{v1beta1constants.SecretNameGardenerInternal, g.values.ServerInCluster},
 		}
-		serviceAccountNames = make([]string, 0, len(accessNameToServer))
+		serviceAccountNames = make([]string, 0, len(accessNamesToServers))
 	)
 
-	for name, server := range accessNameToServer {
+	for _, v := range accessNamesToServers {
 		var (
-			shootAccessSecret = gutil.NewShootAccessSecret(name, g.namespace).WithNameOverride(name)
-			kubeconfig        = kutil.NewKubeconfig(g.namespace, server, g.values.caCertificate, clientcmdv1.AuthInfo{Token: ""})
+			shootAccessSecret = gutil.NewShootAccessSecret(v.name, g.namespace).WithNameOverride(v.name)
+			kubeconfig        = kutil.NewKubeconfig(g.namespace, v.server, g.values.caCertificate, clientcmdv1.AuthInfo{Token: ""})
 		)
 
 		serviceAccountNames = append(serviceAccountNames, shootAccessSecret.ServiceAccountName)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
This PR ensures a stable order for the subjects added to the `ClusterRoleBinding` in the `gardeneraccess` package (introduced with #5012).

**Special notes for your reviewer**:
Seen in https://concourse.ci.gardener.cloud/builds/27275925, for example.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
