### PR TITLE
Adapt usages of `kutil.{SetMetaDataLabel}` to `metav1.{SetMetaDataLabel}`

### DIFF
--- a/landscaper/pkg/controlplane/controller/flow_garden_namespace.go
+++ b/landscaper/pkg/controlplane/controller/flow_garden_namespace.go
@@ -19,7 +19,6 @@ import (
 
 	gardencorev1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/controllerutils"
-	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -36,9 +35,9 @@ func (o *operation) PrepareGardenNamespace(ctx context.Context) error {
 
 	// create + label garden namespace
 	if _, err := controllerutils.CreateOrGetAndMergePatch(ctx, client, gardenNamespace, func() error {
-		kutil.SetMetaDataLabel(&gardenNamespace.ObjectMeta, gardencorev1beta1constants.GardenRole, gardencorev1beta1constants.GardenRoleProject)
-		kutil.SetMetaDataLabel(&gardenNamespace.ObjectMeta, gardencorev1beta1constants.ProjectName, gardencorev1beta1constants.GardenRoleProject)
-		kutil.SetMetaDataLabel(&gardenNamespace.ObjectMeta, gardencorev1beta1constants.LabelApp, "gardener")
+		metav1.SetMetaDataLabel(&gardenNamespace.ObjectMeta, gardencorev1beta1constants.GardenRole, gardencorev1beta1constants.GardenRoleProject)
+		metav1.SetMetaDataLabel(&gardenNamespace.ObjectMeta, gardencorev1beta1constants.ProjectName, gardencorev1beta1constants.GardenRoleProject)
+		metav1.SetMetaDataLabel(&gardenNamespace.ObjectMeta, gardencorev1beta1constants.LabelApp, "gardener")
 		return nil
 	}); err != nil {
 		return err

--- a/landscaper/pkg/controlplane/controller/operation_reconcile.go
+++ b/landscaper/pkg/controlplane/controller/operation_reconcile.go
@@ -24,7 +24,6 @@ import (
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/operation/etcdencryption"
 	"github.com/gardener/gardener/pkg/utils/flow"
-	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -59,9 +58,9 @@ func (o *operation) Reconcile(ctx context.Context) (*exports.Exports, bool, bool
 
 				// create + label garden namespace
 				if _, err := controllerutils.CreateOrGetAndMergePatch(ctx, client, gardenNamespace, func() error {
-					kutil.SetMetaDataLabel(&gardenNamespace.ObjectMeta, gardencorev1beta1constants.GardenRole, gardencorev1beta1constants.GardenRoleProject)
-					kutil.SetMetaDataLabel(&gardenNamespace.ObjectMeta, gardencorev1beta1constants.ProjectName, gardencorev1beta1constants.GardenRoleProject)
-					kutil.SetMetaDataLabel(&gardenNamespace.ObjectMeta, gardencorev1beta1constants.LabelApp, "gardener")
+					metav1.SetMetaDataLabel(&gardenNamespace.ObjectMeta, gardencorev1beta1constants.GardenRole, gardencorev1beta1constants.GardenRoleProject)
+					metav1.SetMetaDataLabel(&gardenNamespace.ObjectMeta, gardencorev1beta1constants.ProjectName, gardencorev1beta1constants.GardenRoleProject)
+					metav1.SetMetaDataLabel(&gardenNamespace.ObjectMeta, gardencorev1beta1constants.LabelApp, "gardener")
 					return nil
 				}); err != nil {
 					return err

--- a/pkg/controllermanager/controller/controllerregistration/seed_control.go
+++ b/pkg/controllermanager/controller/controllerregistration/seed_control.go
@@ -489,14 +489,14 @@ func deployNeededInstallation(
 			return err
 		}
 		seedSpecHash := utils.HashForMap(seedSpecMap)[:16]
-		kutil.SetMetaDataLabel(&controllerInstallation.ObjectMeta, common.SeedSpecHash, seedSpecHash)
+		metav1.SetMetaDataLabel(&controllerInstallation.ObjectMeta, common.SeedSpecHash, seedSpecHash)
 
 		registrationSpecMap, err := convertObjToMap(controllerRegistration.Spec)
 		if err != nil {
 			return err
 		}
 		registrationSpecHash := utils.HashForMap(registrationSpecMap)[:16]
-		kutil.SetMetaDataLabel(&controllerInstallation.ObjectMeta, common.RegistrationSpecHash, registrationSpecHash)
+		metav1.SetMetaDataLabel(&controllerInstallation.ObjectMeta, common.RegistrationSpecHash, registrationSpecHash)
 
 		if controllerDeployment != nil {
 			// Add all fields that are relevant for the hash calculation as `ControllerDeployment`s don't have a `spec` field.
@@ -510,7 +510,7 @@ func deployNeededInstallation(
 				return err
 			}
 			deploymentSpecHash := utils.HashForMap(deploymentMap)[:16]
-			kutil.SetMetaDataLabel(&controllerInstallation.ObjectMeta, common.ControllerDeploymentHash, deploymentSpecHash)
+			metav1.SetMetaDataLabel(&controllerInstallation.ObjectMeta, common.ControllerDeploymentHash, deploymentSpecHash)
 		}
 		controllerInstallation.Spec = installationSpec
 		return nil

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation_control.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation_control.go
@@ -199,8 +199,8 @@ func (r *reconciler) reconcile(ctx context.Context, gardenClient client.Client, 
 
 	namespace := getNamespaceForControllerInstallation(controllerInstallation)
 	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, seedClient.Client(), namespace, func() error {
-		kutil.SetMetaDataLabel(&namespace.ObjectMeta, v1beta1constants.GardenRole, v1beta1constants.GardenRoleExtension)
-		kutil.SetMetaDataLabel(&namespace.ObjectMeta, v1beta1constants.LabelControllerRegistrationName, controllerRegistration.Name)
+		metav1.SetMetaDataLabel(&namespace.ObjectMeta, v1beta1constants.GardenRole, v1beta1constants.GardenRoleExtension)
+		metav1.SetMetaDataLabel(&namespace.ObjectMeta, v1beta1constants.LabelControllerRegistrationName, controllerRegistration.Name)
 		return nil
 	}); err != nil {
 		return reconcile.Result{}, err

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -363,7 +363,7 @@ func RunReconcileSeedFlow(
 
 	// create + label garden namespace
 	if _, err := controllerutils.CreateOrGetAndMergePatch(ctx, seedClient, gardenNamespace, func() error {
-		kutil.SetMetaDataLabel(&gardenNamespace.ObjectMeta, "role", v1beta1constants.GardenNamespace)
+		metav1.SetMetaDataLabel(&gardenNamespace.ObjectMeta, "role", v1beta1constants.GardenNamespace)
 		return nil
 	}); err != nil {
 		return err
@@ -372,7 +372,7 @@ func RunReconcileSeedFlow(
 	// label kube-system namespace
 	namespaceKubeSystem := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: metav1.NamespaceSystem}}
 	patch := client.MergeFrom(namespaceKubeSystem.DeepCopy())
-	kutil.SetMetaDataLabel(&namespaceKubeSystem.ObjectMeta, "role", metav1.NamespaceSystem)
+	metav1.SetMetaDataLabel(&namespaceKubeSystem.ObjectMeta, "role", metav1.NamespaceSystem)
 	if err := seedClient.Patch(ctx, namespaceKubeSystem, patch); err != nil {
 		return err
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind cleanup

**What this PR does / why we need it**:
Adapt usages of kutil.{SetMetaDataLabel} to metav1.{SetMetaDataLabel}.

**Which issue(s) this PR fixes**:
Fixes #4576

CC - @ialidzhikov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
