### PR TITLE
Clean up migration logic in logging deployment

### DIFF
--- a/pkg/operation/botanist/logging.go
+++ b/pkg/operation/botanist/logging.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/gardener/gardener/charts"
 	gardencore "github.com/gardener/gardener/pkg/apis/core"
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/features"
 	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
@@ -33,7 +32,6 @@ import (
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // DeploySeedLogging will install the Helm release "seed-bootstrap/charts/loki" in the Seed clusters.
@@ -114,16 +112,6 @@ func (b *Botanist) DeploySeedLogging(ctx context.Context) error {
 				"loki": currentResources["loki"],
 			}
 		}
-	}
-
-	// .spec.selector of a StatefulSet is immutable. If StatefulSet's .spec.selector contains
-	// the deprecated role label key, we delete it and let it to be re-created below with the chart apply.
-	// TODO (ialidzhikov): remove in a future version
-	stsKeys := []client.ObjectKey{
-		kutil.Key(b.Shoot.SeedNamespace, v1beta1constants.StatefulSetNameLoki),
-	}
-	if err := common.DeleteStatefulSetsHavingDeprecatedRoleLabelKey(ctx, b.K8sSeedClient.Client(), stsKeys); err != nil {
-		return err
 	}
 
 	if err := b.K8sSeedClient.ChartApplier().Apply(ctx, filepath.Join(charts.Path, "seed-bootstrap", "charts", "loki"), b.Shoot.SeedNamespace, fmt.Sprintf("%s-logging", b.Shoot.SeedNamespace), kubernetes.Values(lokiValues)); err != nil {

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -21,7 +21,6 @@ import (
 	"math/big"
 	"net"
 	"strings"
-	"time"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
@@ -366,32 +365,5 @@ func DeleteGrafanaByRole(ctx context.Context, k8sClient kubernetes.Interface, na
 		ctx, fmt.Sprintf("grafana-%s", role), metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
-	return nil
-}
-
-// DeleteStatefulSetsHavingDeprecatedRoleLabelKey deletes the StatefulSets with the passed object keys if
-// the corresponding StatefulSet .spec.selector contains the deprecated "garden.sapcloud.io/role" label key.
-func DeleteStatefulSetsHavingDeprecatedRoleLabelKey(ctx context.Context, c client.Client, keys []client.ObjectKey) error {
-	for _, key := range keys {
-		sts := &appsv1.StatefulSet{}
-		if err := c.Get(ctx, key, sts); err != nil {
-			if apierrors.IsNotFound(err) {
-				continue
-			}
-
-			return err
-		}
-
-		if _, ok := sts.Spec.Selector.MatchLabels[v1beta1constants.DeprecatedGardenRole]; ok {
-			if err := c.Delete(ctx, sts); client.IgnoreNotFound(err) != nil {
-				return err
-			}
-
-			if err := kutil.WaitUntilResourceDeleted(ctx, c, sts, 2*time.Second); err != nil {
-				return err
-			}
-		}
-	}
-
 	return nil
 }

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -957,18 +957,6 @@ func RunReconcileSeedFlow(
 		return err
 	}
 
-	// .spec.selector of a StatefulSet is immutable. If StatefulSet's .spec.selector contains
-	// the deprecated role label key, we delete it and let it to be re-created below with the chart apply.
-	// TODO (ialidzhikov): remove in a future version
-	if loggingEnabled {
-		stsKeys := []client.ObjectKey{
-			kutil.Key(v1beta1constants.GardenNamespace, v1beta1constants.StatefulSetNameLoki),
-		}
-		if err := common.DeleteStatefulSetsHavingDeprecatedRoleLabelKey(ctx, seedClient, stsKeys); err != nil {
-			return err
-		}
-	}
-
 	values := kubernetes.Values(map[string]interface{}{
 		"priorityClassName": v1beta1constants.PriorityClassNameShootControlPlane,
 		"global": map[string]interface{}{


### PR DESCRIPTION
/kind cleanup

The corresponding migration logic was introduced with https://github.com/gardener/gardener/pull/4783 to make possible removal of deprecated label from `.spec.selector` of the loki StatefulSets (the field is immutable).

Part of https://github.com/gardener/gardener/issues/1649

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
