### PR TITLE
[API Server] Add support for projected service account tokens

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/clusterrolebinding-apiserver-auth-delegator.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/clusterrolebinding-apiserver-auth-delegator.yaml
@@ -9,7 +9,13 @@ roleRef:
   kind: ClusterRole
   name: system:auth-delegator
 subjects:
+{{- if and .Values.global.deployment.virtualGarden.enabled .Values.global.deployment.virtualGarden.apiserver.user.name }}
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: {{ .Values.global.deployment.virtualGarden.apiserver.user.name  }}
+{{- else }}
 - kind: ServiceAccount
   name: "{{ required ".Values.global.apiserver.serviceAccountName is required" .Values.global.apiserver.serviceAccountName }}"
   namespace: garden
+{{- end }}
 {{- end }}

--- a/charts/gardener/controlplane/charts/application/templates/clusterrolebinding-apiserver.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/clusterrolebinding-apiserver.yaml
@@ -15,7 +15,13 @@ roleRef:
   kind: ClusterRole
   name: gardener.cloud:system:apiserver
 subjects:
+{{- if and .Values.global.deployment.virtualGarden.enabled .Values.global.deployment.virtualGarden.apiserver.user.name }}
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: {{ .Values.global.deployment.virtualGarden.apiserver.user.name  }}
+{{- else }}
 - kind: ServiceAccount
   name: "{{ required ".Values.global.apiserver.serviceAccountName is required" .Values.global.apiserver.serviceAccountName }}"
   namespace: garden
+{{- end }}
 {{- end }}

--- a/charts/gardener/controlplane/charts/application/templates/rolebinding-apiserver-auth-reader.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/rolebinding-apiserver-auth-reader.yaml
@@ -16,7 +16,13 @@ roleRef:
   kind: Role
   name: extension-apiserver-authentication-reader
 subjects:
+{{- if and .Values.global.deployment.virtualGarden.enabled .Values.global.deployment.virtualGarden.apiserver.user.name }}
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: {{ .Values.global.deployment.virtualGarden.apiserver.user.name  }}
+{{- else }}
 - kind: ServiceAccount
   name: "{{ required ".Values.global.apiserver.serviceAccountName is required" .Values.global.apiserver.serviceAccountName }}"
   namespace: garden
+{{- end }}
 {{- end }}

--- a/charts/gardener/controlplane/charts/application/templates/serviceaccount-apiserver.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/serviceaccount-apiserver.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.global.deployment.virtualGarden.enabled .Values.global.apiserver.enabled }}
+{{- if .Values.global.apiserver.enabled }}
+{{- if and .Values.global.deployment.virtualGarden.enabled ( not .Values.global.deployment.virtualGarden.apiserver.user.name ) }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -10,4 +11,5 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+{{- end }}
 {{- end }}

--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
@@ -54,8 +54,15 @@ spec:
 {{ toYaml .Values.global.apiserver.podLabels | indent 8 }}
         {{- end }}
     spec:
-      {{- if not .Values.global.apiserver.kubeconfig }}
+      {{- if not .Values.global.deployment.virtualGarden.enabled }}
       serviceAccountName: {{ required ".Values.global.apiserver.serviceAccountName is required" .Values.global.apiserver.serviceAccountName }}
+      {{- else if and .Values.global.deployment.virtualGarden.enabled .Values.global.deployment.virtualGarden.apiserver.user.name }}
+      {{- if .Values.global.apiserver.serviceAccountTokenVolumeProjection.enabled }}
+      serviceAccountName: {{ required ".Values.global.apiserver.serviceAccountName is required" .Values.global.apiserver.serviceAccountName }}
+      {{- end }}
+      {{- end }}
+      {{- if .Values.global.apiserver.kubeconfig }}
+      automountServiceAccountToken: false
       {{- end }}
       {{- if or .Values.global.apiserver.hvpa.enabled (gt (int .Values.global.apiserver.replicaCount) 1) }}
       affinity:
@@ -307,6 +314,11 @@ spec:
           mountPath: /etc/gardener-apiserver/kubeconfig
           readOnly: true
         {{- end }}
+        {{- if .Values.global.apiserver.serviceAccountTokenVolumeProjection.enabled }}
+        - name: service-account-token
+          mountPath: /var/run/secrets/projected/serviceaccount
+          readOnly: true
+        {{- end }}
         {{- if .Values.global.apiserver.audit.policy }}
         - name: gardener-audit-policy-config
           mountPath: /etc/gardener-apiserver/audit
@@ -389,6 +401,17 @@ spec:
       - name: gardener-apiserver-kubeconfig
         secret:
           secretName: gardener-apiserver-kubeconfig
+      {{- end }}
+      {{- if .Values.global.apiserver.serviceAccountTokenVolumeProjection.enabled }}
+      - name: service-account-token
+        projected:
+          sources:
+          - serviceAccountToken:
+              path: token
+              expirationSeconds: {{ .Values.global.apiserver.serviceAccountTokenVolumeProjection.expirationSeconds }}
+              {{- if .Values.global.apiserver.serviceAccountTokenVolumeProjection.audience }}
+              audience: {{ .Values.global.apiserver.serviceAccountTokenVolumeProjection.audience }}
+              {{- end }}
       {{- end }}
       {{- if .Values.global.apiserver.audit.policy }}
       - name: gardener-audit-policy-config

--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/serviceaccount.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/serviceaccount.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.global.apiserver.enabled (not .Values.global.apiserver.kubeconfig) }}
+{{- if .Values.global.apiserver.enabled }}
+{{- if not .Values.global.deployment.virtualGarden.enabled }}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -10,4 +11,19 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+{{- else if and .Values.global.deployment.virtualGarden.enabled .Values.global.deployment.virtualGarden.apiserver.user.name }}
+{{- if .Values.global.apiserver.serviceAccountTokenVolumeProjection.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ required ".Values.global.apiserver.serviceAccountName is required" .Values.global.apiserver.serviceAccountName }}
+  namespace: garden
+  labels:
+    app: gardener
+    role: apiserver
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+{{- end }}
+{{- end }}
 {{- end }}

--- a/charts/gardener/controlplane/values.yaml
+++ b/charts/gardener/controlplane/values.yaml
@@ -133,6 +133,10 @@ global:
           enabled: false
           audience: mutating-webhook
           expirationSeconds: 3600
+    serviceAccountTokenVolumeProjection:
+      enabled: false
+      expirationSeconds: 43200
+      audience: ""
     vpa: false
     hvpa:
       enabled: false
@@ -521,6 +525,9 @@ global:
       enabled: false
       clusterIP: 1.2.3.4
       createNamespace: true
+      apiserver:
+        user:
+          name: ""
       admission:
         user:
           name: ""


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:

- The ability to configure the gardener apiserver to use service account token volume projection ([ref](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection)).
- The ability to configure a user instead of a service account subject in the `clusterrolebinding` definition when using a "virtual garden" setup. This will enable other possibilities for authentication to the virtual garden, i.e., leveraging [oidc-webhook-authenticator](https://github.com/gardener/oidc-webhook-authenticator).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Related to #5386 and #5427 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Gardener API Server now supports configuration for enabling service account token volume projection. It is exposed through the `.Values.global.apiserver.serviceAccountTokenVolumeProjection` section in the respective chart's values.
```

```feature operator
It is now possible to configure a `user` instead of a `serviceaccount` subject in the `clusterrolebinding` for the Gardener API Server when using virtual garden setup by setting `.Values.global.virtualGarden.apiserver.user.name`.
```

