### PR TITLE
[GEP-18] Adapt `service-account-key` secret to new secrets manager

### DIFF
--- a/pkg/operation/botanist/component/kubeapiserver/deployment.go
+++ b/pkg/operation/botanist/component/kubeapiserver/deployment.go
@@ -120,7 +120,8 @@ func (k *kubeAPIServer) reconcileDeployment(
 	configMapEgressSelector *corev1.ConfigMap,
 	secretETCDEncryptionConfiguration *corev1.Secret,
 	secretOIDCCABundle *corev1.Secret,
-	secretServiceAccountSigningKey *corev1.Secret,
+	secretUserProvidedServiceAccountSigningKey *corev1.Secret,
+	secretServiceAccountKey *corev1.Secret,
 	secretStaticToken *corev1.Secret,
 	secretBasicAuth *corev1.Secret,
 ) error {
@@ -345,7 +346,7 @@ func (k *kubeAPIServer) reconcileDeployment(
 							Name: volumeNameServiceAccountKey,
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
-									SecretName: k.secrets.ServiceAccountKey.Name,
+									SecretName: secretServiceAccountKey.Name,
 								},
 							},
 						},
@@ -401,7 +402,7 @@ func (k *kubeAPIServer) reconcileDeployment(
 		k.handlePodMutatorSettings(deployment)
 		k.handleVPNSettings(deployment, configMapEgressSelector)
 		k.handleOIDCSettings(deployment, secretOIDCCABundle)
-		k.handleServiceAccountSigningKeySettings(deployment, secretServiceAccountSigningKey)
+		k.handleServiceAccountSigningKeySettings(deployment, secretUserProvidedServiceAccountSigningKey)
 
 		utilruntime.Must(references.InjectAnnotations(deployment))
 		return nil

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
@@ -60,6 +60,7 @@ import (
 
 var _ = BeforeSuite(func() {
 	DeferCleanup(test.WithVar(&secretutils.GenerateRandomString, secretutils.FakeGenerateRandomString))
+	DeferCleanup(test.WithVar(&secretutils.GenerateKey, secretutils.FakeGenerateKey))
 	DeferCleanup(test.WithVar(&secretutils.Clock, clock.NewFakeClock(time.Time{})))
 })
 
@@ -95,8 +96,7 @@ var _ = Describe("KubeAPIServer", func() {
 		secretChecksumKubeAPIServerToKubelet = "12345"
 		secretNameServer                     = "Server-secret"
 		secretChecksumServer                 = "12345"
-		secretNameServiceAccountKey          = "ServiceAccountKey-secret"
-		secretChecksumServiceAccountKey      = "12345"
+		secretNameServiceAccountKey          = "service-account-key-c37a87f6"
 		secretNameVPNSeed                    = "VPNSeed-secret"
 		secretChecksumVPNSeed                = "12345"
 		secretNameVPNSeedTLSAuth             = "VPNSeedTLSAuth-secret"
@@ -139,7 +139,6 @@ var _ = Describe("KubeAPIServer", func() {
 			KubeAggregator:         component.Secret{Name: secretNameKubeAggregator, Checksum: secretChecksumKubeAggregator},
 			KubeAPIServerToKubelet: component.Secret{Name: secretNameKubeAPIServerToKubelet, Checksum: secretChecksumKubeAPIServerToKubelet},
 			Server:                 component.Secret{Name: secretNameServer, Checksum: secretChecksumServer},
-			ServiceAccountKey:      component.Secret{Name: secretNameServiceAccountKey, Checksum: secretChecksumServiceAccountKey},
 			VPNSeed:                &component.Secret{Name: secretNameVPNSeed, Checksum: secretChecksumVPNSeed},
 			VPNSeedTLSAuth:         &component.Secret{Name: secretNameVPNSeedTLSAuth, Checksum: secretChecksumVPNSeedTLSAuth},
 			VPNSeedServerTLSAuth:   &component.Secret{Name: secretNameVPNSeedServerTLSAuth, Checksum: secretChecksumVPNSeedServerTLSAuth},
@@ -240,9 +239,6 @@ var _ = Describe("KubeAPIServer", func() {
 				),
 				Entry("Server missing",
 					"Server", func(s *Secrets) { s.Server.Name = "" }, Values{},
-				),
-				Entry("ServiceAccountKey missing",
-					"ServiceAccountKey", func(s *Secrets) { s.ServiceAccountKey.Name = "" }, Values{},
 				),
 				Entry("ReversedVPN disabled but VPNSeed missing",
 					"VPNSeed", func(s *Secrets) { s.VPNSeed = nil }, Values{VPN: VPNConfig{ReversedVPNEnabled: false}},
@@ -1430,7 +1426,7 @@ rules:
 					deployAndRead()
 
 					Expect(deployment.Annotations).To(Equal(map[string]string{
-						"reference.resources.gardener.cloud/secret-7e9b40c7":    secretNameServiceAccountKey,
+						"reference.resources.gardener.cloud/secret-a709ce3a":    secretNameServiceAccountKey,
 						"reference.resources.gardener.cloud/secret-71fba891":    secretNameCA,
 						"reference.resources.gardener.cloud/secret-91c30740":    secretNameCAEtcd,
 						"reference.resources.gardener.cloud/secret-9282d44f":    secretNameCAFrontProxy,
@@ -1479,7 +1475,6 @@ rules:
 
 					Expect(deployment.Spec.Template.Annotations).To(Equal(map[string]string{
 						"checksum/secret-" + secretNameCAEtcd:                   secretChecksumCAEtcd,
-						"checksum/secret-" + secretNameServiceAccountKey:        secretChecksumServiceAccountKey,
 						"checksum/secret-" + secretNameVPNSeedServerTLSAuth:     secretChecksumVPNSeedServerTLSAuth,
 						"checksum/secret-" + secretNameVPNSeed:                  secretChecksumVPNSeed,
 						"checksum/secret-" + secretNameCA:                       secretChecksumCA,
@@ -1490,7 +1485,7 @@ rules:
 						"checksum/secret-" + secretNameKubeAPIServerToKubelet:   secretChecksumKubeAPIServerToKubelet,
 						"checksum/secret-" + secretNameServer:                   secretChecksumServer,
 						"checksum/secret-" + secretNameVPNSeedTLSAuth:           secretChecksumVPNSeedTLSAuth,
-						"reference.resources.gardener.cloud/secret-7e9b40c7":    secretNameServiceAccountKey,
+						"reference.resources.gardener.cloud/secret-a709ce3a":    secretNameServiceAccountKey,
 						"reference.resources.gardener.cloud/secret-71fba891":    secretNameCA,
 						"reference.resources.gardener.cloud/secret-91c30740":    secretNameCAEtcd,
 						"reference.resources.gardener.cloud/secret-9282d44f":    secretNameCAFrontProxy,

--- a/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager_test.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager_test.go
@@ -97,8 +97,7 @@ var _ = Describe("KubeControllerManager", func() {
 		}
 
 		// checksums
-		secretChecksumCA                = "1234"
-		secretChecksumServiceAccountKey = "1234"
+		secretChecksumCA = "1234"
 
 		genericTokenKubeconfigSecretName = "generic-token-kubeconfig"
 		vpaName                          = "kube-controller-manager-vpa"
@@ -142,20 +141,12 @@ var _ = Describe("KubeControllerManager", func() {
 					kubeControllerManager.SetSecrets(Secrets{})
 					Expect(kubeControllerManager.Deploy(ctx)).To(MatchError(ContainSubstring("missing CA secret information")))
 				})
-
-				It("should return an error because the ServiceAccountKey secret information is not provided", func() {
-					kubeControllerManager.SetSecrets(Secrets{
-						CA: component.Secret{Name: "ca", Checksum: secretChecksumCA},
-					})
-					Expect(kubeControllerManager.Deploy(ctx)).To(MatchError(ContainSubstring("missing ServiceAccountKey secret information")))
-				})
 			})
 
 			Context("secret information available", func() {
 				BeforeEach(func() {
 					kubeControllerManager.SetSecrets(Secrets{
-						CA:                component.Secret{Name: "ca", Checksum: secretChecksumCA},
-						ServiceAccountKey: component.Secret{Name: "service-account-key", Checksum: secretChecksumServiceAccountKey},
+						CA: component.Secret{Name: "ca", Checksum: secretChecksumCA},
 					})
 				})
 
@@ -465,8 +456,7 @@ var _ = Describe("KubeControllerManager", func() {
 							Template: corev1.PodTemplateSpec{
 								ObjectMeta: metav1.ObjectMeta{
 									Annotations: map[string]string{
-										"checksum/secret-ca":                  secretChecksumCA,
-										"checksum/secret-service-account-key": secretChecksumServiceAccountKey,
+										"checksum/secret-ca": secretChecksumCA,
 									},
 									Labels: map[string]string{
 										"app":                                "kubernetes",
@@ -644,8 +634,7 @@ subjects:
 					)
 
 					kubeControllerManager.SetSecrets(Secrets{
-						CA:                component.Secret{Name: "ca", Checksum: secretChecksumCA},
-						ServiceAccountKey: component.Secret{Name: "service-account-key", Checksum: secretChecksumServiceAccountKey},
+						CA: component.Secret{Name: "ca", Checksum: secretChecksumCA},
 					})
 
 					kubeControllerManager.SetReplicaCount(replicas)

--- a/pkg/operation/botanist/kubeapiserver.go
+++ b/pkg/operation/botanist/kubeapiserver.go
@@ -414,7 +414,6 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 		KubeAggregator:         component.Secret{Name: kubeapiserver.SecretNameKubeAggregator, Checksum: b.LoadCheckSum(kubeapiserver.SecretNameKubeAggregator)},
 		KubeAPIServerToKubelet: component.Secret{Name: kubeapiserver.SecretNameKubeAPIServerToKubelet, Checksum: b.LoadCheckSum(kubeapiserver.SecretNameKubeAPIServerToKubelet)},
 		Server:                 component.Secret{Name: kubeapiserver.SecretNameServer, Checksum: b.LoadCheckSum(kubeapiserver.SecretNameServer)},
-		ServiceAccountKey:      component.Secret{Name: v1beta1constants.SecretNameServiceAccountKey, Checksum: b.LoadCheckSum(v1beta1constants.SecretNameServiceAccountKey)},
 	}
 
 	if values.VPN.ReversedVPNEnabled {
@@ -474,6 +473,7 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 		gardenerResourceDataList.Delete("static-token")
 		gardenerResourceDataList.Delete("kube-apiserver-basic-auth")
 		gardenerResourceDataList.Delete("etcdEncryptionConfiguration")
+		gardenerResourceDataList.Delete("service-account-key")
 		*gardenerResourceData = gardenerResourceDataList
 		return nil
 	}); err != nil {

--- a/pkg/operation/botanist/kubeapiserver_test.go
+++ b/pkg/operation/botanist/kubeapiserver_test.go
@@ -1098,7 +1098,6 @@ var _ = Describe("KubeAPIServer", func() {
 					KubeAggregator:         component.Secret{Name: "kube-aggregator", Checksum: botanist.LoadCheckSum("kube-aggregator")},
 					KubeAPIServerToKubelet: component.Secret{Name: "kube-apiserver-kubelet", Checksum: botanist.LoadCheckSum("kube-apiserver-kubelet")},
 					Server:                 component.Secret{Name: "kube-apiserver", Checksum: botanist.LoadCheckSum("kube-apiserver")},
-					ServiceAccountKey:      component.Secret{Name: "service-account-key", Checksum: botanist.LoadCheckSum("service-account-key")},
 				}
 				mutateSecrets(&secrets)
 

--- a/pkg/operation/botanist/kubecontrollermanager.go
+++ b/pkg/operation/botanist/kubecontrollermanager.go
@@ -74,8 +74,7 @@ func (b *Botanist) DeployKubeControllerManager(ctx context.Context) error {
 
 	b.Shoot.Components.ControlPlane.KubeControllerManager.SetReplicaCount(replicaCount)
 	b.Shoot.Components.ControlPlane.KubeControllerManager.SetSecrets(kubecontrollermanager.Secrets{
-		CA:                component.Secret{Name: v1beta1constants.SecretNameCACluster, Checksum: b.LoadCheckSum(v1beta1constants.SecretNameCACluster)},
-		ServiceAccountKey: component.Secret{Name: v1beta1constants.SecretNameServiceAccountKey, Checksum: b.LoadCheckSum(v1beta1constants.SecretNameServiceAccountKey)},
+		CA: component.Secret{Name: v1beta1constants.SecretNameCACluster, Checksum: b.LoadCheckSum(v1beta1constants.SecretNameCACluster)},
 	})
 
 	return b.Shoot.Components.ControlPlane.KubeControllerManager.Deploy(ctx)

--- a/pkg/operation/botanist/kubecontrollermanager_test.go
+++ b/pkg/operation/botanist/kubecontrollermanager_test.go
@@ -100,13 +100,10 @@ var _ = Describe("KubeControllerManager", func() {
 			kubeAPIServer         *mockkubeapiserver.MockInterface
 			kubeControllerManager *mockkubecontrollermanager.MockInterface
 
-			secretNameCA                = "ca"
-			secretNameServiceAccountKey = "service-account-key"
-			checksumCA                  = "56"
-			checksumServiceAccountKey   = "78"
-			secrets                     = kubecontrollermanager.Secrets{
-				CA:                component.Secret{Name: secretNameCA, Checksum: checksumCA},
-				ServiceAccountKey: component.Secret{Name: secretNameServiceAccountKey, Checksum: checksumServiceAccountKey},
+			secretNameCA = "ca"
+			checksumCA   = "56"
+			secrets      = kubecontrollermanager.Secrets{
+				CA: component.Secret{Name: secretNameCA, Checksum: checksumCA},
 			}
 		)
 
@@ -116,7 +113,6 @@ var _ = Describe("KubeControllerManager", func() {
 
 			botanist.K8sSeedClient = kubernetesClient
 			botanist.StoreCheckSum(secretNameCA, checksumCA)
-			botanist.StoreCheckSum(secretNameServiceAccountKey, checksumServiceAccountKey)
 			botanist.Shoot = &shootpkg.Shoot{
 				Components: &shootpkg.Components{
 					ControlPlane: &shootpkg.ControlPlane{

--- a/pkg/operation/botanist/wanted_secrets.go
+++ b/pkg/operation/botanist/wanted_secrets.go
@@ -168,13 +168,6 @@ func (b *Botanist) generateWantedSecretConfigs(certificateAuthorities map[string
 			PasswordLength: 32,
 		},
 
-		// Secret definition for service-account-key
-		&secrets.RSASecretConfig{
-			Name:       v1beta1constants.SecretNameServiceAccountKey,
-			Bits:       4096,
-			UsedForSSH: false,
-		},
-
 		// Secret definition for etcd server
 		&secrets.CertificateSecretConfig{
 			Name: etcd.SecretNameServer,

--- a/pkg/utils/secrets/manager/generate.go
+++ b/pkg/utils/secrets/manager/generate.go
@@ -262,6 +262,16 @@ func (m *manager) keepExistingSecretsIfNeeded(ctx context.Context, configName st
 			secretutils.DataKeyEncryptionKeyName: existingEncryptionKey,
 			secretutils.DataKeyEncryptionSecret:  existingEncryptionSecret,
 		}, nil
+
+	case "service-account-key":
+		if err := m.client.Get(ctx, kutil.Key(m.namespace, "service-account-key"), existingSecret); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return nil, err
+			}
+			return newData, nil
+		}
+
+		return existingSecret.Data, nil
 	}
 
 	return newData, nil

--- a/pkg/utils/secrets/manager/generate_test.go
+++ b/pkg/utils/secrets/manager/generate_test.go
@@ -626,6 +626,49 @@ resources:
 					}))
 				})
 			})
+
+			Context("service account key", func() {
+				var (
+					oldData = map[string][]byte{"id_rsa": []byte("some-old-key")}
+					config  *secretutils.RSASecretConfig
+				)
+
+				BeforeEach(func() {
+					config = &secretutils.RSASecretConfig{
+						Name: "service-account-key",
+						Bits: 4096,
+					}
+				})
+
+				It("should generate a new key if old secret does not exist", func() {
+					By("generating secret")
+					secret, err := m.Generate(ctx, config)
+					Expect(err).NotTo(HaveOccurred())
+
+					By("verifying new key was generated")
+					Expect(secret.Data).NotTo(Equal(oldData))
+				})
+
+				It("should keep the existing key if old secret still exists", func() {
+					By("creating existing secret with old key")
+					existingSecret := &corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "service-account-key",
+							Namespace: namespace,
+						},
+						Type: corev1.SecretTypeOpaque,
+						Data: oldData,
+					}
+					Expect(fakeClient.Create(ctx, existingSecret)).To(Succeed())
+
+					By("generating secret")
+					secret, err := m.Generate(ctx, config)
+					Expect(err).NotTo(HaveOccurred())
+
+					By("verifying old password was kept")
+					Expect(secret.Data).To(Equal(oldData))
+				})
+			})
 		})
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement
/merge squash

**What this PR does / why we need it**:
This PR adapts the `service-account-key` secret to new secrets manager.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/3292#issuecomment-1036058890

/invite @timebertt @BeckerMax 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
