### PR TITLE
Scrape logs from shoot kube-system namespace

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,6 @@ require (
 	gonum.org/v1/gonum v0.8.2
 	google.golang.org/genproto v0.0.0-20220107163113-42d7afdf6368 // indirect
 	gopkg.in/yaml.v2 v2.4.0
-	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	istio.io/api v0.0.0-20211118170605-3f0f902cdfd1
 	istio.io/client-go v1.12.0
 	k8s.io/api v0.23.3

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -611,6 +611,7 @@ func (d *deployer) deploy(ctx context.Context, operation string) (extensionsv1al
 			SSHPublicKeys:           d.sshPublicKeys,
 			PromtailEnabled:         d.promtailEnabled,
 			LokiIngress:             d.lokiIngressHostName,
+			APIServerURL:            d.apiServerURL,
 		})
 		if err != nil {
 			return nil, err

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/components.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/components.go
@@ -44,4 +44,5 @@ type Context struct {
 	SSHPublicKeys           []string
 	LokiIngress             string
 	PromtailEnabled         bool
+	APIServerURL            string
 }

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/promtail/config.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/promtail/config.go
@@ -18,6 +18,7 @@ import (
 	"bytes"
 	_ "embed"
 	"fmt"
+	"net/url"
 	"text/template"
 
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
@@ -28,7 +29,6 @@ import (
 
 	"github.com/Masterminds/sprig"
 	"github.com/gardener/gardener/pkg/utils"
-	"gopkg.in/yaml.v3"
 	"k8s.io/utils/pointer"
 )
 
@@ -37,6 +37,11 @@ var (
 	//go:embed templates/scripts/fetch-token.tpl.sh
 	tplContentFetchToken string
 	tplFetchToken        *template.Template
+
+	tplNamePromtail = "fetch-token"
+	//go:embed templates/promtail-config.tpl.yaml
+	tplContentPromtail string
+	tplPromtail        *template.Template
 )
 
 func init() {
@@ -45,6 +50,14 @@ func init() {
 		New(tplNameFetchToken).
 		Funcs(sprig.TxtFuncMap()).
 		Parse(tplContentFetchToken)
+	if err != nil {
+		panic(err)
+	}
+
+	tplPromtail, err = template.
+		New(tplNamePromtail).
+		Funcs(sprig.TxtFuncMap()).
+		Parse(tplContentPromtail)
 	if err != nil {
 		panic(err)
 	}
@@ -59,105 +72,26 @@ elif  [ ! -d "$TEMP_JOURNAL_FILE" ] && [ -d "$PERSISTANT_JOURNAL_FILE" ]; then
 	sed -i -e "s|$TEMP_JOURNAL_FILE$|$PERSISTANT_JOURNAL_FILE|g" ` + PathConfig + `
 fi`
 
-type config struct {
-	Server        server        `yaml:"server"`
-	Client        client        `yaml:"client"`
-	Positions     positions     `yaml:"positions"`
-	ScrapeConfigs scrapeConfigs `yaml:"scrape_configs"`
-}
-
-type server struct {
-	Disable        bool   `yaml:"disable,omitempty"`
-	LogLevel       string `yaml:"log_level,omitempty"`
-	HTTPListenPort int    `yaml:"http_listen_port,omitempty"`
-}
-
-type client struct {
-	Url             string    `yaml:"url"`
-	BearerTokenFile string    `yaml:"bearer_token_file"`
-	TLSConfig       tlsConfig `yaml:"tls_config"`
-}
-
-type tlsConfig struct {
-	CAFile     string `yaml:"ca_file,omitempty"`
-	ServerName string `yaml:"server_name,omitempty"`
-}
-
-type positions struct {
-	Filename string `yaml:"filename,omitempty"`
-}
-
-type job map[string]interface{}
-type scrapeConfigs []job
-
-var defaultConfig = config{
-	Server: server{
-		Disable:        true,
-		LogLevel:       "info",
-		HTTPListenPort: ServerPort,
-	},
-	Client: client{
-		Url:             "http://localhost:3100/loki/api/v1/push",
-		BearerTokenFile: PathAuthToken,
-		TLSConfig: tlsConfig{
-			CAFile: PathCACert,
-		},
-	},
-	Positions: positions{
-		Filename: PositionFile,
-	},
-	ScrapeConfigs: scrapeConfigs{
-		{
-			"job_name": "journal",
-			"journal": map[string]interface{}{
-				"json":    false,
-				"max_age": "12h",
-				"path":    "/var/log/journal",
-				"labels": map[string]interface{}{
-					"job": "systemd-journal",
-				},
-			},
-			"relabel_configs": []map[string]interface{}{
-				{
-					"source_labels": []string{"__journal__hostname"},
-					"regex":         "^localhost$",
-					"action":        "drop",
-				},
-				{
-					"source_labels": []string{"__journal__systemd_unit"},
-					"target_label":  "unit",
-				},
-				{
-					"source_labels": []string{"__journal__hostname"},
-					"target_label":  "nodename",
-				},
-				{
-					"source_labels": []string{"__journal_syslog_identifier"},
-					"target_label":  "syslog_identifier",
-				},
-			},
-		},
-	},
-}
-
-func getPromtailConfiguration(ctx components.Context) (config, error) {
-	if ctx.LokiIngress == "" {
-		return config{}, fmt.Errorf("loki ingress url is missing for %s", ctx.ClusterDomain)
-	}
-	conf := defaultConfig
-	conf.Client.Url = "https://" + ctx.LokiIngress + "/loki/api/v1/push"
-	conf.Client.TLSConfig.ServerName = ctx.LokiIngress
-	return conf, nil
-}
-
 func getPromtailConfigurationFile(ctx components.Context) (extensionsv1alpha1.File, error) {
-	conf, err := getPromtailConfiguration(ctx)
+	var config bytes.Buffer
+
+	if ctx.LokiIngress == "" {
+		return extensionsv1alpha1.File{}, fmt.Errorf("loki ingress url is missing")
+	}
+
+	apiServerURL, err := url.Parse(ctx.APIServerURL)
 	if err != nil {
 		return extensionsv1alpha1.File{}, err
 	}
 
-	configYaml, err := yaml.Marshal(&conf)
-	if err != nil {
+	if err := tplPromtail.Execute(&config, map[string]interface{}{
+		"clientURL":         "https://" + ctx.LokiIngress + "/loki/api/v1/push",
+		"pathCACert":        PathCACert,
+		"lokiIngress":       ctx.LokiIngress,
+		"pathAuthToken":     PathAuthToken,
+		"APIServerURL":      ctx.APIServerURL,
+		"APIServerHostname": apiServerURL.Hostname(),
+	}); err != nil {
 		return extensionsv1alpha1.File{}, err
 	}
 
@@ -167,7 +101,7 @@ func getPromtailConfigurationFile(ctx components.Context) (extensionsv1alpha1.Fi
 		Content: extensionsv1alpha1.FileContent{
 			Inline: &extensionsv1alpha1.FileContentInline{
 				Encoding: "b64",
-				Data:     utils.EncodeBase64(configYaml),
+				Data:     utils.EncodeBase64(config.Bytes()),
 			},
 		},
 	}, nil
@@ -211,6 +145,7 @@ func getPromtailUnit(execStartPre, execStartPreConfig, execStart string) extensi
 		Content: pointer.String(`[Unit]
 Description=promtail daemon
 Documentation=https://grafana.com/docs/loki/latest/clients/promtail/
+After=` + unitNameFetchToken + `
 [Install]
 WantedBy=multi-user.target
 [Service]
@@ -225,6 +160,7 @@ MemorySwapMax=0
 Restart=always
 RestartSec=5
 EnvironmentFile=/etc/environment
+ExecStartPre=/bin/sh -c "systemctl set-environment HOSTNAME=$(hostname)"
 ExecStartPre=` + execStartPre + `
 ExecStartPre=` + execStartPreConfig + `
 ExecStart=` + execStart),

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/promtail/templates/promtail-config.tpl.yaml
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/promtail/templates/promtail-config.tpl.yaml
@@ -1,0 +1,89 @@
+server:
+  disable: true
+  log_level: info
+  http_listen_port: 3001
+client:
+  url: {{ .clientURL }}
+  bearer_token_file: {{ .pathAuthToken }}
+  tls_config:
+    ca_file: {{ .pathCACert }}
+    server_name: {{ .lokiIngress }}
+positions:
+  filename: /var/log/positions.yaml
+scrape_configs:
+- job_name: journal
+  journal:
+    json: false
+    labels:
+      job: systemd-journal
+    max_age: 12h
+    path: /var/log/journal
+  relabel_configs:
+  - action: drop
+    regex: ^localhost$
+    source_labels: ['__journal__hostname']
+  - source_labels: ['__journal__systemd_unit']
+    target_label: unit
+  - source_labels: ['__journal__hostname']
+    target_label: nodename
+  - source_labels: ['__journal_syslog_identifier']
+    target_label: syslog_identifier
+- job_name: kubernetes-pods-name
+  pipeline_stages:
+  - cri: {}
+  - labeldrop:
+    - filename
+  kubernetes_sd_configs:
+  - role: pod
+    api_server: {{ .APIServerURL }}
+    tls_config:
+      server_name: {{ .APIServerHostname }}
+      ca_file: {{ .pathCACert }}
+    bearer_token_file: {{ .pathAuthToken }}
+  relabel_configs:
+  - action: drop
+    regex: ''
+    separator: ''
+    source_labels:
+    - __meta_kubernetes_pod_label_gardener_cloud_role
+    - __meta_kubernetes_pod_label_origin
+  - action: replace
+    regex: '.+'
+    replacement: "gardener"
+    source_labels: ['__meta_kubernetes_pod_label_gardener_cloud_role']
+    target_label: __meta_kubernetes_pod_label_origin
+  - action: keep
+    regex: 'gardener'
+    source_labels: ['__meta_kubernetes_pod_label_origin']
+  - action: replace
+    regex: ''
+    replacement: 'default'
+    source_labels: ['__meta_kubernetes_pod_label_gardener_cloud_role']
+    target_label: __meta_kubernetes_pod_label_gardener_cloud_role
+  - source_labels: ['__meta_kubernetes_pod_node_name']
+    target_label: '__host__'
+  - source_labels: ['__meta_kubernetes_pod_node_name']
+    target_label: 'nodename'
+  - action: replace
+    source_labels: ['__meta_kubernetes_namespace']
+    target_label: namespace_name
+  - action: replace
+    source_labels: ['__meta_kubernetes_pod_name']
+    target_label: pod_name
+  - action: replace
+    source_labels: ['__meta_kubernetes_pod_uid']
+    target_label: pod_uid
+  - action: replace
+    source_labels: ['__meta_kubernetes_pod_container_name']
+    target_label: container_name
+  - replacement: /var/log/pods/*$1/*.log
+    separator: /
+    source_labels:
+    - __meta_kubernetes_pod_uid
+    - __meta_kubernetes_pod_container_name
+    target_label: __path__
+  - source_labels: ['__meta_kubernetes_pod_label_gardener_cloud_role']
+    target_label: gardener_cloud_role
+  - source_labels: ['__meta_kubernetes_pod_label_origin']
+    replacement: 'shoot_system'
+    target_label: origin

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -729,7 +729,6 @@ gopkg.in/natefinch/lumberjack.v2
 ## explicit
 gopkg.in/yaml.v2
 # gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
-## explicit
 gopkg.in/yaml.v3
 # istio.io/api v0.0.0-20211118170605-3f0f902cdfd1
 ## explicit


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
Logs from pods with labels `origin=gardener` and `gardener.cloud/role` in the shoot `kube-system` namespace are scraped and sent to Loki under the `operator` tenant.

**Which issue(s) this PR fixes**:
Fixes [#5439](https://github.com/gardener/gardener/issues/5439)

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Logs of the gardener components in the shoot's `kube-system` are scraped and available for the operators.
```
