### PR TITLE
Add profiling for `GRM`

### DIFF
--- a/cmd/gardener-resource-manager/app/app.go
+++ b/cmd/gardener-resource-manager/app/app.go
@@ -49,7 +49,7 @@ var log = runtimelog.Log
 func NewResourceManagerCommand() *cobra.Command {
 	var (
 		managerOpts       = &resourcemanagercmd.ManagerOptions{}
-		profilingOpts     = &resourcemanagercmd.ProfilingOption{}
+		profilingOpts     = &resourcemanagercmd.ProfilingOptions{}
 		sourceClientOpts  = &resourcemanagercmd.SourceClientOptions{}
 		targetClusterOpts = &resourcemanagercmd.TargetClusterOptions{}
 

--- a/docs/monitoring/profiling.md
+++ b/docs/monitoring/profiling.md
@@ -113,3 +113,20 @@ For example:
 $ curl http://localhost:8080/debug/pprof/heap > /tmp/heap-seed-admission-controller
 $ go tool pprof /tmp/heap-seed-admission-controller
 ```
+
+## gardener-resource-manager
+gardener-resource-manager provides the following flags for enabling profiling handlers (disabled by default):
+
+```
+--contention-profiling    Enable lock contention profiling, if profiling is enabled
+--profiling               Enable profiling via web interface host:port/debug/pprof/
+```
+
+The handlers are served on the same port as configured in the `--metrics-bind-address` flag (defaults to `":8080"`) via HTTP.
+
+For example:
+
+```bash
+$ curl http://localhost:8080/debug/pprof/heap > /tmp/heap-resource-manager
+$ go tool pprof /tmp/heap-resource-manager
+```

--- a/docs/monitoring/profiling.md
+++ b/docs/monitoring/profiling.md
@@ -96,9 +96,9 @@ $ curl http://localhost:2723/debug/pprof/heap > /tmp/heap-admission-controller
 $ go tool pprof /tmp/heap-admission-controller
 ```
 
-## gardener-seed-admission-controller
+## gardener-seed-admission-controller, gardener-resource-manager
 
-gardener-seed-admission-controller provides the following flags for enabling profiling handlers (disabled by default):
+gardener-seed-admission-controller and gardener-resource-manager provides the following flags for enabling profiling handlers (disabled by default):
 
 ```
 --contention-profiling    Enable lock contention profiling, if profiling is enabled
@@ -107,26 +107,10 @@ gardener-seed-admission-controller provides the following flags for enabling pro
 
 The handlers are served on the same port as configured in the `--metrics-bind-address` flag (defaults to `":8080"`) via HTTP.
 
-For example:
+For example (gardener-seed-admission-controller):
 
 ```bash
 $ curl http://localhost:8080/debug/pprof/heap > /tmp/heap-seed-admission-controller
 $ go tool pprof /tmp/heap-seed-admission-controller
 ```
 
-## gardener-resource-manager
-gardener-resource-manager provides the following flags for enabling profiling handlers (disabled by default):
-
-```
---contention-profiling    Enable lock contention profiling, if profiling is enabled
---profiling               Enable profiling via web interface host:port/debug/pprof/
-```
-
-The handlers are served on the same port as configured in the `--metrics-bind-address` flag (defaults to `":8080"`) via HTTP.
-
-For example:
-
-```bash
-$ curl http://localhost:8080/debug/pprof/heap > /tmp/heap-resource-manager
-$ go tool pprof /tmp/heap-resource-manager
-```

--- a/pkg/resourcemanager/cmd/profiling.go
+++ b/pkg/resourcemanager/cmd/profiling.go
@@ -16,6 +16,7 @@ package cmd
 
 import "github.com/spf13/pflag"
 
+// ProfilingOption contains options needed to enable profiling.
 type ProfilingOption struct {
 	// EnableProfiling enables profiling via web interface host:port/debug/pprof/.
 	EnableProfiling bool

--- a/pkg/resourcemanager/cmd/profiling.go
+++ b/pkg/resourcemanager/cmd/profiling.go
@@ -16,8 +16,8 @@ package cmd
 
 import "github.com/spf13/pflag"
 
-// ProfilingOption contains options needed to enable profiling.
-type ProfilingOption struct {
+// ProfilingOptions contains options needed to enable profiling.
+type ProfilingOptions struct {
 	// EnableProfiling enables profiling via web interface host:port/debug/pprof/.
 	EnableProfiling bool
 	// EnableContentionProfiling enable lock contention profiling, if profiling is enabled
@@ -25,7 +25,7 @@ type ProfilingOption struct {
 }
 
 // AddFlags adds the needed command line flags to the given FlagSet.
-func (p *ProfilingOption) AddFlags(fs *pflag.FlagSet) {
+func (p *ProfilingOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&p.EnableProfiling, "profiling", false, "Enable profiling via web interface host:port/debug/pprof/")
 	fs.BoolVar(&p.EnableContentionProfiling, "contention-profiling", false, "Enable lock contention profiling, if profiling is enabled")
 }

--- a/pkg/resourcemanager/cmd/profiling.go
+++ b/pkg/resourcemanager/cmd/profiling.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import "github.com/spf13/pflag"
+
+type ProfilingOption struct {
+	// EnableProfiling enables profiling via web interface host:port/debug/pprof/.
+	EnableProfiling bool
+	// EnableContentionProfiling enable lock contention profiling, if profiling is enabled
+	EnableContentionProfiling bool
+}
+
+// AddFlags adds the needed command line flags to the given FlagSet.
+func (p *ProfilingOption) AddFlags(fs *pflag.FlagSet) {
+	fs.BoolVar(&p.EnableProfiling, "profiling", false, "Enable profiling via web interface host:port/debug/pprof/")
+	fs.BoolVar(&p.EnableContentionProfiling, "contention-profiling", false, "Enable lock contention profiling, if profiling is enabled")
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity ops-productivity
/kind enhancement

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/4567

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
gardener-resource-manager now supports enabling profiling handlers. See this [document](https://github.com/gardener/gardener/blob/master/docs/monitoring/profiling.md) for more details.
```
