### PR TITLE
Add profiling for gardener-seed-admission-controller

### DIFF
--- a/docs/monitoring/profiling.md
+++ b/docs/monitoring/profiling.md
@@ -98,4 +98,18 @@ $ go tool pprof /tmp/heap-admission-controller
 
 ## gardener-seed-admission-controller
 
-gardener-seed-admission-controller doesn't support profiling yet. See [gardener/gardener#4567](https://github.com/gardener/gardener/issues/4567).
+gardener-seed-admission-controller provides the following flags for enabling profiling handlers (disabled by default):
+
+```
+--contention-profiling    Enable lock contention profiling, if profiling is enabled
+--profiling               Enable profiling via web interface host:port/debug/pprof/
+```
+
+The handlers are served on the same port as configured in the `--metrics-bind-address` flag (defaults to `":8080"`) via HTTP.
+
+For example:
+
+```bash
+$ curl http://localhost:8080/debug/pprof/heap > /tmp/heap-seed-admission-controller
+$ go tool pprof /tmp/heap-seed-admission-controller
+```

--- a/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller_test.go
+++ b/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller_test.go
@@ -175,6 +175,7 @@ spec:
         - --port=10250
         - --tls-cert-dir=/srv/gardener-seed-admission-controller
         - --allow-invalid-extension-resources=false
+        - --metrics-bind-address=:8080
         - --health-bind-address=:8081
         image: ` + image + `
         imagePullPolicy: IfNotPresent
@@ -186,6 +187,9 @@ spec:
           initialDelaySeconds: 5
         name: gardener-seed-admission-controller
         ports:
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP
         - containerPort: 10250
         readinessProbe:
           httpGet:
@@ -243,6 +247,10 @@ metadata:
   namespace: shoot--foo--bar
 spec:
   ports:
+  - name: metrics
+    port: 8080
+    protocol: TCP
+    targetPort: 8080
   - name: health
     port: 8081
     protocol: TCP


### PR DESCRIPTION
/area quality
/kind enhancement

Part of https://github.com/gardener/gardener/issues/4567

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
gardener-seed-admission-controller now supports enabling profiling handlers. See this [document](https://github.com/gardener/gardener/blob/master/docs/monitoring/profiling.md) for more details.
```
