### PR TITLE
Fix flaky test in ClientMap Internal Suite

### DIFF
--- a/pkg/client/kubernetes/clientmap/internal/garden_clientmap.go
+++ b/pkg/client/kubernetes/clientmap/internal/garden_clientmap.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -38,7 +39,7 @@ type gardenClientMap struct {
 // NewGardenClientMap creates a new gardenClientMap with the given factory.
 func NewGardenClientMap(factory *GardenClientSetFactory) clientmap.ClientMap {
 	return &gardenClientMap{
-		ClientMap: NewGenericClientMap(factory, log.WithValues("clientmap", "GardenClientMap")),
+		ClientMap: NewGenericClientMap(factory, log.WithValues("clientmap", "GardenClientMap"), clock.RealClock{}),
 	}
 }
 

--- a/pkg/client/kubernetes/clientmap/internal/generic_clientmap_test.go
+++ b/pkg/client/kubernetes/clientmap/internal/generic_clientmap_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/apimachinery/pkg/version"
 
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
@@ -62,7 +63,8 @@ var _ = Describe("GenericClientMap", func() {
 			csVersion = &version.Info{GitVersion: "1.18.0"}
 			cs.EXPECT().Version().Return(csVersion.GitVersion).AnyTimes()
 
-			cm = internal.NewGenericClientMap(factory, logr.Discard())
+			fakeClock := clock.NewFakeClock(time.Now())
+			cm = internal.NewGenericClientMap(factory, logr.Discard(), fakeClock)
 
 			origMaxRefreshInterval = internal.MaxRefreshInterval
 			internal.MaxRefreshInterval = 10 * time.Millisecond
@@ -126,7 +128,7 @@ var _ = Describe("GenericClientMap", func() {
 
 				By("should refresh the ClientSet's server version")
 				// let the max refresh interval pass
-				time.Sleep(internal.MaxRefreshInterval)
+				cm.Clock.Sleep(internal.MaxRefreshInterval)
 				cs.EXPECT().DiscoverVersion().Return(&version.Info{GitVersion: "1.18.1"}, nil)
 				clientSet, err := cm.GetClient(ctx, key)
 				Expect(clientSet).To(BeIdenticalTo(cs))
@@ -144,7 +146,7 @@ var _ = Describe("GenericClientMap", func() {
 
 				By("should fail to refresh the ClientSet's server version because DiscoverVersion fails")
 				// let the max refresh interval pass
-				time.Sleep(internal.MaxRefreshInterval)
+				cm.Clock.Sleep(internal.MaxRefreshInterval)
 				cs.EXPECT().DiscoverVersion().Return(nil, fmt.Errorf("fake"))
 				clientSet, err := cm.GetClient(ctx, key)
 				Expect(clientSet).To(BeNil())
@@ -161,14 +163,14 @@ var _ = Describe("GenericClientMap", func() {
 
 				By("should not refresh the ClientSet as version and hash haven't changed")
 				// let the max refresh interval pass
-				time.Sleep(internal.MaxRefreshInterval)
+				cm.Clock.Sleep(internal.MaxRefreshInterval)
 				cs.EXPECT().DiscoverVersion().Return(csVersion, nil)
 				factory.EXPECT().CalculateClientSetHash(ctx, key).Return("hash1", nil)
 				Expect(cm.GetClient(ctx, key)).To(BeIdenticalTo(cs))
 
 				By("should refresh the ClientSet as the hash has changed")
 				// let the max refresh interval pass again
-				time.Sleep(internal.MaxRefreshInterval)
+				cm.Clock.Sleep(internal.MaxRefreshInterval)
 				cs.EXPECT().DiscoverVersion().Return(csVersion, nil)
 				factory.EXPECT().CalculateClientSetHash(ctx, key).Return("hash2", nil)
 
@@ -184,7 +186,7 @@ var _ = Describe("GenericClientMap", func() {
 
 				By("should fail to get the ClientSet again because CalculateClientSetHash fails")
 				// let the max refresh interval pass again
-				time.Sleep(internal.MaxRefreshInterval)
+				cm.Clock.Sleep(internal.MaxRefreshInterval)
 				cs.EXPECT().DiscoverVersion().Return(csVersion, nil)
 				factory.EXPECT().CalculateClientSetHash(ctx, key).Return("", fmt.Errorf("fake"))
 

--- a/pkg/client/kubernetes/clientmap/internal/plant_clientmap.go
+++ b/pkg/client/kubernetes/clientmap/internal/plant_clientmap.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -35,7 +36,7 @@ type plantClientMap struct {
 // NewPlantClientMap creates a new plantClientMap with the given factory.
 func NewPlantClientMap(factory *PlantClientSetFactory) clientmap.ClientMap {
 	return &plantClientMap{
-		ClientMap: NewGenericClientMap(factory, log.WithValues("clientmap", "PlantClientMap")),
+		ClientMap: NewGenericClientMap(factory, log.WithValues("clientmap", "PlantClientMap"), clock.RealClock{}),
 	}
 }
 

--- a/pkg/client/kubernetes/clientmap/internal/seed_clientmap.go
+++ b/pkg/client/kubernetes/clientmap/internal/seed_clientmap.go
@@ -20,6 +20,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	eventsv1 "k8s.io/api/events/v1"
+	"k8s.io/apimachinery/pkg/util/clock"
 	baseconfig "k8s.io/component-base/config"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -35,7 +36,7 @@ type seedClientMap struct {
 // NewSeedClientMap creates a new seedClientMap with the given factory.
 func NewSeedClientMap(factory *SeedClientSetFactory) clientmap.ClientMap {
 	return &seedClientMap{
-		ClientMap: NewGenericClientMap(factory, log.WithValues("clientmap", "SeedClientMap")),
+		ClientMap: NewGenericClientMap(factory, log.WithValues("clientmap", "SeedClientMap"), clock.RealClock{}),
 	}
 }
 

--- a/pkg/client/kubernetes/clientmap/internal/shoot_clientmap.go
+++ b/pkg/client/kubernetes/clientmap/internal/shoot_clientmap.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/clock"
 	clientcmdlatest "k8s.io/client-go/tools/clientcmd/api/latest"
 	clientcmdv1 "k8s.io/client-go/tools/clientcmd/api/v1"
 	baseconfig "k8s.io/component-base/config"
@@ -44,7 +45,7 @@ func NewShootClientMap(factory *ShootClientSetFactory) clientmap.ClientMap {
 	factory.clientKeyToSeedInfo = make(map[ShootClientSetKey]seedInfo)
 	factory.log = logger
 	return &shootClientMap{
-		ClientMap: NewGenericClientMap(factory, logger),
+		ClientMap: NewGenericClientMap(factory, logger, clock.RealClock{}),
 	}
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
Fixes flaky tests in ClientMap Internal suite. It uses `clock.Clock` structure in the `GenericClientMap`, so that we can fake time during unit tests.

Before:
```
$ ginkgo build ./pkg/client/kubernetes/clientmap/internal
$ stress -p 50 ./pkg/client/kubernetes/clientmap/internal/internal.test
...
3641 runs so far, 2 failures (0.05%)
```

After:
```
$ ginkgo build ./pkg/client/kubernetes/clientmap/internal
$ stress -p 50 ./pkg/client/kubernetes/clientmap/internal/internal.test
...
9158 runs so far, 0 failures
```
**Which issue(s) this PR fixes**:
Fixes #5410 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
