### PR TITLE
[release-v1.39] Automated cherry pick of #5351: Increase the logging integration test logger application memory request

### DIFF
--- a/test/framework/resources/templates/logger-app.yaml.tpl
+++ b/test/framework/resources/templates/logger-app.yaml.tpl
@@ -54,10 +54,10 @@ spec:
         resources:
           limits:
             cpu: 8m
-            memory: 20Mi
+            memory: 30Mi
           requests:
             cpu: 4m
-            memory: 3Mi
+            memory: 10Mi
       securityContext:
         fsGroup: 65532
         runAsUser: 65532


### PR DESCRIPTION
/kind/enhancement
/area/logging

Cherry pick of #5351 on release-v1.39.

#5351: Increase the logging integration test logger application memory request

**Release Notes:**
```bugfix developer
Make logging integration tests on flatcar OS more stable by increasing the memory limit and request of the logger application
```