### PR TITLE
[release-v1.39] Automated cherry pick of #5361: Fix the `shootHasBastions` check on Shoot deletion

### DIFF
--- a/pkg/controllermanager/controller/bastion/bastion_control.go
+++ b/pkg/controllermanager/controller/bastion/bastion_control.go
@@ -67,7 +67,7 @@ func (c *Controller) shootAdd(ctx context.Context, obj interface{}) {
 	// list all bastions that reference this shoot
 	// TODO: this should be done via a field-selector
 	bastionList := operationsv1alpha1.BastionList{}
-	listOptions := client.ListOptions{Namespace: shoot.Namespace, Limit: 1}
+	listOptions := client.ListOptions{Namespace: shoot.Namespace}
 
 	if err := c.gardenClient.List(ctx, &bastionList, &listOptions); err != nil {
 		c.log.Error(err, "Failed to list Bastions")


### PR DESCRIPTION
/kind/bug
/area/ops-productivity
/area/quality

Cherry pick of #5361 on release-v1.39.

#5361: Fix the `shootHasBastions` check on Shoot deletion

**Release Notes:**
```bugfix operator
Deletion of Shoot is no longer wrongly blocked because of Bastion in the same Project that is not related to this Shoot.
```