### PR TITLE
[GEP-18] Adapt `loki-tls` secret (for ingress) to new secrets manager

### DIFF
--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -330,6 +330,7 @@ func (b *Botanist) GenerateAndSaveSecrets(ctx context.Context) error {
 			"kube-scheduler-server",
 			"kube-controller-manager-server",
 			"metrics-server",
+			"loki-tls",
 		} {
 			gardenerResourceDataList.Delete(name)
 		}

--- a/pkg/operation/botanist/wanted_secrets.go
+++ b/pkg/operation/botanist/wanted_secrets.go
@@ -243,22 +243,6 @@ func (b *Botanist) generateWantedSecretConfigs(certificateAuthorities map[string
 		},
 	}
 
-	if b.isShootNodeLoggingEnabled() {
-		// Secret definition for loki (ingress)
-		secretList = append(secretList, &secrets.CertificateSecretConfig{
-			Name: common.LokiTLS,
-
-			CommonName:   b.ComputeLokiHost(),
-			Organization: []string{"gardener.cloud:monitoring:ingress"},
-			DNSNames:     b.ComputeLokiHosts(),
-			IPAddresses:  nil,
-
-			CertType:  secrets.ServerCert,
-			SigningCA: certificateAuthorities[v1beta1constants.SecretNameCACluster],
-			Validity:  &endUserCrtValidity,
-		})
-	}
-
 	if gardencorev1beta1helper.SeedSettingDependencyWatchdogProbeEnabled(b.Seed.GetInfo().Spec.Settings) {
 		// Secret definitions for dependency-watchdog-internal and external probes
 		secretList = append(secretList, &secrets.ControlPlaneSecretConfig{

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -68,8 +68,6 @@ const (
 	GrafanaTLS = "grafana-tls"
 	// PrometheusTLS is the name of the secret resource which holds the TLS certificate for Prometheus.
 	PrometheusTLS = "prometheus-tls"
-	// LokiTLS is the name of the secret resource which holds the TLS certificate for Loki.
-	LokiTLS = "loki-tls"
 
 	// EndUserCrtValidity is the time period a user facing certificate is valid.
 	EndUserCrtValidity = 730 * 24 * time.Hour // ~2 years, see https://support.apple.com/en-us/HT210176
@@ -97,5 +95,4 @@ var IngressTLSSecretNames = []string{
 	AlertManagerTLS,
 	GrafanaTLS,
 	PrometheusTLS,
-	LokiTLS,
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement
/merge squash

**What this PR does / why we need it**:
This PR adapts the `loki-tls` secret to new secrets manager.
Note that this PR drops the auto-renewal functionality in case this loki server certificate is about to expire. This will be contributed as a separate PR to the secrets manager so that it can handle this centrally without the users/clients to care.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/3292#issuecomment-1036058890

/invite @timebertt @BeckerMax 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
