### PR TITLE
README.md: Remove statement about K8s e2e tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Continuous conformance test results of the latest stable Gardener release are up
 
 [1] Conformance tests are still executed and validated, unfortunately [no longer shown in TestGrid](https://github.com/kubernetes/test-infra/pull/18509#issuecomment-668204180).
 
-Besides the conformance tests, over 400 additional e2e tests are executed on a daily basis. Get an overview of the test results at [testgrid](https://testgrid.k8s.io/gardener-all).
+Get an overview of the test results at [testgrid](https://testgrid.k8s.io/gardener-all).
 
 ## Start using or developing the Gardener locally
 


### PR DESCRIPTION
/area documentation
/kind cleanup

To my latest understanding, there is no capacity to proactively look into K8s e2e tests (looking into test failures and test setups - some may just need to be skipped because they are not applicable in the Gardener context) and the intention was to drop the execution of these e2e tests for now.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
