### PR TITLE
Better spread coredns across multiple zones

### DIFF
--- a/pkg/operation/botanist/component/coredns/coredns.go
+++ b/pkg/operation/botanist/component/coredns/coredns.go
@@ -350,19 +350,60 @@ import custom/*.server
 					Spec: corev1.PodSpec{
 						Affinity: &corev1.Affinity{
 							PodAntiAffinity: &corev1.PodAntiAffinity{
-								PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{{
-									Weight: 100,
-									PodAffinityTerm: corev1.PodAffinityTerm{
-										TopologyKey: corev1.LabelHostname,
-										LabelSelector: &metav1.LabelSelector{
-											MatchExpressions: []metav1.LabelSelectorRequirement{{
-												Key:      LabelKey,
-												Operator: metav1.LabelSelectorOpIn,
-												Values:   []string{LabelValue},
-											}},
+								PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+									{
+										Weight: 100,
+										PodAffinityTerm: corev1.PodAffinityTerm{
+											TopologyKey: corev1.LabelTopologyZone,
+											LabelSelector: &metav1.LabelSelector{
+												MatchExpressions: []metav1.LabelSelectorRequirement{{
+													Key:      LabelKey,
+													Operator: metav1.LabelSelectorOpIn,
+													Values:   []string{LabelValue},
+												}},
+											},
 										},
 									},
-								}},
+									{
+										Weight: 95,
+										PodAffinityTerm: corev1.PodAffinityTerm{
+											TopologyKey: corev1.LabelHostname,
+											LabelSelector: &metav1.LabelSelector{
+												MatchExpressions: []metav1.LabelSelectorRequirement{{
+													Key:      LabelKey,
+													Operator: metav1.LabelSelectorOpIn,
+													Values:   []string{LabelValue},
+												}},
+											},
+										},
+									},
+								},
+							},
+						},
+						TopologySpreadConstraints: []corev1.TopologySpreadConstraint{
+							{
+								MaxSkew:           2,
+								TopologyKey:       corev1.LabelTopologyZone,
+								WhenUnsatisfiable: "ScheduleAnyway",
+								LabelSelector: &metav1.LabelSelector{
+									MatchExpressions: []metav1.LabelSelectorRequirement{{
+										Key:      LabelKey,
+										Operator: metav1.LabelSelectorOpIn,
+										Values:   []string{LabelValue},
+									}},
+								},
+							},
+							{
+								MaxSkew:           2,
+								TopologyKey:       corev1.LabelHostname,
+								WhenUnsatisfiable: "ScheduleAnyway",
+								LabelSelector: &metav1.LabelSelector{
+									MatchExpressions: []metav1.LabelSelectorRequirement{{
+										Key:      LabelKey,
+										Operator: metav1.LabelSelectorOpIn,
+										Values:   []string{LabelValue},
+									}},
+								},
 							},
 						},
 						PriorityClassName:  "system-cluster-critical",

--- a/pkg/operation/botanist/component/coredns/coredns_test.go
+++ b/pkg/operation/botanist/component/coredns/coredns_test.go
@@ -306,8 +306,17 @@ spec:
                   operator: In
                   values:
                   - kube-dns
-              topologyKey: kubernetes.io/hostname
+              topologyKey: topology.kubernetes.io/zone
             weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: k8s-app
+                  operator: In
+                  values:
+                  - kube-dns
+              topologyKey: kubernetes.io/hostname
+            weight: 95
       containers:
       - args:
         - -conf
@@ -384,6 +393,25 @@ spec:
       tolerations:
       - key: CriticalAddonsOnly
         operator: Exists
+      topologySpreadConstraints:
+      - labelSelector:
+          matchExpressions:
+          - key: k8s-app
+            operator: In
+            values:
+            - kube-dns
+        maxSkew: 2
+        topologyKey: topology.kubernetes.io/zone
+        whenUnsatisfiable: ScheduleAnyway
+      - labelSelector:
+          matchExpressions:
+          - key: k8s-app
+            operator: In
+            values:
+            - kube-dns
+        maxSkew: 2
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
       volumes:
       - configMap:
           items:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
CoreDNS Pods are now better spread across multiple zones. To achieve this pod anti affinity and topology spread constraints are defined. For kubernetes clusters before k8s v1.18 only pod anti affinity is taken into account because the EvenPodsSpread feature gate is not enabled. 

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/5359

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Topology spread constraints and anti affinity are now defined in the coredns deployment for zones to better spread coredns pods across multiple zones.
```
