### PR TITLE
Return /var/log/journal when /run/log/journal is missing in the Promtail service configuration

### DIFF
--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/promtail/config.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/promtail/config.go
@@ -55,6 +55,8 @@ PERSISTANT_JOURNAL_FILE=/var/log/journal
 TEMP_JOURNAL_FILE=/run/log/journal
 if [ ! -d "$PERSISTANT_JOURNAL_FILE" ] && [ -d "$TEMP_JOURNAL_FILE" ]; then
 	sed -i -e "s|$PERSISTANT_JOURNAL_FILE|$TEMP_JOURNAL_FILE|g" ` + PathConfig + `
+elif  [ ! -d "$TEMP_JOURNAL_FILE" ] && [ -d "$PERSISTANT_JOURNAL_FILE" ]; then
+	sed -i -e "s|$TEMP_JOURNAL_FILE$|$PERSISTANT_JOURNAL_FILE|g" ` + PathConfig + `
 fi`
 
 type config struct {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
On Suse OS  `/var/log/journal` does not exist and it has to be either explicitly set in the [/etc/systemd/journald.config](https://documentation.suse.com/sles/15-SP1/html/SLES-all/cha-journalctl.html#sec-journalctl-persistent) to be used or replaced by the ephemeral `/run/log/journal` in the [promtail configuration](https://github.com/gardener/gardener/blob/133b009743dcdb44a2bc28a6caa306e3fed72929/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/promtail/config.go#L54). In Gardener  the second method is used and when `/var/log/journal` is replaced with `/run/log/journal` in the promtail config there is no logic to return `/var/log/journal` back when `/run/log/journal` is no longer used instead of `/var/log/journal`. With this PR if `/var/log/journal` exists and `/run/log/journal` does not, the promteil systemd service prerun script tries to replace the ephemeral storage with the persistent one. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
When SUSE OS node is restarted and "/run/log/journal" the promtail service continue to read from "/var/log/journal".
```
