### PR TITLE
Enable `TokenRequestor` to regenerate tokens even if renew timestamp is not yet reached

### DIFF
--- a/pkg/resourcemanager/controller/tokenrequestor/reconciler.go
+++ b/pkg/resourcemanager/controller/tokenrequestor/reconciler.go
@@ -96,7 +96,7 @@ func (r *reconciler) Reconcile(reconcileCtx context.Context, req reconcile.Reque
 		return reconcile.Result{}, nil
 	}
 
-	mustRequeue, requeueAfter, err := r.requeue(ctx, secret.Annotations)
+	mustRequeue, requeueAfter, err := r.requeue(ctx, secret)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -190,14 +190,14 @@ func (r *reconciler) createServiceAccountToken(ctx context.Context, sa *corev1.S
 	return r.targetCoreV1Client.ServiceAccounts(sa.Namespace).CreateToken(ctx, sa.Name, tokenRequest, metav1.CreateOptions{})
 }
 
-func (r *reconciler) requeue(ctx context.Context, annotations map[string]string) (bool, time.Duration, error) {
-	renewTimestamp := annotations[resourcesv1alpha1.ServiceAccountTokenRenewTimestamp]
+func (r *reconciler) requeue(ctx context.Context, secret *corev1.Secret) (bool, time.Duration, error) {
+	renewTimestamp := secret.Annotations[resourcesv1alpha1.ServiceAccountTokenRenewTimestamp]
 
 	if len(renewTimestamp) == 0 {
 		return false, 0, nil
 	}
 
-	if targetSecret := getTargetSecretFromAnnotations(annotations); targetSecret != nil {
+	if targetSecret := getTargetSecretFromAnnotations(secret.Annotations); targetSecret != nil {
 		if err := r.targetClient.Get(ctx, client.ObjectKeyFromObject(targetSecret), targetSecret); err != nil {
 			if !apierrors.IsNotFound(err) {
 				return false, 0, fmt.Errorf("could not read target secret: %w", err)
@@ -205,6 +205,14 @@ func (r *reconciler) requeue(ctx context.Context, annotations map[string]string)
 			// target secret is not found, so do not requeue to make sure it gets created
 			return false, 0, nil
 		}
+	}
+
+	tokenExists, err := tokenExistsInSecretData(secret.Data)
+	if err != nil {
+		return false, 0, fmt.Errorf("could not check whether token exists in secret data: %w", err)
+	}
+	if !tokenExists {
+		return false, 0, nil
 	}
 
 	renewTime, err := time.Parse(time.RFC3339, renewTimestamp)
@@ -293,6 +301,19 @@ func updateTokenInSecretData(data map[string][]byte, token string) error {
 
 	data[resourcesv1alpha1.DataKeyKubeconfig] = kubeconfigEncoded
 	return nil
+}
+
+func tokenExistsInSecretData(data map[string][]byte) (bool, error) {
+	if _, ok := data[resourcesv1alpha1.DataKeyKubeconfig]; !ok {
+		return data[resourcesv1alpha1.DataKeyToken] != nil, nil
+	}
+
+	_, authInfo, err := decodeKubeconfigAndGetUser(data[resourcesv1alpha1.DataKeyKubeconfig])
+	if err != nil {
+		return false, err
+	}
+
+	return authInfo != nil && authInfo.Token != "", nil
 }
 
 func decodeKubeconfigAndGetUser(data []byte) (*clientcmdv1.Config, *clientcmdv1.AuthInfo, error) {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security robustness
/kind enhancement
/merge squash

**What this PR does / why we need it**:
This PR enables the `TokenRequestor` to regenerate tokens even if renew timestamp is not yet reached in case the token got missing.

**Special notes for your reviewer**:
/invite @timuthy

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
