### PR TITLE
remove the svc.spec.clusterIps from the origin loki svc from the logging integration tests

### DIFF
--- a/test/integration/shoots/logging/seed_logging_stack.go
+++ b/test/integration/shoots/logging/seed_logging_stack.go
@@ -323,6 +323,7 @@ var _ = ginkgo.Describe("Seed logging testing", func() {
 func prepareGardenLokiService(service *corev1.Service) *corev1.Service {
 	// Remove the cluster IP because it could be already in use
 	service.Spec.ClusterIP = ""
+	service.Spec.ClusterIPs = nil
 	return service
 }
 
@@ -341,6 +342,7 @@ func prepareShootLokiService(shootLokiService *corev1.Service, name string, sele
 	shootLokiService.Namespace = v1beta1constants.GardenNamespace
 	shootLokiService.Spec.Selector = selector
 	shootLokiService.Spec.ClusterIP = ""
+	shootLokiService.Spec.ClusterIPs = nil
 	return shootLokiService
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind test

**What this PR does / why we need it**:
After upgrading the seeds to 1.20 the field service.Spec.ClusterIPs contains the service.Spec.ClusterIP.
So when the Loki service is copied from the seed during the logging integration test it retains the IP from the seed in both fields. Previously the IP persisted only in the service.Spec.ClusterIP field so the integration test logic removes it when the new service is constructed based on this service. Now this IP should be removed from service.Spec.ClusterIPs as well. 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Fix logging integration test to remove the IPs from loki.Spec.ClusterIPs
```
