### PR TITLE
Fix gardenlet startup in local setup

### DIFF
--- a/charts/gardener/gardenlet/charts/runtime/templates/serviceaccount.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/serviceaccount.yaml
@@ -10,7 +10,9 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+{{- if .Values.global.gardenlet.invalidateServiceAccountToken }}
 {{- if semverCompare ">= 1.20-0" .Capabilities.KubeVersion.GitVersion }}
 automountServiceAccountToken: false
+{{- end }}
 {{- end }}
 {{- end }}

--- a/charts/gardener/gardenlet/values.yaml
+++ b/charts/gardener/gardenlet/values.yaml
@@ -5,6 +5,7 @@ global:
     replicaCount: 1
     revisionHistoryLimit: 10
     serviceAccountName: gardenlet
+    invalidateServiceAccountToken: true
     image:
       repository: eu.gcr.io/gardener-project/gardener/gardenlet
       tag: latest

--- a/hack/local-development/start-gardenlet
+++ b/hack/local-development/start-gardenlet
@@ -143,7 +143,8 @@ gardenletChartValues="$DEV_DIR/gardenlet-charts-values.yaml"
 yq eval 'del(.apiVersion, .kind)' "$configFile" |
   yq eval '{"config": .}' - > "$tmpConfig"
 yq eval-all 'select(fi==0).global.gardenlet * select(fi==1)' "$GARDENLET_CHARTS_DIR/values.yaml" "$tmpConfig" |
-  yq eval '{"global": {"gardenlet": . }}' - > "$gardenletChartValues"
+  yq eval '{"global": {"gardenlet": . }}' - |
+  yq eval '.global.gardenlet.invalidateServiceAccountToken=false' - > "$gardenletChartValues"
 rm -f "$tmpConfig"
 
 # garden namespace is required for the gardenlet leader election, service account, roles and role bindings.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
After #5280, when the `gardenlet` is running locally (as process) and started against a `Seed` >= 1.20 then it might not be able to connect to the seed cluster. The reason is that the token for the `garden/gardenlet` `ServiceAccount` eventually gets invalidated by GRM. The `start-gardenlet.sh` script tries to read this token which is empty after invalidation.

This PR allows to overwrite the invalidation behaviour (while it's still enabled by default) for the local setup to ensure the local start-up procedures continue to work.

**Special notes for your reviewer**:
/cc @ialidzhikov @timuthy 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
