### PR TITLE
[release-v1.39] Automated cherry pick of #5398: Fix skaffold artifactOverrides for admission-controller

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -65,7 +65,7 @@ deploy:
             image: eu.gcr.io/gardener-project/gardener/controller-manager
           scheduler:
             image: eu.gcr.io/gardener-project/gardener/scheduler
-          admission-controller:
+          admission:
             image: eu.gcr.io/gardener-project/gardener/admission-controller
       imageStrategy:
         helm: {}


### PR DESCRIPTION
/kind/bug
/area/dev-productivity

Cherry pick of #5398 on release-v1.39.

#5398: Fix skaffold artifactOverrides for admission-controller

**Release Notes:**
```other operator
NONE
```