### PR TITLE
🛡 Provide some helpful log messages for `TokenInvalidator` and `TokenRequestor`

### DIFF
--- a/pkg/resourcemanager/controller/tokeninvalidator/reconciler.go
+++ b/pkg/resourcemanager/controller/tokeninvalidator/reconciler.go
@@ -72,7 +72,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		serviceAccount.AutomountServiceAccountToken == nil ||
 		*serviceAccount.AutomountServiceAccountToken {
 
-		log.Info("Removing 'purpose' label since secret is either explicitly skipped or `.automountServiceAccountToken` != false")
+		log.Info("Removing 'consider' label since secret is either explicitly skipped or `.automountServiceAccountToken` != false")
 		return reconcile.Result{}, r.removeConsiderLabel(ctx, secret)
 	}
 

--- a/pkg/resourcemanager/controller/tokeninvalidator/reconciler.go
+++ b/pkg/resourcemanager/controller/tokeninvalidator/reconciler.go
@@ -63,6 +63,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 	if !metav1.HasLabel(secret.ObjectMeta, resourcesv1alpha1.ResourceManagerPurpose) {
 		if err := r.addPurposeLabel(ctx, secret); err != nil {
+			log.Info("Adding 'purpose' label")
 			return reconcile.Result{}, err
 		}
 	}
@@ -71,10 +72,12 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		serviceAccount.AutomountServiceAccountToken == nil ||
 		*serviceAccount.AutomountServiceAccountToken {
 
+		log.Info("Removing 'purpose' label since secret is either explicitly skipped or `.automountServiceAccountToken` != false")
 		return reconcile.Result{}, r.removeConsiderLabel(ctx, secret)
 	}
 
 	if metav1.HasLabel(secret.ObjectMeta, resourcesv1alpha1.StaticTokenConsider) {
+		log.Info("Secret already has 'consider' label, nothing to be done")
 		return reconcile.Result{}, nil
 	}
 
@@ -86,11 +89,13 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	for _, pod := range podList.Items {
 		for _, volume := range pod.Spec.Volumes {
 			if volume.Secret != nil && volume.Secret.SecretName == secret.Name {
+				log.Info("Requeueing since there is still at least one pod mounting secret", "pod", client.ObjectKeyFromObject(&pod))
 				return reconcile.Result{Requeue: true}, nil
 			}
 		}
 	}
 
+	log.Info("Adding 'consider' label")
 	return reconcile.Result{}, r.addConsiderLabel(ctx, secret)
 }
 

--- a/pkg/resourcemanager/controller/tokenrequestor/reconciler.go
+++ b/pkg/resourcemanager/controller/tokenrequestor/reconciler.go
@@ -151,6 +151,8 @@ func (r *reconciler) reconcileSecret(ctx context.Context, log logr.Logger, sourc
 			return err
 		}
 
+		log.Info("Depopulating the token from the source secret")
+
 		if err := r.depopulateToken(sourceSecret)(); err != nil {
 			return err
 		}

--- a/pkg/resourcemanager/controller/tokenrequestor/reconciler.go
+++ b/pkg/resourcemanager/controller/tokenrequestor/reconciler.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
@@ -61,15 +62,9 @@ func NewReconciler(
 type reconciler struct {
 	clock              clock.Clock
 	jitter             func(time.Duration, float64) time.Duration
-	log                logr.Logger
 	targetClient       client.Client
 	targetCoreV1Client corev1clientset.CoreV1Interface
 	client             client.Client
-}
-
-func (r *reconciler) InjectLogger(l logr.Logger) error {
-	r.log = l.WithName(ControllerName)
-	return nil
 }
 
 func (r *reconciler) InjectClient(c client.Client) error {
@@ -78,10 +73,10 @@ func (r *reconciler) InjectClient(c client.Client) error {
 }
 
 func (r *reconciler) Reconcile(reconcileCtx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	log := logf.FromContext(reconcileCtx)
+
 	ctx, cancel := context.WithTimeout(reconcileCtx, time.Minute)
 	defer cancel()
-
-	log := r.log.WithValues("object", req)
 
 	secret := &corev1.Secret{}
 	if err := r.client.Get(ctx, req.NamespacedName, secret); err != nil {
@@ -101,8 +96,11 @@ func (r *reconciler) Reconcile(reconcileCtx context.Context, req reconcile.Reque
 		return reconcile.Result{}, err
 	}
 	if mustRequeue {
+		log.Info("No need to generate new token, renewal is scheduled", "after", requeueAfter)
 		return reconcile.Result{Requeue: true, RequeueAfter: requeueAfter}, nil
 	}
+
+	log.Info("Requesting new token")
 
 	serviceAccount, err := r.reconcileServiceAccount(ctx, secret)
 	if err != nil {
@@ -121,10 +119,11 @@ func (r *reconciler) Reconcile(reconcileCtx context.Context, req reconcile.Reque
 
 	renewDuration := r.renewDuration(tokenRequest.Status.ExpirationTimestamp.Time)
 
-	if err := r.reconcileSecret(ctx, secret, tokenRequest.Status.Token, renewDuration); err != nil {
+	if err := r.reconcileSecret(ctx, log, secret, tokenRequest.Status.Token, renewDuration); err != nil {
 		return reconcile.Result{}, fmt.Errorf("could not update Secret with token: %w", err)
 	}
 
+	log.Info("Successfully requested token and scheduled renewal", "after", renewDuration)
 	return reconcile.Result{Requeue: true, RequeueAfter: renewDuration}, nil
 }
 
@@ -141,12 +140,14 @@ func (r *reconciler) reconcileServiceAccount(ctx context.Context, secret *corev1
 	return serviceAccount, nil
 }
 
-func (r *reconciler) reconcileSecret(ctx context.Context, sourceSecret *corev1.Secret, token string, renewDuration time.Duration) error {
+func (r *reconciler) reconcileSecret(ctx context.Context, log logr.Logger, sourceSecret *corev1.Secret, token string, renewDuration time.Duration) error {
 	patch := client.MergeFrom(sourceSecret.DeepCopy())
 	metav1.SetMetaDataAnnotation(&sourceSecret.ObjectMeta, resourcesv1alpha1.ServiceAccountTokenRenewTimestamp, r.clock.Now().UTC().Add(renewDuration).Format(time.RFC3339))
 
 	if targetSecret := getTargetSecretFromAnnotations(sourceSecret.Annotations); targetSecret != nil {
-		if _, err := controllerutil.CreateOrUpdate(ctx, r.targetClient, targetSecret, r.populateToken(targetSecret, token)); err != nil {
+		log.Info("Populating the token to the target secret", "targetSecret", client.ObjectKeyFromObject(targetSecret))
+
+		if _, err := controllerutil.CreateOrUpdate(ctx, r.targetClient, targetSecret, r.populateToken(log, targetSecret, token)); err != nil {
 			return err
 		}
 
@@ -154,7 +155,9 @@ func (r *reconciler) reconcileSecret(ctx context.Context, sourceSecret *corev1.S
 			return err
 		}
 	} else {
-		if err := r.populateToken(sourceSecret, token)(); err != nil {
+		log.Info("Populating the token to the source secret")
+
+		if err := r.populateToken(log, sourceSecret, token)(); err != nil {
 			return err
 		}
 	}
@@ -162,12 +165,12 @@ func (r *reconciler) reconcileSecret(ctx context.Context, sourceSecret *corev1.S
 	return r.client.Patch(ctx, sourceSecret, patch)
 }
 
-func (r *reconciler) populateToken(secret *corev1.Secret, token string) func() error {
+func (r *reconciler) populateToken(log logr.Logger, secret *corev1.Secret, token string) func() error {
 	return func() error {
 		if secret.Data == nil {
 			secret.Data = make(map[string][]byte, 1)
 		}
-		return updateTokenInSecretData(secret.Data, token)
+		return updateTokenInSecretData(log, secret.Data, token)
 	}
 }
 
@@ -284,11 +287,14 @@ func getTargetSecretFromAnnotations(annotations map[string]string) *corev1.Secre
 	}
 }
 
-func updateTokenInSecretData(data map[string][]byte, token string) error {
+func updateTokenInSecretData(log logr.Logger, data map[string][]byte, token string) error {
 	if _, ok := data[resourcesv1alpha1.DataKeyKubeconfig]; !ok {
+		log.Info("Writing token to data")
 		data[resourcesv1alpha1.DataKeyToken] = []byte(token)
 		return nil
 	}
+
+	log.Info("Writing token as part of kubeconfig to data")
 
 	kubeconfig, authInfo, err := decodeKubeconfigAndGetUser(data[resourcesv1alpha1.DataKeyKubeconfig])
 	if err != nil {

--- a/pkg/resourcemanager/controller/tokenrequestor/reconciler_test.go
+++ b/pkg/resourcemanager/controller/tokenrequestor/reconciler_test.go
@@ -22,7 +22,6 @@ import (
 	. "github.com/gardener/gardener/pkg/resourcemanager/controller/tokenrequestor"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 
-	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
@@ -38,7 +37,6 @@ import (
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 )
@@ -48,7 +46,6 @@ var _ = Describe("Reconciler", func() {
 		var (
 			ctx = context.TODO()
 
-			logger     logr.Logger
 			fakeClock  clock.Clock
 			fakeJitter func(time.Duration, float64) time.Duration
 
@@ -95,7 +92,6 @@ var _ = Describe("Reconciler", func() {
 		)
 
 		BeforeEach(func() {
-			logger = log.Log.WithName("test")
 			fakeNow = time.Date(2021, 10, 4, 10, 0, 0, 0, time.UTC)
 			fakeClock = clock.NewFakeClock(fakeNow)
 			fakeJitter = func(d time.Duration, _ float64) time.Duration { return d }
@@ -105,7 +101,6 @@ var _ = Describe("Reconciler", func() {
 			coreV1Client = &corev1fake.FakeCoreV1{Fake: &testing.Fake{}}
 
 			ctrl = NewReconciler(fakeClock, fakeJitter, targetClient, coreV1Client)
-			Expect(inject.LoggerInto(logger, ctrl)).To(BeTrue())
 			Expect(inject.ClientInto(sourceClient, ctrl)).To(BeTrue())
 
 			secretName = "kube-scheduler"

--- a/pkg/resourcemanager/webhook/tokeninvalidator/add.go
+++ b/pkg/resourcemanager/webhook/tokeninvalidator/add.go
@@ -15,6 +15,7 @@
 package tokeninvalidator
 
 import (
+	runtimelog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
@@ -29,6 +30,6 @@ const (
 // AddToManager adds the webhook handler to the manager.
 func AddToManager(mgr manager.Manager) error {
 	server := mgr.GetWebhookServer()
-	server.Register(WebhookPath, &webhook.Admission{Handler: NewHandler()})
+	server.Register(WebhookPath, &webhook.Admission{Handler: NewHandler(runtimelog.Log.WithName("webhook").WithName(HandlerName))})
 	return nil
 }

--- a/pkg/resourcemanager/webhook/tokeninvalidator/handler.go
+++ b/pkg/resourcemanager/webhook/tokeninvalidator/handler.go
@@ -21,6 +21,7 @@ import (
 	"net/http"
 
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -62,7 +63,7 @@ func (w *tokenInvalidator) Handle(_ context.Context, req admission.Request) admi
 		secret.Data[corev1.ServiceAccountTokenKey] = invalidToken
 
 	case bytes.Equal(secret.Data[corev1.ServiceAccountTokenKey], invalidToken):
-		log.Info("Secret does not have 'consider' label, regenerating token")
+		log.Info("Secret has invalidated token and no 'consider' label, regenerating token")
 		delete(secret.Data, corev1.ServiceAccountTokenKey)
 	}
 

--- a/pkg/resourcemanager/webhook/tokeninvalidator/handler.go
+++ b/pkg/resourcemanager/webhook/tokeninvalidator/handler.go
@@ -21,19 +21,21 @@ import (
 	"net/http"
 
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
-
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 type tokenInvalidator struct {
+	logger  logr.Logger
 	decoder *admission.Decoder
 }
 
 // NewHandler returns a new handler.
-func NewHandler() admission.Handler {
-	return &tokenInvalidator{}
+func NewHandler(logger logr.Logger) admission.Handler {
+	return &tokenInvalidator{logger: logger}
 }
 
 func (w *tokenInvalidator) InjectDecoder(d *admission.Decoder) error {
@@ -47,15 +49,20 @@ func (w *tokenInvalidator) Handle(_ context.Context, req admission.Request) admi
 		return admission.Errored(http.StatusUnprocessableEntity, err)
 	}
 
+	log := w.logger.WithValues("secret", client.ObjectKeyFromObject(secret))
+
 	if secret.Data == nil {
+		log.Info("Secret's data is nil, nothing to be done")
 		return admission.Allowed("data is nil")
 	}
 
 	switch {
 	case metav1.HasLabel(secret.ObjectMeta, resourcesv1alpha1.StaticTokenConsider):
+		log.Info("Secret has 'consider' label, invalidating token")
 		secret.Data[corev1.ServiceAccountTokenKey] = invalidToken
 
 	case bytes.Equal(secret.Data[corev1.ServiceAccountTokenKey], invalidToken):
+		log.Info("Secret does not have 'consider' label, regenerating token")
 		delete(secret.Data, corev1.ServiceAccountTokenKey)
 	}
 

--- a/pkg/resourcemanager/webhook/tokeninvalidator/handler_test.go
+++ b/pkg/resourcemanager/webhook/tokeninvalidator/handler_test.go
@@ -20,6 +20,7 @@ import (
 
 	. "github.com/gardener/gardener/pkg/resourcemanager/webhook/tokeninvalidator"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"gomodules.xyz/jsonpatch/v2"
@@ -29,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
 	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
+	logzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -36,6 +38,8 @@ var _ = Describe("Handler", func() {
 	var (
 		ctx = context.TODO()
 		err error
+
+		logger logr.Logger
 
 		decoder *admission.Decoder
 		encoder runtime.Encoder
@@ -48,11 +52,13 @@ var _ = Describe("Handler", func() {
 	)
 
 	BeforeEach(func() {
+		logger = logzap.New(logzap.WriteTo(GinkgoWriter))
+
 		decoder, err = admission.NewDecoder(kubernetesscheme.Scheme)
 		Expect(err).NotTo(HaveOccurred())
 		encoder = &json.Serializer{}
 
-		handler = NewHandler()
+		handler = NewHandler(logger)
 		Expect(admission.InjectDecoderInto(decoder, handler)).To(BeTrue())
 
 		request = admission.Request{}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement
/merge squash

**What this PR does / why we need it**:
This PR adds some helpful log messages for `TokenInvalidator` and `TokenRequestor` controllers/webhooks part of `gardener-resource-manager`.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/4878

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
