### PR TITLE
Optimize node listing calls to reduce load on API server

### DIFF
--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/executor.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/executor.go
@@ -138,6 +138,7 @@ func Script(
 		"pathKubeletKubeconfigBootstrap":           kubelet.PathKubeconfigBootstrap,
 		"pathKubeletKubeconfigReal":                kubelet.PathKubeconfigReal,
 		"pathLastDownloadedHyperkubeImage":         PathLastDownloadedHyperkubeImage,
+		"pathNodeName":                             kubelet.PathNodeName,
 		"pathScriptCopyKubernetesBinary":           kubelet.PathScriptCopyKubernetesBinary,
 		"bootstrapTokenPlaceholder":                downloader.BootstrapTokenPlaceholder,
 		"cloudConfigUserData":                      utils.EncodeBase64(cloudConfigUserData),

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/executor_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/executor_test.go
@@ -301,32 +301,41 @@ else
   rm -f "/var/lib/cloud-config-downloader/credentials/bootstrap-token"
 fi
 
-NODENAME=
-ANNOTATION_RESTART_SYSTEMD_SERVICES="worker.gardener.cloud/restart-systemd-services"
-
 # Try to find Node object for this machine if already registered to the cluster.
+NODENAME=
+if [[ -s "/var/lib/kubelet/nodename" ]]; then
+  NODENAME="$(cat "/var/lib/kubelet/nodename")"
+else
+  NODENAME="$(/opt/bin/kubectl --kubeconfig="/var/lib/kubelet/kubeconfig-real" get node -l "kubernetes.io/hostname=$(hostname | tr '[:upper:]' '[:lower:]')" -o go-template="{{ if .items }}{{ (index .items 0).metadata.name }}{{ end }}")"
+  echo "$NODENAME" > "/var/lib/kubelet/nodename"
+fi
+
+# Check if node is annotated with information about to-be-restarted systemd services
+ANNOTATION_RESTART_SYSTEMD_SERVICES="worker.gardener.cloud/restart-systemd-services"
 if [[ -f "/var/lib/kubelet/kubeconfig-real" ]]; then
-  NODE="$(/opt/bin/kubectl --kubeconfig="/var/lib/kubelet/kubeconfig-real" get node -l "kubernetes.io/hostname=$(hostname)" -o go-template="{{ if .items }}{{ (index .items 0).metadata.name }}{{ if (index (index .items 0).metadata.annotations \"$ANNOTATION_RESTART_SYSTEMD_SERVICES\") }} {{ index (index .items 0).metadata.annotations \"$ANNOTATION_RESTART_SYSTEMD_SERVICES\" }}{{ end }}{{ end }}")"
+  if [[ ! -z "$NODENAME" ]]; then
+    SYSTEMD_SERVICES_TO_RESTART="$(/opt/bin/kubectl --kubeconfig="/var/lib/kubelet/kubeconfig-real" get node "$NODENAME" -o go-template="{{ if index .metadata.annotations \"$ANNOTATION_RESTART_SYSTEMD_SERVICES\" }}{{ index .metadata.annotations \"$ANNOTATION_RESTART_SYSTEMD_SERVICES\" }}{{ end }}")"
 
-  if [[ ! -z "$NODE" ]]; then
-    NODENAME="$(echo "$NODE" | awk '{print $1}')"
-    SYSTEMD_SERVICES_TO_RESTART="$(echo "$NODE" | awk '{print $2}')"
-  fi
+    # Restart systemd services if requested
+    if [[ ! -z "$SYSTEMD_SERVICES_TO_RESTART" ]]; then
+      restart_ccd=n
+      for service in $(echo "$SYSTEMD_SERVICES_TO_RESTART" | sed "s/,/ /g"); do
+        if [[ ${service} == cloud-config-downloader* ]]; then
+          restart_ccd=y
+          continue
+        fi
 
-  # Restart systemd services if requested
-  restart_ccd=n
-  for service in $(echo "$SYSTEMD_SERVICES_TO_RESTART" | sed "s/,/ /g"); do
-    if [[ ${service} == cloud-config-downloader* ]]; then
-      restart_ccd=y
-      continue
+        echo "Restarting systemd service $service due to $ANNOTATION_RESTART_SYSTEMD_SERVICES annotation"
+        systemctl restart "$service" || true
+      done
+
+      /opt/bin/kubectl --kubeconfig="/var/lib/kubelet/kubeconfig-real" annotate node "$NODENAME" "${ANNOTATION_RESTART_SYSTEMD_SERVICES}-"
+
+      if [[ ${restart_ccd} == "y" ]]; then
+        echo "Restarting systemd service cloud-config-downloader.service due to $ANNOTATION_RESTART_SYSTEMD_SERVICES annotation"
+        systemctl restart "cloud-config-downloader.service" || true
+      fi
     fi
-    echo "Restarting systemd service $service due to $ANNOTATION_RESTART_SYSTEMD_SERVICES annotation"
-    systemctl restart "$service" || true
-  done
-  /opt/bin/kubectl --kubeconfig="/var/lib/kubelet/kubeconfig-real" annotate node "$NODENAME" "${ANNOTATION_RESTART_SYSTEMD_SERVICES}-"
-  if [[ ${restart_ccd} == "y" ]]; then
-    echo "Restarting systemd service cloud-config-downloader.service due to $ANNOTATION_RESTART_SYSTEMD_SERVICES annotation"
-    systemctl restart "cloud-config-downloader.service" || true
   fi
 
   # If the time difference from the last execution till now is smaller than the node-specific delay then we exit early

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/executor_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/executor_test.go
@@ -305,7 +305,7 @@ fi
 NODENAME=
 if [[ -s "/var/lib/kubelet/nodename" ]]; then
   NODENAME="$(cat "/var/lib/kubelet/nodename")"
-else
+elif [[ -f "/var/lib/kubelet/kubeconfig-real" ]]; then
   NODENAME="$(/opt/bin/kubectl --kubeconfig="/var/lib/kubelet/kubeconfig-real" get node -l "kubernetes.io/hostname=$(hostname | tr '[:upper:]' '[:lower:]')" -o go-template="{{ if .items }}{{ (index .items 0).metadata.name }}{{ end }}")"
   echo "$NODENAME" > "/var/lib/kubelet/nodename"
 fi

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/executor_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/executor_test.go
@@ -306,7 +306,7 @@ NODENAME=
 if [[ -s "/var/lib/kubelet/nodename" ]]; then
   NODENAME="$(cat "/var/lib/kubelet/nodename")"
 elif [[ -f "/var/lib/kubelet/kubeconfig-real" ]]; then
-  NODENAME="$(/opt/bin/kubectl --kubeconfig="/var/lib/kubelet/kubeconfig-real" get node -l "kubernetes.io/hostname=$(hostname | tr '[:upper:]' '[:lower:]')" -o go-template="{{ if .items }}{{ (index .items 0).metadata.name }}{{ end }}")"
+  NODENAME="$(/opt/bin/kubectl --kubeconfig="/var/lib/kubelet/kubeconfig-real" get nodes -l "kubernetes.io/hostname=$(hostname | tr '[:upper:]' '[:lower:]')" -o go-template="{{ if .items }}{{ (index .items 0).metadata.name }}{{ end }}")"
   echo "$NODENAME" > "/var/lib/kubelet/nodename"
 fi
 

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/templates/scripts/execute-cloud-config.tpl.sh
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/templates/scripts/execute-cloud-config.tpl.sh
@@ -176,7 +176,7 @@ NODENAME=
 if [[ -s "{{ .pathNodeName }}" ]]; then
   NODENAME="$(cat "{{ .pathNodeName }}")"
 elif [[ -f "{{ .pathKubeletKubeconfigReal }}" ]]; then
-  {{`NODENAME="$(`}}{{ .pathBinaries }}{{`/kubectl --kubeconfig="`}}{{ .pathKubeletKubeconfigReal }}{{`" get node -l "kubernetes.io/hostname=$(hostname | tr '[:upper:]' '[:lower:]')" -o go-template="{{ if .items }}{{ (index .items 0).metadata.name }}{{ end }}")"`}}
+  {{`NODENAME="$(`}}{{ .pathBinaries }}{{`/kubectl --kubeconfig="`}}{{ .pathKubeletKubeconfigReal }}{{`" get nodes -l "kubernetes.io/hostname=$(hostname | tr '[:upper:]' '[:lower:]')" -o go-template="{{ if .items }}{{ (index .items 0).metadata.name }}{{ end }}")"`}}
   echo "$NODENAME" > "{{ .pathNodeName }}"
 fi
 

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/templates/scripts/execute-cloud-config.tpl.sh
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/templates/scripts/execute-cloud-config.tpl.sh
@@ -175,7 +175,7 @@ fi
 NODENAME=
 if [[ -s "{{ .pathNodeName }}" ]]; then
   NODENAME="$(cat "{{ .pathNodeName }}")"
-else
+elif [[ -f "{{ .pathKubeletKubeconfigReal }}" ]]; then
   {{`NODENAME="$(`}}{{ .pathBinaries }}{{`/kubectl --kubeconfig="`}}{{ .pathKubeletKubeconfigReal }}{{`" get node -l "kubernetes.io/hostname=$(hostname | tr '[:upper:]' '[:lower:]')" -o go-template="{{ if .items }}{{ (index .items 0).metadata.name }}{{ end }}")"`}}
   echo "$NODENAME" > "{{ .pathNodeName }}"
 fi

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/templates/scripts/execute-cloud-config.tpl.sh
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/templates/scripts/execute-cloud-config.tpl.sh
@@ -176,7 +176,7 @@ NODENAME=
 if [[ -s "{{ .pathNodeName }}" ]]; then
   NODENAME="$(cat "{{ .pathNodeName }}")"
 else
-  {{`NODENAME="$(`}}{{ .pathBinaries }}{{`/kubectl --kubeconfig="`}}{{ .pathKubeletKubeconfigReal }}{{`" get node -l "kubernetes.io/hostname=$(hostname)" -o go-template="{{ if .items }}{{ (index .items 0).metadata.name }}{{ end }}")"`}}
+  {{`NODENAME="$(`}}{{ .pathBinaries }}{{`/kubectl --kubeconfig="`}}{{ .pathKubeletKubeconfigReal }}{{`" get node -l "kubernetes.io/hostname=$(hostname | tr '[:upper:]' '[:lower:]')" -o go-template="{{ if .items }}{{ (index .items 0).metadata.name }}{{ end }}")"`}}
   echo "$NODENAME" > "{{ .pathNodeName }}"
 fi
 

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/component.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/component.go
@@ -69,6 +69,9 @@ const (
 	PathKubeletDirectory = "/var/lib/kubelet"
 	// PathScriptCopyKubernetesBinary is the path for the script copying downloaded Kubernetes binaries.
 	PathScriptCopyKubernetesBinary = PathKubeletDirectory + "/copy-kubernetes-binary.sh"
+	// PathNodeName is the path for a file containing the name of the Node registered by kubelet for the respective
+	// machine.
+	PathNodeName = PathKubeletDirectory + "/nodename"
 
 	pathVolumePluginDirectory = "/var/lib/kubelet/volumeplugins"
 )

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/component.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/component.go
@@ -94,6 +94,7 @@ func (component) Config(ctx components.Context) ([]extensionsv1alpha1.Unit, []ex
 	if err := tplHealthMonitor.Execute(&healthMonitorScript, map[string]string{
 		"pathBinaries":              v1beta1constants.OperatingSystemConfigFilePathBinaries,
 		"pathKubeletKubeconfigReal": PathKubeconfigReal,
+		"pathNodeName":              PathNodeName,
 	}); err != nil {
 		return nil, nil, err
 	}

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/component_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/component_test.go
@@ -266,7 +266,7 @@ function kubelet_monitoring {
     fi
 
     node_name=
-    if [[ ! -s "/var/lib/kubelet/nodename" ]]; then
+    if [[ -s "/var/lib/kubelet/nodename" ]]; then
       node_name="$(cat "/var/lib/kubelet/nodename")"
     fi
     if [[ -z "$node_name" ]]; then

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/component_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/component_test.go
@@ -275,7 +275,7 @@ function kubelet_monitoring {
       continue
     fi
 
-    node_object="$(kubectl get nodes "$node_name" -o json)"
+    node_object="$(kubectl get node "$node_name" -o json)"
     node_status="$(echo $node_object | jq -r '.status')"
     if [[ -z "$node_status" ]] || [[ "$node_status" == "null" ]]; then
       echo "Node object for this hostname not found in the system, waiting."

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/component_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/component_test.go
@@ -256,6 +256,8 @@ function kubelet_monitoring {
   last_kubelet_ready_state="True"
 
   while [ 1 ]; do
+    node_name="$(cat "/var/lib/kubelet/nodename")"
+
     # Check whether the kubelet's /healthz endpoint reports unhealthiness
     if ! output=$(curl -m $max_seconds -f -s -S http://127.0.0.1:10248/healthz 2>&1); then
       echo $output
@@ -265,8 +267,13 @@ function kubelet_monitoring {
       continue
     fi
 
-    node_object="$(kubectl get nodes -l kubernetes.io/hostname=$(hostname) -o json)"
-    node_status="$(echo $node_object | jq -r '.items[0].status')"
+    if [[ -z "$node_name" ]]; then
+      sleep 20
+      continue
+    fi
+
+    node_object="$(kubectl get nodes "$node_name" -o json)"
+    node_status="$(echo $node_object | jq -r '.status')"
     if [[ -z "$node_status" ]] || [[ "$node_status" == "null" ]]; then
       echo "Node object for this hostname not found in the system, waiting."
       sleep 20
@@ -285,7 +292,6 @@ function kubelet_monitoring {
         if ip address show | grep $K8S_NODE_IP_INTERNAL_LAST_SEEN > /dev/null; then
           echo "Last seen InternalIP "$K8S_NODE_IP_INTERNAL_LAST_SEEN" is still up-to-date";
           server="$(kubectl config view -o jsonpath={.clusters[0].cluster.server})"
-          node_name="$(echo $node_object | jq -r '.items[0].metadata.name')"
           if patch_internal_ip $server $node_name $K8S_NODE_IP_INTERNAL_LAST_SEEN; then
             echo "Successfully updated Node object."
             continue

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/component_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/component_test.go
@@ -256,8 +256,6 @@ function kubelet_monitoring {
   last_kubelet_ready_state="True"
 
   while [ 1 ]; do
-    node_name="$(cat "/var/lib/kubelet/nodename")"
-
     # Check whether the kubelet's /healthz endpoint reports unhealthiness
     if ! output=$(curl -m $max_seconds -f -s -S http://127.0.0.1:10248/healthz 2>&1); then
       echo $output
@@ -267,7 +265,12 @@ function kubelet_monitoring {
       continue
     fi
 
+    node_name=
+    if [[ ! -s "/var/lib/kubelet/nodename" ]]; then
+      node_name="$(cat "/var/lib/kubelet/nodename")"
+    fi
     if [[ -z "$node_name" ]]; then
+      echo "Node name is not known yet, waiting..."
       sleep 20
       continue
     fi

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/templates/scripts/health-monitor.tpl.sh
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/templates/scripts/health-monitor.tpl.sh
@@ -47,7 +47,7 @@ function kubelet_monitoring {
     fi
 
     node_name=
-    if [[ ! -s "{{ .pathNodeName }}" ]]; then
+    if [[ -s "{{ .pathNodeName }}" ]]; then
       node_name="$(cat "{{ .pathNodeName }}")"
     fi
     if [[ -z "$node_name" ]]; then

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/templates/scripts/health-monitor.tpl.sh
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/templates/scripts/health-monitor.tpl.sh
@@ -37,6 +37,8 @@ function kubelet_monitoring {
   last_kubelet_ready_state="True"
 
   while [ 1 ]; do
+    node_name="$(cat "{{ .pathNodeName }}")"
+
     # Check whether the kubelet's /healthz endpoint reports unhealthiness
     if ! output=$(curl -m $max_seconds -f -s -S http://127.0.0.1:10248/healthz 2>&1); then
       echo $output
@@ -46,8 +48,13 @@ function kubelet_monitoring {
       continue
     fi
 
-    node_object="$(kubectl get nodes -l kubernetes.io/hostname=$(hostname) -o json)"
-    node_status="$(echo $node_object | jq -r '.items[0].status')"
+    if [[ -z "$node_name" ]]; then
+      sleep 20
+      continue
+    fi
+
+    node_object="$(kubectl get nodes "$node_name" -o json)"
+    node_status="$(echo $node_object | jq -r '.status')"
     if [[ -z "$node_status" ]] || [[ "$node_status" == "null" ]]; then
       echo "Node object for this hostname not found in the system, waiting."
       sleep 20
@@ -66,7 +73,6 @@ function kubelet_monitoring {
         if ip address show | grep $K8S_NODE_IP_INTERNAL_LAST_SEEN > /dev/null; then
           echo "Last seen InternalIP "$K8S_NODE_IP_INTERNAL_LAST_SEEN" is still up-to-date";
           server="$(kubectl config view -o jsonpath={.clusters[0].cluster.server})"
-          node_name="$(echo $node_object | jq -r '.items[0].metadata.name')"
           if patch_internal_ip $server $node_name $K8S_NODE_IP_INTERNAL_LAST_SEEN; then
             echo "Successfully updated Node object."
             continue

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/templates/scripts/health-monitor.tpl.sh
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/templates/scripts/health-monitor.tpl.sh
@@ -37,8 +37,6 @@ function kubelet_monitoring {
   last_kubelet_ready_state="True"
 
   while [ 1 ]; do
-    node_name="$(cat "{{ .pathNodeName }}")"
-
     # Check whether the kubelet's /healthz endpoint reports unhealthiness
     if ! output=$(curl -m $max_seconds -f -s -S http://127.0.0.1:10248/healthz 2>&1); then
       echo $output
@@ -48,7 +46,12 @@ function kubelet_monitoring {
       continue
     fi
 
+    node_name=
+    if [[ ! -s "{{ .pathNodeName }}" ]]; then
+      node_name="$(cat "{{ .pathNodeName }}")"
+    fi
     if [[ -z "$node_name" ]]; then
+      echo "Node name is not known yet, waiting..."
       sleep 20
       continue
     fi

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/templates/scripts/health-monitor.tpl.sh
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/kubelet/templates/scripts/health-monitor.tpl.sh
@@ -56,7 +56,7 @@ function kubelet_monitoring {
       continue
     fi
 
-    node_object="$(kubectl get nodes "$node_name" -o json)"
+    node_object="$(kubectl get node "$node_name" -o json)"
     node_status="$(echo $node_object | jq -r '.status')"
     if [[ -z "$node_status" ]] || [[ "$node_status" == "null" ]]; then
       echo "Node object for this hostname not found in the system, waiting."


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement
/merge squash

**What this PR does / why we need it**:
The `systemd` services deployed to each shoot cluster worker node do no longer `LIST nodes` calls. Instead, the name of the node is fetched once and then stored in a file on the disk so that the `systemd` services can do `GET node` calls with the respective name of the node. This should reduce the load on the `kube-apiserver` and `etcd`.

**Which issue(s) this PR fixes**:
Fixes #5374

**Special notes for your reviewer**:
/cc @istvanballok @petersutter 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```improvement operator
The `systemd` services deployed to each shoot cluster worker node do no longer `LIST nodes` calls. Instead, the name of the node is fetched once and then stored in a file on the disk so that the `systemd` services can do `GET node` calls with the respective name of the node. This should reduce the load on the `kube-apiserver` and `etcd`.
```
