### PR TITLE
[release-v1.41] Automated cherry pick of #5573: Preserve 'apiserver_audit_(event|error)_total' metrics in aggregated prometheus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ LOGCHECK_DIR := $(TOOLS_DIR)/logcheck
 
 .PHONY: dev-setup
 dev-setup:
-	@if [[ "$(DEV_SETUP_WITH_WEBHOOKS)" == "true" ]]; then ./hack/local-development/dev-setup --with-webhooks; else ./hack/local-development/dev-setup; fi
+	@if [ "$(DEV_SETUP_WITH_WEBHOOKS)" = "true" ]; then ./hack/local-development/dev-setup --with-webhooks; else ./hack/local-development/dev-setup; fi
 
 .PHONY: dev-setup-register-gardener
 dev-setup-register-gardener:

--- a/pkg/operation/botanist/component/kubeapiserver/monitoring.go
+++ b/pkg/operation/botanist/component/kubeapiserver/monitoring.go
@@ -163,6 +163,10 @@ const (
     annotations:
       description: 'The API servers cumulative failure rate in logging audit events is greater than 2%.'
       summary: 'The kubernetes API server has too many failed attempts to log audit events'
+  - record: shoot:` + monitoringMetricApiserverAuditEventTotal + `:sum
+    expr: sum(rate(` + monitoringMetricApiserverAuditEventTotal + `{job="` + monitoringPrometheusJobName + `"}[5m]))
+  - record: shoot:` + monitoringMetricApiserverAuditErrorTotal + `:sum
+    expr: sum(rate(` + monitoringMetricApiserverAuditErrorTotal + `{plugin="webhook",job="` + monitoringPrometheusJobName + `"}[5m]))
   ### API latency ###
   - record: ` + monitoringMetricApiserverLatencySeconds + `:quantile
     expr: histogram_quantile(0.99, sum without (instance, pod) (rate(` + monitoringMetricApiserverRequestDurationSecondsBucket + `[5m])))

--- a/pkg/operation/botanist/component/kubeapiserver/monitoring_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/monitoring_test.go
@@ -171,6 +171,10 @@ metric_relabel_configs:
     annotations:
       description: 'The API servers cumulative failure rate in logging audit events is greater than 2%.'
       summary: 'The kubernetes API server has too many failed attempts to log audit events'
+  - record: shoot:apiserver_audit_event_total:sum
+    expr: sum(rate(apiserver_audit_event_total{job="kube-apiserver"}[5m]))
+  - record: shoot:apiserver_audit_error_total:sum
+    expr: sum(rate(apiserver_audit_error_total{plugin="webhook",job="kube-apiserver"}[5m]))
   ### API latency ###
   - record: apiserver_latency_seconds:quantile
     expr: histogram_quantile(0.99, sum without (instance, pod) (rate(apiserver_request_duration_seconds_bucket[5m])))


### PR DESCRIPTION
/kind/enhancement
/area/monitoring
/area/audit-logging

Cherry pick of #5573 on release-v1.41.

#5573: Preserve 'apiserver_audit_(event|error)_total' metrics in aggregated prometheus

**Release Notes:**
```feature operator
The 'apiserver_audit_(event|error)_total' metrics of the shoot clusters are now preserved in the aggregated prometheus of the seed.
```