### PR TITLE
Forbids change to shoot.spec.seedName in some cases

### DIFF
--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -2552,65 +2552,93 @@ var _ = Describe("validator", func() {
 		})
 
 		Context("control plane migration", func() {
-			It("should fail to change Seed name, because Seed doesn't have configuration for backup", func() {
-				oldSeedName := fmt.Sprintf("old-%s", seedName)
-				oldSeed := seed.DeepCopy()
+			var (
+				oldSeedName string
+				oldSeed     *core.Seed
+				oldShoot    *core.Shoot
+			)
+			BeforeEach(func() {
+				oldSeedName = fmt.Sprintf("old-%s", seedName)
+				oldSeed = seed.DeepCopy()
 				oldSeed.Name = oldSeedName
-				seed.Spec.Backup = nil
 
-				oldShoot := shoot.DeepCopy()
+				oldShoot = shoot.DeepCopy()
 				oldShoot.Spec.SeedName = &oldSeedName
 
 				Expect(coreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&project)).To(Succeed())
 				Expect(coreInformerFactory.Core().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
 				Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 				Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(oldSeed)).To(Succeed())
+			})
+
+			It("should fail to change Seed name, because Seed doesn't have configuration for backup", func() {
+				seed.Spec.Backup = nil
 				attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
-
 				err := admissionHandler.Admit(context.TODO(), attrs, nil)
-
 				Expect(err).To(MatchError(ContainSubstring(fmt.Sprintf("backup is not configured for seed %q", seedName))))
 			})
 
 			It("should fail to change Seed name, because old Seed doesn't have configuration for backup", func() {
-				oldSeedName := fmt.Sprintf("old-%s", seedName)
-				oldSeed := seed.DeepCopy()
-				oldSeed.Name = oldSeedName
 				oldSeed.Spec.Backup = nil
-
-				oldShoot := shoot.DeepCopy()
-				oldShoot.Spec.SeedName = &oldSeedName
-
-				Expect(coreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&project)).To(Succeed())
-				Expect(coreInformerFactory.Core().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
-				Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
-				Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(oldSeed)).To(Succeed())
 				attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
-
 				err := admissionHandler.Admit(context.TODO(), attrs, nil)
-
 				Expect(err).To(MatchError(ContainSubstring(fmt.Sprintf("backup is not configured for old seed %q", oldSeedName))))
 			})
 
 			It("should fail to change Seed name, because cloud provider for new Seed is not equal to cloud provider for old Seed", func() {
-				oldSeedName := fmt.Sprintf("old-%s", seedName)
-				oldSeed := seed.DeepCopy()
-				oldSeed.Name = oldSeedName
 				oldSeed.Spec.Provider.Type = "gcp"
 				seed.Spec.Provider.Type = "aws"
 
-				oldShoot := shoot.DeepCopy()
-				oldShoot.Spec.SeedName = &oldSeedName
-
-				Expect(coreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&project)).To(Succeed())
-				Expect(coreInformerFactory.Core().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
-				Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
-				Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(oldSeed)).To(Succeed())
 				attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
-
 				err := admissionHandler.Admit(context.TODO(), attrs, nil)
-
 				Expect(err).To(HaveOccurred())
+			})
+
+			It("should fail to change Seed name, because the lastOperation is not in state Succeeded", func() {
+				shoot.Status.LastOperation = &core.LastOperation{
+					Type:  core.LastOperationTypeReconcile,
+					State: core.LastOperationStateProcessing,
+				}
+				attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("should fail to change Seed name when other values in the Shoot's spec are changed as well", func() {
+				shoot.Spec.Kubernetes.Version = "1.24"
+				oldShoot.Spec.Kubernetes.Version = "1.23"
+				attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("should fail to change the shoot spec if the shoot cluster is currently being migrated", func() {
+				shoot.Spec.Kubernetes.Version = "1.24"
+				shoot.Status.LastOperation = &core.LastOperation{
+					Type: core.LastOperationTypeMigrate,
+				}
+				oldShoot.Spec.Kubernetes.Version = "1.23"
+				attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("should fail to change the shoot spec if the shoot cluster is currently being restored", func() {
+				shoot.Spec.Kubernetes.Version = "1.24"
+				shoot.Status.LastOperation = &core.LastOperation{
+					Type:  core.LastOperationTypeRestore,
+					State: core.LastOperationStateProcessing,
+				}
+				oldShoot.Spec.Kubernetes.Version = "1.23"
+				attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("should allow changes to Seed name when nothing else has changed", func() {
+				attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
+				err := admissionHandler.Admit(context.TODO(), attrs, nil)
+				Expect(err).NotTo(HaveOccurred())
 			})
 		})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind enhancement

**What this PR does / why we need it**:
- Forbids changes to the `shoot.spec.seedName` and other changes to the `shoot.spec` at the same time.
~- Forbids changes to `shoot.spec.seedName` if the last operation has not completed successfully yet. This is necessary to prevent a scenario in which the `shoot.spec` has changed, triggering a reconciliation and afterwards the `shoot.spec.seedName` is changed. If the operation is restarted for any reason, migration will start with some potential changes not yet applied, which means that they will be applied during restoration.~
- Forbids changes to the `shoot.spec` if the current operation is `restore` or `migrate` and it has not succeeded yet. Or if the `shoot.spec.seedName` field has been updated, but the `gardenlet` has not yet started the migrate operation.


**Which issue(s) this PR fixes**:
Fixes #4901 

**Special notes for your reviewer**:
If there are concrete cases where we would want to migrate a cluster that is currently stuck in an error, before actually fixing the error we could introduce a `force` annotation that allows changes to the `shoot.spec.seedName` in all cases.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `shoot.spec.seedName` field can no longer be changed together with other changes to the `shoot.spec`. Additionally the `shoot.spec` field can no longer be changed if the `shoot.status.lastOperation` is `migrate` or `restore` and it has not completed successfully yet.
```
