### PR TITLE
Switch controller-manager to logr (3)

### DIFF
--- a/pkg/controllermanager/controller/bastion/bastion_control.go
+++ b/pkg/controllermanager/controller/bastion/bastion_control.go
@@ -156,7 +156,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	// bastions for it, so this check here is just a safety measure.
 	if !equality.Semantic.DeepEqual(shoot.Spec.SeedName, bastion.Spec.SeedName) {
 		log.Info("Deleting bastion because the referenced Shoot has been migrated to another Seed",
-			"oldSeedNew", bastion.Spec.SeedName, "newSeedName", shoot.Spec.SeedName)
+			"oldSeedName", bastion.Spec.SeedName, "newSeedName", shoot.Spec.SeedName)
 		return reconcile.Result{}, client.IgnoreNotFound(r.gardenClient.Delete(ctx, bastion))
 	}
 

--- a/pkg/controllermanager/controller/bastion/bastion_control.go
+++ b/pkg/controllermanager/controller/bastion/bastion_control.go
@@ -156,7 +156,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	// bastions for it, so this check here is just a safety measure.
 	if !equality.Semantic.DeepEqual(shoot.Spec.SeedName, bastion.Spec.SeedName) {
 		log.Info("Deleting bastion because the referenced Shoot has been migrated to another Seed",
-			"oldSeed", bastion.Spec.SeedName, "newSeed", shoot.Spec.SeedName)
+			"oldSeedNew", bastion.Spec.SeedName, "newSeedName", shoot.Spec.SeedName)
 		return reconcile.Result{}, client.IgnoreNotFound(r.gardenClient.Delete(ctx, bastion))
 	}
 

--- a/pkg/controllermanager/controller/controllerregistration/controllerregistration.go
+++ b/pkg/controllermanager/controller/controllerregistration/controllerregistration.go
@@ -201,7 +201,7 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 
 	for {
 		if c.controllerRegistrationFinalizerQueue.Len() == 0 && c.seedFinalizerQueue.Len() == 0 && c.seedQueue.Len() == 0 && c.numberOfRunningWorkers == 0 {
-			c.log.V(1).Info("No running ControllerRegistration worker and no items left in the queues. Terminating Bastion controller...")
+			c.log.V(1).Info("No running ControllerRegistration worker and no items left in the queues. Terminating ControllerRegistration controller...")
 			break
 		}
 		c.log.V(1).Info("Waiting for ControllerRegistration workers to finish...", "numberOfRunningWorkers", c.numberOfRunningWorkers, "queueLength", c.controllerRegistrationFinalizerQueue.Len()+c.seedFinalizerQueue.Len()+c.seedQueue.Len())

--- a/pkg/controllermanager/controller/event/event.go
+++ b/pkg/controllermanager/controller/event/event.go
@@ -20,24 +20,31 @@ import (
 	"sync"
 	"time"
 
-	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
-	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
-	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
-	"github.com/gardener/gardener/pkg/controllerutils"
-	"github.com/gardener/gardener/pkg/logger"
-
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
+	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
+	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
+	"github.com/gardener/gardener/pkg/controllerutils"
+)
+
+const (
+	// ControllerName is the name of this controller.
+	ControllerName = "event"
 )
 
 // Controller controls Events.
 type Controller struct {
 	gardenClient client.Client
 	cfg          *config.EventControllerConfiguration
+	log          logr.Logger
 
 	reconciler     reconcile.Reconciler
 	hasSyncedFuncs []cache.InformerSynced
@@ -50,12 +57,15 @@ type Controller struct {
 // NewController instantiates a new event controller
 func NewController(
 	ctx context.Context,
+	log logr.Logger,
 	clientMap clientmap.ClientMap,
 	cfg *config.EventControllerConfiguration,
 ) (
 	*Controller,
 	error,
 ) {
+	log = log.WithName(ControllerName)
+
 	gardenClient, err := clientMap.GetClient(ctx, keys.ForGarden())
 	if err != nil {
 		return nil, err
@@ -71,8 +81,9 @@ func NewController(
 	controller := &Controller{
 		gardenClient: gardenClient.Client(),
 		cfg:          cfg,
+		log:          log,
 
-		reconciler: NewEventReconciler(logger.Logger, gardenClient.Client(), cfg),
+		reconciler: NewEventReconciler(gardenClient.Client(), cfg),
 
 		eventQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "event"),
 		workerCh:   make(chan int),
@@ -92,21 +103,20 @@ func (c *Controller) Run(ctx context.Context) {
 	var waitGroup sync.WaitGroup
 
 	if !cache.WaitForCacheSync(ctx.Done(), c.hasSyncedFuncs...) {
-		logger.Logger.Error("Timed out waiting for caches to sync")
+		c.log.Error(wait.ErrWaitTimeout, "Timed out waiting for caches to sync")
 		return
 	}
 
 	go func() {
 		for res := range c.workerCh {
 			c.numberOfRunningWorkers += res
-			logger.Logger.Debugf("Current number of running Event workers is %d", c.numberOfRunningWorkers)
 		}
 	}()
 
-	logger.Logger.Info("Event controller initialized.")
+	c.log.Info("Event controller initialized")
 
 	for i := 0; i < c.cfg.ConcurrentSyncs; i++ {
-		controllerutils.CreateWorker(ctx, c.eventQueue, "Event", c.reconciler, &waitGroup, c.workerCh)
+		controllerutils.CreateWorker(ctx, c.eventQueue, "Event", c.reconciler, &waitGroup, c.workerCh, controllerutils.WithLogger(c.log))
 	}
 
 	<-ctx.Done()
@@ -114,10 +124,10 @@ func (c *Controller) Run(ctx context.Context) {
 
 	for {
 		if c.eventQueue.Len() == 0 && c.numberOfRunningWorkers == 0 {
-			logger.Logger.Debug("No running Event worker and no items left in the queues. Terminating Event controller...")
+			c.log.V(1).Info("No running Event worker and no items left in the queues. Terminating Event controller...")
 			break
 		}
-		logger.Logger.Debugf("Waiting for %d Event worker(s) to finish (%d item(s) left in the queues)...", c.numberOfRunningWorkers, c.eventQueue.Len())
+		c.log.V(1).Info("Waiting for Event workers to finish...", "numberOfRunningWorkers", c.numberOfRunningWorkers, "queueLength", c.eventQueue.Len())
 		time.Sleep(5 * time.Second)
 	}
 

--- a/pkg/controllermanager/controller/event/event_control_test.go
+++ b/pkg/controllermanager/controller/event/event_control_test.go
@@ -18,8 +18,9 @@ import (
 	"context"
 	"time"
 
+	"github.com/go-logr/logr"
+
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
-	"github.com/gardener/gardener/pkg/logger"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 
 	"github.com/golang/mock/gomock"
@@ -58,8 +59,6 @@ var _ = Describe("eventReconciler", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		k8sGardenRuntimeClient = mockclient.NewMockClient(ctrl)
 
-		logger.Logger = logger.NewNopLogger()
-
 		shootEvent = &corev1.Event{
 			LastTimestamp:  metav1.Time{Time: time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC)},
 			InvolvedObject: corev1.ObjectReference{Kind: "Shoot", APIVersion: "core.gardener.cloud/v1beta1"},
@@ -84,7 +83,7 @@ var _ = Describe("eventReconciler", func() {
 			TTLNonShootEvents: ttl,
 		}
 
-		reconciler = NewEventReconciler(logger.NewNopLogger(), k8sGardenRuntimeClient, cfg)
+		reconciler = NewEventReconciler(k8sGardenRuntimeClient, cfg)
 	})
 
 	AfterEach(func() {
@@ -168,9 +167,9 @@ var _ = Describe("#enqueueEvent", func() {
 	)
 
 	BeforeEach(func() {
-		logger.Logger = logger.NewNopLogger()
 		queue = &fakeQueue{}
 		c = &Controller{
+			log:        logr.Discard(),
 			eventQueue: queue,
 		}
 	})

--- a/pkg/controllermanager/controller/exposureclass/exposureclass_control.go
+++ b/pkg/controllermanager/controller/exposureclass/exposureclass_control.go
@@ -18,13 +18,7 @@ import (
 	"context"
 	"fmt"
 
-	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
-	v1alpha1constants "github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	"github.com/gardener/gardener/pkg/controllerutils"
-	"github.com/gardener/gardener/pkg/logger"
-
-	"github.com/sirupsen/logrus"
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -32,13 +26,19 @@ import (
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	v1alpha1constants "github.com/gardener/gardener/pkg/apis/core/v1alpha1/constants"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/controllerutils"
 )
 
 func (c *Controller) exposureClassAdd(obj interface{}) {
 	key, err := cache.MetaNamespaceKeyFunc(obj)
 	if err != nil {
-		logger.Logger.Errorf("Couldn't get key for object %+v: %v", obj, err)
+		c.log.Error(err, "Couldn't get key for object", "object", obj)
 		return
 	}
 	c.exposureClassQueue.Add(key)
@@ -51,40 +51,39 @@ func (c *Controller) exposureClassUpdate(_, newObj interface{}) {
 func (c *Controller) exposureClassDelete(obj interface{}) {
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 	if err != nil {
-		logger.Logger.Errorf("Couldn't get key for object %+v: %v", obj, err)
+		c.log.Error(err, "Couldn't get key for object", "object", obj)
 		return
 	}
 	c.exposureClassQueue.Add(key)
 }
 
 // NewExposureClassReconciler creates a new instance of a reconciler which reconciles ExposureClass.
-func NewExposureClassReconciler(l logrus.FieldLogger, gardenClient client.Client, recorder record.EventRecorder) reconcile.Reconciler {
+func NewExposureClassReconciler(gardenClient client.Client, recorder record.EventRecorder) reconcile.Reconciler {
 	return &exposureClassReconciler{
-		logger:       l,
 		gardenClient: gardenClient,
 		recorder:     recorder,
 	}
 }
 
 type exposureClassReconciler struct {
-	logger       logrus.FieldLogger
 	gardenClient client.Client
 	recorder     record.EventRecorder
 }
 
 func (r *exposureClassReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log := logf.FromContext(ctx)
+
 	exposureClass := &gardencorev1alpha1.ExposureClass{}
 	if err := r.gardenClient.Get(ctx, request.NamespacedName, exposureClass); err != nil {
 		if apierrors.IsNotFound(err) {
-			r.logger.Infof("Object %q is gone, stop reconciling: %v", request.Name, err)
+			log.Info("Object is gone, stop reconciling")
 			return reconcile.Result{}, nil
 		}
-		r.logger.Infof("Unable to retrieve object %q from store: %v", request.Name, err)
-		return reconcile.Result{}, err
+		return reconcile.Result{}, fmt.Errorf("error retrieving object from store: %w", err)
 	}
 
 	if exposureClass.DeletionTimestamp != nil {
-		return r.delete(ctx, exposureClass)
+		return r.delete(ctx, log, exposureClass)
 	}
 
 	return r.reconcile(ctx, exposureClass)
@@ -93,15 +92,14 @@ func (r *exposureClassReconciler) Reconcile(ctx context.Context, request reconci
 func (r *exposureClassReconciler) reconcile(ctx context.Context, exposureClass *gardencorev1alpha1.ExposureClass) (reconcile.Result, error) {
 	if !controllerutil.ContainsFinalizer(exposureClass, gardencorev1beta1.GardenerName) {
 		if err := controllerutils.StrategicMergePatchAddFinalizers(ctx, r.gardenClient, exposureClass, gardencorev1alpha1.GardenerName); err != nil {
-			r.logger.Errorf("could not add finalizer to ExposureClass: %s", err.Error())
-			return reconcile.Result{}, err
+			return reconcile.Result{}, fmt.Errorf("could not add finalizer to ExposureClass: %w", err)
 		}
 	}
 
 	return reconcile.Result{}, nil
 }
 
-func (r *exposureClassReconciler) delete(ctx context.Context, exposureClass *gardencorev1alpha1.ExposureClass) (reconcile.Result, error) {
+func (r *exposureClassReconciler) delete(ctx context.Context, log logr.Logger, exposureClass *gardencorev1alpha1.ExposureClass) (reconcile.Result, error) {
 	// Ignore the exposure class if it has no gardener finalizer.
 	if !sets.NewString(exposureClass.Finalizers...).Has(gardencorev1alpha1.GardenerName) {
 		return reconcile.Result{}, nil
@@ -115,17 +113,14 @@ func (r *exposureClassReconciler) delete(ctx context.Context, exposureClass *gar
 	}
 
 	if len(associatedShoots) == 0 {
-		r.logger.Infof("No Shoots are referenced to the ExposureClass %q. Deletion accepted.", exposureClass.Name)
+		log.Info("No Shoots are referencing ExposureClass, deletion accepted")
 		if err := controllerutils.PatchRemoveFinalizers(ctx, r.gardenClient, exposureClass, gardencorev1alpha1.GardenerName); client.IgnoreNotFound(err) != nil {
-			r.logger.Errorf("could not remove finalizer from ExposureClass: %s", err.Error())
-			return reconcile.Result{}, err
+			return reconcile.Result{}, fmt.Errorf("could not remove finalizer from ExposureClass: %w", err)
 		}
 		return reconcile.Result{}, nil
 	}
 
-	message := fmt.Sprintf("Can't delete ExposureClasss because it is still associated by the following Shoots: %+v", associatedShoots)
-	r.logger.Info(message)
+	message := fmt.Sprintf("Cannot delete ExposureClasss, because it is still associated by the following Shoots: %+v", associatedShoots)
 	r.recorder.Event(exposureClass, corev1.EventTypeNormal, v1alpha1constants.EventResourceReferenced, message)
-
-	return reconcile.Result{}, fmt.Errorf("ExposureClass %q still has references", exposureClass.Name)
+	return reconcile.Result{}, fmt.Errorf(message)
 }

--- a/pkg/controllermanager/controller/exposureclass/exposureclass_control_test.go
+++ b/pkg/controllermanager/controller/exposureclass/exposureclass_control_test.go
@@ -15,11 +15,11 @@
 package exposureclass
 
 import (
-	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
-	"github.com/gardener/gardener/pkg/logger"
-
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -31,9 +31,9 @@ var _ = Describe("Controller", func() {
 	)
 
 	BeforeEach(func() {
-		logger.Logger = logger.NewNopLogger()
 		queue = &fakeQueue{}
 		c = &Controller{
+			log:                logr.Discard(),
 			exposureClassQueue: queue,
 		}
 	})

--- a/pkg/controllermanager/controller/factory.go
+++ b/pkg/controllermanager/controller/factory.go
@@ -165,7 +165,7 @@ func (f *GardenControllerFactory) Run(ctx context.Context) error {
 	go managedSeedSetController.Run(ctx, f.cfg.Controllers.ManagedSeedSet.ConcurrentSyncs)
 
 	if eventControllerConfig := f.cfg.Controllers.Event; eventControllerConfig != nil {
-		eventController, err := eventcontroller.NewController(ctx, f.clientMap, eventControllerConfig)
+		eventController, err := eventcontroller.NewController(ctx, log, f.clientMap, eventControllerConfig)
 		if err != nil {
 			return fmt.Errorf("failed initializing Event controller: %w", err)
 		}

--- a/pkg/controllermanager/controller/factory.go
+++ b/pkg/controllermanager/controller/factory.go
@@ -110,7 +110,7 @@ func (f *GardenControllerFactory) Run(ctx context.Context) error {
 		return fmt.Errorf("failed initializing CSR controller: %w", err)
 	}
 
-	exposureClassController, err := exposureclasscontroller.NewExposureClassController(ctx, f.clientMap, f.recorder)
+	exposureClassController, err := exposureclasscontroller.NewExposureClassController(ctx, log, f.clientMap, f.recorder)
 	if err != nil {
 		return fmt.Errorf("failed initializing ExposureClass controller: %w", err)
 	}

--- a/pkg/controllermanager/controller/factory.go
+++ b/pkg/controllermanager/controller/factory.go
@@ -44,7 +44,6 @@ import (
 	secretbindingcontroller "github.com/gardener/gardener/pkg/controllermanager/controller/secretbinding"
 	seedcontroller "github.com/gardener/gardener/pkg/controllermanager/controller/seed"
 	shootcontroller "github.com/gardener/gardener/pkg/controllermanager/controller/shoot"
-	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/operation/garden"
 )
 
@@ -115,6 +114,11 @@ func (f *GardenControllerFactory) Run(ctx context.Context) error {
 		return fmt.Errorf("failed initializing ExposureClass controller: %w", err)
 	}
 
+	managedSeedSetController, err := managedseedsetcontroller.NewManagedSeedSetController(ctx, log, f.clientMap, f.cfg, f.recorder)
+	if err != nil {
+		return fmt.Errorf("failed initializing ManagedSeedSet controller: %w", err)
+	}
+
 	plantController, err := plantcontroller.NewController(ctx, log, f.clientMap, f.cfg)
 	if err != nil {
 		return fmt.Errorf("failed initializing Plant controller: %w", err)
@@ -143,11 +147,6 @@ func (f *GardenControllerFactory) Run(ctx context.Context) error {
 	shootController, err := shootcontroller.NewShootController(ctx, f.clientMap, f.cfg, f.recorder)
 	if err != nil {
 		return fmt.Errorf("failed initializing Shoot controller: %w", err)
-	}
-
-	managedSeedSetController, err := managedseedsetcontroller.NewManagedSeedSetController(ctx, f.clientMap, f.cfg, f.recorder, logger.Logger)
-	if err != nil {
-		return fmt.Errorf("failed initializing ManagedSeedSet controller: %w", err)
 	}
 
 	go bastionController.Run(ctx, f.cfg.Controllers.Bastion.ConcurrentSyncs)

--- a/pkg/controllermanager/controller/factory.go
+++ b/pkg/controllermanager/controller/factory.go
@@ -115,7 +115,7 @@ func (f *GardenControllerFactory) Run(ctx context.Context) error {
 		return fmt.Errorf("failed initializing ExposureClass controller: %w", err)
 	}
 
-	plantController, err := plantcontroller.NewController(ctx, f.clientMap, f.cfg)
+	plantController, err := plantcontroller.NewController(ctx, log, f.clientMap, f.cfg)
 	if err != nil {
 		return fmt.Errorf("failed initializing Plant controller: %w", err)
 	}

--- a/pkg/controllermanager/controller/managedseedset/managedseedset.go
+++ b/pkg/controllermanager/controller/managedseedset/managedseedset.go
@@ -20,7 +20,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/sirupsen/logrus"
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
@@ -37,12 +38,19 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
 	"github.com/gardener/gardener/pkg/controllerutils"
+	"github.com/gardener/gardener/pkg/logger"
 	kutils "github.com/gardener/gardener/pkg/utils/kubernetes"
+)
+
+const (
+	// ControllerName is the name of this controller.
+	ControllerName = "managedseedset"
 )
 
 // Controller controls ManagedSeedSets.
 type Controller struct {
 	gardenClient kubernetes.Interface
+	log          logr.Logger
 
 	reconciler reconcile.Reconciler
 
@@ -55,18 +63,18 @@ type Controller struct {
 
 	numberOfRunningWorkers int
 	workerCh               chan int
-
-	logger *logrus.Logger
 }
 
 // NewManagedSeedSetController creates a new Gardener controller for ManagedSeedSets.
 func NewManagedSeedSetController(
 	ctx context.Context,
+	log logr.Logger,
 	clientMap clientmap.ClientMap,
 	config *config.ControllerManagerConfiguration,
 	recorder record.EventRecorder,
-	logger *logrus.Logger,
 ) (*Controller, error) {
+	log = log.WithName(ControllerName)
+
 	gardenClient, err := clientMap.GetClient(ctx, keys.ForGarden())
 	if err != nil {
 		return nil, fmt.Errorf("could not get garden client: %w", err)
@@ -94,11 +102,12 @@ func NewManagedSeedSetController(
 
 	replicaFactory := ReplicaFactoryFunc(NewReplica)
 	replicaGetter := NewReplicaGetter(gardenClient, replicaFactory)
-	actuator := NewActuator(gardenClient, replicaGetter, replicaFactory, config.Controllers.ManagedSeedSet, recorder, logger)
-	reconciler := NewReconciler(gardenClient, actuator, config.Controllers.ManagedSeedSet, logger)
+	actuator := NewActuator(gardenClient, replicaGetter, replicaFactory, config.Controllers.ManagedSeedSet, recorder)
+	reconciler := NewReconciler(gardenClient, actuator, config.Controllers.ManagedSeedSet)
 
 	return &Controller{
 		gardenClient:           gardenClient,
+		log:                    log,
 		reconciler:             reconciler,
 		managedSeedSetInformer: managedSeedSetInformer,
 		shootInformer:          shootInformer,
@@ -106,7 +115,6 @@ func NewManagedSeedSetController(
 		seedInformer:           seedInformer,
 		managedSeedSetQueue:    workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "ManagedSeedSet"),
 		workerCh:               make(chan int),
-		logger:                 logger,
 	}, nil
 }
 
@@ -120,6 +128,9 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 		DeleteFunc: c.managedSeedSetDelete,
 	})
 
+	// TODO: switch to logr once kutils package is migrated
+	logrusLogger := logger.Logger.WithField("logger", "controller."+ControllerName)
+
 	// Add event handler for controlled shoots
 	c.shootInformer.AddEventHandler(&kutils.ControlledResourceEventHandler{
 		ControllerTypes: []kutils.ControllerType{
@@ -130,7 +141,7 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 		ControllerPredicateFactory: kutils.ControllerPredicateFactoryFunc(c.filterShoot),
 		Enqueuer:                   kutils.EnqueuerFunc(func(obj client.Object) { c.managedSeedSetAdd(obj) }),
 		Scheme:                     kubernetes.GardenScheme,
-		Logger:                     c.logger,
+		Logger:                     logrusLogger,
 	})
 
 	// Add event handler for controlled managed seeds
@@ -143,7 +154,7 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 		ControllerPredicateFactory: kutils.ControllerPredicateFactoryFunc(c.filterManagedSeed),
 		Enqueuer:                   kutils.EnqueuerFunc(func(obj client.Object) { c.managedSeedSetAdd(obj) }),
 		Scheme:                     kubernetes.GardenScheme,
-		Logger:                     c.logger,
+		Logger:                     logrusLogger,
 	})
 
 	// Add event handler for controlled seeds
@@ -161,11 +172,11 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 		ControllerPredicateFactory: kutils.ControllerPredicateFactoryFunc(c.filterSeed),
 		Enqueuer:                   kutils.EnqueuerFunc(func(obj client.Object) { c.managedSeedSetAdd(obj) }),
 		Scheme:                     kubernetes.GardenScheme,
-		Logger:                     c.logger,
+		Logger:                     logrusLogger,
 	})
 
 	if !cache.WaitForCacheSync(ctx.Done(), c.managedSeedSetInformer.HasSynced, c.shootInformer.HasSynced, c.managedSeedInformer.HasSynced, c.seedInformer.HasSynced) {
-		c.logger.Error("Timed out waiting for caches to sync")
+		c.log.Error(wait.ErrWaitTimeout, "Timed out waiting for caches to sync")
 		return
 	}
 
@@ -173,14 +184,13 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 	go func() {
 		for res := range c.workerCh {
 			c.numberOfRunningWorkers += res
-			c.logger.Debugf("Current number of running ManagedSeedSet workers is %d", c.numberOfRunningWorkers)
 		}
 	}()
 
-	c.logger.Info("ManagedSeedSet controller initialized.")
+	c.log.Info("ManagedSeedSet controller initialized")
 
 	for i := 0; i < workers; i++ {
-		controllerutils.CreateWorker(ctx, c.managedSeedSetQueue, "ManagedSeedSet", c.reconciler, &waitGroup, c.workerCh)
+		controllerutils.CreateWorker(ctx, c.managedSeedSetQueue, "ManagedSeedSet", c.reconciler, &waitGroup, c.workerCh, controllerutils.WithLogger(c.log))
 	}
 
 	// Shutdown handling
@@ -189,10 +199,10 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 
 	for {
 		if c.managedSeedSetQueue.Len() == 0 && c.numberOfRunningWorkers == 0 {
-			c.logger.Debug("No running ManagedSeedSet worker and no items left in the queues. Terminated ManagedSeedSet controller...")
+			c.log.V(1).Info("No running ManagedSeedSet worker and no items left in the queues. Terminating ManagedSeedSet controller...")
 			break
 		}
-		c.logger.Debugf("Waiting for %d ManagedSeedSet worker(s) to finish (%d item(s) left in the queues)...", c.numberOfRunningWorkers, c.managedSeedSetQueue.Len())
+		c.log.V(1).Info("Waiting for ManagedSeedSet workers to finish...", "numberOfRunningWorkers", c.numberOfRunningWorkers, "queueLength", c.managedSeedSetQueue.Len())
 		time.Sleep(5 * time.Second)
 	}
 

--- a/pkg/controllermanager/controller/managedseedset/managedseedset_predicates.go
+++ b/pkg/controllermanager/controller/managedseedset/managedseedset_predicates.go
@@ -22,7 +22,6 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	operationshoot "github.com/gardener/gardener/pkg/operation/shoot"
-	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
 func (c *Controller) filterShoot(obj, oldObj, controller client.Object, deleted bool) bool {
@@ -42,7 +41,7 @@ func (c *Controller) filterShoot(obj, oldObj, controller client.Object, deleted 
 			return false
 		}
 		if !reflect.DeepEqual(shoot.DeletionTimestamp, oldShoot.DeletionTimestamp) || shootHealthStatus(shoot) != shootHealthStatus(oldShoot) {
-			c.logger.Debugf("Shoot %s was deleted or its health status changed", kutil.ObjectName(shoot))
+			c.log.V(1).Info("Shoot was deleted or its health status changed", "shoot", client.ObjectKeyFromObject(shoot))
 			return true
 		}
 	}
@@ -85,7 +84,7 @@ func (c *Controller) filterManagedSeed(obj, oldObj, controller client.Object, de
 			return false
 		}
 		if !reflect.DeepEqual(managedSeed.DeletionTimestamp, oldManagedSeed.DeletionTimestamp) {
-			c.logger.Debugf("Managed seed %s was deleted", kutil.ObjectName(managedSeed))
+			c.log.V(1).Info("ManagedSeed was deleted", "managedSeed", client.ObjectKeyFromObject(managedSeed))
 			return true
 		}
 	}
@@ -122,7 +121,7 @@ func (c *Controller) filterSeed(obj, oldObj, controller client.Object, _ bool) b
 			return false
 		}
 		if seedReady(seed) != seedReady(oldSeed) {
-			c.logger.Debugf("Seed %s readiness changed", kutil.ObjectName(seed))
+			c.log.V(1).Info("Seed readiness changed", "seed", client.ObjectKeyFromObject(seed))
 			return true
 		}
 	}

--- a/pkg/controllermanager/controller/managedseedset/managedseedset_reconciler_test.go
+++ b/pkg/controllermanager/controller/managedseedset/managedseedset_reconciler_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
 	. "github.com/gardener/gardener/pkg/controllermanager/controller/managedseedset"
 	mockmanagedseedset "github.com/gardener/gardener/pkg/controllermanager/controller/managedseedset/mock"
-	gardenerlogger "github.com/gardener/gardener/pkg/logger"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
@@ -75,7 +74,7 @@ var _ = Describe("Reconciler", func() {
 			SyncPeriod: metav1.Duration{Duration: syncPeriod},
 		}
 
-		reconciler = NewReconciler(gardenClient, actuator, cfg, gardenerlogger.NewNopLogger())
+		reconciler = NewReconciler(gardenClient, actuator, cfg)
 
 		ctx = context.TODO()
 		request = reconcile.Request{NamespacedName: kutil.Key(namespace, name)}
@@ -132,7 +131,7 @@ var _ = Describe("Reconciler", func() {
 				expectPatchManagedSeedSet(func(mss *seedmanagementv1alpha1.ManagedSeedSet) {
 					Expect(mss.Finalizers).To(Equal([]string{gardencorev1beta1.GardenerName}))
 				})
-				actuator.EXPECT().Reconcile(ctx, set).Return(status, false, nil)
+				actuator.EXPECT().Reconcile(ctx, gomock.Any(), set).Return(status, false, nil)
 				expectPatchManagedSeedSetStatus(func(mss *seedmanagementv1alpha1.ManagedSeedSet) {
 					Expect(&mss.Status).To(Equal(status))
 				})
@@ -152,7 +151,7 @@ var _ = Describe("Reconciler", func() {
 
 			It("should reconcile the ManagedSeedSet deletion and update the status", func() {
 				expectGetManagedSeedSet()
-				actuator.EXPECT().Reconcile(ctx, set).Return(status, false, nil)
+				actuator.EXPECT().Reconcile(ctx, gomock.Any(), set).Return(status, false, nil)
 				expectPatchManagedSeedSetStatus(func(mss *seedmanagementv1alpha1.ManagedSeedSet) {
 					Expect(&mss.Status).To(Equal(status))
 				})
@@ -164,7 +163,7 @@ var _ = Describe("Reconciler", func() {
 
 			It("should reconcile the ManagedSeedSet deletion, remove the finalizer, and not update the status", func() {
 				expectGetManagedSeedSet()
-				actuator.EXPECT().Reconcile(ctx, set).Return(status, true, nil)
+				actuator.EXPECT().Reconcile(ctx, gomock.Any(), set).Return(status, true, nil)
 				expectPatchManagedSeedSet(func(mss *seedmanagementv1alpha1.ManagedSeedSet) {
 					Expect(mss.Finalizers).To(BeEmpty())
 				})

--- a/pkg/controllermanager/controller/managedseedset/managedseedset_replica.go
+++ b/pkg/controllermanager/controller/managedseedset/managedseedset_replica.go
@@ -90,6 +90,8 @@ type Replica interface {
 	GetName() string
 	// GetFullName returns this replica's full name.
 	GetFullName() string
+	// GetObjectKey returns this replica's ObjectKey.
+	GetObjectKey() client.ObjectKey
 	// GetOrdinal returns this replica's ordinal. If the replica has no ordinal, -1 is returned.
 	GetOrdinal() int
 	// GetStatus returns this replica's status. If the replica's managed seed doesn't exist,
@@ -176,6 +178,14 @@ func (r *replica) GetFullName() string {
 		return ""
 	}
 	return kutil.ObjectName(r.shoot)
+}
+
+// GetObjectKey returns this replica's ObjectKey. This is the namespace/name of the shoot and managed seed of this replica.
+func (r *replica) GetObjectKey() client.ObjectKey {
+	if r.shoot == nil {
+		return client.ObjectKey{}
+	}
+	return client.ObjectKeyFromObject(r.shoot)
 }
 
 // GetOrdinal returns this replica's ordinal. If the replica has no ordinal, -1 is returned.

--- a/pkg/controllermanager/controller/managedseedset/managedseedset_replica_test.go
+++ b/pkg/controllermanager/controller/managedseedset/managedseedset_replica_test.go
@@ -218,6 +218,15 @@ var _ = Describe("Replica", func() {
 		Entry("should return the shoot full name", shoot(nil, "", "", "", false), namespace+"/"+replicaName),
 	)
 
+	DescribeTable("#GetObjectKey",
+		func(shoot *gardencorev1beta1.Shoot, expected client.ObjectKey) {
+			replica := NewReplica(set, shoot, nil, nil, false)
+			Expect(replica.GetObjectKey()).To(Equal(expected))
+		},
+		Entry("should return an empty key", nil, client.ObjectKey{}),
+		Entry("should return the shoot's key", shoot(nil, "", "", "", false), client.ObjectKey{Namespace: namespace, Name: replicaName}),
+	)
+
 	DescribeTable("#GetOrdinal",
 		func(shoot *gardencorev1beta1.Shoot, ordinal int) {
 			replica := NewReplica(set, shoot, nil, nil, false)

--- a/pkg/controllermanager/controller/managedseedset/mock/mocks.go
+++ b/pkg/controllermanager/controller/managedseedset/mock/mocks.go
@@ -12,7 +12,9 @@ import (
 	v1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	managedseedset "github.com/gardener/gardener/pkg/controllermanager/controller/managedseedset"
 	shoot "github.com/gardener/gardener/pkg/operation/shoot"
+	logr "github.com/go-logr/logr"
 	gomock "github.com/golang/mock/gomock"
+	types "k8s.io/apimachinery/pkg/types"
 	client "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -40,9 +42,9 @@ func (m *MockActuator) EXPECT() *MockActuatorMockRecorder {
 }
 
 // Reconcile mocks base method.
-func (m *MockActuator) Reconcile(arg0 context.Context, arg1 *v1alpha1.ManagedSeedSet) (*v1alpha1.ManagedSeedSetStatus, bool, error) {
+func (m *MockActuator) Reconcile(arg0 context.Context, arg1 logr.Logger, arg2 *v1alpha1.ManagedSeedSet) (*v1alpha1.ManagedSeedSetStatus, bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Reconcile", arg0, arg1)
+	ret := m.ctrl.Call(m, "Reconcile", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*v1alpha1.ManagedSeedSetStatus)
 	ret1, _ := ret[1].(bool)
 	ret2, _ := ret[2].(error)
@@ -50,9 +52,9 @@ func (m *MockActuator) Reconcile(arg0 context.Context, arg1 *v1alpha1.ManagedSee
 }
 
 // Reconcile indicates an expected call of Reconcile.
-func (mr *MockActuatorMockRecorder) Reconcile(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockActuatorMockRecorder) Reconcile(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reconcile", reflect.TypeOf((*MockActuator)(nil).Reconcile), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reconcile", reflect.TypeOf((*MockActuator)(nil).Reconcile), arg0, arg1, arg2)
 }
 
 // MockReplica is a mock of Replica interface.
@@ -160,6 +162,20 @@ func (m *MockReplica) GetName() string {
 func (mr *MockReplicaMockRecorder) GetName() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetName", reflect.TypeOf((*MockReplica)(nil).GetName))
+}
+
+// GetObjectKey mocks base method.
+func (m *MockReplica) GetObjectKey() types.NamespacedName {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetObjectKey")
+	ret0, _ := ret[0].(types.NamespacedName)
+	return ret0
+}
+
+// GetObjectKey indicates an expected call of GetObjectKey.
+func (mr *MockReplicaMockRecorder) GetObjectKey() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetObjectKey", reflect.TypeOf((*MockReplica)(nil).GetObjectKey))
 }
 
 // GetOrdinal mocks base method.

--- a/pkg/controllermanager/controller/plant/plant.go
+++ b/pkg/controllermanager/controller/plant/plant.go
@@ -20,26 +20,33 @@ import (
 	"sync"
 	"time"
 
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
 	"github.com/gardener/gardener/pkg/controllerutils"
-	"github.com/gardener/gardener/pkg/logger"
-
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/workqueue"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-// FinalizerName is the name of the Plant finalizer.
-const FinalizerName = "core.gardener.cloud/plant"
+const (
+	// FinalizerName is the name of the Plant finalizer.
+	FinalizerName = "core.gardener.cloud/plant"
+
+	// ControllerName is the name of this controller.
+	ControllerName = "plant"
+)
 
 // Controller controls Plant.
 type Controller struct {
 	gardenClient client.Client
+	log          logr.Logger
 
 	reconciler     reconcile.Reconciler
 	hasSyncedFuncs []cache.InformerSynced
@@ -52,12 +59,15 @@ type Controller struct {
 // NewController instantiates a new Plant controller.
 func NewController(
 	ctx context.Context,
+	log logr.Logger,
 	clientMap clientmap.ClientMap,
 	config *config.ControllerManagerConfiguration,
 ) (
 	*Controller,
 	error,
 ) {
+	log = log.WithName(ControllerName)
+
 	gardenClient, err := clientMap.GetClient(ctx, keys.ForGarden())
 	if err != nil {
 		return nil, err
@@ -74,7 +84,8 @@ func NewController(
 
 	controller := &Controller{
 		gardenClient: gardenClient.Client(),
-		reconciler:   NewPlantReconciler(logger.Logger, clientMap, gardenClient.Client(), config.Controllers.Plant),
+		log:          log,
+		reconciler:   NewPlantReconciler(clientMap, gardenClient.Client(), config.Controllers.Plant),
 		plantQueue:   workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "plant"),
 		workerCh:     make(chan int),
 	}
@@ -101,21 +112,20 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 	var waitGroup sync.WaitGroup
 
 	if !cache.WaitForCacheSync(ctx.Done(), c.hasSyncedFuncs...) {
-		logger.Logger.Error("Timed out waiting for caches to sync")
+		c.log.Error(wait.ErrWaitTimeout, "Timed out waiting for caches to sync")
 		return
 	}
 
 	go func() {
 		for res := range c.workerCh {
 			c.numberOfRunningWorkers += res
-			logger.Logger.Debugf("Current number of running Plant workers is %d", c.numberOfRunningWorkers)
 		}
 	}()
 
-	logger.Logger.Info("Plant controller initialized.")
+	c.log.Info("Plant controller initialized")
 
 	for i := 0; i < workers; i++ {
-		controllerutils.CreateWorker(ctx, c.plantQueue, "Plant", c.reconciler, &waitGroup, c.workerCh)
+		controllerutils.CreateWorker(ctx, c.plantQueue, "Plant", c.reconciler, &waitGroup, c.workerCh, controllerutils.WithLogger(c.log))
 	}
 
 	// Shutdown handling
@@ -124,10 +134,10 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 
 	for {
 		if c.plantQueue.Len() == 0 && c.numberOfRunningWorkers == 0 {
-			logger.Logger.Debug("No running Plant worker and no items left in the queues. Terminating Plant controller...")
+			c.log.V(1).Info("No running Plant worker and no items left in the queues. Terminating Plant controller...")
 			break
 		}
-		logger.Logger.Debugf("Waiting for %d Plant worker(s) to finish (%d item(s) left in the queues)...", c.numberOfRunningWorkers, c.plantQueue.Len())
+		c.log.V(1).Info("Waiting for Plant workers to finish...", "numberOfRunningWorkers", c.numberOfRunningWorkers, "queueLength", c.plantQueue.Len())
 		time.Sleep(5 * time.Second)
 	}
 

--- a/pkg/controllermanager/controller/plant/plant_control.go
+++ b/pkg/controllermanager/controller/plant/plant_control.go
@@ -19,35 +19,34 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
 	"github.com/gardener/gardener/pkg/controllerutils"
-	"github.com/gardener/gardener/pkg/logger"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
-
-	"github.com/sirupsen/logrus"
-	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/client-go/tools/cache"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 // reconcilePlantForMatchingSecret checks if there is a plant resource that references this secret and then reconciles the plant again
 func (c *Controller) reconcilePlantForMatchingSecret(ctx context.Context, obj interface{}) {
 	secret, ok := obj.(*corev1.Secret)
 	if !ok {
-		logger.Logger.Errorf("Could not convert object %v into Secret", obj)
 		return
 	}
 
 	plantList := &gardencorev1beta1.PlantList{}
 	if err := c.gardenClient.List(ctx, plantList); err != nil {
-		logger.Logger.Errorf("Couldn't list plants for updated secret %+v: %v", obj, err)
+		c.log.Error(err, "Could not list plants for secret", "secret", client.ObjectKeyFromObject(secret))
 		return
 	}
 
@@ -55,10 +54,10 @@ func (c *Controller) reconcilePlantForMatchingSecret(ctx context.Context, obj in
 		if isPlantSecret(plant, kutil.Key(secret.Namespace, secret.Name)) {
 			key, err := cache.MetaNamespaceKeyFunc(&plant)
 			if err != nil {
-				logger.Logger.Errorf("Couldn't get key for plant %+v: %v", plant, err)
+				c.log.Error(err, "Couldn't get key for object", "object", obj)
 				return
 			}
-			logger.Logger.Infof("[PLANT RECONCILE] Reconciling Plant after secret change")
+			c.log.Info("Enqueuing Plant after secret change", "plant", client.ObjectKeyFromObject(&plant), "secret", client.ObjectKeyFromObject(secret))
 			c.plantQueue.Add(key)
 			return
 		}
@@ -81,7 +80,7 @@ func (c *Controller) plantSecretUpdate(ctx context.Context, oldObj, newObj inter
 func (c *Controller) plantAdd(obj interface{}) {
 	key, err := cache.MetaNamespaceKeyFunc(obj)
 	if err != nil {
-		logger.Logger.Errorf("Couldn't get key for object %+v: %v", obj, err)
+		c.log.Error(err, "Couldn't get key for object", "object", obj)
 		return
 	}
 	c.plantQueue.Add(key)
@@ -105,16 +104,15 @@ func (c *Controller) plantUpdate(oldObj, newObj interface{}) {
 func (c *Controller) plantDelete(obj interface{}) {
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 	if err != nil {
-		logger.Logger.Errorf("Couldn't get key for object %+v: %v", obj, err)
+		c.log.Error(err, "Couldn't get key for object", "object", obj)
 		return
 	}
 	c.plantQueue.Add(key)
 }
 
 // NewPlantReconciler creates a new instance of a reconciler which reconciles Plants.
-func NewPlantReconciler(l logrus.FieldLogger, clientMap clientmap.ClientMap, gardenClient client.Client, config *config.PlantControllerConfiguration) reconcile.Reconciler {
+func NewPlantReconciler(clientMap clientmap.ClientMap, gardenClient client.Client, config *config.PlantControllerConfiguration) reconcile.Reconciler {
 	return &plantReconciler{
-		logger:       l,
 		clientMap:    clientMap,
 		gardenClient: gardenClient,
 		config:       config,
@@ -122,21 +120,21 @@ func NewPlantReconciler(l logrus.FieldLogger, clientMap clientmap.ClientMap, gar
 }
 
 type plantReconciler struct {
-	logger       logrus.FieldLogger
 	clientMap    clientmap.ClientMap
 	gardenClient client.Client
 	config       *config.PlantControllerConfiguration
 }
 
 func (r *plantReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log := logf.FromContext(ctx)
+
 	plant := &gardencorev1beta1.Plant{}
 	if err := r.gardenClient.Get(ctx, request.NamespacedName, plant); err != nil {
 		if apierrors.IsNotFound(err) {
-			r.logger.Infof("Object %q is gone, stop reconciling: %v", request.Name, err)
+			log.Info("Object is gone, stop reconciling")
 			return reconcile.Result{}, nil
 		}
-		r.logger.Infof("Unable to retrieve object %q from store: %v", request.Name, err)
-		return reconcile.Result{}, err
+		return reconcile.Result{}, fmt.Errorf("error retrieving object from store: %w", err)
 	}
 
 	if plant.DeletionTimestamp != nil {
@@ -145,17 +143,14 @@ func (r *plantReconciler) Reconcile(ctx context.Context, request reconcile.Reque
 		}
 	}
 
-	if err := r.reconcile(ctx, plant, r.gardenClient); err != nil {
+	if err := r.reconcile(ctx, log, plant, r.gardenClient); err != nil {
 		return reconcile.Result{}, err
 	}
 
 	return reconcile.Result{RequeueAfter: r.config.SyncPeriod.Duration}, nil
 }
 
-func (r *plantReconciler) reconcile(ctx context.Context, plant *gardencorev1beta1.Plant, gardenClient client.Client) error {
-	logger := logger.NewFieldLogger(r.logger, "plant", plant.Name)
-	logger.Infof("[PLANT RECONCILE] %s", plant.Name)
-
+func (r *plantReconciler) reconcile(ctx context.Context, log logr.Logger, plant *gardencorev1beta1.Plant, gardenClient client.Client) error {
 	// Add Finalizers to Plant
 	if !controllerutil.ContainsFinalizer(plant, FinalizerName) {
 		if err := controllerutils.StrategicMergePatchAddFinalizers(ctx, gardenClient, plant, FinalizerName); err != nil {
@@ -184,9 +179,8 @@ func (r *plantReconciler) reconcile(ctx context.Context, plant *gardencorev1beta
 
 	plantClient, err := r.clientMap.GetClient(ctx, keys.ForPlant(plant))
 	if err != nil {
-		msg := fmt.Sprintf("failed to get plant client: %v", err)
-		logger.Error(msg)
-		return updateStatusToUnknown(ctx, gardenClient, plant, msg, conditionAPIServerAvailable, conditionEveryNodeReady)
+		log.Error(err, "Failed to get Plant client")
+		return updateStatusToUnknown(ctx, gardenClient, plant, fmt.Sprintf("failed to get plant client: %v", err), conditionAPIServerAvailable, conditionEveryNodeReady)
 	}
 
 	healthChecker := NewHealthChecker(plantClient.Client(), plantClient.Kubernetes().Discovery())
@@ -194,7 +188,7 @@ func (r *plantReconciler) reconcile(ctx context.Context, plant *gardencorev1beta
 	// Trigger health check
 	conditionAPIServerAvailable, conditionEveryNodeReady = healthChecks(ctx, healthChecker, conditionAPIServerAvailable, conditionEveryNodeReady)
 
-	cloudInfo, err := FetchCloudInfo(ctx, plantClient.Client(), plantClient.Kubernetes().Discovery(), logger)
+	cloudInfo, err := FetchCloudInfo(ctx, plantClient.Client(), plantClient.Kubernetes().Discovery())
 	if err != nil {
 		return fmt.Errorf("failed to fetch cloud info for plant: %w", err)
 	}

--- a/pkg/controllermanager/controller/plant/plant_control.go
+++ b/pkg/controllermanager/controller/plant/plant_control.go
@@ -50,14 +50,15 @@ func (c *Controller) reconcilePlantForMatchingSecret(ctx context.Context, obj in
 		return
 	}
 
-	for _, plant := range plantList.Items {
+	for _, p := range plantList.Items {
+		plant := &p
 		if isPlantSecret(plant, kutil.Key(secret.Namespace, secret.Name)) {
-			key, err := cache.MetaNamespaceKeyFunc(&plant)
+			key, err := cache.MetaNamespaceKeyFunc(plant)
 			if err != nil {
-				c.log.Error(err, "Couldn't get key for object", "object", obj)
+				c.log.Error(err, "Couldn't get key for Plant", "plant", plant)
 				return
 			}
-			c.log.Info("Enqueuing Plant after secret change", "plant", client.ObjectKeyFromObject(&plant), "secret", client.ObjectKeyFromObject(secret))
+			c.log.Info("Enqueuing Plant after secret change", "plant", client.ObjectKeyFromObject(plant), "secret", client.ObjectKeyFromObject(secret))
 			c.plantQueue.Add(key)
 			return
 		}

--- a/pkg/controllermanager/controller/plant/plant_test.go
+++ b/pkg/controllermanager/controller/plant/plant_test.go
@@ -24,7 +24,6 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/controllermanager/controller/plant"
-	"github.com/gardener/gardener/pkg/logger"
 	mockdiscovery "github.com/gardener/gardener/pkg/mock/client-go/discovery"
 	mockrest "github.com/gardener/gardener/pkg/mock/client-go/rest"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
@@ -90,7 +89,6 @@ var _ = Describe("Plant", func() {
 			var (
 				discoveryMockclient = mockdiscovery.NewMockDiscoveryInterface(ctrl)
 				runtimeClient       = mockclient.NewMockClient(ctrl)
-				testLogger          = logger.NewFieldLogger(logger.NewLogger("info", ""), "test", "test-plant")
 			)
 
 			runtimeClient.EXPECT().List(context.TODO(), gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
@@ -101,7 +99,7 @@ var _ = Describe("Plant", func() {
 
 			discoveryMockclient.EXPECT().ServerVersion().Return(&version.Info{GitVersion: "1.15.1"}, nil).AnyTimes()
 
-			statusInfo, err := plant.FetchCloudInfo(context.TODO(), runtimeClient, discoveryMockclient, testLogger)
+			statusInfo, err := plant.FetchCloudInfo(context.TODO(), runtimeClient, discoveryMockclient)
 			Expect(err).To(errMatcher)
 			Expect(statusInfo).To(Equal(expectedInfo))
 		},

--- a/pkg/controllermanager/controller/plant/plant_utils.go
+++ b/pkg/controllermanager/controller/plant/plant_utils.go
@@ -95,6 +95,6 @@ func getRegionNameForNode(node corev1.Node) string {
 	return Unknown
 }
 
-func isPlantSecret(plant gardencorev1beta1.Plant, secretKey client.ObjectKey) bool {
+func isPlantSecret(plant *gardencorev1beta1.Plant, secretKey client.ObjectKey) bool {
 	return plant.Spec.SecretRef.Name == secretKey.Name && plant.Namespace == secretKey.Namespace
 }

--- a/pkg/controllermanager/controller/plant/plant_utils.go
+++ b/pkg/controllermanager/controller/plant/plant_utils.go
@@ -20,7 +20,6 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 
-	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/discovery"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -30,8 +29,8 @@ import (
 const Unknown = "<unknown>"
 
 // FetchCloudInfo deduces the cloud info from the plant cluster
-func FetchCloudInfo(ctx context.Context, plantClient client.Client, discoveryClient discovery.DiscoveryInterface, logger logrus.FieldLogger) (*StatusCloudInfo, error) {
-	cloudInfo, err := getClusterInfo(ctx, plantClient, logger)
+func FetchCloudInfo(ctx context.Context, plantClient client.Client, discoveryClient discovery.DiscoveryInterface) (*StatusCloudInfo, error) {
+	cloudInfo, err := getClusterInfo(ctx, plantClient)
 	if err != nil {
 		return nil, err
 	}
@@ -46,7 +45,7 @@ func FetchCloudInfo(ctx context.Context, plantClient client.Client, discoveryCli
 }
 
 // getClusterInfo gets the kubernetes cluster zones and Region by inspecting labels on nodes in the cluster.
-func getClusterInfo(ctx context.Context, cl client.Client, logger logrus.FieldLogger) (*StatusCloudInfo, error) {
+func getClusterInfo(ctx context.Context, cl client.Client) (*StatusCloudInfo, error) {
 	nodes := &corev1.NodeList{}
 	if err := cl.List(ctx, nodes, client.Limit(1)); err != nil {
 		return nil, err

--- a/pkg/utils/kubernetes/eventhandler.go
+++ b/pkg/utils/kubernetes/eventhandler.go
@@ -87,7 +87,7 @@ type ControlledResourceEventHandler struct {
 	// Scheme is used to resolve types to their GroupKinds.
 	Scheme *runtime.Scheme
 	// Logger is used to log messages.
-	Logger *logrus.Logger
+	Logger logrus.FieldLogger
 }
 
 // ControllerType contains information about a controller type.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging dev-productivity
/kind enhancement

**What this PR does / why we need it**:

Continuation of https://github.com/gardener/gardener/pull/5268
Migrate more controller-manager controllers:
- event controller
- exposureclass controller
- plant controller
- managedseedset controller

Also extend the logging guideline with some new learnings (first commit, to make the other commits more understandable).

**Which issue(s) this PR fixes**:
Part of #4251

**Special notes for your reviewer**:

/squash

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
