### PR TITLE
Add APIServer Network Policy to Blackbox Exporter

### DIFF
--- a/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/deployment.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/deployment.yaml
@@ -30,7 +30,6 @@ spec:
         networking.gardener.cloud/from-seed: allowed
         networking.gardener.cloud/to-dns: allowed
         networking.gardener.cloud/to-public-networks: allowed
-        networking.gardener.cloud/to-apiserver: allowed
     spec:
       tolerations:
       - effect: NoSchedule

--- a/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/deployment.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/deployment.yaml
@@ -30,6 +30,7 @@ spec:
         networking.gardener.cloud/from-seed: allowed
         networking.gardener.cloud/to-dns: allowed
         networking.gardener.cloud/to-public-networks: allowed
+        networking.gardener.cloud/to-apiserver: allowed
     spec:
       tolerations:
       - effect: NoSchedule

--- a/docs/development/process.md
+++ b/docs/development/process.md
@@ -21,10 +21,10 @@ v1.36   | Week 45-46  | November 8, 2021       | November 21, 2021  | [@timebert
 v1.37   | Week 47-48  | November 22, 2021      | December 5, 2021   | [@danielfoehrKn](https://github.com/danielfoehrKn) |
 v1.38   | Week 49-50  | December 6, 2021       | December 19, 2021  | [@rfranzke](https://github.com/rfranzke)           |
 v1.39   | Week 01-02  | January 3, 2022        | January 16, 2022   | [@ialidzhikov](https://github.com/ialidzhikov)     |
-v1.40   | Week 03-04  | January 17, 2022       | January 30, 2022   | [@timuthy](https://github.com/timuthy)             |
-v1.41   | Week 05-06  | January 31, 2022       | February 13, 2022  | [@BeckerMax](https://github.com/BeckerMax)         |
-v1.42   | Week 06-07  | February 14, 2022      | February 27, 2022  | [@stoyanr](https://github.com/stoyanr)             |
-v1.43   | Week 08-09  | February 28, 2022      | March 13, 2022     | [@voelzmo](https://github.com/voelzmo)             |
+v1.39   | Week 03-04  | January 17, 2022       | January 30, 2022   | [@timuthy](https://github.com/timuthy)             |
+v1.40   | Week 05-06  | January 31, 2022       | February 13, 2022  | [@BeckerMax](https://github.com/BeckerMax)         |
+v1.41   | Week 06-07  | February 14, 2022      | February 27, 2022  | [@stoyanr](https://github.com/stoyanr)             |
+v1.42   | Week 08-09  | February 28, 2022      | March 13, 2022     | [@voelzmo](https://github.com/voelzmo)             |
 
 Apart from the release of the next version, the release responsible is also taking care of potential hotfix releases of the last three minor versions.
 The release responsible is the main contact person for coordinating new feature PRs for the next minor versions or cherry-pick PRs for the last three minor versions.


### PR DESCRIPTION
This fixes https://github.com/gardener/gardener/issues/5185

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:
Adds the label to match the network policy for api server communication to the blackbox exporter
**Which issue(s) this PR fixes**:
Fixes #5185 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Adds network policy label to blackbox reporter so it can talk to the K8s APIServer
```
