### PR TITLE
🛡 Eliminate client certificate for `cloud-config-downloader`

### DIFF
--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/downloader/downloader.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/downloader/downloader.go
@@ -20,7 +20,9 @@ import (
 	"strconv"
 	"text/template"
 
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/docker"
 	"github.com/gardener/gardener/pkg/utils"
@@ -94,7 +96,9 @@ const (
 	// PathCredentialsClientKey is a constant for a path containing the 'client private key' credentials part for the
 	// download.
 	PathCredentialsClientKey = PathCredentialsDirectory + "/client.key"
-	// PathBootstrapToken is the path of a file on the shoot worker nodes in which the the bootstrap token for the kubelet
+	// PathCredentialsToken is a constant for a path containing the shoot access 'token' for the cloud-config-downloader.
+	PathCredentialsToken = PathCredentialsDirectory + "/token"
+	// PathBootstrapToken is the path of a file on the shoot worker nodes in which the bootstrap token for the kubelet
 	// bootstrap is stored.
 	PathBootstrapToken = PathCredentialsDirectory + "/bootstrap-token"
 	// BootstrapTokenPlaceholder is the token that is expected to be replaced by the worker controller with the actual token
@@ -118,13 +122,17 @@ func Config(cloudConfigUserDataSecretName, apiServerURL string) ([]extensionsv1a
 	var ccdScript bytes.Buffer
 	if err := tpl.Execute(&ccdScript, map[string]string{
 		"secretName":                cloudConfigUserDataSecretName,
+		"tokenSecretName":           Name,
 		"pathCredentialsServer":     PathCredentialsServer,
 		"pathCredentialsCACert":     PathCredentialsCACert,
 		"pathCredentialsClientCert": PathCredentialsClientCert,
 		"pathCredentialsClientKey":  PathCredentialsClientKey,
+		"pathCredentialsToken":      PathCredentialsToken,
+		"pathBootstrapToken":        PathBootstrapToken,
 		"pathDownloadedChecksum":    PathDownloadedCloudConfigChecksum,
 		"annotationChecksum":        AnnotationKeyChecksum,
 		"dataKeyScript":             DataKeyScript,
+		"dataKeyToken":              resourcesv1alpha1.DataKeyToken,
 	}); err != nil {
 		return nil, nil, err
 	}
@@ -165,28 +173,8 @@ WantedBy=multi-user.target`),
 			Permissions: pointer.Int32(0644),
 			Content: extensionsv1alpha1.FileContent{
 				SecretRef: &extensionsv1alpha1.FileContentSecretRef{
-					Name:    SecretName,
+					Name:    v1beta1constants.SecretNameCACluster,
 					DataKey: secrets.DataKeyCertificateCA,
-				},
-			},
-		},
-		{
-			Path:        PathCredentialsClientCert,
-			Permissions: pointer.Int32(0644),
-			Content: extensionsv1alpha1.FileContent{
-				SecretRef: &extensionsv1alpha1.FileContentSecretRef{
-					Name:    SecretName,
-					DataKey: secrets.ControlPlaneSecretDataKeyCertificatePEM(SecretName),
-				},
-			},
-		},
-		{
-			Path:        PathCredentialsClientKey,
-			Permissions: pointer.Int32(0644),
-			Content: extensionsv1alpha1.FileContent{
-				SecretRef: &extensionsv1alpha1.FileContentSecretRef{
-					Name:    SecretName,
-					DataKey: secrets.ControlPlaneSecretDataKeyPrivateKey(SecretName),
 				},
 			},
 		},
@@ -229,7 +217,7 @@ func GenerateRBACResourcesData(secretNames []string) (map[string][]byte, error) 
 				{
 					APIGroups:     []string{""},
 					Resources:     []string{"secrets"},
-					ResourceNames: secretNames,
+					ResourceNames: append(secretNames, Name),
 					Verbs:         []string{"get"},
 				},
 			},
@@ -245,10 +233,22 @@ func GenerateRBACResourcesData(secretNames []string) (map[string][]byte, error) 
 				Kind:     "Role",
 				Name:     role.Name,
 			},
-			Subjects: []rbacv1.Subject{{
-				Kind: rbacv1.UserKind,
-				Name: SecretName,
-			}},
+			Subjects: []rbacv1.Subject{
+				// TODO(rfranzke): Delete this subject in a future release.
+				{
+					Kind: rbacv1.UserKind,
+					Name: "cloud-config-downloader",
+				},
+				{
+					Kind: rbacv1.GroupKind,
+					Name: bootstraptokenapi.BootstrapDefaultGroup,
+				},
+				{
+					Kind:      rbacv1.ServiceAccountKind,
+					Name:      Name,
+					Namespace: metav1.NamespaceSystem,
+				},
+			},
 		}
 
 		clusterRoleBindingNodeBootstrapper = &rbacv1.ClusterRoleBinding{

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/downloader/downloader.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/downloader/downloader.go
@@ -58,7 +58,7 @@ const (
 	Name = "cloud-config-downloader"
 	// UnitName is the name of the cloud-config-downloader service.
 	UnitName = Name + ".service"
-	// SecretName is a constant for the secret name for the cloud-config-downloader's kubeconfig secret.
+	// SecretName is a constant for the secret name for the cloud-config-downloader's shoot access secret.
 	SecretName = Name
 	// UnitRestartSeconds is the number of seconds after which the cloud-config-downloader unit will be restarted.
 	UnitRestartSeconds = 30

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/downloader/downloader_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/downloader/downloader_test.go
@@ -255,17 +255,21 @@ else
 fi
 
 TOKEN="$(extractDataKeyFromSecret "$SECRET" "token")"
+if [[ -z "$TOKEN" ]]; then
+  echo "Token in shoot access secret $TOKEN_SECRET_NAME is empty"
+  exit 1
+fi
 echo "$TOKEN" > "$PATH_CLOUDCONFIG_DOWNLOADER_TOKEN"
-
-# delete legacy credentials from disk
-# TODO(rfranzke): Delete in future release.
-rm -f "$PATH_CLOUDCONFIG_DOWNLOADER_CLIENT_CERT" "$PATH_CLOUDCONFIG_DOWNLOADER_CLIENT_KEY"
 
 # download and run the cloud config execution script
 if ! SECRET="$(readSecretWithToken "$SECRET_NAME" "$TOKEN")"; then
   echo "Could not retrieve the cloud config script in secret with name $SECRET_NAME"
   exit 1
 fi
+
+# delete legacy credentials from disk
+# TODO(rfranzke): Delete in future release.
+rm -f "$PATH_CLOUDCONFIG_DOWNLOADER_CLIENT_CERT" "$PATH_CLOUDCONFIG_DOWNLOADER_CLIENT_KEY"
 
 CHECKSUM="$(echo "$SECRET" | sed -rn 's/    checksum\/data-script: (.*)/\1/p' | sed -e 's/^"//' -e 's/"$//')"
 echo "$CHECKSUM" > "/var/lib/cloud-config-downloader/downloaded_checksum"

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/downloader/templates/scripts/download-cloud-config.tpl.sh
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/downloader/templates/scripts/download-cloud-config.tpl.sh
@@ -6,30 +6,71 @@ set -o pipefail
 
 {
 SECRET_NAME="{{ .secretName }}"
+TOKEN_SECRET_NAME="{{ .tokenSecretName }}"
 
-PATH_CLOUDCONFIG_DOWNLOADER_SERVER="{{ .pathCredentialsServer }}"
-PATH_CLOUDCONFIG_DOWNLOADER_CA_CERT="{{ .pathCredentialsCACert }}"
 PATH_CLOUDCONFIG_DOWNLOADER_CLIENT_CERT="{{ .pathCredentialsClientCert }}"
 PATH_CLOUDCONFIG_DOWNLOADER_CLIENT_KEY="{{ .pathCredentialsClientKey }}"
-PATH_CLOUDCONFIG_CHECKSUM="{{ .pathDownloadedChecksum }}"
+PATH_BOOTSTRAP_TOKEN="{{ .pathBootstrapToken }}"
+PATH_CLOUDCONFIG_DOWNLOADER_TOKEN="{{ .pathCredentialsToken }}"
 
-if ! SECRET="$(wget \
-  -qO- \
-  --header         "Accept: application/yaml" \
-  --ca-certificate "$PATH_CLOUDCONFIG_DOWNLOADER_CA_CERT" \
-  --certificate    "$PATH_CLOUDCONFIG_DOWNLOADER_CLIENT_CERT" \
-  --private-key    "$PATH_CLOUDCONFIG_DOWNLOADER_CLIENT_KEY" \
-  "$(cat "$PATH_CLOUDCONFIG_DOWNLOADER_SERVER")/api/v1/namespaces/kube-system/secrets/$SECRET_NAME")"; then
+function readSecret() {
+  wget \
+    -qO- \
+    --header         "Accept: application/yaml" \
+    --ca-certificate "{{ .pathCredentialsCACert }}" \
+    "${@:2}" "$(cat "{{ .pathCredentialsServer }}")/api/v1/namespaces/kube-system/secrets/$1"
+}
 
+function readSecretWithToken() {
+  readSecret "$1" "--header=Authorization: Bearer $2"
+}
+
+function readSecretWithClientCertificate() {
+  readSecret "$1" "--certificate=$PATH_CLOUDCONFIG_DOWNLOADER_CLIENT_CERT" "--private-key=$PATH_CLOUDCONFIG_DOWNLOADER_CLIENT_KEY"
+}
+
+function extractDataKeyFromSecret() {
+  echo "$1" | sed -rn "s/  $2: (.*)/\1/p" | base64 -d
+}
+
+# download shoot access token for cloud-config-downloader
+if [[ -f "$PATH_CLOUDCONFIG_DOWNLOADER_TOKEN" ]]; then
+  if ! SECRET="$(readSecretWithToken "$TOKEN_SECRET_NAME" "$(cat "$PATH_CLOUDCONFIG_DOWNLOADER_TOKEN")")"; then
+    echo "Could not retrieve the shoot access secret with name $TOKEN_SECRET_NAME with existing token"
+    exit 1
+  fi
+else
+  if [[ -f "$PATH_BOOTSTRAP_TOKEN" ]]; then
+    if ! SECRET="$(readSecretWithToken "$TOKEN_SECRET_NAME" "$(cat "$PATH_BOOTSTRAP_TOKEN")")"; then
+      echo "Could not retrieve the shoot access secret with name $TOKEN_SECRET_NAME with bootstrap token"
+      exit 1
+    fi
+  else
+    if ! SECRET="$(readSecretWithClientCertificate "$TOKEN_SECRET_NAME")"; then
+      echo "Could not retrieve the shoot access secret with name $TOKEN_SECRET_NAME with client certificate"
+      exit 1
+    fi
+  fi
+fi
+
+TOKEN="$(extractDataKeyFromSecret "$SECRET" "{{ .dataKeyToken }}")"
+echo "$TOKEN" > "$PATH_CLOUDCONFIG_DOWNLOADER_TOKEN"
+
+# delete legacy credentials from disk
+# TODO(rfranzke): Delete in future release.
+rm -f "$PATH_CLOUDCONFIG_DOWNLOADER_CLIENT_CERT" "$PATH_CLOUDCONFIG_DOWNLOADER_CLIENT_KEY"
+
+# download and run the cloud config execution script
+if ! SECRET="$(readSecretWithToken "$SECRET_NAME" "$TOKEN")"; then
   echo "Could not retrieve the cloud config script in secret with name $SECRET_NAME"
   exit 1
 fi
 
 CHECKSUM="$(echo "$SECRET" | sed -rn 's/    {{ .annotationChecksum | replace "/" "\\/" }}: (.*)/\1/p' | sed -e 's/^"//' -e 's/"$//')"
-echo "$CHECKSUM" > "$PATH_CLOUDCONFIG_CHECKSUM"
+echo "$CHECKSUM" > "{{ .pathDownloadedChecksum }}"
 
-SCRIPT="$(echo "$SECRET" | sed -rn 's/  {{ .dataKeyScript }}: (.*)/\1/p')"
-echo "$SCRIPT" | base64 -d | bash
+SCRIPT="$(extractDataKeyFromSecret "$SECRET" "{{ .dataKeyScript }}")"
+echo "$SCRIPT" | bash
 
 exit $?
 }

--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -86,14 +86,10 @@ func (b *Botanist) DeployOperatingSystemConfig(ctx context.Context) error {
 	b.Shoot.Components.Extensions.OperatingSystemConfig.SetCABundle(b.getOperatingSystemConfigCABundle())
 	b.Shoot.Components.Extensions.OperatingSystemConfig.SetKubeletCACertificate(string(b.LoadSecret(v1beta1constants.SecretNameCAKubelet).Data[secrets.DataKeyCertificateCA]))
 
-	publicKeys := []string{
-		string(b.LoadSecret(v1beta1constants.SecretNameSSHKeyPair).Data[secrets.DataKeySSHAuthorizedKeys]),
-	}
-
+	publicKeys := []string{string(b.LoadSecret(v1beta1constants.SecretNameSSHKeyPair).Data[secrets.DataKeySSHAuthorizedKeys])}
 	if secret := b.LoadSecret(v1beta1constants.SecretNameOldSSHKeyPair); secret != nil {
 		publicKeys = append(publicKeys, string(secret.Data[secrets.DataKeySSHAuthorizedKeys]))
 	}
-
 	b.Shoot.Components.Extensions.OperatingSystemConfig.SetSSHPublicKeys(publicKeys)
 
 	if b.isShootNodeLoggingEnabled() {

--- a/pkg/operation/botanist/wanted_secrets.go
+++ b/pkg/operation/botanist/wanted_secrets.go
@@ -20,7 +20,6 @@ import (
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/etcd"
-	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig/downloader"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/kubeapiserver"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/kubecontrollermanager"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/kubescheduler"
@@ -311,26 +310,6 @@ func (b *Botanist) generateWantedSecretConfigs(basicAuthAPIServer *secrets.Basic
 				CertType:  secrets.ClientCert,
 				SigningCA: certificateAuthorities[v1beta1constants.SecretNameCAKubelet],
 			},
-		},
-
-		// Secret definition for cloud-config-downloader
-		&secrets.ControlPlaneSecretConfig{
-			CertificateSecretConfig: &secrets.CertificateSecretConfig{
-				Name: downloader.SecretName,
-
-				CommonName:   downloader.SecretName,
-				Organization: nil,
-				DNSNames:     nil,
-				IPAddresses:  nil,
-
-				CertType:  secrets.ClientCert,
-				SigningCA: certificateAuthorities[v1beta1constants.SecretNameCACluster],
-			},
-
-			KubeConfigRequests: []secrets.KubeConfigRequest{{
-				ClusterName:   b.Shoot.SeedNamespace,
-				APIServerHost: b.Shoot.ComputeOutOfClusterAPIServerAddress(b.APIServerAddress, true),
-			}},
 		},
 
 		// Secret definition for monitoring


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement
/merge squash

**What this PR does / why we need it**:
Similar to #4931, this PR eliminates the client certificate for the `cloud-config-downloader` in favor of a token managed by the `TokenRequestor` controller in `gardener-resource-manager`.

The basic idea is that `cloud-config-downloader` regularly downloads its own token from a `Secret` in the shoot cluster. This secret is used to communicate with the API server for further read requests (e.g., downloading the actual `cloud-config` `Secret` containing the user data for bootstrapping the node) and stored on a file on the disk (similar to how the legacy client certificate was stored).
If the node is newly created then the bootstrap token of the kubelet will be used for the initial reading of this `Secret`.

**Which issue(s) this PR fixes**:
Part of #4661
Part of #4878

**Special notes for your reviewer**:
/invite @BeckerMax
- For safety purposes, we enforce that upgrades must happen from Gardener v1.37 due to #5110.
- ~✅ Based on #5084 which needs to be merged (hence, PR is in "draft" state)~

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```action operator
Before upgrading to this Gardener version make sure that your existing Gardener runs on at least `v1.37`.
```
```noteworthy operator
`cloud-config-downloader` does no longer use a client certificate but an auto-rotated `ServiceAccount` token which is only valid for `90d`.
```