### PR TITLE
[release-v1.38] Automated cherry pick of #5198: Add label to etcd to allow seed API server connections

### DIFF
--- a/pkg/operation/botanist/component/etcd/etcd.go
+++ b/pkg/operation/botanist/component/etcd/etcd.go
@@ -320,6 +320,7 @@ func (e *etcd) Deploy(ctx context.Context) error {
 			v1beta1constants.LabelNetworkPolicyToDNS:             v1beta1constants.LabelNetworkPolicyAllowed,
 			v1beta1constants.LabelNetworkPolicyToPublicNetworks:  v1beta1constants.LabelNetworkPolicyAllowed,
 			v1beta1constants.LabelNetworkPolicyToPrivateNetworks: v1beta1constants.LabelNetworkPolicyAllowed,
+			v1beta1constants.LabelNetworkPolicyToSeedAPIServer:   v1beta1constants.LabelNetworkPolicyAllowed,
 		})
 		e.etcd.Spec.Selector = &metav1.LabelSelector{
 			MatchLabels: utils.MergeStringMaps(e.getLabels(), map[string]string{

--- a/pkg/operation/botanist/component/etcd/etcd_test.go
+++ b/pkg/operation/botanist/component/etcd/etcd_test.go
@@ -238,6 +238,7 @@ var _ = Describe("Etcd", func() {
 						"networking.gardener.cloud/to-dns": "allowed",
 						"networking.gardener.cloud/to-public-networks":  "allowed",
 						"networking.gardener.cloud/to-private-networks": "allowed",
+						"networking.gardener.cloud/to-seed-apiserver":   "allowed",
 					},
 					Selector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{


### PR DESCRIPTION
/kind/bug
/area/control-plane

Cherry pick of #5198 on release-v1.38.

#5198: Add label to etcd to allow seed API server connections

**Release Notes:**
```bugfix operator
An issue has been fixed that caused the `etcd-main` pod to constantly crash on seed clusters that their Kube-Apiservers in the same cluster (usually not managed by Gardener).
```