### PR TITLE
Fix `invalid status` error on Bastion extension status update

### DIFF
--- a/docs/api-reference/extensions.md
+++ b/docs/api-reference/extensions.md
@@ -1996,6 +1996,7 @@ Kubernetes core/v1.LoadBalancerIngress
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Ingress is the external IP and/or hostname of the bastion host.</p>
 </td>
 </tr>

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_bastions.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_bastions.yaml
@@ -293,8 +293,6 @@ spec:
                   what ever data it needs.
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
-            required:
-            - ingress
             type: object
         required:
         - spec

--- a/pkg/apis/extensions/v1alpha1/types_bastion.go
+++ b/pkg/apis/extensions/v1alpha1/types_bastion.go
@@ -80,7 +80,8 @@ type BastionStatus struct {
 	// DefaultStatus is a structure containing common fields used by all extension resources.
 	DefaultStatus `json:",inline"`
 	// Ingress is the external IP and/or hostname of the bastion host.
-	Ingress corev1.LoadBalancerIngress `json:"ingress"`
+	// +optional
+	Ingress *corev1.LoadBalancerIngress `json:"ingress,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/extensions/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/extensions/v1alpha1/zz_generated.deepcopy.go
@@ -340,7 +340,11 @@ func (in *BastionSpec) DeepCopy() *BastionSpec {
 func (in *BastionStatus) DeepCopyInto(out *BastionStatus) {
 	*out = *in
 	in.DefaultStatus.DeepCopyInto(&out.DefaultStatus)
-	in.Ingress.DeepCopyInto(&out.Ingress)
+	if in.Ingress != nil {
+		in, out := &in.Ingress, &out.Ingress
+		*out = new(v1.LoadBalancerIngress)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/operation/botanist/component/extensions/crds/templates/crd-bastion.tpl.yaml
+++ b/pkg/operation/botanist/component/extensions/crds/templates/crd-bastion.tpl.yaml
@@ -289,8 +289,6 @@ spec:
                     what ever data it needs.
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
-              required:
-                - ingress
               type: object
           required:
             - spec


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
When updating the status of a bastions.extensions.gardener.cloud custom resource it fails with the error
`Bastion.extensions.gardener.cloud \“cli-0zh5tkby\” is invalid: status.ingress: Required value`

When starting to reconcile the Bastion and trying to update the status it failed at this point https://github.com/gardener/gardener-extension-provider-aws/blob/be02e4cfa70af128a225491e0aed3458e75c99c9/vendor/github.com/gardener/gardener/extensions/pkg/controller/bastion/reconciler.go#L106-L108 

This issue appeared (in case of `aws` provider extension) by revendoring gardener `v1.39` https://github.com/gardener/gardener-extension-provider-aws/pull/478

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed issue with "Required value" error for `status.ingress` field  of `bastions.extensions.gardener.cloud` custom resource. This field is not required anymore.
```

```breaking dependency
The field `status.ingress` of `bastions.extensions.gardener.cloud` is now optional and thus changed to a pointer
```