### PR TITLE
Add missing test suite

### DIFF
--- a/pkg/apis/core/core_suite_test.go
+++ b/pkg/apis/core/core_suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package v1beta1_test
+package core_test
 
 import (
 	"testing"
@@ -21,7 +21,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestV1beta1(t *testing.T) {
+func TestCore(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "API Core V1beta1 Suite")
+	RunSpecs(t, "API Core Suite")
 }


### PR DESCRIPTION
/area testing
/kind bug

https://github.com/gardener/gardener/pull/5665 added `pkg/apis/core/types_secretbinding_test.go` but missed to add a test suite for this pkg (as there is none atm).

Hence, `make test` says that are no tests to run in this pkg
```
ok  	github.com/gardener/gardener/pkg/apis/core	1.084s [no tests to run]
```

Similar to https://github.com/gardener/gardener/pull/3946

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
