### PR TITLE
[release-v1.36] Automated cherry pick of #5126: gardenlet: Switch update strategy when syncing Shoot Secrets to the garden cluster

### DIFF
--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -487,7 +487,7 @@ func (b *Botanist) SyncShootCredentialsToGarden(ctx context.Context) error {
 				},
 			}
 
-			_, err := controllerutils.CreateOrGetAndStrategicMergePatch(ctx, b.K8sGardenClient.Client(), secretObj, func() error {
+			_, err := controllerutils.GetAndCreateOrStrategicMergePatch(ctx, b.K8sGardenClient.Client(), secretObj, func() error {
 				secretObj.OwnerReferences = []metav1.OwnerReference{
 					*metav1.NewControllerRef(b.Shoot.GetInfo(), gardencorev1beta1.SchemeGroupVersion.WithKind("Shoot")),
 				}


### PR DESCRIPTION
/kind/bug
/area/quality

Cherry pick of #5126 on release-v1.36.

#5126: gardenlet: Switch update strategy when syncing Shoot Secrets to the garden cluster

**Release Notes:**
```bugfix operator
An issue causing the reconciliation of existing Shoot to be marked as Failed when the Secrets quota is exhausted is now fixed.
```