### PR TITLE
Do not yield `--help` output on error

### DIFF
--- a/cmd/gardener-admission-controller/app/gardener_admission_controller.go
+++ b/cmd/gardener-admission-controller/app/gardener_admission_controller.go
@@ -225,9 +225,6 @@ func NewGardenerAdmissionControllerCommand() *cobra.Command {
 				return err
 			}
 
-			cmd.SilenceUsage = true
-			cmd.SilenceErrors = true
-
 			log.Info("Starting "+Name+"...", "version", version.Get())
 			cmd.Flags().VisitAll(func(flag *pflag.Flag) {
 				log.Info(fmt.Sprintf("FLAG: --%s=%s", flag.Name, flag.Value))
@@ -235,6 +232,8 @@ func NewGardenerAdmissionControllerCommand() *cobra.Command {
 
 			return opts.run(cmd.Context())
 		},
+		SilenceUsage:  true,
+		SilenceErrors: true,
 	}
 
 	flags := cmd.Flags()

--- a/cmd/gardener-apiserver/app/gardener_apiserver.go
+++ b/cmd/gardener-apiserver/app/gardener_apiserver.go
@@ -97,6 +97,7 @@ These so-called control plane components are hosted in Kubernetes clusters thems
 			}
 			return opts.Run(c.Context())
 		},
+		SilenceUsage: true,
 	}
 
 	flags := cmd.Flags()

--- a/cmd/gardener-controller-manager/app/gardener_controller_manager.go
+++ b/cmd/gardener-controller-manager/app/gardener_controller_manager.go
@@ -181,6 +181,7 @@ These so-called control plane components are hosted in Kubernetes clusters thems
 			}
 			return opts.run(cmd.Context())
 		},
+		SilenceUsage: true,
 	}
 
 	flags := cmd.Flags()

--- a/cmd/gardener-resource-manager/app/app.go
+++ b/cmd/gardener-resource-manager/app/app.go
@@ -163,6 +163,7 @@ func NewResourceManagerCommand() *cobra.Command {
 					return nil
 				}
 			},
+			SilenceUsage: true,
 		}
 	)
 

--- a/cmd/gardener-scheduler/app/gardener_scheduler.go
+++ b/cmd/gardener-scheduler/app/gardener_scheduler.go
@@ -82,6 +82,7 @@ func NewCommandStartGardenerScheduler() *cobra.Command {
 
 			return runCommand(cmd.Context(), opts)
 		},
+		SilenceUsage: true,
 	}
 
 	flags := cmd.Flags()

--- a/cmd/gardener-seed-admission-controller/app/gardener_seed_admission_controller.go
+++ b/cmd/gardener-seed-admission-controller/app/gardener_seed_admission_controller.go
@@ -63,8 +63,6 @@ func NewSeedAdmissionControllerCommand() *cobra.Command {
 				return err
 			}
 
-			cmd.SilenceUsage = true
-
 			log.Info("Starting "+Name+"...", "version", version.Get())
 			cmd.Flags().VisitAll(func(flag *pflag.Flag) {
 				log.Info(fmt.Sprintf("FLAG: --%s=%s", flag.Name, flag.Value))
@@ -72,6 +70,7 @@ func NewSeedAdmissionControllerCommand() *cobra.Command {
 
 			return opts.Run(cmd.Context())
 		},
+		SilenceUsage: true,
 	}
 
 	flags := cmd.Flags()

--- a/cmd/gardenlet/app/gardenlet.go
+++ b/cmd/gardenlet/app/gardenlet.go
@@ -206,6 +206,7 @@ These so-called control plane components are hosted in Kubernetes clusters thems
 			}
 			return run(cmd.Context(), opts)
 		},
+		SilenceUsage: true,
 	}
 
 	flags := cmd.Flags()


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**Which issue(s) this PR fixes**:
Fixes #4807

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
