### PR TITLE
[release-v1.40] Automated cherry pick of #5451: Make Worker status update more resilient

### DIFF
--- a/extensions/pkg/controller/worker/genericactuator/update.go
+++ b/extensions/pkg/controller/worker/genericactuator/update.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package genericactuator
+
+import (
+	"context"
+	"reflect"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// tryUpdateStatus tries to apply the given transformation function onto the given object, and to update its
+// status afterwards. It retries the status update with an exponential backoff.
+// Deprecated: This function is deprecated and will be removed in a future version. Please don't consider using it.
+// See https://github.com/gardener/gardener/blob/master/docs/development/kubernetes-clients.md#dont-retry-on-conflict
+// for more information.
+func tryUpdateStatus(ctx context.Context, backoff wait.Backoff, c client.Client, obj client.Object, transform func() error) error {
+	return tryUpdate(ctx, backoff, c, obj, c.Status().Update, transform)
+}
+
+func tryUpdate(ctx context.Context, backoff wait.Backoff, c client.Client, obj client.Object, updateFunc func(context.Context, client.Object, ...client.UpdateOption) error, transform func() error) error {
+	resetCopy := obj.DeepCopyObject()
+	return exponentialBackoff(ctx, backoff, func() (bool, error) {
+		if err := c.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
+			return false, err
+		}
+
+		beforeTransform := obj.DeepCopyObject()
+		if err := transform(); err != nil {
+			return false, err
+		}
+
+		if reflect.DeepEqual(obj, beforeTransform) {
+			return true, nil
+		}
+
+		if err := updateFunc(ctx, obj); err != nil {
+			if apierrors.IsConflict(err) {
+				// In case of a conflict we are resetting the obj to its original version, as it was
+				// passed to the function, to ensure that, on the next iteration the
+				// equality check of the obj recieved from the server and the object after
+				// its transformation would be valid. Otherwise the obj would be with mutated
+				// fields in result of the transform function from previous iteration.
+				reflect.ValueOf(obj).Elem().Set(reflect.ValueOf(resetCopy).Elem())
+				return false, nil
+			}
+			return false, err
+		}
+		return true, nil
+	})
+}
+
+func exponentialBackoff(ctx context.Context, backoff wait.Backoff, condition wait.ConditionFunc) error {
+	duration := backoff.Duration
+
+	for i := 0; i < backoff.Steps; i++ {
+		if ok, err := condition(); err != nil || ok {
+			return err
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			adjusted := duration
+			if backoff.Jitter > 0.0 {
+				adjusted = wait.Jitter(duration, backoff.Jitter)
+			}
+			time.Sleep(adjusted)
+			duration = time.Duration(float64(duration) * backoff.Factor)
+		}
+
+		i++
+	}
+
+	return wait.ErrWaitTimeout
+}

--- a/extensions/pkg/controller/worker/genericactuator/update_test.go
+++ b/extensions/pkg/controller/worker/genericactuator/update_test.go
@@ -1,0 +1,94 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package genericactuator
+
+import (
+	"context"
+	"encoding/json"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("#tryUpdate", func() {
+	It("should set state to obj, when conflict occurs", func() {
+		s := runtime.NewScheme()
+		Expect(extensionsv1alpha1.AddToScheme(s)).NotTo(HaveOccurred())
+		objInFakeClient := newInfraObj()
+		objInFakeClient.Status.Conditions = []gardencorev1beta1.Condition{
+			{Type: "Health", Reason: "reason", Message: "messages", Status: "status", LastUpdateTime: metav1.Now()},
+		}
+
+		c := fake.NewClientBuilder().WithScheme(s).WithObjects(objInFakeClient).Build()
+		infraObj := newInfraObj()
+		transform := func() error {
+			infraState, _ := json.Marshal(state{"someState"})
+			infraObj.GetExtensionStatus().SetState(&runtime.RawExtension{Raw: infraState})
+			return nil
+		}
+
+		u := &conflictErrManager{
+			conflictsBeforeUpdate: 2,
+			client:                c,
+		}
+
+		tryUpdateErr := tryUpdate(context.TODO(), retry.DefaultRetry, c, infraObj, u.updateFunc, transform)
+		Expect(tryUpdateErr).NotTo(HaveOccurred())
+
+		objFromFakeClient := &extensionsv1alpha1.Infrastructure{}
+		err := c.Get(context.TODO(), kutil.Key("infraNamespace", "infraName"), objFromFakeClient)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(objFromFakeClient).To(Equal(infraObj))
+	})
+})
+
+type state struct {
+	Name string `json:"name"`
+}
+
+func newInfraObj() *extensionsv1alpha1.Infrastructure {
+	return &extensionsv1alpha1.Infrastructure{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "infraName",
+			Namespace: "infraNamespace",
+		},
+	}
+}
+
+type conflictErrManager struct {
+	conflictsBeforeUpdate int
+	conflictsOccured      int
+	client                client.Client
+}
+
+func (c *conflictErrManager) updateFunc(ctx context.Context, obj client.Object, o ...client.UpdateOption) error {
+	if c.conflictsBeforeUpdate == c.conflictsOccured {
+		return c.client.Status().Update(ctx, obj, o...)
+	}
+
+	c.conflictsOccured++
+	return apierrors.NewConflict(schema.GroupResource{}, "", nil)
+}


### PR DESCRIPTION
/kind/bug
/area/quality

Cherry pick of #5451 on release-v1.40.

#5451: Make Worker status update more resilient

**Release Notes:**
```bugfix dependency
The generic Worker actuator is now more resilient to status updates that fail because of conflicts.
```