### PR TITLE
Fix unmanaged primary DNS provider

### DIFF
--- a/plugin/pkg/global/extensionvalidation/admission.go
+++ b/plugin/pkg/global/extensionvalidation/admission.go
@@ -295,7 +295,7 @@ func (e *ExtensionValidator) validateShoot(kindToTypesMap map[string]sets.String
 
 	if spec.DNS != nil {
 		for i, provider := range spec.DNS.Providers {
-			if provider.Type == nil {
+			if provider.Type == nil || *provider.Type == core.DNSUnmanaged {
 				continue
 			}
 

--- a/plugin/pkg/global/extensionvalidation/admission_test.go
+++ b/plugin/pkg/global/extensionvalidation/admission_test.go
@@ -288,6 +288,7 @@ var _ = Describe("ExtensionValidator", func() {
 					Providers: []core.DNSProvider{
 						{Type: pointer.String("foo-1")},
 						{Type: pointer.String("foo0")},
+						{Type: pointer.String("unmanaged")},
 					},
 				},
 				Extensions: []core.Extension{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
This PR fixes an issue which prevented the configuration of `unmanaged` primary DNS providers.

**Which issue(s) this PR fixes**:
Fixes #4995

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
An issue has been fixed which prevented the configuration of `unmanaged` primary DNS providers.
```
