### PR TITLE
Improve reconciliation of `DNSRecord`s

### DIFF
--- a/docs/usage/shoot_maintenance.md
+++ b/docs/usage/shoot_maintenance.md
@@ -80,10 +80,10 @@ If you hibernate or wake-up your shoot then Gardener gets active right away.
 
 The shoot maintenance controller triggers special operations that are performed as part of the shoot reconciliation.
 
-### Infrastructure Reconciliation
+### `Infrastructure` and `DNSRecord` Reconciliation
 
-The reconciliation of the `Infrastructure` extension resource is only demanded during the shoot's maintenance time window.
-The rationale behind it is to prevent the Gardenlets from sending too many requests against the cloud provider APIs, especially if a user has many shoot clusters in the same cloud provider account.
+The reconciliation of the `Infrastructure` and `DNSRecord` extension resources is only demanded during the shoot's maintenance time window.
+The rationale behind it is to prevent sending too many requests against the cloud provider APIs, especially on large landscapes or if a user has many shoot clusters in the same cloud provider account.
 
 ### Restart Control Plane Controllers
 

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -247,6 +247,15 @@ const (
 	// ShootTaskDeployInfrastructure is a name for a Shoot's infrastructure deployment task. It indicates that the
 	// Infrastructure extension resource shall be reconciled.
 	ShootTaskDeployInfrastructure = "deployInfrastructure"
+	// ShootTaskDeployDNSRecordInternal is a name for a Shoot's internal DNS record deployment task. It indicates that
+	// the internal DNSRecord extension resources shall be reconciled.
+	ShootTaskDeployDNSRecordInternal = "deployDNSRecordInternal"
+	// ShootTaskDeployDNSRecordExternal is a name for a Shoot's external DNS record deployment task. It indicates that
+	// the external DNSRecord extension resources shall be reconciled.
+	ShootTaskDeployDNSRecordExternal = "deployDNSRecordExternal"
+	// ShootTaskDeployDNSRecordIngress is a name for a Shoot's ingress DNS record deployment task. It indicates that
+	// the ingress DNSRecord extension resources shall be reconciled.
+	ShootTaskDeployDNSRecordIngress = "deployDNSRecordIngress"
 	// ShootTaskRestartControlPlanePods is a name for a Shoot task which is dedicated to restart related control plane pods.
 	ShootTaskRestartControlPlanePods = "restartControlPlanePods"
 	// ShootTaskRestartCoreAddons is a name for a Shoot task which is dedicated to restart some core addons.

--- a/pkg/controllermanager/controller/shoot/shoot_maintenance_control.go
+++ b/pkg/controllermanager/controller/shoot/shoot_maintenance_control.go
@@ -208,7 +208,13 @@ func (r *shootMaintenanceReconciler) reconcile(ctx context.Context, shoot *garde
 		metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.ShootOperationRotateSSHKeypair)
 	}
 
-	controllerutils.AddTasks(shoot.Annotations, v1beta1constants.ShootTaskDeployInfrastructure)
+	controllerutils.AddTasks(shoot.Annotations,
+		v1beta1constants.ShootTaskDeployInfrastructure,
+		v1beta1constants.ShootTaskDeployDNSRecordInternal,
+		v1beta1constants.ShootTaskDeployDNSRecordExternal,
+		v1beta1constants.ShootTaskDeployDNSRecordIngress,
+	)
+
 	if utils.IsTrue(r.config.EnableShootControlPlaneRestarter) {
 		controllerutils.AddTasks(shoot.Annotations, v1beta1constants.ShootTaskRestartControlPlanePods)
 	}

--- a/pkg/controllermanager/controller/shoot/shoot_maintenance_control_test.go
+++ b/pkg/controllermanager/controller/shoot/shoot_maintenance_control_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Shoot Maintenance", func() {
 	expirationDateInThePast := metav1.Time{Time: now.AddDate(0, 0, -1)}
 
 	Context("Shoot Maintenance", func() {
-		Describe("ExpirationDateExpired", func() {
+		Describe("#ExpirationDateExpired", func() {
 			It("should determine that expirationDate applies", func() {
 				applies := ExpirationDateExpired(&expirationDateInThePast)
 				Expect(applies).To(Equal(true))
@@ -44,7 +44,7 @@ var _ = Describe("Shoot Maintenance", func() {
 			})
 		})
 
-		Describe("ForceMachineImageUpdateRequired", func() {
+		Describe("#ForceMachineImageUpdateRequired", func() {
 			var (
 				shootCurrentImage = &gardencorev1beta1.ShootMachineImage{
 					Name:    "CoreOs",
@@ -98,7 +98,7 @@ var _ = Describe("Shoot Maintenance", func() {
 		})
 	})
 
-	Describe("MaintainMachineImages", func() {
+	Describe("#MaintainMachineImages", func() {
 		var (
 			shootCurrentImage        *gardencorev1beta1.ShootMachineImage
 			cloudProfile             *gardencorev1beta1.CloudProfile
@@ -385,7 +385,7 @@ var _ = Describe("Shoot Maintenance", func() {
 		})
 	})
 
-	Describe("Maintain Kubernetes Version", func() {
+	Describe("#maintainKubernetesVersion", func() {
 		var (
 			cloudProfile          *gardencorev1beta1.CloudProfile
 			shoot                 *gardencorev1beta1.Shoot

--- a/pkg/operation/botanist/addons_test.go
+++ b/pkg/operation/botanist/addons_test.go
@@ -159,7 +159,7 @@ var _ = Describe("addons", func() {
 		ctrl.Finish()
 	})
 
-	Context("DefaultNginxIngressDNSEntry", func() {
+	Describe("#DefaultNginxIngressDNSEntry", func() {
 		It("should delete the entry when calling Deploy", func() {
 			Expect(client.Create(ctx, &dnsv1alpha1.DNSEntry{
 				ObjectMeta: metav1.ObjectMeta{Name: common.ShootDNSIngressName, Namespace: seedNamespace},
@@ -173,7 +173,7 @@ var _ = Describe("addons", func() {
 		})
 	})
 
-	Context("DefaultNginxIngressDNSOwner", func() {
+	Describe("#DefaultNginxIngressDNSOwner", func() {
 		It("should delete the owner when calling Deploy", func() {
 			Expect(client.Create(ctx, &dnsv1alpha1.DNSOwner{
 				ObjectMeta: metav1.ObjectMeta{Name: seedNamespace + "-" + common.ShootDNSIngressName},
@@ -187,7 +187,7 @@ var _ = Describe("addons", func() {
 		})
 	})
 
-	Context("SetNginxIngressAddress", func() {
+	Describe("#SetNginxIngressAddress", func() {
 		It("does nothing when DNS is disabled", func() {
 			b.Shoot.DisableDNS = true
 
@@ -259,7 +259,7 @@ var _ = Describe("addons", func() {
 		})
 	})
 
-	Context("DefaultIngressDNSRecord", func() {
+	Describe("#DefaultIngressDNSRecord", func() {
 		It("should create a component with correct values when nginx-ingress addon is enabled", func() {
 			c := b.DefaultIngressDNSRecord()
 			c.SetRecordType(extensionsv1alpha1.DNSRecordTypeA)
@@ -276,11 +276,33 @@ var _ = Describe("addons", func() {
 				SecretData: map[string][]byte{
 					"external-foo": []byte("external-bar"),
 				},
-				DNSName:    "*.ingress." + externalDomain,
-				RecordType: extensionsv1alpha1.DNSRecordTypeA,
-				Values:     []string{address},
+				DNSName:           "*.ingress." + externalDomain,
+				RecordType:        extensionsv1alpha1.DNSRecordTypeA,
+				Values:            []string{address},
+				AnnotateOperation: false,
 			}))
 		})
+
+		DescribeTable("should set AnnotateOperation value to true",
+			func(mutateShootFn func()) {
+				mutateShootFn()
+
+				c := b.DefaultIngressDNSRecord()
+
+				Expect(c.GetValues().AnnotateOperation).To(BeTrue())
+			},
+
+			Entry("task annotation present", func() {
+				shoot := b.Shoot.GetInfo()
+				metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "shoot.gardener.cloud/tasks", "deployDNSRecordIngress")
+				b.Shoot.SetInfo(shoot)
+			}),
+			Entry("restore phase", func() {
+				shoot := b.Shoot.GetInfo()
+				shoot.Status.LastOperation = &gardencorev1beta1.LastOperation{Type: gardencorev1beta1.LastOperationTypeRestore}
+				b.Shoot.SetInfo(shoot)
+			}),
+		)
 
 		It("should create a component with correct values when nginx-ingress addon is disabled", func() {
 			b.Shoot.GetInfo().Spec.Addons.NginxIngress.Enabled = false
@@ -300,13 +322,18 @@ var _ = Describe("addons", func() {
 				SecretData: map[string][]byte{
 					"external-foo": []byte("external-bar"),
 				},
-				DNSName:    "*.ingress." + externalDomain,
-				RecordType: extensionsv1alpha1.DNSRecordTypeA,
-				Values:     []string{address},
+				DNSName:           "*.ingress." + externalDomain,
+				RecordType:        extensionsv1alpha1.DNSRecordTypeA,
+				Values:            []string{address},
+				AnnotateOperation: false,
 			}))
 		})
 
 		It("should create a component that creates the DNSRecord and its secret on Deploy", func() {
+			shoot := b.Shoot.GetInfo()
+			metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "shoot.gardener.cloud/tasks", "deployDNSRecordIngress")
+			b.Shoot.SetInfo(shoot)
+
 			c := b.DefaultIngressDNSRecord()
 			c.SetRecordType(extensionsv1alpha1.DNSRecordTypeA)
 			c.SetValues([]string{address})

--- a/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord.go
+++ b/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord.go
@@ -65,9 +65,13 @@ type Values struct {
 	Name string
 	// SecretName is the name of the secret referenced by the DNSRecord resource.
 	SecretName string
-	// ReconcileOnChange specifies that the DNSRecord resource should only be reconciled when first created or if its desired state has changed compared to the current one.
-	// This mode is used for owner DNS records to avoid competing reconciliations during the control plane migration "bad case" scenario.
-	ReconcileOnChange bool
+	// ReconcileOnlyOnChangeOrError specifies that the DNSRecord resource should only be reconciled when first created
+	// or if its last operation was not successful or if its desired state has changed compared to the current one.
+	ReconcileOnlyOnChangeOrError bool
+	// AnnotateOperation indicates if the DNSRecord resource shall be annotated with the respective
+	// "gardener.cloud/operation" (forcing a reconciliation or restoration). If this is false then the DNSRecord object
+	// will be created/updated but the extension controller will not act upon it.
+	AnnotateOperation bool
 	// Type is the type of the DNSRecord provider.
 	Type string
 	// SecretData is the secret data of the DNSRecord (containing provider credentials, etc.)
@@ -140,8 +144,10 @@ func (c *dnsRecord) deploy(ctx context.Context, operation string) (extensionsv1a
 	}
 
 	mutateFn := func() error {
-		metav1.SetMetaDataAnnotation(&c.dnsRecord.ObjectMeta, v1beta1constants.GardenerOperation, operation)
-		metav1.SetMetaDataAnnotation(&c.dnsRecord.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
+		if c.values.AnnotateOperation {
+			metav1.SetMetaDataAnnotation(&c.dnsRecord.ObjectMeta, v1beta1constants.GardenerOperation, operation)
+			metav1.SetMetaDataAnnotation(&c.dnsRecord.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
+		}
 
 		c.dnsRecord.Spec = extensionsv1alpha1.DNSRecordSpec{
 			DefaultSpec: extensionsv1alpha1.DefaultSpec{
@@ -161,7 +167,7 @@ func (c *dnsRecord) deploy(ctx context.Context, operation string) (extensionsv1a
 		return nil
 	}
 
-	if c.values.ReconcileOnChange {
+	if c.values.ReconcileOnlyOnChangeOrError {
 		if err := c.client.Get(ctx, client.ObjectKeyFromObject(c.dnsRecord), c.dnsRecord); err != nil {
 			if !apierrors.IsNotFound(err) {
 				return nil, err

--- a/pkg/operation/seed/nginxingress.go
+++ b/pkg/operation/seed/nginxingress.go
@@ -106,19 +106,22 @@ func getManagedIngressDNSOwner(k8sSeedClient client.Client, seedClusterIdentity 
 
 func getManagedIngressDNSRecord(seedClient client.Client, dnsConfig gardencorev1beta1.SeedDNS, secretData map[string][]byte, seedFQDN string, loadBalancerAddress string, log logrus.FieldLogger) component.DeployMigrateWaiter {
 	values := &dnsrecord.Values{
-		Name:       "seed-ingress",
-		SecretName: "seed-ingress",
-		Namespace:  v1beta1constants.GardenNamespace,
-		SecretData: secretData,
-		DNSName:    seedFQDN,
-		RecordType: extensionsv1alpha1helper.GetDNSRecordType(loadBalancerAddress),
+		Name:                         "seed-ingress",
+		SecretName:                   "seed-ingress",
+		Namespace:                    v1beta1constants.GardenNamespace,
+		SecretData:                   secretData,
+		DNSName:                      seedFQDN,
+		RecordType:                   extensionsv1alpha1helper.GetDNSRecordType(loadBalancerAddress),
+		ReconcileOnlyOnChangeOrError: true,
 	}
+
 	if dnsConfig.Provider != nil {
 		values.Type = dnsConfig.Provider.Type
 		if dnsConfig.Provider.Zones != nil && len(dnsConfig.Provider.Zones.Include) == 1 {
 			values.Zone = &dnsConfig.Provider.Zones.Include[0]
 		}
 	}
+
 	if loadBalancerAddress != "" {
 		values.Values = []string{loadBalancerAddress}
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement
/merge squash

**What this PR does / why we need it**:
As explained in #5526, the `DNSRecord` reconciliation is restricted similar to how we restrict the `Infrastructure` reconciliation. It is only executed

- during shoot creation
- during shoot maintenance
- during shoot reconciliation only when the relevant spec has changed
- during shoot deletion if the record is not healthy (only applies to the internal record)
- during seed creation
- during seed reconciliation only when the relevant spec has changed or when it is not healthy

**Which issue(s) this PR fixes**:
Fixes #5526

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
The `DNSRecord` extension resources for shoot clusters are now only reconciled during shoot creation or maintenance or when they are unhealthy. Similarly, the `DNSRecord` extension resource for seed cluster is now only reconciled during seed creation or when it is unhealthy. Both is to prevent flooding DNS provider APIs which typically have quite low rate limits.
```
