### PR TITLE
Allow Bastion update of finalizer

### DIFF
--- a/plugin/pkg/bastion/validator/admission.go
+++ b/plugin/pkg/bastion/validator/admission.go
@@ -141,7 +141,7 @@ func (v *Bastion) Admit(ctx context.Context, a admission.Attributes, o admission
 	}
 
 	// ensure shoot is alive
-	if shoot.DeletionTimestamp != nil {
+	if a.GetOperation() == admission.Create && shoot.DeletionTimestamp != nil {
 		fieldErr := field.Invalid(shootPath, shootName, "shoot is in deletion")
 		return apierrors.NewInvalid(gk, bastion.Name, field.ErrorList{fieldErr})
 	}

--- a/plugin/pkg/bastion/validator/admission.go
+++ b/plugin/pkg/bastion/validator/admission.go
@@ -130,19 +130,6 @@ func (v *Bastion) Admit(ctx context.Context, a admission.Attributes, o admission
 
 	shootName := bastion.Spec.ShootRef.Name
 
-	if a.GetOperation() == admission.Update {
-		oldBastion, ok := a.GetOldObject().(*operations.Bastion)
-		if !ok {
-			return apierrors.NewBadRequest("could not convert old object to Bastion")
-		}
-
-		oldShootName := oldBastion.Spec.ShootRef.Name
-		if oldShootName != shootName {
-			fieldErr := field.Invalid(shootPath, shootName, "shootRef must not be changed")
-			return apierrors.NewInvalid(gk, bastion.Name, field.ErrorList{fieldErr})
-		}
-	}
-
 	// ensure shoot exists
 	shoot, err := v.coreClient.Core().Shoots(bastion.Namespace).Get(ctx, shootName, metav1.GetOptions{})
 	if err != nil {

--- a/plugin/pkg/bastion/validator/admission_test.go
+++ b/plugin/pkg/bastion/validator/admission_test.go
@@ -245,24 +245,6 @@ var _ = Describe("Bastion", func() {
 			err := admissionHandler.Admit(context.TODO(), getBastionAttributes(bastion, oldBastion, admission.Update), nil)
 			Expect(err).To(Succeed())
 		})
-
-		It("should forbid the Bastion update if the Shoot name changed", func() {
-			coreClient.AddReactor("get", "shoots", func(action testing.Action) (bool, runtime.Object, error) {
-				return true, shoot, nil
-			})
-
-			oldBastion := bastion.DeepCopy()
-			oldBastion.Spec.ShootRef.Name = "other-shoot"
-
-			err := admissionHandler.Admit(context.TODO(), getBastionAttributes(bastion, oldBastion, admission.Update), nil)
-			Expect(err).To(BeInvalidError())
-			Expect(getErrorList(err)).To(ConsistOf(
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("spec.shootRef.name"),
-				})),
-			))
-		})
 	})
 
 	Describe("#Register", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
This PR allows the `Bastion` finalizer to be updated, even if the corresponding `Shoot` is in deletion. Otherwise it is not possible to get rid of the `Bastion`.
This PR also forbids to change the referenced `Shoot` on the bastion

**Which issue(s) this PR fixes**:
Fixes #5344 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The finalizer on the `Bastion` resource in the garden cluster can now be updated even if the referenced `Shoot` is in deletion
```
