### PR TITLE
grafana: Set the default timezone to UTC

### DIFF
--- a/charts/seed-bootstrap/templates/grafana/grafana-deployment.yaml
+++ b/charts/seed-bootstrap/templates/grafana/grafana-deployment.yaml
@@ -50,6 +50,8 @@ spec:
           value: "false"
         - name: GF_ALERTING_ENABLED
           value: "false"
+        - name: GF_DATE_FORMATS_DEFAULT_TIMEZONE
+          value: "UTC"
         volumeMounts:
         - name: grafana-storage
           mountPath: /var/grafana-storage

--- a/charts/seed-monitoring/charts/grafana/templates/grafana-deployment.yaml
+++ b/charts/seed-monitoring/charts/grafana/templates/grafana-deployment.yaml
@@ -57,6 +57,8 @@ spec:
           value: "false"
         - name: GF_ALERTING_ENABLED
           value: "false"
+        - name: GF_DATE_FORMATS_DEFAULT_TIMEZONE
+          value: "UTC"
         volumeMounts:
         - name: grafana-storage
           mountPath: /var/grafana-storage


### PR DESCRIPTION
/area monitoring ops-productivity
/kind enhancement

Currently as operator when I am looking for logs in grafana (or for metrics) in the `Explore` view, the first thing I had to do is to change the timezone (that defaults to `browser`) to `UTC`. 
Previously there was https://github.com/gardener/gardener/pull/4229 but it only switched the dashboards (not the `Explore` view) to use `UTC`.
Let's switch the default timezone for the `Explore` view to UTC as well - I doubt that there will be someone preferring `browser` (the browser's time) over `UTC`.


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Grafana's default timezone is now set to `UTC` (previously it was `browser`).
```
