### PR TITLE
Add `jitterUpdates` field to managed seed controller configuration.

### DIFF
--- a/charts/gardener/gardenlet/charts/runtime/templates/configmap-componentconfig.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/configmap-componentconfig.yaml
@@ -143,6 +143,9 @@ data:
         {{- if .Values.global.gardenlet.config.controllers.managedSeed.syncJitterPeriod }}
         syncJitterPeriod: {{ .Values.global.gardenlet.config.controllers.managedSeed.syncJitterPeriod }}
         {{- end }}
+        {{- if .Values.global.gardenlet.config.controllers.managedSeed.jitterUpdates }}
+        jitterUpdates: {{ .Values.global.gardenlet.config.controllers.managedSeed.jitterUpdates }}
+        {{- end }}
       {{- end }}
       shootMigration:
         concurrentSyncs: {{ required ".Values.global.gardenlet.config.controllers.shootMigration.concurrentSyncs is required" .Values.global.gardenlet.config.controllers.shootMigration.concurrentSyncs }}

--- a/charts/gardener/gardenlet/values.yaml
+++ b/charts/gardener/gardenlet/values.yaml
@@ -110,6 +110,7 @@ global:
           syncPeriod: 1h
           waitSyncPeriod: 15s
           syncJitterPeriod: 5m
+          jitterUpdates: false
         shootMigration:
           concurrentSyncs: 5
           syncPeriod: 1m

--- a/landscaper/pkg/gardenlet/chart/charttest/charttest.go
+++ b/landscaper/pkg/gardenlet/chart/charttest/charttest.go
@@ -684,6 +684,7 @@ func ComputeExpectedGardenletConfiguration(
 			},
 			ManagedSeed: &gardenletconfigv1alpha1.ManagedSeedControllerConfiguration{
 				ConcurrentSyncs: &five,
+				JitterUpdates:   pointer.Bool(false),
 				SyncPeriod: &metav1.Duration{
 					Duration: 1 * time.Hour,
 				},

--- a/landscaper/pkg/gardenlet/generate/openapi/openapi_generated.go
+++ b/landscaper/pkg/gardenlet/generate/openapi/openapi_generated.go
@@ -2942,7 +2942,7 @@ func schema_gardenlet_apis_config_v1alpha1_ManagedSeedControllerConfiguration(re
 					},
 					"jitterUpdates": {
 						SchemaProps: spec.SchemaProps{
-							Description: "JitterUpdates is a bool which when enabled enqueues managed seeds with random duration if there is a change in observed generation(spec change).",
+							Description: "JitterUpdates enables enqueuing managed seeds with a random duration(jitter) in case of an update to the spec. The applied jitterPeriod is taken from SyncJitterPeriod.",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},

--- a/landscaper/pkg/gardenlet/generate/openapi/openapi_generated.go
+++ b/landscaper/pkg/gardenlet/generate/openapi/openapi_generated.go
@@ -2940,6 +2940,13 @@ func schema_gardenlet_apis_config_v1alpha1_ManagedSeedControllerConfiguration(re
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
 						},
 					},
+					"jitterUpdates": {
+						SchemaProps: spec.SchemaProps{
+							Description: "JitterUpdates is a bool which when enabled enqueues managed seeds with random duration if there is a change in observed generation(spec change).",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/pkg/gardenlet/apis/config/types.go
+++ b/pkg/gardenlet/apis/config/types.go
@@ -330,8 +330,8 @@ type ManagedSeedControllerConfiguration struct {
 	// If its value is greater than 0 then the managed seeds will not be enqueued immediately but only after a random
 	// duration between 0 and the configured value. It is defaulted to 5m.
 	SyncJitterPeriod *metav1.Duration
-	// JitterUpdates is a bool which when enabled enqueues managed seeds with random duration if there is a change in
-	// observed generation(spec change).
+	// JitterUpdates enables enqueuing managed seeds with a random duration(jitter) in case of an update to the spec.
+	// The applied jitterPeriod is taken from SyncJitterPeriod.
 	// Defaults to false.
 	JitterUpdates *bool
 }

--- a/pkg/gardenlet/apis/config/types.go
+++ b/pkg/gardenlet/apis/config/types.go
@@ -330,6 +330,10 @@ type ManagedSeedControllerConfiguration struct {
 	// If its value is greater than 0 then the managed seeds will not be enqueued immediately but only after a random
 	// duration between 0 and the configured value. It is defaulted to 5m.
 	SyncJitterPeriod *metav1.Duration
+	// JitterUpdates is a bool which when enabled enqueues managed seeds with random duration if there is a change in
+	// observed generation(spec change).
+	// Defaults to false.
+	JitterUpdates *bool
 }
 
 // ResourcesConfiguration defines the total capacity for seed resources and the amount reserved for use by Gardener.

--- a/pkg/gardenlet/apis/config/v1alpha1/defaults.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/defaults.go
@@ -408,6 +408,11 @@ func SetDefaults_ManagedSeedControllerConfiguration(obj *ManagedSeedControllerCo
 		v := metav1.Duration{Duration: 5 * time.Minute}
 		obj.SyncJitterPeriod = &v
 	}
+
+	if obj.JitterUpdates == nil {
+		falseVar := false
+		obj.JitterUpdates = &falseVar
+	}
 }
 
 // SetDefaults_SNI sets defaults for SNI.

--- a/pkg/gardenlet/apis/config/v1alpha1/defaults.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/defaults.go
@@ -410,8 +410,7 @@ func SetDefaults_ManagedSeedControllerConfiguration(obj *ManagedSeedControllerCo
 	}
 
 	if obj.JitterUpdates == nil {
-		falseVar := false
-		obj.JitterUpdates = &falseVar
+		obj.JitterUpdates = pointer.Bool(false)
 	}
 }
 

--- a/pkg/gardenlet/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/defaults_test.go
@@ -183,6 +183,7 @@ var _ = Describe("Defaults", func() {
 			Expect(obj.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: 1 * time.Hour})))
 			Expect(obj.WaitSyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: 15 * time.Second})))
 			Expect(obj.SyncJitterPeriod).To(PointTo(Equal(metav1.Duration{Duration: 5 * time.Minute})))
+			Expect(obj.JitterUpdates).To(PointTo(Equal(false)))
 		})
 	})
 

--- a/pkg/gardenlet/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/defaults_test.go
@@ -183,7 +183,7 @@ var _ = Describe("Defaults", func() {
 			Expect(obj.SyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: 1 * time.Hour})))
 			Expect(obj.WaitSyncPeriod).To(PointTo(Equal(metav1.Duration{Duration: 15 * time.Second})))
 			Expect(obj.SyncJitterPeriod).To(PointTo(Equal(metav1.Duration{Duration: 5 * time.Minute})))
-			Expect(obj.JitterUpdates).To(PointTo(Equal(false)))
+			Expect(obj.JitterUpdates).To(PointTo(BeFalse()))
 		})
 	})
 

--- a/pkg/gardenlet/apis/config/v1alpha1/types.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/types.go
@@ -408,8 +408,8 @@ type ManagedSeedControllerConfiguration struct {
 	// duration between 0 and the configured value. It is defaulted to 5m.
 	// +optional
 	SyncJitterPeriod *metav1.Duration `json:"syncJitterPeriod,omitempty"`
-	// JitterUpdates is a bool which when enabled enqueues managed seeds with random duration if there is a change in
-	// observed generation(spec change).
+	// JitterUpdates enables enqueuing managed seeds with a random duration(jitter) in case of an update to the spec.
+	// The applied jitterPeriod is taken from SyncJitterPeriod.
 	// +optional
 	JitterUpdates *bool `json:"jitterUpdates,omitempty"`
 }

--- a/pkg/gardenlet/apis/config/v1alpha1/types.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/types.go
@@ -408,6 +408,10 @@ type ManagedSeedControllerConfiguration struct {
 	// duration between 0 and the configured value. It is defaulted to 5m.
 	// +optional
 	SyncJitterPeriod *metav1.Duration `json:"syncJitterPeriod,omitempty"`
+	// JitterUpdates is a bool which when enabled enqueues managed seeds with random duration if there is a change in
+	// observed generation(spec change).
+	// +optional
+	JitterUpdates *bool `json:"jitterUpdates,omitempty"`
 }
 
 // ResourcesConfiguration defines the total capacity for seed resources and the amount reserved for use by Gardener.

--- a/pkg/gardenlet/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/zz_generated.conversion.go
@@ -1209,6 +1209,7 @@ func autoConvert_v1alpha1_ManagedSeedControllerConfiguration_To_config_ManagedSe
 	out.SyncPeriod = (*v1.Duration)(unsafe.Pointer(in.SyncPeriod))
 	out.WaitSyncPeriod = (*v1.Duration)(unsafe.Pointer(in.WaitSyncPeriod))
 	out.SyncJitterPeriod = (*v1.Duration)(unsafe.Pointer(in.SyncJitterPeriod))
+	out.JitterUpdates = (*bool)(unsafe.Pointer(in.JitterUpdates))
 	return nil
 }
 
@@ -1222,6 +1223,7 @@ func autoConvert_config_ManagedSeedControllerConfiguration_To_v1alpha1_ManagedSe
 	out.SyncPeriod = (*v1.Duration)(unsafe.Pointer(in.SyncPeriod))
 	out.WaitSyncPeriod = (*v1.Duration)(unsafe.Pointer(in.WaitSyncPeriod))
 	out.SyncJitterPeriod = (*v1.Duration)(unsafe.Pointer(in.SyncJitterPeriod))
+	out.JitterUpdates = (*bool)(unsafe.Pointer(in.JitterUpdates))
 	return nil
 }
 

--- a/pkg/gardenlet/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -779,6 +779,11 @@ func (in *ManagedSeedControllerConfiguration) DeepCopyInto(out *ManagedSeedContr
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.JitterUpdates != nil {
+		in, out := &in.JitterUpdates, &out.JitterUpdates
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/gardenlet/apis/config/zz_generated.deepcopy.go
+++ b/pkg/gardenlet/apis/config/zz_generated.deepcopy.go
@@ -779,6 +779,11 @@ func (in *ManagedSeedControllerConfiguration) DeepCopyInto(out *ManagedSeedContr
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.JitterUpdates != nil {
+		in, out := &in.JitterUpdates, &out.JitterUpdates
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/gardenlet/controller/managedseed/managedseed_controller.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_controller.go
@@ -44,7 +44,7 @@ func (c *Controller) managedSeedAdd(obj interface{}) {
 
 	if generationChanged {
 		if jitterUpdates {
-			enqueueWithJitterDelay(c, key)
+			c.enqueueWithJitterDelay(key)
 		} else {
 			c.logger.Debugf("Added ManagedSeed %s without delay to the queue", key)
 			c.managedSeedQueue.Add(key)
@@ -53,7 +53,7 @@ func (c *Controller) managedSeedAdd(obj interface{}) {
 		// Spread reconciliation of managed seeds (including gardenlet updates/rollouts) across the configured sync jitter
 		// period to avoid overloading the gardener-apiserver if all gardenlets in all managed seeds are (re)starting
 		// roughly at the same time
-		enqueueWithJitterDelay(c, key)
+		c.enqueueWithJitterDelay(key)
 	}
 }
 
@@ -86,7 +86,7 @@ func (c *Controller) managedSeedDelete(obj interface{}) {
 	c.managedSeedQueue.Add(key)
 }
 
-func enqueueWithJitterDelay(c *Controller, key string) {
+func (c *Controller) enqueueWithJitterDelay(key string) {
 	duration := utils.RandomDurationWithMetaDuration(c.config.Controllers.ManagedSeed.SyncJitterPeriod)
 	c.logger.Infof("Added ManagedSeed %s with delay %s to the queue", key, duration)
 	c.managedSeedQueue.AddAfter(key, duration)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability robustness
/kind enhancement

**What this PR does / why we need it**:
Adds a boolean field `jitterUpdates` to managed seed controller configuration, which when enabled enqueues managed seed object with random duration when there is a change in `Generation` (spec change). 
**Which issue(s) this PR fixes**:
Fixes [#4723](https://github.com/gardener/gardener/issues/4723)

**Special notes for your reviewer**:
Default value of `jitterUpdates` field is set to be false.
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
ManagedSeeds can now specify whether updates to the ManagedSeed spec are applied with a jitter. It can configured via the flag `jitterUpdates` in the managed seed controller configuration.
```
