### PR TITLE
[release-v1.41] Automated cherry pick of #5539: Fix "no matches for kind" errors during shoot reconciliation/deletion

### DIFF
--- a/cmd/gardenlet/app/gardenlet.go
+++ b/cmd/gardenlet/app/gardenlet.go
@@ -70,6 +70,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/component-base/version"
 	"k8s.io/component-base/version/verflag"
+	runtimelog "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // Options has all the context and parameters needed to run a Gardenlet.
@@ -243,6 +244,9 @@ func NewGardenlet(ctx context.Context, cfg *config.GardenletConfiguration) (*Gar
 	if err != nil {
 		return nil, fmt.Errorf("error instantiating zap logger: %w", err)
 	}
+
+	// set the logger used by sigs.k8s.io/controller-runtime
+	runtimelog.SetLogger(log)
 
 	log.Info("Starting gardenlet", "version", version.Get())
 	log.Info("Feature Gates", "featureGates", gardenletfeatures.FeatureGate.String())

--- a/pkg/client/kubernetes/clientmap/internal/alias.go
+++ b/pkg/client/kubernetes/clientmap/internal/alias.go
@@ -25,8 +25,8 @@ import (
 var (
 	// NewClientFromFile is an alias to kubernetes.NewClientFromFile which allows it to be mocked for testing.
 	NewClientFromFile = kubernetes.NewClientFromFile
-	// NewClientFromSecret is an alias to kubernetes.NewClientFromSecret which allows it to be mocked for testing.
-	NewClientFromSecret = kubernetes.NewClientFromSecret
+	// NewClientFromSecretObject is an alias to kubernetes.NewClientFromSecretObject which allows it to be mocked for testing.
+	NewClientFromSecretObject = kubernetes.NewClientFromSecretObject
 	// NewClientSetWithConfig is an alias to kubernetes.NewWithConfig which allows it to be mocked for testing.
 	NewClientSetWithConfig = kubernetes.NewWithConfig
 )

--- a/pkg/client/kubernetes/clientmap/internal/garden_clientmap.go
+++ b/pkg/client/kubernetes/clientmap/internal/garden_clientmap.go
@@ -58,10 +58,10 @@ func (f *GardenClientSetFactory) CalculateClientSetHash(context.Context, clientm
 }
 
 // NewClientSet creates a new ClientSet to the garden cluster.
-func (f *GardenClientSetFactory) NewClientSet(_ context.Context, k clientmap.ClientSetKey) (kubernetes.Interface, error) {
+func (f *GardenClientSetFactory) NewClientSet(_ context.Context, k clientmap.ClientSetKey) (kubernetes.Interface, string, error) {
 	_, ok := k.(GardenClientSetKey)
 	if !ok {
-		return nil, fmt.Errorf("unsupported ClientSetKey: expected %T got %T", GardenClientSetKey{}, k)
+		return nil, "", fmt.Errorf("unsupported ClientSetKey: expected %T got %T", GardenClientSetKey{}, k)
 	}
 
 	configFns := []kubernetes.ConfigFunc{
@@ -84,7 +84,12 @@ func (f *GardenClientSetFactory) NewClientSet(_ context.Context, k clientmap.Cli
 		))
 	}
 
-	return NewClientSetWithConfig(configFns...)
+	clientSet, err := NewClientSetWithConfig(configFns...)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return clientSet, "", nil
 }
 
 // GardenClientSetKey is a ClientSetKey for the garden cluster.

--- a/pkg/client/kubernetes/clientmap/internal/generic_clientmap.go
+++ b/pkg/client/kubernetes/clientmap/internal/generic_clientmap.go
@@ -151,17 +151,12 @@ func (cm *GenericClientMap) addClientSet(ctx context.Context, key clientmap.Clie
 		return entry, nil
 	}
 
-	cm.log.Info("Creating new ClientSet", "key", key.Key())
-	cs, err := cm.factory.NewClientSet(ctx, key)
+	cs, hash, err := cm.factory.NewClientSet(ctx, key)
 	if err != nil {
 		return nil, fmt.Errorf("error creating new ClientSet for key %q: %w", key.Key(), err)
 	}
 
-	// save hash of client set configuration to detect if it should be recreated later on
-	hash, err := cm.factory.CalculateClientSetHash(ctx, key)
-	if err != nil {
-		return nil, fmt.Errorf("error calculating ClientSet hash for key %q: %w", key.Key(), err)
-	}
+	cm.log.Info("Created new ClientSet", "key", key.Key(), "hash", hash)
 
 	entry := &clientMapEntry{
 		clientSet:      cs,

--- a/pkg/client/kubernetes/clientmap/internal/plant_clientmap.go
+++ b/pkg/client/kubernetes/clientmap/internal/plant_clientmap.go
@@ -48,41 +48,50 @@ type PlantClientSetFactory struct {
 
 // CalculateClientSetHash calculates a SHA256 hash of the kubeconfig in the plant secret.
 func (f *PlantClientSetFactory) CalculateClientSetHash(ctx context.Context, k clientmap.ClientSetKey) (string, error) {
-	key, ok := k.(PlantClientSetKey)
-	if !ok {
-		return "", fmt.Errorf("unsupported ClientSetKey: expected %T got %T", PlantClientSetKey{}, k)
-	}
-
-	secretRef, gardenClient, err := f.getPlantSecretRef(ctx, key)
+	_, hash, err := f.getSecretAndComputeHash(ctx, k)
 	if err != nil {
 		return "", err
 	}
 
-	kubeconfigSecret := &corev1.Secret{}
-	if err := gardenClient.Client().Get(ctx, client.ObjectKey{Namespace: key.Namespace, Name: secretRef.Name}, kubeconfigSecret); err != nil {
-		return "", err
-	}
-
-	return utils.ComputeSHA256Hex(kubeconfigSecret.Data[kubernetes.KubeConfig]), nil
+	return hash, nil
 }
 
 // NewClientSet creates a new ClientSet for a Plant cluster.
-func (f *PlantClientSetFactory) NewClientSet(ctx context.Context, k clientmap.ClientSetKey) (kubernetes.Interface, error) {
-	key, ok := k.(PlantClientSetKey)
-	if !ok {
-		return nil, fmt.Errorf("unsupported ClientSetKey: expected %T got %T", PlantClientSetKey{}, k)
-	}
-
-	secretRef, gardenClient, err := f.getPlantSecretRef(ctx, key)
+func (f *PlantClientSetFactory) NewClientSet(ctx context.Context, k clientmap.ClientSetKey) (kubernetes.Interface, string, error) {
+	kubeconfigSecret, hash, err := f.getSecretAndComputeHash(ctx, k)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
-	return NewClientFromSecret(ctx, gardenClient.Client(), key.Namespace, secretRef.Name,
+	clientSet, err := NewClientFromSecretObject(kubeconfigSecret,
 		kubernetes.WithClientOptions(client.Options{
 			Scheme: kubernetes.PlantScheme,
 		}),
 	)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return clientSet, hash, nil
+}
+
+func (f *PlantClientSetFactory) getSecretAndComputeHash(ctx context.Context, k clientmap.ClientSetKey) (*corev1.Secret, string, error) {
+	key, ok := k.(PlantClientSetKey)
+	if !ok {
+		return nil, "", fmt.Errorf("unsupported ClientSetKey: expected %T got %T", PlantClientSetKey{}, k)
+	}
+
+	secretRef, gardenClient, err := f.getPlantSecretRef(ctx, key)
+	if err != nil {
+		return nil, "", err
+	}
+
+	kubeconfigSecret := &corev1.Secret{}
+	if err := gardenClient.Client().Get(ctx, client.ObjectKey{Namespace: key.Namespace, Name: secretRef.Name}, kubeconfigSecret); err != nil {
+		return nil, "", err
+	}
+
+	return kubeconfigSecret, utils.ComputeSHA256Hex(kubeconfigSecret.Data[kubernetes.KubeConfig]), nil
 }
 
 func (f *PlantClientSetFactory) getPlantSecretRef(ctx context.Context, key PlantClientSetKey) (*corev1.LocalObjectReference, kubernetes.Interface, error) {

--- a/pkg/client/kubernetes/clientmap/internal/seed_clientmap.go
+++ b/pkg/client/kubernetes/clientmap/internal/seed_clientmap.go
@@ -46,18 +46,18 @@ type SeedClientSetFactory struct {
 }
 
 // CalculateClientSetHash always returns "" and nil.
-func (f *SeedClientSetFactory) CalculateClientSetHash(ctx context.Context, k clientmap.ClientSetKey) (string, error) {
+func (f *SeedClientSetFactory) CalculateClientSetHash(_ context.Context, _ clientmap.ClientSetKey) (string, error) {
 	return "", nil
 }
 
 // NewClientSet creates a new ClientSet for a Seed cluster.
-func (f *SeedClientSetFactory) NewClientSet(ctx context.Context, k clientmap.ClientSetKey) (kubernetes.Interface, error) {
+func (f *SeedClientSetFactory) NewClientSet(_ context.Context, k clientmap.ClientSetKey) (kubernetes.Interface, string, error) {
 	_, ok := k.(SeedClientSetKey)
 	if !ok {
-		return nil, fmt.Errorf("unsupported ClientSetKey: expected %T, but got %T", SeedClientSetKey(""), k)
+		return nil, "", fmt.Errorf("unsupported ClientSetKey: expected %T, but got %T", SeedClientSetKey(""), k)
 	}
 
-	return NewClientFromFile(
+	clientSet, err := NewClientFromFile(
 		"",
 		f.ClientConnectionConfig.Kubeconfig,
 		kubernetes.WithClientConnectionOptions(f.ClientConnectionConfig),
@@ -71,6 +71,11 @@ func (f *SeedClientSetFactory) NewClientSet(ctx context.Context, k clientmap.Cli
 			&eventsv1.Event{},
 		),
 	)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return clientSet, "", nil
 }
 
 // SeedClientSetKey is a ClientSetKey for a Seed cluster.

--- a/pkg/client/kubernetes/clientmap/internal/shoot_clientmap.go
+++ b/pkg/client/kubernetes/clientmap/internal/shoot_clientmap.go
@@ -20,6 +20,8 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	clientcmdlatest "k8s.io/client-go/tools/clientcmd/api/latest"
+	clientcmdv1 "k8s.io/client-go/tools/clientcmd/api/v1"
 	baseconfig "k8s.io/component-base/config"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -70,41 +72,60 @@ type seedInfo struct {
 
 // CalculateClientSetHash calculates a SHA256 hash of the kubeconfig in the 'gardener' secret in the Shoot's Seed namespace.
 func (f *ShootClientSetFactory) CalculateClientSetHash(ctx context.Context, k clientmap.ClientSetKey) (string, error) {
-	key, ok := k.(ShootClientSetKey)
-	if !ok {
-		return "", fmt.Errorf("unsupported ClientSetKey: expected %T got %T", ShootClientSetKey{}, k)
-	}
-
-	seedNamespace, seedClient, err := f.getSeedNamespace(ctx, key)
+	_, hash, err := f.getSecretAndComputeHash(ctx, k)
 	if err != nil {
 		return "", err
 	}
 
-	kubeconfigSecret := &corev1.Secret{}
-	if err := seedClient.Client().Get(ctx, client.ObjectKey{Namespace: seedNamespace, Name: f.secretName(seedNamespace)}, kubeconfigSecret); err != nil {
-		return "", err
-	}
-
-	return utils.ComputeSHA256Hex(kubeconfigSecret.Data[kubernetes.KubeConfig]), nil
+	return hash, nil
 }
 
 // NewClientSet creates a new ClientSet for a Shoot cluster.
-func (f *ShootClientSetFactory) NewClientSet(ctx context.Context, k clientmap.ClientSetKey) (kubernetes.Interface, error) {
-	key, ok := k.(ShootClientSetKey)
-	if !ok {
-		return nil, fmt.Errorf("unsupported ClientSetKey: expected %T got %T", ShootClientSetKey{}, k)
-	}
-
-	seedNamespace, seedClient, err := f.getSeedNamespace(ctx, key)
+func (f *ShootClientSetFactory) NewClientSet(ctx context.Context, k clientmap.ClientSetKey) (kubernetes.Interface, string, error) {
+	kubeconfigSecret, hash, err := f.getSecretAndComputeHash(ctx, k)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 
-	return NewClientFromSecret(ctx, seedClient.Client(), seedNamespace, f.secretName(seedNamespace),
+	// Kubeconfig secrets are created with empty authinfo and it's expected that gardener-resource-manager eventually
+	// populates a token, so let's check whether the read secret already contains authinfo
+	tokenPopulated, err := isTokenPopulated(kubeconfigSecret)
+	if err != nil {
+		return nil, "", err
+	}
+	if !tokenPopulated {
+		return nil, "", fmt.Errorf("token for shoot kubeconfig was not populated yet")
+	}
+
+	clientSet, err := NewClientFromSecretObject(kubeconfigSecret,
 		kubernetes.WithClientConnectionOptions(f.ClientConnectionConfig),
 		kubernetes.WithClientOptions(client.Options{Scheme: kubernetes.ShootScheme}),
 		kubernetes.WithDisabledCachedClient(),
 	)
+	if err != nil {
+		return nil, "", err
+	}
+
+	return clientSet, hash, nil
+}
+
+func (f *ShootClientSetFactory) getSecretAndComputeHash(ctx context.Context, k clientmap.ClientSetKey) (*corev1.Secret, string, error) {
+	key, ok := k.(ShootClientSetKey)
+	if !ok {
+		return nil, "", fmt.Errorf("unsupported ClientSetKey: expected %T got %T", ShootClientSetKey{}, k)
+	}
+
+	seedNamespace, seedClient, err := f.getSeedNamespace(ctx, key)
+	if err != nil {
+		return nil, "", err
+	}
+
+	kubeconfigSecret := &corev1.Secret{}
+	if err := seedClient.Client().Get(ctx, client.ObjectKey{Namespace: seedNamespace, Name: f.secretName(seedNamespace)}, kubeconfigSecret); err != nil {
+		return nil, "", err
+	}
+
+	return kubeconfigSecret, utils.ComputeSHA256Hex(kubeconfigSecret.Data[kubernetes.KubeConfig]), nil
 }
 
 func (f *ShootClientSetFactory) secretName(seedNamespace string) string {
@@ -204,4 +225,30 @@ type ShootClientSetKey struct {
 // Key returns the string representation of the ClientSetKey.
 func (k ShootClientSetKey) Key() string {
 	return k.Namespace + "/" + k.Name
+}
+
+func isTokenPopulated(secret *corev1.Secret) (bool, error) {
+	kubeconfig := &clientcmdv1.Config{}
+	if _, _, err := clientcmdlatest.Codec.Decode(secret.Data[kubernetes.KubeConfig], nil, kubeconfig); err != nil {
+		return false, err
+	}
+
+	var userName string
+	for _, namedContext := range kubeconfig.Contexts {
+		if namedContext.Name == kubeconfig.CurrentContext {
+			userName = namedContext.Context.AuthInfo
+			break
+		}
+	}
+
+	for _, users := range kubeconfig.AuthInfos {
+		if users.Name == userName {
+			if len(users.AuthInfo.Token) > 0 {
+				return true, nil
+			}
+			return false, nil
+		}
+	}
+
+	return false, nil
 }

--- a/pkg/client/kubernetes/clientmap/internal/shoot_clientmap_test.go
+++ b/pkg/client/kubernetes/clientmap/internal/shoot_clientmap_test.go
@@ -18,16 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/golang/mock/gomock"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	baseconfig "k8s.io/component-base/config"
-	"k8s.io/utils/pointer"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
@@ -36,6 +26,20 @@ import (
 	fakeclientset "github.com/gardener/gardener/pkg/client/kubernetes/fake"
 	. "github.com/gardener/gardener/pkg/client/kubernetes/test"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientcmdlatest "k8s.io/client-go/tools/clientcmd/api/latest"
+	clientcmdv1 "k8s.io/client-go/tools/clientcmd/api/v1"
+	baseconfig "k8s.io/component-base/config"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("ShootClientMap", func() {
@@ -193,7 +197,7 @@ var _ = Describe("ShootClientMap", func() {
 			Expect(err).To(MatchError(ContainSubstring("failed to get Project for Shoot")))
 		})
 
-		It("should use external kubeconfig if LookupHost fails (out-of-cluster)", func() {
+		It("should use external kubeconfig if LookupHost fails (out-of-cluster), failing because of unpopulated token", func() {
 			technicalID := shoot.Status.TechnicalID
 			shoot.Status.TechnicalID = "" // trigger retrieval of project instead of relying on shoot status
 
@@ -203,20 +207,90 @@ var _ = Describe("ShootClientMap", func() {
 					shoot.DeepCopyInto(obj.(*gardencorev1beta1.Shoot))
 					return nil
 				})
+			mockSeedClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: technicalID, Name: "gardener"}, gomock.AssignableToTypeOf(&corev1.Secret{})).
+				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					return nil
+				})
 			internal.LookupHost = func(host string) ([]string, error) {
 				return nil, fakeErr
 			}
 
-			internal.NewClientFromSecret = func(ctx context.Context, c client.Client, namespace, secretName string, fns ...kubernetes.ConfigFunc) (kubernetes.Interface, error) {
-				Expect(c).To(BeIdenticalTo(fakeSeedClientSet.Client()))
-				Expect(namespace).To(Equal(technicalID))
-				Expect(secretName).To(Equal("gardener"))
+			internal.NewClientFromSecretObject = func(secret *corev1.Secret, fns ...kubernetes.ConfigFunc) (kubernetes.Interface, error) {
+				Expect(secret.Namespace).To(Equal(technicalID))
+				Expect(secret.Name).To(Equal("gardener"))
+				return nil, fakeErr
+			}
+
+			cs, err := cm.GetClient(ctx, key)
+			Expect(cs).To(BeNil())
+			Expect(err).To(MatchError(ContainSubstring("token for shoot kubeconfig was not populated yet")))
+		})
+
+		It("should use external kubeconfig if LookupHost fails (out-of-cluster), failing because NewClientFromSecretObject fails", func() {
+			technicalID := shoot.Status.TechnicalID
+			shoot.Status.TechnicalID = "" // trigger retrieval of project instead of relying on shoot status
+
+			fakeErr := fmt.Errorf("fake")
+			mockGardenClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: shoot.Namespace, Name: shoot.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).
+				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					shoot.DeepCopyInto(obj.(*gardencorev1beta1.Shoot))
+					return nil
+				})
+			mockSeedClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: technicalID, Name: "gardener"}, gomock.AssignableToTypeOf(&corev1.Secret{})).
+				DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+					(&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      key.Name,
+							Namespace: key.Namespace,
+						},
+						Data: dataWithPopulatedToken(),
+					}).DeepCopyInto(obj.(*corev1.Secret))
+					return nil
+				})
+			internal.LookupHost = func(host string) ([]string, error) {
+				return nil, fakeErr
+			}
+
+			internal.NewClientFromSecretObject = func(secret *corev1.Secret, fns ...kubernetes.ConfigFunc) (kubernetes.Interface, error) {
+				Expect(secret.Namespace).To(Equal(technicalID))
+				Expect(secret.Name).To(Equal("gardener"))
 				return nil, fakeErr
 			}
 
 			cs, err := cm.GetClient(ctx, key)
 			Expect(cs).To(BeNil())
 			Expect(err).To(MatchError(fmt.Sprintf("error creating new ClientSet for key %q: fake", key.Key())))
+		})
+
+		It("should fail constructing a new ClientSet (in-cluster) because token is not populated", func() {
+			fakeCS := fakeclientset.NewClientSet()
+
+			gomock.InOrder(
+				mockGardenClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: shoot.Namespace, Name: shoot.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).
+					DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						shoot.DeepCopyInto(obj.(*gardencorev1beta1.Shoot))
+						return nil
+					}),
+				mockSeedClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: shoot.Status.TechnicalID, Name: "gardener-internal"}, gomock.AssignableToTypeOf(&corev1.Secret{})).
+					DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						return nil
+					}),
+			)
+
+			internal.NewClientFromSecretObject = func(secret *corev1.Secret, fns ...kubernetes.ConfigFunc) (kubernetes.Interface, error) {
+				Expect(secret.Namespace).To(Equal(shoot.Status.TechnicalID))
+				Expect(secret.Name).To(Equal("gardener-internal"))
+				Expect(fns).To(ConsistOfConfigFuncs(
+					kubernetes.WithClientConnectionOptions(clientConnectionConfig),
+					kubernetes.WithClientOptions(clientOptions),
+					kubernetes.WithDisabledCachedClient(),
+				))
+				return fakeCS, nil
+			}
+
+			cs, err := cm.GetClient(ctx, key)
+			Expect(cs).To(BeNil())
+			Expect(err).To(MatchError(ContainSubstring("token for shoot kubeconfig was not populated yet")))
 		})
 
 		It("should correctly construct a new ClientSet (in-cluster)", func() {
@@ -230,6 +304,13 @@ var _ = Describe("ShootClientMap", func() {
 					}),
 				mockSeedClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: shoot.Status.TechnicalID, Name: "gardener-internal"}, gomock.AssignableToTypeOf(&corev1.Secret{})).
 					DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						(&corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      key.Name,
+								Namespace: key.Namespace,
+							},
+							Data: dataWithPopulatedToken(),
+						}).DeepCopyInto(obj.(*corev1.Secret))
 						return nil
 					}),
 				mockGardenClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: shoot.Namespace, Name: shoot.Name}, gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).
@@ -240,14 +321,20 @@ var _ = Describe("ShootClientMap", func() {
 					}),
 				mockSeedClient.EXPECT().Get(ctx, client.ObjectKey{Namespace: changedTechnicalID, Name: "gardener-internal"}, gomock.AssignableToTypeOf(&corev1.Secret{})).
 					DoAndReturn(func(ctx context.Context, key client.ObjectKey, obj client.Object) error {
+						(&corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      key.Name,
+								Namespace: key.Namespace,
+							},
+							Data: dataWithPopulatedToken(),
+						}).DeepCopyInto(obj.(*corev1.Secret))
 						return nil
 					}),
 			)
 
-			internal.NewClientFromSecret = func(ctx context.Context, c client.Client, namespace, secretName string, fns ...kubernetes.ConfigFunc) (kubernetes.Interface, error) {
-				Expect(c).To(BeIdenticalTo(fakeSeedClientSet.Client()))
-				Expect(namespace).To(Equal(shoot.Status.TechnicalID))
-				Expect(secretName).To(Equal("gardener-internal"))
+			internal.NewClientFromSecretObject = func(secret *corev1.Secret, fns ...kubernetes.ConfigFunc) (kubernetes.Interface, error) {
+				Expect(secret.Namespace).To(Equal(shoot.Status.TechnicalID))
+				Expect(secret.Name).To(Equal("gardener-internal"))
 				Expect(fns).To(ConsistOfConfigFuncs(
 					kubernetes.WithClientConnectionOptions(clientConnectionConfig),
 					kubernetes.WithClientOptions(clientOptions),
@@ -355,3 +442,15 @@ var _ = Describe("ShootClientMap", func() {
 		})
 	})
 })
+
+func dataWithPopulatedToken() map[string][]byte {
+	kubeconfigRaw, err := runtime.Encode(clientcmdlatest.Codec, kutil.NewKubeconfig(
+		"context",
+		"server",
+		[]byte("cacert"),
+		clientcmdv1.AuthInfo{Token: "some-token"},
+	))
+	Expect(err).NotTo(HaveOccurred())
+
+	return map[string][]byte{"kubeconfig": kubeconfigRaw}
+}

--- a/pkg/client/kubernetes/clientmap/mock/mocks.go
+++ b/pkg/client/kubernetes/clientmap/mock/mocks.go
@@ -118,12 +118,13 @@ func (mr *MockClientSetFactoryMockRecorder) CalculateClientSetHash(arg0, arg1 in
 }
 
 // NewClientSet mocks base method.
-func (m *MockClientSetFactory) NewClientSet(arg0 context.Context, arg1 clientmap.ClientSetKey) (kubernetes.Interface, error) {
+func (m *MockClientSetFactory) NewClientSet(arg0 context.Context, arg1 clientmap.ClientSetKey) (kubernetes.Interface, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewClientSet", arg0, arg1)
 	ret0, _ := ret[0].(kubernetes.Interface)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // NewClientSet indicates an expected call of NewClientSet.

--- a/pkg/client/kubernetes/clientmap/types.go
+++ b/pkg/client/kubernetes/clientmap/types.go
@@ -54,8 +54,8 @@ type ClientSetKey interface {
 // A ClientSetFactory can be used by ClientMaps to provide the individual mechanism for
 // constructing new ClientSets for a given ClientSetKey
 type ClientSetFactory interface {
-	// NewClientSet constructs a new ClientSet for the given key.
-	NewClientSet(ctx context.Context, key ClientSetKey) (kubernetes.Interface, error)
+	// NewClientSet constructs a new ClientSet for the given key. It returns the clientset as well as its hash.
+	NewClientSet(ctx context.Context, key ClientSetKey) (kubernetes.Interface, string, error)
 	// CalculateClientSetHash calculates a hash for the configuration that is used to construct a ClientSet
 	// (e.g. kubeconfig secret) to detect if it has changed mid-air and the ClientSet should be refreshed.
 	CalculateClientSetHash(ctx context.Context, key ClientSetKey) (string, error)


### PR DESCRIPTION
/kind/bug
/area/usability

Cherry pick of #5539 on release-v1.41.

#5539: Fix "no matches for kind" errors during shoot reconciliation/deletion

**Release Notes:**
```bugfix user
A bug causing shoot reconciliations or deletions to fail with "no matches for kind" errors has been fixed.
```