### PR TITLE
Ensure GRM token webhooks apply for kubernetes-dashboard namespace

### DIFF
--- a/charts/shoot-addons/charts/kubernetes-dashboard/templates/namespace.yaml
+++ b/charts/shoot-addons/charts/kubernetes-dashboard/templates/namespace.yaml
@@ -3,4 +3,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: kubernetes-dashboard
+  labels:
+    gardener.cloud/purpose: kubernetes-dashboard
 {{- end }}

--- a/pkg/operation/botanist/component/resourcemanager/resource_manager.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager.go
@@ -948,7 +948,7 @@ func (r *resourceManager) buildWebhookNamespaceSelector() *metav1.LabelSelector 
 		MatchExpressions: []metav1.LabelSelectorRequirement{{
 			Key:      v1beta1constants.GardenerPurpose,
 			Operator: namespaceSelectorOperator,
-			Values:   []string{metav1.NamespaceSystem},
+			Values:   []string{metav1.NamespaceSystem, "kubernetes-dashboard"},
 		}},
 	}
 }

--- a/pkg/operation/botanist/component/resourcemanager/resource_manager_test.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager_test.go
@@ -575,7 +575,7 @@ var _ = Describe("ResourceManager", func() {
 						MatchExpressions: []metav1.LabelSelectorRequirement{{
 							Key:      "gardener.cloud/purpose",
 							Operator: metav1.LabelSelectorOpNotIn,
-							Values:   []string{"kube-system"},
+							Values:   []string{"kube-system", "kubernetes-dashboard"},
 						}},
 					},
 					ObjectSelector: &metav1.LabelSelector{
@@ -609,7 +609,7 @@ var _ = Describe("ResourceManager", func() {
 						MatchExpressions: []metav1.LabelSelectorRequirement{{
 							Key:      "gardener.cloud/purpose",
 							Operator: metav1.LabelSelectorOpNotIn,
-							Values:   []string{"kube-system"},
+							Values:   []string{"kube-system", "kubernetes-dashboard"},
 						}},
 					},
 					ObjectSelector: &metav1.LabelSelector{
@@ -665,6 +665,7 @@ webhooks:
       operator: In
       values:
       - kube-system
+      - kubernetes-dashboard
   objectSelector:
     matchLabels:
       resources.gardener.cloud/purpose: token-invalidator
@@ -695,6 +696,7 @@ webhooks:
       operator: In
       values:
       - kube-system
+      - kubernetes-dashboard
   objectSelector:
     matchExpressions:
     - key: projected-token-mount.resources.gardener.cloud/skip


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bug

**What this PR does / why we need it**:
With #5099 we have adapted the `kubernetes-dashboard` components and switched them to projected `ServiceAccount` tokens. However, with newer Kubernetes versions the dashboard pods run in a dedicated namespace called `kubernetes-dashboard` which was not handled by the token-related webhooks of `gardener-resource-manager`.
This caused the dashboard pods to end up in `CrashLoopBackOff` since neither the default Kubernetes `ServiceAccount` mount plugin nor the GRM mount handlers triggered:

```
$ k -n kubernetes-dashboard logs kubernetes-dashboard-6c9c5b585b-64dnk
2021/12/16 03:30:20 Starting overwatch
2021/12/16 03:30:20 Using namespace: kubernetes-dashboard
2021/12/16 03:30:20 Using in-cluster config to connect to apiserver
2021/12/16 03:30:20 Could not init in cluster config: open /var/run/secrets/kubernetes.io/serviceaccount/token: no such file or directory
panic: could not create client config

goroutine 1 [running]:
github.com/kubernetes/dashboard/src/app/backend/client.(*clientManager).initInsecureConfig(0xc000190100)
	/home/runner/work/dashboard/dashboard/src/app/backend/client/manager.go:531 +0x16e
github.com/kubernetes/dashboard/src/app/backend/client.(*clientManager).initInsecureClients(0xc000190100)
	/home/runner/work/dashboard/dashboard/src/app/backend/client/manager.go:507 +0x2f
github.com/kubernetes/dashboard/src/app/backend/client.(*clientManager).init(0xc000190100)
	/home/runner/work/dashboard/dashboard/src/app/backend/client/manager.go:469 +0x39
github.com/kubernetes/dashboard/src/app/backend/client.NewClientManager(...)
	/home/runner/work/dashboard/dashboard/src/app/backend/client/manager.go:551
main.main()
	/home/runner/work/dashboard/dashboard/src/app/backend/dashboard.go:105 +0x21c
```

This PR fixes this by (1) labelling the `Namespace` and (2) extending the `namespaceSelector` in the `MutatingWebhookConfiguration` with the new label.

**Special notes for your reviewer**:
/cc @danielfoehrKn 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
