### PR TITLE
Add rateLimit fields to DNSProvider CRD

### DIFF
--- a/pkg/operation/botanist/component/extensions/crds/templates/crd-dnsowner.tpl.yaml
+++ b/pkg/operation/botanist/component/extensions/crds/templates/crd-dnsowner.tpl.yaml
@@ -19,7 +19,7 @@ spec:
         - jsonPath: .spec.ownerId
           name: OwnerId
           type: string
-        - jsonPath: .spec.active
+        - jsonPath: .status.active
           name: Active
           type: boolean
         - jsonPath: .status.entries.amount

--- a/pkg/operation/botanist/component/extensions/crds/templates/crd-dnsprovider.tpl.yaml
+++ b/pkg/operation/botanist/component/extensions/crds/templates/crd-dnsprovider.tpl.yaml
@@ -76,6 +76,19 @@ spec:
                   description: optional additional provider specific configuration values
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
+                rateLimit:
+                  description: rate limit for create/update operations on DNSEntries assigned to this provider
+                  properties:
+                    burst:
+                      description: Burst allows bursts of up to 'burst' to exceed the rate defined by 'RequestsPerDay', while still maintaining a smoothed rate of 'RequestsPerDay'
+                      type: integer
+                    requestsPerDay:
+                      description: RequestsPerDay is create/update request rate per DNS entry given by requests per day
+                      type: integer
+                  required:
+                    - burst
+                    - requestsPerDay
+                  type: object
                 secretRef:
                   description: access credential for the external DNS system of the given type
                   properties:
@@ -134,6 +147,19 @@ spec:
                 observedGeneration:
                   format: int64
                   type: integer
+                rateLimit:
+                  description: actually used rate limit for create/update operations on DNSEntries assigned to this provider
+                  properties:
+                    burst:
+                      description: Burst allows bursts of up to 'burst' to exceed the rate defined by 'RequestsPerDay', while still maintaining a smoothed rate of 'RequestsPerDay'
+                      type: integer
+                    requestsPerDay:
+                      description: RequestsPerDay is create/update request rate per DNS entry given by requests per day
+                      type: integer
+                  required:
+                    - burst
+                    - requestsPerDay
+                  type: object
                 state:
                   description: state of the provider
                   type: string


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
With PR https://github.com/gardener/external-dns-management/pull/229 optional fields have been added to the `DNSProvider` to specify client-side rate limits.
The custom resource definition is updated to reflect this change.

Additionally the `DNSOwner` CRD has been updated. The JSON path for the printer column `ACTIVE` has been changed to `.status.active` as it is already defined in the `external-dns-management` project.
It was not possible to include this change in the original PR https://github.com/gardener/gardener/pull/4960 because of backwards compatibility. The `.status.active` field was not set in older version of the dns-controller-manager.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add `rateLimit` fields to CRD dnsproviders.dns.gardener.cloud 
```
