### PR TITLE
gardenlet: Switch update strategy when syncing Shoot Secrets to the garden cluster

### DIFF
--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -464,7 +464,7 @@ func (b *Botanist) SyncShootCredentialsToGarden(ctx context.Context) error {
 				},
 			}
 
-			_, err := controllerutils.CreateOrGetAndStrategicMergePatch(ctx, b.K8sGardenClient.Client(), secretObj, func() error {
+			_, err := controllerutils.GetAndCreateOrStrategicMergePatch(ctx, b.K8sGardenClient.Client(), secretObj, func() error {
 				secretObj.OwnerReferences = []metav1.OwnerReference{
 					*metav1.NewControllerRef(b.Shoot.GetInfo(), gardencorev1beta1.SchemeGroupVersion.WithKind("Shoot")),
 				}


### PR DESCRIPTION
/area quality
/kind bug

This PR is similar to https://github.com/gardener/gardener/pull/5051. https://github.com/gardener/gardener/pull/5051 was closed back then because of concerns related to the SeedAuthorizer and that will reject a GET request for non-existing object with reason `no relationship found`.
This is actually not the case. For the well-known Project Secrets the SeedAuthorizer maintains the corresponding relations in its graph.

https://github.com/gardener/gardener/blob/47fb51a1a1c18fb5c0c8ddfcddefde4a663120d0/pkg/admissioncontroller/webhooks/auth/seed/graph/eventhandler_shoot.go#L144-L149

Hence, a GET request for such non-existing Secret will actually return a `404 Not Found` error as expected. This allows us to use the `GetAndCreateOrStrategicMergePatch` func/strategy over `CreateOrGetAndStrategicMergePatch`.

Fixes https://github.com/gardener/gardener/issues/4946

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing the reconciliation of existing Shoot to be marked as Failed when the Secrets quota is exhausted is now fixed.
```
