### PR TITLE
Use field selector for `core.BackupBucket.spec.seedName`

### DIFF
--- a/pkg/controllermanager/controller/controllerregistration/seed_control_test.go
+++ b/pkg/controllermanager/controller/controllerregistration/seed_control_test.go
@@ -73,9 +73,9 @@ var _ = Describe("controllerRegistrationReconciler", func() {
 		type11 = "type11"
 		type12 = "type12"
 
-		backupBucket2 = &gardencorev1beta1.BackupBucket{
+		backupBucket1 = &gardencorev1beta1.BackupBucket{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "bb2",
+				Name: "bb1",
 			},
 			Spec: gardencorev1beta1.BackupBucketSpec{
 				SeedName: &seedName,
@@ -84,9 +84,9 @@ var _ = Describe("controllerRegistrationReconciler", func() {
 				},
 			},
 		}
-		backupBucket3 = &gardencorev1beta1.BackupBucket{
+		backupBucket2 = &gardencorev1beta1.BackupBucket{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "bb3",
+				Name: "bb2",
 			},
 			Spec: gardencorev1beta1.BackupBucketSpec{
 				SeedName: &seedName,
@@ -97,13 +97,13 @@ var _ = Describe("controllerRegistrationReconciler", func() {
 		}
 		backupBucketList = &gardencorev1beta1.BackupBucketList{
 			Items: []gardencorev1beta1.BackupBucket{
+				*backupBucket1,
 				*backupBucket2,
-				*backupBucket3,
 			},
 		}
 		buckets = map[string]gardencorev1beta1.BackupBucket{
+			backupBucket1.Name: *backupBucket1,
 			backupBucket2.Name: *backupBucket2,
-			backupBucket3.Name: *backupBucket3,
 		}
 
 		backupEntry2 = &gardencorev1beta1.BackupEntry{
@@ -112,7 +112,7 @@ var _ = Describe("controllerRegistrationReconciler", func() {
 			},
 			Spec: gardencorev1beta1.BackupEntrySpec{
 				SeedName:   &seedName,
-				BucketName: backupBucket2.Name,
+				BucketName: backupBucket1.Name,
 			},
 		}
 		backupEntry3 = &gardencorev1beta1.BackupEntry{
@@ -121,7 +121,7 @@ var _ = Describe("controllerRegistrationReconciler", func() {
 			},
 			Spec: gardencorev1beta1.BackupEntrySpec{
 				SeedName:   &seedName,
-				BucketName: backupBucket2.Name,
+				BucketName: backupBucket1.Name,
 			},
 		}
 		backupEntryList = &gardencorev1beta1.BackupEntryList{
@@ -492,8 +492,8 @@ var _ = Describe("controllerRegistrationReconciler", func() {
 			kindTypes, bs := computeKindTypesForBackupBuckets(backupBucketList)
 
 			Expect(kindTypes).To(Equal(sets.NewString(
+				extensionsv1alpha1.BackupBucketResource+"/"+backupBucket1.Spec.Provider.Type,
 				extensionsv1alpha1.BackupBucketResource+"/"+backupBucket2.Spec.Provider.Type,
-				extensionsv1alpha1.BackupBucketResource+"/"+backupBucket3.Spec.Provider.Type,
 			)))
 			Expect(bs).To(Equal(buckets))
 		})
@@ -510,7 +510,7 @@ var _ = Describe("controllerRegistrationReconciler", func() {
 			kindTypes := computeKindTypesForBackupEntries(nopLogger, backupEntryList, buckets)
 
 			Expect(kindTypes).To(Equal(sets.NewString(
-				extensionsv1alpha1.BackupEntryResource + "/" + backupBucket2.Spec.Provider.Type,
+				extensionsv1alpha1.BackupEntryResource + "/" + backupBucket1.Spec.Provider.Type,
 			)))
 		})
 	})

--- a/pkg/controllermanager/controller/controllerregistration/seed_control_test.go
+++ b/pkg/controllermanager/controller/controllerregistration/seed_control_test.go
@@ -73,16 +73,6 @@ var _ = Describe("controllerRegistrationReconciler", func() {
 		type11 = "type11"
 		type12 = "type12"
 
-		backupBucket1 = &gardencorev1beta1.BackupBucket{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "bb1",
-			},
-			Spec: gardencorev1beta1.BackupBucketSpec{
-				Provider: gardencorev1beta1.BackupBucketProvider{
-					Type: type1,
-				},
-			},
-		}
 		backupBucket2 = &gardencorev1beta1.BackupBucket{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "bb2",
@@ -107,32 +97,22 @@ var _ = Describe("controllerRegistrationReconciler", func() {
 		}
 		backupBucketList = &gardencorev1beta1.BackupBucketList{
 			Items: []gardencorev1beta1.BackupBucket{
-				*backupBucket1,
 				*backupBucket2,
 				*backupBucket3,
 			},
 		}
 		buckets = map[string]gardencorev1beta1.BackupBucket{
-			backupBucket1.Name: *backupBucket1,
 			backupBucket2.Name: *backupBucket2,
 			backupBucket3.Name: *backupBucket3,
 		}
 
-		backupEntry1 = &gardencorev1beta1.BackupEntry{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "be1",
-			},
-			Spec: gardencorev1beta1.BackupEntrySpec{
-				BucketName: backupBucket1.Name,
-			},
-		}
 		backupEntry2 = &gardencorev1beta1.BackupEntry{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "be2",
 			},
 			Spec: gardencorev1beta1.BackupEntrySpec{
 				SeedName:   &seedName,
-				BucketName: backupBucket1.Name,
+				BucketName: backupBucket2.Name,
 			},
 		}
 		backupEntry3 = &gardencorev1beta1.BackupEntry{
@@ -146,7 +126,6 @@ var _ = Describe("controllerRegistrationReconciler", func() {
 		}
 		backupEntryList = &gardencorev1beta1.BackupEntryList{
 			Items: []gardencorev1beta1.BackupEntry{
-				*backupEntry1,
 				*backupEntry2,
 				*backupEntry3,
 			},
@@ -503,14 +482,14 @@ var _ = Describe("controllerRegistrationReconciler", func() {
 
 	Describe("#computeKindTypesForBackupBuckets", func() {
 		It("should return empty results for empty input", func() {
-			kindTypes, bs := computeKindTypesForBackupBuckets(&gardencorev1beta1.BackupBucketList{}, seedName)
+			kindTypes, bs := computeKindTypesForBackupBuckets(&gardencorev1beta1.BackupBucketList{})
 
 			Expect(kindTypes.Len()).To(BeZero())
 			Expect(bs).To(BeEmpty())
 		})
 
 		It("should correctly compute the result", func() {
-			kindTypes, bs := computeKindTypesForBackupBuckets(backupBucketList, seedName)
+			kindTypes, bs := computeKindTypesForBackupBuckets(backupBucketList)
 
 			Expect(kindTypes).To(Equal(sets.NewString(
 				extensionsv1alpha1.BackupBucketResource+"/"+backupBucket2.Spec.Provider.Type,
@@ -522,17 +501,16 @@ var _ = Describe("controllerRegistrationReconciler", func() {
 
 	Describe("#computeKindTypesForBackupEntries", func() {
 		It("should return empty results for empty input", func() {
-			kindTypes := computeKindTypesForBackupEntries(nopLogger, &gardencorev1beta1.BackupEntryList{}, nil, seedName)
+			kindTypes := computeKindTypesForBackupEntries(nopLogger, &gardencorev1beta1.BackupEntryList{}, nil)
 
 			Expect(kindTypes.Len()).To(BeZero())
 		})
 
 		It("should correctly compute the result", func() {
-			kindTypes := computeKindTypesForBackupEntries(nopLogger, backupEntryList, buckets, seedName)
+			kindTypes := computeKindTypesForBackupEntries(nopLogger, backupEntryList, buckets)
 
 			Expect(kindTypes).To(Equal(sets.NewString(
-				extensionsv1alpha1.BackupEntryResource+"/"+backupBucket1.Spec.Provider.Type,
-				extensionsv1alpha1.BackupEntryResource+"/"+backupBucket2.Spec.Provider.Type,
+				extensionsv1alpha1.BackupEntryResource + "/" + backupBucket2.Spec.Provider.Type,
 			)))
 		})
 	})

--- a/pkg/controllermanager/controller/factory.go
+++ b/pkg/controllermanager/controller/factory.go
@@ -237,5 +237,28 @@ func addAllFieldIndexes(ctx context.Context, indexer client.FieldIndexer) error 
 		return fmt.Errorf("failed to add indexer to Bastion Informer: %w", err)
 	}
 
+	if err := indexer.IndexField(ctx, &gardencorev1beta1.BackupBucket{}, gardencore.BackupBucketSeedName, func(obj client.Object) []string {
+		backupBucket, ok := obj.(*gardencorev1beta1.BackupBucket)
+		if !ok {
+			return []string{""}
+		}
+		if backupBucket.Spec.SeedName == nil {
+			return []string{""}
+		}
+		return []string{*backupBucket.Spec.SeedName}
+	}); err != nil {
+		return fmt.Errorf("failed to add indexer to BackupBucket Informer: %w", err)
+	}
+
+	if err := indexer.IndexField(ctx, &gardencorev1beta1.ControllerInstallation{}, gardencore.SeedRefName, func(obj client.Object) []string {
+		controllerInstallation, ok := obj.(*gardencorev1beta1.ControllerInstallation)
+		if !ok {
+			return []string{""}
+		}
+		return []string{controllerInstallation.Spec.SeedRef.Name}
+	}); err != nil {
+		return fmt.Errorf("failed to add indexer to ControllerInstallation Informer: %w", err)
+	}
+
 	return nil
 }

--- a/pkg/controllermanager/controller/seed/seed_backup_bucket_reconcile_test.go
+++ b/pkg/controllermanager/controller/seed/seed_backup_bucket_reconcile_test.go
@@ -102,8 +102,8 @@ var _ = Describe("BackupBucketReconciler", func() {
 					createBackupBucket("4", seed.Name, nil),
 				}
 
-				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.BackupBucketList{})).DoAndReturn(func(ctx context.Context, list *gardencorev1beta1.BackupBucketList, opts ...client.ListOption) error {
-					(&gardencorev1beta1.BackupBucketList{Items: bbs}).DeepCopyInto(list)
+				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.BackupBucketList{}), client.MatchingFields{"spec.seedName": seed.Name}).DoAndReturn(func(ctx context.Context, list *gardencorev1beta1.BackupBucketList, opts ...client.ListOption) error {
+					(&gardencorev1beta1.BackupBucketList{Items: backupBucketsForSeed(bbs, seed.Name)}).DeepCopyInto(list)
 					return nil
 				})
 			})
@@ -161,8 +161,8 @@ var _ = Describe("BackupBucketReconciler", func() {
 					createBackupBucket("4", "barSeed", nil),
 				}
 
-				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.BackupBucketList{})).DoAndReturn(func(ctx context.Context, list *gardencorev1beta1.BackupBucketList, opts ...client.ListOption) error {
-					(&gardencorev1beta1.BackupBucketList{Items: bbs}).DeepCopyInto(list)
+				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.BackupBucketList{}), client.MatchingFields{"spec.seedName": seed.Name}).DoAndReturn(func(ctx context.Context, list *gardencorev1beta1.BackupBucketList, opts ...client.ListOption) error {
+					(&gardencorev1beta1.BackupBucketList{Items: backupBucketsForSeed(bbs, seed.Name)}).DeepCopyInto(list)
 					return nil
 				})
 			})
@@ -188,8 +188,8 @@ var _ = Describe("BackupBucketReconciler", func() {
 					createBackupBucket("1", seed.Name, &gardencorev1beta1.LastError{Description: "foo error"}),
 					createBackupBucket("2", seed.Name, nil),
 				}
-				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.BackupBucketList{})).DoAndReturn(func(ctx context.Context, list *gardencorev1beta1.BackupBucketList, opts ...client.ListOption) error {
-					(&gardencorev1beta1.BackupBucketList{Items: bbs}).DeepCopyInto(list)
+				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.BackupBucketList{}), client.MatchingFields{"spec.seedName": seed.Name}).DoAndReturn(func(ctx context.Context, list *gardencorev1beta1.BackupBucketList, opts ...client.ListOption) error {
+					(&gardencorev1beta1.BackupBucketList{Items: backupBucketsForSeed(bbs, seed.Name)}).DeepCopyInto(list)
 					return nil
 				})
 			})
@@ -221,8 +221,8 @@ var _ = Describe("BackupBucketReconciler", func() {
 					createBackupBucket("1", "fooSeed", &gardencorev1beta1.LastError{Description: "foo error"}),
 					createBackupBucket("2", "barSeed", nil),
 				}
-				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.BackupBucketList{})).DoAndReturn(func(ctx context.Context, list *gardencorev1beta1.BackupBucketList, opts ...client.ListOption) error {
-					(&gardencorev1beta1.BackupBucketList{Items: bbs}).DeepCopyInto(list)
+				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&gardencorev1beta1.BackupBucketList{}), client.MatchingFields{"spec.seedName": seed.Name}).DoAndReturn(func(ctx context.Context, list *gardencorev1beta1.BackupBucketList, opts ...client.ListOption) error {
+					(&gardencorev1beta1.BackupBucketList{Items: backupBucketsForSeed(bbs, seed.Name)}).DeepCopyInto(list)
 					return nil
 				})
 			})
@@ -264,4 +264,16 @@ func createBackupBucket(name, seedName string, lastErr *gardencorev1beta1.LastEr
 			LastError: lastErr,
 		},
 	}
+}
+
+func backupBucketsForSeed(items []gardencorev1beta1.BackupBucket, seedName string) []gardencorev1beta1.BackupBucket {
+	var out []gardencorev1beta1.BackupBucket
+
+	for _, item := range items {
+		if pointer.StringPtrDerefOr(item.Spec.SeedName, "") == seedName {
+			out = append(out, item)
+		}
+	}
+
+	return out
 }

--- a/pkg/controllerutils/associations.go
+++ b/pkg/controllerutils/associations.go
@@ -21,7 +21,6 @@ import (
 	"github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	gardenoperationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -91,36 +90,6 @@ func DetermineSecretBindingAssociations(ctx context.Context, c client.Client, qu
 // to seed with name <seedName>
 func DetermineBackupBucketAssociations(ctx context.Context, c client.Client, seedName string) ([]string, error) {
 	return determineAssociations(ctx, c, &gardencorev1beta1.BackupBucketList{}, client.MatchingFields{core.BackupBucketSeedName: seedName})
-}
-
-// DetermineBackupEntryAssociations determine the BackupEntry resources which are associated
-// to seed with name <seedName>
-func DetermineBackupEntryAssociations(ctx context.Context, c client.Client, seedName string) ([]string, error) {
-	return determineAssociations(ctx, c, seedName, &gardencorev1beta1.BackupEntryList{}, func(o runtime.Object) (string, error) {
-		backupEntry, ok := o.(*gardencorev1beta1.BackupEntry)
-		if !ok {
-			return "", fmt.Errorf("got unexpected object when expecting BackupEntry")
-		}
-		if backupEntry.Spec.SeedName == nil {
-			return "", nil
-		}
-		return *backupEntry.Spec.SeedName, nil
-	})
-}
-
-// DetermineBastionAssociations determine the Bastion resources which are associated
-// to seed with name <seedName>
-func DetermineBastionAssociations(ctx context.Context, c client.Client, seedName string) ([]string, error) {
-	return determineAssociations(ctx, c, seedName, &gardenoperationsv1alpha1.BastionList{}, func(o runtime.Object) (string, error) {
-		bastion, ok := o.(*gardenoperationsv1alpha1.Bastion)
-		if !ok {
-			return "", fmt.Errorf("got unexpected object when expecting Bastion")
-		}
-		if bastion.Spec.SeedName == nil {
-			return "", nil
-		}
-		return *bastion.Spec.SeedName, nil
-	})
 }
 
 // DetermineControllerInstallationAssociations determine the ControllerInstallation resources which are associated

--- a/pkg/gardenlet/controller/factory.go
+++ b/pkg/gardenlet/controller/factory.go
@@ -294,5 +294,18 @@ func addAllFieldIndexes(ctx context.Context, indexer client.FieldIndexer) error 
 		return fmt.Errorf("failed to add indexer to Bastion Informer: %w", err)
 	}
 
+	if err := indexer.IndexField(ctx, &gardencorev1beta1.BackupBucket{}, gardencore.BackupBucketSeedName, func(obj client.Object) []string {
+		backupBucket, ok := obj.(*gardencorev1beta1.BackupBucket)
+		if !ok {
+			return []string{""}
+		}
+		if backupBucket.Spec.SeedName == nil {
+			return []string{""}
+		}
+		return []string{*backupBucket.Spec.SeedName}
+	}); err != nil {
+		return fmt.Errorf("failed to add indexer to BackupBucket Informer: %w", err)
+	}
+
 	return nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup
/merge squash

**What this PR does / why we need it**:
Use field selector for `core.BackupBucket.spec.seedName`

**Which issue(s) this PR fixes**:
Fixes #5487

**Special notes for your reviewer**:
On the way, I cleaned up or simplified some code which can or already is leveraging field selectors.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
