### PR TITLE
add more context info to client guide

### DIFF
--- a/docs/development/kubernetes-clients.md
+++ b/docs/development/kubernetes-clients.md
@@ -12,6 +12,7 @@ Please familiarize yourself with the following basic Kubernetes API concepts fir
 - [Extending the Kubernetes API](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/) (including Custom Resources and aggregation layer / extension API servers)
 - [Extend the Kubernetes API with CustomResourceDefinitions](https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/)
 - [Working with Kubernetes Objects](https://kubernetes.io/docs/concepts/overview/working-with-objects/)
+- [Sample Controller](https://github.com/kubernetes/sample-controller/blob/master/docs/controller-client-go.md) (the diagram helps to build an understanding of an controller's basic structure)
 
 ## Client Types: Client-Go, Generated, Controller-Runtime
 
@@ -74,6 +75,8 @@ err := c.Update(ctx, deployment)
 // or
 err = c.Update(ctx, shoot)
 ```
+
+A brief introduction to the controller-runtime and its basic constructs can be found [here](https://pkg.go.dev/sigs.k8s.io/controller-runtime)
 
 _Important characteristics of controller-runtime clients:_
 

--- a/docs/development/kubernetes-clients.md
+++ b/docs/development/kubernetes-clients.md
@@ -76,7 +76,7 @@ err := c.Update(ctx, deployment)
 err = c.Update(ctx, shoot)
 ```
 
-A brief introduction to the controller-runtime and its basic constructs can be found [here](https://pkg.go.dev/sigs.k8s.io/controller-runtime)
+A brief introduction to controller-runtime and its basic constructs can be found [here](https://pkg.go.dev/sigs.k8s.io/controller-runtime).
 
 _Important characteristics of controller-runtime clients:_
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
Add a bit more context information to the Kubernetes client guide. 

The guide itself is super helpful, but already requires a rather detailed understanding of a controller's structure. To make it a bit easier for beginners as myself, I've added some links I found useful when reading it.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
NONE
```
