### PR TITLE
`references.InjectAnnotations` now considers `Secret`s/`ConfigMap`s in projected volumes

### DIFF
--- a/pkg/resourcemanager/controller/garbagecollector/references/references.go
+++ b/pkg/resourcemanager/controller/garbagecollector/references/references.go
@@ -187,6 +187,18 @@ func computeAnnotations(spec corev1.PodSpec, additional ...string) map[string]st
 		if volume.ConfigMap != nil {
 			out[AnnotationKey(KindConfigMap, volume.ConfigMap.Name)] = volume.ConfigMap.Name
 		}
+
+		if volume.Projected != nil {
+			for _, source := range volume.Projected.Sources {
+				if source.Secret != nil {
+					out[AnnotationKey(KindSecret, source.Secret.Name)] = source.Secret.Name
+				}
+
+				if source.ConfigMap != nil {
+					out[AnnotationKey(KindConfigMap, source.ConfigMap.Name)] = source.ConfigMap.Name
+				}
+			}
+		}
 	}
 
 	for _, v := range additional {

--- a/pkg/resourcemanager/controller/garbagecollector/references/references_test.go
+++ b/pkg/resourcemanager/controller/garbagecollector/references/references_test.go
@@ -65,11 +65,13 @@ var _ = Describe("References", func() {
 			configMap3            = "cm3"
 			configMap4            = "cm4"
 			configMap5            = "cm5"
+			configMap6            = "cm6"
 			secret1               = "secret1"
 			secret2               = "secret2"
 			secret3               = "secret3"
 			secret4               = "secret4"
 			secret5               = "secret5"
+			secret6               = "secret6"
 			additionalAnnotation1 = "foo"
 			additionalAnnotation2 = "bar"
 
@@ -168,6 +170,28 @@ var _ = Describe("References", func() {
 							},
 						},
 					},
+					{
+						VolumeSource: corev1.VolumeSource{
+							Projected: &corev1.ProjectedVolumeSource{
+								Sources: []corev1.VolumeProjection{
+									{
+										Secret: &corev1.SecretProjection{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: secret6,
+											},
+										},
+									},
+									{
+										ConfigMap: &corev1.ConfigMapProjection{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: configMap6,
+											},
+										},
+									},
+								},
+							},
+						},
+					},
 				},
 			}
 			expectedAnnotationsWithExisting = map[string]string{
@@ -177,11 +201,13 @@ var _ = Describe("References", func() {
 				AnnotationKey(KindConfigMap, configMap3): configMap3,
 				AnnotationKey(KindConfigMap, configMap4): configMap4,
 				AnnotationKey(KindConfigMap, configMap5): configMap5,
+				AnnotationKey(KindConfigMap, configMap6): configMap6,
 				AnnotationKey(KindSecret, secret1):       secret1,
 				AnnotationKey(KindSecret, secret2):       secret2,
 				AnnotationKey(KindSecret, secret3):       secret3,
 				AnnotationKey(KindSecret, secret4):       secret4,
 				AnnotationKey(KindSecret, secret5):       secret5,
+				AnnotationKey(KindSecret, secret6):       secret6,
 				additionalAnnotation1:                    "",
 				additionalAnnotation2:                    "",
 			}
@@ -191,11 +217,13 @@ var _ = Describe("References", func() {
 				AnnotationKey(KindConfigMap, configMap3): configMap3,
 				AnnotationKey(KindConfigMap, configMap4): configMap4,
 				AnnotationKey(KindConfigMap, configMap5): configMap5,
+				AnnotationKey(KindConfigMap, configMap6): configMap6,
 				AnnotationKey(KindSecret, secret1):       secret1,
 				AnnotationKey(KindSecret, secret2):       secret2,
 				AnnotationKey(KindSecret, secret3):       secret3,
 				AnnotationKey(KindSecret, secret4):       secret4,
 				AnnotationKey(KindSecret, secret5):       secret5,
+				AnnotationKey(KindSecret, secret6):       secret6,
 				additionalAnnotation1:                    "",
 				additionalAnnotation2:                    "",
 			}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
`references.InjectAnnotations` now considers `Secret`s/`ConfigMap`s in projected volumes. This fixes an issue where the garbage collector part of `gardener-resource-manager` could clean up in-use `Secret`s or `ConfigMap`s which were only referenced by projected volumes.

**Special notes for your reviewer**:
We will use immutable `Secret`s/`ConfigMap`s as part of projected volumes with #5691, so let's ensure the garbage collector does not wrongly cleanup those resources.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
`references.InjectAnnotations` now considers `Secret`s/`ConfigMap`s in projected volumes. This fixes an issue where the garbage collector part of `gardener-resource-manager` could clean up in-use `Secret`s or `ConfigMap`s which were only referenced by projected volumes.
```
