### PR TITLE
Fix service annotation deletion on reconcile loop

### DIFF
--- a/pkg/client/kubernetes/applier_test.go
+++ b/pkg/client/kubernetes/applier_test.go
@@ -191,6 +191,9 @@ spec:
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "test-service",
 							Namespace: "test-ns",
+							Annotations: map[string]string{
+								"loadbalancer.openstack.org/load-balancer-id": "09199d61-4cca-4c7d-8d9c-405ba7680dbe",
+							},
 						},
 						Spec: corev1.ServiceSpec{
 							ClusterIP: "1.2.3.4",
@@ -209,6 +212,7 @@ spec:
 
 					new = old.DeepCopy()
 					new.Spec.ClusterIP = ""
+					new.Annotations = map[string]string{}
 					expected = old.DeepCopy()
 					expected.ResourceVersion = "2"
 				})

--- a/pkg/resourcemanager/controller/managedresource/merger_test.go
+++ b/pkg/resourcemanager/controller/managedresource/merger_test.go
@@ -831,7 +831,11 @@ var _ = Describe("merger", func() {
 			Expect(corev1.AddToScheme(s)).ToNot(HaveOccurred(), "schema add should succeed")
 
 			old = &corev1.Service{
-				ObjectMeta: metav1.ObjectMeta{},
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"loadbalancer.openstack.org/load-balancer-id": "09199d61-4cca-4c7d-8d9c-405ba7680dbe",
+					},
+				},
 				Spec: corev1.ServiceSpec{
 					ClusterIP: "1.2.3.4",
 					Ports: []corev1.ServicePort{
@@ -849,6 +853,7 @@ var _ = Describe("merger", func() {
 			}
 
 			new = old.DeepCopy()
+			new.Annotations = map[string]string{}
 			expected = old.DeepCopy()
 		})
 
@@ -861,6 +866,7 @@ var _ = Describe("merger", func() {
 				new.Spec.Ports[0].Port = 1234
 				new.Spec.Ports[0].Protocol = corev1.ProtocolUDP
 				new.Spec.Ports[0].TargetPort = intstr.FromInt(989)
+				new.Annotations = old.Annotations
 
 				expected = new.DeepCopy()
 				new.Spec.ClusterIP = ""
@@ -876,6 +882,7 @@ var _ = Describe("merger", func() {
 				new.Spec.Ports[0].Protocol = corev1.ProtocolUDP
 				new.Spec.Ports[0].Port = 999
 				new.Spec.Ports[0].TargetPort = intstr.FromInt(888)
+				new.Annotations = old.Annotations
 
 				expected = new.DeepCopy()
 				new.Spec.ClusterIP = "5.6.7.8"
@@ -887,6 +894,7 @@ var _ = Describe("merger", func() {
 				new.Spec.Ports[0].Port = 999
 				new.Spec.Ports[0].TargetPort = intstr.FromInt(888)
 				new.Spec.Ports[0].NodePort = 444
+				new.Annotations = old.Annotations
 
 				expected = new.DeepCopy()
 			}),
@@ -901,6 +909,7 @@ var _ = Describe("merger", func() {
 				new.Spec.ClusterIP = ""
 				new.Spec.ExternalName = "foo.com"
 				new.Spec.HealthCheckNodePort = 0
+				new.Annotations = old.Annotations
 
 				expected = new.DeepCopy()
 			}),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.

-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
We observed that the load balancer on OpenStack is adding the annotation "loadbalancer.openstack.org/load-balancer-id" on the k8s service of type LoadBalancer.
As the helm charts are not respecting the annotation and removing it the OpenStack cloud controller is adding it back and this causes an continuous update on the service and in the background many unnecessary api request to the OpenStack load balancer apis.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator 
preserve service annotations for nginx-ingress-controller and istio-ingressgateway services
```
