### PR TITLE
[ReversedVPN]: Increased maximum number of hosts in the dns cache config of the envoy proxy.

### DIFF
--- a/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server.go
+++ b/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server.go
@@ -784,6 +784,7 @@ var envoyConfig = `static_resources:
               dns_cache_config:
                 name: dynamic_forward_proxy_cache_config
                 dns_lookup_family: V4_ONLY
+                max_hosts: 8192
           - name: envoy.filters.http.router
           http_protocol_options:
             accept_http_10: true
@@ -830,6 +831,7 @@ var envoyConfig = `static_resources:
         dns_cache_config:
           name: dynamic_forward_proxy_cache_config
           dns_lookup_family: V4_ONLY
+          max_hosts: 8192
   - name: prometheus_stats
     connect_timeout: 0.25s
     type: static

--- a/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server_test.go
+++ b/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server_test.go
@@ -164,6 +164,7 @@ var _ = Describe("VpnSeedServer", func() {
               dns_cache_config:
                 name: dynamic_forward_proxy_cache_config
                 dns_lookup_family: V4_ONLY
+                max_hosts: 8192
           - name: envoy.filters.http.router
           http_protocol_options:
             accept_http_10: true
@@ -210,6 +211,7 @@ var _ = Describe("VpnSeedServer", func() {
         dns_cache_config:
           name: dynamic_forward_proxy_cache_config
           dns_lookup_family: V4_ONLY
+          max_hosts: 8192
   - name: prometheus_stats
     connect_timeout: 0.25s
     type: static


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
[ReversedVPN]: Increased maximum number of hosts in the dns cache config of the envoy proxy.

For very large clusters, the default of 1024 hosts allowed in the dns cache config of the
envoy proxy in the vpn-seed-server side car may not be sufficient. The result is an
immediate 503 response from envoy proxy causing issues when a lot of web hooks are in play.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Increased maximum number of hosts in the dns cache config of the envoy proxy side car of vpn-seed-server.
```

/cc @DockToFuture 