### PR TITLE
add label to cloudprovider secret and adapt webhook

### DIFF
--- a/extensions/pkg/webhook/cloudprovider/cloudprovider.go
+++ b/extensions/pkg/webhook/cloudprovider/cloudprovider.go
@@ -30,9 +30,7 @@ const (
 	WebhookName = "cloudprovider"
 )
 
-var (
-	logger = log.Log.WithName("cloudprovider-webhook")
-)
+var logger = log.Log.WithName("cloudprovider-webhook")
 
 // Args are the requirements to create a cloudprovider webhook.
 type Args struct {
@@ -61,6 +59,11 @@ func New(mgr manager.Manager, args Args) (*extensionswebhook.Webhook, error) {
 		Webhook:  &admission.Webhook{Handler: handler},
 		Path:     WebhookName,
 		Selector: namespaceSelector,
+		ObjectSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				v1beta1constants.GardenerPurpose: v1beta1constants.SecretNameCloudProvider,
+			},
+		},
 	}, nil
 }
 

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -269,6 +269,9 @@ func (b *Botanist) DeployCloudProviderSecret(ctx context.Context) error {
 		secret.Annotations = map[string]string{
 			"checksum/data": checksum,
 		}
+		secret.Labels = map[string]string{
+			v1beta1constants.GardenerPurpose: v1beta1constants.SecretNameCloudProvider,
+		}
 		secret.Type = corev1.SecretTypeOpaque
 		secret.Data = b.Shoot.Secret.Data
 		return nil


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:

This PR: 
a) adds a label to the `cloudprovider` secret deployed on the seeds so that it can be used by webhooks
b) updates the clouprovider webhook to use the new label as object selector.

**Which issue(s) this PR fixes**:
Before the new label the webhook was reacting to all the secrets. In case the extension was not available for some time, the operation of other components e.g. GRM that creates secrets could be halted due to the failing webhook. With this change we should avoid such issues.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Adds a new label to the `cloudprovider` secret so that it can be filtered by controllers.
The `cloudprovider` webhook now filters secrets using the new label of the `cloudprovider` secret.
```
