### PR TITLE
Fix Shoot ClientSet hash calculation in ClientMap

### DIFF
--- a/pkg/client/kubernetes/clientmap/internal/shoot_clientmap_test.go
+++ b/pkg/client/kubernetes/clientmap/internal/shoot_clientmap_test.go
@@ -305,9 +305,7 @@ var _ = Describe("ShootClientMap", func() {
 		})
 
 		Context("correctly calculate hash", func() {
-			var secretName string
-
-			AfterEach(func() {
+			test := func(secretName string) {
 				changedTechnicalID := "foo"
 				gomock.InOrder(
 					mockGardenClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: shoot.Namespace, Name: shoot.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).
@@ -342,17 +340,17 @@ var _ = Describe("ShootClientMap", func() {
 				hash, err = factory.CalculateClientSetHash(ctx, keys.ForShoot(shoot))
 				Expect(hash).To(Equal("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"))
 				Expect(err).NotTo(HaveOccurred())
-			})
+			}
 
 			It("when in-cluster", func() {
-				secretName = "gardener-internal"
+				test("gardener-internal")
 			})
 
 			It("when out-of-cluster", func() {
 				internal.LookupHost = func(host string) ([]string, error) {
 					return nil, nil
 				}
-				secretName = "gardener"
+				test("gardener")
 			})
 		})
 	})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bug

**What this PR does / why we need it**:
Already introduced with #2449, the hash calulation for the Shoot clientset was always using the `gardener` secret (even if the client itself was then constructed based on the `gardener-internal` secret). We never noticed this since these secrets were static earlier, however, with #5012 this is no longer the case. Without this PR, clients may not be invalidated and refreshed again since the decision is taken based on the wrong secret.

On the way, I dropped the code for falling back to `gardener` in case the `gardener-internal` secret does not exist. This was only needed for migration purposes when we introduced `gardener-internal` back then, however, today we can expect that always both secret exists (or none at all).

**Special notes for your reviewer**:
/squash
/cc @timuthy @timebertt 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
