### PR TITLE
Clean up Secrets related to the old logging stack

### DIFF
--- a/pkg/operation/botanist/logging.go
+++ b/pkg/operation/botanist/logging.go
@@ -114,13 +114,17 @@ func (b *Botanist) DeploySeedLogging(ctx context.Context) error {
 		return err
 	}
 
-	// TODO(rfranzke): Remove in a future release.
+	// TODO(ialidzhikov): Remove in a future release.
 	return kutil.DeleteObjects(ctx, b.K8sSeedClient.Client(),
-		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: b.Shoot.SeedNamespace, Name: "loki-config"}},
-		&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: b.Shoot.SeedNamespace, Name: "telegraf-config"}},
-		// Follow-up of https://github.com/gardener/gardener/pull/5010 (loki `ServiceAccount` got removed and was never
-		// used.
+		// Follow-up of https://github.com/gardener/gardener/pull/5010 (loki ServiceAccount got removed and was never
+		// used).
 		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Namespace: b.Shoot.SeedNamespace, Name: "loki"}},
+		// Follow-up of https://github.com/gardener/gardener/pull/2515 (Secrets related to the old logging stack were
+		// not deleted).
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: b.Shoot.SeedNamespace, Name: "kibana-tls"}},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: b.Shoot.SeedNamespace, Name: "curator-sg-credentials"}},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: b.Shoot.SeedNamespace, Name: "sg-admin-client"}},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: b.Shoot.SeedNamespace, Name: "admin-sg-credentials"}},
 	)
 }
 

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -517,10 +517,16 @@ func RunReconcileSeedFlow(
 
 	lokiValues["enabled"] = loggingEnabled
 
-	// Follow-up of https://github.com/gardener/gardener/pull/5010 (loki `ServiceAccount` got removed and was never
-	// used.
-	// TODO(rfranzke): Delete this in a future release.
-	if err := seedClient.Delete(ctx, &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "loki", Namespace: v1beta1constants.GardenNamespace}}); client.IgnoreNotFound(err) != nil {
+	// TODO(ialidzhikov): Remove in a future release.
+	if err := kutil.DeleteObjects(ctx, seedClient,
+		// Follow-up of https://github.com/gardener/gardener/pull/5010 (loki ServiceAccount got removed and was never
+		// used).
+		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Namespace: v1beta1constants.GardenNamespace, Name: "loki"}},
+		// Follow-up of https://github.com/gardener/gardener/pull/2515 (Secrets related to the old logging stack were
+		// not deleted).
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: v1beta1constants.GardenNamespace, Name: "kibana-tls"}},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: v1beta1constants.GardenNamespace, Name: "fluentd-es-sg-credentials"}},
+	); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
/area logging
/kind cleanup

It seems that with https://github.com/gardener/gardener/pull/2515 the following logging related Secrets were not deleted:
- in the Shoot ns -> `kibana-tls`, `curator-sg-credentials`, `sg-admin-client`, `admin-sg-credentials`
- in the garden ns -> `kibana-tls`, `fluentd-es-sg-credentials`

```
$ k get secrets -A --no-headers --field-selector=metadata.name=kibana-tls | wc -l
27
$ k get secrets -A --no-headers --field-selector=metadata.name=curator-sg-credentials | wc -l
26
$ k get secrets -A --no-headers --field-selector=metadata.name=sg-admin-client | wc -l
26
$ k get secrets -A --no-headers --field-selector=metadata.name=admin-sg-credentials | wc -l
26
$ k get secrets -A --no-headers --field-selector=metadata.name=fluentd-es-sg-credentials | wc -l
1
```

This PR also removes the clean up logic for `loki-config` and `telegraf-config` ConfigMaps from https://github.com/gardener/gardener/pull/4904 (the logic was present since v1.35.0).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
