### PR TITLE
Fix formating bug for seed nginx-ingress controller deployment

### DIFF
--- a/charts/seed-bootstrap/charts/nginx-ingress/templates/controller-deployment.yaml
+++ b/charts/seed-bootstrap/charts/nginx-ingress/templates/controller-deployment.yaml
@@ -63,7 +63,7 @@ spec:
             - --publish-service=garden/nginx-ingress-controller
             - --election-id=ingress-controller-seed-leader
             - --ingress-class={{ .Values.global.ingressClass }}
-            {{- if semverCompare ">= 1.22-0" .Capabilities.KubeVersion.GitVersion -}}
+            {{- if semverCompare ">= 1.22-0" .Capabilities.KubeVersion.GitVersion }}
             - --controller-class={{ include "nginx-ingress.class" . }}
             {{- end }}
             - --update-status=true


### PR DESCRIPTION
/area control-plane
/kind bug

**What this PR does / why we need it**:

Without this fix the deployment of the nginx ingress controller for Seeds with K8s version >= 1.22 has a formatting bug which prevents it from picking up the the right ingress-class.

Deployment yaml with Seed K8s version 1.22.3 before this fix:
```
  containers:
  - args:
    - /nginx-ingress-controller
    - --default-backend-service=garden/nginx-ingress-k8s-backend
    - --enable-ssl-passthrough=true
    - --publish-service=garden/nginx-ingress-controller
    - --election-id=ingress-controller-seed-leader
    - --ingress-class=nginx-ingress-gardener- --controller-class=k8s.io/nginx-ingress-gardener
(...)
```

Introduced with: https://github.com/gardener/gardener/pull/4614


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue preventing the seed-nginx-ingress-controller to pick the right ingress class for Seeds with K8s version >=1.22.0 is now fixed.
```
