### PR TITLE
Set default resource lock to leases for extensions

### DIFF
--- a/extensions/pkg/controller/cmd/options.go
+++ b/extensions/pkg/controller/cmd/options.go
@@ -153,7 +153,7 @@ func (b *OptionAggregator) Complete() error {
 type ManagerOptions struct {
 	// LeaderElection is whether leader election is turned on or not.
 	LeaderElection bool
-	// LeaderElectionResourceLock is the resource type used for leader election (defaults to `configmapsleases`).
+	// LeaderElectionResourceLock is the resource type used for leader election (defaults to `leases`).
 	//
 	// When changing the default resource lock, please make sure to migrate via multilocks to
 	// avoid situations where multiple running instances of your controller have each acquired leadership
@@ -185,11 +185,8 @@ type ManagerOptions struct {
 func (m *ManagerOptions) AddFlags(fs *pflag.FlagSet) {
 	defaultLeaderElectionResourceLock := m.LeaderElectionResourceLock
 	if defaultLeaderElectionResourceLock == "" {
-		// explicitly default to configmapleases if no default is specified for migration purposes
-		// same as in controller-runtime, see
-		// https://github.com/kubernetes-sigs/controller-runtime/blob/a763c9a36c6f18660799384c9765348942bda53a/pkg/leaderelection/leader_election.go#L59-L64
-		// we might consider changing this default after many releases
-		defaultLeaderElectionResourceLock = resourcelock.ConfigMapsLeasesResourceLock
+		// explicitly default to leases if no default is specified
+		defaultLeaderElectionResourceLock = resourcelock.LeasesResourceLock
 	}
 
 	fs.BoolVar(&m.LeaderElection, LeaderElectionFlag, m.LeaderElection, "Whether to use leader election or not when running this controller manager.")

--- a/extensions/pkg/controller/cmd/options_test.go
+++ b/extensions/pkg/controller/cmd/options_test.go
@@ -229,7 +229,7 @@ var _ = Describe("Options", func() {
 				}))
 			})
 
-			It("should default resource lock to configmapsleases", func() {
+			It("should default resource lock to leases", func() {
 				fs := pflag.NewFlagSet(name, pflag.ExitOnError)
 				opts := ManagerOptions{}
 
@@ -247,7 +247,7 @@ var _ = Describe("Options", func() {
 				)).NotTo(HaveOccurred())
 				Expect(opts).To(Equal(ManagerOptions{
 					LeaderElection:             true,
-					LeaderElectionResourceLock: "configmapsleases",
+					LeaderElectionResourceLock: "leases",
 					LeaderElectionID:           leaderElectionID,
 					LeaderElectionNamespace:    leaderElectionNamespace,
 				}))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
CC - @ialidzhikov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking dependency
The default leader election of extensions has been changed from `configmapsleases` to `leases`. Please make sure, that you had at least `gardener@v1.17.0` in your go.mod before upgrading to this version so that it has successfully acquired leadership with the hybrid resource lock (`configmapsleases`) at least once.
```
