### PR TITLE
Adds worker finalizer during restore operation

### DIFF
--- a/extensions/pkg/controller/worker/reconciler.go
+++ b/extensions/pkg/controller/worker/reconciler.go
@@ -211,6 +211,10 @@ func (r *reconciler) reconcile(ctx context.Context, logger logr.Logger, worker *
 }
 
 func (r *reconciler) restore(ctx context.Context, logger logr.Logger, worker *extensionsv1alpha1.Worker, cluster *extensionscontroller.Cluster) (reconcile.Result, error) {
+	if err := controllerutils.EnsureFinalizer(ctx, r.reader, r.client, worker, FinalizerName); err != nil {
+		return reconcile.Result{}, err
+	}
+
 	if err := r.statusUpdater.Processing(ctx, worker, gardencorev1beta1.LastOperationTypeRestore, "Restoring the worker"); err != nil {
 		return reconcile.Result{}, err
 	}
@@ -229,7 +233,6 @@ func (r *reconciler) restore(ctx context.Context, logger logr.Logger, worker *ex
 		return reconcile.Result{}, fmt.Errorf("error removing annotation from worker: %+v", err)
 	}
 
-	// requeue to trigger reconciliation
 	return reconcile.Result{}, nil
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind bug

**What this PR does / why we need it**:
Finalizers were not porperly added to the worker resource once the restore operation starts. This used to work previously because a `reconcile` operation was automatically triggered (sometimes due to status updates and the fact that the `restore` operation annotation is still present on the resource) and the finalizers would get properly added.

All other extension controllers add finalizers to their respective resources.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @timebertt @stoyanr 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Finalizers are now properly added to the `Worker` resource at the start of a `restore` operation.
```
