### PR TITLE
Promote `UseDNSRecords` feature gate to GA

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -32,8 +32,6 @@ The following tables are a summary of the feature gates that you can set on diff
 | SeedKubeScheduler                            | `false` | `Alpha` | `1.15` |        |
 | ReversedVPN                                  | `false` | `Alpha` | `1.22` | `1.41` |
 | ReversedVPN                                  | `true`  | `Beta`  | `1.42` |        |
-| UseDNSRecords                                | `false` | `Alpha` | `1.27` | `1.38` |
-| UseDNSRecords                                | `true`  | `Beta`  | `1.39` |        |
 | RotateSSHKeypairOnMaintenance                | `false` | `Alpha` | `1.28` |        |
 | DenyInvalidExtensionResources                | `false` | `Alpha` | `1.31` | `1.41` |
 | DenyInvalidExtensionResources                | `true`  | `Beta`  | `1.42` |        |
@@ -67,6 +65,9 @@ The following tables are a summary of the feature gates that you can set on diff
 | AdminKubeconfigRequest                       | `false` | `Alpha`   | `1.24` | `1.38` |
 | AdminKubeconfigRequest                       | `true`  | `Beta`    | `1.39` | `1.41` |
 | AdminKubeconfigRequest                       | `true`  | `GA`      | `1.42` |        |
+| UseDNSRecords                                | `false` | `Alpha`   | `1.27` | `1.38` |
+| UseDNSRecords                                | `true`  | `Beta`    | `1.39` | `1.43` |
+| UseDNSRecords                                | `true`  | `GA`      | `1.44` |        |
 
 ## Using a feature
 

--- a/docs/extensions/dnsrecord.md
+++ b/docs/extensions/dnsrecord.md
@@ -127,7 +127,7 @@ If this feature gate is enabled, all three DNS records mentioned above (internal
 These providers can be used for `DNSEntry` resources needed by workloads deployed on the shoot cluster.
 
 If the feature gate is disabled, Gardener will not create any `DNSRecord` resources and use `DNSProvider` / `DNSEntry` resources for its DNS records. 
-The feature gate was introduced in `v1.27` and was in `Alpha` stage (disabled by default) until `v1.38` (including). With `v1.39` the feature gate is graduated to `Beta` and it is enabled by default.
+The feature gate was introduced in `v1.27` and was in `Alpha` stage (disabled by default) until `v1.38` (including). With `v1.44` the feature gate is graduated to `GA` and can't be disabled.
 
 In order to successfully reconcile a shoot with the feature gate enabled, extension controllers for `DNSRecord` resources for types used in the default, internal and custom domain secrets should be registered via `ControllerRegistration` resources.
 

--- a/example/20-componentconfig-gardener-controller-manager.yaml
+++ b/example/20-componentconfig-gardener-controller-manager.yaml
@@ -83,5 +83,4 @@ debugging:
   enableContentionProfiling: false
 featureGates:
   CachedRuntimeClients: true
-  UseDNSRecords: true
   RotateSSHKeypairOnMaintenance: false

--- a/example/20-componentconfig-gardenlet.yaml
+++ b/example/20-componentconfig-gardenlet.yaml
@@ -115,7 +115,6 @@ featureGates:
   CachedRuntimeClients: true
   SeedKubeScheduler: false
   ReversedVPN: true
-  UseDNSRecords: true
   DenyInvalidExtensionResources: true
   CopyEtcdBackupsDuringControlPlaneMigration: false
   ForceRestore: false

--- a/example/gardener-local/controlplane/values.yaml
+++ b/example/gardener-local/controlplane/values.yaml
@@ -154,7 +154,6 @@ global:
         maxSize: 0
         policy: ""
     featureGates:
-      UseDNSRecords: true
       SeedChange: true
       WorkerPoolKubernetesVersion: true
       ShootCARotation: true
@@ -261,7 +260,6 @@ global:
           port: 2718
       featureGates:
         CachedRuntimeClients: true
-        UseDNSRecords: true
     resources: {}
 
   # General system configuration

--- a/example/gardener-local/gardenlet/values.yaml
+++ b/example/gardener-local/gardenlet/values.yaml
@@ -45,7 +45,6 @@ global:
         CachedRuntimeClients: true
         SeedKubeScheduler: false
         ReversedVPN: true
-        UseDNSRecords: true
         DenyInvalidExtensionResources: true
         ShootCARotation: true
       seedConfig:

--- a/pkg/controllermanager/controller/controllerregistration/seed_control.go
+++ b/pkg/controllermanager/controller/controllerregistration/seed_control.go
@@ -25,10 +25,8 @@ import (
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	controllermanagerfeatures "github.com/gardener/gardener/pkg/controllermanager/features"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/extensions"
-	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/operation/common"
 	gardenpkg "github.com/gardener/gardener/pkg/operation/garden"
@@ -37,7 +35,6 @@ import (
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
-	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -239,8 +236,7 @@ func computeKindTypesForShoots(
 				log.Info("Could not determine external domain for shoot", "err", err, "shoot", client.ObjectKeyFromObject(shoot))
 			}
 
-			out <- shootpkg.ComputeRequiredExtensions(shoot, seed, controllerRegistrationList, internalDomain, externalDomain,
-				controllermanagerfeatures.FeatureGate.Enabled(features.UseDNSRecords))
+			out <- shootpkg.ComputeRequiredExtensions(shoot, seed, controllerRegistrationList, internalDomain, externalDomain)
 		}(shoot.DeepCopy())
 	}
 
@@ -269,11 +265,7 @@ func computeKindTypesForSeed(
 	}
 
 	if seed.Spec.DNS.Provider != nil {
-		if controllermanagerfeatures.FeatureGate.Enabled(features.UseDNSRecords) {
-			wantedKindTypeCombinations.Insert(extensions.Id(extensionsv1alpha1.DNSRecordResource, seed.Spec.DNS.Provider.Type))
-		} else {
-			wantedKindTypeCombinations.Insert(extensions.Id(dnsv1alpha1.DNSProviderKind, seed.Spec.DNS.Provider.Type))
-		}
+		wantedKindTypeCombinations.Insert(extensions.Id(extensionsv1alpha1.DNSRecordResource, seed.Spec.DNS.Provider.Type))
 	}
 
 	return wantedKindTypeCombinations

--- a/pkg/controllermanager/controller/controllerregistration/seed_control_test.go
+++ b/pkg/controllermanager/controller/controllerregistration/seed_control_test.go
@@ -20,14 +20,11 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	controllermanagerfeatures "github.com/gardener/gardener/pkg/controllermanager/features"
 	"github.com/gardener/gardener/pkg/extensions"
-	"github.com/gardener/gardener/pkg/features"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	"github.com/gardener/gardener/pkg/operation/common"
 	gardenpkg "github.com/gardener/gardener/pkg/operation/garden"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
-	"github.com/gardener/gardener/pkg/utils/test"
 
 	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	"github.com/go-logr/logr"
@@ -526,40 +523,7 @@ var _ = Describe("controllerRegistrationReconciler", func() {
 			goleak.VerifyNone(GinkgoT(), ignoreCurrent)
 		})
 
-		It("should correctly compute the result for a seed without DNS taint if the feature gate is disabled", func() {
-			defer test.WithFeatureGate(controllermanagerfeatures.FeatureGate, features.UseDNSRecords, false)()
-
-			kindTypes := computeKindTypesForShoots(ctx, nopLogger, nil, shootList, seedWithShootDNSEnabled, controllerRegistrationList, internalDomain, nil)
-
-			Expect(kindTypes).To(Equal(sets.NewString(
-				// seedWithShootDNSEnabled types
-				extensionsv1alpha1.BackupBucketResource+"/"+type8,
-				extensionsv1alpha1.BackupEntryResource+"/"+type8,
-				extensionsv1alpha1.ControlPlaneResource+"/"+type11,
-
-				// shoot2 types
-				extensionsv1alpha1.ControlPlaneResource+"/"+type2,
-				extensionsv1alpha1.InfrastructureResource+"/"+type2,
-				extensionsv1alpha1.WorkerResource+"/"+type2,
-				extensionsv1alpha1.OperatingSystemConfigResource+"/"+type5,
-				extensionsv1alpha1.NetworkResource+"/"+type3,
-				extensionsv1alpha1.ExtensionResource+"/"+type4,
-
-				// shoot3 types
-				extensionsv1alpha1.ControlPlaneResource+"/"+type6,
-				extensionsv1alpha1.InfrastructureResource+"/"+type6,
-				extensionsv1alpha1.WorkerResource+"/"+type6,
-				dnsv1alpha1.DNSProviderKind+"/"+type7,
-				extensionsv1alpha1.ContainerRuntimeResource+"/"+type12,
-
-				// internal domain + globally enabled extensions
-				extensionsv1alpha1.ExtensionResource+"/"+type10,
-				dnsv1alpha1.DNSProviderKind+"/"+type9,
-			)))
-		})
-
-		It("should correctly compute the result for a seed without DNS taint if the feature gate is enabled", func() {
-			defer test.WithFeatureGate(controllermanagerfeatures.FeatureGate, features.UseDNSRecords, true)()
+		It("should correctly compute the result for a seed without DNS taint", func() {
 
 			kindTypes := computeKindTypesForShoots(ctx, nopLogger, nil, shootList, seedWithShootDNSEnabled, controllerRegistrationList, internalDomain, nil)
 
@@ -676,27 +640,7 @@ var _ = Describe("controllerRegistrationReconciler", func() {
 	Describe("#computeKindTypesForSeed", func() {
 		var providerType = "fake-provider-type"
 
-		It("should add the DNSProvider extension if the feature gate is disabled", func() {
-			defer test.WithFeatureGate(controllermanagerfeatures.FeatureGate, features.UseDNSRecords, false)()
-
-			seed := &gardencorev1beta1.Seed{
-				Spec: gardencorev1beta1.SeedSpec{
-					DNS: gardencorev1beta1.SeedDNS{
-						Provider: &gardencorev1beta1.SeedDNSProvider{
-							Type: providerType,
-						},
-					},
-				},
-			}
-
-			expected := sets.NewString(extensions.Id(dnsv1alpha1.DNSProviderKind, providerType))
-			actual := computeKindTypesForSeed(seed)
-			Expect(actual).To(Equal(expected))
-		})
-
-		It("should add the DNSRecord extension if the feature gate is enabled", func() {
-			defer test.WithFeatureGate(controllermanagerfeatures.FeatureGate, features.UseDNSRecords, true)()
-
+		It("should add the DNSRecord extension", func() {
 			seed := &gardencorev1beta1.Seed{
 				Spec: gardencorev1beta1.SeedSpec{
 					DNS: gardencorev1beta1.SeedDNS{

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -89,6 +89,7 @@ const (
 	// owner: @stoyanr
 	// alpha: v1.27.0
 	// beta: v1.39.0
+	// GA: v1.44.0
 	UseDNSRecords featuregate.Feature = "UseDNSRecords"
 
 	// RotateSSHKeypairOnMaintenance enables SSH keypair rotation in the maintenance controller of the gardener-controller-manager.
@@ -168,7 +169,7 @@ var allFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	SeedKubeScheduler:             {Default: false, PreRelease: featuregate.Alpha},
 	ReversedVPN:                   {Default: true, PreRelease: featuregate.Beta},
 	AdminKubeconfigRequest:        {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
-	UseDNSRecords:                 {Default: true, PreRelease: featuregate.Beta},
+	UseDNSRecords:                 {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	RotateSSHKeypairOnMaintenance: {Default: false, PreRelease: featuregate.Alpha},
 	DenyInvalidExtensionResources: {Default: true, PreRelease: featuregate.Beta},
 	WorkerPoolKubernetesVersion:   {Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/gardenlet/controller/shoot/shoot_control_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_delete.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
 	"github.com/gardener/gardener/pkg/controllerutils"
+	"github.com/gardener/gardener/pkg/features"
 	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 	"github.com/gardener/gardener/pkg/operation"
 	botanistpkg "github.com/gardener/gardener/pkg/operation/botanist"
@@ -151,7 +152,7 @@ func (r *shootReconciler) runDeleteShootFlow(ctx context.Context, o *operation.O
 			return err
 		}),
 		errors.ToExecute("Get additional DNS providers that are used by DNSEntry resources", func() error {
-			if !gardenletfeatures.DisabledDNSProviderManagement() {
+			if !gardenletfeatures.FeatureGate.Enabled(features.DisableDNSProviderManagement) {
 				if additionalDNSProviders, err = getUsedAdditionalDNSProviders(ctx, o); err != nil {
 					return err
 				}
@@ -251,7 +252,7 @@ func (r *shootReconciler) runDeleteShootFlow(ctx context.Context, o *operation.O
 			Name: "Deploying additional DNS providers",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
 				return botanist.DeployDNSProviders(ctx, additionalDNSProviders)
-			}).RetryUntilTimeout(defaultInterval, defaultTimeout).DoIf(nonTerminatingNamespace && !gardenletfeatures.DisabledDNSProviderManagement()),
+			}).RetryUntilTimeout(defaultInterval, defaultTimeout).DoIf(nonTerminatingNamespace && !gardenletfeatures.FeatureGate.Enabled(features.DisableDNSProviderManagement)),
 			Dependencies: flow.NewTaskIDs(deployReferencedResources, deployInternalDomainDNSRecord, deployOwnerDomainDNSRecord),
 		})
 		_ = g.Add(flow.Task{
@@ -616,7 +617,7 @@ func (r *shootReconciler) runDeleteShootFlow(ctx context.Context, o *operation.O
 		})
 		deleteDNSProviders = g.Add(flow.Task{
 			Name:         "Deleting additional DNS providers",
-			Fn:           flow.TaskFn(botanist.DeleteDNSProviders).DoIf(!gardenletfeatures.DisabledDNSProviderManagement()),
+			Fn:           flow.TaskFn(botanist.DeleteDNSProviders).DoIf(!gardenletfeatures.FeatureGate.Enabled(features.DisableDNSProviderManagement)),
 			Dependencies: flow.NewTaskIDs(destroyInternalDomainDNSRecord, destroyOwnerDomainDNSRecord),
 		})
 		destroyReferencedResources = g.Add(flow.Task{

--- a/pkg/gardenlet/controller/shoot/shoot_control_migrate.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_migrate.go
@@ -26,6 +26,7 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/controllerutils"
+	"github.com/gardener/gardener/pkg/features"
 	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 	"github.com/gardener/gardener/pkg/operation"
 	botanistpkg "github.com/gardener/gardener/pkg/operation/botanist"
@@ -366,7 +367,7 @@ func (r *shootReconciler) runPrepareShootForMigrationFlow(ctx context.Context, o
 		})
 		destroyDNSProviders = g.Add(flow.Task{
 			Name:         "Deleting DNS providers",
-			Fn:           flow.TaskFn(botanist.DeleteDNSProviders).DoIf(!gardenletfeatures.DisabledDNSProviderManagement()),
+			Fn:           flow.TaskFn(botanist.DeleteDNSProviders).DoIf(!gardenletfeatures.FeatureGate.Enabled(features.DisableDNSProviderManagement)),
 			Dependencies: flow.NewTaskIDs(migrateIngressDNSRecord, migrateExternalDNSRecord, migrateInternalDNSRecord, migrateOwnerDNSRecord),
 		})
 		createETCDSnapshot = g.Add(flow.Task{

--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -24,6 +24,7 @@ import (
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
 	"github.com/gardener/gardener/pkg/controllerutils"
+	"github.com/gardener/gardener/pkg/features"
 	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 	"github.com/gardener/gardener/pkg/operation"
 	botanistpkg "github.com/gardener/gardener/pkg/operation/botanist"
@@ -532,7 +533,7 @@ func (r *shootReconciler) runReconcileShootFlow(ctx context.Context, o *operatio
 		})
 		_ = g.Add(flow.Task{
 			Name:         "Deploying additional DNS providers",
-			Fn:           flow.TaskFn(botanist.DeployAdditionalDNSProviders).DoIf(!o.Shoot.HibernationEnabled && !gardenletfeatures.DisabledDNSProviderManagement()),
+			Fn:           flow.TaskFn(botanist.DeployAdditionalDNSProviders).DoIf(!o.Shoot.HibernationEnabled && !gardenletfeatures.FeatureGate.Enabled(features.DisableDNSProviderManagement)),
 			Dependencies: flow.NewTaskIDs(deployInternalDomainDNSRecord, deployExternalDomainDNSRecord, deployIngressDomainDNSRecord, deployOwnerDomainDNSRecord),
 		})
 		vpnLBReady = g.Add(flow.Task{

--- a/pkg/gardenlet/features/features.go
+++ b/pkg/gardenlet/features/features.go
@@ -42,8 +42,3 @@ func RegisterFeatureGates() {
 		features.ShootCARotation,
 	)))
 }
-
-// DisabledDNSProviderManagement returns true if `DisableDNSProviderManagement` is effective.
-func DisabledDNSProviderManagement() bool {
-	return FeatureGate.Enabled(features.DisableDNSProviderManagement)
-}

--- a/pkg/gardenlet/features/features.go
+++ b/pkg/gardenlet/features/features.go
@@ -45,5 +45,5 @@ func RegisterFeatureGates() {
 
 // DisabledDNSProviderManagement returns true if `DisableDNSProviderManagement` is effective.
 func DisabledDNSProviderManagement() bool {
-	return FeatureGate.Enabled(features.UseDNSRecords) && FeatureGate.Enabled(features.DisableDNSProviderManagement)
+	return FeatureGate.Enabled(features.DisableDNSProviderManagement)
 }

--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -25,8 +25,6 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	"github.com/gardener/gardener/pkg/features"
-	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 	"github.com/gardener/gardener/pkg/operation"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/etcd"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/logging"
@@ -212,8 +210,7 @@ func (b *Botanist) RequiredExtensionsReady(ctx context.Context) error {
 		return err
 	}
 
-	requiredExtensions := shootpkg.ComputeRequiredExtensions(b.Shoot.GetInfo(), b.Seed.GetInfo(), controllerRegistrationList, b.Garden.InternalDomain, b.Shoot.ExternalDomain,
-		gardenletfeatures.FeatureGate.Enabled(features.UseDNSRecords))
+	requiredExtensions := shootpkg.ComputeRequiredExtensions(b.Shoot.GetInfo(), b.Seed.GetInfo(), controllerRegistrationList, b.Garden.InternalDomain, b.Shoot.ExternalDomain)
 
 	for _, controllerInstallation := range controllerInstallationList.Items {
 		if controllerInstallation.Spec.SeedRef.Name != b.Seed.GetInfo().Name {

--- a/pkg/operation/botanist/dns.go
+++ b/pkg/operation/botanist/dns.go
@@ -24,6 +24,7 @@ import (
 	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1helper "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1/helper"
+	"github.com/gardener/gardener/pkg/features"
 	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/dns"
@@ -422,7 +423,7 @@ func (b *Botanist) DestroyInternalDNS(ctx context.Context) error {
 
 // DestroyExternalDNS destroys the external DNSEntry, DNSOwner, and DNSProvider resources.
 func (b *Botanist) DestroyExternalDNS(ctx context.Context) error {
-	if gardenletfeatures.DisabledDNSProviderManagement() {
+	if gardenletfeatures.FeatureGate.Enabled(features.DisableDNSProviderManagement) {
 		return component.OpDestroyAndWait(
 			b.Shoot.Components.Extensions.DNS.ExternalEntry,
 			b.Shoot.Components.Extensions.DNS.ExternalOwner,
@@ -457,7 +458,7 @@ func (b *Botanist) MigrateExternalDNS(ctx context.Context, keepProvider bool) er
 			return err
 		}
 
-		if gardenletfeatures.DisabledDNSProviderManagement() {
+		if gardenletfeatures.FeatureGate.Enabled(features.DisableDNSProviderManagement) {
 			return nil
 		}
 		// Deploy the DNSProvider resource

--- a/pkg/operation/botanist/dnsresources_test.go
+++ b/pkg/operation/botanist/dnsresources_test.go
@@ -133,8 +133,7 @@ var _ = Describe("dnsrecord", func() {
 	})
 
 	Describe("#DeployInternalDNSResources", func() {
-		It("should delete the DNSOwner, DNSProvider, and DNSEntry resources, and then deploy the DNSRecord resource if the feature gate is enabled", func() {
-			defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.UseDNSRecords, true)()
+		It("should delete the DNSOwner, DNSProvider, and DNSEntry resources, and then deploy the DNSRecord resource", func() {
 			gomock.InOrder(
 				internalDNSOwner.EXPECT().Destroy(ctx),
 				internalDNSOwner.EXPECT().WaitCleanup(ctx),
@@ -147,28 +146,10 @@ var _ = Describe("dnsrecord", func() {
 			)
 			Expect(b.DeployInternalDNSResources(ctx)).To(Succeed())
 		})
-
-		It("should migrate and delete the DNSRecord resource, and then deploy the DNSOwner, DNSProvider, and DNSEntry resources if the feature gate is disabled", func() {
-			defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.UseDNSRecords, false)()
-			gomock.InOrder(
-				internalDNSRecord.EXPECT().Migrate(ctx),
-				internalDNSRecord.EXPECT().WaitMigrate(ctx),
-				internalDNSRecord.EXPECT().Destroy(ctx),
-				internalDNSRecord.EXPECT().WaitCleanup(ctx),
-				internalDNSOwner.EXPECT().Deploy(ctx),
-				internalDNSOwner.EXPECT().Wait(ctx),
-				internalDNSProvider.EXPECT().Deploy(ctx),
-				internalDNSProvider.EXPECT().Wait(ctx),
-				internalDNSEntry.EXPECT().Deploy(ctx),
-				internalDNSEntry.EXPECT().Wait(ctx),
-			)
-			Expect(b.DeployInternalDNSResources(ctx)).To(Succeed())
-		})
 	})
 
 	Describe("#DeployExternalDNSResources", func() {
-		It("should delete the DNSOwner and DNSEntry resources, and then deploy the DNSProvider and DNSRecord resources if the feature gate is enabled", func() {
-			defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.UseDNSRecords, true)()
+		It("should delete the DNSOwner and DNSEntry resources, and then deploy the DNSProvider and DNSRecord resources", func() {
 			gomock.InOrder(
 				externalDNSOwner.EXPECT().Destroy(ctx),
 				externalDNSOwner.EXPECT().WaitCleanup(ctx),
@@ -181,28 +162,10 @@ var _ = Describe("dnsrecord", func() {
 			)
 			Expect(b.DeployExternalDNSResources(ctx)).To(Succeed())
 		})
-
-		It("should migrate and delete the DNSRecord resource, and then deploy the DNSOwner, DNSProvider, and DNSEntry resources if the feature gate is disabled", func() {
-			defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.UseDNSRecords, false)()
-			gomock.InOrder(
-				externalDNSRecord.EXPECT().Migrate(ctx),
-				externalDNSRecord.EXPECT().WaitMigrate(ctx),
-				externalDNSRecord.EXPECT().Destroy(ctx),
-				externalDNSRecord.EXPECT().WaitCleanup(ctx),
-				externalDNSOwner.EXPECT().Deploy(ctx),
-				externalDNSOwner.EXPECT().Wait(ctx),
-				externalDNSProvider.EXPECT().Deploy(ctx),
-				externalDNSProvider.EXPECT().Wait(ctx),
-				externalDNSEntry.EXPECT().Deploy(ctx),
-				externalDNSEntry.EXPECT().Wait(ctx),
-			)
-			Expect(b.DeployExternalDNSResources(ctx)).To(Succeed())
-		})
 	})
 
 	Describe("#DeployIngressDNSResources", func() {
-		It("should delete the DNSOwner and DNSEntry resources, and then deploy the DNSRecord resource if the feature gate is enabled", func() {
-			defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.UseDNSRecords, true)()
+		It("should delete the DNSOwner and DNSEntry resources, and then deploy the DNSRecord resource", func() {
 			gomock.InOrder(
 				ingressDNSOwner.EXPECT().Destroy(ctx),
 				ingressDNSOwner.EXPECT().WaitCleanup(ctx),
@@ -213,26 +176,10 @@ var _ = Describe("dnsrecord", func() {
 			)
 			Expect(b.DeployIngressDNSResources(ctx)).To(Succeed())
 		})
-
-		It("should migrate and delete the DNSRecord resource, and then deploy the DNSOwner and DNSEntry resources if the feature gate is disabled", func() {
-			defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.UseDNSRecords, false)()
-			gomock.InOrder(
-				ingressDNSRecord.EXPECT().Migrate(ctx),
-				ingressDNSRecord.EXPECT().WaitMigrate(ctx),
-				ingressDNSRecord.EXPECT().Destroy(ctx),
-				ingressDNSRecord.EXPECT().WaitCleanup(ctx),
-				ingressDNSOwner.EXPECT().Deploy(ctx),
-				ingressDNSOwner.EXPECT().Wait(ctx),
-				ingressDNSEntry.EXPECT().Deploy(ctx),
-				ingressDNSEntry.EXPECT().Wait(ctx),
-			)
-			Expect(b.DeployIngressDNSResources(ctx)).To(Succeed())
-		})
 	})
 
 	Describe("#DeployOwnerDNSResources", func() {
-		It("should deploy the owner DNSRecord resource if the feature gate is enabled", func() {
-			defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.UseDNSRecords, true)()
+		It("should deploy the owner DNSRecord resource", func() {
 			gomock.InOrder(
 				ownerDNSRecord.EXPECT().Deploy(ctx),
 				ownerDNSRecord.EXPECT().Wait(ctx),
@@ -240,17 +187,7 @@ var _ = Describe("dnsrecord", func() {
 			Expect(b.DeployOwnerDNSResources(ctx)).To(Succeed())
 		})
 
-		It("should delete the owner DNSRecord resource if the feature gate is disabled", func() {
-			defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.UseDNSRecords, false)()
-			gomock.InOrder(
-				ownerDNSRecord.EXPECT().Destroy(ctx),
-				ownerDNSRecord.EXPECT().WaitCleanup(ctx),
-			)
-			Expect(b.DeployOwnerDNSResources(ctx)).To(Succeed())
-		})
-
 		It("should delete the owner DNSRecord resource if owner checks are disabled", func() {
-			defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.UseDNSRecords, true)()
 			b.Seed.GetInfo().Spec.Settings = &gardencorev1beta1.SeedSettings{
 				OwnerChecks: &gardencorev1beta1.SeedSettingOwnerChecks{
 					Enabled: false,
@@ -295,7 +232,6 @@ var _ = Describe("dnsrecord", func() {
 			Expect(b.DestroyExternalDNSResources(ctx)).To(Succeed())
 		})
 		It("should delete all external DNS resources but DNSProvider if feature DisabledDNSProviderManagement is set", func() {
-			defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.UseDNSRecords, true)()
 			defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.DisableDNSProviderManagement, true)()
 			gomock.InOrder(
 				externalDNSEntry.EXPECT().Destroy(ctx),
@@ -380,8 +316,7 @@ var _ = Describe("dnsrecord", func() {
 	})
 
 	Describe("#MigrateOwnerDNSResources", func() {
-		It("should migrate the owner DNSRecord resource if the feature gate is enabled", func() {
-			defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.UseDNSRecords, true)()
+		It("should migrate the owner DNSRecord resource", func() {
 			gomock.InOrder(
 				ownerDNSRecord.EXPECT().Migrate(ctx),
 				ownerDNSRecord.EXPECT().WaitMigrate(ctx),
@@ -389,17 +324,7 @@ var _ = Describe("dnsrecord", func() {
 			Expect(b.MigrateOwnerDNSResources(ctx)).To(Succeed())
 		})
 
-		It("should delete the owner DNSRecord resource if the feature gate is disabled", func() {
-			defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.UseDNSRecords, false)()
-			gomock.InOrder(
-				ownerDNSRecord.EXPECT().Destroy(ctx),
-				ownerDNSRecord.EXPECT().WaitCleanup(ctx),
-			)
-			Expect(b.MigrateOwnerDNSResources(ctx)).To(Succeed())
-		})
-
 		It("should delete the owner DNSRecord resource if owner checks are disabled", func() {
-			defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.UseDNSRecords, true)()
 			b.Seed.GetInfo().Spec.Settings = &gardencorev1beta1.SeedSettings{
 				OwnerChecks: &gardencorev1beta1.SeedSettingOwnerChecks{
 					Enabled: false,

--- a/pkg/operation/botanist/dnsresources_test.go
+++ b/pkg/operation/botanist/dnsresources_test.go
@@ -231,7 +231,7 @@ var _ = Describe("dnsrecord", func() {
 			)
 			Expect(b.DestroyExternalDNSResources(ctx)).To(Succeed())
 		})
-		It("should delete all external DNS resources but DNSProvider if feature DisabledDNSProviderManagement is set", func() {
+		It("should delete all external DNS resources but DNSProvider if feature DisableDNSProviderManagement is set", func() {
 			defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.DisableDNSProviderManagement, true)()
 			gomock.InOrder(
 				externalDNSEntry.EXPECT().Destroy(ctx),

--- a/pkg/operation/botanist/etcd.go
+++ b/pkg/operation/botanist/etcd.go
@@ -116,7 +116,7 @@ func (b *Botanist) DeployEtcd(ctx context.Context) error {
 			FullSnapshotSchedule: snapshotSchedule,
 		})
 
-		if gardenletfeatures.FeatureGate.Enabled(features.UseDNSRecords) && gardencorev1beta1helper.SeedSettingOwnerChecksEnabled(b.Seed.GetInfo().Spec.Settings) {
+		if gardencorev1beta1helper.SeedSettingOwnerChecksEnabled(b.Seed.GetInfo().Spec.Settings) {
 			b.Shoot.Components.ControlPlane.EtcdMain.SetOwnerCheckConfig(&etcd.OwnerCheckConfig{
 				Name: gutil.GetOwnerDomain(b.Shoot.InternalClusterDomain),
 				ID:   *b.Seed.GetInfo().Status.ClusterIdentity,

--- a/pkg/operation/botanist/etcd_test.go
+++ b/pkg/operation/botanist/etcd_test.go
@@ -366,8 +366,6 @@ var _ = Describe("Etcd", func() {
 			})
 
 			It("should set the secrets and deploy with owner checks", func() {
-				defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.UseDNSRecords, true)()
-
 				expectGetBackupSecret()
 				expectSetBackupConfig()
 				expectSetOwnerCheckConfig()
@@ -378,23 +376,11 @@ var _ = Describe("Etcd", func() {
 			})
 
 			It("should set the secrets and deploy without owner checks if they are disabled", func() {
-				defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.UseDNSRecords, true)()
 				botanist.Seed.GetInfo().Spec.Settings = &gardencorev1beta1.SeedSettings{
 					OwnerChecks: &gardencorev1beta1.SeedSettingOwnerChecks{
 						Enabled: false,
 					},
 				}
-
-				expectGetBackupSecret()
-				expectSetBackupConfig()
-				etcdMain.EXPECT().Deploy(ctx)
-				etcdEvents.EXPECT().Deploy(ctx)
-
-				Expect(botanist.DeployEtcd(ctx)).To(Succeed())
-			})
-
-			It("should set the secrets and deploy without owner checks if the UseDNSRecords feature gate is disabled", func() {
-				defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.UseDNSRecords, false)()
 
 				expectGetBackupSecret()
 				expectSetBackupConfig()

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -1066,9 +1066,6 @@ func runCreateSeedFlow(
 	if err != nil {
 		return err
 	}
-	if err := updateDNSProviderSecret(ctx, seedClient, emptyDNSProviderSecret(), secretData, seed); err != nil {
-		return err
-	}
 
 	// setup for flow graph
 	var ingressLoadBalancerAddress string
@@ -1199,9 +1196,6 @@ func RunDeleteSeedFlow(
 	if err != nil {
 		return err
 	}
-	if err := updateDNSProviderSecret(ctx, seedClient, emptyDNSProviderSecret(), secretData, seed); err != nil {
-		return err
-	}
 
 	// setup for flow graph
 	var (
@@ -1304,53 +1298,25 @@ func RunDeleteSeedFlow(
 }
 
 func deployDNSResources(ctx context.Context, dnsEntry, dnsOwner component.DeployWaiter, dnsRecord component.DeployMigrateWaiter, deployDNSProviderTask, destroyDNSProviderTask flow.TaskFn) error {
-	if gardenletfeatures.FeatureGate.Enabled(features.UseDNSRecords) {
-		if err := dnsOwner.Destroy(ctx); err != nil {
-			return err
-		}
-		if err := dnsOwner.WaitCleanup(ctx); err != nil {
-			return err
-		}
-		if err := destroyDNSProviderTask(ctx); err != nil {
-			return err
-		}
-		if err := dnsEntry.Destroy(ctx); err != nil {
-			return err
-		}
-		if err := dnsEntry.WaitCleanup(ctx); err != nil {
-			return err
-		}
-		if err := dnsRecord.Deploy(ctx); err != nil {
-			return err
-		}
-		return dnsRecord.Wait(ctx)
-	} else {
-		if err := dnsRecord.Migrate(ctx); err != nil {
-			return err
-		}
-		if err := dnsRecord.WaitMigrate(ctx); err != nil {
-			return err
-		}
-		if err := dnsRecord.Destroy(ctx); err != nil {
-			return err
-		}
-		if err := dnsRecord.WaitCleanup(ctx); err != nil {
-			return err
-		}
-		if err := dnsOwner.Deploy(ctx); err != nil {
-			return err
-		}
-		if err := dnsOwner.Wait(ctx); err != nil {
-			return err
-		}
-		if err := deployDNSProviderTask(ctx); err != nil {
-			return err
-		}
-		if err := dnsEntry.Deploy(ctx); err != nil {
-			return err
-		}
-		return dnsEntry.Wait(ctx)
+	if err := dnsOwner.Destroy(ctx); err != nil {
+		return err
 	}
+	if err := dnsOwner.WaitCleanup(ctx); err != nil {
+		return err
+	}
+	if err := destroyDNSProviderTask(ctx); err != nil {
+		return err
+	}
+	if err := dnsEntry.Destroy(ctx); err != nil {
+		return err
+	}
+	if err := dnsEntry.WaitCleanup(ctx); err != nil {
+		return err
+	}
+	if err := dnsRecord.Deploy(ctx); err != nil {
+		return err
+	}
+	return dnsRecord.Wait(ctx)
 }
 
 func destroyDNSResources(ctx context.Context, dnsEntry, dnsOwner, dnsRecord component.DeployWaiter, destroyDNSProviderTask flow.TaskFn) error {
@@ -1386,20 +1352,6 @@ func ensureNoControllerInstallations(c client.Client, seedName string) func(ctx 
 		}
 		return nil
 	}
-}
-
-// updateDNSProviderSecret updates the DNSProvider secret in the garden namespace of the seed. This is only needed
-// if the `UseDNSRecords` feature gate is not enabled.
-func updateDNSProviderSecret(ctx context.Context, seedClient client.Client, secret *corev1.Secret, secretData map[string][]byte, seed *Seed) error {
-	if dnsConfig := seed.GetInfo().Spec.DNS; dnsConfig.Provider != nil && !gardenletfeatures.FeatureGate.Enabled(features.UseDNSRecords) {
-		_, err := controllerutils.GetAndCreateOrMergePatch(ctx, seedClient, secret, func() error {
-			secret.Type = corev1.SecretTypeOpaque
-			secret.Data = secretData
-			return nil
-		})
-		return err
-	}
-	return nil
 }
 
 func deployDNSProviderTask(seedClient client.Client, dnsConfig gardencorev1beta1.SeedDNS) func(ctx context.Context) error {

--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -598,7 +598,7 @@ func ToNetworks(s *gardencorev1beta1.Shoot) (*Networks, error) {
 
 // ComputeRequiredExtensions compute the extension kind/type combinations that are required for the
 // reconciliation flow.
-func ComputeRequiredExtensions(shoot *gardencorev1beta1.Shoot, seed *gardencorev1beta1.Seed, controllerRegistrationList *gardencorev1beta1.ControllerRegistrationList, internalDomain, externalDomain *garden.Domain, useDNSRecords bool) sets.String {
+func ComputeRequiredExtensions(shoot *gardencorev1beta1.Shoot, seed *gardencorev1beta1.Seed, controllerRegistrationList *gardencorev1beta1.ControllerRegistrationList, internalDomain, externalDomain *garden.Domain) sets.String {
 	requiredExtensions := sets.NewString()
 
 	if seed.Spec.Backup != nil {
@@ -642,7 +642,7 @@ func ComputeRequiredExtensions(shoot *gardencorev1beta1.Shoot, seed *gardencorev
 			for _, provider := range shoot.Spec.DNS.Providers {
 				if provider.Type != nil && *provider.Type != core.DNSUnmanaged {
 					requiredExtensions.Insert(gardenerextensions.Id(dnsv1alpha1.DNSProviderKind, *provider.Type))
-					if provider.Primary != nil && *provider.Primary && useDNSRecords {
+					if provider.Primary != nil && *provider.Primary {
 						requiredExtensions.Insert(gardenerextensions.Id(extensionsv1alpha1.DNSRecordResource, *provider.Type))
 					}
 				}
@@ -650,18 +650,12 @@ func ComputeRequiredExtensions(shoot *gardencorev1beta1.Shoot, seed *gardencorev
 		}
 
 		if internalDomain != nil && internalDomain.Provider != core.DNSUnmanaged {
-			if useDNSRecords {
-				requiredExtensions.Insert(gardenerextensions.Id(extensionsv1alpha1.DNSRecordResource, internalDomain.Provider))
-			} else {
-				requiredExtensions.Insert(gardenerextensions.Id(dnsv1alpha1.DNSProviderKind, internalDomain.Provider))
-			}
+			requiredExtensions.Insert(gardenerextensions.Id(extensionsv1alpha1.DNSRecordResource, internalDomain.Provider))
 		}
 
 		if externalDomain != nil && externalDomain.Provider != core.DNSUnmanaged {
 			requiredExtensions.Insert(gardenerextensions.Id(dnsv1alpha1.DNSProviderKind, externalDomain.Provider))
-			if useDNSRecords {
-				requiredExtensions.Insert(gardenerextensions.Id(extensionsv1alpha1.DNSRecordResource, externalDomain.Provider))
-			}
+			requiredExtensions.Insert(gardenerextensions.Id(extensionsv1alpha1.DNSRecordResource, externalDomain.Provider))
 		}
 	}
 

--- a/pkg/operation/shoot/shoot_test.go
+++ b/pkg/operation/shoot/shoot_test.go
@@ -477,185 +477,94 @@ var _ = Describe("shoot", func() {
 			}
 		})
 
-		Context("when not using DNSRecords", func() {
-			It("should compute the correct list of required extensions", func() {
-				result := ComputeRequiredExtensions(shoot, seed, controllerRegistrationList, internalDomain, externalDomain, false)
+		It("should compute the correct list of required extensions", func() {
+			result := ComputeRequiredExtensions(shoot, seed, controllerRegistrationList, internalDomain, externalDomain)
 
-				Expect(result).To(Equal(sets.NewString(
-					extensions.Id(extensionsv1alpha1.BackupBucketResource, backupProvider),
-					extensions.Id(extensionsv1alpha1.BackupEntryResource, backupProvider),
-					extensions.Id(extensionsv1alpha1.ControlPlaneResource, seedProvider),
-					extensions.Id(extensionsv1alpha1.ControlPlaneResource, shootProvider),
-					extensions.Id(extensionsv1alpha1.InfrastructureResource, shootProvider),
-					extensions.Id(extensionsv1alpha1.NetworkResource, networkingType),
-					extensions.Id(extensionsv1alpha1.WorkerResource, shootProvider),
-					extensions.Id(extensionsv1alpha1.ExtensionResource, extensionType1),
-					extensions.Id(extensionsv1alpha1.OperatingSystemConfigResource, oscType),
-					extensions.Id(extensionsv1alpha1.ContainerRuntimeResource, containerRuntimeType),
-					extensions.Id(dnsv1alpha1.DNSProviderKind, dnsProviderType1),
-					extensions.Id(dnsv1alpha1.DNSProviderKind, dnsProviderType2),
-					extensions.Id(dnsv1alpha1.DNSProviderKind, dnsProviderType3),
-					extensions.Id(extensionsv1alpha1.ExtensionResource, extensionType2),
-				)))
-			})
-
-			It("should compute the correct list of required extensions (no seed backup)", func() {
-				seed.Spec.Backup = nil
-
-				result := ComputeRequiredExtensions(shoot, seed, controllerRegistrationList, internalDomain, externalDomain, false)
-
-				Expect(result).To(Equal(sets.NewString(
-					extensions.Id(extensionsv1alpha1.ControlPlaneResource, seedProvider),
-					extensions.Id(extensionsv1alpha1.ControlPlaneResource, shootProvider),
-					extensions.Id(extensionsv1alpha1.InfrastructureResource, shootProvider),
-					extensions.Id(extensionsv1alpha1.NetworkResource, networkingType),
-					extensions.Id(extensionsv1alpha1.WorkerResource, shootProvider),
-					extensions.Id(extensionsv1alpha1.ExtensionResource, extensionType1),
-					extensions.Id(extensionsv1alpha1.OperatingSystemConfigResource, oscType),
-					extensions.Id(extensionsv1alpha1.ContainerRuntimeResource, containerRuntimeType),
-					extensions.Id(dnsv1alpha1.DNSProviderKind, dnsProviderType1),
-					extensions.Id(dnsv1alpha1.DNSProviderKind, dnsProviderType2),
-					extensions.Id(dnsv1alpha1.DNSProviderKind, dnsProviderType3),
-					extensions.Id(extensionsv1alpha1.ExtensionResource, extensionType2),
-				)))
-			})
-
-			It("should compute the correct list of required extensions (seed disables DNS)", func() {
-				seed.Spec.Settings.ShootDNS.Enabled = false
-
-				result := ComputeRequiredExtensions(shoot, seed, controllerRegistrationList, internalDomain, externalDomain, false)
-
-				Expect(result).To(Equal(sets.NewString(
-					extensions.Id(extensionsv1alpha1.BackupBucketResource, backupProvider),
-					extensions.Id(extensionsv1alpha1.BackupEntryResource, backupProvider),
-					extensions.Id(extensionsv1alpha1.ControlPlaneResource, seedProvider),
-					extensions.Id(extensionsv1alpha1.ControlPlaneResource, shootProvider),
-					extensions.Id(extensionsv1alpha1.InfrastructureResource, shootProvider),
-					extensions.Id(extensionsv1alpha1.NetworkResource, networkingType),
-					extensions.Id(extensionsv1alpha1.WorkerResource, shootProvider),
-					extensions.Id(extensionsv1alpha1.ExtensionResource, extensionType1),
-					extensions.Id(extensionsv1alpha1.OperatingSystemConfigResource, oscType),
-					extensions.Id(extensionsv1alpha1.ContainerRuntimeResource, containerRuntimeType),
-					extensions.Id(extensionsv1alpha1.ExtensionResource, extensionType2),
-				)))
-			})
-
-			It("should compute the correct list of required extensions (shoot explicitly disables globally enabled extension)", func() {
-				shoot.Spec.Extensions = append(shoot.Spec.Extensions, gardencorev1beta1.Extension{
-					Type:     extensionType2,
-					Disabled: pointer.Bool(true),
-				})
-
-				result := ComputeRequiredExtensions(shoot, seed, controllerRegistrationList, internalDomain, externalDomain, false)
-
-				Expect(result).To(Equal(sets.NewString(
-					extensions.Id(extensionsv1alpha1.BackupBucketResource, backupProvider),
-					extensions.Id(extensionsv1alpha1.BackupEntryResource, backupProvider),
-					extensions.Id(extensionsv1alpha1.ControlPlaneResource, seedProvider),
-					extensions.Id(extensionsv1alpha1.ControlPlaneResource, shootProvider),
-					extensions.Id(extensionsv1alpha1.InfrastructureResource, shootProvider),
-					extensions.Id(extensionsv1alpha1.NetworkResource, networkingType),
-					extensions.Id(extensionsv1alpha1.WorkerResource, shootProvider),
-					extensions.Id(extensionsv1alpha1.ExtensionResource, extensionType1),
-					extensions.Id(extensionsv1alpha1.OperatingSystemConfigResource, oscType),
-					extensions.Id(extensionsv1alpha1.ContainerRuntimeResource, containerRuntimeType),
-					extensions.Id(dnsv1alpha1.DNSProviderKind, dnsProviderType1),
-					extensions.Id(dnsv1alpha1.DNSProviderKind, dnsProviderType2),
-					extensions.Id(dnsv1alpha1.DNSProviderKind, dnsProviderType3),
-				)))
-			})
+			Expect(result).To(Equal(sets.NewString(
+				extensions.Id(extensionsv1alpha1.BackupBucketResource, backupProvider),
+				extensions.Id(extensionsv1alpha1.BackupEntryResource, backupProvider),
+				extensions.Id(extensionsv1alpha1.ControlPlaneResource, seedProvider),
+				extensions.Id(extensionsv1alpha1.ControlPlaneResource, shootProvider),
+				extensions.Id(extensionsv1alpha1.InfrastructureResource, shootProvider),
+				extensions.Id(extensionsv1alpha1.NetworkResource, networkingType),
+				extensions.Id(extensionsv1alpha1.WorkerResource, shootProvider),
+				extensions.Id(extensionsv1alpha1.ExtensionResource, extensionType1),
+				extensions.Id(extensionsv1alpha1.OperatingSystemConfigResource, oscType),
+				extensions.Id(extensionsv1alpha1.ContainerRuntimeResource, containerRuntimeType),
+				extensions.Id(extensionsv1alpha1.DNSRecordResource, dnsProviderType1),
+				extensions.Id(extensionsv1alpha1.DNSRecordResource, dnsProviderType2),
+				extensions.Id(dnsv1alpha1.DNSProviderKind, dnsProviderType2),
+				extensions.Id(dnsv1alpha1.DNSProviderKind, dnsProviderType3),
+				extensions.Id(extensionsv1alpha1.ExtensionResource, extensionType2),
+			)))
 		})
 
-		Context("when using DNSRecords", func() {
-			It("should compute the correct list of required extensions", func() {
-				result := ComputeRequiredExtensions(shoot, seed, controllerRegistrationList, internalDomain, externalDomain, true)
+		It("should compute the correct list of required extensions (no seed backup)", func() {
+			seed.Spec.Backup = nil
 
-				Expect(result).To(Equal(sets.NewString(
-					extensions.Id(extensionsv1alpha1.BackupBucketResource, backupProvider),
-					extensions.Id(extensionsv1alpha1.BackupEntryResource, backupProvider),
-					extensions.Id(extensionsv1alpha1.ControlPlaneResource, seedProvider),
-					extensions.Id(extensionsv1alpha1.ControlPlaneResource, shootProvider),
-					extensions.Id(extensionsv1alpha1.InfrastructureResource, shootProvider),
-					extensions.Id(extensionsv1alpha1.NetworkResource, networkingType),
-					extensions.Id(extensionsv1alpha1.WorkerResource, shootProvider),
-					extensions.Id(extensionsv1alpha1.ExtensionResource, extensionType1),
-					extensions.Id(extensionsv1alpha1.OperatingSystemConfigResource, oscType),
-					extensions.Id(extensionsv1alpha1.ContainerRuntimeResource, containerRuntimeType),
-					extensions.Id(extensionsv1alpha1.DNSRecordResource, dnsProviderType1),
-					extensions.Id(extensionsv1alpha1.DNSRecordResource, dnsProviderType2),
-					extensions.Id(dnsv1alpha1.DNSProviderKind, dnsProviderType2),
-					extensions.Id(dnsv1alpha1.DNSProviderKind, dnsProviderType3),
-					extensions.Id(extensionsv1alpha1.ExtensionResource, extensionType2),
-				)))
+			result := ComputeRequiredExtensions(shoot, seed, controllerRegistrationList, internalDomain, externalDomain)
+
+			Expect(result).To(Equal(sets.NewString(
+				extensions.Id(extensionsv1alpha1.ControlPlaneResource, seedProvider),
+				extensions.Id(extensionsv1alpha1.ControlPlaneResource, shootProvider),
+				extensions.Id(extensionsv1alpha1.InfrastructureResource, shootProvider),
+				extensions.Id(extensionsv1alpha1.NetworkResource, networkingType),
+				extensions.Id(extensionsv1alpha1.WorkerResource, shootProvider),
+				extensions.Id(extensionsv1alpha1.ExtensionResource, extensionType1),
+				extensions.Id(extensionsv1alpha1.OperatingSystemConfigResource, oscType),
+				extensions.Id(extensionsv1alpha1.ContainerRuntimeResource, containerRuntimeType),
+				extensions.Id(extensionsv1alpha1.DNSRecordResource, dnsProviderType1),
+				extensions.Id(extensionsv1alpha1.DNSRecordResource, dnsProviderType2),
+				extensions.Id(dnsv1alpha1.DNSProviderKind, dnsProviderType2),
+				extensions.Id(dnsv1alpha1.DNSProviderKind, dnsProviderType3),
+				extensions.Id(extensionsv1alpha1.ExtensionResource, extensionType2),
+			)))
+		})
+
+		It("should compute the correct list of required extensions (seed disables DNS)", func() {
+			seed.Spec.Settings.ShootDNS.Enabled = false
+
+			result := ComputeRequiredExtensions(shoot, seed, controllerRegistrationList, internalDomain, externalDomain)
+
+			Expect(result).To(Equal(sets.NewString(
+				extensions.Id(extensionsv1alpha1.BackupBucketResource, backupProvider),
+				extensions.Id(extensionsv1alpha1.BackupEntryResource, backupProvider),
+				extensions.Id(extensionsv1alpha1.ControlPlaneResource, seedProvider),
+				extensions.Id(extensionsv1alpha1.ControlPlaneResource, shootProvider),
+				extensions.Id(extensionsv1alpha1.InfrastructureResource, shootProvider),
+				extensions.Id(extensionsv1alpha1.NetworkResource, networkingType),
+				extensions.Id(extensionsv1alpha1.WorkerResource, shootProvider),
+				extensions.Id(extensionsv1alpha1.ExtensionResource, extensionType1),
+				extensions.Id(extensionsv1alpha1.OperatingSystemConfigResource, oscType),
+				extensions.Id(extensionsv1alpha1.ContainerRuntimeResource, containerRuntimeType),
+				extensions.Id(extensionsv1alpha1.ExtensionResource, extensionType2),
+			)))
+		})
+
+		It("should compute the correct list of required extensions (shoot explicitly disables globally enabled extension)", func() {
+			shoot.Spec.Extensions = append(shoot.Spec.Extensions, gardencorev1beta1.Extension{
+				Type:     extensionType2,
+				Disabled: pointer.Bool(true),
 			})
 
-			It("should compute the correct list of required extensions (no seed backup)", func() {
-				seed.Spec.Backup = nil
+			result := ComputeRequiredExtensions(shoot, seed, controllerRegistrationList, internalDomain, externalDomain)
 
-				result := ComputeRequiredExtensions(shoot, seed, controllerRegistrationList, internalDomain, externalDomain, true)
-
-				Expect(result).To(Equal(sets.NewString(
-					extensions.Id(extensionsv1alpha1.ControlPlaneResource, seedProvider),
-					extensions.Id(extensionsv1alpha1.ControlPlaneResource, shootProvider),
-					extensions.Id(extensionsv1alpha1.InfrastructureResource, shootProvider),
-					extensions.Id(extensionsv1alpha1.NetworkResource, networkingType),
-					extensions.Id(extensionsv1alpha1.WorkerResource, shootProvider),
-					extensions.Id(extensionsv1alpha1.ExtensionResource, extensionType1),
-					extensions.Id(extensionsv1alpha1.OperatingSystemConfigResource, oscType),
-					extensions.Id(extensionsv1alpha1.ContainerRuntimeResource, containerRuntimeType),
-					extensions.Id(extensionsv1alpha1.DNSRecordResource, dnsProviderType1),
-					extensions.Id(extensionsv1alpha1.DNSRecordResource, dnsProviderType2),
-					extensions.Id(dnsv1alpha1.DNSProviderKind, dnsProviderType2),
-					extensions.Id(dnsv1alpha1.DNSProviderKind, dnsProviderType3),
-					extensions.Id(extensionsv1alpha1.ExtensionResource, extensionType2),
-				)))
-			})
-
-			It("should compute the correct list of required extensions (seed disables DNS)", func() {
-				seed.Spec.Settings.ShootDNS.Enabled = false
-
-				result := ComputeRequiredExtensions(shoot, seed, controllerRegistrationList, internalDomain, externalDomain, true)
-
-				Expect(result).To(Equal(sets.NewString(
-					extensions.Id(extensionsv1alpha1.BackupBucketResource, backupProvider),
-					extensions.Id(extensionsv1alpha1.BackupEntryResource, backupProvider),
-					extensions.Id(extensionsv1alpha1.ControlPlaneResource, seedProvider),
-					extensions.Id(extensionsv1alpha1.ControlPlaneResource, shootProvider),
-					extensions.Id(extensionsv1alpha1.InfrastructureResource, shootProvider),
-					extensions.Id(extensionsv1alpha1.NetworkResource, networkingType),
-					extensions.Id(extensionsv1alpha1.WorkerResource, shootProvider),
-					extensions.Id(extensionsv1alpha1.ExtensionResource, extensionType1),
-					extensions.Id(extensionsv1alpha1.OperatingSystemConfigResource, oscType),
-					extensions.Id(extensionsv1alpha1.ContainerRuntimeResource, containerRuntimeType),
-					extensions.Id(extensionsv1alpha1.ExtensionResource, extensionType2),
-				)))
-			})
-
-			It("should compute the correct list of required extensions (shoot explicitly disables globally enabled extension)", func() {
-				shoot.Spec.Extensions = append(shoot.Spec.Extensions, gardencorev1beta1.Extension{
-					Type:     extensionType2,
-					Disabled: pointer.Bool(true),
-				})
-
-				result := ComputeRequiredExtensions(shoot, seed, controllerRegistrationList, internalDomain, externalDomain, true)
-
-				Expect(result).To(Equal(sets.NewString(
-					extensions.Id(extensionsv1alpha1.BackupBucketResource, backupProvider),
-					extensions.Id(extensionsv1alpha1.BackupEntryResource, backupProvider),
-					extensions.Id(extensionsv1alpha1.ControlPlaneResource, seedProvider),
-					extensions.Id(extensionsv1alpha1.ControlPlaneResource, shootProvider),
-					extensions.Id(extensionsv1alpha1.InfrastructureResource, shootProvider),
-					extensions.Id(extensionsv1alpha1.NetworkResource, networkingType),
-					extensions.Id(extensionsv1alpha1.WorkerResource, shootProvider),
-					extensions.Id(extensionsv1alpha1.ExtensionResource, extensionType1),
-					extensions.Id(extensionsv1alpha1.OperatingSystemConfigResource, oscType),
-					extensions.Id(extensionsv1alpha1.ContainerRuntimeResource, containerRuntimeType),
-					extensions.Id(extensionsv1alpha1.DNSRecordResource, dnsProviderType1),
-					extensions.Id(extensionsv1alpha1.DNSRecordResource, dnsProviderType2),
-					extensions.Id(dnsv1alpha1.DNSProviderKind, dnsProviderType2),
-					extensions.Id(dnsv1alpha1.DNSProviderKind, dnsProviderType3),
-				)))
-			})
+			Expect(result).To(Equal(sets.NewString(
+				extensions.Id(extensionsv1alpha1.BackupBucketResource, backupProvider),
+				extensions.Id(extensionsv1alpha1.BackupEntryResource, backupProvider),
+				extensions.Id(extensionsv1alpha1.ControlPlaneResource, seedProvider),
+				extensions.Id(extensionsv1alpha1.ControlPlaneResource, shootProvider),
+				extensions.Id(extensionsv1alpha1.InfrastructureResource, shootProvider),
+				extensions.Id(extensionsv1alpha1.NetworkResource, networkingType),
+				extensions.Id(extensionsv1alpha1.WorkerResource, shootProvider),
+				extensions.Id(extensionsv1alpha1.ExtensionResource, extensionType1),
+				extensions.Id(extensionsv1alpha1.OperatingSystemConfigResource, oscType),
+				extensions.Id(extensionsv1alpha1.ContainerRuntimeResource, containerRuntimeType),
+				extensions.Id(extensionsv1alpha1.DNSRecordResource, dnsProviderType1),
+				extensions.Id(extensionsv1alpha1.DNSRecordResource, dnsProviderType2),
+				extensions.Id(dnsv1alpha1.DNSProviderKind, dnsProviderType2),
+				extensions.Id(dnsv1alpha1.DNSProviderKind, dnsProviderType3),
+			)))
 		})
 	})
 })

--- a/plugin/pkg/global/extensionlabels/admission.go
+++ b/plugin/pkg/global/extensionlabels/admission.go
@@ -26,12 +26,10 @@ import (
 	admissioninitializer "github.com/gardener/gardener/pkg/apiserver/admission/initializer"
 	internalcoreinformers "github.com/gardener/gardener/pkg/client/core/informers/internalversion"
 	corelisters "github.com/gardener/gardener/pkg/client/core/listers/core/internalversion"
-	"github.com/gardener/gardener/pkg/features"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/admission"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 )
 
 const (
@@ -178,7 +176,7 @@ func addMetaDataLabelsSeed(seed *core.Seed) {
 		metav1.SetMetaDataLabel(&seed.ObjectMeta, v1beta1constants.LabelExtensionProviderTypePrefix+seed.Spec.Backup.Provider, "true")
 	}
 
-	if seed.Spec.DNS.Provider != nil && utilfeature.DefaultFeatureGate.Enabled(features.UseDNSRecords) {
+	if seed.Spec.DNS.Provider != nil {
 		metav1.SetMetaDataLabel(&seed.ObjectMeta, v1beta1constants.LabelExtensionDNSRecordTypePrefix+seed.Spec.DNS.Provider.Type, "true")
 	}
 }
@@ -205,9 +203,7 @@ func addMetaDataLabelsShoot(shoot *core.Shoot) {
 			if provider.Type == nil || *provider.Type == core.DNSUnmanaged {
 				continue
 			}
-			if utilfeature.DefaultFeatureGate.Enabled(features.UseDNSRecords) {
-				metav1.SetMetaDataLabel(&shoot.ObjectMeta, v1beta1constants.LabelExtensionDNSRecordTypePrefix+*provider.Type, "true")
-			}
+			metav1.SetMetaDataLabel(&shoot.ObjectMeta, v1beta1constants.LabelExtensionDNSRecordTypePrefix+*provider.Type, "true")
 		}
 	}
 	metav1.SetMetaDataLabel(&shoot.ObjectMeta, v1beta1constants.LabelExtensionProviderTypePrefix+shoot.Spec.Provider.Type, "true")

--- a/plugin/pkg/global/extensionvalidation/admission.go
+++ b/plugin/pkg/global/extensionvalidation/admission.go
@@ -26,7 +26,6 @@ import (
 	admissioninitializer "github.com/gardener/gardener/pkg/apiserver/admission/initializer"
 	externalcoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
 	corev1beta1listers "github.com/gardener/gardener/pkg/client/core/listers/core/v1beta1"
-	"github.com/gardener/gardener/pkg/features"
 
 	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 	"github.com/hashicorp/go-multierror"
@@ -36,7 +35,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/admission"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 )
 
 const (
@@ -270,11 +268,7 @@ func (e *ExtensionValidator) validateSeed(kindToTypesMap map[string]sets.String,
 
 	if spec.Ingress != nil && spec.DNS.Provider != nil {
 		provider := spec.DNS.Provider
-		if utilfeature.DefaultFeatureGate.Enabled(features.UseDNSRecords) {
-			requiredExtensions = append(requiredExtensions, requiredExtension{extensionsv1alpha1.DNSRecordResource, provider.Type, fmt.Sprintf("%s extension type: %s", message, field.NewPath("spec", "dns", "provider").Child("type"))})
-		} else {
-			requiredExtensions = append(requiredExtensions, requiredExtension{dnsv1alpha1.DNSProviderKind, provider.Type, fmt.Sprintf("%s dns type: %s", message, field.NewPath("spec", "dns", "provider").Child("type"))})
-		}
+		requiredExtensions = append(requiredExtensions, requiredExtension{extensionsv1alpha1.DNSRecordResource, provider.Type, fmt.Sprintf("%s extension type: %s", message, field.NewPath("spec", "dns", "provider").Child("type"))})
 	}
 
 	return requiredExtensions.areRegistered(kindToTypesMap)
@@ -300,7 +294,7 @@ func (e *ExtensionValidator) validateShoot(kindToTypesMap map[string]sets.String
 			}
 
 			requiredExtensions = append(requiredExtensions, requiredExtension{dnsv1alpha1.DNSProviderKind, *provider.Type, fmt.Sprintf("%s dns type: %s", message, field.NewPath("spec", "dns", "providers").Index(i).Child("type"))})
-			if provider.Primary != nil && *provider.Primary && utilfeature.DefaultFeatureGate.Enabled(features.UseDNSRecords) {
+			if provider.Primary != nil && *provider.Primary {
 				requiredExtensions = append(requiredExtensions, requiredExtension{extensionsv1alpha1.DNSRecordResource, *provider.Type, fmt.Sprintf("%s extension type: %s", message, field.NewPath("spec", "dns", "providers").Index(i).Child("type"))})
 			}
 		}

--- a/plugin/pkg/global/extensionvalidation/admission_test.go
+++ b/plugin/pkg/global/extensionvalidation/admission_test.go
@@ -22,7 +22,6 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	externalcoreinformers "github.com/gardener/gardener/pkg/client/core/informers/externalversions"
-	"github.com/gardener/gardener/pkg/features"
 	. "github.com/gardener/gardener/plugin/pkg/global/extensionvalidation"
 
 	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
@@ -30,7 +29,6 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apiserver/pkg/admission"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/utils/pointer"
 )
 
@@ -210,9 +208,7 @@ var _ = Describe("ExtensionValidator", func() {
 			DNSExtension = dnsv1alpha1.DNSProviderKind
 		)
 
-		if utilfeature.DefaultFeatureGate.Enabled(features.UseDNSRecords) {
-			DNSExtension = extensionsv1alpha1.DNSRecordResource
-		}
+		DNSExtension = extensionsv1alpha1.DNSRecordResource
 
 		var (
 			kindToTypes = []struct {

--- a/plugin/pkg/global/extensionvalidation/admission_test.go
+++ b/plugin/pkg/global/extensionvalidation/admission_test.go
@@ -205,10 +205,7 @@ var _ = Describe("ExtensionValidator", func() {
 					},
 				},
 			}
-			DNSExtension = dnsv1alpha1.DNSProviderKind
 		)
-
-		DNSExtension = extensionsv1alpha1.DNSRecordResource
 
 		var (
 			kindToTypes = []struct {
@@ -217,7 +214,7 @@ var _ = Describe("ExtensionValidator", func() {
 				{extensionsv1alpha1.ControlPlaneResource, seed.Spec.Provider.Type},
 				{extensionsv1alpha1.BackupBucketResource, seed.Spec.Backup.Provider},
 				{extensionsv1alpha1.BackupEntryResource, seed.Spec.Backup.Provider},
-				{DNSExtension, seed.Spec.DNS.Provider.Type},
+				{extensionsv1alpha1.DNSRecordResource, seed.Spec.DNS.Provider.Type},
 			}
 			registerAllExtensions = func() {
 				for _, registration := range kindToTypes {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
The `UseDNSRecords` feature gate in the apiserver, controllermanager and gardenlet has been promoted to `GA`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The `UseDNSRecords` feature gate in the `apiserver`, `controllermanager` and `gardenlet` has been promoted to `GA`. ```
