### PR TITLE
🛡 Eliminate client certificate for `gardener-resource-manager`

### DIFF
--- a/pkg/operation/botanist/component/resourcemanager/resource_manager.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gardener/gardener/pkg/resourcemanager/webhook/projectedtokenmount"
 	"github.com/gardener/gardener/pkg/resourcemanager/webhook/tokeninvalidator"
 	"github.com/gardener/gardener/pkg/utils"
+	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
@@ -47,6 +48,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	autoscalingv1beta2 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1beta2"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -61,12 +63,10 @@ const (
 	SecretName = "gardener-resource-manager"
 	// SecretNameServer is the name of the gardener-resource-manager server certificate secret.
 	SecretNameServer = "gardener-resource-manager-server"
+	// SecretNameShootAccess is the name of the shoot access secret for the gardener-resource-manager.
+	SecretNameShootAccess = gutil.SecretNamePrefixShootAccess + v1beta1constants.DeploymentNameGardenerResourceManager
 	// LabelValue is a constant for the value of the 'app' label on Kubernetes resources.
 	LabelValue = "gardener-resource-manager"
-
-	// UserName is the name that should be used for the secret that the gardener resource manager uses to
-	// authenticate itself with the kube-apiserver (e.g., the common name in its client certificate).
-	UserName = "gardener.cloud:system:gardener-resource-manager"
 
 	clusterRoleName    = "gardener-resource-manager-seed"
 	containerName      = v1beta1constants.DeploymentNameGardenerResourceManager
@@ -77,10 +77,8 @@ const (
 	roleName           = "gardener-resource-manager"
 	serviceAccountName = "gardener-resource-manager"
 
-	volumeNameKubeconfig           = "gardener-resource-manager"
 	volumeNameCerts                = "tls"
 	volumeNameAPIServerAccess      = "kube-api-access-gardener"
-	volumeMountPathKubeconfig      = "/etc/gardener-resource-manager"
 	volumeMountPathCerts           = "/etc/gardener-resource-manager-tls"
 	volumeMountPathAPIServerAccess = "/var/run/secrets/kubernetes.io/serviceaccount"
 
@@ -215,6 +213,13 @@ func (r *resourceManager) Deploy(ctx context.Context) error {
 		return fmt.Errorf("missing server secret information")
 	}
 
+	if r.values.TargetDiffersFromSourceCluster {
+		r.secrets.shootAccess = r.newShootAccessSecret()
+		if err := r.secrets.shootAccess.WithTokenExpirationDuration("24h").Reconcile(ctx, r.client); err != nil {
+			return err
+		}
+	}
+
 	fns := []func(context.Context) error{
 		r.ensureServiceAccount,
 		r.ensureRBAC,
@@ -235,6 +240,11 @@ func (r *resourceManager) Deploy(ctx context.Context) error {
 		if err := fn(ctx); err != nil {
 			return err
 		}
+	}
+
+	// TODO(rfranzke): Remove in a future release.
+	if r.values.TargetDiffersFromSourceCluster {
+		return kutil.DeleteObject(ctx, r.client, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "gardener-resource-manager", Namespace: r.namespace}})
 	}
 
 	return nil
@@ -262,6 +272,8 @@ func (r *resourceManager) Destroy(ctx context.Context) error {
 		if err := managedresources.WaitUntilDeleted(timeoutCtx, r.client, r.namespace, ManagedResourceName); err != nil {
 			return err
 		}
+
+		objectsToDelete = append(objectsToDelete, r.newShootAccessSecret().Secret)
 	} else {
 		objectsToDelete = append(objectsToDelete, r.emptyMutatingWebhookConfiguration())
 	}
@@ -607,22 +619,10 @@ func (r *resourceManager) ensureDeployment(ctx context.Context) error {
 			})
 		}
 
-		if r.secrets.Kubeconfig.Name != "" {
-			metav1.SetMetaDataAnnotation(&deployment.Spec.Template.ObjectMeta, "checksum/secret-"+r.secrets.Kubeconfig.Name, r.secrets.Kubeconfig.Checksum)
-			deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, corev1.Volume{
-				Name: volumeNameKubeconfig,
-				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						SecretName:  r.secrets.Kubeconfig.Name,
-						DefaultMode: pointer.Int32(420),
-					},
-				},
-			})
-			deployment.Spec.Template.Spec.Containers[0].VolumeMounts = append(deployment.Spec.Template.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
-				MountPath: volumeMountPathKubeconfig,
-				Name:      volumeNameKubeconfig,
-				ReadOnly:  true,
-			})
+		if r.values.TargetDiffersFromSourceCluster {
+			if r.secrets.shootAccess != nil {
+				utilruntime.Must(gutil.InjectGenericKubeconfig(deployment, r.secrets.shootAccess.Secret.Name))
+			}
 		}
 
 		if r.secrets.RootCA != nil {
@@ -719,8 +719,8 @@ func (r *resourceManager) computeCommand() []string {
 	if r.secrets.Server.Name != "" {
 		cmd = append(cmd, fmt.Sprintf("--tls-cert-dir=%s", volumeMountPathCerts))
 	}
-	if r.secrets.Kubeconfig.Name != "" {
-		cmd = append(cmd, fmt.Sprintf("--target-kubeconfig=%s/%s", volumeMountPathKubeconfig, secrets.DataKeyKubeconfig))
+	if r.values.TargetDiffersFromSourceCluster {
+		cmd = append(cmd, "--target-kubeconfig="+gutil.PathGenericKubeconfig)
 	}
 	return cmd
 }
@@ -815,12 +815,32 @@ func (r *resourceManager) ensureShootResources(ctx context.Context) error {
 		registry = managedresources.NewRegistry(kubernetes.ShootScheme, kubernetes.ShootCodec, kubernetes.ShootSerializer)
 
 		mutatingWebhookConfiguration = r.emptyMutatingWebhookConfiguration()
+
+		clusterRoleBinding = &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "gardener.cloud:target:resource-manager",
+				Annotations: map[string]string{resourcesv1alpha1.KeepObject: "true"},
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: rbacv1.GroupName,
+				Kind:     "ClusterRole",
+				Name:     "cluster-admin",
+			},
+			Subjects: []rbacv1.Subject{{
+				Kind:      rbacv1.ServiceAccountKind,
+				Name:      r.secrets.shootAccess.ServiceAccountName,
+				Namespace: metav1.NamespaceSystem,
+			}},
+		}
 	)
 
 	mutatingWebhookConfiguration.Labels = appLabel()
 	mutatingWebhookConfiguration.Webhooks = GetMutatingWebhookConfigurationWebhooks(r.buildWebhookNamespaceSelector(), r.buildWebhookClientConfig)
 
-	data, err := registry.AddAllAndSerialize(mutatingWebhookConfiguration)
+	data, err := registry.AddAllAndSerialize(
+		mutatingWebhookConfiguration,
+		clusterRoleBinding,
+	)
 	if err != nil {
 		return err
 	}
@@ -868,6 +888,10 @@ func (r *resourceManager) ensureNetworkPolicy(ctx context.Context) error {
 
 func (r *resourceManager) emptyNetworkPolicy() *networkingv1.NetworkPolicy {
 	return &networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Name: "allow-kube-apiserver-to-gardener-resource-manager", Namespace: r.namespace}}
+}
+
+func (r *resourceManager) newShootAccessSecret() *gutil.ShootAccessSecret {
+	return gutil.NewShootAccessSecret(SecretNameShootAccess, r.namespace)
 }
 
 // GetMutatingWebhookConfigurationWebhooks returns the MutatingWebhooks for the resourcemanager component for reuse
@@ -1045,9 +1069,6 @@ func (r *resourceManager) SetSecrets(s Secrets) { r.secrets = s }
 
 // Secrets is collection of secrets for the gardener-resource-manager.
 type Secrets struct {
-	// Kubeconfig enables the gardener-resource-manager to deploy resources into a different cluster than the one it is
-	// running in.
-	Kubeconfig component.Secret
 	// ServerCA is a secret containing a CA certificate which was used to sign the server certificate provided in the
 	// 'Server' secret.
 	ServerCA component.Secret
@@ -1056,4 +1077,6 @@ type Secrets struct {
 	Server component.Secret
 	// RootCA is a secret containing the root CA secret of the target cluster.
 	RootCA *component.Secret
+
+	shootAccess *gutil.ShootAccessSecret
 }

--- a/pkg/operation/botanist/resource_manager.go
+++ b/pkg/operation/botanist/resource_manager.go
@@ -16,21 +16,35 @@ package botanist
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/gardener/gardener/charts"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/resourcemanager"
 	"github.com/gardener/gardener/pkg/utils"
+	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/managedresources"
+	retryutils "github.com/gardener/gardener/pkg/utils/retry"
+	secretutils "github.com/gardener/gardener/pkg/utils/secrets"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apiserver/pkg/authentication/user"
 	"k8s.io/component-base/version"
 	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // DefaultResourceManager returns an instance of Gardener Resource Manager with defaults configured for being deployed in a Shoot namespace
@@ -85,14 +99,58 @@ func (b *Botanist) DefaultResourceManager() (resourcemanager.Interface, error) {
 	), nil
 }
 
+// TimeoutWaitForGardenerResourceManagerBootstrapping is the maximum time the bootstrap process for the
+// gardener-resource-manager may take.
+// Exposed for testing.
+var TimeoutWaitForGardenerResourceManagerBootstrapping = 2 * time.Minute
+
 // DeployGardenerResourceManager deploys the gardener-resource-manager
 func (b *Botanist) DeployGardenerResourceManager(ctx context.Context) error {
-	b.Shoot.Components.ControlPlane.ResourceManager.SetSecrets(resourcemanager.Secrets{
-		Kubeconfig: component.Secret{Name: resourcemanager.SecretName, Checksum: b.LoadCheckSum(resourcemanager.SecretName)},
-		ServerCA:   component.Secret{Name: v1beta1constants.SecretNameCACluster, Checksum: b.LoadCheckSum(v1beta1constants.SecretNameCACluster), Data: b.LoadSecret(v1beta1constants.SecretNameCACluster).Data},
-		Server:     component.Secret{Name: resourcemanager.SecretNameServer, Checksum: b.LoadCheckSum(resourcemanager.SecretNameServer)},
-		RootCA:     &component.Secret{Name: v1beta1constants.SecretNameCACluster, Checksum: b.LoadCheckSum(v1beta1constants.SecretNameCACluster)},
-	})
+	var (
+		bootstrapKubeconfigSecret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "shoot-access-gardener-resource-manager-bootstrap",
+				Namespace: b.Shoot.SeedNamespace,
+			},
+		}
+		secrets = resourcemanager.Secrets{
+			ServerCA: component.Secret{Name: v1beta1constants.SecretNameCACluster, Checksum: b.LoadCheckSum(v1beta1constants.SecretNameCACluster), Data: b.LoadSecret(v1beta1constants.SecretNameCACluster).Data},
+			Server:   component.Secret{Name: resourcemanager.SecretNameServer, Checksum: b.LoadCheckSum(resourcemanager.SecretNameServer)},
+			RootCA:   &component.Secret{Name: v1beta1constants.SecretNameCACluster, Checksum: b.LoadCheckSum(v1beta1constants.SecretNameCACluster)},
+		}
+	)
+
+	mustBootstrap, err := b.mustBootstrapGardenerResourceManager(ctx)
+	if err != nil {
+		return err
+	}
+
+	if mustBootstrap {
+		if err := b.reconcileGardenerResourceManagerBootstrapKubeconfigSecret(ctx, bootstrapKubeconfigSecret); err != nil {
+			return err
+		}
+
+		secrets.BootstrapKubeconfig = &component.Secret{Name: bootstrapKubeconfigSecret.Name, Checksum: utils.ComputeSecretChecksum(bootstrapKubeconfigSecret.Data)}
+		b.Shoot.Components.ControlPlane.ResourceManager.SetSecrets(secrets)
+
+		if err := b.Shoot.Components.ControlPlane.ResourceManager.Deploy(ctx); err != nil {
+			return err
+		}
+
+		timeoutCtx, cancel := context.WithTimeout(ctx, TimeoutWaitForGardenerResourceManagerBootstrapping)
+		defer cancel()
+
+		if err := b.waitUntilGardenerResourceManagerBootstrapped(timeoutCtx); err != nil {
+			return err
+		}
+	}
+
+	if err := b.K8sSeedClient.Client().Delete(ctx, bootstrapKubeconfigSecret); client.IgnoreNotFound(err) != nil {
+		return err
+	}
+
+	secrets.BootstrapKubeconfig = nil
+	b.Shoot.Components.ControlPlane.ResourceManager.SetSecrets(secrets)
 
 	return b.Shoot.Components.ControlPlane.ResourceManager.Deploy(ctx)
 }
@@ -100,4 +158,111 @@ func (b *Botanist) DeployGardenerResourceManager(ctx context.Context) error {
 // ScaleGardenerResourceManagerToOne scales the gardener-resource-manager deployment
 func (b *Botanist) ScaleGardenerResourceManagerToOne(ctx context.Context) error {
 	return kubernetes.ScaleDeployment(ctx, b.K8sSeedClient.Client(), kutil.Key(b.Shoot.SeedNamespace, v1beta1constants.DeploymentNameGardenerResourceManager), 1)
+}
+
+func (b *Botanist) mustBootstrapGardenerResourceManager(ctx context.Context) (bool, error) {
+	shootAccessSecret := gutil.NewShootAccessSecret(resourcemanager.SecretNameShootAccess, b.Shoot.SeedNamespace)
+	if err := b.K8sSeedClient.Client().Get(ctx, client.ObjectKeyFromObject(shootAccessSecret.Secret), shootAccessSecret.Secret); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return false, err
+		}
+		return true, nil // Shoot access secret does not yet exist.
+	}
+
+	renewTime, err2 := time.Parse(time.RFC3339, shootAccessSecret.Secret.Annotations[resourcesv1alpha1.ServiceAccountTokenRenewTimestamp])
+	if err2 != nil {
+		return false, fmt.Errorf("could not parse renew timestamp: %w", err2)
+	}
+	if time.Now().UTC().After(renewTime.UTC()) {
+		return true, nil // Shoot token was not renewed.
+	}
+
+	managedResource := &resourcesv1alpha1.ManagedResource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resourcemanager.ManagedResourceName,
+			Namespace: b.Shoot.SeedNamespace,
+		},
+	}
+
+	if err := b.K8sSeedClient.Client().Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource); err != nil {
+		if !apierrors.IsNotFound(err) {
+			return false, err
+		}
+		return true, nil // ManagedResource (containing the RBAC resources) does not yet exist.
+	}
+
+	if conditionApplied := v1beta1helper.GetCondition(managedResource.Status.Conditions, resourcesv1alpha1.ResourcesApplied); conditionApplied != nil &&
+		conditionApplied.Status == gardencorev1beta1.ConditionFalse &&
+		strings.Contains(conditionApplied.Message, `forbidden: User "system:serviceaccount:kube-system:gardener-resource-manager" cannot`) {
+		return true, nil // ServiceAccount lost access.
+	}
+
+	return false, nil
+}
+
+func (b *Botanist) reconcileGardenerResourceManagerBootstrapKubeconfigSecret(ctx context.Context, bootstrapKubeconfigSecret *corev1.Secret) error {
+	caCertificateSecret := b.LoadSecret(v1beta1constants.SecretNameCACluster)
+
+	caCertificate, err := secretutils.LoadCertificate(v1beta1constants.SecretNameCACluster, caCertificateSecret.Data[secretutils.DataKeyPrivateKeyCA], caCertificateSecret.Data[secretutils.DataKeyCertificateCA])
+	if err != nil {
+		return err
+	}
+
+	controlPlaneSecret, err := (&secretutils.ControlPlaneSecretConfig{
+		CertificateSecretConfig: &secretutils.CertificateSecretConfig{
+			Name:         bootstrapKubeconfigSecret.Name,
+			CommonName:   "gardener.cloud:system:gardener-resource-manager",
+			Organization: []string{user.SystemPrivilegedGroup},
+			SigningCA:    caCertificate,
+			CertType:     secretutils.ClientCert,
+			Validity:     utils.DurationPtr(10 * time.Minute),
+		},
+		KubeConfigRequests: []secretutils.KubeConfigRequest{{
+			ClusterName:   b.Shoot.SeedNamespace,
+			APIServerHost: b.Shoot.ComputeInClusterAPIServerAddress(true),
+		}},
+	}).GenerateControlPlane()
+	if err != nil {
+		return err
+	}
+
+	_, err = controllerutils.GetAndCreateOrMergePatch(ctx, b.K8sSeedClient.Client(), bootstrapKubeconfigSecret, func() error {
+		bootstrapKubeconfigSecret.Type = corev1.SecretTypeOpaque
+		bootstrapKubeconfigSecret.Data = map[string][]byte{resourcesv1alpha1.DataKeyKubeconfig: controlPlaneSecret.Kubeconfig}
+		return nil
+	})
+	return err
+}
+
+func (b *Botanist) waitUntilGardenerResourceManagerBootstrapped(ctx context.Context) error {
+	shootAccessSecret := gutil.NewShootAccessSecret(resourcemanager.SecretNameShootAccess, b.Shoot.SeedNamespace)
+
+	if err := retryutils.Until(ctx, 5*time.Second, func(ctx context.Context) (bool, error) {
+		if err2 := b.K8sSeedClient.Client().Get(ctx, client.ObjectKeyFromObject(shootAccessSecret.Secret), shootAccessSecret.Secret); err2 != nil {
+			if apierrors.IsNotFound(err2) {
+				return retryutils.MinorError(err2)
+			}
+			return retryutils.SevereError(err2)
+		}
+
+		renewTimestamp, ok := shootAccessSecret.Secret.Annotations[resourcesv1alpha1.ServiceAccountTokenRenewTimestamp]
+		if !ok {
+			return retryutils.MinorError(fmt.Errorf("token not yet generated"))
+		}
+
+		renewTime, err2 := time.Parse(time.RFC3339, renewTimestamp)
+		if err2 != nil {
+			return retryutils.SevereError(fmt.Errorf("could not parse renew timestamp: %w", err2))
+		}
+
+		if time.Now().UTC().After(renewTime.UTC()) {
+			return retryutils.MinorError(fmt.Errorf("token not yet renewed"))
+		}
+
+		return retryutils.Ok()
+	}); err != nil {
+		return err
+	}
+
+	return managedresources.WaitUntilHealthy(ctx, b.K8sSeedClient.Client(), b.Shoot.SeedNamespace, resourcemanager.ManagedResourceName)
 }

--- a/pkg/operation/botanist/resource_manager_test.go
+++ b/pkg/operation/botanist/resource_manager_test.go
@@ -17,18 +17,30 @@ package botanist_test
 import (
 	"context"
 	"fmt"
+	"time"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	fakekubernetes "github.com/gardener/gardener/pkg/client/kubernetes/fake"
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	"github.com/gardener/gardener/pkg/operation"
 	. "github.com/gardener/gardener/pkg/operation/botanist"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/resourcemanager"
 	mockresourcemanager "github.com/gardener/gardener/pkg/operation/botanist/component/resourcemanager/mock"
 	shootpkg "github.com/gardener/gardener/pkg/operation/shoot"
+	"github.com/gardener/gardener/pkg/utils/test"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("ResourceManager", func() {
@@ -50,28 +62,86 @@ var _ = Describe("ResourceManager", func() {
 		var (
 			resourceManager *mockresourcemanager.MockInterface
 
-			ctx           = context.TODO()
-			seedNamespace = "fake-seed-ns"
-			fakeErr       = fmt.Errorf("fake err")
+			ctx     = context.TODO()
+			fakeErr = fmt.Errorf("fake err")
 
-			secretName         = "gardener-resource-manager"
-			secretNameServer   = "gardener-resource-manager-server"
-			secretNameCA       = "ca"
-			checksum           = "1234"
-			checksumServer     = "5678"
-			checksumCA         = "9012"
-			secretDataServerCA = map[string][]byte{"ca.crt": []byte("cert")}
+			c             *mockclient.MockClient
+			k8sSeedClient kubernetes.Interface
+
+			seedNamespace = "fake-seed-ns"
+
+			secretNameCA         = "ca"
+			secretNameServer     = "gardener-resource-manager-server"
+			secretChecksumServer = "5678"
+			secretChecksumCA     = "9012"
+			secretDataServerCA   = map[string][]byte{
+				"ca.crt": []byte(`-----BEGIN CERTIFICATE-----
+MIIDYDCCAkigAwIBAgIUEb00DjvE8F0HiGOlQY/B/AG1AjMwDQYJKoZIhvcNAQEL
+BQAwSDELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1TYW4gRnJh
+bmNpc2NvMRQwEgYDVQQDEwtleGFtcGxlLm5ldDAeFw0yMDA1MTEwODU0MDBaFw0y
+NTA1MTAwODU0MDBaMEgxCzAJBgNVBAYTAlVTMQswCQYDVQQIEwJDQTEWMBQGA1UE
+BxMNU2FuIEZyYW5jaXNjbzEUMBIGA1UEAxMLZXhhbXBsZS5uZXQwggEiMA0GCSqG
+SIb3DQEBAQUAA4IBDwAwggEKAoIBAQC/YYT0dKAY9/1lR20Gs2CfAYdR3dMcc5bE
+ncD6pWoes8eZ54Am9J572o7hvVto73S/FcxF5Do06owJPVRZvHcgI4tRzbMvj5Is
+XyqmMyRayoayBKkaM6f/mOPjGonSIPl90ZboaDARp9Vk9MfoLoXvRWLLF/TNpQf9
+Y2rAPkInJ0fekooZewob/amoTw2Ek/KLWaQHjr6LfddL0yXotniIG6iWddSmcrON
+zZEAskqNqgau6kmfK06XUK2hyJL6voeTyPchtQh83bXG/Rih43CzO3qDY6IMnJH3
+0wsGFrJDsLq/9bDO8X3xFwU7YoH628BzIyFHuixEz5uNdwE35L7LAgMBAAGjQjBA
+MA4GA1UdDwEB/wQEAwIBBjAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBRIb9F1
+tE70YCjoXdjm5LeJSK9eojANBgkqhkiG9w0BAQsFAAOCAQEAdVb8yUICkTt/jENU
+gvYBF3EGr8nNVC728Vatx1gmzVgudCydqHWx7clV5nuLgikXziNBpEwvr2ige3WL
+BwJ041CL8wBM2A/hhYkiujulpw0M1rzp/RGUvr5fxIHVvkaztB1lksWx83JCFzwC
+u8zZlKIZNR44i5pcrMylzLuyiwoFF4dJrYOgCbV2STAnDUEsT4k15ifT98Cg3Yuz
+xyIt/1Lw9rpEEUEB1hg3ouLDh4xjXFlJWSMw8X+n0DXToRWUrU1WPGut4C2uX58Y
+RMn7d2EqHa/0L8QHsfJBSb4IiCZ3lkPnTICC0E9/dXagH0jq76TPcmFjIy1vIPuX
+nvslPg==
+-----END CERTIFICATE-----`),
+				"ca.key": []byte(`-----BEGIN RSA PRIVATE KEY-----
+MIIEogIBAAKCAQEAv2GE9HSgGPf9ZUdtBrNgnwGHUd3THHOWxJ3A+qVqHrPHmeeA
+JvSee9qO4b1baO90vxXMReQ6NOqMCT1UWbx3ICOLUc2zL4+SLF8qpjMkWsqGsgSp
+GjOn/5jj4xqJ0iD5fdGW6GgwEafVZPTH6C6F70Viyxf0zaUH/WNqwD5CJydH3pKK
+GXsKG/2pqE8NhJPyi1mkB46+i33XS9Ml6LZ4iBuolnXUpnKzjc2RALJKjaoGrupJ
+nytOl1CtociS+r6Hk8j3IbUIfN21xv0YoeNwszt6g2OiDJyR99MLBhayQ7C6v/Ww
+zvF98RcFO2KB+tvAcyMhR7osRM+bjXcBN+S+ywIDAQABAoIBAETvJWrAD2KvALDY
+V2cQeX8Ml+dfFUmsQOQ1RmuB5YWFkCHZhwmBFwzZnpmlESXtCopBmcCbAnRI/4Pc
+eWORRP9ojig7BY3eEvK0nLIcvb2OMZIxp49uh9bDBWKqDnaHthYhxk+UJ6xUXcLt
+gIwbJdcXkQxCZsUj6orUooD4a++Zz7YGrfPZ7f1MTzhipzjwrv9sn4iTXJfijk+D
+IpE1HA+jfSsnd0bENKRUoP58+iS0bNZnIspKL2PYUSVJwkDs5r/WLEAqkjT/j8oH
+Sr/pHIQIh18Snp16urJPIuI0aHTG79qcD4Bcighr/mif2CehitInoPgSu5YlJ3Ki
+y0jiORECgYEAwmVihnZVhk1rW5b9JAyj7mzlezdQJU5FtEqOn00H8ARgygFJNKK1
+TpZxPC5nTRrnRSdeH6m4WPtSO/4lXfSY2oiO2f/S1gwWF13i1clBFxwiRnfpeDhF
+LWWE/m6UvjSqoFF9D2g5NTTAtV55OgTT0NuPM0Dl9nRsyqLS2qceXXUCgYEA/AeH
+5l9eUjYttDIM9zPKXSyqFzBME6P+Lje2znCRFkS0l6xPXecdjMg8zWF3CMuYKbdl
+BfXqaArUdtPHN2yS3SolZkPtUdRsYncq0skmQqFjvAqsvxhHmd9vJ+14bK6qFwf9
+Xk+0+6mvGXABiwfGtgKRGRVXptP065jIZP254z8CgYB68vivpqRM/yZJlWOhq0T7
+hXBW0BMmpSy87PLrmiLNEVfOK6YLXmVhwRD5STgYsk1XlaCYUhXAYaQPQZyMoikS
+/o+rHXxR2O8X9E+Fe3ZpkWe0Ph8x5BUMs0q8SWBWNKU+JIv+dKLKHgVMMOZnZao6
+TMNzXTaU++na98R4en5gCQKBgDmwG5pOsA9PWWzKnA8laqejJpfCNVe1jOPVWuGs
+AHnBZjjldxE+apQj7U7xhUadG4pI8TXJEUuZVwKP/SShlIhNMlxTJgo5/kkXj9TJ
+uBk+Sc7r/piLHTCKZS4VfCAcZtB4wrUIt5t3Pp4q9h91uzVEJyQ/r11/XKtkwFHl
+hdwPAoGARP6NCOGqsjC1lpasktu7nO9OB01BRBY234rInHijTDORY65nn5OuL/Xb
+WifluILPHrTS8ZUNpjy6j2CUG626TPUORKmMw+p199Ve3VxlMp2g29INt+HwwJUO
+nQwHTbS7lsjLl4cdJWWZ/k1euUyKSpeJtSIwiXyF2kogjOoNh84=
+-----END RSA PRIVATE KEY-----`),
+			}
+			secrets resourcemanager.Secrets
+
+			bootstrapKubeconfigSecret *corev1.Secret
+			shootAccessSecret         *corev1.Secret
+			managedResource           *resourcesv1alpha1.ManagedResource
 		)
 
 		BeforeEach(func() {
 			resourceManager = mockresourcemanager.NewMockInterface(ctrl)
 
-			botanist.StoreCheckSum(secretName, checksum)
-			botanist.StoreCheckSum(secretNameCA, checksumCA)
-			botanist.StoreCheckSum(secretNameServer, checksumServer)
+			c = mockclient.NewMockClient(ctrl)
+			k8sSeedClient = fakekubernetes.NewClientSetBuilder().WithClient(c).Build()
 
+			botanist.StoreCheckSum(secretNameCA, secretChecksumCA)
+			botanist.StoreCheckSum(secretNameServer, secretChecksumServer)
 			botanist.StoreSecret(secretNameCA, &corev1.Secret{Data: secretDataServerCA})
 
+			botanist.K8sSeedClient = k8sSeedClient
 			botanist.Shoot = &shootpkg.Shoot{
 				Components: &shootpkg.Components{
 					ControlPlane: &shootpkg.ControlPlane{
@@ -81,22 +151,322 @@ var _ = Describe("ResourceManager", func() {
 				SeedNamespace: seedNamespace,
 			}
 
-			resourceManager.EXPECT().SetSecrets(resourcemanager.Secrets{
-				Kubeconfig: component.Secret{Name: secretName, Checksum: checksum},
-				ServerCA:   component.Secret{Name: secretNameCA, Checksum: checksumCA, Data: secretDataServerCA},
-				Server:     component.Secret{Name: secretNameServer, Checksum: checksumServer},
-				RootCA:     &component.Secret{Name: secretNameCA, Checksum: checksumCA},
+			secrets = resourcemanager.Secrets{
+				ServerCA: component.Secret{Name: secretNameCA, Checksum: secretChecksumCA, Data: secretDataServerCA},
+				Server:   component.Secret{Name: secretNameServer, Checksum: secretChecksumServer},
+				RootCA:   &component.Secret{Name: secretNameCA, Checksum: secretChecksumCA},
+			}
+
+			bootstrapKubeconfigSecret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "shoot-access-gardener-resource-manager-bootstrap",
+					Namespace: seedNamespace,
+				},
+			}
+			shootAccessSecret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "shoot-access-gardener-resource-manager",
+					Namespace: seedNamespace,
+					Annotations: map[string]string{
+						"serviceaccount.resources.gardener.cloud/token-renew-timestamp": time.Now().Add(time.Hour).Format(time.RFC3339),
+					},
+				},
+			}
+			managedResource = &resourcesv1alpha1.ManagedResource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "shoot-core-gardener-resource-manager",
+					Namespace: seedNamespace,
+				},
+			}
+		})
+
+		Context("w/o bootstrapping", func() {
+			BeforeEach(func() {
+				gomock.InOrder(
+					// ensure bootstrapping prerequisites are not met
+					c.EXPECT().Get(ctx, client.ObjectKeyFromObject(shootAccessSecret), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret) error {
+						obj.Annotations = map[string]string{"serviceaccount.resources.gardener.cloud/token-renew-timestamp": time.Now().Add(time.Hour).Format(time.RFC3339)}
+						return nil
+					}),
+					c.EXPECT().Get(ctx, client.ObjectKeyFromObject(managedResource), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})),
+
+					// always delete bootstrap kubeconfig
+					c.EXPECT().Delete(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, obj *corev1.Secret, opts ...client.DeleteOption) error {
+						Expect(obj.Name).To(Equal(bootstrapKubeconfigSecret.Name))
+						Expect(obj.Namespace).To(Equal(bootstrapKubeconfigSecret.Namespace))
+						return nil
+					}),
+
+					// set secrets
+					resourceManager.EXPECT().SetSecrets(secrets),
+				)
+			})
+
+			It("should delete the bootstrap kubeconfig secret (if exists), set the secrets and deploy", func() {
+				resourceManager.EXPECT().Deploy(ctx)
+				Expect(botanist.DeployGardenerResourceManager(ctx)).To(Succeed())
+			})
+
+			It("should fail when the deploy function fails", func() {
+				resourceManager.EXPECT().Deploy(ctx).Return(fakeErr)
+				Expect(botanist.DeployGardenerResourceManager(ctx)).To(MatchError(fakeErr))
 			})
 		})
 
-		It("should set the secrets and deploy", func() {
-			resourceManager.EXPECT().Deploy(ctx)
-			Expect(botanist.DeployGardenerResourceManager(ctx)).To(Succeed())
-		})
+		Context("w/ bootstrapping", func() {
+			Context("with success", func() {
+				AfterEach(func() {
+					defer test.WithVar(&TimeoutWaitForGardenerResourceManagerBootstrapping, time.Second)()
 
-		It("should fail when the deploy function fails", func() {
-			resourceManager.EXPECT().Deploy(ctx).Return(fakeErr)
-			Expect(botanist.DeployGardenerResourceManager(ctx)).To(MatchError(fakeErr))
+					gomock.InOrder(
+						// create bootstrap kubeconfig
+						c.EXPECT().Get(ctx, client.ObjectKeyFromObject(bootstrapKubeconfigSecret), gomock.AssignableToTypeOf(&corev1.Secret{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+						c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, s *corev1.Secret, _ ...client.CreateOption) error {
+							Expect(s.Data["kubeconfig"]).NotTo(BeNil())
+							return nil
+						}),
+
+						// set secrets and deploy with bootstrap kubeconfig
+						resourceManager.EXPECT().SetSecrets(&secretMatcher{
+							bootstrapKubeconfigName: &bootstrapKubeconfigSecret.Name,
+							serverCA:                secrets.ServerCA,
+							server:                  secrets.Server,
+							rootCA:                  secrets.RootCA,
+						}),
+						resourceManager.EXPECT().Deploy(ctx),
+
+						// wait for shoot access secret to be reconciled and managed resource to be healthy
+						c.EXPECT().Get(gomock.Any(), client.ObjectKeyFromObject(shootAccessSecret), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret) error {
+							obj.Annotations = map[string]string{"serviceaccount.resources.gardener.cloud/token-renew-timestamp": time.Now().Add(time.Hour).Format(time.RFC3339)}
+							return nil
+						}),
+						c.EXPECT().Get(gomock.Any(), client.ObjectKeyFromObject(managedResource), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *resourcesv1alpha1.ManagedResource) error {
+							obj.Status.ObservedGeneration = obj.Generation
+							obj.Status.Conditions = []gardencorev1beta1.Condition{
+								{Type: "ResourcesApplied", Status: gardencorev1beta1.ConditionTrue},
+								{Type: "ResourcesHealthy", Status: gardencorev1beta1.ConditionTrue},
+							}
+							return nil
+						}),
+
+						// delete bootstrap kubeconfig
+						c.EXPECT().Delete(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, obj *corev1.Secret, opts ...client.DeleteOption) error {
+							Expect(obj.Name).To(Equal(bootstrapKubeconfigSecret.Name))
+							Expect(obj.Namespace).To(Equal(bootstrapKubeconfigSecret.Namespace))
+							return nil
+						}),
+
+						// set secrets and deploy with shoot access token
+						resourceManager.EXPECT().SetSecrets(secrets),
+						resourceManager.EXPECT().Deploy(ctx),
+					)
+
+					Expect(botanist.DeployGardenerResourceManager(ctx)).To(Succeed())
+				})
+
+				It("bootstraps because the shoot access secret was not found", func() {
+					c.EXPECT().Get(ctx, client.ObjectKeyFromObject(shootAccessSecret), gomock.AssignableToTypeOf(&corev1.Secret{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
+				})
+
+				It("bootstraps because the shoot access secret was not renewed", func() {
+					c.EXPECT().Get(ctx, client.ObjectKeyFromObject(shootAccessSecret), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret) error {
+						obj.Annotations = map[string]string{"serviceaccount.resources.gardener.cloud/token-renew-timestamp": time.Now().Add(-time.Hour).Format(time.RFC3339)}
+						return nil
+					})
+				})
+
+				It("bootstraps because the managed resource was not found", func() {
+					c.EXPECT().Get(ctx, client.ObjectKeyFromObject(shootAccessSecret), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret) error {
+						obj.Annotations = map[string]string{"serviceaccount.resources.gardener.cloud/token-renew-timestamp": time.Now().Add(time.Hour).Format(time.RFC3339)}
+						return nil
+					})
+					c.EXPECT().Get(ctx, client.ObjectKeyFromObject(managedResource), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
+				})
+
+				It("bootstraps because the managed resource indicates that the shoot access token lost access", func() {
+					c.EXPECT().Get(ctx, client.ObjectKeyFromObject(shootAccessSecret), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret) error {
+						obj.Annotations = map[string]string{"serviceaccount.resources.gardener.cloud/token-renew-timestamp": time.Now().Add(time.Hour).Format(time.RFC3339)}
+						return nil
+					})
+					c.EXPECT().Get(ctx, client.ObjectKeyFromObject(managedResource), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *resourcesv1alpha1.ManagedResource) error {
+						obj.Status.ObservedGeneration = obj.Generation
+						obj.Status.Conditions = []gardencorev1beta1.Condition{
+							{Type: "ResourcesApplied", Status: gardencorev1beta1.ConditionFalse, Message: `forbidden: User "system:serviceaccount:kube-system:gardener-resource-manager" cannot do anything`},
+							{Type: "ResourcesHealthy", Status: gardencorev1beta1.ConditionTrue},
+						}
+						return nil
+					})
+				})
+			})
+
+			Context("with failure", func() {
+				BeforeEach(func() {
+					// ensure bootstrapping preconditions are met
+					c.EXPECT().Get(ctx, client.ObjectKeyFromObject(shootAccessSecret), gomock.AssignableToTypeOf(&corev1.Secret{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
+				})
+
+				It("fails because the bootstrap kubeconfig secret cannot be created", func() {
+					gomock.InOrder(
+						c.EXPECT().Get(ctx, client.ObjectKeyFromObject(bootstrapKubeconfigSecret), gomock.AssignableToTypeOf(&corev1.Secret{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+						c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Return(fakeErr),
+					)
+
+					Expect(botanist.DeployGardenerResourceManager(ctx)).To(MatchError(fakeErr))
+				})
+
+				Context("waiting for bootstrapping process", func() {
+					BeforeEach(func() {
+						gomock.InOrder(
+							// create bootstrap kubeconfig
+							c.EXPECT().Get(ctx, client.ObjectKeyFromObject(bootstrapKubeconfigSecret), gomock.AssignableToTypeOf(&corev1.Secret{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+							c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})),
+
+							// set secrets and deploy with bootstrap kubeconfig
+							resourceManager.EXPECT().SetSecrets(&secretMatcher{
+								bootstrapKubeconfigName: &bootstrapKubeconfigSecret.Name,
+								serverCA:                secrets.ServerCA,
+								server:                  secrets.Server,
+								rootCA:                  secrets.RootCA,
+							}),
+							resourceManager.EXPECT().Deploy(ctx),
+						)
+					})
+
+					It("fails because the shoot access token was not generated", func() {
+						defer test.WithVar(&TimeoutWaitForGardenerResourceManagerBootstrapping, time.Millisecond)()
+
+						c.EXPECT().Get(gomock.Any(), client.ObjectKeyFromObject(shootAccessSecret), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret) error {
+							obj.Annotations = nil
+							return nil
+						})
+
+						Expect(botanist.DeployGardenerResourceManager(ctx)).To(MatchError(ContainSubstring("token not yet generated")))
+					})
+
+					It("fails because the shoot access token renew timestamp cannot be parsed", func() {
+						defer test.WithVar(&TimeoutWaitForGardenerResourceManagerBootstrapping, time.Millisecond)()
+
+						c.EXPECT().Get(gomock.Any(), client.ObjectKeyFromObject(shootAccessSecret), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret) error {
+							obj.Annotations = map[string]string{"serviceaccount.resources.gardener.cloud/token-renew-timestamp": "foo"}
+							return nil
+						})
+
+						Expect(botanist.DeployGardenerResourceManager(ctx).Error()).To(ContainSubstring("could not parse renew timestamp"))
+					})
+
+					It("fails because the shoot access token was not renewed", func() {
+						defer test.WithVar(&TimeoutWaitForGardenerResourceManagerBootstrapping, time.Millisecond)()
+
+						c.EXPECT().Get(gomock.Any(), client.ObjectKeyFromObject(shootAccessSecret), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret) error {
+							obj.Annotations = map[string]string{"serviceaccount.resources.gardener.cloud/token-renew-timestamp": time.Now().Add(-time.Hour).Format(time.RFC3339)}
+							return nil
+						})
+
+						Expect(botanist.DeployGardenerResourceManager(ctx).Error()).To(ContainSubstring("token not yet renewed"))
+					})
+
+					It("fails because the managed resource is not getting healthy", func() {
+						defer test.WithVar(&TimeoutWaitForGardenerResourceManagerBootstrapping, time.Millisecond)()
+
+						gomock.InOrder(
+							c.EXPECT().Get(gomock.Any(), client.ObjectKeyFromObject(shootAccessSecret), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret) error {
+								obj.Annotations = map[string]string{"serviceaccount.resources.gardener.cloud/token-renew-timestamp": time.Now().Add(time.Hour).Format(time.RFC3339)}
+								return nil
+							}),
+							c.EXPECT().Get(gomock.Any(), client.ObjectKeyFromObject(managedResource), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *resourcesv1alpha1.ManagedResource) error {
+								obj.Status.ObservedGeneration = -1
+								return nil
+							}),
+						)
+
+						Expect(botanist.DeployGardenerResourceManager(ctx).Error()).To(ContainSubstring(fmt.Sprintf("managed resource %s/%s is not healthy", seedNamespace, managedResource.Name)))
+					})
+				})
+
+				It("fails because the bootstrap kubeconfig cannot be deleted", func() {
+					gomock.InOrder(
+						// create bootstrap kubeconfig
+						c.EXPECT().Get(ctx, client.ObjectKeyFromObject(bootstrapKubeconfigSecret), gomock.AssignableToTypeOf(&corev1.Secret{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+						c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, s *corev1.Secret, _ ...client.CreateOption) error {
+							Expect(s.Data["kubeconfig"]).NotTo(BeNil())
+							return nil
+						}),
+
+						// set secrets and deploy with bootstrap kubeconfig
+						resourceManager.EXPECT().SetSecrets(&secretMatcher{
+							bootstrapKubeconfigName: &bootstrapKubeconfigSecret.Name,
+							serverCA:                secrets.ServerCA,
+							server:                  secrets.Server,
+							rootCA:                  secrets.RootCA,
+						}),
+						resourceManager.EXPECT().Deploy(ctx),
+
+						// wait for shoot access secret to be reconciled and managed resource to be healthy
+						c.EXPECT().Get(gomock.Any(), client.ObjectKeyFromObject(shootAccessSecret), gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret) error {
+							obj.Annotations = map[string]string{"serviceaccount.resources.gardener.cloud/token-renew-timestamp": time.Now().Add(time.Hour).Format(time.RFC3339)}
+							return nil
+						}),
+						c.EXPECT().Get(gomock.Any(), client.ObjectKeyFromObject(managedResource), gomock.AssignableToTypeOf(&resourcesv1alpha1.ManagedResource{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *resourcesv1alpha1.ManagedResource) error {
+							obj.Status.ObservedGeneration = obj.Generation
+							obj.Status.Conditions = []gardencorev1beta1.Condition{
+								{Type: "ResourcesApplied", Status: gardencorev1beta1.ConditionTrue},
+								{Type: "ResourcesHealthy", Status: gardencorev1beta1.ConditionTrue},
+							}
+							return nil
+						}),
+
+						// delete bootstrap kubeconfig
+						c.EXPECT().Delete(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(_ context.Context, obj *corev1.Secret, opts ...client.DeleteOption) error {
+							Expect(obj.Name).To(Equal(bootstrapKubeconfigSecret.Name))
+							Expect(obj.Namespace).To(Equal(bootstrapKubeconfigSecret.Namespace))
+							return fakeErr
+						}),
+					)
+
+					Expect(botanist.DeployGardenerResourceManager(ctx)).To(MatchError(fakeErr))
+				})
+			})
 		})
 	})
 })
+
+type secretMatcher struct {
+	bootstrapKubeconfigName *string
+	serverCA                component.Secret
+	server                  component.Secret
+	rootCA                  *component.Secret
+}
+
+func (m *secretMatcher) Matches(x interface{}) bool {
+	req, ok := x.(resourcemanager.Secrets)
+	if !ok {
+		return false
+	}
+
+	if m.bootstrapKubeconfigName != nil && (req.BootstrapKubeconfig == nil || req.BootstrapKubeconfig.Name != *m.bootstrapKubeconfigName) {
+		return false
+	}
+
+	if !apiequality.Semantic.DeepEqual(m.serverCA, req.ServerCA) {
+		return false
+	}
+
+	if !apiequality.Semantic.DeepEqual(m.server, req.Server) {
+		return false
+	}
+
+	if m.rootCA != nil && (req.RootCA == nil || !apiequality.Semantic.DeepEqual(*m.rootCA, *req.RootCA)) {
+		return false
+	}
+
+	return true
+}
+
+func (m *secretMatcher) String() string {
+	return fmt.Sprintf(`Secret Matcher:
+bootstrapKubeconfigName: %v,
+serverCA: %v
+server: %v
+rootCA: %v
+`, m.bootstrapKubeconfigName, m.serverCA, m.server, m.rootCA)
+}

--- a/pkg/operation/botanist/wanted_secrets.go
+++ b/pkg/operation/botanist/wanted_secrets.go
@@ -223,26 +223,6 @@ func (b *Botanist) generateWantedSecretConfigs(basicAuthAPIServer *secrets.Basic
 			},
 		},
 
-		// Secret definition for gardener-resource-manager
-		&secrets.ControlPlaneSecretConfig{
-			CertificateSecretConfig: &secrets.CertificateSecretConfig{
-				Name: resourcemanager.SecretName,
-
-				CommonName:   resourcemanager.UserName,
-				Organization: []string{user.SystemPrivilegedGroup},
-				DNSNames:     nil,
-				IPAddresses:  nil,
-
-				CertType:  secrets.ClientCert,
-				SigningCA: certificateAuthorities[v1beta1constants.SecretNameCACluster],
-			},
-
-			KubeConfigRequests: []secrets.KubeConfigRequest{{
-				ClusterName:   b.Shoot.SeedNamespace,
-				APIServerHost: b.Shoot.ComputeInClusterAPIServerAddress(true),
-			}},
-		},
-
 		// Secret definition for gardener-resource-manager server
 		&secrets.CertificateSecretConfig{
 			Name: resourcemanager.SecretNameServer,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement
/merge squash

**What this PR does / why we need it**:
Similar to #4931, this PR eliminates the client certificate for the `gardener-resource-manager` in favor of a token managed by its own `TokenRequestor` controller.

Unlike the prior PRs related to #4661, this PR is a bit different since `gardener-resource-manager` is special as it's "the root" of the token issuing. 
The basic idea is that it manages a regular shoot access token for itself, just like all other components use such token. However, for the bootstrapping process (initial token issuing), a temporary client certificate will be generated which is only valid for `10m` and is only used such that GRM generates its own shoot access token. Once this has happened, GRM will be redeployed without the bootstrap kubeconfig, i.e., from then on it'll use its shoot access token and renew it periodically.

There are certain conditions when gardenlet retriggers this bootstrap process:

- Shoot access token was not renewed
- ManagedResource indicates that the token lost access

Obviously, this only works when gardenlet reconciles the shoot cluster.

**Which issue(s) this PR fixes**:
Part of #4661
Part of #4878

**Special notes for your reviewer**:
/invite @BeckerMax

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
`gardener-resource-manager` does no longer use a client certificate but an auto-rotated `ServiceAccount` token which is only valid for `24h`.
```