### PR TITLE
[release-v1.39] Automated cherry pick of #5381: Fixes restoration of worker resource

### DIFF
--- a/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
@@ -138,6 +138,9 @@ func (a *genericActuator) restoreMachineSetsAndMachines(ctx context.Context, log
 				}
 			}
 
+			// Patch() is used here instead of Update() so that only the machine.Status.Node field is modified as a workaround
+			// for https://github.com/gardener/machine-controller-manager/issues/642. Check also https://github.com/kubernetes/kubernetes/issues/86811.
+			// Calling Update() would include the whole MachineStatus in the request - including fields of type metav1.Time causing the mentioned issues.
 			patch := client.MergeFrom(newMachine.DeepCopy())
 			newMachine.Status.Node = machine.Status.Node
 			return a.client.Status().Patch(ctx, newMachine, patch)

--- a/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
@@ -138,8 +138,9 @@ func (a *genericActuator) restoreMachineSetsAndMachines(ctx context.Context, log
 				}
 			}
 
-			newMachine.Status = machine.Status
-			return a.client.Status().Update(ctx, newMachine)
+			patch := client.MergeFrom(newMachine.DeepCopy())
+			newMachine.Status.Node = machine.Status.Node
+			return a.client.Status().Patch(ctx, newMachine, patch)
 		}
 	}
 


### PR DESCRIPTION
/kind/bug
/area/control-plane-migration

Cherry pick of #5381 on release-v1.39.

#5381: Fixes restoration of worker resource

**Release Notes:**
```bugfix operator
Fixes an issue that prevents the status of `Machine` objects to be modified during the restore phase of control plane migration. Patch is now used to do the modification instead of an update call.
```