### PR TITLE
[release-v1.37] Automated cherry pick of #5131: Several improvements for the `resources.gardener.cloud/preserve-{replicas,resources}` option for managed resources

### DIFF
--- a/docs/concepts/resource-manager.md
+++ b/docs/concepts/resource-manager.md
@@ -167,6 +167,16 @@ In some cases it is not desirable to update or re-apply some of the cluster comp
 For these resources, the annotation "resources.gardener.cloud/ignore" needs to be set to "true" or a truthy value (Truthy values are "1", "t", "T", "true", "TRUE", "True") in the corresponding managed resource secrets,
 this can be done from the components that create the managed resource secrets, for example Gardener extensions or Gardener. Once this is done, the resource will be initially created and later ignored during reconciliation.
 
+#### Preserving `replicas` or `resources` in Workload Resources
+
+The objects which are part of the `ManagedResource` can be annotated with
+
+- `resources.gardener.cloud/preserve-replicas=true` in case the `.spec.replicas` field of workload resources like `Deployment`s, `StatefulSet`s, etc. shall be preserved during updates.
+- `resources.gardener.cloud/preserve-resources=true` in case the `.spec.containers[*].resources` fields of all containers of workload resources like `Deployment`s, `StatefulSet`s, etc. shall be preserved during updates.
+
+> This can be useful if there are non-standard horizontal/vertical auto-scaling mechanisms in place.
+Standard mechanisms like `HorizontalPodAutoscaler` or `VerticalPodAutoscaler` will be auto-recognized by `gardener-resource-manager`, i.e., in such cases the annotations are not needed.
+
 #### Origin
 
 All the objects managed by the resource manager get a dedicated annotation

--- a/pkg/apis/resources/v1alpha1/types.go
+++ b/pkg/apis/resources/v1alpha1/types.go
@@ -44,7 +44,7 @@ const (
 	PreserveReplicas = "resources.gardener.cloud/preserve-replicas"
 	// PreserveResources is a constant for an annotation on a resource managed by a ManagedResource. If set to
 	// true then the controller will keep the resource requests and limits in Pod templates (e.g. in a
-	// DeploymentSpec) during updates to the resource.
+	// DeploymentSpec) during updates to the resource. This applies for all containers.
 	PreserveResources = "resources.gardener.cloud/preserve-resources"
 
 	// StaticTokenSkip is a constant for a label on a ServiceAccount which indicates that this ServiceAccount should not

--- a/pkg/resourcemanager/controller/managedresource/merger.go
+++ b/pkg/resourcemanager/controller/managedresource/merger.go
@@ -223,15 +223,6 @@ func mergeCronJob(scheme *runtime.Scheme, oldObj, newObj runtime.Object, preserv
 		return err
 	}
 
-	// Do not overwrite a CronJob's '.spec.jobTemplate.spec.selector' if the new CronJobs's '.spec.jobTemplate.spec.selector'
-	// field is unset.
-	if newCronJob.Spec.JobTemplate.Spec.Selector == nil && oldCronJob.Spec.JobTemplate.Spec.Selector != nil {
-		newCronJob.Spec.JobTemplate.Spec.Selector = oldCronJob.Spec.JobTemplate.Spec.Selector
-	}
-
-	// Do not overwrite CronJob managed labels as 'controller-uid' and 'job-name'. '.spec.jobTemplate.spec.template' is immutable.
-	newCronJob.Spec.JobTemplate.Spec.Template.Labels = labels.Merge(oldCronJob.Spec.JobTemplate.Spec.Template.Labels, newCronJob.Spec.JobTemplate.Spec.Template.Labels)
-
 	mergePodTemplate(&oldCronJob.Spec.JobTemplate.Spec.Template, &newCronJob.Spec.JobTemplate.Spec.Template, preserveResources)
 
 	return scheme.Convert(newCronJob, newObj, nil)

--- a/pkg/resourcemanager/controller/managedresource/merger.go
+++ b/pkg/resourcemanager/controller/managedresource/merger.go
@@ -145,14 +145,10 @@ func mergePodTemplate(oldPod, newPod *corev1.PodTemplateSpec, preserveResources 
 	}
 
 	// Do not overwrite a PodTemplate's resource requests / limits if it is scaled by an HVPA
-	for _, newContainer := range newPod.Spec.Containers {
-		newContainerName := newContainer.Name
-
-		for _, oldContainer := range oldPod.Spec.Containers {
-			oldContainerName := oldContainer.Name
-
-			if newContainerName == oldContainerName {
-				mergeContainer(&oldContainer, &newContainer, preserveResources)
+	for i, newContainer := range newPod.Spec.Containers {
+		for j, oldContainer := range oldPod.Spec.Containers {
+			if newContainer.Name == oldContainer.Name {
+				mergeContainer(&oldPod.Spec.Containers[j], &newPod.Spec.Containers[i], preserveResources)
 			}
 		}
 	}
@@ -231,7 +227,7 @@ func mergeStatefulSet(scheme *runtime.Scheme, oldObj, newObj runtime.Object, pre
 		newStatefulSet.Spec.VolumeClaimTemplates = oldStatefulSet.Spec.VolumeClaimTemplates
 	}
 
-	mergePodTemplate(&oldStatefulSet.Spec.Template, &oldStatefulSet.Spec.Template, preserveResources)
+	mergePodTemplate(&oldStatefulSet.Spec.Template, &newStatefulSet.Spec.Template, preserveResources)
 
 	return scheme.Convert(newStatefulSet, newObj, nil)
 }

--- a/pkg/resourcemanager/controller/managedresource/merger.go
+++ b/pkg/resourcemanager/controller/managedresource/merger.go
@@ -153,6 +153,7 @@ func mergePodTemplate(oldPod, newPod *corev1.PodTemplateSpec, preserveResources 
 		for j, oldContainer := range oldPod.Spec.Containers {
 			if newContainer.Name == oldContainer.Name {
 				mergeContainer(&oldPod.Spec.Containers[j], &newPod.Spec.Containers[i], preserveResources)
+				break
 			}
 		}
 	}

--- a/pkg/resourcemanager/controller/managedresource/merger_test.go
+++ b/pkg/resourcemanager/controller/managedresource/merger_test.go
@@ -798,39 +798,6 @@ var _ = Describe("merger", func() {
 			new = old.DeepCopy()
 		})
 
-		It("should not overwrite old .spec.selector if the new one is nil", func() {
-			new.Spec.JobTemplate.Spec.Selector = nil
-
-			expected := old.DeepCopy()
-
-			Expect(mergeCronJob(s, old, new, false)).NotTo(HaveOccurred(), "merge should be successful")
-			Expect(new).To(Equal(expected))
-		})
-
-		It("should not overwrite old .spec.template.labels if the new one is nil", func() {
-			new.Spec.JobTemplate.Spec.Template.Labels = nil
-
-			expected := old.DeepCopy()
-
-			Expect(mergeCronJob(s, old, new, false)).NotTo(HaveOccurred(), "merge should be successful")
-			Expect(new).To(Equal(expected))
-		})
-
-		It("should be able to merge new .spec.template.labels with the old ones", func() {
-			new.Spec.JobTemplate.Spec.Template.Labels = map[string]string{"app": "myapp", "version": "v0.1.0"}
-
-			expected := old.DeepCopy()
-			expected.Spec.JobTemplate.Spec.Template.Labels = map[string]string{
-				"app":            "myapp",
-				"controller-uid": "1a2b3c",
-				"job-name":       "pi",
-				"version":        "v0.1.0",
-			}
-
-			Expect(mergeCronJob(s, old, new, false)).NotTo(HaveOccurred(), "merge should be successful")
-			Expect(new).To(Equal(expected))
-		})
-
 		It("should overwrite old .spec.containers[*].resources if preserveResources is false", func() {
 			new.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Resources = corev1.ResourceRequirements{}
 

--- a/pkg/resourcemanager/controller/managedresource/merger_test.go
+++ b/pkg/resourcemanager/controller/managedresource/merger_test.go
@@ -261,6 +261,29 @@ var _ = Describe("merger", func() {
 		})
 	})
 
+	var defaultPodTemplateSpec corev1.PodTemplateSpec
+	BeforeEach(func() {
+		defaultPodTemplateSpec = corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "foo-container",
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("50m"),
+								corev1.ResourceMemory: resource.MustParse("150Mi"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("500m"),
+								corev1.ResourceMemory: resource.MustParse("1Gi"),
+							},
+						},
+					},
+				},
+			},
+		}
+	})
+
 	Describe("#mergeDeployment", func() {
 		var (
 			old, new *appsv1.Deployment
@@ -278,15 +301,7 @@ var _ = Describe("merger", func() {
 						MatchLabels: map[string]string{"controller-uid": "1a2b3c"},
 					},
 					Replicas: pointer.Int32Ptr(1),
-					Template: corev1.PodTemplateSpec{
-						Spec: corev1.PodSpec{
-							Containers: []corev1.Container{
-								{
-									Name: "foo-container",
-								},
-							},
-						},
-					},
+					Template: defaultPodTemplateSpec,
 				},
 			}
 
@@ -319,6 +334,25 @@ var _ = Describe("merger", func() {
 			Expect(mergeDeployment(s, old, new, false, false)).NotTo(HaveOccurred(), "merge should be successful")
 			Expect(new).To(Equal(expected))
 		})
+
+		It("should overwrite old .spec.containers[*].resources if preserveResources is false", func() {
+			new.Spec.Template.Spec.Containers[0].Resources = corev1.ResourceRequirements{}
+
+			expected := old.DeepCopy()
+			expected.Spec.Template.Spec.Containers[0].Resources = new.Spec.Template.Spec.Containers[0].Resources
+
+			Expect(mergeDeployment(s, old, new, true, false)).NotTo(HaveOccurred(), "merge should be successful")
+			Expect(new).To(Equal(expected))
+		})
+
+		It("should not overwrite old .spec.containers[*].resources if preserveResources is true", func() {
+			new.Spec.Template.Spec.Containers[0].Resources = corev1.ResourceRequirements{}
+
+			expected := old.DeepCopy()
+
+			Expect(mergeDeployment(s, old, new, true, true)).NotTo(HaveOccurred(), "merge should be successful")
+			Expect(new).To(Equal(expected))
+		})
 	})
 
 	Describe("#mergeDeploymentAnnotations", func() {
@@ -342,25 +376,7 @@ var _ = Describe("merger", func() {
 						MatchLabels: map[string]string{"controller-uid": "1a2b3c"},
 					},
 					Replicas: pointer.Int32Ptr(1),
-					Template: corev1.PodTemplateSpec{
-						Spec: corev1.PodSpec{
-							Containers: []corev1.Container{
-								{
-									Name: "foo-container",
-									Resources: corev1.ResourceRequirements{
-										Requests: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("50m"),
-											corev1.ResourceMemory: resource.MustParse("150Mi"),
-										},
-										Limits: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("500m"),
-											corev1.ResourceMemory: resource.MustParse("1Gi"),
-										},
-									},
-								},
-							},
-						},
-					},
+					Template: defaultPodTemplateSpec,
 				},
 			}
 
@@ -439,7 +455,7 @@ var _ = Describe("merger", func() {
 		})
 	})
 
-	Describe("#mergeStatefulset", func() {
+	Describe("#mergeStatefulSet", func() {
 		var (
 			old, new *appsv1.StatefulSet
 			s        *runtime.Scheme
@@ -456,15 +472,7 @@ var _ = Describe("merger", func() {
 						MatchLabels: map[string]string{"controller-uid": "1a2b3c"},
 					},
 					Replicas: pointer.Int32Ptr(1),
-					Template: corev1.PodTemplateSpec{
-						Spec: corev1.PodSpec{
-							Containers: []corev1.Container{
-								{
-									Name: "foo-container",
-								},
-							},
-						},
-					},
+					Template: defaultPodTemplateSpec,
 				},
 			}
 
@@ -498,12 +506,22 @@ var _ = Describe("merger", func() {
 			Expect(new).To(Equal(expected))
 		})
 
-		It("should use new .spec.replicas if preserveReplicas is false", func() {
-			new.Spec.Replicas = pointer.Int32Ptr(2)
+		It("should overwrite old .spec.containers[*].resources if preserveResources is false", func() {
+			new.Spec.Template.Spec.Containers[0].Resources = corev1.ResourceRequirements{}
 
-			expected := new.DeepCopy()
+			expected := old.DeepCopy()
+			expected.Spec.Template.Spec.Containers[0].Resources = new.Spec.Template.Spec.Containers[0].Resources
 
-			Expect(mergeStatefulSet(s, old, new, false, false)).NotTo(HaveOccurred(), "merge should be successful")
+			Expect(mergeStatefulSet(s, old, new, true, false)).NotTo(HaveOccurred(), "merge should be successful")
+			Expect(new).To(Equal(expected))
+		})
+
+		It("should not overwrite old .spec.containers[*].resources if preserveResources is true", func() {
+			new.Spec.Template.Spec.Containers[0].Resources = corev1.ResourceRequirements{}
+
+			expected := old.DeepCopy()
+
+			Expect(mergeStatefulSet(s, old, new, true, true)).NotTo(HaveOccurred(), "merge should be successful")
 			Expect(new).To(Equal(expected))
 		})
 


### PR DESCRIPTION
/kind/bug
/kind/enhancement
/kind/api-change
/area/scalability

Cherry pick of #5131 on release-v1.37.

#5131: Several improvements for the `resources.gardener.cloud/preserve-{replicas,resources}` option for managed resources

**Release Notes:**
```bugfix developer
The `resources.gardener.cloud/preserve-resources` annotation does now work properly for `StatefulSet`s.
```
```feature developer
Support for the `resources.gardener.cloud/preserve-resources` annotation was added for `Job`s, `CronJob`s, and `DaemonSet`s.
```