### PR TITLE
[release-v1.39] Automated cherry pick of #5471: Properly restore multiple machines if present in the worker state

### DIFF
--- a/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_restore.go
@@ -143,7 +143,9 @@ func (a *genericActuator) restoreMachineSetsAndMachines(ctx context.Context, log
 			// Calling Update() would include the whole MachineStatus in the request - including fields of type metav1.Time causing the mentioned issues.
 			patch := client.MergeFrom(newMachine.DeepCopy())
 			newMachine.Status.Node = machine.Status.Node
-			return a.client.Status().Patch(ctx, newMachine, patch)
+			if err := a.client.Status().Patch(ctx, newMachine, patch); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
/kind/bug
/area/control-plane-migration

Cherry pick of #5471 on release-v1.39.

#5471: Properly restore multiple machines if present in the worker state

**Release Notes:**
```bugfix dependency
Fixes a bug that caused only one `Machine` object to be restored, and all others to be recreated during control plane migration.
```