### PR TITLE
Increase the cental Loki storage to 100Gi by default and make it conf…

### DIFF
--- a/charts/gardener/gardenlet/values.yaml
+++ b/charts/gardener/gardenlet/values.yaml
@@ -193,6 +193,7 @@ global:
     #     activeDeadlineDuration: "3h"
     # seedConfig: {}
     # logging:
+    #   enabled: false
     #   fluentBit:
     #     output: |-
     #       [Output]

--- a/docs/deployment/configuring_logging.md
+++ b/docs/deployment/configuring_logging.md
@@ -74,3 +74,22 @@ logging:
   loki:
     enabled: false
 ```
+
+# Configuring central Loki storage capacity
+
+By default, the central Loki has `100Gi` of storage capacity.
+To overwrite the current central Loki storage capacity, the `logging.loki.garden.storage` setting in the gardenlet's component configuration should be altered.
+If you need to increase it you can do so without losing the current data by specifying higher capacity. Doing so, the Loki's `PersistentVolume` capacity will be increased instead of deleting the current PV.
+However, if you specify less capacity then the `PersistentVolume` will be deleted and with it the logs, too.
+
+```yaml
+logging:
+  enabled: true
+  fluentBit:
+    output: |-
+      [Output]
+          ...
+  loki:
+    garden:
+      storage: "200Gi"
+```

--- a/example/20-componentconfig-gardenlet.yaml
+++ b/example/20-componentconfig-gardenlet.yaml
@@ -136,6 +136,7 @@ featureGates:
 #     enabled: true
 #     garden:
 #       priority: 100
+#       storage: "100Gi"
 #   shootNodeLogging:
 #     shootPurposes:
 #     - "development"

--- a/pkg/gardenlet/apis/config/types.go
+++ b/pkg/gardenlet/apis/config/types.go
@@ -18,6 +18,7 @@ import (
 	gardencore "github.com/gardener/gardener/pkg/apis/core"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	componentbaseconfig "k8s.io/component-base/config"
 	"k8s.io/klog"
@@ -375,7 +376,7 @@ type FluentBit struct {
 type Loki struct {
 	// Enabled is used to enable or disable the shoot and seed Loki.
 	// If FluentBit is used with a custom output the Loki can, Loki is maybe unused and can be disabled.
-	// If not set, by default Loki is enabled
+	// If not set, by default Loki is enabled.
 	Enabled *bool
 	// Garden contains configuration for the Loki in garden namespace.
 	Garden *GardenLoki
@@ -383,13 +384,16 @@ type Loki struct {
 
 // GardenLoki contains configuration for the Loki in garden namespace.
 type GardenLoki struct {
-	// Priority is the priority value for the Loki
+	// Priority is the priority value for the Loki.
 	Priority *int32
+	// Storage is the disk storage capacity of the central Loki.
+	// Defaults to 100Gi.
+	Storage *resource.Quantity
 }
 
 // ShootNodeLogging contains configuration for the shoot node logging.
 type ShootNodeLogging struct {
-	// ShootPurposes determines which shoots can have node logging by their purpose
+	// ShootPurposes determines which shoots can have node logging by their purpose.
 	ShootPurposes []gardencore.ShootPurpose
 }
 
@@ -397,11 +401,11 @@ type ShootNodeLogging struct {
 type Logging struct {
 	// Enabled is used to enable or disable logging stack for clusters.
 	Enabled *bool
-	// FluentBit contains configurations for the fluent-bit
+	// FluentBit contains configurations for the fluent-bit.
 	FluentBit *FluentBit
-	// Loki contains configuration for the Loki
+	// Loki contains configuration for the Loki.
 	Loki *Loki
-	// ShootNodeLogging contains configurations for the shoot node logging
+	// ShootNodeLogging contains configurations for the shoot node logging.
 	ShootNodeLogging *ShootNodeLogging
 }
 

--- a/pkg/gardenlet/apis/config/v1alpha1/defaults.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/defaults.go
@@ -78,6 +78,10 @@ func SetDefaults_GardenletConfiguration(obj *GardenletConfiguration) {
 		obj.Server.HTTPS.Port = 2720
 	}
 
+	if obj.Logging == nil {
+		obj.Logging = &Logging{}
+	}
+
 	// TODO: consider enabling profiling by default (like in k8s components)
 
 	if obj.SNI == nil {
@@ -455,5 +459,24 @@ func SetDefaults_SNIIngress(obj *SNIIngress) {
 			v1beta1constants.LabelApp: DefaultIngressGatewayAppLabelValue,
 			"istio":                   "ingressgateway",
 		}
+	}
+}
+
+// SetDefaults_Logging sets defaults for the Logging stack.
+func SetDefaults_Logging(obj *Logging) {
+	if obj.Enabled == nil {
+		obj.Enabled = pointer.BoolPtr(false)
+	}
+	if obj.Loki == nil {
+		obj.Loki = &Loki{}
+	}
+	if obj.Loki.Enabled == nil {
+		obj.Loki.Enabled = obj.Enabled
+	}
+	if obj.Loki.Garden == nil {
+		obj.Loki.Garden = &GardenLoki{}
+	}
+	if obj.Loki.Garden.Storage == nil {
+		obj.Loki.Garden.Storage = &DefaultCentralLokiStorage
 	}
 }

--- a/pkg/gardenlet/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/defaults_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"k8s.io/klog"
@@ -165,6 +166,18 @@ var _ = Describe("Defaults", func() {
 				SetObjectDefaults_GardenletConfiguration(obj)
 
 				Expect(obj.LeaderElection).To(Equal(expectedLeaderElection))
+			})
+		})
+
+		Describe("Logging settings", func() {
+			It("should correctly default Logging configuration", func() {
+				SetObjectDefaults_GardenletConfiguration(obj)
+				Expect(obj.Logging).NotTo(BeNil())
+				Expect(obj.Logging.Enabled).To(PointTo(Equal(false)))
+				Expect(obj.Logging.Loki).NotTo(BeNil())
+				Expect(obj.Logging.Loki.Enabled).To(PointTo(Equal(false)))
+				Expect(obj.Logging.Loki.Garden).NotTo(BeNil())
+				Expect(obj.Logging.Loki.Garden.Storage).To(PointTo(Equal(resource.MustParse("100Gi"))))
 			})
 		})
 	})

--- a/pkg/gardenlet/apis/config/v1alpha1/types.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/types.go
@@ -20,6 +20,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	componentbaseconfigv1alpha1 "k8s.io/component-base/config/v1alpha1"
 	"k8s.io/klog"
@@ -471,7 +472,12 @@ type Loki struct {
 // GardenLoki contains configuration for the Loki in garden namespace.
 type GardenLoki struct {
 	// Priority is the priority value for the Loki
+	// +optional
 	Priority *int `json:"priority,omitempty" yaml:"priority,omitempty"`
+	// Storage is the disk storage capacity of the central Loki.
+	// Defaults to 100Gi.
+	// +optional
+	Storage *resource.Quantity `json:"storage,omitempty" yaml:"storage,omitempty"`
 }
 
 // ShootNodeLogging contains configuration for the shoot node logging.
@@ -709,3 +715,6 @@ const (
 
 // DefaultControllerSyncPeriod is a default value for sync period for controllers.
 var DefaultControllerSyncPeriod = metav1.Duration{Duration: time.Minute}
+
+// DefaultCentralLokiStorage is a default value for garden/loki's storage.
+var DefaultCentralLokiStorage = resource.MustParse("100Gi")

--- a/pkg/gardenlet/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/zz_generated.conversion.go
@@ -28,6 +28,7 @@ import (
 	v1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	config "github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	corev1 "k8s.io/api/core/v1"
+	resource "k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
@@ -852,6 +853,7 @@ func autoConvert_v1alpha1_GardenLoki_To_config_GardenLoki(in *GardenLoki, out *c
 	} else {
 		out.Priority = nil
 	}
+	out.Storage = (*resource.Quantity)(unsafe.Pointer(in.Storage))
 	return nil
 }
 
@@ -868,6 +870,7 @@ func autoConvert_config_GardenLoki_To_v1alpha1_GardenLoki(in *config.GardenLoki,
 	} else {
 		out.Priority = nil
 	}
+	out.Storage = (*resource.Quantity)(unsafe.Pointer(in.Storage))
 	return nil
 }
 

--- a/pkg/gardenlet/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -431,6 +431,11 @@ func (in *GardenLoki) DeepCopyInto(out *GardenLoki) {
 		*out = new(int)
 		**out = **in
 	}
+	if in.Storage != nil {
+		in, out := &in.Storage, &out.Storage
+		x := (*in).DeepCopy()
+		*out = &x
+	}
 	return
 }
 

--- a/pkg/gardenlet/apis/config/v1alpha1/zz_generated.defaults.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/zz_generated.defaults.go
@@ -98,6 +98,9 @@ func SetObjectDefaults_GardenletConfiguration(in *GardenletConfiguration) {
 	if in.LeaderElection != nil {
 		SetDefaults_LeaderElectionConfiguration(in.LeaderElection)
 	}
+	if in.Logging != nil {
+		SetDefaults_Logging(in.Logging)
+	}
 	if in.SNI != nil {
 		SetDefaults_SNI(in.SNI)
 		if in.SNI.Ingress != nil {

--- a/pkg/gardenlet/apis/config/zz_generated.deepcopy.go
+++ b/pkg/gardenlet/apis/config/zz_generated.deepcopy.go
@@ -431,6 +431,11 @@ func (in *GardenLoki) DeepCopyInto(out *GardenLoki) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.Storage != nil {
+		in, out := &in.Storage, &out.Storage
+		x := (*in).DeepCopy()
+		*out = &x
+	}
 	return
 }
 

--- a/pkg/gardenlet/controller/managedseed/charttest/charttest.go
+++ b/pkg/gardenlet/controller/managedseed/charttest/charttest.go
@@ -608,11 +608,12 @@ func ComputeExpectedGardenletConfiguration(
 		five   = 5
 		twenty = 20
 
-		logLevelInfo        = "info"
-		logFormatJson       = "json"
-		lockObjectName      = "gardenlet-leader-election"
-		lockObjectNamespace = "garden"
-		kubernetesLogLevel  = new(klog.Level)
+		logLevelInfo              = "info"
+		logFormatJson             = "json"
+		lockObjectName            = "gardenlet-leader-election"
+		lockObjectNamespace       = "garden"
+		kubernetesLogLevel        = new(klog.Level)
+		defaultCentralLokiStorage = resource.MustParse("100Gi")
 	)
 	Expect(kubernetesLogLevel.Set("0")).ToNot(HaveOccurred())
 
@@ -775,8 +776,17 @@ func ComputeExpectedGardenletConfiguration(
 			ResourceName:      lockObjectName,
 			ResourceNamespace: lockObjectNamespace,
 		},
-		LogLevel:           &logLevelInfo,
-		LogFormat:          &logFormatJson,
+		LogLevel:  &logLevelInfo,
+		LogFormat: &logFormatJson,
+		Logging: &gardenletconfigv1alpha1.Logging{
+			Enabled: pointer.BoolPtr(false),
+			Loki: &gardenletconfigv1alpha1.Loki{
+				Enabled: pointer.BoolPtr(false),
+				Garden: &gardenletconfigv1alpha1.GardenLoki{
+					Storage: &defaultCentralLokiStorage,
+				},
+			},
+		},
 		KubernetesLogLevel: kubernetesLogLevel,
 		Server: &gardenletconfigv1alpha1.ServerConfiguration{HTTPS: gardenletconfigv1alpha1.HTTPSServer{
 			Server: gardenletconfigv1alpha1.Server{

--- a/pkg/operation/seed/seed_test.go
+++ b/pkg/operation/seed/seed_test.go
@@ -16,17 +16,25 @@ package seed_test
 
 import (
 	"context"
+	"fmt"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/logger"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	. "github.com/gardener/gardener/pkg/operation/seed"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -142,6 +150,184 @@ var _ = Describe("seed", func() {
 			})
 
 			Expect(seed.GetValidVolumeSize(size)).To(Equal(size))
+		})
+	})
+
+	Describe("#ResizeOrDeleteLokiDataVolumeIfStorageNotTheSame", func() {
+		const (
+			lokiPVCName         = "loki-loki-0"
+			lokiStatefulSetName = "loki"
+			gardenNamespace     = "garden"
+		)
+		var (
+			ctx               = context.TODO()
+			log               = logger.NewNopLogger()
+			lokiPVCObjectMeta = metav1.ObjectMeta{
+				Name:      lokiPVCName,
+				Namespace: gardenNamespace,
+			}
+			lokiPVC = &corev1.PersistentVolumeClaim{
+				ObjectMeta: lokiPVCObjectMeta,
+				Spec: corev1.PersistentVolumeClaimSpec{
+					Resources: corev1.ResourceRequirements{
+						Requests: map[corev1.ResourceName]resource.Quantity{
+							"storage": resource.MustParse("100Gi"),
+						},
+					},
+				},
+			}
+			patch       = client.MergeFrom(lokiPVC.DeepCopy())
+			statefulset = &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      lokiStatefulSetName,
+					Namespace: gardenNamespace,
+				},
+			}
+			scaledToZeroLokiStatefulset = appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       lokiStatefulSetName,
+					Namespace:  gardenNamespace,
+					Generation: 2,
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: pointer.Int32Ptr(0),
+				},
+				Status: appsv1.StatefulSetStatus{
+					ObservedGeneration: 2,
+					Replicas:           0,
+					AvailableReplicas:  0,
+				},
+			}
+			zeroReplicaRawPatch     = client.RawPatch(types.MergePatchType, []byte(`{"spec":{"replicas":0}}`))
+			errNotFound             = &apierrors.StatusError{ErrStatus: metav1.Status{Reason: metav1.StatusReasonNotFound}}
+			errForbidden            = &apierrors.StatusError{ErrStatus: metav1.Status{Reason: metav1.StatusReasonForbidden}}
+			new200GiStorageQuantity = resource.MustParse("200Gi")
+			new100GiStorageQuantity = resource.MustParse("100Gi")
+			new80GiStorageQuantity  = resource.MustParse("80Gi")
+			lokiPVCKey              = kutil.Key("garden", "loki-loki-0")
+			lokiStatefulSetKey      = kutil.Key("garden", "loki")
+			funcGetLokiPVC          = func(_ context.Context, _ types.NamespacedName, pvc *corev1.PersistentVolumeClaim) error {
+				*pvc = *lokiPVC
+				return nil
+			}
+			funcGetScaledToZeroLokiStatefulset = func(_ context.Context, _ types.NamespacedName, sts *appsv1.StatefulSet) error {
+				*sts = scaledToZeroLokiStatefulset
+				return nil
+			}
+			funcPatchTo200GiStorage = func(_ context.Context, pvc *corev1.PersistentVolumeClaim, _ client.Patch, _ ...interface{}) error {
+				if pvc.Spec.Resources.Requests.Storage().Cmp(resource.MustParse("200Gi")) != 0 {
+					return fmt.Errorf("expect 200Gi found %v", *pvc.Spec.Resources.Requests.Storage())
+				}
+				return nil
+			}
+			objectOfTypePVC = gomock.AssignableToTypeOf(&corev1.PersistentVolumeClaim{})
+			objectOfTypeSTS = gomock.AssignableToTypeOf(&appsv1.StatefulSet{})
+		)
+
+		It("should patch garden/loki's PVC when new size is greater than the current one", func() {
+			runtimeClient.EXPECT().Get(ctx, lokiPVCKey, objectOfTypePVC).DoAndReturn(funcGetLokiPVC)
+			runtimeClient.EXPECT().Patch(ctx, statefulset, zeroReplicaRawPatch)
+			runtimeClient.EXPECT().Get(gomock.Any(), lokiStatefulSetKey, objectOfTypeSTS).DoAndReturn(funcGetScaledToZeroLokiStatefulset)
+			runtimeClient.EXPECT().Patch(ctx, objectOfTypePVC, gomock.AssignableToTypeOf(patch)).DoAndReturn(funcPatchTo200GiStorage)
+			runtimeClient.EXPECT().Delete(ctx, statefulset)
+			Expect(ResizeOrDeleteLokiDataVolumeIfStorageNotTheSame(ctx, runtimeClient, new200GiStorageQuantity, log)).To(Succeed())
+		})
+
+		It("should delete garden/loki's PVC when new size is less than the current one", func() {
+			runtimeClient.EXPECT().Get(ctx, lokiPVCKey, objectOfTypePVC).DoAndReturn(funcGetLokiPVC)
+			runtimeClient.EXPECT().Patch(ctx, statefulset, zeroReplicaRawPatch)
+			runtimeClient.EXPECT().Get(gomock.Any(), lokiStatefulSetKey, objectOfTypeSTS).DoAndReturn(funcGetScaledToZeroLokiStatefulset)
+			runtimeClient.EXPECT().Delete(ctx, lokiPVC)
+			runtimeClient.EXPECT().Delete(ctx, statefulset)
+			Expect(ResizeOrDeleteLokiDataVolumeIfStorageNotTheSame(ctx, runtimeClient, new80GiStorageQuantity, log)).To(Succeed())
+		})
+
+		It("shouldn't do anything when garden/loki's PVC is missing", func() {
+			runtimeClient.EXPECT().Get(ctx, lokiPVCKey, objectOfTypePVC).Return(errNotFound)
+			Expect(ResizeOrDeleteLokiDataVolumeIfStorageNotTheSame(ctx, runtimeClient, new80GiStorageQuantity, log)).To(Succeed())
+		})
+
+		It("shouldn't do anything when garden/loki's PVC storage is the same as the new one", func() {
+			runtimeClient.EXPECT().Get(ctx, lokiPVCKey, objectOfTypePVC).DoAndReturn(funcGetLokiPVC)
+			Expect(ResizeOrDeleteLokiDataVolumeIfStorageNotTheSame(ctx, runtimeClient, new100GiStorageQuantity, log)).To(Succeed())
+		})
+
+		It("should proceed with the garden/loki's PVC resizing when Loki StatefulSet is missing", func() {
+			runtimeClient.EXPECT().Get(ctx, lokiPVCKey, objectOfTypePVC).DoAndReturn(funcGetLokiPVC)
+			runtimeClient.EXPECT().Patch(ctx, statefulset, zeroReplicaRawPatch).Return(errNotFound)
+			runtimeClient.EXPECT().Patch(ctx, objectOfTypePVC, gomock.AssignableToTypeOf(patch)).DoAndReturn(funcPatchTo200GiStorage)
+			runtimeClient.EXPECT().Delete(ctx, statefulset).Return(errNotFound)
+			Expect(ResizeOrDeleteLokiDataVolumeIfStorageNotTheSame(ctx, runtimeClient, new200GiStorageQuantity, log)).To(Succeed())
+		})
+
+		It("should succeed with the garden/loki's PVC resizing when Loki StatefulSet was deleted during function execution", func() {
+			runtimeClient.EXPECT().Get(ctx, lokiPVCKey, objectOfTypePVC).DoAndReturn(funcGetLokiPVC)
+			runtimeClient.EXPECT().Patch(ctx, statefulset, zeroReplicaRawPatch)
+			runtimeClient.EXPECT().Get(gomock.Any(), lokiStatefulSetKey, objectOfTypeSTS).DoAndReturn(funcGetScaledToZeroLokiStatefulset)
+			runtimeClient.EXPECT().Patch(ctx, objectOfTypePVC, gomock.AssignableToTypeOf(patch)).DoAndReturn(funcPatchTo200GiStorage)
+			runtimeClient.EXPECT().Delete(ctx, statefulset).Return(errNotFound)
+			Expect(ResizeOrDeleteLokiDataVolumeIfStorageNotTheSame(ctx, runtimeClient, new200GiStorageQuantity, log)).To(Succeed())
+		})
+
+		It("should not fail with patching garden/loki's PVC when the PVC itself was deleted during function execution", func() {
+			runtimeClient.EXPECT().Get(ctx, lokiPVCKey, objectOfTypePVC).DoAndReturn(funcGetLokiPVC)
+			runtimeClient.EXPECT().Patch(ctx, statefulset, zeroReplicaRawPatch)
+			runtimeClient.EXPECT().Get(gomock.Any(), lokiStatefulSetKey, objectOfTypeSTS).DoAndReturn(funcGetScaledToZeroLokiStatefulset)
+			runtimeClient.EXPECT().Patch(ctx, objectOfTypePVC, gomock.AssignableToTypeOf(patch)).Return(errNotFound)
+			runtimeClient.EXPECT().Delete(ctx, statefulset)
+			Expect(ResizeOrDeleteLokiDataVolumeIfStorageNotTheSame(ctx, runtimeClient, new200GiStorageQuantity, log)).To(Succeed())
+		})
+
+		It("should not fail with deleting garden/loki's PVC when the PVC itself was deleted during function execution", func() {
+			runtimeClient.EXPECT().Get(ctx, lokiPVCKey, objectOfTypePVC).DoAndReturn(funcGetLokiPVC)
+			runtimeClient.EXPECT().Patch(ctx, statefulset, zeroReplicaRawPatch)
+			runtimeClient.EXPECT().Get(gomock.Any(), lokiStatefulSetKey, objectOfTypeSTS).DoAndReturn(funcGetScaledToZeroLokiStatefulset)
+			runtimeClient.EXPECT().Delete(ctx, lokiPVC).Return(errNotFound)
+			runtimeClient.EXPECT().Delete(ctx, statefulset)
+			Expect(ResizeOrDeleteLokiDataVolumeIfStorageNotTheSame(ctx, runtimeClient, new80GiStorageQuantity, log)).To(Succeed())
+		})
+
+		It("should not neglect errors when getting garden/loki's PVC", func() {
+			runtimeClient.EXPECT().Get(ctx, lokiPVCKey, objectOfTypePVC).Return(errForbidden)
+			Expect(ResizeOrDeleteLokiDataVolumeIfStorageNotTheSame(ctx, runtimeClient, new80GiStorageQuantity, log)).ToNot(Succeed())
+		})
+
+		It("should not neglect errors when patching garden/loki's StatefulSet", func() {
+			runtimeClient.EXPECT().Get(ctx, lokiPVCKey, objectOfTypePVC).DoAndReturn(funcGetLokiPVC)
+			runtimeClient.EXPECT().Patch(ctx, statefulset, zeroReplicaRawPatch).Return(errForbidden)
+			Expect(ResizeOrDeleteLokiDataVolumeIfStorageNotTheSame(ctx, runtimeClient, new80GiStorageQuantity, log)).ToNot(Succeed())
+		})
+
+		It("should not neglect errors when getting garden/loki's StatefulSet", func() {
+			runtimeClient.EXPECT().Get(ctx, lokiPVCKey, objectOfTypePVC).DoAndReturn(funcGetLokiPVC)
+			runtimeClient.EXPECT().Patch(ctx, statefulset, zeroReplicaRawPatch)
+			runtimeClient.EXPECT().Get(gomock.Any(), lokiStatefulSetKey, objectOfTypeSTS).Return(errForbidden)
+			Expect(ResizeOrDeleteLokiDataVolumeIfStorageNotTheSame(ctx, runtimeClient, new80GiStorageQuantity, log)).ToNot(Succeed())
+		})
+
+		It("should not neglect errors when patching garden/loki's PVC", func() {
+			runtimeClient.EXPECT().Get(ctx, lokiPVCKey, objectOfTypePVC).DoAndReturn(funcGetLokiPVC)
+			runtimeClient.EXPECT().Patch(ctx, statefulset, zeroReplicaRawPatch)
+			runtimeClient.EXPECT().Get(gomock.Any(), lokiStatefulSetKey, objectOfTypeSTS).DoAndReturn(funcGetScaledToZeroLokiStatefulset)
+			runtimeClient.EXPECT().Patch(ctx, objectOfTypePVC, gomock.AssignableToTypeOf(patch)).Return(errForbidden)
+			Expect(ResizeOrDeleteLokiDataVolumeIfStorageNotTheSame(ctx, runtimeClient, new200GiStorageQuantity, log)).ToNot(Succeed())
+		})
+
+		It("should not neglect errors when deleting garden/loki's PVC", func() {
+			runtimeClient.EXPECT().Get(ctx, lokiPVCKey, objectOfTypePVC).DoAndReturn(funcGetLokiPVC)
+			runtimeClient.EXPECT().Patch(ctx, statefulset, zeroReplicaRawPatch)
+			runtimeClient.EXPECT().Get(gomock.Any(), lokiStatefulSetKey, objectOfTypeSTS).DoAndReturn(funcGetScaledToZeroLokiStatefulset)
+			runtimeClient.EXPECT().Delete(ctx, lokiPVC).Return(errForbidden)
+			Expect(ResizeOrDeleteLokiDataVolumeIfStorageNotTheSame(ctx, runtimeClient, new80GiStorageQuantity, log)).ToNot(Succeed())
+		})
+
+		It("should not neglect errors when deleting garden/loki's StatefulSet", func() {
+			runtimeClient.EXPECT().Get(ctx, lokiPVCKey, objectOfTypePVC).DoAndReturn(funcGetLokiPVC)
+			runtimeClient.EXPECT().Patch(ctx, statefulset, zeroReplicaRawPatch)
+			runtimeClient.EXPECT().Get(gomock.Any(), lokiStatefulSetKey, objectOfTypeSTS).DoAndReturn(funcGetScaledToZeroLokiStatefulset)
+			runtimeClient.EXPECT().Delete(ctx, lokiPVC)
+			runtimeClient.EXPECT().Delete(ctx, statefulset).Return(errForbidden)
+			Expect(ResizeOrDeleteLokiDataVolumeIfStorageNotTheSame(ctx, runtimeClient, new80GiStorageQuantity, log)).ToNot(Succeed())
 		})
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorize it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
With this PR the central Loki storage capacity is increased from 30Gi to 100Gi and it is configurable via `Gardenlet ` configuration. Since we start to store the logs from shoots in `Creating` and `Deleting` states we started lacking storage capacity or inodes. By increasing the Loki PV size we provide more space and more inode without deleting the existing logs. In case the central Loki instances of different landscapes need more storage it can be simply increased via the `gardenlet` configuration.
In case we set lower storage capacity the current central Loki PVCs and their PVs will be deleted with the logs.

Because on Azure resizing a disk is not allowed when the disk is attached first we scale down the central Loki StatefulSet to zero. Then we patch the Loki PVC and finally, we delete the Loki StatefulSet.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The storage capacity of the central Loki is now configurable (via the gardenlet's component config). The default storage capacity is increased from `30Gi` to `100Gi`.
```
