### PR TITLE
[GEP-18] Adapt VPN-related secrets to new secrets manager

### DIFF
--- a/pkg/operation/botanist/component/kubeapiserver/deployment.go
+++ b/pkg/operation/botanist/component/kubeapiserver/deployment.go
@@ -128,6 +128,7 @@ func (k *kubeAPIServer) reconcileDeployment(
 	secretKubeAggregator *corev1.Secret,
 	secretHTTPProxy *corev1.Secret,
 	secretLegacyVPNSeed *corev1.Secret,
+	secretLegacyVPNSeedTLSAuth *corev1.Secret,
 ) error {
 	var (
 		maxSurge       = intstr.FromString("25%")
@@ -419,7 +420,7 @@ func (k *kubeAPIServer) reconcileDeployment(
 		k.handleHostCertVolumes(deployment)
 		k.handleSNISettings(deployment)
 		k.handlePodMutatorSettings(deployment)
-		k.handleVPNSettings(deployment, configMapEgressSelector, vpnCASecret, secretHTTPProxy, secretLegacyVPNSeed)
+		k.handleVPNSettings(deployment, configMapEgressSelector, vpnCASecret, secretHTTPProxy, secretLegacyVPNSeed, secretLegacyVPNSeedTLSAuth)
 		k.handleOIDCSettings(deployment, secretOIDCCABundle)
 		k.handleServiceAccountSigningKeySettings(deployment, secretUserProvidedServiceAccountSigningKey)
 
@@ -672,6 +673,7 @@ func (k *kubeAPIServer) handleVPNSettings(
 	vpnCASecret *corev1.Secret,
 	secretHTTPProxy *corev1.Secret,
 	secretLegacyVPNSeed *corev1.Secret,
+	secretLegacyVPNSeedTLSAuth *corev1.Secret,
 ) {
 	if !k.values.VPN.ReversedVPNEnabled {
 		deployment.Spec.Template.Spec.InitContainers = []corev1.Container{{
@@ -785,7 +787,7 @@ func (k *kubeAPIServer) handleVPNSettings(
 			{
 				Name: volumeNameVPNSeedTLSAuth,
 				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{SecretName: k.secrets.VPNSeedTLSAuth.Name},
+					Secret: &corev1.SecretVolumeSource{SecretName: secretLegacyVPNSeedTLSAuth.Name},
 				},
 			},
 		}...)

--- a/pkg/operation/botanist/component/kubeapiserver/deployment.go
+++ b/pkg/operation/botanist/component/kubeapiserver/deployment.go
@@ -38,10 +38,11 @@ import (
 )
 
 const (
-	// SecretNameVPNSeed is the name of the secret containing the certificates for the vpn-seed.
-	SecretNameVPNSeed = "vpn-seed"
+	// SecretNameServer is the name of the secret for the kube-apiserver server certificates.
+	SecretNameServer = "kube-apiserver"
 	// SecretNameVPNSeedTLSAuth is the name of the secret containing the TLS auth for the vpn-seed.
 	SecretNameVPNSeedTLSAuth = "vpn-seed-tlsauth"
+	secretNameLegacyVPNSeed  = "vpn-seed"
 
 	secretNameServer                 = "kube-apiserver"
 	secretNameKubeAPIServerToKubelet = "kube-apiserver-kubelet"
@@ -126,6 +127,7 @@ func (k *kubeAPIServer) reconcileDeployment(
 	secretKubeletClient *corev1.Secret,
 	secretKubeAggregator *corev1.Secret,
 	secretHTTPProxy *corev1.Secret,
+	secretLegacyVPNSeed *corev1.Secret,
 ) error {
 	var (
 		maxSurge       = intstr.FromString("25%")
@@ -417,7 +419,7 @@ func (k *kubeAPIServer) reconcileDeployment(
 		k.handleHostCertVolumes(deployment)
 		k.handleSNISettings(deployment)
 		k.handlePodMutatorSettings(deployment)
-		k.handleVPNSettings(deployment, configMapEgressSelector, vpnCASecret, secretHTTPProxy)
+		k.handleVPNSettings(deployment, configMapEgressSelector, vpnCASecret, secretHTTPProxy, secretLegacyVPNSeed)
 		k.handleOIDCSettings(deployment, secretOIDCCABundle)
 		k.handleServiceAccountSigningKeySettings(deployment, secretUserProvidedServiceAccountSigningKey)
 
@@ -669,6 +671,7 @@ func (k *kubeAPIServer) handleVPNSettings(
 	configMapEgressSelector *corev1.ConfigMap,
 	vpnCASecret *corev1.Secret,
 	secretHTTPProxy *corev1.Secret,
+	secretLegacyVPNSeed *corev1.Secret,
 ) {
 	if !k.values.VPN.ReversedVPNEnabled {
 		deployment.Spec.Template.Spec.InitContainers = []corev1.Container{{
@@ -776,7 +779,7 @@ func (k *kubeAPIServer) handleVPNSettings(
 			{
 				Name: volumeNameVPNSeed,
 				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{SecretName: k.secrets.VPNSeed.Name},
+					Secret: &corev1.SecretVolumeSource{SecretName: secretLegacyVPNSeed.Name},
 				},
 			},
 			{

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
@@ -584,9 +584,6 @@ type Secrets struct {
 	CA component.Secret
 	// CAFrontProxy is the certificate authority for the front-proxy.
 	CAFrontProxy component.Secret
-	// VPNSeedServerTLSAuth is the TLS auth information for the vpn-seed server.
-	// Only relevant if VPNConfig.ReversedVPNEnabled is true.
-	VPNSeedServerTLSAuth *component.Secret
 }
 
 type secret struct {
@@ -596,9 +593,8 @@ type secret struct {
 
 func (s *Secrets) all() map[string]secret {
 	return map[string]secret{
-		"CA":                   {Secret: &s.CA},
-		"CAFrontProxy":         {Secret: &s.CAFrontProxy},
-		"VPNSeedServerTLSAuth": {Secret: s.VPNSeedServerTLSAuth, isRequired: func(v Values) bool { return v.VPN.ReversedVPNEnabled }},
+		"CA":           {Secret: &s.CA},
+		"CAFrontProxy": {Secret: &s.CAFrontProxy},
 	}
 }
 

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
@@ -376,6 +376,11 @@ func (k *kubeAPIServer) Deploy(ctx context.Context) error {
 		return err
 	}
 
+	secretLegacyVPNSeedTLSAuth, err := k.reconcileSecretLegacyVPNSeedTLSAuth(ctx)
+	if err != nil {
+		return err
+	}
+
 	if err := k.reconcileDeployment(
 		ctx,
 		deployment,
@@ -393,6 +398,7 @@ func (k *kubeAPIServer) Deploy(ctx context.Context) error {
 		secretKubeAggregator,
 		secretHTTPProxy,
 		secretLegacyVPNSeed,
+		secretLegacyVPNSeedTLSAuth,
 	); err != nil {
 		return err
 	}
@@ -578,9 +584,6 @@ type Secrets struct {
 	CA component.Secret
 	// CAFrontProxy is the certificate authority for the front-proxy.
 	CAFrontProxy component.Secret
-	// VPNSeedTLSAuth is the TLS auth information for the vpn-seed.
-	// Only relevant if VPNConfig.ReversedVPNEnabled is false.
-	VPNSeedTLSAuth *component.Secret
 	// VPNSeedServerTLSAuth is the TLS auth information for the vpn-seed server.
 	// Only relevant if VPNConfig.ReversedVPNEnabled is true.
 	VPNSeedServerTLSAuth *component.Secret
@@ -595,7 +598,6 @@ func (s *Secrets) all() map[string]secret {
 	return map[string]secret{
 		"CA":                   {Secret: &s.CA},
 		"CAFrontProxy":         {Secret: &s.CAFrontProxy},
-		"VPNSeedTLSAuth":       {Secret: s.VPNSeedTLSAuth, isRequired: func(v Values) bool { return !v.VPN.ReversedVPNEnabled }},
 		"VPNSeedServerTLSAuth": {Secret: s.VPNSeedServerTLSAuth, isRequired: func(v Values) bool { return v.VPN.ReversedVPNEnabled }},
 	}
 }

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
@@ -61,6 +61,7 @@ import (
 var _ = BeforeSuite(func() {
 	DeferCleanup(test.WithVar(&secretutils.GenerateRandomString, secretutils.FakeGenerateRandomString))
 	DeferCleanup(test.WithVar(&secretutils.GenerateKey, secretutils.FakeGenerateKey))
+	DeferCleanup(test.WithVar(&secretutils.GenerateVPNKey, secretutils.FakeGenerateVPNKey))
 	DeferCleanup(test.WithVar(&secretutils.Clock, clock.NewFakeClock(time.Time{})))
 })
 
@@ -93,8 +94,7 @@ var _ = Describe("KubeAPIServer", func() {
 		secretNameServer                   = "kube-apiserver"
 		secretNameServiceAccountKey        = "service-account-key-c37a87f6"
 		secretNameVPNSeed                  = "vpn-seed"
-		secretNameVPNSeedTLSAuth           = "VPNSeedTLSAuth-secret"
-		secretChecksumVPNSeedTLSAuth       = "12345"
+		secretNameVPNSeedTLSAuth           = "vpn-seed-tlsauth-de1d12a3"
 		secretNameVPNSeedServerTLSAuth     = "VPNSeedServerTLSAuth-secret"
 		secretChecksumVPNSeedServerTLSAuth = "12345"
 		secrets                            Secrets
@@ -127,7 +127,6 @@ var _ = Describe("KubeAPIServer", func() {
 		secrets = Secrets{
 			CA:                   component.Secret{Name: secretNameCA, Checksum: secretChecksumCA},
 			CAFrontProxy:         component.Secret{Name: secretNameCAFrontProxy, Checksum: secretChecksumCAFrontProxy},
-			VPNSeedTLSAuth:       &component.Secret{Name: secretNameVPNSeedTLSAuth, Checksum: secretChecksumVPNSeedTLSAuth},
 			VPNSeedServerTLSAuth: &component.Secret{Name: secretNameVPNSeedServerTLSAuth, Checksum: secretChecksumVPNSeedServerTLSAuth},
 		}
 
@@ -211,9 +210,6 @@ var _ = Describe("KubeAPIServer", func() {
 				),
 				Entry("CAFrontProxy missing",
 					"CAFrontProxy", func(s *Secrets) { s.CAFrontProxy.Name = "" }, Values{},
-				),
-				Entry("ReversedVPN disabled but VPNSeedTLSAuth missing",
-					"VPNSeedTLSAuth", func(s *Secrets) { s.VPNSeedTLSAuth = nil }, Values{VPN: VPNConfig{ReversedVPNEnabled: false}},
 				),
 				Entry("ReversedVPN enabled but VPNSeedServerTLSAuth missing",
 					"VPNSeedServerTLSAuth", func(s *Secrets) { s.VPNSeedServerTLSAuth = nil }, Values{VPN: VPNConfig{ReversedVPNEnabled: true}},
@@ -1404,7 +1400,7 @@ rules:
 						"reference.resources.gardener.cloud/secret-998b2966":    secretNameKubeAggregator,
 						"reference.resources.gardener.cloud/secret-3ddd1800":    secretNameServer,
 						"reference.resources.gardener.cloud/secret-1c730dbc":    secretNameVPNSeed,
-						"reference.resources.gardener.cloud/secret-e638c9f3":    secretNameVPNSeedTLSAuth,
+						"reference.resources.gardener.cloud/secret-2fb65543":    secretNameVPNSeedTLSAuth,
 						"reference.resources.gardener.cloud/secret-430944e0":    secretNameStaticToken,
 						"reference.resources.gardener.cloud/secret-b1b53288":    secretNameETCDEncryptionConfig,
 						"reference.resources.gardener.cloud/configmap-130aa219": secretNameAdmissionConfig,
@@ -1446,7 +1442,6 @@ rules:
 						"checksum/secret-" + secretNameVPNSeedServerTLSAuth:     secretChecksumVPNSeedServerTLSAuth,
 						"checksum/secret-" + secretNameCA:                       secretChecksumCA,
 						"checksum/secret-" + secretNameCAFrontProxy:             secretChecksumCAFrontProxy,
-						"checksum/secret-" + secretNameVPNSeedTLSAuth:           secretChecksumVPNSeedTLSAuth,
 						"reference.resources.gardener.cloud/secret-a709ce3a":    secretNameServiceAccountKey,
 						"reference.resources.gardener.cloud/secret-71fba891":    secretNameCA,
 						"reference.resources.gardener.cloud/secret-e01f5645":    secretNameCAEtcd,
@@ -1456,7 +1451,7 @@ rules:
 						"reference.resources.gardener.cloud/secret-998b2966":    secretNameKubeAggregator,
 						"reference.resources.gardener.cloud/secret-3ddd1800":    secretNameServer,
 						"reference.resources.gardener.cloud/secret-1c730dbc":    secretNameVPNSeed,
-						"reference.resources.gardener.cloud/secret-e638c9f3":    secretNameVPNSeedTLSAuth,
+						"reference.resources.gardener.cloud/secret-2fb65543":    secretNameVPNSeedTLSAuth,
 						"reference.resources.gardener.cloud/secret-430944e0":    secretNameStaticToken,
 						"reference.resources.gardener.cloud/secret-b1b53288":    secretNameETCDEncryptionConfig,
 						"reference.resources.gardener.cloud/configmap-130aa219": secretNameAdmissionConfig,

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
@@ -92,8 +92,7 @@ var _ = Describe("KubeAPIServer", func() {
 		secretNameKubeAPIServerToKubelet   = "kube-apiserver-kubelet"
 		secretNameServer                   = "kube-apiserver"
 		secretNameServiceAccountKey        = "service-account-key-c37a87f6"
-		secretNameVPNSeed                  = "VPNSeed-secret"
-		secretChecksumVPNSeed              = "12345"
+		secretNameVPNSeed                  = "vpn-seed"
 		secretNameVPNSeedTLSAuth           = "VPNSeedTLSAuth-secret"
 		secretChecksumVPNSeedTLSAuth       = "12345"
 		secretNameVPNSeedServerTLSAuth     = "VPNSeedServerTLSAuth-secret"
@@ -128,7 +127,6 @@ var _ = Describe("KubeAPIServer", func() {
 		secrets = Secrets{
 			CA:                   component.Secret{Name: secretNameCA, Checksum: secretChecksumCA},
 			CAFrontProxy:         component.Secret{Name: secretNameCAFrontProxy, Checksum: secretChecksumCAFrontProxy},
-			VPNSeed:              &component.Secret{Name: secretNameVPNSeed, Checksum: secretChecksumVPNSeed},
 			VPNSeedTLSAuth:       &component.Secret{Name: secretNameVPNSeedTLSAuth, Checksum: secretChecksumVPNSeedTLSAuth},
 			VPNSeedServerTLSAuth: &component.Secret{Name: secretNameVPNSeedServerTLSAuth, Checksum: secretChecksumVPNSeedServerTLSAuth},
 		}
@@ -213,9 +211,6 @@ var _ = Describe("KubeAPIServer", func() {
 				),
 				Entry("CAFrontProxy missing",
 					"CAFrontProxy", func(s *Secrets) { s.CAFrontProxy.Name = "" }, Values{},
-				),
-				Entry("ReversedVPN disabled but VPNSeed missing",
-					"VPNSeed", func(s *Secrets) { s.VPNSeed = nil }, Values{VPN: VPNConfig{ReversedVPNEnabled: false}},
 				),
 				Entry("ReversedVPN disabled but VPNSeedTLSAuth missing",
 					"VPNSeedTLSAuth", func(s *Secrets) { s.VPNSeedTLSAuth = nil }, Values{VPN: VPNConfig{ReversedVPNEnabled: false}},
@@ -1408,7 +1403,7 @@ rules:
 						"reference.resources.gardener.cloud/secret-c1267cc2":    secretNameKubeAPIServerToKubelet,
 						"reference.resources.gardener.cloud/secret-998b2966":    secretNameKubeAggregator,
 						"reference.resources.gardener.cloud/secret-3ddd1800":    secretNameServer,
-						"reference.resources.gardener.cloud/secret-9f3de87f":    secretNameVPNSeed,
+						"reference.resources.gardener.cloud/secret-1c730dbc":    secretNameVPNSeed,
 						"reference.resources.gardener.cloud/secret-e638c9f3":    secretNameVPNSeedTLSAuth,
 						"reference.resources.gardener.cloud/secret-430944e0":    secretNameStaticToken,
 						"reference.resources.gardener.cloud/secret-b1b53288":    secretNameETCDEncryptionConfig,
@@ -1449,7 +1444,6 @@ rules:
 
 					Expect(deployment.Spec.Template.Annotations).To(Equal(map[string]string{
 						"checksum/secret-" + secretNameVPNSeedServerTLSAuth:     secretChecksumVPNSeedServerTLSAuth,
-						"checksum/secret-" + secretNameVPNSeed:                  secretChecksumVPNSeed,
 						"checksum/secret-" + secretNameCA:                       secretChecksumCA,
 						"checksum/secret-" + secretNameCAFrontProxy:             secretChecksumCAFrontProxy,
 						"checksum/secret-" + secretNameVPNSeedTLSAuth:           secretChecksumVPNSeedTLSAuth,
@@ -1461,7 +1455,7 @@ rules:
 						"reference.resources.gardener.cloud/secret-c1267cc2":    secretNameKubeAPIServerToKubelet,
 						"reference.resources.gardener.cloud/secret-998b2966":    secretNameKubeAggregator,
 						"reference.resources.gardener.cloud/secret-3ddd1800":    secretNameServer,
-						"reference.resources.gardener.cloud/secret-9f3de87f":    secretNameVPNSeed,
+						"reference.resources.gardener.cloud/secret-1c730dbc":    secretNameVPNSeed,
 						"reference.resources.gardener.cloud/secret-e638c9f3":    secretNameVPNSeedTLSAuth,
 						"reference.resources.gardener.cloud/secret-430944e0":    secretNameStaticToken,
 						"reference.resources.gardener.cloud/secret-b1b53288":    secretNameETCDEncryptionConfig,

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
@@ -79,25 +79,23 @@ var _ = Describe("KubeAPIServer", func() {
 		kapi                Interface
 		version             = semver.MustParse("1.22.1")
 
-		secretNameBasicAuthentication      = "kube-apiserver-basic-auth-426b1845"
-		secretNameStaticToken              = "kube-apiserver-static-token-c069a0e6"
-		secretNameCA                       = "CA-secret"
-		secretChecksumCA                   = "12345"
-		secretNameCAEtcd                   = "ca-etcd"
-		secretNameCAFrontProxy             = "CAFrontProxy-secret"
-		secretChecksumCAFrontProxy         = "12345"
-		secretNameCAVPN                    = "ca-vpn"
-		secretNameEtcd                     = "etcd-client"
-		secretNameHTTPProxy                = "kube-apiserver-http-proxy"
-		secretNameKubeAggregator           = "kube-aggregator"
-		secretNameKubeAPIServerToKubelet   = "kube-apiserver-kubelet"
-		secretNameServer                   = "kube-apiserver"
-		secretNameServiceAccountKey        = "service-account-key-c37a87f6"
-		secretNameVPNSeed                  = "vpn-seed"
-		secretNameVPNSeedTLSAuth           = "vpn-seed-tlsauth-de1d12a3"
-		secretNameVPNSeedServerTLSAuth     = "VPNSeedServerTLSAuth-secret"
-		secretChecksumVPNSeedServerTLSAuth = "12345"
-		secrets                            Secrets
+		secretNameBasicAuthentication    = "kube-apiserver-basic-auth-426b1845"
+		secretNameStaticToken            = "kube-apiserver-static-token-c069a0e6"
+		secretNameCA                     = "CA-secret"
+		secretChecksumCA                 = "12345"
+		secretNameCAEtcd                 = "ca-etcd"
+		secretNameCAFrontProxy           = "CAFrontProxy-secret"
+		secretChecksumCAFrontProxy       = "12345"
+		secretNameCAVPN                  = "ca-vpn"
+		secretNameEtcd                   = "etcd-client"
+		secretNameHTTPProxy              = "kube-apiserver-http-proxy"
+		secretNameKubeAggregator         = "kube-aggregator"
+		secretNameKubeAPIServerToKubelet = "kube-apiserver-kubelet"
+		secretNameServer                 = "kube-apiserver"
+		secretNameServiceAccountKey      = "service-account-key-c37a87f6"
+		secretNameVPNSeed                = "vpn-seed"
+		secretNameVPNSeedTLSAuth         = "vpn-seed-tlsauth-de1d12a3"
+		secrets                          Secrets
 
 		secretNameAdmissionConfig      = "kube-apiserver-admission-config-e38ff146"
 		secretNameETCDEncryptionConfig = "kube-apiserver-etcd-encryption-configuration-235f7353"
@@ -125,9 +123,8 @@ var _ = Describe("KubeAPIServer", func() {
 		kapi = New(kubernetesInterface, namespace, sm, Values{Version: version})
 
 		secrets = Secrets{
-			CA:                   component.Secret{Name: secretNameCA, Checksum: secretChecksumCA},
-			CAFrontProxy:         component.Secret{Name: secretNameCAFrontProxy, Checksum: secretChecksumCAFrontProxy},
-			VPNSeedServerTLSAuth: &component.Secret{Name: secretNameVPNSeedServerTLSAuth, Checksum: secretChecksumVPNSeedServerTLSAuth},
+			CA:           component.Secret{Name: secretNameCA, Checksum: secretChecksumCA},
+			CAFrontProxy: component.Secret{Name: secretNameCAFrontProxy, Checksum: secretChecksumCAFrontProxy},
 		}
 
 		deployment = &appsv1.Deployment{
@@ -210,9 +207,6 @@ var _ = Describe("KubeAPIServer", func() {
 				),
 				Entry("CAFrontProxy missing",
 					"CAFrontProxy", func(s *Secrets) { s.CAFrontProxy.Name = "" }, Values{},
-				),
-				Entry("ReversedVPN enabled but VPNSeedServerTLSAuth missing",
-					"VPNSeedServerTLSAuth", func(s *Secrets) { s.VPNSeedServerTLSAuth = nil }, Values{VPN: VPNConfig{ReversedVPNEnabled: true}},
 				),
 			)
 		})
@@ -1439,7 +1433,6 @@ rules:
 					deployAndRead()
 
 					Expect(deployment.Spec.Template.Annotations).To(Equal(map[string]string{
-						"checksum/secret-" + secretNameVPNSeedServerTLSAuth:     secretChecksumVPNSeedServerTLSAuth,
 						"checksum/secret-" + secretNameCA:                       secretChecksumCA,
 						"checksum/secret-" + secretNameCAFrontProxy:             secretChecksumCAFrontProxy,
 						"reference.resources.gardener.cloud/secret-a709ce3a":    secretNameServiceAccountKey,

--- a/pkg/operation/botanist/component/kubeapiserver/secrets.go
+++ b/pkg/operation/botanist/component/kubeapiserver/secrets.go
@@ -327,3 +327,19 @@ func (k *kubeAPIServer) reconcileSecretLegacyVPNSeed(ctx context.Context) (*core
 	// TODO(rfranzke): Remove this in a future release.
 	return secret, kutil.DeleteObject(ctx, k.client.Client(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "vpn-seed", Namespace: k.namespace}})
 }
+
+func (k *kubeAPIServer) reconcileSecretLegacyVPNSeedTLSAuth(ctx context.Context) (*corev1.Secret, error) {
+	if k.values.VPN.ReversedVPNEnabled {
+		return nil, nil
+	}
+
+	secret, err := k.secretsManager.Generate(ctx, &secretutils.VPNTLSAuthConfig{
+		Name: SecretNameVPNSeedTLSAuth,
+	}, secretsmanager.Rotate(secretsmanager.InPlace))
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO(rfranzke): Remove this in a future release.
+	return secret, kutil.DeleteObject(ctx, k.client.Client(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "vpn-seed-tlsauth", Namespace: k.namespace}})
+}

--- a/pkg/operation/botanist/component/kubeapiserver/secrets.go
+++ b/pkg/operation/botanist/component/kubeapiserver/secrets.go
@@ -309,3 +309,21 @@ func (k *kubeAPIServer) reconcileSecretHTTPProxy(ctx context.Context) (*corev1.S
 	// TODO(rfranzke): Remove this in a future release.
 	return secret, kutil.DeleteObject(ctx, k.client.Client(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "kube-apiserver-http-proxy", Namespace: k.namespace}})
 }
+
+func (k *kubeAPIServer) reconcileSecretLegacyVPNSeed(ctx context.Context) (*corev1.Secret, error) {
+	if k.values.VPN.ReversedVPNEnabled {
+		return nil, nil
+	}
+
+	secret, err := k.secretsManager.Generate(ctx, &secretutils.CertificateSecretConfig{
+		Name:       secretNameLegacyVPNSeed,
+		CommonName: UserNameVPNSeed,
+		CertType:   secretutils.ClientCert,
+	}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCACluster), secretsmanager.Rotate(secretsmanager.InPlace))
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO(rfranzke): Remove this in a future release.
+	return secret, kutil.DeleteObject(ctx, k.client.Client(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "vpn-seed", Namespace: k.namespace}})
+}

--- a/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server_suite_test.go
+++ b/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server_suite_test.go
@@ -17,6 +17,9 @@ package vpnseedserver_test
 import (
 	"testing"
 
+	secretutils "github.com/gardener/gardener/pkg/utils/secrets"
+	"github.com/gardener/gardener/pkg/utils/test"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -25,3 +28,8 @@ func TestVpnSeedServer(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Botanist Component VpnSeedServer Suite")
 }
+
+var _ = BeforeSuite(func() {
+	DeferCleanup(test.WithVar(&secretutils.GenerateKey, secretutils.FakeGenerateKey))
+	DeferCleanup(test.WithVar(&secretutils.GenerateVPNKey, secretutils.FakeGenerateVPNKey))
+})

--- a/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server_test.go
+++ b/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server_test.go
@@ -22,10 +22,12 @@ import (
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	. "github.com/gardener/gardener/pkg/operation/botanist/component/vpnseedserver"
+	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
+	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 
-	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	protobuftypes "github.com/gogo/protobuf/types"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
@@ -50,6 +52,7 @@ var _ = Describe("VpnSeedServer", func() {
 	var (
 		ctrl          *gomock.Controller
 		c             *mockclient.MockClient
+		sm            secretsmanager.Interface
 		vpnSeedServer Interface
 
 		ctx                     = context.TODO()
@@ -72,17 +75,13 @@ var _ = Describe("VpnSeedServer", func() {
 			Labels:    istioLabels,
 		}
 
-		secretNameTLSAuth     = VpnSeedServerTLSAuth
-		secretChecksumTLSAuth = "1234"
-		secretDataTLSAuth     = map[string][]byte{"vpn.tlsauth": []byte("baz")}
-		secretNameServer      = DeploymentName
-		secretChecksumServer  = "5678"
-		secretDataServer      = map[string][]byte{"ca.crt": []byte("baz"), "tls.crt": []byte("baz"), "tls.key": []byte("baz")}
-		secretNameDH          = "vpn-seed-server-dh"
-		secretChecksumDH      = "9012"
-		secretDataDH          = map[string][]byte{"dh2048.pem": []byte("baz")}
-		secrets               = Secrets{
-			TLSAuth:          component.Secret{Name: secretNameTLSAuth, Checksum: secretChecksumTLSAuth, Data: secretDataTLSAuth},
+		secretNameServer     = DeploymentName
+		secretChecksumServer = "5678"
+		secretDataServer     = map[string][]byte{"ca.crt": []byte("baz"), "tls.crt": []byte("baz"), "tls.key": []byte("baz")}
+		secretNameDH         = "vpn-seed-server-dh"
+		secretChecksumDH     = "9012"
+		secretDataDH         = map[string][]byte{"dh2048.pem": []byte("baz")}
+		secrets              = Secrets{
 			Server:           component.Secret{Name: secretNameServer, Checksum: secretChecksumServer, Data: secretDataServer},
 			DiffieHellmanKey: component.Secret{Name: secretNameDH, Checksum: secretChecksumDH, Data: secretDataDH},
 		}
@@ -236,12 +235,6 @@ admin:
 			Data:       secretDataServer,
 		}
 
-		secretTLSAuth = &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{Name: VpnSeedServerTLSAuth, Namespace: namespace},
-			Type:       corev1.SecretTypeOpaque,
-			Data:       secretDataTLSAuth,
-		}
-
 		secretDH = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{Name: "vpn-seed-server-dh", Namespace: namespace},
 			Type:       corev1.SecretTypeOpaque,
@@ -251,7 +244,6 @@ admin:
 
 	Expect(kutil.MakeUnique(configMap)).To(Succeed())
 	Expect(kutil.MakeUnique(secretServer)).To(Succeed())
-	Expect(kutil.MakeUnique(secretTLSAuth)).To(Succeed())
 	Expect(kutil.MakeUnique(secretDH)).To(Succeed())
 
 	var (
@@ -363,7 +355,7 @@ admin:
 											MountPath: "/srv/secrets/vpn-server",
 										},
 										{
-											Name:      VpnSeedServerTLSAuth,
+											Name:      "tls-auth",
 											MountPath: "/srv/secrets/tlsauth",
 										},
 										{
@@ -437,10 +429,10 @@ admin:
 									},
 								},
 								{
-									Name: VpnSeedServerTLSAuth,
+									Name: "tls-auth",
 									VolumeSource: corev1.VolumeSource{
 										Secret: &corev1.SecretVolumeSource{
-											SecretName:  secretTLSAuth.Name,
+											SecretName:  "vpn-seed-server-tlsauth-a1d0aa00",
 											DefaultMode: pointer.Int32(0400),
 										},
 									},
@@ -651,8 +643,9 @@ admin:
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		c = mockclient.NewMockClient(ctrl)
+		sm = fakesecretsmanager.New(c, namespace)
 
-		vpnSeedServer = New(c, namespace, envoyImage, vpnImage, &kubeAPIServerHost, serviceNetwork, podNetwork, nil, replicas, istioIngressGateway)
+		vpnSeedServer = New(c, namespace, sm, envoyImage, vpnImage, &kubeAPIServerHost, serviceNetwork, podNetwork, nil, replicas, istioIngressGateway)
 	})
 
 	AfterEach(func() {
@@ -661,18 +654,13 @@ admin:
 
 	Describe("#Deploy", func() {
 		Context("missing secret information", func() {
-			It("should return an error because the TLSAuth secret information is not provided", func() {
-				Expect(vpnSeedServer.Deploy(ctx)).To(MatchError(ContainSubstring("missing TLSAuth secret information")))
-			})
-
 			It("should return an error because the DH secret information is not provided", func() {
-				vpnSeedServer.SetSecrets(Secrets{TLSAuth: component.Secret{Name: secretNameTLSAuth, Checksum: secretChecksumTLSAuth}})
+				vpnSeedServer.SetSecrets(Secrets{})
 				Expect(vpnSeedServer.Deploy(ctx)).To(MatchError(ContainSubstring("missing DH secret information")))
 			})
 
 			It("should return an error because the Server secret information is not provided", func() {
 				vpnSeedServer.SetSecrets(Secrets{
-					TLSAuth:          component.Secret{Name: secretNameTLSAuth, Checksum: secretChecksumTLSAuth},
 					DiffieHellmanKey: component.Secret{Name: secretNameDH, Checksum: secretChecksumDH},
 				})
 				Expect(vpnSeedServer.Deploy(ctx)).To(MatchError(ContainSubstring("missing server secret information")))
@@ -685,8 +673,22 @@ admin:
 				vpnSeedServer.SetSeedNamespaceObjectUID(namespaceUID)
 			})
 
+			It("should fail because the tls auth secret cannot be created", func() {
+				gomock.InOrder(
+					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).DoAndReturn(func(ctx context.Context, obj client.Object, _ ...client.CreateOption) error {
+						Expect(obj.GetName()).To(HavePrefix("vpn-seed-server-tlsauth"))
+						return fakeErr
+					}),
+				)
+
+				Expect(vpnSeedServer.Deploy(ctx)).To(MatchError(fakeErr))
+			})
+
 			It("should fail because the configmap cannot be created", func() {
 				gomock.InOrder(
+					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(ctx context.Context, obj client.Object, _ ...client.CreateOption) {
+						Expect(obj.GetName()).To(HavePrefix("vpn-seed-server-tlsauth"))
+					}),
 					c.EXPECT().Create(ctx, configMap).Return(fakeErr),
 				)
 
@@ -695,6 +697,9 @@ admin:
 
 			It("should fail because the server secret cannot be created", func() {
 				gomock.InOrder(
+					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(ctx context.Context, obj client.Object, _ ...client.CreateOption) {
+						Expect(obj.GetName()).To(HavePrefix("vpn-seed-server-tlsauth"))
+					}),
 					c.EXPECT().Create(ctx, configMap),
 					c.EXPECT().Create(ctx, secretServer).Return(fakeErr),
 				)
@@ -702,21 +707,13 @@ admin:
 				Expect(vpnSeedServer.Deploy(ctx)).To(MatchError(fakeErr))
 			})
 
-			It("should fail because the tlsAuth secret cannot be created", func() {
-				gomock.InOrder(
-					c.EXPECT().Create(ctx, configMap),
-					c.EXPECT().Create(ctx, secretServer),
-					c.EXPECT().Create(ctx, secretTLSAuth).Return(fakeErr),
-				)
-
-				Expect(vpnSeedServer.Deploy(ctx)).To(MatchError(fakeErr))
-			})
-
 			It("should fail because the dh secret cannot be created", func() {
 				gomock.InOrder(
+					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(ctx context.Context, obj client.Object, _ ...client.CreateOption) {
+						Expect(obj.GetName()).To(HavePrefix("vpn-seed-server-tlsauth"))
+					}),
 					c.EXPECT().Create(ctx, configMap),
 					c.EXPECT().Create(ctx, secretServer),
-					c.EXPECT().Create(ctx, secretTLSAuth),
 					c.EXPECT().Create(ctx, secretDH).Return(fakeErr),
 				)
 
@@ -725,9 +722,11 @@ admin:
 
 			It("should fail because the networkpolicy cannot be created", func() {
 				gomock.InOrder(
+					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(ctx context.Context, obj client.Object, _ ...client.CreateOption) {
+						Expect(obj.GetName()).To(HavePrefix("vpn-seed-server-tlsauth"))
+					}),
 					c.EXPECT().Create(ctx, configMap),
 					c.EXPECT().Create(ctx, secretServer),
-					c.EXPECT().Create(ctx, secretTLSAuth),
 					c.EXPECT().Create(ctx, secretDH),
 					c.EXPECT().Get(ctx, kutil.Key(namespace, "allow-to-vpn-seed-server"), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()).Return(fakeErr),
@@ -738,9 +737,11 @@ admin:
 
 			It("should fail because the deployment cannot be created", func() {
 				gomock.InOrder(
+					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(ctx context.Context, obj client.Object, _ ...client.CreateOption) {
+						Expect(obj.GetName()).To(HavePrefix("vpn-seed-server-tlsauth"))
+					}),
 					c.EXPECT().Create(ctx, configMap),
 					c.EXPECT().Create(ctx, secretServer),
-					c.EXPECT().Create(ctx, secretTLSAuth),
 					c.EXPECT().Create(ctx, secretDH),
 					c.EXPECT().Get(ctx, kutil.Key(namespace, "allow-to-vpn-seed-server"), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()),
@@ -753,9 +754,11 @@ admin:
 
 			It("should fail because the destinationRule cannot be created", func() {
 				gomock.InOrder(
+					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(ctx context.Context, obj client.Object, _ ...client.CreateOption) {
+						Expect(obj.GetName()).To(HavePrefix("vpn-seed-server-tlsauth"))
+					}),
 					c.EXPECT().Create(ctx, configMap),
 					c.EXPECT().Create(ctx, secretServer),
-					c.EXPECT().Create(ctx, secretTLSAuth),
 					c.EXPECT().Create(ctx, secretDH),
 					c.EXPECT().Get(ctx, kutil.Key(namespace, "allow-to-vpn-seed-server"), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()),
@@ -770,9 +773,11 @@ admin:
 
 			It("should fail because the service cannot be created", func() {
 				gomock.InOrder(
+					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(ctx context.Context, obj client.Object, _ ...client.CreateOption) {
+						Expect(obj.GetName()).To(HavePrefix("vpn-seed-server-tlsauth"))
+					}),
 					c.EXPECT().Create(ctx, configMap),
 					c.EXPECT().Create(ctx, secretServer),
-					c.EXPECT().Create(ctx, secretTLSAuth),
 					c.EXPECT().Create(ctx, secretDH),
 					c.EXPECT().Get(ctx, kutil.Key(namespace, "allow-to-vpn-seed-server"), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()),
@@ -789,9 +794,11 @@ admin:
 
 			It("should fail because the vpa cannot be created", func() {
 				gomock.InOrder(
+					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(ctx context.Context, obj client.Object, _ ...client.CreateOption) {
+						Expect(obj.GetName()).To(HavePrefix("vpn-seed-server-tlsauth"))
+					}),
 					c.EXPECT().Create(ctx, configMap),
 					c.EXPECT().Create(ctx, secretServer),
-					c.EXPECT().Create(ctx, secretTLSAuth),
 					c.EXPECT().Create(ctx, secretDH),
 					c.EXPECT().Get(ctx, kutil.Key(namespace, "allow-to-vpn-seed-server"), gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()),
@@ -810,6 +817,9 @@ admin:
 
 			It("should successfully deploy all resources (w/o node network)", func() {
 				gomock.InOrder(
+					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(ctx context.Context, obj client.Object, _ ...client.CreateOption) {
+						Expect(obj.GetName()).To(HavePrefix("vpn-seed-server-tlsauth"))
+					}),
 					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&corev1.ConfigMap{}), gomock.Any()).
 						Do(func(ctx context.Context, obj client.Object, _ ...client.CreateOption) {
 							Expect(obj).To(DeepEqual(configMap))
@@ -817,10 +827,6 @@ admin:
 					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()).
 						Do(func(ctx context.Context, obj client.Object, _ ...client.CreateOption) {
 							Expect(obj).To(DeepEqual(secretServer))
-						}),
-					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()).
-						Do(func(ctx context.Context, obj client.Object, _ ...client.CreateOption) {
-							Expect(obj).To(DeepEqual(secretTLSAuth))
 						}),
 					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()).
 						Do(func(ctx context.Context, obj client.Object, _ ...client.CreateOption) {
@@ -853,7 +859,6 @@ admin:
 						}),
 					c.EXPECT().Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName + "-envoy-config"}}),
 					c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
-					c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName + "-tlsauth"}}),
 					c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName + "-dh"}}),
 					c.EXPECT().Delete(ctx, &networkingv1beta1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
 					c.EXPECT().Delete(ctx, &networkingv1beta1.VirtualService{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
@@ -863,11 +868,14 @@ admin:
 			})
 
 			It("should successfully deploy all resources (w/ node network)", func() {
-				vpnSeedServer = New(c, namespace, envoyImage, vpnImage, &kubeAPIServerHost, serviceNetwork, podNetwork, &nodeNetwork, replicas, istioIngressGateway)
+				vpnSeedServer = New(c, namespace, sm, envoyImage, vpnImage, &kubeAPIServerHost, serviceNetwork, podNetwork, &nodeNetwork, replicas, istioIngressGateway)
 				vpnSeedServer.SetSecrets(secrets)
 				vpnSeedServer.SetSeedNamespaceObjectUID(namespaceUID)
 
 				gomock.InOrder(
+					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&corev1.Secret{})).Do(func(ctx context.Context, obj client.Object, _ ...client.CreateOption) {
+						Expect(obj.GetName()).To(HavePrefix("vpn-seed-server-tlsauth"))
+					}),
 					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&corev1.ConfigMap{}), gomock.Any()).
 						Do(func(ctx context.Context, obj client.Object, _ ...client.CreateOption) {
 							Expect(obj).To(DeepEqual(configMap))
@@ -875,10 +883,6 @@ admin:
 					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()).
 						Do(func(ctx context.Context, obj client.Object, _ ...client.CreateOption) {
 							Expect(obj).To(DeepEqual(secretServer))
-						}),
-					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()).
-						Do(func(ctx context.Context, obj client.Object, _ ...client.CreateOption) {
-							Expect(obj).To(DeepEqual(secretTLSAuth))
 						}),
 					c.EXPECT().Create(ctx, gomock.AssignableToTypeOf(&corev1.Secret{}), gomock.Any()).
 						Do(func(ctx context.Context, obj client.Object, _ ...client.CreateOption) {
@@ -911,7 +915,6 @@ admin:
 						}),
 					c.EXPECT().Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName + "-envoy-config"}}),
 					c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
-					c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName + "-tlsauth"}}),
 					c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName + "-dh"}}),
 					c.EXPECT().Delete(ctx, &networkingv1beta1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
 					c.EXPECT().Delete(ctx, &networkingv1beta1.VirtualService{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
@@ -1001,21 +1004,6 @@ admin:
 			Expect(vpnSeedServer.Destroy(ctx)).To(MatchError(fakeErr))
 		})
 
-		It("should fail because the tlsAuth secret cannot be deleted", func() {
-			gomock.InOrder(
-				c.EXPECT().Delete(ctx, &networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "allow-to-vpn-seed-server"}}),
-				c.EXPECT().Delete(ctx, &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
-				c.EXPECT().Delete(ctx, &networkingv1beta1.DestinationRule{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
-				c.EXPECT().Delete(ctx, &corev1.Service{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: ServiceName}}),
-				c.EXPECT().Delete(ctx, &autoscalingv1beta2.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName + "-vpa"}}),
-				c.EXPECT().Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName + "-envoy-config"}}),
-				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
-				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName + "-tlsauth"}}).Return(fakeErr),
-			)
-
-			Expect(vpnSeedServer.Destroy(ctx)).To(MatchError(fakeErr))
-		})
-
 		It("should fail because the dh secret cannot be deleted", func() {
 			gomock.InOrder(
 				c.EXPECT().Delete(ctx, &networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "allow-to-vpn-seed-server"}}),
@@ -1025,7 +1013,6 @@ admin:
 				c.EXPECT().Delete(ctx, &autoscalingv1beta2.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName + "-vpa"}}),
 				c.EXPECT().Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName + "-envoy-config"}}),
 				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
-				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName + "-tlsauth"}}),
 				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName + "-dh"}}).Return(fakeErr),
 			)
 
@@ -1041,7 +1028,6 @@ admin:
 				c.EXPECT().Delete(ctx, &autoscalingv1beta2.VerticalPodAutoscaler{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName + "-vpa"}}),
 				c.EXPECT().Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName + "-envoy-config"}}),
 				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
-				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName + "-tlsauth"}}),
 				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName + "-dh"}}),
 				c.EXPECT().Delete(ctx, &networkingv1beta1.Gateway{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),
 				c.EXPECT().Delete(ctx, &networkingv1beta1.VirtualService{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: DeploymentName}}),

--- a/pkg/operation/botanist/component/vpnshoot/monitoring_test.go
+++ b/pkg/operation/botanist/component/vpnshoot/monitoring_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Monitoring", func() {
 	var component component.MonitoringComponent
 
 	BeforeEach(func() {
-		component = New(nil, "", Values{})
+		component = New(nil, "", nil, Values{})
 	})
 
 	It("should successfully test the alerting rules", func() {

--- a/pkg/operation/botanist/component/vpnshoot/vpnshoot_suite_test.go
+++ b/pkg/operation/botanist/component/vpnshoot/vpnshoot_suite_test.go
@@ -17,6 +17,9 @@ package vpnshoot_test
 import (
 	"testing"
 
+	secretutils "github.com/gardener/gardener/pkg/utils/secrets"
+	"github.com/gardener/gardener/pkg/utils/test"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -25,3 +28,7 @@ func TestVPNShoot(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Botanist Component VPNShoot Suite")
 }
+
+var _ = BeforeSuite(func() {
+	DeferCleanup(test.WithVar(&secretutils.GenerateKey, secretutils.FakeGenerateKey))
+})

--- a/pkg/operation/botanist/kubeapiserver.go
+++ b/pkg/operation/botanist/kubeapiserver.go
@@ -435,7 +435,6 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 	if values.VPN.ReversedVPNEnabled {
 		secrets.VPNSeedServerTLSAuth = &component.Secret{Name: vpnseedserver.SecretNameTLSAuth, Checksum: b.LoadCheckSum(vpnseedserver.SecretNameTLSAuth)}
 	} else {
-		secrets.VPNSeed = &component.Secret{Name: kubeapiserver.SecretNameVPNSeed, Checksum: b.LoadCheckSum(kubeapiserver.SecretNameVPNSeed)}
 		secrets.VPNSeedTLSAuth = &component.Secret{Name: kubeapiserver.SecretNameVPNSeedTLSAuth, Checksum: b.LoadCheckSum(kubeapiserver.SecretNameVPNSeedTLSAuth)}
 	}
 

--- a/pkg/operation/botanist/kubeapiserver.go
+++ b/pkg/operation/botanist/kubeapiserver.go
@@ -434,8 +434,6 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 
 	if values.VPN.ReversedVPNEnabled {
 		secrets.VPNSeedServerTLSAuth = &component.Secret{Name: vpnseedserver.SecretNameTLSAuth, Checksum: b.LoadCheckSum(vpnseedserver.SecretNameTLSAuth)}
-	} else {
-		secrets.VPNSeedTLSAuth = &component.Secret{Name: kubeapiserver.SecretNameVPNSeedTLSAuth, Checksum: b.LoadCheckSum(kubeapiserver.SecretNameVPNSeedTLSAuth)}
 	}
 
 	b.Shoot.Components.ControlPlane.KubeAPIServer.SetSecrets(secrets)

--- a/pkg/operation/botanist/kubeapiserver.go
+++ b/pkg/operation/botanist/kubeapiserver.go
@@ -433,7 +433,7 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 	}
 
 	if values.VPN.ReversedVPNEnabled {
-		secrets.VPNSeedServerTLSAuth = &component.Secret{Name: vpnseedserver.VpnSeedServerTLSAuth, Checksum: b.LoadCheckSum(vpnseedserver.VpnSeedServerTLSAuth)}
+		secrets.VPNSeedServerTLSAuth = &component.Secret{Name: vpnseedserver.SecretNameTLSAuth, Checksum: b.LoadCheckSum(vpnseedserver.SecretNameTLSAuth)}
 	} else {
 		secrets.VPNSeed = &component.Secret{Name: kubeapiserver.SecretNameVPNSeed, Checksum: b.LoadCheckSum(kubeapiserver.SecretNameVPNSeed)}
 		secrets.VPNSeedTLSAuth = &component.Secret{Name: kubeapiserver.SecretNameVPNSeedTLSAuth, Checksum: b.LoadCheckSum(kubeapiserver.SecretNameVPNSeedTLSAuth)}

--- a/pkg/operation/botanist/kubeapiserver.go
+++ b/pkg/operation/botanist/kubeapiserver.go
@@ -30,7 +30,6 @@ import (
 	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/kubeapiserver"
-	"github.com/gardener/gardener/pkg/operation/botanist/component/vpnseedserver"
 	"github.com/gardener/gardener/pkg/utils"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/pkg/utils/images"
@@ -430,10 +429,6 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 	secrets := kubeapiserver.Secrets{
 		CA:           component.Secret{Name: v1beta1constants.SecretNameCACluster, Checksum: b.LoadCheckSum(v1beta1constants.SecretNameCACluster)},
 		CAFrontProxy: component.Secret{Name: v1beta1constants.SecretNameCAFrontProxy, Checksum: b.LoadCheckSum(v1beta1constants.SecretNameCAFrontProxy)},
-	}
-
-	if values.VPN.ReversedVPNEnabled {
-		secrets.VPNSeedServerTLSAuth = &component.Secret{Name: vpnseedserver.SecretNameTLSAuth, Checksum: b.LoadCheckSum(vpnseedserver.SecretNameTLSAuth)}
 	}
 
 	b.Shoot.Components.ControlPlane.KubeAPIServer.SetSecrets(secrets)

--- a/pkg/operation/botanist/kubeapiserver_test.go
+++ b/pkg/operation/botanist/kubeapiserver_test.go
@@ -1078,7 +1078,6 @@ var _ = Describe("KubeAPIServer", func() {
 			Entry("reversed vpn disabled",
 				kubeapiserver.Values{VPN: kubeapiserver.VPNConfig{ReversedVPNEnabled: false}},
 				func(s *kubeapiserver.Secrets) {
-					s.VPNSeed = &component.Secret{Name: "vpn-seed", Checksum: botanist.LoadCheckSum("vpn-seed")}
 					s.VPNSeedTLSAuth = &component.Secret{Name: "vpn-seed-tlsauth", Checksum: botanist.LoadCheckSum("vpn-seed-tlsauth")}
 				},
 			),

--- a/pkg/operation/botanist/kubeapiserver_test.go
+++ b/pkg/operation/botanist/kubeapiserver_test.go
@@ -1074,19 +1074,6 @@ var _ = Describe("KubeAPIServer", func() {
 
 				Expect(botanist.DeployKubeAPIServer(ctx)).To(Succeed())
 			},
-
-			Entry("reversed vpn disabled",
-				kubeapiserver.Values{VPN: kubeapiserver.VPNConfig{ReversedVPNEnabled: false}},
-				func(s *kubeapiserver.Secrets) {
-					s.VPNSeedTLSAuth = &component.Secret{Name: "vpn-seed-tlsauth", Checksum: botanist.LoadCheckSum("vpn-seed-tlsauth")}
-				},
-			),
-			Entry("reversed vpn enabled",
-				kubeapiserver.Values{VPN: kubeapiserver.VPNConfig{ReversedVPNEnabled: true}},
-				func(s *kubeapiserver.Secrets) {
-					s.VPNSeedServerTLSAuth = &component.Secret{Name: "vpn-seed-server-tlsauth", Checksum: botanist.LoadCheckSum("vpn-seed-server-tlsauth")}
-				},
-			),
 		)
 
 		Describe("ExternalHostname", func() {

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -340,18 +340,13 @@ func (b *Botanist) GenerateAndSaveSecrets(ctx context.Context) error {
 			"vpn-shoot-client",
 			"vpn-seed-server-tlsauth",
 			"vpn-seed",
+			"vpn-seed-tlsauth",
 		} {
 			gardenerResourceDataList.Delete(name)
 		}
 
 		if b.Shoot.GetInfo().DeletionTimestamp == nil {
 			if b.Shoot.ReversedVPNEnabled {
-				if err := b.cleanupSecrets(ctx, &gardenerResourceDataList,
-					kubeapiserver.SecretNameVPNSeedTLSAuth,
-				); err != nil {
-					return err
-				}
-
 				// Delete existing VPN-related secrets which were not signed with the newly introduced ca-vpn so that
 				// they get regenerated.
 				// TODO(rfranzke): Remove in a future version.

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -338,6 +338,7 @@ func (b *Botanist) GenerateAndSaveSecrets(ctx context.Context) error {
 			"gardener-resource-manager-server",
 			"vpn-shoot",
 			"vpn-shoot-client",
+			"vpn-seed-server-tlsauth",
 		} {
 			gardenerResourceDataList.Delete(name)
 		}
@@ -364,7 +365,6 @@ func (b *Botanist) GenerateAndSaveSecrets(ctx context.Context) error {
 			} else {
 				if err := b.cleanupSecrets(ctx, &gardenerResourceDataList,
 					vpnseedserver.DeploymentName,
-					vpnseedserver.VpnSeedServerTLSAuth,
 				); err != nil {
 					return err
 				}

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -29,7 +29,6 @@ import (
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/kubeapiserver"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/vpnseedserver"
-	"github.com/gardener/gardener/pkg/operation/botanist/component/vpnshoot"
 	"github.com/gardener/gardener/pkg/operation/seed"
 	"github.com/gardener/gardener/pkg/operation/shootsecrets"
 	"github.com/gardener/gardener/pkg/utils"
@@ -337,6 +336,8 @@ func (b *Botanist) GenerateAndSaveSecrets(ctx context.Context) error {
 			"alertmanager-tls",
 			"grafana-tls",
 			"gardener-resource-manager-server",
+			"vpn-shoot",
+			"vpn-shoot-client",
 		} {
 			gardenerResourceDataList.Delete(name)
 		}
@@ -346,7 +347,6 @@ func (b *Botanist) GenerateAndSaveSecrets(ctx context.Context) error {
 				if err := b.cleanupSecrets(ctx, &gardenerResourceDataList,
 					kubeapiserver.SecretNameVPNSeed,
 					kubeapiserver.SecretNameVPNSeedTLSAuth,
-					vpnshoot.SecretNameVPNShoot,
 				); err != nil {
 					return err
 				}
@@ -357,7 +357,6 @@ func (b *Botanist) GenerateAndSaveSecrets(ctx context.Context) error {
 				if gardenerResourceDataList.Get(v1beta1constants.SecretNameCAVPN) == nil {
 					if err := b.cleanupSecrets(ctx, &gardenerResourceDataList,
 						vpnseedserver.DeploymentName,
-						vpnshoot.SecretNameVPNShootClient,
 					); err != nil {
 						return err
 					}
@@ -365,7 +364,6 @@ func (b *Botanist) GenerateAndSaveSecrets(ctx context.Context) error {
 			} else {
 				if err := b.cleanupSecrets(ctx, &gardenerResourceDataList,
 					vpnseedserver.DeploymentName,
-					vpnshoot.SecretNameVPNShootClient,
 					vpnseedserver.VpnSeedServerTLSAuth,
 				); err != nil {
 					return err

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -28,7 +28,6 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/kubeapiserver"
-	"github.com/gardener/gardener/pkg/operation/botanist/component/vpnseedserver"
 	"github.com/gardener/gardener/pkg/operation/seed"
 	"github.com/gardener/gardener/pkg/operation/shootsecrets"
 	"github.com/gardener/gardener/pkg/utils"
@@ -341,30 +340,12 @@ func (b *Botanist) GenerateAndSaveSecrets(ctx context.Context) error {
 			"vpn-seed-server-tlsauth",
 			"vpn-seed",
 			"vpn-seed-tlsauth",
+			"vpn-seed-server",
 		} {
 			gardenerResourceDataList.Delete(name)
 		}
 
 		if b.Shoot.GetInfo().DeletionTimestamp == nil {
-			if b.Shoot.ReversedVPNEnabled {
-				// Delete existing VPN-related secrets which were not signed with the newly introduced ca-vpn so that
-				// they get regenerated.
-				// TODO(rfranzke): Remove in a future version.
-				if gardenerResourceDataList.Get(v1beta1constants.SecretNameCAVPN) == nil {
-					if err := b.cleanupSecrets(ctx, &gardenerResourceDataList,
-						vpnseedserver.DeploymentName,
-					); err != nil {
-						return err
-					}
-				}
-			} else {
-				if err := b.cleanupSecrets(ctx, &gardenerResourceDataList,
-					vpnseedserver.DeploymentName,
-				); err != nil {
-					return err
-				}
-			}
-
 			if !gardencorev1beta1helper.SeedSettingDependencyWatchdogProbeEnabled(b.Seed.GetInfo().Spec.Settings) {
 				if err := b.cleanupSecrets(ctx, &gardenerResourceDataList, kubeapiserver.DependencyWatchdogInternalProbeSecretName, kubeapiserver.DependencyWatchdogExternalProbeSecretName); err != nil {
 					return err

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -339,6 +339,7 @@ func (b *Botanist) GenerateAndSaveSecrets(ctx context.Context) error {
 			"vpn-shoot",
 			"vpn-shoot-client",
 			"vpn-seed-server-tlsauth",
+			"vpn-seed",
 		} {
 			gardenerResourceDataList.Delete(name)
 		}
@@ -346,7 +347,6 @@ func (b *Botanist) GenerateAndSaveSecrets(ctx context.Context) error {
 		if b.Shoot.GetInfo().DeletionTimestamp == nil {
 			if b.Shoot.ReversedVPNEnabled {
 				if err := b.cleanupSecrets(ctx, &gardenerResourceDataList,
-					kubeapiserver.SecretNameVPNSeed,
 					kubeapiserver.SecretNameVPNSeedTLSAuth,
 				); err != nil {
 					return err

--- a/pkg/operation/botanist/vpnseedserver.go
+++ b/pkg/operation/botanist/vpnseedserver.go
@@ -67,6 +67,7 @@ func (b *Botanist) DefaultVPNSeedServer() (vpnseedserver.Interface, error) {
 	return vpnseedserver.New(
 		b.K8sSeedClient.Client(),
 		b.Shoot.SeedNamespace,
+		b.SecretsManager,
 		imageAPIServerProxy.String(),
 		imageVPNSeedServer.String(),
 		kubeAPIServerHost,
@@ -95,7 +96,6 @@ func (b *Botanist) DeployVPNServer(ctx context.Context) error {
 	}
 
 	b.Shoot.Components.ControlPlane.VPNSeedServer.SetSecrets(vpnseedserver.Secrets{
-		TLSAuth:          component.Secret{Name: vpnseedserver.VpnSeedServerTLSAuth, Checksum: b.LoadCheckSum(vpnseedserver.VpnSeedServerTLSAuth), Data: b.LoadSecret(vpnseedserver.VpnSeedServerTLSAuth).Data},
 		Server:           component.Secret{Name: vpnseedserver.DeploymentName, Checksum: b.LoadCheckSum(vpnseedserver.DeploymentName), Data: b.LoadSecret(vpnseedserver.DeploymentName).Data},
 		DiffieHellmanKey: component.Secret{Name: v1beta1constants.GardenRoleOpenVPNDiffieHellman, Checksum: checkSumDH, Data: openvpnDiffieHellmanSecret},
 	})

--- a/pkg/operation/botanist/vpnseedserver.go
+++ b/pkg/operation/botanist/vpnseedserver.go
@@ -96,7 +96,6 @@ func (b *Botanist) DeployVPNServer(ctx context.Context) error {
 	}
 
 	b.Shoot.Components.ControlPlane.VPNSeedServer.SetSecrets(vpnseedserver.Secrets{
-		Server:           component.Secret{Name: vpnseedserver.DeploymentName, Checksum: b.LoadCheckSum(vpnseedserver.DeploymentName), Data: b.LoadSecret(vpnseedserver.DeploymentName).Data},
 		DiffieHellmanKey: component.Secret{Name: v1beta1constants.GardenRoleOpenVPNDiffieHellman, Checksum: checkSumDH, Data: openvpnDiffieHellmanSecret},
 	})
 

--- a/pkg/operation/botanist/vpnseedserver_test.go
+++ b/pkg/operation/botanist/vpnseedserver_test.go
@@ -120,10 +120,8 @@ var _ = Describe("VPNSeedServer", func() {
 			ctx     = context.TODO()
 			fakeErr = fmt.Errorf("fake err")
 
-			secretNameServer     = vpnseedserver.DeploymentName
-			secretChecksumServer = "5678"
-			secretNameDH         = v1beta1constants.GardenRoleOpenVPNDiffieHellman
-			secretChecksumDH     = "9012"
+			secretNameDH     = v1beta1constants.GardenRoleOpenVPNDiffieHellman
+			secretChecksumDH = "9012"
 
 			namespaceUID = types.UID("1234")
 		)
@@ -131,9 +129,7 @@ var _ = Describe("VPNSeedServer", func() {
 		BeforeEach(func() {
 			vpnSeedServer = mockvpnseedserver.NewMockInterface(ctrl)
 
-			botanist.StoreCheckSum(secretNameServer, secretChecksumServer)
 			botanist.StoreCheckSum(secretNameDH, secretChecksumDH)
-			botanist.StoreSecret(secretNameServer, &corev1.Secret{})
 			botanist.StoreSecret(secretNameDH, &corev1.Secret{})
 			botanist.Shoot = &shootpkg.Shoot{
 				Components: &shootpkg.Components{
@@ -162,7 +158,6 @@ var _ = Describe("VPNSeedServer", func() {
 
 		BeforeEach(func() {
 			vpnSeedServer.EXPECT().SetSecrets(vpnseedserver.Secrets{
-				Server:           component.Secret{Name: vpnseedserver.DeploymentName, Checksum: secretChecksumServer},
 				DiffieHellmanKey: component.Secret{Name: secretNameDH, Checksum: secretChecksumDH},
 			})
 			vpnSeedServer.EXPECT().SetSeedNamespaceObjectUID(namespaceUID)

--- a/pkg/operation/botanist/vpnseedserver_test.go
+++ b/pkg/operation/botanist/vpnseedserver_test.go
@@ -120,12 +120,10 @@ var _ = Describe("VPNSeedServer", func() {
 			ctx     = context.TODO()
 			fakeErr = fmt.Errorf("fake err")
 
-			secretNameTLSAuth     = vpnseedserver.VpnSeedServerTLSAuth
-			secretChecksumTLSAuth = "1234"
-			secretNameServer      = vpnseedserver.DeploymentName
-			secretChecksumServer  = "5678"
-			secretNameDH          = v1beta1constants.GardenRoleOpenVPNDiffieHellman
-			secretChecksumDH      = "9012"
+			secretNameServer     = vpnseedserver.DeploymentName
+			secretChecksumServer = "5678"
+			secretNameDH         = v1beta1constants.GardenRoleOpenVPNDiffieHellman
+			secretChecksumDH     = "9012"
 
 			namespaceUID = types.UID("1234")
 		)
@@ -133,10 +131,8 @@ var _ = Describe("VPNSeedServer", func() {
 		BeforeEach(func() {
 			vpnSeedServer = mockvpnseedserver.NewMockInterface(ctrl)
 
-			botanist.StoreCheckSum(secretNameTLSAuth, secretChecksumTLSAuth)
 			botanist.StoreCheckSum(secretNameServer, secretChecksumServer)
 			botanist.StoreCheckSum(secretNameDH, secretChecksumDH)
-			botanist.StoreSecret(secretNameTLSAuth, &corev1.Secret{})
 			botanist.StoreSecret(secretNameServer, &corev1.Secret{})
 			botanist.StoreSecret(secretNameDH, &corev1.Secret{})
 			botanist.Shoot = &shootpkg.Shoot{
@@ -166,7 +162,6 @@ var _ = Describe("VPNSeedServer", func() {
 
 		BeforeEach(func() {
 			vpnSeedServer.EXPECT().SetSecrets(vpnseedserver.Secrets{
-				TLSAuth:          component.Secret{Name: secretNameTLSAuth, Checksum: secretChecksumTLSAuth},
 				Server:           component.Secret{Name: vpnseedserver.DeploymentName, Checksum: secretChecksumServer},
 				DiffieHellmanKey: component.Secret{Name: secretNameDH, Checksum: secretChecksumDH},
 			})

--- a/pkg/operation/botanist/vpnshoot.go
+++ b/pkg/operation/botanist/vpnshoot.go
@@ -70,6 +70,7 @@ func (b *Botanist) DefaultVPNShoot() (vpnshoot.Interface, error) {
 	return vpnshoot.New(
 		b.K8sSeedClient.Client(),
 		b.Shoot.SeedNamespace,
+		b.SecretsManager,
 		values,
 	), nil
 }
@@ -80,7 +81,6 @@ func (b *Botanist) DeployVPNShoot(ctx context.Context) error {
 
 	if b.Shoot.ReversedVPNEnabled {
 		secrets.TLSAuth = component.Secret{Name: vpnseedserver.VpnSeedServerTLSAuth, Checksum: b.LoadCheckSum(vpnseedserver.VpnSeedServerTLSAuth), Data: b.LoadSecret(vpnseedserver.VpnSeedServerTLSAuth).Data}
-		secrets.Server = component.Secret{Name: vpnshoot.SecretNameVPNShootClient, Checksum: b.LoadCheckSum(vpnshoot.SecretNameVPNShootClient), Data: b.LoadSecret(vpnshoot.SecretNameVPNShootClient).Data}
 	} else {
 		checkSumDH := diffieHellmanKeyChecksum
 		openvpnDiffieHellmanSecret := map[string][]byte{"dh2048.pem": []byte(DefaultDiffieHellmanKey)}
@@ -91,7 +91,6 @@ func (b *Botanist) DeployVPNShoot(ctx context.Context) error {
 
 		secrets.TLSAuth = component.Secret{Name: kubeapiserver.SecretNameVPNSeedTLSAuth, Checksum: b.LoadCheckSum(kubeapiserver.SecretNameVPNSeedTLSAuth), Data: b.LoadSecret(kubeapiserver.SecretNameVPNSeedTLSAuth).Data}
 		secrets.DH = &component.Secret{Name: v1beta1constants.GardenRoleOpenVPNDiffieHellman, Checksum: checkSumDH, Data: openvpnDiffieHellmanSecret}
-		secrets.Server = component.Secret{Name: vpnshoot.SecretNameVPNShoot, Checksum: b.LoadCheckSum(vpnshoot.SecretNameVPNShoot), Data: b.LoadSecret(vpnshoot.SecretNameVPNShoot).Data}
 	}
 
 	b.Shoot.Components.SystemComponents.VPNShoot.SetSecrets(secrets)

--- a/pkg/operation/botanist/vpnshoot.go
+++ b/pkg/operation/botanist/vpnshoot.go
@@ -19,7 +19,6 @@ import (
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
-	"github.com/gardener/gardener/pkg/operation/botanist/component/kubeapiserver"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/vpnseedserver"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/vpnshoot"
 	"github.com/gardener/gardener/pkg/utils/images"
@@ -87,7 +86,6 @@ func (b *Botanist) DeployVPNShoot(ctx context.Context) error {
 			checkSumDH = b.LoadCheckSum(v1beta1constants.GardenRoleOpenVPNDiffieHellman)
 		}
 
-		secrets.TLSAuth = component.Secret{Name: kubeapiserver.SecretNameVPNSeedTLSAuth, Checksum: b.LoadCheckSum(kubeapiserver.SecretNameVPNSeedTLSAuth), Data: b.LoadSecret(kubeapiserver.SecretNameVPNSeedTLSAuth).Data}
 		secrets.DH = &component.Secret{Name: v1beta1constants.GardenRoleOpenVPNDiffieHellman, Checksum: checkSumDH, Data: openvpnDiffieHellmanSecret}
 	}
 

--- a/pkg/operation/botanist/vpnshoot.go
+++ b/pkg/operation/botanist/vpnshoot.go
@@ -79,9 +79,7 @@ func (b *Botanist) DefaultVPNShoot() (vpnshoot.Interface, error) {
 func (b *Botanist) DeployVPNShoot(ctx context.Context) error {
 	secrets := vpnshoot.Secrets{}
 
-	if b.Shoot.ReversedVPNEnabled {
-		secrets.TLSAuth = component.Secret{Name: vpnseedserver.VpnSeedServerTLSAuth, Checksum: b.LoadCheckSum(vpnseedserver.VpnSeedServerTLSAuth), Data: b.LoadSecret(vpnseedserver.VpnSeedServerTLSAuth).Data}
-	} else {
+	if !b.Shoot.ReversedVPNEnabled {
 		checkSumDH := diffieHellmanKeyChecksum
 		openvpnDiffieHellmanSecret := map[string][]byte{"dh2048.pem": []byte(DefaultDiffieHellmanKey)}
 		if dh := b.LoadSecret(v1beta1constants.GardenRoleOpenVPNDiffieHellman); dh != nil {

--- a/pkg/operation/botanist/wanted_secrets.go
+++ b/pkg/operation/botanist/wanted_secrets.go
@@ -21,9 +21,7 @@ import (
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/dependencywatchdog"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/kubeapiserver"
-	"github.com/gardener/gardener/pkg/operation/botanist/component/vpnseedserver"
 	"github.com/gardener/gardener/pkg/operation/common"
-	"github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/secrets"
 )
 
@@ -84,19 +82,6 @@ func (b *Botanist) generateWantedSecretConfigs(certificateAuthorities map[string
 				APIServerHost: b.Shoot.ComputeOutOfClusterAPIServerAddress(b.APIServerAddress, true),
 			}},
 		})
-	}
-
-	if b.Shoot.ReversedVPNEnabled {
-		secretList = append(secretList,
-			// Secret definition for vpn-seed-server (OpenVPN server side)
-			&secrets.CertificateSecretConfig{
-				Name:       "vpn-seed-server",
-				CommonName: "vpn-seed-server",
-				DNSNames:   kubernetes.DNSNamesForService(vpnseedserver.ServiceName, b.Shoot.SeedNamespace),
-				CertType:   secrets.ServerCert,
-				SigningCA:  certificateAuthorities[v1beta1constants.SecretNameCAVPN],
-			},
-		)
 	}
 
 	if b.Shoot.WantsVerticalPodAutoscaler {

--- a/pkg/operation/botanist/wanted_secrets.go
+++ b/pkg/operation/botanist/wanted_secrets.go
@@ -99,14 +99,6 @@ func (b *Botanist) generateWantedSecretConfigs(certificateAuthorities map[string
 		)
 	} else {
 		secretList = append(secretList,
-			// Secret definition for vpn-seed (OpenVPN client side)
-			&secrets.CertificateSecretConfig{
-				Name:       kubeapiserver.SecretNameVPNSeed,
-				CommonName: kubeapiserver.UserNameVPNSeed,
-				CertType:   secrets.ClientCert,
-				SigningCA:  certificateAuthorities[v1beta1constants.SecretNameCACluster],
-			},
-
 			&secrets.VPNTLSAuthConfig{
 				Name: kubeapiserver.SecretNameVPNSeedTLSAuth,
 			},

--- a/pkg/operation/botanist/wanted_secrets.go
+++ b/pkg/operation/botanist/wanted_secrets.go
@@ -97,12 +97,6 @@ func (b *Botanist) generateWantedSecretConfigs(certificateAuthorities map[string
 				SigningCA:  certificateAuthorities[v1beta1constants.SecretNameCAVPN],
 			},
 		)
-	} else {
-		secretList = append(secretList,
-			&secrets.VPNTLSAuthConfig{
-				Name: kubeapiserver.SecretNameVPNSeedTLSAuth,
-			},
-		)
 	}
 
 	if b.Shoot.WantsVerticalPodAutoscaler {

--- a/pkg/operation/botanist/wanted_secrets.go
+++ b/pkg/operation/botanist/wanted_secrets.go
@@ -22,7 +22,6 @@ import (
 	"github.com/gardener/gardener/pkg/operation/botanist/component/dependencywatchdog"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/kubeapiserver"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/vpnseedserver"
-	"github.com/gardener/gardener/pkg/operation/botanist/component/vpnshoot"
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/secrets"
@@ -89,14 +88,6 @@ func (b *Botanist) generateWantedSecretConfigs(certificateAuthorities map[string
 
 	if b.Shoot.ReversedVPNEnabled {
 		secretList = append(secretList,
-			// Secret definition for vpn-shoot (OpenVPN client side)
-			&secrets.CertificateSecretConfig{
-				Name:       vpnshoot.SecretNameVPNShootClient,
-				CommonName: "vpn-shoot-client",
-				CertType:   secrets.ClientCert,
-				SigningCA:  certificateAuthorities[v1beta1constants.SecretNameCAVPN],
-			},
-
 			// Secret definition for vpn-seed-server (OpenVPN server side)
 			&secrets.CertificateSecretConfig{
 				Name:       "vpn-seed-server",
@@ -112,14 +103,6 @@ func (b *Botanist) generateWantedSecretConfigs(certificateAuthorities map[string
 		)
 	} else {
 		secretList = append(secretList,
-			// Secret definition for vpn-shoot (OpenVPN server side)
-			&secrets.CertificateSecretConfig{
-				Name:       vpnshoot.SecretNameVPNShoot,
-				CommonName: "vpn-shoot",
-				CertType:   secrets.ServerCert,
-				SigningCA:  certificateAuthorities[v1beta1constants.SecretNameCACluster],
-			},
-
 			// Secret definition for vpn-seed (OpenVPN client side)
 			&secrets.CertificateSecretConfig{
 				Name:       kubeapiserver.SecretNameVPNSeed,

--- a/pkg/operation/botanist/wanted_secrets.go
+++ b/pkg/operation/botanist/wanted_secrets.go
@@ -96,10 +96,6 @@ func (b *Botanist) generateWantedSecretConfigs(certificateAuthorities map[string
 				CertType:   secrets.ServerCert,
 				SigningCA:  certificateAuthorities[v1beta1constants.SecretNameCAVPN],
 			},
-
-			&secrets.VPNTLSAuthConfig{
-				Name: vpnseedserver.VpnSeedServerTLSAuth,
-			},
 		)
 	} else {
 		secretList = append(secretList,

--- a/pkg/utils/secrets/alias.go
+++ b/pkg/utils/secrets/alias.go
@@ -65,6 +65,13 @@ i/WyG5dokMowEJSvpCBwHbAYMLlNK7oMUpXlqcRoYo24U6Mwj68=
 -----END RSA PRIVATE KEY-----`))
 	}
 
+	// GenerateVPNKey is an alias for generateVPNKey. Exposed for testing.
+	GenerateVPNKey = generateVPNKey
+	// FakeGenerateVPNKey is a fake for GenerateVPNKey.
+	FakeGenerateVPNKey = func() ([]byte, error) {
+		return []byte("key"), nil
+	}
+
 	// Clock is an alias for clock.RealClock. Exposed for testing.
 	Clock clock.Clock = clock.RealClock{}
 )

--- a/pkg/utils/secrets/vpn_tlsauth.go
+++ b/pkg/utils/secrets/vpn_tlsauth.go
@@ -89,7 +89,7 @@ func (s *VPNTLSAuthConfig) generateKey() (key []byte, err error) {
 	if s.VPNTLSAuthKeyGenerator != nil {
 		key, err = s.VPNTLSAuthKeyGenerator()
 	} else {
-		key, err = generateKeyDefault()
+		key, err = GenerateVPNKey()
 	}
 	return
 }
@@ -102,7 +102,7 @@ func (v *VPNTLSAuth) SecretData() map[string][]byte {
 	return data
 }
 
-func generateKeyDefault() ([]byte, error) {
+func generateVPNKey() ([]byte, error) {
 	var (
 		out bytes.Buffer
 		cmd = exec.Command("openvpn", "--genkey", "--secret", "/dev/stdout")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement
/merge squash

**What this PR does / why we need it**:
This PR adapts the VPN-related secrets (`vpn-shoot-client`, `vpn-seed-server`, `vpn-seed-server-tlsauth`, `vpn-shoot`, `vpn-seed`, `vpn-seed-tlsauth`) to the new secrets manager.

Note that the `kube-apiserver-http-proxy` secret (used only when `ReversedVPN` is enabled) will be handled as part of #5671.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/3292#issuecomment-1036058890

/invite @timebertt @BeckerMax 
/invite @ScheererJ @DockToFuture 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
