### PR TITLE
Add version skew policy document

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -148,6 +148,7 @@
 ## Deployment
 
 * [Setup Gardener on a Kubernetes cluster](deployment/setup_gardener.md)
+* [Version Skew Policy](deployment/version_skew_policy.md)
 * [Deploying Gardenlets](deployment/deploy_gardenlet.md)
     * [Automatic Deployment of Gardenlets](deployment/deploy_gardenlet_automatically.md)
     * [Deploy a Gardenlet Manually](deployment/deploy_gardenlet_manually.md)

--- a/docs/concepts/gardenlet.md
+++ b/docs/concepts/gardenlet.md
@@ -248,10 +248,6 @@ into all of your seeds (if they aren’t managed, as mentioned earlier).
 
 More information: [Deploy a Gardenlet](../deployment/deploy_gardenlet.md) for all instructions.
 
-## Gardenlet Allowed Version Skew
-
-The gardenlet version should always match the Gardener control plane version and may be at most (e.g. during the update of an installation) one minor version behind (never ahead).
-
 ## Related Links
 
 [Gardener Architecture](https://github.com/gardener/documentation/wiki/Architecture)

--- a/docs/deployment/version_skew_policy.md
+++ b/docs/deployment/version_skew_policy.md
@@ -1,0 +1,70 @@
+# Version Skew Policy
+
+This document describes the maximum version skew supported between various Gardener components.
+
+## Supported Gardener Versions
+
+Gardener versions are expressed as `x.y.z`, where `x` is the major version, `y` is the minor version, and `z` is the patch version, following Semantic Versioning terminology.
+
+The Gardener project maintains release branches for the most recent three minor releases.
+
+Applicable fixes, including security fixes, may be backported to those three release branches, depending on severity and feasibility.
+Patch releases are cut from those branches at a regular cadence, plus additional urgent releases, when required.
+
+For more information, see [this document](../development/process.md#releases).
+
+### Supported Version Skew
+
+Technically, we follow the same [policy](https://kubernetes.io/releases/version-skew-policy/) as the Kubernetes project.
+However, given that our release cadence is much more frequent compared to Kubernetes (every `14d` vs. every `120d`), in many cases it is possible to skip a version.
+Still, to be on the safe side, it is highly recommended following the described policy.
+
+#### gardener-apiserver
+
+In multi-instance setups of Gardener, the newest and oldest `gardener-apiserver` instances must be within one minor version.
+
+Example:
+
+- newest `gardener-apiserver` is at **1.37**
+- other `gardener-apiserver` instances are supported at **1.37** and **v1.36**
+
+#### gardener-controller-manager, gardener-scheduler, gardener-admission-controller, gardenlet
+
+`gardener-controller-manager`, `gardener-scheduler`, `gardener-admission-controller`, and `gardenlet` must not be newer than the `gardener-apiserver` instances they communicate with.
+They are expected to match the `gardener-apiserver` minor version, but may be up to one minor version older (to allow live upgrades).
+
+Example:
+
+- `gardener-apiserver` is at **v1.37**
+- `gardener-controller-manager`, `gardener-scheduler`, `gardener-admission-controller`, and `gardenlet` are supported at **1.37** and **v1.36**
+
+### Supported Component Upgrade Order
+
+The supported version skew between components has implications on the order in which components must be upgraded.
+This section describes the order in which components must be upgraded to transition an existing Gardener installation from version **1.37** to version **1.38**.
+
+#### gardener-apiserver
+
+Pre-requisites:
+
+- In a single-instance setup, the existing `gardener-apiserver` instance is **1.37**
+- In a multi-instance setup, all `gardener-apiserver` instances are at **1.37** or **1.38** (this ensures maximum skew of 1 minor version between the oldest and newest `gardener-apiserver` instance)
+- The `gardener-controller-manager`, `gardener-scheduler`, `gardener-admission-controller`, and `gardenlet` instances that communicate with this `gardener-apiserver` are at version **1.37** (this ensures they are not newer than the existing API server version, and are within 1 minor version of the new API server version)
+
+Action:
+
+- Upgrade `gardener-apiserver` to **1.38**
+
+#### gardener-controller-manager, gardener-scheduler, gardener-admission-controller, gardenlet
+
+Pre-requisites:
+
+- The `gardener-apiserver` instances these components communicate with are at **1.38** (in multi-instance setups in which these components can communicate with any `gardener-apiserver` instance in the cluster, all `gardener-apiserver` instances must be upgraded before upgrading these components)
+
+Action:
+
+- Upgrade `gardener-controller-manager`, `gardener-scheduler`, `gardener-admission-controller`, and `gardenlet` to **1.38**
+
+## Supported Kubernetes Versions
+
+Please refer to [this document](../usage/supported_k8s_versions.md).

--- a/docs/deployment/version_skew_policy.md
+++ b/docs/deployment/version_skew_policy.md
@@ -9,7 +9,7 @@ Gardener versions are expressed as `x.y.z`, where `x` is the major version, `y` 
 The Gardener project maintains release branches for the most recent three minor releases.
 
 Applicable fixes, including security fixes, may be backported to those three release branches, depending on severity and feasibility.
-Patch releases are cut from those branches at a regular cadence, plus additional urgent releases, when required.
+Patch releases are cut from those branches at a regular cadence, plus additional urgent releases when required.
 
 For more information, see [this document](../development/process.md#releases).
 
@@ -17,7 +17,7 @@ For more information, see [this document](../development/process.md#releases).
 
 Technically, we follow the same [policy](https://kubernetes.io/releases/version-skew-policy/) as the Kubernetes project.
 However, given that our release cadence is much more frequent compared to Kubernetes (every `14d` vs. every `120d`), in many cases it is possible to skip a version.
-Still, to be on the safe side, it is highly recommended following the described policy.
+Still, to be on the safe side, it is highly recommended to follow the described policy.
 
 #### gardener-apiserver
 
@@ -49,7 +49,7 @@ Pre-requisites:
 
 - In a single-instance setup, the existing `gardener-apiserver` instance is **1.37**
 - In a multi-instance setup, all `gardener-apiserver` instances are at **1.37** or **1.38** (this ensures maximum skew of 1 minor version between the oldest and newest `gardener-apiserver` instance)
-- The `gardener-controller-manager`, `gardener-scheduler`, `gardener-admission-controller`, and `gardenlet` instances that communicate with this `gardener-apiserver` are at version **1.37** (this ensures they are not newer than the existing API server version, and are within 1 minor version of the new API server version)
+- The `gardener-controller-manager`, `gardener-scheduler`, `gardener-admission-controller`, and `gardenlet` instances that communicate with this `gardener-apiserver` are at version **1.37** (this ensures they are not newer than the existing API server version and are within 1 minor version of the new API server version)
 
 Action:
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation open-source
/kind enhancement

**What this PR does / why we need it**:
This PR adds a version skew policy document.

Practically, we always followed and proclaimed this policy, however, it was not documented yet.
Also, since there are two PRs which depend on v1.37 to be deployed (#5121 and #5128), let's now make this policy official.

**Which issue(s) this PR fixes**:
Fixes #4916

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
An official version skew policy document was added. You can take a look [here](https://github.com/gardener/gardener/blob/master/docs/deployment/version_skew_policy.md).
```
