### PR TITLE
Small improvement in containerd config file initialization

### DIFF
--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/containerd/initializer_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/containerd/initializer_test.go
@@ -99,7 +99,7 @@ const (
 
 FILE=/etc/containerd/config.toml
 if [ ! -s "$FILE" ]; then
-  mkdir -p /etc/containerd
+  mkdir -p $(dirname $FILE)
   containerd config default > "$FILE"
 fi
 

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/containerd/templates/scripts/init.tpl.sh
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/containerd/templates/scripts/init.tpl.sh
@@ -2,7 +2,7 @@
 
 FILE=/etc/containerd/config.toml
 if [ ! -s "$FILE" ]; then
-  mkdir -p /etc/containerd
+  mkdir -p $(dirname $FILE)
   containerd config default > "$FILE"
 fi
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Small improvement in containerd config file initialization. This way changing the dirpath in `FILE` will not require change of the `mkdir` command

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
