### PR TITLE
Increased kube-proxy memory limit to eight times the size.

### DIFF
--- a/pkg/operation/botanist/component/kubeproxy/kube_proxy_test.go
+++ b/pkg/operation/botanist/component/kubeproxy/kube_proxy_test.go
@@ -485,7 +485,7 @@ spec:
 					out += `
           limits:
             cpu: 80m
-            memory: 256Mi`
+            memory: 2Gi`
 				}
 
 				out += `

--- a/pkg/operation/botanist/component/kubeproxy/resources.go
+++ b/pkg/operation/botanist/component/kubeproxy/resources.go
@@ -534,7 +534,7 @@ func (k *kubeProxy) computePoolResourcesData(pool WorkerPool) (map[string][]byte
 	if k.values.VPAEnabled {
 		daemonSet.Spec.Template.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("80m"),
-			corev1.ResourceMemory: resource.MustParse("256Mi"),
+			corev1.ResourceMemory: resource.MustParse("2048Mi"),
 		}
 
 		vpaUpdateMode := autoscalingv1beta2.UpdateModeAuto


### PR DESCRIPTION

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind post-mortem
/kind bug

**What this PR does / why we need it**:
Increased kube-proxy memory limit to eight times the size.

Even though the vertical pod autoscaler is configured for kube-proxy there
might be intermediate states when the vertical pod autoscaler is not applying
its recommendations. For larger clusters the currently defined memory limit
might be too low. This change increases it to be on the safe side as kube-proxy
is crucial for setting up the service network and especially if externalTrafficPolicy
is set to local as it then also acts as the health endpoint for load balancers.
**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Increased the static memory limit of kube-proxy for cases where the vertical pod autoscaler is not acting as planned.
```
