### PR TITLE
[GEP-18] Drop unused `prometheus-kubelet` secret

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
@@ -113,8 +113,6 @@ spec:
             cpu: 50m
             memory: 350Mi
         volumeMounts:
-        - mountPath: /srv/kubernetes/prometheus-kubelet
-          name: prometheus-kubelet
         - mountPath: /srv/kubernetes/etcd/ca
           name: ca-etcd
         - mountPath: /srv/kubernetes/etcd/client
@@ -214,9 +212,6 @@ spec:
       - name: shoot-access
         secret:
           secretName: shoot-access-prometheus
-      - name: prometheus-kubelet
-        secret:
-          secretName: prometheus-kubelet
       - name: blackbox-exporter-config-prometheus
         configMap:
           name: blackbox-exporter-config-prometheus

--- a/pkg/operation/botanist/monitoring.go
+++ b/pkg/operation/botanist/monitoring.go
@@ -300,6 +300,11 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 		return err
 	}
 
+	// TODO(rfranzke): Remove in a future release.
+	if err := kutil.DeleteObject(ctx, b.K8sSeedClient.Client(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "prometheus-kubelet", Namespace: b.Shoot.SeedNamespace}}); err != nil {
+		return err
+	}
+
 	// Check if we want to deploy an alertmanager into the shoot namespace.
 	if b.Shoot.WantsAlertmanager {
 		var (

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -326,6 +326,7 @@ func (b *Botanist) GenerateAndSaveSecrets(ctx context.Context) error {
 			// TODO(rfranzke): Uncomment this in a future release once all monitoring configurations of extensions have been
 			// adapted.
 			// "prometheus",
+			"prometheus-kubelet",
 			"kube-scheduler-server",
 		} {
 			gardenerResourceDataList.Delete(name)

--- a/pkg/operation/botanist/wanted_secrets.go
+++ b/pkg/operation/botanist/wanted_secrets.go
@@ -166,20 +166,6 @@ func (b *Botanist) generateWantedSecretConfigs(certificateAuthorities map[string
 			}},
 		},
 
-		// Secret definition for prometheus to kubelets communication
-		&secrets.ControlPlaneSecretConfig{
-			Name: "prometheus-kubelet",
-			CertificateSecretConfig: &secrets.CertificateSecretConfig{
-				CommonName:   "gardener.cloud:monitoring:prometheus",
-				Organization: []string{"gardener.cloud:monitoring"},
-				DNSNames:     nil,
-				IPAddresses:  nil,
-
-				CertType:  secrets.ClientCert,
-				SigningCA: certificateAuthorities[v1beta1constants.SecretNameCAKubelet],
-			},
-		},
-
 		// Secret definition for monitoring
 		&secrets.BasicAuthSecretConfig{
 			Name:   common.MonitoringIngressCredentials,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement
/merge squash

**What this PR does / why we need it**:
This PR drops the unused `prometheus-kubelet` secret.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/3292#issuecomment-1036058890

**Special notes for your reviewer**:
/invite @timebertt @BeckerMax 
/invite @wyb1 @istvanballok 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
