### PR TITLE
Prevent `cloud-controller-manager`-related `ServiceAccount`s from being invalidated for Kubernetes < 1.21

### DIFF
--- a/docs/development/new-kubernetes-version.md
+++ b/docs/development/new-kubernetes-version.md
@@ -62,7 +62,7 @@ Run the [`.ci/check-and-release`](https://github.com/gardener/hyperkube/blob/mas
   - See [this](https://github.com/gardener/gardener/pull/5255/commits/97923b0604300ff805def8eae981ed388d5e4a83) example commit.
 - Maintain the `ServiceAccount` names for the controllers part of `kube-controller-manager`:
   - The names are maintained in [this](https://github.com/gardener/gardener/blob/master/pkg/operation/botanist/component/shootsystem/shootsystem.go) file.
-  - To maintain this list for new Kubernetes versions, run `hack/compare-kcm-controllers.sh <old-version> <new-version>` (e.g. `hack/compare-kcm-controllers.sh 1.22 1.23`).
+  - To maintain this list for new Kubernetes versions, run `hack/compare-k8s-controllers.sh <old-version> <new-version>` (e.g. `hack/compare-k8s-controllers.sh 1.22 1.23`).
   - It will present 2 lists of controllers: those added and those removed in `<new-version>` compared to `<old-version>`.
   - Double check whether such `ServiceAccount` indeed appears in the `kube-system` namespace when creating a cluster with `<new-version>`. Note that it sometimes might be hidden behind a default-off feature gate. You can create a local cluster with the new version using the [local provider](https://github.com/gardener/gardener/blob/master/docs/development/getting_started_locally.md).
   - If it appears, add all added controllers to the list based on the Kubernetes version ([example](https://github.com/gardener/gardener/blob/5f87b18b951e104c2c25a7145548c8a2d08adefc/pkg/operation/botanist/component/shootsystem/shootsystem.go#L170-L174)).

--- a/pkg/operation/botanist/component/shootsystem/shootsystem.go
+++ b/pkg/operation/botanist/component/shootsystem/shootsystem.go
@@ -140,7 +140,6 @@ func (s *shootSystem) getServiceAccountNamesToInvalidate() []string {
 		"job-controller",
 		"metadata-informers",
 		"namespace-controller",
-		"node-controller",
 		"persistent-volume-binder",
 		"pod-garbage-collector",
 		"pv-protection-controller",
@@ -149,9 +148,7 @@ func (s *shootSystem) getServiceAccountNamesToInvalidate() []string {
 		"replication-controller",
 		"resourcequota-controller",
 		"root-ca-cert-publisher",
-		"route-controller",
 		"service-account-controller",
-		"service-controller",
 		"shared-informers",
 		"statefulset-controller",
 		"token-cleaner",
@@ -170,6 +167,18 @@ func (s *shootSystem) getServiceAccountNamesToInvalidate() []string {
 	if versionutils.ConstraintK8sGreaterEqual120.Check(s.values.KubernetesVersion) {
 		kubeControllerManagerServiceAccountNames = append(kubeControllerManagerServiceAccountNames,
 			"storage-version-garbage-collector",
+		)
+	}
+
+	// The cloud-controller-manager library was only adapted beginning with Kubernetes 1.21 to not rely on the static
+	// ServiceAccount secrets anymore. Prior versions still need them, so let's add the ServiceAccount names for
+	// controllers which are part of cloud-controller-managers only for 1.21+.
+	// See https://github.com/kubernetes/kubernetes/pull/99291 for more details.
+	if versionutils.ConstraintK8sGreaterEqual121.Check(s.values.KubernetesVersion) {
+		kubeControllerManagerServiceAccountNames = append(kubeControllerManagerServiceAccountNames,
+			"node-controller",
+			"route-controller",
+			"service-controller",
 		)
 	}
 

--- a/pkg/operation/botanist/component/shootsystem/shootsystem.go
+++ b/pkg/operation/botanist/component/shootsystem/shootsystem.go
@@ -116,7 +116,7 @@ func (s *shootSystem) computeResourcesData() (map[string][]byte, error) {
 func (s *shootSystem) getServiceAccountNamesToInvalidate() []string {
 	// Well-known {kube,cloud}-controller-manager controllers using a token for ServiceAccounts in the shoot
 	// To maintain this list for each new Kubernetes version:
-	// * Run hack/compare-kcm-controllers.sh <old-version> <new-version> (e.g. 'hack/compare-kcm-controllers.sh 1.22 1.23').
+	// * Run hack/compare-k8s-controllers.sh <old-version> <new-version> (e.g. 'hack/compare-k8s-controllers.sh 1.22 1.23').
 	//   It will present 2 lists of controllers: those added and those removed in <new-version> compared to <old-version>.
 	// * Double check whether such ServiceAccount indeed appears in the kube-system namespace when creating a cluster
 	//   with <new-version>. Note that it sometimes might be hidden behind a default-off feature gate.

--- a/pkg/operation/botanist/component/shootsystem/shootsystem_test.go
+++ b/pkg/operation/botanist/component/shootsystem/shootsystem_test.go
@@ -138,7 +138,6 @@ metadata:
 			"job-controller",
 			"metadata-informers",
 			"namespace-controller",
-			"node-controller",
 			"persistent-volume-binder",
 			"pod-garbage-collector",
 			"pv-protection-controller",
@@ -147,9 +146,7 @@ metadata:
 			"replication-controller",
 			"resourcequota-controller",
 			"root-ca-cert-publisher",
-			"route-controller",
 			"service-account-controller",
-			"service-controller",
 			"shared-informers",
 			"statefulset-controller",
 			"token-cleaner",
@@ -187,12 +184,28 @@ metadata:
 
 		Context("k8s >= 1.20", func() {
 			BeforeEach(func() {
-				values.KubernetesVersion = semver.MustParse("1.21.4")
+				values.KubernetesVersion = semver.MustParse("1.20.4")
 				component = New(c, namespace, values)
 			})
 
 			It("should successfully deploy all resources", func() {
 				names := append(defaultKCMControllerSANames, "default", "endpointslicemirroring-controller", "ephemeral-volume-controller", "storage-version-garbage-collector")
+
+				Expect(managedResourceSecret.Data).To(HaveLen(len(names)))
+				for _, name := range names {
+					Expect(string(managedResourceSecret.Data["serviceaccount__kube-system__"+name+".yaml"])).To(Equal(serviceAccountYAMLFor(name)))
+				}
+			})
+		})
+
+		Context("k8s >= 1.21", func() {
+			BeforeEach(func() {
+				values.KubernetesVersion = semver.MustParse("1.21.4")
+				component = New(c, namespace, values)
+			})
+
+			It("should successfully deploy all resources", func() {
+				names := append(defaultKCMControllerSANames, "default", "endpointslicemirroring-controller", "ephemeral-volume-controller", "storage-version-garbage-collector", "service-controller", "route-controller", "node-controller")
 
 				Expect(managedResourceSecret.Data).To(HaveLen(len(names)))
 				for _, name := range names {

--- a/pkg/utils/version/version.go
+++ b/pkg/utils/version/version.go
@@ -43,6 +43,8 @@ var (
 	ConstraintK8sLessEqual121 *semver.Constraints
 	// ConstraintK8sEqual121 is a version constraint for versions == 1.21.
 	ConstraintK8sEqual121 *semver.Constraints
+	// ConstraintK8sGreaterEqual121 is a version constraint for versions >= 1.21.
+	ConstraintK8sGreaterEqual121 *semver.Constraints
 	// ConstraintK8sLessEqual122 is a version constraint for versions <= 1.22.
 	ConstraintK8sLessEqual122 *semver.Constraints
 	// ConstraintK8sEqual122 is a version constraint for versions == 1.22.
@@ -75,6 +77,8 @@ func init() {
 	ConstraintK8sLessEqual121, err = semver.NewConstraint("<= 1.21.x")
 	utilruntime.Must(err)
 	ConstraintK8sEqual121, err = semver.NewConstraint("1.21.x")
+	utilruntime.Must(err)
+	ConstraintK8sGreaterEqual121, err = semver.NewConstraint(">= 1.21")
 	utilruntime.Must(err)
 	ConstraintK8sLessEqual122, err = semver.NewConstraint("<= 1.22.x")
 	utilruntime.Must(err)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bug

**What this PR does / why we need it**:
The `cloud-controller-manager` Golang library maintained in https://github.com/kubernetes/kubernetes/tree/master/staging/src/k8s.io/cloud-provider/ was only adapted beginning with Kubernetes 1.21 to not rely on the static `ServiceAccount` secrets anymore. Prior versions still need them, so let's add the `ServiceAccount` names for controllers which are part of `cloud-controller-managers` only for 1.21+.

See https://github.com/kubernetes/kubernetes/pull/99291 for more details.

Initially introduced with #5422 (I've adapted the release note of this PR to reflect this change since it was not yet released and adding a release note to this PR is confusing since both will appear in the release).

**Special notes for your reviewer**:
/invite @plkokanov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
