### PR TITLE
Install correct version of promtool

### DIFF
--- a/hack/tools/install-promtool.sh
+++ b/hack/tools/install-promtool.sh
@@ -22,7 +22,20 @@ TOOLS_BIN_DIR=${TOOLS_BIN_DIR:-$(dirname $0)/bin}
 
 platform=$(uname -s | tr '[:upper:]' '[:lower:]')
 version="2.24.1"
-archive_name="prometheus-${version}.${platform}-amd64"
+case $(uname -m) in
+  aarch64)
+    arch="arm64"
+    ;;
+  x86_64)
+    arch="amd64"
+    ;;
+  *)
+    echo "Unknown architecture"
+    exit -1
+    ;;
+esac
+
+archive_name="prometheus-${version}.${platform}-${arch}"
 file_name="${archive_name}.tar.gz"
 
 temp_dir="$(mktemp -d)"


### PR DESCRIPTION
Detect the architecture with uname and use that to download the appropriate
prometheus binary.

Signed-off-by: Ali Saidi <alisaidi@amazon.com>

/area dev-productivity

**What this PR does / why we need it**:
Allows `make test` to run an a Graviton2 (arm64) linux machine successfully

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
NONE

```other operator

```
