### PR TITLE
Add gardener control plane authentication docu

### DIFF
--- a/docs/deployment/authentication_gardener_control_plane.md
+++ b/docs/deployment/authentication_gardener_control_plane.md
@@ -1,0 +1,81 @@
+# Authentication of Gardener control plane components against the Garden cluster
+
+**Note:** This document refers to Gardener's API server, admission controller, controller manager and scheduler components. Any reference to the term **Gardener control plane component** can be replaced with any of the mentioned above.
+
+There are several authentication possibilities depending on whether or not [the concept of *Virtual Garden*](https://github.com/gardener/garden-setup#concept-the-virtual-cluster) is used.
+
+## *Virtual Garden* is not used, i.e., the `runtime` Garden cluster is also the `target` Garden cluster.
+
+**Automounted Service Account Token**
+The easiest way to deploy a **Gardener control plane component** will be to not provide `kubeconfig` at all. This way in-cluster configuration and an automounted service account token will be used. The drawback of this approach is that the automounted token will not be automatically rotated.
+
+**Service Account Token Volume Projection**
+Another solution will be to use [Service Account Token Volume Projection](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection) combined with a `kubeconfig` referencing a token file (see example below).
+```yaml
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    certificate-authority-data: <CA-DATA>
+    server: https://default.kubernetes.svc.cluster.local
+  name: garden
+contexts:
+- context:
+    cluster: garden
+    user: garden
+  name: garden
+current-context: garden
+users:
+- name: garden
+  user:
+    tokenFile: /var/run/secrets/projected/serviceaccount/token
+```
+
+This will allow for automatic rotation of the service account token by the `kubelet`. The configuration can be achieved by setting both `.Values.global.GardenerControlPlaneComponent.serviceAccountTokenVolumeProjection.enabled: true` and `.Values.global.GardenerControlPlaneComponent.kubeconfig` in the respective chart's `values.yaml` file.
+
+## *Virtual Garden* is used, i.e., the `runtime` Garden cluster is different from the `target` Garden cluster.
+
+**Service Account**
+The easiest way to setup the authentication will be to create a service account and the respective roles will be bound to this service account in the `target` cluster. Then use the generated service account token and craft a `kubeconfig` which will be used by the workload in the `runtime` cluster. This approach does not provide a solution for the rotation of the service account token. However, this setup can be achieved by setting `.Values.global.deployment.virtualGarden.enabled: true` and following these steps:
+
+1. Deploy the `application` part of the charts in the `target` cluster.
+2. Get the service account token and craft the `kubeconfig`.
+3. Set the crafted `kubeconfig` and deploy the `runtime` part of the charts in the `runtime` cluster.
+
+**Client Certificate**
+Another solution will be to bind the roles in the `target` cluster to a `User` subject instead of a service account and use a client certificate for authentication. This approach does not provide a solution for the client certificate rotation. However, this setup can be achieved by setting both `.Values.global.deployment.virtualGarden.enabled: true` and `.Values.global.deployment.virtualGarden.GardenerControlPlaneComponent.user.name`, then following these steps:
+
+1. Generate a client certificate for the `target` cluster for the respective user.
+2. Deploy the `application` part of the charts in the `target` cluster.
+3. Craft a `kubeconfig` using the already generated client certificate.
+4. Set the crafted `kubeconfig` and deploy the `runtime` part of the charts in the `runtime` cluster.
+
+**Projected Service Account Token**
+This approach requires an already deployed and configured [oidc-webhook-authenticator](https://github.com/gardener/oidc-webhook-authenticator) for the `target` cluster. Also the `runtime` cluster should be registered as a trusted identity provider in the `target` cluster. Then projected service accounts tokens from the `runtime` cluster can be used to authenticate against the `target` cluster. The needed steps are as follows:
+
+1. Deploy [OWA](https://github.com/gardener/oidc-webhook-authenticator) and establish the needed trust.
+2. Set `.Values.global.deployment.virtualGarden.enabled: true` and `.Values.global.deployment.virtualGarden.GardenerControlPlaneComponent.user.name`. **Note:** username value will depend on the trust configuration, e.g., `<prefix>:system:serviceaccount:<namespace>:<serviceaccount>`
+3. Set `.Values.global.GardenerControlPlaneComponent.serviceAccountTokenVolumeProjection.enabled: true` and `.Values.global.GardenerControlPlaneComponent.serviceAccountTokenVolumeProjection.audience`. **Note:** audience value will depend on the trust configuration, e.g., `<cliend-id-from-trust-config>`.
+4. Craft a kubeconfig (see example below).
+5. Deploy the `application` part of the charts in the `target` cluster.
+6. Deploy the `runtime` part of the charts in the `runtime` cluster.
+
+```yaml
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    certificate-authority-data: <CA-DATA>
+    server: https://virtual-garden.api
+  name: virtual-garden
+contexts:
+- context:
+    cluster: virtual-garden
+    user: virtual-garden
+  name: virtual-garden
+current-context: virtual-garden
+users:
+- name: virtual-garden
+  user:
+    tokenFile: /var/run/secrets/projected/serviceaccount/token
+```

--- a/docs/deployment/authentication_gardener_control_plane.md
+++ b/docs/deployment/authentication_gardener_control_plane.md
@@ -31,7 +31,7 @@ users:
     tokenFile: /var/run/secrets/projected/serviceaccount/token
 ```
 
-This will allow for automatic rotation of the service account token by the `kubelet`. The configuration can be achieved by setting both `.Values.global.GardenerControlPlaneComponent.serviceAccountTokenVolumeProjection.enabled: true` and `.Values.global.GardenerControlPlaneComponent.kubeconfig` in the respective chart's `values.yaml` file.
+This will allow for automatic rotation of the service account token by the `kubelet`. The configuration can be achieved by setting both `.Values.global.<GardenerControlPlaneComponent>.serviceAccountTokenVolumeProjection.enabled: true` and `.Values.global.<GardenerControlPlaneComponent>.kubeconfig` in the respective chart's `values.yaml` file.
 
 ## *Virtual Garden* is used, i.e., the `runtime` Garden cluster is different from the `target` Garden cluster.
 
@@ -43,7 +43,7 @@ The easiest way to setup the authentication will be to create a service account 
 3. Set the crafted `kubeconfig` and deploy the `runtime` part of the charts in the `runtime` cluster.
 
 **Client Certificate**
-Another solution will be to bind the roles in the `target` cluster to a `User` subject instead of a service account and use a client certificate for authentication. This approach does not provide a solution for the client certificate rotation. However, this setup can be achieved by setting both `.Values.global.deployment.virtualGarden.enabled: true` and `.Values.global.deployment.virtualGarden.GardenerControlPlaneComponent.user.name`, then following these steps:
+Another solution will be to bind the roles in the `target` cluster to a `User` subject instead of a service account and use a client certificate for authentication. This approach does not provide a solution for the client certificate rotation. However, this setup can be achieved by setting both `.Values.global.deployment.virtualGarden.enabled: true` and `.Values.global.deployment.virtualGarden.<GardenerControlPlaneComponent>.user.name`, then following these steps:
 
 1. Generate a client certificate for the `target` cluster for the respective user.
 2. Deploy the `application` part of the charts in the `target` cluster.
@@ -54,8 +54,8 @@ Another solution will be to bind the roles in the `target` cluster to a `User` s
 This approach requires an already deployed and configured [oidc-webhook-authenticator](https://github.com/gardener/oidc-webhook-authenticator) for the `target` cluster. Also the `runtime` cluster should be registered as a trusted identity provider in the `target` cluster. Then projected service accounts tokens from the `runtime` cluster can be used to authenticate against the `target` cluster. The needed steps are as follows:
 
 1. Deploy [OWA](https://github.com/gardener/oidc-webhook-authenticator) and establish the needed trust.
-2. Set `.Values.global.deployment.virtualGarden.enabled: true` and `.Values.global.deployment.virtualGarden.GardenerControlPlaneComponent.user.name`. **Note:** username value will depend on the trust configuration, e.g., `<prefix>:system:serviceaccount:<namespace>:<serviceaccount>`
-3. Set `.Values.global.GardenerControlPlaneComponent.serviceAccountTokenVolumeProjection.enabled: true` and `.Values.global.GardenerControlPlaneComponent.serviceAccountTokenVolumeProjection.audience`. **Note:** audience value will depend on the trust configuration, e.g., `<cliend-id-from-trust-config>`.
+2. Set `.Values.global.deployment.virtualGarden.enabled: true` and `.Values.global.deployment.virtualGarden.<GardenerControlPlaneComponent>.user.name`. **Note:** username value will depend on the trust configuration, e.g., `<prefix>:system:serviceaccount:<namespace>:<serviceaccount>`
+3. Set `.Values.global.<GardenerControlPlaneComponent>.serviceAccountTokenVolumeProjection.enabled: true` and `.Values.global.<GardenerControlPlaneComponent>.serviceAccountTokenVolumeProjection.audience`. **Note:** audience value will depend on the trust configuration, e.g., `<cliend-id-from-trust-config>`.
 4. Craft a kubeconfig (see example below).
 5. Deploy the `application` part of the charts in the `target` cluster.
 6. Deploy the `runtime` part of the charts in the `runtime` cluster.

--- a/docs/deployment/setup_gardener.md
+++ b/docs/deployment/setup_gardener.md
@@ -10,7 +10,7 @@ Please always make sure that you use the Helm chart version that matches the Gar
 ## Deploying the Gardener control plane (API server, admission controller, controller manager, scheduler)
 
 The [configuration values](../../charts/gardener/controlplane/values.yaml) depict the various options to configure the different components.
-Please consult [this document](../usage/configuration.md) to get a detailed explanation of what can be configured for which component.
+Please consult [this document](../usage/configuration.md) for component specific configurations and [this document](./authentication_gardener_control_plane.md) for authentication related specifics.
 
 Also note that all resources and deployments need to be created in the `garden` namespace (not overrideable).
 If you enable the Gardener admission controller as part of you setup, please make sure the `garden` namespace is labelled with `app: gardener`.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area documentation
  /area quality
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
This PR adds a document explaining types of authentication which can be used when deploying the Gardener control plane components.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This PR makes sense to be merged after all of the control plane components support the set of described authentication methods.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
