### PR TITLE
[release-v1.39] Automated cherry pick of #5416: Fix `invalid status` error on Bastion extension status update

### DIFF
--- a/docs/api-reference/extensions.md
+++ b/docs/api-reference/extensions.md
@@ -1971,6 +1971,7 @@ Kubernetes core/v1.LoadBalancerIngress
 </em>
 </td>
 <td>
+<em>(Optional)</em>
 <p>Ingress is the external IP and/or hostname of the bastion host.</p>
 </td>
 </tr>

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_bastions.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_bastions.yaml
@@ -292,8 +292,6 @@ spec:
                   what ever data it needs.
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
-            required:
-            - ingress
             type: object
         required:
         - spec

--- a/pkg/apis/extensions/v1alpha1/types_bastion.go
+++ b/pkg/apis/extensions/v1alpha1/types_bastion.go
@@ -78,7 +78,8 @@ type BastionStatus struct {
 	// DefaultStatus is a structure containing common fields used by all extension resources.
 	DefaultStatus `json:",inline"`
 	// Ingress is the external IP and/or hostname of the bastion host.
-	Ingress corev1.LoadBalancerIngress `json:"ingress"`
+	// +optional
+	Ingress *corev1.LoadBalancerIngress `json:"ingress,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/extensions/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/extensions/v1alpha1/zz_generated.deepcopy.go
@@ -340,7 +340,11 @@ func (in *BastionSpec) DeepCopy() *BastionSpec {
 func (in *BastionStatus) DeepCopyInto(out *BastionStatus) {
 	*out = *in
 	in.DefaultStatus.DeepCopyInto(&out.DefaultStatus)
-	in.Ingress.DeepCopyInto(&out.Ingress)
+	if in.Ingress != nil {
+		in, out := &in.Ingress, &out.Ingress
+		*out = new(v1.LoadBalancerIngress)
+		(*in).DeepCopyInto(*out)
+	}
 	return
 }
 

--- a/pkg/operation/botanist/component/extensions/crds/templates/crd-bastion.tpl.yaml
+++ b/pkg/operation/botanist/component/extensions/crds/templates/crd-bastion.tpl.yaml
@@ -289,8 +289,6 @@ spec:
                     what ever data it needs.
                   type: object
                   x-kubernetes-preserve-unknown-fields: true
-              required:
-                - ingress
               type: object
           required:
             - spec


### PR DESCRIPTION
/kind/bug
/kind/api-change
/area/quality
/merge/squash

Cherry pick of #5416 on release-v1.39.

#5416: Fix `invalid status` error on Bastion extension status update

**Release Notes:**
```bugfix operator
Fixed issue with "Required value" error for `status.ingress` field of `bastions.extensions.gardener.cloud` custom resource. This field is not required anymore.
```
```breaking dependency
The field `status.ingress` of `bastions.extensions.gardener.cloud` is now optional and thus changed to a pointer
```