### PR TITLE
Always drop 'reference' annotations in managed resources

### DIFF
--- a/pkg/resourcemanager/controller/managedresource/merger_test.go
+++ b/pkg/resourcemanager/controller/managedresource/merger_test.go
@@ -153,14 +153,15 @@ var _ = Describe("merger", func() {
 		})
 
 		It("should merge current and desired .metadata.annotations", func() {
-			current.SetAnnotations(map[string]string{"foo": "bar"})
-			desired.SetAnnotations(map[string]string{"other": "baz"})
+			current.SetAnnotations(map[string]string{"foo": "bar", "reference.resources.gardener.cloud/secret-foo": "bar"})
+			desired.SetAnnotations(map[string]string{"other": "baz", "reference.resources.gardener.cloud/secret-bar": "foo"})
 			existingAnnotations := map[string]string{"existing": "ignored"}
 
 			expected := desired.DeepCopy()
 			expected.SetAnnotations(map[string]string{
 				"foo":   "bar",
 				"other": "baz",
+				"reference.resources.gardener.cloud/secret-bar": "foo",
 			})
 			addAnnotations(origin, expected)
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
In https://github.com/gardener/gardener/pull/5056 we have observed that existing `reference` annotations on objects remain and never get deleted in case
- managed resources are migrated from one `ManagedResource` to another.
- in the same change new `reference` annotations get computed.

With this PR, the `ManagedResource` reconciler in GRM is enhanced to always drop such 'reference' annotations from the old object (since there is anyways no reasonable scenario in which they should be kept if they are not part of the `desired` object).

**Special notes for your reviewer**:
/cc @shafeeqes 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
