### PR TITLE
[release-v1.38] Automated cherry pick of #5228: Revert hvpa-controller to use static `ServiceAccount` token

### DIFF
--- a/charts/seed-bootstrap/charts/hvpa/templates/controller-deployment.yaml
+++ b/charts/seed-bootstrap/charts/hvpa/templates/controller-deployment.yaml
@@ -5,7 +5,9 @@ metadata:
   namespace: garden
   labels:
 {{ toYaml .Values.labels | indent 4 }}
+{{- if .Values.readyForProjectedServiceAccountTokens }}
 automountServiceAccountToken: false
+{{- end }}
 ---
 apiVersion: {{ include "deploymentversion" . }}
 kind: Deployment
@@ -24,7 +26,7 @@ spec:
 {{ toYaml .Values.labels | indent 6 }}
   template:
     metadata:
-{{- if .Values.global.readyForProjectedServiceAccountTokens }}
+{{- if .Values.readyForProjectedServiceAccountTokens }}
       annotations:
         # TODO(rfranzke): Remove in a future release.
         security.gardener.cloud/trigger: rollout

--- a/charts/seed-bootstrap/charts/hvpa/values.yaml
+++ b/charts/seed-bootstrap/charts/hvpa/values.yaml
@@ -6,3 +6,5 @@ enabled: false
 podAnnotations: {}
 labels:
   gardener.cloud/role: hvpa
+
+readyForProjectedServiceAccountTokens: false


### PR DESCRIPTION
/kind/bug
/area/security
/kind/regression
/area/control-plane

Cherry pick of #5228 on release-v1.38.

#5228: Revert hvpa-controller to use static `ServiceAccount` token

**Release Notes:**
```bugfix operator
hvpa-controller component is reverted back to use static `ServiceAccount` tokens as currently the component cannot properly handle projected `ServiceAccount` tokens.
```