### PR TITLE
gardener-controller-manager: Enable SecretBinding provider controller

### DIFF
--- a/docs/deployment/secret_binding_provider_controller.md
+++ b/docs/deployment/secret_binding_provider_controller.md
@@ -20,3 +20,8 @@ A Gardener landscape operator can follow the following steps:
 
    The `SecretBindingProviderValidation` feature gate of Gardener API server enables set of validations for the SecretBinding provider field. It forbids creating a Shoot that has a different provider type from the referenced SecretBinding's one. It also enforces immutability on the field.
    After making sure that SecretBinding provider controller is enabled and it populated the `.provider.type` field of a majority of the SecretBindings on a Gardener landscape (the SecretBindings that are unused will have their provider type unset), a Gardener landscape operator has to disable the SecretBinding provider controller and to enable the `SecretBindingProviderValidation` feature gate of Gardener API server. To disable the SecretBinding provider controller, in the ControllerManagerConfiguration set the `controller.secretBindingProvider.concurentSyncs` field to `0`.
+
+## Implementation History
+
+- Gardener v1.38: SecretBinding resource has a new optional field `.provider.type`. SecretBinding provider controller is disabled by default. `SecretBindingProviderValidation` feature gate of Gardener API server is disabled by default.
+- Gardener v1.42: SecretBinding provider controller is enabled by default.

--- a/example/20-componentconfig-gardener-controller-manager.yaml
+++ b/example/20-componentconfig-gardener-controller-manager.yaml
@@ -14,7 +14,7 @@ controllers:
   secretBinding:
     concurrentSyncs: 5
   secretBindingProvider:
-    concurrentSyncs: 0
+    concurrentSyncs: 5
   seed:
     concurrentSyncs: 5
     syncPeriod: 30s

--- a/pkg/controllermanager/apis/config/v1alpha1/defaults.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/defaults.go
@@ -126,10 +126,7 @@ func SetDefaults_ControllerManagerConfiguration(obj *ControllerManagerConfigurat
 
 	if obj.Controllers.SecretBindingProvider == nil {
 		obj.Controllers.SecretBindingProvider = &SecretBindingProviderControllerConfiguration{
-			// The SecretBinding provider controller is disabled by default as it is considered alpha.
-			//
-			// TODO (ialidzhikov): Enable the controller by default.
-			ConcurrentSyncs: 0,
+			ConcurrentSyncs: 5,
 		}
 	}
 

--- a/pkg/controllermanager/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/defaults_test.go
@@ -77,6 +77,8 @@ var _ = Describe("Defaults", func() {
 
 			Expect(obj.Controllers.SecretBinding).NotTo(BeNil())
 			Expect(obj.Controllers.SecretBinding.ConcurrentSyncs).To(Equal(5))
+			Expect(obj.Controllers.SecretBindingProvider).NotTo(BeNil())
+			Expect(obj.Controllers.SecretBindingProvider.ConcurrentSyncs).To(Equal(5))
 
 			Expect(obj.Controllers.Seed).NotTo(BeNil())
 			Expect(obj.Controllers.Seed.ConcurrentSyncs).To(Equal(5))


### PR DESCRIPTION
/area control-plane
/kind enhancement

Part of https://github.com/gardener/gardener/issues/4888

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
gardener-controller-manager's SecretBinding provider controller is now enabled by default.
```
