### PR TITLE
Update helm version for install-requirements

### DIFF
--- a/hack/install-requirements.sh
+++ b/hack/install-requirements.sh
@@ -22,7 +22,7 @@ echo "> [DEPRECATED] Installing requirements"
 
 export GO111MODULE=on
 curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.41.1
-curl -s "https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3" | bash -s -- --version 'v3.5.4'
+curl -s "https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3" | bash -s -- --version 'v3.6.3'
 
 platform=$(uname -s)
 if [[ ${platform} == "Linux" ]]; then

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -49,7 +49,7 @@ YQ                         := $(TOOLS_BIN_DIR)/yq
 # default tool versions
 DOCFORGE_VERSION ?= v0.21.0
 GOLANGCI_LINT_VERSION ?= v1.44.0
-HELM_VERSION ?= v3.5.4
+HELM_VERSION ?= v3.6.3
 KIND_VERSION ?= v0.11.1
 SKAFFOLD_VERSION ?= v1.35.0
 YQ_VERSION ?= v4.9.6


### PR DESCRIPTION
Update Helm version to latest 3.6.x. Solves checksum issue with `make install-requirements` on `Darwin/arm64`

Signed-off-by: Brian Topping <brian.topping@sap.com>

**How to categorize this PR?**
/area dev-productivity
/kind bug
/needs second-opinion

**What this PR does / why we need it**:
When executing `make install-requirements` on M1 Mac, the Helm install fails for v3.5.4. The problem is M1 support did not occur until 3.6 and the install script is pulling the wrong archive hash for the archive. 

**NOTE:** Needs review for specific version choice. Not sure about other dependencies on the version. Latest Helm version is `3.8.0`.

**Release note**:
```bugfix developer
The helm version is now updated to v3.6.3 to prevent `make install-requirements` from failing on M1 Macs.
```
