### PR TITLE
Revert project controller to use a cached client

### DIFF
--- a/pkg/controllermanager/controller/project/project_control.go
+++ b/pkg/controllermanager/controller/project/project_control.go
@@ -109,10 +109,10 @@ func (r *projectReconciler) Reconcile(ctx context.Context, request reconcile.Req
 	projectLogger.Infof("[PROJECT RECONCILE] %s", project.Name)
 
 	if project.DeletionTimestamp != nil {
-		return r.delete(ctx, project, r.gardenClient.Client(), r.gardenClient.APIReader())
+		return r.delete(ctx, project, r.gardenClient.Client())
 	}
 
-	return r.reconcile(ctx, project, r.gardenClient.Client(), r.gardenClient.APIReader())
+	return r.reconcile(ctx, project, r.gardenClient.Client())
 }
 
 func newProjectLogger(project *gardencorev1beta1.Project) logrus.FieldLogger {

--- a/pkg/controllermanager/controller/project/project_control_delete.go
+++ b/pkg/controllermanager/controller/project/project_control_delete.go
@@ -33,9 +33,9 @@ import (
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 )
 
-func (r *projectReconciler) delete(ctx context.Context, project *gardencorev1beta1.Project, gardenClient client.Client, gardenReader client.Reader) (reconcile.Result, error) {
+func (r *projectReconciler) delete(ctx context.Context, project *gardencorev1beta1.Project, gardenClient client.Client) (reconcile.Result, error) {
 	if namespace := project.Spec.Namespace; namespace != nil {
-		inUse, err := kutil.IsNamespaceInUse(ctx, gardenReader, *namespace, gardencorev1beta1.SchemeGroupVersion.WithKind("ShootList"))
+		inUse, err := kutil.IsNamespaceInUse(ctx, gardenClient, *namespace, gardencorev1beta1.SchemeGroupVersion.WithKind("ShootList"))
 		if err != nil {
 			return reconcile.Result{}, fmt.Errorf("failed to check if namespace is empty: %w", err)
 		}


### PR DESCRIPTION
/area quality
/kind enhancement

In https://github.com/gardener/gardener/pull/5322#pullrequestreview-870226826 @timebertt raised concerns wrt to the switch to `APIReader`.
I think it is safe to switch back to `Client` as the project controller no longer relies on the Project status when takes decision to add the `keep-after-project-deletion` annotation (now it relies on the `created-by-project-controller` annotation on the Namespace).

I also drafted a small script to reproduce #5192 - https://gist.github.com/ialidzhikov/5afa1a4a949d38fa6991d19a133ab603.

In my remote-setup with v1.38.4 and v1.39.2 the issue is always reproducible - 5/5.
With the master branch - 0/5.
With the patch from this PR - 0/5.

**Which issue(s) this PR fixes**:
Follow-up after https://github.com/gardener/gardener/pull/5322

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
