### PR TITLE
Fix the `shootHasBastions` check on Shoot deletion

### DIFF
--- a/pkg/controllermanager/controller/bastion/bastion_control.go
+++ b/pkg/controllermanager/controller/bastion/bastion_control.go
@@ -67,7 +67,7 @@ func (c *Controller) shootAdd(ctx context.Context, obj interface{}) {
 	// list all bastions that reference this shoot
 	// TODO: this should be done via a field-selector
 	bastionList := operationsv1alpha1.BastionList{}
-	listOptions := client.ListOptions{Namespace: shoot.Namespace, Limit: 1}
+	listOptions := client.ListOptions{Namespace: shoot.Namespace}
 
 	if err := c.gardenClient.List(ctx, &bastionList, &listOptions); err != nil {
 		c.log.Error(err, "Failed to list Bastions")


### PR DESCRIPTION
/area quality ops-productivity
/kind bug

Fixes #5323

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Deletion of Shoot is no longer wrongly blocked because of Bastion in the same Project that is not related to this Shoot.
```
