### PR TITLE
[release-v1.37] Automated cherry pick of #5116: Specify minAllowed for the gardener-resource-manager VPA

### DIFF
--- a/pkg/operation/botanist/component/resourcemanager/resource_manager.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager.go
@@ -199,6 +199,15 @@ type Values struct {
 	// WatchedNamespace restricts the gardener-resource-manager to only watch ManagedResources in the defined namespace.
 	// If not set the gardener-resource-manager controller watches for ManagedResources in all namespaces
 	WatchedNamespace *string
+	// VPA contains information for configuring VerticalPodAutoscaler settings for the gardener-resource-manager deployment.
+	VPA *VPAConfig
+}
+
+// VPAConfig contains information for configuring VerticalPodAutoscaler settings for the gardener-resource-manager deployment.
+type VPAConfig struct {
+	// MinAllowed specifies the minimal amount of resources that will be recommended
+	// for the container.
+	MinAllowed corev1.ResourceList
 }
 
 func (r *resourceManager) Deploy(ctx context.Context) error {
@@ -743,6 +752,14 @@ func (r *resourceManager) ensureVPA(ctx context.Context) error {
 		}
 		vpa.Spec.UpdatePolicy = &autoscalingv1beta2.PodUpdatePolicy{
 			UpdateMode: &vpaUpdateMode,
+		}
+		vpa.Spec.ResourcePolicy = &autoscalingv1beta2.PodResourcePolicy{
+			ContainerPolicies: []autoscalingv1beta2.ContainerResourcePolicy{
+				{
+					ContainerName: autoscalingv1beta2.DefaultContainerResourcePolicy,
+					MinAllowed:    r.values.VPA.MinAllowed,
+				},
+			},
 		}
 		return nil
 	})

--- a/pkg/operation/botanist/component/resourcemanager/resource_manager_test.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager_test.go
@@ -268,6 +268,12 @@ var _ = Describe("ResourceManager", func() {
 			TargetDiffersFromSourceCluster:       true,
 			TargetDisableCache:                   &targetDisableCache,
 			WatchedNamespace:                     &watchedNamespace,
+			VPA: &VPAConfig{
+				MinAllowed: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("20m"),
+					corev1.ResourceMemory: resource.MustParse("30Mi"),
+				},
+			},
 		}
 		resourceManager = New(c, deployNamespace, image, replicas, cfg)
 		resourceManager.SetSecrets(secrets)
@@ -518,6 +524,17 @@ var _ = Describe("ResourceManager", func() {
 				},
 				UpdatePolicy: &autoscalingv1beta2.PodUpdatePolicy{
 					UpdateMode: &updateMode,
+				},
+				ResourcePolicy: &autoscalingv1beta2.PodResourcePolicy{
+					ContainerPolicies: []autoscalingv1beta2.ContainerResourcePolicy{
+						{
+							ContainerName: autoscalingv1beta2.DefaultContainerResourcePolicy,
+							MinAllowed: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("20m"),
+								corev1.ResourceMemory: resource.MustParse("30Mi"),
+							},
+						},
+					},
 				},
 			},
 		}

--- a/pkg/operation/botanist/resource_manager.go
+++ b/pkg/operation/botanist/resource_manager.go
@@ -27,6 +27,8 @@ import (
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/component-base/version"
 	"k8s.io/utils/pointer"
 )
@@ -57,6 +59,12 @@ func (b *Botanist) DefaultResourceManager() (resourcemanager.Interface, error) {
 		SyncPeriod:                           utils.DurationPtr(time.Minute),
 		TargetDisableCache:                   pointer.Bool(true),
 		WatchedNamespace:                     pointer.String(b.Shoot.SeedNamespace),
+		VPA: &resourcemanager.VPAConfig{
+			MinAllowed: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("20m"),
+				corev1.ResourceMemory: resource.MustParse("30Mi"),
+			},
+		},
 	}
 
 	// ensure grm is present during hibernation (if the cluster is not hibernated yet) to reconcile any changes to

--- a/pkg/operation/seed/components.go
+++ b/pkg/operation/seed/components.go
@@ -45,6 +45,7 @@ import (
 	scalerapi "github.com/gardener/dependency-watchdog/pkg/scaler/api"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/component-base/version"
 	"k8s.io/utils/pointer"
@@ -119,6 +120,12 @@ func defaultGardenerResourceManager(c client.Client, imageVector imagevector.Ima
 		HealthSyncPeriod:                     utils.DurationPtr(time.Minute),
 		ResourceClass:                        pointer.String(v1beta1constants.SeedResourceManagerClass),
 		SyncPeriod:                           utils.DurationPtr(time.Hour),
+		VPA: &resourcemanager.VPAConfig{
+			MinAllowed: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("20m"),
+				corev1.ResourceMemory: resource.MustParse("64Mi"),
+			},
+		},
 	})
 
 	gardenerResourceManager.SetSecrets(resourcemanager.Secrets{


### PR DESCRIPTION
/kind/enhancement
/area/control-plane
/area/auto-scaling

Cherry pick of #5116 on release-v1.37.

#5116: Specify minAllowed for the gardener-resource-manager VPA

**Release Notes:**
```other operator
The gardener-resource-manager VPA does now specify minAllowed values to prevent too low resource recommendations from VPA that lead to OOM.
```