### PR TITLE
[release-v1.38] Automated cherry pick of #5263: Add projected volumes to psp for kube-proxy

### DIFF
--- a/charts/shoot-core/components/charts/kube-proxy/templates/psp/kube-proxy-psp.yaml
+++ b/charts/shoot-core/components/charts/kube-proxy/templates/psp/kube-proxy-psp.yaml
@@ -8,6 +8,7 @@ spec:
   - hostPath
   - secret
   - configMap
+  - projected
   hostNetwork: true
   hostPorts:
   - min: {{ .Values.ports.metrics }}


### PR DESCRIPTION
/kind/bug
/area/networking

Cherry pick of #5263 on release-v1.38.

#5263: Add projected volumes to psp for kube-proxy

**Release Notes:**
```bugfix user
An issue preventing kube-proxy Pods to be created when Shoot `.spec.kubernetes.allowPrivilegedContainers=false` is now fixed.
```