### PR TITLE
Replace -ginkgo.noColor with -ginkgo.no-color

### DIFF
--- a/.test-defs/CreateManagedSeed.yaml
+++ b/.test-defs/CreateManagedSeed.yaml
@@ -11,7 +11,7 @@ spec:
   args:
   - >-
     go test -timeout=0 -mod=vendor ./test/testmachinery/system/managed_seed_creation
-    --v -ginkgo.v -ginkgo.progress -ginkgo.noColor
+    --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
     -kubecfg="$TM_KUBECONFIG_PATH/gardener.config"
     -managed-seed-name=$MANAGED_SEED_NAME
     -shoot-name=$SHOOT_NAME

--- a/.test-defs/CreateShoot.yaml
+++ b/.test-defs/CreateShoot.yaml
@@ -11,7 +11,7 @@ spec:
   args:
   - >-
     go test -timeout=0 -mod=vendor ./test/testmachinery/system/shoot_creation
-    --v -ginkgo.v -ginkgo.progress -ginkgo.noColor
+    --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
     -verbose=debug
     -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
     -seed-kubecfg-path=$TM_KUBECONFIG_PATH/seed.config

--- a/.test-defs/DeleteManagedSeed.yaml
+++ b/.test-defs/DeleteManagedSeed.yaml
@@ -11,7 +11,7 @@ spec:
   args:
   - >-
     go test -timeout=0 -mod=vendor ./test/testmachinery/system/managed_seed_deletion
-    --v -ginkgo.v -ginkgo.progress -ginkgo.noColor
+    --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
     -kubecfg="$TM_KUBECONFIG_PATH/gardener.config"
     -managed-seed-name=$MANAGED_SEED_NAME
   image: eu.gcr.io/gardener-project/3rd/golang:1.17.7

--- a/.test-defs/DeleteShoot.yaml
+++ b/.test-defs/DeleteShoot.yaml
@@ -11,7 +11,7 @@ spec:
   args:
   - >-
     go test -timeout=0 -mod=vendor ./test/testmachinery/system/shoot_deletion
-    --v -ginkgo.v -ginkgo.progress -ginkgo.noColor
+    --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
     --shoot-name=$SHOOT_NAME
     --project-namespace=$PROJECT_NAMESPACE
     --kubecfg="$TM_KUBECONFIG_PATH/gardener.config"

--- a/.test-defs/GardenletLandscaper.yaml
+++ b/.test-defs/GardenletLandscaper.yaml
@@ -11,7 +11,7 @@ spec:
   args:
   - >-
     go test -timeout=0 -mod=vendor ./test/testmachinery/landscaper/gardenlet
-    --v -ginkgo.v -ginkgo.progress -ginkgo.noColor
+    --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
     -verbose=debug
     -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
     -seed-kubecfg-path=$TM_KUBECONFIG_PATH/seed.config

--- a/.test-defs/HibernateShoot.yaml
+++ b/.test-defs/HibernateShoot.yaml
@@ -11,7 +11,7 @@ spec:
   args:
   - >-
     go test -timeout=0 -mod=vendor ./test/testmachinery/system/shoot_hibernation
-    --v -ginkgo.v -ginkgo.progress -ginkgo.noColor
+    --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
     --shoot-name=$SHOOT_NAME
     --project-namespace=$PROJECT_NAMESPACE
     --kubecfg="$TM_KUBECONFIG_PATH/gardener.config"

--- a/.test-defs/MigrateShoot.yaml
+++ b/.test-defs/MigrateShoot.yaml
@@ -11,7 +11,7 @@ spec:
   args:
   - >-
     go test -timeout=0 -mod=vendor ./test/testmachinery/system/shoot_cp_migration
-    --v -ginkgo.v -ginkgo.progress -ginkgo.noColor
+    --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
     -target-seed-name=$SEED_NAME
     -shoot-name=$SHOOT_NAME
     -shoot-namespace=$PROJECT_NAMESPACE

--- a/.test-defs/ReconcileShoots.yaml
+++ b/.test-defs/ReconcileShoots.yaml
@@ -11,7 +11,7 @@ spec:
   args:
   - >-
     go test -timeout=0 -mod=vendor ./test/testmachinery/system/complete_reconcile
-    --v -ginkgo.v -ginkgo.progress -ginkgo.noColor --verbose=debug
+    --v -ginkgo.v -ginkgo.progress -ginkgo.no-color --verbose=debug
     -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
     -version=$GARDENER_VERSION
 

--- a/.test-defs/ShootKubernetesUpdateTest.yaml
+++ b/.test-defs/ShootKubernetesUpdateTest.yaml
@@ -13,7 +13,7 @@ spec:
   args:
   - >-
     go test -timeout=0 -mod=vendor ./test/testmachinery/system/shoot_update
-    --v -ginkgo.v -ginkgo.progress -ginkgo.noColor -verbose=debug
+    --v -ginkgo.v -ginkgo.progress -ginkgo.no-color -verbose=debug
     -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
     -shoot-name=$SHOOT_NAME
     -project-namespace=$PROJECT_NAMESPACE

--- a/.test-defs/TestSuiteGardenerBeta.yaml
+++ b/.test-defs/TestSuiteGardenerBeta.yaml
@@ -12,7 +12,7 @@ spec:
   args:
     - >-
       go test -timeout=0 -mod=vendor ./test/testmachinery/suites/gardener
-      --v -ginkgo.v -ginkgo.progress -ginkgo.noColor
+      --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
       --report-file=$TM_EXPORT_PATH/report.json
       -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
       -project-namespace=$PROJECT_NAMESPACE

--- a/.test-defs/TestSuiteGardenerBetaSerial.yaml
+++ b/.test-defs/TestSuiteGardenerBetaSerial.yaml
@@ -14,7 +14,7 @@ spec:
   args:
     - >-
       go test -timeout=0 -mod=vendor ./test/testmachinery/suites/gardener
-      --v -ginkgo.v -ginkgo.progress -ginkgo.noColor
+      --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
       --report-file=$TM_EXPORT_PATH/report.json
       -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
       -project-namespace=$PROJECT_NAMESPACE

--- a/.test-defs/TestSuiteGardenerDefault.yaml
+++ b/.test-defs/TestSuiteGardenerDefault.yaml
@@ -12,7 +12,7 @@ spec:
   args:
     - >-
       go test -timeout=0 -mod=vendor ./test/testmachinery/suites/gardener
-      --v -ginkgo.v -ginkgo.progress -ginkgo.noColor
+      --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
       --report-file=$TM_EXPORT_PATH/report.json
       -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
       -project-namespace=$PROJECT_NAMESPACE

--- a/.test-defs/TestSuiteGardenerDefaultSerial.yaml
+++ b/.test-defs/TestSuiteGardenerDefaultSerial.yaml
@@ -14,7 +14,7 @@ spec:
   args:
     - >-
       go test -timeout=0 -mod=vendor ./test/testmachinery/suites/gardener
-      --v -ginkgo.v -ginkgo.progress -ginkgo.noColor
+      --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
       --report-file=$TM_EXPORT_PATH/report.json
       -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
       -project-namespace=$PROJECT_NAMESPACE

--- a/.test-defs/TestSuiteGardenerRelease.yaml
+++ b/.test-defs/TestSuiteGardenerRelease.yaml
@@ -12,7 +12,7 @@ spec:
   args:
     - >-
       go test -timeout=0 -mod=vendor ./test/testmachinery/suites/gardener
-      --v -ginkgo.v -ginkgo.progress -ginkgo.noColor
+      --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
       --report-file=$TM_EXPORT_PATH/report.json
       -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
       -project-namespace=$PROJECT_NAMESPACE

--- a/.test-defs/TestSuiteGardenerReleaseSerial.yaml
+++ b/.test-defs/TestSuiteGardenerReleaseSerial.yaml
@@ -14,7 +14,7 @@ spec:
   args:
     - >-
       go test -timeout=0 -mod=vendor ./test/testmachinery/suites/gardener
-      --v -ginkgo.v -ginkgo.progress -ginkgo.noColor
+      --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
       --report-file=$TM_EXPORT_PATH/report.json
       -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
       -project-namespace=$PROJECT_NAMESPACE

--- a/.test-defs/TestSuiteShootBeta.yaml
+++ b/.test-defs/TestSuiteShootBeta.yaml
@@ -12,7 +12,7 @@ spec:
   args:
     - >-
       go test -timeout=0 -mod=vendor ./test/testmachinery/suites/shoot
-      --v -ginkgo.v -ginkgo.progress -ginkgo.noColor
+      --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
       --report-file=$TM_EXPORT_PATH/report.json
       -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
       -shoot-name=$SHOOT_NAME

--- a/.test-defs/TestSuiteShootBetaDisruptive.yaml
+++ b/.test-defs/TestSuiteShootBetaDisruptive.yaml
@@ -14,7 +14,7 @@ spec:
   args:
     - >-
       go test -timeout=0 -mod=vendor ./test/testmachinery/suites/shoot
-      --v -ginkgo.v -ginkgo.progress -ginkgo.noColor
+      --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
       --report-file=$TM_EXPORT_PATH/report.json
       -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
       -shoot-name=$SHOOT_NAME

--- a/.test-defs/TestSuiteShootBetaSerial.yaml
+++ b/.test-defs/TestSuiteShootBetaSerial.yaml
@@ -14,7 +14,7 @@ spec:
   args:
     - >-
       go test -timeout=0 -mod=vendor ./test/testmachinery/suites/shoot
-      --v -ginkgo.v -ginkgo.progress -ginkgo.noColor
+      --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
       --report-file=$TM_EXPORT_PATH/report.json
       -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
       -shoot-name=$SHOOT_NAME

--- a/.test-defs/TestSuiteShootDefault.yaml
+++ b/.test-defs/TestSuiteShootDefault.yaml
@@ -12,7 +12,7 @@ spec:
   args:
     - >-
       go test -timeout=0 -mod=vendor ./test/testmachinery/suites/shoot
-      --v -ginkgo.v -ginkgo.progress -ginkgo.noColor
+      --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
       --report-file=$TM_EXPORT_PATH/report.json
       -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
       -shoot-name=$SHOOT_NAME

--- a/.test-defs/TestSuiteShootDefaultDisruptive.yaml
+++ b/.test-defs/TestSuiteShootDefaultDisruptive.yaml
@@ -14,7 +14,7 @@ spec:
   args:
     - >-
       go test -timeout=0 -mod=vendor ./test/testmachinery/suites/shoot
-      --v -ginkgo.v -ginkgo.progress -ginkgo.noColor
+      --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
       --report-file=$TM_EXPORT_PATH/report.json
       -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
       -shoot-name=$SHOOT_NAME

--- a/.test-defs/TestSuiteShootDefaultSerial.yaml
+++ b/.test-defs/TestSuiteShootDefaultSerial.yaml
@@ -14,7 +14,7 @@ spec:
   args:
     - >-
       go test -timeout=0 -mod=vendor ./test/testmachinery/suites/shoot
-      --v -ginkgo.v -ginkgo.progress -ginkgo.noColor
+      --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
       --report-file=$TM_EXPORT_PATH/report.json
       -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
       -shoot-name=$SHOOT_NAME

--- a/.test-defs/TestSuiteShootRelease.yaml
+++ b/.test-defs/TestSuiteShootRelease.yaml
@@ -12,7 +12,7 @@ spec:
   args:
     - >-
       go test -timeout=0 -mod=vendor ./test/testmachinery/suites/shoot
-      --v -ginkgo.v -ginkgo.progress -ginkgo.noColor
+      --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
       --report-file=$TM_EXPORT_PATH/report.json
       -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
       -shoot-name=$SHOOT_NAME

--- a/.test-defs/TestSuiteShootReleaseDisruptive.yaml
+++ b/.test-defs/TestSuiteShootReleaseDisruptive.yaml
@@ -14,7 +14,7 @@ spec:
   args:
     - >-
       go test -timeout=0 -mod=vendor ./test/testmachinery/suites/shoot
-      --v -ginkgo.v -ginkgo.progress -ginkgo.noColor
+      --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
       --report-file=$TM_EXPORT_PATH/report.json
       -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
       -shoot-name=$SHOOT_NAME

--- a/.test-defs/TestSuiteShootReleaseSerial.yaml
+++ b/.test-defs/TestSuiteShootReleaseSerial.yaml
@@ -14,7 +14,7 @@ spec:
   args:
     - >-
       go test -timeout=0 -mod=vendor ./test/testmachinery/suites/shoot
-      --v -ginkgo.v -ginkgo.progress -ginkgo.noColor
+      --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
       --report-file=$TM_EXPORT_PATH/report.json
       -kubecfg=$TM_KUBECONFIG_PATH/gardener.config
       -shoot-name=$SHOOT_NAME

--- a/.test-defs/WakeUpShoot.yaml
+++ b/.test-defs/WakeUpShoot.yaml
@@ -11,7 +11,7 @@ spec:
   args:
   - >-
     go test -timeout=0 -mod=vendor ./test/testmachinery/system/shoot_hibernation_wakeup
-    --v -ginkgo.v -ginkgo.progress -ginkgo.noColor
+    --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
     --shoot-name=$SHOOT_NAME
     --project-namespace=$PROJECT_NAMESPACE
     --kubecfg="$TM_KUBECONFIG_PATH/gardener.config"

--- a/docs/development/testmachinery_tests.md
+++ b/docs/development/testmachinery_tests.md
@@ -68,7 +68,7 @@ A suite can be executed by running the suite definition with ginkgo's `focus` an
 to control the execution of specific labeled test. See example below:
 ```console
 go test -timeout=0 -mod=vendor ./test/testmachinery/suites/shoot \
-      --v -ginkgo.v -ginkgo.progress -ginkgo.noColor \
+      --v -ginkgo.v -ginkgo.progress -ginkgo.no-color \
       --report-file=/tmp/report.json \                     # write elasticsearch formatted output to a file
       --disable-dump=false \                               # disables dumping of teh current state if a test fails
       -kubecfg=/path/to/gardener/kubeconfig \
@@ -100,7 +100,7 @@ The newly created test can be tested by focusing the test with the default ginkg
 and run the shoot test suite with:
 ```
 go test -timeout=0 -mod=vendor ./test/testmachinery/suites/shoot \
-      --v -ginkgo.v -ginkgo.progress -ginkgo.noColor \
+      --v -ginkgo.v -ginkgo.progress -ginkgo.no-color \
       --report-file=/tmp/report.json \                     # write elasticsearch formatted output to a file
       --disable-dump=false \                               # disables dumping of the current state if a test fails
       -kubecfg=/path/to/gardener/kubeconfig \
@@ -111,7 +111,7 @@ go test -timeout=0 -mod=vendor ./test/testmachinery/suites/shoot \
 or for the gardener suite with:
 ```
 go test -timeout=0 -mod=vendor ./test/testmachinery/suites/gardener \
-      --v -ginkgo.v -ginkgo.progress -ginkgo.noColor \
+      --v -ginkgo.v -ginkgo.progress -ginkgo.no-color \
       --report-file=/tmp/report.json \                     # write elasticsearch formatted output to a file
       --disable-dump=false \                               # disables dumping of the current state if a test fails
       -kubecfg=/path/to/gardener/kubeconfig \
@@ -123,7 +123,7 @@ go test -timeout=0 -mod=vendor ./test/testmachinery/suites/gardener \
 Alternatively, a test can be triggered by specifying a ginkgo focus regex with the name of the test e.g.
 ```
 go test -timeout=0 -mod=vendor ./test/testmachinery/suites/gardener \
-      --v -ginkgo.v -ginkgo.progress -ginkgo.noColor \
+      --v -ginkgo.v -ginkgo.progress -ginkgo.no-color \
       --report-file=/tmp/report.json \                     # write elasticsearch formatted output to a file
       -kubecfg=/path/to/gardener/kubeconfig \
       -project-namespace=<gardener project namespace> \

--- a/docs/proposals/09-test-framework.md
+++ b/docs/proposals/09-test-framework.md
@@ -59,7 +59,7 @@ spec:
   args:
   - >-
     go test -timeout=0 -mod=vendor ./test/integration/suite
-    --v -ginkgo.v -ginkgo.progress -ginkgo.noColor
+    --v -ginkgo.v -ginkgo.progress -ginkgo.no-color
     -ginkgo.focus="[GARDENER] [BETA]"
 ```
 Using this approach, the overall number of testsuites is then reduced to a fixed number (excluding the system steps) of `test suites * labelCombinations`.


### PR DESCRIPTION
/area testing
/kind cleanup


Current test runs yield the following deprecation notice:
```
You're using deprecated Ginkgo functionality:
=============================================
  --ginkgo.noColor is deprecated, use --ginkgo.no-color instead
  Learn more at: https://onsi.github.io/ginkgo/MIGRATING_TO_V2#changed-command-line-flags
```

Part of https://github.com/gardener/gardener/issues/5311

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
