### PR TITLE
Fixed broken links 01.2022

### DIFF
--- a/docs/proposals/04-new-core-gardener-cloud-apis.md
+++ b/docs/proposals/04-new-core-gardener-cloud-apis.md
@@ -21,7 +21,7 @@
 ## Summary
 
 In [GEP-1](https://github.com/gardener/gardener/blob/master/docs/proposals/01-extensibility.md) we have proposed how to (re-)design Gardener to allow providers maintaining their provider-specific knowledge out of the core tree.
-Meanwhile, we have progressed a lot and are about to remove the [`CloudBotanist` interface](../../pkg/operation/botanist/types.go) entirely.
+Meanwhile, we have progressed a lot and are about to remove the [`CloudBotanist` interface](https://github.com/gardener/gardener/blob/de75a5bfcbedd16ba341ace0eb58be2a87049dcb/pkg/operation/cloudbotanist/types.go) entirely.
 The only missing aspect that will allow providers to really maintain their code out of the core is to design new APIs.
 
 This proposal describes how the new `Shoot`, `Seed` etc. APIs will be re-designed to cope with the changes made with extensibility.

--- a/docs/proposals/04-new-core-gardener-cloud-apis.md
+++ b/docs/proposals/04-new-core-gardener-cloud-apis.md
@@ -21,7 +21,7 @@
 ## Summary
 
 In [GEP-1](https://github.com/gardener/gardener/blob/master/docs/proposals/01-extensibility.md) we have proposed how to (re-)design Gardener to allow providers maintaining their provider-specific knowledge out of the core tree.
-Meanwhile, we have progressed a lot and are about to remove the [`CloudBotanist` interface](https://github.com/gardener/gardener/blob/master/pkg/operation/cloudbotanist/types.go) entirely.
+Meanwhile, we have progressed a lot and are about to remove the [`CloudBotanist` interface](../../pkg/operation/botanist/types.go) entirely.
 The only missing aspect that will allow providers to really maintain their code out of the core is to design new APIs.
 
 This proposal describes how the new `Shoot`, `Seed` etc. APIs will be re-designed to cope with the changes made with extensibility.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
This PR fixes broken links in the Gardener website.
**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc developer
NONE
```
