### PR TITLE
[GEP-18] Ensure components restart in case CA bundle changes

### DIFF
--- a/charts/seed-bootstrap/charts/loki/templates/statefulset.yaml
+++ b/charts/seed-bootstrap/charts/loki/templates/statefulset.yaml
@@ -2,6 +2,9 @@
 reference.resources.gardener.cloud/configmap-{{ include "loki.config.name" . | sha256sum | trunc 8 }}: {{ include "loki.config.name" . }}
 {{- if .Values.rbacSidecarEnabled }}
 reference.resources.gardener.cloud/configmap-{{ include "telegraf.config.name" . | sha256sum | trunc 8 }}: {{ include "telegraf.config.name" . }}
+{{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations }}
+{{- end }}
 {{- end }}
 {{- end -}}
 ---

--- a/charts/seed-bootstrap/charts/loki/values.yaml
+++ b/charts/seed-bootstrap/charts/loki/values.yaml
@@ -13,6 +13,7 @@ global:
 authEnabled: true
 
 annotations: {}
+podAnnotations: {}
 
 rbacSidecarEnabled: false
 kubeRBACProxyKubeconfigCheckSum: bed9a4ef5410793c023b3551308661a1a1acafe9f93c9393714ce4f2c0134ac3

--- a/charts/seed-monitoring/charts/core/charts/kube-state-metrics-shoot/templates/deployment.yaml
+++ b/charts/seed-monitoring/charts/core/charts/kube-state-metrics-shoot/templates/deployment.yaml
@@ -20,6 +20,10 @@ spec:
       maxUnavailable: 1
   template:
     metadata:
+{{- if .Values.podAnnotations }}
+      annotations:
+{{ toYaml .Values.podAnnotations | indent 8 }}
+{{- end }}
       labels:
         gardener.cloud/role: monitoring
         component: kube-state-metrics

--- a/charts/seed-monitoring/charts/core/charts/kube-state-metrics-shoot/values.yaml
+++ b/charts/seed-monitoring/charts/core/charts/kube-state-metrics-shoot/values.yaml
@@ -1,3 +1,4 @@
 images:
   kube-state-metrics: image-repository:image-tag
 replicas: 1
+podAnnotations: {}

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -24,7 +24,7 @@ const (
 	// SecretNameCAFrontProxy is a constant for the name of a Kubernetes secret object that contains the CA
 	// certificate of the kube-aggregator a shoot cluster.
 	SecretNameCAFrontProxy = "ca-front-proxy"
-	// SecretNameCAKubelet is a constant for the name of a Kubernetes secret object that contains the CA
+	// SecretNameCAKubelet is a constant for the name of a Kubernetes secret object that contains the client CA
 	// certificate of the kubelet of a shoot cluster.
 	SecretNameCAKubelet = "ca-kubelet"
 	// SecretNameCAMetricsServer is a constant for the name of a Kubernetes secret object that contains the CA

--- a/pkg/operation/botanist/clusterautoscaler.go
+++ b/pkg/operation/botanist/clusterautoscaler.go
@@ -17,6 +17,7 @@ package botanist
 import (
 	"context"
 
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/clusterautoscaler"
 	"github.com/gardener/gardener/pkg/utils/images"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
@@ -41,6 +42,9 @@ func (b *Botanist) DefaultClusterAutoscaler() (clusterautoscaler.Interface, erro
 // DeployClusterAutoscaler deploys the Kubernetes cluster-autoscaler.
 func (b *Botanist) DeployClusterAutoscaler(ctx context.Context) error {
 	if b.Shoot.WantsClusterAutoscaler {
+		b.Shoot.Components.ControlPlane.ClusterAutoscaler.SetSecrets(clusterautoscaler.Secrets{
+			GenericTokenKubeconfigChecksum: b.LoadCheckSum(v1beta1constants.SecretNameGenericTokenKubeconfig),
+		})
 		b.Shoot.Components.ControlPlane.ClusterAutoscaler.SetNamespaceUID(b.SeedNamespaceObject.UID)
 		b.Shoot.Components.ControlPlane.ClusterAutoscaler.SetMachineDeployments(b.Shoot.Components.Extensions.Worker.MachineDeployments())
 

--- a/pkg/operation/botanist/component/clusterautoscaler/cluster_autoscaler_test.go
+++ b/pkg/operation/botanist/component/clusterautoscaler/cluster_autoscaler_test.go
@@ -90,6 +90,11 @@ var _ = Describe("ClusterAutoscaler", func() {
 			IgnoreTaints:                  configIgnoreTaints,
 		}
 
+		genericTokenKubeconfigChecksum = "1234"
+		secrets                        = Secrets{
+			GenericTokenKubeconfigChecksum: genericTokenKubeconfigChecksum,
+		}
+
 		serviceAccountName        = "cluster-autoscaler"
 		secretName                = "shoot-access-cluster-autoscaler"
 		clusterRoleBindingName    = "cluster-autoscaler-" + namespace
@@ -318,7 +323,7 @@ var _ = Describe("ClusterAutoscaler", func() {
 				},
 			}
 
-			Expect(gutil.InjectGenericKubeconfig(deploy, secret.Name)).To(Succeed())
+			Expect(gutil.InjectGenericKubeconfig(deploy, secret.Name, genericTokenKubeconfigChecksum)).To(Succeed())
 			return deploy
 		}
 
@@ -497,6 +502,7 @@ subjects:
 		c = mockclient.NewMockClient(ctrl)
 
 		clusterAutoscaler = New(c, namespace, image, replicas, nil)
+		clusterAutoscaler.SetSecrets(secrets)
 		clusterAutoscaler.SetNamespaceUID(namespaceUID)
 		clusterAutoscaler.SetMachineDeployments(machineDeployments)
 	})
@@ -666,6 +672,7 @@ subjects:
 				}
 
 				clusterAutoscaler = New(c, namespace, image, replicas, config)
+				clusterAutoscaler.SetSecrets(secrets)
 				clusterAutoscaler.SetNamespaceUID(namespaceUID)
 				clusterAutoscaler.SetMachineDeployments(machineDeployments)
 

--- a/pkg/operation/botanist/component/clusterautoscaler/mock/mocks.go
+++ b/pkg/operation/botanist/component/clusterautoscaler/mock/mocks.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 
 	v1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	clusterautoscaler "github.com/gardener/gardener/pkg/operation/botanist/component/clusterautoscaler"
 	gomock "github.com/golang/mock/gomock"
 	types "k8s.io/apimachinery/pkg/types"
 )
@@ -116,6 +117,18 @@ func (m *MockInterface) SetNamespaceUID(arg0 types.UID) {
 func (mr *MockInterfaceMockRecorder) SetNamespaceUID(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetNamespaceUID", reflect.TypeOf((*MockInterface)(nil).SetNamespaceUID), arg0)
+}
+
+// SetSecrets mocks base method.
+func (m *MockInterface) SetSecrets(arg0 clusterautoscaler.Secrets) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetSecrets", arg0)
+}
+
+// SetSecrets indicates an expected call of SetSecrets.
+func (mr *MockInterfaceMockRecorder) SetSecrets(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSecrets", reflect.TypeOf((*MockInterface)(nil).SetSecrets), arg0)
 }
 
 // Wait mocks base method.

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/component.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/component.go
@@ -61,7 +61,7 @@ const (
 	// PathKubeconfigReal is the path for the kubelet's real kubeconfig (with client certificate after the TLS
 	// bootstrapping process finished).
 	PathKubeconfigReal = PathKubeletDirectory + "/kubeconfig-real"
-	// PathKubeletCACert is the path for the kubelet's certificate authority.
+	// PathKubeletCACert is the path for the kubelet's client certificate authority.
 	PathKubeletCACert = PathKubeletDirectory + "/ca.crt"
 	// PathKubeletConfig is the path for the kubelet's config file.
 	PathKubeletConfig = v1beta1constants.OperatingSystemConfigFilePathKubeletConfig

--- a/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager.go
@@ -293,7 +293,7 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 			},
 		}
 
-		utilruntime.Must(gutil.InjectGenericKubeconfig(deployment, shootAccessSecret.Secret.Name))
+		utilruntime.Must(gutil.InjectGenericKubeconfig(deployment, shootAccessSecret.Secret.Name, k.secrets.GenericTokenKubeconfigChecksum))
 		return nil
 	}); err != nil {
 		return err
@@ -594,4 +594,6 @@ type Secrets struct {
 	// ServiceAccountKey is a secret containing a PEM-encoded private RSA or ECDSA key used to sign service account tokens.
 	// used for the flag: --service-account-private-key-file
 	ServiceAccountKey component.Secret
+	// GenericTokenKubeconfigChecksum is the checksum of the generic token kubeconfig used for shoot access secrets.
+	GenericTokenKubeconfigChecksum string
 }

--- a/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager_test.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager_test.go
@@ -93,7 +93,8 @@ var _ = Describe("KubeControllerManager", func() {
 		// checksums
 		secretChecksumServer            = "5678"
 		secretChecksumCA                = "1234"
-		secretChecksumServiceAccountKey = "1234"
+		secretChecksumServiceAccountKey = "9012"
+		genericTokenKubeconfigChecksum  = "3456"
 
 		vpaName                   = "kube-controller-manager-vpa"
 		hvpaName                  = "kube-controller-manager"
@@ -150,9 +151,10 @@ var _ = Describe("KubeControllerManager", func() {
 			Context("secret information available", func() {
 				BeforeEach(func() {
 					kubeControllerManager.SetSecrets(Secrets{
-						Server:            component.Secret{Name: "kube-controller-manager-server", Checksum: secretChecksumServer},
-						CA:                component.Secret{Name: "ca", Checksum: secretChecksumCA},
-						ServiceAccountKey: component.Secret{Name: "service-account-key", Checksum: secretChecksumServiceAccountKey},
+						Server:                         component.Secret{Name: "kube-controller-manager-server", Checksum: secretChecksumServer},
+						CA:                             component.Secret{Name: "ca", Checksum: secretChecksumCA},
+						ServiceAccountKey:              component.Secret{Name: "service-account-key", Checksum: secretChecksumServiceAccountKey},
+						GenericTokenKubeconfigChecksum: genericTokenKubeconfigChecksum,
 					})
 				})
 
@@ -562,7 +564,7 @@ var _ = Describe("KubeControllerManager", func() {
 						},
 					}
 
-					Expect(gutil.InjectGenericKubeconfig(deploy, secret.Name)).To(Succeed())
+					Expect(gutil.InjectGenericKubeconfig(deploy, secret.Name, genericTokenKubeconfigChecksum)).To(Succeed())
 					return deploy
 				}
 
@@ -641,9 +643,10 @@ subjects:
 					)
 
 					kubeControllerManager.SetSecrets(Secrets{
-						Server:            component.Secret{Name: "kube-controller-manager-server", Checksum: secretChecksumServer},
-						CA:                component.Secret{Name: "ca", Checksum: secretChecksumCA},
-						ServiceAccountKey: component.Secret{Name: "service-account-key", Checksum: secretChecksumServiceAccountKey},
+						Server:                         component.Secret{Name: "kube-controller-manager-server", Checksum: secretChecksumServer},
+						CA:                             component.Secret{Name: "ca", Checksum: secretChecksumCA},
+						ServiceAccountKey:              component.Secret{Name: "service-account-key", Checksum: secretChecksumServiceAccountKey},
+						GenericTokenKubeconfigChecksum: genericTokenKubeconfigChecksum,
 					})
 
 					kubeControllerManager.SetReplicaCount(replicas)

--- a/pkg/operation/botanist/component/kubescheduler/kube_scheduler.go
+++ b/pkg/operation/botanist/component/kubescheduler/kube_scheduler.go
@@ -264,7 +264,7 @@ func (k *kubeScheduler) Deploy(ctx context.Context) error {
 			},
 		}
 
-		utilruntime.Must(gutil.InjectGenericKubeconfig(deployment, shootAccessSecret.Secret.Name))
+		utilruntime.Must(gutil.InjectGenericKubeconfig(deployment, shootAccessSecret.Secret.Name, k.secrets.GenericTokenKubeconfigChecksum))
 		utilruntime.Must(references.InjectAnnotations(deployment))
 		return nil
 	}); err != nil {
@@ -447,4 +447,6 @@ func init() {
 type Secrets struct {
 	// Server is a secret for the HTTPS server inside the kube-scheduler (which is used for metrics and health checks).
 	Server component.Secret
+	// GenericTokenKubeconfigChecksum is the checksum of the generic token kubeconfig used for shoot access secrets.
+	GenericTokenKubeconfigChecksum string
 }

--- a/pkg/operation/botanist/component/kubescheduler/kube_scheduler_test.go
+++ b/pkg/operation/botanist/component/kubescheduler/kube_scheduler_test.go
@@ -62,9 +62,13 @@ var _ = Describe("KubeScheduler", func() {
 		configEmpty *gardencorev1beta1.KubeSchedulerConfig
 		configFull  = &gardencorev1beta1.KubeSchedulerConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{"Foo": true, "Bar": false, "Baz": false}}, KubeMaxPDVols: pointer.String("23")}
 
-		secretNameServer     = "server-secret"
-		secretChecksumServer = "5678"
-		secrets              = Secrets{Server: component.Secret{Name: secretNameServer, Checksum: secretChecksumServer}}
+		secretNameServer               = "server-secret"
+		secretChecksumServer           = "5678"
+		genericTokenKubeconfigChecksum = "9012"
+		secrets                        = Secrets{
+			Server:                         component.Secret{Name: secretNameServer, Checksum: secretChecksumServer},
+			GenericTokenKubeconfigChecksum: genericTokenKubeconfigChecksum,
+		}
 
 		vpaName                   = "kube-scheduler-vpa"
 		serviceName               = "kube-scheduler"
@@ -269,7 +273,7 @@ var _ = Describe("KubeScheduler", func() {
 				},
 			}
 
-			Expect(gutil.InjectGenericKubeconfig(deploy, secret.Name)).To(Succeed())
+			Expect(gutil.InjectGenericKubeconfig(deploy, secret.Name, genericTokenKubeconfigChecksum)).To(Succeed())
 			Expect(references.InjectAnnotations(deploy)).To(Succeed())
 			return deploy
 		}

--- a/pkg/operation/botanist/component/resourcemanager/resource_manager.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager.go
@@ -641,7 +641,7 @@ func (r *resourceManager) ensureDeployment(ctx context.Context) error {
 					ReadOnly:  true,
 				})
 			} else if r.secrets.shootAccess != nil {
-				utilruntime.Must(gutil.InjectGenericKubeconfig(deployment, r.secrets.shootAccess.Secret.Name))
+				utilruntime.Must(gutil.InjectGenericKubeconfig(deployment, r.secrets.shootAccess.Secret.Name, r.secrets.GenericTokenKubeconfigChecksum))
 			}
 		}
 
@@ -1106,6 +1106,8 @@ type Secrets struct {
 	Server component.Secret
 	// RootCA is a secret containing the root CA secret of the target cluster.
 	RootCA *component.Secret
+	// GenericTokenKubeconfigChecksum is the checksum of the generic token kubeconfig used for shoot access secrets.
+	GenericTokenKubeconfigChecksum string
 
 	shootAccess *gutil.ShootAccessSecret
 }

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -65,8 +65,8 @@ func (b *Botanist) DeployVerticalPodAutoscaler(ctx context.Context) error {
 		admissionController = map[string]interface{}{
 			"replicas": b.Shoot.GetReplicas(1),
 			"podAnnotations": map[string]interface{}{
-				"checksum/secret-vpa-tls-certs":            b.LoadCheckSum(common.VPASecretName),
-				"checksum/secret-vpa-admission-controller": b.LoadCheckSum("vpa-admission-controller"),
+				"checksum/secret-vpa-tls-certs": b.LoadCheckSum(common.VPASecretName),
+				"checksum/secret-ca":            b.LoadCheckSum(v1beta1constants.SecretNameCACluster),
 			},
 			"podLabels": utils.MergeMaps(podLabels, map[string]interface{}{
 				v1beta1constants.LabelNetworkPolicyFromShootAPIServer: "allowed",
@@ -80,7 +80,7 @@ func (b *Botanist) DeployVerticalPodAutoscaler(ctx context.Context) error {
 		recommender = map[string]interface{}{
 			"replicas": b.Shoot.GetReplicas(1),
 			"podAnnotations": map[string]interface{}{
-				"checksum/secret-vpa-recommender": b.LoadCheckSum("vpa-recommender"),
+				"checksum/secret-ca": b.LoadCheckSum(v1beta1constants.SecretNameCACluster),
 			},
 			"podLabels":                    podLabels,
 			"createServiceAccount":         false,
@@ -90,7 +90,7 @@ func (b *Botanist) DeployVerticalPodAutoscaler(ctx context.Context) error {
 		updater = map[string]interface{}{
 			"replicas": b.Shoot.GetReplicas(1),
 			"podAnnotations": map[string]interface{}{
-				"checksum/secret-vpa-updater": b.LoadCheckSum("vpa-updater"),
+				"checksum/secret-ca": b.LoadCheckSum(v1beta1constants.SecretNameCACluster),
 			},
 			"podLabels":              podLabels,
 			"createServiceAccount":   false,

--- a/pkg/operation/botanist/kubecontrollermanager.go
+++ b/pkg/operation/botanist/kubecontrollermanager.go
@@ -73,9 +73,10 @@ func (b *Botanist) DeployKubeControllerManager(ctx context.Context) error {
 
 	b.Shoot.Components.ControlPlane.KubeControllerManager.SetReplicaCount(replicaCount)
 	b.Shoot.Components.ControlPlane.KubeControllerManager.SetSecrets(kubecontrollermanager.Secrets{
-		CA:                component.Secret{Name: v1beta1constants.SecretNameCACluster, Checksum: b.LoadCheckSum(v1beta1constants.SecretNameCACluster)},
-		ServiceAccountKey: component.Secret{Name: v1beta1constants.SecretNameServiceAccountKey, Checksum: b.LoadCheckSum(v1beta1constants.SecretNameServiceAccountKey)},
-		Server:            component.Secret{Name: kubecontrollermanager.SecretNameServer, Checksum: b.LoadCheckSum(kubecontrollermanager.SecretNameServer)},
+		CA:                             component.Secret{Name: v1beta1constants.SecretNameCACluster, Checksum: b.LoadCheckSum(v1beta1constants.SecretNameCACluster)},
+		ServiceAccountKey:              component.Secret{Name: v1beta1constants.SecretNameServiceAccountKey, Checksum: b.LoadCheckSum(v1beta1constants.SecretNameServiceAccountKey)},
+		Server:                         component.Secret{Name: kubecontrollermanager.SecretNameServer, Checksum: b.LoadCheckSum(kubecontrollermanager.SecretNameServer)},
+		GenericTokenKubeconfigChecksum: b.LoadCheckSum(v1beta1constants.SecretNameGenericTokenKubeconfig),
 	})
 
 	return b.Shoot.Components.ControlPlane.KubeControllerManager.Deploy(ctx)

--- a/pkg/operation/botanist/kubecontrollermanager_test.go
+++ b/pkg/operation/botanist/kubecontrollermanager_test.go
@@ -100,16 +100,19 @@ var _ = Describe("KubeControllerManager", func() {
 			kubeAPIServer         *mockkubeapiserver.MockInterface
 			kubeControllerManager *mockkubecontrollermanager.MockInterface
 
-			secretNameServer            = "kube-controller-manager-server"
-			secretNameCA                = "ca"
-			secretNameServiceAccountKey = "service-account-key"
-			checksumServer              = "34"
-			checksumCA                  = "56"
-			checksumServiceAccountKey   = "78"
-			secrets                     = kubecontrollermanager.Secrets{
-				Server:            component.Secret{Name: secretNameServer, Checksum: checksumServer},
-				CA:                component.Secret{Name: secretNameCA, Checksum: checksumCA},
-				ServiceAccountKey: component.Secret{Name: secretNameServiceAccountKey, Checksum: checksumServiceAccountKey},
+			secretNameServer                 = "kube-controller-manager-server"
+			secretNameCA                     = "ca"
+			secretNameServiceAccountKey      = "service-account-key"
+			secretNameGenericTokenKubeconfig = "generic-token-kubeconfig"
+			checksumServer                   = "34"
+			checksumCA                       = "56"
+			checksumServiceAccountKey        = "78"
+			checksumGenericTokenKubeconfig   = "90"
+			secrets                          = kubecontrollermanager.Secrets{
+				Server:                         component.Secret{Name: secretNameServer, Checksum: checksumServer},
+				CA:                             component.Secret{Name: secretNameCA, Checksum: checksumCA},
+				ServiceAccountKey:              component.Secret{Name: secretNameServiceAccountKey, Checksum: checksumServiceAccountKey},
+				GenericTokenKubeconfigChecksum: checksumGenericTokenKubeconfig,
 			}
 		)
 
@@ -121,6 +124,7 @@ var _ = Describe("KubeControllerManager", func() {
 			botanist.StoreCheckSum(secretNameServer, checksumServer)
 			botanist.StoreCheckSum(secretNameCA, checksumCA)
 			botanist.StoreCheckSum(secretNameServiceAccountKey, checksumServiceAccountKey)
+			botanist.StoreCheckSum(secretNameGenericTokenKubeconfig, checksumGenericTokenKubeconfig)
 			botanist.Shoot = &shootpkg.Shoot{
 				Components: &shootpkg.Components{
 					ControlPlane: &shootpkg.ControlPlane{

--- a/pkg/operation/botanist/kubescheduler.go
+++ b/pkg/operation/botanist/kubescheduler.go
@@ -17,6 +17,7 @@ package botanist
 import (
 	"context"
 
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/kubescheduler"
 	"github.com/gardener/gardener/pkg/utils/images"
@@ -43,7 +44,8 @@ func (b *Botanist) DefaultKubeScheduler() (kubescheduler.Interface, error) {
 // DeployKubeScheduler deploys the Kubernetes scheduler.
 func (b *Botanist) DeployKubeScheduler(ctx context.Context) error {
 	b.Shoot.Components.ControlPlane.KubeScheduler.SetSecrets(kubescheduler.Secrets{
-		Server: component.Secret{Name: kubescheduler.SecretNameServer, Checksum: b.LoadCheckSum(kubescheduler.SecretNameServer)},
+		Server:                         component.Secret{Name: kubescheduler.SecretNameServer, Checksum: b.LoadCheckSum(kubescheduler.SecretNameServer)},
+		GenericTokenKubeconfigChecksum: b.LoadCheckSum(v1beta1constants.SecretNameGenericTokenKubeconfig),
 	})
 
 	return b.Shoot.Components.ControlPlane.KubeScheduler.Deploy(ctx)

--- a/pkg/operation/botanist/kubescheduler_test.go
+++ b/pkg/operation/botanist/kubescheduler_test.go
@@ -82,16 +82,19 @@ var _ = Describe("KubeScheduler", func() {
 		var (
 			kubeScheduler *mockkubescheduler.MockInterface
 
-			ctx              = context.TODO()
-			fakeErr          = fmt.Errorf("fake err")
-			secretNameServer = "kube-scheduler-server"
-			checksumServer   = "5678"
+			ctx                              = context.TODO()
+			fakeErr                          = fmt.Errorf("fake err")
+			secretNameServer                 = "kube-scheduler-server"
+			secretNameGenericTokenKubeconfig = "generic-token-kubeconfig"
+			checksumServer                   = "5678"
+			checksumGenericTokenKubeconfig   = "9012"
 		)
 
 		BeforeEach(func() {
 			kubeScheduler = mockkubescheduler.NewMockInterface(ctrl)
 
 			botanist.StoreCheckSum(secretNameServer, checksumServer)
+			botanist.StoreCheckSum(secretNameGenericTokenKubeconfig, checksumGenericTokenKubeconfig)
 			botanist.Shoot = &shootpkg.Shoot{
 				Components: &shootpkg.Components{
 					ControlPlane: &shootpkg.ControlPlane{
@@ -101,7 +104,8 @@ var _ = Describe("KubeScheduler", func() {
 			}
 
 			kubeScheduler.EXPECT().SetSecrets(kubescheduler.Secrets{
-				Server: component.Secret{Name: secretNameServer, Checksum: checksumServer},
+				Server:                         component.Secret{Name: secretNameServer, Checksum: checksumServer},
+				GenericTokenKubeconfigChecksum: checksumGenericTokenKubeconfig,
 			})
 		})
 

--- a/pkg/operation/botanist/logging.go
+++ b/pkg/operation/botanist/logging.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/gardener/gardener/charts"
 	gardencore "github.com/gardener/gardener/pkg/apis/core"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/features"
 	gardenlethelper "github.com/gardener/gardener/pkg/gardenlet/apis/config/helper"
@@ -77,6 +78,9 @@ func (b *Botanist) DeploySeedLogging(ctx context.Context) error {
 
 	if b.isShootNodeLoggingEnabled() {
 		lokiValues["rbacSidecarEnabled"] = true
+		lokiValues["podAnnotations"] = map[string]interface{}{
+			"checksum/secret-" + v1beta1constants.SecretNameGenericTokenKubeconfig: b.LoadCheckSum(v1beta1constants.SecretNameGenericTokenKubeconfig),
+		}
 		lokiValues["ingress"] = map[string]interface{}{
 			"class": ingressClass,
 			"hosts": []map[string]interface{}{

--- a/pkg/operation/botanist/resource_manager.go
+++ b/pkg/operation/botanist/resource_manager.go
@@ -104,9 +104,10 @@ func (b *Botanist) DeployGardenerResourceManager(ctx context.Context) error {
 			},
 		}
 		secrets = resourcemanager.Secrets{
-			ServerCA: component.Secret{Name: v1beta1constants.SecretNameCACluster, Checksum: b.LoadCheckSum(v1beta1constants.SecretNameCACluster), Data: b.LoadSecret(v1beta1constants.SecretNameCACluster).Data},
-			Server:   component.Secret{Name: resourcemanager.SecretNameServer, Checksum: b.LoadCheckSum(resourcemanager.SecretNameServer)},
-			RootCA:   &component.Secret{Name: v1beta1constants.SecretNameCACluster, Checksum: b.LoadCheckSum(v1beta1constants.SecretNameCACluster)},
+			ServerCA:                       component.Secret{Name: v1beta1constants.SecretNameCACluster, Checksum: b.LoadCheckSum(v1beta1constants.SecretNameCACluster), Data: b.LoadSecret(v1beta1constants.SecretNameCACluster).Data},
+			Server:                         component.Secret{Name: resourcemanager.SecretNameServer, Checksum: b.LoadCheckSum(resourcemanager.SecretNameServer)},
+			RootCA:                         &component.Secret{Name: v1beta1constants.SecretNameCACluster, Checksum: b.LoadCheckSum(v1beta1constants.SecretNameCACluster)},
+			GenericTokenKubeconfigChecksum: b.LoadCheckSum(v1beta1constants.SecretNameGenericTokenKubeconfig),
 		}
 	)
 

--- a/pkg/operation/botanist/resource_manager_test.go
+++ b/pkg/operation/botanist/resource_manager_test.go
@@ -75,11 +75,13 @@ var _ = Describe("ResourceManager", func() {
 
 			seedNamespace = "fake-seed-ns"
 
-			secretNameCA         = "ca"
-			secretNameServer     = "gardener-resource-manager-server"
-			secretChecksumServer = "5678"
-			secretChecksumCA     = "9012"
-			secretDataServerCA   = map[string][]byte{
+			secretNameCA                     = "ca"
+			secretNameServer                 = "gardener-resource-manager-server"
+			secretChecksumServer             = "5678"
+			secretNameGenericTokenKubeconfig = "generic-token-kubeconfig"
+			checksumGenericTokenKubeconfig   = "3456"
+			secretChecksumCA                 = "9012"
+			secretDataServerCA               = map[string][]byte{
 				"ca.crt": []byte(`-----BEGIN CERTIFICATE-----
 MIIDYDCCAkigAwIBAgIUEb00DjvE8F0HiGOlQY/B/AG1AjMwDQYJKoZIhvcNAQEL
 BQAwSDELMAkGA1UEBhMCVVMxCzAJBgNVBAgTAkNBMRYwFAYDVQQHEw1TYW4gRnJh
@@ -145,6 +147,7 @@ nQwHTbS7lsjLl4cdJWWZ/k1euUyKSpeJtSIwiXyF2kogjOoNh84=
 
 			botanist.StoreCheckSum(secretNameCA, secretChecksumCA)
 			botanist.StoreCheckSum(secretNameServer, secretChecksumServer)
+			botanist.StoreCheckSum(secretNameGenericTokenKubeconfig, checksumGenericTokenKubeconfig)
 			botanist.StoreSecret(secretNameCA, &corev1.Secret{Data: secretDataServerCA})
 
 			botanist.K8sSeedClient = k8sSeedClient
@@ -166,9 +169,10 @@ nQwHTbS7lsjLl4cdJWWZ/k1euUyKSpeJtSIwiXyF2kogjOoNh84=
 			})
 
 			secrets = resourcemanager.Secrets{
-				ServerCA: component.Secret{Name: secretNameCA, Checksum: secretChecksumCA, Data: secretDataServerCA},
-				Server:   component.Secret{Name: secretNameServer, Checksum: secretChecksumServer},
-				RootCA:   &component.Secret{Name: secretNameCA, Checksum: secretChecksumCA},
+				ServerCA:                       component.Secret{Name: secretNameCA, Checksum: secretChecksumCA, Data: secretDataServerCA},
+				Server:                         component.Secret{Name: secretNameServer, Checksum: secretChecksumServer},
+				RootCA:                         &component.Secret{Name: secretNameCA, Checksum: secretChecksumCA},
+				GenericTokenKubeconfigChecksum: checksumGenericTokenKubeconfig,
 			}
 
 			bootstrapKubeconfigSecret = &corev1.Secret{

--- a/pkg/operation/botanist/vpnseedserver.go
+++ b/pkg/operation/botanist/vpnseedserver.go
@@ -97,6 +97,7 @@ func (b *Botanist) DeployVPNServer(ctx context.Context) error {
 	b.Shoot.Components.ControlPlane.VPNSeedServer.SetSecrets(vpnseedserver.Secrets{
 		TLSAuth:          component.Secret{Name: vpnseedserver.VpnSeedServerTLSAuth, Checksum: b.LoadCheckSum(vpnseedserver.VpnSeedServerTLSAuth), Data: b.LoadSecret(vpnseedserver.VpnSeedServerTLSAuth).Data},
 		Server:           component.Secret{Name: vpnseedserver.DeploymentName, Checksum: b.LoadCheckSum(vpnseedserver.DeploymentName), Data: b.LoadSecret(vpnseedserver.DeploymentName).Data},
+		CA:               component.Secret{Name: v1beta1constants.SecretNameCACluster, Checksum: b.LoadCheckSum(v1beta1constants.SecretNameCACluster)},
 		DiffieHellmanKey: component.Secret{Name: v1beta1constants.GardenRoleOpenVPNDiffieHellman, Checksum: checkSumDH, Data: openvpnDiffieHellmanSecret},
 	})
 

--- a/pkg/operation/botanist/vpnseedserver_test.go
+++ b/pkg/operation/botanist/vpnseedserver_test.go
@@ -124,6 +124,8 @@ var _ = Describe("VPNSeedServer", func() {
 			secretChecksumTLSAuth = "1234"
 			secretNameServer      = vpnseedserver.DeploymentName
 			secretChecksumServer  = "5678"
+			secretNameCA          = "ca"
+			secretChecksumCA      = "3456"
 			secretNameDH          = v1beta1constants.GardenRoleOpenVPNDiffieHellman
 			secretChecksumDH      = "9012"
 
@@ -135,9 +137,11 @@ var _ = Describe("VPNSeedServer", func() {
 
 			botanist.StoreCheckSum(secretNameTLSAuth, secretChecksumTLSAuth)
 			botanist.StoreCheckSum(secretNameServer, secretChecksumServer)
+			botanist.StoreCheckSum(secretNameCA, secretChecksumCA)
 			botanist.StoreCheckSum(secretNameDH, secretChecksumDH)
 			botanist.StoreSecret(secretNameTLSAuth, &corev1.Secret{})
 			botanist.StoreSecret(secretNameServer, &corev1.Secret{})
+			botanist.StoreSecret(secretNameCA, &corev1.Secret{})
 			botanist.StoreSecret(secretNameDH, &corev1.Secret{})
 			botanist.Shoot = &shootpkg.Shoot{
 				Components: &shootpkg.Components{
@@ -167,7 +171,8 @@ var _ = Describe("VPNSeedServer", func() {
 		BeforeEach(func() {
 			vpnSeedServer.EXPECT().SetSecrets(vpnseedserver.Secrets{
 				TLSAuth:          component.Secret{Name: secretNameTLSAuth, Checksum: secretChecksumTLSAuth},
-				Server:           component.Secret{Name: vpnseedserver.DeploymentName, Checksum: secretChecksumServer},
+				Server:           component.Secret{Name: secretNameServer, Checksum: secretChecksumServer},
+				CA:               component.Secret{Name: secretNameCA, Checksum: secretChecksumCA},
 				DiffieHellmanKey: component.Secret{Name: secretNameDH, Checksum: secretChecksumDH},
 			})
 			vpnSeedServer.EXPECT().SetSeedNamespaceObjectUID(namespaceUID)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement
/merge squash



**What this PR does / why we need it**:
This PR ensures that the components restart in case the CA bundle changes by injecting the respective checksums of the mounted secrets as annotations into the `Pod` templates.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/3292#issuecomment-1036058890

**Special notes for your reviewer**:
/invite @timebertt @BeckerMax 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
