### PR TITLE
Allow list renamed kube scheduler metrics

### DIFF
--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/kubernetes-control-plane-status-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/kubernetes-control-plane-status-dashboard.json
@@ -1943,7 +1943,7 @@
           "steppedLine": false,
           "targets": [
             {
-              "expr": "cluster:scheduler_e2e_scheduling_latency_seconds:quantile",
+              "expr": "cluster:scheduler_e2e_scheduling_duration_seconds:quantile",
               "format": "time_series",
               "intervalFactor": 2,
               "legendFormat": "{{quantile}}",

--- a/pkg/operation/botanist/component/kubescheduler/monitoring.go
+++ b/pkg/operation/botanist/component/kubescheduler/monitoring.go
@@ -27,12 +27,12 @@ import (
 const (
 	monitoringPrometheusJobName = "kube-scheduler"
 
-	monitoringMetricSchedulerBindingLatencyMicrosecondsBucket             = "scheduler_binding_latency_microseconds_bucket"
-	monitoringMetricSchedulerE2ESchedulingLatencyMicrosecondsBucket       = "scheduler_e2e_scheduling_latency_microseconds_bucket"
-	monitoringMetricSchedulerSchedulingAlgorithmLatencyMicrosecondsBucket = "scheduler_scheduling_algorithm_latency_microseconds_bucket"
-	monitoringMetricRestClientRequestsTotal                               = "rest_client_requests_total"
-	monitoringMetricProcessMaxFds                                         = "process_max_fds"
-	monitoringMetricProcessOpenFds                                        = "process_open_fds"
+	monitoringMetricSchedulerBindingDurationSecondsBucket             = "scheduler_binding_duration_seconds_bucket"
+	monitoringMetricSchedulerE2ESchedulingDurationSecondsBucket       = "scheduler_e2e_scheduling_duration_seconds_bucket"
+	monitoringMetricSchedulerSchedulingAlgorithmDurationSecondsBucket = "scheduler_scheduling_algorithm_duration_seconds_bucket"
+	monitoringMetricRestClientRequestsTotal                           = "rest_client_requests_total"
+	monitoringMetricProcessMaxFds                                     = "process_max_fds"
+	monitoringMetricProcessOpenFds                                    = "process_open_fds"
 
 	monitoringAlertingRules = `groups:
 - name: kube-scheduler.rules
@@ -49,41 +49,41 @@ const (
       description: New pods are not being assigned to nodes.
       summary: Kube Scheduler is down.
 
-  ### Scheduling latency ###
-  - record: cluster:scheduler_e2e_scheduling_latency_seconds:quantile
-    expr: histogram_quantile(0.99, sum(` + monitoringMetricSchedulerE2ESchedulingLatencyMicrosecondsBucket + `) BY (le, cluster)) / 1e+06
+  ### Scheduling duration ###
+  - record: cluster:scheduler_e2e_scheduling_duration_seconds:quantile
+    expr: histogram_quantile(0.99, sum(` + monitoringMetricSchedulerE2ESchedulingDurationSecondsBucket + `) BY (le, cluster))
     labels:
       quantile: "0.99"
-  - record: cluster:scheduler_e2e_scheduling_latency_seconds:quantile
-    expr: histogram_quantile(0.9, sum(` + monitoringMetricSchedulerE2ESchedulingLatencyMicrosecondsBucket + `) BY (le, cluster)) / 1e+06
+  - record: cluster:scheduler_e2e_scheduling_duration_seconds:quantile
+    expr: histogram_quantile(0.9, sum(` + monitoringMetricSchedulerE2ESchedulingDurationSecondsBucket + `) BY (le, cluster))
     labels:
       quantile: "0.9"
-  - record: cluster:scheduler_e2e_scheduling_latency_seconds:quantile
-    expr: histogram_quantile(0.5, sum(` + monitoringMetricSchedulerE2ESchedulingLatencyMicrosecondsBucket + `) BY (le, cluster)) / 1e+06
+  - record: cluster:scheduler_e2e_scheduling_duration_seconds:quantile
+    expr: histogram_quantile(0.5, sum(` + monitoringMetricSchedulerE2ESchedulingDurationSecondsBucket + `) BY (le, cluster))
     labels:
       quantile: "0.5"
-  - record: cluster:scheduler_scheduling_algorithm_latency_seconds:quantile
-    expr: histogram_quantile(0.99, sum(` + monitoringMetricSchedulerSchedulingAlgorithmLatencyMicrosecondsBucket + `) BY (le, cluster)) / 1e+06
+  - record: cluster:scheduler_scheduling_algorithm_duration_seconds:quantile
+    expr: histogram_quantile(0.99, sum(` + monitoringMetricSchedulerSchedulingAlgorithmDurationSecondsBucket + `) BY (le, cluster))
     labels:
       quantile: "0.99"
-  - record: cluster:scheduler_scheduling_algorithm_latency_seconds:quantile
-    expr: histogram_quantile(0.9, sum(` + monitoringMetricSchedulerSchedulingAlgorithmLatencyMicrosecondsBucket + `) BY (le, cluster)) / 1e+06
+  - record: cluster:scheduler_scheduling_algorithm_duration_seconds:quantile
+    expr: histogram_quantile(0.9, sum(` + monitoringMetricSchedulerSchedulingAlgorithmDurationSecondsBucket + `) BY (le, cluster))
     labels:
       quantile: "0.9"
-  - record: cluster:scheduler_scheduling_algorithm_latency_seconds:quantile
-    expr: histogram_quantile(0.5, sum(` + monitoringMetricSchedulerSchedulingAlgorithmLatencyMicrosecondsBucket + `) BY (le, cluster)) / 1e+06
+  - record: cluster:scheduler_scheduling_algorithm_duration_seconds:quantile
+    expr: histogram_quantile(0.5, sum(` + monitoringMetricSchedulerSchedulingAlgorithmDurationSecondsBucket + `) BY (le, cluster))
     labels:
       quantile: "0.5"
-  - record: cluster:scheduler_binding_latency_seconds:quantile
-    expr: histogram_quantile(0.99, sum(` + monitoringMetricSchedulerBindingLatencyMicrosecondsBucket + `) BY (le, cluster)) / 1e+06
+  - record: cluster:scheduler_binding_duration_seconds:quantile
+    expr: histogram_quantile(0.99, sum(` + monitoringMetricSchedulerBindingDurationSecondsBucket + `) BY (le, cluster))
     labels:
       quantile: "0.99"
-  - record: cluster:scheduler_binding_latency_seconds:quantile
-    expr: histogram_quantile(0.9, sum(` + monitoringMetricSchedulerBindingLatencyMicrosecondsBucket + `) BY (le, cluster)) / 1e+06
+  - record: cluster:scheduler_binding_duration_seconds:quantile
+    expr: histogram_quantile(0.9, sum(` + monitoringMetricSchedulerBindingDurationSecondsBucket + `) BY (le, cluster))
     labels:
       quantile: "0.9"
-  - record: cluster:scheduler_binding_latency_seconds:quantile
-    expr: histogram_quantile(0.5, sum(` + monitoringMetricSchedulerBindingLatencyMicrosecondsBucket + `) BY (le, cluster)) / 1e+06
+  - record: cluster:scheduler_binding_duration_seconds:quantile
+    expr: histogram_quantile(0.5, sum(` + monitoringMetricSchedulerBindingDurationSecondsBucket + `) BY (le, cluster))
     labels:
       quantile: "0.5"
 `
@@ -91,9 +91,9 @@ const (
 
 var (
 	monitoringAllowedMetrics = []string{
-		monitoringMetricSchedulerBindingLatencyMicrosecondsBucket,
-		monitoringMetricSchedulerE2ESchedulingLatencyMicrosecondsBucket,
-		monitoringMetricSchedulerSchedulingAlgorithmLatencyMicrosecondsBucket,
+		monitoringMetricSchedulerBindingDurationSecondsBucket,
+		monitoringMetricSchedulerE2ESchedulingDurationSecondsBucket,
+		monitoringMetricSchedulerSchedulingAlgorithmDurationSecondsBucket,
 		monitoringMetricRestClientRequestsTotal,
 		monitoringMetricProcessMaxFds,
 		monitoringMetricProcessOpenFds,

--- a/pkg/operation/botanist/component/kubescheduler/monitoring_test.go
+++ b/pkg/operation/botanist/component/kubescheduler/monitoring_test.go
@@ -83,7 +83,7 @@ relabel_configs:
 metric_relabel_configs:
 - source_labels: [ __name__ ]
   action: keep
-  regex: ^(scheduler_binding_latency_microseconds_bucket|scheduler_e2e_scheduling_latency_microseconds_bucket|scheduler_scheduling_algorithm_latency_microseconds_bucket|rest_client_requests_total|process_max_fds|process_open_fds)$
+  regex: ^(scheduler_binding_duration_seconds_bucket|scheduler_e2e_scheduling_duration_seconds_bucket|scheduler_scheduling_algorithm_duration_seconds_bucket|rest_client_requests_total|process_max_fds|process_open_fds)$
 `
 
 	expectedAlertingRule = `groups:
@@ -101,41 +101,41 @@ metric_relabel_configs:
       description: New pods are not being assigned to nodes.
       summary: Kube Scheduler is down.
 
-  ### Scheduling latency ###
-  - record: cluster:scheduler_e2e_scheduling_latency_seconds:quantile
-    expr: histogram_quantile(0.99, sum(scheduler_e2e_scheduling_latency_microseconds_bucket) BY (le, cluster)) / 1e+06
+  ### Scheduling duration ###
+  - record: cluster:scheduler_e2e_scheduling_duration_seconds:quantile
+    expr: histogram_quantile(0.99, sum(scheduler_e2e_scheduling_duration_seconds_bucket) BY (le, cluster))
     labels:
       quantile: "0.99"
-  - record: cluster:scheduler_e2e_scheduling_latency_seconds:quantile
-    expr: histogram_quantile(0.9, sum(scheduler_e2e_scheduling_latency_microseconds_bucket) BY (le, cluster)) / 1e+06
+  - record: cluster:scheduler_e2e_scheduling_duration_seconds:quantile
+    expr: histogram_quantile(0.9, sum(scheduler_e2e_scheduling_duration_seconds_bucket) BY (le, cluster))
     labels:
       quantile: "0.9"
-  - record: cluster:scheduler_e2e_scheduling_latency_seconds:quantile
-    expr: histogram_quantile(0.5, sum(scheduler_e2e_scheduling_latency_microseconds_bucket) BY (le, cluster)) / 1e+06
+  - record: cluster:scheduler_e2e_scheduling_duration_seconds:quantile
+    expr: histogram_quantile(0.5, sum(scheduler_e2e_scheduling_duration_seconds_bucket) BY (le, cluster))
     labels:
       quantile: "0.5"
-  - record: cluster:scheduler_scheduling_algorithm_latency_seconds:quantile
-    expr: histogram_quantile(0.99, sum(scheduler_scheduling_algorithm_latency_microseconds_bucket) BY (le, cluster)) / 1e+06
+  - record: cluster:scheduler_scheduling_algorithm_duration_seconds:quantile
+    expr: histogram_quantile(0.99, sum(scheduler_scheduling_algorithm_duration_seconds_bucket) BY (le, cluster))
     labels:
       quantile: "0.99"
-  - record: cluster:scheduler_scheduling_algorithm_latency_seconds:quantile
-    expr: histogram_quantile(0.9, sum(scheduler_scheduling_algorithm_latency_microseconds_bucket) BY (le, cluster)) / 1e+06
+  - record: cluster:scheduler_scheduling_algorithm_duration_seconds:quantile
+    expr: histogram_quantile(0.9, sum(scheduler_scheduling_algorithm_duration_seconds_bucket) BY (le, cluster))
     labels:
       quantile: "0.9"
-  - record: cluster:scheduler_scheduling_algorithm_latency_seconds:quantile
-    expr: histogram_quantile(0.5, sum(scheduler_scheduling_algorithm_latency_microseconds_bucket) BY (le, cluster)) / 1e+06
+  - record: cluster:scheduler_scheduling_algorithm_duration_seconds:quantile
+    expr: histogram_quantile(0.5, sum(scheduler_scheduling_algorithm_duration_seconds_bucket) BY (le, cluster))
     labels:
       quantile: "0.5"
-  - record: cluster:scheduler_binding_latency_seconds:quantile
-    expr: histogram_quantile(0.99, sum(scheduler_binding_latency_microseconds_bucket) BY (le, cluster)) / 1e+06
+  - record: cluster:scheduler_binding_duration_seconds:quantile
+    expr: histogram_quantile(0.99, sum(scheduler_binding_duration_seconds_bucket) BY (le, cluster))
     labels:
       quantile: "0.99"
-  - record: cluster:scheduler_binding_latency_seconds:quantile
-    expr: histogram_quantile(0.9, sum(scheduler_binding_latency_microseconds_bucket) BY (le, cluster)) / 1e+06
+  - record: cluster:scheduler_binding_duration_seconds:quantile
+    expr: histogram_quantile(0.9, sum(scheduler_binding_duration_seconds_bucket) BY (le, cluster))
     labels:
       quantile: "0.9"
-  - record: cluster:scheduler_binding_latency_seconds:quantile
-    expr: histogram_quantile(0.5, sum(scheduler_binding_latency_microseconds_bucket) BY (le, cluster)) / 1e+06
+  - record: cluster:scheduler_binding_duration_seconds:quantile
+    expr: histogram_quantile(0.5, sum(scheduler_binding_duration_seconds_bucket) BY (le, cluster))
     labels:
       quantile: "0.5"
 `


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

The name of the kube scheduler metrics changed. This PR adjusts the allow list and recording rules accordingly.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/cc @dguendisch 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix kube scheduler metrics collection
```
