### PR TITLE
Fix resources dir path (2)

### DIFF
--- a/test/framework/commonframework.go
+++ b/test/framework/commonframework.go
@@ -83,7 +83,7 @@ func (f *CommonFramework) BeforeEach() {
 		} else {
 			// This is the default location if the framework is running in one of the gardener/shoot suites.
 			// Otherwise the resource dir has to be adjusted
-			f.ResourcesDir, err = filepath.Abs(filepath.Join("..", "..", "framework", "resources"))
+			f.ResourcesDir, err = filepath.Abs(filepath.Join("..", "..", "..", "framework", "resources"))
 		}
 		ExpectNoError(err)
 	}
@@ -103,7 +103,7 @@ func CommonAfterSuite() {
 	// run all registered cleanup functions
 	RunCleanupActions()
 
-	resourcesDir, err := filepath.Abs(filepath.Join("..", "..", "framework", "resources"))
+	resourcesDir, err := filepath.Abs(filepath.Join("..", "..", "..", "framework", "resources"))
 	ExpectNoError(err)
 	err = os.RemoveAll(filepath.Join(resourcesDir, "charts"))
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())


### PR DESCRIPTION
/area testing
/kind bug
/kind regression

Similar to https://github.com/gardener/gardener/pull/5505

Currently the guestbook
```
$ go test -timeout=0 -mod=vendor ./test/testmachinery/suites/shoot \
      --v -ginkgo.v -ginkgo.progress -ginkgo.noColor \
      --report-file=/tmp/report.json \
      -kubecfg=$KUBECONFIG \
      -shoot-name=$SHOOT_NAME \
      -project-namespace=$PROJECT_NAMESPACE \
      -ginkgo.focus="should deploy guestbook app successfully"
```

fails with:
```
  Unexpected error:
      <*fmt.wrapError | 0xc001006d20>: {
          msg: "unable to download chart artifacts for chart stable/redis with version 10.2.1: Couldn't load repositories file /go/src/github.com/gardener/gardener/test/testmachinery/framework/resources/repository/repositories.yaml).\nYou might need to run `helm init` (or `helm init --client-only` if tiller is already installed)",
          err: <*errors.errorString | 0xc0007f8820>{
              s: "Couldn't load repositories file (/go/src/github.com/gardener/gardener/test/testmachinery/framework/resources/repository/repositories.yaml).\nYou might need to run `helm init` (or `helm init --client-only` if tiller is already installed)",
          },
      }
      unable to download chart artifacts for chart stable/redis with version 10.2.1: Couldn't load repositories file /go/src/github.com/gardener/gardener/test/testmachinery/framework/resources/repository/repositories.yaml).
      You might need to run `helm init` (or `helm init --client-only` if tiller is already installed)
  occurred
  In [It] at: /go/src/github.com/gardener/gardener/test/framework/applications/guestbooktest.go:165
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
