### PR TITLE
[release-v1.39] Automated cherry pick of #5345: Allow Bastion update of finalizer

### DIFF
--- a/plugin/pkg/bastion/validator/admission.go
+++ b/plugin/pkg/bastion/validator/admission.go
@@ -141,7 +141,7 @@ func (v *Bastion) Admit(ctx context.Context, a admission.Attributes, o admission
 	}
 
 	// ensure shoot is alive
-	if shoot.DeletionTimestamp != nil {
+	if a.GetOperation() == admission.Create && shoot.DeletionTimestamp != nil {
 		fieldErr := field.Invalid(shootPath, shootName, "shoot is in deletion")
 		return apierrors.NewInvalid(gk, bastion.Name, field.ErrorList{fieldErr})
 	}

--- a/plugin/pkg/bastion/validator/admission.go
+++ b/plugin/pkg/bastion/validator/admission.go
@@ -130,19 +130,6 @@ func (v *Bastion) Admit(ctx context.Context, a admission.Attributes, o admission
 
 	shootName := bastion.Spec.ShootRef.Name
 
-	if a.GetOperation() == admission.Update {
-		oldBastion, ok := a.GetOldObject().(*operations.Bastion)
-		if !ok {
-			return apierrors.NewBadRequest("could not convert old object to Bastion")
-		}
-
-		oldShootName := oldBastion.Spec.ShootRef.Name
-		if oldShootName != shootName {
-			fieldErr := field.Invalid(shootPath, shootName, "shootRef must not be changed")
-			return apierrors.NewInvalid(gk, bastion.Name, field.ErrorList{fieldErr})
-		}
-	}
-
 	// ensure shoot exists
 	shoot, err := v.coreClient.Core().Shoots(bastion.Namespace).Get(ctx, shootName, metav1.GetOptions{})
 	if err != nil {

--- a/plugin/pkg/bastion/validator/admission_test.go
+++ b/plugin/pkg/bastion/validator/admission_test.go
@@ -245,24 +245,6 @@ var _ = Describe("Bastion", func() {
 			err := admissionHandler.Admit(context.TODO(), getBastionAttributes(bastion, oldBastion, admission.Update), nil)
 			Expect(err).To(Succeed())
 		})
-
-		It("should forbid the Bastion update if the Shoot name changed", func() {
-			coreClient.AddReactor("get", "shoots", func(action testing.Action) (bool, runtime.Object, error) {
-				return true, shoot, nil
-			})
-
-			oldBastion := bastion.DeepCopy()
-			oldBastion.Spec.ShootRef.Name = "other-shoot"
-
-			err := admissionHandler.Admit(context.TODO(), getBastionAttributes(bastion, oldBastion, admission.Update), nil)
-			Expect(err).To(BeInvalidError())
-			Expect(getErrorList(err)).To(ConsistOf(
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("spec.shootRef.name"),
-				})),
-			))
-		})
 	})
 
 	Describe("#Register", func() {


### PR DESCRIPTION
/kind/bug
/area/quality
/squash

Cherry pick of #5345 on release-v1.39.

#5345: Allow Bastion update of finalizer

**Release Notes:**
```bugfix operator
The finalizer on the `Bastion` resource in the garden cluster can now be updated even if the referenced `Shoot` is in deletion
```