### PR TITLE
Add a priority class for istiod and istio-ingressgateway.

### DIFF
--- a/charts/istio/istio-ingress/templates/deployment.yaml
+++ b/charts/istio/istio-ingress/templates/deployment.yaml
@@ -189,6 +189,7 @@ spec:
               path: istio-token
               expirationSeconds: 43200
               audience: istio-ca
+      priorityClassName: {{ .Values.priorityClassName }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/charts/istio/istio-ingress/templates/priorityclass-istioingressgateway.yaml
+++ b/charts/istio/istio-ingress/templates/priorityclass-istioingressgateway.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: {{ include "priorityclassversion" . }}
+kind: PriorityClass
+metadata:
+  name: {{ .Values.priorityClassName }}
+value: 1000000000
+globalDefault: false
+description: "This class is used to ensure that the istio-ingressgateway has a high priority and is not preempted in favor of other pods."

--- a/charts/istio/istio-ingress/values.yaml
+++ b/charts/istio/istio-ingress/values.yaml
@@ -16,3 +16,4 @@ ports: []
 #- name: tcp
 #  port: 8443
 #  targetPort: 8443
+priorityClassName: istio-ingressgateway

--- a/charts/istio/istio-istiod/templates/deployment.yaml
+++ b/charts/istio/istio-istiod/templates/deployment.yaml
@@ -133,6 +133,7 @@ spec:
       - name: config-volume
         configMap:
           name: istio
+      priorityClassName: {{ .Values.priorityClassName }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/charts/istio/istio-istiod/templates/priorityclass-istiod.yaml
+++ b/charts/istio/istio-istiod/templates/priorityclass-istiod.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: {{ include "priorityclassversion" . }}
+kind: PriorityClass
+metadata:
+  name: {{ .Values.priorityClassName }}
+value: 1000000000
+globalDefault: false
+description: "This class is used to ensure that istiod has a high priority and is not preempted in favor of other pods."

--- a/charts/istio/istio-istiod/values.yaml
+++ b/charts/istio/istio-istiod/values.yaml
@@ -6,3 +6,4 @@ labels:
 deployNamespace: false
 ports:
   https: 10250
+priorityClassName: istiod


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Add a priority class for istiod and istio-ingressgateway with the same priority as the reversed-vpn-auth-server.

**Which issue(s) this PR fixes**:
Fixes #5463

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
istiod and istio-ingressgateway do now define a PriorityClass to make sure that they have high priority in the scheduling queue and that they are not preempted (evicted) in favour of other Pods.
```
