### PR TITLE
Switch update strategy for shoot condition controller

### DIFF
--- a/pkg/controllermanager/controller/shoot/shoot.go
+++ b/pkg/controllermanager/controller/shoot/shoot.go
@@ -177,7 +177,7 @@ func NewShootController(
 		},
 		Ctx:                        ctx,
 		Reader:                     gardenClient.Cache(),
-		ControllerPredicateFactory: kutils.ControllerPredicateFactoryFunc(shootController.filterSeedForShootConditions),
+		ControllerPredicateFactory: kutils.ControllerPredicateFactoryFunc(FilterSeedForShootConditions),
 		Enqueuer:                   kutils.EnqueuerFunc(func(obj client.Object) { shootController.shootConditionsAdd(obj) }),
 		Scheme:                     kubernetes.GardenScheme,
 		Logger:                     logger.Logger,

--- a/pkg/controllermanager/controller/shoot/shoot_conditions_control.go
+++ b/pkg/controllermanager/controller/shoot/shoot_conditions_control.go
@@ -95,7 +95,7 @@ func (r *shootConditionsReconciler) Reconcile(ctx context.Context, request recon
 	}
 
 	// Build new shoot conditions
-	// First remove all existing seed conditions and then then add the current seed conditions
+	// First remove all existing seed conditions and then add the current seed conditions
 	// if the shoot is still registered as seed
 	seedConditionTypes := []gardencorev1beta1.ConditionType{
 		gardencorev1beta1.SeedBackupBucketsReady,

--- a/pkg/controllermanager/controller/shoot/shoot_conditions_control_test.go
+++ b/pkg/controllermanager/controller/shoot/shoot_conditions_control_test.go
@@ -1,0 +1,73 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shoot_test
+
+import (
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/controllermanager/controller/shoot"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("#FilterSeedForShootConditions", func() {
+	var (
+		oldSeed, newSeed *gardencorev1beta1.Seed
+		gardenletReady   = []gardencorev1beta1.Condition{
+			{
+				Type:   gardencorev1beta1.SeedGardenletReady,
+				Status: gardencorev1beta1.ConditionTrue,
+			}}
+		gardenletNotReady = []gardencorev1beta1.Condition{
+			{
+				Type:   gardencorev1beta1.SeedGardenletReady,
+				Status: gardencorev1beta1.ConditionFalse,
+			}}
+	)
+
+	BeforeEach(func() {
+		oldSeed = &gardencorev1beta1.Seed{}
+		newSeed = &gardencorev1beta1.Seed{}
+	})
+
+	It("should accept in case of cache resync update events", func() {
+		newSeed.ResourceVersion = "1"
+		oldSeed.ResourceVersion = "1"
+
+		Expect(shoot.FilterSeedForShootConditions(newSeed, oldSeed, nil, false)).To(BeTrue())
+	})
+	It("should accept in case of deletion events", func() {
+		Expect(shoot.FilterSeedForShootConditions(newSeed, nil, nil, true)).To(BeTrue())
+	})
+	It("should accept in case of create events", func() {
+		Expect(shoot.FilterSeedForShootConditions(newSeed, nil, nil, false)).To(BeTrue())
+	})
+	It("should accept if conditions differ", func() {
+		newSeed.ResourceVersion = "1"
+		oldSeed.ResourceVersion = "2"
+		newSeed.Status.Conditions = gardenletReady
+		oldSeed.Status.Conditions = gardenletNotReady
+
+		Expect(shoot.FilterSeedForShootConditions(newSeed, oldSeed, nil, false)).To(BeTrue())
+	})
+	It("should deny if conditions are the same", func() {
+		newSeed.ResourceVersion = "1"
+		oldSeed.ResourceVersion = "2"
+		newSeed.Status.Conditions = gardenletReady
+		oldSeed.Status.Conditions = gardenletReady
+
+		Expect(shoot.FilterSeedForShootConditions(newSeed, oldSeed, nil, false)).To(BeFalse())
+	})
+})


### PR DESCRIPTION
**How to categorize this PR?**
/kind bug

**What this PR does / why we need it**:
This fixes the issues described in https://github.com/gardener/gardener/issues/5295 . In some cases the shoot conditions controller would not or only partially update Seed conditions in the shoot resource for managedSeeds.

For the problem description see https://github.com/gardener/gardener/issues/5295#issuecomment-1017415479 for a description of the solutions see the commit messages.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/5295

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixes bugs which could cause Seed conditions not being properly copied over to the corresponding Shoot due to a stale cache.
```
