### PR TITLE
[GEP-18] Adapt `gardener-resource-manager-server` and its bootstrap kubeconfig secret to new secrets manager

### DIFF
--- a/pkg/operation/botanist/component/resourcemanager/resource_manager.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager.go
@@ -624,7 +624,6 @@ func (r *resourceManager) ensureDeployment(ctx context.Context) error {
 
 		if r.values.TargetDiffersFromSourceCluster {
 			if r.secrets.BootstrapKubeconfig != nil {
-				metav1.SetMetaDataAnnotation(&deployment.Spec.Template.ObjectMeta, "checksum/secret-"+r.secrets.BootstrapKubeconfig.Name, r.secrets.BootstrapKubeconfig.Checksum)
 				deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, corev1.Volume{
 					Name: volumeNameBootstrapKubeconfig,
 					VolumeSource: corev1.VolumeSource{

--- a/pkg/operation/botanist/component/resourcemanager/resource_manager.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager.go
@@ -55,25 +55,23 @@ import (
 )
 
 const (
-	// ServiceName is the name of the service of the gardener-resource-manager.
-	ServiceName = "gardener-resource-manager"
 	// ManagedResourceName is the name for the ManagedResource containing resources deployed to the shoot cluster.
 	ManagedResourceName = "shoot-core-gardener-resource-manager"
-	// SecretNameServer is the name of the gardener-resource-manager server certificate secret.
-	SecretNameServer = "gardener-resource-manager-server"
 	// SecretNameShootAccess is the name of the shoot access secret for the gardener-resource-manager.
 	SecretNameShootAccess = gutil.SecretNamePrefixShootAccess + v1beta1constants.DeploymentNameGardenerResourceManager
 	// LabelValue is a constant for the value of the 'app' label on Kubernetes resources.
 	LabelValue = "gardener-resource-manager"
 
+	serviceName        = "gardener-resource-manager"
+	secretNameServer   = "gardener-resource-manager-server"
 	clusterRoleName    = "gardener-resource-manager-seed"
+	roleName           = "gardener-resource-manager"
+	serviceAccountName = "gardener-resource-manager"
 	containerName      = v1beta1constants.DeploymentNameGardenerResourceManager
 	healthPort         = 8081
 	metricsPort        = 8080
 	serverPort         = 10250
 	serverServicePort  = 443
-	roleName           = "gardener-resource-manager"
-	serviceAccountName = "gardener-resource-manager"
 
 	volumeNameBootstrapKubeconfig  = "kubeconfig-bootstrap"
 	volumeNameCerts                = "tls"
@@ -193,6 +191,8 @@ type Values struct {
 	ResourceClass *string
 	// RetryPeriod configures the retry period for leader election
 	RetryPeriod *time.Duration
+	// SecretNameServerCA is the name of the server CA secret.
+	SecretNameServerCA string
 	// SyncPeriod configures the duration of how often existing resources should be synced
 	SyncPeriod *time.Duration
 	// TargetDiffersFromSourceCluster states whether the target cluster is a different one than the source cluster
@@ -214,10 +214,6 @@ type VPAConfig struct {
 }
 
 func (r *resourceManager) Deploy(ctx context.Context) error {
-	if r.secrets.Server.Name == "" || r.secrets.Server.Checksum == "" {
-		return fmt.Errorf("missing server secret information")
-	}
-
 	if r.values.TargetDiffersFromSourceCluster {
 		r.secrets.shootAccess = r.newShootAccessSecret()
 		if err := r.secrets.shootAccess.WithTokenExpirationDuration("24h").Reconcile(ctx, r.client); err != nil {
@@ -248,11 +244,7 @@ func (r *resourceManager) Deploy(ctx context.Context) error {
 	}
 
 	// TODO(rfranzke): Remove in a future release.
-	if r.values.TargetDiffersFromSourceCluster && pointer.Int32Deref(r.values.Replicas, 0) > 0 {
-		return kutil.DeleteObject(ctx, r.client, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "gardener-resource-manager", Namespace: r.namespace}})
-	}
-
-	return nil
+	return kutil.DeleteObject(ctx, r.client, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "gardener-resource-manager-server", Namespace: r.namespace}})
 }
 
 func (r *resourceManager) Destroy(ctx context.Context) error {
@@ -447,7 +439,7 @@ func (r *resourceManager) ensureService(ctx context.Context) error {
 }
 
 func (r *resourceManager) emptyService() *corev1.Service {
-	return &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: ServiceName, Namespace: r.namespace}}
+	return &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: r.namespace}}
 }
 
 // TODO(rfranzke): Remove this special handling when we only support seed clusters of at least K8s 1.20.
@@ -469,6 +461,17 @@ func (r *resourceManager) ensureDeployment(ctx context.Context) error {
 	deployment := r.emptyDeployment()
 
 	rootCAVolumeSourceName, err := r.getRootCAVolumeSourceName(ctx)
+	if err != nil {
+		return err
+	}
+
+	secretServer, err := r.secretsManager.Generate(ctx, &secrets.CertificateSecretConfig{
+		Name:                        secretNameServer,
+		CommonName:                  v1beta1constants.DeploymentNameGardenerResourceManager,
+		DNSNames:                    kutil.DNSNamesForService(serviceName, r.namespace),
+		CertType:                    secrets.ServerCert,
+		SkipPublishingCACertificate: true,
+	}, secretsmanager.SignedByCA(r.values.SecretNameServerCA), secretsmanager.Rotate(secretsmanager.InPlace))
 	if err != nil {
 		return err
 	}
@@ -553,70 +556,70 @@ func (r *resourceManager) ensureDeployment(ctx context.Context) error {
 							},
 							InitialDelaySeconds: 10,
 						},
-						VolumeMounts: []corev1.VolumeMount{{
-							Name:      volumeNameAPIServerAccess,
-							MountPath: volumeMountPathAPIServerAccess,
-							ReadOnly:  true,
-						}},
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      volumeNameAPIServerAccess,
+								MountPath: volumeMountPathAPIServerAccess,
+								ReadOnly:  true,
+							},
+							{
+								MountPath: volumeMountPathCerts,
+								Name:      volumeNameCerts,
+								ReadOnly:  true,
+							},
+						},
 					},
 				},
-				Volumes: []corev1.Volume{{
-					Name: volumeNameAPIServerAccess,
-					VolumeSource: corev1.VolumeSource{
-						Projected: &corev1.ProjectedVolumeSource{
-							DefaultMode: pointer.Int32(420),
-							Sources: []corev1.VolumeProjection{
-								{
-									ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
-										ExpirationSeconds: pointer.Int64(60 * 60 * 12),
-										Path:              "token",
-									},
-								},
-								{
-									Secret: &corev1.SecretProjection{
-										LocalObjectReference: corev1.LocalObjectReference{
-											Name: rootCAVolumeSourceName,
+				Volumes: []corev1.Volume{
+					{
+						Name: volumeNameAPIServerAccess,
+						VolumeSource: corev1.VolumeSource{
+							Projected: &corev1.ProjectedVolumeSource{
+								DefaultMode: pointer.Int32(420),
+								Sources: []corev1.VolumeProjection{
+									{
+										ServiceAccountToken: &corev1.ServiceAccountTokenProjection{
+											ExpirationSeconds: pointer.Int64(60 * 60 * 12),
+											Path:              "token",
 										},
-										Items: []corev1.KeyToPath{{
-											Key:  "ca.crt",
-											Path: "ca.crt",
-										}},
 									},
-								},
-								{
-									DownwardAPI: &corev1.DownwardAPIProjection{
-										Items: []corev1.DownwardAPIVolumeFile{{
-											FieldRef: &corev1.ObjectFieldSelector{
-												APIVersion: "v1",
-												FieldPath:  "metadata.namespace",
+									{
+										Secret: &corev1.SecretProjection{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: rootCAVolumeSourceName,
 											},
-											Path: "namespace",
-										}},
+											Items: []corev1.KeyToPath{{
+												Key:  "ca.crt",
+												Path: "ca.crt",
+											}},
+										},
+									},
+									{
+										DownwardAPI: &corev1.DownwardAPIProjection{
+											Items: []corev1.DownwardAPIVolumeFile{{
+												FieldRef: &corev1.ObjectFieldSelector{
+													APIVersion: "v1",
+													FieldPath:  "metadata.namespace",
+												},
+												Path: "namespace",
+											}},
+										},
 									},
 								},
 							},
 						},
 					},
-				}},
-			},
-		}
-
-		if r.secrets.Server.Name != "" {
-			metav1.SetMetaDataAnnotation(&deployment.Spec.Template.ObjectMeta, "checksum/secret-"+r.secrets.Server.Name, r.secrets.Server.Checksum)
-			deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, corev1.Volume{
-				Name: volumeNameCerts,
-				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						SecretName:  r.secrets.Server.Name,
-						DefaultMode: pointer.Int32(420),
+					{
+						Name: volumeNameCerts,
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{
+								SecretName:  secretServer.Name,
+								DefaultMode: pointer.Int32(420),
+							},
+						},
 					},
 				},
-			})
-			deployment.Spec.Template.Spec.Containers[0].VolumeMounts = append(deployment.Spec.Template.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
-				MountPath: volumeMountPathCerts,
-				Name:      volumeNameCerts,
-				ReadOnly:  true,
-			})
+			},
 		}
 
 		if r.values.TargetDiffersFromSourceCluster {
@@ -737,9 +740,7 @@ func (r *resourceManager) computeCommand() []string {
 		cmd = append(cmd, "--target-disable-cache")
 	}
 	cmd = append(cmd, fmt.Sprintf("--port=%d", serverPort))
-	if r.secrets.Server.Name != "" {
-		cmd = append(cmd, fmt.Sprintf("--tls-cert-dir=%s", volumeMountPathCerts))
-	}
+	cmd = append(cmd, fmt.Sprintf("--tls-cert-dir=%s", volumeMountPathCerts))
 	if r.values.TargetDiffersFromSourceCluster {
 		cmd = append(cmd, "--target-kubeconfig="+gutil.PathGenericKubeconfig)
 	}
@@ -815,9 +816,14 @@ func (r *resourceManager) emptyPodDisruptionBudget() *policyv1beta1.PodDisruptio
 func (r *resourceManager) ensureMutatingWebhookConfiguration(ctx context.Context) error {
 	mutatingWebhookConfiguration := r.emptyMutatingWebhookConfiguration()
 
+	secretServerCA, found := r.secretsManager.Get(r.values.SecretNameServerCA)
+	if !found {
+		return fmt.Errorf("secret %q not found", r.values.SecretNameServerCA)
+	}
+
 	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, r.client, mutatingWebhookConfiguration, func() error {
 		mutatingWebhookConfiguration.Labels = appLabel()
-		mutatingWebhookConfiguration.Webhooks = GetMutatingWebhookConfigurationWebhooks(r.buildWebhookNamespaceSelector(), r.buildWebhookClientConfig)
+		mutatingWebhookConfiguration.Webhooks = GetMutatingWebhookConfigurationWebhooks(r.buildWebhookNamespaceSelector(), secretServerCA, r.buildWebhookClientConfig)
 		return nil
 	})
 	return err
@@ -832,6 +838,11 @@ func (r *resourceManager) emptyMutatingWebhookConfiguration() *admissionregistra
 }
 
 func (r *resourceManager) ensureShootResources(ctx context.Context) error {
+	secretServerCA, found := r.secretsManager.Get(r.values.SecretNameServerCA)
+	if !found {
+		return fmt.Errorf("secret %q not found", r.values.SecretNameServerCA)
+	}
+
 	var (
 		registry = managedresources.NewRegistry(kubernetes.ShootScheme, kubernetes.ShootCodec, kubernetes.ShootSerializer)
 
@@ -856,7 +867,7 @@ func (r *resourceManager) ensureShootResources(ctx context.Context) error {
 	)
 
 	mutatingWebhookConfiguration.Labels = appLabel()
-	mutatingWebhookConfiguration.Webhooks = GetMutatingWebhookConfigurationWebhooks(r.buildWebhookNamespaceSelector(), r.buildWebhookClientConfig)
+	mutatingWebhookConfiguration.Webhooks = GetMutatingWebhookConfigurationWebhooks(r.buildWebhookNamespaceSelector(), secretServerCA, r.buildWebhookClientConfig)
 
 	data, err := registry.AddAllAndSerialize(
 		mutatingWebhookConfiguration,
@@ -917,7 +928,7 @@ func (r *resourceManager) newShootAccessSecret() *gutil.ShootAccessSecret {
 
 // GetMutatingWebhookConfigurationWebhooks returns the MutatingWebhooks for the resourcemanager component for reuse
 // between the component and integration tests.
-func GetMutatingWebhookConfigurationWebhooks(namespaceSelector *metav1.LabelSelector, buildClientConfigFn func(string) admissionregistrationv1.WebhookClientConfig) []admissionregistrationv1.MutatingWebhook {
+func GetMutatingWebhookConfigurationWebhooks(namespaceSelector *metav1.LabelSelector, secretServerCA *corev1.Secret, buildClientConfigFn func(*corev1.Secret, string) admissionregistrationv1.WebhookClientConfig) []admissionregistrationv1.MutatingWebhook {
 	var (
 		failurePolicy = admissionregistrationv1.Fail
 		matchPolicy   = admissionregistrationv1.Exact
@@ -942,7 +953,7 @@ func GetMutatingWebhookConfigurationWebhooks(namespaceSelector *metav1.LabelSele
 			ObjectSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{resourcesv1alpha1.ResourceManagerPurpose: resourcesv1alpha1.LabelPurposeTokenInvalidation},
 			},
-			ClientConfig:            buildClientConfigFn(tokeninvalidator.WebhookPath),
+			ClientConfig:            buildClientConfigFn(secretServerCA, tokeninvalidator.WebhookPath),
 			AdmissionReviewVersions: []string{admissionv1beta1.SchemeGroupVersion.Version, admissionv1.SchemeGroupVersion.Version},
 			FailurePolicy:           &failurePolicy,
 			MatchPolicy:             &matchPolicy,
@@ -973,7 +984,7 @@ func GetMutatingWebhookConfigurationWebhooks(namespaceSelector *metav1.LabelSele
 					},
 				},
 			},
-			ClientConfig:            buildClientConfigFn(projectedtokenmount.WebhookPath),
+			ClientConfig:            buildClientConfigFn(secretServerCA, projectedtokenmount.WebhookPath),
 			AdmissionReviewVersions: []string{admissionv1beta1.SchemeGroupVersion.Version, admissionv1.SchemeGroupVersion.Version},
 			FailurePolicy:           &failurePolicy,
 			MatchPolicy:             &matchPolicy,
@@ -998,14 +1009,14 @@ func (r *resourceManager) buildWebhookNamespaceSelector() *metav1.LabelSelector 
 	}
 }
 
-func (r *resourceManager) buildWebhookClientConfig(path string) admissionregistrationv1.WebhookClientConfig {
-	clientConfig := admissionregistrationv1.WebhookClientConfig{CABundle: r.secrets.ServerCA.Data[secrets.DataKeyCertificateCA]}
+func (r *resourceManager) buildWebhookClientConfig(secretServerCA *corev1.Secret, path string) admissionregistrationv1.WebhookClientConfig {
+	clientConfig := admissionregistrationv1.WebhookClientConfig{CABundle: secretServerCA.Data[secrets.DataKeyCertificateBundle]}
 
 	if r.values.TargetDiffersFromSourceCluster {
-		clientConfig.URL = pointer.String(fmt.Sprintf("https://%s.%s:%d%s", ServiceName, r.namespace, serverServicePort, path))
+		clientConfig.URL = pointer.String(fmt.Sprintf("https://%s.%s:%d%s", serviceName, r.namespace, serverServicePort, path))
 	} else {
 		clientConfig.Service = &admissionregistrationv1.ServiceReference{
-			Name:      ServiceName,
+			Name:      serviceName,
 			Namespace: r.namespace,
 			Path:      &path,
 		}
@@ -1099,12 +1110,6 @@ type Secrets struct {
 	// BootstrapKubeconfig is the kubeconfig of the gardener-resource-manager used during the bootstrapping process. Its
 	// token requestor controller will request a JWT token for itself with this kubeconfig.
 	BootstrapKubeconfig *component.Secret
-	// ServerCA is a secret containing a CA certificate which was used to sign the server certificate provided in the
-	// 'Server' secret.
-	ServerCA component.Secret
-	// Server is a secret containing a x509 TLS server certificate and key for the HTTPS server inside the
-	// gardener-resource-manager (which is used for webhooks).
-	Server component.Secret
 	// RootCA is a secret containing the root CA secret of the target cluster.
 	RootCA *component.Secret
 

--- a/pkg/operation/botanist/component/resourcemanager/resource_manager_suite_test.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager_suite_test.go
@@ -17,6 +17,9 @@ package resourcemanager
 import (
 	"testing"
 
+	secretutils "github.com/gardener/gardener/pkg/utils/secrets"
+	"github.com/gardener/gardener/pkg/utils/test"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -25,3 +28,7 @@ func TestGardenerResourceManager(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Botanist Component ResourceManager Suite")
 }
+
+var _ = BeforeSuite(func() {
+	DeferCleanup(test.WithVar(&secretutils.GenerateKey, secretutils.FakeGenerateKey))
+})

--- a/pkg/operation/botanist/component/resourcemanager/resource_manager_test.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager_test.go
@@ -915,9 +915,9 @@ subjects:
 			})
 
 			It("should successfully deploy all resources (w/ bootstrap kubeconfig)", func() {
-				secretNameBootstrapKubeconfig, secretChecksumBootstrapKubeconfig := "bootstrap-kubeconfig", "bootchecksum"
+				secretNameBootstrapKubeconfig := "bootstrap-kubeconfig"
 
-				secrets.BootstrapKubeconfig = &component.Secret{Name: secretNameBootstrapKubeconfig, Checksum: secretChecksumBootstrapKubeconfig}
+				secrets.BootstrapKubeconfig = &component.Secret{Name: secretNameBootstrapKubeconfig}
 				resourceManager = New(c, deployNamespace, sm, image, cfg)
 				resourceManager.SetSecrets(secrets)
 
@@ -954,7 +954,6 @@ subjects:
 					c.EXPECT().Get(ctx, kutil.Key(deployNamespace, "gardener-resource-manager"), gomock.AssignableToTypeOf(&appsv1.Deployment{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&appsv1.Deployment{}), gomock.Any()).
 						Do(func(ctx context.Context, obj runtime.Object, _ client.Patch, _ ...client.PatchOption) {
-							metav1.SetMetaDataAnnotation(&deployment.Spec.Template.ObjectMeta, "checksum/secret-"+secretNameBootstrapKubeconfig, secretChecksumBootstrapKubeconfig)
 							deployment.Spec.Template.Spec.Containers[0].VolumeMounts[len(deployment.Spec.Template.Spec.Containers[0].VolumeMounts)-1].Name = "kubeconfig-bootstrap"
 							deployment.Spec.Template.Spec.Volumes[len(deployment.Spec.Template.Spec.Volumes)-1] = corev1.Volume{
 								Name: "kubeconfig-bootstrap",

--- a/pkg/operation/botanist/resource_manager.go
+++ b/pkg/operation/botanist/resource_manager.go
@@ -69,6 +69,7 @@ func (b *Botanist) DefaultResourceManager() (resourcemanager.Interface, error) {
 		MaxConcurrentTokenInvalidatorWorkers: pointer.Int32(5),
 		MaxConcurrentTokenRequestorWorkers:   pointer.Int32(5),
 		MaxConcurrentRootCAPublisherWorkers:  pointer.Int32(5),
+		SecretNameServerCA:                   v1beta1constants.SecretNameCACluster,
 		SyncPeriod:                           utils.DurationPtr(time.Minute),
 		TargetDiffersFromSourceCluster:       true,
 		TargetDisableCache:                   pointer.Bool(true),
@@ -105,9 +106,7 @@ func (b *Botanist) DeployGardenerResourceManager(ctx context.Context) error {
 			},
 		}
 		secrets = resourcemanager.Secrets{
-			ServerCA: component.Secret{Name: v1beta1constants.SecretNameCACluster, Checksum: b.LoadCheckSum(v1beta1constants.SecretNameCACluster), Data: b.LoadSecret(v1beta1constants.SecretNameCACluster).Data},
-			Server:   component.Secret{Name: resourcemanager.SecretNameServer, Checksum: b.LoadCheckSum(resourcemanager.SecretNameServer)},
-			RootCA:   &component.Secret{Name: v1beta1constants.SecretNameCACluster, Checksum: b.LoadCheckSum(v1beta1constants.SecretNameCACluster)},
+			RootCA: &component.Secret{Name: v1beta1constants.SecretNameCACluster, Checksum: b.LoadCheckSum(v1beta1constants.SecretNameCACluster)},
 		}
 	)
 

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -333,6 +333,7 @@ func (b *Botanist) GenerateAndSaveSecrets(ctx context.Context) error {
 			"kube-controller-manager-server",
 			"metrics-server",
 			"loki-tls",
+			"gardener-resource-manager-server",
 		} {
 			gardenerResourceDataList.Delete(name)
 		}

--- a/pkg/operation/botanist/wanted_secrets.go
+++ b/pkg/operation/botanist/wanted_secrets.go
@@ -22,7 +22,6 @@ import (
 	"github.com/gardener/gardener/pkg/operation/botanist/component/dependencywatchdog"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/etcd"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/kubeapiserver"
-	"github.com/gardener/gardener/pkg/operation/botanist/component/resourcemanager"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/vpnseedserver"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/vpnshoot"
 	"github.com/gardener/gardener/pkg/operation/common"
@@ -35,8 +34,6 @@ import (
 // authentication credentials, etc.
 func (b *Botanist) generateWantedSecretConfigs(certificateAuthorities map[string]*secrets.Certificate) ([]secrets.ConfigInterface, error) {
 	var (
-		gardenerResourceManagerCertDNSNames = kubernetes.DNSNamesForService(resourcemanager.ServiceName, b.Shoot.SeedNamespace)
-
 		etcdCertDNSNames = append(
 			b.Shoot.Components.ControlPlane.EtcdMain.ServiceDNSNames(),
 			b.Shoot.Components.ControlPlane.EtcdEvents.ServiceDNSNames()...,
@@ -46,19 +43,6 @@ func (b *Botanist) generateWantedSecretConfigs(certificateAuthorities map[string
 	)
 
 	secretList := []secrets.ConfigInterface{
-		// Secret definition for gardener-resource-manager server
-		&secrets.CertificateSecretConfig{
-			Name: resourcemanager.SecretNameServer,
-
-			CommonName:   v1beta1constants.DeploymentNameGardenerResourceManager,
-			Organization: nil,
-			DNSNames:     gardenerResourceManagerCertDNSNames,
-			IPAddresses:  nil,
-
-			CertType:  secrets.ServerCert,
-			SigningCA: certificateAuthorities[v1beta1constants.SecretNameCACluster],
-		},
-
 		// Secret definition for prometheus
 		// TODO(rfranzke): Delete this in a future release once all monitoring configurations of extensions have been
 		// adapted.

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -257,18 +257,6 @@ func generateWantedSecrets(seed *Seed, certificateAuthorities map[string]*secret
 			SigningCA: certificateAuthorities[v1beta1constants.SecretNameCASeed],
 			Validity:  &endUserCrtValidity,
 		},
-		// Secret definition for gardener-resource-manager server
-		&secretutils.CertificateSecretConfig{
-			Name: resourcemanager.SecretNameServer,
-
-			CommonName:   v1beta1constants.DeploymentNameGardenerResourceManager,
-			Organization: nil,
-			DNSNames:     kutil.DNSNamesForService(resourcemanager.ServiceName, v1beta1constants.GardenNamespace),
-			IPAddresses:  nil,
-
-			CertType:  secretutils.ServerCert,
-			SigningCA: certificateAuthorities[v1beta1constants.SecretNameCASeed],
-		},
 	}
 
 	return secretList, nil
@@ -498,7 +486,7 @@ func RunReconcileSeedFlow(
 
 	// Deploy gardener-resource-manager first since it serves central functionality (e.g., projected token mount webhook)
 	// which is required for all other components to start-up.
-	gardenerResourceManager, err := defaultGardenerResourceManager(seedClient, imageVector, deployedSecretsMap[v1beta1constants.SecretNameCASeed], deployedSecretsMap[resourcemanager.SecretNameServer])
+	gardenerResourceManager, err := defaultGardenerResourceManager(seedClient, imageVector, secretsManager)
 	if err != nil {
 		return err
 	}

--- a/pkg/utils/secrets/manager/generate.go
+++ b/pkg/utils/secrets/manager/generate.go
@@ -450,8 +450,13 @@ func SignedByCA(name string) GenerateOption {
 			return nil
 		}
 
-		certificateConfig, ok := config.(*secretutils.CertificateSecretConfig)
-		if !ok {
+		var certificateConfig *secretutils.CertificateSecretConfig
+		switch cfg := config.(type) {
+		case *secretutils.CertificateSecretConfig:
+			certificateConfig = cfg
+		case *secretutils.ControlPlaneSecretConfig:
+			certificateConfig = cfg.CertificateSecretConfig
+		default:
 			return fmt.Errorf("could not apply option to %T, expected *secrets.CertificateSecretConfig", config)
 		}
 

--- a/test/integration/resourcemanager/tokeninvalidator/tokeninvalidator_suite_test.go
+++ b/test/integration/resourcemanager/tokeninvalidator/tokeninvalidator_suite_test.go
@@ -27,6 +27,7 @@ import (
 	. "github.com/onsi/gomega"
 	"go.uber.org/zap/zapcore"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -113,7 +114,7 @@ func getMutatingWebhookConfigurations() []*admissionregistrationv1.MutatingWebho
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "gardener-resource-manager",
 			},
-			Webhooks: resourcemanager.GetMutatingWebhookConfigurationWebhooks(nil, func(path string) admissionregistrationv1.WebhookClientConfig {
+			Webhooks: resourcemanager.GetMutatingWebhookConfigurationWebhooks(nil, nil, func(_ *corev1.Secret, path string) admissionregistrationv1.WebhookClientConfig {
 				return admissionregistrationv1.WebhookClientConfig{
 					Service: &admissionregistrationv1.ServiceReference{
 						Path: &path,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement
/merge squash

**What this PR does / why we need it**:
This PR adapts the `gardener-resource-manager-server` secret to new secrets manager. Note that this includes both GRMs (in `garden` namespace in seed and in shoot namespaces in seed).

For the GRM deployed to shoot namespaces, the bootstrap kubeconfig secret (`shoot-access-gardener-resource-manager-bootstrap`) is also adapted such that it always contains the entire CA bundle.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/3292#issuecomment-1036058890

**Special notes for your reviewer**:
Similar to https://github.com/gardener/gardener/pull/5503/commits/3cce8f4d27cdb9b6c1c2509b23eca6014944370d#diff-255c9a6a892cf804326019de8721e7e509842e90b6190e30bac0b377d876bac6

/invite @timebertt @BeckerMax 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
