### PR TITLE
Keep the namespace and pod labels

### DIFF
--- a/charts/seed-bootstrap/charts/monitoring/templates/config.yaml
+++ b/charts/seed-bootstrap/charts/monitoring/templates/config.yaml
@@ -30,6 +30,10 @@ data:
         target_label: __address__
       - action: labelmap
         regex: __meta_kubernetes_pod_label_(.+)
+      - source_labels: [ __meta_kubernetes_namespace ]
+        target_label: namespace
+      - source_labels: [ __meta_kubernetes_pod_name ]
+        target_label: pod
 
     - job_name: garden
       scheme: https
@@ -53,6 +57,10 @@ data:
         target_label: __address__
       - action: labelmap
         regex: __meta_kubernetes_pod_label_(.+)
+      - source_labels: [ __meta_kubernetes_namespace ]
+        target_label: namespace
+      - source_labels: [ __meta_kubernetes_pod_name ]
+        target_label: pod
 
     - job_name: cadvisor
       metrics_path: /federate


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

The "extensions" and "garden" scrape configuration scrapes the pods that
are marked with an annotation in the garden and extension-.+ namespaces.

See #4560 for more details.

Previously, only the pod labels were kept as metric labels, the pod name
and the namespace were missing.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The namespace and pod labels are kept for the metrics in the seed-prometheus.
```
