### PR TITLE
Prevent creation of `ssh-keypair.old` secret on Shoot creation.

### DIFF
--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -269,7 +269,7 @@ const (
 	// ShootOperationRotateCAComplete is a constant for an annotation on a Shoot indicating that the rotation of the
 	// certificate authorities shall be completed.
 	ShootOperationRotateCAComplete = "rotate-ca-complete"
-	
+
 	// SeedResourceManagerClass is the resource-class managed by the Gardener-Resource-Manager
 	// instance in the garden namespace on the seeds.
 	SeedResourceManagerClass = "seed"

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -155,6 +155,9 @@ const (
 	// GardenerOperationKeepalive is a constant for the value of the operation annotation describing an
 	// operation that extends the lifetime of the object having the operation annotation.
 	GardenerOperationKeepalive = "keepalive"
+	// GardenerSSHRotation is the key for an annotation of a Shoot cluster whose value indicates the rotation
+	// of ssh-keypair secret.
+	GardenerSSHRotation = "gardener.cloud/ssh-keypair"
 
 	// DeprecatedGardenRole is the key for an annotation on a Kubernetes object indicating what it is used for.
 	//
@@ -269,6 +272,9 @@ const (
 	// ShootOperationRotateCAComplete is a constant for an annotation on a Shoot indicating that the rotation of the
 	// certificate authorities shall be completed.
 	ShootOperationRotateCAComplete = "rotate-ca-complete"
+	// ShootOperationSSHKeypairRotated is a constant for an annotation on a Shoot indicating that the SSH keypair for the shoot nodes
+	// has been rotated atleast once.
+	ShootOperationSSHKeypairRotated = "rotated"
 
 	// SeedResourceManagerClass is the resource-class managed by the Gardener-Resource-Manager
 	// instance in the garden namespace on the seeds.

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -155,9 +155,6 @@ const (
 	// GardenerOperationKeepalive is a constant for the value of the operation annotation describing an
 	// operation that extends the lifetime of the object having the operation annotation.
 	GardenerOperationKeepalive = "keepalive"
-	// GardenerSSHRotation is the key for an annotation of a Shoot cluster whose value indicates the rotation
-	// of ssh-keypair secret.
-	GardenerSSHRotation = "gardener.cloud/ssh-keypair"
 
 	// DeprecatedGardenRole is the key for an annotation on a Kubernetes object indicating what it is used for.
 	//
@@ -272,10 +269,7 @@ const (
 	// ShootOperationRotateCAComplete is a constant for an annotation on a Shoot indicating that the rotation of the
 	// certificate authorities shall be completed.
 	ShootOperationRotateCAComplete = "rotate-ca-complete"
-	// ShootOperationSSHKeypairRotated is a constant for an annotation on a Shoot indicating that the SSH keypair for the shoot nodes
-	// has been rotated atleast once.
-	ShootOperationSSHKeypairRotated = "rotated"
-
+	
 	// SeedResourceManagerClass is the resource-class managed by the Gardener-Resource-Manager
 	// instance in the garden namespace on the seeds.
 	SeedResourceManagerClass = "seed"

--- a/pkg/operation/botanist/wanted_secrets.go
+++ b/pkg/operation/botanist/wanted_secrets.go
@@ -290,13 +290,6 @@ func (b *Botanist) generateWantedSecretConfigs(basicAuthAPIServer *secrets.Basic
 			UsedForSSH: true,
 		},
 
-		// Secret definition for ssh-keypair.old
-		&secrets.RSASecretConfig{
-			Name:       v1beta1constants.SecretNameOldSSHKeyPair,
-			Bits:       4096,
-			UsedForSSH: true,
-		},
-
 		// Secret definition for service-account-key
 		&secrets.RSASecretConfig{
 			Name:       v1beta1constants.SecretNameServiceAccountKey,
@@ -386,6 +379,14 @@ func (b *Botanist) generateWantedSecretConfigs(basicAuthAPIServer *secrets.Basic
 		},
 	}
 
+	// Secret definition for ssh-keypair.old
+	if b.Shoot.GetInfo().Annotations[v1beta1constants.GardenerSSHRotation] == v1beta1constants.ShootOperationSSHKeypairRotated {
+		secretList = append(secretList, &secrets.RSASecretConfig{
+			Name:       v1beta1constants.SecretNameOldSSHKeyPair,
+			Bits:       4096,
+			UsedForSSH: true,
+		})
+	}
 	// Secret definition for kubecfg
 	var kubecfgToken *secrets.Token
 	if staticToken != nil {

--- a/pkg/operation/botanist/wanted_secrets.go
+++ b/pkg/operation/botanist/wanted_secrets.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"net"
 
-	gardencorev1alpha1helper "github.com/gardener/gardener/pkg/apis/core/v1alpha1/helper"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/dependencywatchdog"
@@ -404,16 +403,6 @@ func (b *Botanist) generateWantedSecretConfigs(basicAuthAPIServer *secrets.Basic
 			APIServerHost: b.Shoot.ComputeOutOfClusterAPIServerAddress(b.APIServerAddress, false),
 		}},
 	})
-
-	// Secret definition for ssh-keypair.old
-	gardenerResourceDataList := gardencorev1alpha1helper.GardenerResourceDataList(b.GetShootState().Spec.Gardener)
-	if secret := gardenerResourceDataList.Get(v1beta1constants.SecretNameOldSSHKeyPair); secret != nil {
-		secretList = append(secretList, &secrets.RSASecretConfig{
-			Name:       v1beta1constants.SecretNameOldSSHKeyPair,
-			Bits:       4096,
-			UsedForSSH: true,
-		})
-	}
 
 	if b.isShootNodeLoggingEnabled() {
 		// Secret definition for loki (ingress)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
Prevent gardenlet from creating  ssh-keypair.old Secret on Shoot creation.
**Which issue(s) this PR fixes**:
Fixes [#4527 ](https://github.com/gardener/gardener/issues/4527)

**Special notes for your reviewer**:
A new annotation field `gardener.cloud/ssh-keypair` is added to shoot when `ssh-keypair` is rotated. 
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
