### PR TITLE
Add PriorityClass to `gardener-seed-admission-controller` and `gardener-resource-manager`

### DIFF
--- a/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller.go
+++ b/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller.go
@@ -40,6 +40,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	policyv1beta1 "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -171,6 +172,16 @@ func (g *gardenerSeedAdmissionController) Deploy(ctx context.Context) error {
 			}},
 		}
 
+		priorityClass = &schedulingv1.PriorityClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   Name,
+				Labels: getLabels(),
+			},
+			Value:         500,
+			GlobalDefault: false,
+			Description:   "This class is used to ensure that the gardener-seed-admission-controller has a high priority and is not preempted in favor of other pods.",
+		}
+
 		service = &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      Name,
@@ -244,6 +255,7 @@ func (g *gardenerSeedAdmissionController) Deploy(ctx context.Context) error {
 								},
 							},
 						},
+						PriorityClassName:  priorityClass.Name,
 						ServiceAccountName: serviceAccount.Name,
 						Containers: []corev1.Container{{
 							Name:            containerName,
@@ -359,6 +371,7 @@ func (g *gardenerSeedAdmissionController) Deploy(ctx context.Context) error {
 		serviceAccount,
 		clusterRole,
 		clusterRoleBinding,
+		priorityClass,
 		service,
 		secret,
 		deployment,

--- a/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller_test.go
+++ b/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller_test.go
@@ -127,6 +127,20 @@ subjects:
   name: gardener-seed-admission-controller
   namespace: shoot--foo--bar
 `
+
+		priorityClassYAML = `apiVersion: scheduling.k8s.io/v1
+description: This class is used to ensure that the gardener-seed-admission-controller
+  has a high priority and is not preempted in favor of other pods.
+kind: PriorityClass
+metadata:
+  creationTimestamp: null
+  labels:
+    app: gardener
+    role: seed-admission-controller
+  name: gardener-seed-admission-controller
+value: 500
+`
+
 		deploymentYAML = `apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -208,6 +222,7 @@ spec:
         - mountPath: /srv/gardener-seed-admission-controller
           name: gardener-seed-admission-controller-tls
           readOnly: true
+      priorityClassName: gardener-seed-admission-controller
       serviceAccountName: gardener-seed-admission-controller
       volumes:
       - name: gardener-seed-admission-controller-tls
@@ -444,6 +459,7 @@ status: {}
 				"clusterrolebinding____gardener-seed-admission-controller.yaml":                       []byte(clusterRoleBindingYAML),
 				"deployment__shoot--foo--bar__gardener-seed-admission-controller.yaml":                []byte(deploymentYAML),
 				"poddisruptionbudget__shoot--foo--bar__gardener-seed-admission-controller.yaml":       []byte(pdbYAML),
+				"priorityclass____gardener-seed-admission-controller.yaml":                            []byte(priorityClassYAML),
 				"secret__shoot--foo--bar__" + secretName + ".yaml":                                    []byte(secretYAML),
 				"service__shoot--foo--bar__gardener-seed-admission-controller.yaml":                   []byte(serviceYAML),
 				"serviceaccount__shoot--foo--bar__gardener-seed-admission-controller.yaml":            []byte(serviceAccountYAML),


### PR DESCRIPTION
/area quality
/kind enhancement
/squash

Part of https://github.com/gardener/gardener/issues/5634

**Special notes for your reviewer**:
I picked priority `500` for gardener-seed-admission-controller and `1000` for gardener-resource-manager but I am open for adjustments/suggestions.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
gardener-seed-admission-controller and garden/gardener-resource-manager components do now have a `PriorityClass` to make sure that they have high priority in the scheduling queue and that they are not preempted (evicted) in favour of other Pods.
```
