### PR TITLE
Fix invalid node check when pool overwrites Kubernetes version

### DIFF
--- a/pkg/operation/care/checker.go
+++ b/pkg/operation/care/checker.go
@@ -196,7 +196,7 @@ func (b *HealthChecker) checkStatefulSets(condition gardencorev1beta1.Condition,
 	return nil
 }
 
-func (b *HealthChecker) checkNodes(condition gardencorev1beta1.Condition, nodes []corev1.Node, workerGroupName string) *gardencorev1beta1.Condition {
+func (b *HealthChecker) checkNodes(condition gardencorev1beta1.Condition, nodes []corev1.Node, workerGroupName string, workerGroupKubernetesVersion *semver.Version) *gardencorev1beta1.Condition {
 	for _, object := range nodes {
 		if err := health.CheckNode(&object); err != nil {
 			var (
@@ -213,16 +213,15 @@ func (b *HealthChecker) checkNodes(condition gardencorev1beta1.Condition, nodes 
 			c := b.FailedCondition(condition, "VersionParseError", fmt.Sprintf("Error checking for same major minor Kubernetes version for node %q: %+v", object.Name, err))
 			return &c
 		}
-
-		if sameMajorMinor.Check(b.kubernetesVersion) {
+		if sameMajorMinor.Check(workerGroupKubernetesVersion) {
 			equal, err := semver.NewConstraint("= " + object.Status.NodeInfo.KubeletVersion)
 			if err != nil {
 				c := b.FailedCondition(condition, "VersionParseError", fmt.Sprintf("Error checking for equal Kubernetes versions for node %q: %+v", object.Name, err))
 				return &c
 			}
 
-			if !equal.Check(b.kubernetesVersion) {
-				c := b.FailedCondition(condition, "KubeletVersionMismatch", fmt.Sprintf("The kubelet version for node %q (%s) does not match the desired Kubernetes version (v%s)", object.Name, object.Status.NodeInfo.KubeletVersion, b.kubernetesVersion.Original()))
+			if !equal.Check(workerGroupKubernetesVersion) {
+				c := b.FailedCondition(condition, "KubeletVersionMismatch", fmt.Sprintf("The kubelet version for node %q (%s) does not match the desired Kubernetes version (v%s)", object.Name, object.Status.NodeInfo.KubeletVersion, workerGroupKubernetesVersion.Original()))
 				return &c
 			}
 		}
@@ -436,7 +435,12 @@ func (b *HealthChecker) CheckClusterNodes(
 	for _, worker := range workers {
 		nodes := workerPoolToNodes[worker.Name]
 
-		if exitCondition := b.checkNodes(condition, nodes, worker.Name); exitCondition != nil {
+		kubernetesVersion, err := gardencorev1beta1helper.CalculateEffectiveKubernetesVersion(b.kubernetesVersion, worker.Kubernetes)
+		if err != nil {
+			return nil, err
+		}
+
+		if exitCondition := b.checkNodes(condition, nodes, worker.Name, kubernetesVersion); exitCondition != nil {
 			return exitCondition, nil
 		}
 

--- a/pkg/operation/care/health_check_test.go
+++ b/pkg/operation/care/health_check_test.go
@@ -678,6 +678,22 @@ var _ = Describe("health check", func() {
 				},
 				cloudConfigSecretChecksums,
 				BeNil()),
+			Entry("too old Kubernetes patch version with pool version overwrite",
+				[]corev1.Node{
+					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1}, nil, "v1.18.2"),
+				},
+				[]gardencorev1beta1.Worker{
+					{
+						Name:    workerPoolName1,
+						Maximum: 10,
+						Minimum: 1,
+						Kubernetes: &gardencorev1beta1.WorkerKubernetes{
+							Version: pointer.String("1.18.3"),
+						},
+					},
+				},
+				cloudConfigSecretChecksums,
+				PointTo(beConditionWithStatusAndMsg(gardencorev1beta1.ConditionFalse, "KubeletVersionMismatch", fmt.Sprintf("The kubelet version for node %q (v1.18.2) does not match the desired Kubernetes version (v1.18.3)", nodeName)))),
 			Entry("different Kubernetes minor version (all healthy)",
 				[]corev1.Node{
 					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1}, nil, "v1.18.2"),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind bug

**What this PR does / why we need it**:
Before this commit, when a pool overwrote the Kubernetes version then it yielded the following failing `EveryNodeReady` condition in the `Shoot`:

```yaml
    - lastTransitionTime: "2022-02-11T10:34:40Z"
      lastUpdateTime: "2022-02-11T10:35:24Z"
      message: The kubelet version for node "shoot--foo--bar-worker-2-z1-5d4f4-dnls5"
        (v1.22.2) does not match the desired Kubernetes version (v1.22.3)
      reason: KubeletVersionMismatch
      status: Progressing
      type: EveryNodeReady
```

The spec looked as follows:

```yaml
spec:
  kubernetes:
    version: 1.22.3
  provider:
    workers:
    - name: worker-1
    - name: worker-2
      kubernetes:
        version: 1.22.2
    - name: worker-3
      kubernetes:
        version: 1.22.1
```

This PR fixes this issue.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/3501

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
The `EveryNodeReady` shoot condition is now correctly computed even if a worker pool overwrites the Kubernetes version.
```
