### PR TITLE
Fix GRM/KCM replicas when hibernation failed

### DIFF
--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
@@ -53,6 +53,8 @@ const (
 type Interface interface {
 	component.DeployWaiter
 	component.MonitoringComponent
+	// GetAutoscalingReplicas gets the Replicas field in the AutoscalingConfig of the Values of the deployer.
+	GetAutoscalingReplicas() *int32
 	// GetValues returns the current configuration values of the deployer.
 	GetValues() Values
 	// SetSecrets sets the secrets.
@@ -401,6 +403,10 @@ func (k *kubeAPIServer) GetValues() Values {
 
 func (k *kubeAPIServer) SetAutoscalingAPIServerResources(resources corev1.ResourceRequirements) {
 	k.values.Autoscaling.APIServerResources = resources
+}
+
+func (k *kubeAPIServer) GetAutoscalingReplicas() *int32 {
+	return k.values.Autoscaling.Replicas
 }
 
 func (k *kubeAPIServer) SetAutoscalingReplicas(replicas *int32) {

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
@@ -2544,6 +2544,14 @@ rules:
 		})
 	})
 
+	Describe("#GetAutoscalingReplicas", func() {
+		It("should properly get the field", func() {
+			v := pointer.Int32(2)
+			kapi.SetAutoscalingReplicas(v)
+			Expect(kapi.GetAutoscalingReplicas()).To(Equal(v))
+		})
+	})
+
 	Describe("#SetAutoscalingReplicas", func() {
 		It("should properly set the field", func() {
 			v := pointer.Int32(2)

--- a/pkg/operation/botanist/component/kubeapiserver/mock/mocks.go
+++ b/pkg/operation/botanist/component/kubeapiserver/mock/mocks.go
@@ -79,6 +79,20 @@ func (mr *MockInterfaceMockRecorder) Destroy(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Destroy", reflect.TypeOf((*MockInterface)(nil).Destroy), arg0)
 }
 
+// GetAutoscalingReplicas mocks base method.
+func (m *MockInterface) GetAutoscalingReplicas() *int32 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAutoscalingReplicas")
+	ret0, _ := ret[0].(*int32)
+	return ret0
+}
+
+// GetAutoscalingReplicas indicates an expected call of GetAutoscalingReplicas.
+func (mr *MockInterfaceMockRecorder) GetAutoscalingReplicas() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAutoscalingReplicas", reflect.TypeOf((*MockInterface)(nil).GetAutoscalingReplicas))
+}
+
 // GetValues mocks base method.
 func (m *MockInterface) GetValues() kubeapiserver.Values {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
This PR fixes the `Deploying gardener-resource-manager` step in the shoot reconciliation when clusters are hibernating.

Any error that happens after the [Hibernating control plane](https://github.com/gardener/gardener/blob/e7a01cb4883c956463218f4f1919c7058e23acd2/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go#L540) causes anohter reconciliation and the GRM to be scaled up if 
a) the service account token has never been created
b) the `ManagedResource` is not applied
c) the service account token is expired (see [here](https://github.com/gardener/gardener/blob/e7a01cb4883c956463218f4f1919c7058e23acd2/pkg/operation/botanist/resource_manager.go#L161:20))

We observed a) especially during the rollout of Gardener v1.39.0 for clusters that were hibernating at that time.

Furthermore, the failure is not self-healing and required ops intervention (scaling GRM manually to `0`)

<details>
<summary>Last operation error</summary>
<pre>
lastOperation:
    description: >-
      Flow "Shoot cluster reconciliation" encountered task errors: [task
      "Deploying gardener-resource-manager" failed: retry failed with context
      deadline exceeded, last error: retry failed with context deadline
      exceeded, last error: token not yet generated] Operation will be retried.
    lastUpdateTime: '2022-01-26T10:35:37Z'
</pre>
</details>

<details>
<summary>Control plane deployments</summary>
<pre>
NAME                         READY   UP-TO-DATE   AVAILABLE   AGE
cert-controller-manager      0/0     0            0           5h50m
cloud-controller-manager     1/1     1            1           5h51m
csi-driver-controller-disk   1/1     1            1           5h51m
csi-driver-controller-file   1/1     1            1           5h51m
csi-snapshot-controller      1/1     1            1           5h51m
gardener-resource-manager    2/3     3            2           5h50m
grafana-operators            0/0     0            0           5h52m
grafana-users                0/0     0            0           5h52m
kube-apiserver               0/0     0            0           5h51m
kube-controller-manager      0/1     1            0           5h50m
kube-scheduler               0/0     0            0           5h50m
kube-state-metrics           0/0     0            0           5h43m
machine-controller-manager   0/0     0            0           5h50m
remedy-controller-azure      1/1     1            1           5h51m
shoot-dns-service            0/0     0            0           5h50m
vpa-admission-controller     0/0     0            0           5h43m
vpa-recommender              1/1     1            1           5h43m
vpa-updater                  1/1     1            1           5h43m
vpn-seed-server              0/0     0            0           5h52m
</pre>
</details>

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed which caused clusters which are being hibernated from succeeding because of a Gardener-Resource-Manager deployment issue.
```
