### PR TITLE
[ReversedVPN]: Add several panels to identify issues with DNS cache host limit faster.

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
@@ -272,6 +272,8 @@ allowedMetrics:
   - envoy_dns_cache_dynamic_forward_proxy_cache_config_dns_query_attempt
   - envoy_dns_cache_dynamic_forward_proxy_cache_config_dns_query_failure
   - envoy_dns_cache_dynamic_forward_proxy_cache_config_dns_query_success
+  - envoy_dns_cache_dynamic_forward_proxy_cache_config_host_overflow
+  - envoy_dns_cache_dynamic_forward_proxy_cache_config_num_hosts
   - envoy_http_downstream_cx_rx_bytes_total
   - envoy_http_downstream_cx_total
   - envoy_http_downstream_cx_tx_bytes_total

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/vpn-seed-server/envoy-proxy-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/vpn-seed-server/envoy-proxy-dashboard.json
@@ -1860,6 +1860,103 @@
       "targets": [
         {
           "exemplar": true,
+          "expr": "sum(rate(envoy_http_downstream_rq_xx{envoy_http_conn_manager_prefix=\"ingress_http\", envoy_response_code_class=\"4\",job=\"reversed-vpn-envoy-side-car\"}[$__rate_interval]))/ sum(rate(\nenvoy_http_downstream_rq_xx{envoy_http_conn_manager_prefix=\"ingress_http\",job=\"reversed-vpn-envoy-side-car\"}[$__rate_interval]))",
+          "interval": "",
+          "legendFormat": "4xx error rate",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Downstream client error rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:425",
+          "format": "percent",
+          "label": null,
+          "logBase": 1,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:426",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "This graph shows the client error rate of the reversed vpn server envoy proxy sidecar container.",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 76
+      },
+      "hiddenSeries": false,
+      "id": 49,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.11",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
           "expr": "sum(rate(envoy_cluster_external_upstream_rq_xx{envoy_cluster_name=\"dynamic_forward_proxy_cluster\", envoy_response_code_class=\"4\",job=\"reversed-vpn-envoy-side-car\"}[$__rate_interval]))/ sum(rate(\nenvoy_cluster_external_upstream_rq_xx{envoy_cluster_name=\"dynamic_forward_proxy_cluster\",job=\"reversed-vpn-envoy-side-car\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "4xx error rate",
@@ -1870,7 +1967,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Client error rate",
+      "title": "Upstream client error rate",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1925,11 +2022,108 @@
       "gridPos": {
         "h": 9,
         "w": 12,
-        "x": 12,
-        "y": 76
+        "x": 0,
+        "y": 85
       },
       "hiddenSeries": false,
       "id": 3,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.11",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(envoy_http_downstream_rq_xx{envoy_http_conn_manager_prefix=\"ingress_http\", envoy_response_code_class=\"5\",job=\"reversed-vpn-envoy-side-car\"}[$__rate_interval]))/ sum(rate(\nenvoy_http_downstream_rq_xx{envoy_http_conn_manager_prefix=\"ingress_http\",job=\"reversed-vpn-envoy-side-car\"}[$__rate_interval]))",
+          "interval": "",
+          "legendFormat": "5xx error rate",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Downstream server error rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:425",
+          "format": "percentunit",
+          "label": null,
+          "logBase": 1,
+          "max": "1",
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:426",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "This graph shows the server error rate of the reversed vpn server envoy proxy sidecar container.",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 85
+      },
+      "hiddenSeries": false,
+      "id": 50,
       "legend": {
         "avg": false,
         "current": false,
@@ -1967,7 +2161,104 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Server error rate",
+      "title": "Upstream server error rate",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:425",
+          "format": "percent",
+          "label": null,
+          "logBase": 1,
+          "max": "100",
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:426",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "This graph shows the successful response rate of the reversed vpn server envoy proxy sidecar container.",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 94
+      },
+      "hiddenSeries": false,
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.11",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(envoy_http_downstream_rq_xx{envoy_http_conn_manager_prefix=\"ingress_http\", envoy_response_code_class=\"2\",job=\"reversed-vpn-envoy-side-car\"}[$__rate_interval]))/ sum(rate(\nenvoy_http_downstream_rq_xx{envoy_http_conn_manager_prefix=\"ingress_http\",job=\"reversed-vpn-envoy-side-car\"}[$__rate_interval]))",
+          "interval": "",
+          "legendFormat": "2xx successful response rate",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Downstream successful response rate",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -2022,11 +2313,11 @@
       "gridPos": {
         "h": 9,
         "w": 12,
-        "x": 0,
-        "y": 85
+        "x": 12,
+        "y": 94
       },
       "hiddenSeries": false,
-      "id": 2,
+      "id": 51,
       "legend": {
         "avg": false,
         "current": false,
@@ -2064,7 +2355,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Successful response rate",
+      "title": "Upstream successful response rate",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -2110,7 +2401,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 94
+        "y": 103
       },
       "id": 30,
       "panels": [],
@@ -2133,7 +2424,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 95
+        "y": 104
       },
       "hiddenSeries": false,
       "id": 32,
@@ -2229,7 +2520,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 95
+        "y": 104
       },
       "hiddenSeries": false,
       "id": 34,
@@ -2325,7 +2616,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 103
+        "y": 112
       },
       "hiddenSeries": false,
       "id": 33,
@@ -2366,7 +2657,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "Successful dns queries",
+      "title": "Successful DNS queries",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -2406,13 +2697,207 @@
       }
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 112
+      },
+      "hiddenSeries": false,
+      "id": 47,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.11",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "envoy_dns_cache_dynamic_forward_proxy_cache_config_num_hosts{job=\"reversed-vpn-envoy-side-car\"}",
+          "interval": "",
+          "legendFormat": "hosts",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "DNS Cache Hosts",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1384",
+          "decimals": 0,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1385",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 120
+      },
+      "hiddenSeries": false,
+      "id": 48,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.11",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "envoy_dns_cache_dynamic_forward_proxy_cache_config_host_overflow{job=\"reversed-vpn-envoy-side-car\"}",
+          "interval": "",
+          "legendFormat": "host overflows",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "DNS Cache Host Overflows",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:119",
+          "decimals": 0,
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "$$hashKey": "object:120",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
       "collapsed": false,
       "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 111
+        "y": 128
       },
       "id": 36,
       "panels": [],
@@ -2435,7 +2920,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 112
+        "y": 129
       },
       "hiddenSeries": false,
       "id": 38,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area monitoring
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
[ReversedVPN]: Add several panels to identify issues with DNS cache host limit faster.

The DNS cache of the vpn-seed-server's envoy proxy side car has a host limit. To help identify
scenarios faster, in which this limit is hit, the reversed vpn's dashboard is extended by several
panels. Now, both upstream and downstream request rates are visible. In addition to that,
the current number of hosts in the DNS cache is shown together with the amount of host overflows.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add several panels to identify issues with DNS cache host limit faster.
```

Screenshots:
![image](https://user-images.githubusercontent.com/30600170/160138471-21d9a1b5-9f69-4bb1-a955-d3500784cfdb.png)
![image](https://user-images.githubusercontent.com/30600170/160138601-885b8c7b-5769-4f98-bbd8-dc08fbe8fc63.png)

/cc @DockToFuture @istvanballok @wyb1 