### PR TITLE
Promote `DenyInvalidExtensionResources` feature gate to beta

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -36,7 +36,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | UseDNSRecords                                | `false` | `Alpha` | `1.27` | `1.38` |
 | UseDNSRecords                                | `true`  | `Beta`  | `1.39` |        |
 | RotateSSHKeypairOnMaintenance                | `false` | `Alpha` | `1.28` |        |
-| DenyInvalidExtensionResources                | `false` | `Alpha` | `1.31` |        |
+| DenyInvalidExtensionResources                | `false` | `Alpha` | `1.31` | `1.41` |
+| DenyInvalidExtensionResources                | `true`  | `Beta`  | `1.42` |        |
 | WorkerPoolKubernetesVersion                  | `false` | `Alpha` | `1.35` |        |
 | CopyEtcdBackupsDuringControlPlaneMigration   | `false` | `Alpha` | `1.37` |        |
 | SecretBindingProviderValidation              | `false` | `Alpha` | `1.38` |        |

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -97,6 +97,7 @@ const (
 	// DenyInvalidExtensionResources causes the seed-admission-controller to deny invalid extension resources (instead of just logging validation errors).
 	// owner: @stoyanr
 	// alpha: v1.31.0
+	// beta: v1.42.0
 	DenyInvalidExtensionResources featuregate.Feature = "DenyInvalidExtensionResources"
 
 	// WorkerPoolKubernetesVersion allows to overwrite the Kubernetes version used for shoot clusters per worker pool.

--- a/pkg/gardenlet/features/features.go
+++ b/pkg/gardenlet/features/features.go
@@ -33,7 +33,7 @@ var (
 		features.SeedKubeScheduler:                          {Default: false, PreRelease: featuregate.Alpha},
 		features.ReversedVPN:                                {Default: false, PreRelease: featuregate.Alpha},
 		features.UseDNSRecords:                              {Default: true, PreRelease: featuregate.Beta},
-		features.DenyInvalidExtensionResources:              {Default: false, PreRelease: featuregate.Alpha},
+		features.DenyInvalidExtensionResources:              {Default: true, PreRelease: featuregate.Beta},
 		features.CopyEtcdBackupsDuringControlPlaneMigration: {Default: false, PreRelease: featuregate.Alpha},
 		features.ForceRestore:                               {Default: false, PreRelease: featuregate.Alpha},
 		features.DisableDNSProviderManagement:               {Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller_test.go
+++ b/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller_test.go
@@ -174,7 +174,7 @@ spec:
         - /gardener-seed-admission-controller
         - --port=10250
         - --tls-cert-dir=/srv/gardener-seed-admission-controller
-        - --allow-invalid-extension-resources=true
+        - --allow-invalid-extension-resources=false
         - --health-bind-address=:8081
         image: ` + image + `
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
The `DenyInvalidExtensionResources` feature gate for `seed-admission-controller` has been promoted to `beta`


**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `DenyInvalidExtensionResources ` feature gate in the `seed-admission-controller` has been promoted to beta and is now enabled by default.
```
