### PR TITLE
Change the Throttle factor to Throttle %

### DIFF
--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-pods-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-pods-dashboard.json
@@ -144,7 +144,7 @@
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
-      "description": "The experimental \"Throttle factor\" metric tries to estimate how much more time the execution of the pod takes due to CPU throttling. A factor of 1 means no throttling, a factor of 2 could be OK, a factor of 10 could indicate underprovisioned requests/limits or contention for the burstable CPU shares",
+      "description": "The \"Throttle %\" metric shows the percentage of the 100ms time slots where the CPU usage reaches the quota.\n\n0% means the quota is not reached. 100% means the quota is reached in all the 100ms time slots.",
       "editable": true,
       "error": false,
       "fieldConfig": {
@@ -190,7 +190,7 @@
       "renderer": "flot",
       "seriesOverrides": [
         {
-          "alias": "Throttle factor",
+          "alias": "Throttle %",
           "dashLength": 5,
           "dashes": true,
           "yaxis": 2
@@ -231,11 +231,11 @@
           "refId": "C"
         },
         {
-          "expr": "1 / (1 -\nmax(\nrate(container_cpu_cfs_throttled_periods_total{container=~\"$container\",pod=~\"$pod\"}[$__rate_interval])\n/\nrate(container_cpu_cfs_periods_total{container=~\"$container\",pod=~\"$pod\"}[$__rate_interval])\n))",
+          "expr": "max(\nrate(container_cpu_cfs_throttled_periods_total{container=~\"$container\",pod=~\"$pod\"}[$__rate_interval])\n/\nrate(container_cpu_cfs_periods_total{container=~\"$container\",pod=~\"$pod\"}[$__rate_interval])\n)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "Throttle factor",
+          "legendFormat": "Throttle %",
           "refId": "D"
         }
       ],
@@ -268,11 +268,11 @@
           "show": true
         },
         {
-          "format": "short",
+          "format": "percentunit",
           "label": null,
           "logBase": 1,
-          "max": null,
-          "min": "1",
+          "max": "1",
+          "min": "0",
           "show": true
         }
       ],


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

If all the 100ms time slots are throttled, the throttle factor
is +Inf due to division by 0. The new Throttle % is in the range of 0..1

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

<img width="1431" alt="image" src="https://user-images.githubusercontent.com/23032437/154022123-e220dbcf-fdd8-48e4-aef5-b8153e54b1d1.png">
<img width="1428" alt="image" src="https://user-images.githubusercontent.com/23032437/154022369-a5a30783-8e29-4967-9989-f23073e9a07a.png">

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Change the Throttle factor metric to Throttle % in the Kubernetes Pods dashboard
```
