### PR TITLE
[release-v1.37] Automated cherry pick of #5354: Delete kube-apiserver-http-proxy secret if ReversedVPN is disabled

### DIFF
--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -99,7 +99,11 @@ func (b *Botanist) GenerateAndSaveSecrets(ctx context.Context) error {
 					}
 				}
 			} else {
-				if err := b.cleanupSecrets(ctx, &gardenerResourceDataList, vpnseedserver.DeploymentName, vpnseedserver.VpnShootSecretName, vpnseedserver.VpnSeedServerTLSAuth); err != nil {
+				if err := b.cleanupSecrets(ctx, &gardenerResourceDataList,
+					vpnseedserver.DeploymentName,
+					vpnseedserver.VpnShootSecretName,
+					vpnseedserver.VpnSeedServerTLSAuth,
+					kubeapiserver.SecretNameHTTPProxy); err != nil {
 					return err
 				}
 			}


### PR DESCRIPTION
/kind/bug
/area/control-plane

Cherry pick of #5354 on release-v1.37.

#5354: Delete kube-apiserver-http-proxy secret if ReversedVPN is disabled

**Release Notes:**
```bugfix operator
When the `ReversedVPN` feature gate is disabled, the `kube-apiserver-http-proxy` secret is properly removed from the `ShootState` and the shoot's control plane.
```