### PR TITLE
[release-v1.40] Automated cherry pick of #5482: Set ingress DNSRecord component values even if the addon is disabled

### DIFF
--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -148,7 +148,8 @@ func (b *Botanist) DefaultIngressDNSRecord() extensionsdnsrecord.Interface {
 		Namespace:  b.Shoot.SeedNamespace,
 		TTL:        b.Config.Controllers.Shoot.DNSEntryTTLSeconds,
 	}
-	if b.NeedsIngressDNS() {
+	// Set component values even if the nginx-ingress addons is not enabled.
+	if b.NeedsExternalDNS() {
 		values.Type = b.Shoot.ExternalDomain.Provider
 		if b.Shoot.ExternalDomain.Zone != "" {
 			values.Zone = &b.Shoot.ExternalDomain.Zone

--- a/pkg/operation/botanist/addons_test.go
+++ b/pkg/operation/botanist/addons_test.go
@@ -260,6 +260,52 @@ var _ = Describe("addons", func() {
 	})
 
 	Context("DefaultIngressDNSRecord", func() {
+		It("should create a component with correct values when nginx-ingress addon is enabled", func() {
+			c := b.DefaultIngressDNSRecord()
+			c.SetRecordType(extensionsv1alpha1.DNSRecordTypeA)
+			c.SetValues([]string{address})
+
+			actual := c.GetValues()
+			Expect(actual).To(DeepEqual(&dnsrecord.Values{
+				Name:       b.Shoot.GetInfo().Name + "-" + common.ShootDNSIngressName,
+				SecretName: DNSRecordSecretPrefix + "-" + b.Shoot.GetInfo().Name + "-" + v1beta1constants.DNSRecordExternalName,
+				Namespace:  seedNamespace,
+				TTL:        pointer.Int64(ttl),
+				Type:       externalProvider,
+				Zone:       pointer.String(externalZone),
+				SecretData: map[string][]byte{
+					"external-foo": []byte("external-bar"),
+				},
+				DNSName:    "*.ingress." + externalDomain,
+				RecordType: extensionsv1alpha1.DNSRecordTypeA,
+				Values:     []string{address},
+			}))
+		})
+
+		It("should create a component with correct values when nginx-ingress addon is disabled", func() {
+			b.Shoot.GetInfo().Spec.Addons.NginxIngress.Enabled = false
+
+			c := b.DefaultIngressDNSRecord()
+			c.SetRecordType(extensionsv1alpha1.DNSRecordTypeA)
+			c.SetValues([]string{address})
+
+			actual := c.GetValues()
+			Expect(actual).To(DeepEqual(&dnsrecord.Values{
+				Name:       b.Shoot.GetInfo().Name + "-" + common.ShootDNSIngressName,
+				SecretName: DNSRecordSecretPrefix + "-" + b.Shoot.GetInfo().Name + "-" + v1beta1constants.DNSRecordExternalName,
+				Namespace:  seedNamespace,
+				TTL:        pointer.Int64(ttl),
+				Type:       externalProvider,
+				Zone:       pointer.String(externalZone),
+				SecretData: map[string][]byte{
+					"external-foo": []byte("external-bar"),
+				},
+				DNSName:    "*.ingress." + externalDomain,
+				RecordType: extensionsv1alpha1.DNSRecordTypeA,
+				Values:     []string{address},
+			}))
+		})
+
 		It("should create a component that creates the DNSRecord and its secret on Deploy", func() {
 			c := b.DefaultIngressDNSRecord()
 			c.SetRecordType(extensionsv1alpha1.DNSRecordTypeA)

--- a/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord.go
+++ b/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord.go
@@ -52,6 +52,7 @@ var TimeNow = time.Now
 // Interface is an interface for managing DNSRecords
 type Interface interface {
 	component.DeployMigrateWaiter
+	GetValues() *Values
 	SetRecordType(extensionsv1alpha1.DNSRecordType)
 	SetValues([]string)
 }
@@ -276,6 +277,11 @@ func (c *dnsRecord) WaitCleanup(ctx context.Context) error {
 		c.waitInterval,
 		c.waitTimeout,
 	)
+}
+
+// GetValues returns the current configuration values of the deployer.
+func (c *dnsRecord) GetValues() *Values {
+	return c.values
 }
 
 // SetRecordType sets the record type in the values.

--- a/pkg/operation/botanist/component/extensions/dnsrecord/mock/mocks.go
+++ b/pkg/operation/botanist/component/extensions/dnsrecord/mock/mocks.go
@@ -10,6 +10,7 @@ import (
 
 	v1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	v1alpha10 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	dnsrecord "github.com/gardener/gardener/pkg/operation/botanist/component/extensions/dnsrecord"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -62,6 +63,20 @@ func (m *MockInterface) Destroy(arg0 context.Context) error {
 func (mr *MockInterfaceMockRecorder) Destroy(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Destroy", reflect.TypeOf((*MockInterface)(nil).Destroy), arg0)
+}
+
+// GetValues mocks base method.
+func (m *MockInterface) GetValues() *dnsrecord.Values {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetValues")
+	ret0, _ := ret[0].(*dnsrecord.Values)
+	return ret0
+}
+
+// GetValues indicates an expected call of GetValues.
+func (mr *MockInterfaceMockRecorder) GetValues() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetValues", reflect.TypeOf((*MockInterface)(nil).GetValues))
 }
 
 // Migrate mocks base method.

--- a/pkg/operation/botanist/dnsrecord_test.go
+++ b/pkg/operation/botanist/dnsrecord_test.go
@@ -174,6 +174,28 @@ var _ = Describe("dnsrecord", func() {
 	})
 
 	Context("DefaultExternalDNSRecord", func() {
+		It("should create a component with correct values", func() {
+			r := b.DefaultExternalDNSRecord()
+			r.SetRecordType(extensionsv1alpha1.DNSRecordTypeA)
+			r.SetValues([]string{address})
+
+			actual := r.GetValues()
+			Expect(actual).To(DeepEqual(&dnsrecord.Values{
+				Name:       b.Shoot.GetInfo().Name + "-" + v1beta1constants.DNSRecordExternalName,
+				SecretName: DNSRecordSecretPrefix + "-" + b.Shoot.GetInfo().Name + "-" + v1beta1constants.DNSRecordExternalName,
+				Namespace:  seedNamespace,
+				TTL:        pointer.Int64(ttl),
+				Type:       externalProvider,
+				Zone:       pointer.String(externalZone),
+				SecretData: map[string][]byte{
+					"external-foo": []byte("external-bar"),
+				},
+				DNSName:    "api." + externalDomain,
+				RecordType: extensionsv1alpha1.DNSRecordTypeA,
+				Values:     []string{address},
+			}))
+		})
+
 		It("should create a component that creates the DNSRecord and its secret on Deploy", func() {
 			r := b.DefaultExternalDNSRecord()
 			r.SetRecordType(extensionsv1alpha1.DNSRecordTypeA)
@@ -236,6 +258,28 @@ var _ = Describe("dnsrecord", func() {
 	})
 
 	Context("DefaultInternalDNSRecord", func() {
+		It("should create a component with correct values", func() {
+			c := b.DefaultInternalDNSRecord()
+			c.SetRecordType(extensionsv1alpha1.DNSRecordTypeA)
+			c.SetValues([]string{address})
+
+			actual := c.GetValues()
+			Expect(actual).To(DeepEqual(&dnsrecord.Values{
+				Name:       b.Shoot.GetInfo().Name + "-" + v1beta1constants.DNSRecordInternalName,
+				SecretName: DNSRecordSecretPrefix + "-" + b.Shoot.GetInfo().Name + "-" + v1beta1constants.DNSRecordInternalName,
+				Namespace:  seedNamespace,
+				TTL:        pointer.Int64(ttl),
+				Type:       internalProvider,
+				Zone:       pointer.String(internalZone),
+				SecretData: map[string][]byte{
+					"internal-foo": []byte("internal-bar"),
+				},
+				DNSName:    "api." + internalDomain,
+				RecordType: extensionsv1alpha1.DNSRecordTypeA,
+				Values:     []string{address},
+			}))
+		})
+
 		It("should create a component that creates the DNSRecord and its secret on Deploy", func() {
 			r := b.DefaultInternalDNSRecord()
 			r.SetRecordType(extensionsv1alpha1.DNSRecordTypeA)


### PR DESCRIPTION
/kind/bug
/area/quality

Cherry pick of #5482 on release-v1.40.

#5482: Set ingress DNSRecord component values even if the addon is disabled

**Release Notes:**
```bugfix operator
An issue preventing the nginx-ingress addon to be disabled is now fixed.
```