### PR TITLE
[GEP-18] Prepare reusing secrets manager in extensions

### DIFF
--- a/docs/development/secrets_management.md
+++ b/docs/development/secrets_management.md
@@ -81,6 +81,7 @@ External components that want to reuse the `SecretsManager` should consider the 
   The given identity is added as a value for the `manager-identity` label on managed `Secret`s. 
   This label is used by the `Cleanup` function to select only those `Secret`s that are actually managed by the particular `SecretManager` instance. This is done to prevent removing still needed `Secret`s that are managed by other instances.
 - Generate dedicated CAs for signing certificates instead of depending on CAs managed by gardenlet.
+- Names of `Secret`s managed by external `SecretsManager` instances must not conflict with `Secret` names from other instances (e.g. gardenlet).
 - For CAs that should be rotated in lock-step with the Shoot CAs managed by gardenlet, components need to pass information about the last rotation initiation time and the current rotation phase to the `SecretsManager` upon initialization.
   The relevant information can be retrieved from the `Cluster` resource under `.spec.shoot.status.credentials.rotation.certificateAuthorities`.
 - Independent of the specific identity, secrets marked with the `Persist` option are automatically saved in the `ShootState` resource by gardenlet and are also restored by gardenlet on Control Plane Migration to the new Seed.

--- a/docs/development/secrets_management.md
+++ b/docs/development/secrets_management.md
@@ -1,10 +1,12 @@
 # Secrets Management for Seed and Shoot Cluster
 
-🚧️ Please note that the work in the new secrets management is ongoing and hence not yet completed.
+> 🚧️ Please note that the work in the new secrets management is ongoing and hence not yet completed.
 Accordingly, expect adaptations to this document and implementation details.
 
 The gardenlet needs to create quite some amount of credentials (certificates, private keys, passwords, etc.) for seed and shoot clusters in order to ensure secure deployments.
 Such credentials typically should be rotated regularly, and they potentially need to be persisted such that they don't get lost in case of a control plane migration or a lost seed cluster.
+
+## SecretsManager Introduction
 
 These requirements can be covered by using the `SecretsManager` package maintained in [`pkg/utils/secrets/manager`](pkg/utils/secrets/manager).
 It is built on top of the `ConfigInterface` and `DataInterface` interfaces part of [`pkg/utils/secrets`](pkg/utils/secrets) and provides the following functions:
@@ -68,6 +70,20 @@ if err != nil {
 ```
 
 As explained above, this returns the bundle secret for the CA `my-ca` which might potentially contain both the current and the old CA (in case of rotation/regeneration).
+
+## Reusing the SecretsManager in Other Components
+
+While the `SecretsManager` is primarily used by gardenlet, it can be reused by other components (e.g. extensions) as well for managing secrets that are specific to the component or extension. For example, provider extensions might use their own `SecretsManager` instance for managing the serving certificate of `cloud-controller-manager`.
+
+External components that want to reuse the `SecretsManager` should consider the following aspects:
+
+- On initialization of a `SecretsManager`, pass an `identity` specific to the component, for example the extension name (gardenlet uses `gardenlet` as the `SecretsManager`'s identity). 
+  The given identity is added as a value for the `manager-identity` label on managed `Secret`s. 
+  This label is used by the `Cleanup` function to select only those `Secret`s that are actually managed by the particular `SecretManager` instance. This is done to prevent removing still needed `Secret`s that are managed by other instances.
+- Generate dedicated CAs for signing certificates instead of depending on CAs managed by gardenlet.
+- For CAs that should be rotated in lock-step with the Shoot CAs managed by gardenlet, components need to pass information about the last rotation initiation time and the current rotation phase to the `SecretsManager` upon initialization.
+  The relevant information can be retrieved from the `Cluster` resource under `.spec.shoot.status.credentials.rotation.certificateAuthorities`.
+- Independent of the specific identity, secrets marked with the `Persist` option are automatically saved in the `ShootState` resource by gardenlet and are also restored by gardenlet on Control Plane Migration to the new Seed.
 
 ## Implementation Details
 

--- a/docs/extensions/conventions.md
+++ b/docs/extensions/conventions.md
@@ -1,6 +1,6 @@
 # General conventions
 
-All the extensions that are registered to Gardener are deployed to the seed clusters (at the moment, every extension is installed to every seed cluster, however, in the future Gardener will be more smart to determine which extensions needs to be placed into which seed).
+All the extensions that are registered to Gardener are deployed to the seed clusters, on which they are required (also see [ControllerRegistration](controllerregistration.md)).
 
 Some of these extensions might need to create global resources in the seed (e.g., `ClusterRole`s), i.e., it's important to have a naming scheme to avoid conflicts as it cannot be checked or validated upfront that two extensions don't use the same names.
 
@@ -32,11 +32,10 @@ nodeSelector:
   worker.gardener.cloud/system-components: "true"
 ```
 
-## How to create certificates/kubeconfigs for the shoot cluster?
+## How to create certificates for the shoot cluster?
 
-Gardener creates several certificate authorities (CA) that are used to create server/client certificates for various components.
+Gardener creates several certificate authorities (CA) that are used to create server certificates for various components.
 For example, the shoot's etcd has its own CA, the kube-aggregator has its own CA as well, and both are different to the actual cluster's CA.
 
-These CAs are stored as `Secret`s in the shoot namespace (see [this](https://github.com/gardener/gardener/blob/master/pkg/apis/core/v1beta1/constants/types_constants.go) for the actual names).
-Extension controllers may use them to create further certificates/kubeconfigs for potential other components they need to deploy to the seed or shoot.
-[These utility functions](https://github.com/gardener/gardener/tree/master/pkg/utils/secrets) should help with the creation and management.
+Extensions should do the same and generate dedicated CAs for their components (e.g. for signing a server certificate for cloud-controller-manager). They should not depend on the CA secrets managed by gardenlet.
+You can take a look at the [Secrets Management document](../development/secrets_management.md) for more details on how this can be achieved.

--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -40,6 +40,8 @@ import (
 const (
 	// DefaultInterval is the default interval for retry operations.
 	DefaultInterval = 5 * time.Second
+	// SecretManagerIdentityGardenlet is the identity for the secret manager used inside gardenlet.
+	SecretManagerIdentityGardenlet = "gardenlet"
 )
 
 // New takes an operation object <o> and creates a new Botanist object. It checks whether the given Shoot DNS
@@ -71,7 +73,7 @@ func New(ctx context.Context, o *operation.Operation) (*Botanist, error) {
 		return nil, err
 	}
 
-	o.SecretsManager = secretsmanager.New(logf.Log.WithName("secretsmanager"), b.K8sSeedClient.Client(), b.Shoot.SeedNamespace, b.lastSecretRotationStartTimes())
+	o.SecretsManager = secretsmanager.New(logf.Log.WithName("secretsmanager"), b.K8sSeedClient.Client(), b.Shoot.SeedNamespace, SecretManagerIdentityGardenlet, b.lastSecretRotationStartTimes())
 
 	// extension components
 	o.Shoot.Components.Extensions.ContainerRuntime = b.DefaultContainerRuntime()

--- a/pkg/utils/secrets/manager/cleanup.go
+++ b/pkg/utils/secrets/manager/cleanup.go
@@ -26,7 +26,8 @@ import (
 func (m *manager) Cleanup(ctx context.Context) error {
 	secretList := &corev1.SecretList{}
 	if err := m.client.List(ctx, secretList, client.InNamespace(m.namespace), client.MatchingLabels{
-		LabelKeyManagedBy: LabelValueSecretsManager,
+		LabelKeyManagedBy:       LabelValueSecretsManager,
+		LabelKeyManagerIdentity: m.identity,
 	}); err != nil {
 		return err
 	}

--- a/pkg/utils/secrets/manager/cleanup_test.go
+++ b/pkg/utils/secrets/manager/cleanup_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Cleanup", func() {
 
 	BeforeEach(func() {
 		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetesscheme.Scheme).Build()
-		m = New(logr.Discard(), fakeClient, namespace, nil).(*manager)
+		m = New(logr.Discard(), fakeClient, namespace, "test", nil).(*manager)
 	})
 
 	Describe("#Cleanup", func() {

--- a/pkg/utils/secrets/manager/fake/fake_manager.go
+++ b/pkg/utils/secrets/manager/fake/fake_manager.go
@@ -28,6 +28,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+// ManagerIdentity is the fake secret manager's identity.
+const ManagerIdentity = "fake"
+
 type fakeManager struct {
 	client    client.Client
 	namespace string
@@ -68,7 +71,7 @@ func (m *fakeManager) Generate(ctx context.Context, config secretutils.ConfigInt
 		return nil, err
 	}
 
-	objectMeta, err := secretsmanager.ObjectMeta(m.namespace, config, "", nil, &options.Persist, nil)
+	objectMeta, err := secretsmanager.ObjectMeta(m.namespace, ManagerIdentity, config, "", nil, &options.Persist, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/utils/secrets/manager/fake/fake_manager_test.go
+++ b/pkg/utils/secrets/manager/fake/fake_manager_test.go
@@ -83,6 +83,7 @@ var _ = Describe("FakeManager", func() {
 				Labels: map[string]string{
 					"name":                          name,
 					"managed-by":                    "secrets-manager",
+					"manager-identity":              "fake",
 					"checksum-of-config":            configChecksum,
 					"last-rotation-initiation-time": "",
 					"rotation-strategy":             "inplace",
@@ -123,6 +124,7 @@ var _ = Describe("FakeManager", func() {
 					Labels: map[string]string{
 						"name":                          name,
 						"managed-by":                    "secrets-manager",
+						"manager-identity":              "fake",
 						"checksum-of-config":            configChecksum,
 						"last-rotation-initiation-time": "",
 						"rotation-strategy":             "keepold",

--- a/pkg/utils/secrets/manager/generate.go
+++ b/pkg/utils/secrets/manager/generate.go
@@ -40,7 +40,7 @@ func (m *manager) Generate(ctx context.Context, config secretutils.ConfigInterfa
 		bundleFor = pointer.String(strings.TrimSuffix(config.GetName(), nameSuffixBundle))
 	}
 
-	objectMeta, err := ObjectMeta(m.namespace, config, m.lastRotationInitiationTimes[config.GetName()], options.signingCAChecksum, &options.Persist, bundleFor)
+	objectMeta, err := ObjectMeta(m.namespace, m.identity, config, m.lastRotationInitiationTimes[config.GetName()], options.signingCAChecksum, &options.Persist, bundleFor)
 	if err != nil {
 		return nil, err
 	}
@@ -167,8 +167,9 @@ func (m *manager) keepExistingSecretsIfNeeded(ctx context.Context, configName st
 func (m *manager) storeOldSecrets(ctx context.Context, name, currentSecretName string) error {
 	secretList := &corev1.SecretList{}
 	if err := m.client.List(ctx, secretList, client.InNamespace(m.namespace), client.MatchingLabels{
-		LabelKeyName:      name,
-		LabelKeyManagedBy: LabelValueSecretsManager,
+		LabelKeyName:            name,
+		LabelKeyManagedBy:       LabelValueSecretsManager,
+		LabelKeyManagerIdentity: m.identity,
 	}); err != nil {
 		return err
 	}

--- a/pkg/utils/secrets/manager/generate_test.go
+++ b/pkg/utils/secrets/manager/generate_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Generate", func() {
 
 	BeforeEach(func() {
 		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetesscheme.Scheme).Build()
-		m = New(logr.Discard(), fakeClient, namespace, nil).(*manager)
+		m = New(logr.Discard(), fakeClient, namespace, "test", nil).(*manager)
 	})
 
 	Describe("#Generate", func() {
@@ -101,7 +101,7 @@ var _ = Describe("Generate", func() {
 				expectSecretWasCreated(ctx, fakeClient, secret)
 
 				By("changing last rotation initiation time and generate again")
-				m = New(logr.Discard(), fakeClient, namespace, map[string]time.Time{name: time.Now()}).(*manager)
+				m = New(logr.Discard(), fakeClient, namespace, "test", map[string]time.Time{name: time.Now()}).(*manager)
 
 				newSecret, err := m.Generate(ctx, config)
 				Expect(err).NotTo(HaveOccurred())
@@ -198,8 +198,9 @@ var _ = Describe("Generate", func() {
 				By("finding created bundle secret")
 				secretList := &corev1.SecretList{}
 				Expect(fakeClient.List(ctx, secretList, client.InNamespace(namespace), client.MatchingLabels{
-					"managed-by": "secrets-manager",
-					"bundle-for": name,
+					"managed-by":       "secrets-manager",
+					"manager-identity": "test",
+					"bundle-for":       name,
 				})).To(Succeed())
 				Expect(secretList.Items).To(HaveLen(1))
 
@@ -223,7 +224,7 @@ var _ = Describe("Generate", func() {
 				oldBundleSecret := secretInfos.bundle.obj
 
 				By("changing secret config and generate again")
-				m = New(logr.Discard(), fakeClient, namespace, map[string]time.Time{name: time.Now()}).(*manager)
+				m = New(logr.Discard(), fakeClient, namespace, "test", map[string]time.Time{name: time.Now()}).(*manager)
 				newSecret, err := m.Generate(ctx, config, Rotate(KeepOld))
 				Expect(err).NotTo(HaveOccurred())
 				expectSecretWasCreated(ctx, fakeClient, newSecret)
@@ -231,8 +232,9 @@ var _ = Describe("Generate", func() {
 				By("finding created bundle secret")
 				secretList := &corev1.SecretList{}
 				Expect(fakeClient.List(ctx, secretList, client.InNamespace(namespace), client.MatchingLabels{
-					"managed-by": "secrets-manager",
-					"bundle-for": name,
+					"managed-by":       "secrets-manager",
+					"manager-identity": "test",
+					"bundle-for":       name,
 				})).To(Succeed())
 				Expect(secretList.Items).To(HaveLen(2))
 
@@ -283,7 +285,7 @@ var _ = Describe("Generate", func() {
 				expectSecretWasCreated(ctx, fakeClient, serverSecret)
 
 				By("rotating CA")
-				m = New(logr.Discard(), fakeClient, namespace, map[string]time.Time{caName: time.Now()}).(*manager)
+				m = New(logr.Discard(), fakeClient, namespace, "test", map[string]time.Time{caName: time.Now()}).(*manager)
 				newCASecret, err := m.Generate(ctx, caConfig, Rotate(KeepOld))
 				Expect(err).NotTo(HaveOccurred())
 				expectSecretWasCreated(ctx, fakeClient, newCASecret)
@@ -310,7 +312,7 @@ var _ = Describe("Generate", func() {
 				expectSecretWasCreated(ctx, fakeClient, clientSecret)
 
 				By("rotating CA")
-				m = New(logr.Discard(), fakeClient, namespace, map[string]time.Time{caName: time.Now()}).(*manager)
+				m = New(logr.Discard(), fakeClient, namespace, "test", map[string]time.Time{caName: time.Now()}).(*manager)
 				newCASecret, err := m.Generate(ctx, caConfig, Rotate(KeepOld))
 				Expect(err).NotTo(HaveOccurred())
 				expectSecretWasCreated(ctx, fakeClient, newCASecret)

--- a/pkg/utils/secrets/manager/manager_test.go
+++ b/pkg/utils/secrets/manager/manager_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Manager", func() {
 		It("should generate the expected object meta for a never-rotated CA cert secret", func() {
 			config := &secretutils.CertificateSecretConfig{Name: configName}
 
-			meta, err := ObjectMeta(namespace, config, "", nil, nil, nil)
+			meta, err := ObjectMeta(namespace, "test", config, "", nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(meta).To(Equal(metav1.ObjectMeta{
@@ -46,6 +46,7 @@ var _ = Describe("Manager", func() {
 				Labels: map[string]string{
 					"name":                          configName,
 					"managed-by":                    "secrets-manager",
+					"manager-identity":              "test",
 					"checksum-of-config":            "1645436262831067767",
 					"last-rotation-initiation-time": "",
 				},
@@ -55,7 +56,7 @@ var _ = Describe("Manager", func() {
 		It("should generate the expected object meta for a rotated CA cert secret", func() {
 			config := &secretutils.CertificateSecretConfig{Name: configName}
 
-			meta, err := ObjectMeta(namespace, config, lastRotationInitiationTime, nil, nil, nil)
+			meta, err := ObjectMeta(namespace, "test", config, lastRotationInitiationTime, nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(meta).To(Equal(metav1.ObjectMeta{
@@ -64,6 +65,7 @@ var _ = Describe("Manager", func() {
 				Labels: map[string]string{
 					"name":                          configName,
 					"managed-by":                    "secrets-manager",
+					"manager-identity":              "test",
 					"checksum-of-config":            "1645436262831067767",
 					"last-rotation-initiation-time": "1646060228",
 				},
@@ -77,12 +79,13 @@ var _ = Describe("Manager", func() {
 					SigningCA: &secretutils.Certificate{},
 				}
 
-				meta, err := ObjectMeta(namespace, config, lastRotationInitiationTime, signingCAChecksum, persist, bundleFor)
+				meta, err := ObjectMeta(namespace, "test", config, lastRotationInitiationTime, signingCAChecksum, persist, bundleFor)
 				Expect(err).NotTo(HaveOccurred())
 
 				labels := map[string]string{
 					"name":                          configName,
 					"managed-by":                    "secrets-manager",
+					"manager-identity":              "test",
 					"checksum-of-config":            "17861245496710117091",
 					"last-rotation-initiation-time": "1646060228",
 				}

--- a/test/integration/gardenlet/shootsecret/shootsecret_suite_test.go
+++ b/test/integration/gardenlet/shootsecret/shootsecret_suite_test.go
@@ -41,7 +41,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
-func TestShootRetry(t *testing.T) {
+func TestShootSecret(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "ShootSecret Controller Integration Test Suite")
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement
/merge squash

**What this PR does / why we need it**:

Prepare reusing secrets manager in extensions by
- documenting what the consider
- introducing secrets manager identity
- augmenting relevant test cases

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/3292#issuecomment-1036058890

**Special notes for your reviewer**:

Note that `user-kubeconfig` and `kube-apiserver-static-token` secrets will leak if you rotate the kubeconfig of shoots created with `v1.43.0-dev` before reconciling them with this revision. As this is only relevant for shoot created with an unreleased version and the feature is in alpha state, we don't bother adding migration logic.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
