### PR TITLE
Add liveness probe to the apiserver-proxy proxy container.

### DIFF
--- a/charts/shoot-core/components/charts/apiserver-proxy/templates/apiserver-proxy-daemonset.yaml
+++ b/charts/shoot-core/components/charts/apiserver-proxy/templates/apiserver-proxy-daemonset.yaml
@@ -111,6 +111,15 @@ spec:
           periodSeconds: 2
           successThreshold: 1
           timeoutSeconds: 1
+        livenessProbe:
+          httpGet:
+            path: /ready
+            port: {{ .Values.adminPort }}
+          initialDelaySeconds: 1
+          periodSeconds: 10
+          successThreshold: 1
+          timeoutSeconds: 1
+          failureThreshold: 3
         ports:
         - name: metrics
           containerPort: {{ .Values.adminPort }}


### PR DESCRIPTION


**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Add liveness probe to the apiserver-proxy proxy container.

In some rare cases, the proxy containers runs into a busy loop during startup.
The liveness probe should ensure that the container gets restarted after 30 seconds
in case it does not come up properly.

**Which issue(s) this PR fixes**:
Fixes #5541 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The proxy container of the apiserver-proxy now has a liveness probe ensuring that failing containers get restarted.
```

/invite @DockToFuture @timuthy 