### PR TITLE
[release-v1.41] Automated cherry pick of #5589: Fix flaky e2e hibernation/wake-up shoot test suite

### DIFF
--- a/extensions/pkg/controller/healthcheck/healtcheck_actuator.go
+++ b/extensions/pkg/controller/healthcheck/healtcheck_actuator.go
@@ -112,7 +112,6 @@ func (a *Actuator) ExecuteHealthCheckFunctions(ctx context.Context, request type
 		wg          sync.WaitGroup
 	)
 
-	wg.Add(len(a.healthChecks))
 	for _, hc := range a.healthChecks {
 		// clone to avoid problems during parallel execution
 		check := hc.HealthCheck.DeepCopy()
@@ -139,6 +138,7 @@ func (a *Actuator) ExecuteHealthCheckFunctions(ctx context.Context, request type
 
 		check.SetLoggerSuffix(a.provider, a.extensionKind)
 
+		wg.Add(1)
 		go func(ctx context.Context, request types.NamespacedName, check HealthCheck, preCheckFunc PreCheckFunc, healthConditionType string) {
 			defer wg.Done()
 

--- a/extensions/pkg/controller/healthcheck/reconciler.go
+++ b/extensions/pkg/controller/healthcheck/reconciler.go
@@ -77,6 +77,9 @@ func (r *reconciler) InjectClient(client client.Client) error {
 }
 
 func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	ctx, cancel := context.WithTimeout(ctx, r.syncPeriod.Duration/2)
+	defer cancel()
+
 	extension := r.registeredExtension.getExtensionObjFunc()
 
 	if err := r.client.Get(ctx, request.NamespacedName, extension); err != nil {


### PR DESCRIPTION
/kind/bug
/area/testing

Cherry pick of #5589 on release-v1.41.

#5589: Fix flaky e2e hibernation/wake-up shoot test suite

**Release Notes:**
```bugfix dependency
A bug in the extensions health check library has been fixed which could prevent status reporting for the `Worker` resources.
```