### PR TITLE
Nit: Correct the version of the ForceRestore feature gate

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -39,7 +39,7 @@ The following tables are a summary of the feature gates that you can set on diff
 | WorkerPoolKubernetesVersion                  | `false` | `Alpha` | `1.35` |        |
 | CopyEtcdBackupsDuringControlPlaneMigration   | `false` | `Alpha` | `1.37` |        |
 | SecretBindingProviderValidation              | `false` | `Alpha` | `1.38` |        |
-| ForceRestore                                 | `false` | `Alpha` | `1.38` |        |
+| ForceRestore                                 | `false` | `Alpha` | `1.39` |        |
 
 ## Feature gates for graduated or deprecated features
 

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -125,6 +125,6 @@ const (
 	// if the preparation for migration in the source seed is not finished after a certain grace period
 	// and is considered unlikely to succeed ("bad case" scenario).
 	// owner: @stoyanr
-	// alpha: v1.38.0
+	// alpha: v1.39.0
 	ForceRestore featuregate.Feature = "ForceRestore"
 )


### PR DESCRIPTION
/area documentation

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
