### PR TITLE
Fix usage of `IsDeleting` predicate for extension resources

### DIFF
--- a/extensions/pkg/controller/backupbucket/controller.go
+++ b/extensions/pkg/controller/backupbucket/controller.go
@@ -67,7 +67,10 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 		predicate.Or(
 			predicateutils.HasOperationAnnotation(),
 			extensionspredicate.LastOperationNotSuccessful(),
-			extensionspredicate.IsDeleting(),
+			predicate.And(
+				predicate.GenerationChangedPredicate{},
+				extensionspredicate.IsDeleting(),
+			),
 		),
 	}
 }

--- a/extensions/pkg/controller/backupentry/controller.go
+++ b/extensions/pkg/controller/backupentry/controller.go
@@ -66,7 +66,10 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 		predicate.Or(
 			predicateutils.HasOperationAnnotation(),
 			extensionspredicate.LastOperationNotSuccessful(),
-			extensionspredicate.IsDeleting(),
+			predicate.And(
+				predicate.GenerationChangedPredicate{},
+				extensionspredicate.IsDeleting(),
+			),
 		),
 	}
 }

--- a/extensions/pkg/controller/bastion/controller.go
+++ b/extensions/pkg/controller/bastion/controller.go
@@ -60,7 +60,10 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 		predicate.Or(
 			predicateutils.HasOperationAnnotation(),
 			extensionspredicate.LastOperationNotSuccessful(),
-			extensionspredicate.IsDeleting(),
+			predicate.And(
+				predicate.GenerationChangedPredicate{},
+				extensionspredicate.IsDeleting(),
+			),
 		),
 	}
 }

--- a/extensions/pkg/controller/containerruntime/controller.go
+++ b/extensions/pkg/controller/containerruntime/controller.go
@@ -75,7 +75,10 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 		predicate.Or(
 			predicateutils.HasOperationAnnotation(),
 			extensionspredicate.LastOperationNotSuccessful(),
-			extensionspredicate.IsDeleting(),
+			predicate.And(
+				predicate.GenerationChangedPredicate{},
+				extensionspredicate.IsDeleting(),
+			),
 		),
 		extensionspredicate.ShootNotFailed(),
 	}

--- a/extensions/pkg/controller/controlplane/controller.go
+++ b/extensions/pkg/controller/controlplane/controller.go
@@ -65,7 +65,10 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 		predicate.Or(
 			predicateutils.HasOperationAnnotation(),
 			extensionspredicate.LastOperationNotSuccessful(),
-			extensionspredicate.IsDeleting(),
+			predicate.And(
+				predicate.GenerationChangedPredicate{},
+				extensionspredicate.IsDeleting(),
+			),
 		),
 		extensionspredicate.ShootNotFailed(),
 	}

--- a/extensions/pkg/controller/dnsrecord/controller.go
+++ b/extensions/pkg/controller/dnsrecord/controller.go
@@ -65,7 +65,10 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 		predicate.Or(
 			predicateutils.HasOperationAnnotation(),
 			extensionspredicate.LastOperationNotSuccessful(),
-			extensionspredicate.IsDeleting(),
+			predicate.And(
+				predicate.GenerationChangedPredicate{},
+				extensionspredicate.IsDeleting(),
+			),
 		),
 		extensionspredicate.ShootNotFailed(),
 	}

--- a/extensions/pkg/controller/extension/controller.go
+++ b/extensions/pkg/controller/extension/controller.go
@@ -75,7 +75,10 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 		predicate.Or(
 			predicateutils.HasOperationAnnotation(),
 			extensionspredicate.LastOperationNotSuccessful(),
-			extensionspredicate.IsDeleting(),
+			predicate.And(
+				predicate.GenerationChangedPredicate{},
+				extensionspredicate.IsDeleting(),
+			),
 		),
 		extensionspredicate.ShootNotFailed(),
 	}

--- a/extensions/pkg/controller/infrastructure/controller.go
+++ b/extensions/pkg/controller/infrastructure/controller.go
@@ -71,7 +71,10 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 		predicate.Or(
 			predicateutils.HasOperationAnnotation(),
 			extensionspredicate.LastOperationNotSuccessful(),
-			extensionspredicate.IsDeleting(),
+			predicate.And(
+				predicate.GenerationChangedPredicate{},
+				extensionspredicate.IsDeleting(),
+			),
 		),
 		extensionspredicate.ShootNotFailed(),
 	}

--- a/extensions/pkg/controller/network/controller.go
+++ b/extensions/pkg/controller/network/controller.go
@@ -65,7 +65,10 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 		predicate.Or(
 			predicateutils.HasOperationAnnotation(),
 			extensionspredicate.LastOperationNotSuccessful(),
-			extensionspredicate.IsDeleting(),
+			predicate.And(
+				predicate.GenerationChangedPredicate{},
+				extensionspredicate.IsDeleting(),
+			),
 		),
 		extensionspredicate.ShootNotFailed(),
 	}

--- a/extensions/pkg/controller/operatingsystemconfig/controller.go
+++ b/extensions/pkg/controller/operatingsystemconfig/controller.go
@@ -69,7 +69,10 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 		predicate.Or(
 			predicateutils.HasOperationAnnotation(),
 			extensionspredicate.LastOperationNotSuccessful(),
-			extensionspredicate.IsDeleting(),
+			predicate.And(
+				predicate.GenerationChangedPredicate{},
+				extensionspredicate.IsDeleting(),
+			),
 		),
 	}
 }

--- a/extensions/pkg/controller/worker/controller.go
+++ b/extensions/pkg/controller/worker/controller.go
@@ -70,7 +70,10 @@ func DefaultPredicates(ignoreOperationAnnotation bool) []predicate.Predicate {
 		predicate.Or(
 			predicateutils.HasOperationAnnotation(),
 			extensionspredicate.LastOperationNotSuccessful(),
-			extensionspredicate.IsDeleting(),
+			predicate.And(
+				predicate.GenerationChangedPredicate{},
+				extensionspredicate.IsDeleting(),
+			),
 		),
 		extensionspredicate.ShootNotFailed(),
 	}


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/kind bug

**What this PR does / why we need it**:
Fixes the usage of `IsDeleting` predicate for extension resources to ensure that the resource not reconciled on every event (including status changes) when the deletion timestamp is non-nil, but only on events that change the generation (such as the actual deletion) and on create (to make sure resources with a deletion timestamp are reconciled when an extension is restarted).

Without this fix, it's for example impossible to use the `RequeueAfterError` mechanism in the `Delete` methods of an actuator, the resource is always requeued immediately because a status update happens before that and the `IsDeleting` predicate is true, see e.g. https://github.com/gardener/gardener-extension-provider-azure/pull/410#issuecomment-988609540.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```bugfix operator
NONE
```
