### PR TITLE
adapt esreporter to ginkgo v2 report type

### DIFF
--- a/test/framework/reporter/esreporter.go
+++ b/test/framework/reporter/esreporter.go
@@ -134,7 +134,12 @@ func (reporter *GardenerESReporter) processReport(report ginkgo.Report) {
 		}
 
 		if spec.State == types.SpecStateFailed || spec.State == types.SpecStateInterrupted || spec.State == types.SpecStatePanicked {
-			reporter.suite.Failures++
+			if spec.State == types.SpecStateFailed {
+				reporter.suite.Failures++
+			} else {
+				reporter.suite.Errors++
+			}
+
 			testCase.FailureMessage = &FailureMessage{
 				Type:    PhaseForState(spec.State),
 				Message: failureMessage(spec.Failure),
@@ -147,12 +152,11 @@ func (reporter *GardenerESReporter) processReport(report ginkgo.Report) {
 
 	}
 
-	if reporter.suite.Failures != 0 {
+	if reporter.suite.Failures != 0 || reporter.suite.Errors != 0 {
 		reporter.suite.Phase = SpecPhaseFailed
 	}
 	reporter.suite.Tests = report.PreRunStats.SpecsThatWillRun
 	reporter.suite.Duration = math.Trunc(report.RunTime.Seconds()*1000) / 1000
-	reporter.suite.Errors = 0
 }
 
 func (reporter *GardenerESReporter) storeResults() {

--- a/test/framework/reporter/esreporter.go
+++ b/test/framework/reporter/esreporter.go
@@ -23,8 +23,8 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/onsi/ginkgo/v2/config"
-	"github.com/onsi/ginkgo/v2/reporters"
+	"github.com/onsi/ginkgo/v2"
+
 	"github.com/onsi/ginkgo/v2/types"
 )
 
@@ -38,7 +38,7 @@ type TestSuiteMetadata struct {
 	Duration float64     `json:"duration"`
 }
 
-// TestCase is one instanace of a test execution
+// TestCase is one instance of a test execution
 type TestCase struct {
 	Metadata       *TestSuiteMetadata `json:"suite"`
 	Name           string             `json:"name"`
@@ -50,7 +50,7 @@ type TestCase struct {
 	SystemOut      string             `json:"system-out,omitempty"`
 }
 
-// FailureMessage describes the error and the log output if a error occurred.
+// FailureMessage describes the error and the log output if an error occurred.
 type FailureMessage struct {
 	Type    ESSpecPhase `json:"type"`
 	Message string      `json:"message"`
@@ -72,7 +72,7 @@ const (
 	SpecPhaseInterrupted ESSpecPhase = "Interrupted"
 )
 
-// GardenerESReporter is a custom ginkgo exporter for gardener integration tests that write a summary of the tests in a
+// GardenerESReporter is a custom ginkgo exporter for gardener integration tests that write a summary of the tests in an
 // elastic search json report.
 type GardenerESReporter struct {
 	suite         *TestSuiteMetadata
@@ -85,14 +85,9 @@ type GardenerESReporter struct {
 
 var matchLabel, _ = regexp.Compile(`\\[(.*?)\\]`)
 
-// NewDeprecatedGardenerESReporter creates a new Gardener elasticsearch reporter.
-// The json bulk will be stored in the passed filename in the given es index.
-// It can be used with reporters.ReportViaDeprecatedReporter in ginkgo v2 to get the same reporting as in ginkgo v1.
-// However, it must be invoked in ReportAfterSuite instead of passed to RunSpecsWithDefaultAndCustomReporters, hence
-// it was renamed to force dependent repositories to adapt.
-// Deprecated: this needs to be reworked to ginkgo's new reporting infrastructure, ReportViaDeprecatedReporter will be
-// removed in a future version of ginkgo v2, see https://onsi.github.io/ginkgo/MIGRATING_TO_V2#removed-custom-reporters
-func NewDeprecatedGardenerESReporter(filename, index string) reporters.DeprecatedReporter {
+// newGardenerESReporter creates a new Gardener elasticsearch reporter.
+// Any report will be encoded to json and stored to the passed filename in the given es index.
+func newGardenerESReporter(filename, index string) *GardenerESReporter {
 	reporter := &GardenerESReporter{
 		filename:  filename,
 		testCases: []TestCase{},
@@ -104,50 +99,58 @@ func NewDeprecatedGardenerESReporter(filename, index string) reporters.Deprecate
 	return reporter
 }
 
-// SuiteWillBegin is the first function that is invoked by ginkgo when a test suites starts.
-// It is used to setup metadata information about the suite
-func (reporter *GardenerESReporter) SuiteWillBegin(config config.GinkgoConfigType, summary *types.SuiteSummary) {
+// ReportResults implements reporting based on the ginkgo v2 Report type
+// while maintaining the existing structure of the elastic index.
+// ReportsResults is intended to be called once in an ReportAfterSuite node.
+func ReportResults(filename, index string, report ginkgo.Report) {
+	reporter := newGardenerESReporter(filename, index)
 	reporter.suite = &TestSuiteMetadata{
-		Name:  summary.SuiteDescription,
+		Name:  report.SuiteDescription,
 		Phase: SpecPhaseSucceeded,
 	}
-	reporter.testSuiteName = summary.SuiteDescription
-}
+	reporter.testSuiteName = report.SuiteDescription
 
-// SpecDidComplete analysis the completed test and creates new es entry
-func (reporter *GardenerESReporter) SpecDidComplete(specSummary *types.SpecSummary) {
-	// do not report skipped tests
-	if specSummary.State == types.SpecStateSkipped || specSummary.State == types.SpecStatePending {
-		return
-	}
-
-	testCase := TestCase{
-		Metadata:  reporter.suite,
-		Name:      strings.Join(specSummary.ComponentTexts[1:], " "),
-		ShortName: getShortName(specSummary.ComponentTexts[len(specSummary.ComponentTexts)-1]),
-		Phase:     PhaseForState(specSummary.State),
-		Labels:    parseLabels(strings.Join(specSummary.ComponentTexts[1:], " ")),
-	}
-	if specSummary.State == types.SpecStateFailed || specSummary.State == types.SpecStateInterrupted || specSummary.State == types.SpecStatePanicked {
-		testCase.FailureMessage = &FailureMessage{
-			Type:    PhaseForState(specSummary.State),
-			Message: failureMessage(specSummary.Failure),
+	for _, spec := range report.SpecReports {
+		// do not report skipped tests
+		if spec.State == types.SpecStateSkipped || spec.State == types.SpecStatePending {
+			continue
 		}
-		testCase.SystemOut = specSummary.CapturedOutput
-		reporter.suite.Phase = SpecPhaseFailed
-	}
-	testCase.Duration = specSummary.RunTime.Seconds()
-	reporter.testCases = append(reporter.testCases, testCase)
-}
 
-// SuiteDidEnd collects the metadata for the whole test suite and writes the results
-// as elasticsearch json bulk to the specified location.
-func (reporter *GardenerESReporter) SuiteDidEnd(summary *types.SuiteSummary) {
-	reporter.suite.Tests = summary.NumberOfSpecsThatWillBeRun
-	reporter.suite.Duration = math.Trunc(summary.RunTime.Seconds()*1000) / 1000
-	reporter.suite.Failures = summary.NumberOfFailedSpecs
+		var componentTexts []string
+		componentTexts = append(componentTexts, spec.ContainerHierarchyTexts...)
+		componentTexts = append(componentTexts, spec.LeafNodeText)
+		testCaseName := strings.Join(componentTexts[1:], " ")
+		testCase := TestCase{
+			Metadata:  reporter.suite,
+			Name:      testCaseName,
+			ShortName: getShortName(componentTexts[len(componentTexts)-1]),
+			Phase:     PhaseForState(spec.State),
+			Labels:    parseLabels(testCaseName),
+		}
+
+		if spec.State == types.SpecStateFailed || spec.State == types.SpecStateInterrupted || spec.State == types.SpecStatePanicked {
+			reporter.suite.Failures++
+			testCase.FailureMessage = &FailureMessage{
+				Type:    PhaseForState(spec.State),
+				Message: failureMessage(spec.Failure),
+			}
+			testCase.SystemOut = spec.CombinedOutput()
+			reporter.suite.Phase = SpecPhaseFailed
+		}
+
+		testCase.Duration = spec.RunTime.Seconds()
+		reporter.testCases = append(reporter.testCases, testCase)
+
+	}
+
+	reporter.suite.Tests = report.PreRunStats.SpecsThatWillRun
+	reporter.suite.Duration = math.Trunc(report.RunTime.Seconds()*1000) / 1000
 	reporter.suite.Errors = 0
 
+	reporter.storeResults()
+}
+
+func (reporter *GardenerESReporter) storeResults() {
 	dir := filepath.Dir(reporter.filename)
 	if _, err := os.Stat(dir); err != nil {
 		if !os.IsNotExist(err) {
@@ -187,17 +190,8 @@ func (reporter *GardenerESReporter) SuiteDidEnd(summary *types.SuiteSummary) {
 	}
 }
 
-// SpecWillRun is implemented as a noop to satisfy the reporter interface for ginkgo.
-func (reporter *GardenerESReporter) SpecWillRun(specSummary *types.SpecSummary) {}
-
-// BeforeSuiteDidRun is implemented as a noop to satisfy the reporter interface for ginkgo.
-func (reporter *GardenerESReporter) BeforeSuiteDidRun(setupSummary *types.SetupSummary) {}
-
-// AfterSuiteDidRun is implemented as a noop to satisfy the reporter interface for ginkgo.
-func (reporter *GardenerESReporter) AfterSuiteDidRun(setupSummary *types.SetupSummary) {}
-
-func failureMessage(failure types.SpecFailure) string {
-	return fmt.Sprintf("%s\n%s\n%s", failure.ComponentCodeLocation.String(), failure.Message, failure.Location.String())
+func failureMessage(failure types.Failure) string {
+	return fmt.Sprintf("%s\n%s\n%s", failure.FailureNodeLocation.String(), failure.Message, failure.Location.String())
 }
 
 // parseLabels returns all labels of a test that have teh format [<label>]
@@ -215,7 +209,7 @@ func getShortName(name string) string {
 	return strings.TrimSpace(short)
 }
 
-// getESIndexString returns a bulk index configuration string for a index.
+// getESIndexString returns a bulk index configuration string for an index.
 func getESIndexString(index string) string {
 	format := `{ "index": { "_index": "%s", "_type": "_doc" } }`
 	return fmt.Sprintf(format, index)

--- a/test/framework/reporter/esreporter_test.go
+++ b/test/framework/reporter/esreporter_test.go
@@ -1,3 +1,17 @@
+// Copyright 2022 Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package reporter
 
 import (

--- a/test/framework/reporter/esreporter_test.go
+++ b/test/framework/reporter/esreporter_test.go
@@ -1,0 +1,141 @@
+package reporter
+
+import (
+	"fmt"
+	"math"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/types"
+	. "github.com/onsi/gomega"
+)
+
+func TestGardenerESReporter(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Gardener ES Reporter Test Suite")
+}
+
+const (
+	reportFileName             = "/tmp/report_test.json"
+	indexName                  = "test-index"
+	mockReportSuiteDescription = "mock report suite"
+	testCaseName               = "[DEFAULT] [REPORT] Should complete successfully"
+)
+
+var _ = Describe("processReport tests", func() {
+
+	var (
+		reporter                    *GardenerESReporter
+		mockReport                  Report
+		mockContainerHierarchyTexts []string
+		suiteDuration               float64
+		testCaseDuration            float64
+	)
+
+	BeforeEach(func() {
+		reporter = newGardenerESReporter(reportFileName, indexName)
+		mockReport.SuiteDescription = mockReportSuiteDescription
+		mockContainerHierarchyTexts = []string{"DESCRIBE"}
+		mockReport.RunTime = time.Duration(2000000000)
+		mockReport.SpecReports = []SpecReport{
+			{
+				ContainerHierarchyTexts:    mockContainerHierarchyTexts,
+				LeafNodeText:               testCaseName,
+				RunTime:                    time.Duration(1000000000),
+				Failure:                    types.Failure{},
+				CapturedGinkgoWriterOutput: "",
+				CapturedStdOutErr:          "",
+			},
+		}
+		suiteDuration = math.Trunc(mockReport.RunTime.Seconds()*1000) / 1000
+		testCaseDuration = time.Duration(1000000000).Seconds()
+	})
+
+	It("should setup test suite metadata correctly", func() {
+		expectedIndex := append([]byte(fmt.Sprintf(`{ "index": { "_index": "%s", "_type": "_doc" } }`, indexName)), []byte("\n")...)
+		mockReport.PreRunStats.SpecsThatWillRun = 0
+
+		reporter.processReport(mockReport)
+
+		Expect(reporter.filename).To(Equal(reportFileName))
+		Expect(reporter.index).To(Equal(expectedIndex))
+		Expect(reporter.testSuiteName).To(Equal(mockReportSuiteDescription))
+		Expect(reporter.suite.Name).To(Equal(mockReportSuiteDescription))
+		Expect(reporter.suite.Failures).To(Equal(0))
+		Expect(reporter.suite.Phase).To(Equal(SpecPhaseSucceeded))
+		Expect(reporter.suite.Tests).To(Equal(0))
+		Expect(reporter.suite.Duration).To(Equal(suiteDuration))
+		Expect(reporter.suite.Errors).To(Equal(0))
+	})
+
+	It("should process one successful test correctly", func() {
+		mockReport.PreRunStats.SpecsThatWillRun = 1
+		mockReport.SpecReports[0].State = types.SpecStatePassed
+
+		reporter.processReport(mockReport)
+
+		Expect(reporter.suite.Tests).To(Equal(1))
+		Expect(reporter.suite.Failures).To(Equal(0))
+		Expect(reporter.suite.Phase).To(Equal(SpecPhaseSucceeded))
+
+		Expect(len(reporter.testCases)).To(Equal(1))
+		Expect(reporter.testCases[0].Metadata.Name).To(Equal(mockReportSuiteDescription))
+		Expect(reporter.testCases[0].Name).To(Equal(testCaseName))
+		Expect(reporter.testCases[0].ShortName).To(Equal(testCaseName))
+		Expect(reporter.testCases[0].Phase).To(Equal(SpecPhaseSucceeded))
+		Expect(reporter.testCases[0].Duration).To(Equal(testCaseDuration))
+	})
+
+	It("should process one failed test correctly", func() {
+		stderr := "stderr - something failed"
+		failureMessage := "something went wrong"
+		location := types.CodeLocation{
+			FileName:       "test.go",
+			LineNumber:     10,
+			FullStackTrace: "some text",
+		}
+		failureLocation := types.CodeLocation{
+			FileName:       "error.go",
+			LineNumber:     20,
+			FullStackTrace: "some error",
+		}
+		mockReport.PreRunStats.SpecsThatWillRun = 1
+		mockReport.SpecReports[0].State = types.SpecStateFailed
+		mockReport.SpecReports[0].Failure = types.Failure{
+			Message:             failureMessage,
+			Location:            location,
+			FailureNodeLocation: failureLocation,
+		}
+		mockReport.SpecReports[0].CapturedStdOutErr = stderr
+
+		reporter.processReport(mockReport)
+
+		Expect(reporter.suite.Tests).To(Equal(1))
+		Expect(reporter.suite.Failures).To(Equal(1))
+		Expect(reporter.suite.Phase).To(Equal(SpecPhaseFailed))
+
+		Expect(len(reporter.testCases)).To(Equal(1))
+		Expect(reporter.testCases[0].Metadata.Name).To(Equal(mockReportSuiteDescription))
+		Expect(reporter.testCases[0].Name).To(Equal(testCaseName))
+		Expect(reporter.testCases[0].ShortName).To(Equal(testCaseName))
+		Expect(reporter.testCases[0].Phase).To(Equal(SpecPhaseFailed))
+		Expect(reporter.testCases[0].Duration).To(Equal(testCaseDuration))
+		Expect(reporter.testCases[0].FailureMessage).NotTo(BeNil())
+		Expect(reporter.testCases[0].FailureMessage.Type).To(Equal(SpecPhaseFailed))
+		Expect(reporter.testCases[0].FailureMessage.Message).To(Equal(fmt.Sprintf("%s\n%s\n%s", failureLocation.String(), failureMessage, location.String())))
+		Expect(reporter.testCases[0].SystemOut).To(Equal(stderr))
+	})
+
+	It("should process one skipped test correctly", func() {
+		mockReport.PreRunStats.SpecsThatWillRun = 0
+		mockReport.SpecReports[0].State = types.SpecStateSkipped
+
+		reporter.processReport(mockReport)
+
+		Expect(reporter.suite.Tests).To(Equal(0))
+		Expect(reporter.suite.Failures).To(Equal(0))
+		Expect(reporter.suite.Phase).To(Equal(SpecPhaseSucceeded))
+		Expect(len(reporter.testCases)).To(Equal(0))
+	})
+})

--- a/test/framework/reporter/esreporter_test.go
+++ b/test/framework/reporter/esreporter_test.go
@@ -113,6 +113,48 @@ var _ = Describe("processReport tests", func() {
 
 		Expect(reporter.suite.Tests).To(Equal(1))
 		Expect(reporter.suite.Failures).To(Equal(1))
+		Expect(reporter.suite.Errors).To(Equal(0))
+		Expect(reporter.suite.Phase).To(Equal(SpecPhaseFailed))
+
+		Expect(len(reporter.testCases)).To(Equal(1))
+		Expect(reporter.testCases[0].Metadata.Name).To(Equal(mockReportSuiteDescription))
+		Expect(reporter.testCases[0].Name).To(Equal(testCaseName))
+		Expect(reporter.testCases[0].ShortName).To(Equal(testCaseName))
+		Expect(reporter.testCases[0].Phase).To(Equal(SpecPhaseFailed))
+		Expect(reporter.testCases[0].Duration).To(Equal(testCaseDuration))
+		Expect(reporter.testCases[0].FailureMessage).NotTo(BeNil())
+		Expect(reporter.testCases[0].FailureMessage.Type).To(Equal(SpecPhaseFailed))
+		Expect(reporter.testCases[0].FailureMessage.Message).To(Equal(fmt.Sprintf("%s\n%s\n%s", failureLocation.String(), failureMessage, location.String())))
+		Expect(reporter.testCases[0].SystemOut).To(Equal(stderr))
+	})
+
+	It("should process one panicked test correctly", func() {
+		stderr := "stderr - something panicked"
+		failureMessage := "something went utterly wrong"
+		location := types.CodeLocation{
+			FileName:       "test.go",
+			LineNumber:     10,
+			FullStackTrace: "some text",
+		}
+		failureLocation := types.CodeLocation{
+			FileName:       "error.go",
+			LineNumber:     20,
+			FullStackTrace: "some error",
+		}
+		mockReport.PreRunStats.SpecsThatWillRun = 1
+		mockReport.SpecReports[0].State = types.SpecStatePanicked
+		mockReport.SpecReports[0].Failure = types.Failure{
+			Message:             failureMessage,
+			Location:            location,
+			FailureNodeLocation: failureLocation,
+		}
+		mockReport.SpecReports[0].CapturedStdOutErr = stderr
+
+		reporter.processReport(mockReport)
+
+		Expect(reporter.suite.Tests).To(Equal(1))
+		Expect(reporter.suite.Failures).To(Equal(0))
+		Expect(reporter.suite.Errors).To(Equal(1))
 		Expect(reporter.suite.Phase).To(Equal(SpecPhaseFailed))
 
 		Expect(len(reporter.testCases)).To(Equal(1))

--- a/test/testmachinery/suites/gardener/run_suite_test.go
+++ b/test/testmachinery/suites/gardener/run_suite_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
-	"github.com/onsi/ginkgo/v2/reporters"
 	. "github.com/onsi/gomega"
 
 	"github.com/gardener/gardener/test/framework"
@@ -61,5 +60,5 @@ func TestGardenerSuite(t *testing.T) {
 }
 
 var _ = ReportAfterSuite("Report to Elasticsearch", func(report Report) {
-	reporters.ReportViaDeprecatedReporter(reporter.NewDeprecatedGardenerESReporter(*reportFilePath, *esIndex), report)
+	reporter.ReportResults(*reportFilePath, *esIndex, report)
 })

--- a/test/testmachinery/suites/shoot/run_suite_test.go
+++ b/test/testmachinery/suites/shoot/run_suite_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
-	"github.com/onsi/ginkgo/v2/reporters"
 	. "github.com/onsi/gomega"
 
 	"github.com/gardener/gardener/test/framework"
@@ -67,5 +66,5 @@ func TestGardenerSuite(t *testing.T) {
 }
 
 var _ = ReportAfterSuite("Report to Elasticsearch", func(report Report) {
-	reporters.ReportViaDeprecatedReporter(reporter.NewDeprecatedGardenerESReporter(*reportFilePath, *esIndex), report)
+	reporter.ReportResults(*reportFilePath, *esIndex, report)
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind cleanup

**What this PR does / why we need it**:
Following the switch to ginkgo v2, the custom reporter still implemented `DeprecatedReporter` and was invoked via `ReportViaDeprecatedReporter` .  The PR drops the usage of deprecated structures and interfaces and implements a custom reporting using the new `Report` type only. 

**Which issue(s) this PR fixes**:
Fixes #5321

**Special notes for your reviewer**:
/invite @dguendisch @timebertt @rfranzke 

I'm not entirely sure regarding the categorization of the release note. @timebertt would be great, if you could double-check. Thanks!

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking dependency
Use ginkgo v2 `Report` structures and drop usage of deprecated custom reporter. To adapt, replace the call of `reporters.ReportViaDeprecatedReporter` within any `ReportAfterSuite` node with `reporter.ReportResults(*reportFilePath, *esIndex, report)`
```

**Testing**
Since there are no unit/integration tests and the expected output structure contains timestamps / durations, I did a smal manual testing to qualify things.

Reports generated by testruns are attached to this PR, but here are also snippets to compare the relevant structure.

__using the new reporter - succeeded step__
```
{ "index": { "_index": "gardener-testsuite", "_type": "_doc" } }
{"suite":{"name":"Shoot Test Suite","phase":"Failed","tests":9,"failures":8,"errors":0,"duration":367.428},"name":"[DEFAULT] [RELEASE] [SHOOT] should download shoot kubeconfig successfully","shortName":"[DEFAULT] [RELEASE] [SHOOT] should download shoot kubeconfig successfully","phase":"Succeeded","duration":0.080158809}
```

__using the deprecated reporter - succeeded step__
```
{ "index": { "_index": "gardener-testsuite", "_type": "_doc" } }
{"suite":{"name":"Shoot Test Suite","phase":"Failed","tests":9,"failures":8,"errors":0,"duration":366.86},"name":"[DEFAULT] [RELEASE] [SHOOT] should download shoot kubeconfig successfully","shortName":"[DEFAULT] [RELEASE] [SHOOT] should download shoot kubeconfig successfully","phase":"Succeeded","duration":0.069546686}
```
__using the new reporter - failed step__
```
{"index": { "_index": "gardener-testsuite", "_type": "_doc" } }
{"suite":{"name":"Shoot Test Suite","phase":"Failed","tests":9,"failures":8,"errors":0,"duration":367.428},"name":" [DEFAULT] [SHOOT] should read runtime metrics","shortName":"[DEFAULT] [SHOOT] should read runtime metrics","phase":"Failed","failure":{"type":"Failed","message":"/go/src/github.com/gardener/gardener/test/framework/gingko_utils.go:26\nUnexpected error:\n    \u003c*errors.errorString | 0xc000b8a1a0\u003e: {\n        s: \"could not find template in \\\"/go/src/github.com/gardener/gardener/test/testmachinery/framework/resources/templates/simple-load-deployment.yaml.tpl\\\"\",\n    }\n    could not find template in \"/go/src/github.com/gardener/gardener/test/testmachinery/framework/resources/templates/simple-load-deployment.yaml.tpl\"\noccurred\n/go/src/github.com/gardener/gardener/test/testmachinery/shoots/applications/metrics.go:71"},"duration":10.507470436,"system-out":"[BeforeEach] Shoot application metrics testing..."}
```

__using the deprecated reporter - failed step__
```
{ "index": { "_index": "gardener-testsuite", "_type": "_doc" } }
{"suite":{"name":"Shoot Test Suite","phase":"Failed","tests":9,"failures":8,"errors":0,"duration":366.86},"name":" [DEFAULT] [SHOOT] should read runtime metrics","shortName":"[DEFAULT] [SHOOT] should read runtime metrics","phase":"Failed","failure":{"type":"Failed","message":"/go/src/github.com/gardener/gardener/test/framework/gingko_utils.go:26\nUnexpected error:\n    \u003c*errors.errorString | 0xc000be2f20\u003e: {\n        s: \"could not find template in \\\"/go/src/github.com/gardener/gardener/test/testmachinery/framework/resources/templates/simple-load-deployment.yaml.tpl\\\"\",\n    }\n    could not find template in \"/go/src/github.com/gardener/gardener/test/testmachinery/framework/resources/templates/simple-load-deployment.yaml.tpl\"\noccurred\n/go/src/github.com/gardener/gardener/test/testmachinery/shoots/applications/metrics.go:71"},"duration":10.346779425,"system-out":"[BeforeEach] Shoot application metrics testing..."}
```

[deprecated_report.txt](https://github.com/gardener/gardener/files/8169729/deprecated_report.txt)
[new_report.txt](https://github.com/gardener/gardener/files/8170508/new_report.txt)

