### PR TITLE
Properly restore multiple machines if present in the worker state

### DIFF
--- a/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
@@ -143,7 +143,9 @@ func (a *genericActuator) restoreMachineSetsAndMachines(ctx context.Context, log
 			// Calling Update() would include the whole MachineStatus in the request - including fields of type metav1.Time causing the mentioned issues.
 			patch := client.MergeFrom(newMachine.DeepCopy())
 			newMachine.Status.Node = machine.Status.Node
-			return a.client.Status().Patch(ctx, newMachine, patch)
+			if err := a.client.Status().Patch(ctx, newMachine, patch); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/extensions/pkg/controller/worker/genericactuator/actuator_test.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_test.go
@@ -348,8 +348,10 @@ var _ = Describe("Actuator", func() {
 			machineDeployments worker.MachineDeployments
 			expectedMachineSet machinev1alpha1.MachineSet
 			expectedMachine    machinev1alpha1.Machine
+			expectedMachine2   machinev1alpha1.Machine
 
-			machineWithoutNode *machinev1alpha1.Machine
+			machineWithoutNode  *machinev1alpha1.Machine
+			machineWithoutNode2 *machinev1alpha1.Machine
 
 			alreadyExistsError = apierrors.NewAlreadyExists(schema.GroupResource{Resource: "Machines"}, "machine")
 		)
@@ -377,15 +379,26 @@ var _ = Describe("Actuator", func() {
 				},
 			}
 
+			expectedMachine2 = machinev1alpha1.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "machine-two",
+					Namespace: "test-ns",
+				},
+				Status: machinev1alpha1.MachineStatus{
+					Node: "node-name-two",
+				},
+			}
+
 			machineDeployments = worker.MachineDeployments{
 				{
 					State: &worker.MachineDeploymentState{
-						Replicas: 1,
+						Replicas: 2,
 						MachineSets: []machinev1alpha1.MachineSet{
 							expectedMachineSet,
 						},
 						Machines: []machinev1alpha1.Machine{
 							expectedMachine,
+							expectedMachine2,
 						},
 					},
 				},
@@ -393,6 +406,9 @@ var _ = Describe("Actuator", func() {
 
 			machineWithoutNode = expectedMachine.DeepCopy()
 			machineWithoutNode.Status.Node = ""
+
+			machineWithoutNode2 = expectedMachine2.DeepCopy()
+			machineWithoutNode2.Status.Node = ""
 		})
 
 		AfterEach(func() {
@@ -402,8 +418,11 @@ var _ = Describe("Actuator", func() {
 		It("should deploy machinesets and machines present in the machine deployments' state", func() {
 			mockClient.EXPECT().Create(ctx, &expectedMachineSet)
 			mockClient.EXPECT().Create(ctx, machineWithoutNode)
+			mockClient.EXPECT().Create(ctx, machineWithoutNode2)
+			mockClient.EXPECT().Status().Return(mockClient)
 			mockClient.EXPECT().Status().Return(mockClient)
 			test.EXPECTPatch(ctx, mockClient, &expectedMachine, machineWithoutNode, types.MergePatchType)
+			test.EXPECTPatch(ctx, mockClient, &expectedMachine2, machineWithoutNode2, types.MergePatchType)
 
 			Expect(a.restoreMachineSetsAndMachines(ctx, logger, machineDeployments)).To(Succeed())
 		})
@@ -411,9 +430,12 @@ var _ = Describe("Actuator", func() {
 		It("should update the machine status if machineset and machine already exist", func() {
 			mockClient.EXPECT().Create(ctx, &expectedMachineSet).Return(alreadyExistsError)
 			mockClient.EXPECT().Create(ctx, machineWithoutNode).Return(alreadyExistsError)
+			mockClient.EXPECT().Create(ctx, machineWithoutNode2)
 			mockClient.EXPECT().Get(ctx, client.ObjectKeyFromObject(machineWithoutNode), machineWithoutNode)
 			mockClient.EXPECT().Status().Return(mockClient)
+			mockClient.EXPECT().Status().Return(mockClient)
 			test.EXPECTPatch(ctx, mockClient, &expectedMachine, machineWithoutNode, types.MergePatchType)
+			test.EXPECTPatch(ctx, mockClient, &expectedMachine2, machineWithoutNode2, types.MergePatchType)
 
 			Expect(a.restoreMachineSetsAndMachines(ctx, logger, machineDeployments)).To(Succeed())
 		})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind bug

**What this PR does / why we need it**:
This PR fixes an issue where only one of the `Machine` objects would get restored, whereas all the rest would get recreated. This was happening because the loop which was iterating over the machines that should be restored was exiting too early.

**Which issue(s) this PR fixes**:
Fixes #5423 

**Special notes for your reviewer**:
/cc @kris94 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix dependency
Fixes a bug that caused only one `Machine` object to be restored, and all others to be recreated during control plane migration.
```
