### PR TITLE
Add VPA-recommender scrape config to seed-prometheus

### DIFF
--- a/charts/seed-bootstrap/charts/monitoring/templates/config.yaml
+++ b/charts/seed-bootstrap/charts/monitoring/templates/config.yaml
@@ -109,7 +109,7 @@ data:
             - source_labels: [__meta_kubernetes_pod_label_app]
               regex: vpa-recommender
               action: keep
-            - source_labels: [ __meta_kubernetes_service_port_name ]
+            - source_labels: [__meta_kubernetes_pod_container_port_name]
               regex: metrics
               action: keep
             - action: labelmap

--- a/charts/seed-bootstrap/charts/monitoring/templates/config.yaml
+++ b/charts/seed-bootstrap/charts/monitoring/templates/config.yaml
@@ -101,3 +101,23 @@ data:
     - job_name: prometheus
       static_configs:
       - targets: [ localhost:9090 ]
+
+    - job_name: vpa-recommender
+      kubernetes_sd_configs:
+        - role: pod
+          relabel_configs:
+            - source_labels: [__meta_kubernetes_pod_label_app]
+              regex: ^vpa-recommender$
+              action: keep
+            - source_labels: [ __address__ ]
+              action: replace
+              regex: ([^:]+)(?::\d+)?
+              replacement: $1:8942
+              target_label: __address__
+            - action: labelmap
+              regex: __meta_kubernetes_pod_label_(.+)
+            - source_labels: [ __meta_kubernetes_namespace ]
+              target_label: namespace
+            - source_labels: [ __meta_kubernetes_pod_name ]
+              target_label: pod
+

--- a/charts/seed-bootstrap/charts/monitoring/templates/config.yaml
+++ b/charts/seed-bootstrap/charts/monitoring/templates/config.yaml
@@ -107,7 +107,7 @@ data:
         - role: pod
           relabel_configs:
             - source_labels: [__meta_kubernetes_pod_label_app]
-              regex: ^vpa-recommender$
+              regex: vpa-recommender
               action: keep
             - source_labels: [ __address__ ]
               action: replace

--- a/charts/seed-bootstrap/charts/monitoring/templates/config.yaml
+++ b/charts/seed-bootstrap/charts/monitoring/templates/config.yaml
@@ -109,11 +109,9 @@ data:
             - source_labels: [__meta_kubernetes_pod_label_app]
               regex: vpa-recommender
               action: keep
-            - source_labels: [ __address__ ]
-              action: replace
-              regex: ([^:]+)(?::\d+)?
-              replacement: $1:8942
-              target_label: __address__
+            - source_labels: [ __meta_kubernetes_service_port_name ]
+              regex: metrics
+              action: keep
             - action: labelmap
               regex: __meta_kubernetes_pod_label_(.+)
             - source_labels: [ __meta_kubernetes_namespace ]

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-recommender.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-recommender.yaml
@@ -75,6 +75,9 @@ spec:
             memory: 200Mi
         ports:
         - containerPort: 8080
+          name: server
+        - containerPort: 8942
+          name: metrics
 {{- if not .Values.recommender.createServiceAccount }}
       volumes:
       - name: shoot-access


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
Add vpa-recommender scrape config to seed-prometheus-config, such that the metrics provided by the individual `vpa-recommender` pods installed in the soil's seed-namespaces can be scraped.

**Special notes for your reviewer**:
How do I test this works? 
Is this really how you add a statically defined metrics scraping port, or do I still need to annotate this on the pod?

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Add VPA-recommender scrape config to seed-prometheus
```
