### PR TITLE
Add exported fields to the controlplane blueprint 

### DIFF
--- a/landscaper/common/generate/blueprint/generate.go
+++ b/landscaper/common/generate/blueprint/generate.go
@@ -228,7 +228,7 @@ func writeExportExecutions(exportedFields []BlueprintField, blueprintDirectory s
 
 	fields := make(map[string]string, len(exportedFields))
 	for _, field := range exportedFields {
-		fields[field.Name] = fmt.Sprintf("{{- index .values \"deployitems\" \"%s\" \"%s\" | nindent 4 }}", *containerDeployerName, field.Name)
+		fields[field.Name] = fmt.Sprintf("{{- index .values \"deployitems\" \"%s\" \"%s\" | toYaml | nindent 4 }}", *containerDeployerName, field.Name)
 	}
 
 	exportExecutions := ExportExecutions{Exports: fields}
@@ -245,31 +245,6 @@ func writeExportExecutions(exportedFields []BlueprintField, blueprintDirectory s
 
 	return ioutil.WriteFile(fmt.Sprintf("%s/%s", blueprintDirectory, *exportExecutionFileName), yamlOut, 0640)
 }
-
-// exports:
-//  virtualGardenApiserverCaPem: |
-//    {{- index .values "deployitems" "virtual-garden-container-deployer" "virtualGardenApiserverCaPem" | nindent 4 }}
-//
-//  etcdCaPem: |
-//    {{- index .values "deployitems" "virtual-garden-container-deployer" "etcdCaPem" | nindent 4 }}
-//
-//  etcdClientTlsPem: |
-//    {{- index .values "deployitems" "virtual-garden-container-deployer" "etcdClientTlsPem" | nindent 4 }}
-//
-//  etcdClientTlsKeyPem: |
-//    {{- index .values "deployitems" "virtual-garden-container-deployer" "etcdClientTlsKeyPem" | nindent 4 }}
-//
-//  etcdUrl: |
-//    {{- index .values "deployitems" "virtual-garden-container-deployer" "etcdUrl" | nindent 4 }}
-//
-//  virtualGardenEndpoint: |
-//    {{- index .values "deployitems" "virtual-garden-container-deployer" "virtualGardenEndpoint" | nindent 4 }}
-//
-//  virtualGardenCluster:
-//    type: landscaper.gardener.cloud/kubernetes-cluster
-//    config:
-//      kubeconfig: |
-//        {{- index .values "deployitems" "virtual-garden-container-deployer" "kubeconfigYaml" | nindent 8 }}
 
 func getTopLevelFields(importDefinition common.OpenAPIDefinition) ([]byte, []BlueprintField, error) {
 	var topLevelFields []BlueprintField

--- a/landscaper/common/generate/blueprint/generate.go
+++ b/landscaper/common/generate/blueprint/generate.go
@@ -69,7 +69,7 @@ type BlueprintSchema struct {
 	Items []BlueprintSchema `json:"items,omitempty"`
 }
 
-// ExportExecutions are the wxport executions of blueprint corresponding to the exported fields
+// ExportExecutions are the export executions of blueprint corresponding to the exported fields
 type ExportExecutions struct {
 	// Exports are the exported fields
 	Exports map[string]string `json:"exports,omitempty"`

--- a/landscaper/common/generate/openapi/generate.go
+++ b/landscaper/common/generate/openapi/generate.go
@@ -140,11 +140,11 @@ func execute() error {
 			return fmt.Errorf("import path is not a directory")
 		}
 
-	filter := sets.NewString(strings.Split(filterPackages, filterPackagesDelimiter)...)
-	discoveredPackages, err := parseImportPackages(inputDir, rootDirectory, sets.NewString(rootPackage), filter)
-	if err != nil {
-		return err
-	}
+		filter := sets.NewString(strings.Split(filterPackages, filterPackagesDelimiter)...)
+		discoveredPackages, err := parseImportPackages(inputDir, rootDirectory, sets.NewString(rootPackages), filter)
+		if err != nil {
+			return err
+		}
 
 		inputPackages = append(inputPackages, discoveredPackages...)
 

--- a/landscaper/common/utils/exports.go
+++ b/landscaper/common/utils/exports.go
@@ -15,7 +15,6 @@
 package utils
 
 import (
-	"io/ioutil"
 	"os"
 
 	"sigs.k8s.io/yaml"
@@ -30,5 +29,5 @@ func ExportsToFile(exp *exports.Exports, path string) error {
 		return err
 	}
 
-	return ioutil.WriteFile(path, b, os.ModePerm)
+	return os.WriteFile(path, b, os.ModePerm)
 }

--- a/landscaper/pkg/controlplane/apis/exports/doc.go
+++ b/landscaper/pkg/controlplane/apis/exports/doc.go
@@ -1,0 +1,17 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +k8s:openapi-gen=true
+
+package exports

--- a/landscaper/pkg/controlplane/apis/exports/exports.go
+++ b/landscaper/pkg/controlplane/apis/exports/exports.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,20 +16,32 @@ package exports
 
 // Exports defines the structure for the exported data which might be consumed by other components.
 type Exports struct {
-	GardenerIdentity                         string `json:"gardenerIdentity" yaml:"gardenerIdentity"`
-	GardenerAPIServerEncryptionConfiguration string `json:"gardenerAPIServerEncryptionConfiguration" yaml:"gardenerAPIServerEncryptionConfiguration"`
-	OpenVPNDiffieHellmanKey                  string `json:"openVPNDiffieHellmanKey" yaml:"openVPNDiffieHellmanKey"`
+	// GardenerIdentity is the identity of the Gardener installation
+	GardenerIdentity string `json:"gardenerIdentity"`
+	// GardenerAPIServerEncryptionConfiguration is the encryption configuration of the Gardener API Server
+	GardenerAPIServerEncryptionConfiguration string `json:"gardenerAPIServerEncryptionConfiguration"`
+	// OpenVPNDiffieHellmanKey is the Diffie-Hellman-Key used for the Shoot<->Seed VPN
+	OpenVPNDiffieHellmanKey string `json:"openVPNDiffieHellmanKey"`
 
-	GardenerAPIServerCA           Certificate  `json:"gardenerAPIServerCA" yaml:"gardenerAPIServerCA"`
-	GardenerAdmissionControllerCA *Certificate `json:"gardenerAdmissionControllerCA,omitempty" yaml:"gardenerAdmissionControllerCA,omitempty"`
+	// GardenerAPIServerCA is the PEM encoded CA certificate of the Gardener API Server
+	GardenerAPIServerCA Certificate `json:"gardenerAPIServerCA" yaml:"gardenerAPIServerCA"`
+	// GardenerAPIServerCA is the PEM encoded CA certificate of the Gardener Admission Controller
+	GardenerAdmissionControllerCA *Certificate `json:"gardenerAdmissionControllerCA,omitempty"`
 
-	GardenerAPIServerTLSServing           Certificate  `json:"gardenerAPIServerTLSServing" yaml:"gardenerAPIServerTLSServing"`
-	GardenerControllerManagerTLSServing   Certificate  `json:"gardenerControllerManagerTLSServing" yaml:"gardenerControllerManagerTLSServing"`
-	GardenerAdmissionControllerTLSServing *Certificate `json:"gardenerAdmissionControllerTLSServing,omitempty" yaml:"gardenerAdmissionControllerTLSServing,omitempty"`
+	// GardenerAPIServerTLSServing is the TLS serving certificate of the Gardener API Server
+	GardenerAPIServerTLSServing Certificate `json:"gardenerAPIServerTLSServing"`
+	// GardenerControllerManagerTLSServing is the TLS serving certificate of the Gardener Controller Manager
+	GardenerControllerManagerTLSServing Certificate `json:"gardenerControllerManagerTLSServing"`
+	// GardenerAdmissionControllerTLSServing is the TLS serving certificate of the Gardener Admission Controller
+	GardenerAdmissionControllerTLSServing *Certificate `json:"gardenerAdmissionControllerTLSServing,omitempty"`
 }
 
+// Certificate represents an  exported certificate
 type Certificate struct {
-	Rotated bool   `json:"rotated" yaml:"rotated"`
-	Crt     string `json:"crt" yaml:"crt"`
-	Key     string `json:"key" yaml:"key"`
+	// Rotated defines if the certificate has been rotated due to expiration during execution
+	Rotated bool `json:"rotated"`
+	// Crt is the x509 certificate
+	Crt string `json:"crt"`
+	// Key is the RSA private key
+	Key string `json:"key"`
 }

--- a/landscaper/pkg/controlplane/apis/exports/exports.go
+++ b/landscaper/pkg/controlplane/apis/exports/exports.go
@@ -24,7 +24,7 @@ type Exports struct {
 	OpenVPNDiffieHellmanKey string `json:"openVPNDiffieHellmanKey"`
 
 	// GardenerAPIServerCA is the PEM encoded CA certificate of the Gardener API Server
-	GardenerAPIServerCA Certificate `json:"gardenerAPIServerCA" yaml:"gardenerAPIServerCA"`
+	GardenerAPIServerCA Certificate `json:"gardenerAPIServerCA"`
 	// GardenerAPIServerCA is the PEM encoded CA certificate of the Gardener Admission Controller
 	GardenerAdmissionControllerCA *Certificate `json:"gardenerAdmissionControllerCA,omitempty"`
 
@@ -36,7 +36,7 @@ type Exports struct {
 	GardenerAdmissionControllerTLSServing *Certificate `json:"gardenerAdmissionControllerTLSServing,omitempty"`
 }
 
-// Certificate represents an  exported certificate
+// Certificate represents an exported certificate
 type Certificate struct {
 	// Rotated defines if the certificate has been rotated due to expiration during execution
 	Rotated bool `json:"rotated"`

--- a/landscaper/pkg/controlplane/blueprint/blueprint.yaml
+++ b/landscaper/pkg/controlplane/blueprint/blueprint.yaml
@@ -5,7 +5,7 @@ kind: Blueprint
 # For reference, see: https://json-schema.org/specification-links.html#draft-4
 jsonSchema: "http://json-schema.org/draft-04/schema"
 imports:
-  
+
   - name: alerting
     required: false
     schema:
@@ -82,7 +82,7 @@ imports:
   
 
 exports:
-  
+
   - name: gardenerAPIServerCA
     required: true
     schema:

--- a/landscaper/pkg/controlplane/blueprint/blueprint.yaml
+++ b/landscaper/pkg/controlplane/blueprint/blueprint.yaml
@@ -80,6 +80,47 @@ imports:
       ref: blueprint://schema/com.github.gardener.gardener.landscaper.pkg.controlplane.apis.imports.v1alpha1.VirtualGarden.yaml
   
 
+exports:
+  
+  - name: gardenerAPIServerCA
+    required: true
+    schema:
+      ref: blueprint://schema/com.github.gardener.gardener.landscaper.pkg.controlplane.apis.exports.Certificate.yaml
+  - name: gardenerAPIServerEncryptionConfiguration
+    required: true
+    schema:
+      description: GardenerAPIServerEncryptionConfiguration is the encryption configuration
+        of the Gardener API Server
+      type: string
+  - name: gardenerAPIServerTLSServing
+    required: true
+    schema:
+      ref: blueprint://schema/com.github.gardener.gardener.landscaper.pkg.controlplane.apis.exports.Certificate.yaml
+  - name: gardenerAdmissionControllerCA
+    required: false
+    schema:
+      ref: blueprint://schema/com.github.gardener.gardener.landscaper.pkg.controlplane.apis.exports.Certificate.yaml
+  - name: gardenerAdmissionControllerTLSServing
+    required: false
+    schema:
+      ref: blueprint://schema/com.github.gardener.gardener.landscaper.pkg.controlplane.apis.exports.Certificate.yaml
+  - name: gardenerControllerManagerTLSServing
+    required: true
+    schema:
+      ref: blueprint://schema/com.github.gardener.gardener.landscaper.pkg.controlplane.apis.exports.Certificate.yaml
+  - name: gardenerIdentity
+    required: true
+    schema:
+      description: GardenerIdentity is the identity of the Gardener installation
+      type: string
+  - name: openVPNDiffieHellmanKey
+    required: true
+    schema:
+      description: OpenVPNDiffieHellmanKey is the Diffie-Hellman-Key used for the Shoot<->Seed
+        VPN
+      type: string
+  
+
 # For what can be referenced in the deployExecutions, please see:
 # https://github.com/gardener/landscaper/blob/master/docs/usage/Blueprints.md#deployexecutions
 deployExecutions:

--- a/landscaper/pkg/controlplane/blueprint/blueprint.yaml
+++ b/landscaper/pkg/controlplane/blueprint/blueprint.yaml
@@ -156,6 +156,10 @@ deployExecutions:
           {{ $resource := getResource .cd "name" "landscaper-controlplane" }}
           image: {{ $resource.access.imageReference }}
 
+# Syntax in the export executions: '.values "deployitems" "<name of deployitem. Here: deploy>" "<exported-field>"'
+# toYaml is needed because the program exports a go struct, not a yaml
+# Example:
+#  - gardenerAPIServerCA: 'index .values "deployitems" "deploy" "gardenerAPIServerCA" | toYaml | nindent 4'
 exportExecutions:
   - name: export-execution
     file: /export-execution.yaml

--- a/landscaper/pkg/controlplane/blueprint/blueprint.yaml
+++ b/landscaper/pkg/controlplane/blueprint/blueprint.yaml
@@ -74,6 +74,7 @@ imports:
   - name: runtimeCluster
     required: true
     targetType: landscaper.gardener.cloud/kubernetes-cluster
+    type: target
   - name: virtualGarden
     required: false
     schema:
@@ -155,3 +156,7 @@ deployExecutions:
           {{ $resource := getResource .cd "name" "landscaper-controlplane" }}
           image: {{ $resource.access.imageReference }}
 
+exportExecutions:
+  - name: export-execution
+    file: /export-execution.yaml
+    type: GoTemplate

--- a/landscaper/pkg/controlplane/blueprint/export-execution.yaml
+++ b/landscaper/pkg/controlplane/blueprint/export-execution.yaml
@@ -1,0 +1,17 @@
+exports:
+  gardenerAPIServerCA: '{{- index .values "deployitems" "default" "gardenerAPIServerCA"
+    | nindent 4 }}'
+  gardenerAPIServerEncryptionConfiguration: '{{- index .values "deployitems" "default"
+    "gardenerAPIServerEncryptionConfiguration" | nindent 4 }}'
+  gardenerAPIServerTLSServing: '{{- index .values "deployitems" "default" "gardenerAPIServerTLSServing"
+    | nindent 4 }}'
+  gardenerAdmissionControllerCA: '{{- index .values "deployitems" "default" "gardenerAdmissionControllerCA"
+    | nindent 4 }}'
+  gardenerAdmissionControllerTLSServing: '{{- index .values "deployitems" "default"
+    "gardenerAdmissionControllerTLSServing" | nindent 4 }}'
+  gardenerControllerManagerTLSServing: '{{- index .values "deployitems" "default"
+    "gardenerControllerManagerTLSServing" | nindent 4 }}'
+  gardenerIdentity: '{{- index .values "deployitems" "default" "gardenerIdentity"
+    | nindent 4 }}'
+  openVPNDiffieHellmanKey: '{{- index .values "deployitems" "default" "openVPNDiffieHellmanKey"
+    | nindent 4 }}'

--- a/landscaper/pkg/controlplane/blueprint/export-execution.yaml
+++ b/landscaper/pkg/controlplane/blueprint/export-execution.yaml
@@ -1,17 +1,17 @@
 exports:
-  gardenerAPIServerCA: '{{- index .values "deployitems" "default" "gardenerAPIServerCA"
-    | nindent 4 }}'
-  gardenerAPIServerEncryptionConfiguration: '{{- index .values "deployitems" "default"
-    "gardenerAPIServerEncryptionConfiguration" | nindent 4 }}'
-  gardenerAPIServerTLSServing: '{{- index .values "deployitems" "default" "gardenerAPIServerTLSServing"
-    | nindent 4 }}'
-  gardenerAdmissionControllerCA: '{{- index .values "deployitems" "default" "gardenerAdmissionControllerCA"
-    | nindent 4 }}'
-  gardenerAdmissionControllerTLSServing: '{{- index .values "deployitems" "default"
-    "gardenerAdmissionControllerTLSServing" | nindent 4 }}'
-  gardenerControllerManagerTLSServing: '{{- index .values "deployitems" "default"
-    "gardenerControllerManagerTLSServing" | nindent 4 }}'
-  gardenerIdentity: '{{- index .values "deployitems" "default" "gardenerIdentity"
-    | nindent 4 }}'
-  openVPNDiffieHellmanKey: '{{- index .values "deployitems" "default" "openVPNDiffieHellmanKey"
-    | nindent 4 }}'
+  gardenerAPIServerCA: '{{- index .values "deployitems" "deploy" "gardenerAPIServerCA"
+    | toYaml | nindent 4 }}'
+  gardenerAPIServerEncryptionConfiguration: '{{- index .values "deployitems" "deploy"
+    "gardenerAPIServerEncryptionConfiguration" | toYaml | nindent 4 }}'
+  gardenerAPIServerTLSServing: '{{- index .values "deployitems" "deploy" "gardenerAPIServerTLSServing"
+    | toYaml | nindent 4 }}'
+  gardenerAdmissionControllerCA: '{{- index .values "deployitems" "deploy" "gardenerAdmissionControllerCA"
+    | toYaml | nindent 4 }}'
+  gardenerAdmissionControllerTLSServing: '{{- index .values "deployitems" "deploy"
+    "gardenerAdmissionControllerTLSServing" | toYaml | nindent 4 }}'
+  gardenerControllerManagerTLSServing: '{{- index .values "deployitems" "deploy" "gardenerControllerManagerTLSServing"
+    | toYaml | nindent 4 }}'
+  gardenerIdentity: '{{- index .values "deployitems" "deploy" "gardenerIdentity" |
+    toYaml | nindent 4 }}'
+  openVPNDiffieHellmanKey: '{{- index .values "deployitems" "deploy" "openVPNDiffieHellmanKey"
+    | toYaml | nindent 4 }}'

--- a/landscaper/pkg/controlplane/blueprint/schema/com.github.gardener.gardener.landscaper.pkg.controlplane.apis.exports.Certificate.yaml
+++ b/landscaper/pkg/controlplane/blueprint/schema/com.github.gardener.gardener.landscaper.pkg.controlplane.apis.exports.Certificate.yaml
@@ -1,0 +1,20 @@
+description: Certificate represents an  exported certificate
+properties:
+  crt:
+    default: ""
+    description: Crt is the x509 certificate
+    type: string
+  key:
+    default: ""
+    description: Key is the RSA private key
+    type: string
+  rotated:
+    default: false
+    description: Rotated defines if the certificate has been rotated due to expiration
+      during execution
+    type: boolean
+required:
+- rotated
+- crt
+- key
+type: object

--- a/landscaper/pkg/controlplane/blueprint/schema/com.github.gardener.gardener.landscaper.pkg.controlplane.apis.exports.Certificate.yaml
+++ b/landscaper/pkg/controlplane/blueprint/schema/com.github.gardener.gardener.landscaper.pkg.controlplane.apis.exports.Certificate.yaml
@@ -1,4 +1,4 @@
-description: Certificate represents an  exported certificate
+description: Certificate represents an exported certificate
 properties:
   crt:
     default: ""

--- a/landscaper/pkg/controlplane/generate/generate-blueprint.go
+++ b/landscaper/pkg/controlplane/generate/generate-blueprint.go
@@ -44,6 +44,19 @@ func init() {
 	}
 }
 
+var (
+	// openAPIImportKey identifies the key in the OpenAPI definitions that identifies import definition
+	openAPIImportKey = "github.com/gardener/gardener/landscaper/pkg/controlplane/apis/imports/v1alpha1.Imports"
+	// openAPIRootExportKey identifies the key in the OpenAPI definitions that identifies export definition
+	openAPIRootExportKey = "github.com/gardener/gardener/landscaper/pkg/controlplane/apis/exports.Exports"
+	// blueprintDirectory the directory where the blueprint filesystem is written to
+	blueprintDirectory = "landscaper/pkg/controlplane/blueprint"
+	// has to match the name of the deploy item in the blueprint
+	deployItemName = "deploy"
+	// has to match the export executions declaration in the blueprint
+	deployExecutionsFilename = "export-execution.yaml"
+)
+
 func main() {
 	scheme := runtime.NewScheme()
 	if err := importsv1alpha1.AddToScheme(scheme); err != nil {
@@ -53,12 +66,12 @@ func main() {
 	if err := generate.RenderBlueprint(
 		tpl,
 		scheme,
-		"github.com/gardener/gardener/landscaper/pkg/controlplane/apis/imports/v1alpha1.Imports",
-		pointer.String("github.com/gardener/gardener/landscaper/pkg/controlplane/apis/exports.Exports"),
+		openAPIImportKey,
+		pointer.String(openAPIRootExportKey),
 		openapi.GetOpenAPIDefinitions,
-		"landscaper/pkg/controlplane/blueprint",
-		pointer.String("export-execution.yaml"),
-		pointer.String("default"),
+		blueprintDirectory,
+		pointer.String(deployExecutionsFilename),
+		pointer.String(deployItemName),
 	); err != nil {
 		panic(err)
 	}

--- a/landscaper/pkg/controlplane/generate/generate-blueprint.go
+++ b/landscaper/pkg/controlplane/generate/generate-blueprint.go
@@ -23,6 +23,7 @@ import (
 	importsv1alpha1 "github.com/gardener/gardener/landscaper/pkg/controlplane/apis/imports/v1alpha1"
 	"github.com/gardener/gardener/landscaper/pkg/controlplane/generate/openapi"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
 )
 
 var (
@@ -53,6 +54,7 @@ func main() {
 		tpl,
 		scheme,
 		"github.com/gardener/gardener/landscaper/pkg/controlplane/apis/imports/v1alpha1.Imports",
+		pointer.String("github.com/gardener/gardener/landscaper/pkg/controlplane/apis/exports.Exports"),
 		openapi.GetOpenAPIDefinitions,
 		"landscaper/pkg/controlplane/blueprint",
 	); err != nil {

--- a/landscaper/pkg/controlplane/generate/generate-blueprint.go
+++ b/landscaper/pkg/controlplane/generate/generate-blueprint.go
@@ -57,6 +57,8 @@ func main() {
 		pointer.String("github.com/gardener/gardener/landscaper/pkg/controlplane/apis/exports.Exports"),
 		openapi.GetOpenAPIDefinitions,
 		"landscaper/pkg/controlplane/blueprint",
+		pointer.String("export-execution.yaml"),
+		pointer.String("default"),
 	); err != nil {
 		panic(err)
 	}

--- a/landscaper/pkg/controlplane/generate/generate-blueprint.go
+++ b/landscaper/pkg/controlplane/generate/generate-blueprint.go
@@ -44,7 +44,7 @@ func init() {
 	}
 }
 
-var (
+const (
 	// openAPIImportKey identifies the key in the OpenAPI definitions that identifies import definition
 	openAPIImportKey = "github.com/gardener/gardener/landscaper/pkg/controlplane/apis/imports/v1alpha1.Imports"
 	// openAPIRootExportKey identifies the key in the OpenAPI definitions that identifies export definition

--- a/landscaper/pkg/controlplane/generate/generate-openapi.sh
+++ b/landscaper/pkg/controlplane/generate/generate-openapi.sh
@@ -34,7 +34,7 @@ rm -Rf ${PROJECT_ROOT}/landscaper/pkg/controlplane/generate/openapi/openapi_gene
 # generation (./generate.go) uses a placeholder for the missing JSONSchema.
 go run ${PROJECT_ROOT}/landscaper/common/generate/openapi \
   --root-directory ${PROJECT_ROOT} \
-  --input-directory ${PROJECT_ROOT}/landscaper/pkg/controlplane/apis/imports/v1alpha1 \
+  --input-directories ${PROJECT_ROOT}/landscaper/pkg/controlplane/apis/imports/v1alpha1,${PROJECT_ROOT}/landscaper/pkg/controlplane/apis/exports \
   --output-path ${PROJECT_ROOT}/landscaper/pkg/controlplane/generate \
-  --package github.com/gardener/gardener/landscaper/pkg/controlplane/apis/imports/v1alpha1 \
+  --packages github.com/gardener/gardener/landscaper/pkg/controlplane/apis/imports/v1alpha1,github.com/gardener/gardener/landscaper/pkg/controlplane/apis/exports \
   --verbosity 1

--- a/landscaper/pkg/controlplane/generate/openapi/openapi_generated.go
+++ b/landscaper/pkg/controlplane/generate/openapi/openapi_generated.go
@@ -46,6 +46,8 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"github.com/gardener/component-spec/bindings-go/apis/v2.Source":                                                                      schema_component_spec_bindings_go_apis_v2_Source(ref),
 		"github.com/gardener/component-spec/bindings-go/apis/v2.SourceRef":                                                                   schema_component_spec_bindings_go_apis_v2_SourceRef(ref),
 		"github.com/gardener/component-spec/bindings-go/apis/v2.UnstructuredAccessType":                                                      schema_component_spec_bindings_go_apis_v2_UnstructuredAccessType(ref),
+		"github.com/gardener/gardener/landscaper/pkg/controlplane/apis/exports.Certificate":                                                  schema_pkg_controlplane_apis_exports_Certificate(ref),
+		"github.com/gardener/gardener/landscaper/pkg/controlplane/apis/exports.Exports":                                                      schema_pkg_controlplane_apis_exports_Exports(ref),
 		"github.com/gardener/gardener/landscaper/pkg/controlplane/apis/imports/v1alpha1.APIServerAdmissionConfiguration":                     schema_controlplane_apis_imports_v1alpha1_APIServerAdmissionConfiguration(ref),
 		"github.com/gardener/gardener/landscaper/pkg/controlplane/apis/imports/v1alpha1.APIServerAdmissionWebhookCredentials":                schema_controlplane_apis_imports_v1alpha1_APIServerAdmissionWebhookCredentials(ref),
 		"github.com/gardener/gardener/landscaper/pkg/controlplane/apis/imports/v1alpha1.APIServerAdmissionWebhookCredentialsTokenProjection": schema_controlplane_apis_imports_v1alpha1_APIServerAdmissionWebhookCredentialsTokenProjection(ref),
@@ -1128,6 +1130,117 @@ func schema_component_spec_bindings_go_apis_v2_UnstructuredAccessType(ref common
 				Required: []string{"type", "object"},
 			},
 		},
+	}
+}
+
+func schema_pkg_controlplane_apis_exports_Certificate(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "Certificate represents an  exported certificate",
+				Type:        []string{"object"},
+				Properties: map[string]spec.Schema{
+					"rotated": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Rotated defines if the certificate has been rotated due to expiration during execution",
+							Default:     false,
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"crt": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Crt is the x509 certificate",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"key": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Key is the RSA private key",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+				},
+				Required: []string{"rotated", "crt", "key"},
+			},
+		},
+	}
+}
+
+func schema_pkg_controlplane_apis_exports_Exports(ref common.ReferenceCallback) common.OpenAPIDefinition {
+	return common.OpenAPIDefinition{
+		Schema: spec.Schema{
+			SchemaProps: spec.SchemaProps{
+				Description: "Exports defines the structure for the exported data which might be consumed by other components.",
+				Type:        []string{"object"},
+				Properties: map[string]spec.Schema{
+					"gardenerIdentity": {
+						SchemaProps: spec.SchemaProps{
+							Description: "GardenerIdentity is the identity of the Gardener installation",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"gardenerAPIServerEncryptionConfiguration": {
+						SchemaProps: spec.SchemaProps{
+							Description: "GardenerAPIServerEncryptionConfiguration is the encryption configuration of the Gardener API Server",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"openVPNDiffieHellmanKey": {
+						SchemaProps: spec.SchemaProps{
+							Description: "OpenVPNDiffieHellmanKey is the Diffie-Hellman-Key used for the Shoot<->Seed VPN",
+							Default:     "",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
+					"gardenerAPIServerCA": {
+						SchemaProps: spec.SchemaProps{
+							Description: "GardenerAPIServerCA is the PEM encoded CA certificate of the Gardener API Server",
+							Default:     map[string]interface{}{},
+							Ref:         ref("github.com/gardener/gardener/landscaper/pkg/controlplane/apis/exports.Certificate"),
+						},
+					},
+					"gardenerAdmissionControllerCA": {
+						SchemaProps: spec.SchemaProps{
+							Description: "GardenerAPIServerCA is the PEM encoded CA certificate of the Gardener Admission Controller",
+							Ref:         ref("github.com/gardener/gardener/landscaper/pkg/controlplane/apis/exports.Certificate"),
+						},
+					},
+					"gardenerAPIServerTLSServing": {
+						SchemaProps: spec.SchemaProps{
+							Description: "GardenerAPIServerTLSServing is the TLS serving certificate of the Gardener API Server",
+							Default:     map[string]interface{}{},
+							Ref:         ref("github.com/gardener/gardener/landscaper/pkg/controlplane/apis/exports.Certificate"),
+						},
+					},
+					"gardenerControllerManagerTLSServing": {
+						SchemaProps: spec.SchemaProps{
+							Description: "GardenerControllerManagerTLSServing is the TLS serving certificate of the Gardener Controller Manager",
+							Default:     map[string]interface{}{},
+							Ref:         ref("github.com/gardener/gardener/landscaper/pkg/controlplane/apis/exports.Certificate"),
+						},
+					},
+					"gardenerAdmissionControllerTLSServing": {
+						SchemaProps: spec.SchemaProps{
+							Description: "GardenerAdmissionControllerTLSServing is the TLS serving certificate of the Gardener Admission Controller",
+							Ref:         ref("github.com/gardener/gardener/landscaper/pkg/controlplane/apis/exports.Certificate"),
+						},
+					},
+				},
+				Required: []string{"gardenerIdentity", "gardenerAPIServerEncryptionConfiguration", "openVPNDiffieHellmanKey", "gardenerAPIServerCA", "gardenerAPIServerTLSServing", "gardenerControllerManagerTLSServing"},
+			},
+		},
+		Dependencies: []string{
+			"github.com/gardener/gardener/landscaper/pkg/controlplane/apis/exports.Certificate"},
 	}
 }
 

--- a/landscaper/pkg/controlplane/generate/openapi/openapi_generated.go
+++ b/landscaper/pkg/controlplane/generate/openapi/openapi_generated.go
@@ -1137,7 +1137,7 @@ func schema_pkg_controlplane_apis_exports_Certificate(ref common.ReferenceCallba
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "Certificate represents an  exported certificate",
+				Description: "Certificate represents an exported certificate",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"rotated": {

--- a/landscaper/pkg/controlplane/generate/templates/blueprint-controlplane.tpl.yaml
+++ b/landscaper/pkg/controlplane/generate/templates/blueprint-controlplane.tpl.yaml
@@ -44,6 +44,10 @@ deployExecutions:
           {{ `{{ $resource := getResource .cd "name" "landscaper-controlplane" }}` }}
           image: {{ `{{ $resource.access.imageReference }}` }}
 
+# Syntax in the export executions: '.values "deployitems" "<name of deployitem. Here: deploy>" "<exported-field>"'
+# toYaml is needed because the program exports a go struct, not a yaml
+# Example:
+#  - gardenerAPIServerCA: 'index .values "deployitems" "deploy" "gardenerAPIServerCA" | toYaml | nindent 4'
 exportExecutions:
   - name: export-execution
     file: /export-execution.yaml

--- a/landscaper/pkg/controlplane/generate/templates/blueprint-controlplane.tpl.yaml
+++ b/landscaper/pkg/controlplane/generate/templates/blueprint-controlplane.tpl.yaml
@@ -5,10 +5,10 @@ kind: Blueprint
 # For reference, see: https://json-schema.org/specification-links.html#draft-4
 jsonSchema: "http://json-schema.org/draft-04/schema"
 imports:
-  {{ .imports | nindent 2 }}
+{{ .imports | nindent 2 }}
 
 exports:
-  {{ .exports | nindent 2 }}
+{{ .exports | nindent 2 }}
 
 # For what can be referenced in the deployExecutions, please see:
 # https://github.com/gardener/landscaper/blob/master/docs/usage/Blueprints.md#deployexecutions

--- a/landscaper/pkg/controlplane/generate/templates/blueprint-controlplane.tpl.yaml
+++ b/landscaper/pkg/controlplane/generate/templates/blueprint-controlplane.tpl.yaml
@@ -44,3 +44,7 @@ deployExecutions:
           {{ `{{ $resource := getResource .cd "name" "landscaper-controlplane" }}` }}
           image: {{ `{{ $resource.access.imageReference }}` }}
 
+exportExecutions:
+  - name: export-execution
+    file: /export-execution.yaml
+    type: GoTemplate

--- a/landscaper/pkg/controlplane/generate/templates/blueprint-controlplane.tpl.yaml
+++ b/landscaper/pkg/controlplane/generate/templates/blueprint-controlplane.tpl.yaml
@@ -7,6 +7,9 @@ jsonSchema: "http://json-schema.org/draft-04/schema"
 imports:
   {{ .imports | nindent 2 }}
 
+exports:
+  {{ .exports | nindent 2 }}
+
 # For what can be referenced in the deployExecutions, please see:
 # https://github.com/gardener/landscaper/blob/master/docs/usage/Blueprints.md#deployexecutions
 deployExecutions:

--- a/landscaper/pkg/gardenlet/blueprint/blueprint.yaml
+++ b/landscaper/pkg/gardenlet/blueprint/blueprint.yaml
@@ -30,6 +30,7 @@ imports:
   - name: gardenCluster
     required: true
     targetType: landscaper.gardener.cloud/kubernetes-cluster
+    type: target
   - name: imageVectorOverwrite
     required: false
     schema:
@@ -47,6 +48,7 @@ imports:
   - name: seedCluster
     required: true
     targetType: landscaper.gardener.cloud/kubernetes-cluster
+    type: target
   
 
 # For what can be referenced in the deployExecutions, please see:

--- a/landscaper/pkg/gardenlet/generate/generate-blueprint.go
+++ b/landscaper/pkg/gardenlet/generate/generate-blueprint.go
@@ -53,8 +53,11 @@ func main() {
 		tpl,
 		scheme,
 		"github.com/gardener/gardener/landscaper/pkg/gardenlet/apis/imports/v1alpha1.Imports",
+		nil,
 		openapi.GetOpenAPIDefinitions,
 		"landscaper/pkg/gardenlet/blueprint",
+		nil,
+		nil,
 	); err != nil {
 		panic(err)
 	}

--- a/landscaper/pkg/gardenlet/generate/generate-openapi.sh
+++ b/landscaper/pkg/gardenlet/generate/generate-openapi.sh
@@ -34,8 +34,8 @@ rm -Rf ${PROJECT_ROOT}/landscaper/pkg/gardenlet/generate/openapi/openapi_generat
 # generation (./generate.go) uses a placeholder for the missing JSONSchema.
 go run ${PROJECT_ROOT}/landscaper/common/generate/openapi \
   --root-directory ${PROJECT_ROOT} \
-  --input-directory ${PROJECT_ROOT}/landscaper/pkg/gardenlet/apis/imports/v1alpha1 \
+  --input-directories ${PROJECT_ROOT}/landscaper/pkg/gardenlet/apis/imports/v1alpha1 \
   --output-path ${PROJECT_ROOT}/landscaper/pkg/gardenlet/generate \
-  --package github.com/gardener/gardener/landscaper/pkg/gardenlet/apis/imports/v1alpha1 \
+  --packages github.com/gardener/gardener/landscaper/pkg/gardenlet/apis/imports/v1alpha1 \
   --filter-packages github.com/gardener/gardener/pkg/apis/core/v1beta1 \
   --verbosity 1


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/kind enhancement

**What this PR does / why we need it**:

Adds exported fields to the controlplane blueprint
 - enhanced the blueprint generator to also handle exports

Exported fields are needed for dependent components needing to import this information.
This is also important so that certificate rotations can be propagated to downstream components.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
