### PR TITLE
gardener-apiserver: Allow SecretBinding update when provider=nil

### DIFF
--- a/pkg/apis/core/validation/secretbinding_test.go
+++ b/pkg/apis/core/validation/secretbinding_test.go
@@ -101,20 +101,20 @@ var _ = Describe("SecretBinding Validation Tests", func() {
 			secretBinding.Provider = &core.SecretBindingProvider{}
 
 			errorList := ValidateSecretBinding(secretBinding)
-
-			Expect(errorList).To(HaveLen(3))
-			Expect(*errorList[0]).To(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeRequired),
-				"Field": Equal("metadata.name"),
-			}))
-			Expect(*errorList[1]).To(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeRequired),
-				"Field": Equal("metadata.namespace"),
-			}))
-			Expect(*errorList[2]).To(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeRequired),
-				"Field": Equal("secretRef.name"),
-			}))
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("metadata.name"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("metadata.namespace"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("secretRef.name"),
+				})),
+			))
 		})
 
 		It("should forbid empty stated Quota names", func() {
@@ -124,11 +124,12 @@ var _ = Describe("SecretBinding Validation Tests", func() {
 
 			errorList := ValidateSecretBinding(secretBinding)
 
-			Expect(errorList).To(HaveLen(1))
-			Expect(*errorList[0]).To(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeRequired),
-				"Field": Equal("quotas[0].name"),
-			}))
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("quotas[0].name"),
+				})),
+			))
 		})
 	})
 
@@ -158,15 +159,16 @@ var _ = Describe("SecretBinding Validation Tests", func() {
 
 			errorList := ValidateSecretBindingUpdate(newSecretBinding, secretBinding)
 
-			Expect(errorList).To(HaveLen(2))
-			Expect(*errorList[0]).To(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeInvalid),
-				"Field": Equal("secretRef"),
-			}))
-			Expect(*errorList[1]).To(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeInvalid),
-				"Field": Equal("quotas"),
-			}))
+			Expect(errorList).To(ConsistOf(
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("secretRef"),
+				})),
+				PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeInvalid),
+					"Field": Equal("quotas"),
+				})),
+			))
 		})
 
 		Context("when SecretBindingProviderValidation=false", func() {
@@ -203,11 +205,12 @@ var _ = Describe("SecretBinding Validation Tests", func() {
 
 				errorList := ValidateSecretBindingUpdate(newSecretBinding, secretBinding)
 
-				Expect(errorList).To(HaveLen(1))
-				Expect(*errorList[0]).To(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeInvalid),
-					"Field": Equal("provider"),
-				}))
+				Expect(errorList).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeInvalid),
+						"Field": Equal("provider"),
+					})),
+				))
 			})
 
 			It("should allow updating the SecretBinding provider when the field is not set", func() {
@@ -267,18 +270,20 @@ var _ = Describe("SecretBinding Validation Tests", func() {
 				defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.SecretBindingProviderValidation, true)()
 
 				errorList := ValidateSecretBindingProvider(nil)
-				Expect(errorList).To(HaveLen(1))
-				Expect(*errorList[0]).To(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("provider"),
-				}))
+				Expect(errorList).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeRequired),
+						"Field": Equal("provider"),
+					})),
+				))
 
 				errorList = ValidateSecretBindingProvider(&core.SecretBindingProvider{})
-				Expect(errorList).To(HaveLen(1))
-				Expect(*errorList[0]).To(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("provider.type"),
-				}))
+				Expect(errorList).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeRequired),
+						"Field": Equal("provider.type"),
+					})),
+				))
 			})
 
 			It("should succeed when provider is valid", func() {

--- a/pkg/apis/core/validation/secretbinding_test.go
+++ b/pkg/apis/core/validation/secretbinding_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 var _ = Describe("SecretBinding Validation Tests", func() {
-	Describe("#ValidateSecretBinding, #ValidateSecretBindingUpdate", func() {
+	Describe("#ValidateSecretBinding", func() {
 		var secretBinding *core.SecretBinding
 
 		BeforeEach(func() {
@@ -102,7 +102,7 @@ var _ = Describe("SecretBinding Validation Tests", func() {
 
 			errorList := ValidateSecretBinding(secretBinding)
 
-			Expect(errorList).To(HaveLen(4))
+			Expect(errorList).To(HaveLen(3))
 			Expect(*errorList[0]).To(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeRequired),
 				"Field": Equal("metadata.name"),
@@ -114,10 +114,6 @@ var _ = Describe("SecretBinding Validation Tests", func() {
 			Expect(*errorList[2]).To(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeRequired),
 				"Field": Equal("secretRef.name"),
-			}))
-			Expect(*errorList[3]).To(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeRequired),
-				"Field": Equal("provider.type"),
 			}))
 		})
 
@@ -134,8 +130,25 @@ var _ = Describe("SecretBinding Validation Tests", func() {
 				"Field": Equal("quotas[0].name"),
 			}))
 		})
+	})
 
-		It("should forbid updating the secret binding spec", func() {
+	Describe("#ValidateSecretBindingUpdate", func() {
+		var secretBinding *core.SecretBinding
+
+		BeforeEach(func() {
+			secretBinding = &core.SecretBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "profile",
+					Namespace: "garden",
+				},
+				SecretRef: corev1.SecretReference{
+					Name:      "my-secret",
+					Namespace: "my-namespace",
+				},
+			}
+		})
+
+		It("should forbid updating the SecretBinding spec", func() {
 			newSecretBinding := prepareSecretBindingForUpdate(secretBinding)
 			newSecretBinding.SecretRef.Name = "another-name"
 			newSecretBinding.Quotas = append(newSecretBinding.Quotas, corev1.ObjectReference{
@@ -156,8 +169,27 @@ var _ = Describe("SecretBinding Validation Tests", func() {
 			}))
 		})
 
+		Context("when SecretBindingProviderValidation=false", func() {
+			It("should allow updating the SecretBinding provider", func() {
+				defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.SecretBindingProviderValidation, false)()
+
+				secretBinding.Provider = &core.SecretBindingProvider{
+					Type: "old-type",
+				}
+
+				newSecretBinding := prepareSecretBindingForUpdate(secretBinding)
+				newSecretBinding.Provider = &core.SecretBindingProvider{
+					Type: "new-type",
+				}
+
+				errorList := ValidateSecretBindingUpdate(newSecretBinding, secretBinding)
+
+				Expect(errorList).To(BeEmpty())
+			})
+		})
+
 		Context("when SecretBindingProviderValidation=true", func() {
-			It("should forbid updating the secret binding provider", func() {
+			It("should forbid updating the SecretBinding provider when the field is already set", func() {
 				defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.SecretBindingProviderValidation, true)()
 
 				secretBinding.Provider = &core.SecretBindingProvider{
@@ -177,30 +209,86 @@ var _ = Describe("SecretBinding Validation Tests", func() {
 					"Field": Equal("provider"),
 				}))
 			})
+
+			It("should allow updating the SecretBinding provider when the field is not set", func() {
+				defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.SecretBindingProviderValidation, true)()
+
+				secretBinding.Provider = nil
+
+				newSecretBinding := prepareSecretBindingForUpdate(secretBinding)
+				newSecretBinding.Provider = &core.SecretBindingProvider{
+					Type: "new-type",
+				}
+
+				errorList := ValidateSecretBindingUpdate(newSecretBinding, secretBinding)
+
+				Expect(errorList).To(BeEmpty())
+			})
+
+			It("should allow updating SecretBinding when provider is nil", func() {
+				defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.SecretBindingProviderValidation, true)()
+
+				now := metav1.Now()
+				secretBinding.DeletionTimestamp = &now
+				secretBinding.Finalizers = []string{core.GardenerName}
+				secretBinding.Provider = nil
+
+				newSecretBinding := prepareSecretBindingForUpdate(secretBinding)
+				newSecretBinding.Finalizers = []string{}
+
+				errorList := ValidateSecretBindingUpdate(newSecretBinding, secretBinding)
+
+				Expect(errorList).To(BeEmpty())
+			})
+		})
+	})
+
+	Describe("#ValidateSecretBindingProvider", func() {
+		Context("when SecretBindingProviderValidation=false", func() {
+			It("should succeed when provider is nil", func() {
+				defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.SecretBindingProviderValidation, false)()
+
+				errorList := ValidateSecretBindingProvider(nil)
+				Expect(errorList).To(BeEmpty())
+			})
+
+			It("should succeed when provider is valid", func() {
+				defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.SecretBindingProviderValidation, false)()
+
+				errorList := ValidateSecretBindingProvider(&core.SecretBindingProvider{
+					Type: "foo",
+				})
+				Expect(errorList).To(BeEmpty())
+			})
 		})
 
-		It("should allow nil provider when SecretBindingProviderValidation feature gate is not enabled", func() {
-			defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.SecretBindingProviderValidation, false)()
+		Context("when SecretBindingProviderValidation=true", func() {
+			It("should return err when provider is nil or empty", func() {
+				defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.SecretBindingProviderValidation, true)()
 
-			secretBinding.Provider = nil
+				errorList := ValidateSecretBindingProvider(nil)
+				Expect(errorList).To(HaveLen(1))
+				Expect(*errorList[0]).To(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("provider"),
+				}))
 
-			errorList := ValidateSecretBinding(secretBinding)
+				errorList = ValidateSecretBindingProvider(&core.SecretBindingProvider{})
+				Expect(errorList).To(HaveLen(1))
+				Expect(*errorList[0]).To(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("provider.type"),
+				}))
+			})
 
-			Expect(errorList).To(BeEmpty())
-		})
+			It("should succeed when provider is valid", func() {
+				defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.SecretBindingProviderValidation, true)()
 
-		It("should forbid nil provider when SecretBindingProviderValidation feature gate is enabled", func() {
-			defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.SecretBindingProviderValidation, true)()
-
-			secretBinding.Provider = nil
-
-			errorList := ValidateSecretBinding(secretBinding)
-
-			Expect(errorList).To(HaveLen(1))
-			Expect(*errorList[0]).To(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeRequired),
-				"Field": Equal("provider"),
-			}))
+				errorList := ValidateSecretBindingProvider(&core.SecretBindingProvider{
+					Type: "foo",
+				})
+				Expect(errorList).To(BeEmpty())
+			})
 		})
 	})
 })

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -1114,7 +1114,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					}))))
 				})
 
-				It("should not allow ivalid total number of worker nodes", func() {
+				It("should not allow invalid total number of worker nodes", func() {
 					shoot.Spec.Kubernetes.KubeControllerManager.NodeCIDRMaskSize = pointer.Int32(24)
 					shoot.Spec.Networking.Pods = pointer.String("100.96.0.0/16")
 					worker1.Maximum = 128

--- a/pkg/registry/core/secretbinding/secretbinding_suite_test.go
+++ b/pkg/registry/core/secretbinding/secretbinding_suite_test.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secretbinding_test
+
+import (
+	"testing"
+
+	"github.com/gardener/gardener/pkg/apiserver/features"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestShoot(t *testing.T) {
+	features.RegisterFeatureGates()
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Registry SecretBinding Suite")
+}

--- a/pkg/registry/core/secretbinding/strategy.go
+++ b/pkg/registry/core/secretbinding/strategy.go
@@ -43,7 +43,10 @@ func (secretBindingStrategy) PrepareForCreate(ctx context.Context, obj runtime.O
 
 func (secretBindingStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	binding := obj.(*core.SecretBinding)
-	return validation.ValidateSecretBinding(binding)
+	allErrs := field.ErrorList{}
+	allErrs = append(allErrs, validation.ValidateSecretBinding(binding)...)
+	allErrs = append(allErrs, validation.ValidateSecretBindingProvider(binding.Provider)...)
+	return allErrs
 }
 
 func (secretBindingStrategy) Canonicalize(obj runtime.Object) {

--- a/pkg/registry/core/secretbinding/strategy_test.go
+++ b/pkg/registry/core/secretbinding/strategy_test.go
@@ -77,20 +77,22 @@ var _ = Describe("Strategy", func() {
 				secretBinding.Provider = nil
 
 				errorList := secretbindingregistry.Strategy.Validate(context.TODO(), secretBinding)
-				Expect(errorList).To(HaveLen(1))
-				Expect(*errorList[0]).To(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("provider"),
-				}))
+				Expect(errorList).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeRequired),
+						"Field": Equal("provider"),
+					})),
+				))
 
 				secretBinding.Provider = &core.SecretBindingProvider{}
 
 				errorList = secretbindingregistry.Strategy.Validate(context.TODO(), secretBinding)
-				Expect(errorList).To(HaveLen(1))
-				Expect(*errorList[0]).To(MatchFields(IgnoreExtras, Fields{
-					"Type":  Equal(field.ErrorTypeRequired),
-					"Field": Equal("provider.type"),
-				}))
+				Expect(errorList).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":  Equal(field.ErrorTypeRequired),
+						"Field": Equal("provider.type"),
+					})),
+				))
 			})
 
 			It("should allow creating SecretBinding when provider is valid", func() {

--- a/pkg/registry/core/secretbinding/strategy_test.go
+++ b/pkg/registry/core/secretbinding/strategy_test.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secretbinding_test
+
+import (
+	"context"
+
+	"github.com/gardener/gardener/pkg/apis/core"
+	"github.com/gardener/gardener/pkg/features"
+	secretbindingregistry "github.com/gardener/gardener/pkg/registry/core/secretbinding"
+	"github.com/gardener/gardener/pkg/utils/test"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
+)
+
+var _ = Describe("Strategy", func() {
+	var secretBinding *core.SecretBinding
+
+	BeforeEach(func() {
+		secretBinding = &core.SecretBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "profile",
+				Namespace: "garden",
+			},
+			SecretRef: corev1.SecretReference{
+				Name:      "my-secret",
+				Namespace: "my-namespace",
+			},
+		}
+	})
+
+	Describe("#Validate", func() {
+		Context("when SecretBindingProviderValidation=false", func() {
+			It("should allow creating SecretBinding when provider is nil", func() {
+				defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.SecretBindingProviderValidation, false)()
+
+				secretBinding.Provider = nil
+
+				errorList := secretbindingregistry.Strategy.Validate(context.TODO(), secretBinding)
+				Expect(errorList).To(BeEmpty())
+			})
+
+			It("should allow creating SecretBinding when provider is valid", func() {
+				defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.SecretBindingProviderValidation, false)()
+
+				secretBinding.Provider = &core.SecretBindingProvider{
+					Type: "foo",
+				}
+
+				errorList := secretbindingregistry.Strategy.Validate(context.TODO(), secretBinding)
+				Expect(errorList).To(BeEmpty())
+			})
+		})
+
+		Context("when SecretBindingProviderValidation=true", func() {
+			It("should forbid creating SecretBinding when provider is nil or empty", func() {
+				defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.SecretBindingProviderValidation, true)()
+
+				secretBinding.Provider = nil
+
+				errorList := secretbindingregistry.Strategy.Validate(context.TODO(), secretBinding)
+				Expect(errorList).To(HaveLen(1))
+				Expect(*errorList[0]).To(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("provider"),
+				}))
+
+				secretBinding.Provider = &core.SecretBindingProvider{}
+
+				errorList = secretbindingregistry.Strategy.Validate(context.TODO(), secretBinding)
+				Expect(errorList).To(HaveLen(1))
+				Expect(*errorList[0]).To(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("provider.type"),
+				}))
+			})
+
+			It("should allow creating SecretBinding when provider is valid", func() {
+				defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.SecretBindingProviderValidation, true)()
+
+				secretBinding.Provider = &core.SecretBindingProvider{
+					Type: "foo",
+				}
+
+				errorList := secretbindingregistry.Strategy.Validate(context.TODO(), secretBinding)
+				Expect(errorList).To(BeEmpty())
+			})
+		})
+	})
+})

--- a/pkg/registry/core/shoot/strategy.go
+++ b/pkg/registry/core/shoot/strategy.go
@@ -133,10 +133,10 @@ func mustIncreaseGenerationForSpecChanges(oldShoot, newShoot *core.Shoot) bool {
 
 func (shootStrategy) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
 	shoot := obj.(*core.Shoot)
-	errorList := field.ErrorList{}
-	errorList = append(errorList, validation.ValidateShoot(shoot)...)
-	errorList = append(errorList, validation.ValidateTotalNodeCountWithPodCIDR(shoot)...)
-	return errorList
+	allErrs := field.ErrorList{}
+	allErrs = append(allErrs, validation.ValidateShoot(shoot)...)
+	allErrs = append(allErrs, validation.ValidateTotalNodeCountWithPodCIDR(shoot)...)
+	return allErrs
 }
 
 func (shootStrategy) Canonicalize(obj runtime.Object) {


### PR DESCRIPTION
/area quality
/kind bug

Currently when the `SecretBindingProviderValidation` feature gate is enabled, apiserver wrongly rejects update requests for SecretBindings with `provider=nil`:
- for example the GCM cannot remove a finalizer during deletion of SecretBinding with `provider=nil`.
   ```
   {"level":"error","ts":"2022-03-20T11:35:35.460Z","logger":"controller.secretbinding","msg":"Error reconciling request","name":"bar","namespace":"garden-foo","error":"failed to remove finalizer from SecretBinding: SecretBinding.core.gardener.cloud \"bar\" is invalid: provider: Required value: must specify a provider","stacktrace":"github.com/gardener/gardener/pkg/controllerutils.worker\n\t/go/src/github.com/gardener/gardener/pkg/controllerutils/worker.go:145\ngithub.com/gardener/gardener/pkg/controllerutils.CreateWorker.func1.1\n\t/go/src/github.com/gardener/gardener/pkg/controllerutils/worker.go:64\nk8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext.func1\n\t/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:188\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\t/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\t/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\t/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext\n\t/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:188\nk8s.io/apimachinery/pkg/util/wait.UntilWithContext\n\t/go/src/github.com/gardener/gardener/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:99\ngithub.com/gardener/gardener/pkg/controllerutils.CreateWorker.func1\n\t/go/src/github.com/gardener/gardener/pkg/controllerutils/worker.go:63"}
   ```

- or in general update request to the SecretBinding with `provider=nil` is wrongly rejected:
   ```
   $ k -n garden-foo annotate sb bar foo=bar
   The SecretBinding "bar" is invalid: provider: Required value: must specify a provider
   ```

This PR moves the `ValidateSecretBindingProvider` func to be called only on `strategy.Validate` (and not on `strategy.ValidateUpdate`) that is called during create request only. `strategy.ValidateUpdate` still performs immutability check for the field when it is set, hence it is not allowed to unset the field when the feature gate is enabled.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing update request to SecretBinding with `provider=nil` to wrongly be rejected when the `SecretBindingProviderValidation` feature gate is enabled is now fixed.
```
