### PR TITLE
Implement the core.Object interface for SecretBinding types

### DIFF
--- a/pkg/apis/core/types_secretbinding.go
+++ b/pkg/apis/core/types_secretbinding.go
@@ -38,6 +38,15 @@ type SecretBinding struct {
 	Provider *SecretBindingProvider
 }
 
+// GetProviderType gets the type of the provider.
+func (sb *SecretBinding) GetProviderType() string {
+	if sb.Provider == nil {
+		return ""
+	}
+
+	return sb.Provider.Type
+}
+
 // SecretBindingProvider defines the provider type of the SecretBinding.
 type SecretBindingProvider struct {
 	// Type is the type of the provider.

--- a/pkg/apis/core/types_secretbinding_test.go
+++ b/pkg/apis/core/types_secretbinding_test.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package core_test
+
+import (
+	gardencore "github.com/gardener/gardener/pkg/apis/core"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("SecretBinding", func() {
+	DescribeTable("#GetProviderType",
+		func(secretBinding *gardencore.SecretBinding, expected string) {
+			actual := secretBinding.GetProviderType()
+			Expect(actual).To(Equal(expected))
+		},
+		Entry("when provider is nil", &gardencore.SecretBinding{Provider: nil}, ""),
+		Entry("when provider is set", &gardencore.SecretBinding{Provider: &gardencore.SecretBindingProvider{Type: "foo"}}, "foo"),
+	)
+})

--- a/pkg/apis/core/v1alpha1/types_secretbinding.go
+++ b/pkg/apis/core/v1alpha1/types_secretbinding.go
@@ -41,6 +41,15 @@ type SecretBinding struct {
 	Provider *SecretBindingProvider `json:"provider,omitempty" protobuf:"bytes,4,opt,name=provider"`
 }
 
+// GetProviderType gets the type of the provider.
+func (sb *SecretBinding) GetProviderType() string {
+	if sb.Provider == nil {
+		return ""
+	}
+
+	return sb.Provider.Type
+}
+
 // SecretBindingProvider defines the provider type of the SecretBinding.
 type SecretBindingProvider struct {
 	// Type is the type of the provider.

--- a/pkg/apis/core/v1alpha1/types_secretbinding_test.go
+++ b/pkg/apis/core/v1alpha1/types_secretbinding_test.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1alpha1_test
+
+import (
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("SecretBinding", func() {
+	DescribeTable("#GetProviderType",
+		func(secretBinding *gardencorev1alpha1.SecretBinding, expected string) {
+			actual := secretBinding.GetProviderType()
+			Expect(actual).To(Equal(expected))
+		},
+		Entry("when provider is nil", &gardencorev1alpha1.SecretBinding{Provider: nil}, ""),
+		Entry("when provider is set", &gardencorev1alpha1.SecretBinding{Provider: &gardencorev1alpha1.SecretBindingProvider{Type: "foo"}}, "foo"),
+	)
+})

--- a/pkg/apis/core/v1beta1/types_secretbinding.go
+++ b/pkg/apis/core/v1beta1/types_secretbinding.go
@@ -41,6 +41,15 @@ type SecretBinding struct {
 	Provider *SecretBindingProvider `json:"provider,omitempty" protobuf:"bytes,4,opt,name=provider"`
 }
 
+// GetProviderType gets the type of the provider.
+func (sb *SecretBinding) GetProviderType() string {
+	if sb.Provider == nil {
+		return ""
+	}
+
+	return sb.Provider.Type
+}
+
 // SecretBindingProvider defines the provider type of the SecretBinding.
 type SecretBindingProvider struct {
 	// Type is the type of the provider.

--- a/pkg/apis/core/v1beta1/types_secretbinding_test.go
+++ b/pkg/apis/core/v1beta1/types_secretbinding_test.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package v1beta1_test
+
+import (
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("SecretBinding", func() {
+	DescribeTable("#GetProviderType",
+		func(secretBinding *gardencorev1beta1.SecretBinding, expected string) {
+			actual := secretBinding.GetProviderType()
+			Expect(actual).To(Equal(expected))
+		},
+		Entry("when provider is nil", &gardencorev1beta1.SecretBinding{Provider: nil}, ""),
+		Entry("when provider is set", &gardencorev1beta1.SecretBinding{Provider: &gardencorev1beta1.SecretBindingProvider{Type: "foo"}}, "foo"),
+	)
+})

--- a/plugin/pkg/global/resourcereferencemanager/admission_test.go
+++ b/plugin/pkg/global/resourcereferencemanager/admission_test.go
@@ -20,7 +20,6 @@ import (
 	"net/http"
 
 	"github.com/gardener/gardener/pkg/apis/core"
-	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	corefake "github.com/gardener/gardener/pkg/client/core/clientset/internalversion/fake"
@@ -108,7 +107,7 @@ var _ = Describe("resourcereferencemanager", func() {
 				},
 			}
 
-			controllerDeployment = gardencore.ControllerDeployment{
+			controllerDeployment = core.ControllerDeployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: controllerDeploymentName,
 				},

--- a/plugin/pkg/managedseed/validator/admission_test.go
+++ b/plugin/pkg/managedseed/validator/admission_test.go
@@ -18,7 +18,6 @@ import (
 	"context"
 
 	"github.com/gardener/gardener/pkg/apis/core"
-	gardencore "github.com/gardener/gardener/pkg/apis/core"
 	gardencorehelper "github.com/gardener/gardener/pkg/apis/core/helper"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
@@ -280,7 +279,7 @@ var _ = Describe("ManagedSeed", func() {
 
 		Context("seed template", func() {
 			BeforeEach(func() {
-				managedSeed.Spec.SeedTemplate = &gardencore.SeedTemplate{
+				managedSeed.Spec.SeedTemplate = &core.SeedTemplate{
 					Spec: core.SeedSpec{
 						Backup: &core.SeedBackup{},
 					},
@@ -294,7 +293,7 @@ var _ = Describe("ManagedSeed", func() {
 
 				err := admissionHandler.Admit(context.TODO(), getManagedSeedAttributes(managedSeed), nil)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(managedSeed.Spec.SeedTemplate).To(Equal(&gardencore.SeedTemplate{
+				Expect(managedSeed.Spec.SeedTemplate).To(Equal(&core.SeedTemplate{
 					Spec: seed(false).Spec,
 				}))
 			})
@@ -316,7 +315,7 @@ var _ = Describe("ManagedSeed", func() {
 
 				err := admissionHandler.Admit(context.TODO(), getManagedSeedAttributes(managedSeed), nil)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(managedSeed.Spec.SeedTemplate).To(Equal(&gardencore.SeedTemplate{
+				Expect(managedSeed.Spec.SeedTemplate).To(Equal(&core.SeedTemplate{
 					Spec: seed(true).Spec,
 				}))
 			})


### PR DESCRIPTION
/area usability
/kind enhancement

With this PR the `{core,v1alpha1,v1beta1.SecretBinding}` types implement the [`core.Object`](https://github.com/gardener/gardener/blob/a119ad0709f26dd5fd0f8df0c74c64c17833a220/pkg/apis/core/types.go#L25-L30) interface. This makes possible usage of the SecretBinding types with the [`GardenCoreProviderType`](https://github.com/gardener/gardener/blob/master/extensions/pkg/predicate/predicate.go#L121-L150) predicate. The latter is used widely in provider extension admission controllers to filter objects that have the corresponding provider type.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other dependency
The `SecretBinding` types now implement the `core.Object` interface which makes possible usage of the `SecretBinding` types with the `GardenCoreProviderType` predicate.
```
