### PR TITLE
[release-v1.37] Automated cherry pick of #5151: Fix json tags for etcd worker config

### DIFF
--- a/pkg/gardenlet/apis/config/types.go
+++ b/pkg/gardenlet/apis/config/types.go
@@ -419,14 +419,14 @@ type ETCDConfig struct {
 // ETCDController contains config specific to ETCD controller
 type ETCDController struct {
 	// Workers specify number of worker threads in ETCD controller
-	// Defaults to 3
+	// Defaults to 50
 	Workers *int64
 }
 
 // CustodianController contains config specific to custodian controller
 type CustodianController struct {
 	// Workers specify number of worker threads in custodian controller
-	// Defaults to 3
+	// Defaults to 10
 	Workers *int64
 }
 

--- a/pkg/gardenlet/apis/config/v1alpha1/types.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/types.go
@@ -504,7 +504,7 @@ type ETCDConfig struct {
 // ETCDController contains config specific to ETCD controller
 type ETCDController struct {
 	// Workers specify number of worker threads in ETCD controller
-	// Defaults to 3
+	// Defaults to 50
 	// +optional
 	Workers *int64 `json:"workers,omitempty"`
 }
@@ -512,7 +512,7 @@ type ETCDController struct {
 // CustodianController contains config specific to custodian controller
 type CustodianController struct {
 	// Workers specify number of worker threads in custodian controller
-	// Defaults to 3
+	// Defaults to 10
 	// +optional
 	Workers *int64 `json:"workers,omitempty"`
 }

--- a/pkg/gardenlet/apis/config/v1alpha1/types.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/types.go
@@ -506,7 +506,7 @@ type ETCDController struct {
 	// Workers specify number of worker threads in ETCD controller
 	// Defaults to 3
 	// +optional
-	Workers *int64 `json:"etcdControllerWorkers,omitempty"`
+	Workers *int64 `json:"workers,omitempty"`
 }
 
 // CustodianController contains config specific to custodian controller
@@ -514,7 +514,7 @@ type CustodianController struct {
 	// Workers specify number of worker threads in custodian controller
 	// Defaults to 3
 	// +optional
-	Workers *int64 `json:"custodianControllerWorkers,omitempty"`
+	Workers *int64 `json:"workers,omitempty"`
 }
 
 // BackupCompactionController contains config specific to backup compaction controller
@@ -522,7 +522,7 @@ type BackupCompactionController struct {
 	// Workers specify number of worker threads in backup compaction controller
 	// Defaults to 3
 	// +optional
-	Workers *int64 `json:"compactionControllerWorkers,omitempty"`
+	Workers *int64 `json:"workers,omitempty"`
 	// EnableBackupCompaction enables automatic compaction of etcd backups
 	// Defaults to false
 	// +optional


### PR DESCRIPTION
/kind/api-change
/area/control-plane

Cherry pick of #5151 on release-v1.37.

#5151: Fix json tags for etcd worker config

**Release Notes:**
```bugfix operator
An issue has been fixed that prevented etcd worker counts from being set correctly in the `GardenletConfiguration`.
```