### PR TITLE
Add nodeTemplate to MachineClass CRD

### DIFF
--- a/extensions/pkg/controller/worker/templates/machineclasses.tpl.yaml
+++ b/extensions/pkg/controller/worker/templates/machineclasses.tpl.yaml
@@ -54,6 +54,7 @@ spec:
                   must be unique.
                 type: string
             type: object
+            x-kubernetes-preserve-unknown-fields: true
           kind:
             description: 'Kind is a string value representing the REST resource this
                   object represents. Servers may infer this from the endpoint the client
@@ -61,6 +62,36 @@ spec:
             type: string
           metadata:
             type: object
+          nodeTemplate:
+            description: NodeTemplate contains subfields to track all node resources
+              and other node info required to scale nodegroup from zero
+            properties:
+              capacity:
+                additionalProperties:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                  x-kubernetes-int-or-string: true
+                description: Capacity contains subfields to track all node resources
+                  required to scale nodegroup from zero
+                type: object
+              instanceType:
+                description: Instance type of the node belonging to nodeGroup
+                type: string
+              region:
+                description: Region of the expected node belonging to nodeGroup
+                type: string
+              zone:
+                description: Zone of the expected node belonging to nodeGroup
+                type: string
+            required:
+            - capacity
+            - instanceType
+            - region
+            - zone
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
           provider:
             description: Provider is the combination of name and location of cloud-specific
               drivers.

--- a/extensions/pkg/controller/worker/templates/machineclasses.tpl.yaml
+++ b/extensions/pkg/controller/worker/templates/machineclasses.tpl.yaml
@@ -54,7 +54,6 @@ spec:
                   must be unique.
                 type: string
             type: object
-            x-kubernetes-preserve-unknown-fields: true
           kind:
             description: 'Kind is a string value representing the REST resource this
                   object represents. Servers may infer this from the endpoint the client


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
Adds nodeTemplate field to machineClass CRD . Without this the scale-from-zero feature won't work
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix dependency
MachineClass CRD has been updated with `nodeTemplate` field. This is essential for scale-from-zero feature of CA to work.
```
