### PR TITLE
[release-v1.39] Automated cherry pick of #5324: Revert "Use `systemd` as cgroup driver for shoots >= 1.23"

### DIFF
--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/config.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/config.go
@@ -51,7 +51,7 @@ func Config(kubernetesVersion *semver.Version, clusterDNSAddress, clusterDomain 
 				CacheUnauthorizedTTL: metav1.Duration{Duration: 30 * time.Second},
 			},
 		},
-		CgroupDriver:                     "systemd",
+		CgroupDriver:                     "cgroupfs",
 		CgroupRoot:                       "/",
 		CgroupsPerQOS:                    pointer.Bool(true),
 		ClusterDNS:                       []string{clusterDNSAddress},
@@ -101,10 +101,6 @@ func Config(kubernetesVersion *semver.Version, clusterDNSAddress, clusterDomain 
 
 	if !version.ConstraintK8sLess119.Check(kubernetesVersion) {
 		config.VolumePluginDir = pathVolumePluginDirectory
-	}
-
-	if version.ConstraintK8sLessEqual122.Check(kubernetesVersion) {
-		config.CgroupDriver = "cgroupfs"
 	}
 
 	return config

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/config_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/config_test.go
@@ -371,56 +371,6 @@ var _ = Describe("Config", func() {
 		),
 
 		Entry(
-			"kubernetes 1.21 w/o defaults",
-			"1.21.1",
-			clusterDNSAddress,
-			clusterDomain,
-			components.ConfigurableKubeletConfigParameters{},
-			kubeletConfigWithDefaults,
-			func(cfg *kubeletconfigv1beta1.KubeletConfiguration) {
-				cfg.RotateCertificates = true
-				cfg.VolumePluginDir = "/var/lib/kubelet/volumeplugins"
-			},
-		),
-		Entry(
-			"kubernetes 1.21 w/ defaults",
-			"1.21.1",
-			clusterDNSAddress,
-			clusterDomain,
-			params,
-			kubeletConfigWithParams,
-			func(cfg *kubeletconfigv1beta1.KubeletConfiguration) {
-				cfg.RotateCertificates = true
-				cfg.VolumePluginDir = "/var/lib/kubelet/volumeplugins"
-			},
-		),
-
-		Entry(
-			"kubernetes 1.22 w/o defaults",
-			"1.22.1",
-			clusterDNSAddress,
-			clusterDomain,
-			components.ConfigurableKubeletConfigParameters{},
-			kubeletConfigWithDefaults,
-			func(cfg *kubeletconfigv1beta1.KubeletConfiguration) {
-				cfg.RotateCertificates = true
-				cfg.VolumePluginDir = "/var/lib/kubelet/volumeplugins"
-			},
-		),
-		Entry(
-			"kubernetes 1.22 w/ defaults",
-			"1.22.1",
-			clusterDNSAddress,
-			clusterDomain,
-			params,
-			kubeletConfigWithParams,
-			func(cfg *kubeletconfigv1beta1.KubeletConfiguration) {
-				cfg.RotateCertificates = true
-				cfg.VolumePluginDir = "/var/lib/kubelet/volumeplugins"
-			},
-		),
-
-		Entry(
 			"kubernetes 1.23 w/o defaults",
 			"1.23.1",
 			clusterDNSAddress,
@@ -428,7 +378,6 @@ var _ = Describe("Config", func() {
 			components.ConfigurableKubeletConfigParameters{},
 			kubeletConfigWithDefaults,
 			func(cfg *kubeletconfigv1beta1.KubeletConfiguration) {
-				cfg.CgroupDriver = "systemd"
 				cfg.RotateCertificates = true
 				cfg.VolumePluginDir = "/var/lib/kubelet/volumeplugins"
 			},
@@ -441,7 +390,6 @@ var _ = Describe("Config", func() {
 			params,
 			kubeletConfigWithParams,
 			func(cfg *kubeletconfigv1beta1.KubeletConfiguration) {
-				cfg.CgroupDriver = "systemd"
 				cfg.RotateCertificates = true
 				cfg.VolumePluginDir = "/var/lib/kubelet/volumeplugins"
 			},


### PR DESCRIPTION
/kind/enhancement
/area/open-source

Cherry pick of #5324 on release-v1.39.

#5324: Revert "Use `systemd` as cgroup driver for shoots >= 1.23"

**Release Notes:**
```noteworthy user
Shoot clusters using Kubernetes 1.23 or above will continue to use the `cgroupfs` cgroup driver (the change to use `systemd` was reverted).
```