### PR TITLE
🛡 Switch seed components to projected `ServiceAccount` tokens

### DIFF
--- a/charts/istio/istio-ingress/templates/deployment.yaml
+++ b/charts/istio/istio-ingress/templates/deployment.yaml
@@ -23,6 +23,8 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
         checksum/configmap-bootstrap-config-override: {{ include (print $.Template.BasePath "/bootstrap-config-override.yaml") . | sha256sum }}
+        # TODO(rfranzke): Remove in a future release.
+        security.gardener.cloud/trigger: rollout
     spec:
       serviceAccountName: istio-ingressgateway
       securityContext:

--- a/charts/istio/istio-ingress/templates/serviceaccount.yaml
+++ b/charts/istio/istio-ingress/templates/serviceaccount.yaml
@@ -5,3 +5,4 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
 {{ .Values.labels | toYaml | indent 4 }}
+automountServiceAccountToken: false

--- a/charts/istio/istio-istiod/templates/deployment.yaml
+++ b/charts/istio/istio-istiod/templates/deployment.yaml
@@ -22,6 +22,8 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
         checksum/istio-config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        # TODO(rfranzke): Remove in a future release.
+        security.gardener.cloud/trigger: rollout
     spec:
       serviceAccountName: istiod
       securityContext:

--- a/charts/istio/istio-istiod/templates/serviceaccount.yaml
+++ b/charts/istio/istio-istiod/templates/serviceaccount.yaml
@@ -5,3 +5,4 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
 {{ .Values.labels | toYaml | indent 4 }}
+automountServiceAccountToken: false

--- a/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-daemonset.yaml
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-daemonset.yaml
@@ -19,6 +19,8 @@ spec:
   template:
     metadata:
       annotations:
+        # TODO(rfranzke): Remove in a future release.
+        security.gardener.cloud/trigger: rollout
 {{ include "fluent-bit.daemonset.annotations" . | indent 8 }}
       labels:
 {{ toYaml .Values.labels | indent 8 }}

--- a/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-daemonset.yaml
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-daemonset.yaml
@@ -111,7 +111,6 @@ spec:
           mountPath: /fluent-bit/plugins
       serviceAccount: fluent-bit
       serviceAccountName: fluent-bit
-      automountServiceAccountToken: true
       terminationGracePeriodSeconds: 10
       tolerations:
       - key: node-role.kubernetes.io/master

--- a/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-service-account.yaml
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-service-account.yaml
@@ -5,3 +5,4 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- toYaml .Values.labels | nindent 4 }}
+automountServiceAccountToken: false

--- a/charts/seed-bootstrap/charts/hvpa/templates/controller-deployment.yaml
+++ b/charts/seed-bootstrap/charts/hvpa/templates/controller-deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: garden
   labels:
 {{ toYaml .Values.labels | indent 4 }}
+automountServiceAccountToken: false
 ---
 apiVersion: {{ include "deploymentversion" . }}
 kind: Deployment
@@ -23,6 +24,11 @@ spec:
 {{ toYaml .Values.labels | indent 6 }}
   template:
     metadata:
+{{- if .Values.global.readyForProjectedServiceAccountTokens }}
+      annotations:
+        # TODO(rfranzke): Remove in a future release.
+        security.gardener.cloud/trigger: rollout
+{{- end }}
       labels:
         app: hvpa-controller
 {{ toYaml .Values.labels | indent 8 }}

--- a/charts/seed-bootstrap/charts/kube-state-metrics/templates/deployment.yaml
+++ b/charts/seed-bootstrap/charts/kube-state-metrics/templates/deployment.yaml
@@ -20,6 +20,9 @@ spec:
       maxUnavailable: 1
   template:
     metadata:
+      annotations:
+        # TODO(rfranzke): Remove in a future release.
+        security.gardener.cloud/trigger: rollout
       labels:
         role: monitoring
         component: kube-state-metrics

--- a/charts/seed-bootstrap/charts/kube-state-metrics/templates/serviceaccount.yaml
+++ b/charts/seed-bootstrap/charts/kube-state-metrics/templates/serviceaccount.yaml
@@ -6,3 +6,4 @@ metadata:
   labels:
     component: kube-state-metrics
     type: seed
+automountServiceAccountToken: false

--- a/charts/seed-bootstrap/charts/monitoring/templates/serviceaccount.yaml
+++ b/charts/seed-bootstrap/charts/monitoring/templates/serviceaccount.yaml
@@ -6,3 +6,4 @@ metadata:
   labels:
     app: seed-prometheus
     role: monitoring
+automountServiceAccountToken: false

--- a/charts/seed-bootstrap/charts/monitoring/templates/statefulset.yaml
+++ b/charts/seed-bootstrap/charts/monitoring/templates/statefulset.yaml
@@ -16,6 +16,9 @@ spec:
   serviceName: seed-prometheus
   template:
     metadata:
+      annotations:
+        # TODO(rfranzke): Remove in a future release.
+        security.gardener.cloud/trigger: rollout
       labels:
         app: seed-prometheus
         role: monitoring

--- a/charts/seed-bootstrap/charts/nginx-ingress/templates/controller-deployment.yaml
+++ b/charts/seed-bootstrap/charts/nginx-ingress/templates/controller-deployment.yaml
@@ -23,6 +23,8 @@ spec:
   template:
     metadata:
       annotations:
+        # TODO(rfranzke): Remove in a future release.
+        security.gardener.cloud/trigger: rollout
 {{ include "nginx-ingress.deployment.annotations" . | indent 8 }}
       labels:
         app: nginx-ingress

--- a/charts/seed-bootstrap/charts/nginx-ingress/templates/serviceaccount.yaml
+++ b/charts/seed-bootstrap/charts/nginx-ingress/templates/serviceaccount.yaml
@@ -6,3 +6,4 @@ metadata:
     app: nginx-ingress
   name: nginx-ingress
   namespace: garden
+automountServiceAccountToken: false

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/serviceaccount-admission-controller.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/serviceaccount-admission-controller.yaml
@@ -7,4 +7,5 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
   {{ toYaml .Values.labels | indent 4 }}
+automountServiceAccountToken: false
 {{- end }}

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/serviceaccount-recommender.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/serviceaccount-recommender.yaml
@@ -6,4 +6,5 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
 {{ toYaml .Values.labels | indent 4 }}
+automountServiceAccountToken: false
 {{- end }}

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/serviceaccount-updater.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/serviceaccount-updater.yaml
@@ -6,4 +6,5 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
 {{ toYaml .Values.labels | indent 4 }}
+automountServiceAccountToken: false
 {{- end }}

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-admission-controller.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-admission-controller.yaml
@@ -20,9 +20,15 @@ spec:
       app: vpa-admission-controller
   template:
     metadata:
-{{- if .Values.admissionController.podAnnotations }}
+  {{- if or .Values.admissionController.podAnnotations .Values.admissionController.createServiceAccount }}
       annotations:
+  {{- if .Values.admissionController.createServiceAccount }}
+        # TODO(rfranzke): Remove in a future release.
+        security.gardener.cloud/trigger: rollout
+{{- end }}
+{{- if .Values.admissionController.podAnnotations }}
 {{ toYaml .Values.admissionController.podAnnotations | indent 8 }}
+{{- end }}
 {{- end }}
       labels:
         app: vpa-admission-controller

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-recommender.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-recommender.yaml
@@ -20,9 +20,15 @@ spec:
       app: vpa-recommender
   template:
     metadata:
-{{- if .Values.recommender.podAnnotations }}
+{{- if or .Values.recommender.podAnnotations .Values.recommender.createServiceAccount }}
       annotations:
+{{- if .Values.recommender.createServiceAccount }}
+        # TODO(rfranzke): Remove in a future release.
+        security.gardener.cloud/trigger: rollout
+{{- end }}
+{{- if .Values.recommender.podAnnotations }}
 {{ toYaml .Values.recommender.podAnnotations | indent 8 }}
+{{- end }}
 {{- end }}
       labels:
         app: vpa-recommender

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-updater.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-updater.yaml
@@ -19,9 +19,15 @@ spec:
       app: vpa-updater
   template:
     metadata:
-{{- if .Values.updater.podAnnotations }}
+{{- if or .Values.updater.podAnnotations .Values.updater.createServiceAccount }}
       annotations:
+{{- if .Values.updater.createServiceAccount }}
+        # TODO(rfranzke): Remove in a future release.
+        security.gardener.cloud/trigger: rollout
+{{- end }}
+{{- if .Values.updater.podAnnotations }}
 {{ toYaml .Values.updater.podAnnotations | indent 8 }}
+{{- end }}
 {{- end }}
       labels:
         app: vpa-updater

--- a/charts/seed-bootstrap/templates/aggregate-prometheus/serviceaccount.yaml
+++ b/charts/seed-bootstrap/templates/aggregate-prometheus/serviceaccount.yaml
@@ -6,3 +6,4 @@ metadata:
   labels:
     app: aggregate-prometheus
     role: monitoring
+automountServiceAccountToken: false

--- a/charts/seed-bootstrap/templates/aggregate-prometheus/statefulset.yaml
+++ b/charts/seed-bootstrap/templates/aggregate-prometheus/statefulset.yaml
@@ -16,6 +16,9 @@ spec:
   serviceName: aggregate-prometheus
   template:
     metadata:
+      annotations:
+        # TODO(rfranzke): Remove in a future release.
+        security.gardener.cloud/trigger: rollout
       labels:
         app: aggregate-prometheus
         role: monitoring

--- a/charts/seed-bootstrap/templates/grafana/grafana-deployment.yaml
+++ b/charts/seed-bootstrap/templates/grafana/grafana-deployment.yaml
@@ -32,6 +32,7 @@ spec:
         networking.gardener.cloud/to-loki: allowed
         component: grafana
     spec:
+      automountServiceAccountToken: false
       containers:
       - name: grafana
         image: {{ index .Values.global.images "grafana" }}

--- a/charts/seed-bootstrap/templates/prometheus/serviceaccount.yaml
+++ b/charts/seed-bootstrap/templates/prometheus/serviceaccount.yaml
@@ -6,3 +6,4 @@ metadata:
   labels:
     app: prometheus
     role: monitoring
+automountServiceAccountToken: false

--- a/charts/seed-bootstrap/templates/prometheus/statefulset.yaml
+++ b/charts/seed-bootstrap/templates/prometheus/statefulset.yaml
@@ -16,6 +16,9 @@ spec:
   serviceName: prometheus
   template:
     metadata:
+      annotations:
+        # TODO(rfranzke): Remove in a future release.
+        security.gardener.cloud/trigger: rollout
       labels:
         app: prometheus
         role: monitoring

--- a/charts/seed-bootstrap/templates/vpa-exporter/deployment-exporter.yaml
+++ b/charts/seed-bootstrap/templates/vpa-exporter/deployment-exporter.yaml
@@ -15,6 +15,9 @@ spec:
       app: vpa-exporter
   template:
     metadata:
+      annotations:
+        # TODO(rfranzke): Remove in a future release.
+        security.gardener.cloud/trigger: rollout
       labels:
         app: vpa-exporter
 {{ toYaml .Values.vpa.exporter.labels | indent 8 }}

--- a/charts/seed-bootstrap/templates/vpa-exporter/serviceaccount-exporter.yaml
+++ b/charts/seed-bootstrap/templates/vpa-exporter/serviceaccount-exporter.yaml
@@ -4,3 +4,4 @@ kind: ServiceAccount
 metadata:
   name: vpa-exporter
   namespace: {{ .Release.Namespace }}
+automountServiceAccountToken: false

--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     app: prometheus
     role: monitoring
+automountServiceAccountToken: false
 ---
 apiVersion: v1
 kind: Service
@@ -49,6 +50,8 @@ spec:
     metadata:
       annotations:
         checksum/configmap-blackbox-exporter: {{ include (print $.Template.BasePath "/blackbox-exporter-config.yaml") . | sha256sum }}
+        # TODO(rfranzke): Remove in a future release.
+        security.gardener.cloud/trigger: rollout
 {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
 {{- end }}

--- a/pkg/operation/botanist/component/dependencywatchdog/bootstrap.go
+++ b/pkg/operation/botanist/component/dependencywatchdog/bootstrap.go
@@ -134,6 +134,7 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 				Name:      b.name(),
 				Namespace: b.namespace,
 			},
+			AutomountServiceAccountToken: pointer.Bool(false),
 		}
 
 		clusterRole = &rbacv1.ClusterRole{
@@ -202,6 +203,10 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 				Selector:             &metav1.LabelSelector{MatchLabels: b.getLabels()},
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							// TODO(rfranzke): Remove in a future release.
+							"security.gardener.cloud/trigger": "rollout",
+						},
 						Labels: b.podLabels(),
 					},
 					Spec: corev1.PodSpec{

--- a/pkg/operation/botanist/component/dependencywatchdog/bootstrap_test.go
+++ b/pkg/operation/botanist/component/dependencywatchdog/bootstrap_test.go
@@ -65,6 +65,7 @@ var _ = Describe("DependencyWatchdog", func() {
 				configMapName = dwdName + "-config-" + configMapDataHash
 
 				serviceAccountYAML = `apiVersion: v1
+automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
   creationTimestamp: null
@@ -240,6 +241,7 @@ spec:
     metadata:
       annotations:
         ` + references.AnnotationKey(references.KindConfigMap, configMapName) + `: ` + configMapName + `
+        security.gardener.cloud/trigger: rollout
       creationTimestamp: null`
 
 					if role == RoleEndpoint {

--- a/pkg/operation/botanist/component/etcd/bootstrap.go
+++ b/pkg/operation/botanist/component/etcd/bootstrap.go
@@ -95,6 +95,7 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 				Namespace: b.namespace,
 				Labels:    labels(),
 			},
+			AutomountServiceAccountToken: pointer.Bool(false),
 		}
 
 		clusterRole = &rbacv1.ClusterRole{
@@ -235,6 +236,10 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 				},
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							// TODO(rfranzke): Remove in a future release.
+							"security.gardener.cloud/trigger": "rollout",
+						},
 						Labels: labels(),
 					},
 					Spec: corev1.PodSpec{

--- a/pkg/operation/botanist/component/etcd/bootstrap_test.go
+++ b/pkg/operation/botanist/component/etcd/bootstrap_test.go
@@ -94,6 +94,7 @@ var _ = Describe("Etcd", func() {
 			configMapName = "etcd-druid-imagevector-overwrite-4475dd36"
 
 			serviceAccountYAML = `apiVersion: v1
+automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
   creationTimestamp: null
@@ -317,6 +318,8 @@ spec:
   strategy: {}
   template:
     metadata:
+      annotations:
+        security.gardener.cloud/trigger: rollout
       creationTimestamp: null
       labels:
         gardener.cloud/role: etcd-druid
@@ -368,6 +371,7 @@ spec:
     metadata:
       annotations:
         ` + references.AnnotationKey(references.KindConfigMap, configMapName) + `: ` + configMapName + `
+        security.gardener.cloud/trigger: rollout
       creationTimestamp: null
       labels:
         gardener.cloud/role: etcd-druid

--- a/pkg/operation/botanist/component/gardenerkubescheduler/gardener_kube_scheduler.go
+++ b/pkg/operation/botanist/component/gardenerkubescheduler/gardener_kube_scheduler.go
@@ -192,6 +192,10 @@ func (k *kubeScheduler) Deploy(ctx context.Context) error {
 				Selector:             &metav1.LabelSelector{MatchLabels: getLabels()},
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							// TODO(rfranzke): Remove in a future release.
+							"security.gardener.cloud/trigger": "rollout",
+						},
 						Labels: getLabels(),
 					},
 					Spec: corev1.PodSpec{
@@ -268,11 +272,14 @@ func (k *kubeScheduler) Deploy(ctx context.Context) error {
 				},
 			},
 		}
-		serviceAccount = &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{
-			Name:      Name,
-			Namespace: k.namespace,
-			Labels:    getLabels(),
-		}}
+		serviceAccount = &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      Name,
+				Namespace: k.namespace,
+				Labels:    getLabels(),
+			},
+			AutomountServiceAccountToken: pointer.Bool(false),
+		}
 		roleBinding = &rbacv1.RoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      roleBindingName,

--- a/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller.go
+++ b/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller.go
@@ -112,6 +112,7 @@ func (g *gardenerSeedAdmissionController) Deploy(ctx context.Context) error {
 				Namespace: g.namespace,
 				Labels:    getLabels(),
 			},
+			AutomountServiceAccountToken: pointer.Bool(false),
 		}
 
 		clusterRole = &rbacv1.ClusterRole{
@@ -206,7 +207,13 @@ func (g *gardenerSeedAdmissionController) Deploy(ctx context.Context) error {
 				},
 				Selector: &metav1.LabelSelector{MatchLabels: getLabels()},
 				Template: corev1.PodTemplateSpec{
-					ObjectMeta: metav1.ObjectMeta{Labels: getLabels()},
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							// TODO(rfranzke): Remove in a future release.
+							"security.gardener.cloud/trigger": "rollout",
+						},
+						Labels: getLabels(),
+					},
 					Spec: corev1.PodSpec{
 						Affinity: &corev1.Affinity{
 							PodAntiAffinity: &corev1.PodAntiAffinity{

--- a/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller_test.go
+++ b/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller_test.go
@@ -153,6 +153,7 @@ spec:
     metadata:
       annotations:
         ` + references.AnnotationKey(references.KindSecret, secretName) + `: ` + secretName + `
+        security.gardener.cloud/trigger: rollout
       creationTimestamp: null
       labels:
         app: gardener
@@ -241,6 +242,7 @@ status:
   loadBalancer: {}
 `
 		serviceAccountYAML = `apiVersion: v1
+automountServiceAccountToken: false
 kind: ServiceAccount
 metadata:
   creationTimestamp: null


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement
/merge squash

**What this PR does / why we need it**:
Similar to #5099, this PR adapts all components deployed by Gardener into the shoot cluster to use projected `ServiceAccount` tokens (instead of the static tokens).

**Which issue(s) this PR fixes**:
Part of #4659
Part of #4878

**Special notes for your reviewer**:
- We have to trigger a rollout of the pods, hence, there is a change in the `.metadata.annotations` section of the respective pod templates.
- This PR depends on #5098 (released with `v1.37`), i.e., upgrading to a version containing this PR can only be done from at least Gardener v1.37.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```action operator
Before upgrading to this Gardener version make sure that your existing Gardener runs on at least `v1.37`.
```
```noteworthy operator
All seed system components deployed by Gardener have been switched to projected `ServiceAccount` tokens (instead of continued usage of static tokens).
```
