### PR TITLE
gardener-controller-manager: Enable the audit policy configmap reference protection by default

### DIFF
--- a/charts/gardener/controlplane/values.yaml
+++ b/charts/gardener/controlplane/values.yaml
@@ -394,7 +394,7 @@ global:
           syncPeriod: 24h
         shootReference:
           concurrentSyncs: 5
-          protectAuditPolicyConfigMaps: false
+          protectAuditPolicyConfigMaps: true
         shootRetry:
           concurrentSyncs: 5
           retryPeriod: 10m

--- a/docs/concepts/controller-manager.md
+++ b/docs/concepts/controller-manager.md
@@ -118,13 +118,10 @@ The scanned shoot also gets this finalizer to enable a proper garbage collection
 When an object is not actively referenced anymore because the shoot specification has changed or all related shoots were deleted (are in deletion), the controller will remove the added finalizer again, so that the object can safely be deleted or garbage collected.
 
 The Shoot Reference Controller can inspect the following references:
+- DNS provider secrets (`.spec.dns.provider`)
+- Audit policy configmaps (`.spec.kubernetes.kubeAPIServer.auditConfig.auditPolicy.configMapRef`)
 
-- Enabled by default:
-  - DNS provider secrets (`.spec.dns.provider`)
-- Disabled by default:
-  - Audit policy configmaps (`.spec.kubernetes.kubeAPIServer.auditConfig.auditPolicy.configMapRef`)
-
-> If you want to enable the audit policy configmap protection then you can set the `.controllers.shootReference.protectAuditPolicyConfigMaps` to `true` in the component configuration.
+> The audit policy configmap protection is configurable and enabled by default. If you want to disable it then you can set the `.controllers.shootReference.protectAuditPolicyConfigMaps` to `false` in the component configuration.
 
 Further checks might be added in the future.
 

--- a/pkg/controllermanager/apis/config/v1alpha1/defaults.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/defaults.go
@@ -138,6 +138,10 @@ func SetDefaults_ControllerManagerConfiguration(obj *ControllerManagerConfigurat
 			ConcurrentSyncs: 5,
 		}
 	}
+	if obj.Controllers.ShootReference.ProtectAuditPolicyConfigMaps == nil {
+		v := true
+		obj.Controllers.ShootReference.ProtectAuditPolicyConfigMaps = &v
+	}
 
 	if obj.Controllers.ShootRetry == nil {
 		obj.Controllers.ShootRetry = &ShootRetryControllerConfiguration{

--- a/pkg/controllermanager/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/defaults_test.go
@@ -86,6 +86,7 @@ var _ = Describe("Defaults", func() {
 
 			Expect(obj.Controllers.ShootReference).NotTo(BeNil())
 			Expect(obj.Controllers.ShootReference.ConcurrentSyncs).To(Equal(5))
+			Expect(obj.Controllers.ShootReference.ProtectAuditPolicyConfigMaps).To(PointTo(BeTrue()))
 
 			Expect(obj.Controllers.ShootRetry).NotTo(BeNil())
 			Expect(obj.Controllers.ShootRetry.ConcurrentSyncs).To(Equal(5))


### PR DESCRIPTION
/area control-plane ops-productivity
/kind cleanup

Part of https://github.com/gardener/gardener/issues/5412

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The audit policy configmap protection by the Shoot reference controller of gardener-controller-manager is now enabled by default (but still configurable).
```
