### PR TITLE
[release-v1.40] Automated cherry pick of #5428: Increase ginkgo timeout for default serial shoot suite

### DIFF
--- a/.test-defs/CreateManagedSeed.yaml
+++ b/.test-defs/CreateManagedSeed.yaml
@@ -4,6 +4,7 @@ metadata:
 spec:
   owner: gardener-oq@listserv.sap.com
   description: Tests the creation of a managed seed.
+
   activeDeadlineSeconds: 7200
 
   command: [bash, -c]

--- a/.test-defs/CreateShoot.yaml
+++ b/.test-defs/CreateShoot.yaml
@@ -4,6 +4,7 @@ metadata:
 spec:
   owner: gardener-oq@listserv.sap.com
   description: Tests the creation of a shoot.
+
   activeDeadlineSeconds: 7200
 
   command: [bash, -c]

--- a/.test-defs/DeleteManagedSeed.yaml
+++ b/.test-defs/DeleteManagedSeed.yaml
@@ -4,6 +4,7 @@ metadata:
 spec:
   owner: gardener-oq@listserv.sap.com
   description: Tests the deletion of a managed seed.
+
   activeDeadlineSeconds: 4200
 
   command: [bash, -c]

--- a/.test-defs/DeleteShoot.yaml
+++ b/.test-defs/DeleteShoot.yaml
@@ -4,7 +4,8 @@ metadata:
 spec:
   owner: gardener-oq@listserv.sap.com
   description: Tests the deletion of a shoot.
-  activeDeadlineSeconds: 3600
+
+  activeDeadlineSeconds: 4200
 
   command: [bash, -c]
   args:

--- a/.test-defs/GardenletLandscaper.yaml
+++ b/.test-defs/GardenletLandscaper.yaml
@@ -4,6 +4,7 @@ metadata:
 spec:
   owner: gardener-oq@listserv.sap.com
   description: Tests the Gardenlet landscaper
+
   activeDeadlineSeconds: 7200
 
   command: [bash, -c]

--- a/.test-defs/HibernateShoot.yaml
+++ b/.test-defs/HibernateShoot.yaml
@@ -4,7 +4,8 @@ metadata:
 spec:
   owner: gardener-oq@listserv.sap.com
   description: Tests the hibernation of a shoot.
-  activeDeadlineSeconds: 3600
+
+  activeDeadlineSeconds: 4200
 
   command: [bash, -c]
   args:

--- a/.test-defs/MigrateShoot.yaml
+++ b/.test-defs/MigrateShoot.yaml
@@ -4,7 +4,8 @@ metadata:
 spec:
   owner: gardener-oq@listserv.sap.com
   description: Tests the migration of a shoot.
-  activeDeadlineSeconds: 3600
+
+  activeDeadlineSeconds: 4200
 
   command: [bash, -c]
   args:

--- a/.test-defs/ReconcileShoots.yaml
+++ b/.test-defs/ReconcileShoots.yaml
@@ -5,7 +5,7 @@ spec:
   owner: gardener-oq@listserv.sap.com
   description: Tests to wait and check if all shoots are successfully reconciled
 
-  activeDeadlineSeconds: 3600
+  activeDeadlineSeconds: 4200
 
   command: [bash, -c]
   args:

--- a/.test-defs/ShootKubernetesUpdateTest.yaml
+++ b/.test-defs/ShootKubernetesUpdateTest.yaml
@@ -4,7 +4,8 @@ metadata:
 spec:
   owner: gardener-oq@listserv.sap.com
   description: Tests the kubernetes update of a shoot.
-  activeDeadlineSeconds: 3600
+
+  activeDeadlineSeconds: 4200
 
   labels: ["shoot"]
 

--- a/.test-defs/TestSuiteShootDefault.yaml
+++ b/.test-defs/TestSuiteShootDefault.yaml
@@ -5,7 +5,7 @@ spec:
   owner: gardener-oq@listserv.sap.com
   description: shoot test suites that includes all default tests
 
-  activeDeadlineSeconds: 7200
+  activeDeadlineSeconds: 8100
   labels: ["shoot", "default"]
 
   command: [bash, -c]
@@ -20,5 +20,6 @@ spec:
       -fenced=$FENCED
       -ginkgo.focus="\[DEFAULT\]"
       -ginkgo.skip="\[SERIAL\]|\[DISRUPTIVE\]"
+      -ginkgo.timeout=2h
 
   image: eu.gcr.io/gardener-project/3rd/golang:1.17.6

--- a/.test-defs/TestSuiteShootDefaultSerial.yaml
+++ b/.test-defs/TestSuiteShootDefaultSerial.yaml
@@ -22,5 +22,6 @@ spec:
       -fenced=$FENCED
       -ginkgo.focus="\[DEFAULT\].*\[SERIAL\]"
       -ginkgo.skip="\[DISRUPTIVE\]"
+      -ginkgo.timeout=3h
 
   image: eu.gcr.io/gardener-project/3rd/golang:1.17.6

--- a/.test-defs/TestSuiteShootDefaultSerial.yaml
+++ b/.test-defs/TestSuiteShootDefaultSerial.yaml
@@ -5,7 +5,7 @@ spec:
   owner: gardener-oq@listserv.sap.com
   description: shoot test suites that includes all serial default tests
 
-  activeDeadlineSeconds: 7200
+  activeDeadlineSeconds: 8100
   labels: ["shoot", "default"]
   behavior:
   - serial
@@ -22,6 +22,6 @@ spec:
       -fenced=$FENCED
       -ginkgo.focus="\[DEFAULT\].*\[SERIAL\]"
       -ginkgo.skip="\[DISRUPTIVE\]"
-      -ginkgo.timeout=3h
+      -ginkgo.timeout=2h
 
   image: eu.gcr.io/gardener-project/3rd/golang:1.17.6

--- a/.test-defs/WakeUpShoot.yaml
+++ b/.test-defs/WakeUpShoot.yaml
@@ -4,7 +4,8 @@ metadata:
 spec:
   owner: gardener-oq@listserv.sap.com
   description: Tests the wake-up of a shoot.
-  activeDeadlineSeconds: 3600
+  
+  activeDeadlineSeconds: 4200
 
   command: [bash, -c]
   args:


### PR DESCRIPTION
/kind/regression
/area/testing

Cherry pick of #5428 on release-v1.40.

#5428: Increase ginkgo timeout for default serial shoot suite

**Release Notes:**
```bugfix operator
Increase the ginkgo timeout for default shoot serial test suite to prevent timeouts on tests
```