### PR TITLE
Enhancements in the hibernation integration tests to make the compatible with ManagedSeeds

### DIFF
--- a/test/framework/k8s_utils.go
+++ b/test/framework/k8s_utils.go
@@ -310,6 +310,10 @@ func ShootCreationCompleted(newShoot *gardencorev1beta1.Shoot) (bool, string) {
 
 	for _, condition := range newShoot.Status.Conditions {
 		if condition.Status != gardencorev1beta1.ConditionTrue {
+			hibernation := newShoot.Spec.Hibernation
+			if condition.Type == gardencorev1beta1.SeedGardenletReady && hibernation != nil && hibernation.Enabled != nil && *hibernation.Enabled {
+				continue
+			}
 			return false, fmt.Sprintf("condition type %s is not true yet, had message %s with reason %s", condition.Type, condition.Message, condition.Reason)
 		}
 	}

--- a/test/framework/shootframework.go
+++ b/test/framework/shootframework.go
@@ -49,6 +49,7 @@ type ShootConfig struct {
 
 	CreateTestNamespace         bool
 	DisableTestNamespaceCleanup bool
+	SkipSeedInitialization      bool
 }
 
 // ShootFramework represents the shoot test framework that includes
@@ -194,7 +195,7 @@ func (f *ShootFramework) AddShoot(ctx context.Context, shootName, shootNamespace
 	}
 
 	// seed could be temporarily offline so no specified seed is a valid state
-	if shoot.Spec.SeedName != nil {
+	if shoot.Spec.SeedName != nil && !f.Config.SkipSeedInitialization {
 		f.Seed, f.SeedClient, err = f.GetSeed(ctx, *shoot.Spec.SeedName)
 		if err != nil {
 			return err

--- a/test/system/shoot_hibernation/hibernation_test.go
+++ b/test/system/shoot_hibernation/hibernation_test.go
@@ -28,12 +28,14 @@ func init() {
 }
 
 var _ = Describe("Shoot hibernation testing", func() {
-	f := framework.NewShootFramework(nil)
+	f := framework.NewShootFramework(&framework.ShootConfig{
+		SkipSeedInitialization: true,
+	})
 
 	framework.CIt("should hibernate shoot", func(ctx context.Context) {
 		hibernation := f.Shoot.Spec.Hibernation
 		if hibernation != nil && hibernation.Enabled != nil && *hibernation.Enabled {
-			Fail("shoot is already hibernated")
+			Skip("shoot is already hibernated")
 		}
 
 		err := f.HibernateShoot(ctx)

--- a/test/system/shoot_hibernation_wakeup/hibernation_test.go
+++ b/test/system/shoot_hibernation_wakeup/hibernation_test.go
@@ -28,12 +28,14 @@ func init() {
 }
 
 var _ = Describe("Shoot hibernation wake-up testing", func() {
-	f := framework.NewShootFramework(nil)
+	f := framework.NewShootFramework(&framework.ShootConfig{
+		SkipSeedInitialization: true,
+	})
 
 	framework.CIt("should wake up shoot", func(ctx context.Context) {
 		hibernation := f.Shoot.Spec.Hibernation
 		if hibernation == nil || hibernation.Enabled == nil || !*hibernation.Enabled {
-			Fail("shoot is already woken up")
+			Skip("shoot is already woken up")
 		}
 
 		err := f.WakeUpShoot(ctx)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
This PR makes small adjustments to the `hibernation` and `wake-up` integration tests in order to make them compatible with `ManagedSeeds`.
1. When the shoot is being hibernated the test waits until all status conditions in the shoot points that the components are healthy. In case of hibernation the `gardenlet` will stop posting ready status and the condition will appears with `condition.Status != gardencorev1beta1.ConditionTrue` which is fine, so it needs to be skipped in the checks, otherwise the integration test will never finish and eventually it fail will time out.
2. Initialising the `SeedClient` is not needed in this case and it can cause different errors, if the `kubeconfig` in the `secretRef` use different authentication method than the allowed [here](https://github.com/gardener/gardener/blob/d0d451bb98bce04fd65e3246dff379cb3b319e6c/pkg/client/kubernetes/client.go#L219)
3. If the soot is already hibernated or waken-up the tests should not fail, but be skipped instead as we do in the `delete` test.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
