### PR TITLE
Promote `AdminKubeconfigRequest` feature gate to GA

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -32,8 +32,6 @@ The following tables are a summary of the feature gates that you can set on diff
 | SeedKubeScheduler                            | `false` | `Alpha` | `1.15` |        |
 | ReversedVPN                                  | `false` | `Alpha` | `1.22` | `1.41` |
 | ReversedVPN                                  | `true`  | `Beta`  | `1.42` |        |
-| AdminKubeconfigRequest                       | `false` | `Alpha` | `1.24` | `1.38` |
-| AdminKubeconfigRequest                       | `true`  | `Beta`  | `1.39` |        |
 | UseDNSRecords                                | `false` | `Alpha` | `1.27` | `1.38` |
 | UseDNSRecords                                | `true`  | `Beta`  | `1.39` |        |
 | RotateSSHKeypairOnMaintenance                | `false` | `Alpha` | `1.28` |        |
@@ -64,6 +62,9 @@ The following tables are a summary of the feature gates that you can set on diff
 | DisallowKubeconfigRotationForShootInDeletion |         | `Removed` | `1.38` |        |
 | Logging                                      | `false` | `Alpha`   | `0.13` | `1.40` |
 | Logging                                      | `false` | `Removed` | `1.41` |        |
+| AdminKubeconfigRequest                       | `false` | `Alpha`   | `1.24` | `1.38` |
+| AdminKubeconfigRequest                       | `true`  | `Beta`    | `1.39` | `1.41` |
+| AdminKubeconfigRequest                       | `true`  | `GA`      | `1.42` |        |
 
 ## Using a feature
 

--- a/docs/proposals/16-adminkubeconfig-subresource.md
+++ b/docs/proposals/16-adminkubeconfig-subresource.md
@@ -96,7 +96,7 @@ status:
         client-key-data: LS0tLS1CRUd...
 ```
 
-The `AdminKubeconfigRequest` feature gate (enabled by default starting from `v1.39`) enables the above mentioned API in the `gardener-apiserver`. The old `{shoot-name}.kubeconfig` is kept, but deprecated and will be removed in the future.
+New feature gate called `AdminKubeconfigRequest` enables the above mentioned API in the `gardener-apiserver`. The old `{shoot-name}.kubeconfig` is kept, but deprecated and will be removed in the future.
 
 In order to get the server's address used in the `kubeconfig`, the Shoot's `status` should be updated with new entries:
 

--- a/example/gardener-local/controlplane/values.yaml
+++ b/example/gardener-local/controlplane/values.yaml
@@ -156,7 +156,6 @@ global:
     featureGates:
       UseDNSRecords: true
       SeedChange: true
-      AdminKubeconfigRequest: true
       WorkerPoolKubernetesVersion: true
       ShootCARotation: true
     resources: {}

--- a/pkg/apiserver/features/features.go
+++ b/pkg/apiserver/features/features.go
@@ -24,7 +24,7 @@ import (
 
 var featureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	features.SeedChange:                      {Default: false, PreRelease: featuregate.Alpha},
-	features.AdminKubeconfigRequest:          {Default: true, PreRelease: featuregate.Beta},
+	features.AdminKubeconfigRequest:          {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	features.UseDNSRecords:                   {Default: true, PreRelease: featuregate.Beta},
 	features.WorkerPoolKubernetesVersion:     {Default: false, PreRelease: featuregate.Alpha},
 	features.SecretBindingProviderValidation: {Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -82,6 +82,7 @@ const (
 	// owner: @petersutter
 	// alpha: v1.24.0
 	// beta: v1.39.0
+	// GA: v1.42.0
 	AdminKubeconfigRequest featuregate.Feature = "AdminKubeconfigRequest"
 
 	// UseDNSRecords enables using DNSRecords resources for Gardener DNS records instead of DNSProvider and DNSEntry resources.

--- a/pkg/registry/core/shoot/storage/storage.go
+++ b/pkg/registry/core/shoot/storage/storage.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/gardener/gardener/pkg/apis/core"
-	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/registry/core/shoot"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,7 +28,6 @@ import (
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
 	"k8s.io/apiserver/pkg/storage"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 )
 
 // REST implements a RESTStorage for shoots against etcd
@@ -53,13 +51,11 @@ func NewStorage(optsGetter generic.RESTOptionsGetter, shootStateStore *genericre
 		Status: shootStatusRest,
 	}
 
-	if utilfeature.DefaultFeatureGate.Enabled(features.AdminKubeconfigRequest) {
-		s.AdminKubeconfig = &AdminKubeconfigREST{
-			shootStateStorage:    shootStateStore,
-			shootStorage:         shootRest,
-			clock:                clock.RealClock{},
-			maxExpirationSeconds: int64(max.Seconds()),
-		}
+	s.AdminKubeconfig = &AdminKubeconfigREST{
+		shootStateStorage:    shootStateStore,
+		shootStorage:         shootRest,
+		clock:                clock.RealClock{},
+		maxExpirationSeconds: int64(max.Seconds()),
 	}
 
 	return s


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
The `AdminKubeconfigRequest` feature gate in the `gardener-apiserver` has been promoted to GA.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The `AdminKubeconfigRequest` feature gate in the `gardener-apiserver` has been promoted to GA.
```
