### PR TITLE
Promote `AdminKubeconfigRequest` feature gate to beta

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -32,7 +32,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | SeedChange                                   | `false` | `Alpha` | `1.12` |        |
 | SeedKubeScheduler                            | `false` | `Alpha` | `1.15` |        |
 | ReversedVPN                                  | `false` | `Alpha` | `1.22` |        |
-| AdminKubeconfigRequest                       | `false` | `Alpha` | `1.24` |        |
+| AdminKubeconfigRequest                       | `false` | `Alpha` | `1.24` | `1.38` |
+| AdminKubeconfigRequest                       | `true`  | `Beta`  | `1.39` |        |
 | UseDNSRecords                                | `false` | `Alpha` | `1.27` |        |
 | RotateSSHKeypairOnMaintenance                | `false` | `Alpha` | `1.28` |        |
 | DenyInvalidExtensionResources                | `false` | `Alpha` | `1.31` |        |

--- a/docs/proposals/16-adminkubeconfig-subresource.md
+++ b/docs/proposals/16-adminkubeconfig-subresource.md
@@ -96,7 +96,7 @@ status:
         client-key-data: LS0tLS1CRUd...
 ```
 
-New feature gate called `AdminKubeconfigRequest` would enable this API in the `gardener-apiserver`. The old `{shoot-name}.kubeconfig` would be kept, but deprecated and removed in the future.
+The `AdminKubeconfigRequest` feature gate (enabled by default starting from `v1.39`) enables the above mentioned API in the `gardener-apiserver`. The old `{shoot-name}.kubeconfig` is kept, but deprecated and will be removed in the future.
 
 In order to get the server's address used in the `kubeconfig`, the Shoot's `status` should be updated with new entries:
 

--- a/hack/local-development/start-apiserver
+++ b/hack/local-development/start-apiserver
@@ -57,7 +57,6 @@ apiserver_flags="
   --tls-cert-file $TLS_CERT_FILE \
   --tls-private-key-file $TLS_KEY_FILE \
   --feature-gates SeedChange=true \
-  --feature-gates AdminKubeconfigRequest=true \
   --feature-gates UseDNSRecords=true \
   --feature-gates WorkerPoolKubernetesVersion=true \
   --shoot-admin-kubeconfig-max-expiration=1h \

--- a/pkg/apiserver/features/features.go
+++ b/pkg/apiserver/features/features.go
@@ -24,7 +24,7 @@ import (
 
 var featureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	features.SeedChange:                      {Default: false, PreRelease: featuregate.Alpha},
-	features.AdminKubeconfigRequest:          {Default: false, PreRelease: featuregate.Alpha},
+	features.AdminKubeconfigRequest:          {Default: true, PreRelease: featuregate.Beta},
 	features.UseDNSRecords:                   {Default: false, PreRelease: featuregate.Alpha},
 	features.WorkerPoolKubernetesVersion:     {Default: false, PreRelease: featuregate.Alpha},
 	features.SecretBindingProviderValidation: {Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -85,6 +85,7 @@ const (
 	// AdminKubeconfigRequest enables the AdminKubeconfigRequest endpoint on shoot resources.
 	// owner: @petersutter
 	// alpha: v1.24.0
+	// beta: v1.39.0
 	AdminKubeconfigRequest featuregate.Feature = "AdminKubeconfigRequest"
 
 	// UseDNSRecords enables using DNSRecords resources for Gardener DNS records instead of DNSProvider and DNSEntry resources.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/kind enhancement

**What this PR does / why we need it**:
The `AdminKubeconfigRequest` feature gate  in the `apiserver` has been promoted to beta.

**Special notes for your reviewer**:
@BeckerMax 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `AdminKubeconfigRequest` feature gate in the `apiserver` has been promoted to beta and is now enabled by default.
```
