### PR TITLE
[Scheduler] Add support for projected service account tokens

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/clusterrolebinding-scheduler.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/clusterrolebinding-scheduler.yaml
@@ -15,7 +15,13 @@ roleRef:
   kind: ClusterRole
   name: gardener.cloud:system:scheduler
 subjects:
+{{- if and .Values.global.deployment.virtualGarden.enabled .Values.global.deployment.virtualGarden.scheduler.user.name }}
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: {{ .Values.global.deployment.virtualGarden.scheduler.user.name  }}
+{{- else }}
 - kind: ServiceAccount
   name: "{{ required ".Values.global.scheduler.serviceAccountName is required" .Values.global.scheduler.serviceAccountName }}"
   namespace: garden
+{{- end }}
 {{- end }}

--- a/charts/gardener/controlplane/charts/application/templates/serviceaccount-scheduler.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/serviceaccount-scheduler.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.global.deployment.virtualGarden.enabled .Values.global.scheduler.enabled }}
+{{- if .Values.global.scheduler.enabled }}
+{{- if and .Values.global.deployment.virtualGarden.enabled ( not .Values.global.deployment.virtualGarden.scheduler.user.name ) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -10,4 +11,5 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+{{- end }}
 {{- end }}

--- a/charts/gardener/controlplane/charts/runtime/templates/scheduler/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/scheduler/deployment.yaml
@@ -34,8 +34,15 @@ spec:
 {{ toYaml .Values.global.scheduler.podLabels | indent 8 }}
         {{- end }}
     spec:
-      {{- if not .Values.global.scheduler.kubeconfig }}
+      {{- if not .Values.global.deployment.virtualGarden.enabled }}
       serviceAccountName: {{ required ".Values.global.scheduler.serviceAccountName is required" .Values.global.scheduler.serviceAccountName }}
+      {{- else if and .Values.global.deployment.virtualGarden.enabled .Values.global.deployment.virtualGarden.scheduler.user.name }}
+      {{- if .Values.global.scheduler.serviceAccountTokenVolumeProjection.enabled }}
+      serviceAccountName: {{ required ".Values.global.scheduler.serviceAccountName is required" .Values.global.scheduler.serviceAccountName }}
+      {{- end }}
+      {{- end }}
+      {{- if .Values.global.scheduler.kubeconfig }}
+      automountServiceAccountToken: false
       {{- end }}
       {{- if gt (int .Values.global.scheduler.replicaCount) 1 }}
       affinity:
@@ -81,6 +88,11 @@ spec:
           mountPath: /etc/gardener-scheduler/kubeconfig
           readOnly: true
         {{- end }}
+        {{- if .Values.global.scheduler.serviceAccountTokenVolumeProjection.enabled }}
+        - name: service-account-token
+          mountPath: /var/run/secrets/projected/serviceaccount
+          readOnly: true
+        {{- end }}
         - name: gardener-scheduler-config
           mountPath: /etc/gardener-scheduler/config
       volumes:
@@ -88,6 +100,17 @@ spec:
       - name: gardener-scheduler-kubeconfig
         secret:
           secretName: gardener-scheduler-kubeconfig
+      {{- end }}
+      {{- if .Values.global.scheduler.serviceAccountTokenVolumeProjection.enabled }}
+      - name: service-account-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              path: token
+              expirationSeconds: {{ .Values.global.scheduler.serviceAccountTokenVolumeProjection.expirationSeconds }}
+              {{- if .Values.global.scheduler.serviceAccountTokenVolumeProjection.audience }}
+              audience: {{ .Values.global.scheduler.serviceAccountTokenVolumeProjection.audience }}
+              {{- end }}
       {{- end }}
       - name: gardener-scheduler-config
         configMap:

--- a/charts/gardener/controlplane/charts/runtime/templates/scheduler/serviceaccount.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/scheduler/serviceaccount.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.global.scheduler.enabled (not .Values.global.scheduler.kubeconfig) }}
+{{- if .Values.global.scheduler.enabled }}
+{{- if not .Values.global.deployment.virtualGarden.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -10,4 +11,19 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+{{- else if and .Values.global.deployment.virtualGarden.enabled .Values.global.deployment.virtualGarden.scheduler.user.name }}
+{{- if .Values.global.scheduler.serviceAccountTokenVolumeProjection.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ required ".Values.global.scheduler.serviceAccountName is required" .Values.global.scheduler.serviceAccountName }}
+  namespace: garden
+  labels:
+    app: gardener
+    role: scheduler
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+{{- end }}
+{{- end }}
 {{- end }}

--- a/charts/gardener/controlplane/values.yaml
+++ b/charts/gardener/controlplane/values.yaml
@@ -461,6 +461,10 @@ global:
   # podAnnotations: # YAML formatted annotations used for pod template
   # podLabels: # YAML formatted labels used for pod template
     vpa: false
+    serviceAccountTokenVolumeProjection:
+      enabled: false
+      expirationSeconds: 43200
+      audience: ""
     config:
       clientConnection:
       # acceptContentTypes: application/json
@@ -525,6 +529,9 @@ global:
         user:
           name: ""
       controller:
+        user:
+          name: ""
+      scheduler:
         user:
           name: ""
 

--- a/cmd/gardener-scheduler/app/gardener_scheduler.go
+++ b/cmd/gardener-scheduler/app/gardener_scheduler.go
@@ -128,7 +128,7 @@ func runCommand(ctx context.Context, opts *Options) error {
 	}
 
 	// Prepare REST config
-	restCfg, err := kubernetes.RESTConfigFromClientConnectionConfiguration(&cfg.ClientConnection, nil)
+	restCfg, err := kubernetes.RESTConfigFromClientConnectionConfiguration(&cfg.ClientConnection, nil, kubernetes.AuthTokenFile)
 	if err != nil {
 		return fmt.Errorf("failed to create Kubernetes REST configuration: %w", err)
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:

- The ability to configure the gardener scheduler to use service account token volume projection ([ref](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection)).
- The ability to configure a user instead of a service account subject in the `clusterrolebinding` definition when using a "virtual garden" setup. This will enable other possibilities for authentication to the virtual garden, i.e., leveraging [oidc-webhook-authenticator](https://github.com/gardener/oidc-webhook-authenticator).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Related to #5386 and #5427 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Gardener Scheduler now supports configuration for enabling service account token volume projection. It is exposed through the `.Values.global.scheduler.serviceAccountTokenVolumeProjection` section in the respective chart's values.
```

```feature operator
It is now possible to configure a `user` instead of a `serviceaccount` subject in the `clusterrolebinding` for the Gardener Scheduler when using virtual garden setup by setting `.Values.global.virtualGarden.scheduler.user.name`.
```

