### PR TITLE
Add timeout to `WaitCleanup` for DNS resources

### DIFF
--- a/pkg/operation/botanist/component/extensions/dns/dnsentry.go
+++ b/pkg/operation/botanist/component/extensions/dns/dnsentry.go
@@ -114,5 +114,7 @@ func (e *entry) Wait(ctx context.Context) error {
 }
 
 func (e *entry) WaitCleanup(ctx context.Context) error {
-	return kutil.WaitUntilResourceDeleted(ctx, e.client, e.dnsEntry, 5*time.Second)
+	timeoutCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+	return kutil.WaitUntilResourceDeleted(timeoutCtx, e.client, e.dnsEntry, 5*time.Second)
 }

--- a/pkg/operation/botanist/component/extensions/dns/dnsowner.go
+++ b/pkg/operation/botanist/component/extensions/dns/dnsowner.go
@@ -81,5 +81,7 @@ func (o *owner) Destroy(ctx context.Context) error {
 func (o *owner) Wait(_ context.Context) error { return nil }
 
 func (o *owner) WaitCleanup(ctx context.Context) error {
-	return kutil.WaitUntilResourceDeleted(ctx, o.client, o.dnsOwner, 5*time.Second)
+	timeoutCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+	return kutil.WaitUntilResourceDeleted(timeoutCtx, o.client, o.dnsOwner, 5*time.Second)
 }

--- a/pkg/operation/botanist/component/extensions/dns/dnsprovider.go
+++ b/pkg/operation/botanist/component/extensions/dns/dnsprovider.go
@@ -146,5 +146,7 @@ func (p *provider) Wait(ctx context.Context) error {
 }
 
 func (p *provider) WaitCleanup(ctx context.Context) error {
-	return kutil.WaitUntilResourceDeleted(ctx, p.client, p.dnsProvider, 5*time.Second)
+	timeoutCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+	return kutil.WaitUntilResourceDeleted(timeoutCtx, p.client, p.dnsProvider, 5*time.Second)
 }

--- a/pkg/operation/botanist/dns.go
+++ b/pkg/operation/botanist/dns.go
@@ -399,8 +399,10 @@ func (b *Botanist) DeleteDNSProviders(ctx context.Context) error {
 		return err
 	}
 
+	timeoutCtx, cancel := context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
 	return kutil.WaitUntilResourcesDeleted(
-		ctx,
+		timeoutCtx,
 		b.K8sSeedClient.Client(),
 		&dnsv1alpha1.DNSProviderList{},
 		5*time.Second,


### PR DESCRIPTION
**How to categorize this PR?**

/area networking
/kind bug

**What this PR does / why we need it**:
Adds a timeout to the `WaitCleanup` method of the components responsible for `DNSProvider`, `DNSEntry`, and `DNSOwner` resources, as well as to the `DeleteDNSProviders` botanist method. These methods were previously invoking `WaitUntilResourceDeleted` or `WaitUntilResourcesDeleted` without setting a timeout, which could lead to endless waits in some situations, e.g. during the `Deploying internal domain DNS record` step after `UseDNSRecord` feature gate was enabled, if the `DNSProvider` resource could not be deleted for whatever reason.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```bugfix operator
Endless waits are now avoided when deleting `DNSProvider`, `DNSEntry`, and `DNSOwner` resources.
```
