### PR TITLE
Fix wrongfully added  `keep-after-project-deletion` annotation

### DIFF
--- a/docs/usage/projects.md
+++ b/docs/usage/projects.md
@@ -44,7 +44,7 @@ The name of the resulting namespace will be generated and look like `garden-dev-
 It's also possible to adopt existing namespaces by labeling them `gardener.cloud/role=project` and `project.gardener.cloud/name=dev` beforehand (otherwise, they cannot be adopted). 
 
 When deleting a Project resource, the corresponding namespace is also deleted. 
-To keep a namespace after project deletion, an administrator/operator (not Project members!) can label the project-namespace with `namespace.gardener.cloud/keep-after-project-deletion`.
+To keep a namespace after project deletion, an administrator/operator (not Project members!) can annotate the project-namespace with `namespace.gardener.cloud/keep-after-project-deletion`.
 
 The `spec.description` and `.spec.purpose` fields can be used to describe to fellow team members and Gardener operators what this project is used for.
 

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -499,6 +499,10 @@ const (
 	// should not be deleted if the corresponding `Project` gets deleted. Please note that all project related labels
 	// from the namespace will be removed when the project is being deleted.
 	NamespaceKeepAfterProjectDeletion = "namespace.gardener.cloud/keep-after-project-deletion"
+	// NamespaceCreatedByProject is a constant for annotation on a `Namespace` resource that states that it
+	// was created by the project because either the user didn't specify the namespace in the project `spec.Namespace`
+	// or the specified namespace was not present.
+	NamespaceCreatedByProject = "namespace.gardener.cloud/created-by-project"
 
 	// DefaultVpnRange is the default network range for the vpn between seed and shoot cluster.
 	DefaultVpnRange = "192.168.123.0/24"

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -499,10 +499,10 @@ const (
 	// should not be deleted if the corresponding `Project` gets deleted. Please note that all project related labels
 	// from the namespace will be removed when the project is being deleted.
 	NamespaceKeepAfterProjectDeletion = "namespace.gardener.cloud/keep-after-project-deletion"
-	// NamespaceCreatedByProject is a constant for annotation on a `Namespace` resource that states that it
-	// was created by the project because either the user didn't specify the namespace in the project `spec.Namespace`
+	// NamespaceCreatedByProjectController is a constant for annotation on a `Namespace` resource that states that it
+	// was created by the project controller because either the Project's `spec.namespace` field was not specified
 	// or the specified namespace was not present.
-	NamespaceCreatedByProject = "namespace.gardener.cloud/created-by-project"
+	NamespaceCreatedByProjectController = "namespace.gardener.cloud/created-by-project-controller"
 
 	// DefaultVpnRange is the default network range for the vpn between seed and shoot cluster.
 	DefaultVpnRange = "192.168.123.0/24"

--- a/pkg/controllermanager/controller/project/project_control.go
+++ b/pkg/controllermanager/controller/project/project_control.go
@@ -109,7 +109,7 @@ func (r *projectReconciler) Reconcile(ctx context.Context, request reconcile.Req
 	projectLogger.Infof("[PROJECT RECONCILE] %s", project.Name)
 
 	if project.DeletionTimestamp != nil {
-		return r.delete(ctx, project, r.gardenClient.Client(), r.gardenClient.Client())
+		return r.delete(ctx, project, r.gardenClient.Client(), r.gardenClient.APIReader())
 	}
 
 	return r.reconcile(ctx, project, r.gardenClient.Client(), r.gardenClient.APIReader())

--- a/pkg/controllermanager/controller/project/project_control.go
+++ b/pkg/controllermanager/controller/project/project_control.go
@@ -112,7 +112,7 @@ func (r *projectReconciler) Reconcile(ctx context.Context, request reconcile.Req
 		return r.delete(ctx, project, r.gardenClient.Client(), r.gardenClient.Client())
 	}
 
-	return r.reconcile(ctx, project, r.gardenClient.Client(), r.gardenClient.Client())
+	return r.reconcile(ctx, project, r.gardenClient.Client(), r.gardenClient.APIReader())
 }
 
 func newProjectLogger(project *gardencorev1beta1.Project) logrus.FieldLogger {

--- a/pkg/controllermanager/controller/project/project_control_delete.go
+++ b/pkg/controllermanager/controller/project/project_control_delete.go
@@ -94,6 +94,7 @@ func (r *projectReconciler) releaseNamespace(ctx context.Context, gardenClient c
 	if keepNamespace {
 		delete(namespace.Annotations, v1beta1constants.NamespaceProject)
 		delete(namespace.Annotations, v1beta1constants.NamespaceKeepAfterProjectDeletion)
+		delete(namespace.Annotations, v1beta1constants.NamespaceCreatedByProject)
 		delete(namespace.Labels, v1beta1constants.ProjectName)
 		delete(namespace.Labels, v1beta1constants.GardenRole)
 		for i := len(namespace.OwnerReferences) - 1; i >= 0; i-- {

--- a/pkg/controllermanager/controller/project/project_control_delete.go
+++ b/pkg/controllermanager/controller/project/project_control_delete.go
@@ -94,7 +94,7 @@ func (r *projectReconciler) releaseNamespace(ctx context.Context, gardenClient c
 	if keepNamespace {
 		delete(namespace.Annotations, v1beta1constants.NamespaceProject)
 		delete(namespace.Annotations, v1beta1constants.NamespaceKeepAfterProjectDeletion)
-		delete(namespace.Annotations, v1beta1constants.NamespaceCreatedByProject)
+		delete(namespace.Annotations, v1beta1constants.NamespaceCreatedByProjectController)
 		delete(namespace.Labels, v1beta1constants.ProjectName)
 		delete(namespace.Labels, v1beta1constants.GardenRole)
 		for i := len(namespace.OwnerReferences) - 1; i >= 0; i-- {

--- a/pkg/controllermanager/controller/project/project_control_reconcile.go
+++ b/pkg/controllermanager/controller/project/project_control_reconcile.go
@@ -169,6 +169,7 @@ func (r *projectReconciler) reconcileNamespaceForProject(ctx context.Context, ga
 				Annotations:     projectAnnotations,
 			},
 		}
+		obj.Annotations[v1beta1constants.NamespaceCreatedByProject] = "true"
 		return obj, gardenClient.Create(ctx, obj)
 	}
 
@@ -186,6 +187,7 @@ func (r *projectReconciler) reconcileNamespaceForProject(ctx context.Context, ga
 				Annotations:     projectAnnotations,
 			},
 		}
+		obj.Annotations[v1beta1constants.NamespaceCreatedByProject] = "true"
 		return obj, gardenClient.Create(ctx, obj)
 	}
 
@@ -203,9 +205,9 @@ func (r *projectReconciler) reconcileNamespaceForProject(ctx context.Context, ga
 	namespace.Labels = utils.MergeStringMaps(namespace.Labels, projectLabels)
 	namespace.Annotations = utils.MergeStringMaps(namespace.Annotations, projectAnnotations)
 
-	// If the project is reconciled for the first time then its observed generation is 0. Only in this case we want
+	// If the namespace creation was not triggred by the  project only in this case we want
 	// to add the "keep-after-project-deletion" annotation to the namespace when we adopt it.
-	if project.Status.ObservedGeneration == 0 {
+	if !metav1.HasAnnotation(namespace.ObjectMeta, v1beta1constants.NamespaceCreatedByProject) {
 		namespace.Annotations[v1beta1constants.NamespaceKeepAfterProjectDeletion] = "true"
 	}
 

--- a/pkg/controllermanager/controller/project/project_control_reconcile.go
+++ b/pkg/controllermanager/controller/project/project_control_reconcile.go
@@ -169,7 +169,7 @@ func (r *projectReconciler) reconcileNamespaceForProject(ctx context.Context, ga
 				Annotations:     projectAnnotations,
 			},
 		}
-		obj.Annotations[v1beta1constants.NamespaceCreatedByProject] = "true"
+		obj.Annotations[v1beta1constants.NamespaceCreatedByProjectController] = "true"
 		return obj, gardenClient.Create(ctx, obj)
 	}
 
@@ -187,7 +187,7 @@ func (r *projectReconciler) reconcileNamespaceForProject(ctx context.Context, ga
 				Annotations:     projectAnnotations,
 			},
 		}
-		obj.Annotations[v1beta1constants.NamespaceCreatedByProject] = "true"
+		obj.Annotations[v1beta1constants.NamespaceCreatedByProjectController] = "true"
 		return obj, gardenClient.Create(ctx, obj)
 	}
 
@@ -205,9 +205,9 @@ func (r *projectReconciler) reconcileNamespaceForProject(ctx context.Context, ga
 	namespace.Labels = utils.MergeStringMaps(namespace.Labels, projectLabels)
 	namespace.Annotations = utils.MergeStringMaps(namespace.Annotations, projectAnnotations)
 
-	// If the namespace creation was not triggred by the  project only in this case we want
-	// to add the "keep-after-project-deletion" annotation to the namespace when we adopt it.
-	if !metav1.HasAnnotation(namespace.ObjectMeta, v1beta1constants.NamespaceCreatedByProject) {
+	// Add the "keep-after-project-deletion" annotation to the namespace only when we adopt it
+	// (i.e. the namespace was not created by the project controller).
+	if !metav1.HasAnnotation(namespace.ObjectMeta, v1beta1constants.NamespaceCreatedByProjectController) {
 		namespace.Annotations[v1beta1constants.NamespaceKeepAfterProjectDeletion] = "true"
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**Which issue(s) this PR fixes**:
Fixes #5192

**Special notes for your reviewer**:
CC - @ialidzhikov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing the `namespace.gardener.cloud/keep-after-project-deletion="true"` annotation to be wrongly added to the Project Namespace when the Project controller does not adopt existing Project Namespace is now fixed.
```
