### PR TITLE
Add integration test for GRM secret controller

### DIFF
--- a/test/integration/resourcemanager/secret/secret_suite_test.go
+++ b/test/integration/resourcemanager/secret/secret_suite_test.go
@@ -1,0 +1,137 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secret_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	resourcemanagercmd "github.com/gardener/gardener/pkg/resourcemanager/cmd"
+	secretcontroller "github.com/gardener/gardener/pkg/resourcemanager/controller/secret"
+	resourcemanagerpredicate "github.com/gardener/gardener/pkg/resourcemanager/predicate"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/zap/zapcore"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+func TestSecretController(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Secret Controller Integration Test Suite")
+}
+
+const (
+	// testID is used for generating test namespace names
+	testID = "secret-controller-test"
+)
+
+var (
+	ctx       = context.Background()
+	mgrCancel context.CancelFunc
+	log       logr.Logger
+
+	testEnv    *envtest.Environment
+	testScheme *runtime.Scheme
+	testClient client.Client
+
+	testNamespace *corev1.Namespace
+)
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true), func(options *zap.Options) {
+		options.TimeEncoder = zapcore.ISO8601TimeEncoder
+	}))
+	log = logf.Log.WithName("secret-test")
+
+	By("starting test environment")
+	testEnv = &envtest.Environment{
+		CRDInstallOptions: envtest.CRDInstallOptions{
+			Paths: []string{filepath.Join("..", "..", "..", "..", "example", "resource-manager", "10-crd-resources.gardener.cloud_managedresources.yaml")},
+		},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	restConfig, err := testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(restConfig).NotTo(BeNil())
+
+	DeferCleanup(func() {
+		By("stopping test environment")
+		Expect(testEnv.Stop()).To(Succeed())
+	})
+
+	By("creating test client")
+	testScheme = runtime.NewScheme()
+	Expect(resourcemanagercmd.AddToSourceScheme(testScheme)).To(Succeed())
+	Expect(resourcemanagercmd.AddToTargetScheme(testScheme)).To(Succeed())
+
+	testClient, err = client.New(restConfig, client.Options{Scheme: testScheme})
+	Expect(err).NotTo(HaveOccurred())
+
+	By("creating test namespace")
+	testNamespace = &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: testID + "-",
+		},
+	}
+	Expect(testClient.Create(ctx, testNamespace)).To(Or(Succeed(), BeAlreadyExistsError()))
+
+	DeferCleanup(func() {
+		By("deleting test namespace")
+		Expect(testClient.Delete(ctx, testNamespace)).To(Or(Succeed(), BeNotFoundError()))
+	})
+
+	By("setting up manager")
+	mgrScheme := runtime.NewScheme()
+	Expect(resourcemanagercmd.AddToSourceScheme(mgrScheme)).To(Succeed())
+
+	mgr, err := manager.New(restConfig, manager.Options{
+		Scheme:             mgrScheme,
+		MetricsBindAddress: "0",
+		Namespace:          testNamespace.Name,
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	By("registering controller")
+	Expect(secretcontroller.AddToManagerWithOptions(mgr, secretcontroller.ControllerConfig{
+		MaxConcurrentWorkers: 5,
+		ClassFilter:          *resourcemanagerpredicate.NewClassFilter(""),
+	})).To(Succeed())
+
+	By("starting manager")
+	var mgrContext context.Context
+	mgrContext, mgrCancel = context.WithCancel(ctx)
+
+	go func() {
+		defer GinkgoRecover()
+		Expect(mgr.Start(mgrContext)).To(Succeed())
+	}()
+
+	DeferCleanup(func() {
+		By("stopping manager")
+		mgrCancel()
+	})
+})

--- a/test/integration/resourcemanager/secret/secret_test.go
+++ b/test/integration/resourcemanager/secret/secret_test.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package secret_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+)
+
+const (
+	finalizerName = "resources.gardener.cloud/gardener-resource-manager"
+)
+
+var _ = Describe("Secret controller tests", func() {
+	var (
+		managedResource *resourcesv1alpha1.ManagedResource
+		secret          *corev1.Secret
+	)
+
+	BeforeEach(func() {
+		managedResource = &resourcesv1alpha1.ManagedResource{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:    testNamespace.Name,
+				GenerateName: "test-",
+			},
+			Spec: resourcesv1alpha1.ManagedResourceSpec{
+				SecretRefs: []corev1.LocalObjectReference{{
+					Name: "foo",
+				}},
+			},
+		}
+
+		secret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "foo",
+				Namespace: testNamespace.Name,
+			},
+		}
+	})
+
+	Context("Secret finalizer", func() {
+		JustBeforeEach(func() {
+			By("creating secret for test")
+			Expect(testClient.Create(ctx, secret)).To(Succeed())
+			By("creating ManagedResource for test")
+			Expect(testClient.Create(ctx, managedResource)).To(Succeed())
+			log.Info("Created ManagedResource for test", "managedResource", client.ObjectKeyFromObject(managedResource))
+		})
+
+		AfterEach(func() {
+			Expect(testClient.Delete(ctx, managedResource)).To(Or(Succeed(), BeNotFoundError()))
+			Expect(testClient.Delete(ctx, secret)).To(Or(Succeed(), BeNotFoundError()))
+			// Wait for clean up of the secret
+			Eventually(func() error {
+				return testClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)
+			}).Should(BeNotFoundError())
+		})
+
+		It("should successfully add finalizer to all the secrets reference by managed resource", func() {
+			Eventually(func(g Gomega) []string {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
+				return secret.ObjectMeta.Finalizers
+			}).Should(
+				ContainElement(finalizerName),
+			)
+		})
+
+		It("should remove finalizer from secret which are no longer referenced by any managed resource", func() {
+			By("update ManagedResource to reference some other secret")
+			patch := client.MergeFrom(managedResource.DeepCopy())
+			managedResource.Spec.SecretRefs[0].Name = "bar"
+			Expect(testClient.Patch(ctx, managedResource, patch)).To(Succeed())
+
+			Eventually(func(g Gomega) []string {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
+				return secret.ObjectMeta.Finalizers
+			}).ShouldNot(
+				ContainElement(finalizerName),
+			)
+		})
+
+		It("should do nothing if there is no MR refrencing the secret", func() {
+			secret = &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bar",
+					Namespace: testNamespace.Name,
+				},
+			}
+			Expect(testClient.Create(ctx, secret)).To(Succeed())
+
+			Eventually(func(g Gomega) []string {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
+				return secret.ObjectMeta.Finalizers
+			}).ShouldNot(
+				ContainElement(finalizerName),
+			)
+		})
+	})
+})

--- a/test/integration/resourcemanager/secret/secret_test.go
+++ b/test/integration/resourcemanager/secret/secret_test.go
@@ -32,8 +32,8 @@ const (
 var _ = Describe("Secret controller tests", func() {
 	var (
 		managedResource *resourcesv1alpha1.ManagedResource
-		secret_foo      *corev1.Secret
-		secret_bar      *corev1.Secret
+		secretFoo       *corev1.Secret
+		secretBar       *corev1.Secret
 	)
 
 	BeforeEach(func() {
@@ -54,14 +54,14 @@ var _ = Describe("Secret controller tests", func() {
 			},
 		}
 
-		secret_foo = &corev1.Secret{
+		secretFoo = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "foo",
 				Namespace: testNamespace.Name,
 			},
 		}
 
-		secret_bar = &corev1.Secret{
+		secretBar = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "bar",
 				Namespace: testNamespace.Name,
@@ -72,8 +72,8 @@ var _ = Describe("Secret controller tests", func() {
 	Context("Secret finalizer", func() {
 		JustBeforeEach(func() {
 			By("creating secret for test")
-			Expect(testClient.Create(ctx, secret_foo)).To(Succeed())
-			Expect(testClient.Create(ctx, secret_bar)).To(Succeed())
+			Expect(testClient.Create(ctx, secretFoo)).To(Succeed())
+			Expect(testClient.Create(ctx, secretBar)).To(Succeed())
 			By("creating ManagedResource for test")
 			Expect(testClient.Create(ctx, managedResource)).To(Succeed())
 			log.Info("Created ManagedResource for test", "managedResource", client.ObjectKeyFromObject(managedResource))
@@ -81,27 +81,27 @@ var _ = Describe("Secret controller tests", func() {
 
 		AfterEach(func() {
 			Expect(testClient.Delete(ctx, managedResource)).To(Or(Succeed(), BeNotFoundError()))
-			Expect(testClient.Delete(ctx, secret_foo)).To(Or(Succeed(), BeNotFoundError()))
-			Expect(testClient.Delete(ctx, secret_bar)).To(Or(Succeed(), BeNotFoundError()))
+			Expect(testClient.Delete(ctx, secretFoo)).To(Or(Succeed(), BeNotFoundError()))
+			Expect(testClient.Delete(ctx, secretBar)).To(Or(Succeed(), BeNotFoundError()))
 			// Wait for clean up of the secret
 			Eventually(func() error {
-				return testClient.Get(ctx, client.ObjectKeyFromObject(secret_foo), secret_foo)
+				return testClient.Get(ctx, client.ObjectKeyFromObject(secretFoo), secretFoo)
 			}).Should(BeNotFoundError())
 			Eventually(func() error {
-				return testClient.Get(ctx, client.ObjectKeyFromObject(secret_bar), secret_bar)
+				return testClient.Get(ctx, client.ObjectKeyFromObject(secretBar), secretBar)
 			}).Should(BeNotFoundError())
 		})
 
 		It("should successfully add finalizer to all the secrets which are referenced by ManagedResources", func() {
 			Eventually(func(g Gomega) []string {
-				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(secret_foo), secret_foo)).To(Succeed())
-				return secret_foo.ObjectMeta.Finalizers
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(secretFoo), secretFoo)).To(Succeed())
+				return secretFoo.ObjectMeta.Finalizers
 			}).Should(
 				ContainElement(finalizerName),
 			)
 			Eventually(func(g Gomega) []string {
-				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(secret_bar), secret_bar)).To(Succeed())
-				return secret_bar.ObjectMeta.Finalizers
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(secretBar), secretBar)).To(Succeed())
+				return secretBar.ObjectMeta.Finalizers
 			}).Should(
 				ContainElement(finalizerName),
 			)
@@ -114,8 +114,8 @@ var _ = Describe("Secret controller tests", func() {
 			Expect(testClient.Patch(ctx, managedResource, patch)).To(Succeed())
 
 			Eventually(func(g Gomega) []string {
-				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(secret_foo), secret_foo)).To(Succeed())
-				return secret_foo.ObjectMeta.Finalizers
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(secretFoo), secretFoo)).To(Succeed())
+				return secretFoo.ObjectMeta.Finalizers
 			}).ShouldNot(
 				ContainElement(finalizerName),
 			)

--- a/test/integration/resourcemanager/secret/secret_test.go
+++ b/test/integration/resourcemanager/secret/secret_test.go
@@ -74,7 +74,7 @@ var _ = Describe("Secret controller tests", func() {
 			}).Should(BeNotFoundError())
 		})
 
-		It("should successfully add finalizer to all the secrets reference by managed resource", func() {
+		It("should successfully add finalizer to all the secrets which are referenced by ManagedResources", func() {
 			Eventually(func(g Gomega) []string {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
 				return secret.ObjectMeta.Finalizers
@@ -83,7 +83,7 @@ var _ = Describe("Secret controller tests", func() {
 			)
 		})
 
-		It("should remove finalizer from secret which are no longer referenced by any managed resource", func() {
+		It("should remove finalizer from secrets which are no longer referenced by any ManagedResource", func() {
 			By("update ManagedResource to reference some other secret")
 			patch := client.MergeFrom(managedResource.DeepCopy())
 			managedResource.Spec.SecretRefs[0].Name = "bar"
@@ -97,7 +97,7 @@ var _ = Describe("Secret controller tests", func() {
 			)
 		})
 
-		It("should do nothing if there is no MR refrencing the secret", func() {
+		It("should do nothing if there is no ManagedResource referencing the secret", func() {
 			secret = &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "bar",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
Add integration test for resource-manager secret controller. Checks basic functionality i.e. finalizers on the secret are added/removed correctly.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/4805

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
