### PR TITLE
Do not overwrite spec.selector for Jobs

### DIFF
--- a/pkg/resourcemanager/controller/managedresource/merger.go
+++ b/pkg/resourcemanager/controller/managedresource/merger.go
@@ -197,11 +197,8 @@ func mergeJob(scheme *runtime.Scheme, oldObj, newObj runtime.Object) error {
 		return err
 	}
 
-	// Do not overwrite a Job's '.spec.selector' if the new Jobs's '.spec.selector'
-	// field is unset.
-	if newJob.Spec.Selector == nil && oldJob.Spec.Selector != nil {
-		newJob.Spec.Selector = oldJob.Spec.Selector
-	}
+	// Do not overwrite a Job's '.spec.selector' since it is immutable.
+	newJob.Spec.Selector = oldJob.Spec.Selector
 
 	// Do not overwrite Job managed labels as 'controller-uid' and 'job-name'. '.spec.template' is immutable.
 	newJob.Spec.Template.Labels = labels.Merge(oldJob.Spec.Template.Labels, newJob.Spec.Template.Labels)

--- a/pkg/resourcemanager/controller/managedresource/merger_test.go
+++ b/pkg/resourcemanager/controller/managedresource/merger_test.go
@@ -658,8 +658,10 @@ var _ = Describe("merger", func() {
 			new = old.DeepCopy()
 		})
 
-		It("should not overwrite old .spec.selector if the new one is nil", func() {
-			new.Spec.Selector = nil
+		It("should not overwrite old .spec.selector", func() {
+			new.Spec.Selector = &metav1.LabelSelector{
+				MatchLabels: map[string]string{"foo": "bar"},
+			}
 
 			expected := old.DeepCopy()
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
`spec.selector` is immutable for `Job` objects.

See https://github.com/kubernetes/kubernetes/blob/c16b2afc1d3c32462f068ea08cdc4791bd97b947/pkg/apis/batch/validation/validation.go#L238.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Gardener-Resource-Manager does not try overwrite the immutable field `.spec.selector` of `Job` objects anymore.
```
