### PR TITLE
[release-v1.39] Automated cherry pick of #5327: remove the svc.spec.clusterIps from the origin loki svc from the logging integration tests

### DIFF
--- a/test/integration/shoots/logging/seed_logging_stack.go
+++ b/test/integration/shoots/logging/seed_logging_stack.go
@@ -323,6 +323,7 @@ var _ = ginkgo.Describe("Seed logging testing", func() {
 func prepareGardenLokiService(service *corev1.Service) *corev1.Service {
 	// Remove the cluster IP because it could be already in use
 	service.Spec.ClusterIP = ""
+	service.Spec.ClusterIPs = nil
 	return service
 }
 
@@ -341,6 +342,7 @@ func prepareShootLokiService(shootLokiService *corev1.Service, name string, sele
 	shootLokiService.Namespace = v1beta1constants.GardenNamespace
 	shootLokiService.Spec.Selector = selector
 	shootLokiService.Spec.ClusterIP = ""
+	shootLokiService.Spec.ClusterIPs = nil
 	return shootLokiService
 }
 


### PR DESCRIPTION
/kind/test
/area/logging

Cherry pick of #5327 on release-v1.39.

#5327: remove the svc.spec.clusterIps from the origin loki svc from the logging integration tests

**Release Notes:**
```bugfix developer
Fix logging integration test to remove the IPs from loki.Spec.ClusterIPs
```