### PR TITLE
Revert "[GEP-8] Deprecation warning for IGW AWS annotations"

### DIFF
--- a/charts/istio/istio-ingress/templates/service.yaml
+++ b/charts/istio/istio-ingress/templates/service.yaml
@@ -4,9 +4,6 @@ metadata:
   name: istio-ingressgateway
   namespace: {{ .Release.Namespace }}
   annotations:
-    # Deprecated: These AWS-specific annotation are deprecated. You need to apply them via
-    # the '.spec.settings.loadBalancerServices.annotations' field of the Seed.
-    # TODO (mvladev): remove the annotations in v1.17.0
     service.alpha.kubernetes.io/aws-load-balancer-type: "nlb"
     service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
 {{- if .Values.annotations }}

--- a/pkg/operation/botanist/component/istio/ingress_gateway_test.go
+++ b/pkg/operation/botanist/component/istio/ingress_gateway_test.go
@@ -128,10 +128,6 @@ var _ = Describe("ingress", func() {
 
 		Expect(c.Get(ctx, client.ObjectKey{Name: "istio-ingressgateway", Namespace: deployNS}, svc)).To(Succeed())
 		Expect(svc.Annotations).To(HaveKeyWithValue("foo", "bar"))
-
-		// TODO (mvladev): remove the deprecated annotations in v1.17.0
-		Expect(svc.Annotations).To(HaveKeyWithValue("service.alpha.kubernetes.io/aws-load-balancer-type", "nlb"), "DEPRECATED - SHOULD BE REMOVED IN 1.17.0")
-		Expect(svc.Annotations).To(HaveKeyWithValue("service.beta.kubernetes.io/aws-load-balancer-type", "nlb"), "DEPRECATED - SHOULD BE REMOVED IN 1.17.0")
 	})
 
 	Context("ExposureClass handlers", func() {
@@ -159,23 +155,6 @@ var _ = Describe("ingress", func() {
 			Expect(actualNS.Labels).To(HaveKeyWithValue("istio-injection", "disabled"))
 			Expect(actualNS.Labels).To(HaveKeyWithValue(v1alpha1constants.GardenRole, v1alpha1constants.GardenRoleExposureClassHandler))
 			Expect(actualNS.Labels).To(HaveKeyWithValue(v1alpha1constants.LabelExposureClassHandlerName, exposureClassHandlerName))
-		})
-	})
-
-	Context("DEPRECATED aws loadbalancer annotations", func() {
-		BeforeEach(func() {
-			igwAnnotations = map[string]string{
-				"service.alpha.kubernetes.io/aws-load-balancer-type": "not-nlb",
-				"service.beta.kubernetes.io/aws-load-balancer-type":  "not-nlb",
-			}
-		})
-
-		It("should be overwritten", func() {
-			svc := &corev1.Service{}
-
-			Expect(c.Get(ctx, client.ObjectKey{Name: "istio-ingressgateway", Namespace: deployNS}, svc)).To(Succeed())
-			Expect(svc.Annotations).To(HaveKeyWithValue("service.alpha.kubernetes.io/aws-load-balancer-type", "not-nlb"))
-			Expect(svc.Annotations).To(HaveKeyWithValue("service.beta.kubernetes.io/aws-load-balancer-type", "not-nlb"))
 		})
 	})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind cleanup

**What this PR does / why we need it**:
This PR reverts #3185 as suggested here https://github.com/gardener/gardener/issues/4578#issuecomment-1004104325

**Which issue(s) this PR fixes**:
Fixes #4578

CC - @ialidzhikov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
