### PR TITLE
Add disk size information to local provider docs

### DIFF
--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -15,6 +15,9 @@ Based on [Skaffold](https://skaffold.dev/), the container images for all require
 - Make sure your Docker daemon is up-to-date, up and running and has enough resources (at least `8` CPUs and `8Gi` memory; see [here](https://docs.docker.com/desktop/mac/#resources) how to configure the resources for Docker for Mac).
   > Please note that 8 CPU / 8Gi memory might not be enough for more than two `Shoot` clusters, i.e., you might need to increase these values if you want to run additional `Shoot`s.
 
+  Additionally, please configure at least `120Gi` of disk size for the Docker daemon.
+  > Tip: With `docker system df` and `docker system prune -a` you can cleanup unused data.
+
 ## Setting up the KinD cluster (garden and seed)
 
 ```bash

--- a/docs/development/getting_started_locally.md
+++ b/docs/development/getting_started_locally.md
@@ -14,6 +14,9 @@ The Gardener components, however, will be run as regular processes on your machi
 
 - Make sure your Docker daemon is up-to-date, up and running and has enough resources (at least `4` CPUs and `4Gi` memory; see [here](https://docs.docker.com/desktop/mac/#resources) how to configure the resources for Docker for Mac).
   > Please note that 4 CPU / 4Gi memory might not be enough for more than one `Shoot` cluster, i.e., you might need to increase these values if you want to run additional `Shoot`s.
+
+  Additionally, please configure at least `120Gi` of disk size for the Docker daemon.
+  > Tip: With `docker system df` and `docker system prune -a` you can cleanup unused data.
 - Make sure that you increase the maximum number of open files on your host:
   - On Mac, run `sudo launchctl limit maxfiles 65536 200000`
   - On Linux, extend the `/etc/security/limits.conf` file with


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
Add disk size information to local provider docs to prevent folks from running into `DiskPressure` or likewise issues.

**Special notes for your reviewer**:
/cc @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
