### PR TITLE
Add validation logic for `ContainerRuntime` extension

### DIFF
--- a/pkg/apis/extensions/validation/backupbucket.go
+++ b/pkg/apis/extensions/validation/backupbucket.go
@@ -77,14 +77,14 @@ func ValidateBackupBucketSpecUpdate(new, old *extensionsv1alpha1.BackupBucketSpe
 }
 
 // ValidateBackupBucketStatus validates the status of a BackupBucket object.
-func ValidateBackupBucketStatus(spec *extensionsv1alpha1.BackupBucketStatus, fldPath *field.Path) field.ErrorList {
+func ValidateBackupBucketStatus(status *extensionsv1alpha1.BackupBucketStatus, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	return allErrs
 }
 
-// ValidateBackupBucketStatusUpdate validates the status field of a BackupBucket object.
-func ValidateBackupBucketStatusUpdate(newStatus, oldStatus extensionsv1alpha1.BackupBucketStatus) field.ErrorList {
+// ValidateBackupBucketStatusUpdate validates the status field of a BackupBucket object before an update.
+func ValidateBackupBucketStatusUpdate(newStatus, oldStatus *extensionsv1alpha1.BackupBucketStatus, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	return allErrs

--- a/pkg/apis/extensions/validation/backupentry.go
+++ b/pkg/apis/extensions/validation/backupentry.go
@@ -81,14 +81,14 @@ func ValidateBackupEntrySpecUpdate(new, old *extensionsv1alpha1.BackupEntrySpec,
 }
 
 // ValidateBackupEntryStatus validates the status of a BackupEntry object.
-func ValidateBackupEntryStatus(spec *extensionsv1alpha1.BackupEntryStatus, fldPath *field.Path) field.ErrorList {
+func ValidateBackupEntryStatus(status *extensionsv1alpha1.BackupEntryStatus, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	return allErrs
 }
 
-// ValidateBackupEntryStatusUpdate validates the status field of a BackupEntry object.
-func ValidateBackupEntryStatusUpdate(newStatus, oldStatus extensionsv1alpha1.BackupEntryStatus) field.ErrorList {
+// ValidateBackupEntryStatusUpdate validates the status field of a BackupEntry object before an update.
+func ValidateBackupEntryStatusUpdate(newStatus, oldStatus *extensionsv1alpha1.BackupEntryStatus, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	return allErrs

--- a/pkg/apis/extensions/validation/bastion.go
+++ b/pkg/apis/extensions/validation/bastion.go
@@ -77,14 +77,14 @@ func ValidateBastionSpecUpdate(new, old *extensionsv1alpha1.BastionSpec, deletio
 }
 
 // ValidateBastionStatus validates the status of a Bastion object.
-func ValidateBastionStatus(spec *extensionsv1alpha1.BastionStatus, fldPath *field.Path) field.ErrorList {
+func ValidateBastionStatus(status *extensionsv1alpha1.BastionStatus, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	return allErrs
 }
 
-// ValidateBastionStatusUpdate validates the status field of a Bastion object.
-func ValidateBastionStatusUpdate(newStatus, oldStatus extensionsv1alpha1.BastionStatus) field.ErrorList {
+// ValidateBastionStatusUpdate validates the status field of a Bastion object before an update.
+func ValidateBastionStatusUpdate(newStatus, oldStatus *extensionsv1alpha1.BastionStatus, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	return allErrs

--- a/pkg/apis/extensions/validation/containerruntime.go
+++ b/pkg/apis/extensions/validation/containerruntime.go
@@ -17,15 +17,75 @@ package validation
 import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
 // ValidateContainerRuntime validates a ContainerRuntime object.
 func ValidateContainerRuntime(cr *extensionsv1alpha1.ContainerRuntime) field.ErrorList {
-	return nil
+	allErrs := field.ErrorList{}
+	allErrs = append(allErrs, apivalidation.ValidateObjectMeta(&cr.ObjectMeta, true, apivalidation.NameIsDNSSubdomain, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, ValidateContainerRuntimeSpec(&cr.Spec, field.NewPath("spec"))...)
+
+	return allErrs
 }
 
 // ValidateContainerRuntimeUpdate validates a ContainerRuntime object before an update.
 func ValidateContainerRuntimeUpdate(new, old *extensionsv1alpha1.ContainerRuntime) field.ErrorList {
-	return nil
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&new.ObjectMeta, &old.ObjectMeta, field.NewPath("metadata"))...)
+	allErrs = append(allErrs, ValidateContainerRuntimeSpecUpdate(&new.Spec, &old.Spec, new.DeletionTimestamp != nil, field.NewPath("spec"))...)
+	allErrs = append(allErrs, ValidateContainerRuntime(new)...)
+
+	return allErrs
+}
+
+// ValidateContainerRuntimeSpec validates the spec of a ContainerRuntime object.
+func ValidateContainerRuntimeSpec(spec *extensionsv1alpha1.ContainerRuntimeSpec, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if len(spec.Type) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath.Child("type"), "field is required"))
+	}
+
+	if len(spec.BinaryPath) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath.Child("binaryPath"), "field is required"))
+	}
+
+	if len(spec.WorkerPool.Name) == 0 {
+		allErrs = append(allErrs, field.Required(fldPath.Child("workerPool", "name"), "field is required"))
+	}
+
+	return allErrs
+}
+
+// ValidateContainerRuntimeSpecUpdate validates the spec of a ContainerRuntime object before an update.
+func ValidateContainerRuntimeSpecUpdate(new, old *extensionsv1alpha1.ContainerRuntimeSpec, deletionTimestampSet bool, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if deletionTimestampSet && !apiequality.Semantic.DeepEqual(new, old) {
+		allErrs = append(allErrs, apivalidation.ValidateImmutableField(new, old, fldPath)...)
+		return allErrs
+	}
+
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Type, old.Type, fldPath.Child("type"))...)
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.WorkerPool.Name, old.WorkerPool.Name, fldPath.Child("workerPool", "name"))...)
+
+	return allErrs
+}
+
+// ValidateContainerRuntimeStatus validates the status of a ContainerRuntime object.
+func ValidateContainerRuntimeStatus(status *extensionsv1alpha1.ContainerRuntimeStatus, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	return allErrs
+}
+
+// ValidateContainerRuntimeStatusUpdate validates the status of a ContainerRuntime object before an update.
+func ValidateContainerRuntimeStatusUpdate(newStatus, oldStatus *extensionsv1alpha1.ContainerRuntimeStatus, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	return allErrs
 }

--- a/pkg/apis/extensions/validation/containerruntime_test.go
+++ b/pkg/apis/extensions/validation/containerruntime_test.go
@@ -1,0 +1,123 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package validation_test
+
+import (
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	. "github.com/gardener/gardener/pkg/apis/extensions/validation"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+)
+
+var _ = Describe("ContainerRuntime validation tests", func() {
+	var cr *extensionsv1alpha1.ContainerRuntime
+
+	BeforeEach(func() {
+		cr = &extensionsv1alpha1.ContainerRuntime{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-cr",
+				Namespace: "shoot-namespace-seed",
+			},
+			Spec: extensionsv1alpha1.ContainerRuntimeSpec{
+				DefaultSpec: extensionsv1alpha1.DefaultSpec{
+					Type: "provider",
+				},
+				BinaryPath: "/test/path",
+				WorkerPool: extensionsv1alpha1.ContainerRuntimeWorkerPool{
+					Name: "test-workerPool",
+				},
+			},
+		}
+	})
+
+	Describe("#ValidContainerRuntime", func() {
+		It("should forbid empty ContainerRuntime resources", func() {
+			errorList := ValidateContainerRuntime(&extensionsv1alpha1.ContainerRuntime{})
+
+			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeRequired),
+				"Field": Equal("metadata.name"),
+			})), PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeRequired),
+				"Field": Equal("metadata.namespace"),
+			})), PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeRequired),
+				"Field": Equal("spec.type"),
+			})), PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeRequired),
+				"Field": Equal("spec.binaryPath"),
+			})), PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeRequired),
+				"Field": Equal("spec.workerPool.name"),
+			}))))
+		})
+
+		It("should allow valid ContainerRuntime resources", func() {
+			errorList := ValidateContainerRuntime(cr)
+
+			Expect(errorList).To(BeEmpty())
+		})
+	})
+
+	Describe("#ValidContainerRuntimeUpdate", func() {
+		It("should prevent updating anything if deletion time stamp is set", func() {
+			now := metav1.Now()
+			cr.DeletionTimestamp = &now
+			newContainerRuntime := prepareContainerRuntimeForUpdate(cr)
+			newContainerRuntime.Spec.BinaryPath = "changed-binaryPath"
+
+			errorList := ValidateContainerRuntimeUpdate(newContainerRuntime, cr)
+
+			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeInvalid),
+				"Field": Equal("spec"),
+			}))))
+		})
+
+		It("should prevent updating the type and workerPool ", func() {
+			newContainerRuntime := prepareContainerRuntimeForUpdate(cr)
+			newContainerRuntime.Spec.Type = "changed-type"
+			newContainerRuntime.Spec.WorkerPool.Name = "changed-workerpool-name"
+
+			errorList := ValidateContainerRuntimeUpdate(newContainerRuntime, cr)
+
+			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeInvalid),
+				"Field": Equal("spec.type"),
+			})), PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeInvalid),
+				"Field": Equal("spec.workerPool.name"),
+			}))))
+		})
+
+		It("should allow updating the binaryPath", func() {
+			newContainerRuntime := prepareContainerRuntimeForUpdate(cr)
+			newContainerRuntime.Spec.BinaryPath = "changed-binary-path"
+
+			errorList := ValidateContainerRuntimeUpdate(newContainerRuntime, cr)
+			Expect(errorList).To(BeEmpty())
+		})
+	})
+})
+
+func prepareContainerRuntimeForUpdate(obj *extensionsv1alpha1.ContainerRuntime) *extensionsv1alpha1.ContainerRuntime {
+	newObj := obj.DeepCopy()
+	newObj.ResourceVersion = "1"
+	return newObj
+}

--- a/pkg/apis/extensions/validation/controlplane.go
+++ b/pkg/apis/extensions/validation/controlplane.go
@@ -84,14 +84,14 @@ func ValidateControlPlaneSpecUpdate(new, old *extensionsv1alpha1.ControlPlaneSpe
 }
 
 // ValidateControlPlaneStatus validates the status of a ControlPlane object.
-func ValidateControlPlaneStatus(spec *extensionsv1alpha1.ControlPlaneStatus, fldPath *field.Path) field.ErrorList {
+func ValidateControlPlaneStatus(status *extensionsv1alpha1.ControlPlaneStatus, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	return allErrs
 }
 
-// ValidateControlPlaneStatusUpdate validates the status field of a ControlPlane object.
-func ValidateControlPlaneStatusUpdate(newStatus, oldStatus extensionsv1alpha1.ControlPlaneStatus) field.ErrorList {
+// ValidateControlPlaneStatusUpdate validates the status field of a ControlPlane object before an update.
+func ValidateControlPlaneStatusUpdate(newStatus, oldStatus *extensionsv1alpha1.ControlPlaneStatus, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	return allErrs

--- a/pkg/apis/extensions/validation/dnsrecord.go
+++ b/pkg/apis/extensions/validation/dnsrecord.go
@@ -108,14 +108,14 @@ func ValidateDNSRecordSpecUpdate(new, old *extensionsv1alpha1.DNSRecordSpec, del
 }
 
 // ValidateDNSRecordStatus validates the status of a DNSRecord object.
-func ValidateDNSRecordStatus(spec *extensionsv1alpha1.DNSRecordStatus, fldPath *field.Path) field.ErrorList {
+func ValidateDNSRecordStatus(status *extensionsv1alpha1.DNSRecordStatus, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	return allErrs
 }
 
-// ValidateDNSRecordStatusUpdate validates the status field of a DNSRecord object.
-func ValidateDNSRecordStatusUpdate(newStatus, oldStatus extensionsv1alpha1.DNSRecordStatus) field.ErrorList {
+// ValidateDNSRecordStatusUpdate validates the status field of a DNSRecord object before an update.
+func ValidateDNSRecordStatusUpdate(newStatus, oldStatus *extensionsv1alpha1.DNSRecordStatus, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	return allErrs

--- a/pkg/apis/extensions/validation/extension.go
+++ b/pkg/apis/extensions/validation/extension.go
@@ -68,14 +68,14 @@ func ValidateExtensionSpecUpdate(new, old *extensionsv1alpha1.ExtensionSpec, del
 }
 
 // ValidateExtensionStatus validates the status of a Extension object.
-func ValidateExtensionStatus(spec *extensionsv1alpha1.ExtensionStatus, fldPath *field.Path) field.ErrorList {
+func ValidateExtensionStatus(status *extensionsv1alpha1.ExtensionStatus, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	return allErrs
 }
 
-// ValidateExtensionStatusUpdate validates the status field of a Extension object.
-func ValidateExtensionStatusUpdate(newStatus, oldStatus extensionsv1alpha1.ExtensionStatus) field.ErrorList {
+// ValidateExtensionStatusUpdate validates the status field of a Extension object before an update.
+func ValidateExtensionStatusUpdate(newStatus, oldStatus *extensionsv1alpha1.ExtensionStatus, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	return allErrs

--- a/pkg/apis/extensions/validation/infrastructure.go
+++ b/pkg/apis/extensions/validation/infrastructure.go
@@ -77,14 +77,14 @@ func ValidateInfrastructureSpecUpdate(new, old *extensionsv1alpha1.Infrastructur
 }
 
 // ValidateInfrastructureStatus validates the status of a Infrastructure object.
-func ValidateInfrastructureStatus(spec *extensionsv1alpha1.InfrastructureStatus, fldPath *field.Path) field.ErrorList {
+func ValidateInfrastructureStatus(status *extensionsv1alpha1.InfrastructureStatus, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	return allErrs
 }
 
-// ValidateInfrastructureStatusUpdate validates the status field of a Infrastructure object.
-func ValidateInfrastructureStatusUpdate(newStatus, oldStatus extensionsv1alpha1.InfrastructureStatus) field.ErrorList {
+// ValidateInfrastructureStatusUpdate validates the status field of a Infrastructure object before an update.
+func ValidateInfrastructureStatusUpdate(newStatus, oldStatus *extensionsv1alpha1.InfrastructureStatus, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	return allErrs

--- a/pkg/apis/extensions/validation/network.go
+++ b/pkg/apis/extensions/validation/network.go
@@ -88,14 +88,14 @@ func ValidateNetworkSpecUpdate(new, old *extensionsv1alpha1.NetworkSpec, deletio
 }
 
 // ValidateNetworkStatus validates the status of a Network object.
-func ValidateNetworkStatus(spec *extensionsv1alpha1.NetworkStatus, fldPath *field.Path) field.ErrorList {
+func ValidateNetworkStatus(status *extensionsv1alpha1.NetworkStatus, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	return allErrs
 }
 
-// ValidateNetworkStatusUpdate validates the status field of a Network object.
-func ValidateNetworkStatusUpdate(newStatus, oldStatus extensionsv1alpha1.NetworkStatus) field.ErrorList {
+// ValidateNetworkStatusUpdate validates the status field of a Network object before an update.
+func ValidateNetworkStatusUpdate(newStatus, oldStatus *extensionsv1alpha1.NetworkStatus, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	return allErrs

--- a/pkg/apis/extensions/validation/operatingsystemconfig.go
+++ b/pkg/apis/extensions/validation/operatingsystemconfig.go
@@ -153,14 +153,14 @@ func ValidateOperatingSystemConfigSpecUpdate(new, old *extensionsv1alpha1.Operat
 }
 
 // ValidateOperatingSystemConfigStatus validates the status of a OperatingSystemConfig object.
-func ValidateOperatingSystemConfigStatus(spec *extensionsv1alpha1.OperatingSystemConfigStatus, fldPath *field.Path) field.ErrorList {
+func ValidateOperatingSystemConfigStatus(status *extensionsv1alpha1.OperatingSystemConfigStatus, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	return allErrs
 }
 
-// ValidateOperatingSystemConfigStatusUpdate validates the status field of a OperatingSystemConfig object.
-func ValidateOperatingSystemConfigStatusUpdate(newStatus, oldStatus extensionsv1alpha1.OperatingSystemConfigStatus) field.ErrorList {
+// ValidateOperatingSystemConfigStatusUpdate validates the status field of a OperatingSystemConfig object before an update.
+func ValidateOperatingSystemConfigStatusUpdate(newStatus, oldStatus *extensionsv1alpha1.OperatingSystemConfigStatus, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	return allErrs

--- a/pkg/apis/extensions/validation/worker.go
+++ b/pkg/apis/extensions/validation/worker.go
@@ -117,14 +117,14 @@ func ValidateWorkerSpecUpdate(new, old *extensionsv1alpha1.WorkerSpec, deletionT
 }
 
 // ValidateWorkerStatus validates the status of a Worker object.
-func ValidateWorkerStatus(spec *extensionsv1alpha1.WorkerStatus, fldPath *field.Path) field.ErrorList {
+func ValidateWorkerStatus(status *extensionsv1alpha1.WorkerStatus, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	return allErrs
 }
 
-// ValidateWorkerStatusUpdate validates the status field of a Worker object.
-func ValidateWorkerStatusUpdate(newStatus, oldStatus extensionsv1alpha1.WorkerStatus) field.ErrorList {
+// ValidateWorkerStatusUpdate validates the status field of a Worker object before an update.
+func ValidateWorkerStatusUpdate(newStatus, oldStatus *extensionsv1alpha1.WorkerStatus, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	return allErrs


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR introduces validation logic for `ContainerRuntime` object.

**Which issue(s) this PR fixes**:
Fixes #4561

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
