### PR TITLE
Add check-docforge step on two additional verify flows

### DIFF
--- a/.ci/verify
+++ b/.ci/verify
@@ -59,9 +59,9 @@ if [ $use_cache = yes ] ; then
 else
   if [ "${TEST_COV+yes}" = yes ] ; then
     # supposed to be run in release jobs
-    make verify-extended
+    make verify-extended check-docforge
   else
     # run test instead of test-cov to speed-up jobs, as coverage slows down tests significantly
-    make check-generate verify
+    make check-generate verify check-docforge
   fi
 fi


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
It is intended that `check-docforge` step should exist on all of the verify flows.

@timebertt Thanks for noticing that it was missing! 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@timebertt 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
