### PR TITLE
[GEP-18] Adapt `kube-controller-manager-server` secret to new secrets manager

### DIFF
--- a/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager_suite_test.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager_suite_test.go
@@ -17,6 +17,9 @@ package kubecontrollermanager_test
 import (
 	"testing"
 
+	secretutils "github.com/gardener/gardener/pkg/utils/secrets"
+	"github.com/gardener/gardener/pkg/utils/test"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -25,3 +28,7 @@ func TestKubeControllerManager(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Botanist Component KubeControllerManager Suite")
 }
+
+var _ = BeforeSuite(func() {
+	DeferCleanup(test.WithVar(&secretutils.GenerateKey, secretutils.FakeGenerateKey))
+})

--- a/pkg/operation/botanist/component/kubecontrollermanager/monitoring.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/monitoring.go
@@ -72,7 +72,7 @@ relabel_configs:
   - __meta_kubernetes_service_name
   - __meta_kubernetes_endpoint_port_name
   action: keep
-  regex: ` + ServiceName + `;` + portNameMetrics + `
+  regex: ` + serviceName + `;` + portNameMetrics + `
 - action: labelmap
   regex: __meta_kubernetes_service_label_(.+)
 - source_labels: [ __meta_kubernetes_pod_name ]

--- a/pkg/operation/botanist/component/kubescheduler/kube_scheduler_suite_test.go
+++ b/pkg/operation/botanist/component/kubescheduler/kube_scheduler_suite_test.go
@@ -17,6 +17,9 @@ package kubescheduler_test
 import (
 	"testing"
 
+	secretutils "github.com/gardener/gardener/pkg/utils/secrets"
+	"github.com/gardener/gardener/pkg/utils/test"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -25,3 +28,7 @@ func TestKubeScheduler(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Botanist Component KubeScheduler Suite")
 }
+
+var _ = BeforeSuite(func() {
+	DeferCleanup(test.WithVar(&secretutils.GenerateKey, secretutils.FakeGenerateKey))
+})

--- a/pkg/operation/botanist/kubecontrollermanager.go
+++ b/pkg/operation/botanist/kubecontrollermanager.go
@@ -76,7 +76,6 @@ func (b *Botanist) DeployKubeControllerManager(ctx context.Context) error {
 	b.Shoot.Components.ControlPlane.KubeControllerManager.SetSecrets(kubecontrollermanager.Secrets{
 		CA:                component.Secret{Name: v1beta1constants.SecretNameCACluster, Checksum: b.LoadCheckSum(v1beta1constants.SecretNameCACluster)},
 		ServiceAccountKey: component.Secret{Name: v1beta1constants.SecretNameServiceAccountKey, Checksum: b.LoadCheckSum(v1beta1constants.SecretNameServiceAccountKey)},
-		Server:            component.Secret{Name: kubecontrollermanager.SecretNameServer, Checksum: b.LoadCheckSum(kubecontrollermanager.SecretNameServer)},
 	})
 
 	return b.Shoot.Components.ControlPlane.KubeControllerManager.Deploy(ctx)

--- a/pkg/operation/botanist/kubecontrollermanager_test.go
+++ b/pkg/operation/botanist/kubecontrollermanager_test.go
@@ -100,14 +100,11 @@ var _ = Describe("KubeControllerManager", func() {
 			kubeAPIServer         *mockkubeapiserver.MockInterface
 			kubeControllerManager *mockkubecontrollermanager.MockInterface
 
-			secretNameServer            = "kube-controller-manager-server"
 			secretNameCA                = "ca"
 			secretNameServiceAccountKey = "service-account-key"
-			checksumServer              = "34"
 			checksumCA                  = "56"
 			checksumServiceAccountKey   = "78"
 			secrets                     = kubecontrollermanager.Secrets{
-				Server:            component.Secret{Name: secretNameServer, Checksum: checksumServer},
 				CA:                component.Secret{Name: secretNameCA, Checksum: checksumCA},
 				ServiceAccountKey: component.Secret{Name: secretNameServiceAccountKey, Checksum: checksumServiceAccountKey},
 			}
@@ -118,7 +115,6 @@ var _ = Describe("KubeControllerManager", func() {
 			kubeControllerManager = mockkubecontrollermanager.NewMockInterface(ctrl)
 
 			botanist.K8sSeedClient = kubernetesClient
-			botanist.StoreCheckSum(secretNameServer, checksumServer)
 			botanist.StoreCheckSum(secretNameCA, checksumCA)
 			botanist.StoreCheckSum(secretNameServiceAccountKey, checksumServiceAccountKey)
 			botanist.Shoot = &shootpkg.Shoot{

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -327,6 +327,7 @@ func (b *Botanist) GenerateAndSaveSecrets(ctx context.Context) error {
 			// adapted.
 			// "prometheus",
 			"kube-scheduler-server",
+			"kube-controller-manager-server",
 		} {
 			gardenerResourceDataList.Delete(name)
 		}

--- a/pkg/operation/botanist/wanted_secrets.go
+++ b/pkg/operation/botanist/wanted_secrets.go
@@ -23,7 +23,6 @@ import (
 	"github.com/gardener/gardener/pkg/operation/botanist/component/dependencywatchdog"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/etcd"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/kubeapiserver"
-	"github.com/gardener/gardener/pkg/operation/botanist/component/kubecontrollermanager"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/metricsserver"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/resourcemanager"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/vpnseedserver"
@@ -53,7 +52,6 @@ func (b *Botanist) generateWantedSecretConfigs(certificateAuthorities map[string
 			b.Shoot.GetInfo().Status.TechnicalID,
 		}, kubernetes.DNSNamesForService("kubernetes", metav1.NamespaceDefault)...)
 
-		kubeControllerManagerCertDNSNames   = kubernetes.DNSNamesForService(kubecontrollermanager.ServiceName, b.Shoot.SeedNamespace)
 		gardenerResourceManagerCertDNSNames = kubernetes.DNSNamesForService(resourcemanager.ServiceName, b.Shoot.SeedNamespace)
 
 		etcdCertDNSNames = append(
@@ -115,20 +113,6 @@ func (b *Botanist) generateWantedSecretConfigs(certificateAuthorities map[string
 
 				CertType:  secrets.ClientCert,
 				SigningCA: certificateAuthorities[v1beta1constants.SecretNameCAFrontProxy],
-			},
-		},
-
-		// Secret definition for kube-controller-manager server
-		&secrets.ControlPlaneSecretConfig{
-			Name: kubecontrollermanager.SecretNameServer,
-			CertificateSecretConfig: &secrets.CertificateSecretConfig{
-				CommonName:   v1beta1constants.DeploymentNameKubeControllerManager,
-				Organization: nil,
-				DNSNames:     kubeControllerManagerCertDNSNames,
-				IPAddresses:  nil,
-
-				CertType:  secrets.ServerCert,
-				SigningCA: certificateAuthorities[v1beta1constants.SecretNameCACluster],
 			},
 		},
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement
/merge squash

**What this PR does / why we need it**:
This PR adapts the `kube-controller-manager-server` secret to new secrets manager.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/3292#issuecomment-1036058890

**Special notes for your reviewer**:
Similar to https://github.com/gardener/gardener/pull/5503/commits/3cce8f4d27cdb9b6c1c2509b23eca6014944370d#diff-255c9a6a892cf804326019de8721e7e509842e90b6190e30bac0b377d876bac6

/invite @timebertt @BeckerMax 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
