### PR TITLE
Update the release schedule

### DIFF
--- a/docs/development/process.md
+++ b/docs/development/process.md
@@ -21,10 +21,10 @@ v1.36   | Week 45-46  | November 8, 2021       | November 21, 2021  | [@timebert
 v1.37   | Week 47-48  | November 22, 2021      | December 5, 2021   | [@danielfoehrKn](https://github.com/danielfoehrKn) |
 v1.38   | Week 49-50  | December 6, 2021       | December 19, 2021  | [@rfranzke](https://github.com/rfranzke)           |
 v1.39   | Week 01-02  | January 3, 2022        | January 16, 2022   | [@ialidzhikov](https://github.com/ialidzhikov)     |
-v1.40   | Week 03-04  | January 17, 2022       | January 30, 2022   | [@timuthy](https://github.com/timuthy)             |
-v1.41   | Week 05-06  | January 31, 2022       | February 13, 2022  | [@BeckerMax](https://github.com/BeckerMax)         |
-v1.42   | Week 06-07  | February 14, 2022      | February 27, 2022  | [@stoyanr](https://github.com/stoyanr)             |
-v1.43   | Week 08-09  | February 28, 2022      | March 13, 2022     | [@voelzmo](https://github.com/voelzmo)             |
+v1.39   | Week 03-04  | January 17, 2022       | January 30, 2022   | [@timuthy](https://github.com/timuthy)             |
+v1.40   | Week 05-06  | January 31, 2022       | February 13, 2022  | [@BeckerMax](https://github.com/BeckerMax)         |
+v1.41   | Week 06-07  | February 14, 2022      | February 27, 2022  | [@stoyanr](https://github.com/stoyanr)             |
+v1.42   | Week 08-09  | February 28, 2022      | March 13, 2022     | [@voelzmo](https://github.com/voelzmo)             |
 
 Apart from the release of the next version, the release responsible is also taking care of potential hotfix releases of the last three minor versions.
 The release responsible is the main contact person for coordinating new feature PRs for the next minor versions or cherry-pick PRs for the last three minor versions.


### PR DESCRIPTION
/area documentation

The release validation for v1.39 has started relatively late (11.02) and there are still items in the v1.39 milestone. That's why we decided to postpone the v1.39 release and to move it to the next cycle.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
