### PR TITLE
Fixed file permissions of keys in vpn-shoot.

### DIFF
--- a/pkg/operation/botanist/component/vpnshoot/vpnshoot.go
+++ b/pkg/operation/botanist/component/vpnshoot/vpnshoot.go
@@ -567,7 +567,7 @@ func (v *vpnShoot) getVolumes(secret, secretTLSAuth, secretDH *corev1.Secret) []
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName:  secret.Name,
-					DefaultMode: pointer.Int32(400),
+					DefaultMode: pointer.Int32(0400),
 				},
 			},
 		},
@@ -576,7 +576,7 @@ func (v *vpnShoot) getVolumes(secret, secretTLSAuth, secretDH *corev1.Secret) []
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName:  secretTLSAuth.Name,
-					DefaultMode: pointer.Int32(400),
+					DefaultMode: pointer.Int32(0400),
 				},
 			},
 		},
@@ -587,7 +587,7 @@ func (v *vpnShoot) getVolumes(secret, secretTLSAuth, secretDH *corev1.Secret) []
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName:  secretDH.Name,
-					DefaultMode: pointer.Int32(400),
+					DefaultMode: pointer.Int32(0400),
 				},
 			},
 		})

--- a/pkg/operation/botanist/component/vpnshoot/vpnshoot_test.go
+++ b/pkg/operation/botanist/component/vpnshoot/vpnshoot_test.go
@@ -364,17 +364,17 @@ spec:
       volumes:
       - name: vpn-shoot
         secret:
-          defaultMode: 400
+          defaultMode: 256
           secretName: ` + secretNameTest + `
       - name: vpn-shoot-tlsauth
         secret:
-          defaultMode: 400
+          defaultMode: 256
           secretName: ` + secretNameTLSAuthTest
 				if !reversedVPNEnabled {
 					out += `
       - name: vpn-shoot-dh
         secret:
-          defaultMode: 400
+          defaultMode: 256
           secretName: ` + secretNameDHTest
 				}
 				out += `


### PR DESCRIPTION

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Fixed file permissions of keys in vpn-shoot.

With the refactoring of the vpn-shoot from helm charts into go code (#5056)
the file permissions was changed in an incorrect way from octal to decimal.
0400 (octal) implies read-only permission to the owner while 400 (decimal)
implies read/write to owner and write to the group.

This should remove the corresponding warnings from the vpn-shoot log output.

**Which issue(s) this PR fixes**:
Incorrect file permissions for the keys in `vpn-shoot` resulting in warning output from `openvpn`.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The file permissions of the keys in vpn-shoot are now properly set so that openvpn will not issue warnings.
```

/cc @shafeeqes 