### PR TITLE
Federate vpn and api server availability metrics

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/apiserver-connectivity-check.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/apiserver-connectivity-check.rules.yaml
@@ -14,3 +14,13 @@ groups:
       description: The Api server has been unreachable for 3 minutes via the kubernetes service in the shoot.
   - record: shoot:availability
     expr: probe_success{job="blackbox-exporter-k8s-service-check"} == bool 1
+    labels:
+      kind: shoot
+  - record: shoot:availability
+    expr: probe_success{job="blackbox-apiserver"} == bool 1
+    labels:
+      kind: seed
+  - record: shoot:availability
+    expr: probe_success{job="tunnel-probe-apiserver-proxy"} == bool 1
+    labels:
+      kind: vpn


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

Previously only the probe metric from the shoot was federated. This change
federates the probe metric accessing the API Server via its external
endpoint and checks the vpn connection.

The `bool` operator guarantees a value for the metric -> 0 or 1.

/cc @marwinski 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Federate vpn and api server availability metrics
```
