### PR TITLE
Clean up deletion of Secrets related to the old logging stack

### DIFF
--- a/pkg/operation/botanist/logging.go
+++ b/pkg/operation/botanist/logging.go
@@ -137,18 +137,8 @@ func (b *Botanist) DeploySeedLogging(ctx context.Context) error {
 		return err
 	}
 
-	// TODO(ialidzhikov): Remove in a future release.
+	// TODO(rfranzke): Remove in a future release.
 	return kutil.DeleteObjects(ctx, b.K8sSeedClient.Client(),
-		// Follow-up of https://github.com/gardener/gardener/pull/5010 (loki ServiceAccount got removed and was never
-		// used).
-		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Namespace: b.Shoot.SeedNamespace, Name: "loki"}},
-		// Follow-up of https://github.com/gardener/gardener/pull/2515 (Secrets related to the old logging stack were
-		// not deleted).
-		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: b.Shoot.SeedNamespace, Name: "kibana-tls"}},
-		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: b.Shoot.SeedNamespace, Name: "curator-sg-credentials"}},
-		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: b.Shoot.SeedNamespace, Name: "sg-admin-client"}},
-		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: b.Shoot.SeedNamespace, Name: "admin-sg-credentials"}},
-		// TODO(rfranzke): Remove in a future release.
 		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: b.Shoot.SeedNamespace, Name: "loki-tls"}},
 	)
 }

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -527,19 +527,6 @@ func RunReconcileSeedFlow(
 
 	lokiValues["enabled"] = loggingEnabled
 
-	// TODO(ialidzhikov): Remove in a future release.
-	if err := kutil.DeleteObjects(ctx, seedClient,
-		// Follow-up of https://github.com/gardener/gardener/pull/5010 (loki ServiceAccount got removed and was never
-		// used).
-		&corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Namespace: v1beta1constants.GardenNamespace, Name: "loki"}},
-		// Follow-up of https://github.com/gardener/gardener/pull/2515 (Secrets related to the old logging stack were
-		// not deleted).
-		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: v1beta1constants.GardenNamespace, Name: "kibana-tls"}},
-		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: v1beta1constants.GardenNamespace, Name: "fluentd-es-sg-credentials"}},
-	); err != nil {
-		return err
-	}
-
 	if loggingEnabled {
 		// check if loki is disabled in gardenlet config
 		if !gardenlethelper.IsLokiEnabled(conf) {


### PR DESCRIPTION
/area control-plane
/kind cleanup

The cleanup logic for the loki ServiceAccount was introduced in v1.39.0 and the cleanup logic for the old logging Secrets - in v1.42.0. I guess it should be safe to clean up the cleanup logic in v1.44.0.

Follow-up after https://github.com/gardener/gardener/pull/5279 and https://github.com/gardener/gardener/pull/5495

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
