### PR TITLE
Add priority for default-domains to select which default-domain is used for new shoots

### DIFF
--- a/docs/usage/configuration.md
+++ b/docs/usage/configuration.md
@@ -60,6 +60,7 @@ When the `gardenlet` starts it scans the `garden` namespace of the garden cluste
 * **Default domain secrets** (optional), contain the DNS provider credentials (having appropriate privileges) which will be used to create/delete DNS records for a default domain for shoots (e.g., `example.com`), please see [this](../../example/10-secret-default-domain.yaml) for an example.
   * Not every end-user/stakeholder/customer has its own domain, however, Gardener needs to create a DNS record for every shoot cluster.
   * As landscape operator you might want to define a default domain owned and controlled by you that is used for all shoot clusters that don't specify their own domain.
+  * If you have multiple default domain secrets defined you can add a priority as an annotation (`dns.gardener.cloud/domain-default-priority`) to select which domain should be used for new shoots while creation. The domain with the highest priority is selected while shoot creation. If there is no annotation defined the default priority is `0`, also all non integer values are considered as priority `0`.
 
 :warning: Please note that the mentioned domain secrets are only needed if you have at least one seed cluster that is not specifing `.spec.settings.shootDNS.enabled=false`.
 Seeds with this taint don't create any DNS records for shoots scheduled on it, hence, if you only have such seeds, you don't need to create the domain secrets.

--- a/example/10-secret-default-domain.yaml
+++ b/example/10-secret-default-domain.yaml
@@ -9,6 +9,7 @@ metadata:
   annotations:
     dns.gardener.cloud/provider: aws-route53
     dns.gardener.cloud/domain: example.com
+  # dns.gardener.cloud/domain-default-priority: "10"
   # dns.gardener.cloud/include-zones: "first-zone-id,second-zone-id"
   # dns.gardener.cloud/exclude-zones: "first-zone-id,second-zone-id"
 type: Opaque

--- a/pkg/utils/gardener/dns.go
+++ b/pkg/utils/gardener/dns.go
@@ -26,6 +26,9 @@ const (
 	// DNSDomain is the key for an annotation on a Kubernetes Secret object whose value must point to a valid
 	// domain name.
 	DNSDomain = "dns.gardener.cloud/domain"
+	// DNSDefaultDomainPriority is the priority of the default domain. In case of multiple default domains
+	// the default domain with the highest priority is selected per default for new shoots.
+	DNSDefaultDomainPriority = "dns.gardener.cloud/domain-default-priority"
 	// DNSZone is the key for an annotation on a Kubernetes Secret object whose value must point to a valid
 	// DNS hosted zone id.
 	DNSZone = "dns.gardener.cloud/zone"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:

While shoot creation without a specified domain `spec.dns.domain`, the gardener is creating a domain from the `default-domain`s. Therefore the gardener gets all `default-domain`s as a slice and creates a new domain from first `default-domain` item of the slice. 
https://github.com/gardener/gardener/blob/master/plugin/pkg/shoot/dns/admission.go#L368

I added a new annotation for the secret which is used to sort the list. If no annotation is set or the annotation is a non int value the default priority is 0. To don't break something I used the `sort.SliceStable` to keep the current order if the priority values are the same.

This is needed because we want add a new domain which should be used in future for new shoot cluster per default.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Add priority for default-domains to select which default-domain is used for new shoots
```
