### PR TITLE
🛡 Use projected `ServiceAccount` token for `gardenlet`

### DIFF
--- a/charts/gardener/gardenlet/charts/runtime/templates/deployment.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/deployment.yaml
@@ -121,6 +121,11 @@ spec:
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
+        {{- if semverCompare ">= 1.20-0" .Capabilities.KubeVersion.GitVersion }}
+        - name: kube-api-access-gardener
+          mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+          readOnly: true
+        {{- end }}
         {{- if .Values.global.gardenlet.config.gardenClientConnection.kubeconfig }}
         - name: gardenlet-kubeconfig-garden
           mountPath: /etc/gardenlet/kubeconfig-garden
@@ -152,6 +157,26 @@ spec:
 {{ toYaml .Values.global.gardenlet.additionalVolumeMounts | indent 8 }}
 {{- end }}
       volumes:
+      {{- if semverCompare ">= 1.20-0" .Capabilities.KubeVersion.GitVersion }}
+      - name: kube-api-access-gardener
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              path: token
+              expirationSeconds: 43200
+          - configMap:
+              name: kube-root-ca.crt
+              items:
+              - key: ca.crt
+                path: ca.crt
+          - downwardAPI:
+              items:
+              - path: namespace
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+      {{- end }}
       {{- if .Values.global.gardenlet.config.gardenClientConnection.kubeconfig }}
       - name: gardenlet-kubeconfig-garden
         secret:

--- a/charts/gardener/gardenlet/charts/runtime/templates/serviceaccount.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/serviceaccount.yaml
@@ -10,4 +10,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+{{- if semverCompare ">= 1.20-0" .Capabilities.KubeVersion.GitVersion }}
+automountServiceAccountToken: false
+{{- end }}
 {{- end }}


### PR DESCRIPTION
Only in case Kubernetes is >= 1.20 since only then the `RootCAConfigMap` feature gate is enabled by default

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
The `gardenlet` was switched to use a projected `ServiceAccount` token for accessing the seed cluster's API server in case Kubernetes >= 1.20 (since only then the `RootCAConfigMap` feature gate is enabled by default). Note that the gardenlet deployment cannot rely on the "projected token mount" webhook (unlike many other deployments in the seed) since it is the first component running in the seed cluster.

**Which issue(s) this PR fixes**:
Part of #4659
Part of #4878

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
In case `gardenlet` runs on a cluster with at least Kubernetes 1.20 then it will use a projected `ServiceAccount` token only valid for `12h` for communicating with the (seed) cluster's API Server.
```
