### PR TITLE
Fix `make docker-images`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -107,7 +107,7 @@ ENTRYPOINT ["/landscaper-controlplane"]
 ############# gardener-extension-provider-local #############
 FROM base AS gardener-extension-provider-local
 
-COPY --from=builder /gardener-extension-provider-local /gardener-extension-provider-local
+COPY --from=builder /go/bin/gardener-extension-provider-local /gardener-extension-provider-local
 COPY charts/gardener/provider-local /charts/gardener/provider-local
 
 WORKDIR /


### PR DESCRIPTION
/area quality dev-productivity
/kind bug
/kind regression

```
$ make docker-images REGiSTRY=<registry>

 => ERROR [gardener-extension-provider-local 1/3] COPY --from=builder /gardener-extension-p  0.0s
------
 > [gardener-extension-provider-local 1/3] COPY --from=builder /gardener-extension-provider-local /gardener-extension-provider-local:
------
failed to compute cache key: "/gardener-extension-provider-local" not found: not found
make: *** [docker-images] Error 1
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
