### PR TITLE
Adapt SecretBinding table convertor

### DIFF
--- a/pkg/registry/core/secretbinding/storage/tableconvertor.go
+++ b/pkg/registry/core/secretbinding/storage/tableconvertor.go
@@ -38,6 +38,7 @@ func newTableConvertor() rest.TableConvertor {
 		headers: []metav1beta1.TableColumnDefinition{
 			{Name: "Name", Type: "string", Format: "name", Description: swaggerMetadataDescriptions["name"]},
 			{Name: "Secret", Type: "string", Format: "name", Description: swaggerMetadataDescriptions["secret"]},
+			{Name: "Provider", Type: "string", Format: "name", Description: swaggerMetadataDescriptions["provider"]},
 			{Name: "Age", Type: "date", Description: swaggerMetadataDescriptions["creationTimestamp"]},
 		},
 	}
@@ -71,6 +72,11 @@ func (c *convertor) ConvertToTable(ctx context.Context, obj runtime.Object, tabl
 
 		cells = append(cells, sb.Name)
 		cells = append(cells, sb.SecretRef.Namespace+"/"+sb.SecretRef.Name)
+		if provider := sb.Provider; provider != nil {
+			cells = append(cells, provider.Type)
+		} else {
+			cells = append(cells, "<none>")
+		}
 		cells = append(cells, metatable.ConvertToHumanReadableDateType(sb.CreationTimestamp))
 
 		return cells, nil


### PR DESCRIPTION
/area usability
/kind enhancement

Part of https://github.com/gardener/gardener/issues/4888

Old:
```
$ k -n garden-foo get sb
NAME              SECRET                            AGE
shoot-baz-local   garden-foo/shoot-alicloud-local   271d
shoot-bar-local   garden-foo/shoot-aws-local        273d
shoot-foo-local   garden-foo/shoot-azure-local      268d
```

New:

```
$ k -n garden-foo get sb
NAME              SECRET                            PROVIDER    AGE
shoot-baz-local   garden-foo/shoot-alicloud-local   alicloud    271d
shoot-bar-local   garden-foo/shoot-aws-local        aws         273d
shoot-foo-local   garden-foo/shoot-azure-local      <none>      268d
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `kubectl get secretbinding` table view was adapted to show the provider type field of the SecretBinding resource.
```
