### PR TITLE
Specify field's immutability details in field's doc string

### DIFF
--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -103,7 +103,7 @@ BackupBucketProvider
 </em>
 </td>
 <td>
-<p>Provider hold the details of cloud provider of the object store.</p>
+<p>Provider holds the details of cloud provider of the object store. This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -142,7 +142,8 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>SeedName holds the name of the seed allocated to BackupBucket for running controller.</p>
+<p>SeedName holds the name of the seed allocated to BackupBucket for running controller.
+This field is immutable.</p>
 </td>
 </tr>
 </table>
@@ -578,7 +579,8 @@ ControllerInstallationSpec
 </em>
 </td>
 <td>
-<p>Spec contains the specification of this installation.</p>
+<p>Spec contains the specification of this installation.
+If the object&rsquo;s deletion timestamp is set, this field is immutable.</p>
 <br/>
 <br/>
 <table>
@@ -592,7 +594,8 @@ Kubernetes core/v1.ObjectReference
 </em>
 </td>
 <td>
-<p>RegistrationRef is used to reference a ControllerRegistration resource.</p>
+<p>RegistrationRef is used to reference a ControllerRegistration resource.
+The name field of the RegistrationRef is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -605,7 +608,7 @@ Kubernetes core/v1.ObjectReference
 </em>
 </td>
 <td>
-<p>SeedRef is used to reference a Seed resource.</p>
+<p>SeedRef is used to reference a Seed resource. The name field of the SeedRef is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -695,7 +698,8 @@ ControllerRegistrationSpec
 </em>
 </td>
 <td>
-<p>Spec contains the specification of this registration.</p>
+<p>Spec contains the specification of this registration.
+If the object&rsquo;s deletion timestamp is set, this field is immutable.</p>
 <br/>
 <br/>
 <table>
@@ -789,7 +793,8 @@ PlantSpec
 </em>
 </td>
 <td>
-<p>Spec contains the specification of this Plant.</p>
+<p>Spec contains the specification of this Plant.
+If the object&rsquo;s deletion timestamp is set, this field is immutable.</p>
 <br/>
 <br/>
 <table>
@@ -912,7 +917,7 @@ Kubernetes rbac/v1.Subject
 <td>
 <em>(Optional)</em>
 <p>CreatedBy is a subject representing a user name, an email address, or any other identifier of a user
-who created the project.</p>
+who created the project. This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -983,7 +988,8 @@ string
 <td>
 <em>(Optional)</em>
 <p>Namespace is the name of the namespace that has been created for the Project object.
-A nil value means that Gardener will determine the name of the namespace.</p>
+A nil value means that Gardener will determine the name of the namespace.
+This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -1115,7 +1121,7 @@ Kubernetes core/v1.ObjectReference
 </em>
 </td>
 <td>
-<p>Scope is the scope of the Quota object, either &lsquo;project&rsquo; or &lsquo;secret&rsquo;.</p>
+<p>Scope is the scope of the Quota object, either &lsquo;project&rsquo; or &lsquo;secret&rsquo;. This field is immutable.</p>
 </td>
 </tr>
 </table>
@@ -1179,7 +1185,8 @@ Kubernetes core/v1.SecretReference
 </em>
 </td>
 <td>
-<p>SecretRef is a reference to a secret object in the same or another namespace.</p>
+<p>SecretRef is a reference to a secret object in the same or another namespace.
+This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -1193,7 +1200,8 @@ Kubernetes core/v1.SecretReference
 </td>
 <td>
 <em>(Optional)</em>
-<p>Quotas is a list of references to Quota objects in the same or another namespace.</p>
+<p>Quotas is a list of references to Quota objects in the same or another namespace.
+This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -1207,7 +1215,8 @@ SecretBindingProvider
 </td>
 <td>
 <em>(Optional)</em>
-<p>Provider defines the provider type of the SecretBinding.</p>
+<p>Provider defines the provider type of the SecretBinding.
+This field is immutable when the SecretBindingProviderValidation feature gate is enabled.</p>
 </td>
 </tr>
 </tbody>
@@ -1395,7 +1404,7 @@ Ingress
 </td>
 <td>
 <em>(Optional)</em>
-<p>Ingress configures Ingress specific settings of the Seed cluster.</p>
+<p>Ingress configures Ingress specific settings of the Seed cluster. This field is immutable.</p>
 </td>
 </tr>
 </table>
@@ -1473,7 +1482,8 @@ ShootSpec
 </td>
 <td>
 <em>(Optional)</em>
-<p>Specification of the Shoot cluster.</p>
+<p>Specification of the Shoot cluster.
+If the object&rsquo;s deletion timestamp is set, this field is immutable.</p>
 <br/>
 <br/>
 <table>
@@ -1499,7 +1509,7 @@ string
 </em>
 </td>
 <td>
-<p>CloudProfileName is a name of a CloudProfile object.</p>
+<p>CloudProfileName is a name of a CloudProfile object. This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -1634,7 +1644,7 @@ string
 </em>
 </td>
 <td>
-<p>Region is a name of a region.</p>
+<p>Region is a name of a region. This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -1646,7 +1656,8 @@ string
 </td>
 <td>
 <p>SecretBindingName is the name of the a SecretBinding that has a reference to the provider secret.
-The credentials inside the provider secret will be used to create the shoot in the respective account.</p>
+The credentials inside the provider secret will be used to create the shoot in the respective account.
+This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -1658,7 +1669,8 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>SeedName is the name of the seed cluster that runs the control plane of the Shoot.</p>
+<p>SeedName is the name of the seed cluster that runs the control plane of the Shoot.
+This field is immutable when the SeedChange feature gate is disabled.</p>
 </td>
 </tr>
 <tr>
@@ -1712,7 +1724,8 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>ExposureClassName is the optional name of an exposure class to apply a control plane endpoint exposure strategy.</p>
+<p>ExposureClassName is the optional name of an exposure class to apply a control plane endpoint exposure strategy.
+This field is immutable.</p>
 </td>
 </tr>
 </table>
@@ -2076,7 +2089,7 @@ BackupBucketProvider
 </em>
 </td>
 <td>
-<p>Provider hold the details of cloud provider of the object store.</p>
+<p>Provider holds the details of cloud provider of the object store. This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -2115,7 +2128,8 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>SeedName holds the name of the seed allocated to BackupBucket for running controller.</p>
+<p>SeedName holds the name of the seed allocated to BackupBucket for running controller.
+This field is immutable.</p>
 </td>
 </tr>
 </tbody>
@@ -2983,7 +2997,8 @@ Kubernetes core/v1.ObjectReference
 </em>
 </td>
 <td>
-<p>RegistrationRef is used to reference a ControllerRegistration resource.</p>
+<p>RegistrationRef is used to reference a ControllerRegistration resource.
+The name field of the RegistrationRef is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -2996,7 +3011,7 @@ Kubernetes core/v1.ObjectReference
 </em>
 </td>
 <td>
-<p>SeedRef is used to reference a Seed resource.</p>
+<p>SeedRef is used to reference a Seed resource. The name field of the SeedRef is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -3250,7 +3265,7 @@ bool
 <em>(Optional)</em>
 <p>Primary determines if the controller backed by this ControllerRegistration is responsible for the extension
 resource&rsquo;s lifecycle. This field defaults to true. There must be exactly one primary controller for this kind/type
-combination.</p>
+combination. This field is immutable.</p>
 </td>
 </tr>
 </tbody>
@@ -3282,7 +3297,7 @@ string
 <td>
 <em>(Optional)</em>
 <p>Domain is the external available domain of the Shoot cluster. This domain will be written into the
-kubeconfig that is handed out to end-users. Once set it is immutable.</p>
+kubeconfig that is handed out to end-users. This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -4338,7 +4353,7 @@ int32
 </td>
 <td>
 <em>(Optional)</em>
-<p>NodeCIDRMaskSize defines the mask size for node cidr in cluster (default is 24)</p>
+<p>NodeCIDRMaskSize defines the mask size for node cidr in cluster (default is 24). This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -6189,7 +6204,7 @@ string
 </em>
 </td>
 <td>
-<p>Type identifies the type of the networking plugin.</p>
+<p>Type identifies the type of the networking plugin. This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -6215,7 +6230,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Pods is the CIDR of the pod network.</p>
+<p>Pods is the CIDR of the pod network. This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -6227,7 +6242,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Nodes is the CIDR of the entire node network.</p>
+<p>Nodes is the CIDR of the entire node network. This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -6239,7 +6254,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Services is the CIDR of the service network.</p>
+<p>Services is the CIDR of the service network. This field is immutable.</p>
 </td>
 </tr>
 </tbody>
@@ -6710,7 +6725,7 @@ Kubernetes rbac/v1.Subject
 <td>
 <em>(Optional)</em>
 <p>CreatedBy is a subject representing a user name, an email address, or any other identifier of a user
-who created the project.</p>
+who created the project. This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -6781,7 +6796,8 @@ string
 <td>
 <em>(Optional)</em>
 <p>Namespace is the name of the namespace that has been created for the Project object.
-A nil value means that Gardener will determine the name of the namespace.</p>
+A nil value means that Gardener will determine the name of the namespace.
+This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -6961,7 +6977,7 @@ string
 </em>
 </td>
 <td>
-<p>Type is the type of the provider.</p>
+<p>Type is the type of the provider. This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -7075,7 +7091,7 @@ Kubernetes core/v1.ObjectReference
 </em>
 </td>
 <td>
-<p>Scope is the scope of the Quota object, either &lsquo;project&rsquo; or &lsquo;secret&rsquo;.</p>
+<p>Scope is the scope of the Quota object, either &lsquo;project&rsquo; or &lsquo;secret&rsquo;. This field is immutable.</p>
 </td>
 </tr>
 </tbody>
@@ -7250,7 +7266,7 @@ string
 </em>
 </td>
 <td>
-<p>Provider is a provider name.</p>
+<p>Provider is a provider name. This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -7276,7 +7292,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Region is a region name.</p>
+<p>Region is a region name. This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -7323,7 +7339,7 @@ string
 <td>
 <em>(Optional)</em>
 <p>IngressDomain is the domain of the Seed cluster pointing to the ingress controller endpoint. It will be used
-to construct ingress URLs for system applications running in Shoot clusters. Once set this field is immutable.
+to construct ingress URLs for system applications running in Shoot clusters. This field is immutable.
 This will be removed in the next API version and replaced by spec.ingress.domain.</p>
 </td>
 </tr>
@@ -7440,7 +7456,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Nodes is the CIDR of the node network.</p>
+<p>Nodes is the CIDR of the node network. This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -7451,7 +7467,7 @@ string
 </em>
 </td>
 <td>
-<p>Pods is the CIDR of the pod network.</p>
+<p>Pods is the CIDR of the pod network. This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -7462,7 +7478,7 @@ string
 </em>
 </td>
 <td>
-<p>Services is the CIDR of the service network.</p>
+<p>Services is the CIDR of the service network. This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -8157,7 +8173,7 @@ Ingress
 </td>
 <td>
 <em>(Optional)</em>
-<p>Ingress configures Ingress specific settings of the Seed cluster.</p>
+<p>Ingress configures Ingress specific settings of the Seed cluster. This field is immutable.</p>
 </td>
 </tr>
 </tbody>
@@ -8241,7 +8257,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>ClusterIdentity is the identity of the Seed cluster</p>
+<p>ClusterIdentity is the identity of the Seed cluster. This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -8499,7 +8515,7 @@ Ingress
 </td>
 <td>
 <em>(Optional)</em>
-<p>Ingress configures Ingress specific settings of the Seed cluster.</p>
+<p>Ingress configures Ingress specific settings of the Seed cluster. This field is immutable.</p>
 </td>
 </tr>
 </table>
@@ -8866,7 +8882,7 @@ string
 </em>
 </td>
 <td>
-<p>CloudProfileName is a name of a CloudProfile object.</p>
+<p>CloudProfileName is a name of a CloudProfile object. This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -9001,7 +9017,7 @@ string
 </em>
 </td>
 <td>
-<p>Region is a name of a region.</p>
+<p>Region is a name of a region. This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -9013,7 +9029,8 @@ string
 </td>
 <td>
 <p>SecretBindingName is the name of the a SecretBinding that has a reference to the provider secret.
-The credentials inside the provider secret will be used to create the shoot in the respective account.</p>
+The credentials inside the provider secret will be used to create the shoot in the respective account.
+This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -9025,7 +9042,8 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>SeedName is the name of the seed cluster that runs the control plane of the Shoot.</p>
+<p>SeedName is the name of the seed cluster that runs the control plane of the Shoot.
+This field is immutable when the SeedChange feature gate is disabled.</p>
 </td>
 </tr>
 <tr>
@@ -9079,7 +9097,8 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>ExposureClassName is the optional name of an exposure class to apply a control plane endpoint exposure strategy.</p>
+<p>ExposureClassName is the optional name of an exposure class to apply a control plane endpoint exposure strategy.
+This field is immutable.</p>
 </td>
 </tr>
 </tbody>
@@ -9231,7 +9250,7 @@ string
 </td>
 <td>
 <p>TechnicalID is the name that is used for creating the Seed namespace, the infrastructure resources, and
-basically everything that is related to this particular Shoot.</p>
+basically everything that is related to this particular Shoot. This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -9245,7 +9264,7 @@ k8s.io/apimachinery/pkg/types.UID
 </td>
 <td>
 <p>UID is a unique identifier for the Shoot cluster to avoid portability between Kubernetes clusters.
-It is used to compute unique hashes.</p>
+It is used to compute unique hashes. This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -9257,7 +9276,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>ClusterIdentity is the identity of the Shoot cluster</p>
+<p>ClusterIdentity is the identity of the Shoot cluster. This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -9356,7 +9375,7 @@ string
 </em>
 </td>
 <td>
-<p>CloudProfileName is a name of a CloudProfile object.</p>
+<p>CloudProfileName is a name of a CloudProfile object. This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -9491,7 +9510,7 @@ string
 </em>
 </td>
 <td>
-<p>Region is a name of a region.</p>
+<p>Region is a name of a region. This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -9503,7 +9522,8 @@ string
 </td>
 <td>
 <p>SecretBindingName is the name of the a SecretBinding that has a reference to the provider secret.
-The credentials inside the provider secret will be used to create the shoot in the respective account.</p>
+The credentials inside the provider secret will be used to create the shoot in the respective account.
+This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -9515,7 +9535,8 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>SeedName is the name of the seed cluster that runs the control plane of the Shoot.</p>
+<p>SeedName is the name of the seed cluster that runs the control plane of the Shoot.
+This field is immutable when the SeedChange feature gate is disabled.</p>
 </td>
 </tr>
 <tr>
@@ -9569,7 +9590,8 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>ExposureClassName is the optional name of an exposure class to apply a control plane endpoint exposure strategy.</p>
+<p>ExposureClassName is the optional name of an exposure class to apply a control plane endpoint exposure strategy.
+This field is immutable.</p>
 </td>
 </tr>
 </table>

--- a/docs/api-reference/extensions.md
+++ b/docs/api-reference/extensions.md
@@ -89,6 +89,8 @@ BackupBucketSpec
 </em>
 </td>
 <td>
+<p>Specification of the BackupBucket.
+If the object&rsquo;s deletion timestamp is set, this field is immutable.</p>
 <br/>
 <br/>
 <table>
@@ -116,7 +118,7 @@ string
 </em>
 </td>
 <td>
-<p>Region is the region of this bucket.</p>
+<p>Region is the region of this bucket. This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -205,6 +207,8 @@ BackupEntrySpec
 </em>
 </td>
 <td>
+<p>Specification of the BackupEntry.
+If the object&rsquo;s deletion timestamp is set, this field is immutable.</p>
 <br/>
 <br/>
 <table>
@@ -247,7 +251,7 @@ string
 </em>
 </td>
 <td>
-<p>Region is the region of this Entry.</p>
+<p>Region is the region of this Entry. This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -348,7 +352,8 @@ BastionSpec
 </em>
 </td>
 <td>
-<p>Spec is the specification of this Bastion.</p>
+<p>Spec is the specification of this Bastion.
+If the object&rsquo;s deletion timestamp is set, this field is immutable.</p>
 <br/>
 <br/>
 <table>
@@ -377,7 +382,8 @@ DefaultSpec
 </td>
 <td>
 <p>UserData is the base64-encoded user data for the bastion instance. This should
-contain code to provision the SSH key on the bastion instance.</p>
+contain code to provision the SSH key on the bastion instance.
+This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -570,6 +576,8 @@ ContainerRuntimeSpec
 </em>
 </td>
 <td>
+<p>Specification of the ContainerRuntime.
+If the object&rsquo;s deletion timestamp is set, this field is immutable.</p>
 <br/>
 <br/>
 <table>
@@ -686,6 +694,8 @@ ControlPlaneSpec
 </em>
 </td>
 <td>
+<p>Specification of the ControlPlane.
+If the object&rsquo;s deletion timestamp is set, this field is immutable.</p>
 <br/>
 <br/>
 <table>
@@ -716,7 +726,8 @@ Purpose
 </td>
 <td>
 <em>(Optional)</em>
-<p>Purpose contains the data if a cloud provider needs additional components in order to expose the control plane.</p>
+<p>Purpose contains the data if a cloud provider needs additional components in order to expose the control plane.
+This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -742,7 +753,7 @@ string
 </em>
 </td>
 <td>
-<p>Region is the region of this control plane.</p>
+<p>Region is the region of this control plane. This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -830,6 +841,8 @@ DNSRecordSpec
 </em>
 </td>
 <td>
+<p>Specification of the DNSRecord.
+If the object&rsquo;s deletion timestamp is set, this field is immutable.</p>
 <br/>
 <br/>
 <table>
@@ -896,7 +909,7 @@ string
 </em>
 </td>
 <td>
-<p>Name is the fully qualified domain name, e.g. &ldquo;api.<shoot domain>&rdquo;.</p>
+<p>Name is the fully qualified domain name, e.g. &ldquo;api.<shoot domain>&rdquo;. This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -909,7 +922,7 @@ DNSRecordType
 </em>
 </td>
 <td>
-<p>RecordType is the DNS record type. Only A, CNAME, and TXT records are currently supported.</p>
+<p>RecordType is the DNS record type. Only A, CNAME, and TXT records are currently supported. This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -1008,6 +1021,8 @@ ExtensionSpec
 </em>
 </td>
 <td>
+<p>Specification of the Extension.
+If the object&rsquo;s deletion timestamp is set, this field is immutable.</p>
 <br/>
 <br/>
 <table>
@@ -1100,6 +1115,8 @@ InfrastructureSpec
 </em>
 </td>
 <td>
+<p>Specification of the Infrastructure.
+If the object&rsquo;s deletion timestamp is set, this field is immutable.</p>
 <br/>
 <br/>
 <table>
@@ -1127,7 +1144,7 @@ string
 </em>
 </td>
 <td>
-<p>Region is the region of this infrastructure.</p>
+<p>Region is the region of this infrastructure. This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -1228,6 +1245,8 @@ NetworkSpec
 </em>
 </td>
 <td>
+<p>Specification of the Network.
+If the object&rsquo;s deletion timestamp is set, this field is immutable.</p>
 <br/>
 <br/>
 <table>
@@ -1255,7 +1274,7 @@ string
 </em>
 </td>
 <td>
-<p>PodCIDR defines the CIDR that will be used for pods.</p>
+<p>PodCIDR defines the CIDR that will be used for pods. This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -1266,7 +1285,7 @@ string
 </em>
 </td>
 <td>
-<p>ServiceCIDR defines the CIDR that will be used for services.</p>
+<p>ServiceCIDR defines the CIDR that will be used for services. This field is immutable.</p>
 </td>
 </tr>
 </table>
@@ -1342,6 +1361,8 @@ OperatingSystemConfigSpec
 </em>
 </td>
 <td>
+<p>Specification of the OperatingSystemConfig.
+If the object&rsquo;s deletion timestamp is set, this field is immutable.</p>
 <br/>
 <br/>
 <table>
@@ -1387,7 +1408,8 @@ OperatingSystemConfigPurpose
 <td>
 <p>Purpose describes how the result of this OperatingSystemConfig is used by Gardener. Either it
 gets sent to the <code>Worker</code> extension controller to bootstrap a VM, or it is downloaded by the
-cloud-config-downloader script already running on a bootstrapped VM.</p>
+cloud-config-downloader script already running on a bootstrapped VM.
+This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -1506,6 +1528,8 @@ WorkerSpec
 </em>
 </td>
 <td>
+<p>Specification of the Worker.
+If the object&rsquo;s deletion timestamp is set, this field is immutable.</p>
 <br/>
 <br/>
 <table>
@@ -1548,7 +1572,7 @@ string
 </em>
 </td>
 <td>
-<p>Region is the name of the region where the worker pool should be deployed to.</p>
+<p>Region is the name of the region where the worker pool should be deployed to. This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -1648,7 +1672,7 @@ string
 </em>
 </td>
 <td>
-<p>Region is the region of this bucket.</p>
+<p>Region is the region of this bucket. This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -1772,7 +1796,7 @@ string
 </em>
 </td>
 <td>
-<p>Region is the region of this Entry.</p>
+<p>Region is the region of this Entry. This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -1910,7 +1934,8 @@ DefaultSpec
 </td>
 <td>
 <p>UserData is the base64-encoded user data for the bastion instance. This should
-contain code to provision the SSH key on the bastion instance.</p>
+contain code to provision the SSH key on the bastion instance.
+This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -2230,7 +2255,8 @@ string
 </em>
 </td>
 <td>
-<p>Name specifies the name of the worker pool the container runtime should be available for.</p>
+<p>Name specifies the name of the worker pool the container runtime should be available for.
+This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -2292,7 +2318,8 @@ Purpose
 </td>
 <td>
 <em>(Optional)</em>
-<p>Purpose contains the data if a cloud provider needs additional components in order to expose the control plane.</p>
+<p>Purpose contains the data if a cloud provider needs additional components in order to expose the control plane.
+This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -2318,7 +2345,7 @@ string
 </em>
 </td>
 <td>
-<p>Region is the region of this control plane.</p>
+<p>Region is the region of this control plane. This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -2451,7 +2478,7 @@ string
 </em>
 </td>
 <td>
-<p>Name is the fully qualified domain name, e.g. &ldquo;api.<shoot domain>&rdquo;.</p>
+<p>Name is the fully qualified domain name, e.g. &ldquo;api.<shoot domain>&rdquo;. This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -2464,7 +2491,7 @@ DNSRecordType
 </em>
 </td>
 <td>
-<p>RecordType is the DNS record type. Only A, CNAME, and TXT records are currently supported.</p>
+<p>RecordType is the DNS record type. Only A, CNAME, and TXT records are currently supported. This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -3147,7 +3174,7 @@ string
 </em>
 </td>
 <td>
-<p>Region is the region of this infrastructure.</p>
+<p>Region is the region of this infrastructure. This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -3362,7 +3389,7 @@ string
 </em>
 </td>
 <td>
-<p>PodCIDR defines the CIDR that will be used for pods.</p>
+<p>PodCIDR defines the CIDR that will be used for pods. This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -3373,7 +3400,7 @@ string
 </em>
 </td>
 <td>
-<p>ServiceCIDR defines the CIDR that will be used for services.</p>
+<p>ServiceCIDR defines the CIDR that will be used for services. This field is immutable.</p>
 </td>
 </tr>
 </tbody>
@@ -3518,7 +3545,8 @@ OperatingSystemConfigPurpose
 <td>
 <p>Purpose describes how the result of this OperatingSystemConfig is used by Gardener. Either it
 gets sent to the <code>Worker</code> extension controller to bootstrap a VM, or it is downloaded by the
-cloud-config-downloader script already running on a bootstrapped VM.</p>
+cloud-config-downloader script already running on a bootstrapped VM.
+This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -4124,7 +4152,7 @@ string
 </em>
 </td>
 <td>
-<p>Region is the name of the region where the worker pool should be deployed to.</p>
+<p>Region is the name of the region where the worker pool should be deployed to. This field is immutable.</p>
 </td>
 </tr>
 <tr>

--- a/docs/api-reference/operations.md
+++ b/docs/api-reference/operations.md
@@ -81,7 +81,7 @@ Kubernetes core/v1.LocalObjectReference
 </em>
 </td>
 <td>
-<p>ShootRef defines the target shoot for a Bastion.</p>
+<p>ShootRef defines the target shoot for a Bastion. The name field of the ShootRef is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -117,7 +117,7 @@ string
 </em>
 </td>
 <td>
-<p>SSHPublicKey is the user&rsquo;s public key.</p>
+<p>SSHPublicKey is the user&rsquo;s public key. This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -211,7 +211,7 @@ Kubernetes core/v1.LocalObjectReference
 </em>
 </td>
 <td>
-<p>ShootRef defines the target shoot for a Bastion.</p>
+<p>ShootRef defines the target shoot for a Bastion. The name field of the ShootRef is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -247,7 +247,7 @@ string
 </em>
 </td>
 <td>
-<p>SSHPublicKey is the user&rsquo;s public key.</p>
+<p>SSHPublicKey is the user&rsquo;s public key. This field is immutable.</p>
 </td>
 </tr>
 <tr>

--- a/docs/api-reference/seedmanagement.md
+++ b/docs/api-reference/seedmanagement.md
@@ -86,7 +86,8 @@ Shoot
 </td>
 <td>
 <em>(Optional)</em>
-<p>Shoot references a Shoot that should be registered as Seed.</p>
+<p>Shoot references a Shoot that should be registered as Seed.
+This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -223,7 +224,7 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <p>Selector is a label query over ManagedSeeds and Shoots that should match the replica count.
-It must match the ManagedSeeds and Shoots template&rsquo;s labels.</p>
+It must match the ManagedSeeds and Shoots template&rsquo;s labels. This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -279,8 +280,8 @@ int32
 </td>
 <td>
 <em>(Optional)</em>
-<p>RevisionHistoryLimit is the maximum number of revisions that will
-be maintained in the ManagedSeedSet&rsquo;s revision history. Defaults to 10.</p>
+<p>RevisionHistoryLimit is the maximum number of revisions that will be maintained
+in the ManagedSeedSet&rsquo;s revision history. Defaults to 10. This field is immutable.</p>
 </td>
 </tr>
 </table>
@@ -370,7 +371,8 @@ Bootstrap
 <em>(Optional)</em>
 <p>Bootstrap is the mechanism that should be used for bootstrapping gardenlet connection to the Garden cluster. One of ServiceAccount, BootstrapToken, None.
 If set to ServiceAccount or BootstrapToken, a service account or a bootstrap token will be created in the garden cluster and used to compute the bootstrap kubeconfig.
-If set to None, the gardenClientConnection.kubeconfig field will be used to connect to the Garden cluster. Defaults to BootstrapToken.</p>
+If set to None, the gardenClientConnection.kubeconfig field will be used to connect to the Garden cluster. Defaults to BootstrapToken.
+This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -383,7 +385,7 @@ bool
 <td>
 <em>(Optional)</em>
 <p>MergeWithParent specifies whether the GardenletConfiguration of the parent gardenlet
-should be merged with the specified GardenletConfiguration. Defaults to true.</p>
+should be merged with the specified GardenletConfiguration. Defaults to true. This field is immutable.</p>
 </td>
 </tr>
 </tbody>
@@ -648,7 +650,7 @@ Kubernetes meta/v1.LabelSelector
 </td>
 <td>
 <p>Selector is a label query over ManagedSeeds and Shoots that should match the replica count.
-It must match the ManagedSeeds and Shoots template&rsquo;s labels.</p>
+It must match the ManagedSeeds and Shoots template&rsquo;s labels. This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -704,8 +706,8 @@ int32
 </td>
 <td>
 <em>(Optional)</em>
-<p>RevisionHistoryLimit is the maximum number of revisions that will
-be maintained in the ManagedSeedSet&rsquo;s revision history. Defaults to 10.</p>
+<p>RevisionHistoryLimit is the maximum number of revisions that will be maintained
+in the ManagedSeedSet&rsquo;s revision history. Defaults to 10. This field is immutable.</p>
 </td>
 </tr>
 </tbody>
@@ -894,7 +896,8 @@ Shoot
 </td>
 <td>
 <em>(Optional)</em>
-<p>Shoot references a Shoot that should be registered as Seed.</p>
+<p>Shoot references a Shoot that should be registered as Seed.
+This field is immutable.</p>
 </td>
 </tr>
 <tr>
@@ -1034,7 +1037,8 @@ Shoot
 </td>
 <td>
 <em>(Optional)</em>
-<p>Shoot references a Shoot that should be registered as Seed.</p>
+<p>Shoot references a Shoot that should be registered as Seed.
+This field is immutable.</p>
 </td>
 </tr>
 <tr>

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_backupbuckets.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_backupbuckets.yaml
@@ -54,14 +54,15 @@ spec:
           metadata:
             type: object
           spec:
-            description: BackupBucketSpec is the spec for an BackupBucket resource.
+            description: Specification of the BackupBucket. If the object's deletion
+              timestamp is set, this field is immutable.
             properties:
               providerConfig:
                 description: ProviderConfig is the provider specific configuration.
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               region:
-                description: Region is the region of this bucket.
+                description: Region is the region of this bucket. This field is immutable.
                 type: string
               secretRef:
                 description: SecretRef is a reference to a secret that contains the

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_backupentries.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_backupentries.yaml
@@ -58,7 +58,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: BackupEntrySpec is the spec for an BackupEntry resource.
+            description: Specification of the BackupEntry. If the object's deletion
+              timestamp is set, this field is immutable.
             properties:
               backupBucketProviderStatus:
                 description: BackupBucketProviderStatus contains the provider status
@@ -75,7 +76,7 @@ spec:
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               region:
-                description: Region is the region of this Entry.
+                description: Region is the region of this Entry. This field is immutable.
                 type: string
               secretRef:
                 description: SecretRef is a reference to a secret that contains the

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_bastions.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_bastions.yaml
@@ -48,7 +48,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: Spec is the specification of this Bastion.
+            description: Spec is the specification of this Bastion. If the object's
+              deletion timestamp is set, this field is immutable.
             properties:
               ingress:
                 description: Ingress controls from where the created bastion host
@@ -90,7 +91,7 @@ spec:
               userData:
                 description: UserData is the base64-encoded user data for the bastion
                   instance. This should contain code to provision the SSH key on the
-                  bastion instance.
+                  bastion instance. This field is immutable.
                 format: byte
                 type: string
             required:

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_containerruntimes.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_containerruntimes.yaml
@@ -50,7 +50,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: ContainerRuntimeSpec is the spec for a ContainerRuntime resource.
+            description: Specification of the ContainerRuntime. If the object's deletion
+              timestamp is set, this field is immutable.
             properties:
               binaryPath:
                 description: BinaryPath is the Worker's machine path where container
@@ -69,7 +70,7 @@ spec:
                 properties:
                   name:
                     description: Name specifies the name of the worker pool the container
-                      runtime should be available for.
+                      runtime should be available for. This field is immutable.
                     type: string
                   selector:
                     description: Selector is the label selector used by the extension

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_controlplanes.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_controlplanes.yaml
@@ -53,7 +53,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: ControlPlaneSpec is the spec of a ControlPlane resource.
+            description: Specification of the ControlPlane. If the object's deletion
+              timestamp is set, this field is immutable.
             properties:
               infrastructureProviderStatus:
                 description: InfrastructureProviderStatus contains the provider status
@@ -67,10 +68,11 @@ spec:
                 x-kubernetes-preserve-unknown-fields: true
               purpose:
                 description: Purpose contains the data if a cloud provider needs additional
-                  components in order to expose the control plane.
+                  components in order to expose the control plane. This field is immutable.
                 type: string
               region:
-                description: Region is the region of this control plane.
+                description: Region is the region of this control plane. This field
+                  is immutable.
                 type: string
               secretRef:
                 description: SecretRef is a reference to a secret that contains the

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_dnsrecords.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_dnsrecords.yaml
@@ -55,11 +55,12 @@ spec:
           metadata:
             type: object
           spec:
-            description: DNSRecordSpec is the spec of a DNSRecord resource.
+            description: Specification of the DNSRecord. If the object's deletion
+              timestamp is set, this field is immutable.
             properties:
               name:
                 description: Name is the fully qualified domain name, e.g. "api.<shoot
-                  domain>".
+                  domain>". This field is immutable.
                 type: string
               providerConfig:
                 description: ProviderConfig is the provider specific configuration.
@@ -67,7 +68,7 @@ spec:
                 x-kubernetes-preserve-unknown-fields: true
               recordType:
                 description: RecordType is the DNS record type. Only A, CNAME, and
-                  TXT records are currently supported.
+                  TXT records are currently supported. This field is immutable.
                 type: string
               region:
                 description: Region is the region of this DNS record. If not specified,

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_extensions.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_extensions.yaml
@@ -49,7 +49,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: ExtensionSpec is the spec for a Extension resource.
+            description: Specification of the Extension. If the object's deletion
+              timestamp is set, this field is immutable.
             properties:
               providerConfig:
                 description: ProviderConfig is the provider specific configuration.

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_infrastructures.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_infrastructures.yaml
@@ -53,14 +53,16 @@ spec:
           metadata:
             type: object
           spec:
-            description: InfrastructureSpec is the spec for an Infrastructure resource.
+            description: Specification of the Infrastructure. If the object's deletion
+              timestamp is set, this field is immutable.
             properties:
               providerConfig:
                 description: ProviderConfig is the provider specific configuration.
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               region:
-                description: Region is the region of this infrastructure.
+                description: Region is the region of this infrastructure. This field
+                  is immutable.
                 type: string
               secretRef:
                 description: SecretRef is a reference to a secret that contains the

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_networks.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_networks.yaml
@@ -55,10 +55,12 @@ spec:
           metadata:
             type: object
           spec:
-            description: NetworkSpec is the spec for an Network resource.
+            description: Specification of the Network. If the object's deletion timestamp
+              is set, this field is immutable.
             properties:
               podCIDR:
                 description: PodCIDR defines the CIDR that will be used for pods.
+                  This field is immutable.
                 type: string
               providerConfig:
                 description: ProviderConfig is the provider specific configuration.
@@ -66,6 +68,7 @@ spec:
                 x-kubernetes-preserve-unknown-fields: true
               serviceCIDR:
                 description: ServiceCIDR defines the CIDR that will be used for services.
+                  This field is immutable.
                 type: string
               type:
                 description: Type contains the instance of the resource's kind.

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
@@ -54,8 +54,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: OperatingSystemConfigSpec is the spec for a OperatingSystemConfig
-              resource.
+            description: Specification of the OperatingSystemConfig. If the object's
+              deletion timestamp is set, this field is immutable.
             properties:
               criConfig:
                 description: CRI config is a structure contains configurations of
@@ -138,7 +138,7 @@ spec:
                 description: Purpose describes how the result of this OperatingSystemConfig
                   is used by Gardener. Either it gets sent to the `Worker` extension
                   controller to bootstrap a VM, or it is downloaded by the cloud-config-downloader
-                  script already running on a bootstrapped VM.
+                  script already running on a bootstrapped VM. This field is immutable.
                 type: string
               reloadConfigFilePath:
                 description: ReloadConfigFilePath is the path to the generated operating

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_workers.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_workers.yaml
@@ -51,7 +51,8 @@ spec:
           metadata:
             type: object
           spec:
-            description: WorkerSpec is the spec for a Worker resource.
+            description: Specification of the Worker. If the object's deletion timestamp
+              is set, this field is immutable.
             properties:
               infrastructureProviderStatus:
                 description: InfrastructureProviderStatus is a raw extension field
@@ -284,7 +285,7 @@ spec:
                 x-kubernetes-preserve-unknown-fields: true
               region:
                 description: Region is the name of the region where the worker pool
-                  should be deployed to.
+                  should be deployed to. This field is immutable.
                 type: string
               secretRef:
                 description: SecretRef is a reference to a secret that contains the

--- a/landscaper/pkg/gardenlet/generate/openapi/openapi_generated.go
+++ b/landscaper/pkg/gardenlet/generate/openapi/openapi_generated.go
@@ -1235,14 +1235,14 @@ func schema_pkg_apis_seedmanagement_v1alpha1_Gardenlet(ref common.ReferenceCallb
 					},
 					"bootstrap": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Bootstrap is the mechanism that should be used for bootstrapping gardenlet connection to the Garden cluster. One of ServiceAccount, BootstrapToken, None. If set to ServiceAccount or BootstrapToken, a service account or a bootstrap token will be created in the garden cluster and used to compute the bootstrap kubeconfig. If set to None, the gardenClientConnection.kubeconfig field will be used to connect to the Garden cluster. Defaults to BootstrapToken.",
+							Description: "Bootstrap is the mechanism that should be used for bootstrapping gardenlet connection to the Garden cluster. One of ServiceAccount, BootstrapToken, None. If set to ServiceAccount or BootstrapToken, a service account or a bootstrap token will be created in the garden cluster and used to compute the bootstrap kubeconfig. If set to None, the gardenClientConnection.kubeconfig field will be used to connect to the Garden cluster. Defaults to BootstrapToken. This field is immutable.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"mergeWithParent": {
 						SchemaProps: spec.SchemaProps{
-							Description: "MergeWithParent specifies whether the GardenletConfiguration of the parent gardenlet should be merged with the specified GardenletConfiguration. Defaults to true.",
+							Description: "MergeWithParent specifies whether the GardenletConfiguration of the parent gardenlet should be merged with the specified GardenletConfiguration. Defaults to true. This field is immutable.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
@@ -1636,7 +1636,7 @@ func schema_pkg_apis_seedmanagement_v1alpha1_ManagedSeedSetSpec(ref common.Refer
 					},
 					"selector": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Selector is a label query over ManagedSeeds and Shoots that should match the replica count. It must match the ManagedSeeds and Shoots template's labels.",
+							Description: "Selector is a label query over ManagedSeeds and Shoots that should match the replica count. It must match the ManagedSeeds and Shoots template's labels. This field is immutable.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector"),
 						},
@@ -1663,7 +1663,7 @@ func schema_pkg_apis_seedmanagement_v1alpha1_ManagedSeedSetSpec(ref common.Refer
 					},
 					"revisionHistoryLimit": {
 						SchemaProps: spec.SchemaProps{
-							Description: "RevisionHistoryLimit is the maximum number of revisions that will be maintained in the ManagedSeedSet's revision history. Defaults to 10.",
+							Description: "RevisionHistoryLimit is the maximum number of revisions that will be maintained in the ManagedSeedSet's revision history. Defaults to 10. This field is immutable.",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -1792,7 +1792,7 @@ func schema_pkg_apis_seedmanagement_v1alpha1_ManagedSeedSpec(ref common.Referenc
 				Properties: map[string]spec.Schema{
 					"shoot": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Shoot references a Shoot that should be registered as Seed.",
+							Description: "Shoot references a Shoot that should be registered as Seed. This field is immutable.",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1.Shoot"),
 						},
 					},

--- a/pkg/apis/core/types_backupbucket.go
+++ b/pkg/apis/core/types_backupbucket.go
@@ -48,13 +48,14 @@ type BackupBucketList struct {
 
 // BackupBucketSpec is the specification of a Backup Bucket.
 type BackupBucketSpec struct {
-	// Provider holds the details of cloud provider of the object store.
+	// Provider holds the details of cloud provider of the object store. This field is immutable.
 	Provider BackupBucketProvider
 	// ProviderConfig is the configuration passed to BackupBucket resource.
 	ProviderConfig *runtime.RawExtension
 	// SecretRef is a reference to a secret that contains the credentials to access object store.
 	SecretRef corev1.SecretReference
 	// SeedName holds the name of the seed allocated to BackupBucket for running controller.
+	// This field is immutable.
 	SeedName *string
 }
 

--- a/pkg/apis/core/types_controllerinstallation.go
+++ b/pkg/apis/core/types_controllerinstallation.go
@@ -30,6 +30,7 @@ type ControllerInstallation struct {
 	// Standard object metadata.
 	metav1.ObjectMeta
 	// Spec contains the specification of this installation.
+	// If the object's deletion timestamp is set, this field is immutable.
 	Spec ControllerInstallationSpec
 	// Status contains the status of this installation.
 	Status ControllerInstallationStatus
@@ -49,8 +50,9 @@ type ControllerInstallationList struct {
 // ControllerInstallationSpec is the specification of a ControllerInstallation.
 type ControllerInstallationSpec struct {
 	// RegistrationRef is used to reference a ControllerRegistration resource.
+	// The name field of the RegistrationRef is immutable.
 	RegistrationRef corev1.ObjectReference
-	// SeedRef is used to reference a Seed resource.
+	// SeedRef is used to reference a Seed resource. The name field of the SeedRef is immutable.
 	SeedRef corev1.ObjectReference
 	// DeploymentRef is used to reference a ControllerDeployment resource.
 	DeploymentRef *corev1.ObjectReference

--- a/pkg/apis/core/types_controllerregistration.go
+++ b/pkg/apis/core/types_controllerregistration.go
@@ -28,6 +28,7 @@ type ControllerRegistration struct {
 	// Standard object metadata.
 	metav1.ObjectMeta
 	// Spec contains the specification of this registration.
+	// If the object's deletion timestamp is set, this field is immutable.
 	Spec ControllerRegistrationSpec
 }
 
@@ -64,7 +65,7 @@ type ControllerResource struct {
 	ReconcileTimeout *metav1.Duration
 	// Primary determines if the controller backed by this ControllerRegistration is responsible for the extension
 	// resource's lifecycle. This field defaults to true. There must be exactly one primary controller for this kind/type
-	// combination.
+	// combination. This field is immutable.
 	Primary *bool
 }
 

--- a/pkg/apis/core/types_exposureclass.go
+++ b/pkg/apis/core/types_exposureclass.go
@@ -28,8 +28,10 @@ type ExposureClass struct {
 	// Standard object metadata.
 	metav1.ObjectMeta
 	// Handler is the name of the handler which applies the control plane endpoint exposure strategy.
+	// This field is immutable.
 	Handler string
 	// Scheduling holds information how to select applicable Seed's for ExposureClass usage.
+	// This field is immutable.
 	Scheduling *ExposureClassScheduling
 }
 

--- a/pkg/apis/core/types_plant.go
+++ b/pkg/apis/core/types_plant.go
@@ -28,6 +28,7 @@ type Plant struct {
 	// Standard object metadata.
 	metav1.ObjectMeta
 	// Spec contains the specification of this Plant.
+	// If the object's deletion timestamp is set, this field is immutable.
 	Spec PlantSpec
 	// Status contains the status of this Plant.
 	Status PlantStatus

--- a/pkg/apis/core/types_project.go
+++ b/pkg/apis/core/types_project.go
@@ -48,7 +48,7 @@ type ProjectList struct {
 // ProjectSpec is the specification of a Project.
 type ProjectSpec struct {
 	// CreatedBy is a subject representing a user name, an email address, or any other identifier of a user
-	// who created the project.
+	// who created the project. This field is immutable.
 	CreatedBy *rbacv1.Subject
 	// Description is a human-readable description of what the project is used for.
 	Description *string
@@ -62,6 +62,7 @@ type ProjectSpec struct {
 	Members []ProjectMember
 	// Namespace is the name of the namespace that has been created for the Project object.
 	// A nil value means that Gardener will determine the name of the namespace.
+	// This field is immutable.
 	Namespace *string
 	// Tolerations contains the default tolerations and a list for allowed taints on seed clusters.
 	Tolerations *ProjectTolerations

--- a/pkg/apis/core/types_quota.go
+++ b/pkg/apis/core/types_quota.go
@@ -48,7 +48,7 @@ type QuotaSpec struct {
 	ClusterLifetimeDays *int32
 	// Metrics is a list of resources which will be put under constraints.
 	Metrics corev1.ResourceList
-	// Scope is the scope of the Quota object, either 'project' or 'secret'.
+	// Scope is the scope of the Quota object, either 'project' or 'secret'. This field is immutable.
 	Scope corev1.ObjectReference
 }
 

--- a/pkg/apis/core/types_secretbinding.go
+++ b/pkg/apis/core/types_secretbinding.go
@@ -28,10 +28,13 @@ type SecretBinding struct {
 	// Standard object metadata.
 	metav1.ObjectMeta
 	// SecretRef is a reference to a secret object in the same or another namespace.
+	// This field is immutable.
 	SecretRef corev1.SecretReference
 	// Quotas is a list of references to Quota objects in the same or another namespace.
+	// This field is immutable.
 	Quotas []corev1.ObjectReference
 	// Provider defines the provider type of the SecretBinding.
+	// This field is immutable when the SecretBindingProviderValidation feature gate is enabled.
 	Provider *SecretBindingProvider
 }
 

--- a/pkg/apis/core/types_seed.go
+++ b/pkg/apis/core/types_seed.go
@@ -77,7 +77,7 @@ type SeedSpec struct {
 	Taints []SeedTaint
 	// Volume contains settings for persistentvolumes created in the seed cluster.
 	Volume *SeedVolume
-	// Ingress configures Ingress specific settings of the Seed cluster.
+	// Ingress configures Ingress specific settings of the Seed cluster. This field is immutable.
 	Ingress *Ingress
 }
 
@@ -97,7 +97,7 @@ type SeedStatus struct {
 	// ObservedGeneration is the most recent generation observed for this Seed. It corresponds to the
 	// Seed's generation, which is updated on mutation by the API Server.
 	ObservedGeneration int64
-	// ClusterIdentity is the identity of Seed cluster
+	// ClusterIdentity is the identity of the Seed cluster. This field is immutable.
 	ClusterIdentity *string
 	// Capacity represents the total resources of a seed.
 	Capacity corev1.ResourceList
@@ -110,11 +110,11 @@ type SeedStatus struct {
 
 // SeedBackup contains the object store configuration for backups for shoot (currently only etcd).
 type SeedBackup struct {
-	// Provider is a provider name.
+	// Provider is a provider name. This field is immutable.
 	Provider string
 	// ProviderConfig is the configuration passed to BackupBucket resource.
 	ProviderConfig *runtime.RawExtension
-	// Region is a region name.
+	// Region is a region name. This field is immutable.
 	Region *string
 	// SecretRef is a reference to a Secret object containing the cloud provider credentials for
 	// the object store where backups should be stored. It should have enough privileges to manipulate
@@ -125,7 +125,7 @@ type SeedBackup struct {
 // SeedDNS contains the external domain and configuration for the DNS provider
 type SeedDNS struct {
 	// IngressDomain is the domain of the Seed cluster pointing to the ingress controller endpoint. It will be used
-	// to construct ingress URLs for system applications running in Shoot clusters. Once set this field is immutable.
+	// to construct ingress URLs for system applications running in Shoot clusters. This field is immutable.
 	// This will be removed in the next API version and replaced by spec.ingress.domain.
 	IngressDomain *string
 	// Provider configures a DNSProvider
@@ -163,11 +163,11 @@ type IngressController struct {
 
 // SeedNetworks contains CIDRs for the pod, service and node networks of a Kubernetes cluster.
 type SeedNetworks struct {
-	// Nodes is the CIDR of the node network.
+	// Nodes is the CIDR of the node network. This field is immutable.
 	Nodes *string
-	// Pods is the CIDR of the pod network.
+	// Pods is the CIDR of the pod network. This field is immutable.
 	Pods string
-	// Services is the CIDR of the service network.
+	// Services is the CIDR of the service network. This field is immutable.
 	Services string
 	// ShootDefaults contains the default networks CIDRs for shoots.
 	ShootDefaults *ShootNetworks

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -35,6 +35,7 @@ type Shoot struct {
 	// Standard object metadata.
 	metav1.ObjectMeta
 	// Specification of the Shoot cluster.
+	// If the object's deletion timestamp is set, this field is immutable.
 	Spec ShootSpec
 	// Most recently observed status of the Shoot cluster.
 	Status ShootStatus
@@ -63,7 +64,7 @@ type ShootTemplate struct {
 type ShootSpec struct {
 	// Addons contains information about enabled/disabled addons and their configuration.
 	Addons *Addons
-	// CloudProfileName is a name of a CloudProfile object.
+	// CloudProfileName is a name of a CloudProfile object. This field is immutable.
 	CloudProfileName string
 	// DNS contains information about the DNS settings of the Shoot.
 	DNS *DNS
@@ -84,12 +85,14 @@ type ShootSpec struct {
 	Provider Provider
 	// Purpose is the purpose class for this cluster.
 	Purpose *ShootPurpose
-	// Region is a name of a region.
+	// Region is a name of a region. This field is immutable.
 	Region string
 	// SecretBindingName is the name of the a SecretBinding that has a reference to the provider secret.
 	// The credentials inside the provider secret will be used to create the shoot in the respective account.
+	// This field is immutable.
 	SecretBindingName string
 	// SeedName is the name of the seed cluster that runs the control plane of the Shoot.
+	// This field is immutable when the SeedChange feature gate is disabled.
 	SeedName *string
 	// SeedSelector is an optional selector which must match a seed's labels for the shoot to be scheduled on that seed.
 	SeedSelector *SeedSelector
@@ -98,6 +101,7 @@ type ShootSpec struct {
 	// Tolerations contains the tolerations for taints on seed clusters.
 	Tolerations []Toleration
 	// ExposureClassName is the optional name of an exposure class to apply a control plane endpoint exposure strategy.
+	// This field is immutable.
 	ExposureClassName *string
 }
 
@@ -130,12 +134,12 @@ type ShootStatus struct {
 	// after a successful create/reconcile operation. It will be used when control planes are moved between Seeds.
 	SeedName *string
 	// TechnicalID is the name that is used for creating the Seed namespace, the infrastructure resources, and
-	// basically everything that is related to this particular Shoot.
+	// basically everything that is related to this particular Shoot. This field is immutable.
 	TechnicalID string
 	// UID is a unique identifier for the Shoot cluster to avoid portability between Kubernetes clusters.
-	// It is used to compute unique hashes.
+	// It is used to compute unique hashes. This field is immutable.
 	UID types.UID
-	// ClusterIdentity is the identity of the Shoot cluster
+	// ClusterIdentity is the identity of the Shoot cluster. This field is immutable.
 	ClusterIdentity *string
 	// List of addresses on which the Kube API server can be reached.
 	AdvertisedAddresses []ShootAdvertisedAddress
@@ -203,7 +207,7 @@ type NginxIngress struct {
 // DNS holds information about the provider, the hosted zone id and the domain.
 type DNS struct {
 	// Domain is the external available domain of the Shoot cluster. This domain will be written into the
-	// kubeconfig that is handed out to end-users. Once set it is immutable.
+	// kubeconfig that is handed out to end-users. This field is immutable.
 	Domain *string
 	// Providers is a list of DNS providers that shall be enabled for this shoot cluster. Only relevant if
 	// not a default domain is used.
@@ -546,7 +550,7 @@ type KubeControllerManagerConfig struct {
 	KubernetesConfig
 	// HorizontalPodAutoscalerConfig contains horizontal pod autoscaler configuration settings for the kube-controller-manager.
 	HorizontalPodAutoscalerConfig *HorizontalPodAutoscalerConfig
-	// NodeCIDRMaskSize defines the mask size for node cidr in cluster (default is 24)
+	// NodeCIDRMaskSize defines the mask size for node cidr in cluster (default is 24). This field is immutable.
 	NodeCIDRMaskSize *int32
 	// PodEvictionTimeout defines the grace period for deleting pods on failed nodes.
 	PodEvictionTimeout *metav1.Duration
@@ -731,15 +735,15 @@ type KubeletConfigReserved struct {
 
 // Networking defines networking parameters for the shoot cluster.
 type Networking struct {
-	// Type identifies the type of the networking plugin.
+	// Type identifies the type of the networking plugin. This field is immutable.
 	Type string
 	// ProviderConfig is the configuration passed to network resource.
 	ProviderConfig *runtime.RawExtension
-	// Pods is the CIDR of the pod network.
+	// Pods is the CIDR of the pod network. This field is immutable.
 	Pods *string
-	// Nodes is the CIDR of the entire node network.
+	// Nodes is the CIDR of the entire node network. This field is immutable.
 	Nodes *string
-	// Services is the CIDR of the service network.
+	// Services is the CIDR of the service network. This field is immutable.
 	Services *string
 }
 
@@ -815,7 +819,7 @@ type Alerting struct {
 // Provider contains provider-specific information that are handed-over to the provider-specific
 // extension controller.
 type Provider struct {
-	// Type is the type of the provider.
+	// Type is the type of the provider. This field is immutable.
 	Type string
 	// ControlPlaneConfig contains the provider-specific control plane config blob. Please look up the concrete
 	// definition in the documentation of your provider extension.

--- a/pkg/apis/core/types_shootextensionstatus.go
+++ b/pkg/apis/core/types_shootextensionstatus.go
@@ -48,7 +48,7 @@ type ShootExtensionStatusList struct {
 type ExtensionStatus struct {
 	// Kind of the extension resource
 	Kind string
-	// Type of the extension resource
+	// Type of the extension resource. This field is immutable.
 	Type string
 	// Purpose of the extension resource
 	Purpose *string

--- a/pkg/apis/core/v1alpha1/generated.proto
+++ b/pkg/apis/core/v1alpha1/generated.proto
@@ -129,7 +129,7 @@ message BackupBucketProvider {
 
 // BackupBucketSpec is the specification of a Backup Bucket.
 message BackupBucketSpec {
-  // Provider hold the details of cloud provider of the object store.
+  // Provider holds the details of cloud provider of the object store. This field is immutable.
   optional BackupBucketProvider provider = 1;
 
   // ProviderConfig is the configuration passed to BackupBucket resource.
@@ -140,6 +140,7 @@ message BackupBucketSpec {
   optional k8s.io.api.core.v1.SecretReference secretRef = 3;
 
   // Seed holds the name of the seed allocated to BackupBucket for running controller.
+  // This field is immutable.
   // +optional
   optional string seed = 4;
 }
@@ -431,6 +432,7 @@ message ControllerInstallation {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec contains the specification of this installation.
+  // If the object's deletion timestamp is set, this field is immutable.
   optional ControllerInstallationSpec spec = 2;
 
   // Status contains the status of this installation.
@@ -450,9 +452,10 @@ message ControllerInstallationList {
 // ControllerInstallationSpec is the specification of a ControllerInstallation.
 message ControllerInstallationSpec {
   // RegistrationRef is used to reference a ControllerRegistration resource.
+  // The name field of the RegistrationRef is immutable.
   optional k8s.io.api.core.v1.ObjectReference registrationRef = 1;
 
-  // SeedRef is used to reference a Seed resource.
+  // SeedRef is used to reference a Seed resource. The name field of the SeedRef is immutable.
   optional k8s.io.api.core.v1.ObjectReference seedRef = 2;
 
   // DeploymentRef is used to reference a ControllerDeployment resource.
@@ -479,6 +482,7 @@ message ControllerRegistration {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec contains the specification of this registration.
+  // If the object's deletion timestamp is set, this field is immutable.
   optional ControllerRegistrationSpec spec = 2;
 }
 
@@ -540,7 +544,7 @@ message ControllerResource {
 
   // Primary determines if the controller backed by this ControllerRegistration is responsible for the extension
   // resource's lifecycle. This field defaults to true. There must be exactly one primary controller for this kind/type
-  // combination.
+  // combination. This field is immutable.
   // +optional
   optional bool primary = 5;
 }
@@ -548,7 +552,7 @@ message ControllerResource {
 // DNS holds information about the provider, the hosted zone id and the domain.
 message DNS {
   // Domain is the external available domain of the Shoot cluster. This domain will be written into the
-  // kubeconfig that is handed out to end-users. Once set it is immutable.
+  // kubeconfig that is handed out to end-users. This field is immutable.
   // +optional
   optional string domain = 1;
 
@@ -653,9 +657,11 @@ message ExposureClass {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Handler is the name of the handler which applies the control plane endpoint exposure strategy.
+  // This field is immutable.
   optional string handler = 2;
 
   // Scheduling holds information how to select applicable Seed's for ExposureClass usage.
+  // This field is immutable.
   // +optional
   optional ExposureClassScheduling scheduling = 3;
 }
@@ -726,7 +732,7 @@ message ExtensionStatus {
   // Kind of the extension resource
   optional string kind = 1;
 
-  // Type of the extension resource
+  // Type of the extension resource. This field is immutable.
   optional string type = 2;
 
   // Purpose of the extension resource
@@ -919,7 +925,7 @@ message KubeControllerManagerConfig {
   // +optional
   optional HorizontalPodAutoscalerConfig horizontalPodAutoscaler = 2;
 
-  // NodeCIDRMaskSize defines the mask size for node cidr in cluster (default is 24)
+  // NodeCIDRMaskSize defines the mask size for node cidr in cluster (default is 24). This field is immutable.
   // +optional
   optional int32 nodeCIDRMaskSize = 3;
 
@@ -1407,22 +1413,22 @@ message NamedResourceReference {
 
 // Networking defines networking parameters for the shoot cluster.
 message Networking {
-  // Type identifies the type of the networking plugin.
+  // Type identifies the type of the networking plugin. This field is immutable.
   optional string type = 1;
 
   // ProviderConfig is the configuration passed to network resource.
   // +optional
   optional k8s.io.apimachinery.pkg.runtime.RawExtension providerConfig = 2;
 
-  // Pods is the CIDR of the pod network.
+  // Pods is the CIDR of the pod network. This field is immutable.
   // +optional
   optional string pods = 3;
 
-  // Nodes is the CIDR of the entire node network.
+  // Nodes is the CIDR of the entire node network. This field is immutable.
   // +optional
   optional string nodes = 4;
 
-  // Services is the CIDR of the service network.
+  // Services is the CIDR of the service network. This field is immutable.
   // +optional
   optional string services = 5;
 }
@@ -1509,6 +1515,7 @@ message Plant {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec contains the specification of this Plant.
+  // If the object's deletion timestamp is set, this field is immutable.
   optional PlantSpec spec = 2;
 
   // Status contains the status of this Plant.
@@ -1600,7 +1607,7 @@ message ProjectMember {
 // ProjectSpec is the specification of a Project.
 message ProjectSpec {
   // CreatedBy is a subject representing a user name, an email address, or any other identifier of a user
-  // who created the project.
+  // who created the project. This field is immutable.
   // +optional
   optional k8s.io.api.rbac.v1.Subject createdBy = 1;
 
@@ -1628,6 +1635,7 @@ message ProjectSpec {
 
   // Namespace is the name of the namespace that has been created for the Project object.
   // A nil value means that Gardener will determine the name of the namespace.
+  // This field is immutable.
   // +optional
   optional string namespace = 6;
 
@@ -1678,7 +1686,7 @@ message ProjectTolerations {
 // Provider contains provider-specific information that are handed-over to the provider-specific
 // extension controller.
 message Provider {
-  // Type is the type of the provider.
+  // Type is the type of the provider. This field is immutable.
   optional string type = 1;
 
   // ControlPlaneConfig contains the provider-specific control plane config blob. Please look up the concrete
@@ -1727,7 +1735,7 @@ message QuotaSpec {
   // Metrics is a list of resources which will be put under constraints.
   map<string, k8s.io.apimachinery.pkg.api.resource.Quantity> metrics = 2;
 
-  // Scope is the scope of the Quota object, either 'project' or 'secret'.
+  // Scope is the scope of the Quota object, either 'project' or 'secret'. This field is immutable.
   optional k8s.io.api.core.v1.ObjectReference scope = 3;
 }
 
@@ -1779,13 +1787,16 @@ message SecretBinding {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // SecretRef is a reference to a secret object in the same or another namespace.
+  // This field is immutable.
   optional k8s.io.api.core.v1.SecretReference secretRef = 2;
 
   // Quotas is a list of references to Quota objects in the same or another namespace.
+  // This field is immutable.
   // +optional
   repeated k8s.io.api.core.v1.ObjectReference quotas = 3;
 
   // Provider defines the provider type of the SecretBinding.
+  // This field is immutable when the SecretBindingProviderValidation feature gate is enabled.
   // +optional
   optional SecretBindingProvider provider = 4;
 }
@@ -1823,14 +1834,14 @@ message Seed {
 
 // SeedBackup contains the object store configuration for backups for shoot (currently only etcd).
 message SeedBackup {
-  // Provider is a provider name.
+  // Provider is a provider name. This field is immutable.
   optional string provider = 1;
 
   // ProviderConfig is the configuration passed to BackupBucket resource.
   // +optional
   optional k8s.io.apimachinery.pkg.runtime.RawExtension providerConfig = 2;
 
-  // Region is a region name.
+  // Region is a region name. This field is immutable.
   // +optional
   optional string region = 3;
 
@@ -1843,7 +1854,7 @@ message SeedBackup {
 // SeedDNS contains DNS-relevant information about this seed cluster.
 message SeedDNS {
   // IngressDomain is the domain of the Seed cluster pointing to the ingress controller endpoint. It will be used
-  // to construct ingress URLs for system applications running in Shoot clusters. Once set this field is immutable.
+  // to construct ingress URLs for system applications running in Shoot clusters. This field is immutable.
   // This will be removed in the next API version and replaced by spec.ingress.domain.
   // +optional
   optional string ingressDomain = 1;
@@ -1882,14 +1893,14 @@ message SeedList {
 
 // SeedNetworks contains CIDRs for the pod, service and node networks of a Kubernetes cluster.
 message SeedNetworks {
-  // Nodes is the CIDR of the node network.
+  // Nodes is the CIDR of the node network. This field is immutable.
   // +optional
   optional string nodes = 1;
 
-  // Pods is the CIDR of the pod network.
+  // Pods is the CIDR of the pod network. This field is immutable.
   optional string pods = 2;
 
-  // Services is the CIDR of the service network.
+  // Services is the CIDR of the service network. This field is immutable.
   optional string services = 3;
 
   // ShootDefaults contains the default networks CIDRs for shoots.
@@ -2064,7 +2075,7 @@ message SeedSpec {
   // +optional
   optional SeedSettings settings = 9;
 
-  // Ingress configures Ingress specific settings of the Seed cluster.
+  // Ingress configures Ingress specific settings of the Seed cluster. This field is immutable.
   // +optional
   optional Ingress ingress = 10;
 }
@@ -2090,7 +2101,7 @@ message SeedStatus {
   // +optional
   optional int64 observedGeneration = 4;
 
-  // ClusterIdentity is the identity of the Seed cluster
+  // ClusterIdentity is the identity of the Seed cluster. This field is immutable.
   // +optional
   optional string clusterIdentity = 5;
 
@@ -2166,6 +2177,7 @@ message Shoot {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Specification of the Shoot cluster.
+  // If the object's deletion timestamp is set, this field is immutable.
   // +optional
   optional ShootSpec spec = 2;
 
@@ -2249,7 +2261,7 @@ message ShootSpec {
   // +optional
   optional Addons addons = 1;
 
-  // CloudProfileName is a name of a CloudProfile object.
+  // CloudProfileName is a name of a CloudProfile object. This field is immutable.
   optional string cloudProfileName = 2;
 
   // DNS contains information about the DNS settings of the Shoot.
@@ -2286,14 +2298,16 @@ message ShootSpec {
   // +optional
   optional string purpose = 11;
 
-  // Region is a name of a region.
+  // Region is a name of a region. This field is immutable.
   optional string region = 12;
 
   // SecretBindingName is the name of the a SecretBinding that has a reference to the provider secret.
   // The credentials inside the provider secret will be used to create the shoot in the respective account.
+  // This field is immutable.
   optional string secretBindingName = 13;
 
   // SeedName is the name of the seed cluster that runs the control plane of the Shoot.
+  // This field is immutable when the SeedChange feature gate is disabled.
   // +optional
   optional string seedName = 14;
 
@@ -2312,6 +2326,7 @@ message ShootSpec {
   repeated Toleration tolerations = 17;
 
   // ExposureClassName is the optional name of an exposure class to apply a control plane endpoint exposure strategy.
+  // This field is immutable.
   // +optional
   optional string exposureClassName = 18;
 }
@@ -2402,14 +2417,14 @@ message ShootStatus {
   optional string seed = 10;
 
   // TechnicalID is the name that is used for creating the Seed namespace, the infrastructure resources, and
-  // basically everything that is related to this particular Shoot.
+  // basically everything that is related to this particular Shoot. This field is immutable.
   optional string technicalID = 11;
 
   // UID is a unique identifier for the Shoot cluster to avoid portability between Kubernetes clusters.
-  // It is used to compute unique hashes.
+  // It is used to compute unique hashes. This field is immutable.
   optional string uid = 12;
 
-  // ClusterIdentity is the identity of the Shoot cluster
+  // ClusterIdentity is the identity of the Shoot cluster. This field is immutable.
   // +optional
   optional string clusterIdentity = 13;
 

--- a/pkg/apis/core/v1alpha1/types_backupbucket.go
+++ b/pkg/apis/core/v1alpha1/types_backupbucket.go
@@ -49,7 +49,7 @@ type BackupBucketList struct {
 
 // BackupBucketSpec is the specification of a Backup Bucket.
 type BackupBucketSpec struct {
-	// Provider hold the details of cloud provider of the object store.
+	// Provider holds the details of cloud provider of the object store. This field is immutable.
 	Provider BackupBucketProvider `json:"provider" protobuf:"bytes,1,opt,name=provider"`
 	// ProviderConfig is the configuration passed to BackupBucket resource.
 	// +optional
@@ -57,6 +57,7 @@ type BackupBucketSpec struct {
 	// SecretRef is a reference to a secret that contains the credentials to access object store.
 	SecretRef corev1.SecretReference `json:"secretRef" protobuf:"bytes,3,opt,name=secretRef"`
 	// Seed holds the name of the seed allocated to BackupBucket for running controller.
+	// This field is immutable.
 	// +optional
 	Seed *string `json:"seed,omitempty" protobuf:"bytes,4,opt,name=seed"`
 }

--- a/pkg/apis/core/v1alpha1/types_controllerinstallation.go
+++ b/pkg/apis/core/v1alpha1/types_controllerinstallation.go
@@ -30,6 +30,7 @@ type ControllerInstallation struct {
 	// Standard object metadata.
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// Spec contains the specification of this installation.
+	// If the object's deletion timestamp is set, this field is immutable.
 	Spec ControllerInstallationSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 	// Status contains the status of this installation.
 	Status ControllerInstallationStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
@@ -50,8 +51,9 @@ type ControllerInstallationList struct {
 // ControllerInstallationSpec is the specification of a ControllerInstallation.
 type ControllerInstallationSpec struct {
 	// RegistrationRef is used to reference a ControllerRegistration resource.
+	// The name field of the RegistrationRef is immutable.
 	RegistrationRef corev1.ObjectReference `json:"registrationRef" protobuf:"bytes,1,opt,name=registrationRef"`
-	// SeedRef is used to reference a Seed resource.
+	// SeedRef is used to reference a Seed resource. The name field of the SeedRef is immutable.
 	SeedRef corev1.ObjectReference `json:"seedRef" protobuf:"bytes,2,opt,name=seedRef"`
 	// DeploymentRef is used to reference a ControllerDeployment resource.
 	// +optional

--- a/pkg/apis/core/v1alpha1/types_controllerregistration.go
+++ b/pkg/apis/core/v1alpha1/types_controllerregistration.go
@@ -28,6 +28,7 @@ type ControllerRegistration struct {
 	// Standard object metadata.
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// Spec contains the specification of this registration.
+	// If the object's deletion timestamp is set, this field is immutable.
 	Spec ControllerRegistrationSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 }
 
@@ -69,7 +70,7 @@ type ControllerResource struct {
 	ReconcileTimeout *metav1.Duration `json:"reconcileTimeout,omitempty" protobuf:"bytes,4,opt,name=reconcileTimeout"`
 	// Primary determines if the controller backed by this ControllerRegistration is responsible for the extension
 	// resource's lifecycle. This field defaults to true. There must be exactly one primary controller for this kind/type
-	// combination.
+	// combination. This field is immutable.
 	// +optional
 	Primary *bool `json:"primary,omitempty" protobuf:"varint,5,opt,name=primary"`
 }

--- a/pkg/apis/core/v1alpha1/types_exposureclass.go
+++ b/pkg/apis/core/v1alpha1/types_exposureclass.go
@@ -29,8 +29,10 @@ type ExposureClass struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// Handler is the name of the handler which applies the control plane endpoint exposure strategy.
+	// This field is immutable.
 	Handler string `json:"handler" protobuf:"bytes,2,opt,name=handler"`
 	// Scheduling holds information how to select applicable Seed's for ExposureClass usage.
+	// This field is immutable.
 	// +optional
 	Scheduling *ExposureClassScheduling `json:"scheduling,omitempty" protobuf:"bytes,3,opt,name=scheduling"`
 }

--- a/pkg/apis/core/v1alpha1/types_plant.go
+++ b/pkg/apis/core/v1alpha1/types_plant.go
@@ -29,6 +29,7 @@ type Plant struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// Spec contains the specification of this Plant.
+	// If the object's deletion timestamp is set, this field is immutable.
 	Spec PlantSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 	// Status contains the status of this Plant.
 	Status PlantStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`

--- a/pkg/apis/core/v1alpha1/types_project.go
+++ b/pkg/apis/core/v1alpha1/types_project.go
@@ -52,7 +52,7 @@ type ProjectList struct {
 // ProjectSpec is the specification of a Project.
 type ProjectSpec struct {
 	// CreatedBy is a subject representing a user name, an email address, or any other identifier of a user
-	// who created the project.
+	// who created the project. This field is immutable.
 	// +optional
 	CreatedBy *rbacv1.Subject `json:"createdBy,omitempty" protobuf:"bytes,1,opt,name=createdBy"`
 	// Description is a human-readable description of what the project is used for.
@@ -75,6 +75,7 @@ type ProjectSpec struct {
 	Members []ProjectMember `json:"members,omitempty" protobuf:"bytes,5,rep,name=members"`
 	// Namespace is the name of the namespace that has been created for the Project object.
 	// A nil value means that Gardener will determine the name of the namespace.
+	// This field is immutable.
 	// +optional
 	Namespace *string `json:"namespace,omitempty" protobuf:"bytes,6,opt,name=namespace"`
 	// Tolerations contains the default tolerations and a whitelist for taints on seed clusters.

--- a/pkg/apis/core/v1alpha1/types_quota.go
+++ b/pkg/apis/core/v1alpha1/types_quota.go
@@ -52,6 +52,6 @@ type QuotaSpec struct {
 	ClusterLifetimeDays *int32 `json:"clusterLifetimeDays,omitempty" protobuf:"varint,1,opt,name=clusterLifetimeDays"`
 	// Metrics is a list of resources which will be put under constraints.
 	Metrics corev1.ResourceList `json:"metrics" protobuf:"bytes,2,rep,name=metrics,casttype=k8s.io/api/core/v1.ResourceList,castkey=k8s.io/api/core/v1.ResourceName"`
-	// Scope is the scope of the Quota object, either 'project' or 'secret'.
+	// Scope is the scope of the Quota object, either 'project' or 'secret'. This field is immutable.
 	Scope corev1.ObjectReference `json:"scope" protobuf:"bytes,3,opt,name=scope"`
 }

--- a/pkg/apis/core/v1alpha1/types_secretbinding.go
+++ b/pkg/apis/core/v1alpha1/types_secretbinding.go
@@ -29,11 +29,14 @@ type SecretBinding struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// SecretRef is a reference to a secret object in the same or another namespace.
+	// This field is immutable.
 	SecretRef corev1.SecretReference `json:"secretRef" protobuf:"bytes,2,opt,name=secretRef"`
 	// Quotas is a list of references to Quota objects in the same or another namespace.
+	// This field is immutable.
 	// +optional
 	Quotas []corev1.ObjectReference `json:"quotas,omitempty" protobuf:"bytes,3,rep,name=quotas"`
 	// Provider defines the provider type of the SecretBinding.
+	// This field is immutable when the SecretBindingProviderValidation feature gate is enabled.
 	// +optional
 	Provider *SecretBindingProvider `json:"provider,omitempty" protobuf:"bytes,4,opt,name=provider"`
 }

--- a/pkg/apis/core/v1alpha1/types_seed.go
+++ b/pkg/apis/core/v1alpha1/types_seed.go
@@ -79,7 +79,7 @@ type SeedSpec struct {
 	// Settings contains certain settings for this seed cluster.
 	// +optional
 	Settings *SeedSettings `json:"settings,omitempty" protobuf:"bytes,9,opt,name=settings"`
-	// Ingress configures Ingress specific settings of the Seed cluster.
+	// Ingress configures Ingress specific settings of the Seed cluster. This field is immutable.
 	// +optional
 	Ingress *Ingress `json:"ingress,omitempty" protobuf:"bytes,10,opt,name=ingress"`
 }
@@ -101,7 +101,7 @@ type SeedStatus struct {
 	// Seed's generation, which is updated on mutation by the API Server.
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty" protobuf:"varint,4,opt,name=observedGeneration"`
-	// ClusterIdentity is the identity of the Seed cluster
+	// ClusterIdentity is the identity of the Seed cluster. This field is immutable.
 	// +optional
 	ClusterIdentity *string `json:"clusterIdentity,omitempty" protobuf:"bytes,5,opt,name=clusterIdentity"`
 	// ClientCertificateExpirationTimestamp is the timestamp at which gardenlet's client certificate expires.
@@ -111,12 +111,12 @@ type SeedStatus struct {
 
 // SeedBackup contains the object store configuration for backups for shoot (currently only etcd).
 type SeedBackup struct {
-	// Provider is a provider name.
+	// Provider is a provider name. This field is immutable.
 	Provider string `json:"provider" protobuf:"bytes,1,opt,name=provider"`
 	// ProviderConfig is the configuration passed to BackupBucket resource.
 	// +optional
 	ProviderConfig *runtime.RawExtension `json:"providerConfig,omitempty" protobuf:"bytes,2,opt,name=providerConfig"`
-	// Region is a region name.
+	// Region is a region name. This field is immutable.
 	// +optional
 	Region *string `json:"region,omitempty" protobuf:"bytes,3,opt,name=region"`
 	// SecretRef is a reference to a Secret object containing the cloud provider credentials for
@@ -128,7 +128,7 @@ type SeedBackup struct {
 // SeedDNS contains DNS-relevant information about this seed cluster.
 type SeedDNS struct {
 	// IngressDomain is the domain of the Seed cluster pointing to the ingress controller endpoint. It will be used
-	// to construct ingress URLs for system applications running in Shoot clusters. Once set this field is immutable.
+	// to construct ingress URLs for system applications running in Shoot clusters. This field is immutable.
 	// This will be removed in the next API version and replaced by spec.ingress.domain.
 	// +optional
 	IngressDomain *string `json:"ingressDomain,omitempty" protobuf:"bytes,1,opt,name=ingressDomain"`
@@ -171,12 +171,12 @@ type IngressController struct {
 
 // SeedNetworks contains CIDRs for the pod, service and node networks of a Kubernetes cluster.
 type SeedNetworks struct {
-	// Nodes is the CIDR of the node network.
+	// Nodes is the CIDR of the node network. This field is immutable.
 	// +optional
 	Nodes *string `json:"nodes,omitempty" protobuf:"bytes,1,opt,name=nodes"`
-	// Pods is the CIDR of the pod network.
+	// Pods is the CIDR of the pod network. This field is immutable.
 	Pods string `json:"pods" protobuf:"bytes,2,opt,name=pods"`
-	// Services is the CIDR of the service network.
+	// Services is the CIDR of the service network. This field is immutable.
 	Services string `json:"services" protobuf:"bytes,3,opt,name=services"`
 	// ShootDefaults contains the default networks CIDRs for shoots.
 	// +optional

--- a/pkg/apis/core/v1alpha1/types_shoot.go
+++ b/pkg/apis/core/v1alpha1/types_shoot.go
@@ -37,6 +37,7 @@ type Shoot struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// Specification of the Shoot cluster.
+	// If the object's deletion timestamp is set, this field is immutable.
 	// +optional
 	Spec ShootSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 	// Most recently observed status of the Shoot cluster.
@@ -61,7 +62,7 @@ type ShootSpec struct {
 	// Addons contains information about enabled/disabled addons and their configuration.
 	// +optional
 	Addons *Addons `json:"addons,omitempty" protobuf:"bytes,1,opt,name=addons"`
-	// CloudProfileName is a name of a CloudProfile object.
+	// CloudProfileName is a name of a CloudProfile object. This field is immutable.
 	CloudProfileName string `json:"cloudProfileName" protobuf:"bytes,2,opt,name=cloudProfileName"`
 	// DNS contains information about the DNS settings of the Shoot.
 	// +optional
@@ -88,12 +89,14 @@ type ShootSpec struct {
 	// Purpose is the purpose class for this cluster.
 	// +optional
 	Purpose *ShootPurpose `json:"purpose,omitempty" protobuf:"bytes,11,opt,name=purpose"`
-	// Region is a name of a region.
+	// Region is a name of a region. This field is immutable.
 	Region string `json:"region" protobuf:"bytes,12,opt,name=region"`
 	// SecretBindingName is the name of the a SecretBinding that has a reference to the provider secret.
 	// The credentials inside the provider secret will be used to create the shoot in the respective account.
+	// This field is immutable.
 	SecretBindingName string `json:"secretBindingName" protobuf:"bytes,13,opt,name=secretBindingName"`
 	// SeedName is the name of the seed cluster that runs the control plane of the Shoot.
+	// This field is immutable when the SeedChange feature gate is disabled.
 	// +optional
 	SeedName *string `json:"seedName,omitempty" protobuf:"bytes,14,opt,name=seedName"`
 	// SeedSelector is an optional selector which must match a seed's labels for the shoot to be scheduled on that seed.
@@ -108,6 +111,7 @@ type ShootSpec struct {
 	// +optional
 	Tolerations []Toleration `json:"tolerations,omitempty" patchStrategy:"merge" patchMergeKey:"key" protobuf:"bytes,17,rep,name=tolerations"`
 	// ExposureClassName is the optional name of an exposure class to apply a control plane endpoint exposure strategy.
+	// This field is immutable.
 	// +optional
 	ExposureClassName *string `json:"exposureClassName,omitempty" protobuf:"bytes,18,opt,name=exposureClassName"`
 }
@@ -150,12 +154,12 @@ type ShootStatus struct {
 	// +optional
 	Seed *string `json:"seed,omitempty" protobuf:"bytes,10,opt,name=seed"`
 	// TechnicalID is the name that is used for creating the Seed namespace, the infrastructure resources, and
-	// basically everything that is related to this particular Shoot.
+	// basically everything that is related to this particular Shoot. This field is immutable.
 	TechnicalID string `json:"technicalID" protobuf:"bytes,11,opt,name=technicalID"`
 	// UID is a unique identifier for the Shoot cluster to avoid portability between Kubernetes clusters.
-	// It is used to compute unique hashes.
+	// It is used to compute unique hashes. This field is immutable.
 	UID types.UID `json:"uid" protobuf:"bytes,12,opt,name=uid"`
-	// ClusterIdentity is the identity of the Shoot cluster
+	// ClusterIdentity is the identity of the Shoot cluster. This field is immutable.
 	// +optional
 	ClusterIdentity *string `json:"clusterIdentity,omitempty" protobuf:"bytes,13,opt,name=clusterIdentity"`
 	// List of addresses on which the Kube API server can be reached.
@@ -234,7 +238,7 @@ type NginxIngress struct {
 // DNS holds information about the provider, the hosted zone id and the domain.
 type DNS struct {
 	// Domain is the external available domain of the Shoot cluster. This domain will be written into the
-	// kubeconfig that is handed out to end-users. Once set it is immutable.
+	// kubeconfig that is handed out to end-users. This field is immutable.
 	// +optional
 	Domain *string `json:"domain,omitempty" protobuf:"bytes,1,opt,name=domain"`
 	// Providers is a list of DNS providers that shall be enabled for this shoot cluster. Only relevant if
@@ -679,7 +683,7 @@ type KubeControllerManagerConfig struct {
 	// HorizontalPodAutoscalerConfig contains horizontal pod autoscaler configuration settings for the kube-controller-manager.
 	// +optional
 	HorizontalPodAutoscalerConfig *HorizontalPodAutoscalerConfig `json:"horizontalPodAutoscaler,omitempty" protobuf:"bytes,2,opt,name=horizontalPodAutoscaler"`
-	// NodeCIDRMaskSize defines the mask size for node cidr in cluster (default is 24)
+	// NodeCIDRMaskSize defines the mask size for node cidr in cluster (default is 24). This field is immutable.
 	// +optional
 	NodeCIDRMaskSize *int32 `json:"nodeCIDRMaskSize,omitempty" protobuf:"varint,3,opt,name=nodeCIDRMaskSize"`
 	// PodEvictionTimeout defines the grace period for deleting pods on failed nodes. Defaults to 2m.
@@ -927,18 +931,18 @@ type KubeletConfigReserved struct {
 
 // Networking defines networking parameters for the shoot cluster.
 type Networking struct {
-	// Type identifies the type of the networking plugin.
+	// Type identifies the type of the networking plugin. This field is immutable.
 	Type string `json:"type" protobuf:"bytes,1,opt,name=type"`
 	// ProviderConfig is the configuration passed to network resource.
 	// +optional
 	ProviderConfig *runtime.RawExtension `json:"providerConfig,omitempty" protobuf:"bytes,2,opt,name=providerConfig"`
-	// Pods is the CIDR of the pod network.
+	// Pods is the CIDR of the pod network. This field is immutable.
 	// +optional
 	Pods *string `json:"pods,omitempty" protobuf:"bytes,3,opt,name=pods"`
-	// Nodes is the CIDR of the entire node network.
+	// Nodes is the CIDR of the entire node network. This field is immutable.
 	// +optional
 	Nodes *string `json:"nodes,omitempty" protobuf:"bytes,4,opt,name=nodes"`
-	// Services is the CIDR of the service network.
+	// Services is the CIDR of the service network. This field is immutable.
 	// +optional
 	Services *string `json:"services,omitempty" protobuf:"bytes,5,opt,name=services"`
 }
@@ -1020,7 +1024,7 @@ type Alerting struct {
 // Provider contains provider-specific information that are handed-over to the provider-specific
 // extension controller.
 type Provider struct {
-	// Type is the type of the provider.
+	// Type is the type of the provider. This field is immutable.
 	Type string `json:"type" protobuf:"bytes,1,opt,name=type"`
 	// ControlPlaneConfig contains the provider-specific control plane config blob. Please look up the concrete
 	// definition in the documentation of your provider extension.

--- a/pkg/apis/core/v1alpha1/types_shootextensionstatus.go
+++ b/pkg/apis/core/v1alpha1/types_shootextensionstatus.go
@@ -52,7 +52,7 @@ type ShootExtensionStatusList struct {
 type ExtensionStatus struct {
 	// Kind of the extension resource
 	Kind string `json:"kind" protobuf:"bytes,1,opt,name=kind"`
-	// Type of the extension resource
+	// Type of the extension resource. This field is immutable.
 	Type string `json:"type" protobuf:"bytes,2,opt,name=type"`
 	// Purpose of the extension resource
 	// +optional

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -128,7 +128,7 @@ message BackupBucketProvider {
 
 // BackupBucketSpec is the specification of a Backup Bucket.
 message BackupBucketSpec {
-  // Provider hold the details of cloud provider of the object store.
+  // Provider holds the details of cloud provider of the object store. This field is immutable.
   optional BackupBucketProvider provider = 1;
 
   // ProviderConfig is the configuration passed to BackupBucket resource.
@@ -139,6 +139,7 @@ message BackupBucketSpec {
   optional k8s.io.api.core.v1.SecretReference secretRef = 3;
 
   // SeedName holds the name of the seed allocated to BackupBucket for running controller.
+  // This field is immutable.
   // +optional
   optional string seedName = 4;
 }
@@ -430,6 +431,7 @@ message ControllerInstallation {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec contains the specification of this installation.
+  // If the object's deletion timestamp is set, this field is immutable.
   optional ControllerInstallationSpec spec = 2;
 
   // Status contains the status of this installation.
@@ -449,9 +451,10 @@ message ControllerInstallationList {
 // ControllerInstallationSpec is the specification of a ControllerInstallation.
 message ControllerInstallationSpec {
   // RegistrationRef is used to reference a ControllerRegistration resource.
+  // The name field of the RegistrationRef is immutable.
   optional k8s.io.api.core.v1.ObjectReference registrationRef = 1;
 
-  // SeedRef is used to reference a Seed resource.
+  // SeedRef is used to reference a Seed resource. The name field of the SeedRef is immutable.
   optional k8s.io.api.core.v1.ObjectReference seedRef = 2;
 
   // DeploymentRef is used to reference a ControllerDeployment resource.
@@ -478,6 +481,7 @@ message ControllerRegistration {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec contains the specification of this registration.
+  // If the object's deletion timestamp is set, this field is immutable.
   optional ControllerRegistrationSpec spec = 2;
 }
 
@@ -539,7 +543,7 @@ message ControllerResource {
 
   // Primary determines if the controller backed by this ControllerRegistration is responsible for the extension
   // resource's lifecycle. This field defaults to true. There must be exactly one primary controller for this kind/type
-  // combination.
+  // combination. This field is immutable.
   // +optional
   optional bool primary = 5;
 }
@@ -547,7 +551,7 @@ message ControllerResource {
 // DNS holds information about the provider, the hosted zone id and the domain.
 message DNS {
   // Domain is the external available domain of the Shoot cluster. This domain will be written into the
-  // kubeconfig that is handed out to end-users. Once set it is immutable.
+  // kubeconfig that is handed out to end-users. This field is immutable.
   // +optional
   optional string domain = 1;
 
@@ -829,7 +833,7 @@ message KubeControllerManagerConfig {
   // +optional
   optional HorizontalPodAutoscalerConfig horizontalPodAutoscaler = 2;
 
-  // NodeCIDRMaskSize defines the mask size for node cidr in cluster (default is 24)
+  // NodeCIDRMaskSize defines the mask size for node cidr in cluster (default is 24). This field is immutable.
   // +optional
   optional int32 nodeCIDRMaskSize = 3;
 
@@ -1317,22 +1321,22 @@ message NamedResourceReference {
 
 // Networking defines networking parameters for the shoot cluster.
 message Networking {
-  // Type identifies the type of the networking plugin.
+  // Type identifies the type of the networking plugin. This field is immutable.
   optional string type = 1;
 
   // ProviderConfig is the configuration passed to network resource.
   // +optional
   optional k8s.io.apimachinery.pkg.runtime.RawExtension providerConfig = 2;
 
-  // Pods is the CIDR of the pod network.
+  // Pods is the CIDR of the pod network. This field is immutable.
   // +optional
   optional string pods = 3;
 
-  // Nodes is the CIDR of the entire node network.
+  // Nodes is the CIDR of the entire node network. This field is immutable.
   // +optional
   optional string nodes = 4;
 
-  // Services is the CIDR of the service network.
+  // Services is the CIDR of the service network. This field is immutable.
   // +optional
   optional string services = 5;
 }
@@ -1419,6 +1423,7 @@ message Plant {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Spec contains the specification of this Plant.
+  // If the object's deletion timestamp is set, this field is immutable.
   optional PlantSpec spec = 2;
 
   // Status contains the status of this Plant.
@@ -1510,7 +1515,7 @@ message ProjectMember {
 // ProjectSpec is the specification of a Project.
 message ProjectSpec {
   // CreatedBy is a subject representing a user name, an email address, or any other identifier of a user
-  // who created the project.
+  // who created the project. This field is immutable.
   // +optional
   optional k8s.io.api.rbac.v1.Subject createdBy = 1;
 
@@ -1538,6 +1543,7 @@ message ProjectSpec {
 
   // Namespace is the name of the namespace that has been created for the Project object.
   // A nil value means that Gardener will determine the name of the namespace.
+  // This field is immutable.
   // +optional
   optional string namespace = 6;
 
@@ -1588,7 +1594,7 @@ message ProjectTolerations {
 // Provider contains provider-specific information that are handed-over to the provider-specific
 // extension controller.
 message Provider {
-  // Type is the type of the provider.
+  // Type is the type of the provider. This field is immutable.
   optional string type = 1;
 
   // ControlPlaneConfig contains the provider-specific control plane config blob. Please look up the concrete
@@ -1637,7 +1643,7 @@ message QuotaSpec {
   // Metrics is a list of resources which will be put under constraints.
   map<string, k8s.io.apimachinery.pkg.api.resource.Quantity> metrics = 2;
 
-  // Scope is the scope of the Quota object, either 'project' or 'secret'.
+  // Scope is the scope of the Quota object, either 'project' or 'secret'. This field is immutable.
   optional k8s.io.api.core.v1.ObjectReference scope = 3;
 }
 
@@ -1681,13 +1687,16 @@ message SecretBinding {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // SecretRef is a reference to a secret object in the same or another namespace.
+  // This field is immutable.
   optional k8s.io.api.core.v1.SecretReference secretRef = 2;
 
   // Quotas is a list of references to Quota objects in the same or another namespace.
+  // This field is immutable.
   // +optional
   repeated k8s.io.api.core.v1.ObjectReference quotas = 3;
 
   // Provider defines the provider type of the SecretBinding.
+  // This field is immutable when the SecretBindingProviderValidation feature gate is enabled.
   // +optional
   optional SecretBindingProvider provider = 4;
 }
@@ -1725,14 +1734,14 @@ message Seed {
 
 // SeedBackup contains the object store configuration for backups for shoot (currently only etcd).
 message SeedBackup {
-  // Provider is a provider name.
+  // Provider is a provider name. This field is immutable.
   optional string provider = 1;
 
   // ProviderConfig is the configuration passed to BackupBucket resource.
   // +optional
   optional k8s.io.apimachinery.pkg.runtime.RawExtension providerConfig = 2;
 
-  // Region is a region name.
+  // Region is a region name. This field is immutable.
   // +optional
   optional string region = 3;
 
@@ -1745,7 +1754,7 @@ message SeedBackup {
 // SeedDNS contains DNS-relevant information about this seed cluster.
 message SeedDNS {
   // IngressDomain is the domain of the Seed cluster pointing to the ingress controller endpoint. It will be used
-  // to construct ingress URLs for system applications running in Shoot clusters. Once set this field is immutable.
+  // to construct ingress URLs for system applications running in Shoot clusters. This field is immutable.
   // This will be removed in the next API version and replaced by spec.ingress.domain.
   // +optional
   optional string ingressDomain = 1;
@@ -1784,14 +1793,14 @@ message SeedList {
 
 // SeedNetworks contains CIDRs for the pod, service and node networks of a Kubernetes cluster.
 message SeedNetworks {
-  // Nodes is the CIDR of the node network.
+  // Nodes is the CIDR of the node network. This field is immutable.
   // +optional
   optional string nodes = 1;
 
-  // Pods is the CIDR of the pod network.
+  // Pods is the CIDR of the pod network. This field is immutable.
   optional string pods = 2;
 
-  // Services is the CIDR of the service network.
+  // Services is the CIDR of the service network. This field is immutable.
   optional string services = 3;
 
   // ShootDefaults contains the default networks CIDRs for shoots.
@@ -1966,7 +1975,7 @@ message SeedSpec {
   // +optional
   optional SeedSettings settings = 8;
 
-  // Ingress configures Ingress specific settings of the Seed cluster.
+  // Ingress configures Ingress specific settings of the Seed cluster. This field is immutable.
   // +optional
   optional Ingress ingress = 9;
 }
@@ -1992,7 +2001,7 @@ message SeedStatus {
   // +optional
   optional int64 observedGeneration = 4;
 
-  // ClusterIdentity is the identity of the Seed cluster
+  // ClusterIdentity is the identity of the Seed cluster. This field is immutable.
   // +optional
   optional string clusterIdentity = 5;
 
@@ -2088,6 +2097,7 @@ message Shoot {
   optional k8s.io.apimachinery.pkg.apis.meta.v1.ObjectMeta metadata = 1;
 
   // Specification of the Shoot cluster.
+  // If the object's deletion timestamp is set, this field is immutable.
   // +optional
   optional ShootSpec spec = 2;
 
@@ -2148,7 +2158,7 @@ message ShootSpec {
   // +optional
   optional Addons addons = 1;
 
-  // CloudProfileName is a name of a CloudProfile object.
+  // CloudProfileName is a name of a CloudProfile object. This field is immutable.
   optional string cloudProfileName = 2;
 
   // DNS contains information about the DNS settings of the Shoot.
@@ -2185,14 +2195,16 @@ message ShootSpec {
   // +optional
   optional string purpose = 11;
 
-  // Region is a name of a region.
+  // Region is a name of a region. This field is immutable.
   optional string region = 12;
 
   // SecretBindingName is the name of the a SecretBinding that has a reference to the provider secret.
   // The credentials inside the provider secret will be used to create the shoot in the respective account.
+  // This field is immutable.
   optional string secretBindingName = 13;
 
   // SeedName is the name of the seed cluster that runs the control plane of the Shoot.
+  // This field is immutable when the SeedChange feature gate is disabled.
   // +optional
   optional string seedName = 14;
 
@@ -2211,6 +2223,7 @@ message ShootSpec {
   repeated Toleration tolerations = 17;
 
   // ExposureClassName is the optional name of an exposure class to apply a control plane endpoint exposure strategy.
+  // This field is immutable.
   // +optional
   optional string exposureClassName = 18;
 }
@@ -2259,14 +2272,14 @@ message ShootStatus {
   optional string seedName = 9;
 
   // TechnicalID is the name that is used for creating the Seed namespace, the infrastructure resources, and
-  // basically everything that is related to this particular Shoot.
+  // basically everything that is related to this particular Shoot. This field is immutable.
   optional string technicalID = 10;
 
   // UID is a unique identifier for the Shoot cluster to avoid portability between Kubernetes clusters.
-  // It is used to compute unique hashes.
+  // It is used to compute unique hashes. This field is immutable.
   optional string uid = 11;
 
-  // ClusterIdentity is the identity of the Shoot cluster
+  // ClusterIdentity is the identity of the Shoot cluster. This field is immutable.
   // +optional
   optional string clusterIdentity = 12;
 

--- a/pkg/apis/core/v1beta1/types_backupbucket.go
+++ b/pkg/apis/core/v1beta1/types_backupbucket.go
@@ -49,7 +49,7 @@ type BackupBucketList struct {
 
 // BackupBucketSpec is the specification of a Backup Bucket.
 type BackupBucketSpec struct {
-	// Provider hold the details of cloud provider of the object store.
+	// Provider holds the details of cloud provider of the object store. This field is immutable.
 	Provider BackupBucketProvider `json:"provider" protobuf:"bytes,1,opt,name=provider"`
 	// ProviderConfig is the configuration passed to BackupBucket resource.
 	// +optional
@@ -57,6 +57,7 @@ type BackupBucketSpec struct {
 	// SecretRef is a reference to a secret that contains the credentials to access object store.
 	SecretRef corev1.SecretReference `json:"secretRef" protobuf:"bytes,3,opt,name=secretRef"`
 	// SeedName holds the name of the seed allocated to BackupBucket for running controller.
+	// This field is immutable.
 	// +optional
 	SeedName *string `json:"seedName,omitempty" protobuf:"bytes,4,opt,name=seedName"`
 }

--- a/pkg/apis/core/v1beta1/types_controllerinstallation.go
+++ b/pkg/apis/core/v1beta1/types_controllerinstallation.go
@@ -30,6 +30,7 @@ type ControllerInstallation struct {
 	// Standard object metadata.
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// Spec contains the specification of this installation.
+	// If the object's deletion timestamp is set, this field is immutable.
 	Spec ControllerInstallationSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 	// Status contains the status of this installation.
 	Status ControllerInstallationStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`
@@ -50,8 +51,9 @@ type ControllerInstallationList struct {
 // ControllerInstallationSpec is the specification of a ControllerInstallation.
 type ControllerInstallationSpec struct {
 	// RegistrationRef is used to reference a ControllerRegistration resource.
+	// The name field of the RegistrationRef is immutable.
 	RegistrationRef corev1.ObjectReference `json:"registrationRef" protobuf:"bytes,1,opt,name=registrationRef"`
-	// SeedRef is used to reference a Seed resource.
+	// SeedRef is used to reference a Seed resource. The name field of the SeedRef is immutable.
 	SeedRef corev1.ObjectReference `json:"seedRef" protobuf:"bytes,2,opt,name=seedRef"`
 	// DeploymentRef is used to reference a ControllerDeployment resource.
 	// +optional

--- a/pkg/apis/core/v1beta1/types_controllerregistration.go
+++ b/pkg/apis/core/v1beta1/types_controllerregistration.go
@@ -28,6 +28,7 @@ type ControllerRegistration struct {
 	// Standard object metadata.
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// Spec contains the specification of this registration.
+	// If the object's deletion timestamp is set, this field is immutable.
 	Spec ControllerRegistrationSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 }
 
@@ -69,7 +70,7 @@ type ControllerResource struct {
 	ReconcileTimeout *metav1.Duration `json:"reconcileTimeout,omitempty" protobuf:"bytes,4,opt,name=reconcileTimeout"`
 	// Primary determines if the controller backed by this ControllerRegistration is responsible for the extension
 	// resource's lifecycle. This field defaults to true. There must be exactly one primary controller for this kind/type
-	// combination.
+	// combination. This field is immutable.
 	// +optional
 	Primary *bool `json:"primary,omitempty" protobuf:"varint,5,opt,name=primary"`
 }

--- a/pkg/apis/core/v1beta1/types_plant.go
+++ b/pkg/apis/core/v1beta1/types_plant.go
@@ -29,6 +29,7 @@ type Plant struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// Spec contains the specification of this Plant.
+	// If the object's deletion timestamp is set, this field is immutable.
 	Spec PlantSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 	// Status contains the status of this Plant.
 	Status PlantStatus `json:"status,omitempty" protobuf:"bytes,3,opt,name=status"`

--- a/pkg/apis/core/v1beta1/types_project.go
+++ b/pkg/apis/core/v1beta1/types_project.go
@@ -52,7 +52,7 @@ type ProjectList struct {
 // ProjectSpec is the specification of a Project.
 type ProjectSpec struct {
 	// CreatedBy is a subject representing a user name, an email address, or any other identifier of a user
-	// who created the project.
+	// who created the project. This field is immutable.
 	// +optional
 	CreatedBy *rbacv1.Subject `json:"createdBy,omitempty" protobuf:"bytes,1,opt,name=createdBy"`
 	// Description is a human-readable description of what the project is used for.
@@ -75,6 +75,7 @@ type ProjectSpec struct {
 	Members []ProjectMember `json:"members,omitempty" protobuf:"bytes,5,rep,name=members"`
 	// Namespace is the name of the namespace that has been created for the Project object.
 	// A nil value means that Gardener will determine the name of the namespace.
+	// This field is immutable.
 	// +optional
 	Namespace *string `json:"namespace,omitempty" protobuf:"bytes,6,opt,name=namespace"`
 	// Tolerations contains the tolerations for taints on seed clusters.

--- a/pkg/apis/core/v1beta1/types_quota.go
+++ b/pkg/apis/core/v1beta1/types_quota.go
@@ -52,6 +52,6 @@ type QuotaSpec struct {
 	ClusterLifetimeDays *int32 `json:"clusterLifetimeDays,omitempty" protobuf:"varint,1,opt,name=clusterLifetimeDays"`
 	// Metrics is a list of resources which will be put under constraints.
 	Metrics corev1.ResourceList `json:"metrics" protobuf:"bytes,2,rep,name=metrics,casttype=k8s.io/api/core/v1.ResourceList,castkey=k8s.io/api/core/v1.ResourceName"`
-	// Scope is the scope of the Quota object, either 'project' or 'secret'.
+	// Scope is the scope of the Quota object, either 'project' or 'secret'. This field is immutable.
 	Scope corev1.ObjectReference `json:"scope" protobuf:"bytes,3,opt,name=scope"`
 }

--- a/pkg/apis/core/v1beta1/types_secretbinding.go
+++ b/pkg/apis/core/v1beta1/types_secretbinding.go
@@ -29,11 +29,14 @@ type SecretBinding struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// SecretRef is a reference to a secret object in the same or another namespace.
+	// This field is immutable.
 	SecretRef corev1.SecretReference `json:"secretRef" protobuf:"bytes,2,opt,name=secretRef"`
 	// Quotas is a list of references to Quota objects in the same or another namespace.
+	// This field is immutable.
 	// +optional
 	Quotas []corev1.ObjectReference `json:"quotas,omitempty" protobuf:"bytes,3,rep,name=quotas"`
 	// Provider defines the provider type of the SecretBinding.
+	// This field is immutable when the SecretBindingProviderValidation feature gate is enabled.
 	// +optional
 	Provider *SecretBindingProvider `json:"provider,omitempty" protobuf:"bytes,4,opt,name=provider"`
 }

--- a/pkg/apis/core/v1beta1/types_seed.go
+++ b/pkg/apis/core/v1beta1/types_seed.go
@@ -85,7 +85,7 @@ type SeedSpec struct {
 	// Settings contains certain settings for this seed cluster.
 	// +optional
 	Settings *SeedSettings `json:"settings,omitempty" protobuf:"bytes,8,opt,name=settings"`
-	// Ingress configures Ingress specific settings of the Seed cluster.
+	// Ingress configures Ingress specific settings of the Seed cluster. This field is immutable.
 	// +optional
 	Ingress *Ingress `json:"ingress,omitempty" protobuf:"bytes,9,opt,name=ingress"`
 }
@@ -107,7 +107,7 @@ type SeedStatus struct {
 	// Seed's generation, which is updated on mutation by the API Server.
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty" protobuf:"varint,4,opt,name=observedGeneration"`
-	// ClusterIdentity is the identity of the Seed cluster
+	// ClusterIdentity is the identity of the Seed cluster. This field is immutable.
 	// +optional
 	ClusterIdentity *string `json:"clusterIdentity,omitempty" protobuf:"bytes,5,opt,name=clusterIdentity"`
 	// Capacity represents the total resources of a seed.
@@ -124,12 +124,12 @@ type SeedStatus struct {
 
 // SeedBackup contains the object store configuration for backups for shoot (currently only etcd).
 type SeedBackup struct {
-	// Provider is a provider name.
+	// Provider is a provider name. This field is immutable.
 	Provider string `json:"provider" protobuf:"bytes,1,opt,name=provider"`
 	// ProviderConfig is the configuration passed to BackupBucket resource.
 	// +optional
 	ProviderConfig *runtime.RawExtension `json:"providerConfig,omitempty" protobuf:"bytes,2,opt,name=providerConfig"`
-	// Region is a region name.
+	// Region is a region name. This field is immutable.
 	// +optional
 	Region *string `json:"region,omitempty" protobuf:"bytes,3,opt,name=region"`
 	// SecretRef is a reference to a Secret object containing the cloud provider credentials for
@@ -141,7 +141,7 @@ type SeedBackup struct {
 // SeedDNS contains DNS-relevant information about this seed cluster.
 type SeedDNS struct {
 	// IngressDomain is the domain of the Seed cluster pointing to the ingress controller endpoint. It will be used
-	// to construct ingress URLs for system applications running in Shoot clusters. Once set this field is immutable.
+	// to construct ingress URLs for system applications running in Shoot clusters. This field is immutable.
 	// This will be removed in the next API version and replaced by spec.ingress.domain.
 	// +optional
 	IngressDomain *string `json:"ingressDomain,omitempty" protobuf:"bytes,1,opt,name=ingressDomain"`
@@ -184,12 +184,12 @@ type IngressController struct {
 
 // SeedNetworks contains CIDRs for the pod, service and node networks of a Kubernetes cluster.
 type SeedNetworks struct {
-	// Nodes is the CIDR of the node network.
+	// Nodes is the CIDR of the node network. This field is immutable.
 	// +optional
 	Nodes *string `json:"nodes,omitempty" protobuf:"bytes,1,opt,name=nodes"`
-	// Pods is the CIDR of the pod network.
+	// Pods is the CIDR of the pod network. This field is immutable.
 	Pods string `json:"pods" protobuf:"bytes,2,opt,name=pods"`
-	// Services is the CIDR of the service network.
+	// Services is the CIDR of the service network. This field is immutable.
 	Services string `json:"services" protobuf:"bytes,3,opt,name=services"`
 	// ShootDefaults contains the default networks CIDRs for shoots.
 	// +optional

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -37,6 +37,7 @@ type Shoot struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty" protobuf:"bytes,1,opt,name=metadata"`
 	// Specification of the Shoot cluster.
+	// If the object's deletion timestamp is set, this field is immutable.
 	// +optional
 	Spec ShootSpec `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 	// Most recently observed status of the Shoot cluster.
@@ -71,7 +72,7 @@ type ShootSpec struct {
 	// Addons contains information about enabled/disabled addons and their configuration.
 	// +optional
 	Addons *Addons `json:"addons,omitempty" protobuf:"bytes,1,opt,name=addons"`
-	// CloudProfileName is a name of a CloudProfile object.
+	// CloudProfileName is a name of a CloudProfile object. This field is immutable.
 	CloudProfileName string `json:"cloudProfileName" protobuf:"bytes,2,opt,name=cloudProfileName"`
 	// DNS contains information about the DNS settings of the Shoot.
 	// +optional
@@ -98,12 +99,14 @@ type ShootSpec struct {
 	// Purpose is the purpose class for this cluster.
 	// +optional
 	Purpose *ShootPurpose `json:"purpose,omitempty" protobuf:"bytes,11,opt,name=purpose,casttype=ShootPurpose"`
-	// Region is a name of a region.
+	// Region is a name of a region. This field is immutable.
 	Region string `json:"region" protobuf:"bytes,12,opt,name=region"`
 	// SecretBindingName is the name of the a SecretBinding that has a reference to the provider secret.
 	// The credentials inside the provider secret will be used to create the shoot in the respective account.
+	// This field is immutable.
 	SecretBindingName string `json:"secretBindingName" protobuf:"bytes,13,opt,name=secretBindingName"`
 	// SeedName is the name of the seed cluster that runs the control plane of the Shoot.
+	// This field is immutable when the SeedChange feature gate is disabled.
 	// +optional
 	SeedName *string `json:"seedName,omitempty" protobuf:"bytes,14,opt,name=seedName"`
 	// SeedSelector is an optional selector which must match a seed's labels for the shoot to be scheduled on that seed.
@@ -118,6 +121,7 @@ type ShootSpec struct {
 	// +optional
 	Tolerations []Toleration `json:"tolerations,omitempty" patchStrategy:"merge" patchMergeKey:"key" protobuf:"bytes,17,rep,name=tolerations"`
 	// ExposureClassName is the optional name of an exposure class to apply a control plane endpoint exposure strategy.
+	// This field is immutable.
 	// +optional
 	ExposureClassName *string `json:"exposureClassName,omitempty" protobuf:"bytes,18,opt,name=exposureClassName"`
 }
@@ -162,12 +166,12 @@ type ShootStatus struct {
 	// +optional
 	SeedName *string `json:"seedName,omitempty" protobuf:"bytes,9,opt,name=seedName"`
 	// TechnicalID is the name that is used for creating the Seed namespace, the infrastructure resources, and
-	// basically everything that is related to this particular Shoot.
+	// basically everything that is related to this particular Shoot. This field is immutable.
 	TechnicalID string `json:"technicalID" protobuf:"bytes,10,opt,name=technicalID"`
 	// UID is a unique identifier for the Shoot cluster to avoid portability between Kubernetes clusters.
-	// It is used to compute unique hashes.
+	// It is used to compute unique hashes. This field is immutable.
 	UID types.UID `json:"uid" protobuf:"bytes,11,opt,name=uid,casttype=k8s.io/apimachinery/pkg/types.UID"`
-	// ClusterIdentity is the identity of the Shoot cluster
+	// ClusterIdentity is the identity of the Shoot cluster. This field is immutable.
 	// +optional
 	ClusterIdentity *string `json:"clusterIdentity,omitempty" protobuf:"bytes,12,opt,name=clusterIdentity"`
 	// List of addresses on which the Kube API server can be reached.
@@ -246,7 +250,7 @@ type NginxIngress struct {
 // DNS holds information about the provider, the hosted zone id and the domain.
 type DNS struct {
 	// Domain is the external available domain of the Shoot cluster. This domain will be written into the
-	// kubeconfig that is handed out to end-users. Once set it is immutable.
+	// kubeconfig that is handed out to end-users. This field is immutable.
 	// +optional
 	Domain *string `json:"domain,omitempty" protobuf:"bytes,1,opt,name=domain"`
 	// Providers is a list of DNS providers that shall be enabled for this shoot cluster. Only relevant if
@@ -691,7 +695,7 @@ type KubeControllerManagerConfig struct {
 	// HorizontalPodAutoscalerConfig contains horizontal pod autoscaler configuration settings for the kube-controller-manager.
 	// +optional
 	HorizontalPodAutoscalerConfig *HorizontalPodAutoscalerConfig `json:"horizontalPodAutoscaler,omitempty" protobuf:"bytes,2,opt,name=horizontalPodAutoscaler"`
-	// NodeCIDRMaskSize defines the mask size for node cidr in cluster (default is 24)
+	// NodeCIDRMaskSize defines the mask size for node cidr in cluster (default is 24). This field is immutable.
 	// +optional
 	NodeCIDRMaskSize *int32 `json:"nodeCIDRMaskSize,omitempty" protobuf:"varint,3,opt,name=nodeCIDRMaskSize"`
 	// PodEvictionTimeout defines the grace period for deleting pods on failed nodes. Defaults to 2m.
@@ -939,18 +943,18 @@ type KubeletConfigReserved struct {
 
 // Networking defines networking parameters for the shoot cluster.
 type Networking struct {
-	// Type identifies the type of the networking plugin.
+	// Type identifies the type of the networking plugin. This field is immutable.
 	Type string `json:"type" protobuf:"bytes,1,opt,name=type"`
 	// ProviderConfig is the configuration passed to network resource.
 	// +optional
 	ProviderConfig *runtime.RawExtension `json:"providerConfig,omitempty" protobuf:"bytes,2,opt,name=providerConfig"`
-	// Pods is the CIDR of the pod network.
+	// Pods is the CIDR of the pod network. This field is immutable.
 	// +optional
 	Pods *string `json:"pods,omitempty" protobuf:"bytes,3,opt,name=pods"`
-	// Nodes is the CIDR of the entire node network.
+	// Nodes is the CIDR of the entire node network. This field is immutable.
 	// +optional
 	Nodes *string `json:"nodes,omitempty" protobuf:"bytes,4,opt,name=nodes"`
-	// Services is the CIDR of the service network.
+	// Services is the CIDR of the service network. This field is immutable.
 	// +optional
 	Services *string `json:"services,omitempty" protobuf:"bytes,5,opt,name=services"`
 }
@@ -1032,7 +1036,7 @@ type Alerting struct {
 // Provider contains provider-specific information that are handed-over to the provider-specific
 // extension controller.
 type Provider struct {
-	// Type is the type of the provider.
+	// Type is the type of the provider. This field is immutable.
 	Type string `json:"type" protobuf:"bytes,1,opt,name=type"`
 	// ControlPlaneConfig contains the provider-specific control plane config blob. Please look up the concrete
 	// definition in the documentation of your provider extension.

--- a/pkg/apis/extensions/v1alpha1/types_backupbucket.go
+++ b/pkg/apis/extensions/v1alpha1/types_backupbucket.go
@@ -39,7 +39,8 @@ type BackupBucket struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-
+	// Specification of the BackupBucket.
+	// If the object's deletion timestamp is set, this field is immutable.
 	Spec BackupBucketSpec `json:"spec"`
 	// +optional
 	Status BackupBucketStatus `json:"status"`
@@ -71,7 +72,7 @@ type BackupBucketList struct {
 type BackupBucketSpec struct {
 	// DefaultSpec is a structure containing common fields used by all extension resources.
 	DefaultSpec `json:",inline"`
-	// Region is the region of this bucket.
+	// Region is the region of this bucket. This field is immutable.
 	Region string `json:"region"`
 	// SecretRef is a reference to a secret that contains the credentials to access object store.
 	SecretRef corev1.SecretReference `json:"secretRef"`

--- a/pkg/apis/extensions/v1alpha1/types_backupentry.go
+++ b/pkg/apis/extensions/v1alpha1/types_backupentry.go
@@ -41,7 +41,8 @@ type BackupEntry struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-
+	// Specification of the BackupEntry.
+	// If the object's deletion timestamp is set, this field is immutable.
 	Spec BackupEntrySpec `json:"spec"`
 	// +optional
 	Status BackupEntryStatus `json:"status"`
@@ -79,7 +80,7 @@ type BackupEntrySpec struct {
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// +optional
 	BackupBucketProviderStatus *runtime.RawExtension `json:"backupBucketProviderStatus,omitempty"`
-	// Region is the region of this Entry.
+	// Region is the region of this Entry. This field is immutable.
 	Region string `json:"region"`
 	// BucketName is the name of backup bucket for this Backup Entry.
 	BucketName string `json:"bucketName"`

--- a/pkg/apis/extensions/v1alpha1/types_bastion.go
+++ b/pkg/apis/extensions/v1alpha1/types_bastion.go
@@ -40,6 +40,7 @@ type Bastion struct {
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// Spec is the specification of this Bastion.
+	// If the object's deletion timestamp is set, this field is immutable.
 	Spec BastionSpec `json:"spec"`
 	// Status is the bastion's status.
 	// +optional
@@ -62,6 +63,7 @@ type BastionSpec struct {
 	DefaultSpec `json:",inline"`
 	// UserData is the base64-encoded user data for the bastion instance. This should
 	// contain code to provision the SSH key on the bastion instance.
+	// This field is immutable.
 	UserData []byte `json:"userData"`
 	// Ingress controls from where the created bastion host should be reachable.
 	Ingress []BastionIngressPolicy `json:"ingress"`

--- a/pkg/apis/extensions/v1alpha1/types_containerruntime.go
+++ b/pkg/apis/extensions/v1alpha1/types_containerruntime.go
@@ -42,7 +42,9 @@ type ContainerRuntime struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-	Spec              ContainerRuntimeSpec `json:"spec"`
+	// Specification of the ContainerRuntime.
+	// If the object's deletion timestamp is set, this field is immutable.
+	Spec ContainerRuntimeSpec `json:"spec"`
 	// +optional
 	Status ContainerRuntimeStatus `json:"status"`
 }
@@ -82,6 +84,7 @@ type ContainerRuntimeSpec struct {
 // ContainerRuntimeWorkerPool identifies a Shoot worker pool by its name and selector.
 type ContainerRuntimeWorkerPool struct {
 	// Name specifies the name of the worker pool the container runtime should be available for.
+	// This field is immutable.
 	Name string `json:"name"`
 	// Selector is the label selector used by the extension to match the nodes belonging to the worker pool.
 	Selector metav1.LabelSelector `json:"selector"`

--- a/pkg/apis/extensions/v1alpha1/types_controlplane.go
+++ b/pkg/apis/extensions/v1alpha1/types_controlplane.go
@@ -38,7 +38,8 @@ const ControlPlaneResource = "ControlPlane"
 type ControlPlane struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-
+	// Specification of the ControlPlane.
+	// If the object's deletion timestamp is set, this field is immutable.
 	Spec ControlPlaneSpec `json:"spec"`
 	// +optional
 	Status ControlPlaneStatus `json:"status"`
@@ -75,6 +76,7 @@ type ControlPlaneSpec struct {
 	// DefaultSpec is a structure containing common fields used by all extension resources.
 	DefaultSpec `json:",inline"`
 	// Purpose contains the data if a cloud provider needs additional components in order to expose the control plane.
+	// This field is immutable.
 	// +optional
 	Purpose *Purpose `json:"purpose,omitempty"`
 	// InfrastructureProviderStatus contains the provider status that has
@@ -83,7 +85,7 @@ type ControlPlaneSpec struct {
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// +optional
 	InfrastructureProviderStatus *runtime.RawExtension `json:"infrastructureProviderStatus,omitempty"`
-	// Region is the region of this control plane.
+	// Region is the region of this control plane. This field is immutable.
 	Region string `json:"region"`
 	// SecretRef is a reference to a secret that contains the cloud provider specific credentials.
 	SecretRef corev1.SecretReference `json:"secretRef"`

--- a/pkg/apis/extensions/v1alpha1/types_dnsrecord.go
+++ b/pkg/apis/extensions/v1alpha1/types_dnsrecord.go
@@ -38,7 +38,8 @@ const DNSRecordResource = "DNSRecord"
 type DNSRecord struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-
+	// Specification of the DNSRecord.
+	// If the object's deletion timestamp is set, this field is immutable.
 	Spec DNSRecordSpec `json:"spec"`
 	// +optional
 	Status DNSRecordStatus `json:"status"`
@@ -79,9 +80,9 @@ type DNSRecordSpec struct {
 	// getting all hosted zones of the account and searching for the longest zone name that is a suffix of Name.
 	// +optional
 	Zone *string `json:"zone,omitempty"`
-	// Name is the fully qualified domain name, e.g. "api.<shoot domain>".
+	// Name is the fully qualified domain name, e.g. "api.<shoot domain>". This field is immutable.
 	Name string `json:"name"`
-	// RecordType is the DNS record type. Only A, CNAME, and TXT records are currently supported.
+	// RecordType is the DNS record type. Only A, CNAME, and TXT records are currently supported. This field is immutable.
 	RecordType DNSRecordType `json:"recordType"`
 	// Values is a list of IP addresses for A records, a single hostname for CNAME records, or a list of texts for TXT records.
 	Values []string `json:"values"`

--- a/pkg/apis/extensions/v1alpha1/types_extension.go
+++ b/pkg/apis/extensions/v1alpha1/types_extension.go
@@ -36,7 +36,8 @@ type Extension struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-
+	// Specification of the Extension.
+	// If the object's deletion timestamp is set, this field is immutable.
 	Spec ExtensionSpec `json:"spec"`
 	// +optional
 	Status ExtensionStatus `json:"status"`

--- a/pkg/apis/extensions/v1alpha1/types_infrastructure.go
+++ b/pkg/apis/extensions/v1alpha1/types_infrastructure.go
@@ -38,7 +38,8 @@ type Infrastructure struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-
+	// Specification of the Infrastructure.
+	// If the object's deletion timestamp is set, this field is immutable.
 	Spec InfrastructureSpec `json:"spec"`
 	// +optional
 	Status InfrastructureStatus `json:"status"`
@@ -70,7 +71,7 @@ type InfrastructureList struct {
 type InfrastructureSpec struct {
 	// DefaultSpec is a structure containing common fields used by all extension resources.
 	DefaultSpec `json:",inline"`
-	// Region is the region of this infrastructure.
+	// Region is the region of this infrastructure. This field is immutable.
 	Region string `json:"region"`
 	// SecretRef is a reference to a secret that contains the actual result of the generated cloud config.
 	SecretRef corev1.SecretReference `json:"secretRef"`

--- a/pkg/apis/extensions/v1alpha1/types_network.go
+++ b/pkg/apis/extensions/v1alpha1/types_network.go
@@ -38,7 +38,8 @@ type Network struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-
+	// Specification of the Network.
+	// If the object's deletion timestamp is set, this field is immutable.
 	Spec NetworkSpec `json:"spec"`
 	// +optional
 	Status NetworkStatus `json:"status"`
@@ -70,9 +71,9 @@ type NetworkList struct {
 type NetworkSpec struct {
 	// DefaultSpec is a structure containing common fields used by all extension resources.
 	DefaultSpec `json:",inline"`
-	// PodCIDR defines the CIDR that will be used for pods.
+	// PodCIDR defines the CIDR that will be used for pods. This field is immutable.
 	PodCIDR string `json:"podCIDR"`
-	// ServiceCIDR defines the CIDR that will be used for services.
+	// ServiceCIDR defines the CIDR that will be used for services. This field is immutable.
 	ServiceCIDR string `json:"serviceCIDR"`
 }
 

--- a/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
+++ b/pkg/apis/extensions/v1alpha1/types_operatingsystemconfig.go
@@ -38,7 +38,8 @@ type OperatingSystemConfig struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-
+	// Specification of the OperatingSystemConfig.
+	// If the object's deletion timestamp is set, this field is immutable.
 	Spec OperatingSystemConfigSpec `json:"spec"`
 	// +optional
 	Status OperatingSystemConfigStatus `json:"status"`
@@ -82,6 +83,7 @@ type OperatingSystemConfigSpec struct {
 	// Purpose describes how the result of this OperatingSystemConfig is used by Gardener. Either it
 	// gets sent to the `Worker` extension controller to bootstrap a VM, or it is downloaded by the
 	// cloud-config-downloader script already running on a bootstrapped VM.
+	// This field is immutable.
 	Purpose OperatingSystemConfigPurpose `json:"purpose"`
 	// ReloadConfigFilePath is the path to the generated operating system configuration. If set, controllers
 	// are asked to use it when determining the .status.command of this resource. For example, if for CoreOS

--- a/pkg/apis/extensions/v1alpha1/types_worker.go
+++ b/pkg/apis/extensions/v1alpha1/types_worker.go
@@ -42,7 +42,8 @@ type Worker struct {
 	metav1.TypeMeta `json:",inline"`
 	// +optional
 	metav1.ObjectMeta `json:"metadata,omitempty"`
-
+	// Specification of the Worker.
+	// If the object's deletion timestamp is set, this field is immutable.
 	Spec WorkerSpec `json:"spec"`
 	// +optional
 	Status WorkerStatus `json:"status"`
@@ -81,7 +82,7 @@ type WorkerSpec struct {
 	// +kubebuilder:pruning:PreserveUnknownFields
 	// +optional
 	InfrastructureProviderStatus *runtime.RawExtension `json:"infrastructureProviderStatus,omitempty"`
-	// Region is the name of the region where the worker pool should be deployed to.
+	// Region is the name of the region where the worker pool should be deployed to. This field is immutable.
 	Region string `json:"region"`
 	// SecretRef is a reference to a secret that contains the cloud provider specific credentials.
 	SecretRef corev1.SecretReference `json:"secretRef"`

--- a/pkg/apis/operations/types_bastion.go
+++ b/pkg/apis/operations/types_bastion.go
@@ -48,14 +48,14 @@ type BastionList struct {
 
 // BastionSpec is the specification of a Bastion.
 type BastionSpec struct {
-	// ShootRef defines the target shoot for a Bastion.
+	// ShootRef defines the target shoot for a Bastion. The name field of the ShootRef is immutable.
 	ShootRef corev1.LocalObjectReference
 	// SeedName is the name of the seed to which this Bastion is currently scheduled. This field is populated
 	// at the beginning of a create/reconcile operation.
 	SeedName *string
 	// ProviderType is cloud provider used by the referenced Shoot.
 	ProviderType *string
-	// SSHPublicKey is the user's public key.
+	// SSHPublicKey is the user's public key. This field is immutable.
 	SSHPublicKey string
 	// Ingress controls from where the created bastion host should be reachable.
 	Ingress []BastionIngressPolicy

--- a/pkg/apis/operations/v1alpha1/generated.proto
+++ b/pkg/apis/operations/v1alpha1/generated.proto
@@ -61,7 +61,7 @@ message BastionList {
 
 // BastionSpec is the specification of a Bastion.
 message BastionSpec {
-  // ShootRef defines the target shoot for a Bastion.
+  // ShootRef defines the target shoot for a Bastion. The name field of the ShootRef is immutable.
   optional k8s.io.api.core.v1.LocalObjectReference shootRef = 1;
 
   // SeedName is the name of the seed to which this Bastion is currently scheduled. This field is populated
@@ -73,7 +73,7 @@ message BastionSpec {
   // +optional
   optional string providerType = 3;
 
-  // SSHPublicKey is the user's public key.
+  // SSHPublicKey is the user's public key. This field is immutable.
   optional string sshPublicKey = 4;
 
   // Ingress controls from where the created bastion host should be reachable.

--- a/pkg/apis/operations/v1alpha1/types_bastion.go
+++ b/pkg/apis/operations/v1alpha1/types_bastion.go
@@ -57,7 +57,7 @@ type BastionList struct {
 
 // BastionSpec is the specification of a Bastion.
 type BastionSpec struct {
-	// ShootRef defines the target shoot for a Bastion.
+	// ShootRef defines the target shoot for a Bastion. The name field of the ShootRef is immutable.
 	ShootRef corev1.LocalObjectReference `json:"shootRef" protobuf:"bytes,1,opt,name=shootRef"`
 	// SeedName is the name of the seed to which this Bastion is currently scheduled. This field is populated
 	// at the beginning of a create/reconcile operation.
@@ -66,7 +66,7 @@ type BastionSpec struct {
 	// ProviderType is cloud provider used by the referenced Shoot.
 	// +optional
 	ProviderType *string `json:"providerType,omitempty" protobuf:"bytes,3,opt,name=providerType"`
-	// SSHPublicKey is the user's public key.
+	// SSHPublicKey is the user's public key. This field is immutable.
 	SSHPublicKey string `json:"sshPublicKey" protobuf:"bytes,4,opt,name=sshPublicKey"`
 	// Ingress controls from where the created bastion host should be reachable.
 	Ingress []BastionIngressPolicy `json:"ingress" protobuf:"bytes,5,opt,name=ingress"`

--- a/pkg/apis/seedmanagement/types_managedseed.go
+++ b/pkg/apis/seedmanagement/types_managedseed.go
@@ -58,6 +58,7 @@ type ManagedSeedTemplate struct {
 // ManagedSeedSpec is the specification of a ManagedSeed.
 type ManagedSeedSpec struct {
 	// Shoot references a Shoot that should be registered as Seed.
+	// This field is immutable.
 	Shoot *Shoot
 	// SeedTemplate is a template for a Seed object, that should be used to register a given cluster as a Seed.
 	// Either SeedTemplate or Gardenlet must be specified. When Seed is specified, the ManagedSeed controller will not deploy a gardenlet into the cluster
@@ -84,9 +85,10 @@ type Gardenlet struct {
 	// Bootstrap is the mechanism that should be used for bootstrapping gardenlet connection to the Garden cluster. One of ServiceAccount, BootstrapToken, None.
 	// If set to ServiceAccount or BootstrapToken, a service account or a bootstrap token will be created in the garden cluster and used to compute the bootstrap kubeconfig.
 	// If set to None, the gardenClientConnection.kubeconfig field will be used to connect to the Garden cluster. Defaults to BootstrapToken.
+	// This field is immutable.
 	Bootstrap *Bootstrap
 	// MergeWithParent specifies whether the GardenletConfiguration of the parent gardenlet
-	// should be merged with the specified GardenletConfiguration. Defaults to true.
+	// should be merged with the specified GardenletConfiguration. Defaults to true. This field is immutable.
 	MergeWithParent *bool
 }
 

--- a/pkg/apis/seedmanagement/types_managedseedset.go
+++ b/pkg/apis/seedmanagement/types_managedseedset.go
@@ -50,7 +50,7 @@ type ManagedSeedSetSpec struct {
 	// Replicas is the desired number of replicas of the given Template. Defaults to 1.
 	Replicas *int32
 	// Selector is a label query over ManagedSeeds and Shoots that should match the replica count.
-	// It must match the ManagedSeeds and Shoots template's labels.
+	// It must match the ManagedSeeds and Shoots template's labels. This field is immutable.
 	Selector metav1.LabelSelector
 	// Template describes the ManagedSeed that will be created if insufficient replicas are detected.
 	// Each ManagedSeed created / updated by the ManagedSeedSet will fulfill this template.
@@ -62,8 +62,8 @@ type ManagedSeedSetSpec struct {
 	// employed to update ManagedSeeds / Shoots in the ManagedSeedSet when a revision is made to
 	// Template / ShootTemplate.
 	UpdateStrategy *UpdateStrategy
-	// RevisionHistoryLimit is the maximum number of revisions that will
-	// be maintained in the ManagedSeedSet's revision history. Defaults to 10.
+	// RevisionHistoryLimit is the maximum number of revisions that will be maintained
+	// in the ManagedSeedSet's revision history. Defaults to 10. This field is immutable.
 	RevisionHistoryLimit *int32
 }
 

--- a/pkg/apis/seedmanagement/v1alpha1/generated.proto
+++ b/pkg/apis/seedmanagement/v1alpha1/generated.proto
@@ -43,11 +43,12 @@ message Gardenlet {
   // Bootstrap is the mechanism that should be used for bootstrapping gardenlet connection to the Garden cluster. One of ServiceAccount, BootstrapToken, None.
   // If set to ServiceAccount or BootstrapToken, a service account or a bootstrap token will be created in the garden cluster and used to compute the bootstrap kubeconfig.
   // If set to None, the gardenClientConnection.kubeconfig field will be used to connect to the Garden cluster. Defaults to BootstrapToken.
+  // This field is immutable.
   // +optional
   optional string bootstrap = 3;
 
   // MergeWithParent specifies whether the GardenletConfiguration of the parent gardenlet
-  // should be merged with the specified GardenletConfiguration. Defaults to true.
+  // should be merged with the specified GardenletConfiguration. Defaults to true. This field is immutable.
   // +optional
   optional bool mergeWithParent = 4;
 }
@@ -173,7 +174,7 @@ message ManagedSeedSetSpec {
   optional int32 replicas = 1;
 
   // Selector is a label query over ManagedSeeds and Shoots that should match the replica count.
-  // It must match the ManagedSeeds and Shoots template's labels.
+  // It must match the ManagedSeeds and Shoots template's labels. This field is immutable.
   optional k8s.io.apimachinery.pkg.apis.meta.v1.LabelSelector selector = 2;
 
   // Template describes the ManagedSeed that will be created if insufficient replicas are detected.
@@ -190,8 +191,8 @@ message ManagedSeedSetSpec {
   // +optional
   optional UpdateStrategy updateStrategy = 5;
 
-  // RevisionHistoryLimit is the maximum number of revisions that will
-  // be maintained in the ManagedSeedSet's revision history. Defaults to 10.
+  // RevisionHistoryLimit is the maximum number of revisions that will be maintained
+  // in the ManagedSeedSet's revision history. Defaults to 10. This field is immutable.
   // +optional
   optional int32 revisionHistoryLimit = 6;
 }
@@ -248,6 +249,7 @@ message ManagedSeedSetStatus {
 // ManagedSeedSpec is the specification of a ManagedSeed.
 message ManagedSeedSpec {
   // Shoot references a Shoot that should be registered as Seed.
+  // This field is immutable.
   // +optional
   optional Shoot shoot = 1;
 

--- a/pkg/apis/seedmanagement/v1alpha1/types_managedseed.go
+++ b/pkg/apis/seedmanagement/v1alpha1/types_managedseed.go
@@ -64,6 +64,7 @@ type ManagedSeedTemplate struct {
 // ManagedSeedSpec is the specification of a ManagedSeed.
 type ManagedSeedSpec struct {
 	// Shoot references a Shoot that should be registered as Seed.
+	// This field is immutable.
 	// +optional
 	Shoot *Shoot `json:"shoot,omitempty" protobuf:"bytes,1,opt,name=shoot"`
 	// SeedTemplate is a template for a Seed object, that should be used to register a given cluster as a Seed.
@@ -95,10 +96,11 @@ type Gardenlet struct {
 	// Bootstrap is the mechanism that should be used for bootstrapping gardenlet connection to the Garden cluster. One of ServiceAccount, BootstrapToken, None.
 	// If set to ServiceAccount or BootstrapToken, a service account or a bootstrap token will be created in the garden cluster and used to compute the bootstrap kubeconfig.
 	// If set to None, the gardenClientConnection.kubeconfig field will be used to connect to the Garden cluster. Defaults to BootstrapToken.
+	// This field is immutable.
 	// +optional
 	Bootstrap *Bootstrap `json:"bootstrap,omitempty" protobuf:"bytes,3,opt,name=bootstrap"`
 	// MergeWithParent specifies whether the GardenletConfiguration of the parent gardenlet
-	// should be merged with the specified GardenletConfiguration. Defaults to true.
+	// should be merged with the specified GardenletConfiguration. Defaults to true. This field is immutable.
 	// +optional
 	MergeWithParent *bool `json:"mergeWithParent,omitempty" protobuf:"varint,4,opt,name=mergeWithParent"`
 }

--- a/pkg/apis/seedmanagement/v1alpha1/types_managedseedset.go
+++ b/pkg/apis/seedmanagement/v1alpha1/types_managedseedset.go
@@ -55,7 +55,7 @@ type ManagedSeedSetSpec struct {
 	// +optional
 	Replicas *int32 `json:"replicas,omitempty" protobuf:"varint,1,opt,name=replicas"`
 	// Selector is a label query over ManagedSeeds and Shoots that should match the replica count.
-	// It must match the ManagedSeeds and Shoots template's labels.
+	// It must match the ManagedSeeds and Shoots template's labels. This field is immutable.
 	Selector metav1.LabelSelector `json:"selector" protobuf:"bytes,2,opt,name=selector"`
 	// Template describes the ManagedSeed that will be created if insufficient replicas are detected.
 	// Each ManagedSeed created / updated by the ManagedSeedSet will fulfill this template.
@@ -68,8 +68,8 @@ type ManagedSeedSetSpec struct {
 	// Template / ShootTemplate.
 	// +optional
 	UpdateStrategy *UpdateStrategy `json:"updateStrategy,omitempty" protobuf:"bytes,5,opt,name=updateStrategy"`
-	// RevisionHistoryLimit is the maximum number of revisions that will
-	// be maintained in the ManagedSeedSet's revision history. Defaults to 10.
+	// RevisionHistoryLimit is the maximum number of revisions that will be maintained
+	// in the ManagedSeedSet's revision history. Defaults to 10. This field is immutable.
 	// +optional
 	RevisionHistoryLimit *int32 `json:"revisionHistoryLimit,omitempty" protobuf:"varint,6,opt,name=revisionHistoryLimit"`
 }

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -1123,7 +1123,7 @@ func schema_pkg_apis_core_v1alpha1_BackupBucketSpec(ref common.ReferenceCallback
 				Properties: map[string]spec.Schema{
 					"provider": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Provider hold the details of cloud provider of the object store.",
+							Description: "Provider holds the details of cloud provider of the object store. This field is immutable.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1alpha1.BackupBucketProvider"),
 						},
@@ -1143,7 +1143,7 @@ func schema_pkg_apis_core_v1alpha1_BackupBucketSpec(ref common.ReferenceCallback
 					},
 					"seed": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Seed holds the name of the seed allocated to BackupBucket for running controller.",
+							Description: "Seed holds the name of the seed allocated to BackupBucket for running controller. This field is immutable.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -2030,7 +2030,7 @@ func schema_pkg_apis_core_v1alpha1_ControllerInstallation(ref common.ReferenceCa
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Spec contains the specification of this installation.",
+							Description: "Spec contains the specification of this installation. If the object's deletion timestamp is set, this field is immutable.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1alpha1.ControllerInstallationSpec"),
 						},
@@ -2110,14 +2110,14 @@ func schema_pkg_apis_core_v1alpha1_ControllerInstallationSpec(ref common.Referen
 				Properties: map[string]spec.Schema{
 					"registrationRef": {
 						SchemaProps: spec.SchemaProps{
-							Description: "RegistrationRef is used to reference a ControllerRegistration resource.",
+							Description: "RegistrationRef is used to reference a ControllerRegistration resource. The name field of the RegistrationRef is immutable.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.ObjectReference"),
 						},
 					},
 					"seedRef": {
 						SchemaProps: spec.SchemaProps{
-							Description: "SeedRef is used to reference a Seed resource.",
+							Description: "SeedRef is used to reference a Seed resource. The name field of the SeedRef is immutable.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.ObjectReference"),
 						},
@@ -2208,7 +2208,7 @@ func schema_pkg_apis_core_v1alpha1_ControllerRegistration(ref common.ReferenceCa
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Spec contains the specification of this registration.",
+							Description: "Spec contains the specification of this registration. If the object's deletion timestamp is set, this field is immutable.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1alpha1.ControllerRegistrationSpec"),
 						},
@@ -2387,7 +2387,7 @@ func schema_pkg_apis_core_v1alpha1_ControllerResource(ref common.ReferenceCallba
 					},
 					"primary": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Primary determines if the controller backed by this ControllerRegistration is responsible for the extension resource's lifecycle. This field defaults to true. There must be exactly one primary controller for this kind/type combination.",
+							Description: "Primary determines if the controller backed by this ControllerRegistration is responsible for the extension resource's lifecycle. This field defaults to true. There must be exactly one primary controller for this kind/type combination. This field is immutable.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
@@ -2410,7 +2410,7 @@ func schema_pkg_apis_core_v1alpha1_DNS(ref common.ReferenceCallback) common.Open
 				Properties: map[string]spec.Schema{
 					"domain": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Domain is the external available domain of the Shoot cluster. This domain will be written into the kubeconfig that is handed out to end-users. Once set it is immutable.",
+							Description: "Domain is the external available domain of the Shoot cluster. This domain will be written into the kubeconfig that is handed out to end-users. This field is immutable.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -2705,7 +2705,7 @@ func schema_pkg_apis_core_v1alpha1_ExposureClass(ref common.ReferenceCallback) c
 					},
 					"handler": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Handler is the name of the handler which applies the control plane endpoint exposure strategy.",
+							Description: "Handler is the name of the handler which applies the control plane endpoint exposure strategy. This field is immutable.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -2713,7 +2713,7 @@ func schema_pkg_apis_core_v1alpha1_ExposureClass(ref common.ReferenceCallback) c
 					},
 					"scheduling": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Scheduling holds information how to select applicable Seed's for ExposureClass usage.",
+							Description: "Scheduling holds information how to select applicable Seed's for ExposureClass usage. This field is immutable.",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1alpha1.ExposureClassScheduling"),
 						},
 					},
@@ -2930,7 +2930,7 @@ func schema_pkg_apis_core_v1alpha1_ExtensionStatus(ref common.ReferenceCallback)
 					},
 					"type": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Type of the extension resource",
+							Description: "Type of the extension resource. This field is immutable.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -3403,7 +3403,7 @@ func schema_pkg_apis_core_v1alpha1_KubeControllerManagerConfig(ref common.Refere
 					},
 					"nodeCIDRMaskSize": {
 						SchemaProps: spec.SchemaProps{
-							Description: "NodeCIDRMaskSize defines the mask size for node cidr in cluster (default is 24)",
+							Description: "NodeCIDRMaskSize defines the mask size for node cidr in cluster (default is 24). This field is immutable.",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -4558,7 +4558,7 @@ func schema_pkg_apis_core_v1alpha1_Networking(ref common.ReferenceCallback) comm
 				Properties: map[string]spec.Schema{
 					"type": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Type identifies the type of the networking plugin.",
+							Description: "Type identifies the type of the networking plugin. This field is immutable.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -4572,21 +4572,21 @@ func schema_pkg_apis_core_v1alpha1_Networking(ref common.ReferenceCallback) comm
 					},
 					"pods": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Pods is the CIDR of the pod network.",
+							Description: "Pods is the CIDR of the pod network. This field is immutable.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"nodes": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Nodes is the CIDR of the entire node network.",
+							Description: "Nodes is the CIDR of the entire node network. This field is immutable.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"services": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Services is the CIDR of the service network.",
+							Description: "Services is the CIDR of the service network. This field is immutable.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -4827,7 +4827,7 @@ func schema_pkg_apis_core_v1alpha1_Plant(ref common.ReferenceCallback) common.Op
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Spec contains the specification of this Plant.",
+							Description: "Spec contains the specification of this Plant. If the object's deletion timestamp is set, this field is immutable.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1alpha1.PlantSpec"),
 						},
@@ -5166,7 +5166,7 @@ func schema_pkg_apis_core_v1alpha1_ProjectSpec(ref common.ReferenceCallback) com
 				Properties: map[string]spec.Schema{
 					"createdBy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "CreatedBy is a subject representing a user name, an email address, or any other identifier of a user who created the project.",
+							Description: "CreatedBy is a subject representing a user name, an email address, or any other identifier of a user who created the project. This field is immutable.",
 							Ref:         ref("k8s.io/api/rbac/v1.Subject"),
 						},
 					},
@@ -5206,7 +5206,7 @@ func schema_pkg_apis_core_v1alpha1_ProjectSpec(ref common.ReferenceCallback) com
 					},
 					"namespace": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Namespace is the name of the namespace that has been created for the Project object. A nil value means that Gardener will determine the name of the namespace.",
+							Description: "Namespace is the name of the namespace that has been created for the Project object. A nil value means that Gardener will determine the name of the namespace. This field is immutable.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -5336,7 +5336,7 @@ func schema_pkg_apis_core_v1alpha1_Provider(ref common.ReferenceCallback) common
 				Properties: map[string]spec.Schema{
 					"type": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Type is the type of the provider.",
+							Description: "Type is the type of the provider. This field is immutable.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -5508,7 +5508,7 @@ func schema_pkg_apis_core_v1alpha1_QuotaSpec(ref common.ReferenceCallback) commo
 					},
 					"scope": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Scope is the scope of the Quota object, either 'project' or 'secret'.",
+							Description: "Scope is the scope of the Quota object, either 'project' or 'secret'. This field is immutable.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.ObjectReference"),
 						},
@@ -5695,14 +5695,14 @@ func schema_pkg_apis_core_v1alpha1_SecretBinding(ref common.ReferenceCallback) c
 					},
 					"secretRef": {
 						SchemaProps: spec.SchemaProps{
-							Description: "SecretRef is a reference to a secret object in the same or another namespace.",
+							Description: "SecretRef is a reference to a secret object in the same or another namespace. This field is immutable.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.SecretReference"),
 						},
 					},
 					"quotas": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Quotas is a list of references to Quota objects in the same or another namespace.",
+							Description: "Quotas is a list of references to Quota objects in the same or another namespace. This field is immutable.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -5716,7 +5716,7 @@ func schema_pkg_apis_core_v1alpha1_SecretBinding(ref common.ReferenceCallback) c
 					},
 					"provider": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Provider defines the provider type of the SecretBinding.",
+							Description: "Provider defines the provider type of the SecretBinding. This field is immutable when the SecretBindingProviderValidation feature gate is enabled.",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1alpha1.SecretBindingProvider"),
 						},
 					},
@@ -5861,7 +5861,7 @@ func schema_pkg_apis_core_v1alpha1_SeedBackup(ref common.ReferenceCallback) comm
 				Properties: map[string]spec.Schema{
 					"provider": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Provider is a provider name.",
+							Description: "Provider is a provider name. This field is immutable.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -5875,7 +5875,7 @@ func schema_pkg_apis_core_v1alpha1_SeedBackup(ref common.ReferenceCallback) comm
 					},
 					"region": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Region is a region name.",
+							Description: "Region is a region name. This field is immutable.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -5905,7 +5905,7 @@ func schema_pkg_apis_core_v1alpha1_SeedDNS(ref common.ReferenceCallback) common.
 				Properties: map[string]spec.Schema{
 					"ingressDomain": {
 						SchemaProps: spec.SchemaProps{
-							Description: "IngressDomain is the domain of the Seed cluster pointing to the ingress controller endpoint. It will be used to construct ingress URLs for system applications running in Shoot clusters. Once set this field is immutable. This will be removed in the next API version and replaced by spec.ingress.domain.",
+							Description: "IngressDomain is the domain of the Seed cluster pointing to the ingress controller endpoint. It will be used to construct ingress URLs for system applications running in Shoot clusters. This field is immutable. This will be removed in the next API version and replaced by spec.ingress.domain.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -6027,14 +6027,14 @@ func schema_pkg_apis_core_v1alpha1_SeedNetworks(ref common.ReferenceCallback) co
 				Properties: map[string]spec.Schema{
 					"nodes": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Nodes is the CIDR of the node network.",
+							Description: "Nodes is the CIDR of the node network. This field is immutable.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"pods": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Pods is the CIDR of the pod network.",
+							Description: "Pods is the CIDR of the pod network. This field is immutable.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -6042,7 +6042,7 @@ func schema_pkg_apis_core_v1alpha1_SeedNetworks(ref common.ReferenceCallback) co
 					},
 					"services": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Services is the CIDR of the service network.",
+							Description: "Services is the CIDR of the service network. This field is immutable.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -6511,7 +6511,7 @@ func schema_pkg_apis_core_v1alpha1_SeedSpec(ref common.ReferenceCallback) common
 					},
 					"ingress": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Ingress configures Ingress specific settings of the Seed cluster.",
+							Description: "Ingress configures Ingress specific settings of the Seed cluster. This field is immutable.",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1alpha1.Ingress"),
 						},
 					},
@@ -6573,7 +6573,7 @@ func schema_pkg_apis_core_v1alpha1_SeedStatus(ref common.ReferenceCallback) comm
 					},
 					"clusterIdentity": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ClusterIdentity is the identity of the Seed cluster",
+							Description: "ClusterIdentity is the identity of the Seed cluster. This field is immutable.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -6763,7 +6763,7 @@ func schema_pkg_apis_core_v1alpha1_Shoot(ref common.ReferenceCallback) common.Op
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Specification of the Shoot cluster.",
+							Description: "Specification of the Shoot cluster. If the object's deletion timestamp is set, this field is immutable.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1alpha1.ShootSpec"),
 						},
@@ -7043,7 +7043,7 @@ func schema_pkg_apis_core_v1alpha1_ShootSpec(ref common.ReferenceCallback) commo
 					},
 					"cloudProfileName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "CloudProfileName is a name of a CloudProfile object.",
+							Description: "CloudProfileName is a name of a CloudProfile object. This field is immutable.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -7117,7 +7117,7 @@ func schema_pkg_apis_core_v1alpha1_ShootSpec(ref common.ReferenceCallback) commo
 					},
 					"region": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Region is a name of a region.",
+							Description: "Region is a name of a region. This field is immutable.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -7125,7 +7125,7 @@ func schema_pkg_apis_core_v1alpha1_ShootSpec(ref common.ReferenceCallback) commo
 					},
 					"secretBindingName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "SecretBindingName is the name of the a SecretBinding that has a reference to the provider secret. The credentials inside the provider secret will be used to create the shoot in the respective account.",
+							Description: "SecretBindingName is the name of the a SecretBinding that has a reference to the provider secret. The credentials inside the provider secret will be used to create the shoot in the respective account. This field is immutable.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -7133,7 +7133,7 @@ func schema_pkg_apis_core_v1alpha1_ShootSpec(ref common.ReferenceCallback) commo
 					},
 					"seedName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "SeedName is the name of the seed cluster that runs the control plane of the Shoot.",
+							Description: "SeedName is the name of the seed cluster that runs the control plane of the Shoot. This field is immutable when the SeedChange feature gate is disabled.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -7180,7 +7180,7 @@ func schema_pkg_apis_core_v1alpha1_ShootSpec(ref common.ReferenceCallback) commo
 					},
 					"exposureClassName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ExposureClassName is the optional name of an exposure class to apply a control plane endpoint exposure strategy.",
+							Description: "ExposureClassName is the optional name of an exposure class to apply a control plane endpoint exposure strategy. This field is immutable.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -7461,7 +7461,7 @@ func schema_pkg_apis_core_v1alpha1_ShootStatus(ref common.ReferenceCallback) com
 					},
 					"technicalID": {
 						SchemaProps: spec.SchemaProps{
-							Description: "TechnicalID is the name that is used for creating the Seed namespace, the infrastructure resources, and basically everything that is related to this particular Shoot.",
+							Description: "TechnicalID is the name that is used for creating the Seed namespace, the infrastructure resources, and basically everything that is related to this particular Shoot. This field is immutable.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -7469,7 +7469,7 @@ func schema_pkg_apis_core_v1alpha1_ShootStatus(ref common.ReferenceCallback) com
 					},
 					"uid": {
 						SchemaProps: spec.SchemaProps{
-							Description: "UID is a unique identifier for the Shoot cluster to avoid portability between Kubernetes clusters. It is used to compute unique hashes.",
+							Description: "UID is a unique identifier for the Shoot cluster to avoid portability between Kubernetes clusters. It is used to compute unique hashes. This field is immutable.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -7477,7 +7477,7 @@ func schema_pkg_apis_core_v1alpha1_ShootStatus(ref common.ReferenceCallback) com
 					},
 					"clusterIdentity": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ClusterIdentity is the identity of the Shoot cluster",
+							Description: "ClusterIdentity is the identity of the Shoot cluster. This field is immutable.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -8316,7 +8316,7 @@ func schema_pkg_apis_core_v1beta1_BackupBucketSpec(ref common.ReferenceCallback)
 				Properties: map[string]spec.Schema{
 					"provider": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Provider hold the details of cloud provider of the object store.",
+							Description: "Provider holds the details of cloud provider of the object store. This field is immutable.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1beta1.BackupBucketProvider"),
 						},
@@ -8336,7 +8336,7 @@ func schema_pkg_apis_core_v1beta1_BackupBucketSpec(ref common.ReferenceCallback)
 					},
 					"seedName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "SeedName holds the name of the seed allocated to BackupBucket for running controller.",
+							Description: "SeedName holds the name of the seed allocated to BackupBucket for running controller. This field is immutable.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -9223,7 +9223,7 @@ func schema_pkg_apis_core_v1beta1_ControllerInstallation(ref common.ReferenceCal
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Spec contains the specification of this installation.",
+							Description: "Spec contains the specification of this installation. If the object's deletion timestamp is set, this field is immutable.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1beta1.ControllerInstallationSpec"),
 						},
@@ -9303,14 +9303,14 @@ func schema_pkg_apis_core_v1beta1_ControllerInstallationSpec(ref common.Referenc
 				Properties: map[string]spec.Schema{
 					"registrationRef": {
 						SchemaProps: spec.SchemaProps{
-							Description: "RegistrationRef is used to reference a ControllerRegistration resource.",
+							Description: "RegistrationRef is used to reference a ControllerRegistration resource. The name field of the RegistrationRef is immutable.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.ObjectReference"),
 						},
 					},
 					"seedRef": {
 						SchemaProps: spec.SchemaProps{
-							Description: "SeedRef is used to reference a Seed resource.",
+							Description: "SeedRef is used to reference a Seed resource. The name field of the SeedRef is immutable.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.ObjectReference"),
 						},
@@ -9401,7 +9401,7 @@ func schema_pkg_apis_core_v1beta1_ControllerRegistration(ref common.ReferenceCal
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Spec contains the specification of this registration.",
+							Description: "Spec contains the specification of this registration. If the object's deletion timestamp is set, this field is immutable.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1beta1.ControllerRegistrationSpec"),
 						},
@@ -9580,7 +9580,7 @@ func schema_pkg_apis_core_v1beta1_ControllerResource(ref common.ReferenceCallbac
 					},
 					"primary": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Primary determines if the controller backed by this ControllerRegistration is responsible for the extension resource's lifecycle. This field defaults to true. There must be exactly one primary controller for this kind/type combination.",
+							Description: "Primary determines if the controller backed by this ControllerRegistration is responsible for the extension resource's lifecycle. This field defaults to true. There must be exactly one primary controller for this kind/type combination. This field is immutable.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
@@ -9603,7 +9603,7 @@ func schema_pkg_apis_core_v1beta1_DNS(ref common.ReferenceCallback) common.OpenA
 				Properties: map[string]spec.Schema{
 					"domain": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Domain is the external available domain of the Shoot cluster. This domain will be written into the kubeconfig that is handed out to end-users. Once set it is immutable.",
+							Description: "Domain is the external available domain of the Shoot cluster. This domain will be written into the kubeconfig that is handed out to end-users. This field is immutable.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -10310,7 +10310,7 @@ func schema_pkg_apis_core_v1beta1_KubeControllerManagerConfig(ref common.Referen
 					},
 					"nodeCIDRMaskSize": {
 						SchemaProps: spec.SchemaProps{
-							Description: "NodeCIDRMaskSize defines the mask size for node cidr in cluster (default is 24)",
+							Description: "NodeCIDRMaskSize defines the mask size for node cidr in cluster (default is 24). This field is immutable.",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -11465,7 +11465,7 @@ func schema_pkg_apis_core_v1beta1_Networking(ref common.ReferenceCallback) commo
 				Properties: map[string]spec.Schema{
 					"type": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Type identifies the type of the networking plugin.",
+							Description: "Type identifies the type of the networking plugin. This field is immutable.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -11479,21 +11479,21 @@ func schema_pkg_apis_core_v1beta1_Networking(ref common.ReferenceCallback) commo
 					},
 					"pods": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Pods is the CIDR of the pod network.",
+							Description: "Pods is the CIDR of the pod network. This field is immutable.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"nodes": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Nodes is the CIDR of the entire node network.",
+							Description: "Nodes is the CIDR of the entire node network. This field is immutable.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"services": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Services is the CIDR of the service network.",
+							Description: "Services is the CIDR of the service network. This field is immutable.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -11734,7 +11734,7 @@ func schema_pkg_apis_core_v1beta1_Plant(ref common.ReferenceCallback) common.Ope
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Spec contains the specification of this Plant.",
+							Description: "Spec contains the specification of this Plant. If the object's deletion timestamp is set, this field is immutable.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1beta1.PlantSpec"),
 						},
@@ -12073,7 +12073,7 @@ func schema_pkg_apis_core_v1beta1_ProjectSpec(ref common.ReferenceCallback) comm
 				Properties: map[string]spec.Schema{
 					"createdBy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "CreatedBy is a subject representing a user name, an email address, or any other identifier of a user who created the project.",
+							Description: "CreatedBy is a subject representing a user name, an email address, or any other identifier of a user who created the project. This field is immutable.",
 							Ref:         ref("k8s.io/api/rbac/v1.Subject"),
 						},
 					},
@@ -12113,7 +12113,7 @@ func schema_pkg_apis_core_v1beta1_ProjectSpec(ref common.ReferenceCallback) comm
 					},
 					"namespace": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Namespace is the name of the namespace that has been created for the Project object. A nil value means that Gardener will determine the name of the namespace.",
+							Description: "Namespace is the name of the namespace that has been created for the Project object. A nil value means that Gardener will determine the name of the namespace. This field is immutable.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -12243,7 +12243,7 @@ func schema_pkg_apis_core_v1beta1_Provider(ref common.ReferenceCallback) common.
 				Properties: map[string]spec.Schema{
 					"type": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Type is the type of the provider.",
+							Description: "Type is the type of the provider. This field is immutable.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -12415,7 +12415,7 @@ func schema_pkg_apis_core_v1beta1_QuotaSpec(ref common.ReferenceCallback) common
 					},
 					"scope": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Scope is the scope of the Quota object, either 'project' or 'secret'.",
+							Description: "Scope is the scope of the Quota object, either 'project' or 'secret'. This field is immutable.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.ObjectReference"),
 						},
@@ -12556,14 +12556,14 @@ func schema_pkg_apis_core_v1beta1_SecretBinding(ref common.ReferenceCallback) co
 					},
 					"secretRef": {
 						SchemaProps: spec.SchemaProps{
-							Description: "SecretRef is a reference to a secret object in the same or another namespace.",
+							Description: "SecretRef is a reference to a secret object in the same or another namespace. This field is immutable.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.SecretReference"),
 						},
 					},
 					"quotas": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Quotas is a list of references to Quota objects in the same or another namespace.",
+							Description: "Quotas is a list of references to Quota objects in the same or another namespace. This field is immutable.",
 							Type:        []string{"array"},
 							Items: &spec.SchemaOrArray{
 								Schema: &spec.Schema{
@@ -12577,7 +12577,7 @@ func schema_pkg_apis_core_v1beta1_SecretBinding(ref common.ReferenceCallback) co
 					},
 					"provider": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Provider defines the provider type of the SecretBinding.",
+							Description: "Provider defines the provider type of the SecretBinding. This field is immutable when the SecretBindingProviderValidation feature gate is enabled.",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1beta1.SecretBindingProvider"),
 						},
 					},
@@ -12722,7 +12722,7 @@ func schema_pkg_apis_core_v1beta1_SeedBackup(ref common.ReferenceCallback) commo
 				Properties: map[string]spec.Schema{
 					"provider": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Provider is a provider name.",
+							Description: "Provider is a provider name. This field is immutable.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -12736,7 +12736,7 @@ func schema_pkg_apis_core_v1beta1_SeedBackup(ref common.ReferenceCallback) commo
 					},
 					"region": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Region is a region name.",
+							Description: "Region is a region name. This field is immutable.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -12766,7 +12766,7 @@ func schema_pkg_apis_core_v1beta1_SeedDNS(ref common.ReferenceCallback) common.O
 				Properties: map[string]spec.Schema{
 					"ingressDomain": {
 						SchemaProps: spec.SchemaProps{
-							Description: "IngressDomain is the domain of the Seed cluster pointing to the ingress controller endpoint. It will be used to construct ingress URLs for system applications running in Shoot clusters. Once set this field is immutable. This will be removed in the next API version and replaced by spec.ingress.domain.",
+							Description: "IngressDomain is the domain of the Seed cluster pointing to the ingress controller endpoint. It will be used to construct ingress URLs for system applications running in Shoot clusters. This field is immutable. This will be removed in the next API version and replaced by spec.ingress.domain.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -12888,14 +12888,14 @@ func schema_pkg_apis_core_v1beta1_SeedNetworks(ref common.ReferenceCallback) com
 				Properties: map[string]spec.Schema{
 					"nodes": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Nodes is the CIDR of the node network.",
+							Description: "Nodes is the CIDR of the node network. This field is immutable.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"pods": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Pods is the CIDR of the pod network.",
+							Description: "Pods is the CIDR of the pod network. This field is immutable.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -12903,7 +12903,7 @@ func schema_pkg_apis_core_v1beta1_SeedNetworks(ref common.ReferenceCallback) com
 					},
 					"services": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Services is the CIDR of the service network.",
+							Description: "Services is the CIDR of the service network. This field is immutable.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -13372,7 +13372,7 @@ func schema_pkg_apis_core_v1beta1_SeedSpec(ref common.ReferenceCallback) common.
 					},
 					"ingress": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Ingress configures Ingress specific settings of the Seed cluster.",
+							Description: "Ingress configures Ingress specific settings of the Seed cluster. This field is immutable.",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1beta1.Ingress"),
 						},
 					},
@@ -13434,7 +13434,7 @@ func schema_pkg_apis_core_v1beta1_SeedStatus(ref common.ReferenceCallback) commo
 					},
 					"clusterIdentity": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ClusterIdentity is the identity of the Seed cluster",
+							Description: "ClusterIdentity is the identity of the Seed cluster. This field is immutable.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -13683,7 +13683,7 @@ func schema_pkg_apis_core_v1beta1_Shoot(ref common.ReferenceCallback) common.Ope
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Specification of the Shoot cluster.",
+							Description: "Specification of the Shoot cluster. If the object's deletion timestamp is set, this field is immutable.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1beta1.ShootSpec"),
 						},
@@ -13863,7 +13863,7 @@ func schema_pkg_apis_core_v1beta1_ShootSpec(ref common.ReferenceCallback) common
 					},
 					"cloudProfileName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "CloudProfileName is a name of a CloudProfile object.",
+							Description: "CloudProfileName is a name of a CloudProfile object. This field is immutable.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -13937,7 +13937,7 @@ func schema_pkg_apis_core_v1beta1_ShootSpec(ref common.ReferenceCallback) common
 					},
 					"region": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Region is a name of a region.",
+							Description: "Region is a name of a region. This field is immutable.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -13945,7 +13945,7 @@ func schema_pkg_apis_core_v1beta1_ShootSpec(ref common.ReferenceCallback) common
 					},
 					"secretBindingName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "SecretBindingName is the name of the a SecretBinding that has a reference to the provider secret. The credentials inside the provider secret will be used to create the shoot in the respective account.",
+							Description: "SecretBindingName is the name of the a SecretBinding that has a reference to the provider secret. The credentials inside the provider secret will be used to create the shoot in the respective account. This field is immutable.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -13953,7 +13953,7 @@ func schema_pkg_apis_core_v1beta1_ShootSpec(ref common.ReferenceCallback) common
 					},
 					"seedName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "SeedName is the name of the seed cluster that runs the control plane of the Shoot.",
+							Description: "SeedName is the name of the seed cluster that runs the control plane of the Shoot. This field is immutable when the SeedChange feature gate is disabled.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -14000,7 +14000,7 @@ func schema_pkg_apis_core_v1beta1_ShootSpec(ref common.ReferenceCallback) common
 					},
 					"exposureClassName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ExposureClassName is the optional name of an exposure class to apply a control plane endpoint exposure strategy.",
+							Description: "ExposureClassName is the optional name of an exposure class to apply a control plane endpoint exposure strategy. This field is immutable.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -14118,7 +14118,7 @@ func schema_pkg_apis_core_v1beta1_ShootStatus(ref common.ReferenceCallback) comm
 					},
 					"technicalID": {
 						SchemaProps: spec.SchemaProps{
-							Description: "TechnicalID is the name that is used for creating the Seed namespace, the infrastructure resources, and basically everything that is related to this particular Shoot.",
+							Description: "TechnicalID is the name that is used for creating the Seed namespace, the infrastructure resources, and basically everything that is related to this particular Shoot. This field is immutable.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -14126,7 +14126,7 @@ func schema_pkg_apis_core_v1beta1_ShootStatus(ref common.ReferenceCallback) comm
 					},
 					"uid": {
 						SchemaProps: spec.SchemaProps{
-							Description: "UID is a unique identifier for the Shoot cluster to avoid portability between Kubernetes clusters. It is used to compute unique hashes.",
+							Description: "UID is a unique identifier for the Shoot cluster to avoid portability between Kubernetes clusters. It is used to compute unique hashes. This field is immutable.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -14134,7 +14134,7 @@ func schema_pkg_apis_core_v1beta1_ShootStatus(ref common.ReferenceCallback) comm
 					},
 					"clusterIdentity": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ClusterIdentity is the identity of the Shoot cluster",
+							Description: "ClusterIdentity is the identity of the Shoot cluster. This field is immutable.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -14794,7 +14794,7 @@ func schema_pkg_apis_operations_v1alpha1_BastionSpec(ref common.ReferenceCallbac
 				Properties: map[string]spec.Schema{
 					"shootRef": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ShootRef defines the target shoot for a Bastion.",
+							Description: "ShootRef defines the target shoot for a Bastion. The name field of the ShootRef is immutable.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/api/core/v1.LocalObjectReference"),
 						},
@@ -14815,7 +14815,7 @@ func schema_pkg_apis_operations_v1alpha1_BastionSpec(ref common.ReferenceCallbac
 					},
 					"sshPublicKey": {
 						SchemaProps: spec.SchemaProps{
-							Description: "SSHPublicKey is the user's public key.",
+							Description: "SSHPublicKey is the user's public key. This field is immutable.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -14926,14 +14926,14 @@ func schema_pkg_apis_seedmanagement_v1alpha1_Gardenlet(ref common.ReferenceCallb
 					},
 					"bootstrap": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Bootstrap is the mechanism that should be used for bootstrapping gardenlet connection to the Garden cluster. One of ServiceAccount, BootstrapToken, None. If set to ServiceAccount or BootstrapToken, a service account or a bootstrap token will be created in the garden cluster and used to compute the bootstrap kubeconfig. If set to None, the gardenClientConnection.kubeconfig field will be used to connect to the Garden cluster. Defaults to BootstrapToken.",
+							Description: "Bootstrap is the mechanism that should be used for bootstrapping gardenlet connection to the Garden cluster. One of ServiceAccount, BootstrapToken, None. If set to ServiceAccount or BootstrapToken, a service account or a bootstrap token will be created in the garden cluster and used to compute the bootstrap kubeconfig. If set to None, the gardenClientConnection.kubeconfig field will be used to connect to the Garden cluster. Defaults to BootstrapToken. This field is immutable.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"mergeWithParent": {
 						SchemaProps: spec.SchemaProps{
-							Description: "MergeWithParent specifies whether the GardenletConfiguration of the parent gardenlet should be merged with the specified GardenletConfiguration. Defaults to true.",
+							Description: "MergeWithParent specifies whether the GardenletConfiguration of the parent gardenlet should be merged with the specified GardenletConfiguration. Defaults to true. This field is immutable.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},
@@ -15327,7 +15327,7 @@ func schema_pkg_apis_seedmanagement_v1alpha1_ManagedSeedSetSpec(ref common.Refer
 					},
 					"selector": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Selector is a label query over ManagedSeeds and Shoots that should match the replica count. It must match the ManagedSeeds and Shoots template's labels.",
+							Description: "Selector is a label query over ManagedSeeds and Shoots that should match the replica count. It must match the ManagedSeeds and Shoots template's labels. This field is immutable.",
 							Default:     map[string]interface{}{},
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.LabelSelector"),
 						},
@@ -15354,7 +15354,7 @@ func schema_pkg_apis_seedmanagement_v1alpha1_ManagedSeedSetSpec(ref common.Refer
 					},
 					"revisionHistoryLimit": {
 						SchemaProps: spec.SchemaProps{
-							Description: "RevisionHistoryLimit is the maximum number of revisions that will be maintained in the ManagedSeedSet's revision history. Defaults to 10.",
+							Description: "RevisionHistoryLimit is the maximum number of revisions that will be maintained in the ManagedSeedSet's revision history. Defaults to 10. This field is immutable.",
 							Type:        []string{"integer"},
 							Format:      "int32",
 						},
@@ -15483,7 +15483,7 @@ func schema_pkg_apis_seedmanagement_v1alpha1_ManagedSeedSpec(ref common.Referenc
 				Properties: map[string]spec.Schema{
 					"shoot": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Shoot references a Shoot that should be registered as Seed.",
+							Description: "Shoot references a Shoot that should be registered as Seed. This field is immutable.",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1.Shoot"),
 						},
 					},


### PR DESCRIPTION
/area documentation
/kind enhancement

Fixes https://github.com/gardener/gardener/issues/4827

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc user
Gardener API reference does now contain information if a field is immutable.
```
