### PR TITLE
[GEP-18] Adapt `{alertmanager,prometheus,grafana}-tls` secrets (for ingress) to new secrets manager

### DIFF
--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -39,6 +39,8 @@ import (
 // DefaultInterval is the default interval for retry operations.
 const DefaultInterval = 5 * time.Second
 
+var ingressTLSCertificateValidity = 730 * 24 * time.Hour // ~2 years, see https://support.apple.com/en-us/HT210176
+
 // New takes an operation object <o> and creates a new Botanist object. It checks whether the given Shoot DNS
 // domain is covered by a default domain, and if so, it sets the <DefaultDomainSecret> attribute on the Botanist
 // object.

--- a/pkg/operation/botanist/logging.go
+++ b/pkg/operation/botanist/logging.go
@@ -84,15 +84,13 @@ func (b *Botanist) DeploySeedLogging(ctx context.Context) error {
 	}
 
 	if b.isShootNodeLoggingEnabled() {
-		validity := common.EndUserCrtValidity
-
-		credentialsSecret, err := b.SecretsManager.Generate(ctx, &secrets.CertificateSecretConfig{
+		ingressTLSSecret, err := b.SecretsManager.Generate(ctx, &secrets.CertificateSecretConfig{
 			Name:         "loki-tls",
 			CommonName:   b.ComputeLokiHost(),
 			Organization: []string{"gardener.cloud:monitoring:ingress"},
 			DNSNames:     b.ComputeLokiHosts(),
 			CertType:     secrets.ServerCert,
-			Validity:     &validity,
+			Validity:     &ingressTLSCertificateValidity,
 		}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCACluster))
 		if err != nil {
 			return err
@@ -104,7 +102,7 @@ func (b *Botanist) DeploySeedLogging(ctx context.Context) error {
 			"hosts": []map[string]interface{}{
 				{
 					"hostName":    b.ComputeLokiHost(),
-					"secretName":  credentialsSecret.Name,
+					"secretName":  ingressTLSSecret.Name,
 					"serviceName": "loki",
 					"servicePort": 8080,
 					"backendPath": "/loki/api/v1/push",

--- a/pkg/operation/botanist/monitoring.go
+++ b/pkg/operation/botanist/monitoring.go
@@ -361,23 +361,34 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 			}
 		}
 
-		alertManagerTLSOverride := common.AlertManagerTLS
+		var alertManagerIngressTLSSecretName string
 		if b.ControlPlaneWildcardCert != nil {
-			alertManagerTLSOverride = b.ControlPlaneWildcardCert.GetName()
-		}
-
-		hosts := []map[string]interface{}{
-			{
-				"hostName":   b.ComputeAlertManagerHost(),
-				"secretName": alertManagerTLSOverride,
-			},
+			alertManagerIngressTLSSecretName = b.ControlPlaneWildcardCert.GetName()
+		} else {
+			ingressTLSSecret, err := b.SecretsManager.Generate(ctx, &secrets.CertificateSecretConfig{
+				Name:         "alertmanager-tls",
+				CommonName:   "alertmanager",
+				Organization: []string{"gardener.cloud:monitoring:ingress"},
+				DNSNames:     b.ComputeAlertManagerHosts(),
+				CertType:     secrets.ServerCert,
+				Validity:     &ingressTLSCertificateValidity,
+			}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCACluster))
+			if err != nil {
+				return err
+			}
+			alertManagerIngressTLSSecretName = ingressTLSSecret.Name
 		}
 
 		alertManagerValues, err := b.InjectSeedShootImages(map[string]interface{}{
 			"ingress": map[string]interface{}{
 				"class":           ingressClass,
 				"basicAuthSecret": basicAuthUsers,
-				"hosts":           hosts,
+				"hosts": []map[string]interface{}{
+					{
+						"hostName":   b.ComputeAlertManagerHost(),
+						"secretName": alertManagerIngressTLSSecretName,
+					},
+				},
 			},
 			"replicas":     b.Shoot.GetReplicas(1),
 			"storage":      b.Seed.GetValidVolumeSize("1Gi"),
@@ -398,6 +409,7 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 	return kutil.DeleteObjects(ctx, b.K8sSeedClient.Client(),
 		// TODO(rfranzke): Remove in a future release.
 		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "kube-state-metrics", Namespace: b.Shoot.SeedNamespace}},
+		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "alertmanager-tls", Namespace: b.Shoot.SeedNamespace}},
 	)
 }
 

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -333,6 +333,7 @@ func (b *Botanist) GenerateAndSaveSecrets(ctx context.Context) error {
 			"loki-tls",
 			"prometheus-tls",
 			"alertmanager-tls",
+			"grafana-tls",
 			"gardener-resource-manager-server",
 		} {
 			gardenerResourceDataList.Delete(name)

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -331,6 +331,7 @@ func (b *Botanist) GenerateAndSaveSecrets(ctx context.Context) error {
 			"kube-controller-manager-server",
 			"metrics-server",
 			"loki-tls",
+			"prometheus-tls",
 			"gardener-resource-manager-server",
 		} {
 			gardenerResourceDataList.Delete(name)

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -332,6 +332,7 @@ func (b *Botanist) GenerateAndSaveSecrets(ctx context.Context) error {
 			"metrics-server",
 			"loki-tls",
 			"prometheus-tls",
+			"alertmanager-tls",
 			"gardener-resource-manager-server",
 		} {
 			gardenerResourceDataList.Delete(name)

--- a/pkg/operation/botanist/wanted_secrets.go
+++ b/pkg/operation/botanist/wanted_secrets.go
@@ -38,8 +38,6 @@ func (b *Botanist) generateWantedSecretConfigs(certificateAuthorities map[string
 			b.Shoot.Components.ControlPlane.EtcdMain.ServiceDNSNames(),
 			b.Shoot.Components.ControlPlane.EtcdEvents.ServiceDNSNames()...,
 		)
-
-		endUserCrtValidity = common.EndUserCrtValidity
 	)
 
 	secretList := []secrets.ConfigInterface{
@@ -106,20 +104,6 @@ func (b *Botanist) generateWantedSecretConfigs(certificateAuthorities map[string
 
 			CertType:  secrets.ClientCert,
 			SigningCA: certificateAuthorities[v1beta1constants.SecretNameCAETCD],
-		},
-
-		// Secret definition for grafana (ingress)
-		&secrets.CertificateSecretConfig{
-			Name: common.GrafanaTLS,
-
-			CommonName:   "grafana",
-			Organization: []string{"gardener.cloud:monitoring:ingress"},
-			DNSNames:     b.ComputeGrafanaHosts(),
-			IPAddresses:  nil,
-
-			CertType:  secrets.ServerCert,
-			SigningCA: certificateAuthorities[v1beta1constants.SecretNameCACluster],
-			Validity:  &endUserCrtValidity,
 		},
 	}
 

--- a/pkg/operation/botanist/wanted_secrets.go
+++ b/pkg/operation/botanist/wanted_secrets.go
@@ -135,20 +135,6 @@ func (b *Botanist) generateWantedSecretConfigs(certificateAuthorities map[string
 			SigningCA: certificateAuthorities[v1beta1constants.SecretNameCACluster],
 			Validity:  &endUserCrtValidity,
 		},
-
-		// Secret definition for prometheus (ingress)
-		&secrets.CertificateSecretConfig{
-			Name: common.PrometheusTLS,
-
-			CommonName:   "prometheus",
-			Organization: []string{"gardener.cloud:monitoring:ingress"},
-			DNSNames:     b.ComputePrometheusHosts(),
-			IPAddresses:  nil,
-
-			CertType:  secrets.ServerCert,
-			SigningCA: certificateAuthorities[v1beta1constants.SecretNameCACluster],
-			Validity:  &endUserCrtValidity,
-		},
 	}
 
 	if gardencorev1beta1helper.SeedSettingDependencyWatchdogProbeEnabled(b.Seed.GetInfo().Spec.Settings) {

--- a/pkg/operation/botanist/wanted_secrets.go
+++ b/pkg/operation/botanist/wanted_secrets.go
@@ -108,20 +108,6 @@ func (b *Botanist) generateWantedSecretConfigs(certificateAuthorities map[string
 			SigningCA: certificateAuthorities[v1beta1constants.SecretNameCAETCD],
 		},
 
-		// Secret definition for alertmanager (ingress)
-		&secrets.CertificateSecretConfig{
-			Name: common.AlertManagerTLS,
-
-			CommonName:   "alertmanager",
-			Organization: []string{"gardener.cloud:monitoring:ingress"},
-			DNSNames:     b.ComputeAlertManagerHosts(),
-			IPAddresses:  nil,
-
-			CertType:  secrets.ServerCert,
-			SigningCA: certificateAuthorities[v1beta1constants.SecretNameCACluster],
-			Validity:  &endUserCrtValidity,
-		},
-
 		// Secret definition for grafana (ingress)
 		&secrets.CertificateSecretConfig{
 			Name: common.GrafanaTLS,

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -62,9 +62,6 @@ const (
 	// IstioNamespace is the istio-system namespace
 	IstioNamespace = "istio-system"
 
-	// GrafanaTLS is the name of the secret resource which holds the TLS certificate for Grafana.
-	GrafanaTLS = "grafana-tls"
-
 	// EndUserCrtValidity is the time period a user facing certificate is valid.
 	EndUserCrtValidity = 730 * 24 * time.Hour // ~2 years, see https://support.apple.com/en-us/HT210176
 

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -62,8 +62,6 @@ const (
 	// IstioNamespace is the istio-system namespace
 	IstioNamespace = "istio-system"
 
-	// AlertManagerTLS is the name of the secret resource which holds the TLS certificate for Alert Manager.
-	AlertManagerTLS = "alertmanager-tls"
 	// GrafanaTLS is the name of the secret resource which holds the TLS certificate for Grafana.
 	GrafanaTLS = "grafana-tls"
 

--- a/pkg/operation/common/types.go
+++ b/pkg/operation/common/types.go
@@ -66,8 +66,6 @@ const (
 	AlertManagerTLS = "alertmanager-tls"
 	// GrafanaTLS is the name of the secret resource which holds the TLS certificate for Grafana.
 	GrafanaTLS = "grafana-tls"
-	// PrometheusTLS is the name of the secret resource which holds the TLS certificate for Prometheus.
-	PrometheusTLS = "prometheus-tls"
 
 	// EndUserCrtValidity is the time period a user facing certificate is valid.
 	EndUserCrtValidity = 730 * 24 * time.Hour // ~2 years, see https://support.apple.com/en-us/HT210176

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -304,9 +304,10 @@ func DeleteAlertmanager(ctx context.Context, k8sClient client.Client, namespace 
 				Namespace: namespace,
 			},
 		},
+		// TODO(rfranzke): Remove this secret in a future release.
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      AlertManagerTLS,
+				Name:      "alertmanager-tls",
 				Namespace: namespace,
 			},
 		},

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -235,7 +235,7 @@ func generateWantedSecrets(seed *Seed, certificateAuthorities map[string]*secret
 			SigningCA: certificateAuthorities[v1beta1constants.SecretNameCASeed],
 		},
 		&secretutils.CertificateSecretConfig{
-			Name: common.GrafanaTLS,
+			Name: "grafana-tls",
 
 			CommonName:   "grafana",
 			Organization: []string{"gardener.cloud:monitoring:ingress"},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement
/merge squash

**What this PR does / why we need it**:
Similar to #5664, this PR adapts the `{alertmanager,prometheus,grafana}-tls` secrets used for ingress to new secrets manager.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/3292#issuecomment-1036058890

/invite @timebertt @BeckerMax 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
