### PR TITLE
Bootstrap GRM when deleting hibernated shoot

### DIFF
--- a/pkg/operation/botanist/component/resourcemanager/mock/mocks.go
+++ b/pkg/operation/botanist/component/resourcemanager/mock/mocks.go
@@ -63,6 +63,32 @@ func (mr *MockInterfaceMockRecorder) Destroy(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Destroy", reflect.TypeOf((*MockInterface)(nil).Destroy), arg0)
 }
 
+// GetReplicas mocks base method.
+func (m *MockInterface) GetReplicas() int32 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetReplicas")
+	ret0, _ := ret[0].(int32)
+	return ret0
+}
+
+// GetReplicas indicates an expected call of GetReplicas.
+func (mr *MockInterfaceMockRecorder) GetReplicas() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReplicas", reflect.TypeOf((*MockInterface)(nil).GetReplicas))
+}
+
+// SetReplicas mocks base method.
+func (m *MockInterface) SetReplicas(arg0 int32) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetReplicas", arg0)
+}
+
+// SetReplicas indicates an expected call of SetReplicas.
+func (mr *MockInterfaceMockRecorder) SetReplicas(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetReplicas", reflect.TypeOf((*MockInterface)(nil).SetReplicas), arg0)
+}
+
 // SetSecrets mocks base method.
 func (m *MockInterface) SetSecrets(arg0 resourcemanager.Secrets) {
 	m.ctrl.T.Helper()

--- a/pkg/operation/botanist/resource_manager.go
+++ b/pkg/operation/botanist/resource_manager.go
@@ -160,8 +160,8 @@ func (b *Botanist) ScaleGardenerResourceManagerToOne(ctx context.Context) error 
 }
 
 func (b *Botanist) mustBootstrapGardenerResourceManager(ctx context.Context) (bool, error) {
-	if b.Shoot.HibernationEnabled && b.Shoot.GetInfo().Status.IsHibernated {
-		return false, nil // Shoot is already hibernated
+	if b.Shoot.HibernationEnabled && b.Shoot.GetInfo().Status.IsHibernated && b.Shoot.Components.ControlPlane.ResourceManager.GetReplicas() == 0 {
+		return false, nil // Shoot is already hibernated and GRM should not be scaled up
 	}
 
 	shootAccessSecret := gutil.NewShootAccessSecret(resourcemanager.SecretNameShootAccess, b.Shoot.SeedNamespace)

--- a/pkg/operation/botanist/resource_manager.go
+++ b/pkg/operation/botanist/resource_manager.go
@@ -69,8 +69,9 @@ func (b *Botanist) DefaultResourceManager() (resourcemanager.Interface, error) {
 		MaxConcurrentTokenInvalidatorWorkers: pointer.Int32(5),
 		MaxConcurrentTokenRequestorWorkers:   pointer.Int32(5),
 		MaxConcurrentRootCAPublisherWorkers:  pointer.Int32(5),
-		TargetDiffersFromSourceCluster:       true,
+		Replicas:                             int32(3),
 		SyncPeriod:                           utils.DurationPtr(time.Minute),
+		TargetDiffersFromSourceCluster:       true,
 		TargetDisableCache:                   pointer.Bool(true),
 		WatchedNamespace:                     pointer.String(b.Shoot.SeedNamespace),
 		VPA: &resourcemanager.VPAConfig{
@@ -85,16 +86,14 @@ func (b *Botanist) DefaultResourceManager() (resourcemanager.Interface, error) {
 	// MRs (e.g. caused by extension upgrades) that are necessary for completing the hibernation flow.
 	// grm is scaled down later on as part of the HibernateControlPlane step, so we only specify replicas=0 if
 	// the shoot is already hibernated.
-	replicas := int32(3)
 	if b.Shoot.HibernationEnabled && b.Shoot.GetInfo().Status.IsHibernated {
-		replicas = 0
+		cfg.Replicas = 0
 	}
 
 	return resourcemanager.New(
 		b.K8sSeedClient.Client(),
 		b.Shoot.SeedNamespace,
 		image.String(),
-		replicas,
 		cfg,
 	), nil
 }

--- a/pkg/operation/seed/components.go
+++ b/pkg/operation/seed/components.go
@@ -114,11 +114,12 @@ func defaultGardenerResourceManager(c client.Client, imageVector imagevector.Ima
 	}
 	image = &imagevector.Image{Repository: repository, Tag: &tag}
 
-	gardenerResourceManager := resourcemanager.New(c, v1beta1constants.GardenNamespace, image.String(), 3, resourcemanager.Values{
+	gardenerResourceManager := resourcemanager.New(c, v1beta1constants.GardenNamespace, image.String(), resourcemanager.Values{
 		ConcurrentSyncs:                      pointer.Int32(20),
 		MaxConcurrentTokenInvalidatorWorkers: pointer.Int32(5),
 		MaxConcurrentRootCAPublisherWorkers:  pointer.Int32(5),
 		HealthSyncPeriod:                     utils.DurationPtr(time.Minute),
+		Replicas:                             int32(3),
 		ResourceClass:                        pointer.String(v1beta1constants.SeedResourceManagerClass),
 		SyncPeriod:                           utils.DurationPtr(time.Hour),
 		VPA: &resourcemanager.VPAConfig{

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -1206,7 +1206,7 @@ func RunDeleteSeedFlow(
 		dnsRecord       = getManagedIngressDNSRecord(seedClient, seed.GetInfo().Spec.DNS, secretData, seed.GetIngressFQDN("*"), "", log)
 		autoscaler      = clusterautoscaler.NewBootstrapper(seedClient, v1beta1constants.GardenNamespace)
 		gsac            = seedadmissioncontroller.New(seedClient, v1beta1constants.GardenNamespace, "")
-		resourceManager = resourcemanager.New(seedClient, v1beta1constants.GardenNamespace, "", 0, resourcemanager.Values{})
+		resourceManager = resourcemanager.New(seedClient, v1beta1constants.GardenNamespace, "", resourcemanager.Values{})
 		etcdDruid       = etcd.NewBootstrapper(seedClient, v1beta1constants.GardenNamespace, conf, "", nil)
 		networkPolicies = networkpolicies.NewBootstrapper(seedClient, v1beta1constants.GardenNamespace, networkpolicies.GlobalValues{})
 		clusterIdentity = clusteridentity.NewForSeed(seedClient, v1beta1constants.GardenNamespace, "")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug
/merge squash
/milestone v1.39

**What this PR does / why we need it**:
After #5246, there is still a bug when it comes to deleting a hibernated shoot as reported in #5267. Note that this particular issue is not strictly related to migration from v1.38 to higher versions but can also happen for shoots created and hibernated with v1.39 or above.

This PR fixes it by extending the [preconditions for skipping the bootstrap process](https://github.com/gardener/gardener/blob/8b63c0d87301ab65ab011c9ae3034761c0f2b72a/pkg/operation/botanist/resource_manager.go#L164-L166) with the condition that the desired replicas must be `0`. If they are larger than `0` (as in the hibernated shoot deletion case where GRM needs to be scaled up to clean the system) the bootstrapping process may be allowed.
In order to realize this, two methods for setting and getting the replicas had to be introduced in the `resourcemanager.Interface`. The shoot deletion flow no longer first deploys GRM and then scales it up but uses the setter method before deploying it to ensure the correct replicas are configured (only in case shoot resources have to be cleaned up).

**Which issue(s) this PR fixes**:
Fixes #5267

**Special notes for your reviewer**:
Thanks @ialidzhikov for reporting and reproducing!

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
