### PR TITLE
`AdminKubeconfig` falls back to old data type

### DIFF
--- a/pkg/registry/core/shoot/storage/admin_kubeconfig.go
+++ b/pkg/registry/core/shoot/storage/admin_kubeconfig.go
@@ -129,7 +129,12 @@ func (r *AdminKubeconfigREST) Create(ctx context.Context, name string, obj runti
 		return nil, errors.NewInternalError(err)
 	}
 
-	caCert, err := secrets.LoadCertificate("", data[secrets.DataKeyPrivateKeyCA], data[secrets.DataKeyCertificateCA])
+	keyPrivateKey, keyCertificate := secrets.DataKeyPrivateKeyCA, secrets.DataKeyCertificateCA
+	if ca.Type == "certificate" {
+		keyPrivateKey, keyCertificate = "privateKey", "certificate"
+	}
+
+	caCert, err := secrets.LoadCertificate("", data[keyPrivateKey], data[keyCertificate])
 	if err != nil {
 		return nil, errors.NewInternalError(err)
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
With #5594, the `AdminKubeconfig` shoot subresource was adapted to the new data type in the `ShootState`. However, when shoots are only reconciled in `24h` then it will not work for such shoots. Hence, we need to fallback to the old data type. This is similar to what was done in https://github.com/gardener/gardenlogin-controller-manager/pull/24.

**Special notes for your reviewer**:
/cc @timebertt @holgerkoser 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
