### PR TITLE
[GEP-18] Auto-renew secrets which are about to expire

### DIFF
--- a/docs/development/secrets_management.md
+++ b/docs/development/secrets_management.md
@@ -4,7 +4,7 @@
 Accordingly, expect adaptations to this document and implementation details.
 
 The gardenlet needs to create quite some amount of credentials (certificates, private keys, passwords, etc.) for seed and shoot clusters in order to ensure secure deployments.
-Such credentials typically should be rotated regularly, and they potentially need to be persisted such that they don't get lost in case of a control plane migration or a lost seed cluster.
+Such credentials typically should be renewed automatically when their validity expires, rotated regularly, and they potentially need to be persisted such that they don't get lost in case of a control plane migration or a lost seed cluster.
 
 ## SecretsManager Introduction
 
@@ -20,6 +20,7 @@ It is built on top of the `ConfigInterface` and `DataInterface` interfaces part 
   - `Persist()`: This marks the secret such that it gets persisted in the `ShootState` resource in the garden cluster. Consequently, it should only be used for secrets related to a shoot cluster.
   - `Rotate(rotationStrategy)`: This specifies the strategy in case this secret is to be rotated or regenerated (either `InPlace` which immediately forgets about the old secret, or `KeepOld` which keeps the old secret in the system).
   - `IgnoreOldSecrets()`: This specifies whether old secrets should be considered and loaded (which is done by default). It should be used when old secrets are no longer important and can be "forgotten" (e.g. in ["phase 2" (`t2`) of the CA certificate rotation](../proposals/18-shoot-CA-rotation.md#rotation-sequence-for-cluster-and-client-ca)).
+  - `Validity(time.Duration)`: This specifies how long the secret should be valid. For certificate secret configurations, the manager will automatically deduce this information from the generated certificate.
 
 - `Get(string, ...GetOption) (*corev1.Secret, bool)`
 
@@ -58,13 +59,14 @@ if err != nil {
 }
 ```
 
-As explained above, the caller does not need to care about the rotation or the persistence of this secret - all of these concerns are handled by the secrets manager.
+As explained above, the caller does not need to care about the renewal, rotation or the persistence of this secret - all of these concerns are handled by the secrets manager.
+Automatic renewal of secrets happens when their validity  approaches 80%. 
 
 In case a CA certificate is needed by some component then it can be retrieved as follows:
 
 ```go
 caSecret, found := k.secretsManager.Get("my-ca")
-if err != nil {
+if !found {
     return fmt.Errorf("secret my-ca not found")
 }
 ```

--- a/docs/development/secrets_management.md
+++ b/docs/development/secrets_management.md
@@ -60,7 +60,7 @@ if err != nil {
 ```
 
 As explained above, the caller does not need to care about the renewal, rotation or the persistence of this secret - all of these concerns are handled by the secrets manager.
-Automatic renewal of secrets happens when their validity  approaches 80%. 
+Automatic renewal of secrets happens when their validity  approaches 80% or less than `10d` are left until expiration.
 
 In case a CA certificate is needed by some component then it can be retrieved as follows:
 

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -72,9 +72,6 @@ const (
 	// EndUserCrtValidity is the time period a user facing certificate is valid.
 	EndUserCrtValidity = 730 * 24 * time.Hour // ~2 years, see https://support.apple.com/en-us/HT210176
 
-	// CrtRenewalWindow is the time window in which certificates are supposed to be replaced before they expire.
-	CrtRenewalWindow = 30 * 24 * time.Hour
-
 	// ShootDNSIngressName is a constant for the DNS resources used for the shoot ingress addon.
 	ShootDNSIngressName = "ingress"
 
@@ -88,11 +85,3 @@ const (
 	// for users monitoring for shoots.
 	MonitoringIngressCredentialsUsers = "monitoring-ingress-credentials-users"
 )
-
-// IngressTLSSecretNames are the secrets which contain operator or user facing x509 certificates.
-// These are usually exposed via an `Ingress` in the shoot control plane.
-var IngressTLSSecretNames = []string{
-	AlertManagerTLS,
-	GrafanaTLS,
-	PrometheusTLS,
-}

--- a/pkg/utils/secrets/certificates.go
+++ b/pkg/utils/secrets/certificates.go
@@ -489,14 +489,3 @@ func SelfGenerateTLSServerCertificate(name string, dnsNames []string, ips []net.
 
 	return certificate, caCertificate, tempDir, nil
 }
-
-// CertificateIsExpired returns `true` if the given certificate is expired.
-// The given `renewalWindow` lets the certificate expire earlier.
-func CertificateIsExpired(clock clock.Clock, cert []byte, renewalWindow time.Duration) (bool, error) {
-	x509, err := utils.DecodeCertificate(cert)
-	if err != nil {
-		return false, err
-	}
-
-	return clock.Now().After(x509.NotAfter.Add(-renewalWindow)), nil
-}

--- a/pkg/utils/secrets/certificates_test.go
+++ b/pkg/utils/secrets/certificates_test.go
@@ -15,14 +15,11 @@
 package secrets_test
 
 import (
-	"time"
-
 	"github.com/gardener/gardener/pkg/utils"
 	. "github.com/gardener/gardener/pkg/utils/secrets"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/util/clock"
 )
 
 var _ = Describe("Certificate Secrets", func() {
@@ -172,66 +169,6 @@ var _ = Describe("Certificate Secrets", func() {
 					DataKeyPrivateKey:  []byte("foo"),
 					DataKeyCertificate: []byte("bar"),
 				}))
-			})
-		})
-	})
-
-	Describe("#CertificateIsExpired", func() {
-		// Validity
-		// Not Before: Sep 18 06:15:51 2017 GMT
-		// Not After : Sep 16 06:15:51 2027 GMT
-		var (
-			cert = []byte(`-----BEGIN CERTIFICATE-----
-MIIDBzCCAe+gAwIBAgIJAJL7bJOMij7vMA0GCSqGSIb3DQEBBQUAMBoxGDAWBgNV
-BAMMD3d3dy5leGFtcGxlLmNvbTAeFw0xNzA5MTgwNjE1NTFaFw0yNzA5MTYwNjE1
-NTFaMBoxGDAWBgNVBAMMD3d3dy5leGFtcGxlLmNvbTCCASIwDQYJKoZIhvcNAQEB
-BQADggEPADCCAQoCggEBAK48vFUoR3+IKiTa63tE+pOyYob4wczIC5co2PWRVhPu
-2FKNhQuD76MDNf8yXIQ8xO6QNT1BPJCdg3qjAjdSD0qIdyG6/vh1VZyeBXrXtTzm
-JGmKIX8+R3W5UKtWIKWrRc31DEUFoU+jJySd2jIeAcNuc4dFgdhanV/FLChrIm3Q
-PWxteKT0eNvnBEdH6kwj5OnXOWRX+hjL4GHq373y4KdWrSF4lZkdFAWEdWwpQC5q
-8PrU7OPw01mVeCyvmgdaxLxlW3SgD9E/SSWF9MtAf03k5FGXOLHdY4dL3u5oWWdz
-UUKB/NZPnohf4/eOsOKU8rSO0iY+798J/r6NX1oJ50cCAwEAAaNQME4wHQYDVR0O
-BBYEFIDD01YMrL/eV2fQfQvid9SfZrw2MB8GA1UdIwQYMBaAFIDD01YMrL/eV2fQ
-fQvid9SfZrw2MAwGA1UdEwQFMAMBAf8wDQYJKoZIhvcNAQEFBQADggEBAGF63ihH
-v1t2/0RjyVmBelGIifWm9NlgcV/WKT/ZAuz33+Otr4H2KzcAHaSZuaNaQq/DKQ92
-oGxA9X9xpnCc9aMfbggCsmCvzDIkbEJ/U2SyGbYu4VozgwvXgwH+JShFBfDyepOq
-IHwwHZmSRUqCFTYxCUSWJrJ4AK+8bI47RRcqHa4P0A7h+P63sS5IyyK371Q2ANga
-gmnUK+HpzDfHnVuv5FVr3fl7vs4gP4KyQ74+WG3UX7t9Goqj1DRfRRccRzNh/cC8
-YjxuTtX5W7FiUTXLdvib2Rve46PMlprOKABr0D0ajo05SvkDBTZpIle1CTcp0fmk
-knrjCu4WX+cJxJk=
------END CERTIFICATE-----`)
-			noRenewalWindow = 0 * time.Second
-		)
-
-		Context("when certificate is expired", func() {
-			var fakeClock clock.Clock
-
-			BeforeEach(func() {
-				time, err := time.Parse(time.RFC3339, "2027-09-16T06:16:00+00:00")
-				Expect(err).NotTo(HaveOccurred())
-				fakeClock = clock.NewFakeClock(time)
-			})
-
-			It("should detect expired certificate", func() {
-				Expect(CertificateIsExpired(fakeClock, cert, noRenewalWindow)).To(BeTrue())
-			})
-		})
-
-		Context("when certificate is valid", func() {
-			var fakeClock clock.Clock
-
-			BeforeEach(func() {
-				time, err := time.Parse(time.RFC3339, "2027-08-17T06:16:00+00:00")
-				Expect(err).NotTo(HaveOccurred())
-				fakeClock = clock.NewFakeClock(time)
-			})
-
-			It("should return valid certificate", func() {
-				Expect(CertificateIsExpired(fakeClock, cert, noRenewalWindow)).To(BeFalse())
-			})
-
-			It("should return expired certificate because of 30 days renewal window", func() {
-				Expect(CertificateIsExpired(fakeClock, cert, 30*24*time.Hour)).To(BeTrue())
 			})
 		})
 	})

--- a/pkg/utils/secrets/manager/cleanup.go
+++ b/pkg/utils/secrets/manager/cleanup.go
@@ -19,16 +19,12 @@ import (
 
 	"github.com/gardener/gardener/pkg/utils/flow"
 
-	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func (m *manager) Cleanup(ctx context.Context) error {
-	secretList := &corev1.SecretList{}
-	if err := m.client.List(ctx, secretList, client.InNamespace(m.namespace), client.MatchingLabels{
-		LabelKeyManagedBy:       LabelValueSecretsManager,
-		LabelKeyManagerIdentity: m.identity,
-	}); err != nil {
+	secretList, err := m.listSecrets(ctx)
+	if err != nil {
 		return err
 	}
 

--- a/pkg/utils/secrets/manager/cleanup_test.go
+++ b/pkg/utils/secrets/manager/cleanup_test.go
@@ -24,6 +24,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/clock"
 	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -44,7 +45,10 @@ var _ = Describe("Cleanup", func() {
 
 	BeforeEach(func() {
 		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetesscheme.Scheme).Build()
-		m = New(logr.Discard(), fakeClient, namespace, testIdentity, nil).(*manager)
+
+		mgr, err := New(logr.Discard(), clock.RealClock{}, fakeClient, namespace, testIdentity, nil)
+		Expect(err).NotTo(HaveOccurred())
+		m = mgr.(*manager)
 	})
 
 	secretList := func(identity string) []*corev1.Secret {

--- a/pkg/utils/secrets/manager/cleanup_test.go
+++ b/pkg/utils/secrets/manager/cleanup_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Cleanup", func() {
 	BeforeEach(func() {
 		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetesscheme.Scheme).Build()
 
-		mgr, err := New(logr.Discard(), clock.RealClock{}, fakeClient, namespace, testIdentity, nil)
+		mgr, err := New(ctx, logr.Discard(), clock.RealClock{}, fakeClient, namespace, testIdentity, nil)
 		Expect(err).NotTo(HaveOccurred())
 		m = mgr.(*manager)
 	})

--- a/pkg/utils/secrets/manager/fake/fake_manager.go
+++ b/pkg/utils/secrets/manager/fake/fake_manager.go
@@ -71,7 +71,7 @@ func (m *fakeManager) Generate(ctx context.Context, config secretutils.ConfigInt
 		return nil, err
 	}
 
-	objectMeta, err := secretsmanager.ObjectMeta(m.namespace, ManagerIdentity, config, "", nil, &options.Persist, nil)
+	objectMeta, err := secretsmanager.ObjectMeta(m.namespace, ManagerIdentity, config, "", nil, nil, &options.Persist, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/utils/secrets/manager/generate_test.go
+++ b/pkg/utils/secrets/manager/generate_test.go
@@ -16,6 +16,7 @@ package manager
 
 import (
 	"context"
+	"strconv"
 	"time"
 
 	secretutils "github.com/gardener/gardener/pkg/utils/secrets"
@@ -27,6 +28,7 @@ import (
 	. "github.com/onsi/gomega/gstruct"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/clock"
 	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -41,14 +43,19 @@ var _ = Describe("Generate", func() {
 	var (
 		ctx       = context.TODO()
 		namespace = "shoot--foo--bar"
+		identity  = "test"
 
 		m          *manager
 		fakeClient client.Client
+		fakeClock  = clock.NewFakeClock(time.Time{})
 	)
 
 	BeforeEach(func() {
 		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetesscheme.Scheme).Build()
-		m = New(logr.Discard(), fakeClient, namespace, "test", nil).(*manager)
+
+		mgr, err := New(logr.Discard(), fakeClock, fakeClient, namespace, identity, nil)
+		Expect(err).NotTo(HaveOccurred())
+		m = mgr.(*manager)
 	})
 
 	Describe("#Generate", func() {
@@ -80,6 +87,22 @@ var _ = Describe("Generate", func() {
 				Expect(secretInfos.bundle).To(BeNil())
 			})
 
+			It("should maintain the lifetime labels (w/o validity)", func() {
+				By("generating new secret")
+				secret, err := m.Generate(ctx, config)
+				Expect(err).NotTo(HaveOccurred())
+
+				By("reading created secret from system")
+				foundSecret := &corev1.Secret{}
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(secret), foundSecret)).To(Succeed())
+
+				By("verifying labels")
+				Expect(foundSecret.Labels).To(And(
+					HaveKeyWithValue("issued-at-time", strconv.FormatInt(fakeClock.Now().Unix(), 10)),
+					Not(HaveKey("valid-until-time")),
+				))
+			})
+
 			It("should generate a new secret when the config changes", func() {
 				By("generating new secret")
 				secret, err := m.Generate(ctx, config)
@@ -107,7 +130,9 @@ var _ = Describe("Generate", func() {
 				expectSecretWasCreated(ctx, fakeClient, secret)
 
 				By("changing last rotation initiation time and generate again")
-				m = New(logr.Discard(), fakeClient, namespace, "test", map[string]time.Time{name: time.Now()}).(*manager)
+				mgr, err := New(logr.Discard(), fakeClock, fakeClient, namespace, identity, map[string]time.Time{name: time.Now()})
+				Expect(err).NotTo(HaveOccurred())
+				m = mgr.(*manager)
 
 				newSecret, err := m.Generate(ctx, config)
 				Expect(err).NotTo(HaveOccurred())
@@ -137,7 +162,7 @@ var _ = Describe("Generate", func() {
 				secretInfos, found := m.getFromStore(name)
 				Expect(found).To(BeTrue())
 				Expect(secretInfos.current.obj).To(Equal(newSecret))
-				Expect(secretInfos.old.obj).To(Equal(secret))
+				Expect(secretInfos.old.obj).To(Equal(withoutTypeMeta(secret)))
 				Expect(secretInfos.bundle).To(BeNil())
 			})
 
@@ -215,7 +240,26 @@ var _ = Describe("Generate", func() {
 				Expect(found).To(BeTrue())
 				Expect(secretInfos.current.obj).To(Equal(secret))
 				Expect(secretInfos.old).To(BeNil())
-				Expect(secretInfos.bundle.obj).To(PointTo(Equal(secretList.Items[0])))
+				Expect(secretInfos.bundle.obj).To(Equal(withTypeMeta(&secretList.Items[0])))
+			})
+
+			It("should maintain the lifetime labels (w/o custom validity)", func() {
+				By("generating new secret")
+				config.Clock = fakeClock
+				secret, err := m.Generate(ctx, config)
+				Expect(err).NotTo(HaveOccurred())
+
+				By("reading created secret from system")
+				foundSecret := &corev1.Secret{}
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(secret), foundSecret)).To(Succeed())
+
+				By("verifying labels")
+				Expect(foundSecret.Labels).To(And(
+					HaveKeyWithValue("issued-at-time", strconv.FormatInt(fakeClock.Now().Unix(), 10)),
+					HaveKeyWithValue("valid-until-time", strconv.FormatInt(fakeClock.Now().AddDate(10, 0, 0).Unix(), 10)),
+				))
+			})
+
 			})
 
 			It("should rotate a CA secret and add old and new to the corresponding bundle", func() {
@@ -230,7 +274,10 @@ var _ = Describe("Generate", func() {
 				oldBundleSecret := secretInfos.bundle.obj
 
 				By("changing secret config and generate again")
-				m = New(logr.Discard(), fakeClient, namespace, "test", map[string]time.Time{name: time.Now()}).(*manager)
+				mgr, err := New(logr.Discard(), fakeClock, fakeClient, namespace, identity, map[string]time.Time{name: time.Now()})
+				Expect(err).NotTo(HaveOccurred())
+				m = mgr.(*manager)
+
 				newSecret, err := m.Generate(ctx, config, Rotate(KeepOld))
 				Expect(err).NotTo(HaveOccurred())
 				expectSecretWasCreated(ctx, fakeClient, newSecret)
@@ -248,7 +295,7 @@ var _ = Describe("Generate", func() {
 				secretInfos, found = m.getFromStore(name)
 				Expect(found).To(BeTrue())
 				Expect(secretInfos.current.obj).To(Equal(newSecret))
-				Expect(secretInfos.old.obj).To(Equal(secret))
+				Expect(secretInfos.old.obj).To(Equal(withoutTypeMeta(secret)))
 				Expect(secretInfos.bundle.obj).NotTo(PointTo(Equal(oldBundleSecret)))
 			})
 		})
@@ -279,6 +326,29 @@ var _ = Describe("Generate", func() {
 				}
 			})
 
+			It("should maintain the lifetime labels (w/o custom validity)", func() {
+				By("generating new CA secret")
+				caSecret, err := m.Generate(ctx, caConfig)
+				Expect(err).NotTo(HaveOccurred())
+				expectSecretWasCreated(ctx, fakeClient, caSecret)
+
+				By("generating new server secret")
+				serverConfig.Clock = fakeClock
+				serverSecret, err := m.Generate(ctx, serverConfig, SignedByCA(caName))
+				Expect(err).NotTo(HaveOccurred())
+				expectSecretWasCreated(ctx, fakeClient, serverSecret)
+
+				By("reading created secret from system")
+				foundSecret := &corev1.Secret{}
+				Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(serverSecret), foundSecret)).To(Succeed())
+
+				By("verifying labels")
+				Expect(foundSecret.Labels).To(And(
+					HaveKeyWithValue("issued-at-time", strconv.FormatInt(fakeClock.Now().Unix(), 10)),
+					HaveKeyWithValue("valid-until-time", strconv.FormatInt(fakeClock.Now().AddDate(10, 0, 0).Unix(), 10)),
+				))
+			})
+
 			It("should keep the same server cert even when the CA rotates", func() {
 				By("generating new CA secret")
 				caSecret, err := m.Generate(ctx, caConfig)
@@ -291,7 +361,10 @@ var _ = Describe("Generate", func() {
 				expectSecretWasCreated(ctx, fakeClient, serverSecret)
 
 				By("rotating CA")
-				m = New(logr.Discard(), fakeClient, namespace, "test", map[string]time.Time{caName: time.Now()}).(*manager)
+				mgr, err := New(logr.Discard(), fakeClock, fakeClient, namespace, identity, map[string]time.Time{name: time.Now()})
+				Expect(err).NotTo(HaveOccurred())
+				m = mgr.(*manager)
+
 				newCASecret, err := m.Generate(ctx, caConfig, Rotate(KeepOld))
 				Expect(err).NotTo(HaveOccurred())
 				expectSecretWasCreated(ctx, fakeClient, newCASecret)
@@ -302,8 +375,7 @@ var _ = Describe("Generate", func() {
 				expectSecretWasCreated(ctx, fakeClient, newServerSecret)
 
 				By("verifying server secret is still the same")
-				serverSecret.TypeMeta = metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"}
-				Expect(newServerSecret).To(Equal(serverSecret))
+				Expect(newServerSecret).To(Equal(withTypeMeta(serverSecret)))
 			})
 
 			It("should regenerate the client cert when the CA rotates", func() {
@@ -318,7 +390,10 @@ var _ = Describe("Generate", func() {
 				expectSecretWasCreated(ctx, fakeClient, clientSecret)
 
 				By("rotating CA")
-				m = New(logr.Discard(), fakeClient, namespace, "test", map[string]time.Time{caName: time.Now()}).(*manager)
+				mgr, err := New(logr.Discard(), fakeClock, fakeClient, namespace, identity, map[string]time.Time{caName: time.Now()})
+				Expect(err).NotTo(HaveOccurred())
+				m = mgr.(*manager)
+
 				newCASecret, err := m.Generate(ctx, caConfig, Rotate(KeepOld))
 				Expect(err).NotTo(HaveOccurred())
 				expectSecretWasCreated(ctx, fakeClient, newCASecret)
@@ -329,7 +404,6 @@ var _ = Describe("Generate", func() {
 				expectSecretWasCreated(ctx, fakeClient, newClientSecret)
 
 				By("verifying client secret is changed")
-				clientSecret.TypeMeta = metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"}
 				Expect(newClientSecret).NotTo(Equal(clientSecret))
 			})
 		})
@@ -630,12 +704,21 @@ resources:
 	})
 })
 
-func expectSecretWasCreated(ctx context.Context, fakeClient client.Client, obj *corev1.Secret) {
-	secret := obj.DeepCopy()
-	secret.TypeMeta = metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"}
-
+func expectSecretWasCreated(ctx context.Context, fakeClient client.Client, secret *corev1.Secret) {
 	foundSecret := &corev1.Secret{}
 	Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(secret), foundSecret)).To(Succeed())
 
-	Expect(foundSecret).To(Equal(secret))
+	Expect(foundSecret).To(Equal(withTypeMeta(secret)))
+}
+
+func withTypeMeta(obj *corev1.Secret) *corev1.Secret {
+	secret := obj.DeepCopy()
+	secret.TypeMeta = metav1.TypeMeta{APIVersion: "v1", Kind: "Secret"}
+	return secret
+}
+
+func withoutTypeMeta(obj *corev1.Secret) *corev1.Secret {
+	secret := obj.DeepCopy()
+	secret.TypeMeta = metav1.TypeMeta{}
+	return secret
 }

--- a/pkg/utils/secrets/manager/generate_test.go
+++ b/pkg/utils/secrets/manager/generate_test.go
@@ -276,7 +276,7 @@ var _ = Describe("Generate", func() {
 				))
 			})
 
-			It("should maintain the lifetime labels (w/ custom validity)", func() {
+			It("should maintain the lifetime labels (w/ custom validity which is ignored for certificates)", func() {
 				By("generating new secret")
 				config.Clock = fakeClock
 				secret, err := m.Generate(ctx, config, Validity(time.Hour))
@@ -380,7 +380,7 @@ var _ = Describe("Generate", func() {
 				))
 			})
 
-			It("should maintain the lifetime labels (w/ custom validity)", func() {
+			It("should maintain the lifetime labels (w/ custom validity which is ignored for certificates)", func() {
 				By("generating new CA secret")
 				caSecret, err := m.Generate(ctx, caConfig)
 				Expect(err).NotTo(HaveOccurred())
@@ -388,7 +388,7 @@ var _ = Describe("Generate", func() {
 
 				By("generating new server secret")
 				serverConfig.Clock = fakeClock
-				serverSecret, err := m.Generate(ctx, serverConfig, SignedByCA(caName))
+				serverSecret, err := m.Generate(ctx, serverConfig, SignedByCA(caName), Validity(time.Hour))
 				Expect(err).NotTo(HaveOccurred())
 				expectSecretWasCreated(ctx, fakeClient, serverSecret)
 

--- a/pkg/utils/secrets/manager/generate_test.go
+++ b/pkg/utils/secrets/manager/generate_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Generate", func() {
 	BeforeEach(func() {
 		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetesscheme.Scheme).Build()
 
-		mgr, err := New(logr.Discard(), fakeClock, fakeClient, namespace, identity, nil)
+		mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, nil)
 		Expect(err).NotTo(HaveOccurred())
 		m = mgr.(*manager)
 	})
@@ -146,7 +146,7 @@ var _ = Describe("Generate", func() {
 				expectSecretWasCreated(ctx, fakeClient, secret)
 
 				By("changing last rotation initiation time and generate again")
-				mgr, err := New(logr.Discard(), fakeClock, fakeClient, namespace, identity, map[string]time.Time{name: time.Now()})
+				mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, map[string]time.Time{name: time.Now()})
 				Expect(err).NotTo(HaveOccurred())
 				m = mgr.(*manager)
 
@@ -305,7 +305,7 @@ var _ = Describe("Generate", func() {
 				oldBundleSecret := secretInfos.bundle.obj
 
 				By("changing secret config and generate again")
-				mgr, err := New(logr.Discard(), fakeClock, fakeClient, namespace, identity, map[string]time.Time{name: time.Now()})
+				mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, map[string]time.Time{name: time.Now()})
 				Expect(err).NotTo(HaveOccurred())
 				m = mgr.(*manager)
 
@@ -415,7 +415,7 @@ var _ = Describe("Generate", func() {
 				expectSecretWasCreated(ctx, fakeClient, serverSecret)
 
 				By("rotating CA")
-				mgr, err := New(logr.Discard(), fakeClock, fakeClient, namespace, identity, map[string]time.Time{name: time.Now()})
+				mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, map[string]time.Time{name: time.Now()})
 				Expect(err).NotTo(HaveOccurred())
 				m = mgr.(*manager)
 
@@ -444,7 +444,7 @@ var _ = Describe("Generate", func() {
 				expectSecretWasCreated(ctx, fakeClient, clientSecret)
 
 				By("rotating CA")
-				mgr, err := New(logr.Discard(), fakeClock, fakeClient, namespace, identity, map[string]time.Time{caName: time.Now()})
+				mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, map[string]time.Time{caName: time.Now()})
 				Expect(err).NotTo(HaveOccurred())
 				m = mgr.(*manager)
 

--- a/pkg/utils/secrets/manager/manager.go
+++ b/pkg/utils/secrets/manager/manager.go
@@ -26,6 +26,7 @@ import (
 	"github.com/mitchellh/hashstructure/v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -49,9 +50,16 @@ const (
 	LabelKeyBundleFor = "bundle-for"
 	// LabelKeyPersist is a constant for a key of a label on a Secret describing that it should get persisted.
 	LabelKeyPersist = "persist"
-	// LabelKeyLastRotationInitiationTime is a constant for a key of a value on a Secret describing the unix timestamps
+	// LabelKeyLastRotationInitiationTime is a constant for a key of a label on a Secret describing the unix timestamps
 	// of when the last secret rotation was initiated.
 	LabelKeyLastRotationInitiationTime = "last-rotation-initiation-time"
+	// LabelKeyIssuedAtTime is a constant for a key of a label on a Secret describing the time of when the secret data
+	// was created. In case the data contains a certificate it is the time part of the certificate's 'not before' field.
+	LabelKeyIssuedAtTime = "issued-at-time"
+	// LabelKeyValidUntilTime is a constant for a key of a label on a Secret describing the time of how long the secret
+	// data is valid. In case the data contains a certificate it is the time part of the certificate's 'not after'
+	// field.
+	LabelKeyValidUntilTime = "valid-until-time"
 
 	// LabelValueTrue is a constant for a value of a label on a Secret describing the value 'true'.
 	LabelValueTrue = "true"
@@ -64,12 +72,13 @@ const (
 type (
 	manager struct {
 		lock                        sync.Mutex
+		clock                       clock.Clock
+		store                       secretStore
 		logger                      logr.Logger
 		client                      client.Client
 		namespace                   string
-		lastRotationInitiationTimes nameToUnixTime
-		store                       secretStore
 		identity                    string
+		lastRotationInitiationTimes nameToUnixTime
 	}
 
 	nameToUnixTime map[string]string
@@ -98,21 +107,32 @@ const (
 )
 
 // New returns a new manager for secrets in a given namespace.
-func New(logger logr.Logger, client client.Client, namespace string, identity string, secretNamesToTimes map[string]time.Time) Interface {
-	lastRotationInitiationTimes := make(map[string]string)
+func New(
+	logger logr.Logger,
+	clock clock.Clock,
+	c client.Client,
+	namespace string,
+	identity string,
+	secretNamesToTimes map[string]time.Time,
+) (
+	Interface,
+	error,
+) {
+	m := &manager{
+		store:                       make(secretStore),
+		clock:                       clock,
+		logger:                      logger.WithValues("namespace", namespace),
+		client:                      c,
+		namespace:                   namespace,
+		identity:                    identity,
+		lastRotationInitiationTimes: make(map[string]string),
+	}
 
 	for name, time := range secretNamesToTimes {
-		lastRotationInitiationTimes[name] = strconv.FormatInt(time.UTC().Unix(), 10)
+		m.lastRotationInitiationTimes[name] = unixTime(time)
 	}
 
-	return &manager{
-		logger:                      logger.WithValues("namespace", namespace),
-		client:                      client,
-		namespace:                   namespace,
-		store:                       make(secretStore),
-		lastRotationInitiationTimes: lastRotationInitiationTimes,
-		identity:                    identity,
-	}
+	return m, nil
 }
 
 func (m *manager) addToStore(name string, secret *corev1.Secret, class secretClass) error {
@@ -174,6 +194,7 @@ func ObjectMeta(
 	managerIdentity string,
 	config secretutils.ConfigInterface,
 	lastRotationInitiationTime string,
+	validUntilTime *string,
 	signingCAChecksum *string,
 	persist *bool,
 	bundleFor *string,
@@ -196,6 +217,10 @@ func ObjectMeta(
 
 	if signingCAChecksum != nil {
 		labels[LabelKeyChecksumSigningCA] = *signingCAChecksum
+	}
+
+	if validUntilTime != nil {
+		labels[LabelKeyValidUntilTime] = *validUntilTime
 	}
 
 	if persist != nil && *persist {
@@ -249,4 +274,8 @@ func secretTypeForData(data map[string][]byte) corev1.SecretType {
 		secretType = corev1.SecretTypeTLS
 	}
 	return secretType
+}
+
+func unixTime(in time.Time) string {
+	return strconv.FormatInt(in.UTC().Unix(), 10)
 }

--- a/pkg/utils/secrets/manager/manager_test.go
+++ b/pkg/utils/secrets/manager/manager_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Manager", func() {
 		It("should generate the expected object meta for a never-rotated CA cert secret", func() {
 			config := &secretutils.CertificateSecretConfig{Name: configName}
 
-			meta, err := ObjectMeta(namespace, "test", config, "", nil, nil, nil)
+			meta, err := ObjectMeta(namespace, "test", config, "", nil, nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(meta).To(Equal(metav1.ObjectMeta{
@@ -56,7 +56,7 @@ var _ = Describe("Manager", func() {
 		It("should generate the expected object meta for a rotated CA cert secret", func() {
 			config := &secretutils.CertificateSecretConfig{Name: configName}
 
-			meta, err := ObjectMeta(namespace, "test", config, lastRotationInitiationTime, nil, nil, nil)
+			meta, err := ObjectMeta(namespace, "test", config, lastRotationInitiationTime, nil, nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(meta).To(Equal(metav1.ObjectMeta{
@@ -73,13 +73,13 @@ var _ = Describe("Manager", func() {
 		})
 
 		DescribeTable("check different label options",
-			func(nameInfix string, signingCAChecksum *string, persist *bool, bundleFor *string, extraLabels map[string]string) {
+			func(nameInfix string, signingCAChecksum *string, validUntilTime *string, persist *bool, bundleFor *string, extraLabels map[string]string) {
 				config := &secretutils.CertificateSecretConfig{
 					Name:      configName,
 					SigningCA: &secretutils.Certificate{},
 				}
 
-				meta, err := ObjectMeta(namespace, "test", config, lastRotationInitiationTime, signingCAChecksum, persist, bundleFor)
+				meta, err := ObjectMeta(namespace, "test", config, lastRotationInitiationTime, validUntilTime, signingCAChecksum, persist, bundleFor)
 				Expect(err).NotTo(HaveOccurred())
 
 				labels := map[string]string{
@@ -97,10 +97,11 @@ var _ = Describe("Manager", func() {
 				}))
 			},
 
-			Entry("no extras", "a9c2fcb9", nil, nil, nil, nil),
-			Entry("with signing ca checksum", "a11a0b2d", pointer.String("checksum"), nil, nil, map[string]string{"checksum-of-signing-ca": "checksum"}),
-			Entry("with persist", "a9c2fcb9", nil, pointer.Bool(true), nil, map[string]string{"persist": "true"}),
-			Entry("with bundleFor", "a9c2fcb9", nil, nil, pointer.String("bundle-origin"), map[string]string{"bundle-for": "bundle-origin"}),
+			Entry("no extras", "a9c2fcb9", nil, nil, nil, nil, nil),
+			Entry("with signing ca checksum", "a11a0b2d", pointer.String("checksum"), nil, nil, nil, map[string]string{"checksum-of-signing-ca": "checksum"}),
+			Entry("with valid until time", "a9c2fcb9", nil, pointer.String("validuntil"), nil, nil, map[string]string{"valid-until-time": "validuntil"}),
+			Entry("with persist", "a9c2fcb9", nil, nil, pointer.Bool(true), nil, map[string]string{"persist": "true"}),
+			Entry("with bundleFor", "a9c2fcb9", nil, nil, nil, pointer.String("bundle-origin"), map[string]string{"bundle-for": "bundle-origin"}),
 		)
 	})
 

--- a/pkg/utils/secrets/manager/manager_test.go
+++ b/pkg/utils/secrets/manager/manager_test.go
@@ -12,21 +12,160 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package manager_test
+package manager
 
 import (
+	"context"
+	"strconv"
+	"time"
+
 	"github.com/gardener/gardener/pkg/utils"
 	secretutils "github.com/gardener/gardener/pkg/utils/secrets"
-	. "github.com/gardener/gardener/pkg/utils/secrets/manager"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/clock"
+	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var _ = Describe("Manager", func() {
+	Describe("#New", func() {
+		var (
+			ctx       = context.TODO()
+			namespace = "some-namespace"
+			identity  = "test"
+
+			m          *manager
+			fakeClient client.Client
+			fakeClock  = clock.NewFakeClock(time.Time{})
+		)
+
+		BeforeEach(func() {
+			fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetesscheme.Scheme).Build()
+		})
+
+		It("should create a new instance w/ empty last rotation initiation times map", func() {
+			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, nil)
+			Expect(err).NotTo(HaveOccurred())
+			m = mgr.(*manager)
+
+			Expect(m.lastRotationInitiationTimes).To(BeEmpty())
+		})
+
+		It("should create a new instance w/ provided last rotation initiation times", func() {
+			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, map[string]time.Time{"foo": fakeClock.Now()})
+			Expect(err).NotTo(HaveOccurred())
+			m = mgr.(*manager)
+
+			Expect(m.lastRotationInitiationTimes).To(Equal(nameToUnixTime{"foo": "-62135596800"}))
+		})
+
+		It("should create a new instance w/ overwritten last rotation initiation times", func() {
+			existingSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret1",
+					Namespace: namespace,
+					Labels: map[string]string{
+						"name":                          "secret1",
+						"managed-by":                    "secrets-manager",
+						"manager-identity":              identity,
+						"last-rotation-initiation-time": "-100",
+					},
+				},
+			}
+			Expect(fakeClient.Create(ctx, existingSecret)).To(Succeed())
+
+			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, map[string]time.Time{"secret1": fakeClock.Now()})
+			Expect(err).NotTo(HaveOccurred())
+			m = mgr.(*manager)
+
+			Expect(m.lastRotationInitiationTimes).To(Equal(nameToUnixTime{"secret1": "-62135596800"}))
+		})
+
+		It("should create a new instance w/ both existing and provided last rotation initiation times", func() {
+			existingSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret1",
+					Namespace: namespace,
+					Labels: map[string]string{
+						"name":                          "secret1",
+						"managed-by":                    "secrets-manager",
+						"manager-identity":              identity,
+						"last-rotation-initiation-time": "-100",
+					},
+				},
+			}
+			Expect(fakeClient.Create(ctx, existingSecret)).To(Succeed())
+
+			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, map[string]time.Time{"foo": fakeClock.Now()})
+			Expect(err).NotTo(HaveOccurred())
+			m = mgr.(*manager)
+
+			Expect(m.lastRotationInitiationTimes).To(Equal(nameToUnixTime{
+				"foo":     "-62135596800",
+				"secret1": "-100",
+			}))
+		})
+
+		It("should create a new instance and auto-renew a secret which is about to expire", func() {
+			fakeClock = clock.NewFakeClock(time.Date(2000, 1, 1, 1, 1, 1, 1, time.UTC))
+
+			existingSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret1",
+					Namespace: namespace,
+					Labels: map[string]string{
+						"name":                          "secret1",
+						"managed-by":                    "secrets-manager",
+						"manager-identity":              identity,
+						"last-rotation-initiation-time": "-100",
+						"issued-at-time":                strconv.FormatInt(fakeClock.Now().Add(-24*time.Hour).Unix(), 10),
+						"valid-until-time":              strconv.FormatInt(fakeClock.Now().Add(time.Hour).Unix(), 10),
+					},
+				},
+			}
+			Expect(fakeClient.Create(ctx, existingSecret)).To(Succeed())
+
+			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, nil)
+			Expect(err).NotTo(HaveOccurred())
+			m = mgr.(*manager)
+
+			Expect(m.lastRotationInitiationTimes).To(Equal(nameToUnixTime{"secret1": strconv.FormatInt(fakeClock.Now().Unix(), 10)}))
+		})
+
+		It("should create a new instance and NOT auto-renew a secret since it's still valid for a longer time", func() {
+			fakeClock = clock.NewFakeClock(time.Date(2000, 1, 1, 1, 1, 1, 1, time.UTC))
+
+			existingSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret1",
+					Namespace: namespace,
+					Labels: map[string]string{
+						"name":                          "secret1",
+						"managed-by":                    "secrets-manager",
+						"manager-identity":              identity,
+						"last-rotation-initiation-time": "-100",
+						"issued-at-time":                strconv.FormatInt(fakeClock.Now().Add(-24*time.Hour).Unix(), 10),
+						"valid-until-time":              strconv.FormatInt(fakeClock.Now().Add(24*time.Hour).Unix(), 10),
+					},
+				},
+			}
+			Expect(fakeClient.Create(ctx, existingSecret)).To(Succeed())
+
+			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, nil)
+			Expect(err).NotTo(HaveOccurred())
+			m = mgr.(*manager)
+
+			Expect(m.lastRotationInitiationTimes).To(Equal(nameToUnixTime{"secret1": "-100"}))
+		})
+	})
+
 	Describe("#ObjectMeta", func() {
 		var (
 			configName                 = "config-name"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement
/merge squash

**What this PR does / why we need it**:
This PR adds new functionality to the secrets manager:

1. All secrets will now get `issued-at-time` and `valid-until-time` labels. For certificate secrets, both values are deduced from the generated certificate itself. For non-certificate secrets the `valid-until-time` is empty unless explicitly provided via the new `Validity(time.Duration)` option for `Generate`. The `issued-at-time` is the current time (for existing secrets it will be time of the first reconciliation, so it is a little imprecise here, but it doesn't matter given that this entire functionality is pretty new).
2. Based on this information, the secrets manager can trigger automatic renewal of secrets which have reached 80%+ of their validity. This is done in the `New` function by listing all existing secrets and checking those two labels.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/3292#issuecomment-1036058890

**Special notes for your reviewer**:
This does now drop functionality for renewing the ingress TLS secrets, however, the `loki-tls` secret was already adapted to the new secrets manager as part of #5664 and there is another PR for adapting the `{alertmanager,prometheus,grafana}-tls` secrets (#5682).

/invite @timebertt 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
3. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
The secrets manager is now able to automatically renew secrets which are about to expire. This is done as part of the regular reconciliation flows when the respective secret has reached 80% of its validity.
```
