### PR TITLE
Preserve other annotations/labels on shoot `Namespace`s

### DIFF
--- a/pkg/operation/botanist/namespaces_test.go
+++ b/pkg/operation/botanist/namespaces_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gardener/gardener/pkg/operation/garden"
 	"github.com/gardener/gardener/pkg/operation/seed"
 	"github.com/gardener/gardener/pkg/operation/shoot"
+	"github.com/gardener/gardener/pkg/utils"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -282,6 +283,45 @@ var _ = Describe("Namespaces", func() {
 						"backup.gardener.cloud/provider":              seedProviderType,
 						"extensions.gardener.cloud/" + extensionType1: "true",
 					},
+					ResourceVersion: "2",
+				},
+			}))
+		})
+
+		It("should not overwrite other annotations or labels", func() {
+			var (
+				customAnnotations = map[string]string{"foo": "bar"}
+				customLabels      = map[string]string{"bar": "foo"}
+			)
+
+			Expect(fakeSeedClient.Create(ctx, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        namespace,
+					Annotations: customAnnotations,
+					Labels:      customLabels,
+				},
+			})).To(Succeed())
+
+			Expect(botanist.SeedNamespaceObject).To(BeNil())
+			Expect(botanist.DeploySeedNamespace(ctx)).To(Succeed())
+			Expect(botanist.SeedNamespaceObject).To(Equal(&corev1.Namespace{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "Namespace",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: namespace,
+					Annotations: utils.MergeStringMaps(customAnnotations, map[string]string{
+						"shoot.gardener.cloud/uid": string(uid),
+					}),
+					Labels: utils.MergeStringMaps(customLabels, map[string]string{
+						"gardener.cloud/role":                         "shoot",
+						"seed.gardener.cloud/provider":                seedProviderType,
+						"shoot.gardener.cloud/provider":               shootProviderType,
+						"networking.shoot.gardener.cloud/provider":    networkingProviderType,
+						"backup.gardener.cloud/provider":              seedProviderType,
+						"extensions.gardener.cloud/" + extensionType3: "true",
+					}),
 					ResourceVersion: "2",
 				},
 			}))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind bug
/merge squash

**What this PR does / why we need it**:
This PR 

1. refactors the `namespace_test.go` tests to work with a fake client instead of a mock client.
2. fixes a bug in the `DeploySeedNamespace` function which removes all manually applied annotations/labels from `Shoot` namespaces in the seed cluster.

**Special notes for your reviewer**:
/cc @dguendisch @istvanballok @wyb1 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Manually applied annotations or labels are now preserved on shoot `Namespace`s in the seed clusters.
```
