### PR TITLE
[release-v1.37] Automated cherry pick of #5399: Always validate AuditPolicy

### DIFF
--- a/pkg/admissioncontroller/webhooks/admission/auditpolicy/admission_test.go
+++ b/pkg/admissioncontroller/webhooks/admission/auditpolicy/admission_test.go
@@ -19,6 +19,9 @@ import (
 	"fmt"
 	"net/http"
 
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
 	"github.com/gardener/gardener/pkg/admissioncontroller/webhooks/admission/auditpolicy"
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -56,6 +59,7 @@ var _ = Describe("handler", func() {
 
 		ctrl       *gomock.Controller
 		mockReader *mockclient.MockReader
+		fakeClient client.Client
 
 		statusCodeAllowed       int32 = http.StatusOK
 		statusCodeInvalid       int32 = http.StatusUnprocessableEntity
@@ -66,7 +70,7 @@ var _ = Describe("handler", func() {
 		cmName         = "fake-cm-name"
 		cmNamespace    = "fake-cm-namespace"
 		shootName      = "fake-shoot-name"
-		shootNamespace = "fake-shoot-namespace"
+		shootNamespace = cmNamespace
 
 		cm            *v1.ConfigMap
 		shootv1beta1  *gardencorev1beta1.Shoot
@@ -132,6 +136,7 @@ rules:
 
 		ctrl = gomock.NewController(GinkgoT())
 		mockReader = mockclient.NewMockReader(ctrl)
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).Build()
 
 		var err error
 		decoder, err = admission.NewDecoder(kubernetes.GardenScheme)
@@ -142,6 +147,53 @@ rules:
 		Expect(admission.InjectDecoderInto(decoder, handler)).To(BeTrue())
 
 		request = admission.Request{}
+
+		shootv1beta1 = &gardencorev1beta1.Shoot{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: gardencorev1beta1.SchemeGroupVersion.String(),
+				Kind:       "Shoot",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      shootName,
+				Namespace: shootNamespace,
+			},
+			Spec: gardencorev1beta1.ShootSpec{
+				Kubernetes: gardencorev1beta1.Kubernetes{
+					KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
+						AuditConfig: &gardencorev1beta1.AuditConfig{
+							AuditPolicy: &gardencorev1beta1.AuditPolicy{
+								ConfigMapRef: &v1.ObjectReference{
+									Name: cmName,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		shootv1alpha1 = &gardencorev1alpha1.Shoot{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: gardencorev1alpha1.SchemeGroupVersion.String(),
+				Kind:       "Shoot",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      shootName,
+				Namespace: shootNamespace,
+			},
+			Spec: gardencorev1alpha1.ShootSpec{
+				Kubernetes: gardencorev1alpha1.Kubernetes{
+					KubeAPIServer: &gardencorev1alpha1.KubeAPIServerConfig{
+						AuditConfig: &gardencorev1alpha1.AuditConfig{
+							AuditPolicy: &gardencorev1alpha1.AuditPolicy{
+								ConfigMapRef: &v1.ObjectReference{
+									Name: cmName,
+								},
+							},
+						},
+					},
+				},
+			},
+		}
 	})
 
 	AfterEach(func() {
@@ -183,52 +235,6 @@ rules:
 	Context("Shoots", func() {
 		BeforeEach(func() {
 			request.Kind = metav1.GroupVersionKind{Group: "core.gardener.cloud", Version: "v1beta1", Kind: "Shoot"}
-			shootv1beta1 = &gardencorev1beta1.Shoot{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: gardencorev1beta1.SchemeGroupVersion.String(),
-					Kind:       "Shoot",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      shootName,
-					Namespace: shootNamespace,
-				},
-				Spec: gardencorev1beta1.ShootSpec{
-					Kubernetes: gardencorev1beta1.Kubernetes{
-						KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
-							AuditConfig: &gardencorev1beta1.AuditConfig{
-								AuditPolicy: &gardencorev1beta1.AuditPolicy{
-									ConfigMapRef: &v1.ObjectReference{
-										Name: cmName,
-									},
-								},
-							},
-						},
-					},
-				},
-			}
-			shootv1alpha1 = &gardencorev1alpha1.Shoot{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: gardencorev1alpha1.SchemeGroupVersion.String(),
-					Kind:       "Shoot",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      shootName,
-					Namespace: shootNamespace,
-				},
-				Spec: gardencorev1alpha1.ShootSpec{
-					Kubernetes: gardencorev1alpha1.Kubernetes{
-						KubeAPIServer: &gardencorev1alpha1.KubeAPIServerConfig{
-							AuditConfig: &gardencorev1alpha1.AuditConfig{
-								AuditPolicy: &gardencorev1alpha1.AuditPolicy{
-									ConfigMapRef: &v1.ObjectReference{
-										Name: cmName,
-									},
-								},
-							},
-						},
-					},
-				},
-			}
 		})
 
 		It("should ignore subresources", func() {
@@ -418,14 +424,13 @@ rules:
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      cmName,
 					Namespace: cmNamespace,
-					Finalizers: []string{
-						"gardener.cloud/reference-protection",
-					},
 				},
 				Data: map[string]string{
 					"policy": validAuditPolicy,
 				},
 			}
+
+			Expect(inject.CacheInto(fakeCache{Reader: fakeClient}, handler)).To(BeTrue())
 		})
 
 		Context("ignored requests", func() {
@@ -446,28 +451,27 @@ rules:
 			BeforeEach(func() {
 				request.Name = cmName
 				request.Namespace = cmNamespace
-
-				shootv1beta1 = &gardencorev1beta1.Shoot{}
-				shootv1beta1.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
-					AuditConfig: &gardencorev1beta1.AuditConfig{
-						AuditPolicy: &gardencorev1beta1.AuditPolicy{
-							ConfigMapRef: &v1.ObjectReference{Name: cmName},
-						},
-					},
-				}
 			})
 
 			Context("Allow", func() {
-				It("does not have a finalizer from a Shoot", func() {
-					cm.ObjectMeta.Finalizers = nil
+				It("is not reference by any shoot", func() {
+					shootInSameNamespaceButNotReferencing := shootv1beta1.DeepCopy()
+					shootInSameNamespaceButNotReferencing.Spec.Kubernetes.KubeAPIServer = nil
+					Expect(fakeClient.Create(ctx, shootInSameNamespaceButNotReferencing)).To(Succeed())
+					shootInDifferentNamespaceAndReferencing := shootv1beta1.DeepCopy()
+					shootInDifferentNamespaceAndReferencing.Namespace = shootNamespace + "other"
+					Expect(fakeClient.Create(ctx, shootInDifferentNamespaceAndReferencing)).To(Succeed())
+
 					test(admissionv1.Update, cm, cm, true, statusCodeAllowed, "configmap is not referenced by a Shoot", "")
 				})
 
 				It("did not change policy field", func() {
+					Expect(fakeClient.Create(ctx, shootv1beta1)).To(Succeed())
 					test(admissionv1.Update, cm, cm, true, statusCodeAllowed, "audit policy not changed", "")
 				})
 
 				It("should allow if the auditPolicy is changed to something valid", func() {
+					Expect(fakeClient.Create(ctx, shootv1beta1)).To(Succeed())
 					shootv1beta1.Spec.Kubernetes.Version = "1.15"
 					newCm := cm.DeepCopy()
 					newCm.Data["policy"] = anotherValidAuditPolicy
@@ -477,6 +481,10 @@ rules:
 			})
 
 			Context("Deny", func() {
+				BeforeEach(func() {
+					Expect(fakeClient.Create(ctx, shootv1beta1)).To(Succeed())
+				})
+
 				It("has no data key", func() {
 					newCm := cm.DeepCopy()
 					newCm.Data = nil
@@ -508,3 +516,10 @@ rules:
 		})
 	})
 })
+
+// fakeCache implements cache.Cache by delegating to the given client.Reader.
+// This is used to inject a fake cache into the handler that is based on a fake client.
+type fakeCache struct {
+	client.Reader
+	cache.Informers
+}

--- a/pkg/admissioncontroller/webhooks/auth/seed/graph/eventhandler_shoot.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/graph/eventhandler_shoot.go
@@ -52,7 +52,7 @@ func (g *graph) setupShootWatch(_ context.Context, informer cache.Informer) {
 				!apiequality.Semantic.DeepEqual(oldShoot.Status.SeedName, newShoot.Status.SeedName) ||
 				!apiequality.Semantic.DeepEqual(oldShoot.Spec.SecretBindingName, newShoot.Spec.SecretBindingName) ||
 				!apiequality.Semantic.DeepEqual(oldShoot.Spec.CloudProfileName, newShoot.Spec.CloudProfileName) ||
-				!gardencorev1beta1helper.ShootAuditPolicyConfigMapRefEqual(oldShoot.Spec.Kubernetes.KubeAPIServer, newShoot.Spec.Kubernetes.KubeAPIServer) ||
+				gardencorev1beta1helper.GetShootAuditPolicyConfigMapName(oldShoot.Spec.Kubernetes.KubeAPIServer) != gardencorev1beta1helper.GetShootAuditPolicyConfigMapName(newShoot.Spec.Kubernetes.KubeAPIServer) ||
 				!gardencorev1beta1helper.ShootDNSProviderSecretNamesEqual(oldShoot.Spec.DNS, newShoot.Spec.DNS) ||
 				!gardencorev1beta1helper.ShootSecretResourceReferencesEqual(oldShoot.Spec.Resources, newShoot.Spec.Resources) {
 				g.handleShootCreateOrUpdate(newShoot)

--- a/pkg/apis/core/helper/helpers.go
+++ b/pkg/apis/core/helper/helpers.go
@@ -312,6 +312,24 @@ func FindVersionsWithSameMajorMinor(versions []core.ExpirableVersion, version se
 	return result, nil
 }
 
+// GetShootAuditPolicyConfigMapName returns the Shoot's ConfigMap reference name for the audit policy.
+func GetShootAuditPolicyConfigMapName(apiServerConfig *core.KubeAPIServerConfig) string {
+	if ref := GetShootAuditPolicyConfigMapRef(apiServerConfig); ref != nil {
+		return ref.Name
+	}
+	return ""
+}
+
+// GetShootAuditPolicyConfigMapRef returns the Shoot's ConfigMap reference for the audit policy.
+func GetShootAuditPolicyConfigMapRef(apiServerConfig *core.KubeAPIServerConfig) *corev1.ObjectReference {
+	if apiServerConfig != nil &&
+		apiServerConfig.AuditConfig != nil &&
+		apiServerConfig.AuditConfig.AuditPolicy != nil {
+		return apiServerConfig.AuditConfig.AuditPolicy.ConfigMapRef
+	}
+	return nil
+}
+
 // HibernationIsEnabled checks if the given shoot's desired state is hibernated.
 func HibernationIsEnabled(shoot *core.Shoot) bool {
 	return shoot.Spec.Hibernation != nil && shoot.Spec.Hibernation.Enabled != nil && *shoot.Spec.Hibernation.Enabled

--- a/pkg/apis/core/helper/helpers_test.go
+++ b/pkg/apis/core/helper/helpers_test.go
@@ -397,7 +397,7 @@ var _ = Describe("helper", func() {
 
 	Describe("GetShootAuditPolicyConfigMapName", func() {
 		test := func(description string, config *core.KubeAPIServerConfig, expectedName string) {
-			It(description, Offset(1), func() {
+			It(description, func() {
 				Expect(GetShootAuditPolicyConfigMapName(config)).To(Equal(expectedName))
 			})
 		}
@@ -423,7 +423,7 @@ var _ = Describe("helper", func() {
 
 	Describe("GetShootAuditPolicyConfigMapRef", func() {
 		test := func(description string, config *core.KubeAPIServerConfig, expectedRef *corev1.ObjectReference) {
-			It(description, Offset(1), func() {
+			It(description, func() {
 				Expect(GetShootAuditPolicyConfigMapRef(config)).To(Equal(expectedRef))
 			})
 		}

--- a/pkg/apis/core/helper/helpers_test.go
+++ b/pkg/apis/core/helper/helpers_test.go
@@ -395,6 +395,58 @@ var _ = Describe("helper", func() {
 		Entry("systemComponents.allowed = true", &core.Worker{SystemComponents: &core.WorkerSystemComponents{Allow: true}}, true),
 	)
 
+	Describe("GetShootAuditPolicyConfigMapName", func() {
+		test := func(description string, config *core.KubeAPIServerConfig, expectedName string) {
+			It(description, Offset(1), func() {
+				Expect(GetShootAuditPolicyConfigMapName(config)).To(Equal(expectedName))
+			})
+		}
+
+		test("KubeAPIServerConfig = nil", nil, "")
+		test("AuditConfig = nil", &core.KubeAPIServerConfig{}, "")
+		test("AuditPolicy = nil", &core.KubeAPIServerConfig{
+			AuditConfig: &core.AuditConfig{},
+		}, "")
+		test("ConfigMapRef = nil", &core.KubeAPIServerConfig{
+			AuditConfig: &core.AuditConfig{
+				AuditPolicy: &core.AuditPolicy{},
+			},
+		}, "")
+		test("ConfigMapRef set", &core.KubeAPIServerConfig{
+			AuditConfig: &core.AuditConfig{
+				AuditPolicy: &core.AuditPolicy{
+					ConfigMapRef: &corev1.ObjectReference{Name: "foo"},
+				},
+			},
+		}, "foo")
+	})
+
+	Describe("GetShootAuditPolicyConfigMapRef", func() {
+		test := func(description string, config *core.KubeAPIServerConfig, expectedRef *corev1.ObjectReference) {
+			It(description, Offset(1), func() {
+				Expect(GetShootAuditPolicyConfigMapRef(config)).To(Equal(expectedRef))
+			})
+		}
+
+		test("KubeAPIServerConfig = nil", nil, nil)
+		test("AuditConfig = nil", &core.KubeAPIServerConfig{}, nil)
+		test("AuditPolicy = nil", &core.KubeAPIServerConfig{
+			AuditConfig: &core.AuditConfig{},
+		}, nil)
+		test("ConfigMapRef = nil", &core.KubeAPIServerConfig{
+			AuditConfig: &core.AuditConfig{
+				AuditPolicy: &core.AuditPolicy{},
+			},
+		}, nil)
+		test("ConfigMapRef set", &core.KubeAPIServerConfig{
+			AuditConfig: &core.AuditConfig{
+				AuditPolicy: &core.AuditPolicy{
+					ConfigMapRef: &corev1.ObjectReference{Name: "foo"},
+				},
+			},
+		}, &corev1.ObjectReference{Name: "foo"})
+	})
+
 	DescribeTable("#HibernationIsEnabled",
 		func(shoot *core.Shoot, hibernated bool) {
 			Expect(HibernationIsEnabled(shoot)).To(Equal(hibernated))

--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -1322,31 +1322,6 @@ func SeedBackupSecretRefEqual(oldBackup, newBackup *gardencorev1beta1.SeedBackup
 	return apiequality.Semantic.DeepEqual(oldSecretRef, newSecretRef)
 }
 
-// ShootAuditPolicyConfigMapRefEqual returns true if the name of the ConfigMap reference for the audit policy
-// configuration is the same.
-func ShootAuditPolicyConfigMapRefEqual(oldAPIServerConfig, newAPIServerConfig *gardencorev1beta1.KubeAPIServerConfig) bool {
-	var (
-		oldConfigMapRefName string
-		newConfigMapRefName string
-	)
-
-	if oldAPIServerConfig != nil &&
-		oldAPIServerConfig.AuditConfig != nil &&
-		oldAPIServerConfig.AuditConfig.AuditPolicy != nil &&
-		oldAPIServerConfig.AuditConfig.AuditPolicy.ConfigMapRef != nil {
-		oldConfigMapRefName = oldAPIServerConfig.AuditConfig.AuditPolicy.ConfigMapRef.Name
-	}
-
-	if newAPIServerConfig != nil &&
-		newAPIServerConfig.AuditConfig != nil &&
-		newAPIServerConfig.AuditConfig.AuditPolicy != nil &&
-		newAPIServerConfig.AuditConfig.AuditPolicy.ConfigMapRef != nil {
-		newConfigMapRefName = newAPIServerConfig.AuditConfig.AuditPolicy.ConfigMapRef.Name
-	}
-
-	return oldConfigMapRefName == newConfigMapRefName
-}
-
 // ShootDNSProviderSecretNamesEqual returns true when all the secretNames in the `.spec.dns.providers[]` list are the
 // same.
 func ShootDNSProviderSecretNamesEqual(oldDNS, newDNS *gardencorev1beta1.DNS) bool {
@@ -1395,6 +1370,24 @@ func ShootSecretResourceReferencesEqual(oldResources, newResources []gardencorev
 	}
 
 	return oldNames.Equal(newNames)
+}
+
+// GetShootAuditPolicyConfigMapName returns the Shoot's ConfigMap reference name for the audit policy.
+func GetShootAuditPolicyConfigMapName(apiServerConfig *gardencorev1beta1.KubeAPIServerConfig) string {
+	if ref := GetShootAuditPolicyConfigMapRef(apiServerConfig); ref != nil {
+		return ref.Name
+	}
+	return ""
+}
+
+// GetShootAuditPolicyConfigMapRef returns the Shoot's ConfigMap reference for the audit policy.
+func GetShootAuditPolicyConfigMapRef(apiServerConfig *gardencorev1beta1.KubeAPIServerConfig) *corev1.ObjectReference {
+	if apiServerConfig != nil &&
+		apiServerConfig.AuditConfig != nil &&
+		apiServerConfig.AuditConfig.AuditPolicy != nil {
+		return apiServerConfig.AuditConfig.AuditPolicy.ConfigMapRef
+	}
+	return nil
 }
 
 // ShootWantsAnonymousAuthentication returns true if anonymous authentication is set explicitly to 'true' and false otherwise.

--- a/pkg/apis/core/v1beta1/helper/helper_test.go
+++ b/pkg/apis/core/v1beta1/helper/helper_test.go
@@ -2059,7 +2059,7 @@ var _ = Describe("helper", func() {
 
 	Describe("GetShootAuditPolicyConfigMapName", func() {
 		test := func(description string, config *gardencorev1beta1.KubeAPIServerConfig, expectedName string) {
-			It(description, Offset(1), func() {
+			It(description, func() {
 				Expect(GetShootAuditPolicyConfigMapName(config)).To(Equal(expectedName))
 			})
 		}
@@ -2085,7 +2085,7 @@ var _ = Describe("helper", func() {
 
 	Describe("GetShootAuditPolicyConfigMapRef", func() {
 		test := func(description string, config *gardencorev1beta1.KubeAPIServerConfig, expectedRef *corev1.ObjectReference) {
-			It(description, Offset(1), func() {
+			It(description, func() {
 				Expect(GetShootAuditPolicyConfigMapRef(config)).To(Equal(expectedRef))
 			})
 		}


### PR DESCRIPTION
/kind/bug
/area/usability

Cherry pick of #5399 on release-v1.37.

#5399: Always validate AuditPolicy

**Release Notes:**
```bugfix user
Gardener now validates `AuditPolicy` ConfigMaps, even if operators have disabled the reference protection feature for them.
```