### PR TITLE
Added the RBAC for PodDisruptionBudget

### DIFF
--- a/pkg/operation/botanist/component/etcd/bootstrap.go
+++ b/pkg/operation/botanist/component/etcd/bootstrap.go
@@ -37,6 +37,7 @@ import (
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -163,6 +164,11 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 					APIGroups: []string{corev1.GroupName},
 					Resources: []string{"persistentvolumeclaims"},
 					Verbs:     []string{"get", "list", "watch"},
+				},
+				{
+					APIGroups: []string{policyv1beta1.GroupName},
+					Resources: []string{"poddisruptionbudgets"},
+					Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
 				},
 			},
 		}

--- a/pkg/operation/botanist/component/etcd/bootstrap.go
+++ b/pkg/operation/botanist/component/etcd/bootstrap.go
@@ -158,7 +158,7 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 				{
 					APIGroups: []string{coordinationv1.GroupName},
 					Resources: []string{"leases"},
-					Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+					Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete", "deletecollection"},
 				},
 				{
 					APIGroups: []string{corev1.GroupName},

--- a/pkg/operation/botanist/component/etcd/bootstrap_test.go
+++ b/pkg/operation/botanist/component/etcd/bootstrap_test.go
@@ -239,6 +239,7 @@ rules:
   - update
   - patch
   - delete
+  - deletecollection
 - apiGroups:
   - ""
   resources:

--- a/pkg/operation/botanist/component/etcd/bootstrap_test.go
+++ b/pkg/operation/botanist/component/etcd/bootstrap_test.go
@@ -247,6 +247,18 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - patch
+  - update
+  - delete
 `
 			clusterRoleBindingYAML = `apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
**What this PR does / why we need it**:
1. This PR adds the RBAC for PodDisruptionBudget which was introduced by this [PR#250](https://github.com/gardener/etcd-druid/pull/250) of etcd-druid
2. Also adds a `deletecollection` verbs in RBAC for lease object.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Instead of creating/deleting the PodDisruptionBudget when switching between single and multi-node of etcd, it just sets `minAvailable` to `0` for single node etcd.

**Release note**:
```other operator
NONE
```
