### PR TITLE
Delete deprecated error code `ERR_INFRA_INSUFFICIENT_PRIVILEGES`

### DIFF
--- a/docs/usage/shoot_status.md
+++ b/docs/usage/shoot_status.md
@@ -97,7 +97,6 @@ Known error codes are:
 
 - `ERR_INFRA_UNAUTHENTICATED` - indicates that the last error occurred due to the client request not being completed because it lacks valid authentication credentials for the requested resource. It is classified as a non-retryable error code.
 - `ERR_INFRA_UNAUTHORIZED` - indicates that the last error occurred due to the server understanding the request but refusing to authorize it. It is classified as a non-retryable error code.
-- `ERR_INFRA_INSUFFICIENT_PRIVILEGES` - indicates that the last error occurred due to insufficient infrastructure privileges. It is classified as a non-retryable error code. This error code is deprecated in favor of `ERR_INFRA_UNAUTHORIZED` and will be removed in a future version.
 - `ERR_INFRA_QUOTA_EXCEEDED` - indicates that the last error occurred due to infrastructure quota limits. It is classified as a non-retryable error code.
 - `ERR_INFRA_RATE_LIMITS_EXCEEDED` - indicates that the last error occurred due to exceeded infrastructure request rate limits.
 - `ERR_INFRA_DEPENDENCIES` - indicates that the last error occurred due to dependent objects on the infrastructure level. It is classified as a non-retryable error code.

--- a/extensions/pkg/controller/status_test.go
+++ b/extensions/pkg/controller/status_test.go
@@ -157,7 +157,7 @@ var _ = Describe("Status", func() {
 
 					Expect(lastError.Description).To(Equal(description))
 					Expect(lastError.TaskID).To(BeNil())
-					Expect(lastError.Codes).To(ConsistOf(gardencorev1beta1.ErrorInfraInsufficientPrivileges, gardencorev1beta1.ErrorInfraUnauthorized))
+					Expect(lastError.Codes).To(ConsistOf(gardencorev1beta1.ErrorInfraUnauthorized))
 				}),
 			)
 

--- a/pkg/apis/core/types_common.go
+++ b/pkg/apis/core/types_common.go
@@ -28,10 +28,6 @@ const (
 	// ErrorInfraUnauthorized indicates that the last error occurred due to the server understanding the request but refusing to authorize it.
 	// It is classified as a non-retryable error code.
 	ErrorInfraUnauthorized ErrorCode = "ERR_INFRA_UNAUTHORIZED"
-	// ErrorInfraInsufficientPrivileges indicates that the last error occurred due to insufficient infrastructure privileges.
-	// It is classified as a non-retryable error code.
-	// This error code is deprecated in favor of ERR_INFRA_UNAUTHORIZED and will be removed in a future version.
-	ErrorInfraInsufficientPrivileges ErrorCode = "ERR_INFRA_INSUFFICIENT_PRIVILEGES"
 	// ErrorInfraQuotaExceeded indicates that the last error occurred due to infrastructure quota limits.
 	// It is classified as a non-retryable error code.
 	ErrorInfraQuotaExceeded ErrorCode = "ERR_INFRA_QUOTA_EXCEEDED"

--- a/pkg/apis/core/v1alpha1/types_common.go
+++ b/pkg/apis/core/v1alpha1/types_common.go
@@ -26,10 +26,6 @@ const (
 	// ErrorInfraUnauthorized indicates that the last error occurred due to the server understanding the request but refusing to authorize it.
 	// It is classified as a non-retryable error code.
 	ErrorInfraUnauthorized ErrorCode = "ERR_INFRA_UNAUTHORIZED"
-	// ErrorInfraInsufficientPrivileges indicates that the last error occurred due to insufficient infrastructure privileges.
-	// It is classified as a non-retryable error code.
-	// This error code is deprecated in favor of ERR_INFRA_UNAUTHORIZED and will be removed in a future version.
-	ErrorInfraInsufficientPrivileges ErrorCode = "ERR_INFRA_INSUFFICIENT_PRIVILEGES"
 	// ErrorInfraQuotaExceeded indicates that the last error occurred due to infrastructure quota limits.
 	// It is classified as a non-retryable error code.
 	ErrorInfraQuotaExceeded ErrorCode = "ERR_INFRA_QUOTA_EXCEEDED"

--- a/pkg/apis/core/v1beta1/helper/errors.go
+++ b/pkg/apis/core/v1beta1/helper/errors.go
@@ -94,7 +94,6 @@ func DetermineErrorCodes(err error) []gardencorev1beta1.ErrorCode {
 		knownCodes = map[gardencorev1beta1.ErrorCode]func(string) bool{
 			gardencorev1beta1.ErrorInfraUnauthenticated:          unauthenticatedRegexp.MatchString,
 			gardencorev1beta1.ErrorInfraUnauthorized:             unauthorizedRegexp.MatchString,
-			gardencorev1beta1.ErrorInfraInsufficientPrivileges:   unauthorizedRegexp.MatchString,
 			gardencorev1beta1.ErrorInfraQuotaExceeded:            quotaExceededRegexp.MatchString,
 			gardencorev1beta1.ErrorInfraRateLimitsExceeded:       rateLimitsExceededRegexp.MatchString,
 			gardencorev1beta1.ErrorInfraDependencies:             dependenciesRegexp.MatchString,
@@ -265,7 +264,6 @@ func HasNonRetryableErrorCode(lastErrors ...gardencorev1beta1.LastError) bool {
 		for _, code := range lastError.Codes {
 			if code == gardencorev1beta1.ErrorInfraUnauthenticated ||
 				code == gardencorev1beta1.ErrorInfraUnauthorized ||
-				code == gardencorev1beta1.ErrorInfraInsufficientPrivileges ||
 				code == gardencorev1beta1.ErrorInfraDependencies ||
 				code == gardencorev1beta1.ErrorInfraQuotaExceeded ||
 				code == gardencorev1beta1.ErrorInfraRateLimitsExceeded ||

--- a/pkg/apis/core/v1beta1/helper/errors_test.go
+++ b/pkg/apis/core/v1beta1/helper/errors_test.go
@@ -44,10 +44,10 @@ var _ = Describe("errors", func() {
 		Entry("no code to extract", errors.New("foo"), "", errors.New("foo")),
 		Entry("unauthenticated", errors.New("authentication failed"), "", NewErrorWithCodes("authentication failed", gardencorev1beta1.ErrorInfraUnauthenticated)),
 		Entry("unauthenticated", errors.New("invalidauthenticationtokentenant"), "", NewErrorWithCodes("invalidauthenticationtokentenant", gardencorev1beta1.ErrorInfraUnauthenticated)),
-		Entry("unauthorized", errors.New("unauthorized"), "", NewErrorWithCodes("unauthorized", gardencorev1beta1.ErrorInfraInsufficientPrivileges, gardencorev1beta1.ErrorInfraUnauthorized)),
-		Entry("unauthorized with coder", NewErrorWithCodes("", gardencorev1beta1.ErrorInfraInsufficientPrivileges, gardencorev1beta1.ErrorInfraUnauthorized), "", NewErrorWithCodes("", gardencorev1beta1.ErrorInfraInsufficientPrivileges, gardencorev1beta1.ErrorInfraUnauthorized)),
-		Entry("insufficient privileges", errors.New("accessdenied"), "", NewErrorWithCodes("accessdenied", gardencorev1beta1.ErrorInfraInsufficientPrivileges, gardencorev1beta1.ErrorInfraUnauthorized)),
-		Entry("insufficient privileges with coder", NewErrorWithCodes("accessdenied", gardencorev1beta1.ErrorInfraInsufficientPrivileges, gardencorev1beta1.ErrorInfraUnauthorized), "", NewErrorWithCodes("accessdenied", gardencorev1beta1.ErrorInfraInsufficientPrivileges, gardencorev1beta1.ErrorInfraUnauthorized)),
+		Entry("unauthorized", errors.New("unauthorized"), "", NewErrorWithCodes("unauthorized", gardencorev1beta1.ErrorInfraUnauthorized)),
+		Entry("unauthorized with coder", NewErrorWithCodes("", gardencorev1beta1.ErrorInfraUnauthorized), "", NewErrorWithCodes("", gardencorev1beta1.ErrorInfraUnauthorized)),
+		Entry("insufficient privileges", errors.New("accessdenied"), "", NewErrorWithCodes("accessdenied", gardencorev1beta1.ErrorInfraUnauthorized)),
+		Entry("insufficient privileges with coder", NewErrorWithCodes("accessdenied", gardencorev1beta1.ErrorInfraUnauthorized), "", NewErrorWithCodes("accessdenied", gardencorev1beta1.ErrorInfraUnauthorized)),
 		Entry("quota exceeded", errors.New("limitexceeded"), "", NewErrorWithCodes("limitexceeded", gardencorev1beta1.ErrorInfraQuotaExceeded)),
 		Entry("quota exceeded", errors.New("foolimitexceeded"), "", NewErrorWithCodes("foolimitexceeded", gardencorev1beta1.ErrorInfraQuotaExceeded)),
 		Entry("quota exceeded", errors.New("equestlimitexceeded"), "", NewErrorWithCodes("equestlimitexceeded", gardencorev1beta1.ErrorInfraQuotaExceeded)),
@@ -147,16 +147,15 @@ var _ = Describe("errors", func() {
 	})
 
 	var (
-		unauthenticatedError             = gardencorev1beta1.LastError{Codes: []gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorInfraUnauthenticated}}
-		unauthorizedError                = gardencorev1beta1.LastError{Codes: []gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorInfraUnauthorized}}
-		infraInsufficientPrivilegesError = gardencorev1beta1.LastError{Codes: []gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorInfraInsufficientPrivileges}}
-		configurationProblemError        = gardencorev1beta1.LastError{Codes: []gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorConfigurationProblem}}
-		infraQuotaExceededError          = gardencorev1beta1.LastError{Codes: []gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorInfraQuotaExceeded}}
-		infraRateLimitsExceededError     = gardencorev1beta1.LastError{Codes: []gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorInfraRateLimitsExceeded}}
-		infraDependenciesError           = gardencorev1beta1.LastError{Codes: []gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorInfraDependencies}}
-		infraResourcesDepletedError      = gardencorev1beta1.LastError{Codes: []gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorInfraResourcesDepleted}}
-		cleanupClusterResourcesError     = gardencorev1beta1.LastError{Codes: []gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorCleanupClusterResources}}
-		errorWithoutCodes                = gardencorev1beta1.LastError{}
+		unauthenticatedError         = gardencorev1beta1.LastError{Codes: []gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorInfraUnauthenticated}}
+		unauthorizedError            = gardencorev1beta1.LastError{Codes: []gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorInfraUnauthorized}}
+		configurationProblemError    = gardencorev1beta1.LastError{Codes: []gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorConfigurationProblem}}
+		infraQuotaExceededError      = gardencorev1beta1.LastError{Codes: []gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorInfraQuotaExceeded}}
+		infraRateLimitsExceededError = gardencorev1beta1.LastError{Codes: []gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorInfraRateLimitsExceeded}}
+		infraDependenciesError       = gardencorev1beta1.LastError{Codes: []gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorInfraDependencies}}
+		infraResourcesDepletedError  = gardencorev1beta1.LastError{Codes: []gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorInfraResourcesDepleted}}
+		cleanupClusterResourcesError = gardencorev1beta1.LastError{Codes: []gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorCleanupClusterResources}}
+		errorWithoutCodes            = gardencorev1beta1.LastError{}
 	)
 
 	DescribeTable("#HasNonRetryableErrorCode",
@@ -165,9 +164,9 @@ var _ = Describe("errors", func() {
 		},
 
 		Entry("no error given", nil, BeFalse()),
-		Entry("only errors with non-retryable error codes", []gardencorev1beta1.LastError{unauthenticatedError, unauthorizedError, infraInsufficientPrivilegesError, infraQuotaExceededError, infraDependenciesError, configurationProblemError}, BeTrue()),
+		Entry("only errors with non-retryable error codes", []gardencorev1beta1.LastError{unauthenticatedError, unauthorizedError, infraQuotaExceededError, infraDependenciesError, configurationProblemError}, BeTrue()),
 		Entry("only errors with retryable error codes", []gardencorev1beta1.LastError{infraResourcesDepletedError, cleanupClusterResourcesError}, BeFalse()),
-		Entry("errors with both retryable and not retryable error codes", []gardencorev1beta1.LastError{unauthorizedError, unauthenticatedError, infraInsufficientPrivilegesError, configurationProblemError, infraQuotaExceededError, infraRateLimitsExceededError, infraDependenciesError, infraResourcesDepletedError, cleanupClusterResourcesError}, BeTrue()),
+		Entry("errors with both retryable and not retryable error codes", []gardencorev1beta1.LastError{unauthorizedError, unauthenticatedError, configurationProblemError, infraQuotaExceededError, infraRateLimitsExceededError, infraDependenciesError, infraResourcesDepletedError, cleanupClusterResourcesError}, BeTrue()),
 		Entry("errors without error codes", []gardencorev1beta1.LastError{errorWithoutCodes}, BeFalse()),
 	)
 

--- a/pkg/apis/core/v1beta1/types_common.go
+++ b/pkg/apis/core/v1beta1/types_common.go
@@ -26,10 +26,6 @@ const (
 	// ErrorInfraUnauthorized indicates that the last error occurred due to the server understanding the request but refusing to authorize it.
 	// It is classified as a non-retryable error code.
 	ErrorInfraUnauthorized ErrorCode = "ERR_INFRA_UNAUTHORIZED"
-	// ErrorInfraInsufficientPrivileges indicates that the last error occurred due to insufficient infrastructure privileges.
-	// It is classified as a non-retryable error code.
-	// This error code is deprecated in favor of ERR_INFRA_UNAUTHORIZED and will be removed in a future version.
-	ErrorInfraInsufficientPrivileges ErrorCode = "ERR_INFRA_INSUFFICIENT_PRIVILEGES"
 	// ErrorInfraQuotaExceeded indicates that the last error occurred due to infrastructure quota limits.
 	// It is classified as a non-retryable error code.
 	ErrorInfraQuotaExceeded ErrorCode = "ERR_INFRA_QUOTA_EXCEEDED"

--- a/pkg/extensions/customresources_test.go
+++ b/pkg/extensions/customresources_test.go
@@ -240,7 +240,7 @@ var _ = Describe("extensions", func() {
 
 		It("should return error if ready func returns error", func() {
 			fakeError := &specialWrappingError{
-				error: gardencorev1beta1helper.NewErrorWithCodes("foo", gardencorev1beta1.ErrorInfraInsufficientPrivileges, gardencorev1beta1.ErrorInfraUnauthorized),
+				error: gardencorev1beta1helper.NewErrorWithCodes("foo", gardencorev1beta1.ErrorInfraUnauthorized),
 			}
 
 			Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "creating worker succeeds")
@@ -260,7 +260,7 @@ var _ = Describe("extensions", func() {
 				Special()
 			}
 			Expect(errors.As(err, &specialError)).To(BeTrue(), "should properly wrap the error returned by the health func")
-			Expect(gardencorev1beta1helper.ExtractErrorCodes(err)).To(ConsistOf(gardencorev1beta1.ErrorInfraInsufficientPrivileges, gardencorev1beta1.ErrorInfraUnauthorized), "should be able to extract error codes from wrapped error")
+			Expect(gardencorev1beta1helper.ExtractErrorCodes(err)).To(ConsistOf(gardencorev1beta1.ErrorInfraUnauthorized), "should be able to extract error codes from wrapped error")
 		})
 
 		It("should return error if client has not observed latest timestamp annotation", func() {
@@ -516,7 +516,7 @@ var _ = Describe("extensions", func() {
 			expected.ObjectMeta.DeletionTimestamp = &deletionTimestamp
 			expected.Status.LastError = &gardencorev1beta1.LastError{
 				Description: "invalid credentials",
-				Codes:       []gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorInfraInsufficientPrivileges, gardencorev1beta1.ErrorInfraUnauthorized},
+				Codes:       []gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorInfraUnauthorized},
 			}
 
 			Expect(c.Create(ctx, expected)).ToNot(HaveOccurred(), "adding pre-existing worker succeeds")
@@ -527,7 +527,7 @@ var _ = Describe("extensions", func() {
 			Expect(err).To(HaveOccurred())
 
 			// ensure, that errors are properly wrapped
-			Expect(gardencorev1beta1helper.ExtractErrorCodes(err)).To(ConsistOf(gardencorev1beta1.ErrorInfraInsufficientPrivileges, gardencorev1beta1.ErrorInfraUnauthorized), "should be able to extract error codes from wrapped error")
+			Expect(gardencorev1beta1helper.ExtractErrorCodes(err)).To(ConsistOf(gardencorev1beta1.ErrorInfraUnauthorized), "should be able to extract error codes from wrapped error")
 		})
 
 		It("should return success if extensions CRs gets deleted", func() {

--- a/pkg/operation/botanist/component/extensions/dns/dns_test.go
+++ b/pkg/operation/botanist/component/extensions/dns/dns_test.go
@@ -84,7 +84,7 @@ var _ = Describe("#CheckDNSObject", func() {
 
 					var errorWithCodes *helper.ErrorWithCodes
 					Expect(errors.As(err, &errorWithCodes)).To(BeTrue(), "state: "+state)
-					Expect(errorWithCodes.Codes()).To(ConsistOf(gardencorev1beta1.ErrorInfraInsufficientPrivileges, gardencorev1beta1.ErrorInfraUnauthorized), "state: "+state)
+					Expect(errorWithCodes.Codes()).To(ConsistOf(gardencorev1beta1.ErrorInfraUnauthorized), "state: "+state)
 				} else {
 					Expect(retry.IsRetriable(err)).To(BeFalse())
 				}

--- a/pkg/operation/care/health_check_test.go
+++ b/pkg/operation/care/health_check_test.go
@@ -383,7 +383,7 @@ var _ = Describe("health check", func() {
 				etcdEvents,
 			},
 			nil,
-			PointTo(beConditionWithStatusAndCodes(gardencorev1beta1.ConditionFalse, gardencorev1beta1.ErrorInfraInsufficientPrivileges, gardencorev1beta1.ErrorInfraUnauthorized))),
+			PointTo(beConditionWithStatusAndCodes(gardencorev1beta1.ConditionFalse, gardencorev1beta1.ErrorInfraUnauthorized))),
 		Entry("possibly rolling update ongoing (with autoscaler)",
 			shootThatNeedsAutoscaler,
 			[]*appsv1.Deployment{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
Delete deprecated error code `ERR_INFRA_INSUFFICIENT_PRIVILEGES` after #5221 

**Which issue(s) this PR fixes**:
Fixes #2469 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The deprecated error code `ERR_INFRA_INSUFFICIENT_PRIVILEGES` is removed in favour of `ERR_INFRA_UNAUTHORIZED`.
```
