### PR TITLE
[release-v1.39] Automated cherry pick of #5516: Fix data race in `OperatingSystemConfig` component

### DIFF
--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -119,12 +119,9 @@ type OriginalValues struct {
 	Images map[string]*imagevector.Image
 	// KubeletCACertificate is the certificate authority for the kubelet.
 	KubeletCACertificate string
-	// KubeletCLIFlags is the set of configurable kubelet CLI flags. If the respective worker pool provides kubelet
-	// configuration as well then this might get overwritten.
-	KubeletCLIFlags components.ConfigurableKubeletCLIFlags
-	// KubeletConfigParameters is the set of configurable kubelet config parameters. If the respective worker pool
-	// provides kubelet configuration as well then this might get overwritten.
-	KubeletConfigParameters components.ConfigurableKubeletConfigParameters
+	// KubeletConfig is the default kubelet configuration for all worker pools. Individual worker pools might overwrite
+	// this configuration.
+	KubeletConfig *gardencorev1beta1.KubeletConfig
 	// MachineTypes is a list of machine types.
 	MachineTypes []gardencorev1beta1.MachineType
 	// SSHPublicKeys is a list of public SSH keys.
@@ -489,8 +486,8 @@ func (o *operatingSystemConfig) newDeployer(osc *extensionsv1alpha1.OperatingSys
 		}
 	}
 
-	kubeletConfigParameters := o.values.KubeletConfigParameters
-	kubeletCLIFlags := o.values.KubeletCLIFlags
+	kubeletConfigParameters := components.KubeletConfigParametersFromCoreV1beta1KubeletConfig(o.values.KubeletConfig)
+	kubeletCLIFlags := components.KubeletCLIFlagsFromCoreV1beta1KubeletConfig(o.values.KubeletConfig)
 	if worker.Kubernetes != nil && worker.Kubernetes.Kubelet != nil {
 		kubeletConfigParameters = components.KubeletConfigParametersFromCoreV1beta1KubeletConfig(worker.Kubernetes.Kubelet)
 		kubeletCLIFlags = components.KubeletCLIFlagsFromCoreV1beta1KubeletConfig(worker.Kubernetes.Kubelet)

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
@@ -72,14 +72,18 @@ var _ = Describe("OperatingSystemConfig", func() {
 			mockNow *mocktime.MockNow
 			now     time.Time
 
-			apiServerURL            = "https://url-to-apiserver"
-			caBundle                = pointer.String("ca-bundle")
-			clusterDNSAddress       = "cluster-dns"
-			clusterDomain           = "cluster-domain"
-			images                  = map[string]*imagevector.Image{"foo": {}}
-			kubeletCACertificate    = "kubelet-ca"
-			kubeletCLIFlags         = components.ConfigurableKubeletCLIFlags{}
-			kubeletConfigParameters = components.ConfigurableKubeletConfigParameters{}
+			apiServerURL                = "https://url-to-apiserver"
+			caBundle                    = pointer.String("ca-bundle")
+			clusterDNSAddress           = "cluster-dns"
+			clusterDomain               = "cluster-domain"
+			images                      = map[string]*imagevector.Image{"foo": {}}
+			kubeletCACertificate        = "kubelet-ca"
+			evictionHardMemoryAvailable = "100Mi"
+			kubeletConfig               = &gardencorev1beta1.KubeletConfig{
+				EvictionHard: &gardencorev1beta1.KubeletConfigEviction{
+					MemoryAvailable: &evictionHardMemoryAvailable,
+				},
+			}
 			kubeletDataVolumeName   = "foo"
 			machineTypes            []gardencorev1beta1.MachineType
 			sshPublicKeys           = []string{"ssh-public-key", "ssh-public-key-b"}
@@ -174,15 +178,14 @@ var _ = Describe("OperatingSystemConfig", func() {
 					APIServerURL: apiServerURL,
 				},
 				OriginalValues: OriginalValues{
-					CABundle:                caBundle,
-					ClusterDNSAddress:       clusterDNSAddress,
-					ClusterDomain:           clusterDomain,
-					Images:                  images,
-					KubeletCACertificate:    kubeletCACertificate,
-					KubeletConfigParameters: kubeletConfigParameters,
-					KubeletCLIFlags:         kubeletCLIFlags,
-					MachineTypes:            machineTypes,
-					SSHPublicKeys:           sshPublicKeys,
+					CABundle:             caBundle,
+					ClusterDNSAddress:    clusterDNSAddress,
+					ClusterDomain:        clusterDomain,
+					Images:               images,
+					KubeletCACertificate: kubeletCACertificate,
+					KubeletConfig:        kubeletConfig,
+					MachineTypes:         machineTypes,
+					SSHPublicKeys:        sshPublicKeys,
 				},
 			}
 
@@ -215,17 +218,20 @@ var _ = Describe("OperatingSystemConfig", func() {
 					apiServerURL,
 				)
 				originalUnits, originalFiles, _ := originalConfigFn(components.Context{
-					CABundle:                caBundle,
-					ClusterDNSAddress:       clusterDNSAddress,
-					ClusterDomain:           clusterDomain,
-					CRIName:                 criName,
-					Images:                  images,
-					KubeletCACertificate:    kubeletCACertificate,
-					KubeletCLIFlags:         kubeletCLIFlags,
-					KubeletConfigParameters: kubeletConfigParameters,
-					KubeletDataVolumeName:   &kubeletDataVolumeName,
-					KubernetesVersion:       k8sVersion,
-					SSHPublicKeys:           sshPublicKeys,
+					CABundle:             caBundle,
+					ClusterDNSAddress:    clusterDNSAddress,
+					ClusterDomain:        clusterDomain,
+					CRIName:              criName,
+					Images:               images,
+					KubeletCACertificate: kubeletCACertificate,
+					KubeletConfigParameters: components.ConfigurableKubeletConfigParameters{
+						EvictionHard: map[string]string{
+							"memory.available": evictionHardMemoryAvailable,
+						},
+					},
+					KubeletDataVolumeName: &kubeletDataVolumeName,
+					KubernetesVersion:     k8sVersion,
+					SSHPublicKeys:         sshPublicKeys,
 				})
 
 				oscDownloader := &extensionsv1alpha1.OperatingSystemConfig{

--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -26,7 +26,6 @@ import (
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig/downloader"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor"
-	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/nodelocaldns"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
@@ -65,12 +64,11 @@ func (b *Botanist) DefaultOperatingSystemConfig() (operatingsystemconfig.Interfa
 			KubernetesVersion: b.Shoot.KubernetesVersion,
 			Workers:           b.Shoot.GetInfo().Spec.Provider.Workers,
 			OriginalValues: operatingsystemconfig.OriginalValues{
-				ClusterDNSAddress:       clusterDNSAddress,
-				ClusterDomain:           gardencorev1beta1.DefaultDomain,
-				Images:                  images,
-				KubeletConfigParameters: components.KubeletConfigParametersFromCoreV1beta1KubeletConfig(b.Shoot.GetInfo().Spec.Kubernetes.Kubelet),
-				KubeletCLIFlags:         components.KubeletCLIFlagsFromCoreV1beta1KubeletConfig(b.Shoot.GetInfo().Spec.Kubernetes.Kubelet),
-				MachineTypes:            b.Shoot.CloudProfile.Spec.MachineTypes,
+				ClusterDNSAddress: clusterDNSAddress,
+				ClusterDomain:     gardencorev1beta1.DefaultDomain,
+				Images:            images,
+				KubeletConfig:     b.Shoot.GetInfo().Spec.Kubernetes.Kubelet,
+				MachineTypes:      b.Shoot.CloudProfile.Spec.MachineTypes,
 			},
 		},
 		operatingsystemconfig.DefaultInterval,


### PR DESCRIPTION
/kind/bug
/area/usability

Cherry pick of #5516 on release-v1.39.

#5516: Fix data race in `OperatingSystemConfig` component

**Release Notes:**
```other operator
A bug has been fixed causing gardenlet to panic when a `Shoot` with multiple worker pools specifies eviction settings for the kubelet configuration in `.spec.kubernetes.kubelet` while `.spec.provider.workers[].kubernetes.kubelet=nil`.
```