### PR TITLE
[release-v1.40] Automated cherry pick of #5549: Fix race condition leading to `Pod`s without any projected token volumes

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -416,11 +416,6 @@ func (r *shootReconciler) runReconcileShootFlow(ctx context.Context, o *operatio
 			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, ensureShootClusterIdentity, waitUntilOperatingSystemConfigReady),
 		})
 		_ = g.Add(flow.Task{
-			Name:         "Deploying shoot namespaces system component",
-			Fn:           flow.TaskFn(botanist.Shoot.Components.SystemComponents.Namespaces.Deploy).RetryUntilTimeout(defaultInterval, defaultTimeout).SkipIf(o.Shoot.HibernationEnabled),
-			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, waitUntilOperatingSystemConfigReady),
-		})
-		_ = g.Add(flow.Task{
 			Name: "Deploying CoreDNS system component",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				if err := botanist.DeployCoreDNS(ctx); err != nil {

--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -315,6 +315,16 @@ func (r *shootReconciler) runReconcileShootFlow(ctx context.Context, o *operatio
 			Fn:           flow.TaskFn(botanist.Shoot.Components.ControlPlane.ResourceManager.Wait).SkipIf(o.Shoot.HibernationEnabled),
 			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager),
 		})
+		deployShootNamespaces = g.Add(flow.Task{
+			Name:         "Deploying shoot namespaces system component",
+			Fn:           flow.TaskFn(botanist.Shoot.Components.SystemComponents.Namespaces.Deploy).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager),
+		})
+		waitUntilShootNamespacesReady = g.Add(flow.Task{
+			Name:         "Waiting until shoot namespaces have been reconciled",
+			Fn:           flow.TaskFn(botanist.Shoot.Components.SystemComponents.Namespaces.Wait).SkipIf(o.Shoot.HibernationEnabled),
+			Dependencies: flow.NewTaskIDs(waitUntilGardenerResourceManagerReady, deployShootNamespaces),
+		})
 		deployVpnSeedServer = g.Add(flow.Task{
 			Name:         "Deploying vpn-seed-server",
 			Fn:           flow.TaskFn(botanist.DeployVPNServer).RetryUntilTimeout(defaultInterval, defaultTimeout),
@@ -393,7 +403,7 @@ func (r *shootReconciler) runReconcileShootFlow(ctx context.Context, o *operatio
 		deployNetwork = g.Add(flow.Task{
 			Name:         "Deploying shoot network plugin",
 			Fn:           flow.TaskFn(botanist.DeployNetwork).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			Dependencies: flow.NewTaskIDs(deployReferencedResources, deployGardenerResourceManager, waitUntilOperatingSystemConfigReady, deployKubeScheduler),
+			Dependencies: flow.NewTaskIDs(deployReferencedResources, deployGardenerResourceManager, waitUntilOperatingSystemConfigReady, deployKubeScheduler, waitUntilShootNamespacesReady),
 		})
 		waitUntilNetworkIsReady = g.Add(flow.Task{
 			Name:         "Waiting until shoot network plugin has been reconciled",
@@ -421,32 +431,32 @@ func (r *shootReconciler) runReconcileShootFlow(ctx context.Context, o *operatio
 				}
 				return nil
 			}).RetryUntilTimeout(defaultInterval, defaultTimeout).SkipIf(o.Shoot.HibernationEnabled),
-			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, initializeShootClients, waitUntilOperatingSystemConfigReady, deployKubeScheduler),
+			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, initializeShootClients, waitUntilOperatingSystemConfigReady, deployKubeScheduler, waitUntilShootNamespacesReady),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Reconcile node-local-dns system component",
 			Fn:           flow.TaskFn(botanist.ReconcileNodeLocalDNS).SkipIf(o.Shoot.HibernationEnabled),
-			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, initializeShootClients, waitUntilOperatingSystemConfigReady, deployKubeScheduler),
+			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, waitUntilOperatingSystemConfigReady, deployKubeScheduler, waitUntilShootNamespacesReady),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Deploying metrics-server system component",
 			Fn:           flow.TaskFn(botanist.DeployMetricsServer).RetryUntilTimeout(defaultInterval, defaultTimeout).SkipIf(o.Shoot.HibernationEnabled),
-			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, waitUntilOperatingSystemConfigReady, deployKubeScheduler),
+			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, waitUntilOperatingSystemConfigReady, deployKubeScheduler, waitUntilShootNamespacesReady),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Deploying vpn-shoot system component",
 			Fn:           flow.TaskFn(botanist.DeployVPNShoot).RetryUntilTimeout(defaultInterval, defaultTimeout).SkipIf(o.Shoot.HibernationEnabled),
-			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, deployKubeScheduler, deployVpnSeedServer, waitUntilKubeAPIServerIsReady),
+			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, deployKubeScheduler, deployVpnSeedServer, waitUntilShootNamespacesReady),
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Deploying node-problem-detector system component",
 			Fn:           flow.TaskFn(botanist.Shoot.Components.SystemComponents.NodeProblemDetector.Deploy).RetryUntilTimeout(defaultInterval, defaultTimeout).SkipIf(o.Shoot.HibernationEnabled),
-			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, waitUntilOperatingSystemConfigReady),
+			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, waitUntilOperatingSystemConfigReady, waitUntilShootNamespacesReady),
 		})
 		deployManagedResourcesForAddons = g.Add(flow.Task{
 			Name:         "Deploying managed resources for system components and optional addons",
 			Fn:           flow.TaskFn(botanist.DeployManagedResourceForAddons).RetryUntilTimeout(defaultInterval, defaultTimeout).SkipIf(o.Shoot.HibernationEnabled),
-			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, initializeShootClients, ensureShootClusterIdentity, deployKubeScheduler),
+			Dependencies: flow.NewTaskIDs(deployGardenerResourceManager, initializeShootClients, ensureShootClusterIdentity, deployKubeScheduler, waitUntilShootNamespacesReady),
 		})
 		deployManagedResourceForCloudConfigExecutor = g.Add(flow.Task{
 			Name:         "Deploying managed resources for the cloud config executors",

--- a/pkg/resourcemanager/webhook/tokeninvalidator/handler.go
+++ b/pkg/resourcemanager/webhook/tokeninvalidator/handler.go
@@ -21,11 +21,11 @@ import (
 	"net/http"
 
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
@@ -50,7 +50,7 @@ func (w *tokenInvalidator) Handle(_ context.Context, req admission.Request) admi
 		return admission.Errored(http.StatusUnprocessableEntity, err)
 	}
 
-	log := w.logger.WithValues("secret", client.ObjectKeyFromObject(secret))
+	log := w.logger.WithValues("secret", kutil.ObjectKeyForCreateWebhooks(secret))
 
 	if secret.Data == nil {
 		log.Info("Secret's data is nil, nothing to be done")

--- a/pkg/utils/kubernetes/kubernetes.go
+++ b/pkg/utils/kubernetes/kubernetes.go
@@ -662,7 +662,7 @@ func NewKubeconfig(contextName, server string, caCert []byte, authInfo clientcmd
 func ObjectKeyForCreateWebhooks(obj client.Object) client.ObjectKey {
 	namespace := obj.GetNamespace()
 	if len(namespace) == 0 {
-		namespace = "default"
+		namespace = metav1.NamespaceDefault
 	}
 
 	name := obj.GetName()

--- a/pkg/utils/kubernetes/kubernetes.go
+++ b/pkg/utils/kubernetes/kubernetes.go
@@ -657,3 +657,18 @@ func NewKubeconfig(contextName, server string, caCert []byte, authInfo clientcmd
 		}},
 	}
 }
+
+// ObjectKeyForCreateWebhooks creates an object key for an object handled by webhooks registered for CREATE verbs.
+func ObjectKeyForCreateWebhooks(obj client.Object) client.ObjectKey {
+	namespace := obj.GetNamespace()
+	if len(namespace) == 0 {
+		namespace = "default"
+	}
+
+	name := obj.GetName()
+	if len(name) == 0 {
+		name = obj.GetGenerateName()
+	}
+
+	return client.ObjectKey{Namespace: namespace, Name: name}
+}

--- a/pkg/utils/kubernetes/kubernetes_test.go
+++ b/pkg/utils/kubernetes/kubernetes_test.go
@@ -1597,4 +1597,15 @@ var _ = Describe("kubernetes", func() {
 			}))
 		})
 	})
+
+	DescribeTable("#ObjectKeyForCreateWebhooks",
+		func(obj client.Object, expectedKey client.ObjectKey) {
+			Expect(ObjectKeyForCreateWebhooks(obj)).To(Equal(expectedKey))
+		},
+
+		Entry("object w/o namespace with generateName", &corev1.Pod{ObjectMeta: metav1.ObjectMeta{GenerateName: "foo"}}, client.ObjectKey{Namespace: "default", Name: "foo"}),
+		Entry("object w/o namespace with name", &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "foo"}}, client.ObjectKey{Namespace: "default", Name: "foo"}),
+		Entry("object w/ namespace with generateName", &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "bar", GenerateName: "foo"}}, client.ObjectKey{Namespace: "bar", Name: "foo"}),
+		Entry("object w/ namespace with name", &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "bar", Name: "foo"}}, client.ObjectKey{Namespace: "bar", Name: "foo"}),
+	)
 })


### PR DESCRIPTION
/kind/bug
/area/security

Cherry pick of #5549 on release-v1.40.

#5549: Fix race condition leading to `Pod`s without any projected token volumes

**Release Notes:**
```bugfix user
A race condition has been fixed which can lead to pods without any projected token volumes for newly created shoots.
```