### PR TITLE
Add dedicated serviceaccount for blackbox-exporter

### DIFF
--- a/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/deployment.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/deployment.yaml
@@ -32,6 +32,7 @@ spec:
         networking.gardener.cloud/to-public-networks: allowed
         networking.gardener.cloud/to-apiserver: allowed
     spec:
+      serviceAccountName: blackbox-exporter
       tolerations:
       - effect: NoSchedule
         operator: Exists

--- a/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/serviceaccount.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/serviceaccount.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: blackbox-exporter
+  namespace: kube-system
+  labels:
+    gardener.cloud/role: monitoring
+    component: blackbox-exporter
+    origin: gardener
+automountServiceAccountToken: false


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security monitoring
/kind bug

**What this PR does / why we need it**:

Before, blackbox-exporter in the shoot was not specifying any `serviceAccountName` and was hence using the `kube-system/default` service account.
With https://github.com/gardener/gardener/pull/5422, the `kube-system/default` service account specifies `automountServiceAccountToken=false` and because the grm projected token volume webhook does not mount the default service account, blackbox-exporter runs without any service account token mount.

This causes the probe to fail with errors like this:
```
Logs for the probe:
ts=2022-03-09T08:24:52.8028413Z caller=main.go:304 module=http_kubernetes_service target=https://kubernetes.default.svc.cluster.local/healthz level=info msg="Beginning probe" probe=http timeout_seconds=9.5
ts=2022-03-09T08:24:52.803475Z caller=http.go:342 module=http_kubernetes_service target=https://kubernetes.default.svc.cluster.local/healthz level=info msg="Resolving target address" ip_protocol=ip4
ts=2022-03-09T08:24:52.8902673Z caller=http.go:342 module=http_kubernetes_service target=https://kubernetes.default.svc.cluster.local/healthz level=info msg="Resolved target address" ip=10.4.0.1
ts=2022-03-09T08:24:52.891821Z caller=main.go:119 module=http_kubernetes_service target=https://kubernetes.default.svc.cluster.local/healthz level=error msg="Error generating HTTP client" err="unable to load specified CA cert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt: open /var/run/secrets/kubernetes.io/serviceaccount/ca.crt: no such file or directory"
ts=2022-03-09T08:24:52.8920028Z caller=main.go:304 module=http_kubernetes_service target=https://kubernetes.default.svc.cluster.local/healthz level=error msg="Probe failed" duration_seconds=0.0889363
```

Hence, the API server availability from the shoot perspective was always displayed as "down".

This PR introduces a dedicated serviceaccount for blackbox-exporter, which is then mounted as a projected volume and used to authenticate against the API server.
With this, probes are working again.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/4878

**Special notes for your reviewer**:

/invite @rfranzke @kris94 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed that caused the monitoring data to falsely display the API server as unavailable from shoots.
```
