### PR TITLE
Fix flaky e2e hibernation/wake-up shoot test suite

### DIFF
--- a/extensions/pkg/controller/healthcheck/healtcheck_actuator.go
+++ b/extensions/pkg/controller/healthcheck/healtcheck_actuator.go
@@ -112,7 +112,6 @@ func (a *Actuator) ExecuteHealthCheckFunctions(ctx context.Context, request type
 		wg          sync.WaitGroup
 	)
 
-	wg.Add(len(a.healthChecks))
 	for _, hc := range a.healthChecks {
 		// clone to avoid problems during parallel execution
 		check := hc.HealthCheck.DeepCopy()
@@ -139,6 +138,7 @@ func (a *Actuator) ExecuteHealthCheckFunctions(ctx context.Context, request type
 
 		check.SetLoggerSuffix(a.provider, a.extensionKind)
 
+		wg.Add(1)
 		go func(ctx context.Context, request types.NamespacedName, check HealthCheck, preCheckFunc PreCheckFunc, healthConditionType string) {
 			defer wg.Done()
 

--- a/extensions/pkg/controller/healthcheck/reconciler.go
+++ b/extensions/pkg/controller/healthcheck/reconciler.go
@@ -77,6 +77,9 @@ func (r *reconciler) InjectClient(client client.Client) error {
 }
 
 func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	ctx, cancel := context.WithTimeout(ctx, r.syncPeriod.Duration/2)
+	defer cancel()
+
 	extension := r.registeredExtension.getExtensionObjFunc()
 
 	if err := r.client.Get(ctx, request.NamespacedName, extension); err != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug
/merge squash

**What this PR does / why we need it**:
This PR fixes the flaky e2e hibernation/wake-up shoot test suite by only adding to the wait group when a goroutine is actually accordingly started (broken with #5442).

On the way, I introduced a reconciliation timeout context (similar to what we do for other controllers as well) to prevent long-running reconciliations. Also, the REST mapper used for shoot clients is now "lazy" and only performs discovery calls when actually needed.

**Which issue(s) this PR fixes**:
Fixes #5576

**Special notes for your reviewer**:
/invite @timebertt 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix dependency
A bug in the extensions health check library has been fixed which could prevent status reporting for the `Worker` resources.
```
