### PR TITLE
Exclude node from worker healthcheck which are not managed by MCM

### DIFF
--- a/extensions/pkg/controller/healthcheck/worker/helpers.go
+++ b/extensions/pkg/controller/healthcheck/worker/helpers.go
@@ -22,6 +22,7 @@ import (
 
 	machinev1alpha1 "github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var (
@@ -144,6 +145,9 @@ func checkNodesScalingDown(machineList *machinev1alpha1.MachineList, nodeList *c
 
 	var cordonedNodes int
 	for _, node := range nodeList.Items {
+		if metav1.HasAnnotation(node.ObjectMeta, AnnotationKeyNotManagedByMCM) && node.Annotations[AnnotationKeyNotManagedByMCM] == "1" {
+			continue
+		}
 		if node.Spec.Unschedulable {
 			machine, ok := nodeNameToMachine[node.Name]
 			if !ok {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
There is a possibility a node not managed by MCM, respectively Gardener, to be joined in a shoot cluster. This PR excludes nodes annotated with `node.machine.sapcloud.io/not-managed-by-mcm="1"` from the health checks ran by the worker controller.

**Which issue(s) this PR fixes**:
Fixes #5672

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The nodes annotated with `node.machine.sapcloud.io/not-managed-by-mcm="1"` are no longer considered in health checks ran by the worker controller.
```
