### PR TITLE
Fix skaffold artifactOverrides for admission-controller

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -65,7 +65,7 @@ deploy:
             image: eu.gcr.io/gardener-project/gardener/controller-manager
           scheduler:
             image: eu.gcr.io/gardener-project/gardener/scheduler
-          admission-controller:
+          admission:
             image: eu.gcr.io/gardener-project/gardener/admission-controller
       imageStrategy:
         helm: {}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:

Fix skaffold `artifactOverrides` for admission-controller, so that admission-controller is actually deployed with the built image instead of with the `latest` tag.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
