### PR TITLE
[release-v1.39] Automated cherry pick of #5354: Delete kube-apiserver-http-proxy secret if ReversedVPN is disabled

### DIFF
--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -110,6 +110,7 @@ func (b *Botanist) GenerateAndSaveSecrets(ctx context.Context) error {
 					vpnseedserver.DeploymentName,
 					vpnshoot.SecretNameVPNShootClient,
 					vpnseedserver.VpnSeedServerTLSAuth,
+					kubeapiserver.SecretNameHTTPProxy,
 				); err != nil {
 					return err
 				}


### PR DESCRIPTION
/kind/bug
/area/control-plane

Cherry pick of #5354 on release-v1.39.

#5354: Delete kube-apiserver-http-proxy secret if ReversedVPN is disabled

**Release Notes:**
```bugfix operator
When the `ReversedVPN` feature gate is disabled, the `kube-apiserver-http-proxy` secret is properly removed from the `ShootState` and the shoot's control plane.
```