### PR TITLE
Add new collector configs to node exporter

### DIFF
--- a/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
@@ -86,6 +86,8 @@ spec:
         - --collector.loadavg
         - --collector.meminfo
         - --collector.uname
+        - --collector.stat
+        - --collector.pressure
         ports:
         - containerPort: {{ .Values.ports.metrics }}
           protocol: TCP


### PR DESCRIPTION
Request to add a few more collectors to have information for /proc/stat and /proc/pressure/.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

We would want to know the exact boot time of nodes and some internal pressure details, which will help to understand some situations like OOMKilled.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**: 
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add new collector configs to node exporter
```
