### PR TITLE
Allow the seed-prometheus to scrape VPA recommender and updater

### DIFF
--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-recommender.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-recommender.yaml
@@ -32,6 +32,7 @@ spec:
 {{- end }}
       labels:
         app: vpa-recommender
+        networking.gardener.cloud/from-prometheus: allowed
 {{ toYaml .Values.labels | indent 8 }}
 {{- if .Values.admissionController.podLabels }}
 {{ toYaml .Values.admissionController.podLabels | indent 8 }}

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-updater.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-updater.yaml
@@ -31,6 +31,7 @@ spec:
 {{- end }}
       labels:
         app: vpa-updater
+        networking.gardener.cloud/from-prometheus: allowed
 {{ toYaml .Values.labels | indent 8 }}
 {{- if .Values.updater.podLabels }}
 {{ toYaml .Values.updater.podLabels | indent 8 }}

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-updater.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-updater.yaml
@@ -83,7 +83,10 @@ spec:
             cpu: 30m
             memory: 200Mi
         ports:
-        - containerPort: 8080
+        - name: server
+          containerPort: 8080
+        - name: metrics
+          containerPort: 8943
 {{- if not .Values.updater.createServiceAccount }}
       volumes:
       - name: shoot-access

--- a/charts/seed-bootstrap/charts/vpa/values.yaml
+++ b/charts/seed-bootstrap/charts/vpa/values.yaml
@@ -7,6 +7,7 @@ global:
 
 labels:
   gardener.cloud/role: vpa
+  networking.gardener.cloud/from-prometheus: allowed
 
 clusterType: seed
 

--- a/charts/seed-bootstrap/charts/vpa/values.yaml
+++ b/charts/seed-bootstrap/charts/vpa/values.yaml
@@ -7,7 +7,6 @@ global:
 
 labels:
   gardener.cloud/role: vpa
-  networking.gardener.cloud/from-prometheus: allowed
 
 clusterType: seed
 

--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/allow-from-prometheus-network-policy.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/allow-from-prometheus-network-policy.yaml
@@ -18,6 +18,10 @@ spec:
           app: prometheus
           gardener.cloud/role: monitoring
           role: monitoring
+    - podSelector:
+        matchLabels:
+          app: seed-prometheus
+          role: monitoring
     ports:
     - port: metrics
       protocol: TCP


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
Modifies the already existing network policy to also match the seed-prometheus. After merging https://github.com/gardener/gardener/pull/5467 we found that the scraping is blocked by network policies denying the access.

**Special notes for your reviewer**:
The impact of this change is maybe a bit bigger than it needs to be: It allows access from seed-prometheus to pods that as of today don't need to be scraped by it. An alternative that doesn't have this impact would be to introduce a new network policy specifically for the seed-prometheus instead of re-using the existing one. Let me know what you think!

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Allow the seed-prometheus to scrape pods labeled with `networking.gardener.cloud/from-prometheus: allowed`
```
```feature operator
Allow the seed-prometheus to scrape VPA recommender and VPA updater
```
