### PR TITLE
🛡 Eliminate static token for `hvpa-controller`

### DIFF
--- a/charts/seed-bootstrap/charts/hvpa/templates/controller-deployment.yaml
+++ b/charts/seed-bootstrap/charts/hvpa/templates/controller-deployment.yaml
@@ -5,9 +5,7 @@ metadata:
   namespace: garden
   labels:
 {{ toYaml .Values.labels | indent 4 }}
-{{- if .Values.readyForProjectedServiceAccountTokens }}
 automountServiceAccountToken: false
-{{- end }}
 ---
 apiVersion: {{ include "deploymentversion" . }}
 kind: Deployment
@@ -26,11 +24,9 @@ spec:
 {{ toYaml .Values.labels | indent 6 }}
   template:
     metadata:
-{{- if .Values.readyForProjectedServiceAccountTokens }}
       annotations:
         # TODO(rfranzke): Remove in a future release.
         security.gardener.cloud/trigger: rollout
-{{- end }}
       labels:
         app: hvpa-controller
 {{ toYaml .Values.labels | indent 8 }}

--- a/charts/seed-bootstrap/charts/hvpa/values.yaml
+++ b/charts/seed-bootstrap/charts/hvpa/values.yaml
@@ -6,5 +6,3 @@ enabled: false
 podAnnotations: {}
 labels:
   gardener.cloud/role: hvpa
-
-readyForProjectedServiceAccountTokens: false


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
Now that `hvpa-controller@v0.4.0` got released and merged (#5314), we can eliminate the static token for it again. This was originally done with #5128 already but got later reverted with #5228 due to #5222.

**Which issue(s) this PR fixes**:
Part of #4659 
Part of #4878


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
