### PR TITLE
Add validation for locked feature gate

### DIFF
--- a/docs/development/new-kubernetes-version.md
+++ b/docs/development/new-kubernetes-version.md
@@ -59,7 +59,7 @@ Run the [`.ci/check-and-release`](https://github.com/gardener/hyperkube/blob/mas
   - It will present 3 lists of feature gates: those added and those removed in `<new-version>` compared to `<old-version>` and feature gates that got locked to default in `<new-version>`.
   - Add all added feature gates to the map with `<new-version>` as `AddedInVersion` and no `RemovedInVersion`.
   - For any removed feature gates, add `<new-version>` as RemovedInVersion to the already existing feature gate in the map.
-  - For feature gates locked to default, add `<new-version>` as LockedToDefaultInVersion to the already existing feature gate in the map.
+  - For feature gates locked to default, add `<new-version>` as `LockedToDefaultInVersion` to the already existing feature gate in the map.
   - See [this](https://github.com/gardener/gardener/pull/5255/commits/97923b0604300ff805def8eae981ed388d5e4a83) example commit.
 - Maintain the `ServiceAccount` names for the controllers part of `kube-controller-manager`:
   - The names are maintained in [this](https://github.com/gardener/gardener/blob/master/pkg/operation/botanist/component/shootsystem/shootsystem.go) file.

--- a/docs/development/new-kubernetes-version.md
+++ b/docs/development/new-kubernetes-version.md
@@ -56,9 +56,10 @@ Run the [`.ci/check-and-release`](https://github.com/gardener/hyperkube/blob/mas
 - Maintain the Kubernetes feature gates used for validation of `Shoot` resources:
   - The feature gates are maintained in [this](https://github.com/gardener/gardener/blob/master/pkg/utils/validation/features/featuregates.go) file.
   - To maintain this list for new Kubernetes versions, run `hack/compare-k8s-feature-gates.sh <old-version> <new-version>` (e.g. `hack/compare-k8s-feature-gates.sh v1.22 v1.23`).
-  - It will present 2 lists of feature gates: those added and those removed in `<new-version>` compared to `<old-version>`.
+  - It will present 3 lists of feature gates: those added and those removed in `<new-version>` compared to `<old-version>` and feature gates that got locked to default in `<new-version>`.
   - Add all added feature gates to the map with `<new-version>` as `AddedInVersion` and no `RemovedInVersion`.
   - For any removed feature gates, add `<new-version>` as RemovedInVersion to the already existing feature gate in the map.
+  - For feature gates locked to default, add `<new-version>` as LockedToDefaultInVersion to the already existing feature gate in the map.
   - See [this](https://github.com/gardener/gardener/pull/5255/commits/97923b0604300ff805def8eae981ed388d5e4a83) example commit.
 - Maintain the `ServiceAccount` names for the controllers part of `kube-controller-manager`:
   - The names are maintained in [this](https://github.com/gardener/gardener/blob/master/pkg/operation/botanist/component/shootsystem/shootsystem.go) file.

--- a/pkg/utils/validation/features/featuregates.go
+++ b/pkg/utils/validation/features/featuregates.go
@@ -26,9 +26,11 @@ import (
 // Extracted from https://raw.githubusercontent.com/kubernetes/kubernetes/release-${version}/pkg/features/kube_features.go.
 // To maintain this list for each new Kubernetes version:
 // * Run hack/compare-k8s-feature-gates.sh <old-version> <new-version> (e.g. 'hack/compare-k8s-feature-gates.sh 1.22 1.23').
-//   It will present 2 lists of feature gates: those added and those removed in <new-version> compared to <old-version>.
+//   It will present 3 lists of feature gates: those added and those removed in <new-version> compared to <old-version> and
+//   feature gates that got locked to default in `<new-version>`.
 // * Add all added feature gates to the map with <new-version> as AddedInVersion and no RemovedInVersion.
 // * For any removed feature gates, add <new-version> as RemovedInVersion to the already existing feature gate in the map.
+// * For feature gates locked to default, add `<new-version>` as LockedToDefaultInVersion to the already existing feature gate in the map.
 var featureGateVersionRanges = map[string]*FeatureGateVersionRange{
 	// These are special feature gates to toggle all alpha or beta feature gates on and off.
 	// They were introduced in version 1.17 (although they are absent from the corresponding kube_features.go file).

--- a/pkg/utils/validation/features/featuregates.go
+++ b/pkg/utils/validation/features/featuregates.go
@@ -72,12 +72,12 @@ var featureGateVersionRanges = map[string]*FeatureGateVersionRange{
 	"CSIMigrationvSphereComplete":                    {AddedInVersion: "1.19", RemovedInVersion: "1.22"},
 	"CSINodeInfo":                                    {RemovedInVersion: "1.21"},
 	"CSIPersistentVolume":                            {RemovedInVersion: "1.16"},
-	"CSIServiceAccountToken":                         {AddedInVersion: "1.20"},
+	"CSIServiceAccountToken":                         {Default: true, AddedInVersion: "1.20", LockedToDefaultInVersion: "1.22"},
 	"CSIStorageCapacity":                             {AddedInVersion: "1.19"},
-	"CSIVolumeFSGroupPolicy":                         {AddedInVersion: "1.19"},
+	"CSIVolumeFSGroupPolicy":                         {Default: true, AddedInVersion: "1.19", LockedToDefaultInVersion: "1.23"},
 	"CSIVolumeHealth":                                {AddedInVersion: "1.21"},
 	"CSRDuration":                                    {AddedInVersion: "1.22"},
-	"ConfigurableFSGroupPolicy":                      {AddedInVersion: "1.18"},
+	"ConfigurableFSGroupPolicy":                      {Default: true, AddedInVersion: "1.18", LockedToDefaultInVersion: "1.23"},
 	"ControllerManagerLeaderMigration":               {AddedInVersion: "1.21"}, // Missing from docu?
 	"CronJobControllerV2":                            {AddedInVersion: "1.20", RemovedInVersion: "1.23"},
 	"CustomCPUCFSQuotaPeriod":                        {},
@@ -103,9 +103,9 @@ var featureGateVersionRanges = map[string]*FeatureGateVersionRange{
 	"DynamicKubeletConfig":                           {},
 	"EfficientWatchResumption":                       {AddedInVersion: "1.20"},
 	"EnableAggregatedDiscoveryTimeout":               {AddedInVersion: "1.16", RemovedInVersion: "1.17"},
-	"EndpointSlice":                                  {AddedInVersion: "1.16"},
-	"EndpointSliceNodeName":                          {AddedInVersion: "1.20"},
-	"EndpointSliceProxying":                          {AddedInVersion: "1.18"},
+	"EndpointSlice":                                  {Default: true, AddedInVersion: "1.16", LockedToDefaultInVersion: "1.21"},
+	"EndpointSliceNodeName":                          {Default: true, AddedInVersion: "1.20", LockedToDefaultInVersion: "1.21"},
+	"EndpointSliceProxying":                          {Default: true, AddedInVersion: "1.18", LockedToDefaultInVersion: "1.22"},
 	"EndpointSliceTerminatingCondition":              {AddedInVersion: "1.20"},
 	"EphemeralContainers":                            {AddedInVersion: "1.16"},
 	"EvenPodsSpread":                                 {AddedInVersion: "1.16", RemovedInVersion: "1.21"},
@@ -119,18 +119,18 @@ var featureGateVersionRanges = map[string]*FeatureGateVersionRange{
 	"ExternalPolicyForExternalIP":                    {AddedInVersion: "1.18", RemovedInVersion: "1.22"}, // Missing from docu?
 	"GCERegionalPersistentDisk":                      {RemovedInVersion: "1.17"},
 	"GRPCContainerProbe":                             {AddedInVersion: "1.23"},
-	"GenericEphemeralVolume":                         {AddedInVersion: "1.19"},
+	"GenericEphemeralVolume":                         {Default: true, AddedInVersion: "1.19", LockedToDefaultInVersion: "1.23"},
 	"GracefulNodeShutdown":                           {AddedInVersion: "1.20"},
 	"GracefulNodeShutdownBasedOnPodPriority":         {AddedInVersion: "1.23"},
 	"HonorPVReclaimPolicy":                           {AddedInVersion: "1.23"},
 	"HPAContainerMetrics":                            {AddedInVersion: "1.20"},
 	"HPAScaleToZero":                                 {AddedInVersion: "1.16"},
-	"HugePageStorageMediumSize":                      {AddedInVersion: "1.18"},
+	"HugePageStorageMediumSize":                      {Default: true, AddedInVersion: "1.18", LockedToDefaultInVersion: "1.22"},
 	"HugePages":                                      {RemovedInVersion: "1.16"},
 	"HyperVContainer":                                {RemovedInVersion: "1.21"},
-	"IPv6DualStack":                                  {AddedInVersion: "1.16"},
+	"IPv6DualStack":                                  {Default: true, AddedInVersion: "1.16", LockedToDefaultInVersion: "1.23"},
 	"IdentifyPodOS":                                  {AddedInVersion: "1.23"},
-	"ImmutableEphemeralVolumes":                      {AddedInVersion: "1.18"},
+	"ImmutableEphemeralVolumes":                      {Default: true, AddedInVersion: "1.18", LockedToDefaultInVersion: "1.21"},
 	"InTreePluginAWSUnregister":                      {AddedInVersion: "1.21"}, // Missing from docu?
 	"InTreePluginAzureDiskUnregister":                {AddedInVersion: "1.21"}, // Missing from docu?
 	"InTreePluginAzureFileUnregister":                {AddedInVersion: "1.21"}, // Missing from docu?
@@ -140,7 +140,7 @@ var featureGateVersionRanges = map[string]*FeatureGateVersionRange{
 	"InTreePluginRBDUnregister":                      {AddedInVersion: "1.23"},
 	"InTreePluginvSphereUnregister":                  {AddedInVersion: "1.21"}, // Missing from docu?
 	"IndexedJob":                                     {AddedInVersion: "1.21"},
-	"IngressClassNamespacedParams":                   {AddedInVersion: "1.21"},
+	"IngressClassNamespacedParams":                   {Default: true, AddedInVersion: "1.21", LockedToDefaultInVersion: "1.23"},
 	"JobMutableNodeSchedulingDirectives":             {AddedInVersion: "1.23"},
 	"JobReadyPods":                                   {AddedInVersion: "1.23"},
 	"JobTrackingWithFinalizers":                      {AddedInVersion: "1.22"},
@@ -158,7 +158,7 @@ var featureGateVersionRanges = map[string]*FeatureGateVersionRange{
 	"MigrationRBD":                                   {AddedInVersion: "1.23"},
 	"MixedProtocolLBService":                         {AddedInVersion: "1.20"},
 	"MountContainers":                                {RemovedInVersion: "1.17"},
-	"NamespaceDefaultLabelName":                      {AddedInVersion: "1.21"},
+	"NamespaceDefaultLabelName":                      {Default: true, AddedInVersion: "1.21", LockedToDefaultInVersion: "1.22"},
 	"NetworkPolicyEndPort":                           {AddedInVersion: "1.21"},
 	"NodeDisruptionExclusion":                        {AddedInVersion: "1.16", RemovedInVersion: "1.22"},
 	"NodeLease":                                      {RemovedInVersion: "1.23"},
@@ -170,7 +170,7 @@ var featureGateVersionRanges = map[string]*FeatureGateVersionRange{
 	"PodAndContainerStatsFromCRI":                    {AddedInVersion: "1.23"},
 	"PodAffinityNamespaceSelector":                   {AddedInVersion: "1.21"},
 	"PodDeletionCost":                                {AddedInVersion: "1.21"},
-	"PodDisruptionBudget":                            {AddedInVersion: "1.17"}, // Docu says 1.3?
+	"PodDisruptionBudget":                            {Default: true, AddedInVersion: "1.17", LockedToDefaultInVersion: "1.21"}, // Docu says 1.3?
 	"PodOverhead":                                    {AddedInVersion: "1.16"},
 	"PodPriority":                                    {RemovedInVersion: "1.18"},
 	"PodReadinessGates":                              {RemovedInVersion: "1.16"},
@@ -192,11 +192,11 @@ var featureGateVersionRanges = map[string]*FeatureGateVersionRange{
 	"RotateKubeletClientCertificate":                 {RemovedInVersion: "1.21"},
 	"RotateKubeletServerCertificate":                 {},
 	"RunAsGroup":                                     {RemovedInVersion: "1.22"},
-	"RuntimeClass":                                   {},
+	"RuntimeClass":                                   {Default: true, LockedToDefaultInVersion: "1.20"},
 	"SCTPSupport":                                    {RemovedInVersion: "1.22"},
 	"ScheduleDaemonSetPods":                          {RemovedInVersion: "1.18"},
 	"SeccompDefault":                                 {AddedInVersion: "1.22"},
-	"SelectorIndex":                                  {AddedInVersion: "1.18"}, // Missing from docu?
+	"SelectorIndex":                                  {Default: true, AddedInVersion: "1.18", LockedToDefaultInVersion: "1.20"}, // Missing from docu?
 	"ServerSideApply":                                {},
 	"ServerSideFieldValidation":                      {AddedInVersion: "1.23"},
 	"ServiceAccountIssuerDiscovery":                  {AddedInVersion: "1.18", RemovedInVersion: "1.23"},
@@ -207,12 +207,12 @@ var featureGateVersionRanges = map[string]*FeatureGateVersionRange{
 	"ServiceLoadBalancerFinalizer":                   {RemovedInVersion: "1.20"},
 	"ServiceNodeExclusion":                           {RemovedInVersion: "1.22"},
 	"ServiceTopology":                                {AddedInVersion: "1.17", RemovedInVersion: "1.22"},
-	"SetHostnameAsFQDN":                              {AddedInVersion: "1.19"},
+	"SetHostnameAsFQDN":                              {Default: true, AddedInVersion: "1.19", LockedToDefaultInVersion: "1.22"},
 	"SizeMemoryBackedVolumes":                        {AddedInVersion: "1.20"},
 	"StartupProbe":                                   {AddedInVersion: "1.16", RemovedInVersion: "1.23"},
 	"StatefulSetAutoDeletePVC":                       {AddedInVersion: "1.23"},
 	"StatefulSetMinReadySeconds":                     {AddedInVersion: "1.22"},
-	"StorageObjectInUseProtection":                   {},
+	"StorageObjectInUseProtection":                   {Default: true, LockedToDefaultInVersion: "1.23"},
 	"StorageVersionAPI":                              {AddedInVersion: "1.20"},
 	"StorageVersionHash":                             {},
 	"StreamingProxyRedirects":                        {},
@@ -221,7 +221,7 @@ var featureGateVersionRanges = map[string]*FeatureGateVersionRange{
 	"SupportPodPidsLimit":                            {RemovedInVersion: "1.23"},
 	"SuspendJob":                                     {AddedInVersion: "1.21"},
 	"Sysctls":                                        {RemovedInVersion: "1.23"},
-	"TTLAfterFinished":                               {},
+	"TTLAfterFinished":                               {Default: true, LockedToDefaultInVersion: "1.23"},
 	"TaintBasedEvictions":                            {RemovedInVersion: "1.20"},
 	"TaintNodesByCondition":                          {RemovedInVersion: "1.18"},
 	"TokenRequest":                                   {RemovedInVersion: "1.21"},
@@ -235,11 +235,11 @@ var featureGateVersionRanges = map[string]*FeatureGateVersionRange{
 	"VolumeSnapshotDataSource":                       {RemovedInVersion: "1.22"},
 	"VolumeSubpath":                                  {},
 	"VolumeSubpathEnvExpansion":                      {RemovedInVersion: "1.19"},
-	"WarningHeaders":                                 {AddedInVersion: "1.19"},
-	"WatchBookmark":                                  {},
+	"WarningHeaders":                                 {Default: true, AddedInVersion: "1.19", LockedToDefaultInVersion: "1.22"},
+	"WatchBookmark":                                  {Default: true, LockedToDefaultInVersion: "1.17"},
 	"WinDSR":                                         {},
 	"WinOverlay":                                     {},
-	"WindowsEndpointSliceProxying":                   {AddedInVersion: "1.19"},
+	"WindowsEndpointSliceProxying":                   {Default: true, AddedInVersion: "1.19", LockedToDefaultInVersion: "1.22"},
 	"WindowsGMSA":                                    {RemovedInVersion: "1.21"},
 	"WindowsHostProcessContainers":                   {AddedInVersion: "1.22"},
 	"WindowsRunAsUserName":                           {AddedInVersion: "1.16", RemovedInVersion: "1.21"},
@@ -258,8 +258,10 @@ func IsFeatureGateSupported(featureGate, version string) (bool, error) {
 
 // FeatureGateVersionRange represents a version range of type [AddedInVersion, RemovedInVersion).
 type FeatureGateVersionRange struct {
-	AddedInVersion   string
-	RemovedInVersion string
+	Default                  bool
+	AddedInVersion           string
+	LockedToDefaultInVersion string
+	RemovedInVersion         string
 }
 
 // Contains returns true if the range contains the given version, false otherwise.
@@ -280,6 +282,17 @@ func (r *FeatureGateVersionRange) Contains(version string) (bool, error) {
 	return utilsversion.CheckVersionMeetsConstraint(version, constraint)
 }
 
+func isFeatureLockedToDefault(featureGate, version string) (bool, error) {
+	var constraint string
+	vr := featureGateVersionRanges[featureGate]
+	if vr.LockedToDefaultInVersion != "" {
+		constraint = fmt.Sprintf(">= %s", vr.LockedToDefaultInVersion)
+		return utilsversion.CheckVersionMeetsConstraint(version, constraint)
+	}
+
+	return false, nil
+}
+
 // ValidateFeatureGates validates the given Kubernetes feature gates against the given Kubernetes version.
 func ValidateFeatureGates(featureGates map[string]bool, version string, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
@@ -290,6 +303,13 @@ func ValidateFeatureGates(featureGates map[string]bool, version string, fldPath 
 			allErrs = append(allErrs, field.Invalid(fldPath.Child(featureGate), featureGate, err.Error()))
 		} else if !supported {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child(featureGate), fmt.Sprintf("not supported in Kubernetes version %s", version)))
+		} else {
+			isLockedToDefault, err := isFeatureLockedToDefault(featureGate, version)
+			if err != nil {
+				allErrs = append(allErrs, field.Invalid(fldPath.Child(featureGate), featureGate, err.Error()))
+			} else if isLockedToDefault && featureGates[featureGate] != featureGateVersionRanges[featureGate].Default {
+				allErrs = append(allErrs, field.Forbidden(fldPath.Child(featureGate), fmt.Sprintf("cannot set feature gate to %v, feature is locked to %v", featureGates[featureGate], featureGateVersionRanges[featureGate].Default)))
+			}
 		}
 	}
 

--- a/pkg/utils/validation/features/featuregates_test.go
+++ b/pkg/utils/validation/features/featuregates_test.go
@@ -108,7 +108,7 @@ var _ = Describe("featuregates", func() {
 				"BadValue": Equal("Foo"),
 				"Detail":   Equal("unknown feature gate Foo"),
 			})))),
-			Entry("setting non-default value for lockedfeaturegate", map[string]bool{"EndpointSlice": false}, "1.21.5", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+			Entry("setting non-default value for locked feature gate", map[string]bool{"EndpointSlice": false}, "1.21.5", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":   Equal(field.ErrorTypeForbidden),
 				"Field":  Equal(field.NewPath("EndpointSlice").String()),
 				"Detail": Equal("cannot set feature gate to false, feature is locked to true"),

--- a/pkg/utils/validation/features/featuregates_test.go
+++ b/pkg/utils/validation/features/featuregates_test.go
@@ -108,6 +108,11 @@ var _ = Describe("featuregates", func() {
 				"BadValue": Equal("Foo"),
 				"Detail":   Equal("unknown feature gate Foo"),
 			})))),
+			Entry("setting non-default value for lockedfeaturegate", map[string]bool{"EndpointSlice": false}, "1.21.5", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(field.ErrorTypeForbidden),
+				"Field":  Equal(field.NewPath("EndpointSlice").String()),
+				"Detail": Equal("cannot set feature gate to false, feature is locked to true"),
+			})))),
 		)
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind bug

**What this PR does / why we need it**:
This PR adds validation for the locked feature gates. Now Gardener forbids upgrading clusters if the feature gate is locked to default and the user wants to set a value that does not default.

**Which issue(s) this PR fixes**:
Fixes #5362

**Special notes for your reviewer**:
This PR adds doesn't add validation for the feature gate which has been removed in any of the Kubernetes versions supported by the Gardener.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
