### PR TITLE
Allows creation of source BackupEntries in the seedrestriction admission webhook handler

### DIFF
--- a/docs/deployment/gardenlet_api_access.md
+++ b/docs/deployment/gardenlet_api_access.md
@@ -1,7 +1,7 @@
 # Scoped API Access for Gardenlets
 
 By default, `gardenlet`s have administrative access in the garden cluster.
-They are able to execute any API request on any object independent of whether the object is related to the seed cluster the `gardenlet` is responsible fto.
+They are able to execute any API request on any object independent of whether the object is related to the seed cluster the `gardenlet` is responsible for.
 As RBAC is not powerful enough for fine-grained checks and for the sake of security, Gardener provides two optional but recommended configurations for your environments that scope the API access for `gardenlet`s.
 
 Similar to the [`Node` authorization mode in Kubernetes](https://kubernetes.io/docs/reference/access-authn-authz/node/), Gardener features a `SeedAuthorizer` plugin.

--- a/pkg/admissioncontroller/webhooks/admission/seedrestriction/admission_test.go
+++ b/pkg/admissioncontroller/webhooks/admission/seedrestriction/admission_test.go
@@ -473,6 +473,151 @@ var _ = Describe("handler", func() {
 
 					Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
 				})
+
+				Context("when creating a source BackupEntry", func() {
+					const (
+						shootBackupEntryName = "backupentry"
+						shootName            = "foo"
+					)
+
+					var shoot *gardencorev1beta1.Shoot
+
+					BeforeEach(func() {
+						objData, err := runtime.Encode(encoder, &gardencorev1beta1.BackupEntry{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      fmt.Sprintf("%s-%s", v1beta1constants.BackupSourcePrefix, shootBackupEntryName),
+								Namespace: namespace,
+								OwnerReferences: []metav1.OwnerReference{
+									{
+										Name: shootName,
+										Kind: "Shoot",
+									},
+								},
+							},
+							Spec: gardencorev1beta1.BackupEntrySpec{
+								BucketName: bucketName,
+								SeedName:   &seedName,
+							},
+						})
+						Expect(err).NotTo(HaveOccurred())
+						request.Object.Raw = objData
+
+						shoot = &gardencorev1beta1.Shoot{
+							Status: gardencorev1beta1.ShootStatus{
+								LastOperation: &gardencorev1beta1.LastOperation{
+									Type:  gardencorev1beta1.LastOperationTypeRestore,
+									State: gardencorev1beta1.LastOperationStateProcessing,
+								},
+							},
+						}
+					})
+
+					It("should forbid the request because the shoot owning the source BackupEntry could not be found", func() {
+						notFoundErr := apierrors.NewNotFound(schema.GroupResource{}, "")
+						mockCache.EXPECT().Get(ctx, kutil.Key(namespace, shootName), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).Return(notFoundErr)
+
+						Expect(handler.Handle(ctx, request)).To(Equal(admission.Response{
+							AdmissionResponse: admissionv1.AdmissionResponse{
+								Allowed: false,
+								Result: &metav1.Status{
+									Code:    int32(http.StatusInternalServerError),
+									Message: notFoundErr.Error(),
+								},
+							},
+						}))
+					})
+
+					DescribeTable("should forbid the request because a the shoot owning the source BackupEntry is not in restore phase",
+						func(lastOperation *gardencorev1beta1.LastOperation) {
+							mockCache.EXPECT().Get(ctx, kutil.Key(namespace, shootName), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot) error {
+								shoot.Status.LastOperation = lastOperation
+								shoot.DeepCopyInto(obj)
+								return nil
+							})
+
+							Expect(handler.Handle(ctx, request)).To(Equal(admission.Response{
+								AdmissionResponse: admissionv1.AdmissionResponse{
+									Allowed: false,
+									Result: &metav1.Status{
+										Code:    int32(http.StatusForbidden),
+										Message: fmt.Sprintf("creation of source BackupEntry is only allowed during shoot Restore operation (shoot: %s)", shootName),
+									},
+								},
+							}))
+						},
+						Entry("lastOperation is nil", nil),
+						Entry("lastOperation is create", &gardencorev1beta1.LastOperation{Type: gardencorev1beta1.LastOperationTypeCreate}),
+						Entry("lastOperation is reconcile", &gardencorev1beta1.LastOperation{Type: gardencorev1beta1.LastOperationTypeReconcile}),
+						Entry("lastOperation is delete", &gardencorev1beta1.LastOperation{Type: gardencorev1beta1.LastOperationTypeDelete}),
+						Entry("lastOperation is migrate", &gardencorev1beta1.LastOperation{Type: gardencorev1beta1.LastOperationTypeMigrate}),
+					)
+
+					It("should forbid the request because a BackupEntry for the shoot does not exist", func() {
+						notFoundErr := apierrors.NewNotFound(schema.GroupResource{}, "")
+
+						mockCache.EXPECT().Get(ctx, kutil.Key(namespace, shootName), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot) error {
+							shoot.DeepCopyInto(obj)
+							return nil
+						})
+						mockCache.EXPECT().Get(ctx, kutil.Key(namespace, shootBackupEntryName), gomock.AssignableToTypeOf(&gardencorev1beta1.BackupEntry{})).Return(notFoundErr)
+
+						Expect(handler.Handle(ctx, request)).To(Equal(admission.Response{
+							AdmissionResponse: admissionv1.AdmissionResponse{
+								Allowed: false,
+								Result: &metav1.Status{
+									Code:    int32(http.StatusForbidden),
+									Message: fmt.Sprintf("could not find original BackupEntry %s: %v", shootBackupEntryName, notFoundErr.Error()),
+								},
+							},
+						}))
+					})
+
+					It("should forbid the request because the source BackupEntry does not match the BackupEntry for the shoot", func() {
+						mockCache.EXPECT().Get(ctx, kutil.Key(namespace, shootName), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot) error {
+							shoot.DeepCopyInto(obj)
+							return nil
+						})
+						mockCache.EXPECT().Get(ctx, kutil.Key(namespace, shootBackupEntryName), gomock.AssignableToTypeOf(&gardencorev1beta1.BackupEntry{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.BackupEntry) error {
+							be := &gardencorev1beta1.BackupEntry{
+								Spec: gardencorev1beta1.BackupEntrySpec{
+									BucketName: "some-different-bucket",
+									SeedName:   pointer.String("some-differnet-seedname"),
+								},
+							}
+							be.DeepCopyInto(obj)
+							return nil
+						})
+
+						Expect(handler.Handle(ctx, request)).To(Equal(admission.Response{
+							AdmissionResponse: admissionv1.AdmissionResponse{
+								Allowed: false,
+								Result: &metav1.Status{
+									Code:    int32(http.StatusForbidden),
+									Message: fmt.Sprintf("specification of source BackupEntry must equal specification of original BackupEntry %s", shootBackupEntryName),
+								},
+							},
+						}))
+					})
+
+					It("should allow creation of source BackupEntry if a matching BackupEntry exists and shoot is in restore phase", func() {
+						mockCache.EXPECT().Get(ctx, kutil.Key(namespace, shootName), gomock.AssignableToTypeOf(&gardencorev1beta1.Shoot{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.Shoot) error {
+							shoot.DeepCopyInto(obj)
+							return nil
+						})
+						mockCache.EXPECT().Get(ctx, kutil.Key(namespace, shootBackupEntryName), gomock.AssignableToTypeOf(&gardencorev1beta1.BackupEntry{})).DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *gardencorev1beta1.BackupEntry) error {
+							be := &gardencorev1beta1.BackupEntry{
+								Spec: gardencorev1beta1.BackupEntrySpec{
+									BucketName: bucketName,
+									SeedName:   &seedName,
+								},
+							}
+							be.DeepCopyInto(obj)
+							return nil
+						})
+
+						Expect(handler.Handle(ctx, request)).To(Equal(responseAllowed))
+					})
+				})
 			})
 		})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind enhancement

**What this PR does / why we need it**:
Allows the creation of source `BackupEntries` in the seedrestriction admission webhook handler. The creation is only allowed  if all the following conditions are met:
1. The source `backupEntry.Spec.SeedName` is the same as the seed that the `gardenlet` is currently responsible for
2. There already exists a `BackupEntry` for the shoot and its spec matches that of the newly created source `BackupEntry`

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:
I was wondering whether to add an additional check to only allow source `BackupEntries` to be created during the restore phase of control plane migration.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Creation of source `BackupEntries` is allowed by the `gardenlet` responsible for the seed indicated by the `BackupEntry.Spec.SeedName` if the spec of the source `BackupEntry` matches the spec of the already existing `BackupEntry` for the shoot cluster.
```
