### PR TITLE
Destroy gardener-resource-manager early in the shoot deletion flow

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_delete.go
@@ -545,6 +545,11 @@ func (r *shootReconciler) runDeleteShootFlow(ctx context.Context, o *operation.O
 			Fn:           flow.TaskFn(botanist.Shoot.Components.ControlPlane.KubeAPIServerService.Destroy).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(deleteKubeAPIServer, destroyKubeAPIServerSNI),
 		})
+		_ = g.Add(flow.Task{
+			Name:         "Destroying gardener-resource-manager",
+			Fn:           flow.TaskFn(botanist.Shoot.Components.ControlPlane.ResourceManager.Destroy),
+			Dependencies: flow.NewTaskIDs(deleteKubeAPIServer),
+		})
 
 		destroyControlPlaneExposure = g.Add(flow.Task{
 			Name:         "Destroying shoot control plane exposure",

--- a/pkg/operation/botanist/controlplane.go
+++ b/pkg/operation/botanist/controlplane.go
@@ -205,7 +205,7 @@ func (b *Botanist) HibernateControlPlane(ctx context.Context) error {
 		}
 
 		// TODO: check if we can remove this mitigation once there is a garbage collection for VolumeAttachments (ref https://github.com/kubernetes/kubernetes/issues/77324)
-		// Currently on hibernation Machines are forecefully deleted and machine-controller-manager does not wait volumes to be detached.
+		// Currently on hibernation Machines are forcefully deleted and machine-controller-manager does not wait volumes to be detached.
 		// In this case kube-controller-manager cannot delete the corresponding VolumeAttachment objects and they are orphaned.
 		// Such orphaned VolumeAttachments then prevent/block PV deletion. For more details see https://github.com/gardener/gardener-extension-provider-gcp/issues/172.
 		// As the Nodes are already deleted, we can delete all VolumeAttachments.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement 

**What this PR does / why we need it**:
Destroy gardener-resource-manager early in the shoot deletion flow.
In the hibernation flow the GRM is already scaled down to 0 replicas, so no changes needed there.

**Which issue(s) this PR fixes**:
Fixes #5464 

**Special notes for your reviewer**:
@plkokanov I will be grateful if you include this in the v1.41 milestone.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `gardener-resource-manager` is now destroyed early in the deletion flow. In this way there will not be a failing deployment with PDB that prevents graceful termination of seed nodes.
```
