### PR TITLE
Add field selector for `.spec.shootRef` in `Bastion`s

### DIFF
--- a/pkg/apis/operations/field_constants.go
+++ b/pkg/apis/operations/field_constants.go
@@ -20,7 +20,7 @@ const (
 	// BastionSeedName is the field selector path for finding
 	// the Seed cluster of a operations.gardener.cloud/v1alpha1 Bastion.
 	BastionSeedName = "spec.seedName"
-	// ShootRefName is the field selector path for finding
-	// the target Shoot name of a operations.gardener.cloud/v1alpha1 Bastion.
+	// BastionShootName is the field selector path for finding
+	// the Shoot name of a operations.gardener.cloud/v1alpha1 Bastion.
 	BastionShootName = "spec.shootRef.name"
 )

--- a/pkg/apis/operations/field_constants.go
+++ b/pkg/apis/operations/field_constants.go
@@ -20,4 +20,7 @@ const (
 	// BastionSeedName is the field selector path for finding
 	// the Seed cluster of a operations.gardener.cloud/v1alpha1 Bastion.
 	BastionSeedName = "spec.seedName"
+	// ShootRefName is the field selector path for finding
+	// the target Shoot name of a operations.gardener.cloud/v1alpha1 Bastion.
+	BastionShootName = "spec.shootRef.name"
 )

--- a/pkg/apis/operations/v1alpha1/conversions.go
+++ b/pkg/apis/operations/v1alpha1/conversions.go
@@ -28,7 +28,7 @@ func addConversionFuncs(scheme *runtime.Scheme) error {
 	if err := scheme.AddFieldLabelConversionFunc(SchemeGroupVersion.WithKind("Bastion"),
 		func(label, value string) (string, string, error) {
 			switch label {
-			case "metadata.name", "metadata.namespace", operations.BastionSeedName:
+			case "metadata.name", "metadata.namespace", operations.BastionSeedName, operations.BastionShootName:
 				return label, value, nil
 			default:
 				return "", "", fmt.Errorf("field label not supported: %s", label)

--- a/pkg/controllermanager/controller/bastion/bastion_control.go
+++ b/pkg/controllermanager/controller/bastion/bastion_control.go
@@ -21,13 +21,13 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/apis/operations"
 	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
@@ -67,12 +67,8 @@ func (c *Controller) shootAdd(ctx context.Context, obj interface{}) {
 
 	// list all bastions that reference this shoot
 	bastionList := operationsv1alpha1.BastionList{}
-	listOptions := client.ListOptions{
-		Namespace:     shoot.Namespace,
-		FieldSelector: fields.SelectorFromSet(fields.Set{"spec.shootRef.name": shoot.Name}),
-	}
 
-	if err := c.gardenClient.List(ctx, &bastionList, &listOptions); err != nil {
+	if err := c.gardenClient.List(ctx, &bastionList, client.InNamespace(shoot.Namespace), client.MatchingFields{operations.BastionShootName: shoot.Name}); err != nil {
 		c.log.Error(err, "Failed to list Bastions")
 		return
 	}

--- a/pkg/controllermanager/controller/factory.go
+++ b/pkg/controllermanager/controller/factory.go
@@ -25,6 +25,8 @@ import (
 
 	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/apis/operations"
+	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
@@ -223,6 +225,16 @@ func addAllFieldIndexes(ctx context.Context, indexer client.FieldIndexer) error 
 		return []string{ms.Spec.Shoot.Name}
 	}); err != nil {
 		return fmt.Errorf("failed to add indexer to ManagedSeed Informer: %w", err)
+	}
+
+	if err := indexer.IndexField(ctx, &operationsv1alpha1.Bastion{}, operations.BastionShootName, func(obj client.Object) []string {
+		bastion, ok := obj.(*operationsv1alpha1.Bastion)
+		if !ok {
+			return []string{""}
+		}
+		return []string{bastion.Spec.ShootRef.Name}
+	}); err != nil {
+		return fmt.Errorf("failed to add indexer to Bastion Informer: %w", err)
 	}
 
 	return nil

--- a/pkg/gardenlet/controller/factory.go
+++ b/pkg/gardenlet/controller/factory.go
@@ -25,6 +25,8 @@ import (
 	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/apis/operations"
+	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
@@ -280,6 +282,16 @@ func addAllFieldIndexes(ctx context.Context, indexer client.FieldIndexer) error 
 		return []string{""}
 	}); err != nil {
 		return fmt.Errorf("failed to add indexer to ManagedSeed Informer: %w", err)
+	}
+
+	if err := indexer.IndexField(ctx, &operationsv1alpha1.Bastion{}, operations.BastionShootName, func(obj client.Object) []string {
+		bastion, ok := obj.(*operationsv1alpha1.Bastion)
+		if !ok {
+			return []string{""}
+		}
+		return []string{bastion.Spec.ShootRef.Name}
+	}); err != nil {
+		return fmt.Errorf("failed to add indexer to Bastion Informer: %w", err)
 	}
 
 	return nil

--- a/pkg/gardenlet/controller/shoot/shoot_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control.go
@@ -24,6 +24,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/apis/operations"
 	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
@@ -49,7 +50,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
@@ -457,12 +457,8 @@ func (r *shootReconciler) isSeedReadyForMigration(seed *gardencorev1beta1.Seed) 
 func (r *shootReconciler) shootHasBastions(ctx context.Context, shoot *gardencorev1beta1.Shoot, gardenClient kubernetes.Interface) (bool, error) {
 	// list all bastions that reference this shoot
 	bastionList := operationsv1alpha1.BastionList{}
-	listOptions := client.ListOptions{
-		Namespace:     shoot.Namespace,
-		FieldSelector: fields.SelectorFromSet(fields.Set{"spec.shootRef.name": shoot.Name}),
-	}
 
-	if err := gardenClient.Client().List(ctx, &bastionList, &listOptions); err != nil {
+	if err := gardenClient.Client().List(ctx, &bastionList, client.InNamespace(shoot.Namespace), client.MatchingFields{operations.BastionShootName: shoot.Name}); err != nil {
 		return false, fmt.Errorf("failed to list related Bastions: %w", err)
 	}
 

--- a/pkg/registry/core/controllerinstallation/strategy_test.go
+++ b/pkg/registry/core/controllerinstallation/strategy_test.go
@@ -60,6 +60,7 @@ var _ = Describe("GetAttrs", func() {
 		Expect(ls).To(HaveLen(1))
 		Expect(ls.Get("foo")).To(Equal("bar"))
 		Expect(fs.Get(core.SeedRefName)).To(Equal("qux"))
+		Expect(fs.Get(core.RegistrationRefName)).To(Equal("baz"))
 	})
 })
 

--- a/pkg/registry/operations/bastion/storage/storage.go
+++ b/pkg/registry/operations/bastion/storage/storage.go
@@ -56,6 +56,7 @@ func NewREST(optsGetter generic.RESTOptionsGetter) (*REST, *StatusREST) {
 		NewListFunc:              func() runtime.Object { return &operations.BastionList{} },
 		DefaultQualifiedResource: operations.Resource("bastions"),
 		EnableGarbageCollection:  true,
+		PredicateFunc:            bastion.MatchBastion,
 
 		CreateStrategy: bastion.Strategy,
 		UpdateStrategy: bastion.Strategy,

--- a/pkg/registry/operations/bastion/strategy.go
+++ b/pkg/registry/operations/bastion/strategy.go
@@ -166,8 +166,9 @@ func ToSelectableFields(bastion *operations.Bastion) fields.Set {
 	// amount of allocations needed to create the fields.Set. If you add any
 	// field here or the number of object-meta related fields changes, this should
 	// be adjusted.
-	bastionSpecificFieldsSet := make(fields.Set, 3)
+	bastionSpecificFieldsSet := make(fields.Set, 4)
 	bastionSpecificFieldsSet[operations.BastionSeedName] = getSeedName(bastion)
+	bastionSpecificFieldsSet[operations.BastionShootName] = bastion.Spec.ShootRef.Name
 	return generic.AddObjectMetaFieldsSet(bastionSpecificFieldsSet, &bastion.ObjectMeta, true)
 }
 

--- a/pkg/registry/operations/bastion/strategy_test.go
+++ b/pkg/registry/operations/bastion/strategy_test.go
@@ -33,9 +33,15 @@ var _ = Describe("ToSelectableFields", func() {
 	It("should return correct fields", func() {
 		result := ToSelectableFields(newBastion("shoot", "foo"))
 
-		Expect(result).To(HaveLen(3))
+		Expect(result).To(HaveLen(4))
+		Expect(result.Has("metadata.name")).To(BeTrue())
+		Expect(result.Get("metadata.name")).To(Equal("test"))
+		Expect(result.Has("metadata.namespace")).To(BeTrue())
+		Expect(result.Get("metadata.namespace")).To(Equal("test-namespace"))
 		Expect(result.Has(operations.BastionSeedName)).To(BeTrue())
 		Expect(result.Get(operations.BastionSeedName)).To(Equal("foo"))
+		Expect(result.Has(operations.BastionShootName)).To(BeTrue())
+		Expect(result.Get(operations.BastionShootName)).To(Equal("shoot"))
 	})
 })
 
@@ -51,6 +57,7 @@ var _ = Describe("GetAttrs", func() {
 		Expect(ls).To(HaveLen(1))
 		Expect(ls.Get("foo")).To(Equal("bar"))
 		Expect(fs.Get(operations.BastionSeedName)).To(Equal("foo"))
+		Expect(fs.Get(operations.BastionShootName)).To(Equal("shoot"))
 		Expect(err).NotTo(HaveOccurred())
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR introduces field selector for `.spec.shootRef` in `Bastion`s.

**Which issue(s) this PR fixes**:
Fixes #5368 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`gardener-apiserver` does now support a field selector for `Bastion`s by `spec.shootRef.name`
```
