### PR TITLE
Update status in case Bastion blocks Shoot deletion

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control.go
@@ -270,7 +270,9 @@ func (r *shootReconciler) Reconcile(ctx context.Context, request reconcile.Reque
 			return reconcile.Result{}, fmt.Errorf("failed to check for related Bastions: %w", err)
 		}
 		if hasBastions {
-			return reconcile.Result{}, errors.New("shoot has still Bastions")
+			hasBastionErr := errors.New("shoot has still Bastions")
+			updateErr := r.patchShootStatusOperationError(ctx, gardenClient.Client(), shoot, hasBastionErr.Error(), gardencorev1beta1.LastOperationTypeMigrate, shoot.Status.LastErrors...)
+			return reconcile.Result{}, utilerrors.WithSuppressed(hasBastionErr, updateErr)
 		}
 
 		sourceSeed := &gardencorev1beta1.Seed{}
@@ -379,7 +381,9 @@ func (r *shootReconciler) deleteShoot(ctx context.Context, logger logrus.FieldLo
 		return reconcile.Result{}, fmt.Errorf("failed to check for related Bastions: %w", err)
 	}
 	if hasBastions {
-		return reconcile.Result{}, errors.New("shoot has still Bastions")
+		hasBastionError := errors.New("shoot has still Bastions")
+		updateErr := r.patchShootStatusOperationError(ctx, gardenClient.Client(), shoot, hasBastionError.Error(), operationType, shoot.Status.LastErrors...)
+		return reconcile.Result{}, utilerrors.WithSuppressed(hasBastionError, updateErr)
 	}
 
 	// If the .status.lastOperation already indicates that the deletion is successful then we finalize it immediately.

--- a/pkg/gardenlet/controller/shoot/shoot_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control.go
@@ -381,9 +381,9 @@ func (r *shootReconciler) deleteShoot(ctx context.Context, logger logrus.FieldLo
 		return reconcile.Result{}, fmt.Errorf("failed to check for related Bastions: %w", err)
 	}
 	if hasBastions {
-		hasBastionError := errors.New("shoot has still Bastions")
-		updateErr := r.patchShootStatusOperationError(ctx, gardenClient.Client(), shoot, hasBastionError.Error(), operationType, shoot.Status.LastErrors...)
-		return reconcile.Result{}, utilerrors.WithSuppressed(hasBastionError, updateErr)
+		hasBastionErr := errors.New("shoot has still Bastions")
+		updateErr := r.patchShootStatusOperationError(ctx, gardenClient.Client(), shoot, hasBastionErr.Error(), operationType, shoot.Status.LastErrors...)
+		return reconcile.Result{}, utilerrors.WithSuppressed(hasBastionErr, updateErr)
 	}
 
 	// If the .status.lastOperation already indicates that the deletion is successful then we finalize it immediately.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
The Shoot status is updated accordingly in case there are Bastions that block the Shoot deletion.

**Which issue(s) this PR fixes**:
Fixes #5346 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
