### PR TITLE
Improve shoot validation check

### DIFF
--- a/pkg/utils/validation/cidr/disjoint.go
+++ b/pkg/utils/validation/cidr/disjoint.go
@@ -90,21 +90,21 @@ func ValidateShootNetworkDisjointedness(fldPath *field.Path, shootNodes, shootPo
 			allErrs = append(allErrs, field.Invalid(pathServices, *shootServices, "shoot pod network intersects with shoot service network"))
 		}
 		if shootNodes != nil && NetworksIntersect(*shootPods, *shootNodes) {
-			allErrs = append(allErrs, field.Invalid(pathPods, *shootServices, "shoot pod network intersects with shoot node network"))
+			allErrs = append(allErrs, field.Invalid(pathPods, *shootPods, "shoot pod network intersects with shoot node network"))
 		}
 		if shootNodes != nil && NetworksIntersect(*shootServices, *shootNodes) {
 			allErrs = append(allErrs, field.Invalid(pathServices, *shootServices, "shoot service network intersects with shoot node network"))
 		}
 	} else if shootPods != nil {
 		if shootNodes != nil && NetworksIntersect(*shootPods, *shootNodes) {
-			allErrs = append(allErrs, field.Invalid(pathPods, *shootServices, "shoot pod network intersects with shoot node network"))
+			allErrs = append(allErrs, field.Invalid(pathPods, *shootPods, "shoot pod network intersects with shoot node network"))
 		}
-		allErrs = append(allErrs, field.Required(pathServices, "services is required"))
+		allErrs = append(allErrs, field.Required(pathServices, "shoot service network is required"))
 	} else if shootServices != nil {
 		if shootNodes != nil && NetworksIntersect(*shootServices, *shootNodes) {
 			allErrs = append(allErrs, field.Invalid(pathServices, *shootServices, "shoot service network intersects with shoot node network"))
 		}
-		allErrs = append(allErrs, field.Required(pathPods, "pods is required"))
+		allErrs = append(allErrs, field.Required(pathPods, "shoot pod network is required"))
 	} else {
 		allErrs = append(allErrs, field.Required(pathServices, "shoot service network is required"))
 		allErrs = append(allErrs, field.Required(pathPods, "shoot pod network is required"))

--- a/pkg/utils/validation/cidr/disjoint.go
+++ b/pkg/utils/validation/cidr/disjoint.go
@@ -46,6 +46,9 @@ func ValidateNetworkDisjointedness(fldPath *field.Path, shootNodes, shootPods, s
 		if NetworksIntersect(seedPods, *shootServices) {
 			allErrs = append(allErrs, field.Invalid(pathServices, *shootServices, "shoot service network intersects with seed pod network"))
 		}
+		if seedNodes != nil && NetworksIntersect(*seedNodes, *shootServices) {
+			allErrs = append(allErrs, field.Invalid(pathServices, *seedNodes, "shoot service network intersects with seed node network"))
+		}
 		if NetworksIntersect(v1beta1constants.DefaultVpnRange, *shootServices) {
 			allErrs = append(allErrs, field.Invalid(pathServices, *shootServices, fmt.Sprintf("shoot service network intersects with default vpn network (%s)", v1beta1constants.DefaultVpnRange)))
 		}
@@ -60,10 +63,50 @@ func ValidateNetworkDisjointedness(fldPath *field.Path, shootNodes, shootPods, s
 		if NetworksIntersect(seedServices, *shootPods) {
 			allErrs = append(allErrs, field.Invalid(pathPods, *shootPods, "shoot pod network intersects with seed service network"))
 		}
+		if seedNodes != nil && NetworksIntersect(*seedNodes, *shootPods) {
+			allErrs = append(allErrs, field.Invalid(pathPods, *seedNodes, "shoot pod network intersects with seed node network"))
+		}
 		if NetworksIntersect(v1beta1constants.DefaultVpnRange, *shootPods) {
 			allErrs = append(allErrs, field.Invalid(pathPods, *shootPods, fmt.Sprintf("shoot pod network intersects with default vpn network (%s)", v1beta1constants.DefaultVpnRange)))
 		}
 	} else {
+		allErrs = append(allErrs, field.Required(pathPods, "pods is required"))
+	}
+
+	return allErrs
+}
+
+// ValidateShootNetworkDisjointedness validates that the given shoot network is disjoint.
+func ValidateShootNetworkDisjointedness(fldPath *field.Path, shootNodes, shootPods, shootServices *string) field.ErrorList {
+	var (
+		allErrs = field.ErrorList{}
+
+		pathServices = fldPath.Child("services")
+		pathPods     = fldPath.Child("pods")
+	)
+
+	if shootPods != nil && shootServices != nil {
+		if NetworksIntersect(*shootPods, *shootServices) {
+			allErrs = append(allErrs, field.Invalid(pathServices, *shootServices, "shoot pod network intersects with shoot service network"))
+		}
+		if shootNodes != nil && NetworksIntersect(*shootPods, *shootNodes) {
+			allErrs = append(allErrs, field.Invalid(pathPods, *shootServices, "shoot pod network intersects with shoot node network"))
+		}
+		if shootNodes != nil && NetworksIntersect(*shootServices, *shootNodes) {
+			allErrs = append(allErrs, field.Invalid(pathServices, *shootServices, "shoot service network intersects with shoot node network"))
+		}
+	} else if shootPods != nil {
+		if shootNodes != nil && NetworksIntersect(*shootPods, *shootNodes) {
+			allErrs = append(allErrs, field.Invalid(pathPods, *shootServices, "shoot pod network intersects with shoot node network"))
+		}
+		allErrs = append(allErrs, field.Required(pathServices, "services is required"))
+	} else if shootServices != nil {
+		if shootNodes != nil && NetworksIntersect(*shootServices, *shootNodes) {
+			allErrs = append(allErrs, field.Invalid(pathServices, *shootServices, "shoot service network intersects with shoot node network"))
+		}
+		allErrs = append(allErrs, field.Required(pathPods, "pods is required"))
+	} else {
+		allErrs = append(allErrs, field.Required(pathServices, "services is required"))
 		allErrs = append(allErrs, field.Required(pathPods, "pods is required"))
 	}
 

--- a/pkg/utils/validation/cidr/disjoint.go
+++ b/pkg/utils/validation/cidr/disjoint.go
@@ -106,8 +106,8 @@ func ValidateShootNetworkDisjointedness(fldPath *field.Path, shootNodes, shootPo
 		}
 		allErrs = append(allErrs, field.Required(pathPods, "pods is required"))
 	} else {
-		allErrs = append(allErrs, field.Required(pathServices, "services is required"))
-		allErrs = append(allErrs, field.Required(pathPods, "pods is required"))
+		allErrs = append(allErrs, field.Required(pathServices, "shoot service network is required"))
+		allErrs = append(allErrs, field.Required(pathPods, "shoot pod network is required"))
 	}
 
 	return allErrs

--- a/pkg/utils/validation/cidr/disjoint_test.go
+++ b/pkg/utils/validation/cidr/disjoint_test.go
@@ -199,6 +199,33 @@ var _ = Describe("utils", func() {
 				"Field": Equal("[].nodes"),
 			}))))
 		})
+
+		It("should fail due to range overlap of seed node netwok and shoot pod and service network", func() {
+			var (
+				podsCIDR     = seedNodesCIDR
+				servicesCIDR = seedNodesCIDR
+				nodesCIDR    = "10.241.0.0/16"
+			)
+
+			errorList := ValidateNetworkDisjointedness(
+				field.NewPath(""),
+				&nodesCIDR,
+				&podsCIDR,
+				&servicesCIDR,
+				&seedNodesCIDR,
+				seedPodsCIDR,
+				seedServicesCIDR,
+			)
+
+			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeInvalid),
+				"Field": Equal("[].pods"),
+			})), PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeInvalid),
+				"Field": Equal("[].services"),
+			})),
+			))
+		})
 	})
 
 	Describe("#ValidateNetworkDisjointedness IPv6", func() {
@@ -281,6 +308,163 @@ var _ = Describe("utils", func() {
 				"Field": Equal("[].pods"),
 			}))),
 			)
+		})
+
+		It("should fail due to range overlap of seed node netwok and shoot pod and service network", func() {
+			var (
+				podsCIDR     = seedNodesCIDRIPv6
+				servicesCIDR = seedNodesCIDRIPv6
+				nodesCIDR    = "2001:0db8:65a3::/113"
+			)
+
+			errorList := ValidateNetworkDisjointedness(
+				field.NewPath(""),
+				&nodesCIDR,
+				&podsCIDR,
+				&servicesCIDR,
+				&seedNodesCIDRIPv6,
+				seedPodsCIDRIPv6,
+				seedServicesCIDRIPv6,
+			)
+
+			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeInvalid),
+				"Field": Equal("[].pods"),
+			})), PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeInvalid),
+				"Field": Equal("[].services"),
+			})),
+			))
+		})
+	})
+
+	Describe("#ValidateShootNetworkDisjointedness IPv4", func() {
+
+		It("should pass the validation", func() {
+			var (
+				podsCIDR     = "10.242.128.0/17"
+				servicesCIDR = "10.242.0.0/17"
+				nodesCIDR    = "10.241.0.0/16"
+			)
+
+			errorList := ValidateShootNetworkDisjointedness(
+				field.NewPath(""),
+				&nodesCIDR,
+				&podsCIDR,
+				&servicesCIDR,
+			)
+
+			Expect(errorList).To(BeEmpty())
+		})
+
+		It("should fail due to missing fields", func() {
+			errorList := ValidateShootNetworkDisjointedness(
+				field.NewPath(""),
+				nil,
+				nil,
+				nil,
+			)
+
+			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeRequired),
+				"Field": Equal("[].services"),
+			})), PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeRequired),
+				"Field": Equal("[].pods"),
+			})),
+			))
+		})
+
+		It("should fail due to disjointedness of node, service and pod networks", func() {
+			var (
+				nodesCIDR    = "10.241.0.0/16"
+				podsCIDR     = nodesCIDR
+				servicesCIDR = nodesCIDR
+			)
+
+			errorList := ValidateShootNetworkDisjointedness(
+				field.NewPath(""),
+				&nodesCIDR,
+				&podsCIDR,
+				&servicesCIDR,
+			)
+
+			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeInvalid),
+				"Field": Equal("[].services"),
+			})), PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeInvalid),
+				"Field": Equal("[].pods"),
+			})), PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeInvalid),
+				"Field": Equal("[].services"),
+			})),
+			))
+		})
+	})
+
+	Describe("#ValidateShootNetworkDisjointedness IPv6", func() {
+
+		It("should pass the validation", func() {
+			var (
+				podsCIDR     = "2001:0db8:35a3::/113"
+				servicesCIDR = "2001:0db8:45a3::/113"
+				nodesCIDR    = "2001:0db8:55a3::/112"
+			)
+
+			errorList := ValidateShootNetworkDisjointedness(
+				field.NewPath(""),
+				&nodesCIDR,
+				&podsCIDR,
+				&servicesCIDR,
+			)
+
+			Expect(errorList).To(BeEmpty())
+		})
+
+		It("should fail due to missing fields", func() {
+			errorList := ValidateShootNetworkDisjointedness(
+				field.NewPath(""),
+				nil,
+				nil,
+				nil,
+			)
+
+			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeRequired),
+				"Field": Equal("[].services"),
+			})), PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeRequired),
+				"Field": Equal("[].pods"),
+			})),
+			))
+		})
+
+		It("should fail due to disjointedness of node, service and pod networks", func() {
+			var (
+				nodesCIDR    = "2001:0db8:55a3::/112"
+				podsCIDR     = nodesCIDR
+				servicesCIDR = nodesCIDR
+			)
+
+			errorList := ValidateShootNetworkDisjointedness(
+				field.NewPath(""),
+				&nodesCIDR,
+				&podsCIDR,
+				&servicesCIDR,
+			)
+
+			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeInvalid),
+				"Field": Equal("[].services"),
+			})), PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeInvalid),
+				"Field": Equal("[].pods"),
+			})), PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeInvalid),
+				"Field": Equal("[].services"),
+			})),
+			))
 		})
 	})
 })

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -515,6 +515,14 @@ func (c *validationContext) validateShootNetworks() field.ErrorList {
 			}
 		}
 
+		// validate network disjointedness within shoot network
+		allErrs = append(allErrs, cidrvalidation.ValidateShootNetworkDisjointedness(
+			path,
+			c.shoot.Spec.Networking.Nodes,
+			c.shoot.Spec.Networking.Pods,
+			c.shoot.Spec.Networking.Services,
+		)...)
+
 		// validate network disjointedness with seed networks if shoot is being (re)scheduled
 		if !apiequality.Semantic.DeepEqual(c.oldShoot.Spec.SeedName, c.shoot.Spec.SeedName) {
 			allErrs = append(allErrs, cidrvalidation.ValidateNetworkDisjointedness(

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -514,14 +514,15 @@ func (c *validationContext) validateShootNetworks() field.ErrorList {
 				allErrs = append(allErrs, field.Required(path.Child("services"), "services is required"))
 			}
 		}
-
-		// validate network disjointedness within shoot network
-		allErrs = append(allErrs, cidrvalidation.ValidateShootNetworkDisjointedness(
-			path,
-			c.shoot.Spec.Networking.Nodes,
-			c.shoot.Spec.Networking.Pods,
-			c.shoot.Spec.Networking.Services,
-		)...)
+		if c.shoot.DeletionTimestamp == nil {
+			// validate network disjointedness within shoot network
+			allErrs = append(allErrs, cidrvalidation.ValidateShootNetworkDisjointedness(
+				path,
+				c.shoot.Spec.Networking.Nodes,
+				c.shoot.Spec.Networking.Pods,
+				c.shoot.Spec.Networking.Services,
+			)...)
+		}
 
 		// validate network disjointedness with seed networks if shoot is being (re)scheduled
 		if !apiequality.Semantic.DeepEqual(c.oldShoot.Spec.SeedName, c.shoot.Spec.SeedName) {

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -1222,6 +1222,71 @@ var _ = Describe("validator", func() {
 
 					Expect(err).To(BeForbiddenError())
 				})
+
+				It("should reject because the shoot pod and the seed node networks intersect", func() {
+					shoot.Spec.Networking.Pods = &seedNodesCIDR
+
+					Expect(coreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&project)).To(Succeed())
+					Expect(coreInformerFactory.Core().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
+					Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+					attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+
+					err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+					Expect(err).To(BeForbiddenError())
+				})
+
+				It("should reject because the shoot service and the seed node networks intersect", func() {
+					shoot.Spec.Networking.Services = &seedNodesCIDR
+
+					Expect(coreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&project)).To(Succeed())
+					Expect(coreInformerFactory.Core().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
+					Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+					attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+
+					err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+					Expect(err).To(BeForbiddenError())
+				})
+
+				It("should reject because the shoot service and the shoot node networks intersect", func() {
+					shoot.Spec.Networking.Services = shoot.Spec.Networking.Nodes
+
+					Expect(coreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&project)).To(Succeed())
+					Expect(coreInformerFactory.Core().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
+					Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+					attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+
+					err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+					Expect(err).To(BeForbiddenError())
+				})
+
+				It("should reject because the shoot pod and the shoot node networks intersect", func() {
+					shoot.Spec.Networking.Pods = shoot.Spec.Networking.Nodes
+
+					Expect(coreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&project)).To(Succeed())
+					Expect(coreInformerFactory.Core().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
+					Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+					attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+
+					err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+					Expect(err).To(BeForbiddenError())
+				})
+
+				It("should reject because the shoot pod and the shoot service networks intersect", func() {
+					shoot.Spec.Networking.Pods = shoot.Spec.Networking.Services
+
+					Expect(coreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&project)).To(Succeed())
+					Expect(coreInformerFactory.Core().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
+					Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+					attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
+
+					err := admissionHandler.Admit(context.TODO(), attrs, nil)
+
+					Expect(err).To(BeForbiddenError())
+				})
 			})
 
 			Context("dns settings checks", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
This PR improves intersection check between shoot network CIDRs and seed network CIDRs.

**Which issue(s) this PR fixes**:
Fixes #5180
Fixes #5291

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
