### PR TITLE
Do not bootstrap GRM when shoot is hibernated

### DIFF
--- a/pkg/operation/botanist/component/resourcemanager/resource_manager.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager.go
@@ -244,7 +244,7 @@ func (r *resourceManager) Deploy(ctx context.Context) error {
 	}
 
 	// TODO(rfranzke): Remove in a future release.
-	if r.values.TargetDiffersFromSourceCluster {
+	if r.values.TargetDiffersFromSourceCluster && r.replicas > 0 {
 		return kutil.DeleteObject(ctx, r.client, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "gardener-resource-manager", Namespace: r.namespace}})
 	}
 

--- a/pkg/operation/botanist/resource_manager.go
+++ b/pkg/operation/botanist/resource_manager.go
@@ -161,6 +161,10 @@ func (b *Botanist) ScaleGardenerResourceManagerToOne(ctx context.Context) error 
 }
 
 func (b *Botanist) mustBootstrapGardenerResourceManager(ctx context.Context) (bool, error) {
+	if b.Shoot.HibernationEnabled && b.Shoot.GetInfo().Status.IsHibernated {
+		return false, nil // Shoot is already hibernated
+	}
+
 	shootAccessSecret := gutil.NewShootAccessSecret(resourcemanager.SecretNameShootAccess, b.Shoot.SeedNamespace)
 	if err := b.K8sSeedClient.Client().Get(ctx, client.ObjectKeyFromObject(shootAccessSecret.Secret), shootAccessSecret.Secret); err != nil {
 		if !apierrors.IsNotFound(err) {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind regression

**What this PR does / why we need it**:
When an existing `Shoot` is hibernated and later reconciled by a gardenlet built from the `master` branch of Gardener (or the to-be-released `v1.39`+ version) then it fails with:

```text
Flow "Shoot cluster reconciliation" encountered task errors: [task "Deploying gardener-resource-manager" failed: retry failed with context deadline exceeded, last error: retry failed with context deadline exceeded, last error: token not yet generated] Operation will be retried.
```

This PR fixes this by skipping the bootstrap process if the `Shoot` is already hibernated. If a `Shoot` is currently in the phase of getting hibernated then the bootstrap process is still executed since GRM will only be scaled down to `0` later when the `HibernateControlPlane` flow task is executed (consequently, the `DeployGardenerResourceManager` task can still perform the migration from the client cert to the token).

**Special notes for your reviewer**:
/cc @vpnachev @ialidzhikov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
