### PR TITLE
Prevent e2e test to succeed if only deletion fails

### DIFF
--- a/hack/test-e2e-local.sh
+++ b/hack/test-e2e-local.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
 create_failed=yes
+delete_failed=yes
+
 trap shoot_deletion EXIT
 
 function shoot_deletion {
@@ -11,7 +13,11 @@ function shoot_deletion {
     -shoot-name=e2e-local \
     -skip-accessing-shoot=${SKIP_ACCESSING_SHOOT:-true}
 
-  if [ $create_failed = yes ] ; then
+  if [ $? = 0 ] ; then
+    delete_failed=no
+  fi
+
+  if [ $create_failed = yes ] || [ $delete_failed = yes ] ; then
     exit 1
   fi
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
The `test-e2e-local.sh` script can succeed if shoot creation succeeds but deletion fails, see for example https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/5209/pull-gardener-e2e-kind/1480455404826660864. This PR fixes this.

**Which issue(s) this PR fixes**:
Fixes a part of #5240 (https://github.com/gardener/gardener/issues/5240#issuecomment-1009653799)

**Special notes for your reviewer**:
/cc @timebertt 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
