### PR TITLE
Expose networking-type flag in CreateShoot test step

### DIFF
--- a/.test-defs/CreateShoot.yaml
+++ b/.test-defs/CreateShoot.yaml
@@ -28,6 +28,7 @@ spec:
     -networking-provider-config-filepath=$NETWORKING_PROVIDER_CONFIG_FILEPATH
     -workers-config-filepath=$WORKERS_CONFIG_FILEPATH
     -worker-zone=$ZONE
+    -networking-type=$NETWORKING_TYPE
     -networking-pods=$NETWORKING_PODS
     -networking-services=$NETWORKING_SERVICES
     -networking-nodes=$NETWORKING_NODES

--- a/test/framework/shootcreationframework.go
+++ b/test/framework/shootcreationframework.go
@@ -337,6 +337,10 @@ func RegisterShootCreationFrameworkFlags() *ShootCreationConfig {
 	flag.StringVar(&newCfg.startHibernatedFlag, "start-hibernated", "", "the spec.hibernation.enabled to use for this shoot. Optional.")
 	flag.StringVar(&newCfg.allowPrivilegedContainersFlag, "allow-privileged-containers", "", "the spec.kubernetes.allowPrivilegedContainers to use for this shoot. Optional, defaults to true.")
 
+	if newCfg.networkingType == "" {
+		newCfg.networkingType = "calico"
+	}
+
 	newCfg.startHibernated = false
 
 	// ProviderConfigs flags


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind test

**What this PR does / why we need it**:
Right now, it is not possible to configure the network provider used for shoots created during a test run. In order to support tests for non-default providers such as Cilium, the already existing flag `networking-type` will be added to the `create-shoot` test step.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
In order to retain the previous defaulting behavior I added a small change to the evaluation of the flags. Otherwise all tests using `create-shoot` have to specify `networking-type` immediately.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `create-shoot` TestDefinition does now specify the `--networking-type` flag that can be configured via the `$NETWORKING_TYPE` env var.
```
