### PR TITLE
Promote `UseDNSRecords` feature gate to beta

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -34,7 +34,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | ReversedVPN                                  | `false` | `Alpha` | `1.22` |        |
 | AdminKubeconfigRequest                       | `false` | `Alpha` | `1.24` | `1.38` |
 | AdminKubeconfigRequest                       | `true`  | `Beta`  | `1.39` |        |
-| UseDNSRecords                                | `false` | `Alpha` | `1.27` |        |
+| UseDNSRecords                                | `false` | `Alpha` | `1.27` | `1.38` |
+| UseDNSRecords                                | `true`  | `Beta`  | `1.39` |        |
 | RotateSSHKeypairOnMaintenance                | `false` | `Alpha` | `1.28` |        |
 | DenyInvalidExtensionResources                | `false` | `Alpha` | `1.31` |        |
 | WorkerPoolKubernetesVersion                  | `false` | `Alpha` | `1.35` |        |

--- a/docs/extensions/dnsrecord.md
+++ b/docs/extensions/dnsrecord.md
@@ -131,6 +131,16 @@ The feature gate is enabled by default starting from `v1.39`.
 
 In order to successfully reconcile a shoot with the feature gate enabled, extension controllers for `DNSRecord` resources for types used in the default, internal and custom domain secrets should be registered via `ControllerRegistration` resources.
 
+### List of first versions of extensions that supports `DNSRecord`
+
+| Extension                                    | Version  |
+| -------------------------------------------- | -------- |
+| provider-aws                                 | `v1.27.0`|
+| provider-gcp                                 | `v1.18.0`|
+| provider-azure                               | `v1.21.0`|
+| provider-alicloud                            | `v1.26.0`|
+| provider-openstack                           | `v1.21.0`|
+
 ## References and additional resources
 
 * [`DNSRecord` API (Golang specification)](../../pkg/apis/extensions/v1alpha1/types_dnsrecord.go)

--- a/docs/extensions/dnsrecord.md
+++ b/docs/extensions/dnsrecord.md
@@ -127,19 +127,25 @@ If this feature gate is enabled, all three DNS records mentioned above (internal
 These providers can be used for `DNSEntry` resources needed by workloads deployed on the shoot cluster.
 
 If the feature gate is disabled, Gardener will not create any `DNSRecord` resources and use `DNSProvider` / `DNSEntry` resources for its DNS records. 
-The feature gate is enabled by default starting from `v1.39`.
+The feature gate was introduced in `v1.27` and was in `Alpha` stage (disabled by default) until `v1.38` (including). With `v1.39` the feature gate is graduated to `Beta` and it is enabled by default.
 
 In order to successfully reconcile a shoot with the feature gate enabled, extension controllers for `DNSRecord` resources for types used in the default, internal and custom domain secrets should be registered via `ControllerRegistration` resources.
 
-### List of first versions of extensions that supports `DNSRecord`
+### Support for `DNSRecord` resources in the provider extensions
+
+The following table contains information about the provider extension version that adds support for `DNSRecord` resources:
 
 | Extension                                    | Version  |
 | -------------------------------------------- | -------- |
-| provider-aws                                 | `v1.27.0`|
-| provider-gcp                                 | `v1.18.0`|
-| provider-azure                               | `v1.21.0`|
 | provider-alicloud                            | `v1.26.0`|
+| provider-aws                                 | `v1.27.0`|
+| provider-azure                               | `v1.21.0`|
+| provider-gcp                                 | `v1.18.0`|
 | provider-openstack                           | `v1.21.0`|
+| provider-vsphere                             |    N/A   |
+| provider-equinix-metal                       |    N/A   |
+| provider-kubevirt                            |    N/A   |
+| provider-openshift                           |    N/A   |
 
 ## References and additional resources
 

--- a/docs/extensions/dnsrecord.md
+++ b/docs/extensions/dnsrecord.md
@@ -127,7 +127,7 @@ If this feature gate is enabled, all three DNS records mentioned above (internal
 These providers can be used for `DNSEntry` resources needed by workloads deployed on the shoot cluster.
 
 If the feature gate is disabled, Gardener will not create any `DNSRecord` resources and use `DNSProvider` / `DNSEntry` resources for its DNS records. 
-Currently, the feature gate is still in `Alpha` stage and is therefore disabled by default.
+The feature gate is enabled by default starting from `v1.39`.
 
 In order to successfully reconcile a shoot with the feature gate enabled, extension controllers for `DNSRecord` resources for types used in the default, internal and custom domain secrets should be registered via `ControllerRegistration` resources.
 

--- a/hack/local-development/start-apiserver
+++ b/hack/local-development/start-apiserver
@@ -57,7 +57,6 @@ apiserver_flags="
   --tls-cert-file $TLS_CERT_FILE \
   --tls-private-key-file $TLS_KEY_FILE \
   --feature-gates SeedChange=true \
-  --feature-gates UseDNSRecords=true \
   --feature-gates WorkerPoolKubernetesVersion=true \
   --shoot-admin-kubeconfig-max-expiration=1h \
   --enable-admission-plugins=ShootVPAEnabledByDefault \

--- a/pkg/apiserver/features/features.go
+++ b/pkg/apiserver/features/features.go
@@ -25,7 +25,7 @@ import (
 var featureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	features.SeedChange:                      {Default: false, PreRelease: featuregate.Alpha},
 	features.AdminKubeconfigRequest:          {Default: true, PreRelease: featuregate.Beta},
-	features.UseDNSRecords:                   {Default: false, PreRelease: featuregate.Alpha},
+	features.UseDNSRecords:                   {Default: true, PreRelease: featuregate.Beta},
 	features.WorkerPoolKubernetesVersion:     {Default: false, PreRelease: featuregate.Alpha},
 	features.SecretBindingProviderValidation: {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/pkg/controllermanager/features/features.go
+++ b/pkg/controllermanager/features/features.go
@@ -26,7 +26,7 @@ var (
 	FeatureGate  = featuregate.NewFeatureGate()
 	featureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 		features.CachedRuntimeClients:          {Default: true, PreRelease: featuregate.Beta},
-		features.UseDNSRecords:                 {Default: false, PreRelease: featuregate.Alpha},
+		features.UseDNSRecords:                 {Default: true, PreRelease: featuregate.Beta},
 		features.RotateSSHKeypairOnMaintenance: {Default: false, PreRelease: featuregate.Alpha},
 	}
 )

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -91,6 +91,7 @@ const (
 	// UseDNSRecords enables using DNSRecords resources for Gardener DNS records instead of DNSProvider and DNSEntry resources.
 	// owner: @stoyanr
 	// alpha: v1.27.0
+	// beta: v1.39.0
 	UseDNSRecords featuregate.Feature = "UseDNSRecords"
 
 	// RotateSSHKeypairOnMaintenance enables SSH keypair rotation in the maintenance controller of the gardener-controller-manager.

--- a/pkg/gardenlet/features/features.go
+++ b/pkg/gardenlet/features/features.go
@@ -33,7 +33,7 @@ var (
 		features.CachedRuntimeClients:                       {Default: true, PreRelease: featuregate.Beta},
 		features.SeedKubeScheduler:                          {Default: false, PreRelease: featuregate.Alpha},
 		features.ReversedVPN:                                {Default: false, PreRelease: featuregate.Alpha},
-		features.UseDNSRecords:                              {Default: false, PreRelease: featuregate.Alpha},
+		features.UseDNSRecords:                              {Default: true, PreRelease: featuregate.Beta},
 		features.DenyInvalidExtensionResources:              {Default: false, PreRelease: featuregate.Alpha},
 		features.CopyEtcdBackupsDuringControlPlaneMigration: {Default: false, PreRelease: featuregate.Alpha},
 		features.ForceRestore:                               {Default: false, PreRelease: featuregate.Alpha},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/kind enhancement

**What this PR does / why we need it**:
The `UseDNSRecords` feature gate  in the apiserver, controllermanager and gardenlet has been promoted to beta.

**Special notes for your reviewer**:
@BeckerMax 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `UseDNSRecords` feature gate in the `apiserver`, `controllermanager` and `gardenlet` has been promoted to beta and is now enabled by default. Please see [the support for`DNSRecords` resources in provider extensions documentation](https://github.com/gardener/gardener/blob/master/docs/extensions/dnsrecord.md#support-for-dnsrecord-resources-in-the-provider-extensions).
```
