### PR TITLE
Fixes restoration of worker resource

### DIFF
--- a/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
@@ -138,6 +138,9 @@ func (a *genericActuator) restoreMachineSetsAndMachines(ctx context.Context, log
 				}
 			}
 
+			// Patch() is used here instead of Update() so that only the machine.Status.Node field is modified as a workaround
+			// for https://github.com/gardener/machine-controller-manager/issues/642. Check also https://github.com/kubernetes/kubernetes/issues/86811.
+			// Calling Update() would include the whole MachineStatus in the request - including fields of type metav1.Time causing the mentioned issues.
 			patch := client.MergeFrom(newMachine.DeepCopy())
 			newMachine.Status.Node = machine.Status.Node
 			return a.client.Status().Patch(ctx, newMachine, patch)

--- a/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
@@ -138,8 +138,9 @@ func (a *genericActuator) restoreMachineSetsAndMachines(ctx context.Context, log
 				}
 			}
 
-			newMachine.Status = machine.Status
-			return a.client.Status().Update(ctx, newMachine)
+			patch := client.MergeFrom(newMachine.DeepCopy())
+			newMachine.Status.Node = machine.Status.Node
+			return a.client.Status().Patch(ctx, newMachine, patch)
 		}
 	}
 

--- a/extensions/pkg/controller/worker/genericactuator/actuator_test.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_test.go
@@ -18,11 +18,15 @@ import (
 	"context"
 
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
+	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -31,6 +35,8 @@ import (
 	workerhelper "github.com/gardener/gardener/extensions/pkg/controller/worker/helper"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	"github.com/gardener/gardener/pkg/utils/test"
 )
 
 var _ = Describe("Actuator", func() {
@@ -334,19 +340,25 @@ var _ = Describe("Actuator", func() {
 			ctx    = context.TODO()
 			logger = log.Log.WithName("test")
 
-			c client.Client
+			mockCtrl   *gomock.Controller
+			mockClient *mockclient.MockClient
+
 			a *genericActuator
 
 			machineDeployments worker.MachineDeployments
 			expectedMachineSet machinev1alpha1.MachineSet
 			expectedMachine    machinev1alpha1.Machine
+
+			machineWithoutNode *machinev1alpha1.Machine
+
+			alreadyExistsError = apierrors.NewAlreadyExists(schema.GroupResource{Resource: "Machines"}, "machine")
 		)
 
 		BeforeEach(func() {
-			s := runtime.NewScheme()
-			Expect(machinev1alpha1.AddToScheme(s)).To(Succeed())
-			c = fake.NewClientBuilder().WithScheme(s).Build()
-			a = &genericActuator{client: c}
+			mockCtrl = gomock.NewController(GinkgoT())
+			mockClient = mockclient.NewMockClient(mockCtrl)
+
+			a = &genericActuator{client: mockClient}
 
 			expectedMachineSet = machinev1alpha1.MachineSet{
 				ObjectMeta: metav1.ObjectMeta{
@@ -378,30 +390,32 @@ var _ = Describe("Actuator", func() {
 					},
 				},
 			}
+
+			machineWithoutNode = expectedMachine.DeepCopy()
+			machineWithoutNode.Status.Node = ""
+		})
+
+		AfterEach(func() {
+			mockCtrl.Finish()
 		})
 
 		It("should deploy machinesets and machines present in the machine deployments' state", func() {
+			mockClient.EXPECT().Create(ctx, &expectedMachineSet)
+			mockClient.EXPECT().Create(ctx, machineWithoutNode)
+			mockClient.EXPECT().Status().Return(mockClient)
+			test.EXPECTPatch(ctx, mockClient, &expectedMachine, machineWithoutNode, types.MergePatchType)
+
 			Expect(a.restoreMachineSetsAndMachines(ctx, logger, machineDeployments)).To(Succeed())
-
-			createdMachine := &machinev1alpha1.Machine{}
-			Expect(c.Get(ctx, client.ObjectKeyFromObject(&expectedMachine), createdMachine)).To(Succeed())
-			Expect(createdMachine.Status).To(Equal(expectedMachine.Status))
-
-			createdMachineSet := &machinev1alpha1.MachineSet{}
-			Expect(c.Get(ctx, client.ObjectKeyFromObject(&expectedMachineSet), createdMachineSet)).To(Succeed())
 		})
 
 		It("should update the machine status if machineset and machine already exist", func() {
-			Expect(c.Create(ctx, (&expectedMachine).DeepCopy())).To(Succeed())
-			Expect(c.Create(ctx, (&expectedMachineSet).DeepCopy())).To(Succeed())
+			mockClient.EXPECT().Create(ctx, &expectedMachineSet).Return(alreadyExistsError)
+			mockClient.EXPECT().Create(ctx, machineWithoutNode).Return(alreadyExistsError)
+			mockClient.EXPECT().Get(ctx, client.ObjectKeyFromObject(machineWithoutNode), machineWithoutNode)
+			mockClient.EXPECT().Status().Return(mockClient)
+			test.EXPECTPatch(ctx, mockClient, &expectedMachine, machineWithoutNode, types.MergePatchType)
+
 			Expect(a.restoreMachineSetsAndMachines(ctx, logger, machineDeployments)).To(Succeed())
-
-			createdMachine := &machinev1alpha1.Machine{}
-			Expect(c.Get(ctx, client.ObjectKeyFromObject(&expectedMachine), createdMachine)).To(Succeed())
-			Expect(expectedMachine.Status).To(Equal(expectedMachine.Status))
-
-			createdMachineSet := &machinev1alpha1.MachineSet{}
-			Expect(c.Get(ctx, client.ObjectKeyFromObject(&expectedMachineSet), createdMachineSet)).To(Succeed())
 		})
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind bug

**What this PR does / why we need it**:
Fixes an issue that can happen during the restoration of the worker resource:
```
Error restoring worker: failed restoration
      of the machineSet and the machines: Machine.machine.sapcloud.io "<machine-name>"
      is invalid: [status.lastOperation.lastUpdateTime: Invalid value: "null": status.lastOperation.lastUpdateTime
      in body must be of type string: "null", status.currentStatus.lastUpdateTime:
      Invalid value: "null": status.currentStatus.lastUpdateTime in body must be of
      type string: "null"]
```

This was originally fixed in #4681 but then the issue started appearing again after #4799 (which replaced the call to `TryPatch()` with `Update()`.

The error is caused because marshalling a non initialised `metav1.Time` to json returns `null` and the `lastUpdateTime` fields in the `machines` CRD are not nullable. Using `Patch()` to only update the `machine.Status.Node` is a workaround until https://github.com/gardener/machine-controller-manager/issues/642 is fixed.

**Which issue(s) this PR fixes**:
Fixes #5376 

**Special notes for your reviewer**:
/cc @timebertt @BeckerMax (as release responsible)

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixes an issue that prevents the status of `Machine` objects to be modified during the restore phase of control plane migration. Patch is now used to do the modification instead of an update call.
```
