### PR TITLE
[release-v1.39] Automated cherry pick of #5338: Fix bug in generic `ControlPlane` actuator regarding usage of token requestor

### DIFF
--- a/extensions/pkg/controller/controlplane/genericactuator/actuator.go
+++ b/extensions/pkg/controller/controlplane/genericactuator/actuator.go
@@ -78,8 +78,8 @@ type ValuesProvider interface {
 // the values provided by the given values provider.
 func NewActuator(
 	providerName string,
-	secrets secretutil.Interface, shootAccessSecrets []*gutil.ShootAccessSecret, legacySecretNamesToCleanup []string,
-	exposureSecrets secretutil.Interface, exposureShootAccessSecrets []*gutil.ShootAccessSecret, legacyExposureSecretNamesToCleanup []string,
+	secrets secretutil.Interface, shootAccessSecrets func(namespace string) []*gutil.ShootAccessSecret, legacySecretNamesToCleanup []string,
+	exposureSecrets secretutil.Interface, exposureShootAccessSecrets func(namespace string) []*gutil.ShootAccessSecret, legacyExposureSecretNamesToCleanup []string,
 	configChart, controlPlaneChart, controlPlaneShootChart, controlPlaneShootCRDsChart, storageClassesChart, controlPlaneExposureChart chart.Interface,
 	vp ValuesProvider,
 	chartRendererFactory extensionscontroller.ChartRendererFactory,
@@ -93,11 +93,11 @@ func NewActuator(
 		providerName: providerName,
 
 		secrets:                    secrets,
-		shootAccessSecrets:         shootAccessSecrets,
+		shootAccessSecretsFunc:     shootAccessSecrets,
 		legacySecretNamesToCleanup: legacySecretNamesToCleanup,
 
 		exposureSecrets:                    exposureSecrets,
-		exposureShootAccessSecrets:         exposureShootAccessSecrets,
+		exposureShootAccessSecretsFunc:     exposureShootAccessSecrets,
 		legacyExposureSecretNamesToCleanup: legacyExposureSecretNamesToCleanup,
 
 		configChart:                configChart,
@@ -120,14 +120,14 @@ func NewActuator(
 type actuator struct {
 	providerName string
 
-	// Deprecated: Use 'shootAccessSecrets' instead.
+	// Deprecated: Use 'shootAccessSecretsFunc' instead.
 	secrets                    secretutil.Interface
-	shootAccessSecrets         []*gutil.ShootAccessSecret
+	shootAccessSecretsFunc     func(namespace string) []*gutil.ShootAccessSecret
 	legacySecretNamesToCleanup []string
 
-	// Deprecated: Use 'exposureShootAccessSecrets' instead.
+	// Deprecated: Use 'exposureShootAccessSecretsFunc' instead.
 	exposureSecrets                    secretutil.Interface
-	exposureShootAccessSecrets         []*gutil.ShootAccessSecret
+	exposureShootAccessSecretsFunc     func(namespace string) []*gutil.ShootAccessSecret
 	legacyExposureSecretNamesToCleanup []string
 
 	configChart                chart.Interface
@@ -226,9 +226,11 @@ func (a *actuator) reconcileControlPlaneExposure(
 		checksums = controlplane.ComputeChecksums(deployedSecrets, nil)
 	}
 
-	for _, shootAccessSecret := range a.exposureShootAccessSecrets {
-		if err := shootAccessSecret.WithNamespaceOverride(cp.Namespace).Reconcile(ctx, a.client); err != nil {
-			return false, fmt.Errorf("could not reconcile control plane exposure shoot access secret '%s' for controlplane '%s': %w", shootAccessSecret.Secret.Name, kutil.ObjectName(cp), err)
+	if a.exposureShootAccessSecretsFunc != nil {
+		for _, shootAccessSecret := range a.exposureShootAccessSecretsFunc(cp.Namespace) {
+			if err := shootAccessSecret.Reconcile(ctx, a.client); err != nil {
+				return false, fmt.Errorf("could not reconcile control plane exposure shoot access secret '%s' for controlplane '%s': %w", shootAccessSecret.Secret.Name, kutil.ObjectName(cp), err)
+			}
 		}
 	}
 
@@ -284,9 +286,11 @@ func (a *actuator) reconcileControlPlane(
 		}
 	}
 
-	for _, shootAccessSecret := range a.shootAccessSecrets {
-		if err := shootAccessSecret.WithNamespaceOverride(cp.Namespace).Reconcile(ctx, a.client); err != nil {
-			return false, fmt.Errorf("could not reconcile shoot access secret '%s' for controlplane '%s': %w", shootAccessSecret.Secret.Name, kutil.ObjectName(cp), err)
+	if a.shootAccessSecretsFunc != nil {
+		for _, shootAccessSecret := range a.shootAccessSecretsFunc(cp.Namespace) {
+			if err := shootAccessSecret.Reconcile(ctx, a.client); err != nil {
+				return false, fmt.Errorf("could not reconcile shoot access secret '%s' for controlplane '%s': %w", shootAccessSecret.Secret.Name, kutil.ObjectName(cp), err)
+			}
 		}
 	}
 
@@ -437,9 +441,11 @@ func (a *actuator) deleteControlPlaneExposure(
 		}
 	}
 
-	for _, shootAccessSecret := range a.exposureShootAccessSecrets {
-		if err := kutil.DeleteObject(ctx, a.client, shootAccessSecret.WithNamespaceOverride(cp.Namespace).Secret); err != nil {
-			return fmt.Errorf("could not delete control plane exposure shoot access secret '%s' for controlplane '%s': %w", shootAccessSecret.Secret.Name, kutil.ObjectName(cp), err)
+	if a.exposureShootAccessSecretsFunc != nil {
+		for _, shootAccessSecret := range a.exposureShootAccessSecretsFunc(cp.Namespace) {
+			if err := kutil.DeleteObject(ctx, a.client, shootAccessSecret.Secret); err != nil {
+				return fmt.Errorf("could not delete control plane exposure shoot access secret '%s' for controlplane '%s': %w", shootAccessSecret.Secret.Name, kutil.ObjectName(cp), err)
+			}
 		}
 	}
 
@@ -515,9 +521,11 @@ func (a *actuator) deleteControlPlane(
 		}
 	}
 
-	for _, shootAccessSecret := range a.shootAccessSecrets {
-		if err := kutil.DeleteObject(ctx, a.client, shootAccessSecret.WithNamespaceOverride(cp.Namespace).Secret); err != nil {
-			return fmt.Errorf("could not delete shoot access secret '%s' for controlplane '%s': %w", shootAccessSecret.Secret.Name, kutil.ObjectName(cp), err)
+	if a.shootAccessSecretsFunc != nil {
+		for _, shootAccessSecret := range a.shootAccessSecretsFunc(cp.Namespace) {
+			if err := kutil.DeleteObject(ctx, a.client, shootAccessSecret.Secret); err != nil {
+				return fmt.Errorf("could not delete shoot access secret '%s' for controlplane '%s': %w", shootAccessSecret.Secret.Name, kutil.ObjectName(cp), err)
+			}
 		}
 	}
 

--- a/extensions/pkg/controller/controlplane/genericactuator/actuator_test.go
+++ b/extensions/pkg/controller/controlplane/genericactuator/actuator_test.go
@@ -262,9 +262,9 @@ var _ = Describe("Actuator", func() {
 			"replicas": 1,
 		}
 
-		shootAccessSecrets                 []*gutil.ShootAccessSecret
+		shootAccessSecretsFunc             func(string) []*gutil.ShootAccessSecret
 		legacySecretNamesToCleanup         []string
-		exposureShootAccessSecrets         []*gutil.ShootAccessSecret
+		exposureShootAccessSecretsFunc     func(string) []*gutil.ShootAccessSecret
 		legacyExposureSecretNamesToCleanup []string
 
 		errNotFound = &apierrors.StatusError{ErrStatus: metav1.Status{Reason: metav1.StatusReasonNotFound}}
@@ -285,9 +285,13 @@ var _ = Describe("Actuator", func() {
 			Spec:       extensionsv1alpha1.ControlPlaneSpec{},
 		}
 
-		shootAccessSecrets = []*gutil.ShootAccessSecret{gutil.NewShootAccessSecret("new-cp", "")}
+		shootAccessSecretsFunc = func(namespace string) []*gutil.ShootAccessSecret {
+			return []*gutil.ShootAccessSecret{gutil.NewShootAccessSecret("new-cp", namespace)}
+		}
 		legacySecretNamesToCleanup = []string{"legacy-cp"}
-		exposureShootAccessSecrets = []*gutil.ShootAccessSecret{gutil.NewShootAccessSecret("new-cp-exposure", "")}
+		exposureShootAccessSecretsFunc = func(namespace string) []*gutil.ShootAccessSecret {
+			return []*gutil.ShootAccessSecret{gutil.NewShootAccessSecret("new-cp-exposure", namespace)}
+		}
 		legacyExposureSecretNamesToCleanup = []string{"legacy-cp-exposure"}
 	})
 
@@ -383,15 +387,15 @@ var _ = Describe("Actuator", func() {
 			vp.EXPECT().GetStorageClassesChartValues(ctx, cp, cluster).Return(storageClassesChartValues, nil)
 
 			// Handle shoot access secrets and legacy secret cleanup
-			c.EXPECT().Get(ctx, kutil.Key(namespace, shootAccessSecrets[0].Secret.Name), gomock.AssignableToTypeOf(&corev1.Secret{}))
+			c.EXPECT().Get(ctx, kutil.Key(namespace, shootAccessSecretsFunc(namespace)[0].Secret.Name), gomock.AssignableToTypeOf(&corev1.Secret{}))
 			c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()).
 				Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 					Expect(obj).To(DeepEqual(&corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      shootAccessSecrets[0].Secret.Name,
+							Name:      shootAccessSecretsFunc(namespace)[0].Secret.Name,
 							Namespace: namespace,
 							Annotations: map[string]string{
-								"serviceaccount.resources.gardener.cloud/name":      shootAccessSecrets[0].ServiceAccountName,
+								"serviceaccount.resources.gardener.cloud/name":      shootAccessSecretsFunc(namespace)[0].ServiceAccountName,
 								"serviceaccount.resources.gardener.cloud/namespace": "kube-system",
 							},
 							Labels: map[string]string{
@@ -404,7 +408,7 @@ var _ = Describe("Actuator", func() {
 			c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: legacySecretNamesToCleanup[0], Namespace: namespace}})
 
 			// Create actuator
-			a := NewActuator(providerName, secrets, shootAccessSecrets, legacySecretNamesToCleanup, nil, nil, nil, configChart, ccmChart, ccmShootChart, cpShootCRDsChart, storageClassesChart, nil, vp, crf, imageVector, configName, webhooks, webhookServerPort, logger)
+			a := NewActuator(providerName, secrets, shootAccessSecretsFunc, legacySecretNamesToCleanup, nil, nil, nil, configChart, ccmChart, ccmShootChart, cpShootCRDsChart, storageClassesChart, nil, vp, crf, imageVector, configName, webhooks, webhookServerPort, logger)
 			err := a.(inject.Client).InjectClient(c)
 			Expect(err).NotTo(HaveOccurred())
 			a.(*actuator).gardenerClientset = gardenerClientset
@@ -463,11 +467,11 @@ var _ = Describe("Actuator", func() {
 			}
 
 			// Handle shoot access secrets and legacy secret cleanup
-			client.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: shootAccessSecrets[0].Secret.Name, Namespace: namespace}})
+			client.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: shootAccessSecretsFunc(namespace)[0].Secret.Name, Namespace: namespace}})
 			client.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: legacySecretNamesToCleanup[0], Namespace: namespace}})
 
 			// Create actuator
-			a := NewActuator(providerName, secrets, shootAccessSecrets, legacySecretNamesToCleanup, nil, nil, nil, configChart, ccmChart, nil, cpShootCRDsChart, nil, nil, nil, nil, nil, configName, webhooks, webhookServerPort, logger)
+			a := NewActuator(providerName, secrets, shootAccessSecretsFunc, legacySecretNamesToCleanup, nil, nil, nil, configChart, ccmChart, nil, cpShootCRDsChart, nil, nil, nil, nil, nil, configName, webhooks, webhookServerPort, logger)
 			Expect(a.(inject.Client).InjectClient(client)).To(Succeed())
 
 			// Call Delete method and check the result
@@ -500,15 +504,15 @@ var _ = Describe("Actuator", func() {
 			vp.EXPECT().GetControlPlaneExposureChartValues(ctx, cpExposure, cluster, exposureChecksums).Return(controlPlaneExposureChartValues, nil)
 
 			// Handle shoot access secrets and legacy secret cleanup
-			c.EXPECT().Get(ctx, kutil.Key(namespace, exposureShootAccessSecrets[0].Secret.Name), gomock.AssignableToTypeOf(&corev1.Secret{}))
+			c.EXPECT().Get(ctx, kutil.Key(namespace, exposureShootAccessSecretsFunc(namespace)[0].Secret.Name), gomock.AssignableToTypeOf(&corev1.Secret{}))
 			c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()).
 				Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 					Expect(obj).To(DeepEqual(&corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      exposureShootAccessSecrets[0].Secret.Name,
+							Name:      exposureShootAccessSecretsFunc(namespace)[0].Secret.Name,
 							Namespace: namespace,
 							Annotations: map[string]string{
-								"serviceaccount.resources.gardener.cloud/name":      exposureShootAccessSecrets[0].ServiceAccountName,
+								"serviceaccount.resources.gardener.cloud/name":      exposureShootAccessSecretsFunc(namespace)[0].ServiceAccountName,
 								"serviceaccount.resources.gardener.cloud/namespace": "kube-system",
 							},
 							Labels: map[string]string{
@@ -521,7 +525,7 @@ var _ = Describe("Actuator", func() {
 			c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: legacyExposureSecretNamesToCleanup[0], Namespace: namespace}})
 
 			// Create actuator
-			a := NewActuator(providerName, nil, nil, nil, exposureSecrets, exposureShootAccessSecrets, legacyExposureSecretNamesToCleanup, nil, nil, nil, nil, nil, cpExposureChart, vp, nil, imageVector, "", nil, 0, logger)
+			a := NewActuator(providerName, nil, nil, nil, exposureSecrets, exposureShootAccessSecretsFunc, legacyExposureSecretNamesToCleanup, nil, nil, nil, nil, nil, cpExposureChart, vp, nil, imageVector, "", nil, 0, logger)
 			Expect(a.(inject.Client).InjectClient(c)).To(Succeed())
 			a.(*actuator).gardenerClientset = gardenerClientset
 			a.(*actuator).chartApplier = chartApplier
@@ -547,11 +551,11 @@ var _ = Describe("Actuator", func() {
 			cpExposureChart.EXPECT().Delete(ctx, client, namespace).Return(nil)
 
 			// Handle shoot access secrets and legacy secret cleanup
-			client.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: exposureShootAccessSecrets[0].Secret.Name, Namespace: namespace}})
+			client.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: exposureShootAccessSecretsFunc(namespace)[0].Secret.Name, Namespace: namespace}})
 			client.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: legacyExposureSecretNamesToCleanup[0], Namespace: namespace}})
 
 			// Create actuator
-			a := NewActuator(providerName, nil, nil, nil, exposureSecrets, exposureShootAccessSecrets, legacyExposureSecretNamesToCleanup, nil, nil, nil, nil, nil, cpExposureChart, nil, nil, nil, "", nil, 0, logger)
+			a := NewActuator(providerName, nil, nil, nil, exposureSecrets, exposureShootAccessSecretsFunc, legacyExposureSecretNamesToCleanup, nil, nil, nil, nil, nil, cpExposureChart, nil, nil, nil, "", nil, 0, logger)
 			Expect(a.(inject.Client).InjectClient(client)).To(Succeed())
 
 			// Call Delete method and check the result


### PR DESCRIPTION
/kind/bug
/area/security

Cherry pick of #5338 on release-v1.39.

#5338: Fix bug in generic `ControlPlane` actuator regarding usage of token requestor

**Release Notes:**
```bugfix dependency
A bug regarding the usage of the token requestor in the generic `ControlPlane` actuator package has been fixed.
```