### PR TITLE
Increase ginkgo timeout for default serial shoot suite

### DIFF
--- a/.test-defs/CreateManagedSeed.yaml
+++ b/.test-defs/CreateManagedSeed.yaml
@@ -4,6 +4,7 @@ metadata:
 spec:
   owner: gardener-oq@listserv.sap.com
   description: Tests the creation of a managed seed.
+
   activeDeadlineSeconds: 7200
 
   command: [bash, -c]

--- a/.test-defs/CreateShoot.yaml
+++ b/.test-defs/CreateShoot.yaml
@@ -4,6 +4,7 @@ metadata:
 spec:
   owner: gardener-oq@listserv.sap.com
   description: Tests the creation of a shoot.
+
   activeDeadlineSeconds: 7200
 
   command: [bash, -c]

--- a/.test-defs/DeleteManagedSeed.yaml
+++ b/.test-defs/DeleteManagedSeed.yaml
@@ -4,6 +4,7 @@ metadata:
 spec:
   owner: gardener-oq@listserv.sap.com
   description: Tests the deletion of a managed seed.
+
   activeDeadlineSeconds: 4200
 
   command: [bash, -c]

--- a/.test-defs/DeleteShoot.yaml
+++ b/.test-defs/DeleteShoot.yaml
@@ -4,7 +4,8 @@ metadata:
 spec:
   owner: gardener-oq@listserv.sap.com
   description: Tests the deletion of a shoot.
-  activeDeadlineSeconds: 3600
+
+  activeDeadlineSeconds: 4200
 
   command: [bash, -c]
   args:

--- a/.test-defs/GardenletLandscaper.yaml
+++ b/.test-defs/GardenletLandscaper.yaml
@@ -4,6 +4,7 @@ metadata:
 spec:
   owner: gardener-oq@listserv.sap.com
   description: Tests the Gardenlet landscaper
+
   activeDeadlineSeconds: 7200
 
   command: [bash, -c]

--- a/.test-defs/HibernateShoot.yaml
+++ b/.test-defs/HibernateShoot.yaml
@@ -4,7 +4,8 @@ metadata:
 spec:
   owner: gardener-oq@listserv.sap.com
   description: Tests the hibernation of a shoot.
-  activeDeadlineSeconds: 3600
+
+  activeDeadlineSeconds: 4200
 
   command: [bash, -c]
   args:

--- a/.test-defs/MigrateShoot.yaml
+++ b/.test-defs/MigrateShoot.yaml
@@ -4,7 +4,8 @@ metadata:
 spec:
   owner: gardener-oq@listserv.sap.com
   description: Tests the migration of a shoot.
-  activeDeadlineSeconds: 3600
+
+  activeDeadlineSeconds: 4200
 
   command: [bash, -c]
   args:

--- a/.test-defs/ReconcileShoots.yaml
+++ b/.test-defs/ReconcileShoots.yaml
@@ -5,7 +5,7 @@ spec:
   owner: gardener-oq@listserv.sap.com
   description: Tests to wait and check if all shoots are successfully reconciled
 
-  activeDeadlineSeconds: 3600
+  activeDeadlineSeconds: 4200
 
   command: [bash, -c]
   args:

--- a/.test-defs/ShootKubernetesUpdateTest.yaml
+++ b/.test-defs/ShootKubernetesUpdateTest.yaml
@@ -4,7 +4,8 @@ metadata:
 spec:
   owner: gardener-oq@listserv.sap.com
   description: Tests the kubernetes update of a shoot.
-  activeDeadlineSeconds: 3600
+
+  activeDeadlineSeconds: 4200
 
   labels: ["shoot"]
 

--- a/.test-defs/TestSuiteShootDefault.yaml
+++ b/.test-defs/TestSuiteShootDefault.yaml
@@ -5,7 +5,7 @@ spec:
   owner: gardener-oq@listserv.sap.com
   description: shoot test suites that includes all default tests
 
-  activeDeadlineSeconds: 7200
+  activeDeadlineSeconds: 8100
   labels: ["shoot", "default"]
 
   command: [bash, -c]
@@ -20,5 +20,6 @@ spec:
       -fenced=$FENCED
       -ginkgo.focus="\[DEFAULT\]"
       -ginkgo.skip="\[SERIAL\]|\[DISRUPTIVE\]"
+      -ginkgo.timeout=2h
 
   image: eu.gcr.io/gardener-project/3rd/golang:1.17.6

--- a/.test-defs/TestSuiteShootDefaultSerial.yaml
+++ b/.test-defs/TestSuiteShootDefaultSerial.yaml
@@ -22,5 +22,6 @@ spec:
       -fenced=$FENCED
       -ginkgo.focus="\[DEFAULT\].*\[SERIAL\]"
       -ginkgo.skip="\[DISRUPTIVE\]"
+      -ginkgo.timeout=3h
 
   image: eu.gcr.io/gardener-project/3rd/golang:1.17.6

--- a/.test-defs/TestSuiteShootDefaultSerial.yaml
+++ b/.test-defs/TestSuiteShootDefaultSerial.yaml
@@ -5,7 +5,7 @@ spec:
   owner: gardener-oq@listserv.sap.com
   description: shoot test suites that includes all serial default tests
 
-  activeDeadlineSeconds: 7200
+  activeDeadlineSeconds: 8100
   labels: ["shoot", "default"]
   behavior:
   - serial
@@ -22,6 +22,6 @@ spec:
       -fenced=$FENCED
       -ginkgo.focus="\[DEFAULT\].*\[SERIAL\]"
       -ginkgo.skip="\[DISRUPTIVE\]"
-      -ginkgo.timeout=3h
+      -ginkgo.timeout=2h
 
   image: eu.gcr.io/gardener-project/3rd/golang:1.17.6

--- a/.test-defs/WakeUpShoot.yaml
+++ b/.test-defs/WakeUpShoot.yaml
@@ -4,7 +4,8 @@ metadata:
 spec:
   owner: gardener-oq@listserv.sap.com
   description: Tests the wake-up of a shoot.
-  activeDeadlineSeconds: 3600
+  
+  activeDeadlineSeconds: 4200
 
   command: [bash, -c]
   args:


### PR DESCRIPTION
**How to categorize this PR?**
/area testing
/kind regression

**What this PR does / why we need it**:
With the update to ginkgov2 (with  https://github.com/gardener/gardener/pull/5313)  the default for the timeout
is reduced to 1h and is applied to the whole test suite (see doc below).
On slower cloud providers we see test suite runs of over one hour
and consequently running into the suite timeout.


From Ginkgo docs https://onsi.github.io/ginkgo/MIGRATING_TO_V2#timeout-behavior:

> Timeout Behavior
In Ginkgo V1.x, Ginkgo's timeout was managed by go test. This meant that timeouts exited the test suite abruptly with no opportunity for custom reporters or clean up code (e.g. AfterEach, AfterSuite) to run. This is fixed in V2. Ginkgo now manages its own timeout and when a timeout triggers the test winds down gracefully. In fact, a timeout is now functionally equivalent to a user-initiated interrupt.

> In addition, in V1.x when running multiple test suites Ginkgo would give each suite the full timeout allotment (so ginkgo -r -timeout=1h would give each test suite one hour to complete). In V2 the timeout now applies to the entire test suite run so that ginkgo -r -timeout=1h is now guaranteed to exit after (about) one hour.

> Finally, the default timeout has been reduced from 24h down to 1h. Users with long-running tests may need to adjust the timeout in their CI scripts.


**Special notes for your reviewer**:
I will take care of a cherry-pick to v1.40

cc @timebertt 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Increase the ginkgo timeout for default shoot serial test suite to prevent timeouts on tests
```
