### PR TITLE
narrow the promtail k8s pod discovery to kube-system only 

### DIFF
--- a/charts/seed-bootstrap/charts/loki/values.yaml
+++ b/charts/seed-bootstrap/charts/loki/values.yaml
@@ -65,11 +65,11 @@ resources:
       memory: 12Mi
   kubeRBACproxy:
     limits:
-      cpu: 60m
-      memory: 50Mi
+      cpu: 180m
+      memory: 150Mi
     requests:
-      cpu: 30m
-      memory: 15Mi 
+      cpu: 50m
+      memory: 50Mi
   telegraf:
     limits:
       cpu: 15m

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/promtail/config_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/promtail/config_test.go
@@ -153,6 +153,8 @@ scrape_configs:
       server_name: api.test-cluster.com
       ca_file: /var/lib/promtail/ca.crt
     bearer_token_file: /var/lib/promtail/auth-token
+    namespaces:
+      names: ['kube-system']
   relabel_configs:
   - action: drop
     regex: ''

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/promtail/templates/promtail-config.tpl.yaml
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/promtail/templates/promtail-config.tpl.yaml
@@ -40,6 +40,8 @@ scrape_configs:
       server_name: {{ .APIServerHostname }}
       ca_file: {{ .pathCACert }}
     bearer_token_file: {{ .pathAuthToken }}
+    namespaces:
+      names: ['kube-system']
   relabel_configs:
   - action: drop
     regex: ''


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
With this PR when the `promtail` agent installed on each shoot node is trying to discover a pod, it narrows it only to the `kube-system` namespace.
Also the request and limits of the loki's `kube-RBAC-proxy` are increased to meet the increased load.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Logs from shoot components can be retrieved only from pods running in the shoot `kube-system` namespace.
```
