### PR TITLE
Remove CPU limits from gardener components

### DIFF
--- a/charts/gardener/controlplane/values.yaml
+++ b/charts/gardener/controlplane/values.yaml
@@ -26,7 +26,6 @@ global:
         cpu: 100m
         memory: 100Mi
       limits:
-        cpu: 300m
         memory: 256Mi
   # podAnnotations: # YAML formated annotations used for pod template
   # podLabels: # YAML formated labels used for pod template
@@ -273,7 +272,6 @@ global:
         cpu: 100m
         memory: 200Mi
       limits:
-        cpu: 300m
         memory: 512Mi
   # service:
   #   clusterIP: 1.2.3.4
@@ -346,7 +344,6 @@ global:
         cpu: 100m
         memory: 100Mi
       limits:
-        cpu: 750m
         memory: 512Mi
   # podAnnotations: # YAML formated annotations used for pod template
   # podLabels: # YAML formated labels used for pod template
@@ -457,7 +454,6 @@ global:
         cpu: 50m
         memory: 50Mi
       limits:
-        cpu: 300m
         memory: 256Mi
   # podAnnotations: # YAML formatted annotations used for pod template
   # podLabels: # YAML formatted labels used for pod template

--- a/charts/gardener/gardenlet/values.yaml
+++ b/charts/gardener/gardenlet/values.yaml
@@ -15,7 +15,6 @@ global:
         cpu: 100m
         memory: 100Mi
       limits:
-        cpu: 2000m
         memory: 512Mi
   # podAnnotations: # YAML formated annotations used for pod template
   # podLabels: # YAML formated labels used for pod template

--- a/charts/gardener/provider-local/internal/machine-controller-manager/seed/templates/deployment.yaml
+++ b/charts/gardener/provider-local/internal/machine-controller-manager/seed/templates/deployment.yaml
@@ -121,7 +121,6 @@ spec:
             cpu: 50m
             memory: 64Mi
           limits:
-            cpu: 350m
             memory: 256Mi
         volumeMounts:
         {{- if .Values.useTokenRequestor }}

--- a/charts/istio/istio-ingress/templates/deployment.yaml
+++ b/charts/istio/istio-ingress/templates/deployment.yaml
@@ -80,7 +80,6 @@ spec:
             cpu: 1000m
             memory: 2Gi
           limits:
-            cpu: 4000m
             memory: 8Gi
         env:
         - name: NODE_NAME

--- a/charts/istio/istio-istiod/templates/deployment.yaml
+++ b/charts/istio/istio-istiod/templates/deployment.yaml
@@ -100,7 +100,6 @@ spec:
             cpu: 250m
             memory: 256Mi
           limits:
-            cpu: 1000m
             memory: 2048Mi
         securityContext:
           capabilities:

--- a/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-daemonset.yaml
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-daemonset.yaml
@@ -74,7 +74,6 @@ spec:
               fieldPath: spec.nodeName
         resources:
           limits:
-            cpu: 300m
             memory: 400Mi
           requests:
             cpu: 150m

--- a/charts/seed-bootstrap/charts/hvpa/templates/controller-deployment.yaml
+++ b/charts/seed-bootstrap/charts/hvpa/templates/controller-deployment.yaml
@@ -44,7 +44,6 @@ spec:
           - --v=2
         resources:
           limits:
-            cpu: 500m
             memory: 1000Mi
           requests:
             cpu: 50m

--- a/charts/seed-bootstrap/charts/loki/values.yaml
+++ b/charts/seed-bootstrap/charts/loki/values.yaml
@@ -51,28 +51,24 @@ replicas: 1
 resources:
   loki:
     limits:
-      cpu: 450m
       memory: 512Mi
     requests:
       cpu: 200m
       memory: 300Mi
   curator:
     limits:
-      cpu: 200m
       memory: 200Mi
     requests:
       cpu: 10m
       memory: 12Mi
   kubeRBACproxy:
     limits:
-      cpu: 180m
       memory: 150Mi
     requests:
       cpu: 50m
       memory: 50Mi
   telegraf:
     limits:
-      cpu: 15m
       memory: 100Mi
     requests:
       cpu: 5m

--- a/charts/seed-bootstrap/charts/monitoring/values.yaml
+++ b/charts/seed-bootstrap/charts/monitoring/values.yaml
@@ -7,14 +7,12 @@ prometheus:
   resources:
     prometheus:
       limits:
-        cpu: 500m
         memory: 2Gi
       requests:
         cpu: 300m
         memory: 1Gi
     prometheus-config-reloader:
       limits:
-        cpu: 20m
         memory: 50Mi
       requests:
         cpu: 10m

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-admission-controller.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-admission-controller.yaml
@@ -80,7 +80,6 @@ spec:
 {{- end }}
         resources:
           limits:
-            cpu: 120m
             memory: 500Mi
           requests:
             cpu: 30m

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-recommender.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-recommender.yaml
@@ -69,7 +69,6 @@ spec:
         imagePullPolicy: IfNotPresent
         resources:
           limits:
-            cpu: 120m
             memory: 500Mi
           requests:
             cpu: 30m

--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-updater.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-updater.yaml
@@ -78,7 +78,6 @@ spec:
 {{- end }}
         resources:
           limits:
-            cpu: 120m
             memory: 500Mi
           requests:
             cpu: 30m

--- a/charts/seed-bootstrap/templates/alertmanager/alertmanager.yaml
+++ b/charts/seed-bootstrap/templates/alertmanager/alertmanager.yaml
@@ -105,7 +105,6 @@ spec:
             cpu: 5m
             memory: 20Mi
           limits:
-            cpu: 100m
             memory: 60Mi
         volumeMounts:
         - mountPath: /etc/alertmanager/config
@@ -125,7 +124,6 @@ spec:
             cpu: 5m
             memory: 10Mi
           limits:
-            cpu: 10m
             memory: 20Mi
         volumeMounts:
         - mountPath: /etc/alertmanager/config

--- a/charts/seed-bootstrap/templates/grafana/grafana-deployment.yaml
+++ b/charts/seed-bootstrap/templates/grafana/grafana-deployment.yaml
@@ -69,7 +69,6 @@ spec:
             cpu: 10m
             memory: 32Mi
           limits:
-            cpu: 200m
             memory: 128Mi
       volumes:
       - name: grafana-storage

--- a/charts/seed-bootstrap/templates/vpa-exporter/deployment-exporter.yaml
+++ b/charts/seed-bootstrap/templates/vpa-exporter/deployment-exporter.yaml
@@ -39,5 +39,4 @@ spec:
             cpu: 30m
             memory: 50Mi
           limits:
-            cpu: 120m
             memory: 200Mi

--- a/charts/seed-bootstrap/values.yaml
+++ b/charts/seed-bootstrap/values.yaml
@@ -4,14 +4,12 @@ prometheus:
   resources:
     prometheus:
       limits:
-        cpu: 500m
         memory: 2000Mi
       requests:
         cpu: 300m
         memory: 1000Mi
     prometheus-config-reloader:
       limits:
-        cpu: 20m
         memory: 50Mi
       requests:
         cpu: 10m
@@ -57,14 +55,12 @@ aggregatePrometheus:
   resources:
     prometheus:
       limits:
-        cpu: 500m
         memory: 2000Mi
       requests:
         cpu: 300m
         memory: 1000Mi
     prometheus-config-reloader:
       limits:
-        cpu: 20m
         memory: 20Mi
       requests:
         cpu: 10m

--- a/charts/seed-monitoring/charts/alertmanager/templates/alertmanager.yaml
+++ b/charts/seed-monitoring/charts/alertmanager/templates/alertmanager.yaml
@@ -116,7 +116,6 @@ spec:
             cpu: 5m
             memory: 20Mi
           limits:
-            cpu: 100m
             memory: 60Mi
         volumeMounts:
         - mountPath: /etc/alertmanager/config
@@ -136,7 +135,6 @@ spec:
             cpu: 5m
             memory: 10Mi
           limits:
-            cpu: 10m
             memory: 20Mi
         volumeMounts:
         - mountPath: /etc/alertmanager/config

--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
@@ -152,7 +152,6 @@ spec:
             cpu: 5m
             memory: 35Mi
           limits:
-            cpu: 50m
             memory: 128Mi
         volumeMounts:
         - name: blackbox-exporter-config-prometheus
@@ -175,7 +174,6 @@ spec:
             cpu: 5m
             memory: 25Mi
           limits:
-            cpu: 10m
             memory: 25Mi
         volumeMounts:
         - mountPath: /etc/prometheus/config

--- a/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
@@ -336,7 +336,6 @@ resources:
     cpu: 200m
     memory: 360Mi
   limits:
-    cpu: 350m
     memory: 760Mi
 
 #remoteWrite:

--- a/charts/seed-monitoring/charts/grafana/templates/grafana-deployment.yaml
+++ b/charts/seed-monitoring/charts/grafana/templates/grafana-deployment.yaml
@@ -76,7 +76,6 @@ spec:
             cpu: 10m
             memory: 32Mi
           limits:
-            cpu: 200m
             memory: 128Mi
       volumes:
       - name: grafana-storage

--- a/charts/shoot-addons/charts/kubernetes-dashboard/templates/deployment-dashboard.yaml
+++ b/charts/shoot-addons/charts/kubernetes-dashboard/templates/deployment-dashboard.yaml
@@ -70,10 +70,8 @@ spec:
             memory: 50Mi
           limits:
           {{- if .Values.global.vpaEnabled }}
-            cpu: 200m
             memory: 200Mi
           {{- else }}
-            cpu: 300m
             memory: 256Mi
           {{- end }}
       volumes:

--- a/charts/shoot-addons/charts/nginx-ingress/templates/controller-deployment.yaml
+++ b/charts/shoot-addons/charts/nginx-ingress/templates/controller-deployment.yaml
@@ -140,10 +140,8 @@ spec:
               memory: 100Mi
             limits:
             {{- if .Values.global.vpaEnabled }}
-              cpu: 400m
               memory: 400Mi
             {{- else }}
-              cpu: 2000m
               memory: 2048Mi
             {{- end }}
       hostNetwork: {{ .Values.controller.hostNetwork }}

--- a/charts/shoot-addons/charts/nginx-ingress/values.yaml
+++ b/charts/shoot-addons/charts/nginx-ingress/values.yaml
@@ -147,7 +147,6 @@ defaultBackend:
 
   resources: {}
     # limits:
-    #   cpu: 10m
     #   memory: 20Mi
     # requests:
     #   cpu: 10m

--- a/charts/shoot-core/components/charts/apiserver-proxy/templates/apiserver-proxy-daemonset.yaml
+++ b/charts/shoot-core/components/charts/apiserver-proxy/templates/apiserver-proxy-daemonset.yaml
@@ -62,7 +62,6 @@ spec:
             cpu: 20m
             memory: 20Mi
           limits:
-            cpu: 200m
             memory: 200Mi
       containers:
       - name: sidecar
@@ -81,7 +80,6 @@ spec:
             cpu: 20m
             memory: 20Mi
           limits:
-            cpu: 200m
             memory: 200Mi
       - name: proxy
         image: {{ index .Values.images "apiserver-proxy" }}
@@ -101,7 +99,6 @@ spec:
             cpu: 20m
             memory: 20Mi
           limits:
-            cpu: 200m
             memory: 300Mi
         readinessProbe:
           httpGet:

--- a/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/deployment.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/deployment.yaml
@@ -58,10 +58,8 @@ spec:
             memory: 5Mi
           limits:
           {{- if .Values.global.vpaEnabled }}
-            cpu: 40m
             memory: 20Mi
           {{- else }}
-            cpu: 50m
             memory: 35Mi
           {{- end }}
         ports:

--- a/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
@@ -111,10 +111,8 @@ spec:
             memory: 50Mi
           limits:
           {{- if .Values.global.vpaEnabled }}
-            cpu: 150m
             memory: 150Mi
           {{- else }}
-            cpu: 200m
             memory: 200Mi
           {{- end }}
         volumeMounts:

--- a/pkg/gardenlet/controller/managedseed/charttest/charttest.go
+++ b/pkg/gardenlet/controller/managedseed/charttest/charttest.go
@@ -942,7 +942,6 @@ func ComputeExpectedGardenletDeploymentSpec(
 						},
 						Resources: corev1.ResourceRequirements{
 							Limits: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("2000m"),
 								corev1.ResourceMemory: resource.MustParse("512Mi"),
 							},
 							Requests: corev1.ResourceList{

--- a/pkg/gardenlet/controller/managedseed/charttest/gardenlet_chart_test.go
+++ b/pkg/gardenlet/controller/managedseed/charttest/gardenlet_chart_test.go
@@ -418,7 +418,6 @@ var _ = Describe("#Gardenlet Chart Test", func() {
 					corev1.ResourceMemory: resource.MustParse("15Mi"),
 				},
 				Limits: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("900m"),
 					corev1.ResourceMemory: resource.MustParse("25Mi"),
 				},
 			},

--- a/pkg/operation/botanist/component/clusterautoscaler/cluster_autoscaler.go
+++ b/pkg/operation/botanist/component/clusterautoscaler/cluster_autoscaler.go
@@ -220,7 +220,6 @@ func (c *clusterAutoscaler) Deploy(ctx context.Context) error {
 								corev1.ResourceMemory: resource.MustParse("300Mi"),
 							},
 							Limits: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("1"),
 								corev1.ResourceMemory: resource.MustParse("3000Mi"),
 							},
 						},

--- a/pkg/operation/botanist/component/clusterautoscaler/cluster_autoscaler_test.go
+++ b/pkg/operation/botanist/component/clusterautoscaler/cluster_autoscaler_test.go
@@ -314,7 +314,6 @@ var _ = Describe("ClusterAutoscaler", func() {
 											corev1.ResourceMemory: resource.MustParse("300Mi"),
 										},
 										Limits: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("1"),
 											corev1.ResourceMemory: resource.MustParse("3000Mi"),
 										},
 									},

--- a/pkg/operation/botanist/component/coredns/coredns.go
+++ b/pkg/operation/botanist/component/coredns/coredns.go
@@ -499,7 +499,6 @@ import custom/*.server
 									corev1.ResourceMemory: resource.MustParse("15Mi"),
 								},
 								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("250m"),
 									corev1.ResourceMemory: resource.MustParse("500Mi"),
 								},
 							},
@@ -696,7 +695,6 @@ import custom/*.server
 									corev1.ResourceMemory: resource.MustParse("10Mi"),
 								},
 								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("100m"),
 									corev1.ResourceMemory: resource.MustParse("50Mi"),
 								},
 							},

--- a/pkg/operation/botanist/component/coredns/coredns_test.go
+++ b/pkg/operation/botanist/component/coredns/coredns_test.go
@@ -337,7 +337,6 @@ spec:
           timeoutSeconds: 2
         resources:
           limits:
-            cpu: 250m
             memory: 500Mi
           requests:
             cpu: 50m
@@ -541,7 +540,6 @@ spec:
         name: autoscaler
         resources:
           limits:
-            cpu: 100m
             memory: 50Mi
           requests:
             cpu: 20m

--- a/pkg/operation/botanist/component/dependencywatchdog/dependency_watchdog.go
+++ b/pkg/operation/botanist/component/dependencywatchdog/dependency_watchdog.go
@@ -227,7 +227,6 @@ func (d *dependencyWatchdog) Deploy(ctx context.Context) error {
 									corev1.ResourceMemory: resource.MustParse("256Mi"),
 								},
 								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("500m"),
 									corev1.ResourceMemory: resource.MustParse("512Mi"),
 								},
 							},

--- a/pkg/operation/botanist/component/dependencywatchdog/dependency_watchdog_test.go
+++ b/pkg/operation/botanist/component/dependencywatchdog/dependency_watchdog_test.go
@@ -329,7 +329,6 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: 500m
             memory: 512Mi
           requests:
             cpu: 200m

--- a/pkg/operation/botanist/component/etcd/bootstrap.go
+++ b/pkg/operation/botanist/component/etcd/bootstrap.go
@@ -262,7 +262,6 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 										corev1.ResourceMemory: resource.MustParse("128Mi"),
 									},
 									Limits: corev1.ResourceList{
-										corev1.ResourceCPU:    resource.MustParse("300m"),
 										corev1.ResourceMemory: resource.MustParse("512Mi"),
 									},
 								},

--- a/pkg/operation/botanist/component/etcd/bootstrap_test.go
+++ b/pkg/operation/botanist/component/etcd/bootstrap_test.go
@@ -356,7 +356,6 @@ spec:
         - containerPort: 9569
         resources:
           limits:
-            cpu: 300m
             memory: 512Mi
           requests:
             cpu: 50m
@@ -412,7 +411,6 @@ spec:
         - containerPort: 9569
         resources:
           limits:
-            cpu: 300m
             memory: 512Mi
           requests:
             cpu: 50m

--- a/pkg/operation/botanist/component/etcd/etcd.go
+++ b/pkg/operation/botanist/component/etcd/etcd.go
@@ -673,7 +673,6 @@ func (e *etcd) computeContainerResources(existingSts *appsv1.StatefulSet) (*core
 				corev1.ResourceMemory: resource.MustParse("1G"),
 			},
 			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("2300m"),
 				corev1.ResourceMemory: resource.MustParse("6G"),
 			},
 		}
@@ -683,7 +682,6 @@ func (e *etcd) computeContainerResources(existingSts *appsv1.StatefulSet) (*core
 				corev1.ResourceMemory: resource.MustParse("128Mi"),
 			},
 			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("1"),
 				corev1.ResourceMemory: resource.MustParse("10G"),
 			},
 		}

--- a/pkg/operation/botanist/component/etcd/etcd_test.go
+++ b/pkg/operation/botanist/component/etcd/etcd_test.go
@@ -193,7 +193,6 @@ var _ = Describe("Etcd", func() {
 					corev1.ResourceMemory: resource.MustParse("1G"),
 				},
 				Limits: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("2300m"),
 					corev1.ResourceMemory: resource.MustParse("6G"),
 				},
 			}
@@ -207,7 +206,6 @@ var _ = Describe("Etcd", func() {
 					corev1.ResourceMemory: resource.MustParse("128Mi"),
 				},
 				Limits: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("1"),
 					corev1.ResourceMemory: resource.MustParse("10G"),
 				},
 			}

--- a/pkg/operation/botanist/component/gardenerkubescheduler/gardener_kube_scheduler.go
+++ b/pkg/operation/botanist/component/gardenerkubescheduler/gardener_kube_scheduler.go
@@ -248,7 +248,6 @@ func (k *kubeScheduler) Deploy(ctx context.Context) error {
 										corev1.ResourceMemory: resource.MustParse("64Mi"),
 									},
 									Limits: corev1.ResourceList{
-										corev1.ResourceCPU:    resource.MustParse("400m"),
 										corev1.ResourceMemory: resource.MustParse("512Mi"),
 									},
 								},

--- a/pkg/operation/botanist/component/gardenerkubescheduler/gardener_kube_scheduler_test.go
+++ b/pkg/operation/botanist/component/gardenerkubescheduler/gardener_kube_scheduler_test.go
@@ -485,7 +485,6 @@ var _ = Describe("New", func() {
 												corev1.ResourceMemory: resource.MustParse("64Mi"),
 											},
 											Limits: corev1.ResourceList{
-												corev1.ResourceCPU:    resource.MustParse("400m"),
 												corev1.ResourceMemory: resource.MustParse("512Mi"),
 											},
 										},
@@ -689,7 +688,6 @@ var _ = Describe("New", func() {
 												corev1.ResourceMemory: resource.MustParse("64Mi"),
 											},
 											Limits: corev1.ResourceList{
-												corev1.ResourceCPU:    resource.MustParse("400m"),
 												corev1.ResourceMemory: resource.MustParse("512Mi"),
 											},
 										},

--- a/pkg/operation/botanist/component/kubeapiserver/deployment.go
+++ b/pkg/operation/botanist/component/kubeapiserver/deployment.go
@@ -731,7 +731,6 @@ func (k *kubeAPIServer) handleVPNSettings(
 					corev1.ResourceMemory: resource.MustParse("128Mi"),
 				},
 				Limits: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("500m"),
 					corev1.ResourceMemory: resource.MustParse("1000Mi"),
 				},
 			},
@@ -927,7 +926,6 @@ func (k *kubeAPIServer) handlePodMutatorSettings(deployment *appsv1.Deployment) 
 					corev1.ResourceMemory: resource.MustParse("128M"),
 				},
 				Limits: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("200m"),
 					corev1.ResourceMemory: resource.MustParse("500M"),
 				},
 			},

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
@@ -1614,7 +1614,6 @@ rules:
 								corev1.ResourceMemory: resource.MustParse("128Mi"),
 							},
 							Limits: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("500m"),
 								corev1.ResourceMemory: resource.MustParse("1000Mi"),
 							},
 						},
@@ -1683,7 +1682,6 @@ rules:
 								corev1.ResourceMemory: resource.MustParse("128M"),
 							},
 							Limits: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("200m"),
 								corev1.ResourceMemory: resource.MustParse("500M"),
 							},
 						},
@@ -1711,7 +1709,6 @@ rules:
 									corev1.ResourceMemory: resource.MustParse("2Gi"),
 								},
 								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("2"),
 									corev1.ResourceMemory: resource.MustParse("4Gi"),
 								},
 							}

--- a/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager.go
@@ -570,7 +570,6 @@ func (k *kubeControllerManager) computeResourceRequirements(ctx context.Context)
 			corev1.ResourceMemory: resource.MustParse("128Mi"),
 		},
 		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("400m"),
 			corev1.ResourceMemory: resource.MustParse("512Mi"),
 		},
 	}

--- a/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager_test.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager_test.go
@@ -503,7 +503,6 @@ var _ = Describe("KubeControllerManager", func() {
 													corev1.ResourceMemory: resource.MustParse("128Mi"),
 												},
 												Limits: corev1.ResourceList{
-													corev1.ResourceCPU:    resource.MustParse("400m"),
 													corev1.ResourceMemory: resource.MustParse("512Mi"),
 												},
 											},

--- a/pkg/operation/botanist/component/kubeproxy/kube_proxy_test.go
+++ b/pkg/operation/botanist/component/kubeproxy/kube_proxy_test.go
@@ -484,7 +484,6 @@ spec:
 				if vpaEnabled {
 					out += `
           limits:
-            cpu: 80m
             memory: 2Gi`
 				}
 

--- a/pkg/operation/botanist/component/kubeproxy/resources.go
+++ b/pkg/operation/botanist/component/kubeproxy/resources.go
@@ -533,7 +533,6 @@ func (k *kubeProxy) computePoolResourcesData(pool WorkerPool) (map[string][]byte
 
 	if k.values.VPAEnabled {
 		daemonSet.Spec.Template.Spec.Containers[0].Resources.Limits = corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("80m"),
 			corev1.ResourceMemory: resource.MustParse("2048Mi"),
 		}
 

--- a/pkg/operation/botanist/component/kubescheduler/kube_scheduler.go
+++ b/pkg/operation/botanist/component/kubescheduler/kube_scheduler.go
@@ -243,7 +243,6 @@ func (k *kubeScheduler) Deploy(ctx context.Context) error {
 								corev1.ResourceMemory: resource.MustParse("64Mi"),
 							},
 							Limits: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("400m"),
 								corev1.ResourceMemory: resource.MustParse("512Mi"),
 							},
 						},

--- a/pkg/operation/botanist/component/kubescheduler/kube_scheduler_test.go
+++ b/pkg/operation/botanist/component/kubescheduler/kube_scheduler_test.go
@@ -230,7 +230,6 @@ var _ = Describe("KubeScheduler", func() {
 											corev1.ResourceMemory: resource.MustParse("64Mi"),
 										},
 										Limits: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("400m"),
 											corev1.ResourceMemory: resource.MustParse("512Mi"),
 										},
 									},

--- a/pkg/operation/botanist/component/metricsserver/metrics_server.go
+++ b/pkg/operation/botanist/component/metricsserver/metrics_server.go
@@ -348,7 +348,6 @@ func (m *metricsServer) computeResourcesData(serverSecret, caSecret *corev1.Secr
 									corev1.ResourceMemory: resource.MustParse("150Mi"),
 								},
 								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("500m"),
 									corev1.ResourceMemory: resource.MustParse("1Gi"),
 								},
 							},

--- a/pkg/operation/botanist/component/metricsserver/metrics_server_test.go
+++ b/pkg/operation/botanist/component/metricsserver/metrics_server_test.go
@@ -259,7 +259,6 @@ spec:
           periodSeconds: 10
         resources:
           limits:
-            cpu: 500m
             memory: 1Gi
           requests:
             cpu: 50m

--- a/pkg/operation/botanist/component/nginxingress/nginxingress.go
+++ b/pkg/operation/botanist/component/nginxingress/nginxingress.go
@@ -374,7 +374,6 @@ func (n *nginxIngress) computeResourcesData() (map[string][]byte, error) {
 									corev1.ResourceMemory: resource.MustParse("20Mi"),
 								},
 								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("100m"),
 									corev1.ResourceMemory: resource.MustParse("100Mi"),
 								},
 							},
@@ -499,7 +498,6 @@ func (n *nginxIngress) computeResourcesData() (map[string][]byte, error) {
 							},
 							Resources: corev1.ResourceRequirements{
 								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("400m"),
 									corev1.ResourceMemory: resource.MustParse("1500Mi"),
 								},
 								Requests: corev1.ResourceList{

--- a/pkg/operation/botanist/component/nginxingress/nginxingress_test.go
+++ b/pkg/operation/botanist/component/nginxingress/nginxingress_test.go
@@ -400,7 +400,6 @@ spec:
           protocol: TCP
         resources:
           limits:
-            cpu: 100m
             memory: 100Mi
           requests:
             cpu: 20m
@@ -517,7 +516,6 @@ spec:
           timeoutSeconds: 1
         resources:
           limits:
-            cpu: 400m
             memory: 1500Mi
           requests:
             cpu: 100m

--- a/pkg/operation/botanist/component/nodelocaldns/nodelocaldns.go
+++ b/pkg/operation/botanist/component/nodelocaldns/nodelocaldns.go
@@ -383,7 +383,6 @@ ip6.arpa:53 {
 										corev1.ResourceMemory: resource.MustParse("25Mi"),
 									},
 									Limits: corev1.ResourceList{
-										corev1.ResourceCPU:    resource.MustParse("100m"),
 										corev1.ResourceMemory: resource.MustParse("100Mi"),
 									},
 								},

--- a/pkg/operation/botanist/component/nodelocaldns/nodelocaldns_test.go
+++ b/pkg/operation/botanist/component/nodelocaldns/nodelocaldns_test.go
@@ -323,7 +323,6 @@ status:
 										Image: values.Image,
 										Resources: corev1.ResourceRequirements{
 											Limits: corev1.ResourceList{
-												corev1.ResourceCPU:    resource.MustParse("100m"),
 												corev1.ResourceMemory: resource.MustParse("100Mi"),
 											},
 											Requests: corev1.ResourceList{

--- a/pkg/operation/botanist/component/nodeproblemdetector/node_problem_detector.go
+++ b/pkg/operation/botanist/component/nodeproblemdetector/node_problem_detector.go
@@ -438,13 +438,11 @@ func (c *nodeProblemDetector) computeResourcesData() (map[string][]byte, error) 
 func (c *nodeProblemDetector) getResourceLimits() corev1.ResourceList {
 	if c.values.VPAEnabled {
 		return corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("80m"),
 			corev1.ResourceMemory: resource.MustParse("80Mi"),
 		}
 	}
 
 	return corev1.ResourceList{
-		corev1.ResourceCPU:    resource.MustParse("200m"),
 		corev1.ResourceMemory: resource.MustParse("100Mi"),
 	}
 }

--- a/pkg/operation/botanist/component/nodeproblemdetector/node_problem_detector_test.go
+++ b/pkg/operation/botanist/component/nodeproblemdetector/node_problem_detector_test.go
@@ -273,12 +273,10 @@ spec:
 				if vpaEnabled {
 					out += `
           limits:
-            cpu: 80m
             memory: 80Mi`
 				} else {
 					out += `
           limits:
-            cpu: 200m
             memory: 100Mi`
 				}
 				out += `

--- a/pkg/operation/botanist/component/resourcemanager/resource_manager.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager.go
@@ -528,7 +528,6 @@ func (r *resourceManager) ensureDeployment(ctx context.Context) error {
 								corev1.ResourceMemory: resource.MustParse("47Mi"),
 							},
 							Limits: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("400m"),
 								corev1.ResourceMemory: resource.MustParse("512Mi"),
 							},
 						},

--- a/pkg/operation/botanist/component/resourcemanager/resource_manager_test.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager_test.go
@@ -446,7 +446,6 @@ var _ = Describe("ResourceManager", func() {
 										corev1.ResourceMemory: resource.MustParse("47Mi"),
 									},
 									Limits: corev1.ResourceList{
-										corev1.ResourceCPU:    resource.MustParse("400m"),
 										corev1.ResourceMemory: resource.MustParse("512Mi"),
 									},
 								},

--- a/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller.go
+++ b/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller.go
@@ -273,7 +273,6 @@ func (g *gardenerSeedAdmissionController) Deploy(ctx context.Context) error {
 									corev1.ResourceMemory: resource.MustParse("50Mi"),
 								},
 								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("100m"),
 									corev1.ResourceMemory: resource.MustParse("100Mi"),
 								},
 							},

--- a/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller_test.go
+++ b/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller_test.go
@@ -199,7 +199,6 @@ spec:
           initialDelaySeconds: 10
         resources:
           limits:
-            cpu: 100m
             memory: 100Mi
           requests:
             cpu: 20m

--- a/pkg/operation/botanist/component/vpnauthzserver/external_authz_server.go
+++ b/pkg/operation/botanist/component/vpnauthzserver/external_authz_server.go
@@ -145,7 +145,6 @@ func (a *authzServer) Deploy(ctx context.Context) error {
 									corev1.ResourceMemory: resource.MustParse("100Mi"),
 								},
 								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("1"),
 									corev1.ResourceMemory: resource.MustParse("500Mi"),
 								},
 							},

--- a/pkg/operation/botanist/component/vpnauthzserver/external_authz_server_test.go
+++ b/pkg/operation/botanist/component/vpnauthzserver/external_authz_server_test.go
@@ -174,7 +174,6 @@ var _ = Describe("ExtAuthzServer", func() {
 										corev1.ResourceMemory: resource.MustParse("100Mi"),
 									},
 									Limits: corev1.ResourceList{
-										corev1.ResourceCPU:    resource.MustParse("1"),
 										corev1.ResourceMemory: resource.MustParse("500Mi"),
 									},
 								},

--- a/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server.go
+++ b/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server.go
@@ -397,7 +397,6 @@ func (v *vpnSeedServer) Deploy(ctx context.Context) error {
 									corev1.ResourceMemory: resource.MustParse("100Mi"),
 								},
 								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("1"),
 									corev1.ResourceMemory: resource.MustParse("1Gi"),
 								},
 							},
@@ -454,7 +453,6 @@ func (v *vpnSeedServer) Deploy(ctx context.Context) error {
 									corev1.ResourceMemory: resource.MustParse("20Mi"),
 								},
 								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("200m"),
 									corev1.ResourceMemory: resource.MustParse("300Mi"),
 								},
 							},

--- a/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server_test.go
+++ b/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server_test.go
@@ -354,7 +354,6 @@ admin:
 											corev1.ResourceMemory: resource.MustParse("100Mi"),
 										},
 										Limits: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("1"),
 											corev1.ResourceMemory: resource.MustParse("1Gi"),
 										},
 									},
@@ -411,7 +410,6 @@ admin:
 											corev1.ResourceMemory: resource.MustParse("20Mi"),
 										},
 										Limits: corev1.ResourceList{
-											corev1.ResourceCPU:    resource.MustParse("200m"),
 											corev1.ResourceMemory: resource.MustParse("300Mi"),
 										},
 									},

--- a/pkg/operation/botanist/component/vpnshoot/vpnshoot.go
+++ b/pkg/operation/botanist/component/vpnshoot/vpnshoot.go
@@ -530,12 +530,10 @@ func (v *vpnShoot) getEnvVars() []corev1.EnvVar {
 func (v *vpnShoot) getResourceLimits() corev1.ResourceList {
 	if v.values.VPAEnabled {
 		return corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("400m"),
 			corev1.ResourceMemory: resource.MustParse("400Mi"),
 		}
 	}
 	return corev1.ResourceList{
-		corev1.ResourceCPU:    resource.MustParse("1"),
 		corev1.ResourceMemory: resource.MustParse("1Gi"),
 	}
 }

--- a/pkg/operation/botanist/component/vpnshoot/vpnshoot_test.go
+++ b/pkg/operation/botanist/component/vpnshoot/vpnshoot_test.go
@@ -325,12 +325,10 @@ spec:
 				if vpaEnabled {
 					out += `
           limits:
-            cpu: 400m
             memory: 400Mi`
 				} else {
 					out += `
           limits:
-            cpu: "1"
             memory: 1Gi`
 				}
 				out += `

--- a/pkg/operation/botanist/kubeapiserver.go
+++ b/pkg/operation/botanist/kubeapiserver.go
@@ -211,7 +211,6 @@ func (b *Botanist) computeKubeAPIServerAutoscalingConfig() kubeapiserver.Autosca
 						corev1.ResourceMemory: resource.MustParse("2Gi"),
 					},
 					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("4000m"),
 						corev1.ResourceMemory: resource.MustParse("8Gi"),
 					},
 				}
@@ -233,7 +232,7 @@ func (b *Botanist) computeKubeAPIServerAutoscalingConfig() kubeapiserver.Autosca
 func resourcesRequirementsForKubeAPIServer(nodeCount int32, scalingClass string) corev1.ResourceRequirements {
 	var (
 		validScalingClasses        = sets.NewString("small", "medium", "large", "xlarge", "2xlarge")
-		cpuRequest, cpuLimit       string
+		cpuRequest                 string
 		memoryRequest, memoryLimit string
 	)
 
@@ -254,23 +253,23 @@ func resourcesRequirementsForKubeAPIServer(nodeCount int32, scalingClass string)
 
 	switch {
 	case scalingClass == "small":
-		cpuRequest, cpuLimit = "800m", "1000m"
+		cpuRequest = "800m"
 		memoryRequest, memoryLimit = "800Mi", "1200Mi"
 
 	case scalingClass == "medium":
-		cpuRequest, cpuLimit = "1000m", "1200m"
+		cpuRequest = "1000m"
 		memoryRequest, memoryLimit = "1100Mi", "1900Mi"
 
 	case scalingClass == "large":
-		cpuRequest, cpuLimit = "1200m", "1500m"
+		cpuRequest = "1200m"
 		memoryRequest, memoryLimit = "1600Mi", "3900Mi"
 
 	case scalingClass == "xlarge":
-		cpuRequest, cpuLimit = "2500m", "3000m"
+		cpuRequest = "2500m"
 		memoryRequest, memoryLimit = "5200Mi", "5900Mi"
 
 	case scalingClass == "2xlarge":
-		cpuRequest, cpuLimit = "3000m", "4000m"
+		cpuRequest = "3000m"
 		memoryRequest, memoryLimit = "5200Mi", "7800Mi"
 	}
 
@@ -280,7 +279,6 @@ func resourcesRequirementsForKubeAPIServer(nodeCount int32, scalingClass string)
 			corev1.ResourceMemory: resource.MustParse(memoryRequest),
 		},
 		Limits: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse(cpuLimit),
 			corev1.ResourceMemory: resource.MustParse(memoryLimit),
 		},
 	}

--- a/pkg/operation/botanist/kubeapiserver_test.go
+++ b/pkg/operation/botanist/kubeapiserver_test.go
@@ -642,7 +642,6 @@ var _ = Describe("KubeAPIServer", func() {
 								corev1.ResourceMemory: resource.MustParse("2Gi"),
 							},
 							Limits: corev1.ResourceList{
-								corev1.ResourceCPU:    resource.MustParse("4000m"),
 								corev1.ResourceMemory: resource.MustParse("8Gi"),
 							},
 						},
@@ -884,7 +883,6 @@ var _ = Describe("KubeAPIServer", func() {
 						corev1.ResourceMemory: resource.MustParse(expectedMemoryRequest),
 					},
 					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse(expectedCPULimit),
 						corev1.ResourceMemory: resource.MustParse(expectedMemoryLimit),
 					},
 				}))
@@ -988,7 +986,6 @@ var _ = Describe("KubeAPIServer", func() {
 				corev1.ResourceMemory: resource.MustParse("2"),
 			},
 			Limits: corev1.ResourceList{
-				corev1.ResourceCPU:    resource.MustParse("3"),
 				corev1.ResourceMemory: resource.MustParse("4"),
 			},
 		}


### PR DESCRIPTION
**How to categorize this PR?**

/kind enhancement

**What this PR does / why we need it**:
* Removes CPU limits from all components to prevent CPU throttling due to reaching limits.

The following will be added in separate PRs:
* Remove or adjust memory limits from all components to match actual usage on landscapes.
* Fix `VerticalPodAutoscaler` resources to use [RequestsOnly instead of RequestsAndLimits](https://github.com/kubernetes/autoscaler/blob/master/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1/types.go#L209-L215)
* Fix `VerticalPodAutoscaler` and `Hvpa` resources to remove `MaxAllowed` where it's present

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```noteworthy operator
CPU limits from all gardener components have been removed to prevent CPU throttling due to reaching limits.
```
