### PR TITLE
Fix odd number of arguments in logging

### DIFF
--- a/pkg/controllermanager/controller/controllerregistration/seed_control.go
+++ b/pkg/controllermanager/controller/controllerregistration/seed_control.go
@@ -427,7 +427,7 @@ func deployNeededInstallations(
 			continue
 		}
 
-		registrationLog.Info("Deploying wanted ControllerInstallation for ControllerRegistration", registrationName)
+		registrationLog.Info("Deploying wanted ControllerInstallation for ControllerRegistration")
 
 		var (
 			controllerDeployment   *gardencorev1beta1.ControllerDeployment


### PR DESCRIPTION
/area quality
/kind bug

Fixes #5292

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
