### PR TITLE
Silence error on missing optional tools dependency

### DIFF
--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -22,7 +22,10 @@
 ifeq ($(strip $(shell go list -m)),github.com/gardener/gardener)
 TOOLS_PKG_PATH             := hack/tools
 else
-TOOLS_PKG_PATH             := $(shell go list -tags tools -f '{{ .Dir }}' github.com/gardener/gardener/hack/tools)
+# dependency on github.com/gardener/gardener/hack/tools is optional and only needed if other projects want to reuse
+# install-promtool.sh or logcheck. If they don't use it and the project doesn't depend on the package, silence the error
+# to minimize confusion.
+TOOLS_PKG_PATH             := $(shell go list -tags tools -f '{{ .Dir }}' github.com/gardener/gardener/hack/tools 2>/dev/null)
 endif
 
 TOOLS_BIN_DIR              := $(TOOLS_DIR)/bin


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug

Fixes the problem described in https://github.com/gardener/gardener-extension-provider-gcp/pull/411#issuecomment-1068902051

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
