### PR TITLE
seed-prometheus: Fix vpa-recommender scrape config

### DIFF
--- a/charts/seed-bootstrap/charts/monitoring/templates/config.yaml
+++ b/charts/seed-bootstrap/charts/monitoring/templates/config.yaml
@@ -104,18 +104,17 @@ data:
 
     - job_name: vpa-recommender
       kubernetes_sd_configs:
-        - role: pod
-          relabel_configs:
-            - source_labels: [__meta_kubernetes_pod_label_app]
-              regex: vpa-recommender
-              action: keep
-            - source_labels: [__meta_kubernetes_pod_container_port_name]
-              regex: metrics
-              action: keep
-            - action: labelmap
-              regex: __meta_kubernetes_pod_label_(.+)
-            - source_labels: [ __meta_kubernetes_namespace ]
-              target_label: namespace
-            - source_labels: [ __meta_kubernetes_pod_name ]
-              target_label: pod
-
+      - role: pod
+      relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        regex: vpa-recommender
+        action: keep
+      - source_labels: [__meta_kubernetes_pod_container_port_name]
+        regex: metrics
+        action: keep
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+      - source_labels: [ __meta_kubernetes_namespace ]
+        target_label: namespace
+      - source_labels: [ __meta_kubernetes_pod_name ]
+        target_label: pod


### PR DESCRIPTION
/area monitoring
/kind bug
/kind regression

After https://github.com/gardener/gardener/pull/5467 seed-prometheus is failing to start with:
```
$ k -n garden get po seed-prometheus-0
NAME                READY   STATUS             RESTARTS   AGE
seed-prometheus-0   1/2     CrashLoopBackOff   103        8h
```

```
level=error ts=2022-03-04T15:00:54.741Z caller=main.go:360 msg="Error loading config (--config.file=/etc/prometheus/config/prometheus.yaml)" err="parsing YAML file /etc/prometheus/config/prometheus.yaml: yaml: unmarshal errors:\n  line 103: field relabel_configs not found in type kubernetes.plain"
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
