### PR TITLE
Fix Shoot creation integration test

### DIFF
--- a/test/testmachinery/landscaper/gardenlet/landscaper_test.go
+++ b/test/testmachinery/landscaper/gardenlet/landscaper_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Gardenlet landscaper testing", func() {
 	f := landscaperframework.NewGardenletFramework(&landscaperframework.GardenletConfig{
 		GardenerConfig: &framework.GardenerConfig{
 			CommonConfig: &framework.CommonConfig{
-				ResourceDir: "../../framework/resources",
+				ResourceDir: "../../../framework/resources",
 			},
 		},
 		LandscaperCommonConfig: nil,

--- a/test/testmachinery/system/managed_seed_creation/create_test.go
+++ b/test/testmachinery/system/managed_seed_creation/create_test.go
@@ -36,7 +36,7 @@ var _ = Describe("ManagedSeed creation testing", func() {
 	f := framework.NewManagedSeedFramework(&framework.ManagedSeedConfig{
 		GardenerConfig: &framework.GardenerConfig{
 			CommonConfig: &framework.CommonConfig{
-				ResourceDir: "../../framework/resources",
+				ResourceDir: "../../../framework/resources",
 			},
 		},
 	})

--- a/test/testmachinery/system/shoot_creation/create_test.go
+++ b/test/testmachinery/system/shoot_creation/create_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Shoot Creation testing", func() {
 	f := framework.NewShootCreationFramework(&framework.ShootCreationConfig{
 		GardenerConfig: &framework.GardenerConfig{
 			CommonConfig: &framework.CommonConfig{
-				ResourceDir: "../../framework/resources",
+				ResourceDir: "../../../framework/resources",
 			},
 		},
 	})


### PR DESCRIPTION
/area testing
/kind regression
/kind bug

Currently the Shoot creation test fails with:
```
  Expected success, but got an error:
      <*errors.errorString | 0xc000284a40>: {
          s: "shoot template should exist",
      }
      shoot template should exist
  In [It] at: /Users/i331370/go/src/github.com/gardener/gardener/test/testmachinery/system/shoot_creation/create_test.go:58
```

With https://github.com/gardener/gardener/pull/5469 the tests are moved from `test/<foo>/<bar>` to `test/testmachinery/<foo>/<bar>`, hence the relative path to the resource dir has to be adapted as well.

Credits to @hendrikKahl for catching this!

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
