### PR TITLE
[GEP-18] Adapt `kube-apiserver`, `kube-apiserver-kubelet`, `kube-aggregator`, `kube-apiserver-http-proxy` secrets to new secrets manager

### DIFF
--- a/pkg/operation/botanist/component/kubeapiserver/configmaps.go
+++ b/pkg/operation/botanist/component/kubeapiserver/configmaps.go
@@ -124,7 +124,7 @@ func (k *kubeAPIServer) reconcileConfigMapEgressSelector(ctx context.Context, co
 						TCP: &apiserverv1alpha1.TCPTransport{
 							URL: fmt.Sprintf("https://%s:%d", vpnseedserver.ServiceName, vpnseedserver.EnvoyPort),
 							TLSConfig: &apiserverv1alpha1.TLSConfig{
-								CABundle:   fmt.Sprintf("%s/%s", volumeMountPathHTTPProxy, secretutils.DataKeyCertificateCA),
+								CABundle:   fmt.Sprintf("%s/%s", volumeMountPathCAVPN, secretutils.DataKeyCertificateBundle),
 								ClientCert: fmt.Sprintf("%s/%s", volumeMountPathHTTPProxy, secretutils.DataKeyCertificate),
 								ClientKey:  fmt.Sprintf("%s/%s", volumeMountPathHTTPProxy, secretutils.DataKeyPrivateKey),
 							},

--- a/pkg/operation/botanist/component/kubeapiserver/deployment.go
+++ b/pkg/operation/botanist/component/kubeapiserver/deployment.go
@@ -40,8 +40,6 @@ import (
 const (
 	// SecretNameHTTPProxy is the name of the secret for the http proxy.
 	SecretNameHTTPProxy = "kube-apiserver-http-proxy"
-	// SecretNameKubeAggregator is the name of the secret for the kube-aggregator when talking to the kube-apiserver.
-	SecretNameKubeAggregator = "kube-aggregator"
 	// SecretNameVPNSeed is the name of the secret containing the certificates for the vpn-seed.
 	SecretNameVPNSeed = "vpn-seed"
 	// SecretNameVPNSeedTLSAuth is the name of the secret containing the TLS auth for the vpn-seed.
@@ -49,6 +47,7 @@ const (
 
 	secretNameServer                 = "kube-apiserver"
 	secretNameKubeAPIServerToKubelet = "kube-apiserver-kubelet"
+	secretNameKubeAggregator         = "kube-aggregator"
 
 	// ContainerNameKubeAPIServer is the name of the kube-apiserver container.
 	ContainerNameKubeAPIServer            = "kube-apiserver"
@@ -124,6 +123,7 @@ func (k *kubeAPIServer) reconcileDeployment(
 	secretBasicAuth *corev1.Secret,
 	secretServer *corev1.Secret,
 	secretKubeletClient *corev1.Secret,
+	secretKubeAggregator *corev1.Secret,
 ) error {
 	var (
 		maxSurge       = intstr.FromString("25%")
@@ -370,7 +370,7 @@ func (k *kubeAPIServer) reconcileDeployment(
 							Name: volumeNameKubeAggregator,
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
-									SecretName: k.secrets.KubeAggregator.Name,
+									SecretName: secretKubeAggregator.Name,
 								},
 							},
 						},
@@ -476,8 +476,8 @@ func (k *kubeAPIServer) computeKubeAPIServerCommand() []string {
 	}
 
 	out = append(out, "--profiling=false")
-	out = append(out, fmt.Sprintf("--proxy-client-cert-file=%s/%s", volumeMountPathKubeAggregator, secrets.ControlPlaneSecretDataKeyCertificatePEM(SecretNameKubeAggregator)))
-	out = append(out, fmt.Sprintf("--proxy-client-key-file=%s/%s", volumeMountPathKubeAggregator, secrets.ControlPlaneSecretDataKeyPrivateKey(SecretNameKubeAggregator)))
+	out = append(out, fmt.Sprintf("--proxy-client-cert-file=%s/%s", volumeMountPathKubeAggregator, secrets.DataKeyCertificate))
+	out = append(out, fmt.Sprintf("--proxy-client-key-file=%s/%s", volumeMountPathKubeAggregator, secrets.DataKeyPrivateKey))
 	out = append(out, fmt.Sprintf("--requestheader-client-ca-file=%s/%s", volumeMountPathCAFrontProxy, secrets.DataKeyCertificateCA))
 	out = append(out, "--requestheader-extra-headers-prefix=X-Remote-Extra-")
 	out = append(out, "--requestheader-group-headers=X-Remote-Group")

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
@@ -334,6 +334,11 @@ func (k *kubeAPIServer) Deploy(ctx context.Context) error {
 		return err
 	}
 
+	secretKubeAggregator, err := k.reconcileSecretKubeAggregator(ctx)
+	if err != nil {
+		return err
+	}
+
 	secretKubeletClient, err := k.reconcileSecretKubeletClient(ctx)
 	if err != nil {
 		return err
@@ -375,6 +380,7 @@ func (k *kubeAPIServer) Deploy(ctx context.Context) error {
 		secretBasicAuth,
 		secretServer,
 		secretKubeletClient,
+		secretKubeAggregator,
 	); err != nil {
 		return err
 	}
@@ -567,8 +573,6 @@ type Secrets struct {
 	// HTTPProxy is the client certificate for the http proxy to talk to the kube-apiserver..
 	// Only relevant if VPNConfig.ReversedVPNEnabled is true.
 	HTTPProxy *component.Secret
-	// KubeAggregator is the client certificate for the kube-aggregator to talk to the kube-apiserver.
-	KubeAggregator component.Secret
 	// VPNSeed is the client certificate for the vpn-seed to talk to the kube-apiserver.
 	// Only relevant if VPNConfig.ReversedVPNEnabled is false.
 	VPNSeed *component.Secret
@@ -592,7 +596,6 @@ func (s *Secrets) all() map[string]secret {
 		"CAFrontProxy":         {Secret: &s.CAFrontProxy},
 		"Etcd":                 {Secret: &s.Etcd},
 		"HTTPProxy":            {Secret: s.HTTPProxy, isRequired: func(v Values) bool { return v.VPN.ReversedVPNEnabled }},
-		"KubeAggregator":       {Secret: &s.KubeAggregator},
 		"VPNSeed":              {Secret: s.VPNSeed, isRequired: func(v Values) bool { return !v.VPN.ReversedVPNEnabled }},
 		"VPNSeedTLSAuth":       {Secret: s.VPNSeedTLSAuth, isRequired: func(v Values) bool { return !v.VPN.ReversedVPNEnabled }},
 		"VPNSeedServerTLSAuth": {Secret: s.VPNSeedServerTLSAuth, isRequired: func(v Values) bool { return v.VPN.ReversedVPNEnabled }},

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
@@ -334,6 +334,11 @@ func (k *kubeAPIServer) Deploy(ctx context.Context) error {
 		return err
 	}
 
+	secretHTTPProxy, err := k.reconcileSecretHTTPProxy(ctx)
+	if err != nil {
+		return err
+	}
+
 	secretKubeAggregator, err := k.reconcileSecretKubeAggregator(ctx)
 	if err != nil {
 		return err
@@ -381,6 +386,7 @@ func (k *kubeAPIServer) Deploy(ctx context.Context) error {
 		secretServer,
 		secretKubeletClient,
 		secretKubeAggregator,
+		secretHTTPProxy,
 	); err != nil {
 		return err
 	}
@@ -570,9 +576,6 @@ type Secrets struct {
 	CAFrontProxy component.Secret
 	// Etcd is the client certificate for the kube-apiserver to talk to etcd.
 	Etcd component.Secret
-	// HTTPProxy is the client certificate for the http proxy to talk to the kube-apiserver..
-	// Only relevant if VPNConfig.ReversedVPNEnabled is true.
-	HTTPProxy *component.Secret
 	// VPNSeed is the client certificate for the vpn-seed to talk to the kube-apiserver.
 	// Only relevant if VPNConfig.ReversedVPNEnabled is false.
 	VPNSeed *component.Secret
@@ -595,7 +598,6 @@ func (s *Secrets) all() map[string]secret {
 		"CAEtcd":               {Secret: &s.CAEtcd},
 		"CAFrontProxy":         {Secret: &s.CAFrontProxy},
 		"Etcd":                 {Secret: &s.Etcd},
-		"HTTPProxy":            {Secret: s.HTTPProxy, isRequired: func(v Values) bool { return v.VPN.ReversedVPNEnabled }},
 		"VPNSeed":              {Secret: s.VPNSeed, isRequired: func(v Values) bool { return !v.VPN.ReversedVPNEnabled }},
 		"VPNSeedTLSAuth":       {Secret: s.VPNSeedTLSAuth, isRequired: func(v Values) bool { return !v.VPN.ReversedVPNEnabled }},
 		"VPNSeedServerTLSAuth": {Secret: s.VPNSeedServerTLSAuth, isRequired: func(v Values) bool { return v.VPN.ReversedVPNEnabled }},

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
@@ -78,31 +78,30 @@ var _ = Describe("KubeAPIServer", func() {
 		kapi                Interface
 		version             = semver.MustParse("1.22.1")
 
-		secretNameBasicAuthentication        = "kube-apiserver-basic-auth-426b1845"
-		secretNameStaticToken                = "kube-apiserver-static-token-c069a0e6"
-		secretNameCA                         = "CA-secret"
-		secretChecksumCA                     = "12345"
-		secretNameCAEtcd                     = "CAEtcd-secret"
-		secretChecksumCAEtcd                 = "12345"
-		secretNameCAFrontProxy               = "CAFrontProxy-secret"
-		secretChecksumCAFrontProxy           = "12345"
-		secretNameEtcd                       = "Etcd-secret"
-		secretChecksumEtcd                   = "12345"
-		secretNameHTTPProxy                  = "HttpProxy-secret"
-		secretChecksumHTTPProxy              = "12345"
-		secretNameKubeAggregator             = "KubeAggregator-secret"
-		secretChecksumKubeAggregator         = "12345"
-		secretNameKubeAPIServerToKubelet     = "KubeAPIServerToKubelet-secret"
-		secretChecksumKubeAPIServerToKubelet = "12345"
-		secretNameServer                     = "kube-apiserver"
-		secretNameServiceAccountKey          = "service-account-key-c37a87f6"
-		secretNameVPNSeed                    = "VPNSeed-secret"
-		secretChecksumVPNSeed                = "12345"
-		secretNameVPNSeedTLSAuth             = "VPNSeedTLSAuth-secret"
-		secretChecksumVPNSeedTLSAuth         = "12345"
-		secretNameVPNSeedServerTLSAuth       = "VPNSeedServerTLSAuth-secret"
-		secretChecksumVPNSeedServerTLSAuth   = "12345"
-		secrets                              Secrets
+		secretNameBasicAuthentication      = "kube-apiserver-basic-auth-426b1845"
+		secretNameStaticToken              = "kube-apiserver-static-token-c069a0e6"
+		secretNameCA                       = "CA-secret"
+		secretChecksumCA                   = "12345"
+		secretNameCAEtcd                   = "CAEtcd-secret"
+		secretChecksumCAEtcd               = "12345"
+		secretNameCAFrontProxy             = "CAFrontProxy-secret"
+		secretChecksumCAFrontProxy         = "12345"
+		secretNameEtcd                     = "Etcd-secret"
+		secretChecksumEtcd                 = "12345"
+		secretNameHTTPProxy                = "HttpProxy-secret"
+		secretChecksumHTTPProxy            = "12345"
+		secretNameKubeAggregator           = "KubeAggregator-secret"
+		secretChecksumKubeAggregator       = "12345"
+		secretNameKubeAPIServerToKubelet   = "kube-apiserver-kubelet"
+		secretNameServer                   = "kube-apiserver"
+		secretNameServiceAccountKey        = "service-account-key-c37a87f6"
+		secretNameVPNSeed                  = "VPNSeed-secret"
+		secretChecksumVPNSeed              = "12345"
+		secretNameVPNSeedTLSAuth           = "VPNSeedTLSAuth-secret"
+		secretChecksumVPNSeedTLSAuth       = "12345"
+		secretNameVPNSeedServerTLSAuth     = "VPNSeedServerTLSAuth-secret"
+		secretChecksumVPNSeedServerTLSAuth = "12345"
+		secrets                            Secrets
 
 		secretNameAdmissionConfig      = "kube-apiserver-admission-config-e38ff146"
 		secretNameETCDEncryptionConfig = "kube-apiserver-etcd-encryption-configuration-235f7353"
@@ -130,16 +129,15 @@ var _ = Describe("KubeAPIServer", func() {
 		kapi = New(kubernetesInterface, namespace, sm, Values{Version: version})
 
 		secrets = Secrets{
-			CA:                     component.Secret{Name: secretNameCA, Checksum: secretChecksumCA},
-			CAEtcd:                 component.Secret{Name: secretNameCAEtcd, Checksum: secretChecksumCAEtcd},
-			CAFrontProxy:           component.Secret{Name: secretNameCAFrontProxy, Checksum: secretChecksumCAFrontProxy},
-			Etcd:                   component.Secret{Name: secretNameEtcd, Checksum: secretChecksumEtcd},
-			HTTPProxy:              &component.Secret{Name: secretNameHTTPProxy, Checksum: secretChecksumHTTPProxy},
-			KubeAggregator:         component.Secret{Name: secretNameKubeAggregator, Checksum: secretChecksumKubeAggregator},
-			KubeAPIServerToKubelet: component.Secret{Name: secretNameKubeAPIServerToKubelet, Checksum: secretChecksumKubeAPIServerToKubelet},
-			VPNSeed:                &component.Secret{Name: secretNameVPNSeed, Checksum: secretChecksumVPNSeed},
-			VPNSeedTLSAuth:         &component.Secret{Name: secretNameVPNSeedTLSAuth, Checksum: secretChecksumVPNSeedTLSAuth},
-			VPNSeedServerTLSAuth:   &component.Secret{Name: secretNameVPNSeedServerTLSAuth, Checksum: secretChecksumVPNSeedServerTLSAuth},
+			CA:                   component.Secret{Name: secretNameCA, Checksum: secretChecksumCA},
+			CAEtcd:               component.Secret{Name: secretNameCAEtcd, Checksum: secretChecksumCAEtcd},
+			CAFrontProxy:         component.Secret{Name: secretNameCAFrontProxy, Checksum: secretChecksumCAFrontProxy},
+			Etcd:                 component.Secret{Name: secretNameEtcd, Checksum: secretChecksumEtcd},
+			HTTPProxy:            &component.Secret{Name: secretNameHTTPProxy, Checksum: secretChecksumHTTPProxy},
+			KubeAggregator:       component.Secret{Name: secretNameKubeAggregator, Checksum: secretChecksumKubeAggregator},
+			VPNSeed:              &component.Secret{Name: secretNameVPNSeed, Checksum: secretChecksumVPNSeed},
+			VPNSeedTLSAuth:       &component.Secret{Name: secretNameVPNSeedTLSAuth, Checksum: secretChecksumVPNSeedTLSAuth},
+			VPNSeedServerTLSAuth: &component.Secret{Name: secretNameVPNSeedServerTLSAuth, Checksum: secretChecksumVPNSeedServerTLSAuth},
 		}
 
 		deployment = &appsv1.Deployment{
@@ -231,9 +229,6 @@ var _ = Describe("KubeAPIServer", func() {
 				),
 				Entry("KubeAggregator missing",
 					"KubeAggregator", func(s *Secrets) { s.KubeAggregator.Name = "" }, Values{},
-				),
-				Entry("KubeAPIServerToKubelet missing",
-					"KubeAPIServerToKubelet", func(s *Secrets) { s.KubeAPIServerToKubelet.Name = "" }, Values{},
 				),
 				Entry("ReversedVPN disabled but VPNSeed missing",
 					"VPNSeed", func(s *Secrets) { s.VPNSeed = nil }, Values{VPN: VPNConfig{ReversedVPNEnabled: false}},
@@ -1426,7 +1421,7 @@ rules:
 						"reference.resources.gardener.cloud/secret-91c30740":    secretNameCAEtcd,
 						"reference.resources.gardener.cloud/secret-9282d44f":    secretNameCAFrontProxy,
 						"reference.resources.gardener.cloud/secret-c16f0542":    secretNameEtcd,
-						"reference.resources.gardener.cloud/secret-274d0dbb":    secretNameKubeAPIServerToKubelet,
+						"reference.resources.gardener.cloud/secret-c1267cc2":    secretNameKubeAPIServerToKubelet,
 						"reference.resources.gardener.cloud/secret-2e310c99":    secretNameKubeAggregator,
 						"reference.resources.gardener.cloud/secret-3ddd1800":    secretNameServer,
 						"reference.resources.gardener.cloud/secret-9f3de87f":    secretNameVPNSeed,
@@ -1477,14 +1472,13 @@ rules:
 						"checksum/secret-" + secretNameHTTPProxy:                secretChecksumHTTPProxy,
 						"checksum/secret-" + secretNameKubeAggregator:           secretChecksumKubeAggregator,
 						"checksum/secret-" + secretNameCAFrontProxy:             secretChecksumCAFrontProxy,
-						"checksum/secret-" + secretNameKubeAPIServerToKubelet:   secretChecksumKubeAPIServerToKubelet,
 						"checksum/secret-" + secretNameVPNSeedTLSAuth:           secretChecksumVPNSeedTLSAuth,
 						"reference.resources.gardener.cloud/secret-a709ce3a":    secretNameServiceAccountKey,
 						"reference.resources.gardener.cloud/secret-71fba891":    secretNameCA,
 						"reference.resources.gardener.cloud/secret-91c30740":    secretNameCAEtcd,
 						"reference.resources.gardener.cloud/secret-9282d44f":    secretNameCAFrontProxy,
 						"reference.resources.gardener.cloud/secret-c16f0542":    secretNameEtcd,
-						"reference.resources.gardener.cloud/secret-274d0dbb":    secretNameKubeAPIServerToKubelet,
+						"reference.resources.gardener.cloud/secret-c1267cc2":    secretNameKubeAPIServerToKubelet,
 						"reference.resources.gardener.cloud/secret-2e310c99":    secretNameKubeAggregator,
 						"reference.resources.gardener.cloud/secret-3ddd1800":    secretNameServer,
 						"reference.resources.gardener.cloud/secret-9f3de87f":    secretNameVPNSeed,
@@ -1795,8 +1789,8 @@ rules:
 							"--external-hostname="+externalHostname,
 							"--insecure-port=0",
 							"--kubelet-preferred-address-types=InternalIP,Hostname,ExternalIP",
-							"--kubelet-client-certificate=/srv/kubernetes/apiserver-kubelet/kube-apiserver-kubelet.crt",
-							"--kubelet-client-key=/srv/kubernetes/apiserver-kubelet/kube-apiserver-kubelet.key",
+							"--kubelet-client-certificate=/srv/kubernetes/apiserver-kubelet/tls.crt",
+							"--kubelet-client-key=/srv/kubernetes/apiserver-kubelet/tls.key",
 							"--livez-grace-period=1m",
 							"--shutdown-delay-duration=15s",
 							"--profiling=false",

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
@@ -90,8 +90,7 @@ var _ = Describe("KubeAPIServer", func() {
 		secretChecksumEtcd                 = "12345"
 		secretNameHTTPProxy                = "HttpProxy-secret"
 		secretChecksumHTTPProxy            = "12345"
-		secretNameKubeAggregator           = "KubeAggregator-secret"
-		secretChecksumKubeAggregator       = "12345"
+		secretNameKubeAggregator           = "kube-aggregator"
 		secretNameKubeAPIServerToKubelet   = "kube-apiserver-kubelet"
 		secretNameServer                   = "kube-apiserver"
 		secretNameServiceAccountKey        = "service-account-key-c37a87f6"
@@ -134,7 +133,6 @@ var _ = Describe("KubeAPIServer", func() {
 			CAFrontProxy:         component.Secret{Name: secretNameCAFrontProxy, Checksum: secretChecksumCAFrontProxy},
 			Etcd:                 component.Secret{Name: secretNameEtcd, Checksum: secretChecksumEtcd},
 			HTTPProxy:            &component.Secret{Name: secretNameHTTPProxy, Checksum: secretChecksumHTTPProxy},
-			KubeAggregator:       component.Secret{Name: secretNameKubeAggregator, Checksum: secretChecksumKubeAggregator},
 			VPNSeed:              &component.Secret{Name: secretNameVPNSeed, Checksum: secretChecksumVPNSeed},
 			VPNSeedTLSAuth:       &component.Secret{Name: secretNameVPNSeedTLSAuth, Checksum: secretChecksumVPNSeedTLSAuth},
 			VPNSeedServerTLSAuth: &component.Secret{Name: secretNameVPNSeedServerTLSAuth, Checksum: secretChecksumVPNSeedServerTLSAuth},
@@ -226,9 +224,6 @@ var _ = Describe("KubeAPIServer", func() {
 				),
 				Entry("Etcd missing",
 					"Etcd", func(s *Secrets) { s.Etcd.Name = "" }, Values{},
-				),
-				Entry("KubeAggregator missing",
-					"KubeAggregator", func(s *Secrets) { s.KubeAggregator.Name = "" }, Values{},
 				),
 				Entry("ReversedVPN disabled but VPNSeed missing",
 					"VPNSeed", func(s *Secrets) { s.VPNSeed = nil }, Values{VPN: VPNConfig{ReversedVPNEnabled: false}},
@@ -1422,7 +1417,7 @@ rules:
 						"reference.resources.gardener.cloud/secret-9282d44f":    secretNameCAFrontProxy,
 						"reference.resources.gardener.cloud/secret-c16f0542":    secretNameEtcd,
 						"reference.resources.gardener.cloud/secret-c1267cc2":    secretNameKubeAPIServerToKubelet,
-						"reference.resources.gardener.cloud/secret-2e310c99":    secretNameKubeAggregator,
+						"reference.resources.gardener.cloud/secret-998b2966":    secretNameKubeAggregator,
 						"reference.resources.gardener.cloud/secret-3ddd1800":    secretNameServer,
 						"reference.resources.gardener.cloud/secret-9f3de87f":    secretNameVPNSeed,
 						"reference.resources.gardener.cloud/secret-e638c9f3":    secretNameVPNSeedTLSAuth,
@@ -1470,7 +1465,6 @@ rules:
 						"checksum/secret-" + secretNameCA:                       secretChecksumCA,
 						"checksum/secret-" + secretNameEtcd:                     secretChecksumEtcd,
 						"checksum/secret-" + secretNameHTTPProxy:                secretChecksumHTTPProxy,
-						"checksum/secret-" + secretNameKubeAggregator:           secretChecksumKubeAggregator,
 						"checksum/secret-" + secretNameCAFrontProxy:             secretChecksumCAFrontProxy,
 						"checksum/secret-" + secretNameVPNSeedTLSAuth:           secretChecksumVPNSeedTLSAuth,
 						"reference.resources.gardener.cloud/secret-a709ce3a":    secretNameServiceAccountKey,
@@ -1479,7 +1473,7 @@ rules:
 						"reference.resources.gardener.cloud/secret-9282d44f":    secretNameCAFrontProxy,
 						"reference.resources.gardener.cloud/secret-c16f0542":    secretNameEtcd,
 						"reference.resources.gardener.cloud/secret-c1267cc2":    secretNameKubeAPIServerToKubelet,
-						"reference.resources.gardener.cloud/secret-2e310c99":    secretNameKubeAggregator,
+						"reference.resources.gardener.cloud/secret-998b2966":    secretNameKubeAggregator,
 						"reference.resources.gardener.cloud/secret-3ddd1800":    secretNameServer,
 						"reference.resources.gardener.cloud/secret-9f3de87f":    secretNameVPNSeed,
 						"reference.resources.gardener.cloud/secret-e638c9f3":    secretNameVPNSeedTLSAuth,
@@ -1794,8 +1788,8 @@ rules:
 							"--livez-grace-period=1m",
 							"--shutdown-delay-duration=15s",
 							"--profiling=false",
-							"--proxy-client-cert-file=/srv/kubernetes/aggregator/kube-aggregator.crt",
-							"--proxy-client-key-file=/srv/kubernetes/aggregator/kube-aggregator.key",
+							"--proxy-client-cert-file=/srv/kubernetes/aggregator/tls.crt",
+							"--proxy-client-key-file=/srv/kubernetes/aggregator/tls.key",
 							"--requestheader-client-ca-file=/srv/kubernetes/ca-front-proxy/ca.crt",
 							"--requestheader-extra-headers-prefix=X-Remote-Extra-",
 							"--requestheader-group-headers=X-Remote-Group",

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
@@ -94,8 +94,7 @@ var _ = Describe("KubeAPIServer", func() {
 		secretChecksumKubeAggregator         = "12345"
 		secretNameKubeAPIServerToKubelet     = "KubeAPIServerToKubelet-secret"
 		secretChecksumKubeAPIServerToKubelet = "12345"
-		secretNameServer                     = "Server-secret"
-		secretChecksumServer                 = "12345"
+		secretNameServer                     = "kube-apiserver"
 		secretNameServiceAccountKey          = "service-account-key-c37a87f6"
 		secretNameVPNSeed                    = "VPNSeed-secret"
 		secretChecksumVPNSeed                = "12345"
@@ -138,7 +137,6 @@ var _ = Describe("KubeAPIServer", func() {
 			HTTPProxy:              &component.Secret{Name: secretNameHTTPProxy, Checksum: secretChecksumHTTPProxy},
 			KubeAggregator:         component.Secret{Name: secretNameKubeAggregator, Checksum: secretChecksumKubeAggregator},
 			KubeAPIServerToKubelet: component.Secret{Name: secretNameKubeAPIServerToKubelet, Checksum: secretChecksumKubeAPIServerToKubelet},
-			Server:                 component.Secret{Name: secretNameServer, Checksum: secretChecksumServer},
 			VPNSeed:                &component.Secret{Name: secretNameVPNSeed, Checksum: secretChecksumVPNSeed},
 			VPNSeedTLSAuth:         &component.Secret{Name: secretNameVPNSeedTLSAuth, Checksum: secretChecksumVPNSeedTLSAuth},
 			VPNSeedServerTLSAuth:   &component.Secret{Name: secretNameVPNSeedServerTLSAuth, Checksum: secretChecksumVPNSeedServerTLSAuth},
@@ -236,9 +234,6 @@ var _ = Describe("KubeAPIServer", func() {
 				),
 				Entry("KubeAPIServerToKubelet missing",
 					"KubeAPIServerToKubelet", func(s *Secrets) { s.KubeAPIServerToKubelet.Name = "" }, Values{},
-				),
-				Entry("Server missing",
-					"Server", func(s *Secrets) { s.Server.Name = "" }, Values{},
 				),
 				Entry("ReversedVPN disabled but VPNSeed missing",
 					"VPNSeed", func(s *Secrets) { s.VPNSeed = nil }, Values{VPN: VPNConfig{ReversedVPNEnabled: false}},
@@ -1433,7 +1428,7 @@ rules:
 						"reference.resources.gardener.cloud/secret-c16f0542":    secretNameEtcd,
 						"reference.resources.gardener.cloud/secret-274d0dbb":    secretNameKubeAPIServerToKubelet,
 						"reference.resources.gardener.cloud/secret-2e310c99":    secretNameKubeAggregator,
-						"reference.resources.gardener.cloud/secret-e2878235":    secretNameServer,
+						"reference.resources.gardener.cloud/secret-3ddd1800":    secretNameServer,
 						"reference.resources.gardener.cloud/secret-9f3de87f":    secretNameVPNSeed,
 						"reference.resources.gardener.cloud/secret-e638c9f3":    secretNameVPNSeedTLSAuth,
 						"reference.resources.gardener.cloud/secret-430944e0":    secretNameStaticToken,
@@ -1483,7 +1478,6 @@ rules:
 						"checksum/secret-" + secretNameKubeAggregator:           secretChecksumKubeAggregator,
 						"checksum/secret-" + secretNameCAFrontProxy:             secretChecksumCAFrontProxy,
 						"checksum/secret-" + secretNameKubeAPIServerToKubelet:   secretChecksumKubeAPIServerToKubelet,
-						"checksum/secret-" + secretNameServer:                   secretChecksumServer,
 						"checksum/secret-" + secretNameVPNSeedTLSAuth:           secretChecksumVPNSeedTLSAuth,
 						"reference.resources.gardener.cloud/secret-a709ce3a":    secretNameServiceAccountKey,
 						"reference.resources.gardener.cloud/secret-71fba891":    secretNameCA,
@@ -1492,7 +1486,7 @@ rules:
 						"reference.resources.gardener.cloud/secret-c16f0542":    secretNameEtcd,
 						"reference.resources.gardener.cloud/secret-274d0dbb":    secretNameKubeAPIServerToKubelet,
 						"reference.resources.gardener.cloud/secret-2e310c99":    secretNameKubeAggregator,
-						"reference.resources.gardener.cloud/secret-e2878235":    secretNameServer,
+						"reference.resources.gardener.cloud/secret-3ddd1800":    secretNameServer,
 						"reference.resources.gardener.cloud/secret-9f3de87f":    secretNameVPNSeed,
 						"reference.resources.gardener.cloud/secret-e638c9f3":    secretNameVPNSeedTLSAuth,
 						"reference.resources.gardener.cloud/secret-430944e0":    secretNameStaticToken,
@@ -1694,8 +1688,8 @@ rules:
 							"--host=localhost",
 							"--port=9443",
 							"--cert-dir=/srv/kubernetes/apiserver",
-							"--cert-name=kube-apiserver.crt",
-							"--key-name=kube-apiserver.key",
+							"--cert-name=tls.crt",
+							"--key-name=tls.key",
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
@@ -1822,8 +1816,8 @@ rules:
 							"--service-account-key-file=/srv/kubernetes/service-account-key/id_rsa",
 							"--service-account-signing-key-file=/srv/kubernetes/service-account-key/id_rsa",
 							"--token-auth-file=/srv/kubernetes/token/static_tokens.csv",
-							"--tls-cert-file=/srv/kubernetes/apiserver/kube-apiserver.crt",
-							"--tls-private-key-file=/srv/kubernetes/apiserver/kube-apiserver.key",
+							"--tls-cert-file=/srv/kubernetes/apiserver/tls.crt",
+							"--tls-private-key-file=/srv/kubernetes/apiserver/tls.key",
 							"--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256,TLS_AES_256_GCM_SHA384,TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
 							"--v=2",
 						))

--- a/pkg/operation/botanist/component/kubeapiserver/mock/mocks.go
+++ b/pkg/operation/botanist/component/kubeapiserver/mock/mocks.go
@@ -194,6 +194,18 @@ func (mr *MockInterfaceMockRecorder) SetSecrets(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetSecrets", reflect.TypeOf((*MockInterface)(nil).SetSecrets), arg0)
 }
 
+// SetServerCertificateConfig mocks base method.
+func (m *MockInterface) SetServerCertificateConfig(arg0 kubeapiserver.ServerCertificateConfig) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetServerCertificateConfig", arg0)
+}
+
+// SetServerCertificateConfig indicates an expected call of SetServerCertificateConfig.
+func (mr *MockInterfaceMockRecorder) SetServerCertificateConfig(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetServerCertificateConfig", reflect.TypeOf((*MockInterface)(nil).SetServerCertificateConfig), arg0)
+}
+
 // SetServiceAccountConfig mocks base method.
 func (m *MockInterface) SetServiceAccountConfig(arg0 kubeapiserver.ServiceAccountConfig) {
 	m.ctrl.T.Helper()

--- a/pkg/operation/botanist/component/kubeapiserver/secrets.go
+++ b/pkg/operation/botanist/component/kubeapiserver/secrets.go
@@ -290,3 +290,22 @@ func (k *kubeAPIServer) reconcileSecretKubeAggregator(ctx context.Context) (*cor
 	// TODO(rfranzke): Remove this in a future release.
 	return secret, kutil.DeleteObject(ctx, k.client.Client(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "kube-aggregator", Namespace: k.namespace}})
 }
+
+func (k *kubeAPIServer) reconcileSecretHTTPProxy(ctx context.Context) (*corev1.Secret, error) {
+	if !k.values.VPN.ReversedVPNEnabled {
+		return nil, nil
+	}
+
+	secret, err := k.secretsManager.Generate(ctx, &secretutils.CertificateSecretConfig{
+		Name:                        secretNameHTTPProxy,
+		CommonName:                  "kube-apiserver-http-proxy",
+		CertType:                    secretutils.ClientCert,
+		SkipPublishingCACertificate: true,
+	}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCAVPN), secretsmanager.Rotate(secretsmanager.InPlace))
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO(rfranzke): Remove this in a future release.
+	return secret, kutil.DeleteObject(ctx, k.client.Client(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "kube-apiserver-http-proxy", Namespace: k.namespace}})
+}

--- a/pkg/operation/botanist/component/kubeapiserver/secrets.go
+++ b/pkg/operation/botanist/component/kubeapiserver/secrets.go
@@ -260,3 +260,18 @@ func (k *kubeAPIServer) reconcileSecretServer(ctx context.Context) (*corev1.Secr
 	// TODO(rfranzke): Remove this in a future release.
 	return secret, kutil.DeleteObject(ctx, k.client.Client(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "kube-apiserver", Namespace: k.namespace}})
 }
+
+func (k *kubeAPIServer) reconcileSecretKubeletClient(ctx context.Context) (*corev1.Secret, error) {
+	secret, err := k.secretsManager.Generate(ctx, &secretutils.CertificateSecretConfig{
+		Name:                        secretNameKubeAPIServerToKubelet,
+		CommonName:                  userName,
+		CertType:                    secretutils.ClientCert,
+		SkipPublishingCACertificate: true,
+	}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCAKubelet), secretsmanager.Rotate(secretsmanager.InPlace))
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO(rfranzke): Remove this in a future release.
+	return secret, kutil.DeleteObject(ctx, k.client.Client(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "kube-apiserver-kubelet", Namespace: k.namespace}})
+}

--- a/pkg/operation/botanist/component/kubeapiserver/secrets.go
+++ b/pkg/operation/botanist/component/kubeapiserver/secrets.go
@@ -275,3 +275,18 @@ func (k *kubeAPIServer) reconcileSecretKubeletClient(ctx context.Context) (*core
 	// TODO(rfranzke): Remove this in a future release.
 	return secret, kutil.DeleteObject(ctx, k.client.Client(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "kube-apiserver-kubelet", Namespace: k.namespace}})
 }
+
+func (k *kubeAPIServer) reconcileSecretKubeAggregator(ctx context.Context) (*corev1.Secret, error) {
+	secret, err := k.secretsManager.Generate(ctx, &secretutils.CertificateSecretConfig{
+		Name:                        secretNameKubeAggregator,
+		CommonName:                  "system:kube-aggregator",
+		CertType:                    secretutils.ClientCert,
+		SkipPublishingCACertificate: true,
+	}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCAFrontProxy), secretsmanager.Rotate(secretsmanager.InPlace))
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO(rfranzke): Remove this in a future release.
+	return secret, kutil.DeleteObject(ctx, k.client.Client(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "kube-aggregator", Namespace: k.namespace}})
+}

--- a/pkg/operation/botanist/component/kubeapiserver/shoot_resources.go
+++ b/pkg/operation/botanist/component/kubeapiserver/shoot_resources.go
@@ -74,7 +74,7 @@ func (k *kubeAPIServer) computeShootResourcesData() (map[string][]byte, error) {
 			},
 			Subjects: []rbacv1.Subject{{
 				Kind: rbacv1.UserKind,
-				Name: UserName,
+				Name: userName,
 			}},
 		}
 	)

--- a/pkg/operation/botanist/kubeapiserver.go
+++ b/pkg/operation/botanist/kubeapiserver.go
@@ -444,7 +444,6 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 	}
 
 	if values.VPN.ReversedVPNEnabled {
-		secrets.HTTPProxy = &component.Secret{Name: kubeapiserver.SecretNameHTTPProxy, Checksum: b.LoadCheckSum(kubeapiserver.SecretNameHTTPProxy)}
 		secrets.VPNSeedServerTLSAuth = &component.Secret{Name: vpnseedserver.VpnSeedServerTLSAuth, Checksum: b.LoadCheckSum(vpnseedserver.VpnSeedServerTLSAuth)}
 	} else {
 		secrets.VPNSeed = &component.Secret{Name: kubeapiserver.SecretNameVPNSeed, Checksum: b.LoadCheckSum(kubeapiserver.SecretNameVPNSeed)}

--- a/pkg/operation/botanist/kubeapiserver.go
+++ b/pkg/operation/botanist/kubeapiserver.go
@@ -437,12 +437,11 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 	}
 
 	secrets := kubeapiserver.Secrets{
-		CA:                     component.Secret{Name: v1beta1constants.SecretNameCACluster, Checksum: b.LoadCheckSum(v1beta1constants.SecretNameCACluster)},
-		CAEtcd:                 component.Secret{Name: etcd.SecretNameCA, Checksum: b.LoadCheckSum(etcd.SecretNameCA)},
-		CAFrontProxy:           component.Secret{Name: v1beta1constants.SecretNameCAFrontProxy, Checksum: b.LoadCheckSum(v1beta1constants.SecretNameCAFrontProxy)},
-		Etcd:                   component.Secret{Name: etcd.SecretNameClient, Checksum: b.LoadCheckSum(etcd.SecretNameClient)},
-		KubeAggregator:         component.Secret{Name: kubeapiserver.SecretNameKubeAggregator, Checksum: b.LoadCheckSum(kubeapiserver.SecretNameKubeAggregator)},
-		KubeAPIServerToKubelet: component.Secret{Name: kubeapiserver.SecretNameKubeAPIServerToKubelet, Checksum: b.LoadCheckSum(kubeapiserver.SecretNameKubeAPIServerToKubelet)},
+		CA:             component.Secret{Name: v1beta1constants.SecretNameCACluster, Checksum: b.LoadCheckSum(v1beta1constants.SecretNameCACluster)},
+		CAEtcd:         component.Secret{Name: etcd.SecretNameCA, Checksum: b.LoadCheckSum(etcd.SecretNameCA)},
+		CAFrontProxy:   component.Secret{Name: v1beta1constants.SecretNameCAFrontProxy, Checksum: b.LoadCheckSum(v1beta1constants.SecretNameCAFrontProxy)},
+		Etcd:           component.Secret{Name: etcd.SecretNameClient, Checksum: b.LoadCheckSum(etcd.SecretNameClient)},
+		KubeAggregator: component.Secret{Name: kubeapiserver.SecretNameKubeAggregator, Checksum: b.LoadCheckSum(kubeapiserver.SecretNameKubeAggregator)},
 	}
 
 	if values.VPN.ReversedVPNEnabled {

--- a/pkg/operation/botanist/kubeapiserver.go
+++ b/pkg/operation/botanist/kubeapiserver.go
@@ -437,11 +437,10 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 	}
 
 	secrets := kubeapiserver.Secrets{
-		CA:             component.Secret{Name: v1beta1constants.SecretNameCACluster, Checksum: b.LoadCheckSum(v1beta1constants.SecretNameCACluster)},
-		CAEtcd:         component.Secret{Name: etcd.SecretNameCA, Checksum: b.LoadCheckSum(etcd.SecretNameCA)},
-		CAFrontProxy:   component.Secret{Name: v1beta1constants.SecretNameCAFrontProxy, Checksum: b.LoadCheckSum(v1beta1constants.SecretNameCAFrontProxy)},
-		Etcd:           component.Secret{Name: etcd.SecretNameClient, Checksum: b.LoadCheckSum(etcd.SecretNameClient)},
-		KubeAggregator: component.Secret{Name: kubeapiserver.SecretNameKubeAggregator, Checksum: b.LoadCheckSum(kubeapiserver.SecretNameKubeAggregator)},
+		CA:           component.Secret{Name: v1beta1constants.SecretNameCACluster, Checksum: b.LoadCheckSum(v1beta1constants.SecretNameCACluster)},
+		CAEtcd:       component.Secret{Name: etcd.SecretNameCA, Checksum: b.LoadCheckSum(etcd.SecretNameCA)},
+		CAFrontProxy: component.Secret{Name: v1beta1constants.SecretNameCAFrontProxy, Checksum: b.LoadCheckSum(v1beta1constants.SecretNameCAFrontProxy)},
+		Etcd:         component.Secret{Name: etcd.SecretNameClient, Checksum: b.LoadCheckSum(etcd.SecretNameClient)},
 	}
 
 	if values.VPN.ReversedVPNEnabled {

--- a/pkg/operation/botanist/kubeapiserver_test.go
+++ b/pkg/operation/botanist/kubeapiserver_test.go
@@ -1069,11 +1069,10 @@ var _ = Describe("KubeAPIServer", func() {
 		DescribeTable("should correctly set the secrets",
 			func(values kubeapiserver.Values, mutateSecrets func(*kubeapiserver.Secrets)) {
 				secrets := kubeapiserver.Secrets{
-					CA:             component.Secret{Name: "ca", Checksum: botanist.LoadCheckSum("ca")},
-					CAEtcd:         component.Secret{Name: "ca-etcd", Checksum: botanist.LoadCheckSum("ca-etcd")},
-					CAFrontProxy:   component.Secret{Name: "ca-front-proxy", Checksum: botanist.LoadCheckSum("ca-front-proxy")},
-					Etcd:           component.Secret{Name: "etcd-client-tls", Checksum: botanist.LoadCheckSum("etcd-client-tls")},
-					KubeAggregator: component.Secret{Name: "kube-aggregator", Checksum: botanist.LoadCheckSum("kube-aggregator")},
+					CA:           component.Secret{Name: "ca", Checksum: botanist.LoadCheckSum("ca")},
+					CAEtcd:       component.Secret{Name: "ca-etcd", Checksum: botanist.LoadCheckSum("ca-etcd")},
+					CAFrontProxy: component.Secret{Name: "ca-front-proxy", Checksum: botanist.LoadCheckSum("ca-front-proxy")},
+					Etcd:         component.Secret{Name: "etcd-client-tls", Checksum: botanist.LoadCheckSum("etcd-client-tls")},
 				}
 				mutateSecrets(&secrets)
 

--- a/pkg/operation/botanist/kubeapiserver_test.go
+++ b/pkg/operation/botanist/kubeapiserver_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gardener/gardener/pkg/operation/botanist/component/kubeapiserver"
 	mockkubeapiserver "github.com/gardener/gardener/pkg/operation/botanist/component/kubeapiserver/mock"
 	gardenpkg "github.com/gardener/gardener/pkg/operation/garden"
+	seedpkg "github.com/gardener/gardener/pkg/operation/seed"
 	shootpkg "github.com/gardener/gardener/pkg/operation/shoot"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -77,10 +78,12 @@ var _ = Describe("KubeAPIServer", func() {
 		externalClusterDomain = "external.foo.bar.com"
 		podNetwork            *net.IPNet
 		serviceNetwork        *net.IPNet
+		apiServerNetwork      = net.ParseIP("10.0.4.1")
 		podNetworkCIDR        = "10.0.1.0/24"
 		serviceNetworkCIDR    = "10.0.2.0/24"
 		nodeNetworkCIDR       = "10.0.3.0/24"
 		apiServerClusterIP    = "1.2.3.4"
+		apiServerAddress      = "5.6.7.8"
 	)
 
 	BeforeEach(func() {
@@ -107,6 +110,7 @@ var _ = Describe("KubeAPIServer", func() {
 				K8sSeedClient:   k8sSeedClient,
 				SecretsManager:  sm,
 				Garden:          &gardenpkg.Garden{},
+				Seed:            &seedpkg.Seed{},
 				Shoot: &shootpkg.Shoot{
 					SeedNamespace: seedNamespace,
 					Components: &shootpkg.Components{
@@ -117,8 +121,9 @@ var _ = Describe("KubeAPIServer", func() {
 					InternalClusterDomain: internalClusterDomain,
 					ExternalClusterDomain: &externalClusterDomain,
 					Networks: &shootpkg.Networks{
-						Pods:     podNetwork,
-						Services: serviceNetwork,
+						APIServer: apiServerNetwork,
+						Pods:      podNetwork,
+						Services:  serviceNetwork,
 					},
 				},
 				ImageVector: imagevector.ImageVector{
@@ -127,18 +132,35 @@ var _ = Describe("KubeAPIServer", func() {
 					{Name: "kube-apiserver"},
 					{Name: "vpn-seed"},
 				},
+				APIServerAddress:   apiServerAddress,
 				APIServerClusterIP: apiServerClusterIP,
 			},
 		}
+
+		botanist.Seed.SetInfo(&gardencorev1beta1.Seed{
+			Spec: gardencorev1beta1.SeedSpec{
+				Settings: &gardencorev1beta1.SeedSettings{
+					ShootDNS: &gardencorev1beta1.SeedSettingShootDNS{
+						Enabled: true,
+					},
+				},
+			},
+		})
 		botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      shootName,
 				Namespace: projectNamespace,
 			},
 			Spec: gardencorev1beta1.ShootSpec{
+				DNS: &gardencorev1beta1.DNS{
+					Domain: &externalClusterDomain,
+				},
 				Networking: gardencorev1beta1.Networking{
 					Nodes: &nodeNetworkCIDR,
 				},
+			},
+			Status: gardencorev1beta1.ShootStatus{
+				TechnicalID: seedNamespace,
 			},
 		})
 		botanist.SetShootState(&gardencorev1alpha1.ShootState{})
@@ -189,15 +211,13 @@ var _ = Describe("KubeAPIServer", func() {
 			})
 
 			It("should set the field to true if explicitly enabled", func() {
-				botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
-					Spec: gardencorev1beta1.ShootSpec{
-						Kubernetes: gardencorev1beta1.Kubernetes{
-							KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
-								EnableAnonymousAuthentication: pointer.Bool(true),
-							},
-						},
+				shootCopy := botanist.Shoot.GetInfo().DeepCopy()
+				shootCopy.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+					KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
+						EnableAnonymousAuthentication: pointer.Bool(true),
 					},
-				})
+				}
+				botanist.Shoot.SetInfo(shootCopy)
 
 				kubeAPIServer, err := botanist.DefaultKubeAPIServer(ctx)
 				Expect(err).NotTo(HaveOccurred())
@@ -215,15 +235,13 @@ var _ = Describe("KubeAPIServer", func() {
 			It("should set the field to the configured values", func() {
 				apiAudiences := []string{"foo", "bar"}
 
-				botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
-					Spec: gardencorev1beta1.ShootSpec{
-						Kubernetes: gardencorev1beta1.Kubernetes{
-							KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
-								APIAudiences: apiAudiences,
-							},
-						},
+				shootCopy := botanist.Shoot.GetInfo().DeepCopy()
+				shootCopy.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+					KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
+						APIAudiences: apiAudiences,
 					},
-				})
+				}
+				botanist.Shoot.SetInfo(shootCopy)
 
 				kubeAPIServer, err := botanist.DefaultKubeAPIServer(ctx)
 				Expect(err).NotTo(HaveOccurred())
@@ -233,15 +251,13 @@ var _ = Describe("KubeAPIServer", func() {
 			It("should not add gardener audience if already present", func() {
 				apiAudiences := []string{"foo", "bar", "gardener"}
 
-				botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
-					Spec: gardencorev1beta1.ShootSpec{
-						Kubernetes: gardencorev1beta1.Kubernetes{
-							KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
-								APIAudiences: apiAudiences,
-							},
-						},
+				shootCopy := botanist.Shoot.GetInfo().DeepCopy()
+				shootCopy.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+					KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
+						APIAudiences: apiAudiences,
 					},
-				})
+				}
+				botanist.Shoot.SetInfo(shootCopy)
 
 				kubeAPIServer, err := botanist.DefaultKubeAPIServer(ctx)
 				Expect(err).NotTo(HaveOccurred())
@@ -252,16 +268,14 @@ var _ = Describe("KubeAPIServer", func() {
 		Describe("AdmissionPlugins", func() {
 			DescribeTable("should have the expected admission plugins config",
 				func(configuredPlugins, expectedPlugins []gardencorev1beta1.AdmissionPlugin) {
-					botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
-						Spec: gardencorev1beta1.ShootSpec{
-							Kubernetes: gardencorev1beta1.Kubernetes{
-								KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
-									AdmissionPlugins: configuredPlugins,
-								},
-								Version: "1.22.1",
-							},
+					shootCopy := botanist.Shoot.GetInfo().DeepCopy()
+					shootCopy.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+						KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
+							AdmissionPlugins: configuredPlugins,
 						},
-					})
+						Version: "1.22.1",
+					}
+					botanist.Shoot.SetInfo(shootCopy)
 
 					kubeAPIServer, err := botanist.DefaultKubeAPIServer(ctx)
 					Expect(err).NotTo(HaveOccurred())
@@ -368,94 +382,78 @@ var _ = Describe("KubeAPIServer", func() {
 				),
 				Entry("AuditConfig is nil",
 					func() {
-						botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
-							Spec: gardencorev1beta1.ShootSpec{
-								Kubernetes: gardencorev1beta1.Kubernetes{
-									KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{},
-								},
-							},
-						})
+						shootCopy := botanist.Shoot.GetInfo().DeepCopy()
+						shootCopy.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+							KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{},
+						}
+						botanist.Shoot.SetInfo(shootCopy)
 					},
 					nil,
 					Not(HaveOccurred()),
 				),
 				Entry("AuditPolicy is nil",
 					func() {
-						botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
-							Spec: gardencorev1beta1.ShootSpec{
-								Kubernetes: gardencorev1beta1.Kubernetes{
-									KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
-										AuditConfig: &gardencorev1beta1.AuditConfig{},
-									},
-								},
+						shootCopy := botanist.Shoot.GetInfo().DeepCopy()
+						shootCopy.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+							KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
+								AuditConfig: &gardencorev1beta1.AuditConfig{},
 							},
-						})
+						}
+						botanist.Shoot.SetInfo(shootCopy)
 					},
 					nil,
 					Not(HaveOccurred()),
 				),
 				Entry("ConfigMapRef is nil",
 					func() {
-						botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
-							Spec: gardencorev1beta1.ShootSpec{
-								Kubernetes: gardencorev1beta1.Kubernetes{
-									KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
-										AuditConfig: &gardencorev1beta1.AuditConfig{
-											AuditPolicy: &gardencorev1beta1.AuditPolicy{},
-										},
-									},
+						shootCopy := botanist.Shoot.GetInfo().DeepCopy()
+						shootCopy.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+							KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
+								AuditConfig: &gardencorev1beta1.AuditConfig{
+									AuditPolicy: &gardencorev1beta1.AuditPolicy{},
 								},
 							},
-						})
+						}
+						botanist.Shoot.SetInfo(shootCopy)
 					},
 					nil,
 					Not(HaveOccurred()),
 				),
 				Entry("ConfigMapRef is provided but configmap is missing",
 					func() {
-						botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: projectNamespace,
-							},
-							Spec: gardencorev1beta1.ShootSpec{
-								Kubernetes: gardencorev1beta1.Kubernetes{
-									KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
-										AuditConfig: &gardencorev1beta1.AuditConfig{
-											AuditPolicy: &gardencorev1beta1.AuditPolicy{
-												ConfigMapRef: &corev1.ObjectReference{
-													Name: auditPolicyConfigMap.Name,
-												},
-											},
+						shootCopy := botanist.Shoot.GetInfo().DeepCopy()
+						shootCopy.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+							KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
+								AuditConfig: &gardencorev1beta1.AuditConfig{
+									AuditPolicy: &gardencorev1beta1.AuditPolicy{
+										ConfigMapRef: &corev1.ObjectReference{
+											Name: auditPolicyConfigMap.Name,
 										},
 									},
 								},
 							},
-						})
+						}
+						botanist.Shoot.SetInfo(shootCopy)
 					},
 					nil,
 					MatchError(ContainSubstring("not found")),
 				),
 				Entry("ConfigMapRef is provided but configmap is missing while shoot has a deletion timestamp",
 					func() {
-						botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace:         projectNamespace,
-								DeletionTimestamp: &metav1.Time{},
-							},
-							Spec: gardencorev1beta1.ShootSpec{
-								Kubernetes: gardencorev1beta1.Kubernetes{
-									KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
-										AuditConfig: &gardencorev1beta1.AuditConfig{
-											AuditPolicy: &gardencorev1beta1.AuditPolicy{
-												ConfigMapRef: &corev1.ObjectReference{
-													Name: auditPolicyConfigMap.Name,
-												},
-											},
+						shootCopy := botanist.Shoot.GetInfo().DeepCopy()
+						shootCopy.DeletionTimestamp = &metav1.Time{}
+						shootCopy.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+							KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
+								AuditConfig: &gardencorev1beta1.AuditConfig{
+									AuditPolicy: &gardencorev1beta1.AuditPolicy{
+										ConfigMapRef: &corev1.ObjectReference{
+											Name: auditPolicyConfigMap.Name,
 										},
 									},
 								},
 							},
-						})
+						}
+						botanist.Shoot.SetInfo(shootCopy)
 					},
 					&kubeapiserver.AuditConfig{},
 					Not(HaveOccurred()),
@@ -465,24 +463,19 @@ var _ = Describe("KubeAPIServer", func() {
 						auditPolicyConfigMap.Data = nil
 						Expect(gc.Create(ctx, auditPolicyConfigMap)).To(Succeed())
 
-						botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: projectNamespace,
-							},
-							Spec: gardencorev1beta1.ShootSpec{
-								Kubernetes: gardencorev1beta1.Kubernetes{
-									KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
-										AuditConfig: &gardencorev1beta1.AuditConfig{
-											AuditPolicy: &gardencorev1beta1.AuditPolicy{
-												ConfigMapRef: &corev1.ObjectReference{
-													Name: auditPolicyConfigMap.Name,
-												},
-											},
+						shootCopy := botanist.Shoot.GetInfo().DeepCopy()
+						shootCopy.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+							KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
+								AuditConfig: &gardencorev1beta1.AuditConfig{
+									AuditPolicy: &gardencorev1beta1.AuditPolicy{
+										ConfigMapRef: &corev1.ObjectReference{
+											Name: auditPolicyConfigMap.Name,
 										},
 									},
 								},
 							},
-						})
+						}
+						botanist.Shoot.SetInfo(shootCopy)
 					},
 					nil,
 					MatchError(ContainSubstring("missing '.data.policy' in audit policy configmap")),
@@ -491,24 +484,19 @@ var _ = Describe("KubeAPIServer", func() {
 					func() {
 						Expect(gc.Create(ctx, auditPolicyConfigMap)).To(Succeed())
 
-						botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: projectNamespace,
-							},
-							Spec: gardencorev1beta1.ShootSpec{
-								Kubernetes: gardencorev1beta1.Kubernetes{
-									KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
-										AuditConfig: &gardencorev1beta1.AuditConfig{
-											AuditPolicy: &gardencorev1beta1.AuditPolicy{
-												ConfigMapRef: &corev1.ObjectReference{
-													Name: auditPolicyConfigMap.Name,
-												},
-											},
+						shootCopy := botanist.Shoot.GetInfo().DeepCopy()
+						shootCopy.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+							KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
+								AuditConfig: &gardencorev1beta1.AuditConfig{
+									AuditPolicy: &gardencorev1beta1.AuditPolicy{
+										ConfigMapRef: &corev1.ObjectReference{
+											Name: auditPolicyConfigMap.Name,
 										},
 									},
 								},
 							},
-						})
+						}
+						botanist.Shoot.SetInfo(shootCopy)
 					},
 					&kubeapiserver.AuditConfig{
 						Policy: &policy,
@@ -679,15 +667,13 @@ var _ = Describe("KubeAPIServer", func() {
 			It("should set the field to the configured values", func() {
 				eventTTL := &metav1.Duration{Duration: 2 * time.Hour}
 
-				botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
-					Spec: gardencorev1beta1.ShootSpec{
-						Kubernetes: gardencorev1beta1.Kubernetes{
-							KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
-								EventTTL: eventTTL,
-							},
-						},
+				shootCopy := botanist.Shoot.GetInfo().DeepCopy()
+				shootCopy.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+					KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
+						EventTTL: eventTTL,
 					},
-				})
+				}
+				botanist.Shoot.SetInfo(shootCopy)
 
 				kubeAPIServer, err := botanist.DefaultKubeAPIServer(ctx)
 				Expect(err).NotTo(HaveOccurred())
@@ -705,17 +691,15 @@ var _ = Describe("KubeAPIServer", func() {
 			It("should set the field to the configured values", func() {
 				featureGates := map[string]bool{"foo": true, "bar": false}
 
-				botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
-					Spec: gardencorev1beta1.ShootSpec{
-						Kubernetes: gardencorev1beta1.Kubernetes{
-							KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
-								KubernetesConfig: gardencorev1beta1.KubernetesConfig{
-									FeatureGates: featureGates,
-								},
-							},
+				shootCopy := botanist.Shoot.GetInfo().DeepCopy()
+				shootCopy.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+					KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
+						KubernetesConfig: gardencorev1beta1.KubernetesConfig{
+							FeatureGates: featureGates,
 						},
 					},
-				})
+				}
+				botanist.Shoot.SetInfo(shootCopy)
 
 				kubeAPIServer, err := botanist.DefaultKubeAPIServer(ctx)
 				Expect(err).NotTo(HaveOccurred())
@@ -741,27 +725,23 @@ var _ = Describe("KubeAPIServer", func() {
 				),
 				Entry("OIDCConfig is nil",
 					func() {
-						botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
-							Spec: gardencorev1beta1.ShootSpec{
-								Kubernetes: gardencorev1beta1.Kubernetes{
-									KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{},
-								},
-							},
-						})
+						shootCopy := botanist.Shoot.GetInfo().DeepCopy()
+						shootCopy.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+							KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{},
+						}
+						botanist.Shoot.SetInfo(shootCopy)
 					},
 					nil,
 				),
 				Entry("OIDCConfig is not nil",
 					func() {
-						botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
-							Spec: gardencorev1beta1.ShootSpec{
-								Kubernetes: gardencorev1beta1.Kubernetes{
-									KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
-										OIDCConfig: &gardencorev1beta1.OIDCConfig{},
-									},
-								},
+						shootCopy := botanist.Shoot.GetInfo().DeepCopy()
+						shootCopy.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+							KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
+								OIDCConfig: &gardencorev1beta1.OIDCConfig{},
 							},
-						})
+						}
+						botanist.Shoot.SetInfo(shootCopy)
 					},
 					&gardencorev1beta1.OIDCConfig{},
 				),
@@ -781,15 +761,13 @@ var _ = Describe("KubeAPIServer", func() {
 					MaxNonMutatingInflight: pointer.Int32(2),
 				}
 
-				botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
-					Spec: gardencorev1beta1.ShootSpec{
-						Kubernetes: gardencorev1beta1.Kubernetes{
-							KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
-								Requests: requests,
-							},
-						},
+				shootCopy := botanist.Shoot.GetInfo().DeepCopy()
+				shootCopy.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+					KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
+						Requests: requests,
 					},
-				})
+				}
+				botanist.Shoot.SetInfo(shootCopy)
 
 				kubeAPIServer, err := botanist.DefaultKubeAPIServer(ctx)
 				Expect(err).NotTo(HaveOccurred())
@@ -807,15 +785,13 @@ var _ = Describe("KubeAPIServer", func() {
 			It("should set the field to the configured values", func() {
 				runtimeConfig := map[string]bool{"foo": true, "bar": false}
 
-				botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
-					Spec: gardencorev1beta1.ShootSpec{
-						Kubernetes: gardencorev1beta1.Kubernetes{
-							KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
-								RuntimeConfig: runtimeConfig,
-							},
-						},
+				shootCopy := botanist.Shoot.GetInfo().DeepCopy()
+				shootCopy.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+					KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
+						RuntimeConfig: runtimeConfig,
 					},
-				})
+				}
+				botanist.Shoot.SetInfo(shootCopy)
 
 				kubeAPIServer, err := botanist.DefaultKubeAPIServer(ctx)
 				Expect(err).NotTo(HaveOccurred())
@@ -857,7 +833,9 @@ var _ = Describe("KubeAPIServer", func() {
 				),
 				Entry("no node network",
 					func() {
-						botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{})
+						shootCopy := botanist.Shoot.GetInfo().DeepCopy()
+						shootCopy.Spec.Networking.Nodes = nil
+						botanist.Shoot.SetInfo(shootCopy)
 					},
 					kubeapiserver.VPNConfig{
 						ReversedVPNEnabled: false,
@@ -881,15 +859,13 @@ var _ = Describe("KubeAPIServer", func() {
 					Resources: []gardencorev1beta1.ResourceWatchCacheSize{{Resource: "foo"}},
 				}
 
-				botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
-					Spec: gardencorev1beta1.ShootSpec{
-						Kubernetes: gardencorev1beta1.Kubernetes{
-							KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
-								WatchCacheSizes: watchCacheSizes,
-							},
-						},
+				shootCopy := botanist.Shoot.GetInfo().DeepCopy()
+				shootCopy.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+					KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
+						WatchCacheSizes: watchCacheSizes,
 					},
-				})
+				}
+				botanist.Shoot.SetInfo(shootCopy)
 
 				kubeAPIServer, err := botanist.DefaultKubeAPIServer(ctx)
 				Expect(err).NotTo(HaveOccurred())
@@ -949,6 +925,7 @@ var _ = Describe("KubeAPIServer", func() {
 				kubeAPIServer.EXPECT().SetSNIConfig(gomock.Any())
 				kubeAPIServer.EXPECT().SetExternalHostname(gomock.Any())
 				kubeAPIServer.EXPECT().SetExternalServer(gomock.Any())
+				kubeAPIServer.EXPECT().SetServerCertificateConfig(gomock.Any())
 				kubeAPIServer.EXPECT().SetServiceAccountConfig(gomock.Any())
 				kubeAPIServer.EXPECT().Deploy(ctx)
 
@@ -1031,6 +1008,7 @@ var _ = Describe("KubeAPIServer", func() {
 				kubeAPIServer.EXPECT().SetSNIConfig(gomock.Any())
 				kubeAPIServer.EXPECT().SetExternalHostname(gomock.Any())
 				kubeAPIServer.EXPECT().SetExternalServer(gomock.Any())
+				kubeAPIServer.EXPECT().SetServerCertificateConfig(gomock.Any())
 				kubeAPIServer.EXPECT().SetServiceAccountConfig(gomock.Any())
 				kubeAPIServer.EXPECT().Deploy(ctx)
 
@@ -1097,7 +1075,6 @@ var _ = Describe("KubeAPIServer", func() {
 					Etcd:                   component.Secret{Name: "etcd-client-tls", Checksum: botanist.LoadCheckSum("etcd-client-tls")},
 					KubeAggregator:         component.Secret{Name: "kube-aggregator", Checksum: botanist.LoadCheckSum("kube-aggregator")},
 					KubeAPIServerToKubelet: component.Secret{Name: "kube-apiserver-kubelet", Checksum: botanist.LoadCheckSum("kube-apiserver-kubelet")},
-					Server:                 component.Secret{Name: "kube-apiserver", Checksum: botanist.LoadCheckSum("kube-apiserver")},
 				}
 				mutateSecrets(&secrets)
 
@@ -1107,6 +1084,7 @@ var _ = Describe("KubeAPIServer", func() {
 				kubeAPIServer.EXPECT().SetSNIConfig(gomock.Any())
 				kubeAPIServer.EXPECT().SetExternalHostname(gomock.Any())
 				kubeAPIServer.EXPECT().SetExternalServer(gomock.Any())
+				kubeAPIServer.EXPECT().SetServerCertificateConfig(gomock.Any())
 				kubeAPIServer.EXPECT().SetServiceAccountConfig(gomock.Any())
 				kubeAPIServer.EXPECT().Deploy(ctx)
 
@@ -1137,11 +1115,94 @@ var _ = Describe("KubeAPIServer", func() {
 				kubeAPIServer.EXPECT().SetSNIConfig(gomock.Any())
 				kubeAPIServer.EXPECT().SetExternalHostname("api." + internalClusterDomain)
 				kubeAPIServer.EXPECT().SetExternalServer(gomock.Any())
+				kubeAPIServer.EXPECT().SetServerCertificateConfig(gomock.Any())
 				kubeAPIServer.EXPECT().SetServiceAccountConfig(gomock.Any())
 				kubeAPIServer.EXPECT().Deploy(ctx)
 
 				Expect(botanist.DeployKubeAPIServer(ctx)).To(Succeed())
 			})
+		})
+
+		Describe("ServerCertificateConfig", func() {
+			DescribeTable("should have the expected ServerCertificateConfig config",
+				func(prepTest func(), expectedConfig kubeapiserver.ServerCertificateConfig) {
+					if prepTest != nil {
+						prepTest()
+					}
+
+					kubeAPIServer.EXPECT().GetValues()
+					kubeAPIServer.EXPECT().SetAutoscalingReplicas(gomock.Any())
+					kubeAPIServer.EXPECT().SetSecrets(gomock.Any())
+					kubeAPIServer.EXPECT().SetSNIConfig(gomock.Any())
+					kubeAPIServer.EXPECT().SetExternalHostname(gomock.Any())
+					kubeAPIServer.EXPECT().SetExternalServer(gomock.Any())
+					kubeAPIServer.EXPECT().SetServerCertificateConfig(expectedConfig)
+					kubeAPIServer.EXPECT().SetServiceAccountConfig(gomock.Any())
+					kubeAPIServer.EXPECT().Deploy(ctx)
+
+					Expect(botanist.DeployKubeAPIServer(ctx)).To(Succeed())
+				},
+
+				Entry("seed enables DNS, shoot has external domain",
+					nil,
+					kubeapiserver.ServerCertificateConfig{
+						ExtraIPAddresses: []net.IP{apiServerNetwork},
+						ExtraDNSNames: []string{
+							"api." + internalClusterDomain,
+							seedNamespace,
+							externalClusterDomain,
+							"api." + externalClusterDomain,
+						},
+					},
+				),
+				Entry("seed enables DNS, shoot has no external domain",
+					func() {
+						botanist.Shoot.DisableDNS = true
+						botanist.Shoot.ExternalClusterDomain = nil
+					},
+					kubeapiserver.ServerCertificateConfig{
+						ExtraIPAddresses: []net.IP{apiServerNetwork},
+						ExtraDNSNames: []string{
+							"api." + internalClusterDomain,
+							seedNamespace,
+						},
+					},
+				),
+				Entry("seed disables DNS, api server address is IP",
+					func() {
+						seedCopy := botanist.Seed.GetInfo().DeepCopy()
+						seedCopy.Spec.Settings.ShootDNS.Enabled = false
+						botanist.Seed.SetInfo(seedCopy)
+					},
+					kubeapiserver.ServerCertificateConfig{
+						ExtraIPAddresses: []net.IP{apiServerNetwork, net.ParseIP(apiServerAddress)},
+						ExtraDNSNames: []string{
+							"api." + internalClusterDomain,
+							seedNamespace,
+							externalClusterDomain,
+							"api." + externalClusterDomain,
+						},
+					},
+				),
+				Entry("seed disables DNS, api server address is hostname",
+					func() {
+						seedCopy := botanist.Seed.GetInfo().DeepCopy()
+						seedCopy.Spec.Settings.ShootDNS.Enabled = false
+						botanist.Seed.SetInfo(seedCopy)
+						botanist.APIServerAddress = "some-hostname.com"
+					},
+					kubeapiserver.ServerCertificateConfig{
+						ExtraIPAddresses: []net.IP{apiServerNetwork},
+						ExtraDNSNames: []string{
+							"api." + internalClusterDomain,
+							seedNamespace,
+							"some-hostname.com",
+							externalClusterDomain,
+							"api." + externalClusterDomain,
+						},
+					},
+				),
+			)
 		})
 
 		Describe("ServiceAccountConfig", func() {
@@ -1174,6 +1235,7 @@ var _ = Describe("KubeAPIServer", func() {
 					kubeAPIServer.EXPECT().SetSNIConfig(gomock.Any())
 					kubeAPIServer.EXPECT().SetExternalHostname(gomock.Any())
 					kubeAPIServer.EXPECT().SetExternalServer(gomock.Any())
+					kubeAPIServer.EXPECT().SetServerCertificateConfig(gomock.Any())
 					if !expectError {
 						kubeAPIServer.EXPECT().SetServiceAccountConfig(expectedConfig)
 						kubeAPIServer.EXPECT().Deploy(ctx)
@@ -1190,13 +1252,11 @@ var _ = Describe("KubeAPIServer", func() {
 				),
 				Entry("ServiceAccountConfig is nil",
 					func() {
-						botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
-							Spec: gardencorev1beta1.ShootSpec{
-								Kubernetes: gardencorev1beta1.Kubernetes{
-									KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{},
-								},
-							},
-						})
+						shootCopy := botanist.Shoot.GetInfo().DeepCopy()
+						shootCopy.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+							KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{},
+						}
+						botanist.Shoot.SetInfo(shootCopy)
 					},
 					kubeapiserver.ServiceAccountConfig{Issuer: "https://api." + internalClusterDomain},
 					false,
@@ -1204,18 +1264,16 @@ var _ = Describe("KubeAPIServer", func() {
 				),
 				Entry("Issuer is not provided",
 					func() {
-						botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
-							Spec: gardencorev1beta1.ShootSpec{
-								Kubernetes: gardencorev1beta1.Kubernetes{
-									KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
-										ServiceAccountConfig: &gardencorev1beta1.ServiceAccountConfig{
-											ExtendTokenExpiration: &extendTokenExpiration,
-											MaxTokenExpiration:    &maxTokenExpiration,
-										},
-									},
+						shootCopy := botanist.Shoot.GetInfo().DeepCopy()
+						shootCopy.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+							KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
+								ServiceAccountConfig: &gardencorev1beta1.ServiceAccountConfig{
+									ExtendTokenExpiration: &extendTokenExpiration,
+									MaxTokenExpiration:    &maxTokenExpiration,
 								},
 							},
-						})
+						}
+						botanist.Shoot.SetInfo(shootCopy)
 					},
 					kubeapiserver.ServiceAccountConfig{
 						Issuer:                "https://api." + internalClusterDomain,
@@ -1227,17 +1285,15 @@ var _ = Describe("KubeAPIServer", func() {
 				),
 				Entry("Issuer is provided",
 					func() {
-						botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
-							Spec: gardencorev1beta1.ShootSpec{
-								Kubernetes: gardencorev1beta1.Kubernetes{
-									KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
-										ServiceAccountConfig: &gardencorev1beta1.ServiceAccountConfig{
-											Issuer: pointer.String("issuer"),
-										},
-									},
+						shootCopy := botanist.Shoot.GetInfo().DeepCopy()
+						shootCopy.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+							KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
+								ServiceAccountConfig: &gardencorev1beta1.ServiceAccountConfig{
+									Issuer: pointer.String("issuer"),
 								},
 							},
-						})
+						}
+						botanist.Shoot.SetInfo(shootCopy)
 					},
 					kubeapiserver.ServiceAccountConfig{Issuer: "issuer"},
 					false,
@@ -1245,17 +1301,15 @@ var _ = Describe("KubeAPIServer", func() {
 				),
 				Entry("AcceptedIssuers is provided and Issuer is not",
 					func() {
-						botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
-							Spec: gardencorev1beta1.ShootSpec{
-								Kubernetes: gardencorev1beta1.Kubernetes{
-									KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
-										ServiceAccountConfig: &gardencorev1beta1.ServiceAccountConfig{
-											AcceptedIssuers: []string{"issuer1", "issuer2"},
-										},
-									},
+						shootCopy := botanist.Shoot.GetInfo().DeepCopy()
+						shootCopy.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+							KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
+								ServiceAccountConfig: &gardencorev1beta1.ServiceAccountConfig{
+									AcceptedIssuers: []string{"issuer1", "issuer2"},
 								},
 							},
-						})
+						}
+						botanist.Shoot.SetInfo(shootCopy)
 					},
 					kubeapiserver.ServiceAccountConfig{
 						Issuer:          "https://api." + internalClusterDomain,
@@ -1266,18 +1320,16 @@ var _ = Describe("KubeAPIServer", func() {
 				),
 				Entry("AcceptedIssuers and Issuer are provided",
 					func() {
-						botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
-							Spec: gardencorev1beta1.ShootSpec{
-								Kubernetes: gardencorev1beta1.Kubernetes{
-									KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
-										ServiceAccountConfig: &gardencorev1beta1.ServiceAccountConfig{
-											Issuer:          pointer.String("issuer"),
-											AcceptedIssuers: []string{"issuer1", "issuer2"},
-										},
-									},
+						shootCopy := botanist.Shoot.GetInfo().DeepCopy()
+						shootCopy.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+							KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
+								ServiceAccountConfig: &gardencorev1beta1.ServiceAccountConfig{
+									Issuer:          pointer.String("issuer"),
+									AcceptedIssuers: []string{"issuer1", "issuer2"},
 								},
 							},
-						})
+						}
+						botanist.Shoot.SetInfo(shootCopy)
 					},
 					kubeapiserver.ServiceAccountConfig{
 						Issuer:          "issuer",
@@ -1288,15 +1340,13 @@ var _ = Describe("KubeAPIServer", func() {
 				),
 				Entry("AcceptedIssuers is not provided",
 					func() {
-						botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
-							Spec: gardencorev1beta1.ShootSpec{
-								Kubernetes: gardencorev1beta1.Kubernetes{
-									KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
-										ServiceAccountConfig: &gardencorev1beta1.ServiceAccountConfig{},
-									},
-								},
+						shootCopy := botanist.Shoot.GetInfo().DeepCopy()
+						shootCopy.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+							KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
+								ServiceAccountConfig: &gardencorev1beta1.ServiceAccountConfig{},
 							},
-						})
+						}
+						botanist.Shoot.SetInfo(shootCopy)
 					},
 					kubeapiserver.ServiceAccountConfig{Issuer: "https://api." + internalClusterDomain},
 					false,
@@ -1304,15 +1354,13 @@ var _ = Describe("KubeAPIServer", func() {
 				),
 				Entry("SigningKeySecret is nil",
 					func() {
-						botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
-							Spec: gardencorev1beta1.ShootSpec{
-								Kubernetes: gardencorev1beta1.Kubernetes{
-									KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
-										ServiceAccountConfig: &gardencorev1beta1.ServiceAccountConfig{},
-									},
-								},
+						shootCopy := botanist.Shoot.GetInfo().DeepCopy()
+						shootCopy.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+							KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
+								ServiceAccountConfig: &gardencorev1beta1.ServiceAccountConfig{},
 							},
-						})
+						}
+						botanist.Shoot.SetInfo(shootCopy)
 					},
 					kubeapiserver.ServiceAccountConfig{Issuer: "https://api." + internalClusterDomain},
 					false,
@@ -1320,22 +1368,17 @@ var _ = Describe("KubeAPIServer", func() {
 				),
 				Entry("SigningKeySecret is provided but secret is missing",
 					func() {
-						botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: projectNamespace,
-							},
-							Spec: gardencorev1beta1.ShootSpec{
-								Kubernetes: gardencorev1beta1.Kubernetes{
-									KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
-										ServiceAccountConfig: &gardencorev1beta1.ServiceAccountConfig{
-											SigningKeySecret: &corev1.LocalObjectReference{
-												Name: signingKeySecret.Name,
-											},
-										},
+						shootCopy := botanist.Shoot.GetInfo().DeepCopy()
+						shootCopy.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+							KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
+								ServiceAccountConfig: &gardencorev1beta1.ServiceAccountConfig{
+									SigningKeySecret: &corev1.LocalObjectReference{
+										Name: signingKeySecret.Name,
 									},
 								},
 							},
-						})
+						}
+						botanist.Shoot.SetInfo(shootCopy)
 					},
 					nil,
 					true,
@@ -1346,22 +1389,17 @@ var _ = Describe("KubeAPIServer", func() {
 						signingKeySecret.Data = nil
 						Expect(gc.Create(ctx, signingKeySecret)).To(Succeed())
 
-						botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: projectNamespace,
-							},
-							Spec: gardencorev1beta1.ShootSpec{
-								Kubernetes: gardencorev1beta1.Kubernetes{
-									KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
-										ServiceAccountConfig: &gardencorev1beta1.ServiceAccountConfig{
-											SigningKeySecret: &corev1.LocalObjectReference{
-												Name: signingKeySecret.Name,
-											},
-										},
+						shootCopy := botanist.Shoot.GetInfo().DeepCopy()
+						shootCopy.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+							KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
+								ServiceAccountConfig: &gardencorev1beta1.ServiceAccountConfig{
+									SigningKeySecret: &corev1.LocalObjectReference{
+										Name: signingKeySecret.Name,
 									},
 								},
 							},
-						})
+						}
+						botanist.Shoot.SetInfo(shootCopy)
 					},
 					kubeapiserver.ServiceAccountConfig{Issuer: "https://api." + internalClusterDomain},
 					true,
@@ -1371,22 +1409,17 @@ var _ = Describe("KubeAPIServer", func() {
 					func() {
 						Expect(gc.Create(ctx, signingKeySecret)).To(Succeed())
 
-						botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: projectNamespace,
-							},
-							Spec: gardencorev1beta1.ShootSpec{
-								Kubernetes: gardencorev1beta1.Kubernetes{
-									KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
-										ServiceAccountConfig: &gardencorev1beta1.ServiceAccountConfig{
-											SigningKeySecret: &corev1.LocalObjectReference{
-												Name: signingKeySecret.Name,
-											},
-										},
+						shootCopy := botanist.Shoot.GetInfo().DeepCopy()
+						shootCopy.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+							KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
+								ServiceAccountConfig: &gardencorev1beta1.ServiceAccountConfig{
+									SigningKeySecret: &corev1.LocalObjectReference{
+										Name: signingKeySecret.Name,
 									},
 								},
 							},
-						})
+						}
+						botanist.Shoot.SetInfo(shootCopy)
 					},
 					kubeapiserver.ServiceAccountConfig{
 						Issuer:     "https://api." + internalClusterDomain,
@@ -1415,6 +1448,7 @@ var _ = Describe("KubeAPIServer", func() {
 					kubeAPIServer.EXPECT().SetSNIConfig(expectedConfig)
 					kubeAPIServer.EXPECT().SetExternalHostname(gomock.Any())
 					kubeAPIServer.EXPECT().SetExternalServer(gomock.Any())
+					kubeAPIServer.EXPECT().SetServerCertificateConfig(gomock.Any())
 					kubeAPIServer.EXPECT().SetServiceAccountConfig(gomock.Any())
 					kubeAPIServer.EXPECT().Deploy(ctx)
 
@@ -1439,7 +1473,8 @@ var _ = Describe("KubeAPIServer", func() {
 				),
 				Entry("SNI enabled but no need for external DNS",
 					func() {
-						botanist.Shoot.DisableDNS = false
+						botanist.Shoot.DisableDNS = true
+						botanist.Shoot.ExternalClusterDomain = nil
 						botanist.Garden.InternalDomain = &gardenpkg.Domain{}
 						botanist.Shoot.GetInfo().Spec.DNS = nil
 					},
@@ -1497,6 +1532,7 @@ var _ = Describe("KubeAPIServer", func() {
 				kubeAPIServer.EXPECT().SetSNIConfig(gomock.Any())
 				kubeAPIServer.EXPECT().SetExternalHostname(gomock.Any())
 				kubeAPIServer.EXPECT().SetExternalServer("api." + externalClusterDomain)
+				kubeAPIServer.EXPECT().SetServerCertificateConfig(gomock.Any())
 				kubeAPIServer.EXPECT().SetServiceAccountConfig(gomock.Any())
 				kubeAPIServer.EXPECT().Deploy(ctx)
 
@@ -1511,6 +1547,7 @@ var _ = Describe("KubeAPIServer", func() {
 			kubeAPIServer.EXPECT().SetSNIConfig(gomock.Any())
 			kubeAPIServer.EXPECT().SetExternalHostname(gomock.Any())
 			kubeAPIServer.EXPECT().SetExternalServer(gomock.Any())
+			kubeAPIServer.EXPECT().SetServerCertificateConfig(gomock.Any())
 			kubeAPIServer.EXPECT().SetServiceAccountConfig(gomock.Any())
 			kubeAPIServer.EXPECT().Deploy(ctx)
 
@@ -1535,6 +1572,7 @@ var _ = Describe("KubeAPIServer", func() {
 			kubeAPIServer.EXPECT().SetSNIConfig(gomock.Any())
 			kubeAPIServer.EXPECT().SetExternalHostname(gomock.Any())
 			kubeAPIServer.EXPECT().SetExternalServer(gomock.Any())
+			kubeAPIServer.EXPECT().SetServerCertificateConfig(gomock.Any())
 			kubeAPIServer.EXPECT().SetServiceAccountConfig(gomock.Any())
 			kubeAPIServer.EXPECT().Deploy(ctx)
 

--- a/pkg/operation/botanist/kubeapiserver_test.go
+++ b/pkg/operation/botanist/kubeapiserver_test.go
@@ -1069,12 +1069,11 @@ var _ = Describe("KubeAPIServer", func() {
 		DescribeTable("should correctly set the secrets",
 			func(values kubeapiserver.Values, mutateSecrets func(*kubeapiserver.Secrets)) {
 				secrets := kubeapiserver.Secrets{
-					CA:                     component.Secret{Name: "ca", Checksum: botanist.LoadCheckSum("ca")},
-					CAEtcd:                 component.Secret{Name: "ca-etcd", Checksum: botanist.LoadCheckSum("ca-etcd")},
-					CAFrontProxy:           component.Secret{Name: "ca-front-proxy", Checksum: botanist.LoadCheckSum("ca-front-proxy")},
-					Etcd:                   component.Secret{Name: "etcd-client-tls", Checksum: botanist.LoadCheckSum("etcd-client-tls")},
-					KubeAggregator:         component.Secret{Name: "kube-aggregator", Checksum: botanist.LoadCheckSum("kube-aggregator")},
-					KubeAPIServerToKubelet: component.Secret{Name: "kube-apiserver-kubelet", Checksum: botanist.LoadCheckSum("kube-apiserver-kubelet")},
+					CA:             component.Secret{Name: "ca", Checksum: botanist.LoadCheckSum("ca")},
+					CAEtcd:         component.Secret{Name: "ca-etcd", Checksum: botanist.LoadCheckSum("ca-etcd")},
+					CAFrontProxy:   component.Secret{Name: "ca-front-proxy", Checksum: botanist.LoadCheckSum("ca-front-proxy")},
+					Etcd:           component.Secret{Name: "etcd-client-tls", Checksum: botanist.LoadCheckSum("etcd-client-tls")},
+					KubeAggregator: component.Secret{Name: "kube-aggregator", Checksum: botanist.LoadCheckSum("kube-aggregator")},
 				}
 				mutateSecrets(&secrets)
 

--- a/pkg/operation/botanist/kubeapiserver_test.go
+++ b/pkg/operation/botanist/kubeapiserver_test.go
@@ -1099,7 +1099,6 @@ var _ = Describe("KubeAPIServer", func() {
 			Entry("reversed vpn enabled",
 				kubeapiserver.Values{VPN: kubeapiserver.VPNConfig{ReversedVPNEnabled: true}},
 				func(s *kubeapiserver.Secrets) {
-					s.HTTPProxy = &component.Secret{Name: "kube-apiserver-http-proxy", Checksum: botanist.LoadCheckSum("kube-apiserver-http-proxy")}
 					s.VPNSeedServerTLSAuth = &component.Secret{Name: "vpn-seed-server-tlsauth", Checksum: botanist.LoadCheckSum("vpn-seed-server-tlsauth")}
 				},
 			),

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -326,6 +326,7 @@ func (b *Botanist) GenerateAndSaveSecrets(ctx context.Context) error {
 			// "prometheus",
 			"prometheus-kubelet",
 			"kube-apiserver",
+			"kube-apiserver-kubelet",
 			"kube-scheduler-server",
 			"kube-controller-manager-server",
 			"metrics-server",

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -325,6 +325,7 @@ func (b *Botanist) GenerateAndSaveSecrets(ctx context.Context) error {
 			// adapted.
 			// "prometheus",
 			"prometheus-kubelet",
+			"kube-apiserver",
 			"kube-scheduler-server",
 			"kube-controller-manager-server",
 			"metrics-server",

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -328,6 +328,7 @@ func (b *Botanist) GenerateAndSaveSecrets(ctx context.Context) error {
 			"kube-apiserver",
 			"kube-apiserver-kubelet",
 			"kube-aggregator",
+			"kube-apiserver-http-proxy",
 			"kube-scheduler-server",
 			"kube-controller-manager-server",
 			"metrics-server",
@@ -352,7 +353,6 @@ func (b *Botanist) GenerateAndSaveSecrets(ctx context.Context) error {
 				if gardenerResourceDataList.Get(v1beta1constants.SecretNameCAVPN) == nil {
 					if err := b.cleanupSecrets(ctx, &gardenerResourceDataList,
 						vpnseedserver.DeploymentName,
-						kubeapiserver.SecretNameHTTPProxy,
 						vpnshoot.SecretNameVPNShootClient,
 					); err != nil {
 						return err
@@ -363,7 +363,6 @@ func (b *Botanist) GenerateAndSaveSecrets(ctx context.Context) error {
 					vpnseedserver.DeploymentName,
 					vpnshoot.SecretNameVPNShootClient,
 					vpnseedserver.VpnSeedServerTLSAuth,
-					kubeapiserver.SecretNameHTTPProxy,
 				); err != nil {
 					return err
 				}

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -327,6 +327,7 @@ func (b *Botanist) GenerateAndSaveSecrets(ctx context.Context) error {
 			"prometheus-kubelet",
 			"kube-apiserver",
 			"kube-apiserver-kubelet",
+			"kube-aggregator",
 			"kube-scheduler-server",
 			"kube-controller-manager-server",
 			"metrics-server",

--- a/pkg/operation/botanist/wanted_secrets.go
+++ b/pkg/operation/botanist/wanted_secrets.go
@@ -224,14 +224,6 @@ func (b *Botanist) generateWantedSecretConfigs(certificateAuthorities map[string
 			&secrets.VPNTLSAuthConfig{
 				Name: vpnseedserver.VpnSeedServerTLSAuth,
 			},
-
-			// Secret definition for kube-apiserver http proxy client
-			&secrets.CertificateSecretConfig{
-				Name:       kubeapiserver.SecretNameHTTPProxy,
-				CommonName: "kube-apiserver-http-proxy",
-				CertType:   secrets.ClientCert,
-				SigningCA:  certificateAuthorities[v1beta1constants.SecretNameCAVPN],
-			},
 		)
 	} else {
 		secretList = append(secretList,

--- a/pkg/operation/botanist/wanted_secrets.go
+++ b/pkg/operation/botanist/wanted_secrets.go
@@ -46,20 +46,6 @@ func (b *Botanist) generateWantedSecretConfigs(certificateAuthorities map[string
 	)
 
 	secretList := []secrets.ConfigInterface{
-		// Secret definition for kube-apiserver to kubelets communication
-		&secrets.ControlPlaneSecretConfig{
-			Name: kubeapiserver.SecretNameKubeAPIServerToKubelet,
-			CertificateSecretConfig: &secrets.CertificateSecretConfig{
-				CommonName:   kubeapiserver.UserName,
-				Organization: nil,
-				DNSNames:     nil,
-				IPAddresses:  nil,
-
-				CertType:  secrets.ClientCert,
-				SigningCA: certificateAuthorities[v1beta1constants.SecretNameCAKubelet],
-			},
-		},
-
 		// Secret definition for kube-aggregator
 		&secrets.ControlPlaneSecretConfig{
 			Name: kubeapiserver.SecretNameKubeAggregator,

--- a/pkg/operation/botanist/wanted_secrets.go
+++ b/pkg/operation/botanist/wanted_secrets.go
@@ -46,20 +46,6 @@ func (b *Botanist) generateWantedSecretConfigs(certificateAuthorities map[string
 	)
 
 	secretList := []secrets.ConfigInterface{
-		// Secret definition for kube-aggregator
-		&secrets.ControlPlaneSecretConfig{
-			Name: kubeapiserver.SecretNameKubeAggregator,
-			CertificateSecretConfig: &secrets.CertificateSecretConfig{
-				CommonName:   "system:kube-aggregator",
-				Organization: nil,
-				DNSNames:     nil,
-				IPAddresses:  nil,
-
-				CertType:  secrets.ClientCert,
-				SigningCA: certificateAuthorities[v1beta1constants.SecretNameCAFrontProxy],
-			},
-		},
-
 		// Secret definition for gardener-resource-manager server
 		&secrets.CertificateSecretConfig{
 			Name: resourcemanager.SecretNameServer,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement
/merge squash

**What this PR does / why we need it**:
This PR adapts the `kube-apiserver`-related secrets (`kube-apiserver`, `kube-apiserver-kubelet`, `kube-aggregator`, `kube-apiserver-http-proxy`) to the new secrets manager.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/3292#issuecomment-1036058890

/invite @timebertt @BeckerMax 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
