### PR TITLE
Added static information about the pods, e.g. node name and ip, to the pods dashboard.

### DIFF
--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-pods-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-pods-dashboard.json
@@ -6,9 +6,103 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": 24,
-  "iteration": 1591170710914,
+  "iteration": 1646746905974,
   "links": [],
   "panels": [
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 2,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 8,
+      "links": [
+        {
+          "title": "$node",
+          "url": "/d/node-details/node-details?var-Node=${node:queryparam}"
+        }
+      ],
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "text": {},
+        "textMode": "name"
+      },
+      "pluginVersion": "7.2.1",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "kube_pod_info{pod=\"$pod\"}",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        },
+        {
+          "exemplar": true,
+          "expr": "kube_pod_info{pod=\"$pod\"}",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "{{pod_ip}}",
+          "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "kube_pod_info{pod=\"$pod\"}",
+          "format": "time_series",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "{{node}}",
+          "refId": "C"
+        },
+        {
+          "exemplar": true,
+          "expr": "kube_pod_info{pod=\"$pod\"}",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "{{host_ip}}",
+          "refId": "D"
+        }
+      ],
+      "type": "stat"
+    },
     {
       "aliasColors": {},
       "bars": false,
@@ -31,7 +125,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 0
+        "y": 2
       },
       "hiddenSeries": false,
       "id": 1,
@@ -161,7 +255,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 7
+        "y": 9
       },
       "hiddenSeries": false,
       "id": 2,
@@ -303,7 +397,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 14
+        "y": 16
       },
       "hiddenSeries": false,
       "id": 3,
@@ -416,7 +510,7 @@
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 21
+        "y": 23
       },
       "hiddenSeries": false,
       "id": 4,
@@ -525,7 +619,7 @@
         "h": 21,
         "w": 24,
         "x": 0,
-        "y": 28
+        "y": 30
       },
       "id": 6,
       "maxDataPoints": "",
@@ -657,6 +751,38 @@
         "query": "",
         "skipUrlSync": false,
         "type": "textbox"
+      },
+      {
+        "allValue": null,
+        "datasource": null,
+        "definition": "label_values(kube_pod_info{pod=\"$pod\"}, node)",
+        "description": null,
+        "error": null,
+        "hide": 2,
+        "includeAll": false,
+        "label": null,
+        "multi": false,
+        "name": "node",
+        "options": [
+          {
+            "selected": true,
+            "text": "",
+            "value": ""
+          }
+        ],
+        "query": {
+          "query": "label_values(kube_pod_info{pod=\"$pod\"}, node)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 0,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
       }
     ]
   },


### PR DESCRIPTION

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
Added static information about the pods, e.g. node name and ip, to the pods dashboard.

It also includes a link to the node dashboard.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:
<img width="2447" alt="Dashboard Screenshot" src="https://user-images.githubusercontent.com/30600170/157486040-5809932a-bce1-4d94-9978-ed3970c1ae0f.png">

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The pods grafana dashboard now includes the node name and the pod/node ips per pod as well as a link to the node dashboard.
```

/invite @wyb1 @istvanballok 