### PR TITLE
Fix helm chart validation errors on VPA chart

### DIFF
--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrole-actor.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrole-actor.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: gardener.cloud:vpa:{{ include "vpa.rbac-name-infix" . }}:actor
   labels:
-  {{ toYaml .Values.labels | indent 4 }}
+{{ toYaml .Values.labels | indent 4 }}
 rules:
   - apiGroups:
       - ""

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrole-admission-controller.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrole-admission-controller.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: gardener.cloud:vpa:{{ include "vpa.rbac-name-infix" . }}:admission-controller
   labels:
-  {{ toYaml .Values.labels | indent 4 }}
+{{ toYaml .Values.labels | indent 4 }}
 rules:
   - apiGroups:
       - ""

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrole-checkpointer.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrole-checkpointer.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: gardener.cloud:vpa:{{ include "vpa.rbac-name-infix" . }}:checkpoint-actor
   labels:
-  {{ toYaml .Values.labels | indent 4 }}
+{{ toYaml .Values.labels | indent 4 }}
 rules:
   - apiGroups:
       - "poc.autoscaling.k8s.io"

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrole-recommender.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrole-recommender.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: gardener.cloud:vpa:{{ include "vpa.rbac-name-infix" . }}:metrics-reader
   labels:
-  {{ toYaml .Values.labels | indent 4 }}
+{{ toYaml .Values.labels | indent 4 }}
 rules:
   - apiGroups:
       - "metrics.k8s.io"

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrole-target-reader.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrole-target-reader.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: gardener.cloud:vpa:{{ include "vpa.rbac-name-infix" . }}:target-reader
   labels:
-  {{ toYaml .Values.labels | indent 4 }}
+{{ toYaml .Values.labels | indent 4 }}
 rules:
   - apiGroups:
       - '*'

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrole-updater-evictioner.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrole-updater-evictioner.yaml
@@ -5,7 +5,7 @@ kind: ClusterRole
 metadata:
   name: gardener.cloud:vpa:{{ include "vpa.rbac-name-infix" . }}:evictioner
   labels:
-  {{ toYaml .Values.labels | indent 4 }}
+{{ toYaml .Values.labels | indent 4 }}
 rules:
   - apiGroups:
       - "apps"

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-actor.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-actor.yaml
@@ -4,7 +4,7 @@ kind: ClusterRoleBinding
 metadata:
   name: gardener.cloud:vpa:{{ include "vpa.rbac-name-infix" . }}:actor
   labels:
-  {{ toYaml .Values.labels | indent 4 }}
+{{ toYaml .Values.labels | indent 4 }}
   annotations:
     resources.gardener.cloud/delete-on-invalid-update: "true"
 roleRef:

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-admission-controller.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-admission-controller.yaml
@@ -4,7 +4,7 @@ kind: ClusterRoleBinding
 metadata:
   name: gardener.cloud:vpa:{{ include "vpa.rbac-name-infix" . }}:admission-controller
   labels:
-  {{ toYaml .Values.labels | indent 4 }}
+{{ toYaml .Values.labels | indent 4 }}
   annotations:
     resources.gardener.cloud/delete-on-invalid-update: "true"
 roleRef:

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-checkpointer.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-checkpointer.yaml
@@ -4,7 +4,7 @@ kind: ClusterRoleBinding
 metadata:
   name: gardener.cloud:vpa:{{ include "vpa.rbac-name-infix" . }}:checkpoint-actor
   labels:
-  {{ toYaml .Values.labels | indent 4 }}
+{{ toYaml .Values.labels | indent 4 }}
   annotations:
     resources.gardener.cloud/delete-on-invalid-update: "true"
 roleRef:

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-recommender.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-recommender.yaml
@@ -4,7 +4,7 @@ kind: ClusterRoleBinding
 metadata:
   name: gardener.cloud:vpa:{{ include "vpa.rbac-name-infix" . }}:metrics-reader
   labels:
-  {{ toYaml .Values.labels | indent 4 }}
+{{ toYaml .Values.labels | indent 4 }}
   annotations:
     resources.gardener.cloud/delete-on-invalid-update: "true"
 roleRef:

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-target-reader.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-target-reader.yaml
@@ -4,7 +4,7 @@ kind: ClusterRoleBinding
 metadata:
   name: gardener.cloud:vpa:{{ include "vpa.rbac-name-infix" . }}:target-reader
   labels:
-  {{ toYaml .Values.labels | indent 4 }}
+{{ toYaml .Values.labels | indent 4 }}
   annotations:
     resources.gardener.cloud/delete-on-invalid-update: "true"
 roleRef:

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-updater-evictioner.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/clusterrolebinding-updater-evictioner.yaml
@@ -4,7 +4,7 @@ kind: ClusterRoleBinding
 metadata:
   name: gardener.cloud:vpa:{{ include "vpa.rbac-name-infix" . }}:evictioner
   labels:
-  {{ toYaml .Values.labels | indent 4 }}
+{{ toYaml .Values.labels | indent 4 }}
   annotations:
     resources.gardener.cloud/delete-on-invalid-update: "true"
 roleRef:

--- a/charts/seed-bootstrap/charts/vpa/charts/application/templates/serviceaccount-admission-controller.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/application/templates/serviceaccount-admission-controller.yaml
@@ -6,6 +6,6 @@ metadata:
   name: vpa-admission-controller
   namespace: {{ .Release.Namespace }}
   labels:
-  {{ toYaml .Values.labels | indent 4 }}
+{{ toYaml .Values.labels | indent 4 }}
 automountServiceAccountToken: false
 {{- end }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind bug

**What this PR does / why we need it**:
`./hack/check-charts.sh ./charts` failed on the VPA chart due to indentation on the label-inserting statement with the message
```
Error: YAML parse error on seed-bootstrap/charts/vpa/charts/application/templates/clusterrole-actor.yaml: error converting YAML to JSON: yaml: line 6: did not find expected key
```
This can be seen in our Prow builds, e.g. [here](https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/5613/pull-gardener-unit/1504797330694475776). It should no longer fail under this change.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Fixed an indentation issue in the VPA charts which caused a validation error when executing `./hack/check-charts.sh ./charts`
```
