### PR TITLE
Add `Created` condition to `DNSRecord` to allow deletion on unsuccessful creation in infrastructure

### DIFF
--- a/extensions/pkg/controller/dnsrecord/reconciler.go
+++ b/extensions/pkg/controller/dnsrecord/reconciler.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/errors"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -253,7 +252,9 @@ func updateCreatedCondition(status extensionsv1alpha1.Status, conditionStatus ga
 	}
 
 	builder, err := gardencorev1beta1helper.NewConditionBuilder(extensionsv1alpha1.ConditionTypeCreated)
-	utilruntime.Must(err)
+	if err != nil {
+		return err
+	}
 	if c != nil {
 		builder = builder.WithOldCondition(*c)
 	}

--- a/extensions/pkg/controller/dnsrecord/reconciler.go
+++ b/extensions/pkg/controller/dnsrecord/reconciler.go
@@ -275,10 +275,10 @@ func getCreatedConditionStatus(status extensionsv1alpha1.Status) gardencorev1bet
 
 func addCreatedConditionFalse(status extensionsv1alpha1.Status) error {
 	message := "Error on initial record creation in infrastructure"
-	return updateCreatedCondition(status, gardencorev1beta1.ConditionFalse, "error", message, false)
+	return updateCreatedCondition(status, gardencorev1beta1.ConditionFalse, "Error", message, false)
 }
 
 func addCreatedConditionTrue(status extensionsv1alpha1.Status) error {
 	message := "Record was created successfully in infrastructure at least once"
-	return updateCreatedCondition(status, gardencorev1beta1.ConditionTrue, "success", message, true)
+	return updateCreatedCondition(status, gardencorev1beta1.ConditionTrue, "Success", message, true)
 }

--- a/extensions/pkg/controller/dnsrecord/reconciler.go
+++ b/extensions/pkg/controller/dnsrecord/reconciler.go
@@ -241,7 +241,7 @@ func (r *reconciler) delete(ctx context.Context, dns *extensionsv1alpha1.DNSReco
 	return reconcile.Result{}, nil
 }
 
-func updateCreatedCondition(status extensionsv1alpha1.Status, conditionStatus gardencorev1beta1.ConditionStatus, reason string, updateIfExisting bool) error {
+func updateCreatedCondition(status extensionsv1alpha1.Status, conditionStatus gardencorev1beta1.ConditionStatus, reason, message string, updateIfExisting bool) error {
 	conditions := status.GetConditions()
 	c := gardencorev1beta1helper.GetCondition(conditions, extensionsv1alpha1.ConditionTypeCreated)
 	if c != nil && !updateIfExisting {
@@ -259,7 +259,8 @@ func updateCreatedCondition(status extensionsv1alpha1.Status, conditionStatus ga
 	if err != nil {
 		return err
 	}
-	*c, _ = builder.WithStatus(conditionStatus).WithReason(reason).WithMessage("").Build()
+
+	*c, _ = builder.WithOldCondition(*c).WithStatus(conditionStatus).WithReason(reason).WithMessage(message).Build()
 	status.SetConditions(conditions)
 	return nil
 }
@@ -274,9 +275,11 @@ func getCreatedConditionStatus(status extensionsv1alpha1.Status) gardencorev1bet
 }
 
 func addCreatedConditionFalse(status extensionsv1alpha1.Status) error {
-	return updateCreatedCondition(status, gardencorev1beta1.ConditionFalse, "error", false)
+	message := "error on initial record creation in infrastructure"
+	return updateCreatedCondition(status, gardencorev1beta1.ConditionFalse, "error", message, false)
 }
 
 func addCreatedConditionTrue(status extensionsv1alpha1.Status) error {
-	return updateCreatedCondition(status, gardencorev1beta1.ConditionTrue, "success", true)
+	message := "record was created successfully in infrastructure at least once"
+	return updateCreatedCondition(status, gardencorev1beta1.ConditionTrue, "success", message, true)
 }

--- a/extensions/pkg/controller/dnsrecord/reconciler.go
+++ b/extensions/pkg/controller/dnsrecord/reconciler.go
@@ -274,11 +274,11 @@ func getCreatedConditionStatus(status extensionsv1alpha1.Status) gardencorev1bet
 }
 
 func addCreatedConditionFalse(status extensionsv1alpha1.Status) error {
-	message := "error on initial record creation in infrastructure"
+	message := "Error on initial record creation in infrastructure"
 	return updateCreatedCondition(status, gardencorev1beta1.ConditionFalse, "error", message, false)
 }
 
 func addCreatedConditionTrue(status extensionsv1alpha1.Status) error {
-	message := "record was created successfully in infrastructure at least once"
+	message := "Record was created successfully in infrastructure at least once"
 	return updateCreatedCondition(status, gardencorev1beta1.ConditionTrue, "success", message, true)
 }

--- a/extensions/pkg/controller/dnsrecord/reconciler_test.go
+++ b/extensions/pkg/controller/dnsrecord/reconciler_test.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dnsrecord
+
+import (
+	"time"
+
+	"github.com/gardener/gardener/extensions/pkg/controller"
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("reconciler", func() {
+	DescribeTable("#updateCreatedCondition", func(old v1beta1.ConditionStatus, f controller.UpdaterFunc, expected v1beta1.ConditionStatus) {
+		status := &extensionsv1alpha1.DefaultStatus{}
+		switch old {
+		case v1beta1.ConditionUnknown:
+		case v1beta1.ConditionTrue:
+			addCreatedConditionTrue(status)
+		case v1beta1.ConditionFalse:
+			addCreatedConditionFalse(status)
+		}
+		oldTime := time.Now().Add(-1 * time.Second)
+		if len(status.Conditions) > 0 {
+			status.Conditions[0].LastUpdateTime.Time = oldTime
+			status.Conditions[0].LastUpdateTime.Time = oldTime
+		}
+
+		f(status)
+		Expect(len(status.Conditions)).To(Equal(1))
+		Expect(status.Conditions[0].Status).To(Equal(expected))
+		if old != expected {
+			Expect(status.Conditions[0].LastUpdateTime.Time).NotTo(Equal(oldTime))
+		} else {
+			Expect(status.Conditions[0].LastUpdateTime.Time).To(Equal(oldTime))
+		}
+	},
+
+		Entry("empty -> success => true", v1beta1.ConditionUnknown, addCreatedConditionTrue, v1beta1.ConditionTrue),
+		Entry("empty -> error => false", v1beta1.ConditionUnknown, addCreatedConditionFalse, v1beta1.ConditionFalse),
+		Entry("success -> success => true", v1beta1.ConditionTrue, addCreatedConditionTrue, v1beta1.ConditionTrue),
+		Entry("success -> error => true", v1beta1.ConditionTrue, addCreatedConditionFalse, v1beta1.ConditionTrue),
+		Entry("error -> success => false", v1beta1.ConditionFalse, addCreatedConditionTrue, v1beta1.ConditionTrue),
+		Entry("error -> error => false", v1beta1.ConditionFalse, addCreatedConditionFalse, v1beta1.ConditionFalse),
+	)
+})

--- a/extensions/pkg/controller/dnsrecord/reconciler_test.go
+++ b/extensions/pkg/controller/dnsrecord/reconciler_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,13 +27,16 @@ import (
 
 var _ = Describe("reconciler", func() {
 	DescribeTable("#updateCreatedCondition", func(old v1beta1.ConditionStatus, f controller.UpdaterFunc, expected v1beta1.ConditionStatus) {
+		var err error
 		status := &extensionsv1alpha1.DefaultStatus{}
 		switch old {
 		case v1beta1.ConditionUnknown:
 		case v1beta1.ConditionTrue:
-			addCreatedConditionTrue(status)
+			err = addCreatedConditionTrue(status)
+			Expect(err).To(BeNil())
 		case v1beta1.ConditionFalse:
-			addCreatedConditionFalse(status)
+			err = addCreatedConditionFalse(status)
+			Expect(err).To(BeNil())
 		}
 		oldTime := time.Now().Add(-1 * time.Second)
 		if len(status.Conditions) > 0 {
@@ -41,7 +44,8 @@ var _ = Describe("reconciler", func() {
 			status.Conditions[0].LastUpdateTime.Time = oldTime
 		}
 
-		f(status)
+		err = f(status)
+		Expect(err).To(BeNil())
 		Expect(len(status.Conditions)).To(Equal(1))
 		Expect(status.Conditions[0].Status).To(Equal(expected))
 		if old != expected {

--- a/extensions/pkg/controller/status.go
+++ b/extensions/pkg/controller/status.go
@@ -97,6 +97,7 @@ type statusUpdater struct {
 }
 
 var _ = StatusUpdater(&statusUpdater{})
+var _ = StatusUpdaterCustom(&statusUpdater{})
 
 func (s *statusUpdater) InjectClient(c client.Client) {
 	s.client = c

--- a/extensions/pkg/controller/status.go
+++ b/extensions/pkg/controller/status.go
@@ -71,7 +71,7 @@ type StatusUpdater interface {
 	Success(context.Context, extensionsv1alpha1.Object, gardencorev1beta1.LastOperationType, string) error
 }
 
-// UpdaterFunc is a function to perform additional updates of the status
+// UpdaterFunc is a function to perform additional updates of the status.
 type UpdaterFunc func(extensionsv1alpha1.Status) error
 
 // StatusUpdaterCustom contains functions for customized updating statuses of extension resources after a controller operation.

--- a/extensions/pkg/controller/status.go
+++ b/extensions/pkg/controller/status.go
@@ -71,6 +71,21 @@ type StatusUpdater interface {
 	Success(context.Context, extensionsv1alpha1.Object, gardencorev1beta1.LastOperationType, string) error
 }
 
+// UpdaterFunc is a function to perform additional updates of the status
+type UpdaterFunc func(extensionsv1alpha1.Status) error
+
+// StatusUpdaterCustom contains functions for customized updating statuses of extension resources after a controller operation.
+type StatusUpdaterCustom interface {
+	//  InjectClient injects the client into the status updater.
+	InjectClient(client.Client)
+	// Processing updates the last operation of an extension resource when an operation is started.
+	ProcessingCustom(context.Context, extensionsv1alpha1.Object, gardencorev1beta1.LastOperationType, string, UpdaterFunc) error
+	// Error updates the last operation of an extension resource when an operation was erroneous.
+	ErrorCustom(context.Context, extensionsv1alpha1.Object, error, gardencorev1beta1.LastOperationType, string, UpdaterFunc) error
+	// Success updates the last operation of an extension resource when an operation was successful.
+	SuccessCustom(context.Context, extensionsv1alpha1.Object, gardencorev1beta1.LastOperationType, string, UpdaterFunc) error
+}
+
 // NewStatusUpdater returns a new status updater.
 func NewStatusUpdater(logger logr.Logger) *statusUpdater {
 	return &statusUpdater{logger: logger}
@@ -88,6 +103,10 @@ func (s *statusUpdater) InjectClient(c client.Client) {
 }
 
 func (s *statusUpdater) Processing(ctx context.Context, obj extensionsv1alpha1.Object, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
+	return s.ProcessingCustom(ctx, obj, lastOperationType, description, nil)
+}
+
+func (s *statusUpdater) ProcessingCustom(ctx context.Context, obj extensionsv1alpha1.Object, lastOperationType gardencorev1beta1.LastOperationType, description string, updater UpdaterFunc) error {
 	if s.client == nil {
 		return fmt.Errorf("client is not set. Call InjectClient() first")
 	}
@@ -97,10 +116,20 @@ func (s *statusUpdater) Processing(ctx context.Context, obj extensionsv1alpha1.O
 	patch := client.MergeFrom(obj.DeepCopyObject().(client.Object))
 	lastOp := LastOperation(lastOperationType, gardencorev1beta1.LastOperationStateProcessing, 1, description)
 	obj.GetExtensionStatus().SetLastOperation(lastOp)
+	if updater != nil {
+		err := updater(obj.GetExtensionStatus())
+		if err != nil {
+			return err
+		}
+	}
 	return s.client.Status().Patch(ctx, obj, patch)
 }
 
 func (s *statusUpdater) Error(ctx context.Context, obj extensionsv1alpha1.Object, err error, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
+	return s.ErrorCustom(ctx, obj, err, lastOperationType, description, nil)
+}
+
+func (s *statusUpdater) ErrorCustom(ctx context.Context, obj extensionsv1alpha1.Object, err error, lastOperationType gardencorev1beta1.LastOperationType, description string, updater UpdaterFunc) error {
 	if s.client == nil {
 		return fmt.Errorf("client is not set. Call InjectClient() first")
 	}
@@ -114,10 +143,20 @@ func (s *statusUpdater) Error(ctx context.Context, obj extensionsv1alpha1.Object
 	obj.GetExtensionStatus().SetObservedGeneration(obj.GetGeneration())
 	obj.GetExtensionStatus().SetLastOperation(lastOp)
 	obj.GetExtensionStatus().SetLastError(lastErr)
+	if updater != nil {
+		err := updater(obj.GetExtensionStatus())
+		if err != nil {
+			return err
+		}
+	}
 	return s.client.Status().Patch(ctx, obj, patch)
 }
 
 func (s *statusUpdater) Success(ctx context.Context, obj extensionsv1alpha1.Object, lastOperationType gardencorev1beta1.LastOperationType, description string) error {
+	return s.SuccessCustom(ctx, obj, lastOperationType, description, nil)
+}
+
+func (s *statusUpdater) SuccessCustom(ctx context.Context, obj extensionsv1alpha1.Object, lastOperationType gardencorev1beta1.LastOperationType, description string, updater UpdaterFunc) error {
 	if s.client == nil {
 		return fmt.Errorf("client is not set. Call InjectClient() first")
 	}
@@ -129,6 +168,12 @@ func (s *statusUpdater) Success(ctx context.Context, obj extensionsv1alpha1.Obje
 	obj.GetExtensionStatus().SetObservedGeneration(obj.GetGeneration())
 	obj.GetExtensionStatus().SetLastOperation(lastOp)
 	obj.GetExtensionStatus().SetLastError(lastErr)
+	if updater != nil {
+		err := updater(obj.GetExtensionStatus())
+		if err != nil {
+			return err
+		}
+	}
 	return s.client.Status().Patch(ctx, obj, patch)
 }
 

--- a/pkg/apis/extensions/v1alpha1/types_dnsrecord.go
+++ b/pkg/apis/extensions/v1alpha1/types_dnsrecord.go
@@ -110,3 +110,9 @@ const (
 	// DNSRecordTypeTXT specifies that the DNSRecord is of type TXT.
 	DNSRecordTypeTXT DNSRecordType = "TXT"
 )
+
+const (
+	// ConditionTypeCreated specifies the condition type "Created" used as marker if record creation
+	// on infrastructure was performed successfully at least once.
+	ConditionTypeCreated = "Created"
+)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Applying a `DNSRecord` in the DNS infrastructure may fail because of wrong credentials or because the configured provider does not have a matching hosted zone. In this case the `DNSRecord` object cannot be deleted anymore, as the finalizer is always set and the checks on deletion will fail because of the same configuration issue.
With this PR a `Created`condition is added. The status of the condition is set to `True` on the first successful creation of the DNS record in the infrastructure. Otherwise if the creation fails the status is set to `False` if the condition was not already set.
On deletion, the condition is checked. If the status is `False`, the record was never created in the infrastructure and the object can be deleted without further action. If the status is `True`, the standard deletion logic is applied.

**Which issue(s) this PR fixes**:
Fixes https://github.tools.sap/kubernetes-live/issues-live/issues/1255

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other dependency
Add `Created` condition to `DNSRecord` to allow deletion on unsuccessful creation in infrastructure
```

/invite @stoyanr @timuthy 