### PR TITLE
[release-v1.37] Automated cherry pick of #5187: Adds worker finalizer during restore operation

### DIFF
--- a/extensions/pkg/controller/worker/reconciler.go
+++ b/extensions/pkg/controller/worker/reconciler.go
@@ -211,6 +211,10 @@ func (r *reconciler) reconcile(ctx context.Context, logger logr.Logger, worker *
 }
 
 func (r *reconciler) restore(ctx context.Context, logger logr.Logger, worker *extensionsv1alpha1.Worker, cluster *extensionscontroller.Cluster) (reconcile.Result, error) {
+	if err := controllerutils.EnsureFinalizer(ctx, r.reader, r.client, worker, FinalizerName); err != nil {
+		return reconcile.Result{}, err
+	}
+
 	if err := r.statusUpdater.Processing(ctx, worker, gardencorev1beta1.LastOperationTypeRestore, "Restoring the worker"); err != nil {
 		return reconcile.Result{}, err
 	}
@@ -229,7 +233,6 @@ func (r *reconciler) restore(ctx context.Context, logger logr.Logger, worker *ex
 		return reconcile.Result{}, fmt.Errorf("error removing annotation from worker: %+v", err)
 	}
 
-	// requeue to trigger reconciliation
 	return reconcile.Result{}, nil
 }
 


### PR DESCRIPTION
/kind/bug
/area/control-plane-migration

Cherry pick of #5187 on release-v1.37.

#5187: Adds worker finalizer during restore operation

**Release Notes:**
```bugfix operator
Finalizers are now properly added to the `Worker` resource at the start of a `restore` operation.
```