### PR TITLE
🛡 Provide some helpful log messages for `ProjectedTokenMount`

### DIFF
--- a/pkg/resourcemanager/webhook/projectedtokenmount/add.go
+++ b/pkg/resourcemanager/webhook/projectedtokenmount/add.go
@@ -17,6 +17,7 @@ package projectedtokenmount
 import (
 	"github.com/spf13/pflag"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
+	runtimelog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
@@ -44,7 +45,13 @@ type WebhookConfig struct {
 // AddToManagerWithOptions adds the webhook to a Manager with the given config.
 func AddToManagerWithOptions(mgr manager.Manager, conf WebhookConfig) error {
 	server := mgr.GetWebhookServer()
-	server.Register(WebhookPath, &webhook.Admission{Handler: NewHandler(conf.TargetCluster.GetCache(), conf.ExpirationSeconds)})
+	server.Register(WebhookPath, &webhook.Admission{
+		Handler: NewHandler(
+			runtimelog.Log.WithName("webhook").WithName(HandlerName),
+			conf.TargetCluster.GetCache(),
+			conf.ExpirationSeconds,
+		),
+	})
 	return nil
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement
/merge squash

**What this PR does / why we need it**:
Similar to #5341, this PR adds some helpful log messages for the `ProjectedTokenMount` webhook part of `gardener-resource-manager`.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/4878

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
