### PR TITLE
[release-v1.41] Automated cherry pick of #5640: [ReversedVPN]: Increased maximum number of hosts in the dns cache config of the envoy proxy.

### DIFF
--- a/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server.go
+++ b/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server.go
@@ -784,6 +784,7 @@ var envoyConfig = `static_resources:
               dns_cache_config:
                 name: dynamic_forward_proxy_cache_config
                 dns_lookup_family: V4_ONLY
+                max_hosts: 8192
           - name: envoy.filters.http.router
           http_protocol_options:
             accept_http_10: true
@@ -830,6 +831,7 @@ var envoyConfig = `static_resources:
         dns_cache_config:
           name: dynamic_forward_proxy_cache_config
           dns_lookup_family: V4_ONLY
+          max_hosts: 8192
   - name: prometheus_stats
     connect_timeout: 0.25s
     type: static

--- a/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server_test.go
+++ b/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server_test.go
@@ -164,6 +164,7 @@ var _ = Describe("VpnSeedServer", func() {
               dns_cache_config:
                 name: dynamic_forward_proxy_cache_config
                 dns_lookup_family: V4_ONLY
+                max_hosts: 8192
           - name: envoy.filters.http.router
           http_protocol_options:
             accept_http_10: true
@@ -210,6 +211,7 @@ var _ = Describe("VpnSeedServer", func() {
         dns_cache_config:
           name: dynamic_forward_proxy_cache_config
           dns_lookup_family: V4_ONLY
+          max_hosts: 8192
   - name: prometheus_stats
     connect_timeout: 0.25s
     type: static


### PR DESCRIPTION
/kind/bug
/area/networking

Cherry pick of #5640 on release-v1.41.

#5640: [ReversedVPN]: Increased maximum number of hosts in the dns cache config of the envoy proxy.

**Release Notes:**
```other operator
Increased maximum number of hosts in the dns cache config of the envoy proxy side car of vpn-seed-server.
```