### PR TITLE
[release-v1.37] Automated cherry pick of #5209: Set operation annotation when scaling etcd

### DIFF
--- a/pkg/client/kubernetes/scaling.go
+++ b/pkg/client/kubernetes/scaling.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
-	gardencorev1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/utils/retry"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -41,6 +41,9 @@ func ScaleStatefulSet(ctx context.Context, c client.Client, key client.ObjectKey
 	return scaleResource(ctx, c, statefulset, replicas)
 }
 
+// TimeNow returns the current time. Exposed for testing.
+var TimeNow = time.Now
+
 // ScaleEtcd scales an Etcd resource.
 func ScaleEtcd(ctx context.Context, c client.Client, key client.ObjectKey, replicas int) error {
 	etcd := &druidv1alpha1.Etcd{
@@ -59,7 +62,8 @@ func ScaleEtcd(ctx context.Context, c client.Client, key client.ObjectKey, repli
 		etcd.SetAnnotations(make(map[string]string))
 	}
 
-	etcd.Annotations[gardencorev1beta1constants.GardenerOperation] = gardencorev1beta1constants.GardenerOperationReconcile
+	etcd.Annotations[v1beta1constants.GardenerOperation] = v1beta1constants.GardenerOperationReconcile
+	etcd.Annotations[v1beta1constants.GardenerTimestamp] = TimeNow().UTC().String()
 	etcd.Spec.Replicas = replicas
 
 	return c.Patch(ctx, etcd, patch)

--- a/pkg/client/kubernetes/scaling.go
+++ b/pkg/client/kubernetes/scaling.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
+	gardencorev1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/utils/retry"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -40,7 +41,7 @@ func ScaleStatefulSet(ctx context.Context, c client.Client, key client.ObjectKey
 	return scaleResource(ctx, c, statefulset, replicas)
 }
 
-// ScaleEtcd scales a Etcd resource.
+// ScaleEtcd scales an Etcd resource.
 func ScaleEtcd(ctx context.Context, c client.Client, key client.ObjectKey, replicas int) error {
 	etcd := &druidv1alpha1.Etcd{
 		ObjectMeta: metav1.ObjectMeta{
@@ -49,7 +50,19 @@ func ScaleEtcd(ctx context.Context, c client.Client, key client.ObjectKey, repli
 		},
 	}
 
-	return scaleResource(ctx, c, etcd, int32(replicas))
+	if err := c.Get(ctx, key, etcd); err != nil {
+		return err
+	}
+
+	patch := client.MergeFrom(etcd.DeepCopy())
+	if etcd.Annotations == nil {
+		etcd.SetAnnotations(make(map[string]string))
+	}
+
+	etcd.Annotations[gardencorev1beta1constants.GardenerOperation] = gardencorev1beta1constants.GardenerOperationReconcile
+	etcd.Spec.Replicas = replicas
+
+	return c.Patch(ctx, etcd, patch)
 }
 
 // ScaleDeployment scales a Deployment.

--- a/pkg/client/kubernetes/scaling_test.go
+++ b/pkg/client/kubernetes/scaling_test.go
@@ -16,9 +16,11 @@ package kubernetes_test
 
 import (
 	"context"
+	"time"
 
-	gardencorev1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	. "github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/test"
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 	. "github.com/onsi/ginkgo"
@@ -78,12 +80,19 @@ var _ = Describe("scale", func() {
 
 	Context("ScaleEtcd", func() {
 		It("sets scale to 2", func() {
+			now := time.Date(100, 1, 1, 0, 0, 0, 0, time.UTC)
+			nowFunc := func() time.Time {
+				return now
+			}
+			defer test.WithVar(&TimeNow, nowFunc)()
+
 			Expect(ScaleEtcd(ctx, c, key, 2)).NotTo(HaveOccurred(), "scale succeeds")
 
 			updated := &druidv1alpha1.Etcd{}
 			Expect(c.Get(ctx, key, updated)).NotTo(HaveOccurred(), "could get the updated resource")
 
-			Expect(updated.Annotations).To(HaveKeyWithValue(gardencorev1beta1constants.GardenerOperation, gardencorev1beta1constants.GardenerOperationReconcile))
+			Expect(updated.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile))
+			Expect(updated.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerTimestamp, now.String()))
 			Expect(updated.Spec.Replicas).To(BeEquivalentTo(2), "updated replica")
 		})
 	})

--- a/pkg/client/kubernetes/scaling_test.go
+++ b/pkg/client/kubernetes/scaling_test.go
@@ -17,6 +17,9 @@ package kubernetes_test
 import (
 	"context"
 
+	gardencorev1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	. "github.com/gardener/gardener/pkg/client/kubernetes"
+
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -26,8 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
-	. "github.com/gardener/gardener/pkg/client/kubernetes"
 )
 
 var _ = Describe("scale", func() {
@@ -82,6 +83,7 @@ var _ = Describe("scale", func() {
 			updated := &druidv1alpha1.Etcd{}
 			Expect(c.Get(ctx, key, updated)).NotTo(HaveOccurred(), "could get the updated resource")
 
+			Expect(updated.Annotations).To(HaveKeyWithValue(gardencorev1beta1constants.GardenerOperation, gardencorev1beta1constants.GardenerOperationReconcile))
 			Expect(updated.Spec.Replicas).To(BeEquivalentTo(2), "updated replica")
 		})
 	})

--- a/pkg/operation/botanist/etcd_test.go
+++ b/pkg/operation/botanist/etcd_test.go
@@ -17,6 +17,7 @@ package botanist_test
 import (
 	"context"
 	"fmt"
+	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	gardencorev1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
@@ -506,6 +507,12 @@ var _ = Describe("Etcd", func() {
 			})
 
 			It("should scale both etcds to 0", func() {
+				now := time.Date(100, 1, 1, 0, 0, 0, 0, time.UTC)
+				nowFunc := func() time.Time {
+					return now
+				}
+				defer test.WithVar(&kubernetes.TimeNow, nowFunc)()
+
 				c.EXPECT().Get(ctx, client.ObjectKeyFromObject(etcdMain), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(
 					func(_ context.Context, _ client.ObjectKey, etcd *druidv1alpha1.Etcd) error {
 						*etcd = *etcdMain
@@ -520,7 +527,7 @@ var _ = Describe("Etcd", func() {
 					func(_ context.Context, etcd *druidv1alpha1.Etcd, patch client.Patch, _ ...client.PatchOption) error {
 						data, err := patch.Data(etcd)
 						Expect(err).ToNot(HaveOccurred())
-						Expect(string(data)).To(Equal(`{"metadata":{"annotations":{"gardener.cloud/operation":"reconcile"}},"spec":{"replicas":0}}`))
+						Expect(string(data)).To(Equal(`{"metadata":{"annotations":{"gardener.cloud/operation":"reconcile","gardener.cloud/timestamp":"0100-01-01 00:00:00 +0000 UTC"}},"spec":{"replicas":0}}`))
 						return nil
 					}).Times(2)
 
@@ -583,6 +590,12 @@ var _ = Describe("Etcd", func() {
 			})
 
 			It("should scale both etcds to 1", func() {
+				now := time.Date(100, 1, 1, 0, 0, 0, 0, time.UTC)
+				nowFunc := func() time.Time {
+					return now
+				}
+				defer test.WithVar(&kubernetes.TimeNow, nowFunc)()
+
 				c.EXPECT().Get(ctx, client.ObjectKeyFromObject(etcdMain), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(
 					func(_ context.Context, _ client.ObjectKey, etcd *druidv1alpha1.Etcd) error {
 						*etcd = *etcdMain
@@ -597,7 +610,7 @@ var _ = Describe("Etcd", func() {
 					func(_ context.Context, etcd *druidv1alpha1.Etcd, patch client.Patch, _ ...client.PatchOption) error {
 						data, err := patch.Data(etcd)
 						Expect(err).ToNot(HaveOccurred())
-						Expect(string(data)).To(Equal(`{"metadata":{"annotations":{"gardener.cloud/operation":"reconcile"}},"spec":{"replicas":1}}`))
+						Expect(string(data)).To(Equal(`{"metadata":{"annotations":{"gardener.cloud/operation":"reconcile","gardener.cloud/timestamp":"0100-01-01 00:00:00 +0000 UTC"}},"spec":{"replicas":1}}`))
 						return nil
 					}).Times(2)
 

--- a/pkg/operation/botanist/etcd_test.go
+++ b/pkg/operation/botanist/etcd_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardencorev1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	fakeclientset "github.com/gardener/gardener/pkg/client/kubernetes/fake"
@@ -472,10 +473,18 @@ var _ = Describe("Etcd", func() {
 
 	Describe("#ScaleETCDTo*", func() {
 		var (
+			etcdMain, etcdEvents *druidv1alpha1.Etcd
+			replicas             int
+		)
+
+		JustBeforeEach(func() {
 			etcdEvents = &druidv1alpha1.Etcd{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "etcd-events",
 					Namespace: namespace,
+				},
+				Spec: druidv1alpha1.EtcdSpec{
+					Replicas: replicas,
 				},
 			}
 			etcdMain = &druidv1alpha1.Etcd{
@@ -483,57 +492,163 @@ var _ = Describe("Etcd", func() {
 					Name:      "etcd-main",
 					Namespace: namespace,
 				},
+				Spec: druidv1alpha1.EtcdSpec{
+					Replicas: replicas,
+				},
 			}
-		)
-
-		BeforeEach(func() {
 			botanist.K8sSeedClient = kubernetesClient
 			botanist.Shoot = &shootpkg.Shoot{SeedNamespace: namespace}
 		})
 
 		Describe("#ScaleETCDToZero", func() {
-			var patch = client.RawPatch(types.MergePatchType, []byte(`{"spec":{"replicas":0}}`))
+			BeforeEach(func() {
+				replicas = 1
+			})
 
 			It("should scale both etcds to 0", func() {
-				c.EXPECT().Patch(ctx, etcdEvents, patch)
-				c.EXPECT().Patch(ctx, etcdMain, patch)
+				c.EXPECT().Get(ctx, client.ObjectKeyFromObject(etcdMain), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(
+					func(_ context.Context, _ client.ObjectKey, etcd *druidv1alpha1.Etcd) error {
+						*etcd = *etcdMain
+						return nil
+					})
+				c.EXPECT().Get(ctx, client.ObjectKeyFromObject(etcdEvents), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(
+					func(_ context.Context, _ client.ObjectKey, etcd *druidv1alpha1.Etcd) error {
+						*etcd = *etcdEvents
+						return nil
+					})
+				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).DoAndReturn(
+					func(_ context.Context, etcd *druidv1alpha1.Etcd, patch client.Patch, _ ...client.PatchOption) error {
+						data, err := patch.Data(etcd)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(string(data)).To(Equal(`{"metadata":{"annotations":{"gardener.cloud/operation":"reconcile"}},"spec":{"replicas":0}}`))
+						return nil
+					}).Times(2)
 
 				Expect(botanist.ScaleETCDToZero(ctx)).To(Succeed())
 			})
 
 			It("should return the error when scaling etcd-events fails", func() {
-				c.EXPECT().Patch(ctx, etcdEvents, patch).Return(fakeErr)
+				c.EXPECT().Get(ctx, client.ObjectKeyFromObject(etcdEvents), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(
+					func(_ context.Context, _ client.ObjectKey, etcd *druidv1alpha1.Etcd) error {
+						*etcd = *etcdEvents
+						return nil
+					})
+
+				etcdEvents.Annotations = map[string]string{
+					gardencorev1beta1constants.GardenerOperation: gardencorev1beta1constants.GardenerOperationReconcile,
+				}
+				etcdEvents.Spec.Replicas = 0
+				c.EXPECT().Patch(ctx, etcdEvents, gomock.Any()).Return(fakeErr)
 
 				Expect(botanist.ScaleETCDToZero(ctx)).To(MatchError(fakeErr))
 			})
 
 			It("should return the error when scaling etcd-main fails", func() {
-				c.EXPECT().Patch(ctx, etcdEvents, patch)
-				c.EXPECT().Patch(ctx, etcdMain, patch).Return(fakeErr)
+				c.EXPECT().Get(ctx, client.ObjectKeyFromObject(etcdEvents), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(
+					func(_ context.Context, _ client.ObjectKey, etcd *druidv1alpha1.Etcd) error {
+						*etcd = *etcdEvents
+						return nil
+					})
+
+				etcdEvents.Annotations = map[string]string{
+					gardencorev1beta1constants.GardenerOperation: gardencorev1beta1constants.GardenerOperationReconcile,
+				}
+				etcdEvents.Spec.Replicas = 0
+				c.EXPECT().Patch(ctx, etcdEvents, gomock.Any())
+
+				c.EXPECT().Get(ctx, client.ObjectKeyFromObject(etcdMain), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(
+					func(_ context.Context, _ client.ObjectKey, etcd *druidv1alpha1.Etcd) error {
+						*etcd = druidv1alpha1.Etcd{
+							ObjectMeta: etcdMain.ObjectMeta,
+							Spec: druidv1alpha1.EtcdSpec{
+								Replicas: 1,
+							},
+						}
+						return nil
+					})
+
+				etcdMain.Annotations = map[string]string{
+					gardencorev1beta1constants.GardenerOperation: gardencorev1beta1constants.GardenerOperationReconcile,
+				}
+				etcdMain.Spec.Replicas = 0
+				c.EXPECT().Patch(ctx, etcdMain, gomock.Any()).Return(fakeErr)
 
 				Expect(botanist.ScaleETCDToZero(ctx)).To(MatchError(fakeErr))
 			})
 		})
 
 		Describe("#ScaleETCDToOne", func() {
-			var patch = client.RawPatch(types.MergePatchType, []byte(`{"spec":{"replicas":1}}`))
+			BeforeEach(func() {
+				replicas = 0
+			})
 
 			It("should scale both etcds to 1", func() {
-				c.EXPECT().Patch(ctx, etcdEvents, patch)
-				c.EXPECT().Patch(ctx, etcdMain, patch)
+				c.EXPECT().Get(ctx, client.ObjectKeyFromObject(etcdMain), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(
+					func(_ context.Context, _ client.ObjectKey, etcd *druidv1alpha1.Etcd) error {
+						*etcd = *etcdMain
+						return nil
+					})
+				c.EXPECT().Get(ctx, client.ObjectKeyFromObject(etcdEvents), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(
+					func(_ context.Context, _ client.ObjectKey, etcd *druidv1alpha1.Etcd) error {
+						*etcd = *etcdEvents
+						return nil
+					})
+				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).DoAndReturn(
+					func(_ context.Context, etcd *druidv1alpha1.Etcd, patch client.Patch, _ ...client.PatchOption) error {
+						data, err := patch.Data(etcd)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(string(data)).To(Equal(`{"metadata":{"annotations":{"gardener.cloud/operation":"reconcile"}},"spec":{"replicas":1}}`))
+						return nil
+					}).Times(2)
 
 				Expect(botanist.ScaleETCDToOne(ctx)).To(Succeed())
 			})
 
 			It("should return the error when scaling etcd-events fails", func() {
-				c.EXPECT().Patch(ctx, etcdEvents, patch).Return(fakeErr)
+				c.EXPECT().Get(ctx, client.ObjectKeyFromObject(etcdEvents), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(
+					func(_ context.Context, _ client.ObjectKey, etcd *druidv1alpha1.Etcd) error {
+						*etcd = *etcdEvents
+						return nil
+					})
+
+				etcdEvents.Annotations = map[string]string{
+					gardencorev1beta1constants.GardenerOperation: gardencorev1beta1constants.GardenerOperationReconcile,
+				}
+				etcdEvents.Spec.Replicas = 1
+				c.EXPECT().Patch(ctx, etcdEvents, gomock.Any()).Return(fakeErr)
 
 				Expect(botanist.ScaleETCDToOne(ctx)).To(MatchError(fakeErr))
 			})
 
 			It("should return the error when scaling etcd-main fails", func() {
-				c.EXPECT().Patch(ctx, etcdEvents, patch)
-				c.EXPECT().Patch(ctx, etcdMain, patch).Return(fakeErr)
+				c.EXPECT().Get(ctx, client.ObjectKeyFromObject(etcdEvents), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(
+					func(_ context.Context, _ client.ObjectKey, etcd *druidv1alpha1.Etcd) error {
+						*etcd = *etcdEvents
+						return nil
+					})
+
+				etcdEvents.Annotations = map[string]string{
+					gardencorev1beta1constants.GardenerOperation: gardencorev1beta1constants.GardenerOperationReconcile,
+				}
+				etcdEvents.Spec.Replicas = 1
+				c.EXPECT().Patch(ctx, etcdEvents, gomock.Any())
+
+				c.EXPECT().Get(ctx, client.ObjectKeyFromObject(etcdMain), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(
+					func(_ context.Context, _ client.ObjectKey, etcd *druidv1alpha1.Etcd) error {
+						*etcd = druidv1alpha1.Etcd{
+							ObjectMeta: etcdMain.ObjectMeta,
+							Spec: druidv1alpha1.EtcdSpec{
+								Replicas: 1,
+							},
+						}
+						return nil
+					})
+
+				etcdMain.Annotations = map[string]string{
+					gardencorev1beta1constants.GardenerOperation: gardencorev1beta1constants.GardenerOperationReconcile,
+				}
+				etcdMain.Spec.Replicas = 1
+				c.EXPECT().Patch(ctx, etcdMain, gomock.Any()).Return(fakeErr)
 
 				Expect(botanist.ScaleETCDToOne(ctx)).To(MatchError(fakeErr))
 			})


### PR DESCRIPTION
/kind/bug
/area/control-plane

Cherry pick of #5209 on release-v1.37.

#5209: Set operation annotation when scaling etcd

**Release Notes:**
```bugfix operator
A bug has been fixed that caused `etcd` pods still to be active in the control plane even though the cluster was hibernated successfully.  
```