### PR TITLE
Nit: Update the release note category in a doc file

### DIFF
--- a/docs/development/changing-the-api.md
+++ b/docs/development/changing-the-api.md
@@ -32,7 +32,7 @@ Most Gardener components have a component configuration that follows similar pri
 Those component configurations are defined in `pkg/{controllermanager,gardenlet,scheduler},pkg/apis/config`.
 Hence, the above checklist also applies for changes to those APIs.
 However, since these APIs are only used internally and only during the deployment of Gardener the guidelines with respect to changes and backwards-compatibility are slightly relaxed.
-If necessary then it is allowed to remove fields without a proper deprecation period if the release note uses the `action operator` keywords.
+If necessary then it is allowed to remove fields without a proper deprecation period if the release note uses the `breaking operator` keywords.
 
 In addition to the above checklist:
 

--- a/docs/development/testmachinery_tests.md
+++ b/docs/development/testmachinery_tests.md
@@ -39,8 +39,6 @@ test
 └── testmachinery # test machinery tests
    ├── gardener   # actual test cases imported by suites/gardener
    │  └── security
-   ├── landscaper
-   │  └── gardenlet
    ├── plants
    ├── shoots     # actual test cases imported by suites/shoot
    │  ├── applications


### PR DESCRIPTION
Ref https://github.com/gardener/cc-utils/pull/497

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
