### PR TITLE
Use max instead of sum when counting etcd objects

### DIFF
--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/apiserver-overview.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/apiserver-overview.json
@@ -2227,7 +2227,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(etcd_object_counts{job=~\"$apiserver\"}) by (resource)",
+          "expr": "max(etcd_object_counts{job=~\"$apiserver\"}) by (resource)",
           "interval": "",
           "legendFormat": "{{resource}}",
           "refId": "A"

--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/kubernetes-api-server-details.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/kubernetes-api-server-details.json
@@ -596,7 +596,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(max(etcd_object_counts) by (resource)) by (resource)",
+          "expr": "max(etcd_object_counts) by (resource)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,

--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/kubernetes-control-plane-status-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/kubernetes-control-plane-status-dashboard.json
@@ -1209,14 +1209,14 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(max(etcd_object_counts) by (resource)) by (resource)",
+          "expr": "max(etcd_object_counts) by (resource)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{resource}}",
           "refId": "A"
         },
         {
-          "expr": "sum(etcd_object_counts)",
+          "expr": "sum(max(etcd_object_counts) by (resource))",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "total",

--- a/pkg/operation/botanist/component/etcd/monitoring.go
+++ b/pkg/operation/botanist/component/etcd/monitoring.go
@@ -152,7 +152,7 @@ const (
       summary: Etcd3 {{ .role }} DB size has crossed its current practical limit.
 
   - record: shoot:etcd_object_counts:sum_by_resource
-    expr: sum(etcd_object_counts) by (resource)
+    expr: max(etcd_object_counts) by (resource)
 
   {{- if .backupEnabled }}
   # etcd backup failure alerts

--- a/pkg/operation/botanist/component/etcd/monitoring_test.go
+++ b/pkg/operation/botanist/component/etcd/monitoring_test.go
@@ -251,7 +251,7 @@ metric_relabel_configs:
       summary: Etcd3 ` + testRole + ` DB size has crossed its current practical limit.
 
   - record: shoot:etcd_object_counts:sum_by_resource
-    expr: sum(etcd_object_counts) by (resource)
+    expr: max(etcd_object_counts) by (resource)
 `
 
 	alertingRulesBackup = `  # etcd backup failure alerts


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

Since the etcd object counts come from the API Server, multiple API Server
instances will lead to duplicate etcd object count metrics. The use of max
will reduce the metric to a single time series and remove duplicates.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Use max instead of sum when counting etcd objects
```
