### PR TITLE
Fix/seed prometheus network policy

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/allow-from-prometheus-network-policy.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/allow-from-prometheus-network-policy.yaml
@@ -22,6 +22,9 @@ spec:
         matchLabels:
           app: seed-prometheus
           role: monitoring
+      namespaceSelector:
+        matchLabels:
+          role: garden
     ports:
     - port: metrics
       protocol: TCP


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/area monitoring
/kind bug

**What this PR does / why we need it**:
With #5582  we wanted to allow the seed-prometheus to scrape VPAs, but didn't account for the fact that `podSelector` only applies to the same namespace.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
