### PR TITLE
Introduce validation for max worker node count

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -410,6 +410,20 @@ func ValidateNodeCIDRMaskWithMaxPod(maxPod int32, nodeCIDRMaskSize int32) field.
 	return allErrs
 }
 
+// validateTotalNodeCountWithPodCIDR validates if the Pod Network has enough ip addresses (configured via PodCIDR on the network config and the NodeCIDRMask on the kube controller manager) to support the total number of nodes from the worker pools of the shoot
+func validateTotalNodeCountWithPodCIDR(totalNodes int32, nodeCIDRMaskSize int32, podNetworkCIDR string) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	CIDR, _ := strconv.Atoi(podNetworkCIDR[len(podNetworkCIDR)-2:])
+	// first and last IPs are reserved
+	maxNodeCount := int32(math.Pow(2, float64(nodeCIDRMaskSize-int32(CIDR))) - 2)
+
+	if totalNodes > maxNodeCount {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("provider").Child("workers"), totalNodes, fmt.Sprintf("worker configuration incorrect. The spec.networking.pod only supports %d IP addresses. The total of all the nodes specified by the worker pool should be less than %d ", maxNodeCount, maxNodeCount)))
+	}
+	return allErrs
+}
+
 func validateKubeControllerManagerUpdate(newConfig, oldConfig *core.KubeControllerManagerConfig, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
@@ -1015,9 +1029,17 @@ func validateProvider(provider core.Provider, kubernetes core.Kubernetes, fldPat
 		allErrs = append(allErrs, field.Required(fldPath.Child("type"), "must specify a provider type"))
 	}
 
-	var maxPod int32
+	var (
+		maxPod           int32
+		totalNodes       int32
+		nodeCIDRMaskSize int32 = 24
+		podNetworkCIDR         = core.DefaultPodNetworkCIDR
+	)
 	if kubernetes.Kubelet != nil && kubernetes.Kubelet.MaxPods != nil {
 		maxPod = *kubernetes.Kubelet.MaxPods
+	}
+	if networking.Pods != nil {
+		podNetworkCIDR = *networking.Pods
 	}
 
 	for i, worker := range provider.Workers {
@@ -1026,6 +1048,7 @@ func validateProvider(provider core.Provider, kubernetes core.Kubernetes, fldPat
 		if worker.Kubernetes != nil && worker.Kubernetes.Kubelet != nil && worker.Kubernetes.Kubelet.MaxPods != nil && *worker.Kubernetes.Kubelet.MaxPods > maxPod {
 			maxPod = *worker.Kubernetes.Kubelet.MaxPods
 		}
+		totalNodes += worker.Maximum
 	}
 
 	allErrs = append(allErrs, ValidateWorkers(provider.Workers, fldPath.Child("workers"))...)
@@ -1035,8 +1058,12 @@ func validateProvider(provider core.Provider, kubernetes core.Kubernetes, fldPat
 			// default maxPod setting on kubelet
 			maxPod = 110
 		}
+		nodeCIDRMaskSize = *kubernetes.KubeControllerManager.NodeCIDRMaskSize
+
 		allErrs = append(allErrs, ValidateNodeCIDRMaskWithMaxPod(maxPod, *kubernetes.KubeControllerManager.NodeCIDRMaskSize)...)
 	}
+
+	allErrs = append(allErrs, validateTotalNodeCountWithPodCIDR(totalNodes, nodeCIDRMaskSize, podNetworkCIDR)...)
 
 	return allErrs
 }

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -435,6 +435,11 @@ func ValidateTotalNodeCountWithPodCIDR(shoot *core.Shoot) field.ErrorList {
 	}
 
 	cidrMask, _ := podNetwork.Mask.Size()
+	if cidrMask == 0 {
+		allErrs = append(allErrs, field.Invalid(field.NewPath("spec").Child("networking").Child("pods"), podNetwork.String(), fmt.Sprintf("incorrect pod network mask : %s. Please ensure the mask is in proper form", podNetwork.String())))
+		return allErrs
+	}
+
 	maxNodeCount := int32(math.Pow(2, float64(nodeCIDRMaskSize-int32(cidrMask))))
 
 	for _, worker := range shoot.Spec.Provider.Workers {

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -1074,7 +1074,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 						*worker2,
 					}
 
-					errorList := ValidateShoot(shoot)
+					errorList := ValidateTotalNodeCountWithPodCIDR(shoot)
 
 					Expect(errorList).To(BeEmpty())
 				})
@@ -1082,15 +1082,15 @@ var _ = Describe("Shoot Validation Tests", func() {
 				It("should allow valid total number of worker nodes", func() {
 					shoot.Spec.Kubernetes.KubeControllerManager.NodeCIDRMaskSize = pointer.Int32(24)
 					shoot.Spec.Networking.Pods = pointer.String("100.96.0.0/16")
-					worker1.Maximum = 127
-					worker2.Maximum = 127
+					worker1.Maximum = 128
+					worker2.Maximum = 128
 
 					shoot.Spec.Provider.Workers = []core.Worker{
 						*worker1,
 						*worker2,
 					}
 
-					errorList := ValidateShoot(shoot)
+					errorList := ValidateTotalNodeCountWithPodCIDR(shoot)
 
 					Expect(errorList).To(BeEmpty())
 				})
@@ -1106,7 +1106,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 						*worker2,
 					}
 
-					errorList := ValidateShoot(shoot)
+					errorList := ValidateTotalNodeCountWithPodCIDR(shoot)
 
 					Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":  Equal(field.ErrorTypeInvalid),
@@ -1118,14 +1118,14 @@ var _ = Describe("Shoot Validation Tests", func() {
 					shoot.Spec.Kubernetes.KubeControllerManager.NodeCIDRMaskSize = pointer.Int32(24)
 					shoot.Spec.Networking.Pods = pointer.String("100.96.0.0/16")
 					worker1.Maximum = 128
-					worker2.Maximum = 127
+					worker2.Maximum = 129
 
 					shoot.Spec.Provider.Workers = []core.Worker{
 						*worker1,
 						*worker2,
 					}
 
-					errorList := ValidateShoot(shoot)
+					errorList := ValidateTotalNodeCountWithPodCIDR(shoot)
 
 					Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":  Equal(field.ErrorTypeInvalid),

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -1054,6 +1054,85 @@ var _ = Describe("Shoot Validation Tests", func() {
 
 				Expect(errorList).To(HaveLen(0))
 			})
+
+			Context("Worker nodes max count validation", func() {
+				var (
+					worker1 = worker.DeepCopy()
+					worker2 = worker.DeepCopy()
+				)
+				worker1.Name = "worker1"
+				worker2.Name = "worker2"
+
+				It("should allow valid total number of worker nodes", func() {
+					shoot.Spec.Kubernetes.KubeControllerManager.NodeCIDRMaskSize = pointer.Int32(24)
+					shoot.Spec.Networking.Pods = pointer.String("100.96.0.0/20")
+					worker1.Maximum = 4
+					worker2.Maximum = 4
+
+					shoot.Spec.Provider.Workers = []core.Worker{
+						*worker1,
+						*worker2,
+					}
+
+					errorList := ValidateShoot(shoot)
+
+					Expect(errorList).To(BeEmpty())
+				})
+
+				It("should allow valid total number of worker nodes", func() {
+					shoot.Spec.Kubernetes.KubeControllerManager.NodeCIDRMaskSize = pointer.Int32(24)
+					shoot.Spec.Networking.Pods = pointer.String("100.96.0.0/16")
+					worker1.Maximum = 127
+					worker2.Maximum = 127
+
+					shoot.Spec.Provider.Workers = []core.Worker{
+						*worker1,
+						*worker2,
+					}
+
+					errorList := ValidateShoot(shoot)
+
+					Expect(errorList).To(BeEmpty())
+				})
+
+				It("should not allow invalid total number of worker nodes", func() {
+					shoot.Spec.Kubernetes.KubeControllerManager.NodeCIDRMaskSize = pointer.Int32(24)
+					shoot.Spec.Networking.Pods = pointer.String("100.96.0.0/20")
+					worker1.Maximum = 16
+					worker2.Maximum = 16
+
+					shoot.Spec.Provider.Workers = []core.Worker{
+						*worker1,
+						*worker2,
+					}
+
+					errorList := ValidateShoot(shoot)
+
+					Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal("spec.provider.workers"),
+					}))))
+				})
+
+				It("should not allow ivalid total number of worker nodes", func() {
+					shoot.Spec.Kubernetes.KubeControllerManager.NodeCIDRMaskSize = pointer.Int32(24)
+					shoot.Spec.Networking.Pods = pointer.String("100.96.0.0/16")
+					worker1.Maximum = 128
+					worker2.Maximum = 127
+
+					shoot.Spec.Provider.Workers = []core.Worker{
+						*worker1,
+						*worker2,
+					}
+
+					errorList := ValidateShoot(shoot)
+
+					Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal("spec.provider.workers"),
+					}))))
+				})
+			})
 		})
 
 		Context("dns section", func() {

--- a/pkg/registry/core/shoot/strategy.go
+++ b/pkg/registry/core/shoot/strategy.go
@@ -120,7 +120,10 @@ func mustIncreaseGenerationForSpecChanges(oldShoot, newShoot *core.Shoot) bool {
 
 func (shootStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	shoot := obj.(*core.Shoot)
-	return validation.ValidateShoot(shoot)
+	errorList := field.ErrorList{}
+	errorList = append(errorList, validation.ValidateShoot(shoot)...)
+	errorList = append(errorList, validation.ValidateTotalNodeCountWithPodCIDR(shoot)...)
+	return errorList
 }
 
 func (shootStrategy) Canonicalize(obj runtime.Object) {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking ops-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR introduces a validation for the total number of worker nodes in a shoot cluster.
The configured worker pools max Nodes count should not exceed max Nodes count allowed by the Pods CIDR (`spec.networking.pods`). The Pod network calculations that has to be considered are described in https://github.com/gardener/gardener/blob/v1.38.3/docs/usage/shoot_networking.md.
Also, the `nodeCIDRMaskSize` can be customized with the field `spec.kubernetes.kubeControllerManager.nodeCIDRMaskSize`.

The validation is applied only to new shoots, to not break the existing clusters.

**Which issue(s) this PR fixes**:
Fixes #5298 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
A validation is added to validate that the configured worker pools maximum nodes count do not exceed maximum nodes count allowed by the Pods CIDR (`spec.networking.pods`).
```
