### PR TITLE
[release-v1.41] Automated cherry pick of #5543: Add dedicated serviceaccount for blackbox-exporter

### DIFF
--- a/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/deployment.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/deployment.yaml
@@ -32,6 +32,7 @@ spec:
         networking.gardener.cloud/to-public-networks: allowed
         networking.gardener.cloud/to-apiserver: allowed
     spec:
+      serviceAccountName: blackbox-exporter
       tolerations:
       - effect: NoSchedule
         operator: Exists

--- a/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/serviceaccount.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/serviceaccount.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: blackbox-exporter
+  namespace: kube-system
+  labels:
+    gardener.cloud/role: monitoring
+    component: blackbox-exporter
+    origin: gardener
+automountServiceAccountToken: false


### PR DESCRIPTION
/kind/bug
/area/security
/area/monitoring

Cherry pick of #5543 on release-v1.41.

#5543: Add dedicated serviceaccount for blackbox-exporter

**Release Notes:**
```bugfix operator
A bug has been fixed that caused the monitoring data to falsely display the API server as unavailable from shoots.
```