### PR TITLE
Fix failing creation of hibernated shoots

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_delete.go
@@ -41,6 +41,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -315,7 +316,7 @@ func (r *shootReconciler) runDeleteShootFlow(ctx context.Context, o *operation.O
 		setGardenerResourceManagerReplicas = g.Add(flow.Task{
 			Name: "Setting gardener-resource-manager replicas to 3",
 			Fn: flow.TaskFn(func(_ context.Context) error {
-				botanist.Shoot.Components.ControlPlane.ResourceManager.SetReplicas(3)
+				botanist.Shoot.Components.ControlPlane.ResourceManager.SetReplicas(pointer.Int32(3))
 				return nil
 			}).DoIf(cleanupShootResources),
 			Dependencies: flow.NewTaskIDs(waitUntilKubeAPIServerIsReady),

--- a/pkg/operation/botanist/component/resourcemanager/mock/mocks.go
+++ b/pkg/operation/botanist/component/resourcemanager/mock/mocks.go
@@ -64,10 +64,10 @@ func (mr *MockInterfaceMockRecorder) Destroy(arg0 interface{}) *gomock.Call {
 }
 
 // GetReplicas mocks base method.
-func (m *MockInterface) GetReplicas() int32 {
+func (m *MockInterface) GetReplicas() *int32 {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetReplicas")
-	ret0, _ := ret[0].(int32)
+	ret0, _ := ret[0].(*int32)
 	return ret0
 }
 
@@ -78,7 +78,7 @@ func (mr *MockInterfaceMockRecorder) GetReplicas() *gomock.Call {
 }
 
 // SetReplicas mocks base method.
-func (m *MockInterface) SetReplicas(arg0 int32) {
+func (m *MockInterface) SetReplicas(arg0 *int32) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetReplicas", arg0)
 }

--- a/pkg/operation/botanist/component/resourcemanager/resource_manager_test.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
@@ -274,7 +275,7 @@ var _ = Describe("ResourceManager", func() {
 			MaxConcurrentTokenRequestorWorkers:   &maxConcurrentTokenRequestorWorkers,
 			MaxConcurrentRootCAPublisherWorkers:  &maxConcurrentRootCAPublisherWorkers,
 			RenewDeadline:                        &renewDeadline,
-			Replicas:                             replicas,
+			Replicas:                             &replicas,
 			ResourceClass:                        &resourceClass,
 			RetryPeriod:                          &retryPeriod,
 			SyncPeriod:                           &syncPeriod,
@@ -1679,8 +1680,8 @@ subjects:
 			resourceManager = New(nil, "", "", Values{})
 			Expect(resourceManager.GetReplicas()).To(BeZero())
 
-			resourceManager.SetReplicas(replicas)
-			Expect(resourceManager.GetReplicas()).To(Equal(replicas))
+			resourceManager.SetReplicas(&replicas)
+			Expect(resourceManager.GetReplicas()).To(PointTo(Equal(replicas)))
 		})
 	})
 })

--- a/pkg/operation/botanist/resource_manager.go
+++ b/pkg/operation/botanist/resource_manager.go
@@ -69,7 +69,6 @@ func (b *Botanist) DefaultResourceManager() (resourcemanager.Interface, error) {
 		MaxConcurrentTokenInvalidatorWorkers: pointer.Int32(5),
 		MaxConcurrentTokenRequestorWorkers:   pointer.Int32(5),
 		MaxConcurrentRootCAPublisherWorkers:  pointer.Int32(5),
-		Replicas:                             int32(3),
 		SyncPeriod:                           utils.DurationPtr(time.Minute),
 		TargetDiffersFromSourceCluster:       true,
 		TargetDisableCache:                   pointer.Bool(true),
@@ -80,14 +79,6 @@ func (b *Botanist) DefaultResourceManager() (resourcemanager.Interface, error) {
 				corev1.ResourceMemory: resource.MustParse("30Mi"),
 			},
 		},
-	}
-
-	// ensure grm is present during hibernation (if the cluster is not hibernated yet) to reconcile any changes to
-	// MRs (e.g. caused by extension upgrades) that are necessary for completing the hibernation flow.
-	// grm is scaled down later on as part of the HibernateControlPlane step, so we only specify replicas=0 if
-	// the shoot is already hibernated.
-	if b.Shoot.HibernationEnabled && b.Shoot.GetInfo().Status.IsHibernated {
-		cfg.Replicas = 0
 	}
 
 	return resourcemanager.New(

--- a/pkg/operation/seed/components.go
+++ b/pkg/operation/seed/components.go
@@ -119,7 +119,7 @@ func defaultGardenerResourceManager(c client.Client, imageVector imagevector.Ima
 		MaxConcurrentTokenInvalidatorWorkers: pointer.Int32(5),
 		MaxConcurrentRootCAPublisherWorkers:  pointer.Int32(5),
 		HealthSyncPeriod:                     utils.DurationPtr(time.Minute),
-		Replicas:                             int32(3),
+		Replicas:                             pointer.Int32(3),
 		ResourceClass:                        pointer.String(v1beta1constants.SeedResourceManagerClass),
 		SyncPeriod:                           utils.DurationPtr(time.Hour),
 		VPA: &resourcemanager.VPAConfig{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/merge squash

**What this PR does / why we need it**:
This PR fixes an issue preventing hibernated shoots from being created. Details are provided in the individual commit messages.

**Which issue(s) this PR fixes**:
Fixes #5296

**Special notes for your reviewer**:
This PR is similar to #5246 or #5269 given that there are many special cases with hibernation, reconciliation, creation, deletion, etc. With @timebertt we plan to look into integrating more e2e tests during PR verification to prevent regressions like this in the future.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
