### PR TITLE
[CPM IT] Fix the Before calls to be campatible with ginkgo v2

### DIFF
--- a/test/system/shoot_cp_migration/migrate_test.go
+++ b/test/system/shoot_cp_migration/migrate_test.go
@@ -87,11 +87,10 @@ var _ = ginkgo.Describe("Shoot migration testing", func() {
 			Namespace: ServiceAccountNamespace,
 		}}
 
-	CBeforeSuite(func(c context.Context) {
+	CBeforeEach(func(c context.Context) {
 		validateConfig()
 	}, 1*time.Minute)
-
-	CBeforeEach(func(ctx context.Context) {
+	CJustBeforeEach(func(ctx context.Context) {
 		if err := beforeMigration(ctx, t, &guestBookApp, testSecret, testServiceAccount); err != nil {
 			ginkgo.Fail("The Shoot CP Migration preparation steps failed with: " + err.Error())
 		}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind bug

**What this PR does / why we need it**:
This PR rearranges the `Before` calls in the control plane migration integration tests so they can be compatible with `ginkgov2`.
**Which issue(s) this PR fixes**:
Fixes #5350

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
