### PR TITLE
[release-v1.37] Automated cherry pick of #5361: Fix the `shootHasBastions` check on Shoot deletion

### DIFF
--- a/pkg/controllermanager/controller/bastion/bastion_control.go
+++ b/pkg/controllermanager/controller/bastion/bastion_control.go
@@ -67,7 +67,7 @@ func (c *Controller) shootAdd(ctx context.Context, obj interface{}) {
 
 	// list all bastions that reference this shoot
 	bastionList := operationsv1alpha1.BastionList{}
-	listOptions := client.ListOptions{Namespace: shoot.Namespace, Limit: int64(1)}
+	listOptions := client.ListOptions{Namespace: shoot.Namespace}
 
 	if err := c.gardenClient.List(ctx, &bastionList, &listOptions); err != nil {
 		logger.Logger.Errorf("Failed to list Bastions: %v", err)


### PR DESCRIPTION
/kind/bug
/area/ops-productivity
/area/quality

Cherry pick of #5361 on release-v1.37.

#5361: Fix the `shootHasBastions` check on Shoot deletion

**Release Notes:**
```bugfix operator
Deletion of Shoot is no longer wrongly blocked because of Bastion in the same Project that is not related to this Shoot.
```