### PR TITLE
[release-v1.39] Automated cherry pick of #5329: Fix GRM/KCM replicas when hibernation failed

### DIFF
--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
@@ -53,6 +53,8 @@ const (
 type Interface interface {
 	component.DeployWaiter
 	component.MonitoringComponent
+	// GetAutoscalingReplicas gets the Replicas field in the AutoscalingConfig of the Values of the deployer.
+	GetAutoscalingReplicas() *int32
 	// GetValues returns the current configuration values of the deployer.
 	GetValues() Values
 	// SetSecrets sets the secrets.
@@ -401,6 +403,10 @@ func (k *kubeAPIServer) GetValues() Values {
 
 func (k *kubeAPIServer) SetAutoscalingAPIServerResources(resources corev1.ResourceRequirements) {
 	k.values.Autoscaling.APIServerResources = resources
+}
+
+func (k *kubeAPIServer) GetAutoscalingReplicas() *int32 {
+	return k.values.Autoscaling.Replicas
 }
 
 func (k *kubeAPIServer) SetAutoscalingReplicas(replicas *int32) {

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
@@ -2635,6 +2635,14 @@ rules:
 		})
 	})
 
+	Describe("#GetAutoscalingReplicas", func() {
+		It("should properly get the field", func() {
+			v := pointer.Int32(2)
+			kapi.SetAutoscalingReplicas(v)
+			Expect(kapi.GetAutoscalingReplicas()).To(Equal(v))
+		})
+	})
+
 	Describe("#SetAutoscalingReplicas", func() {
 		It("should properly set the field", func() {
 			v := pointer.Int32(2)

--- a/pkg/operation/botanist/component/kubeapiserver/mock/mocks.go
+++ b/pkg/operation/botanist/component/kubeapiserver/mock/mocks.go
@@ -79,6 +79,20 @@ func (mr *MockInterfaceMockRecorder) Destroy(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Destroy", reflect.TypeOf((*MockInterface)(nil).Destroy), arg0)
 }
 
+// GetAutoscalingReplicas mocks base method.
+func (m *MockInterface) GetAutoscalingReplicas() *int32 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAutoscalingReplicas")
+	ret0, _ := ret[0].(*int32)
+	return ret0
+}
+
+// GetAutoscalingReplicas indicates an expected call of GetAutoscalingReplicas.
+func (mr *MockInterfaceMockRecorder) GetAutoscalingReplicas() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAutoscalingReplicas", reflect.TypeOf((*MockInterface)(nil).GetAutoscalingReplicas))
+}
+
 // GetValues mocks base method.
 func (m *MockInterface) GetValues() kubeapiserver.Values {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
/kind/bug
/area/control-plane

Cherry pick of #5329 on release-v1.39.

#5329: Fix GRM/KCM replicas when hibernation failed

**Release Notes:**
```bugfix operator
A bug has been fixed which caused clusters which are being hibernated from succeeding because of a Gardener-Resource-Manager deployment issue.
```