### PR TITLE
Fix start-up of local garden

### DIFF
--- a/hack/local-development/common/helpers
+++ b/hack/local-development/common/helpers
@@ -138,17 +138,6 @@ cleanup_controller_manager_webhook() {
   fi
 }
 
-is_seedauthorizer_enabled() {
-  if [[ $kube_apiserver="$(docker inspect kube-apiserver)" ]]; then
-    auth_mode="$(docker inspect kube-apiserver | jq -r '.[].Args | map(select(startswith("--authorization-mode"))) | .[] | contains("Webhook")')"
-    if [[ "$auth_mode" == "true" ]]; then
-      return 0
-    fi
-    return 1
-  fi
-  return 1
-}
-
 get_host_address () {
   local ip_route=""
   local ip_address=""

--- a/hack/local-development/local-garden/start.sh
+++ b/hack/local-development/local-garden/start.sh
@@ -43,7 +43,7 @@ for i in 1..10; do
 done
 
 echo "# Configuring RBAC resources for Gardener components"
-$(dirname $0)/../dev-setup-configure-rbac "$(dirname $0)/kubeconfigs/default-admin.conf" $(is_seedauthorizer_enabled) "clientcerts"
+$(dirname $0)/../dev-setup-configure-rbac "$(dirname $0)/kubeconfigs/default-admin.conf" "$ACTIVATE_SEEDAUTHORIZER" "clientcerts"
 
 echo "# Applying proxy RBAC for the extension controller"
 echo "# After this step, you can start using the cluster at KUBECONFIG=hack/local-development/local-garden/kubeconfigs/default-admin.conf"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
When running `make local-garden-up` then the following errors are displayed:

```
$ make local-garden-up
# Remove old containers and create the docker user network
c5d76d82e17163cbd38f43a3598f69127b203b8e4b4de7b45dce3d864e0de3da
# Start the nodeless kubernetes environment
Starting gardener-dev kube-etcd cluster!
e14332e5cc580ceb748d2a00791c94bcc335ab2ab17dd8fb81a4bc34269be421
Starting gardener-dev kube-apiserver!
2351199fc5cfd3b8d03cb73a6e6848617a4894938966c62092db1fd8501fe602
Starting gardener-dev kube-controller-manager!
b7eb39d9907d6409744578e57767fc3bd42e27676c22dba886fb62d05dcfafc3
# This etcd will be used to store gardener resources (e.g., seeds, shoots)
Starting gardener-dev gardener-etcd cluster!
fa39a580072d973116f0309f6596555762da3e1265592dac9bfce882f6d2e6ff
# Configuring RBAC resources for Gardener components
./hack/local-development/local-garden/start.sh: line 46: is_seedauthorizer_enabled: command not found
./hack/local-development/local-garden/../dev-setup-configure-rbac: line 24: clientcerts: command not found
…
```

This PR fixes these issues.
/cc @stoyanr

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
