### PR TITLE
Minor cleanups for the reversed VPN authorization server deployment

### DIFF
--- a/pkg/operation/botanist/component/vpnauthzserver/external_authz_server.go
+++ b/pkg/operation/botanist/component/vpnauthzserver/external_authz_server.go
@@ -121,18 +121,15 @@ func (a *authzServer) Deploy(ctx context.Context) error {
 				Spec: corev1.PodSpec{
 					Affinity: &corev1.Affinity{
 						PodAntiAffinity: &corev1.PodAntiAffinity{
-							RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+							PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
 								{
-									LabelSelector: &metav1.LabelSelector{
-										MatchExpressions: []metav1.LabelSelectorRequirement{
-											{
-												Key:      "app",
-												Operator: "In",
-												Values:   []string{DeploymentName},
-											},
+									Weight: 100,
+									PodAffinityTerm: corev1.PodAffinityTerm{
+										TopologyKey: corev1.LabelHostname,
+										LabelSelector: &metav1.LabelSelector{
+											MatchLabels: getLabels(),
 										},
 									},
-									TopologyKey: "kubernetes.io/hostname",
 								},
 							},
 						},

--- a/pkg/operation/botanist/component/vpnauthzserver/external_authz_server.go
+++ b/pkg/operation/botanist/component/vpnauthzserver/external_authz_server.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package extauthzserver
+package vpnauthzserver
 
 import (
 	"context"
@@ -49,14 +49,14 @@ const (
 	ServiceName = DeploymentName
 )
 
-// NewExtAuthServer creates a new instance of DeployWaiter for the auth-server.
-func NewExtAuthServer(
+// New creates a new instance of DeployWaiter for the auth-server.
+func New(
 	client client.Client,
 	namespace string,
 	imageExtAuthzServer string,
 	replicas int32,
 ) component.DeployWaiter {
-	return &authServer{
+	return &authzServer{
 		client:              client,
 		namespace:           namespace,
 		imageExtAuthzServer: imageExtAuthzServer,
@@ -64,14 +64,14 @@ func NewExtAuthServer(
 	}
 }
 
-type authServer struct {
+type authzServer struct {
 	client              client.Client
 	namespace           string
 	imageExtAuthzServer string
 	replicas            int32
 }
 
-func (a *authServer) Deploy(ctx context.Context) error {
+func (a *authzServer) Deploy(ctx context.Context) error {
 	var (
 		deployment      = a.emptyDeployment()
 		destinationRule = a.emptyDestinationRule()
@@ -279,7 +279,7 @@ func (a *authServer) Deploy(ctx context.Context) error {
 	return nil
 }
 
-func (a *authServer) Destroy(ctx context.Context) error {
+func (a *authzServer) Destroy(ctx context.Context) error {
 	return kutil.DeleteObjects(
 		ctx,
 		a.client,
@@ -293,34 +293,34 @@ func (a *authServer) Destroy(ctx context.Context) error {
 	)
 }
 
-func (a *authServer) Wait(_ context.Context) error        { return nil }
-func (a *authServer) WaitCleanup(_ context.Context) error { return nil }
+func (a *authzServer) Wait(_ context.Context) error        { return nil }
+func (a *authzServer) WaitCleanup(_ context.Context) error { return nil }
 
-func (a *authServer) emptyDeployment() *appsv1.Deployment {
+func (a *authzServer) emptyDeployment() *appsv1.Deployment {
 	return &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: DeploymentName, Namespace: a.namespace}}
 }
 
-func (a *authServer) emptyDestinationRule() *networkingv1beta1.DestinationRule {
+func (a *authzServer) emptyDestinationRule() *networkingv1beta1.DestinationRule {
 	return &networkingv1beta1.DestinationRule{ObjectMeta: metav1.ObjectMeta{Name: DeploymentName, Namespace: a.namespace}}
 }
 
-func (a *authServer) emptyService() *corev1.Service {
+func (a *authzServer) emptyService() *corev1.Service {
 	return &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: ServiceName, Namespace: a.namespace}}
 }
 
-func (a *authServer) emptyVirtualService() *networkingv1beta1.VirtualService {
+func (a *authzServer) emptyVirtualService() *networkingv1beta1.VirtualService {
 	return &networkingv1beta1.VirtualService{ObjectMeta: metav1.ObjectMeta{Name: DeploymentName, Namespace: a.namespace}}
 }
 
-func (a *authServer) emptyVPA() *autoscalingv1beta2.VerticalPodAutoscaler {
+func (a *authzServer) emptyVPA() *autoscalingv1beta2.VerticalPodAutoscaler {
 	return &autoscalingv1beta2.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: DeploymentName + "-vpa", Namespace: a.namespace}}
 }
 
-func (a *authServer) emptyPDB() *policyv1beta1.PodDisruptionBudget {
+func (a *authzServer) emptyPDB() *policyv1beta1.PodDisruptionBudget {
 	return &policyv1beta1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Name: DeploymentName + "-pdb", Namespace: a.namespace}}
 }
 
-func (a *authServer) emptyPC() *schedulingv1.PriorityClass {
+func (a *authzServer) emptyPC() *schedulingv1.PriorityClass {
 	return &schedulingv1.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: DeploymentName}}
 }
 

--- a/pkg/operation/botanist/component/vpnauthzserver/external_authz_server.go
+++ b/pkg/operation/botanist/component/vpnauthzserver/external_authz_server.go
@@ -41,15 +41,11 @@ import (
 )
 
 const (
-	// AuthServerPort is the port exposed by the external authorization server
-	AuthServerPort = 9001
-	// DeploymentName is the name of the external authorization server deployment.
-	DeploymentName = "reversed-vpn-auth-server"
-	// ServiceName is the name of the external authorization server service.
-	ServiceName = DeploymentName
+	serverPort = 9001
+	name       = "reversed-vpn-auth-server"
 )
 
-// New creates a new instance of DeployWaiter for the auth-server.
+// New creates a new instance of DeployWaiter for the ReversedVPN authorization server.
 func New(
 	client client.Client,
 	namespace string,
@@ -96,15 +92,11 @@ func (a *authzServer) Deploy(ctx context.Context) error {
 	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, a.client, deployment, func() error {
 		maxSurge := intstr.FromInt(100)
 		maxUnavailable := intstr.FromInt(0)
-		deployment.Labels = map[string]string{
-			v1beta1constants.LabelApp: DeploymentName,
-		}
+		deployment.Labels = getLabels()
 		deployment.Spec = appsv1.DeploymentSpec{
 			Replicas:             pointer.Int32(a.replicas),
 			RevisionHistoryLimit: pointer.Int32(1),
-			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{
-				v1beta1constants.LabelApp: DeploymentName,
-			}},
+			Selector:             &metav1.LabelSelector{MatchLabels: getLabels()},
 			Strategy: appsv1.DeploymentStrategy{
 				RollingUpdate: &appsv1.RollingUpdateDeployment{
 					MaxUnavailable: &maxUnavailable,
@@ -114,9 +106,7 @@ func (a *authzServer) Deploy(ctx context.Context) error {
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						v1beta1constants.LabelApp: DeploymentName,
-					},
+					Labels: getLabels(),
 				},
 				Spec: corev1.PodSpec{
 					Affinity: &corev1.Affinity{
@@ -139,7 +129,7 @@ func (a *authzServer) Deploy(ctx context.Context) error {
 					DNSPolicy:                    corev1.DNSDefault, // make sure to not use the coredns for DNS resolution.
 					Containers: []corev1.Container{
 						{
-							Name:            DeploymentName,
+							Name:            name,
 							Image:           a.imageExtAuthzServer,
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Ports: []corev1.ContainerPort{
@@ -172,7 +162,7 @@ func (a *authzServer) Deploy(ctx context.Context) error {
 	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, a.client, destinationRule, func() error {
 		destinationRule.Spec = istionetworkingv1beta1.DestinationRule{
 			ExportTo: []string{"*"},
-			Host:     fmt.Sprintf("%s.%s.svc.%s", DeploymentName, a.namespace, gardencorev1beta1.DefaultDomain),
+			Host:     fmt.Sprintf("%s.%s.svc.%s", name, a.namespace, gardencorev1beta1.DefaultDomain),
 			TrafficPolicy: &istionetworkingv1beta1.TrafficPolicy{
 				ConnectionPool: &istionetworkingv1beta1.ConnectionPoolSettings{
 					Tcp: &istionetworkingv1beta1.ConnectionPoolSettings_TCPSettings{
@@ -205,14 +195,12 @@ func (a *authzServer) Deploy(ctx context.Context) error {
 		service.Spec.Ports = []corev1.ServicePort{
 			{
 				Name:       "grpc-authz",
-				Port:       AuthServerPort,
-				TargetPort: intstr.FromInt(AuthServerPort),
+				Port:       serverPort,
+				TargetPort: intstr.FromInt(serverPort),
 				Protocol:   corev1.ProtocolTCP,
 			},
 		}
-		service.Spec.Selector = map[string]string{
-			v1beta1constants.LabelApp: DeploymentName,
-		}
+		service.Spec.Selector = getLabels()
 		return nil
 	}); err != nil {
 		return err
@@ -221,12 +209,12 @@ func (a *authzServer) Deploy(ctx context.Context) error {
 	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, a.client, virtualService, func() error {
 		virtualService.Spec = istionetworkingv1beta1.VirtualService{
 			ExportTo: []string{"*"},
-			Hosts:    []string{fmt.Sprintf("%s.%s.svc.%s", DeploymentName, a.namespace, gardencorev1beta1.DefaultDomain)},
+			Hosts:    []string{fmt.Sprintf("%s.%s.svc.%s", name, a.namespace, gardencorev1beta1.DefaultDomain)},
 			Http: []*istionetworkingv1beta1.HTTPRoute{{
 				Route: []*istionetworkingv1beta1.HTTPRouteDestination{{
 					Destination: &istionetworkingv1beta1.Destination{
-						Host: DeploymentName,
-						Port: &istionetworkingv1beta1.PortSelector{Number: AuthServerPort},
+						Host: name,
+						Port: &istionetworkingv1beta1.PortSelector{Number: serverPort},
 					},
 				}},
 			}},
@@ -240,7 +228,7 @@ func (a *authzServer) Deploy(ctx context.Context) error {
 		vpa.Spec.TargetRef = &autoscalingv1.CrossVersionObjectReference{
 			APIVersion: appsv1.SchemeGroupVersion.String(),
 			Kind:       "Deployment",
-			Name:       DeploymentName,
+			Name:       name,
 		}
 		vpa.Spec.UpdatePolicy = &autoscalingv1beta2.PodUpdatePolicy{
 			UpdateMode: &vpaUpdateMode,
@@ -248,7 +236,7 @@ func (a *authzServer) Deploy(ctx context.Context) error {
 		vpa.Spec.ResourcePolicy = &autoscalingv1beta2.PodResourcePolicy{
 			ContainerPolicies: []autoscalingv1beta2.ContainerResourcePolicy{
 				{
-					ContainerName: DeploymentName,
+					ContainerName: name,
 					MinAllowed: corev1.ResourceList{
 						corev1.ResourceCPU:    resource.MustParse("100m"),
 						corev1.ResourceMemory: resource.MustParse("100Mi"),
@@ -294,35 +282,35 @@ func (a *authzServer) Wait(_ context.Context) error        { return nil }
 func (a *authzServer) WaitCleanup(_ context.Context) error { return nil }
 
 func (a *authzServer) emptyDeployment() *appsv1.Deployment {
-	return &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: DeploymentName, Namespace: a.namespace}}
+	return &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: a.namespace}}
 }
 
 func (a *authzServer) emptyDestinationRule() *networkingv1beta1.DestinationRule {
-	return &networkingv1beta1.DestinationRule{ObjectMeta: metav1.ObjectMeta{Name: DeploymentName, Namespace: a.namespace}}
+	return &networkingv1beta1.DestinationRule{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: a.namespace}}
 }
 
 func (a *authzServer) emptyService() *corev1.Service {
-	return &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: ServiceName, Namespace: a.namespace}}
+	return &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: a.namespace}}
 }
 
 func (a *authzServer) emptyVirtualService() *networkingv1beta1.VirtualService {
-	return &networkingv1beta1.VirtualService{ObjectMeta: metav1.ObjectMeta{Name: DeploymentName, Namespace: a.namespace}}
+	return &networkingv1beta1.VirtualService{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: a.namespace}}
 }
 
 func (a *authzServer) emptyVPA() *autoscalingv1beta2.VerticalPodAutoscaler {
-	return &autoscalingv1beta2.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: DeploymentName + "-vpa", Namespace: a.namespace}}
+	return &autoscalingv1beta2.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Name: name + "-vpa", Namespace: a.namespace}}
 }
 
 func (a *authzServer) emptyPDB() *policyv1beta1.PodDisruptionBudget {
-	return &policyv1beta1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Name: DeploymentName + "-pdb", Namespace: a.namespace}}
+	return &policyv1beta1.PodDisruptionBudget{ObjectMeta: metav1.ObjectMeta{Name: name + "-pdb", Namespace: a.namespace}}
 }
 
 func (a *authzServer) emptyPC() *schedulingv1.PriorityClass {
-	return &schedulingv1.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: DeploymentName}}
+	return &schedulingv1.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: name}}
 }
 
 func getLabels() map[string]string {
 	return map[string]string{
-		v1beta1constants.LabelApp: DeploymentName,
+		v1beta1constants.LabelApp: name,
 	}
 }

--- a/pkg/operation/botanist/component/vpnauthzserver/external_authz_server_suite_test.go
+++ b/pkg/operation/botanist/component/vpnauthzserver/external_authz_server_suite_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package extauthzserver_test
+package vpnauthzserver_test
 
 import (
 	"testing"
@@ -21,7 +21,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestExtAuthzServer(t *testing.T) {
+func TestVpnAuthzServer(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Botanist Component ExtAuthzServer Suite")
+	RunSpecs(t, "Botanist Component VpnAuthzServer Suite")
 }

--- a/pkg/operation/botanist/component/vpnauthzserver/external_authz_server_test.go
+++ b/pkg/operation/botanist/component/vpnauthzserver/external_authz_server_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package extauthzserver
+package vpnauthzserver
 
 import (
 	"context"
@@ -317,7 +317,7 @@ var _ = Describe("ExtAuthzServer", func() {
 	}
 
 	JustBeforeEach(func() {
-		defaultDepWaiter = NewExtAuthServer(c, namespace, image, replicas)
+		defaultDepWaiter = New(c, namespace, image, replicas)
 	})
 
 	Describe("#Deploy", func() {

--- a/pkg/operation/botanist/component/vpnauthzserver/external_authz_server_test.go
+++ b/pkg/operation/botanist/component/vpnauthzserver/external_authz_server_test.go
@@ -12,11 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package vpnauthzserver
+package vpnauthzserver_test
 
 import (
 	"context"
 	"fmt"
+
+	"github.com/gardener/gardener/pkg/operation/botanist/component"
+	. "github.com/gardener/gardener/pkg/operation/botanist/component/vpnauthzserver"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 
 	protobuftypes "github.com/gogo/protobuf/types"
 	. "github.com/onsi/ginkgo"
@@ -27,6 +32,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -36,12 +42,6 @@ import (
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	"github.com/gardener/gardener/pkg/operation/botanist/component"
-	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
-	. "github.com/gardener/gardener/pkg/utils/test/matchers"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
 )
 
 var _ = Describe("ExtAuthzServer", func() {
@@ -52,7 +52,7 @@ var _ = Describe("ExtAuthzServer", func() {
 		defaultDepWaiter component.DeployWaiter
 		namespace        = "shoot--foo--bar"
 
-		image                      = "eu.gcr.io/gardener-project/gardener/ext-authz-server:0.1.0"
+		image                      = "some-image"
 		replicas             int32 = 1
 		revisionHistoryLimit int32 = 1
 		maxSurge                   = intstr.FromInt(100)
@@ -60,9 +60,9 @@ var _ = Describe("ExtAuthzServer", func() {
 		maxUnavailablePDB          = intstr.FromInt(1)
 		vpaUpdateMode              = autoscalingv1beta2.UpdateModeAuto
 
-		deploymentName = DeploymentName
-		serviceName    = DeploymentName
-		vpaName        = fmt.Sprintf("%s-vpa", DeploymentName)
+		deploymentName = "reversed-vpn-auth-server"
+		serviceName    = "reversed-vpn-auth-server"
+		vpaName        = fmt.Sprintf("%s-vpa", "reversed-vpn-auth-server")
 
 		expectedDeployment          *appsv1.Deployment
 		expectedDestinationRule     *istionetworkingv1beta1.DestinationRule
@@ -108,7 +108,7 @@ var _ = Describe("ExtAuthzServer", func() {
 				Name:      deploymentName,
 				Namespace: namespace,
 				Labels: map[string]string{
-					"app": DeploymentName,
+					"app": "reversed-vpn-auth-server",
 				},
 				ResourceVersion: "1",
 			},
@@ -120,7 +120,7 @@ var _ = Describe("ExtAuthzServer", func() {
 				Replicas:             &replicas,
 				RevisionHistoryLimit: &revisionHistoryLimit,
 				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{
-					v1beta1constants.LabelApp: DeploymentName,
+					"app": "reversed-vpn-auth-server",
 				}},
 				Strategy: appsv1.DeploymentStrategy{
 					RollingUpdate: &appsv1.RollingUpdateDeployment{
@@ -132,7 +132,7 @@ var _ = Describe("ExtAuthzServer", func() {
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
-							v1beta1constants.LabelApp: DeploymentName,
+							"app": "reversed-vpn-auth-server",
 						},
 					},
 					Spec: corev1.PodSpec{
@@ -154,11 +154,11 @@ var _ = Describe("ExtAuthzServer", func() {
 							},
 						},
 						AutomountServiceAccountToken: pointer.Bool(false),
-						PriorityClassName:            DeploymentName,
+						PriorityClassName:            "reversed-vpn-auth-server",
 						DNSPolicy:                    corev1.DNSDefault, // make sure to not use the coredns for DNS resolution.
 						Containers: []corev1.Container{
 							{
-								Name:            DeploymentName,
+								Name:            "reversed-vpn-auth-server",
 								Image:           image,
 								ImagePullPolicy: corev1.PullIfNotPresent,
 								Ports: []corev1.ContainerPort{
@@ -197,7 +197,7 @@ var _ = Describe("ExtAuthzServer", func() {
 			},
 			Spec: istioapinetworkingv1beta1.DestinationRule{
 				ExportTo: []string{"*"},
-				Host:     fmt.Sprintf("%s.%s.svc.cluster.local", DeploymentName, namespace),
+				Host:     fmt.Sprintf("%s.%s.svc.cluster.local", "reversed-vpn-auth-server", namespace),
 				TrafficPolicy: &istioapinetworkingv1beta1.TrafficPolicy{
 					ConnectionPool: &istioapinetworkingv1beta1.ConnectionPoolSettings{
 						Tcp: &istioapinetworkingv1beta1.ConnectionPoolSettings_TCPSettings{
@@ -240,8 +240,8 @@ var _ = Describe("ExtAuthzServer", func() {
 				Ports: []corev1.ServicePort{
 					{
 						Name:       "grpc-authz",
-						Port:       AuthServerPort,
-						TargetPort: intstr.FromInt(AuthServerPort),
+						Port:       9001,
+						TargetPort: intstr.FromInt(9001),
 						Protocol:   corev1.ProtocolTCP,
 					},
 				},
@@ -260,12 +260,12 @@ var _ = Describe("ExtAuthzServer", func() {
 			},
 			Spec: istioapinetworkingv1beta1.VirtualService{
 				ExportTo: []string{"*"},
-				Hosts:    []string{fmt.Sprintf("%s.%s.svc.cluster.local", DeploymentName, namespace)},
+				Hosts:    []string{fmt.Sprintf("%s.%s.svc.cluster.local", "reversed-vpn-auth-server", namespace)},
 				Http: []*istioapinetworkingv1beta1.HTTPRoute{{
 					Route: []*istioapinetworkingv1beta1.HTTPRouteDestination{{
 						Destination: &istioapinetworkingv1beta1.Destination{
-							Host: DeploymentName,
-							Port: &istioapinetworkingv1beta1.PortSelector{Number: AuthServerPort},
+							Host: "reversed-vpn-auth-server",
+							Port: &istioapinetworkingv1beta1.PortSelector{Number: 9001},
 						},
 					}},
 				}},
@@ -279,7 +279,7 @@ var _ = Describe("ExtAuthzServer", func() {
 				TargetRef: &autoscalingv1.CrossVersionObjectReference{
 					APIVersion: appsv1.SchemeGroupVersion.String(),
 					Kind:       "Deployment",
-					Name:       DeploymentName,
+					Name:       "reversed-vpn-auth-server",
 				},
 				UpdatePolicy: &autoscalingv1beta2.PodUpdatePolicy{
 					UpdateMode: &vpaUpdateMode,
@@ -287,7 +287,7 @@ var _ = Describe("ExtAuthzServer", func() {
 				ResourcePolicy: &autoscalingv1beta2.PodResourcePolicy{
 					ContainerPolicies: []autoscalingv1beta2.ContainerResourcePolicy{
 						{
-							ContainerName: DeploymentName,
+							ContainerName: "reversed-vpn-auth-server",
 							MinAllowed: corev1.ResourceList{
 								corev1.ResourceCPU:    resource.MustParse("100m"),
 								corev1.ResourceMemory: resource.MustParse("100Mi"),
@@ -304,13 +304,17 @@ var _ = Describe("ExtAuthzServer", func() {
 			Name:            deploymentName + "-pdb",
 			Namespace:       namespace,
 			ResourceVersion: "1",
-			Labels:          getLabels(),
+			Labels: map[string]string{
+				"app": deploymentName,
+			},
 		},
 		TypeMeta: metav1.TypeMeta{Kind: "PodDisruptionBudget", APIVersion: "policy/v1beta1"},
 		Spec: policyv1beta1.PodDisruptionBudgetSpec{
 			MaxUnavailable: &maxUnavailablePDB,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: getLabels(),
+				MatchLabels: map[string]string{
+					"app": deploymentName,
+				},
 			},
 		},
 	}

--- a/pkg/operation/botanist/component/vpnauthzserver/external_authz_server_test.go
+++ b/pkg/operation/botanist/component/vpnauthzserver/external_authz_server_test.go
@@ -138,18 +138,17 @@ var _ = Describe("ExtAuthzServer", func() {
 					Spec: corev1.PodSpec{
 						Affinity: &corev1.Affinity{
 							PodAntiAffinity: &corev1.PodAntiAffinity{
-								RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+								PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
 									{
-										LabelSelector: &metav1.LabelSelector{
-											MatchExpressions: []metav1.LabelSelectorRequirement{
-												{
-													Key:      "app",
-													Operator: "In",
-													Values:   []string{DeploymentName},
+										Weight: 100,
+										PodAffinityTerm: corev1.PodAffinityTerm{
+											TopologyKey: "kubernetes.io/hostname",
+											LabelSelector: &metav1.LabelSelector{
+												MatchLabels: map[string]string{
+													"app": "reversed-vpn-auth-server",
 												},
 											},
 										},
-										TopologyKey: "kubernetes.io/hostname",
 									},
 								},
 							},

--- a/pkg/operation/seed/components.go
+++ b/pkg/operation/seed/components.go
@@ -30,13 +30,13 @@ import (
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/dependencywatchdog"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/etcd"
-	"github.com/gardener/gardener/pkg/operation/botanist/component/extauthzserver"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/gardenerkubescheduler"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/kubeapiserver"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/networkpolicies"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/nodelocaldns"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/resourcemanager"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/seedadmissioncontroller"
+	"github.com/gardener/gardener/pkg/operation/botanist/component/vpnauthzserver"
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
@@ -257,7 +257,7 @@ func defaultExternalAuthzServer(
 		return nil, err
 	}
 
-	extAuthServer := extauthzserver.NewExtAuthServer(
+	vpnAuthzServer := vpnauthzserver.New(
 		c,
 		v1beta1constants.GardenNamespace,
 		image.String(),
@@ -265,7 +265,7 @@ func defaultExternalAuthzServer(
 	)
 
 	if gardenletfeatures.FeatureGate.Enabled(features.ManagedIstio) {
-		return extAuthServer, nil
+		return vpnAuthzServer, nil
 	}
 
 	vpnSeedDeployments := &metav1.PartialObjectMetadataList{}
@@ -281,5 +281,5 @@ func defaultExternalAuthzServer(
 		return component.NoOp(), nil
 	}
 
-	return component.OpDestroy(extAuthServer), nil
+	return component.OpDestroy(vpnAuthzServer), nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind cleanup
/merge squash

**What this PR does / why we need it**:
This PR cleans up the package containing the deployment for the reversed VPN authorization server, i.e.,

- renaming it
- adapting the anti-affinity to what we also use for other multi-replica components in the seed cluster (to cater with scenarios where the number of seed nodes is less than the number of replicas)
- streamlining the implementation and the test according to best practices

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
