### PR TITLE
Disable etcd-main downscaling for Shoots with .spec.purpose=infrastructure

### DIFF
--- a/docs/concepts/etcd.md
+++ b/docs/concepts/etcd.md
@@ -37,7 +37,7 @@ all related objects, e.g. the backing `StatefulSet`.
 Gardenlet maintains [HVPA](https://github.com/gardener/hvpa-controller/blob/master/config/samples/autoscaling_v1alpha1_hvpa.yaml)
 objects for etcd `StatefulSet`s if the corresponding [feature gate](../deployment/feature_gates.md) is enabled. This enables
 a vertical scaling for `etcd`. Downscaling is handled more pessimistic to prevent many subsequent `etcd` restarts. Thus,
-for `production` clusters downscaling is deactivated and for all other clusters lower advertised requests/limits are only
+for `production` and `infrastructure` clusters downscaling is deactivated and for all other clusters lower advertised requests/limits are only
 applied during a shoot's maintenance time window.
 
 ## Backup

--- a/pkg/operation/botanist/etcd.go
+++ b/pkg/operation/botanist/etcd.go
@@ -66,7 +66,7 @@ func (b *Botanist) DefaultEtcd(role string, class etcd.Class) (etcd.Interface, e
 	}
 
 	scaleDownUpdateMode := hvpav1alpha1.UpdateModeMaintenanceWindow
-	if (class == etcd.ClassImportant && b.Shoot.Purpose == gardencorev1beta1.ShootPurposeProduction) ||
+	if (class == etcd.ClassImportant && (b.Shoot.Purpose == gardencorev1beta1.ShootPurposeProduction || b.Shoot.Purpose == gardencorev1beta1.ShootPurposeInfrastructure)) ||
 		(metav1.HasAnnotation(b.Shoot.GetInfo().ObjectMeta, v1beta1constants.ShootAlphaControlPlaneScaleDownDisabled)) {
 		scaleDownUpdateMode = hvpav1alpha1.UpdateModeOff
 	}

--- a/pkg/operation/botanist/etcd.go
+++ b/pkg/operation/botanist/etcd.go
@@ -28,6 +28,7 @@ import (
 	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/etcd"
+	"github.com/gardener/gardener/pkg/operation/shoot"
 	"github.com/gardener/gardener/pkg/utils/flow"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -37,6 +38,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
 )
 
 // NewEtcd is a function exposed for testing.
@@ -65,19 +67,23 @@ func (b *Botanist) DefaultEtcd(role string, class etcd.Class) (etcd.Interface, e
 		hvpaEnabled = gardenletfeatures.FeatureGate.Enabled(features.HVPAForShootedSeed)
 	}
 
-	scaleDownUpdateMode := hvpav1alpha1.UpdateModeMaintenanceWindow
-	if (class == etcd.ClassImportant && (b.Shoot.Purpose == gardencorev1beta1.ShootPurposeProduction || b.Shoot.Purpose == gardencorev1beta1.ShootPurposeInfrastructure)) ||
-		(metav1.HasAnnotation(b.Shoot.GetInfo().ObjectMeta, v1beta1constants.ShootAlphaControlPlaneScaleDownDisabled)) {
-		scaleDownUpdateMode = hvpav1alpha1.UpdateModeOff
-	}
-
 	e.SetHVPAConfig(&etcd.HVPAConfig{
 		Enabled:               hvpaEnabled,
 		MaintenanceTimeWindow: *b.Shoot.GetInfo().Spec.Maintenance.TimeWindow,
-		ScaleDownUpdateMode:   &scaleDownUpdateMode,
+		ScaleDownUpdateMode:   getScaleDownUpdateMode(class, b.Shoot),
 	})
 
 	return e, nil
+}
+
+func getScaleDownUpdateMode(c etcd.Class, s *shoot.Shoot) *string {
+	if c == etcd.ClassImportant && (s.Purpose == gardencorev1beta1.ShootPurposeProduction || s.Purpose == gardencorev1beta1.ShootPurposeInfrastructure) {
+		return pointer.String(hvpav1alpha1.UpdateModeOff)
+	}
+	if metav1.HasAnnotation(s.GetInfo().ObjectMeta, v1beta1constants.ShootAlphaControlPlaneScaleDownDisabled) {
+		return pointer.String(hvpav1alpha1.UpdateModeOff)
+	}
+	return pointer.String(hvpav1alpha1.UpdateModeMaintenanceWindow)
 }
 
 // DeployEtcd deploys the etcd main and events.

--- a/pkg/operation/botanist/etcd_test.go
+++ b/pkg/operation/botanist/etcd_test.go
@@ -107,14 +107,14 @@ var _ = Describe("Etcd", func() {
 			})
 
 			computeUpdateMode := func(class etcd.Class, purpose gardencorev1beta1.ShootPurpose) string {
-				if class == etcd.ClassImportant && purpose == gardencorev1beta1.ShootPurposeProduction {
+				if class == etcd.ClassImportant && (purpose == gardencorev1beta1.ShootPurposeProduction || purpose == gardencorev1beta1.ShootPurposeInfrastructure) {
 					return hvpav1alpha1.UpdateModeOff
 				}
 				return hvpav1alpha1.UpdateModeMaintenanceWindow
 			}
 
 			for _, etcdClass := range []etcd.Class{etcd.ClassNormal, etcd.ClassImportant} {
-				for _, shootPurpose := range []gardencorev1beta1.ShootPurpose{gardencorev1beta1.ShootPurposeEvaluation, gardencorev1beta1.ShootPurposeProduction} {
+				for _, shootPurpose := range []gardencorev1beta1.ShootPurpose{gardencorev1beta1.ShootPurposeEvaluation, gardencorev1beta1.ShootPurposeProduction, gardencorev1beta1.ShootPurposeInfrastructure} {
 					var (
 						class   = etcdClass
 						purpose = shootPurpose


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area etcd
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
Disable etcd-main downscaling for Shoots with `.spec.purpose=infrastructure`, similar to what we already do with Shoots labeled with `.spec.purpose=production`, such that we don't introduce regular downtimes due to downscaling in maintenance windows. Once we have a multi-node etcd in place, we might allow downscaling again.

**Which issue(s) this PR fixes**:
Fixes #5622

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
etcd nodes on Shoots labeled with `.spec.purpose=infrastructure` get `UpdateMode=off` instead of `MaintenanceWindow`, which means, they only get scaled up, never down.
```
