### PR TITLE
Promote gardenlet feature gate `ReversedVPN` to beta.

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -30,7 +30,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | CachedRuntimeClients                         | `true`  | `Beta`  | `1.34` |        |
 | SeedChange                                   | `false` | `Alpha` | `1.12` |        |
 | SeedKubeScheduler                            | `false` | `Alpha` | `1.15` |        |
-| ReversedVPN                                  | `false` | `Alpha` | `1.22` |        |
+| ReversedVPN                                  | `false` | `Alpha` | `1.22` | `1.41` |
+| ReversedVPN                                  | `true`  | `Beta`  | `1.42` |        |
 | AdminKubeconfigRequest                       | `false` | `Alpha` | `1.24` | `1.38` |
 | AdminKubeconfigRequest                       | `true`  | `Beta`  | `1.39` |        |
 | UseDNSRecords                                | `false` | `Alpha` | `1.27` | `1.38` |

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -75,6 +75,7 @@ const (
 	// ReversedVPN moves the openvpn server to the seed.
 	// owner: @ScheererJ @DockToFuture
 	// alpha: v1.22.0
+	// beta: v1.42.0
 	ReversedVPN featuregate.Feature = "ReversedVPN"
 
 	// AdminKubeconfigRequest enables the AdminKubeconfigRequest endpoint on shoot resources.

--- a/pkg/gardenlet/features/features.go
+++ b/pkg/gardenlet/features/features.go
@@ -31,7 +31,7 @@ var (
 		features.APIServerSNI:                               {Default: true, PreRelease: featuregate.Beta},
 		features.CachedRuntimeClients:                       {Default: true, PreRelease: featuregate.Beta},
 		features.SeedKubeScheduler:                          {Default: false, PreRelease: featuregate.Alpha},
-		features.ReversedVPN:                                {Default: false, PreRelease: featuregate.Alpha},
+		features.ReversedVPN:                                {Default: true, PreRelease: featuregate.Beta},
 		features.UseDNSRecords:                              {Default: true, PreRelease: featuregate.Beta},
 		features.DenyInvalidExtensionResources:              {Default: false, PreRelease: featuregate.Alpha},
 		features.CopyEtcdBackupsDuringControlPlaneMigration: {Default: false, PreRelease: featuregate.Alpha},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind api-change

**What this PR does / why we need it**:
Promote gardenlet feature gate `ReversedVPN` to beta.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Promote gardenlet feature gate `ReversedVPN` to beta.
```
