### PR TITLE
Improve error messages (2)

### DIFF
--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -1805,7 +1805,7 @@ var _ = Describe("validator", func() {
 							shoot.Spec.Provider.Workers,
 							core.Worker{
 								CRI: &core.CRI{
-									Name: core.CRINameContainerD,
+									Name: "unsupported-cri",
 									ContainerRuntimes: []core.ContainerRuntime{
 										{Type: "supported-cr-1"},
 										{Type: "supported-cr-2"},
@@ -1830,7 +1830,7 @@ var _ = Describe("validator", func() {
 										},
 										CRI: []core.CRI{
 											{
-												Name: "unsupported-cri",
+												Name: core.CRINameContainerD,
 												ContainerRuntimes: []core.ContainerRuntime{
 													{
 														Type: "supported-cr-1",
@@ -1853,6 +1853,7 @@ var _ = Describe("validator", func() {
 						err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
 						Expect(err).To(BeForbiddenError())
+						Expect(err.Error()).To(ContainSubstring("machine image 'cr-image-name@1.2.3' does not support CRI 'unsupported-cri', supported values: [containerd]"))
 					})
 
 					It("should reject unsupported CR", func() {
@@ -1905,7 +1906,7 @@ var _ = Describe("validator", func() {
 						err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
 						Expect(err).To(BeForbiddenError())
-						Expect(err.Error()).To(ContainSubstring("Unsupported value: core.ContainerRuntime{Type:\"unsupported-cr-1\""))
+						Expect(err.Error()).To(ContainSubstring("machine image 'cr-image-name@1.2.3' does not support container runtime 'unsupported-cr-1', supported values: [supported-cr-1 supported-cr-2"))
 					})
 				})
 

--- a/test/testmachinery/shoots/operations/containerruntime.go
+++ b/test/testmachinery/shoots/operations/containerruntime.go
@@ -42,7 +42,7 @@ var _ = Describe("Shoot container runtime testing", func() {
 		}
 
 		if !supportsContainerD(f.CloudProfile.Spec.MachineImages, workerImage) {
-			message := fmt.Sprintf("machine image '%s/%s' does not support containerd", workerImage.Name, *workerImage.Version)
+			message := fmt.Sprintf("machine image '%s@%s' does not support containerd", workerImage.Name, *workerImage.Version)
 			Skip(message)
 		}
 


### PR DESCRIPTION
/area quality
/kind enhancement

This PR improves 2 messages returned by the Shoot admission plugin according to the suggestions from https://github.com/gardener/gardener/issues/5609.

In short, for K8s 1.22+ we default cri.name to `containerd`. If user is updating a Shoot with machine image that does not support containerd from K8s 1.21 to K8s 1.22, then the update is rejected with:
```
error: shoots.core.gardener.cloud "foo" could not be patched: shoots.core.gardener.cloud "foo" is forbidden: [spec.provider.workers[0].cri.name: Unsupported value: "containerd": supported values: "docker"]
```

As explained in https://github.com/gardener/gardener/issues/5609, similar error message can be confusing and it would help to the end user to point that the validation failure comes from the machine image and its supported CRIs and CRs.

Part of https://github.com/gardener/gardener/issues/5609

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
