### PR TITLE
Update nodeTemplate on worker pool machineType update

### DIFF
--- a/pkg/operation/botanist/component/extensions/worker/worker.go
+++ b/pkg/operation/botanist/component/extensions/worker/worker.go
@@ -207,9 +207,9 @@ func (w *worker) deploy(ctx context.Context, operation string) (extensionsv1alph
 			workerPoolKubernetesVersion = *workerPool.Kubernetes.Version
 		}
 
-		nodeTemplate, prevMachineType := w.findExistingNodeTemplateByName(ctx, obj, workerPool.Name)
+		nodeTemplate, machineType := w.findNodeTemplateAndMachineTypeByPoolName(ctx, obj, workerPool.Name)
 
-		if nodeTemplate == nil || prevMachineType != workerPool.Machine.Type {
+		if nodeTemplate == nil || machineType != workerPool.Machine.Type {
 			// initializing nodeTemplate by fetching details from cloudprofile, if present there
 			if machineDetails := gardencorev1beta1helper.FindMachineTypeByName(w.values.MachineTypes, workerPool.Machine.Type); machineDetails != nil {
 				nodeTemplate = &extensionsv1alpha1.NodeTemplate{
@@ -370,7 +370,7 @@ func (w *worker) MachineDeployments() []extensionsv1alpha1.MachineDeployment {
 	return w.machineDeployments
 }
 
-func (w *worker) findExistingNodeTemplateByName(ctx context.Context, obj *extensionsv1alpha1.Worker, poolName string) (*extensionsv1alpha1.NodeTemplate, string) {
+func (w *worker) findNodeTemplateAndMachineTypeByPoolName(ctx context.Context, obj *extensionsv1alpha1.Worker, poolName string) (*extensionsv1alpha1.NodeTemplate, string) {
 	for _, pool := range obj.Spec.Pools {
 		if pool.Name == poolName {
 			return pool.NodeTemplate, pool.MachineType

--- a/pkg/operation/botanist/component/extensions/worker/worker_test.go
+++ b/pkg/operation/botanist/component/extensions/worker/worker_test.go
@@ -411,6 +411,7 @@ var _ = Describe("Worker", func() {
 				Spec: *expectedWorkerSpec,
 			}))
 		})
+
 		It("should initialize nodeTemplate from cloudProfile, when machineType updated for worker pool", func() {
 			defer test.WithVars(&worker.TimeNow, mockNow.Do)()
 			mockNow.EXPECT().Do().Return(now.UTC()).AnyTimes()
@@ -438,9 +439,7 @@ var _ = Describe("Worker", func() {
 			Expect(defaultDepWaiter.Deploy(ctx)).To(Succeed())
 
 			obj := &extensionsv1alpha1.Worker{}
-
-			err := c.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, obj)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(c.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, obj)).To(Succeed())
 
 			Expect(obj).To(DeepEqual(&extensionsv1alpha1.Worker{
 				TypeMeta: metav1.TypeMeta{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind bug

**What this PR does / why we need it**:
Currently nodeTemplate's Capacity fields are not updated if a workerPool's machineType is updated.
This happens as we refer to worker resource for already existing nodeTemplate but don't check if the machineType is same or not.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug preventing the `nodeTemplate` in `Machine`s to be updated when the machine type was changed has been fixed.
```
