### PR TITLE
Revert "Use `systemd` as cgroup driver for shoots >= 1.23"

### DIFF
--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/config.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/config.go
@@ -51,7 +51,7 @@ func Config(kubernetesVersion *semver.Version, clusterDNSAddress, clusterDomain 
 				CacheUnauthorizedTTL: metav1.Duration{Duration: 30 * time.Second},
 			},
 		},
-		CgroupDriver:                     "systemd",
+		CgroupDriver:                     "cgroupfs",
 		CgroupRoot:                       "/",
 		CgroupsPerQOS:                    pointer.Bool(true),
 		ClusterDNS:                       []string{clusterDNSAddress},
@@ -101,10 +101,6 @@ func Config(kubernetesVersion *semver.Version, clusterDNSAddress, clusterDomain 
 
 	if !version.ConstraintK8sLess119.Check(kubernetesVersion) {
 		config.VolumePluginDir = pathVolumePluginDirectory
-	}
-
-	if version.ConstraintK8sLessEqual122.Check(kubernetesVersion) {
-		config.CgroupDriver = "cgroupfs"
 	}
 
 	return config

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/config_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/config_test.go
@@ -382,56 +382,6 @@ var _ = Describe("Config", func() {
 		),
 
 		Entry(
-			"kubernetes 1.21 w/o defaults",
-			"1.21.1",
-			clusterDNSAddress,
-			clusterDomain,
-			components.ConfigurableKubeletConfigParameters{},
-			kubeletConfigWithDefaults,
-			func(cfg *kubeletconfigv1beta1.KubeletConfiguration) {
-				cfg.RotateCertificates = true
-				cfg.VolumePluginDir = "/var/lib/kubelet/volumeplugins"
-			},
-		),
-		Entry(
-			"kubernetes 1.21 w/ defaults",
-			"1.21.1",
-			clusterDNSAddress,
-			clusterDomain,
-			params,
-			kubeletConfigWithParams,
-			func(cfg *kubeletconfigv1beta1.KubeletConfiguration) {
-				cfg.RotateCertificates = true
-				cfg.VolumePluginDir = "/var/lib/kubelet/volumeplugins"
-			},
-		),
-
-		Entry(
-			"kubernetes 1.22 w/o defaults",
-			"1.22.1",
-			clusterDNSAddress,
-			clusterDomain,
-			components.ConfigurableKubeletConfigParameters{},
-			kubeletConfigWithDefaults,
-			func(cfg *kubeletconfigv1beta1.KubeletConfiguration) {
-				cfg.RotateCertificates = true
-				cfg.VolumePluginDir = "/var/lib/kubelet/volumeplugins"
-			},
-		),
-		Entry(
-			"kubernetes 1.22 w/ defaults",
-			"1.22.1",
-			clusterDNSAddress,
-			clusterDomain,
-			params,
-			kubeletConfigWithParams,
-			func(cfg *kubeletconfigv1beta1.KubeletConfiguration) {
-				cfg.RotateCertificates = true
-				cfg.VolumePluginDir = "/var/lib/kubelet/volumeplugins"
-			},
-		),
-
-		Entry(
 			"kubernetes 1.23 w/o defaults",
 			"1.23.1",
 			clusterDNSAddress,
@@ -439,7 +389,6 @@ var _ = Describe("Config", func() {
 			components.ConfigurableKubeletConfigParameters{},
 			kubeletConfigWithDefaults,
 			func(cfg *kubeletconfigv1beta1.KubeletConfiguration) {
-				cfg.CgroupDriver = "systemd"
 				cfg.RotateCertificates = true
 				cfg.VolumePluginDir = "/var/lib/kubelet/volumeplugins"
 			},
@@ -452,7 +401,6 @@ var _ = Describe("Config", func() {
 			params,
 			kubeletConfigWithParams,
 			func(cfg *kubeletconfigv1beta1.KubeletConfiguration) {
-				cfg.CgroupDriver = "systemd"
 				cfg.RotateCertificates = true
 				cfg.VolumePluginDir = "/var/lib/kubelet/volumeplugins"
 			},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:
This reverts commit b16cc48ee3a156297092f8a5672c626a27311358 introduced as part #5255.
It seems that there is more to switching the `cgroup` driver as outlined in https://kubernetes.io/docs/setup/production-environment/container-runtimes/#containerd-systemd. Given that it's not year clear what the consequences of these changes are, let's revert them for now and rather work on them dedicatedly (I'll open an issue for following up).

**Which issue(s) this PR fixes**:
Part of #5102  

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
Shoot clusters using Kubernetes 1.23 or above will continue to use the `cgroupfs` cgroup driver (the change to use `systemd` was reverted).
```
