### PR TITLE
[Controller Manager] Add support for projected service account tokens

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/clusterrolebinding-controller-manager.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/clusterrolebinding-controller-manager.yaml
@@ -15,7 +15,13 @@ roleRef:
   kind: ClusterRole
   name: gardener.cloud:system:controller-manager
 subjects:
+{{- if and .Values.global.deployment.virtualGarden.enabled .Values.global.deployment.virtualGarden.controller.user.name }}
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: {{ .Values.global.deployment.virtualGarden.controller.user.name  }}
+{{- else }}
 - kind: ServiceAccount
   name: "{{ required ".Values.global.controller.serviceAccountName is required" .Values.global.controller.serviceAccountName }}"
   namespace: garden
+{{- end }}
 {{- end }}

--- a/charts/gardener/controlplane/charts/application/templates/serviceaccount-controller-manager.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/serviceaccount-controller-manager.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.global.deployment.virtualGarden.enabled .Values.global.controller.enabled }}
+{{- if .Values.global.controller.enabled }}
+{{- if and .Values.global.deployment.virtualGarden.enabled ( not .Values.global.deployment.virtualGarden.controller.user.name ) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -10,4 +11,5 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+{{- end }}
 {{- end }}

--- a/charts/gardener/controlplane/charts/runtime/templates/controller-manager/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/controller-manager/deployment.yaml
@@ -41,8 +41,15 @@ spec:
 {{ toYaml .Values.global.controller.podLabels | indent 8 }}
         {{- end }}
     spec:
-      {{- if not .Values.global.controller.kubeconfig }}
+      {{- if not .Values.global.deployment.virtualGarden.enabled }}
       serviceAccountName: {{ required ".Values.global.controller.serviceAccountName is required" .Values.global.controller.serviceAccountName }}
+      {{- else if and .Values.global.deployment.virtualGarden.enabled .Values.global.deployment.virtualGarden.controller.user.name }}
+      {{- if .Values.global.controller.serviceAccountTokenVolumeProjection.enabled }}
+      serviceAccountName: {{ required ".Values.global.controller.serviceAccountName is required" .Values.global.controller.serviceAccountName }}
+      {{- end }}
+      {{- end }}
+      {{- if .Values.global.controller.kubeconfig }}
+      automountServiceAccountToken: false
       {{- end }}
       {{- if gt (int .Values.global.controller.replicaCount) 1 }}
       affinity:
@@ -106,6 +113,11 @@ spec:
           mountPath: /etc/gardener-controller-manager/kubeconfig
           readOnly: true
         {{- end }}
+        {{- if .Values.global.controller.serviceAccountTokenVolumeProjection.enabled }}
+        - name: service-account-token
+          mountPath: /var/run/secrets/projected/serviceaccount
+          readOnly: true
+        {{- end }}
         - name: gardener-controller-manager-config
           mountPath: /etc/gardener-controller-manager/config
 {{- if .Values.global.controller.additionalVolumeMounts }}
@@ -121,6 +133,17 @@ spec:
       - name: gardener-controller-manager-kubeconfig
         secret:
           secretName: gardener-controller-manager-kubeconfig
+      {{- end }}
+      {{- if .Values.global.controller.serviceAccountTokenVolumeProjection.enabled }}
+      - name: service-account-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              path: token
+              expirationSeconds: {{ .Values.global.controller.serviceAccountTokenVolumeProjection.expirationSeconds }}
+              {{- if .Values.global.controller.serviceAccountTokenVolumeProjection.audience }}
+              audience: {{ .Values.global.controller.serviceAccountTokenVolumeProjection.audience }}
+              {{- end }}
       {{- end }}
       - name: gardener-controller-manager-config
         configMap:

--- a/charts/gardener/controlplane/charts/runtime/templates/controller-manager/serviceaccount.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/controller-manager/serviceaccount.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.global.controller.enabled (not .Values.global.controller.kubeconfig) }}
+{{- if .Values.global.controller.enabled }}
+{{- if not .Values.global.deployment.virtualGarden.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -10,4 +11,19 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+{{- else if and .Values.global.deployment.virtualGarden.enabled .Values.global.deployment.virtualGarden.controller.user.name }}
+{{- if .Values.global.controller.serviceAccountTokenVolumeProjection.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ required ".Values.global.controller.serviceAccountName is required" .Values.global.controller.serviceAccountName }}
+  namespace: garden
+  labels:
+    app: gardener
+    role: controller-manager
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+{{- end }}
+{{- end }}
 {{- end }}

--- a/charts/gardener/controlplane/values.yaml
+++ b/charts/gardener/controlplane/values.yaml
@@ -352,6 +352,10 @@ global:
     additionalVolumeMounts: []
     env: []
     vpa: false
+    serviceAccountTokenVolumeProjection:
+      enabled: false
+      expirationSeconds: 43200
+      audience: ""
     config:
       gardenClientConnection:
       # acceptContentTypes: application/json
@@ -518,6 +522,9 @@ global:
       clusterIP: 1.2.3.4
       createNamespace: true
       admission:
+        user:
+          name: ""
+      controller:
         user:
           name: ""
 

--- a/cmd/gardener-controller-manager/app/gardener_controller_manager.go
+++ b/cmd/gardener-controller-manager/app/gardener_controller_manager.go
@@ -243,7 +243,7 @@ func NewGardener(ctx context.Context, cfg *config.ControllerManagerConfiguration
 		cfg.GardenClientConnection.Kubeconfig = kubeconfig
 	}
 
-	restCfg, err := kubernetes.RESTConfigFromClientConnectionConfiguration(&cfg.GardenClientConnection, nil)
+	restCfg, err := kubernetes.RESTConfigFromClientConnectionConfiguration(&cfg.GardenClientConnection, nil, kubernetes.AuthTokenFile)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
- The ability to configure the gardener controller manager to use service account token volume projection ([ref](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection)).
- The ability to configure a user instead of a service account subject in the `clusterrolebinding` definition when using a "virtual garden" setup. This will enable other possibilities for authentication to the virtual garden, i.e., leveraging [oidc-webhook-authenticator](https://github.com/gardener/oidc-webhook-authenticator).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Related to #5386 and #5427 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Gardener Controller Manager now supports configuration for enabling service account token volume projection. It is exposed through the `.Values.global.controller.serviceAccountTokenVolumeProjection` section in the respective chart's values.
```

```feature operator
It is now possible to configure a `user` instead of a `serviceaccount` subject in the `clusterrolebinding` for the Gardener Controller Manager when using virtual garden setup by setting `.Values.global.virtualGarden.controller.user.name`.
```

