### PR TITLE
Made the backup compaction feature disabled by default.

### DIFF
--- a/charts/gardener/gardenlet/values.yaml
+++ b/charts/gardener/gardenlet/values.yaml
@@ -161,16 +161,16 @@ global:
       #       namespace: istio-ingress-handler-2
       #       labels:
       #         istio: ingressgateway-handler-2
-      etcdConfig:
-        etcdController:
-          workers: 3
-        custodianController:
-          workers: 3
-        backupCompactionController:
-          workers: 3
-          enableBackupCompaction: true
-          eventsThreshold: 1000000
-          activeDeadlineDuration: "3h"
+      #etcdConfig:
+      #  etcdController:
+      #    workers: 3
+      #  custodianController:
+      #    workers: 3
+      #  backupCompactionController:
+      #    workers: 3
+      #    enableBackupCompaction: true
+      #    eventsThreshold: 1000000
+      #    activeDeadlineDuration: "3h"
     # seedConfig: {}
     # logging:
     #   fluentBit:

--- a/example/20-componentconfig-gardenlet.yaml
+++ b/example/20-componentconfig-gardenlet.yaml
@@ -146,16 +146,16 @@ featureGates:
 #       serviceExternalIP: 10.8.10.11 # Optional external ip for the ingress gateway load balancer.
 #       labels:
 #         network: internal
-etcdConfig:
-  etcdController:
-    workers: 3
-  custodianController:
-    workers: 3
-  backupCompactionController:
-    workers: 3
-    enableBackupCompaction: true
-    eventsThreshold: 1000000
-    activeDeadlineDuration: "3h"
+#etcdConfig:
+#  etcdController:
+#    workers: 3
+#  custodianController:
+#    workers: 3
+#  backupCompactionController:
+#    workers: 3
+#    enableBackupCompaction: true
+#    eventsThreshold: 1000000
+#    activeDeadlineDuration: "3h"
 # monitoring:
 #   shoot:
 #     remoteWrite:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area TODO
/kind TODO

**What this PR does / why we need it**:
We want backup compaction feature on seed disabled by default. Because there is cost implication with this feature. Only the seed owners who can justify the extra cost, can enable the feature for their seeds by modifying gardenlet configs.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Backup compaction feature is disabled by default.
```
