### PR TITLE
Improve `PreCheckFunc` function signature

### DIFF
--- a/extensions/pkg/controller/healthcheck/actuator.go
+++ b/extensions/pkg/controller/healthcheck/actuator.go
@@ -55,7 +55,7 @@ type GetExtensionObjectFunc = func() extensionsv1alpha1.Object
 type GetExtensionObjectListFunc = func() client.ObjectList
 
 // PreCheckFunc checks whether the health check shall be performed based on the given object and cluster.
-type PreCheckFunc = func(client.Object, *extensionscontroller.Cluster) bool
+type PreCheckFunc = func(context.Context, client.Client, client.Object, *extensionscontroller.Cluster) bool
 
 // ConditionTypeToHealthCheck registers a HealthCheck for the given ConditionType. If the PreCheckFunc is not nil it will
 // be executed with the given object before the health check if performed. Otherwise, the health check will always be

--- a/extensions/pkg/controller/healthcheck/healtcheck_actuator.go
+++ b/extensions/pkg/controller/healthcheck/healtcheck_actuator.go
@@ -169,7 +169,7 @@ func (a *Actuator) ExecuteHealthCheckFunctions(ctx context.Context, request type
 					return
 				}
 
-				if !preCheckFunc(obj, cluster) {
+				if !preCheckFunc(ctx, a.seedClient, obj, cluster) {
 					a.logger.V(6).Info("Skipping health check as pre check function returned false", "conditionType", healthConditionType)
 					channel <- channelResult{
 						healthCheckResult: &SingleCheckResult{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR improves the `PreCheckFunc` function signature. This is required so that in extension when a new health check is added, We can add PreCheckFunc that skips the health check untill the object get available.
**Which issue(s) this PR fixes**:
Fixes #

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
