### PR TITLE
Revert hvpa-controller to use static `ServiceAccount` token

### DIFF
--- a/charts/seed-bootstrap/charts/hvpa/templates/controller-deployment.yaml
+++ b/charts/seed-bootstrap/charts/hvpa/templates/controller-deployment.yaml
@@ -5,7 +5,9 @@ metadata:
   namespace: garden
   labels:
 {{ toYaml .Values.labels | indent 4 }}
+{{- if .Values.readyForProjectedServiceAccountTokens }}
 automountServiceAccountToken: false
+{{- end }}
 ---
 apiVersion: {{ include "deploymentversion" . }}
 kind: Deployment
@@ -24,7 +26,7 @@ spec:
 {{ toYaml .Values.labels | indent 6 }}
   template:
     metadata:
-{{- if .Values.global.readyForProjectedServiceAccountTokens }}
+{{- if .Values.readyForProjectedServiceAccountTokens }}
       annotations:
         # TODO(rfranzke): Remove in a future release.
         security.gardener.cloud/trigger: rollout

--- a/charts/seed-bootstrap/charts/hvpa/values.yaml
+++ b/charts/seed-bootstrap/charts/hvpa/values.yaml
@@ -6,3 +6,5 @@ enabled: false
 podAnnotations: {}
 labels:
   gardener.cloud/role: hvpa
+
+readyForProjectedServiceAccountTokens: false


### PR DESCRIPTION
/area control-plane
/area security
/kind bug
/kind regression

As explained in https://github.com/gardener/gardener/issues/5222 `hvpa-controller@v0.3.1` is not ready for usage of projected `ServiceAccount` tokens. This PR reverts the component to use static `ServiceAccount` token. Migration to projected `ServiceAccount` tokens can happen when hvpa-controller vendors client-go >= v0.15.7.

Fixes #5222

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
hvpa-controller component is reverted back to use static `ServiceAccount` tokens as currently the component cannot properly handle projected `ServiceAccount` tokens.
```
