### PR TITLE
🛡 Adapt generic {`Worker`,`ControlPlane`} actuators and `terraformer` library for elimination of static credentials

### DIFF
--- a/extensions/pkg/controller/worker/genericactuator/actuator.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator.go
@@ -66,8 +66,10 @@ type genericActuator struct {
 	chartApplier         gardenerkubernetes.ChartApplier
 	chartRendererFactory extensionscontroller.ChartRendererFactory
 
-	// TODO(rfranzke/BeckerMax): Remove this flag when all provider extensions enable the token requestor.
-	useTokenRequestor bool
+	// TODO(rfranzke/BeckerMax): Remove these flags when all provider extensions enable the token requestor and
+	//  projected token mount.
+	useTokenRequestor      bool
+	useProjectedTokenMount bool
 }
 
 // NewActuator creates a new Actuator that reconciles
@@ -82,16 +84,18 @@ func NewActuator(
 	imageVector imagevector.ImageVector,
 	chartRendererFactory extensionscontroller.ChartRendererFactory,
 	useTokenRequestor bool,
+	useProjectedTokenMount bool,
 ) worker.Actuator {
 	return &genericActuator{
-		logger:               logger.WithName("worker-actuator"),
-		delegateFactory:      delegateFactory,
-		mcmName:              mcmName,
-		mcmSeedChart:         mcmSeedChart,
-		mcmShootChart:        mcmShootChart,
-		imageVector:          imageVector,
-		chartRendererFactory: chartRendererFactory,
-		useTokenRequestor:    useTokenRequestor,
+		logger:                 logger.WithName("worker-actuator"),
+		delegateFactory:        delegateFactory,
+		mcmName:                mcmName,
+		mcmSeedChart:           mcmSeedChart,
+		mcmShootChart:          mcmShootChart,
+		imageVector:            imageVector,
+		chartRendererFactory:   chartRendererFactory,
+		useTokenRequestor:      useTokenRequestor,
+		useProjectedTokenMount: useProjectedTokenMount,
 	}
 }
 

--- a/extensions/pkg/controller/worker/genericactuator/actuator.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator.go
@@ -65,21 +65,33 @@ type genericActuator struct {
 	gardenerClientset    gardenerkubernetes.Interface
 	chartApplier         gardenerkubernetes.ChartApplier
 	chartRendererFactory extensionscontroller.ChartRendererFactory
+
+	// TODO(rfranzke/BeckerMax): Remove this flag when all provider extensions enable the token requestor.
+	useTokenRequestor bool
 }
 
 // NewActuator creates a new Actuator that reconciles
 // Worker resources of Gardener's `extensions.gardener.cloud` API group.
 // It provides a default implementation that allows easier integration of providers.
-func NewActuator(logger logr.Logger, delegateFactory DelegateFactory, mcmName string, mcmSeedChart, mcmShootChart chart.Interface, imageVector imagevector.ImageVector, chartRendererFactory extensionscontroller.ChartRendererFactory) worker.Actuator {
+func NewActuator(
+	logger logr.Logger,
+	delegateFactory DelegateFactory,
+	mcmName string,
+	mcmSeedChart,
+	mcmShootChart chart.Interface,
+	imageVector imagevector.ImageVector,
+	chartRendererFactory extensionscontroller.ChartRendererFactory,
+	useTokenRequestor bool,
+) worker.Actuator {
 	return &genericActuator{
-		logger: logger.WithName("worker-actuator"),
-
+		logger:               logger.WithName("worker-actuator"),
 		delegateFactory:      delegateFactory,
 		mcmName:              mcmName,
 		mcmSeedChart:         mcmSeedChart,
 		mcmShootChart:        mcmShootChart,
 		imageVector:          imageVector,
 		chartRendererFactory: chartRendererFactory,
+		useTokenRequestor:    useTokenRequestor,
 	}
 }
 

--- a/extensions/pkg/controller/worker/genericactuator/machine_controller_manager.go
+++ b/extensions/pkg/controller/worker/genericactuator/machine_controller_manager.go
@@ -33,6 +33,7 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/utils"
+	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 	"github.com/gardener/gardener/pkg/utils/secrets"
@@ -57,12 +58,19 @@ func (a *genericActuator) deployMachineControllerManager(ctx context.Context, lo
 		return err
 	}
 
-	// Generate MCM kubeconfig and inject its checksum into the MCM values.
-	mcmKubeconfigSecret, err := createKubeconfigForMachineControllerManager(ctx, a.client, workerObj.Namespace, a.mcmName)
-	if err != nil {
-		return err
+	mcmValues["useTokenRequestor"] = a.useTokenRequestor
+
+	if a.useTokenRequestor {
+		if err := gutil.NewShootAccessSecret(a.mcmName, workerObj.Namespace).Reconcile(ctx, a.client); err != nil {
+			return err
+		}
+	} else {
+		mcmKubeconfigSecret, err := createKubeconfigForMachineControllerManager(ctx, a.client, workerObj.Namespace, a.mcmName)
+		if err != nil {
+			return err
+		}
+		injectPodAnnotation(mcmValues, "checksum/secret-machine-controller-manager", utils.ComputeChecksum(mcmKubeconfigSecret.Data))
 	}
-	injectPodAnnotation(mcmValues, "checksum/secret-machine-controller-manager", utils.ComputeChecksum(mcmKubeconfigSecret.Data))
 
 	replicaCount, err := replicas()
 	if err != nil {
@@ -84,7 +92,12 @@ func (a *genericActuator) deployMachineControllerManager(ctx context.Context, lo
 		return fmt.Errorf("waiting until deployment/%s is updated: %w", McmDeploymentName, err)
 	}
 
-	return nil
+	// TODO(rfranzke/BeckerMax): Remove in a future release.
+	secretName := a.mcmName
+	if !a.useTokenRequestor {
+		secretName = "shoot-access-" + a.mcmName
+	}
+	return kutil.DeleteObject(ctx, a.client, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: secretName, Namespace: workerObj.Namespace}})
 }
 
 func (a *genericActuator) deleteMachineControllerManager(ctx context.Context, logger logr.Logger, workerObj *extensionsv1alpha1.Worker) error {
@@ -139,6 +152,8 @@ func (a *genericActuator) applyMachineControllerManagerShootChart(ctx context.Co
 	if err != nil {
 		return err
 	}
+
+	values["useTokenRequestor"] = a.useTokenRequestor
 
 	if err := managedresources.RenderChartAndCreate(ctx, workerObj.Namespace, McmShootResourceName, false, a.client, chartRenderer, a.mcmShootChart, values, a.imageVector, metav1.NamespaceSystem, cluster.Shoot.Spec.Kubernetes.Version, true, false); err != nil {
 		return fmt.Errorf("could not apply control plane shoot chart for worker '%s': %w", kutil.ObjectName(workerObj), err)

--- a/extensions/pkg/controller/worker/genericactuator/machine_controller_manager.go
+++ b/extensions/pkg/controller/worker/genericactuator/machine_controller_manager.go
@@ -118,7 +118,11 @@ func (a *genericActuator) deleteMachineControllerManager(ctx context.Context, lo
 		return fmt.Errorf("cleaning up machine-controller-manager resources in seed failed: %w", err)
 	}
 
-	return nil
+	return kutil.DeleteObjects(ctx, a.client,
+		// TODO(rfranzke/BeckerMax): Remove in a future release.
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "shoot-access-" + a.mcmName, Namespace: workerObj.Namespace}},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: a.mcmName, Namespace: workerObj.Namespace}},
+	)
 }
 
 func (a *genericActuator) waitUntilMachineControllerManagerIsDeleted(ctx context.Context, logger logr.Logger, namespace string) error {

--- a/extensions/pkg/controller/worker/genericactuator/machine_controller_manager.go
+++ b/extensions/pkg/controller/worker/genericactuator/machine_controller_manager.go
@@ -59,6 +59,7 @@ func (a *genericActuator) deployMachineControllerManager(ctx context.Context, lo
 	}
 
 	mcmValues["useTokenRequestor"] = a.useTokenRequestor
+	mcmValues["useProjectedTokenMount"] = a.useProjectedTokenMount
 
 	if a.useTokenRequestor {
 		if err := gutil.NewShootAccessSecret(a.mcmName, workerObj.Namespace).Reconcile(ctx, a.client); err != nil {

--- a/extensions/pkg/terraformer/config.go
+++ b/extensions/pkg/terraformer/config.go
@@ -92,6 +92,12 @@ func (t *terraformer) UseV2(v2 bool) Terraformer {
 	return t
 }
 
+// UseProjectedTokenMount configures the useProjectedTokenMount field.
+func (t *terraformer) UseProjectedTokenMount(useProjectedTokenMount bool) Terraformer {
+	t.useProjectedTokenMount = useProjectedTokenMount
+	return t
+}
+
 // SetLogLevel sets the log level of the Terraformer pod. It only takes effect when UseV2 is set to true.
 func (t *terraformer) SetLogLevel(level string) Terraformer {
 	t.logLevel = level

--- a/extensions/pkg/terraformer/mock/mocks.go
+++ b/extensions/pkg/terraformer/mock/mocks.go
@@ -322,6 +322,20 @@ func (mr *MockTerraformerMockRecorder) SetTerminationGracePeriodSeconds(arg0 int
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTerminationGracePeriodSeconds", reflect.TypeOf((*MockTerraformer)(nil).SetTerminationGracePeriodSeconds), arg0)
 }
 
+// UseProjectedTokenMount mocks base method.
+func (m *MockTerraformer) UseProjectedTokenMount(arg0 bool) terraformer.Terraformer {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UseProjectedTokenMount", arg0)
+	ret0, _ := ret[0].(terraformer.Terraformer)
+	return ret0
+}
+
+// UseProjectedTokenMount indicates an expected call of UseProjectedTokenMount.
+func (mr *MockTerraformerMockRecorder) UseProjectedTokenMount(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UseProjectedTokenMount", reflect.TypeOf((*MockTerraformer)(nil).UseProjectedTokenMount), arg0)
+}
+
 // UseV1 mocks base method.
 func (m *MockTerraformer) UseV1(arg0 bool) terraformer.Terraformer {
 	m.ctrl.T.Helper()

--- a/extensions/pkg/terraformer/terraformer.go
+++ b/extensions/pkg/terraformer/terraformer.go
@@ -23,7 +23,6 @@ import (
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -295,15 +294,15 @@ const (
 
 func (t *terraformer) ensureServiceAccount(ctx context.Context) error {
 	serviceAccount := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Namespace: t.namespace, Name: name}}
-	if err := t.client.Get(ctx, client.ObjectKeyFromObject(serviceAccount), serviceAccount); err != nil {
-		if !apierrors.IsNotFound(err) {
-			return err
+	_, err := controllerutils.GetAndCreateOrStrategicMergePatch(ctx, t.client, serviceAccount, func() error {
+		if t.useProjectedTokenMount {
+			serviceAccount.AutomountServiceAccountToken = pointer.Bool(false)
+		} else {
+			serviceAccount.AutomountServiceAccountToken = nil
 		}
-		if err := t.client.Create(ctx, serviceAccount); err != nil {
-			return err
-		}
-	}
-	return nil
+		return nil
+	})
+	return err
 }
 
 func (t *terraformer) ensureRole(ctx context.Context) error {

--- a/extensions/pkg/terraformer/types.go
+++ b/extensions/pkg/terraformer/types.go
@@ -73,6 +73,9 @@ type terraformer struct {
 	deadlineCleaning    time.Duration
 	deadlinePod         time.Duration
 	deadlinePodCreation time.Duration
+
+	// TODO(rfranzke/BeckerMax): Remove these flags when all provider extensions enable the projected token mount.
+	useProjectedTokenMount bool
 }
 
 // RawState represent the terraformer state's raw data
@@ -119,6 +122,7 @@ type Terraformer interface {
 	SetDeadlinePod(time.Duration) Terraformer
 	SetDeadlinePodCreation(time.Duration) Terraformer
 	SetOwnerRef(*metav1.OwnerReference) Terraformer
+	UseProjectedTokenMount(bool) Terraformer
 	InitializeWith(ctx context.Context, initializer Initializer) Terraformer
 	Apply(ctx context.Context) error
 	Destroy(ctx context.Context) error

--- a/pkg/provider-local/controller/controlplane/add.go
+++ b/pkg/provider-local/controller/controlplane/add.go
@@ -49,7 +49,7 @@ type AddOptions struct {
 // The opts.Reconciler is being set with a newly instantiated actuator.
 func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 	return controlplane.Add(mgr, controlplane.AddArgs{
-		Actuator: genericactuator.NewActuator(local.Name, nil, nil, nil, nil, nil,
+		Actuator: genericactuator.NewActuator(local.Name, nil, nil, nil, nil, nil, nil, nil, nil, nil,
 			nil, nil, nil, NewValuesProvider(), extensionscontroller.ChartRendererFactoryFunc(util.NewChartRendererForShoot),
 			imagevector.ImageVector(), "", opts.ShootWebhooks, mgr.GetWebhookServer().Port, logger),
 		ControllerOptions: opts.Controller,

--- a/pkg/provider-local/controller/worker/actuator.go
+++ b/pkg/provider-local/controller/worker/actuator.go
@@ -53,6 +53,8 @@ func NewActuator() worker.Actuator {
 		mcmShootChart,
 		imagevector.ImageVector(),
 		extensionscontroller.ChartRendererFactoryFunc(util.NewChartRendererForShoot),
+		false,
+		false,
 	)
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement
/merge squash

**What this PR does / why we need it**:
This PR adapts the generic {`Worker`,`ControlPlane`} actuators as well as the `terraformer` library for the elimination of static credentials (optionally).

While the `terraformer` doesn't use a kubeconfig to talk to the shoot cluster (hence, just static `ServiceAccount` token invalidation is required here), the generic actuators allow generating client certificate-based kubeconfigs for shoot control plane components (like `cloud-controller-manager`, `machine-controller-manager`, etc.). Those can now be optionally switched to the token requestor.

**Which issue(s) this PR fixes**:
Part of #4661
Part of #4878

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
The `Terraformer` interface does now support a new `UseProjectedTokenMount` method for switching the `terraformer` pods to a projected `ServiceAccount` token. Set this to `true` only when running with Gardener >= `1.37`.
```
```breaking developer
The `NewActuator` function of the generic `Worker` actuator now takes two additional parameters: `useTokenRequestor` (set this to `true` only when running with Gardener >= `1.36`), and `useProjectedTokenMount` (set this to `true` only when running with Gardener >= `1.37`). They allow switching to the token requestor and projected `ServiceAccount` tokens instead of relying on static credentials for the `machine-controller-manager`. Caution: Make sure to adapt your `Deployment`s similar to https://github.com/gardener/gardener/pull/5008/commits/e3cb8d84b9217667aaf5c5ce0ba60204ed4a4db3#diff-4ecb783d75e20fae3586a525a59b334f42474f9465af8defaac8e3da965cff3a when set to `true`.
```
```breaking developer
The `NewActuator` function of the generic `ControlPlane` actuator now takes four additional parameters: `shootAccessSecrets` and `legacySecretNamesToCleanup`, and `exposureShootAccessSecrets` and `legacyExposureSecretNamesToCleanup` (use them only when running with Gardener >= `1.36`). They allow switching to the token requestor instead of relying on static client certificates for the control plane components like `cloud-controller-manager`. Caution: Make sure to adapt your `Deployment`s similar to https://github.com/gardener/gardener/pull/5008/commits/e3cb8d84b9217667aaf5c5ce0ba60204ed4a4db3#diff-4ecb783d75e20fae3586a525a59b334f42474f9465af8defaac8e3da965cff3a when set to `true`.
```