### PR TITLE
[release-v1.37] Automated cherry pick of #5243: Fix timestamp expectation when scaling etcd

### DIFF
--- a/pkg/client/kubernetes/scaling.go
+++ b/pkg/client/kubernetes/scaling.go
@@ -19,8 +19,6 @@ import (
 	"fmt"
 	"time"
 
-	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/utils/retry"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -39,34 +37,6 @@ func ScaleStatefulSet(ctx context.Context, c client.Client, key client.ObjectKey
 	}
 
 	return scaleResource(ctx, c, statefulset, replicas)
-}
-
-// TimeNow returns the current time. Exposed for testing.
-var TimeNow = time.Now
-
-// ScaleEtcd scales an Etcd resource.
-func ScaleEtcd(ctx context.Context, c client.Client, key client.ObjectKey, replicas int) error {
-	etcd := &druidv1alpha1.Etcd{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      key.Name,
-			Namespace: key.Namespace,
-		},
-	}
-
-	if err := c.Get(ctx, key, etcd); err != nil {
-		return err
-	}
-
-	patch := client.MergeFrom(etcd.DeepCopy())
-	if etcd.Annotations == nil {
-		etcd.SetAnnotations(make(map[string]string))
-	}
-
-	etcd.Annotations[v1beta1constants.GardenerOperation] = v1beta1constants.GardenerOperationReconcile
-	etcd.Annotations[v1beta1constants.GardenerTimestamp] = TimeNow().UTC().String()
-	etcd.Spec.Replicas = replicas
-
-	return c.Patch(ctx, etcd, patch)
 }
 
 // ScaleDeployment scales a Deployment.

--- a/pkg/client/kubernetes/scaling_test.go
+++ b/pkg/client/kubernetes/scaling_test.go
@@ -16,11 +16,8 @@ package kubernetes_test
 
 import (
 	"context"
-	"time"
 
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	. "github.com/gardener/gardener/pkg/client/kubernetes"
-	"github.com/gardener/gardener/pkg/utils/test"
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 	. "github.com/onsi/ginkgo"
@@ -75,25 +72,6 @@ var _ = Describe("scale", func() {
 			Expect(c.Get(ctx, key, updated)).NotTo(HaveOccurred(), "could get the updated resource")
 
 			Expect(updated.Spec.Replicas).To(PointTo(BeEquivalentTo(2)), "updated replica")
-		})
-	})
-
-	Context("ScaleEtcd", func() {
-		It("sets scale to 2", func() {
-			now := time.Date(100, 1, 1, 0, 0, 0, 0, time.UTC)
-			nowFunc := func() time.Time {
-				return now
-			}
-			defer test.WithVar(&TimeNow, nowFunc)()
-
-			Expect(ScaleEtcd(ctx, c, key, 2)).NotTo(HaveOccurred(), "scale succeeds")
-
-			updated := &druidv1alpha1.Etcd{}
-			Expect(c.Get(ctx, key, updated)).NotTo(HaveOccurred(), "could get the updated resource")
-
-			Expect(updated.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile))
-			Expect(updated.Annotations).To(HaveKeyWithValue(v1beta1constants.GardenerTimestamp, now.String()))
-			Expect(updated.Spec.Replicas).To(BeEquivalentTo(2), "updated replica")
 		})
 	})
 })

--- a/pkg/gardenlet/controller/shoot/shoot_control_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_delete.go
@@ -255,15 +255,15 @@ func (r *shootReconciler) runDeleteShootFlow(ctx context.Context, o *operation.O
 			Fn:           flow.TaskFn(botanist.DeployEtcd).RetryUntilTimeout(defaultInterval, defaultTimeout).DoIf(cleanupShootResources),
 			Dependencies: flow.NewTaskIDs(deploySecrets, deployCloudProviderSecret, deployOwnerDomainDNSRecord),
 		})
-		_ = g.Add(flow.Task{
-			Name:         "Scale up etcd main and event",
+		scaleETCD = g.Add(flow.Task{
+			Name:         "Scaling up etcd main and event",
 			Fn:           flow.TaskFn(botanist.ScaleETCDToOne).RetryUntilTimeout(defaultInterval, defaultTimeout).DoIf(cleanupShootResources),
 			Dependencies: flow.NewTaskIDs(deployETCD),
 		})
 		waitUntilEtcdReady = g.Add(flow.Task{
 			Name:         "Waiting until main and event etcd report readiness",
 			Fn:           flow.TaskFn(botanist.WaitUntilEtcdsReady).DoIf(cleanupShootResources),
-			Dependencies: flow.NewTaskIDs(deployETCD),
+			Dependencies: flow.NewTaskIDs(scaleETCD),
 		})
 		// Redeploy the control plane to make sure all components that depend on the cloud provider secret are restarted
 		// in case it has changed. Also, it's needed for other control plane components like the kube-apiserver or kube-

--- a/pkg/operation/botanist/component/etcd/etcd.go
+++ b/pkg/operation/botanist/component/etcd/etcd.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gardener/gardener/pkg/utils"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
 
 	"github.com/sirupsen/logrus"
@@ -113,6 +114,8 @@ type Interface interface {
 	Get(context.Context) (*druidv1alpha1.Etcd, error)
 	// SetOwnerCheckConfig sets the owner check configuration.
 	SetOwnerCheckConfig(config *OwnerCheckConfig)
+	// ScaleETCD scales the etcd resource to the given replica count.
+	ScaleETCD(context.Context, int) error
 }
 
 // New creates a new instance of DeployWaiter for the Etcd.
@@ -614,6 +617,36 @@ func (e *etcd) SetBackupConfig(backupConfig *BackupConfig) { e.backupConfig = ba
 func (e *etcd) SetHVPAConfig(hvpaConfig *HVPAConfig)       { e.hvpaConfig = hvpaConfig }
 func (e *etcd) SetOwnerCheckConfig(ownerCheckConfig *OwnerCheckConfig) {
 	e.ownerCheckConfig = ownerCheckConfig
+}
+
+func (e *etcd) ScaleETCD(ctx context.Context, replicas int) error {
+	etcdObj := &druidv1alpha1.Etcd{}
+	if err := e.client.Get(ctx, client.ObjectKeyFromObject(e.etcd), etcdObj); err != nil {
+		return err
+	}
+
+	if expectedTimestamp, ok := e.etcd.Annotations[v1beta1constants.GardenerTimestamp]; ok {
+		if err := health.ObjectHasAnnotationWithValue(v1beta1constants.GardenerTimestamp, expectedTimestamp)(etcdObj); err != nil {
+			return err
+		}
+	}
+
+	if _, ok := etcdObj.Annotations[v1beta1constants.GardenerOperation]; ok {
+		return fmt.Errorf("etcd object still has operation annotation set")
+	}
+
+	patch := client.MergeFrom(etcdObj.DeepCopy())
+	if e.etcd.Annotations == nil {
+		etcdObj.SetAnnotations(make(map[string]string))
+	}
+
+	etcdObj.Annotations[v1beta1constants.GardenerOperation] = v1beta1constants.GardenerOperationReconcile
+	etcdObj.Annotations[v1beta1constants.GardenerTimestamp] = TimeNow().UTC().String()
+	etcdObj.Spec.Replicas = replicas
+
+	e.etcd = etcdObj
+
+	return e.client.Patch(ctx, etcdObj, patch)
 }
 
 func (e *etcd) podLabelSelector() labels.Selector {

--- a/pkg/operation/botanist/component/etcd/etcd.go
+++ b/pkg/operation/botanist/component/etcd/etcd.go
@@ -114,8 +114,8 @@ type Interface interface {
 	Get(context.Context) (*druidv1alpha1.Etcd, error)
 	// SetOwnerCheckConfig sets the owner check configuration.
 	SetOwnerCheckConfig(config *OwnerCheckConfig)
-	// ScaleETCD scales the etcd resource to the given replica count.
-	ScaleETCD(context.Context, int) error
+	// Scale scales the etcd resource to the given replica count.
+	Scale(context.Context, int) error
 }
 
 // New creates a new instance of DeployWaiter for the Etcd.
@@ -619,7 +619,7 @@ func (e *etcd) SetOwnerCheckConfig(ownerCheckConfig *OwnerCheckConfig) {
 	e.ownerCheckConfig = ownerCheckConfig
 }
 
-func (e *etcd) ScaleETCD(ctx context.Context, replicas int) error {
+func (e *etcd) Scale(ctx context.Context, replicas int) error {
 	etcdObj := &druidv1alpha1.Etcd{}
 	if err := e.client.Get(ctx, client.ObjectKeyFromObject(e.etcd), etcdObj); err != nil {
 		return err

--- a/pkg/operation/botanist/component/etcd/etcd_test.go
+++ b/pkg/operation/botanist/component/etcd/etcd_test.go
@@ -1270,7 +1270,7 @@ var _ = Describe("Etcd", func() {
 		})
 	})
 
-	Describe("#ScaleETCD", func() {
+	Describe("#Scale", func() {
 		var etcdObj *druidv1alpha1.Etcd
 
 		BeforeEach(func() {
@@ -1305,7 +1305,7 @@ var _ = Describe("Etcd", func() {
 					return nil
 				})
 
-			Expect(etcd.ScaleETCD(ctx, 1)).To(Succeed())
+			Expect(etcd.Scale(ctx, 1)).To(Succeed())
 		})
 
 		It("should set operation annotation when replica count is unchanged", func() {
@@ -1331,7 +1331,7 @@ var _ = Describe("Etcd", func() {
 					return nil
 				})
 
-			Expect(etcd.ScaleETCD(ctx, 1)).To(Succeed())
+			Expect(etcd.Scale(ctx, 1)).To(Succeed())
 		})
 
 		It("should fail if GardenerTimestamp is unexpected", func() {
@@ -1359,8 +1359,8 @@ var _ = Describe("Etcd", func() {
 				),
 			)
 
-			Expect(etcd.ScaleETCD(ctx, 1)).To(Succeed())
-			Expect(etcd.ScaleETCD(ctx, 1)).Should(MatchError(`object's "gardener.cloud/timestamp" annotation is not "0001-01-01 00:00:00 +0000 UTC" but "foo"`))
+			Expect(etcd.Scale(ctx, 1)).To(Succeed())
+			Expect(etcd.Scale(ctx, 1)).Should(MatchError(`object's "gardener.cloud/timestamp" annotation is not "0001-01-01 00:00:00 +0000 UTC" but "foo"`))
 		})
 
 		It("should fail because operation annotation is set", func() {
@@ -1374,7 +1374,7 @@ var _ = Describe("Etcd", func() {
 				},
 			)
 
-			Expect(etcd.ScaleETCD(ctx, 1)).Should(MatchError(`etcd object still has operation annotation set`))
+			Expect(etcd.Scale(ctx, 1)).Should(MatchError(`etcd object still has operation annotation set`))
 		})
 	})
 })

--- a/pkg/operation/botanist/component/etcd/etcd_test.go
+++ b/pkg/operation/botanist/component/etcd/etcd_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	mockkubernetes "github.com/gardener/gardener/pkg/client/kubernetes/mock"
 	"github.com/gardener/gardener/pkg/logger"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
@@ -1266,6 +1267,114 @@ var _ = Describe("Etcd", func() {
 
 				Expect(etcd.Snapshot(ctx, podExecutor)).To(MatchError(fakeErr))
 			})
+		})
+	})
+
+	Describe("#ScaleETCD", func() {
+		var etcdObj *druidv1alpha1.Etcd
+
+		BeforeEach(func() {
+			etcdObj = &druidv1alpha1.Etcd{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "etcd-test",
+					Namespace: testNamespace,
+				},
+			}
+		})
+
+		It("should scale ETCD from 0 to 1", func() {
+			etcdObj.Spec.Replicas = 0
+
+			nowFunc := func() time.Time {
+				return now
+			}
+			defer test.WithVar(&TimeNow, nowFunc)()
+
+			c.EXPECT().Get(ctx, client.ObjectKeyFromObject(etcdObj), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(
+				func(_ context.Context, _ client.ObjectKey, etcd *druidv1alpha1.Etcd) error {
+					*etcd = *etcdObj
+					return nil
+				},
+			)
+
+			c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).DoAndReturn(
+				func(_ context.Context, etcd *druidv1alpha1.Etcd, patch client.Patch, _ ...client.PatchOption) error {
+					data, err := patch.Data(etcd)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(string(data)).To(Equal(fmt.Sprintf(`{"metadata":{"annotations":{"gardener.cloud/operation":"reconcile","gardener.cloud/timestamp":"%s"}},"spec":{"replicas":1}}`, now.String())))
+					return nil
+				})
+
+			Expect(etcd.ScaleETCD(ctx, 1)).To(Succeed())
+		})
+
+		It("should set operation annotation when replica count is unchanged", func() {
+			etcdObj.Spec.Replicas = 1
+
+			nowFunc := func() time.Time {
+				return now
+			}
+			defer test.WithVar(&TimeNow, nowFunc)()
+
+			c.EXPECT().Get(ctx, client.ObjectKeyFromObject(etcdObj), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(
+				func(_ context.Context, _ client.ObjectKey, etcd *druidv1alpha1.Etcd) error {
+					*etcd = *etcdObj
+					return nil
+				},
+			)
+
+			c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).DoAndReturn(
+				func(_ context.Context, etcd *druidv1alpha1.Etcd, patch client.Patch, _ ...client.PatchOption) error {
+					data, err := patch.Data(etcd)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(string(data)).To(Equal(fmt.Sprintf(`{"metadata":{"annotations":{"gardener.cloud/operation":"reconcile","gardener.cloud/timestamp":"%s"}}}`, now.String())))
+					return nil
+				})
+
+			Expect(etcd.ScaleETCD(ctx, 1)).To(Succeed())
+		})
+
+		It("should fail if GardenerTimestamp is unexpected", func() {
+			nowFunc := func() time.Time {
+				return now
+			}
+			defer test.WithVar(&TimeNow, nowFunc)()
+
+			gomock.InOrder(
+				c.EXPECT().Get(ctx, client.ObjectKeyFromObject(etcdObj), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(
+					func(_ context.Context, _ client.ObjectKey, etcd *druidv1alpha1.Etcd) error {
+						*etcd = *etcdObj
+						return nil
+					},
+				),
+				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()),
+				c.EXPECT().Get(ctx, client.ObjectKeyFromObject(etcdObj), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(
+					func(_ context.Context, _ client.ObjectKey, etcd *druidv1alpha1.Etcd) error {
+						etcdObj.Annotations = map[string]string{
+							v1beta1constants.GardenerTimestamp: "foo",
+						}
+						*etcd = *etcdObj
+						return nil
+					},
+				),
+			)
+
+			Expect(etcd.ScaleETCD(ctx, 1)).To(Succeed())
+			Expect(etcd.ScaleETCD(ctx, 1)).Should(MatchError(`object's "gardener.cloud/timestamp" annotation is not "0001-01-01 00:00:00 +0000 UTC" but "foo"`))
+		})
+
+		It("should fail because operation annotation is set", func() {
+			c.EXPECT().Get(ctx, client.ObjectKeyFromObject(etcdObj), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(
+				func(_ context.Context, _ client.ObjectKey, etcd *druidv1alpha1.Etcd) error {
+					etcdObj.Annotations = map[string]string{
+						v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
+					}
+					*etcd = *etcdObj
+					return nil
+				},
+			)
+
+			Expect(etcd.ScaleETCD(ctx, 1)).Should(MatchError(`etcd object still has operation annotation set`))
 		})
 	})
 })

--- a/pkg/operation/botanist/component/etcd/mock/mocks.go
+++ b/pkg/operation/botanist/component/etcd/mock/mocks.go
@@ -95,6 +95,20 @@ func (mr *MockInterfaceMockRecorder) Get(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockInterface)(nil).Get), arg0)
 }
 
+// ScaleETCD mocks base method.
+func (m *MockInterface) ScaleETCD(arg0 context.Context, arg1 int) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ScaleETCD", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ScaleETCD indicates an expected call of ScaleETCD.
+func (mr *MockInterfaceMockRecorder) ScaleETCD(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScaleETCD", reflect.TypeOf((*MockInterface)(nil).ScaleETCD), arg0, arg1)
+}
+
 // ScrapeConfigs mocks base method.
 func (m *MockInterface) ScrapeConfigs() ([]string, error) {
 	m.ctrl.T.Helper()

--- a/pkg/operation/botanist/component/etcd/mock/mocks.go
+++ b/pkg/operation/botanist/component/etcd/mock/mocks.go
@@ -95,18 +95,18 @@ func (mr *MockInterfaceMockRecorder) Get(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockInterface)(nil).Get), arg0)
 }
 
-// ScaleETCD mocks base method.
-func (m *MockInterface) ScaleETCD(arg0 context.Context, arg1 int) error {
+// Scale mocks base method.
+func (m *MockInterface) Scale(arg0 context.Context, arg1 int) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ScaleETCD", arg0, arg1)
+	ret := m.ctrl.Call(m, "Scale", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// ScaleETCD indicates an expected call of ScaleETCD.
-func (mr *MockInterfaceMockRecorder) ScaleETCD(arg0, arg1 interface{}) *gomock.Call {
+// Scale indicates an expected call of Scale.
+func (mr *MockInterfaceMockRecorder) Scale(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScaleETCD", reflect.TypeOf((*MockInterface)(nil).ScaleETCD), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Scale", reflect.TypeOf((*MockInterface)(nil).Scale), arg0, arg1)
 }
 
 // ScrapeConfigs mocks base method.

--- a/pkg/operation/botanist/etcd.go
+++ b/pkg/operation/botanist/etcd.go
@@ -37,7 +37,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // NewEtcd is a function exposed for testing.
@@ -165,12 +164,10 @@ func (b *Botanist) ScaleETCDToOne(ctx context.Context) error {
 }
 
 func (b *Botanist) scaleETCD(ctx context.Context, replicas int) error {
-	for _, etcd := range []string{v1beta1constants.ETCDEvents, v1beta1constants.ETCDMain} {
-		if err := kubernetes.ScaleEtcd(ctx, b.K8sSeedClient.Client(), kutil.Key(b.Shoot.SeedNamespace, etcd), replicas); client.IgnoreNotFound(err) != nil {
-			return err
-		}
+	if err := b.Shoot.Components.ControlPlane.EtcdMain.ScaleETCD(ctx, replicas); err != nil {
+		return err
 	}
-	return nil
+	return b.Shoot.Components.ControlPlane.EtcdEvents.ScaleETCD(ctx, replicas)
 }
 
 func determineBackupSchedule(shoot *gardencorev1beta1.Shoot) (string, error) {

--- a/pkg/operation/botanist/etcd.go
+++ b/pkg/operation/botanist/etcd.go
@@ -164,10 +164,10 @@ func (b *Botanist) ScaleETCDToOne(ctx context.Context) error {
 }
 
 func (b *Botanist) scaleETCD(ctx context.Context, replicas int) error {
-	if err := b.Shoot.Components.ControlPlane.EtcdMain.ScaleETCD(ctx, replicas); err != nil {
+	if err := b.Shoot.Components.ControlPlane.EtcdMain.Scale(ctx, replicas); err != nil {
 		return err
 	}
-	return b.Shoot.Components.ControlPlane.EtcdEvents.ScaleETCD(ctx, replicas)
+	return b.Shoot.Components.ControlPlane.EtcdEvents.Scale(ctx, replicas)
 }
 
 func determineBackupSchedule(shoot *gardencorev1beta1.Shoot) (string, error) {


### PR DESCRIPTION
/kind/regression
/area/control-plane

Cherry pick of #5243 on release-v1.37.

#5243: Fix timestamp expectation when scaling etcd

**Release Notes:**
```other operator
NONE
```