### PR TITLE
Fix VPA dashboard

### DIFF
--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/vpa-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/vpa-dashboard.json
@@ -236,7 +236,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(container_cpu_usage_seconds_total{pod=~\"$targetName-(.+)\"}[$__rate_interval])) by (container)",
+          "expr": "sum(rate(container_cpu_usage_seconds_total{pod=~\"$targetName-(.+)\"}[$__rate_interval])) by (container) * 1000",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{ container }} actual usage",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:

The unit of the y-axis of the "CPU $recommendation vs CPU Usage" panel
is millicores.

The `sum(rate(container_cpu_usage_seconds_total{...}...))` expression yields
CPU usage in cores, hence it has to be scaled by 1000 to get millicores.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix the "CPU $recommendation vs CPU Usage" panel on the VPA dashboard
```
