### PR TITLE
Disable etcd backup compaction by default

### DIFF
--- a/charts/gardener/gardenlet/values.yaml
+++ b/charts/gardener/gardenlet/values.yaml
@@ -159,16 +159,16 @@ global:
       #       namespace: istio-ingress-handler-2
       #       labels:
       #         istio: ingressgateway-handler-2
-      etcdConfig:
-        etcdController:
-          workers: 3
-        custodianController:
-          workers: 3
-        backupCompactionController:
-          workers: 3
-          enableBackupCompaction: false
-          eventsThreshold: 1000000
-          activeDeadlineDuration: "3h"
+    # etcdConfig:
+    #   etcdController:
+    #     workers: 3
+    #   custodianController:
+    #     workers: 3
+    #   backupCompactionController:
+    #     workers: 3
+    #     enableBackupCompaction: false
+    #     eventsThreshold: 1000000
+    #     activeDeadlineDuration: "3h"
     # seedConfig: {}
     # logging:
     #   fluentBit:

--- a/charts/gardener/gardenlet/values.yaml
+++ b/charts/gardener/gardenlet/values.yaml
@@ -166,7 +166,7 @@ global:
           workers: 3
         backupCompactionController:
           workers: 3
-          enableBackupCompaction: true
+          enableBackupCompaction: false
           eventsThreshold: 1000000
           activeDeadlineDuration: "3h"
     # seedConfig: {}

--- a/example/20-componentconfig-gardenlet.yaml
+++ b/example/20-componentconfig-gardenlet.yaml
@@ -151,7 +151,7 @@ etcdConfig:
     workers: 3
   backupCompactionController:
     workers: 3
-    enableBackupCompaction: true
+    enableBackupCompaction: false
     eventsThreshold: 1000000
     activeDeadlineDuration: "3h"
 # monitoring:

--- a/landscaper/pkg/gardenlet/chart/charttest/charttest.go
+++ b/landscaper/pkg/gardenlet/chart/charttest/charttest.go
@@ -778,7 +778,7 @@ func ComputeExpectedGardenletConfiguration(
 			},
 			BackupCompactionController: &gardenletconfigv1alpha1.BackupCompactionController{
 				Workers:                pointer.Int64(3),
-				EnableBackupCompaction: pointer.BoolPtr(true),
+				EnableBackupCompaction: pointer.BoolPtr(false),
 				EventsThreshold:        pointer.Int64Ptr(1000000),
 				ActiveDeadlineDuration: &metav1.Duration{Duration: time.Hour * 3},
 			},

--- a/landscaper/pkg/gardenlet/chart/charttest/charttest.go
+++ b/landscaper/pkg/gardenlet/chart/charttest/charttest.go
@@ -769,20 +769,6 @@ func ComputeExpectedGardenletConfiguration(
 			Namespace:   pointer.String(gardenletconfigv1alpha1.DefaultSNIIngresNamespace),
 			Labels:      map[string]string{"app": "istio-ingressgateway", "istio": "ingressgateway"},
 		}},
-		ETCDConfig: &gardenletconfigv1alpha1.ETCDConfig{
-			ETCDController: &gardenletconfigv1alpha1.ETCDController{
-				Workers: pointer.Int64(3),
-			},
-			CustodianController: &gardenletconfigv1alpha1.CustodianController{
-				Workers: pointer.Int64(3),
-			},
-			BackupCompactionController: &gardenletconfigv1alpha1.BackupCompactionController{
-				Workers:                pointer.Int64(3),
-				EnableBackupCompaction: pointer.BoolPtr(false),
-				EventsThreshold:        pointer.Int64Ptr(1000000),
-				ActiveDeadlineDuration: &metav1.Duration{Duration: time.Hour * 3},
-			},
-		},
 	}
 
 	if componentConfigUsesTlsServerConfig {
@@ -829,22 +815,7 @@ func VerifyGardenletComponentConfigConfigMap(ctx context.Context, c client.Clien
 	// unmarshal Gardenlet Configuration from deployed Config Map
 	componentConfigYaml := componentConfigCm.Data["config.yaml"]
 	Expect(componentConfigYaml).ToNot(HaveLen(0))
-	gardenletConfig := &gardenletconfigv1alpha1.GardenletConfiguration{
-		ETCDConfig: &gardenletconfigv1alpha1.ETCDConfig{
-			ETCDController: &gardenletconfigv1alpha1.ETCDController{
-				Workers: pointer.Int64(3),
-			},
-			CustodianController: &gardenletconfigv1alpha1.CustodianController{
-				Workers: pointer.Int64(3),
-			},
-			BackupCompactionController: &gardenletconfigv1alpha1.BackupCompactionController{
-				Workers:                pointer.Int64(3),
-				EnableBackupCompaction: pointer.BoolPtr(true),
-				EventsThreshold:        pointer.Int64Ptr(1000000),
-				ActiveDeadlineDuration: &metav1.Duration{Duration: time.Hour * 3},
-			},
-		},
-	}
+	gardenletConfig := &gardenletconfigv1alpha1.GardenletConfiguration{}
 	_, _, err := universalDecoder.Decode([]byte(componentConfigYaml), nil, gardenletConfig)
 	Expect(err).ToNot(HaveOccurred())
 	Expect(*gardenletConfig).To(DeepEqual(expectedGardenletConfig))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
This PR disables the etcd backup compaction feature by default. It should consciously be enabled by operators because the feature comes with certain cost implications (e.g. network traffic) and requires machines with a rather large root disk. 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The etcd backup compaction feature has been disabled by default. It can by enabled anytime via the `etcdConfig` section in the Gardenlet-Componentconfig.
```
