### PR TITLE
Use secretref to provide bootstrap kubeconfig

### DIFF
--- a/charts/gardener/gardenlet/charts/runtime/templates/configmap-componentconfig.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/configmap-componentconfig.yaml
@@ -32,8 +32,13 @@ data:
       {{- end }}
       {{- if .Values.global.gardenlet.config.gardenClientConnection.bootstrapKubeconfig }}
       bootstrapKubeconfig:
+        {{- if .Values.global.gardenlet.config.gardenClientConnection.bootstrapKubeconfig.secretRef }}
+        name: {{ required ".Values.global.gardenlet.config.gardenClientConnection.bootstrapKubeconfig.secretRef.name is required" .Values.global.gardenlet.config.gardenClientConnection.bootstrapKubeconfig.secretRef.name }}
+        namespace: {{ required ".Values.global.gardenlet.config.gardenClientConnection.bootstrapKubeconfig.secretRef.namespace is required" .Values.global.gardenlet.config.gardenClientConnection.bootstrapKubeconfig.secretRef.namespace }}
+        {{- else }}
         name: {{ required ".Values.global.gardenlet.config.gardenClientConnection.bootstrapKubeconfig.name is required" .Values.global.gardenlet.config.gardenClientConnection.bootstrapKubeconfig.name }}
         namespace: {{ required ".Values.global.gardenlet.config.gardenClientConnection.bootstrapKubeconfig.namespace is required" .Values.global.gardenlet.config.gardenClientConnection.bootstrapKubeconfig.namespace }}
+        {{- end }}
       {{- end }}
       {{- if .Values.global.gardenlet.config.gardenClientConnection.kubeconfigSecret }}
       kubeconfigSecret:

--- a/charts/gardener/gardenlet/charts/runtime/templates/deployment.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/deployment.yaml
@@ -33,7 +33,9 @@ spec:
         checksum/configmap-gardenlet-imagevector-overwrite-components: {{ include (print $.Template.BasePath "/configmap-imagevector-overwrite-components.yaml") . | sha256sum }}
         {{- end }}
         {{- if .Values.global.gardenlet.config.gardenClientConnection.bootstrapKubeconfig }}
+        {{- if not .Values.global.gardenlet.config.gardenClientConnection.bootstrapKubeconfig.secretRef }}
         checksum/secret-gardenlet-kubeconfig-garden-bootstrap: {{ include (print $.Template.BasePath "/secret-kubeconfig-garden-bootstrap.yaml") . | sha256sum }}
+        {{- end }}
         {{- end }}
         {{- if .Values.global.gardenlet.config.gardenClientConnection.kubeconfig }}
         checksum/secret-gardenlet-kubeconfig-garden: {{ include (print $.Template.BasePath "/secret-kubeconfig-garden.yaml") . | sha256sum }}

--- a/charts/gardener/gardenlet/charts/runtime/templates/secret-kubeconfig-garden-bootstrap.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/secret-kubeconfig-garden-bootstrap.yaml
@@ -1,4 +1,5 @@
 {{- if and .Values.global.gardenlet.enabled .Values.global.gardenlet.config.gardenClientConnection.bootstrapKubeconfig }}
+{{- if not .Values.global.gardenlet.config.gardenClientConnection.bootstrapKubeconfig.secretRef }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -13,4 +14,5 @@ metadata:
 type: Opaque
 data:
   kubeconfig: {{ required ".Values.global.gardenlet.config.gardenClientConnection.bootstrapKubeconfig.kubeconfig is required" .Values.global.gardenlet.config.gardenClientConnection.bootstrapKubeconfig.kubeconfig | b64enc }}
+{{- end }}
 {{- end }}

--- a/charts/gardener/gardenlet/values.yaml
+++ b/charts/gardener/gardenlet/values.yaml
@@ -36,14 +36,17 @@ global:
       # gardenClusterAddress: https://some-external-ip-address-to-garden-cluster
       # gardenClusterCACert: <base64-ca-cert>
       # bootstrapKubeconfig: # bootstrapKubeconfig contains the kubeconfig that is used to initiate the bootstrap process, i.e.,
-                             # that is used to request a client certificate for the garden cluster. The name and namespace fields
+                             # that is used to request a client certificate for the garden cluster. 
+                             # If the kubeconfig is provided inline, the name and namespace fields
                              # are a reference to a secret that will store this bootstrap kubeconfig. If `kubeconfig` is given
                              # then only this kubeconfig will be considered.
+                             # If you already have a boostrap kubeconfig you can reference it with 
+                             # secretRef.name and secretRef.namespace.
       #   name: gardenlet-kubeconfig-bootstrap
       #   namespace: garden
       #   secretRef:
-      #     name: secretName of your bootstrapKubeconfig
-      #     namespace: namespace of your bootstrapKubeconfig
+      #     name: secretName
+      #     namespace: secretNamespace
       #   kubeconfig: |
       #     some-kubeconfig-for-bootstrapping
       # kubeconfigSecret: # kubeconfigSecret is the reference to a secret object that stores the gardenlet's kubeconfig that

--- a/charts/gardener/gardenlet/values.yaml
+++ b/charts/gardener/gardenlet/values.yaml
@@ -41,6 +41,9 @@ global:
                              # then only this kubeconfig will be considered.
       #   name: gardenlet-kubeconfig-bootstrap
       #   namespace: garden
+      #   secretRef:
+      #     name: secretName of your bootstrapKubeconfig
+      #     namespace: namespace of your bootstrapKubeconfig
       #   kubeconfig: |
       #     some-kubeconfig-for-bootstrapping
       # kubeconfigSecret: # kubeconfigSecret is the reference to a secret object that stores the gardenlet's kubeconfig that


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorize it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR improved the HelmChart handling.

I created a new HelmChart value to avoid inline bootstrapkubeconfig. 
With this approach, you can now reference a kubeconfig for the bootstrap process instead of inline provisioning.

Use this new values to reference a secret: `values.yaml`
```yaml
global:
  gardenlet:
    gardenClientConnection:
      bootstrapKubeconfig:
        secretRef:
          name: <name of the secret>
          namespace: <namespace of the secret>
```

The install process of the gardenlet needs a bootstrap kubeconfig with a token. This token should be in general auto-generated, so I needed a HelmChart process to include this. I build a setup (outside of the gardenlet helm chart) to generate the token and also the bootstrap kubeconfig. Without this change, I have to provide this kubeconfig inline which is impossible with helm functions.
So that's the motivation of this PR



**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
