### PR TITLE
Fix overflowing float to int32 conversion

### DIFF
--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -1785,11 +1785,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeInvalid),
 					"Field": Equal("spec.kubernetes.kubeControllerManager.nodeCIDRMaskSize"),
-				})),
-					PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":  Equal(field.ErrorTypeInvalid),
-						"Field": Equal("spec.kubernetes.kubeControllerManager.nodeCIDRMaskSize"),
-					}))))
+				}))))
 			})
 
 			It("should fail when nodeCIDRMaskSize is out of lower boundary", func() {
@@ -1799,12 +1795,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeInvalid),
 					"Field": Equal("spec.kubernetes.kubeControllerManager.nodeCIDRMaskSize"),
-				})),
-					PointTo(MatchFields(IgnoreExtras, Fields{
-						"Type":  Equal(field.ErrorTypeInvalid),
-						"Field": Equal("spec.kubernetes.kubeControllerManager.nodeCIDRMaskSize"),
-					})),
-				))
+				}))))
 			})
 
 			It("should succeed when nodeCIDRMaskSize is within boundaries", func() {


### PR DESCRIPTION
**How to categorize this PR?**
/area testing
/kind bug

**What this PR does / why we need it**:
ValidateNodeCIDRMaskWithMaxPod calculates the ip addresses available
by doing a float 2**(32-nodeCIDRMaskSize) and casting that to an int32.
Unfortuantely, for nodeCIDRMaskSize 0 (or 1) which is provided in a
unit test this value isn't representable as a int32 and it hits
architecture specific behavior that results in it being a large negative
number on x86_64 but a large positive number of arm64.  The negative
number is intended the following if condition passes while it wouth
otherwise have failed.

This change uses a uint32 in the two places where Pow() is used
to not be subject a the 32b overflow and enables make test to complete
successfully on an arm64 system.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

