### PR TITLE
[GEP-18] Adapt `etcd-server-cert` and `etcd-client-tls` secrets to new secrets manager

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
@@ -201,7 +201,7 @@ spec:
           secretName: ca-etcd
       - name: etcd-client-tls
         secret:
-          secretName: etcd-client-tls
+          secretName: {{ .Values.secretNameEtcdClientCert }}
       # TODO(rfranzke): Delete this in a future release once all monitoring configurations of extensions have been
       #	adapted.
       - name: prometheus-client-cert

--- a/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
@@ -20,6 +20,7 @@ ingress:
   basicAuthSecret: YWRtaW46JGFwcjEkSWRSaVM5c3MkR3U1MHMxaGUwL2Z6Tzh2elE4S1BEMQ==
 
 kubernetesVersion: 1.20.1
+secretNameEtcdClientCert: etcd-client-tls
 secretNameClientCert: prometheus
 
 reversedVPN:

--- a/charts/seed-monitoring/charts/core/values.yaml
+++ b/charts/seed-monitoring/charts/core/values.yaml
@@ -14,6 +14,7 @@ prometheus:
     vpn-seed: image-repository:image-tag
   ingress:
     class: nginx
+  secretNameEtcdClientCert: etcd-client-tls
   secretNameClientCert: prometheus
 kube-state-metrics-seed:
   replicas: 1

--- a/pkg/operation/botanist/component/etcd/etcd.go
+++ b/pkg/operation/botanist/component/etcd/etcd.go
@@ -61,8 +61,6 @@ const (
 	// Such etcds are also unsafe to evict (from the PoV of the cluster-autoscaler when trying to scale down).
 	ClassImportant Class = "important"
 
-	// SecretNameCA is the name of the secret containing the CA certificate and key for the etcd.
-	SecretNameCA = v1beta1constants.SecretNameCAETCD
 	// SecretNameClient is the name of the secret containing the client certificate and key for the etcd.
 	SecretNameClient       = "etcd-client"
 	secretNamePrefixServer = "etcd-server-"

--- a/pkg/operation/botanist/component/etcd/etcd.go
+++ b/pkg/operation/botanist/component/etcd/etcd.go
@@ -31,6 +31,7 @@ import (
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
+	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
 
 	"github.com/sirupsen/logrus"
@@ -124,6 +125,7 @@ func New(
 	c client.Client,
 	logger logrus.FieldLogger,
 	namespace string,
+	secretsManager secretsmanager.Interface,
 	role string,
 	class Class,
 	retainReplicas bool,
@@ -141,6 +143,7 @@ func New(
 		client:                  c,
 		logger:                  etcdLog,
 		namespace:               namespace,
+		secretsManager:          secretsManager,
 		role:                    role,
 		class:                   class,
 		retainReplicas:          retainReplicas,
@@ -160,6 +163,7 @@ type etcd struct {
 	client                  client.Client
 	logger                  logrus.FieldLogger
 	namespace               string
+	secretsManager          secretsmanager.Interface
 	role                    string
 	class                   Class
 	retainReplicas          bool

--- a/pkg/operation/botanist/component/etcd/etcd_suite_test.go
+++ b/pkg/operation/botanist/component/etcd/etcd_suite_test.go
@@ -17,6 +17,9 @@ package etcd_test
 import (
 	"testing"
 
+	secretutils "github.com/gardener/gardener/pkg/utils/secrets"
+	"github.com/gardener/gardener/pkg/utils/test"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -31,3 +34,7 @@ const (
 	testRole      = "test"
 	testROLE      = "Test"
 )
+
+var _ = BeforeSuite(func() {
+	DeferCleanup(test.WithVar(&secretutils.GenerateKey, secretutils.FakeGenerateKey))
+})

--- a/pkg/operation/botanist/component/etcd/etcd_test.go
+++ b/pkg/operation/botanist/component/etcd/etcd_test.go
@@ -80,14 +80,12 @@ var _ = Describe("Etcd", func() {
 		storageCapacityQuantity = resource.MustParse(storageCapacity)
 		defragmentationSchedule = "abcd"
 
-		secretNameCA         = "ca-etcd"
-		secretNameServer     = "etcd-server-tls"
-		secretNameClient     = "etcd-client"
-		secretChecksumCA     = "1234"
-		secretChecksumServer = "5678"
-		secrets              = Secrets{
-			CA:     component.Secret{Name: secretNameCA, Checksum: secretChecksumCA},
-			Server: component.Secret{Name: secretNameServer, Checksum: secretChecksumServer},
+		secretNameCA     = "ca-etcd"
+		secretNameServer = "etcd-server-" + testRole
+		secretNameClient = "etcd-client"
+		secretChecksumCA = "1234"
+		secrets          = Secrets{
+			CA: component.Secret{Name: secretNameCA, Checksum: secretChecksumCA},
 		}
 
 		maintenanceTimeWindow = gardencorev1beta1.MaintenanceTimeWindow{
@@ -228,8 +226,7 @@ var _ = Describe("Etcd", func() {
 					Replicas:          replicas,
 					PriorityClassName: pointer.String("gardener-shoot-controlplane"),
 					Annotations: map[string]string{
-						"checksum/secret-etcd-ca":          secretChecksumCA,
-						"checksum/secret-etcd-server-cert": secretChecksumServer,
+						"checksum/secret-etcd-ca": secretChecksumCA,
 					},
 					Labels: map[string]string{
 						"garden.sapcloud.io/role":          "controlplane",
@@ -492,11 +489,6 @@ var _ = Describe("Etcd", func() {
 		Context("missing secret information", func() {
 			It("should return an error because the CA secret information is not provided", func() {
 				Expect(etcd.Deploy(ctx)).To(MatchError(ContainSubstring("missing CA secret information")))
-			})
-
-			It("should return an error because the server secret information is not provided", func() {
-				etcd.SetSecrets(Secrets{CA: component.Secret{Name: secretNameCA, Checksum: secretChecksumCA}})
-				Expect(etcd.Deploy(ctx)).To(MatchError(ContainSubstring("missing server secret information")))
 			})
 		})
 
@@ -1122,18 +1114,6 @@ var _ = Describe("Etcd", func() {
 			)
 
 			Expect(etcd.Destroy(ctx)).To(MatchError(fakeErr))
-		})
-	})
-
-	Describe("#ServiceDNSNames", func() {
-		It("should return the expected DNS names", func() {
-			Expect(etcd.ServiceDNSNames()).To(ConsistOf(
-				"etcd-"+testRole+"-local",
-				"etcd-"+testRole+"-client",
-				"etcd-"+testRole+"-client."+testNamespace,
-				"etcd-"+testRole+"-client."+testNamespace+".svc",
-				"etcd-"+testRole+"-client."+testNamespace+".svc.cluster.local",
-			))
 		})
 	})
 

--- a/pkg/operation/botanist/component/etcd/etcd_test.go
+++ b/pkg/operation/botanist/component/etcd/etcd_test.go
@@ -22,10 +22,8 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	mockkubernetes "github.com/gardener/gardener/pkg/client/kubernetes/mock"
-	gardenletconfig "github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	"github.com/gardener/gardener/pkg/logger"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
-	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	. "github.com/gardener/gardener/pkg/operation/botanist/component/etcd"
 	"github.com/gardener/gardener/pkg/utils/gardener"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -83,10 +81,6 @@ var _ = Describe("Etcd", func() {
 		secretNameCA     = "ca-etcd"
 		secretNameServer = "etcd-server-" + testRole
 		secretNameClient = "etcd-client"
-		secretChecksumCA = "1234"
-		secrets          = Secrets{
-			CA: component.Secret{Name: secretNameCA, Checksum: secretChecksumCA},
-		}
 
 		maintenanceTimeWindow = gardencorev1beta1.MaintenanceTimeWindow{
 			Begin: "1234",
@@ -225,9 +219,6 @@ var _ = Describe("Etcd", func() {
 				Spec: druidv1alpha1.EtcdSpec{
 					Replicas:          replicas,
 					PriorityClassName: pointer.String("gardener-shoot-controlplane"),
-					Annotations: map[string]string{
-						"checksum/secret-etcd-ca": secretChecksumCA,
-					},
 					Labels: map[string]string{
 						"garden.sapcloud.io/role":          "controlplane",
 						"role":                             testRole,
@@ -252,6 +243,7 @@ var _ = Describe("Etcd", func() {
 									Name:      secretNameCA,
 									Namespace: testNamespace,
 								},
+								DataKey: pointer.String("bundle.crt"),
 							},
 							ServerTLSSecretRef: corev1.SecretReference{
 								Name:      secretNameServer,
@@ -281,7 +273,7 @@ var _ = Describe("Etcd", func() {
 			}
 
 			if class == ClassImportant {
-				obj.Spec.Annotations["cluster-autoscaler.kubernetes.io/safe-to-evict"] = "false"
+				obj.Spec.Annotations = map[string]string{"cluster-autoscaler.kubernetes.io/safe-to-evict": "false"}
 				obj.Spec.Etcd.Metrics = &metricsExtensive
 				obj.Spec.VolumeClaimTemplate = pointer.String(testRole + "-etcd")
 			}
@@ -486,124 +478,417 @@ var _ = Describe("Etcd", func() {
 	})
 
 	Describe("#Deploy", func() {
-		Context("missing secret information", func() {
-			It("should return an error because the CA secret information is not provided", func() {
-				Expect(etcd.Deploy(ctx)).To(MatchError(ContainSubstring("missing CA secret information")))
-			})
+		var scaleDownUpdateMode = hvpav1alpha1.UpdateModeMaintenanceWindow
+		newSetHVPAConfigFunc := func(updateMode string) func() {
+			return func() {
+				etcd.SetHVPAConfig(&HVPAConfig{
+					Enabled:               true,
+					MaintenanceTimeWindow: maintenanceTimeWindow,
+					ScaleDownUpdateMode:   pointer.String(updateMode),
+				})
+			}
+		}
+		setHVPAConfig := newSetHVPAConfigFunc(scaleDownUpdateMode)
+
+		BeforeEach(setHVPAConfig)
+
+		It("should fail because the etcd object retrieval fails", func() {
+			c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(fakeErr)
+
+			Expect(etcd.Deploy(ctx)).To(MatchError(fakeErr))
 		})
 
-		Context("secret information available", func() {
-			var scaleDownUpdateMode = hvpav1alpha1.UpdateModeMaintenanceWindow
-			getSetSecretsAndHVPAConfigFunc := func(updateMode string) func() {
-				return func() {
-					etcd.SetSecrets(secrets)
-					etcd.SetHVPAConfig(&HVPAConfig{
-						Enabled:               true,
-						MaintenanceTimeWindow: maintenanceTimeWindow,
-						ScaleDownUpdateMode:   pointer.String(updateMode),
-					})
+		It("should fail because the statefulset object retrieval fails (using the default sts name)", func() {
+			c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
+			c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(fakeErr)
+
+			Expect(etcd.Deploy(ctx)).To(MatchError(fakeErr))
+		})
+
+		It("should fail because the statefulset object retrieval fails (using the sts name from etcd object)", func() {
+			statefulSetName := "sts-name"
+
+			c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(
+				func(ctx context.Context, _ client.ObjectKey, obj client.Object) error {
+					(&druidv1alpha1.Etcd{
+						Status: druidv1alpha1.EtcdStatus{
+							Etcd: &druidv1alpha1.CrossVersionObjectReference{
+								Name: statefulSetName,
+							},
+						},
+					}).DeepCopyInto(obj.(*druidv1alpha1.Etcd))
+					return nil
+				},
+			)
+			c.EXPECT().Get(ctx, kutil.Key(testNamespace, statefulSetName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(fakeErr)
+
+			Expect(etcd.Deploy(ctx)).To(MatchError(fakeErr))
+		})
+
+		It("should fail because the network policy cannot be created", func() {
+			gomock.InOrder(
+				c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+				c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+
+				c.EXPECT().Get(ctx, kutil.Key(testNamespace, networkPolicyName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
+				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()).Return(fakeErr),
+			)
+
+			Expect(etcd.Deploy(ctx)).To(MatchError(fakeErr))
+		})
+
+		It("should fail because the etcd cannot be created", func() {
+			gomock.InOrder(
+				c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+				c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+
+				c.EXPECT().Get(ctx, kutil.Key(testNamespace, networkPolicyName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
+				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()),
+				c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
+				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Return(fakeErr),
+			)
+
+			Expect(etcd.Deploy(ctx)).To(MatchError(fakeErr))
+		})
+
+		It("should fail because the hvpa cannot be created", func() {
+			gomock.InOrder(
+				c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+				c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+
+				c.EXPECT().Get(ctx, kutil.Key(testNamespace, networkPolicyName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
+				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()),
+				c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
+				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()),
+				c.EXPECT().Get(ctx, kutil.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
+				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Return(fakeErr),
+			)
+
+			Expect(etcd.Deploy(ctx)).To(MatchError(fakeErr))
+		})
+
+		It("should fail because the hvpa cannot be deleted", func() {
+			etcd.SetHVPAConfig(&HVPAConfig{})
+
+			gomock.InOrder(
+				c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+				c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+
+				c.EXPECT().Get(ctx, kutil.Key(testNamespace, networkPolicyName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
+				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()),
+				c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
+				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()),
+				c.EXPECT().Delete(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})).Return(fakeErr),
+			)
+
+			Expect(etcd.Deploy(ctx)).To(MatchError(fakeErr))
+		})
+
+		It("should successfully deploy (normal etcd)", func() {
+			oldTimeNow := TimeNow
+			defer func() { TimeNow = oldTimeNow }()
+			TimeNow = func() time.Time { return now }
+
+			gomock.InOrder(
+				c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+				c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+
+				c.EXPECT().Get(ctx, kutil.Key(testNamespace, networkPolicyName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
+				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
+					Expect(obj).To(DeepEqual(networkPolicy))
+				}),
+				c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
+				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
+					Expect(obj).To(DeepEqual(etcdObjFor(
+						class,
+						1,
+						nil,
+						"",
+						"",
+						nil,
+						nil,
+					)))
+				}),
+				c.EXPECT().Get(ctx, kutil.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
+				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
+					Expect(obj).To(DeepEqual(hvpaFor(class, 1, scaleDownUpdateMode)))
+				}),
+			)
+
+			Expect(etcd.Deploy(ctx)).To(Succeed())
+		})
+
+		It("should not panic during deploy when etcd resource exists, but its status is not yet populated", func() {
+			oldTimeNow := TimeNow
+			defer func() { TimeNow = oldTimeNow }()
+			TimeNow = func() time.Time { return now }
+
+			var (
+				existingReplicas int32 = 245
+				retainReplicas         = true
+			)
+
+			etcd = New(c, log, testNamespace, sm, testRole, class, retainReplicas, storageCapacity, &defragmentationSchedule)
+			setHVPAConfig()
+
+			gomock.InOrder(
+				c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")).DoAndReturn(func(ctx context.Context, _ client.ObjectKey, obj client.Object) error {
+					(&druidv1alpha1.Etcd{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      etcdName,
+							Namespace: testNamespace,
+						},
+						Spec: druidv1alpha1.EtcdSpec{
+							Replicas: existingReplicas,
+						},
+					}).DeepCopyInto(obj.(*druidv1alpha1.Etcd))
+					return nil
+				}),
+				c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+
+				c.EXPECT().Get(ctx, kutil.Key(testNamespace, networkPolicyName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
+				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
+					Expect(obj).To(DeepEqual(networkPolicy))
+				}),
+				c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
+				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(ctx context.Context, obj *druidv1alpha1.Etcd, _ client.Patch, _ ...client.PatchOption) {
+					// ignore status when comparing
+					obj.Status = druidv1alpha1.EtcdStatus{}
+
+					Expect(obj).To(DeepEqual(etcdObjFor(
+						class,
+						existingReplicas,
+						nil,
+						"",
+						"",
+						nil,
+						nil,
+					)))
+				}),
+				c.EXPECT().Get(ctx, kutil.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
+				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
+					Expect(obj).To(DeepEqual(hvpaFor(class, existingReplicas, scaleDownUpdateMode)))
+				}),
+			)
+
+			Expect(etcd.Deploy(ctx)).To(Succeed())
+		})
+
+		It("should successfully deploy (normal etcd) and retain replicas (etcd found)", func() {
+			oldTimeNow := TimeNow
+			defer func() { TimeNow = oldTimeNow }()
+			TimeNow = func() time.Time { return now }
+
+			var (
+				existingReplicas int32 = 245
+				retainReplicas         = true
+			)
+
+			etcd = New(c, log, testNamespace, sm, testRole, class, retainReplicas, storageCapacity, &defragmentationSchedule)
+			setHVPAConfig()
+
+			gomock.InOrder(
+				c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")).DoAndReturn(func(ctx context.Context, _ client.ObjectKey, obj client.Object) error {
+					(&druidv1alpha1.Etcd{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      etcdName,
+							Namespace: testNamespace,
+						},
+						Spec: druidv1alpha1.EtcdSpec{
+							Replicas: existingReplicas,
+						},
+						Status: druidv1alpha1.EtcdStatus{
+							Etcd: &druidv1alpha1.CrossVersionObjectReference{
+								Name: etcdName,
+							},
+						},
+					}).DeepCopyInto(obj.(*druidv1alpha1.Etcd))
+					return nil
+				}),
+				c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+
+				c.EXPECT().Get(ctx, kutil.Key(testNamespace, networkPolicyName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
+				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
+					Expect(obj).To(DeepEqual(networkPolicy))
+				}),
+				c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
+				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(ctx context.Context, obj *druidv1alpha1.Etcd, _ client.Patch, _ ...client.PatchOption) {
+					// ignore status when comparing
+					obj.Status = druidv1alpha1.EtcdStatus{}
+
+					Expect(obj).To(DeepEqual(etcdObjFor(
+						class,
+						existingReplicas,
+						nil,
+						"",
+						"",
+						nil,
+						nil,
+					)))
+				}),
+				c.EXPECT().Get(ctx, kutil.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
+				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
+					Expect(obj).To(DeepEqual(hvpaFor(class, existingReplicas, scaleDownUpdateMode)))
+				}),
+			)
+
+			Expect(etcd.Deploy(ctx)).To(Succeed())
+		})
+
+		It("should successfully deploy (normal etcd) and keep the existing defragmentation schedule", func() {
+			oldTimeNow := TimeNow
+			defer func() { TimeNow = oldTimeNow }()
+			TimeNow = func() time.Time { return now }
+
+			existingDefragmentationSchedule := "foobardefragexisting"
+
+			gomock.InOrder(
+				c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(func(ctx context.Context, _ client.ObjectKey, obj client.Object) error {
+					(&druidv1alpha1.Etcd{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      etcdName,
+							Namespace: testNamespace,
+						},
+						Spec: druidv1alpha1.EtcdSpec{
+							Etcd: druidv1alpha1.EtcdConfig{
+								DefragmentationSchedule: &existingDefragmentationSchedule,
+							},
+						},
+						Status: druidv1alpha1.EtcdStatus{
+							Etcd: &druidv1alpha1.CrossVersionObjectReference{
+								Name: etcdName,
+							},
+						},
+					}).DeepCopyInto(obj.(*druidv1alpha1.Etcd))
+					return nil
+				}),
+				c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+
+				c.EXPECT().Get(ctx, kutil.Key(testNamespace, networkPolicyName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
+				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
+					Expect(obj).To(DeepEqual(networkPolicy))
+				}),
+				c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
+				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(ctx context.Context, obj *druidv1alpha1.Etcd, _ client.Patch, _ ...client.PatchOption) {
+					// ignore status when comparing
+					obj.Status = druidv1alpha1.EtcdStatus{}
+
+					Expect(obj).To(DeepEqual(etcdObjFor(
+						class,
+						1,
+						nil,
+						existingDefragmentationSchedule,
+						"",
+						nil,
+						nil,
+					)))
+				}),
+				c.EXPECT().Get(ctx, kutil.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
+				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
+					Expect(obj).To(DeepEqual(hvpaFor(class, 1, scaleDownUpdateMode)))
+				}),
+			)
+
+			Expect(etcd.Deploy(ctx)).To(Succeed())
+		})
+
+		It("should successfully deploy (normal etcd) and keep the existing resource settings to not interfer with HVPA controller", func() {
+			oldTimeNow := TimeNow
+			defer func() { TimeNow = oldTimeNow }()
+			TimeNow = func() time.Time { return now }
+
+			var (
+				existingResourcesContainerEtcd = corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("1"),
+						corev1.ResourceMemory: resource.MustParse("2G"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("3"),
+						corev1.ResourceMemory: resource.MustParse("4G"),
+					},
 				}
-			}
-			setSecretsAndHVPAConfig := getSetSecretsAndHVPAConfigFunc(scaleDownUpdateMode)
+				existingResourcesContainerBackupRestore = corev1.ResourceRequirements{
+					Requests: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("5"),
+						corev1.ResourceMemory: resource.MustParse("6G"),
+					},
+					Limits: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("7"),
+						corev1.ResourceMemory: resource.MustParse("8G"),
+					},
+				}
+			)
 
-			BeforeEach(setSecretsAndHVPAConfig)
-
-			It("should fail because the etcd object retrieval fails", func() {
-				c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(fakeErr)
-
-				Expect(etcd.Deploy(ctx)).To(MatchError(fakeErr))
-			})
-
-			It("should fail because the statefulset object retrieval fails (using the default sts name)", func() {
-				c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, ""))
-				c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(fakeErr)
-
-				Expect(etcd.Deploy(ctx)).To(MatchError(fakeErr))
-			})
-
-			It("should fail because the statefulset object retrieval fails (using the sts name from etcd object)", func() {
-				statefulSetName := "sts-name"
-
-				c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(
-					func(ctx context.Context, _ client.ObjectKey, obj client.Object) error {
-						(&druidv1alpha1.Etcd{
-							Status: druidv1alpha1.EtcdStatus{
-								Etcd: &druidv1alpha1.CrossVersionObjectReference{
-									Name: statefulSetName,
+			gomock.InOrder(
+				c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+				c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).DoAndReturn(func(ctx context.Context, _ client.ObjectKey, obj client.Object) error {
+					(&appsv1.StatefulSet{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      etcdName,
+							Namespace: testNamespace,
+						},
+						Spec: appsv1.StatefulSetSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{
+										{
+											Name:      "etcd",
+											Resources: existingResourcesContainerEtcd,
+										},
+										{
+											Name:      "backup-restore",
+											Resources: existingResourcesContainerBackupRestore,
+										},
+									},
 								},
 							},
-						}).DeepCopyInto(obj.(*druidv1alpha1.Etcd))
-						return nil
-					},
-				)
-				c.EXPECT().Get(ctx, kutil.Key(testNamespace, statefulSetName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(fakeErr)
+						},
+					}).DeepCopyInto(obj.(*appsv1.StatefulSet))
+					return nil
+				}),
 
-				Expect(etcd.Deploy(ctx)).To(MatchError(fakeErr))
-			})
+				c.EXPECT().Get(ctx, kutil.Key(testNamespace, networkPolicyName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
+				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
+					Expect(obj).To(DeepEqual(networkPolicy))
+				}),
+				c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
+				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
+					Expect(obj).To(DeepEqual(etcdObjFor(
+						class,
+						1,
+						nil,
+						"",
+						"",
+						&existingResourcesContainerEtcd,
+						&existingResourcesContainerBackupRestore,
+					)))
+				}),
+				c.EXPECT().Get(ctx, kutil.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
+				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
+					Expect(obj).To(DeepEqual(hvpaFor(class, 1, scaleDownUpdateMode)))
+				}),
+			)
 
-			It("should fail because the network policy cannot be created", func() {
-				gomock.InOrder(
-					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+			Expect(etcd.Deploy(ctx)).To(Succeed())
+		})
 
-					c.EXPECT().Get(ctx, kutil.Key(testNamespace, networkPolicyName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()).Return(fakeErr),
-				)
-
-				Expect(etcd.Deploy(ctx)).To(MatchError(fakeErr))
-			})
-
-			It("should fail because the etcd cannot be created", func() {
-				gomock.InOrder(
-					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-
-					c.EXPECT().Get(ctx, kutil.Key(testNamespace, networkPolicyName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()),
-					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Return(fakeErr),
-				)
-
-				Expect(etcd.Deploy(ctx)).To(MatchError(fakeErr))
-			})
-
-			It("should fail because the hvpa cannot be created", func() {
-				gomock.InOrder(
-					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-
-					c.EXPECT().Get(ctx, kutil.Key(testNamespace, networkPolicyName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()),
-					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()),
-					c.EXPECT().Get(ctx, kutil.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Return(fakeErr),
-				)
-
-				Expect(etcd.Deploy(ctx)).To(MatchError(fakeErr))
-			})
-
-			It("should fail because the hvpa cannot be deleted", func() {
-				etcd.SetHVPAConfig(&HVPAConfig{})
-
-				gomock.InOrder(
-					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-
-					c.EXPECT().Get(ctx, kutil.Key(testNamespace, networkPolicyName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()),
-					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()),
-					c.EXPECT().Delete(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})).Return(fakeErr),
-				)
-
-				Expect(etcd.Deploy(ctx)).To(MatchError(fakeErr))
-			})
-
-			It("should successfully deploy (normal etcd)", func() {
+		for _, shootPurpose := range []gardencorev1beta1.ShootPurpose{gardencorev1beta1.ShootPurposeEvaluation, gardencorev1beta1.ShootPurposeProduction} {
+			var purpose = shootPurpose
+			It(fmt.Sprintf("should successfully deploy (important etcd): purpose = %q", purpose), func() {
 				oldTimeNow := TimeNow
 				defer func() { TimeNow = oldTimeNow }()
 				TimeNow = func() time.Time { return now }
+
+				class := ClassImportant
+
+				updateMode := hvpav1alpha1.UpdateModeMaintenanceWindow
+				if purpose == gardencorev1beta1.ShootPurposeProduction {
+					updateMode = hvpav1alpha1.UpdateModeOff
+				}
+
+				etcd = New(c, log, testNamespace, sm, testRole, class, retainReplicas, storageCapacity, &defragmentationSchedule)
+				newSetHVPAConfigFunc(updateMode)()
 
 				gomock.InOrder(
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
@@ -627,6 +912,54 @@ var _ = Describe("Etcd", func() {
 					}),
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
+						Expect(obj).To(DeepEqual(hvpaFor(class, 1, updateMode)))
+					}),
+				)
+
+				Expect(etcd.Deploy(ctx)).To(Succeed())
+			})
+		}
+
+		Context("with backup", func() {
+			var backupConfig = &BackupConfig{
+				Provider:             "prov",
+				SecretRefName:        "secret-key",
+				Prefix:               "prefix",
+				Container:            "bucket",
+				FullSnapshotSchedule: "1234",
+			}
+
+			BeforeEach(func() {
+				etcd.SetBackupConfig(backupConfig)
+			})
+
+			It("should successfully deploy (with backup)", func() {
+				oldTimeNow := TimeNow
+				defer func() { TimeNow = oldTimeNow }()
+				TimeNow = func() time.Time { return now }
+
+				gomock.InOrder(
+					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
+
+					c.EXPECT().Get(ctx, kutil.Key(testNamespace, networkPolicyName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
+					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
+						Expect(obj).To(DeepEqual(networkPolicy))
+					}),
+					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
+					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
+						Expect(obj).To(DeepEqual(etcdObjFor(
+							class,
+							1,
+							backupConfig,
+							"",
+							"",
+							nil,
+							nil,
+						)))
+					}),
+					c.EXPECT().Get(ctx, kutil.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
+					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(hvpaFor(class, 1, scaleDownUpdateMode)))
 					}),
 				)
@@ -634,129 +967,12 @@ var _ = Describe("Etcd", func() {
 				Expect(etcd.Deploy(ctx)).To(Succeed())
 			})
 
-			It("should not panic during deploy when etcd resource exists, but its status is not yet populated", func() {
+			It("should successfully deploy (with backup) and keep the existing backup schedule", func() {
 				oldTimeNow := TimeNow
 				defer func() { TimeNow = oldTimeNow }()
 				TimeNow = func() time.Time { return now }
 
-				var (
-					existingReplicas int32 = 245
-					retainReplicas         = true
-				)
-
-				etcd = New(c, log, testNamespace, sm, testRole, class, retainReplicas, storageCapacity, &defragmentationSchedule)
-				setSecretsAndHVPAConfig()
-
-				gomock.InOrder(
-					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")).DoAndReturn(func(ctx context.Context, _ client.ObjectKey, obj client.Object) error {
-						(&druidv1alpha1.Etcd{
-							ObjectMeta: metav1.ObjectMeta{
-								Name:      etcdName,
-								Namespace: testNamespace,
-							},
-							Spec: druidv1alpha1.EtcdSpec{
-								Replicas: existingReplicas,
-							},
-						}).DeepCopyInto(obj.(*druidv1alpha1.Etcd))
-						return nil
-					}),
-					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-
-					c.EXPECT().Get(ctx, kutil.Key(testNamespace, networkPolicyName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-						Expect(obj).To(DeepEqual(networkPolicy))
-					}),
-					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(ctx context.Context, obj *druidv1alpha1.Etcd, _ client.Patch, _ ...client.PatchOption) {
-						// ignore status when comparing
-						obj.Status = druidv1alpha1.EtcdStatus{}
-
-						Expect(obj).To(DeepEqual(etcdObjFor(
-							class,
-							existingReplicas,
-							nil,
-							"",
-							"",
-							nil,
-							nil,
-						)))
-					}),
-					c.EXPECT().Get(ctx, kutil.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-						Expect(obj).To(DeepEqual(hvpaFor(class, existingReplicas, scaleDownUpdateMode)))
-					}),
-				)
-
-				Expect(etcd.Deploy(ctx)).To(Succeed())
-			})
-
-			It("should successfully deploy (normal etcd) and retain replicas (etcd found)", func() {
-				oldTimeNow := TimeNow
-				defer func() { TimeNow = oldTimeNow }()
-				TimeNow = func() time.Time { return now }
-
-				var (
-					existingReplicas int32 = 245
-					retainReplicas         = true
-				)
-
-				etcd = New(c, log, testNamespace, sm, testRole, class, retainReplicas, storageCapacity, &defragmentationSchedule)
-				setSecretsAndHVPAConfig()
-
-				gomock.InOrder(
-					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")).DoAndReturn(func(ctx context.Context, _ client.ObjectKey, obj client.Object) error {
-						(&druidv1alpha1.Etcd{
-							ObjectMeta: metav1.ObjectMeta{
-								Name:      etcdName,
-								Namespace: testNamespace,
-							},
-							Spec: druidv1alpha1.EtcdSpec{
-								Replicas: existingReplicas,
-							},
-							Status: druidv1alpha1.EtcdStatus{
-								Etcd: &druidv1alpha1.CrossVersionObjectReference{
-									Name: etcdName,
-								},
-							},
-						}).DeepCopyInto(obj.(*druidv1alpha1.Etcd))
-						return nil
-					}),
-					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-
-					c.EXPECT().Get(ctx, kutil.Key(testNamespace, networkPolicyName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-						Expect(obj).To(DeepEqual(networkPolicy))
-					}),
-					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(ctx context.Context, obj *druidv1alpha1.Etcd, _ client.Patch, _ ...client.PatchOption) {
-						// ignore status when comparing
-						obj.Status = druidv1alpha1.EtcdStatus{}
-
-						Expect(obj).To(DeepEqual(etcdObjFor(
-							class,
-							existingReplicas,
-							nil,
-							"",
-							"",
-							nil,
-							nil,
-						)))
-					}),
-					c.EXPECT().Get(ctx, kutil.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-						Expect(obj).To(DeepEqual(hvpaFor(class, existingReplicas, scaleDownUpdateMode)))
-					}),
-				)
-
-				Expect(etcd.Deploy(ctx)).To(Succeed())
-			})
-
-			It("should successfully deploy (normal etcd) and keep the existing defragmentation schedule", func() {
-				oldTimeNow := TimeNow
-				defer func() { TimeNow = oldTimeNow }()
-				TimeNow = func() time.Time { return now }
-
-				existingDefragmentationSchedule := "foobardefragexisting"
+				existingBackupSchedule := "foobarbackupexisting"
 
 				gomock.InOrder(
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(func(ctx context.Context, _ client.ObjectKey, obj client.Object) error {
@@ -766,13 +982,13 @@ var _ = Describe("Etcd", func() {
 								Namespace: testNamespace,
 							},
 							Spec: druidv1alpha1.EtcdSpec{
-								Etcd: druidv1alpha1.EtcdConfig{
-									DefragmentationSchedule: &existingDefragmentationSchedule,
+								Backup: druidv1alpha1.BackupSpec{
+									FullSnapshotSchedule: &existingBackupSchedule,
 								},
 							},
 							Status: druidv1alpha1.EtcdStatus{
 								Etcd: &druidv1alpha1.CrossVersionObjectReference{
-									Name: etcdName,
+									Name: "",
 								},
 							},
 						}).DeepCopyInto(obj.(*druidv1alpha1.Etcd))
@@ -785,100 +1001,19 @@ var _ = Describe("Etcd", func() {
 						Expect(obj).To(DeepEqual(networkPolicy))
 					}),
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(ctx context.Context, obj *druidv1alpha1.Etcd, _ client.Patch, _ ...client.PatchOption) {
-						// ignore status when comparing
-						obj.Status = druidv1alpha1.EtcdStatus{}
-
-						Expect(obj).To(DeepEqual(etcdObjFor(
-							class,
-							1,
-							nil,
-							existingDefragmentationSchedule,
-							"",
-							nil,
-							nil,
-						)))
-					}),
-					c.EXPECT().Get(ctx, kutil.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-						Expect(obj).To(DeepEqual(hvpaFor(class, 1, scaleDownUpdateMode)))
-					}),
-				)
-
-				Expect(etcd.Deploy(ctx)).To(Succeed())
-			})
-
-			It("should successfully deploy (normal etcd) and keep the existing resource settings to not interfer with HVPA controller", func() {
-				oldTimeNow := TimeNow
-				defer func() { TimeNow = oldTimeNow }()
-				TimeNow = func() time.Time { return now }
-
-				var (
-					existingResourcesContainerEtcd = corev1.ResourceRequirements{
-						Requests: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("1"),
-							corev1.ResourceMemory: resource.MustParse("2G"),
-						},
-						Limits: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("3"),
-							corev1.ResourceMemory: resource.MustParse("4G"),
-						},
-					}
-					existingResourcesContainerBackupRestore = corev1.ResourceRequirements{
-						Requests: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("5"),
-							corev1.ResourceMemory: resource.MustParse("6G"),
-						},
-						Limits: corev1.ResourceList{
-							corev1.ResourceCPU:    resource.MustParse("7"),
-							corev1.ResourceMemory: resource.MustParse("8G"),
-						},
-					}
-				)
-
-				gomock.InOrder(
-					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).DoAndReturn(func(ctx context.Context, _ client.ObjectKey, obj client.Object) error {
-						(&appsv1.StatefulSet{
-							ObjectMeta: metav1.ObjectMeta{
-								Name:      etcdName,
-								Namespace: testNamespace,
-							},
-							Spec: appsv1.StatefulSetSpec{
-								Template: corev1.PodTemplateSpec{
-									Spec: corev1.PodSpec{
-										Containers: []corev1.Container{
-											{
-												Name:      "etcd",
-												Resources: existingResourcesContainerEtcd,
-											},
-											{
-												Name:      "backup-restore",
-												Resources: existingResourcesContainerBackupRestore,
-											},
-										},
-									},
-								},
-							},
-						}).DeepCopyInto(obj.(*appsv1.StatefulSet))
-						return nil
-					}),
-
-					c.EXPECT().Get(ctx, kutil.Key(testNamespace, networkPolicyName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
-					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-						Expect(obj).To(DeepEqual(networkPolicy))
-					}),
-					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-						Expect(obj).To(DeepEqual(etcdObjFor(
+						expobj := etcdObjFor(
 							class,
 							1,
+							backupConfig,
+							"",
+							existingBackupSchedule,
 							nil,
-							"",
-							"",
-							&existingResourcesContainerEtcd,
-							&existingResourcesContainerBackupRestore,
-						)))
+							nil,
+						)
+						expobj.Status.Etcd = &druidv1alpha1.CrossVersionObjectReference{}
+
+						Expect(obj).To(DeepEqual(expobj))
 					}),
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
@@ -887,162 +1022,6 @@ var _ = Describe("Etcd", func() {
 				)
 
 				Expect(etcd.Deploy(ctx)).To(Succeed())
-			})
-
-			for _, shootPurpose := range []gardencorev1beta1.ShootPurpose{gardencorev1beta1.ShootPurposeEvaluation, gardencorev1beta1.ShootPurposeProduction} {
-				var purpose = shootPurpose
-				It(fmt.Sprintf("should successfully deploy (important etcd): purpose = %q", purpose), func() {
-					oldTimeNow := TimeNow
-					defer func() { TimeNow = oldTimeNow }()
-					TimeNow = func() time.Time { return now }
-
-					class := ClassImportant
-
-					updateMode := hvpav1alpha1.UpdateModeMaintenanceWindow
-					if purpose == gardencorev1beta1.ShootPurposeProduction {
-						updateMode = hvpav1alpha1.UpdateModeOff
-					}
-
-					etcd = New(c, log, testNamespace, sm, testRole, class, retainReplicas, storageCapacity, &defragmentationSchedule)
-					getSetSecretsAndHVPAConfigFunc(updateMode)()
-
-					gomock.InOrder(
-						c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-						c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-
-						c.EXPECT().Get(ctx, kutil.Key(testNamespace, networkPolicyName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
-						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-							Expect(obj).To(DeepEqual(networkPolicy))
-						}),
-						c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
-						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-							Expect(obj).To(DeepEqual(etcdObjFor(
-								class,
-								1,
-								nil,
-								"",
-								"",
-								nil,
-								nil,
-							)))
-						}),
-						c.EXPECT().Get(ctx, kutil.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
-						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-							Expect(obj).To(DeepEqual(hvpaFor(class, 1, updateMode)))
-						}),
-					)
-
-					Expect(etcd.Deploy(ctx)).To(Succeed())
-				})
-			}
-
-			Context("with backup", func() {
-				var backupConfig = &BackupConfig{
-					Provider:             "prov",
-					SecretRefName:        "secret-key",
-					Prefix:               "prefix",
-					Container:            "bucket",
-					FullSnapshotSchedule: "1234",
-					LeaderElection: &gardenletconfig.ETCDBackupLeaderElection{
-						EtcdConnectionTimeout: backupLeaderElectionEtcdConnectionTimeout,
-						ReelectionPeriod:      backupLeaderElectionReelectionPeriod,
-					},
-				}
-
-				BeforeEach(func() {
-					etcd.SetBackupConfig(backupConfig)
-				})
-
-				It("should successfully deploy (with backup)", func() {
-					oldTimeNow := TimeNow
-					defer func() { TimeNow = oldTimeNow }()
-					TimeNow = func() time.Time { return now }
-
-					gomock.InOrder(
-						c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-						c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-
-						c.EXPECT().Get(ctx, kutil.Key(testNamespace, networkPolicyName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
-						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-							Expect(obj).To(DeepEqual(networkPolicy))
-						}),
-						c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
-						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-							Expect(obj).To(DeepEqual(etcdObjFor(
-								class,
-								1,
-								backupConfig,
-								"",
-								"",
-								nil,
-								nil,
-							)))
-						}),
-						c.EXPECT().Get(ctx, kutil.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
-						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-							Expect(obj).To(DeepEqual(hvpaFor(class, 1, scaleDownUpdateMode)))
-						}),
-					)
-
-					Expect(etcd.Deploy(ctx)).To(Succeed())
-				})
-
-				It("should successfully deploy (with backup) and keep the existing backup schedule", func() {
-					oldTimeNow := TimeNow
-					defer func() { TimeNow = oldTimeNow }()
-					TimeNow = func() time.Time { return now }
-
-					existingBackupSchedule := "foobarbackupexisting"
-
-					gomock.InOrder(
-						c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(func(ctx context.Context, _ client.ObjectKey, obj client.Object) error {
-							(&druidv1alpha1.Etcd{
-								ObjectMeta: metav1.ObjectMeta{
-									Name:      etcdName,
-									Namespace: testNamespace,
-								},
-								Spec: druidv1alpha1.EtcdSpec{
-									Backup: druidv1alpha1.BackupSpec{
-										FullSnapshotSchedule: &existingBackupSchedule,
-									},
-								},
-								Status: druidv1alpha1.EtcdStatus{
-									Etcd: &druidv1alpha1.CrossVersionObjectReference{
-										Name: "",
-									},
-								},
-							}).DeepCopyInto(obj.(*druidv1alpha1.Etcd))
-							return nil
-						}),
-						c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
-
-						c.EXPECT().Get(ctx, kutil.Key(testNamespace, networkPolicyName), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
-						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-							Expect(obj).To(DeepEqual(networkPolicy))
-						}),
-						c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
-						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-							expobj := etcdObjFor(
-								class,
-								1,
-								backupConfig,
-								"",
-								existingBackupSchedule,
-								nil,
-								nil,
-							)
-							expobj.Status.Etcd = &druidv1alpha1.CrossVersionObjectReference{}
-
-							Expect(obj).To(DeepEqual(expobj))
-						}),
-						c.EXPECT().Get(ctx, kutil.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
-						c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
-							Expect(obj).To(DeepEqual(hvpaFor(class, 1, scaleDownUpdateMode)))
-						}),
-					)
-
-					Expect(etcd.Deploy(ctx)).To(Succeed())
-				})
 			})
 		})
 	})

--- a/pkg/operation/botanist/component/etcd/etcd_test.go
+++ b/pkg/operation/botanist/component/etcd/etcd_test.go
@@ -82,14 +82,12 @@ var _ = Describe("Etcd", func() {
 
 		secretNameCA         = "ca-etcd"
 		secretNameServer     = "etcd-server-tls"
-		secretNameClient     = "etcd-client-cert"
+		secretNameClient     = "etcd-client"
 		secretChecksumCA     = "1234"
 		secretChecksumServer = "5678"
-		secretChecksumClient = "9012"
 		secrets              = Secrets{
 			CA:     component.Secret{Name: secretNameCA, Checksum: secretChecksumCA},
 			Server: component.Secret{Name: secretNameServer, Checksum: secretChecksumServer},
-			Client: component.Secret{Name: secretNameClient, Checksum: secretChecksumClient},
 		}
 
 		maintenanceTimeWindow = gardencorev1beta1.MaintenanceTimeWindow{
@@ -232,7 +230,6 @@ var _ = Describe("Etcd", func() {
 					Annotations: map[string]string{
 						"checksum/secret-etcd-ca":          secretChecksumCA,
 						"checksum/secret-etcd-server-cert": secretChecksumServer,
-						"checksum/secret-etcd-client-tls":  secretChecksumClient,
 					},
 					Labels: map[string]string{
 						"garden.sapcloud.io/role":          "controlplane",
@@ -500,11 +497,6 @@ var _ = Describe("Etcd", func() {
 			It("should return an error because the server secret information is not provided", func() {
 				etcd.SetSecrets(Secrets{CA: component.Secret{Name: secretNameCA, Checksum: secretChecksumCA}})
 				Expect(etcd.Deploy(ctx)).To(MatchError(ContainSubstring("missing server secret information")))
-			})
-
-			It("should return an error because the client secret information is not provided", func() {
-				etcd.SetSecrets(Secrets{CA: component.Secret{Name: secretNameCA, Checksum: secretChecksumCA}, Server: component.Secret{Name: secretNameServer, Checksum: secretChecksumServer}})
-				Expect(etcd.Deploy(ctx)).To(MatchError(ContainSubstring("missing client secret information")))
 			})
 		})
 

--- a/pkg/operation/botanist/component/etcd/mock/mocks.go
+++ b/pkg/operation/botanist/component/etcd/mock/mocks.go
@@ -124,20 +124,6 @@ func (mr *MockInterfaceMockRecorder) ScrapeConfigs() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScrapeConfigs", reflect.TypeOf((*MockInterface)(nil).ScrapeConfigs))
 }
 
-// ServiceDNSNames mocks base method.
-func (m *MockInterface) ServiceDNSNames() []string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ServiceDNSNames")
-	ret0, _ := ret[0].([]string)
-	return ret0
-}
-
-// ServiceDNSNames indicates an expected call of ServiceDNSNames.
-func (mr *MockInterfaceMockRecorder) ServiceDNSNames() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServiceDNSNames", reflect.TypeOf((*MockInterface)(nil).ServiceDNSNames))
-}
-
 // SetBackupConfig mocks base method.
 func (m *MockInterface) SetBackupConfig(arg0 *etcd.BackupConfig) {
 	m.ctrl.T.Helper()

--- a/pkg/operation/botanist/component/etcd/mock/mocks.go
+++ b/pkg/operation/botanist/component/etcd/mock/mocks.go
@@ -160,18 +160,6 @@ func (mr *MockInterfaceMockRecorder) SetOwnerCheckConfig(arg0 interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetOwnerCheckConfig", reflect.TypeOf((*MockInterface)(nil).SetOwnerCheckConfig), arg0)
 }
 
-// SetSecrets mocks base method.
-func (m *MockInterface) SetSecrets(arg0 etcd.Secrets) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetSecrets", arg0)
-}
-
-// SetSecrets indicates an expected call of SetSecrets.
-func (mr *MockInterfaceMockRecorder) SetSecrets(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSecrets", reflect.TypeOf((*MockInterface)(nil).SetSecrets), arg0)
-}
-
 // Snapshot mocks base method.
 func (m *MockInterface) Snapshot(arg0 context.Context, arg1 kubernetes.PodExecutor) error {
 	m.ctrl.T.Helper()

--- a/pkg/operation/botanist/component/etcd/monitoring_test.go
+++ b/pkg/operation/botanist/component/etcd/monitoring_test.go
@@ -27,7 +27,7 @@ import (
 var _ = Describe("Monitoring", func() {
 	Describe("#ScrapeConfig", func() {
 		It("should successfully test the scrape configuration", func() {
-			etcd := New(nil, nil, testNamespace, testRole, ClassNormal, true, "", nil)
+			etcd := New(nil, nil, testNamespace, nil, testRole, ClassNormal, true, "", nil)
 			test.ScrapeConfigs(etcd, expectedScrapeConfigEtcd, expectedScrapeConfigBackupRestore)
 		})
 	})
@@ -35,7 +35,7 @@ var _ = Describe("Monitoring", func() {
 	Describe("#AlertingRules", func() {
 		Context("w/o backup", func() {
 			It("should successfully test the alerting rules (normal)", func() {
-				etcd := New(nil, nil, testNamespace, testRole, ClassNormal, true, "", nil)
+				etcd := New(nil, nil, testNamespace, nil, testRole, ClassNormal, true, "", nil)
 				test.AlertingRulesWithPromtool(
 					etcd,
 					map[string]string{fmt.Sprintf("kube-etcd3-%s.rules.yaml", testRole): expectedAlertingRulesNormalWithoutBackup},
@@ -44,7 +44,7 @@ var _ = Describe("Monitoring", func() {
 			})
 
 			It("should successfully test the alerting rules (important)", func() {
-				etcd := New(nil, nil, testNamespace, testRole, ClassImportant, true, "", nil)
+				etcd := New(nil, nil, testNamespace, nil, testRole, ClassImportant, true, "", nil)
 				test.AlertingRulesWithPromtool(
 					etcd,
 					map[string]string{fmt.Sprintf("kube-etcd3-%s.rules.yaml", testRole): expectedAlertingRulesImportantWithoutBackup},
@@ -55,7 +55,7 @@ var _ = Describe("Monitoring", func() {
 
 		Context("w/ backup", func() {
 			It("should successfully test the alerting rules (normal)", func() {
-				etcd := New(nil, nil, testNamespace, testRole, ClassNormal, true, "", nil)
+				etcd := New(nil, nil, testNamespace, nil, testRole, ClassNormal, true, "", nil)
 				etcd.SetBackupConfig(&BackupConfig{})
 				test.AlertingRulesWithPromtool(
 					etcd,
@@ -65,7 +65,7 @@ var _ = Describe("Monitoring", func() {
 			})
 
 			It("should successfully test the alerting rules (important)", func() {
-				etcd := New(nil, nil, testNamespace, testRole, ClassImportant, true, "", nil)
+				etcd := New(nil, nil, testNamespace, nil, testRole, ClassImportant, true, "", nil)
 				etcd.SetBackupConfig(&BackupConfig{})
 				test.AlertingRulesWithPromtool(
 					etcd,

--- a/pkg/operation/botanist/component/etcd/waiter_test.go
+++ b/pkg/operation/botanist/component/etcd/waiter_test.go
@@ -89,8 +89,7 @@ var _ = Describe("#Wait", func() {
 
 		etcd = New(c, log, testNamespace, sm, testRole, ClassNormal, false, "12Gi", pointer.String("abcd"))
 		etcd.SetSecrets(Secrets{
-			CA:     component.Secret{Name: "ca", Checksum: "abcdef"},
-			Server: component.Secret{Name: "server", Checksum: "abcdef"},
+			CA: component.Secret{Name: "ca", Checksum: "abcdef"},
 		})
 		etcd.SetHVPAConfig(&HVPAConfig{
 			Enabled: true,

--- a/pkg/operation/botanist/component/etcd/waiter_test.go
+++ b/pkg/operation/botanist/component/etcd/waiter_test.go
@@ -39,7 +39,6 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/logger"
 	mocktime "github.com/gardener/gardener/pkg/mock/go/time"
-	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	. "github.com/gardener/gardener/pkg/operation/botanist/component/etcd"
 	"github.com/gardener/gardener/pkg/utils/retry"
 	retryfake "github.com/gardener/gardener/pkg/utils/retry/fake"
@@ -88,9 +87,6 @@ var _ = Describe("#Wait", func() {
 		)
 
 		etcd = New(c, log, testNamespace, sm, testRole, ClassNormal, false, "12Gi", pointer.String("abcd"))
-		etcd.SetSecrets(Secrets{
-			CA: component.Secret{Name: "ca", Checksum: "abcdef"},
-		})
 		etcd.SetHVPAConfig(&HVPAConfig{
 			Enabled: true,
 			MaintenanceTimeWindow: gardencorev1beta1.MaintenanceTimeWindow{

--- a/pkg/operation/botanist/component/etcd/waiter_test.go
+++ b/pkg/operation/botanist/component/etcd/waiter_test.go
@@ -91,7 +91,6 @@ var _ = Describe("#Wait", func() {
 		etcd.SetSecrets(Secrets{
 			CA:     component.Secret{Name: "ca", Checksum: "abcdef"},
 			Server: component.Secret{Name: "server", Checksum: "abcdef"},
-			Client: component.Secret{Name: "client", Checksum: "abcdef"},
 		})
 		etcd.SetHVPAConfig(&HVPAConfig{
 			Enabled: true,

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
@@ -570,12 +570,8 @@ func getLabels() map[string]string {
 type Secrets struct {
 	// CA is the cluster's certificate authority.
 	CA component.Secret
-	// CAEtcd is the certificate authority for the etcd.
-	CAEtcd component.Secret
 	// CAFrontProxy is the certificate authority for the front-proxy.
 	CAFrontProxy component.Secret
-	// Etcd is the client certificate for the kube-apiserver to talk to etcd.
-	Etcd component.Secret
 	// VPNSeed is the client certificate for the vpn-seed to talk to the kube-apiserver.
 	// Only relevant if VPNConfig.ReversedVPNEnabled is false.
 	VPNSeed *component.Secret
@@ -595,9 +591,7 @@ type secret struct {
 func (s *Secrets) all() map[string]secret {
 	return map[string]secret{
 		"CA":                   {Secret: &s.CA},
-		"CAEtcd":               {Secret: &s.CAEtcd},
 		"CAFrontProxy":         {Secret: &s.CAFrontProxy},
-		"Etcd":                 {Secret: &s.Etcd},
 		"VPNSeed":              {Secret: s.VPNSeed, isRequired: func(v Values) bool { return !v.VPN.ReversedVPNEnabled }},
 		"VPNSeedTLSAuth":       {Secret: s.VPNSeedTLSAuth, isRequired: func(v Values) bool { return !v.VPN.ReversedVPNEnabled }},
 		"VPNSeedServerTLSAuth": {Secret: s.VPNSeedServerTLSAuth, isRequired: func(v Values) bool { return v.VPN.ReversedVPNEnabled }},

--- a/pkg/operation/botanist/etcd.go
+++ b/pkg/operation/botanist/etcd.go
@@ -91,8 +91,7 @@ func getScaleDownUpdateMode(c etcd.Class, s *shoot.Shoot) *string {
 // DeployEtcd deploys the etcd main and events.
 func (b *Botanist) DeployEtcd(ctx context.Context) error {
 	secrets := etcd.Secrets{
-		CA:     component.Secret{Name: etcd.SecretNameCA, Checksum: b.LoadCheckSum(etcd.SecretNameCA)},
-		Server: component.Secret{Name: etcd.SecretNameServer, Checksum: b.LoadCheckSum(etcd.SecretNameServer)},
+		CA: component.Secret{Name: etcd.SecretNameCA, Checksum: b.LoadCheckSum(etcd.SecretNameCA)},
 	}
 
 	b.Shoot.Components.ControlPlane.EtcdMain.SetSecrets(secrets)

--- a/pkg/operation/botanist/etcd.go
+++ b/pkg/operation/botanist/etcd.go
@@ -27,7 +27,6 @@ import (
 	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
-	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/etcd"
 	"github.com/gardener/gardener/pkg/operation/shoot"
 	"github.com/gardener/gardener/pkg/utils/flow"
@@ -90,13 +89,6 @@ func getScaleDownUpdateMode(c etcd.Class, s *shoot.Shoot) *string {
 
 // DeployEtcd deploys the etcd main and events.
 func (b *Botanist) DeployEtcd(ctx context.Context) error {
-	secrets := etcd.Secrets{
-		CA: component.Secret{Name: etcd.SecretNameCA, Checksum: b.LoadCheckSum(etcd.SecretNameCA)},
-	}
-
-	b.Shoot.Components.ControlPlane.EtcdMain.SetSecrets(secrets)
-	b.Shoot.Components.ControlPlane.EtcdEvents.SetSecrets(secrets)
-
 	if b.Seed.GetInfo().Spec.Backup != nil {
 		secret := &corev1.Secret{}
 		if err := b.K8sSeedClient.Client().Get(ctx, kutil.Key(b.Shoot.SeedNamespace, v1beta1constants.BackupSecretName), secret); err != nil {

--- a/pkg/operation/botanist/etcd.go
+++ b/pkg/operation/botanist/etcd.go
@@ -56,6 +56,7 @@ func (b *Botanist) DefaultEtcd(role string, class etcd.Class) (etcd.Interface, e
 		b.K8sSeedClient.Client(),
 		b.Logger,
 		b.Shoot.SeedNamespace,
+		b.SecretsManager,
 		role,
 		class,
 		b.Shoot.HibernationEnabled,

--- a/pkg/operation/botanist/etcd.go
+++ b/pkg/operation/botanist/etcd.go
@@ -93,7 +93,6 @@ func (b *Botanist) DeployEtcd(ctx context.Context) error {
 	secrets := etcd.Secrets{
 		CA:     component.Secret{Name: etcd.SecretNameCA, Checksum: b.LoadCheckSum(etcd.SecretNameCA)},
 		Server: component.Secret{Name: etcd.SecretNameServer, Checksum: b.LoadCheckSum(etcd.SecretNameServer)},
-		Client: component.Secret{Name: etcd.SecretNameClient, Checksum: b.LoadCheckSum(etcd.SecretNameClient)},
 	}
 
 	b.Shoot.Components.ControlPlane.EtcdMain.SetSecrets(secrets)

--- a/pkg/operation/botanist/etcd.go
+++ b/pkg/operation/botanist/etcd.go
@@ -122,10 +122,18 @@ func (b *Botanist) DeployEtcd(ctx context.Context) error {
 		}
 	}
 
-	return flow.Parallel(
+	if err := flow.Parallel(
 		b.Shoot.Components.ControlPlane.EtcdMain.Deploy,
 		b.Shoot.Components.ControlPlane.EtcdEvents.Deploy,
-	)(ctx)
+	)(ctx); err != nil {
+		return err
+	}
+
+	// TODO(rfranzke): Remove in a future release.
+	return kutil.DeleteObjects(ctx, b.K8sSeedClient.Client(),
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "etcd-client-tls", Namespace: b.Shoot.SeedNamespace}},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "etcd-server-cert", Namespace: b.Shoot.SeedNamespace}},
+	)
 }
 
 // WaitUntilEtcdsReady waits until both etcd-main and etcd-events are ready.

--- a/pkg/operation/botanist/etcd_test.go
+++ b/pkg/operation/botanist/etcd_test.go
@@ -252,10 +252,8 @@ var _ = Describe("Etcd", func() {
 
 			secretNameCA     = "ca-etcd"
 			secretNameServer = "etcd-server-cert"
-			secretNameClient = "etcd-client-tls"
 			checksumCA       = "1234"
 			checksumServer   = "5678"
-			checksumClient   = "9012"
 			shootUID         = types.UID("uuid")
 		)
 
@@ -265,7 +263,6 @@ var _ = Describe("Etcd", func() {
 			botanist.K8sSeedClient = kubernetesClient
 			botanist.StoreCheckSum(secretNameCA, checksumCA)
 			botanist.StoreCheckSum(secretNameServer, checksumServer)
-			botanist.StoreCheckSum(secretNameClient, checksumClient)
 			botanist.Seed = &seedpkg.Seed{}
 			botanist.Shoot = &shootpkg.Shoot{
 				Components: &shootpkg.Components{
@@ -298,12 +295,10 @@ var _ = Describe("Etcd", func() {
 			etcdMain.EXPECT().SetSecrets(etcd.Secrets{
 				CA:     component.Secret{Name: secretNameCA, Checksum: checksumCA},
 				Server: component.Secret{Name: secretNameServer, Checksum: checksumServer},
-				Client: component.Secret{Name: secretNameClient, Checksum: checksumClient},
 			})
 			etcdEvents.EXPECT().SetSecrets(etcd.Secrets{
 				CA:     component.Secret{Name: secretNameCA, Checksum: checksumCA},
 				Server: component.Secret{Name: secretNameServer, Checksum: checksumServer},
-				Client: component.Secret{Name: secretNameClient, Checksum: checksumClient},
 			})
 		})
 

--- a/pkg/operation/botanist/etcd_test.go
+++ b/pkg/operation/botanist/etcd_test.go
@@ -37,7 +37,6 @@ import (
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 	"github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
 	"github.com/gardener/gardener/pkg/utils/test"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
 	"github.com/golang/mock/gomock"
@@ -47,6 +46,7 @@ import (
 	gomegatypes "github.com/onsi/gomega/types"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/pointer"
@@ -313,6 +313,10 @@ var _ = Describe("Etcd", func() {
 			It("should set the secrets and deploy", func() {
 				etcdMain.EXPECT().Deploy(ctx)
 				etcdEvents.EXPECT().Deploy(ctx)
+
+				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "etcd-client-tls", Namespace: namespace}})
+				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "etcd-server-cert", Namespace: namespace}})
+
 				Expect(botanist.DeployEtcd(ctx)).To(Succeed())
 			})
 		})
@@ -373,6 +377,8 @@ var _ = Describe("Etcd", func() {
 				expectSetOwnerCheckConfig()
 				etcdMain.EXPECT().Deploy(ctx)
 				etcdEvents.EXPECT().Deploy(ctx)
+				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "etcd-client-tls", Namespace: namespace}})
+				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "etcd-server-cert", Namespace: namespace}})
 
 				Expect(botanist.DeployEtcd(ctx)).To(Succeed())
 			})
@@ -388,6 +394,8 @@ var _ = Describe("Etcd", func() {
 				expectSetBackupConfig()
 				etcdMain.EXPECT().Deploy(ctx)
 				etcdEvents.EXPECT().Deploy(ctx)
+				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "etcd-client-tls", Namespace: namespace}})
+				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "etcd-server-cert", Namespace: namespace}})
 
 				Expect(botanist.DeployEtcd(ctx)).To(Succeed())
 			})

--- a/pkg/operation/botanist/etcd_test.go
+++ b/pkg/operation/botanist/etcd_test.go
@@ -29,7 +29,6 @@ import (
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	"github.com/gardener/gardener/pkg/operation"
 	. "github.com/gardener/gardener/pkg/operation/botanist"
-	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/etcd"
 	mocketcd "github.com/gardener/gardener/pkg/operation/botanist/component/etcd/mock"
 	seedpkg "github.com/gardener/gardener/pkg/operation/seed"
@@ -249,17 +248,13 @@ var _ = Describe("Etcd", func() {
 	Describe("#DeployEtcd", func() {
 		var (
 			etcdMain, etcdEvents *mocketcd.MockInterface
-
-			secretNameCA = "ca-etcd"
-			checksumCA   = "1234"
-			shootUID     = types.UID("uuid")
+			shootUID             = types.UID("uuid")
 		)
 
 		BeforeEach(func() {
 			etcdMain, etcdEvents = mocketcd.NewMockInterface(ctrl), mocketcd.NewMockInterface(ctrl)
 
 			botanist.K8sSeedClient = kubernetesClient
-			botanist.StoreCheckSum(secretNameCA, checksumCA)
 			botanist.Seed = &seedpkg.Seed{}
 			botanist.Shoot = &shootpkg.Shoot{
 				Components: &shootpkg.Components{
@@ -287,13 +282,6 @@ var _ = Describe("Etcd", func() {
 					TechnicalID: namespace,
 					UID:         shootUID,
 				},
-			})
-
-			etcdMain.EXPECT().SetSecrets(etcd.Secrets{
-				CA: component.Secret{Name: secretNameCA, Checksum: checksumCA},
-			})
-			etcdEvents.EXPECT().SetSecrets(etcd.Secrets{
-				CA: component.Secret{Name: secretNameCA, Checksum: checksumCA},
 			})
 		})
 

--- a/pkg/operation/botanist/etcd_test.go
+++ b/pkg/operation/botanist/etcd_test.go
@@ -250,11 +250,9 @@ var _ = Describe("Etcd", func() {
 		var (
 			etcdMain, etcdEvents *mocketcd.MockInterface
 
-			secretNameCA     = "ca-etcd"
-			secretNameServer = "etcd-server-cert"
-			checksumCA       = "1234"
-			checksumServer   = "5678"
-			shootUID         = types.UID("uuid")
+			secretNameCA = "ca-etcd"
+			checksumCA   = "1234"
+			shootUID     = types.UID("uuid")
 		)
 
 		BeforeEach(func() {
@@ -262,7 +260,6 @@ var _ = Describe("Etcd", func() {
 
 			botanist.K8sSeedClient = kubernetesClient
 			botanist.StoreCheckSum(secretNameCA, checksumCA)
-			botanist.StoreCheckSum(secretNameServer, checksumServer)
 			botanist.Seed = &seedpkg.Seed{}
 			botanist.Shoot = &shootpkg.Shoot{
 				Components: &shootpkg.Components{
@@ -293,12 +290,10 @@ var _ = Describe("Etcd", func() {
 			})
 
 			etcdMain.EXPECT().SetSecrets(etcd.Secrets{
-				CA:     component.Secret{Name: secretNameCA, Checksum: checksumCA},
-				Server: component.Secret{Name: secretNameServer, Checksum: checksumServer},
+				CA: component.Secret{Name: secretNameCA, Checksum: checksumCA},
 			})
 			etcdEvents.EXPECT().SetSecrets(etcd.Secrets{
-				CA:     component.Secret{Name: secretNameCA, Checksum: checksumCA},
-				Server: component.Secret{Name: secretNameServer, Checksum: checksumServer},
+				CA: component.Secret{Name: secretNameCA, Checksum: checksumCA},
 			})
 		})
 

--- a/pkg/operation/botanist/kubeapiserver.go
+++ b/pkg/operation/botanist/kubeapiserver.go
@@ -29,7 +29,6 @@ import (
 	"github.com/gardener/gardener/pkg/features"
 	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
-	"github.com/gardener/gardener/pkg/operation/botanist/component/etcd"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/kubeapiserver"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/vpnseedserver"
 	"github.com/gardener/gardener/pkg/utils"
@@ -430,9 +429,7 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 
 	secrets := kubeapiserver.Secrets{
 		CA:           component.Secret{Name: v1beta1constants.SecretNameCACluster, Checksum: b.LoadCheckSum(v1beta1constants.SecretNameCACluster)},
-		CAEtcd:       component.Secret{Name: etcd.SecretNameCA, Checksum: b.LoadCheckSum(etcd.SecretNameCA)},
 		CAFrontProxy: component.Secret{Name: v1beta1constants.SecretNameCAFrontProxy, Checksum: b.LoadCheckSum(v1beta1constants.SecretNameCAFrontProxy)},
-		Etcd:         component.Secret{Name: etcd.SecretNameClient, Checksum: b.LoadCheckSum(etcd.SecretNameClient)},
 	}
 
 	if values.VPN.ReversedVPNEnabled {

--- a/pkg/operation/botanist/kubeapiserver_test.go
+++ b/pkg/operation/botanist/kubeapiserver_test.go
@@ -1058,9 +1058,7 @@ var _ = Describe("KubeAPIServer", func() {
 			func(values kubeapiserver.Values, mutateSecrets func(*kubeapiserver.Secrets)) {
 				secrets := kubeapiserver.Secrets{
 					CA:           component.Secret{Name: "ca", Checksum: botanist.LoadCheckSum("ca")},
-					CAEtcd:       component.Secret{Name: "ca-etcd", Checksum: botanist.LoadCheckSum("ca-etcd")},
 					CAFrontProxy: component.Secret{Name: "ca-front-proxy", Checksum: botanist.LoadCheckSum("ca-front-proxy")},
-					Etcd:         component.Secret{Name: "etcd-client-tls", Checksum: botanist.LoadCheckSum("etcd-client-tls")},
 				}
 				mutateSecrets(&secrets)
 

--- a/pkg/operation/botanist/monitoring.go
+++ b/pkg/operation/botanist/monitoring.go
@@ -29,6 +29,7 @@ import (
 	gardenlethelper "github.com/gardener/gardener/pkg/gardenlet/apis/config/helper"
 	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
+	"github.com/gardener/gardener/pkg/operation/botanist/component/etcd"
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/operation/seed"
 	"github.com/gardener/gardener/pkg/utils"
@@ -174,14 +175,20 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 		return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameGenericTokenKubeconfig)
 	}
 
+	etcdClientSecret, found := b.SecretsManager.Get(etcd.SecretNameClient)
+	if !found {
+		return fmt.Errorf("secret %q not found", etcd.SecretNameClient)
+	}
+
 	var (
 		networks = map[string]interface{}{
 			"pods":     b.Shoot.Networks.Pods.String(),
 			"services": b.Shoot.Networks.Services.String(),
 		}
 		prometheusConfig = map[string]interface{}{
-			"secretNameClientCert": prometheusClientSecret.Name,
-			"kubernetesVersion":    b.Shoot.GetInfo().Spec.Kubernetes.Version,
+			"secretNameEtcdClientCert": etcdClientSecret.Name,
+			"secretNameClientCert":     prometheusClientSecret.Name,
+			"kubernetesVersion":        b.Shoot.GetInfo().Spec.Kubernetes.Version,
 			"nodeLocalDNS": map[string]interface{}{
 				"enabled": b.Shoot.NodeLocalDNSEnabled,
 			},

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -329,6 +329,8 @@ func (b *Botanist) GenerateAndSaveSecrets(ctx context.Context) error {
 			"kube-apiserver-http-proxy",
 			"kube-scheduler-server",
 			"kube-controller-manager-server",
+			"etcd-server-cert",
+			"etcd-client-tls",
 			"metrics-server",
 			"loki-tls",
 			"prometheus-tls",

--- a/pkg/operation/botanist/wanted_secrets.go
+++ b/pkg/operation/botanist/wanted_secrets.go
@@ -20,7 +20,6 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/dependencywatchdog"
-	"github.com/gardener/gardener/pkg/operation/botanist/component/etcd"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/kubeapiserver"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/vpnseedserver"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/vpnshoot"
@@ -33,13 +32,6 @@ import (
 // each containing their specific configuration for the creation of certificates (server/client), RSA key pairs, basic
 // authentication credentials, etc.
 func (b *Botanist) generateWantedSecretConfigs(certificateAuthorities map[string]*secrets.Certificate) ([]secrets.ConfigInterface, error) {
-	var (
-		etcdCertDNSNames = append(
-			b.Shoot.Components.ControlPlane.EtcdMain.ServiceDNSNames(),
-			b.Shoot.Components.ControlPlane.EtcdEvents.ServiceDNSNames()...,
-		)
-	)
-
 	secretList := []secrets.ConfigInterface{
 		// Secret definition for monitoring
 		&secrets.BasicAuthSecretConfig{
@@ -57,19 +49,6 @@ func (b *Botanist) generateWantedSecretConfigs(certificateAuthorities map[string
 
 			Username:       "admin",
 			PasswordLength: 32,
-		},
-
-		// Secret definition for etcd server
-		&secrets.CertificateSecretConfig{
-			Name: etcd.SecretNameServer,
-
-			CommonName:   "etcd-server",
-			Organization: nil,
-			DNSNames:     etcdCertDNSNames,
-			IPAddresses:  nil,
-
-			CertType:  secrets.ServerClientCert,
-			SigningCA: certificateAuthorities[v1beta1constants.SecretNameCAETCD],
 		},
 	}
 

--- a/pkg/operation/botanist/wanted_secrets.go
+++ b/pkg/operation/botanist/wanted_secrets.go
@@ -71,19 +71,6 @@ func (b *Botanist) generateWantedSecretConfigs(certificateAuthorities map[string
 			CertType:  secrets.ServerClientCert,
 			SigningCA: certificateAuthorities[v1beta1constants.SecretNameCAETCD],
 		},
-
-		// Secret definition for etcd server
-		&secrets.CertificateSecretConfig{
-			Name: etcd.SecretNameClient,
-
-			CommonName:   "etcd-client",
-			Organization: nil,
-			DNSNames:     nil,
-			IPAddresses:  nil,
-
-			CertType:  secrets.ClientCert,
-			SigningCA: certificateAuthorities[v1beta1constants.SecretNameCAETCD],
-		},
 	}
 
 	if gardencorev1beta1helper.SeedSettingDependencyWatchdogProbeEnabled(b.Seed.GetInfo().Spec.Settings) {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement
/merge squash

**What this PR does / why we need it**:
This PR adapts the `etcd-server-cert` and `etcd-client-tls` secrets to new secrets manager. It moves the generation into the `etcd` component since it actually belongs there (this is the only component that uses it). The `kubeapiserver` component was adapted as well such that it uses the `Get` function of the secrets manager instead of expecting the etcd secrets being injected from outside.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/3292#issuecomment-1036058890

/invite @timebertt @BeckerMax 
/invite @ishan16696 @abdasgupta @shreyas-s-rao 

**Special notes for your reviewer(s):**
✅ Depends on

- https://github.com/gardener/etcd-custom-image/pull/10,
- https://github.com/gardener/etcd-druid/pull/309,
- https://github.com/gardener/etcd-druid/pull/310,
- https://github.com/gardener/gardener/pull/5693

hence PR is in draft state.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
NONE
```
