### PR TITLE
Add PriorityClass to gardener control plane components

### DIFF
--- a/charts/gardener/controlplane/charts/runtime/templates/admission-controller/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/admission-controller/deployment.yaml
@@ -35,6 +35,7 @@ spec:
 {{ toYaml .Values.global.admission.podLabels | indent 8 }}
         {{- end }}
     spec:
+      priorityClassName: gardener-controlplane
       {{- if not .Values.global.deployment.virtualGarden.enabled }}
       serviceAccountName: {{ required ".Values.global.admission.serviceAccountName is required" .Values.global.admission.serviceAccountName }}
       {{- else if and .Values.global.deployment.virtualGarden.enabled .Values.global.deployment.virtualGarden.admission.user.name }}

--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
@@ -54,6 +54,7 @@ spec:
 {{ toYaml .Values.global.apiserver.podLabels | indent 8 }}
         {{- end }}
     spec:
+      priorityClassName: gardener-controlplane
       {{- if not .Values.global.deployment.virtualGarden.enabled }}
       serviceAccountName: {{ required ".Values.global.apiserver.serviceAccountName is required" .Values.global.apiserver.serviceAccountName }}
       {{- else if and .Values.global.deployment.virtualGarden.enabled .Values.global.deployment.virtualGarden.apiserver.user.name }}

--- a/charts/gardener/controlplane/charts/runtime/templates/controller-manager/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/controller-manager/deployment.yaml
@@ -41,6 +41,7 @@ spec:
 {{ toYaml .Values.global.controller.podLabels | indent 8 }}
         {{- end }}
     spec:
+      priorityClassName: gardener-controlplane
       {{- if not .Values.global.deployment.virtualGarden.enabled }}
       serviceAccountName: {{ required ".Values.global.controller.serviceAccountName is required" .Values.global.controller.serviceAccountName }}
       {{- else if and .Values.global.deployment.virtualGarden.enabled .Values.global.deployment.virtualGarden.controller.user.name }}

--- a/charts/gardener/controlplane/charts/runtime/templates/priorityclass.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/priorityclass.yaml
@@ -1,0 +1,7 @@
+apiVersion: {{ include "priorityclassversion" . }}
+kind: PriorityClass
+metadata:
+  name: gardener-controlplane
+value: 1000000000
+globalDefault: false
+description: "This class is used to ensure that the gardener controlplane components have a high priority and are not preempted in favor of other pods."

--- a/charts/gardener/controlplane/charts/runtime/templates/scheduler/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/scheduler/deployment.yaml
@@ -34,6 +34,7 @@ spec:
 {{ toYaml .Values.global.scheduler.podLabels | indent 8 }}
         {{- end }}
     spec:
+      priorityClassName: gardener-controlplane
       {{- if not .Values.global.deployment.virtualGarden.enabled }}
       serviceAccountName: {{ required ".Values.global.scheduler.serviceAccountName is required" .Values.global.scheduler.serviceAccountName }}
       {{- else if and .Values.global.deployment.virtualGarden.enabled .Values.global.deployment.virtualGarden.scheduler.user.name }}


### PR DESCRIPTION
/area quality
/kind enhancement

This PR adds PriorityClass to gardener control plane components (gardener-apiserver, gardener-admission-controller, gardener-controller-manager and gardener-scheduler) to make sure that these components have high priority in the scheduling queue and that they are not preempted (evicted) by the kube-scheduler to make scheduling of pending Pod with higher priority possible. Ref https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/

Part of #5634

**Special notes for your reviewer**:
~~I set `1000000000` (highest possible value) for gardener-apiserver and `500000000` (`highest possible value` / 2) for the other components as the other components depend on the gardener-apiserver to successfully start and run (for example gardener-scheduler and gardener-controller-manager). But I am also open for feedback, discussion and adjusting the PriorityClass values if needed.~~

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The gardener control plane helm chart does now define a `PriorityClass` for gardener control plane components (gardener-apiserver, gardener-admission-controller, gardener-controller-manager and gardener-scheduler) to make sure that they have high priority in the scheduling queue and that they are not preempted (evicted) in favour of other Pods.
```
