### PR TITLE
Cleanup loki `ServiceAccount` in seed controller

### DIFF
--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -493,6 +493,13 @@ func RunReconcileSeedFlow(
 
 	lokiValues["enabled"] = loggingEnabled
 
+	// Follow-up of https://github.com/gardener/gardener/pull/5010 (loki `ServiceAccount` got removed and was never
+	// used.
+	// TODO(rfranzke): Delete this in a future release.
+	if err := seedClient.Delete(ctx, &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "loki", Namespace: v1beta1constants.GardenNamespace}}); client.IgnoreNotFound(err) != nil {
+		return err
+	}
+
 	// check if loki disabled in gardenlet config
 	if loggingConfig != nil &&
 		loggingConfig.Loki != nil &&


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind cleanup

**What this PR does / why we need it**:
The loki `ServiceAccount` was removed in #5010 since it was unused (see https://github.com/gardener/gardener/pull/5010/files#diff-3e1cf6ac5f5d12c2d0c7f9a4fd3404f00d423f4fbbe1499d2027d4227f81650e), however, there was no special cleanup coding for indeed deleting it from existing systems.

**Special notes for your reviewer**:
/milestone v1.38

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
