### PR TITLE
Remove the DisallowKubeconfigRotationForShootInDeletion feature gate

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -34,9 +34,6 @@ The following tables are a summary of the feature gates that you can set on diff
 | ReversedVPN                                  | `false` | `Alpha` | `1.22` |        |
 | AdminKubeconfigRequest                       | `false` | `Alpha` | `1.24` |        |
 | UseDNSRecords                                | `false` | `Alpha` | `1.27` |        |
-| DisallowKubeconfigRotationForShootInDeletion | `false` | `Alpha` | `1.28` | `1.31` |
-| DisallowKubeconfigRotationForShootInDeletion | `true`  | `Beta`  | `1.32` | `1.35` |
-| DisallowKubeconfigRotationForShootInDeletion | `true`  | `GA`    | `1.36` |        |
 | RotateSSHKeypairOnMaintenance                | `false` | `Alpha` | `1.28` |        |
 | DenyInvalidExtensionResources                | `false` | `Alpha` | `1.31` |        |
 | WorkerPoolKubernetesVersion                  | `false` | `Alpha` | `1.35` |        |
@@ -44,16 +41,20 @@ The following tables are a summary of the feature gates that you can set on diff
 
 ## Feature gates for graduated or deprecated features
 
-| Feature                | Default | Stage     | Since  | Until  |
-| ---------------------- | ------- | --------- | ------ | ------ |
-| NodeLocalDNS           | `false` | `Alpha`   | `1.7`  |        |
-| NodeLocalDNS           |         | `Removed` | `1.26` |        |
-| KonnectivityTunnel     | `false` | `Alpha`   | `1.6`  |        |
-| KonnectivityTunnel     |         | `Removed` | `1.27` |        |
-| MountHostCADirectories | `false` | `Alpha`   | `1.11` | `1.25` |
-| MountHostCADirectories | `true`  | `Beta`    | `1.26` | `1.27` |
-| MountHostCADirectories | `true`  | `GA`      | `1.27` |        |
-| MountHostCADirectories |         | `Removed` | `1.30` |        |
+| Feature                                      | Default | Stage     | Since  | Until  |
+| -------------------------------------------- | ------- | --------- | ------ | ------ |
+| NodeLocalDNS                                 | `false` | `Alpha`   | `1.7`  |        |
+| NodeLocalDNS                                 |         | `Removed` | `1.26` |        |
+| KonnectivityTunnel                           | `false` | `Alpha`   | `1.6`  |        |
+| KonnectivityTunnel                           |         | `Removed` | `1.27` |        |
+| MountHostCADirectories                       | `false` | `Alpha`   | `1.11` | `1.25` |
+| MountHostCADirectories                       | `true`  | `Beta`    | `1.26` | `1.27` |
+| MountHostCADirectories                       | `true`  | `GA`      | `1.27` |        |
+| MountHostCADirectories                       |         | `Removed` | `1.30` |        |
+| DisallowKubeconfigRotationForShootInDeletion | `false` | `Alpha`   | `1.28` | `1.31` |
+| DisallowKubeconfigRotationForShootInDeletion | `true`  | `Beta`    | `1.32` | `1.35` |
+| DisallowKubeconfigRotationForShootInDeletion | `true`  | `GA`      | `1.36` |        |
+| DisallowKubeconfigRotationForShootInDeletion |         | `Removed` | `1.38` |        |
 
 ## Using a feature
 

--- a/hack/local-development/start-apiserver
+++ b/hack/local-development/start-apiserver
@@ -53,7 +53,6 @@ apiserver_flags="
   --feature-gates SeedChange=true \
   --feature-gates AdminKubeconfigRequest=true \
   --feature-gates UseDNSRecords=true \
-  --feature-gates DisallowKubeconfigRotationForShootInDeletion=true \
   --feature-gates WorkerPoolKubernetesVersion=true \
   --shoot-admin-kubeconfig-max-expiration=1h \
   --enable-admission-plugins=ShootVPAEnabledByDefault \

--- a/pkg/apiserver/features/features.go
+++ b/pkg/apiserver/features/features.go
@@ -23,11 +23,10 @@ import (
 )
 
 var featureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	features.SeedChange:                                   {Default: false, PreRelease: featuregate.Alpha},
-	features.AdminKubeconfigRequest:                       {Default: false, PreRelease: featuregate.Alpha},
-	features.UseDNSRecords:                                {Default: false, PreRelease: featuregate.Alpha},
-	features.DisallowKubeconfigRotationForShootInDeletion: {Default: true, PreRelease: featuregate.GA, LockToDefault: true}, // TODO (@acumino): remove DisallowKubeconfigRotationForShootInDeletion in v1.38.
-	features.WorkerPoolKubernetesVersion:                  {Default: false, PreRelease: featuregate.Alpha},
+	features.SeedChange:                  {Default: false, PreRelease: featuregate.Alpha},
+	features.AdminKubeconfigRequest:      {Default: false, PreRelease: featuregate.Alpha},
+	features.UseDNSRecords:               {Default: false, PreRelease: featuregate.Alpha},
+	features.WorkerPoolKubernetesVersion: {Default: false, PreRelease: featuregate.Alpha},
 }
 
 // RegisterFeatureGates registers the feature gates of the Gardener API Server.

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -92,14 +92,6 @@ const (
 	// alpha: v1.27.0
 	UseDNSRecords featuregate.Feature = "UseDNSRecords"
 
-	// DisallowKubeconfigRotationForShootInDeletion when enabled disallows kubeconfig rotations to be requested
-	// for shoots that are already in the deletion phase, i.e. `metadata.deletionTimestamp` is set
-	// owner: @vpnachev
-	// alpha: v1.28.0
-	// beta: v1.32.0
-	// GA: v1.36.0
-	DisallowKubeconfigRotationForShootInDeletion featuregate.Feature = "DisallowKubeconfigRotationForShootInDeletion"
-
 	// RotateSSHKeypairOnMaintenance enables SSH keypair rotation in the maintenance controller of the gardener-controller-manager.
 	// owner: @petersutter
 	// alpha: v1.28.0


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup

**Which issue(s) this PR fixes**:
Part of #4575
CC: @ialidzhikov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
gardener-apiserver's `DisallowKubeconfigRotationForShootInDeletion` feature gate that is GA since v1.36 is unconditionally enabled, and can no longer be specified in the gardener-apiserver's configuration.
```
