### PR TITLE
resource-manager: Improve the CheckDaemonSet func

### DIFF
--- a/pkg/resourcemanager/controller/health/health_checker_test.go
+++ b/pkg/resourcemanager/controller/health/health_checker_test.go
@@ -271,6 +271,7 @@ var _ = Describe("CheckHealth", func() {
 				Status: appsv1.DaemonSetStatus{
 					DesiredNumberScheduled: 1,
 					CurrentNumberScheduled: 1,
+					NumberUnavailable:      1,
 				},
 			}
 		})

--- a/pkg/utils/kubernetes/health/daemonset_test.go
+++ b/pkg/utils/kubernetes/health/daemonset_test.go
@@ -42,6 +42,22 @@ var _ = Describe("Daemonset", func() {
 		Entry("misscheduled pods", &appsv1.DaemonSet{
 			Status: appsv1.DaemonSetStatus{NumberMisscheduled: 1},
 		}, HaveOccurred()),
+		Entry("too many unavailable pods during rollout", &appsv1.DaemonSet{
+			Spec: appsv1.DaemonSetSpec{UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
+				Type: appsv1.RollingUpdateDaemonSetStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDaemonSet{
+					MaxUnavailable: &oneUnavailable,
+				},
+			}},
+			Status: appsv1.DaemonSetStatus{
+				DesiredNumberScheduled: 3,
+				CurrentNumberScheduled: 3,
+				NumberUnavailable:      2,
+				NumberReady:            1,
+				NumberAvailable:        1,
+				UpdatedNumberScheduled: 2,
+			},
+		}, HaveOccurred()),
 		Entry("too many unavailable pods", &appsv1.DaemonSet{
 			Spec: appsv1.DaemonSetSpec{UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
 				Type: appsv1.RollingUpdateDaemonSetStrategyType,
@@ -56,17 +72,27 @@ var _ = Describe("Daemonset", func() {
 				NumberReady:            0,
 			},
 		}, HaveOccurred()),
-		Entry("too less ready pods", &appsv1.DaemonSet{
-			Status: appsv1.DaemonSetStatus{
-				DesiredNumberScheduled: 1,
-				CurrentNumberScheduled: 1,
-			},
-		}, HaveOccurred()),
 		Entry("healthy", &appsv1.DaemonSet{
 			Status: appsv1.DaemonSetStatus{
 				DesiredNumberScheduled: 1,
 				CurrentNumberScheduled: 1,
 				NumberReady:            1,
+			},
+		}, BeNil()),
+		Entry("healthy with allowed unavailable pods during rollout", &appsv1.DaemonSet{
+			Spec: appsv1.DaemonSetSpec{UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
+				Type: appsv1.RollingUpdateDaemonSetStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateDaemonSet{
+					MaxUnavailable: &oneUnavailable,
+				},
+			}},
+			Status: appsv1.DaemonSetStatus{
+				DesiredNumberScheduled: 3,
+				CurrentNumberScheduled: 3,
+				NumberUnavailable:      1,
+				NumberReady:            2,
+				NumberAvailable:        2,
+				UpdatedNumberScheduled: 1,
 			},
 		}, BeNil()),
 	)


### PR DESCRIPTION
/area quality
/kind bug

Currently we see that the `CheckDaemonSet` func is reporting a failing health check for a long time because of a calico-node DaemonSet rollout (or any other DaemonSet rollout with similar spec to the calico-node one):

```
DaemonSet "kube-system/calico-node" is unhealthy: unready pods found (14/15), 2 pods updated.
```

The calico-node update strategy is to roll Pods one by one:
```yaml
  updateStrategy:
    rollingUpdate:
      maxSurge: 0
      maxUnavailable: 1
    type: RollingUpdate
```

On a clusters with a lot of Nodes (> 100) such rollout can take more than 30min.
Unfortunately, currently such `calico-node` rollout is reported as a failing health check by the `CheckDaemonSet` func. The failing check is:
https://github.com/gardener/gardener/blob/7ac4b04feec409f3e5a5208cd06af9a10c755337/pkg/utils/kubernetes/health/daemonset.go#L62-L64

During a rollout `status.numberReady` will be always less than `status.desiredNumberScheduled` - there will be 1 replica that is being rolled. It seems that we introduced this issue with https://github.com/gardener/gardener-resource-manager/pull/103 and we see it now because the ManagedResource health checks were recently fixed with https://github.com/gardener/gardener/pull/5453.

---

This PR:
- Checks for `.status.numberUnavailable > maxUnavailable` only when there is an ongoing rollout (`.status.updatedNumberScheduled < status.desiredNumberScheduled`). Previously `maxUnavailable` replicas were always ignored (no matter there is a rollout or not).
- Replaces the check `.status.numberReady < .status.desiredNumberScheduled` with `.status.numberUnavailable > 0` and executes this check only when there is no ongoing rollout (`.status.updatedNumberScheduled >= status.desiredNumberScheduled`). A ready replica is a replica with a ready condition. An available replica is a replica that is ready for at least minReadySeconds. Ref https://github.com/kubernetes/kubernetes/blob/5984099509fde391ed63769efc0b518a8a5736c3/pkg/controller/daemon/daemon_controller.go#L1132-L1137

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The `CheckDaemonSet` func does no longer return err for a DaemonSet that is in ongoing rollout and has allowed number of unavailable replicas during the rollout.
```
