### PR TITLE
Fix json tags for etcd worker config

### DIFF
--- a/pkg/gardenlet/apis/config/types.go
+++ b/pkg/gardenlet/apis/config/types.go
@@ -426,14 +426,14 @@ type ETCDConfig struct {
 // ETCDController contains config specific to ETCD controller
 type ETCDController struct {
 	// Workers specify number of worker threads in ETCD controller
-	// Defaults to 3
+	// Defaults to 50
 	Workers *int64
 }
 
 // CustodianController contains config specific to custodian controller
 type CustodianController struct {
 	// Workers specify number of worker threads in custodian controller
-	// Defaults to 3
+	// Defaults to 10
 	Workers *int64
 }
 

--- a/pkg/gardenlet/apis/config/v1alpha1/types.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/types.go
@@ -513,7 +513,7 @@ type ETCDConfig struct {
 // ETCDController contains config specific to ETCD controller
 type ETCDController struct {
 	// Workers specify number of worker threads in ETCD controller
-	// Defaults to 3
+	// Defaults to 50
 	// +optional
 	Workers *int64 `json:"workers,omitempty"`
 }
@@ -521,7 +521,7 @@ type ETCDController struct {
 // CustodianController contains config specific to custodian controller
 type CustodianController struct {
 	// Workers specify number of worker threads in custodian controller
-	// Defaults to 3
+	// Defaults to 10
 	// +optional
 	Workers *int64 `json:"workers,omitempty"`
 }

--- a/pkg/gardenlet/apis/config/v1alpha1/types.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/types.go
@@ -515,7 +515,7 @@ type ETCDController struct {
 	// Workers specify number of worker threads in ETCD controller
 	// Defaults to 3
 	// +optional
-	Workers *int64 `json:"etcdControllerWorkers,omitempty"`
+	Workers *int64 `json:"workers,omitempty"`
 }
 
 // CustodianController contains config specific to custodian controller
@@ -523,7 +523,7 @@ type CustodianController struct {
 	// Workers specify number of worker threads in custodian controller
 	// Defaults to 3
 	// +optional
-	Workers *int64 `json:"custodianControllerWorkers,omitempty"`
+	Workers *int64 `json:"workers,omitempty"`
 }
 
 // BackupCompactionController contains config specific to backup compaction controller
@@ -531,7 +531,7 @@ type BackupCompactionController struct {
 	// Workers specify number of worker threads in backup compaction controller
 	// Defaults to 3
 	// +optional
-	Workers *int64 `json:"compactionControllerWorkers,omitempty"`
+	Workers *int64 `json:"workers,omitempty"`
 	// EnableBackupCompaction enables automatic compaction of etcd backups
 	// Defaults to false
 	// +optional


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind api-change
/needs cherry-pick

**What this PR does / why we need it**:
This PR amends the struct tags for `workers` configuration in the `etcdConfig`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This is an incompatible API change. However, the [example](https://github.com/gardener/gardener/blob/c52af1b21cc9a7340c1ca2574f107a2524a5c94c/example/20-componentconfig-gardenlet.yaml#L149-L158) as well as [chart values](https://github.com/gardener/gardener/blob/c52af1b21cc9a7340c1ca2574f107a2524a5c94c/charts/gardener/gardenlet/values.yaml#L164-L173) assume that the fields were called `workers` before, so the likelihood to break someone is rather small. From an end-user perspective setting the values "just" didn't work.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue has been fixed that prevented etcd worker counts from being set correctly in the `GardenletConfiguration`.
```
