### PR TITLE
Delete kube-apiserver-http-proxy secret if ReversedVPN is disabled

### DIFF
--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -109,6 +109,7 @@ func (b *Botanist) GenerateAndSaveSecrets(ctx context.Context) error {
 					vpnseedserver.DeploymentName,
 					vpnshoot.SecretNameVPNShootClient,
 					vpnseedserver.VpnSeedServerTLSAuth,
+					kubeapiserver.SecretNameHTTPProxy,
 				); err != nil {
 					return err
 				}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
With this PR the kube-apiserver-http-proxy will be deleted if the `ReversedVPN` feature gate is disabled. This will prevent the scenario described in #5352 from happening:
> Relatively recently a dedicated CA for the reversed VPN components was added: PR #4942. Previously the secrets required for the reversed VPN were signed with the cluster CA (CN=kubernetes). The shoot clusters that were affected by this issue most likely had the ReversedVPN feature gate enabled and then disabled before PR #4942 so the kube-apiserver-http-proxy secret was generated with the cluster CA. However, when the ReversedVPN feature gate is disabled the kube-apiserver-http-proxy is not deleted.

**Which issue(s) this PR fixes**:
Fixes #5352 

**Special notes for your reviewer**:
Clusters that are currently affected by the issue will not be automatically fixed with this issue and I do not have a good idea on how to do this apart from manually removing the `kube-apiserver-http-proxy` from the shoot's control plane and the `ShootState` or turning the `ReversedVPN` off, reconciling and and then turning it on again.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
When the `ReversedVPN`  feature gate is disabled, the `kube-apiserver-http-proxy` secret is properly removed from the `ShootState` and the shoot's control plane.
```
