### PR TITLE
Ensure the max token expiration during for shoot clusters is within boundaries

### DIFF
--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -8774,7 +8774,9 @@ Kubernetes meta/v1.Duration
 <em>(Optional)</em>
 <p>MaxTokenExpiration is the maximum validity duration of a token created by the service account token issuer. If an
 otherwise valid TokenRequest with a validity duration larger than this value is requested, a token will be issued
-with a validity duration of this value.</p>
+with a validity duration of this value.
+This field must be within [30d,90d] when the ShootMaxTokenExpirationValidation feature gate is enabled.
+This field will be overwritten to be within [30d,90d] when the ShootMaxTokenExpirationOverwrite feature gate is enabled.</p>
 </td>
 </tr>
 <tr>

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -43,6 +43,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | ForceRestore                                 | `false` | `Alpha` | `1.39` |        |
 | DisableDNSProviderManagement                 | `false` | `Alpha` | `1.41` |        |
 | ShootCARotation                              | `false` | `Alpha` | `1.42` |        |
+| ShootMaxTokenExpirationOverwrite             | `false` | `Alpha` | `1.43` |        |
+| ShootMaxTokenExpirationValidation            | `false` | `Alpha` | `1.43` |        |
 
 ## Feature gates for graduated or deprecated features
 
@@ -122,3 +124,5 @@ A *General Availability* (GA) feature is also referred to as a *stable* feature.
 | ForceRestore                               | `gardenlet`                                                      | Enables forcing the shoot's restoration to the destination seed during control plane migration if the preparation for migration in the source seed is not finished after a certain grace period and is considered unlikely to succeed (falling back to the [control plane migration "bad case" scenario](../proposals/17-shoot-control-plane-migration-bad-case.md)). If you enable this feature gate, make sure to also enable `UseDNSRecords` and `CopyEtcdBackupsDuringControlPlaneMigration`. |
 | DisableDNSProviderManagement               | `gardenlet`                                                      | Disables management of `dns.gardener.cloud/v1alpha1.DNSProvider` resources. In this case, the `shoot-dns-service` extension will take this over if it is installed. This feature is only effective if the feature `UseDNSRecords` is `true`. |
 | ShootCARotation                            | `gardener-apiserver`, `gardenlet`                                | Enables the feature to trigger automated CA rotation for shoot clusters. |
+| ShootMaxTokenExpirationOverwrite           | `gardener-apiserver`                                             | Makes the Gardener API server overwriting values in the `.spec.kubernetes.kubeAPIServer.serviceAccountConfig.maxTokenExpiration` field of Shoot specifications to<br>- be at least 720h (30d) when the current value is lower<br>- be at most 2160h (90d) when the current value is higher<br>before persisting the object to etcd. |
+| ShootMaxTokenExpirationValidation          | `gardener-apiserver`                                             | Enables validations on Gardener API server that enforce that the value of the `.spec.kubernetes.kubeAPIServer.serviceAccountConfig.maxTokenExpiration` field<br>- is at least 720h (30d).<br>- is at most 2160h (90d).<br>Only enable this after `ShootMaxTokenExpirationOverwrite` is enabled and all shoots got updated accordingly. |

--- a/example/gardener-local/controlplane/values.yaml
+++ b/example/gardener-local/controlplane/values.yaml
@@ -158,6 +158,8 @@ global:
       SeedChange: true
       WorkerPoolKubernetesVersion: true
       ShootCARotation: true
+      ShootMaxTokenExpirationOverwrite: true
+      ShootMaxTokenExpirationValidation: true
     resources: {}
 
   # Gardener admission controller configuration values

--- a/hack/local-development/start-apiserver
+++ b/hack/local-development/start-apiserver
@@ -59,6 +59,8 @@ apiserver_flags="
   --feature-gates SeedChange=true \
   --feature-gates WorkerPoolKubernetesVersion=true \
   --feature-gates ShootCARotation=true \
+  --feature-gates ShootMaxTokenExpirationOverwrite=true \
+  --feature-gates ShootMaxTokenExpirationValidation=true \
   --shoot-admin-kubeconfig-max-expiration=1h \
   --enable-admission-plugins=ShootVPAEnabledByDefault \
   --v 2"

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -513,6 +513,8 @@ type ServiceAccountConfig struct {
 	// MaxTokenExpiration is the maximum validity duration of a token created by the service account token issuer. If an
 	// otherwise valid TokenRequest with a validity duration larger than this value is requested, a token will be issued
 	// with a validity duration of this value.
+	// This field must be within [30d,90d] when the ShootMaxTokenExpirationValidation feature gate is enabled.
+	// This field will be overwritten to be within [30d,90d] when the ShootMaxTokenExpirationOverwrite feature gate is enabled.
 	MaxTokenExpiration *metav1.Duration
 	// AcceptedIssuers is an additional set of issuers that are used to determine which service account tokens are accepted.
 	// These values are not used to generate new service account tokens. Only useful when service account tokens are also

--- a/pkg/apis/core/v1alpha1/generated.proto
+++ b/pkg/apis/core/v1alpha1/generated.proto
@@ -2183,6 +2183,8 @@ message ServiceAccountConfig {
   // MaxTokenExpiration is the maximum validity duration of a token created by the service account token issuer. If an
   // otherwise valid TokenRequest with a validity duration larger than this value is requested, a token will be issued
   // with a validity duration of this value.
+  // This field must be within [30d,90d] when the ShootMaxTokenExpirationValidation feature gate is enabled.
+  // This field will be overwritten to be within [30d,90d] when the ShootMaxTokenExpirationOverwrite feature gate is enabled.
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.Duration maxTokenExpiration = 4;
 

--- a/pkg/apis/core/v1alpha1/types_shoot.go
+++ b/pkg/apis/core/v1alpha1/types_shoot.go
@@ -634,6 +634,8 @@ type ServiceAccountConfig struct {
 	// MaxTokenExpiration is the maximum validity duration of a token created by the service account token issuer. If an
 	// otherwise valid TokenRequest with a validity duration larger than this value is requested, a token will be issued
 	// with a validity duration of this value.
+	// This field must be within [30d,90d] when the ShootMaxTokenExpirationValidation feature gate is enabled.
+	// This field will be overwritten to be within [30d,90d] when the ShootMaxTokenExpirationOverwrite feature gate is enabled.
 	// +optional
 	MaxTokenExpiration *metav1.Duration `json:"maxTokenExpiration,omitempty" protobuf:"bytes,4,opt,name=maxTokenExpiration"`
 	// AcceptedIssuers is an additional set of issuers that are used to determine which service account tokens are accepted.

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -2099,6 +2099,8 @@ message ServiceAccountConfig {
   // MaxTokenExpiration is the maximum validity duration of a token created by the service account token issuer. If an
   // otherwise valid TokenRequest with a validity duration larger than this value is requested, a token will be issued
   // with a validity duration of this value.
+  // This field must be within [30d,90d] when the ShootMaxTokenExpirationValidation feature gate is enabled.
+  // This field will be overwritten to be within [30d,90d] when the ShootMaxTokenExpirationOverwrite feature gate is enabled.
   // +optional
   optional k8s.io.apimachinery.pkg.apis.meta.v1.Duration maxTokenExpiration = 4;
 

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -646,6 +646,8 @@ type ServiceAccountConfig struct {
 	// MaxTokenExpiration is the maximum validity duration of a token created by the service account token issuer. If an
 	// otherwise valid TokenRequest with a validity duration larger than this value is requested, a token will be issued
 	// with a validity duration of this value.
+	// This field must be within [30d,90d] when the ShootMaxTokenExpirationValidation feature gate is enabled.
+	// This field will be overwritten to be within [30d,90d] when the ShootMaxTokenExpirationOverwrite feature gate is enabled.
 	// +optional
 	MaxTokenExpiration *metav1.Duration `json:"maxTokenExpiration,omitempty" protobuf:"bytes,4,opt,name=maxTokenExpiration"`
 	// AcceptedIssuers is an additional set of issuers that are used to determine which service account tokens are accepted.

--- a/pkg/apiserver/features/features.go
+++ b/pkg/apiserver/features/features.go
@@ -30,5 +30,7 @@ func RegisterFeatureGates() {
 		features.WorkerPoolKubernetesVersion,
 		features.SecretBindingProviderValidation,
 		features.ShootCARotation,
+		features.ShootMaxTokenExpirationOverwrite,
+		features.ShootMaxTokenExpirationValidation,
 	)))
 }

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -138,6 +138,24 @@ const (
 	// owner: @rfranzke
 	// alpha: v1.42.0
 	ShootCARotation featuregate.Feature = "ShootCARotation"
+
+	// ShootMaxTokenExpirationOverwrite makes the Gardener API server overwriting values in the
+	// `.spec.kubernetes.kubeAPIServer.serviceAccountConfig.maxTokenExpiration` field of Shoot specifications to
+	// - be at least 720h (30d) when the current value is lower
+	// - be at most 2160h (90d) when the current value is higher
+	// before persisting the object to etcd.
+	// owner: @rfranzke
+	// alpha: v1.43.0
+	ShootMaxTokenExpirationOverwrite featuregate.Feature = "ShootMaxTokenExpirationOverwrite"
+
+	// ShootMaxTokenExpirationValidation enables validations on Gardener API server that enforce that the value of the
+	// `.spec.kubernetes.kubeAPIServer.serviceAccountConfig.maxTokenExpiration` field
+	// - is at least 720h (30d).
+	// - is at most 2160h (90d).
+	// Only enable this after ShootMaxTokenExpirationOverwrite is enabled and all shoots got updated accordingly.
+	// owner: @rfranzke
+	// alpha: v1.43.0
+	ShootMaxTokenExpirationValidation featuregate.Feature = "ShootMaxTokenExpirationValidation"
 )
 
 var allFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
@@ -159,6 +177,8 @@ var allFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	ForceRestore:                               {Default: false, PreRelease: featuregate.Alpha},
 	DisableDNSProviderManagement:               {Default: false, PreRelease: featuregate.Alpha},
 	ShootCARotation:                            {Default: false, PreRelease: featuregate.Alpha},
+	ShootMaxTokenExpirationOverwrite:           {Default: false, PreRelease: featuregate.Alpha},
+	ShootMaxTokenExpirationValidation:          {Default: false, PreRelease: featuregate.Alpha},
 }
 
 // GetFeatures returns a feature gate map with the respective specifications. Non-existing feature gates are ignored.

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -6798,7 +6798,7 @@ func schema_pkg_apis_core_v1alpha1_ServiceAccountConfig(ref common.ReferenceCall
 					},
 					"maxTokenExpiration": {
 						SchemaProps: spec.SchemaProps{
-							Description: "MaxTokenExpiration is the maximum validity duration of a token created by the service account token issuer. If an otherwise valid TokenRequest with a validity duration larger than this value is requested, a token will be issued with a validity duration of this value.",
+							Description: "MaxTokenExpiration is the maximum validity duration of a token created by the service account token issuer. If an otherwise valid TokenRequest with a validity duration larger than this value is requested, a token will be issued with a validity duration of this value. This field must be within [30d,90d] when the ShootMaxTokenExpirationValidation feature gate is enabled. This field will be overwritten to be within [30d,90d] when the ShootMaxTokenExpirationOverwrite feature gate is enabled.",
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
 						},
 					},
@@ -13915,7 +13915,7 @@ func schema_pkg_apis_core_v1beta1_ServiceAccountConfig(ref common.ReferenceCallb
 					},
 					"maxTokenExpiration": {
 						SchemaProps: spec.SchemaProps{
-							Description: "MaxTokenExpiration is the maximum validity duration of a token created by the service account token issuer. If an otherwise valid TokenRequest with a validity duration larger than this value is requested, a token will be issued with a validity duration of this value.",
+							Description: "MaxTokenExpiration is the maximum validity duration of a token created by the service account token issuer. If an otherwise valid TokenRequest with a validity duration larger than this value is requested, a token will be issued with a validity duration of this value. This field must be within [30d,90d] when the ShootMaxTokenExpirationValidation feature gate is enabled. This field will be overwritten to be within [30d,90d] when the ShootMaxTokenExpirationOverwrite feature gate is enabled.",
 							Ref:         ref("k8s.io/apimachinery/pkg/apis/meta/v1.Duration"),
 						},
 					},

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -207,7 +207,7 @@ func (o *operatingSystemConfig) reconcile(ctx context.Context, reconcileFn func(
 	if err := gutil.
 		NewShootAccessSecret(downloader.SecretName, o.values.Namespace).
 		WithTargetSecret(downloader.SecretName, metav1.NamespaceSystem).
-		WithTokenExpirationDuration("2160h").
+		WithTokenExpirationDuration("720h").
 		Reconcile(ctx, o.client); err != nil {
 		return err
 	}

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
@@ -319,7 +319,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 				Expect(secret.Annotations).To(Equal(map[string]string{
 					"serviceaccount.resources.gardener.cloud/name":                      "cloud-config-downloader",
 					"serviceaccount.resources.gardener.cloud/namespace":                 "kube-system",
-					"serviceaccount.resources.gardener.cloud/token-expiration-duration": "2160h",
+					"serviceaccount.resources.gardener.cloud/token-expiration-duration": "720h",
 					"token-requestor.resources.gardener.cloud/target-secret-name":       "cloud-config-downloader",
 					"token-requestor.resources.gardener.cloud/target-secret-namespace":  "kube-system",
 				}))
@@ -452,7 +452,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 						Annotations: map[string]string{
 							"serviceaccount.resources.gardener.cloud/name":                      "cloud-config-downloader",
 							"serviceaccount.resources.gardener.cloud/namespace":                 "kube-system",
-							"serviceaccount.resources.gardener.cloud/token-expiration-duration": "2160h",
+							"serviceaccount.resources.gardener.cloud/token-expiration-duration": "720h",
 							"token-requestor.resources.gardener.cloud/target-secret-name":       "cloud-config-downloader",
 							"token-requestor.resources.gardener.cloud/target-secret-namespace":  "kube-system",
 						},

--- a/pkg/registry/core/shoot/strategy.go
+++ b/pkg/registry/core/shoot/strategy.go
@@ -75,6 +75,8 @@ func (shootStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Obje
 	}
 
 	if utilfeature.DefaultFeatureGate.Enabled(features.ShootMaxTokenExpirationOverwrite) {
+		// Note that this must be executed after `mustIncreaseGeneration` is called, otherwise we might trigger a
+		// reconciliation outside of the maintenance time window because the spec might change in below call.
 		overwriteMaxTokenExpiration(newShoot)
 	}
 }

--- a/pkg/registry/core/shoot/strategy.go
+++ b/pkg/registry/core/shoot/strategy.go
@@ -17,6 +17,7 @@ package shoot
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/gardener/gardener/pkg/api"
 	"github.com/gardener/gardener/pkg/apis/core"
@@ -26,6 +27,7 @@ import (
 	"github.com/gardener/gardener/pkg/features"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -57,6 +59,10 @@ func (shootStrategy) PrepareForCreate(ctx context.Context, obj runtime.Object) {
 
 	shoot.Generation = 1
 	shoot.Status = core.ShootStatus{}
+
+	if utilfeature.DefaultFeatureGate.Enabled(features.ShootMaxTokenExpirationOverwrite) {
+		overwriteMaxTokenExpiration(shoot)
+	}
 }
 
 func (shootStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
@@ -66,6 +72,25 @@ func (shootStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Obje
 
 	if mustIncreaseGeneration(oldShoot, newShoot) {
 		newShoot.Generation = oldShoot.Generation + 1
+	}
+
+	if utilfeature.DefaultFeatureGate.Enabled(features.ShootMaxTokenExpirationOverwrite) {
+		overwriteMaxTokenExpiration(newShoot)
+	}
+}
+
+func overwriteMaxTokenExpiration(shoot *core.Shoot) {
+	if shoot.Spec.Kubernetes.KubeAPIServer != nil &&
+		shoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig != nil &&
+		shoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.MaxTokenExpiration != nil {
+
+		if shoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.MaxTokenExpiration.Duration < 720*time.Hour {
+			shoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.MaxTokenExpiration = &metav1.Duration{Duration: 720 * time.Hour}
+		}
+
+		if shoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.MaxTokenExpiration.Duration > 2160*time.Hour {
+			shoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.MaxTokenExpiration = &metav1.Duration{Duration: 2160 * time.Hour}
+		}
 	}
 }
 

--- a/pkg/registry/core/shoot/strategy_test.go
+++ b/pkg/registry/core/shoot/strategy_test.go
@@ -51,31 +51,21 @@ var _ = Describe("Strategy", func() {
 			}
 
 			DescribeTable("ShootMaxTokenExpirationOverwrite feature gate enabled",
-				func(maxTokenExpiration, expectedDuration time.Duration) {
-					defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.ShootMaxTokenExpirationOverwrite, true)()
+				func(featureGateEnabled bool, maxTokenExpiration, expectedDuration time.Duration) {
+					defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.ShootMaxTokenExpirationOverwrite, featureGateEnabled)()
 
 					shoot := newShoot(maxTokenExpiration)
 					shootregistry.Strategy.PrepareForCreate(context.TODO(), shoot)
 					Expect(shoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.MaxTokenExpiration.Duration).To(Equal(expectedDuration))
 				},
 
-				Entry("too low value", time.Hour, 720*time.Hour),
-				Entry("too high value", 3000*time.Hour, 2160*time.Hour),
-				Entry("value within boundaries", 1000*time.Hour, 1000*time.Hour),
-			)
+				Entry("feature gate enabled, too low value", true, time.Hour, 720*time.Hour),
+				Entry("feature gate enabled, too high value", true, 3000*time.Hour, 2160*time.Hour),
+				Entry("feature gate enabled, value within boundaries", true, 1000*time.Hour, 1000*time.Hour),
 
-			DescribeTable("ShootMaxTokenExpirationOverwrite feature gate disabled",
-				func(maxTokenExpiration, expectedDuration time.Duration) {
-					defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.ShootMaxTokenExpirationOverwrite, false)()
-
-					shoot := newShoot(maxTokenExpiration)
-					shootregistry.Strategy.PrepareForCreate(context.TODO(), shoot)
-					Expect(shoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.MaxTokenExpiration.Duration).To(Equal(expectedDuration))
-				},
-
-				Entry("too low value", time.Hour, time.Hour),
-				Entry("too high value", 3000*time.Hour, 3000*time.Hour),
-				Entry("value within boundaries", 1000*time.Hour, 1000*time.Hour),
+				Entry("feature gate disabled too low value", false, time.Hour, time.Hour),
+				Entry("feature gate disabled too high value", false, 3000*time.Hour, 3000*time.Hour),
+				Entry("feature gate disabled value within boundaries", false, 1000*time.Hour, 1000*time.Hour),
 			)
 		})
 	})
@@ -474,57 +464,23 @@ var _ = Describe("Strategy", func() {
 				}
 			}
 
-			Context("ShootMaxTokenExpirationOverwrite feature gate enabled", func() {
-				It("should overwrite too low values of max token expiration", func() {
-					defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.ShootMaxTokenExpirationOverwrite, true)()
+			DescribeTable("ShootMaxTokenExpirationOverwrite feature gate enabled",
+				func(featureGateEnabled bool, maxTokenExpiration, expectedDuration time.Duration) {
+					defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.ShootMaxTokenExpirationOverwrite, featureGateEnabled)()
 
-					shoot := newShoot(time.Hour)
-					shootregistry.Strategy.PrepareForUpdate(context.TODO(), shoot, &core.Shoot{})
-					Expect(shoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.MaxTokenExpiration.Duration).To(Equal(720 * time.Hour))
-				})
+					shoot := newShoot(maxTokenExpiration)
+					shootregistry.Strategy.PrepareForCreate(context.TODO(), shoot)
+					Expect(shoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.MaxTokenExpiration.Duration).To(Equal(expectedDuration))
+				},
 
-				It("should overwrite too high values of max token expiration", func() {
-					defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.ShootMaxTokenExpirationOverwrite, true)()
+				Entry("feature gate enabled, too low value", true, time.Hour, 720*time.Hour),
+				Entry("feature gate enabled, too high value", true, 3000*time.Hour, 2160*time.Hour),
+				Entry("feature gate enabled, value within boundaries", true, 1000*time.Hour, 1000*time.Hour),
 
-					shoot := newShoot(3000 * time.Hour)
-					shootregistry.Strategy.PrepareForUpdate(context.TODO(), shoot, &core.Shoot{})
-					Expect(shoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.MaxTokenExpiration.Duration).To(Equal(2160 * time.Hour))
-				})
-
-				It("should keep values within boundaries of max token expiration", func() {
-					defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.ShootMaxTokenExpirationOverwrite, true)()
-
-					shoot := newShoot(1000 * time.Hour)
-					shootregistry.Strategy.PrepareForUpdate(context.TODO(), shoot, &core.Shoot{})
-					Expect(shoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.MaxTokenExpiration.Duration).To(Equal(1000 * time.Hour))
-				})
-			})
-
-			Context("ShootMaxTokenExpirationOverwrite feature gate disabled", func() {
-				It("should not overwrite too low values of max token expiration", func() {
-					defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.ShootMaxTokenExpirationOverwrite, false)()
-
-					shoot := newShoot(time.Hour)
-					shootregistry.Strategy.PrepareForUpdate(context.TODO(), shoot, &core.Shoot{})
-					Expect(shoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.MaxTokenExpiration.Duration).To(Equal(time.Hour))
-				})
-
-				It("should not overwrite too high values of max token expiration", func() {
-					defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.ShootMaxTokenExpirationOverwrite, false)()
-
-					shoot := newShoot(3000 * time.Hour)
-					shootregistry.Strategy.PrepareForUpdate(context.TODO(), shoot, &core.Shoot{})
-					Expect(shoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.MaxTokenExpiration.Duration).To(Equal(3000 * time.Hour))
-				})
-
-				It("should keep values within boundaries of max token expiration", func() {
-					defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.ShootMaxTokenExpirationOverwrite, false)()
-
-					shoot := newShoot(1000 * time.Hour)
-					shootregistry.Strategy.PrepareForUpdate(context.TODO(), shoot, &core.Shoot{})
-					Expect(shoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.MaxTokenExpiration.Duration).To(Equal(1000 * time.Hour))
-				})
-			})
+				Entry("feature gate disabled too low value", false, time.Hour, time.Hour),
+				Entry("feature gate disabled too high value", false, 3000*time.Hour, 3000*time.Hour),
+				Entry("feature gate disabled value within boundaries", false, 1000*time.Hour, 1000*time.Hour),
+			)
 		})
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security usability
/kind enhancement

**What this PR does / why we need it**:
We specify a token expiration duration of `90d` for the `cloud-config-downloader`. However, we also allow that end-users overwrite the maximum token expiration duration via the `Shoot`'s `.spec.kubernetes.kubeAPIServer.serviceAccountConfig.maxTokenExpiration` field. If values lower than `90d` are provided here then the `cloud-config-downloader`'s token will also only be valid for the specified duration. We have seen extreme cases where `1h` was specified here.

Given that `cloud-config-downloader` is a critical component and that it's the only component that can download its own token, a low value (~`1h`) can easily lead to disconnected nodes when the `kube-apiserver` of a shoot is not available for an hour or otherwise not reachable. In such cases, the `cloud-config-downloader` can not refresh its token and gets disconnected, eventually. Such nodes will not receive any updates any longer.

Given that the kubelet's client certificate is valid for `30d`, we now also set the `cloud-config-downloader`'s token validity to `30d`. Additionally, we introduce two new feature gates:

- `ShootMaxTokenExpirationOverwrite` - if enabled then the `gardener-apiserver` overwrites any values for `.spec.kubernetes.kubeAPIServer.serviceAccountConfig.maxTokenExpiration` which are not in `[30d,90d]` to the respective boundary
- `ShootMaxTokenExpirationValidation` - if enabled then the `gardener-apiserver` enforces that values for `.spec.kubernetes.kubeAPIServer.serviceAccountConfig.maxTokenExpiration` are in `[30d,90d]`

End-users can still use token durations of `1h` if required by specifying this explicitly in their `PodSpec`s (the `maxTokenExpiration` field is just an upper bound, no default).

**Special notes for your reviewer**:
✅ Depends on #5535 which needs to be merged first.

/cc @timuthy @vlerenc 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```action user
When the Gardener operators enable the `ShootMaxTokenExpirationOverwrite` feature gate then values for the `.spec.kubernetes.kubeAPIServer.serviceAccountConfig.maxTokenExpiration` field in the `ShootSpec` not in `[30d,90d]` will be overwritten to be within these boundaries. When they enable the `ShootMaxTokenExpirationValidation` feature gate then values in `[30d,90d]` are enforced. Adapt your shoot specifications to match these requirements!
```
```noteworthy operator
There are two new feature gates affecting the values for the `.spec.kubernetes.kubeAPIServer.serviceAccountConfig.maxTokenExpiration` field in the `ShootSpec`:
- `ShootMaxTokenExpirationOverwrite` - if enabled then the `gardener-apiserver` overwrites any values for `.spec.kubernetes.kubeAPIServer.serviceAccountConfig.maxTokenExpiration` which are not in `[30d,90d]` to the respective boundary
- `ShootMaxTokenExpirationValidation` - if enabled then the `gardener-apiserver` enforces that values for `.spec.kubernetes.kubeAPIServer.serviceAccountConfig.maxTokenExpiration` are in `[30d,90d]`
It is recommended to first enable `ShootMaxTokenExpirationOverwrite` to not break users specifying other values, and after some time enable `ShootMaxTokenExpirationValidation` to enforce the boundaries are respected. This is required to ensure all Gardener system components remain functional now that they leverage auto-rotated tokens requested by the `TokenRequest` API.
```
