### PR TITLE
[GEP-18] Adapt seed cluster CA secret to new secrets manager

### DIFF
--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -15,6 +15,9 @@
 package constants
 
 const (
+	// SecretManagerIdentityGardenlet is the identity for the secret manager used inside gardenlet.
+	SecretManagerIdentityGardenlet = "gardenlet"
+
 	// SecretNameCACluster is a constant for the name of a Kubernetes secret object that contains the CA
 	// certificate of a shoot cluster.
 	SecretNameCACluster = "ca"
@@ -33,6 +36,10 @@ const (
 	// SecretNameCAVPN is a constant for the name of a Kubernetes secret object that contains the CA
 	// certificate of the VPN components of a shoot cluster.
 	SecretNameCAVPN = "ca-vpn"
+	// SecretNameCASeed is a constant for the name of a Kubernetes secret object that contains the CA
+	// certificate generated for a seed cluster.
+	SecretNameCASeed = "ca-seed"
+
 	// SecretNameCloudProvider is a constant for the name of a Kubernetes secret object that contains the provider
 	// specific credentials that shall be used to create/delete the shoot.
 	SecretNameCloudProvider = "cloudprovider"

--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -37,12 +37,8 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-const (
-	// DefaultInterval is the default interval for retry operations.
-	DefaultInterval = 5 * time.Second
-	// SecretManagerIdentityGardenlet is the identity for the secret manager used inside gardenlet.
-	SecretManagerIdentityGardenlet = "gardenlet"
-)
+// DefaultInterval is the default interval for retry operations.
+const DefaultInterval = 5 * time.Second
 
 // New takes an operation object <o> and creates a new Botanist object. It checks whether the given Shoot DNS
 // domain is covered by a default domain, and if so, it sets the <DefaultDomainSecret> attribute on the Botanist
@@ -73,7 +69,7 @@ func New(ctx context.Context, o *operation.Operation) (*Botanist, error) {
 		return nil, err
 	}
 
-	o.SecretsManager = secretsmanager.New(logf.Log.WithName("secretsmanager"), b.K8sSeedClient.Client(), b.Shoot.SeedNamespace, SecretManagerIdentityGardenlet, b.lastSecretRotationStartTimes())
+	o.SecretsManager = secretsmanager.New(logf.Log.WithName("secretsmanager"), b.K8sSeedClient.Client(), b.Shoot.SeedNamespace, v1beta1constants.SecretManagerIdentityGardenlet, b.lastSecretRotationStartTimes())
 
 	// extension components
 	o.Shoot.Components.Extensions.ContainerRuntime = b.DefaultContainerRuntime()

--- a/pkg/operation/seed/components.go
+++ b/pkg/operation/seed/components.go
@@ -131,7 +131,7 @@ func defaultGardenerResourceManager(c client.Client, imageVector imagevector.Ima
 	})
 
 	gardenerResourceManager.SetSecrets(resourcemanager.Secrets{
-		ServerCA: component.Secret{Name: caSeed, Checksum: utils.ComputeSecretChecksum(serverCASecret.Data), Data: serverCASecret.Data},
+		ServerCA: component.Secret{Name: v1beta1constants.SecretNameCASeed, Checksum: utils.ComputeSecretChecksum(serverCASecret.Data), Data: serverCASecret.Data},
 		Server:   component.Secret{Name: resourcemanager.SecretNameServer, Checksum: utils.ComputeSecretChecksum(serverSecret.Data)},
 	})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement
/merge squash

**What this PR does / why we need it**:
This PR adapts the seed cluster's CA secret to the new secrets manager.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/3292#issuecomment-1036058890

/invite @timebertt @BeckerMax 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
NONE
```
