### PR TITLE
🛡 Preparations for allowing extension controllers eliminating static credentials

### DIFF
--- a/extensions/pkg/controller/cmd/options.go
+++ b/extensions/pkg/controller/cmd/options.go
@@ -59,6 +59,9 @@ const (
 
 	// DisableFlag is the name of the command line flag to disable individual controllers.
 	DisableFlag = "disable-controllers"
+
+	// GardenerVersionFlag is the name of the command line flag containing the Gardener version.
+	GardenerVersionFlag = "gardener-version"
 )
 
 // LeaderElectionNameID returns a leader election ID for the given name.
@@ -425,4 +428,34 @@ func (d *SwitchOptions) Completed() *SwitchConfig {
 // SwitchConfig is the completed configuration of SwitchOptions.
 type SwitchConfig struct {
 	AddToManager func(manager.Manager) error
+}
+
+// GeneralOptions are command line options that can be set for general configuration.
+type GeneralOptions struct {
+	// GardenerVersion string
+	GardenerVersion string
+
+	config *GeneralConfig
+}
+
+// GeneralConfig is a completed general configuration.
+type GeneralConfig struct {
+	// GardenerVersion string
+	GardenerVersion string
+}
+
+// Complete implements Complete.
+func (r *GeneralOptions) Complete() error {
+	r.config = &GeneralConfig{r.GardenerVersion}
+	return nil
+}
+
+// Completed returns the completed GeneralConfig. Only call this if `Complete` was successful.
+func (r *GeneralOptions) Completed() *GeneralConfig {
+	return r.config
+}
+
+// AddFlags implements Flagger.AddFlags.
+func (r *GeneralOptions) AddFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&r.GardenerVersion, GardenerVersionFlag, "", "Version of the gardenlet.")
 }

--- a/extensions/pkg/controller/cmd/options_test.go
+++ b/extensions/pkg/controller/cmd/options_test.go
@@ -678,4 +678,55 @@ var _ = Describe("Options", func() {
 			})
 		})
 	})
+
+	Context("GeneralOptions", func() {
+		const (
+			name            = "foo"
+			gardenerVersion = "v1.2.3"
+		)
+
+		command := test.NewCommandBuilder(name).
+			Flags(
+				test.StringFlag(GardenerVersionFlag, gardenerVersion),
+			).
+			Command().
+			Slice()
+
+		Describe("#AddFlags", func() {
+			It("should add all flags", func() {
+				fs := pflag.NewFlagSet(name, pflag.ExitOnError)
+				opts := GeneralOptions{}
+
+				opts.AddFlags(fs)
+
+				Expect(fs.Parse(command)).NotTo(HaveOccurred())
+				Expect(opts).To(Equal(GeneralOptions{
+					GardenerVersion: gardenerVersion,
+				}))
+			})
+		})
+
+		Describe("#Complete", func() {
+			It("should complete without error calling BuildConfigFromFlags", func() {
+				opts := GeneralOptions{
+					GardenerVersion: gardenerVersion,
+				}
+
+				Expect(opts.Complete()).NotTo(HaveOccurred())
+			})
+		})
+
+		Describe("#Completed", func() {
+			It("should yield the expected result", func() {
+				opts := GeneralOptions{
+					GardenerVersion: gardenerVersion,
+				}
+
+				Expect(opts.Complete()).NotTo(HaveOccurred())
+				Expect(opts.Completed()).To(Equal(&GeneralConfig{
+					GardenerVersion: gardenerVersion,
+				}))
+			})
+		})
+	})
 })

--- a/extensions/pkg/controller/utils_test.go
+++ b/extensions/pkg/controller/utils_test.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/gardener/gardener/extensions/pkg/controller"
+	. "github.com/gardener/gardener/extensions/pkg/controller"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
@@ -27,7 +27,9 @@ import (
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
 	. "github.com/onsi/gomega"
+	gomegatypes "github.com/onsi/gomega/types"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -53,7 +55,7 @@ var _ = Describe("Utils", func() {
 
 	Describe("UnsafeGuessKind", func() {
 		It("should guess the kind correctly", func() {
-			Expect(controller.UnsafeGuessKind(&extensionsv1alpha1.Infrastructure{})).To(Equal("Infrastructure"))
+			Expect(UnsafeGuessKind(&extensionsv1alpha1.Infrastructure{})).To(Equal("Infrastructure"))
 		})
 	})
 
@@ -141,7 +143,7 @@ var _ = Describe("Utils", func() {
 				c.EXPECT().Update(ctx, worker),
 			)
 
-			Expect(controller.DeleteAllFinalizers(ctx, c, worker)).To(Succeed())
+			Expect(DeleteAllFinalizers(ctx, c, worker)).To(Succeed())
 			Expect(len(worker.Finalizers)).To(Equal(0))
 		})
 	})
@@ -172,7 +174,7 @@ var _ = Describe("Utils", func() {
 			ctx := context.TODO()
 			test.EXPECTPatch(ctx, c, expectedWorker, workerWithAnnotation, types.MergePatchType)
 
-			Expect(controller.RemoveAnnotation(ctx, c, worker, annotation)).To(Succeed())
+			Expect(RemoveAnnotation(ctx, c, worker, annotation)).To(Succeed())
 			Expect(len(worker.Annotations)).To(Equal(1))
 			notdeletedAnnotation, ok := worker.Annotations["test-no-delete-annotation-key"]
 			Expect(ok).To(BeTrue())
@@ -204,7 +206,7 @@ var _ = Describe("Utils", func() {
 			)
 
 			It("should return false when lastOperation is missing", func() {
-				Expect(controller.ShouldSkipOperation(operationType, worker)).To(BeFalse())
+				Expect(ShouldSkipOperation(operationType, worker)).To(BeFalse())
 			})
 
 			It("should return true when lastOperation is migrate and succeeded", func() {
@@ -212,14 +214,14 @@ var _ = Describe("Utils", func() {
 					Type:  gardencorev1beta1.LastOperationTypeMigrate,
 					State: gardencorev1beta1.LastOperationStateSucceeded,
 				}
-				Expect(controller.ShouldSkipOperation(operationType, worker)).To(BeTrue())
+				Expect(ShouldSkipOperation(operationType, worker)).To(BeTrue())
 			})
 
 			It("should return false when lastOperation is not migrate", func() {
 				worker.Status.LastOperation = &gardencorev1beta1.LastOperation{
 					Type: gardencorev1beta1.LastOperationTypeRestore,
 				}
-				Expect(controller.ShouldSkipOperation(operationType, worker)).To(BeFalse())
+				Expect(ShouldSkipOperation(operationType, worker)).To(BeFalse())
 			})
 		})
 
@@ -229,7 +231,7 @@ var _ = Describe("Utils", func() {
 			)
 
 			It("should return false when lastOperation is missing", func() {
-				Expect(controller.ShouldSkipOperation(operationType, worker)).To(BeFalse())
+				Expect(ShouldSkipOperation(operationType, worker)).To(BeFalse())
 			})
 
 			It("should return false when lastOperation is migrate and succeeded", func() {
@@ -237,7 +239,7 @@ var _ = Describe("Utils", func() {
 					Type:  gardencorev1beta1.LastOperationTypeMigrate,
 					State: gardencorev1beta1.LastOperationStateSucceeded,
 				}
-				Expect(controller.ShouldSkipOperation(operationType, worker)).To(BeFalse())
+				Expect(ShouldSkipOperation(operationType, worker)).To(BeFalse())
 			})
 
 			It("should return false when lastOperation is not migrate", func() {
@@ -245,7 +247,7 @@ var _ = Describe("Utils", func() {
 					Type:  gardencorev1beta1.LastOperationTypeReconcile,
 					State: gardencorev1beta1.LastOperationStateSucceeded,
 				}
-				Expect(controller.ShouldSkipOperation(operationType, worker)).To(BeFalse())
+				Expect(ShouldSkipOperation(operationType, worker)).To(BeFalse())
 			})
 		})
 
@@ -255,7 +257,7 @@ var _ = Describe("Utils", func() {
 			)
 
 			It("should return false when lastOperation is missing", func() {
-				Expect(controller.ShouldSkipOperation(operationType, worker)).To(BeFalse())
+				Expect(ShouldSkipOperation(operationType, worker)).To(BeFalse())
 			})
 
 			It("should return true when lastOperation is migrate and succeeded", func() {
@@ -263,7 +265,7 @@ var _ = Describe("Utils", func() {
 					Type:  gardencorev1beta1.LastOperationTypeMigrate,
 					State: gardencorev1beta1.LastOperationStateSucceeded,
 				}
-				Expect(controller.ShouldSkipOperation(operationType, worker)).To(BeTrue())
+				Expect(ShouldSkipOperation(operationType, worker)).To(BeTrue())
 			})
 
 			It("should return false when lastOperation is not migrate", func() {
@@ -271,7 +273,7 @@ var _ = Describe("Utils", func() {
 					Type:  gardencorev1beta1.LastOperationTypeReconcile,
 					State: gardencorev1beta1.LastOperationStateSucceeded,
 				}
-				Expect(controller.ShouldSkipOperation(operationType, worker)).To(BeFalse())
+				Expect(ShouldSkipOperation(operationType, worker)).To(BeFalse())
 			})
 		})
 
@@ -281,7 +283,7 @@ var _ = Describe("Utils", func() {
 			)
 
 			It("should return false when lastOperation is missing", func() {
-				Expect(controller.ShouldSkipOperation(operationType, worker)).To(BeFalse())
+				Expect(ShouldSkipOperation(operationType, worker)).To(BeFalse())
 			})
 
 			It("should return false when lastOperation is migrate and succeeded", func() {
@@ -289,7 +291,7 @@ var _ = Describe("Utils", func() {
 					Type:  gardencorev1beta1.LastOperationTypeMigrate,
 					State: gardencorev1beta1.LastOperationStateSucceeded,
 				}
-				Expect(controller.ShouldSkipOperation(operationType, worker)).To(BeFalse())
+				Expect(ShouldSkipOperation(operationType, worker)).To(BeFalse())
 			})
 
 			It("should return false when lastOperation is not migrate", func() {
@@ -297,7 +299,7 @@ var _ = Describe("Utils", func() {
 					Type:  gardencorev1beta1.LastOperationTypeReconcile,
 					State: gardencorev1beta1.LastOperationStateSucceeded,
 				}
-				Expect(controller.ShouldSkipOperation(operationType, worker)).To(BeFalse())
+				Expect(ShouldSkipOperation(operationType, worker)).To(BeFalse())
 			})
 		})
 	})
@@ -320,27 +322,27 @@ var _ = Describe("Utils", func() {
 			}
 		})
 		It("should return false when lastOperation is missing", func() {
-			Expect(controller.IsMigrated(worker)).To(BeFalse())
+			Expect(IsMigrated(worker)).To(BeFalse())
 		})
 		It("should return false when lastOperation type is not Migrated", func() {
 			worker.Status.LastOperation = &gardencorev1beta1.LastOperation{
 				Type: gardencorev1beta1.LastOperationTypeReconcile,
 			}
-			Expect(controller.IsMigrated(worker)).To(BeFalse())
+			Expect(IsMigrated(worker)).To(BeFalse())
 		})
 		It("should return false when lastOperation type is Migrated but state is not succeeded", func() {
 			worker.Status.LastOperation = &gardencorev1beta1.LastOperation{
 				Type:  gardencorev1beta1.LastOperationTypeMigrate,
 				State: gardencorev1beta1.LastOperationStateProcessing,
 			}
-			Expect(controller.IsMigrated(worker)).To(BeFalse())
+			Expect(IsMigrated(worker)).To(BeFalse())
 		})
 		It("should return true when lastOperation type is Migrated and state is succeeded", func() {
 			worker.Status.LastOperation = &gardencorev1beta1.LastOperation{
 				Type:  gardencorev1beta1.LastOperationTypeMigrate,
 				State: gardencorev1beta1.LastOperationStateSucceeded,
 			}
-			Expect(controller.IsMigrated(worker)).To(BeTrue())
+			Expect(IsMigrated(worker)).To(BeTrue())
 		})
 	})
 
@@ -371,8 +373,40 @@ var _ = Describe("Utils", func() {
 					refSecret.DeepCopyInto(secret)
 					return nil
 				})
-			Expect(controller.GetObjectByReference(ctx, c, ref, namespace, secret)).To(Succeed())
+			Expect(GetObjectByReference(ctx, c, ref, namespace, secret)).To(Succeed())
 			Expect(secret).To(Equal(refSecret))
 		})
 	})
+
+	DescribeTable("#UseTokenRequestor",
+		func(gardenerVersion string, matcher gomegatypes.GomegaMatcher) {
+			Expect(UseTokenRequestor(gardenerVersion)).To(matcher)
+		},
+
+		Entry("return true", "v1.36.0-dev", BeTrue()),
+		Entry("return true", "v1.36.0", BeTrue()),
+		Entry("return true", "v1.36.1", BeTrue()),
+		Entry("return true", "v1.37.0", BeTrue()),
+		Entry("return true", "v1.37.1", BeTrue()),
+		Entry("return true", "v1.38.0-dev", BeTrue()),
+		Entry("return false", "v1.35.0", BeFalse()),
+		Entry("return false", "v1.35.9", BeFalse()),
+		Entry("return false", "", BeFalse()),
+	)
+
+	DescribeTable("#UseServiceAccountTokenVolumeProjection",
+		func(gardenerVersion string, matcher gomegatypes.GomegaMatcher) {
+			Expect(UseServiceAccountTokenVolumeProjection(gardenerVersion)).To(matcher)
+		},
+
+		Entry("return true", "v1.37.0-dev", BeTrue()),
+		Entry("return true", "v1.37.0", BeTrue()),
+		Entry("return true", "v1.37.1", BeTrue()),
+		Entry("return true", "v1.38.0", BeTrue()),
+		Entry("return true", "v1.38.1", BeTrue()),
+		Entry("return true", "v1.39.0-dev", BeTrue()),
+		Entry("return false", "v1.36.0", BeFalse()),
+		Entry("return false", "v1.36.9", BeFalse()),
+		Entry("return false", "", BeFalse()),
+	)
 })

--- a/extensions/pkg/util/shoot.go
+++ b/extensions/pkg/util/shoot.go
@@ -37,6 +37,7 @@ const CAChecksumAnnotation = "checksum/ca"
 // GetOrCreateShootKubeconfig gets or creates a Kubeconfig for a Shoot cluster which has a running control plane in the given `namespace`.
 // If the CA of an existing Kubeconfig has changed, it creates a new Kubeconfig.
 // Newly generated Kubeconfigs are applied with the given `client` to the given `namespace`.
+// Deprecated: Use gutil.NewShootAccessSecret instead.
 func GetOrCreateShootKubeconfig(ctx context.Context, c client.Client, certificateConfig secrets.CertificateSecretConfig, namespace string) (*corev1.Secret, error) {
 	caSecret, ca, err := secrets.LoadCAFromSecret(ctx, c, namespace, v1beta1constants.SecretNameCACluster)
 	if err != nil {

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation.go
@@ -52,7 +52,18 @@ type Controller struct {
 }
 
 // NewController instantiates a new ControllerInstallation controller.
-func NewController(ctx context.Context, clientMap clientmap.ClientMap, config *config.GardenletConfiguration, recorder record.EventRecorder, gardenNamespace *corev1.Namespace, gardenClusterIdentity string) (*Controller, error) {
+func NewController(
+	ctx context.Context,
+	clientMap clientmap.ClientMap,
+	config *config.GardenletConfiguration,
+	recorder record.EventRecorder,
+	identity *gardencorev1beta1.Gardener,
+	gardenNamespace *corev1.Namespace,
+	gardenClusterIdentity string,
+) (
+	*Controller,
+	error,
+) {
 	gardenClient, err := clientMap.GetClient(ctx, keys.ForGarden())
 	if err != nil {
 		return nil, err
@@ -64,7 +75,7 @@ func NewController(ctx context.Context, clientMap clientmap.ClientMap, config *c
 	}
 
 	controller := &Controller{
-		reconciler:     newReconciler(clientMap, recorder, logger.Logger, gardenNamespace, gardenClusterIdentity),
+		reconciler:     newReconciler(clientMap, recorder, logger.Logger, identity, gardenNamespace, gardenClusterIdentity),
 		careReconciler: newCareReconciler(clientMap, logger.Logger, config.Controllers.ControllerInstallationCare),
 
 		controllerInstallationQueue:     workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "controllerinstallation"),

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation_control.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation_control.go
@@ -86,12 +86,14 @@ func newReconciler(
 	clientMap clientmap.ClientMap,
 	recorder record.EventRecorder,
 	l logrus.FieldLogger,
+	identity *gardencorev1beta1.Gardener,
 	gardenNamespace *corev1.Namespace,
 	gardenClusterIdentity string,
 ) reconcile.Reconciler {
 	return &reconciler{
 		clientMap:             clientMap,
 		recorder:              recorder,
+		identity:              identity,
 		logger:                l,
 		gardenNamespace:       gardenNamespace,
 		gardenClusterIdentity: gardenClusterIdentity,
@@ -102,6 +104,7 @@ type reconciler struct {
 	clientMap             clientmap.ClientMap
 	recorder              record.EventRecorder
 	logger                logrus.FieldLogger
+	identity              *gardencorev1beta1.Gardener
 	gardenNamespace       *corev1.Namespace
 	gardenClusterIdentity string
 }
@@ -228,6 +231,7 @@ func (r *reconciler) reconcile(ctx context.Context, gardenClient client.Client, 
 	// Mix-in some standard values for garden and seed.
 	gardenerValues := map[string]interface{}{
 		"gardener": map[string]interface{}{
+			"version": r.identity.Version,
 			"garden": map[string]interface{}{
 				"identity":        r.gardenNamespace.UID, // 'identity' value is deprecated to be replaced by 'clusterIdentity'. Should be removed in a future version.
 				"clusterIdentity": r.gardenClusterIdentity,

--- a/pkg/gardenlet/controller/factory.go
+++ b/pkg/gardenlet/controller/factory.go
@@ -147,7 +147,7 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 		return fmt.Errorf("failed initializing Bastion controller: %w", err)
 	}
 
-	controllerInstallationController, err := controllerinstallationcontroller.NewController(ctx, f.clientMap, f.cfg, f.recorder, gardenNamespace, f.gardenClusterIdentity)
+	controllerInstallationController, err := controllerinstallationcontroller.NewController(ctx, f.clientMap, f.cfg, f.recorder, f.identity, gardenNamespace, f.gardenClusterIdentity)
 	if err != nil {
 		return fmt.Errorf("failed initializing ControllerInstallation controller: %w", err)
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement
/merge squash

**What this PR does / why we need it**:
This PR contains the following improvements:

1. The `ControllerInstallation` controller in gardenlet is now populating the `.gardener.version` field when rendering Helm charts. Extension controllers can use this information to turn on or off certain features (e.g., using the token requestor or projected token mount).
2. New `General{Options,Config}` structures are introduced in the `extensions/pkg/controller/cmd` package for exposing the `--gardener-version` flag. Together with 1. this allows extensions to read the information from the Helm chart values and use it.
3. Two new functions `UseTokenRequestor` and `UseServiceAccountTokenVolumeProjection` are introduced in the `extensions/pkg/controller` package. They can be used to decide (based on the used Gardener version) whether the respective features should be enabled.
4. The `GetOrCreateShootKubeconfig` function in the `extensions/pkg/util` package is deprecated since it generates a kubeconfig with a static client certificate.

**Which issue(s) this PR fixes**:
Part of #4661
Part of #4878

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
The `ControllerInstallation` controller in gardenlet is now populating the `.gardener.version` field when rendering Helm charts. Extension controllers can use this information to turn on or off certain features. The new `General{Options,Config}` structures introduced in the `extensions/pkg/controller/cmd` package can be used for exposing the `--gardener-version` flag. This allows to read the Gardener version information from the Helm chart values and use it.
```
```feature developer
Two new functions `UseTokenRequestor` and `UseServiceAccountTokenVolumeProjection` have been introduced in the `extensions/pkg/controller` package. They can be used to decide (based on the used Gardener version) whether the respective features should be enabled.
```
```noteworthy dependency
The `GetOrCreateShootKubeconfig` function in the `extensions/pkg/util` package is deprecated since it generates a kubeconfig with a static client certificate. Switch to the [token requestor](https://github.com/gardener/gardener/blob/master/docs/concepts/resource-manager.md#tokenrequestor) instead.
```