### PR TITLE
Fix flaky test and Cleanup usages of time.Sleep

### DIFF
--- a/extensions/pkg/controller/common/checkerwatchdog.go
+++ b/extensions/pkg/controller/common/checkerwatchdog.go
@@ -101,7 +101,7 @@ func (w *checkerWatchdog) Start(ctx context.Context) {
 			case <-w.resultChan:
 				resultRequested = true
 				// If the last result is not older than w.interval, use it
-				if !time.Now().After(w.resultTime.Add(w.interval)) {
+				if !w.clock.Now().After(w.resultTime.Add(w.interval)) {
 					w.resultReadyChan <- struct{}{}
 					continue
 				}
@@ -191,5 +191,5 @@ func (w *checkerWatchdog) Result() (bool, error) {
 func (w *checkerWatchdog) setResult(result bool, err error) {
 	w.resultMutex.Lock()
 	defer w.resultMutex.Unlock()
-	w.result, w.err, w.resultTime = result, err, time.Now()
+	w.result, w.err, w.resultTime = result, err, w.clock.Now()
 }

--- a/extensions/pkg/controller/common/checkerwatchdog_test.go
+++ b/extensions/pkg/controller/common/checkerwatchdog_test.go
@@ -126,7 +126,7 @@ var _ = Describe("CheckerWatchdog", func() {
 				// Take twice as long as the timeout to succeed
 				for {
 					select {
-					case <-time.After(timeout * 2):
+					case <-fakeClock.After(timeout * 2):
 						return true, nil
 					case <-ctx.Done():
 						return false, errors.New("context cancelled")

--- a/pkg/client/kubernetes/clientmap/internal/generic_clientmap.go
+++ b/pkg/client/kubernetes/clientmap/internal/generic_clientmap.go
@@ -54,7 +54,7 @@ type GenericClientMap struct {
 
 	log logr.Logger
 
-	Clock clock.Clock
+	clock clock.Clock
 
 	// stopCh is saved on the first call to Start and is used to start the caches of newly created ClientSets.
 	stopCh  <-chan struct{}
@@ -78,7 +78,7 @@ func NewGenericClientMap(factory clientmap.ClientSetFactory, logger logr.Logger,
 		clientSets: make(map[clientmap.ClientSetKey]*clientMapEntry),
 		factory:    factory,
 		log:        logger,
-		Clock:      clock,
+		clock:      clock,
 	}
 }
 
@@ -97,7 +97,7 @@ func (cm *GenericClientMap) GetClient(ctx context.Context, key clientmap.ClientS
 	}()
 
 	if found {
-		if entry.refreshLimiter.AllowN(cm.Clock.Now(), 1) {
+		if entry.refreshLimiter.AllowN(cm.clock.Now(), 1) {
 			shouldRefresh, err := func() (bool, error) {
 				// refresh server version
 				oldVersion := entry.clientSet.Version()
@@ -169,7 +169,7 @@ func (cm *GenericClientMap) addClientSet(ctx context.Context, key clientmap.Clie
 	}
 
 	// avoid checking if the client should be refreshed directly after creating, by directly taking a token here
-	entry.refreshLimiter.AllowN(cm.Clock.Now(), 1)
+	entry.refreshLimiter.AllowN(cm.clock.Now(), 1)
 
 	// add ClientSet to map
 	cm.clientSets[key] = entry

--- a/pkg/operation/botanist/component/nodeproblemdetector/node_problem_detector_test.go
+++ b/pkg/operation/botanist/component/nodeproblemdetector/node_problem_detector_test.go
@@ -504,7 +504,6 @@ status: {}
 		})
 
 		Describe("#WaitCleanup", func() {
-
 			It("should fail when the wait for the managed resource deletion times out", func() {
 				fakeOps.MaxAttempts = 2
 
@@ -512,6 +511,7 @@ status: {}
 
 				Expect(component.WaitCleanup(ctx)).To(MatchError(ContainSubstring("still exists")))
 			})
+
 			It("should not return an error when it's already removed", func() {
 				Expect(component.WaitCleanup(ctx)).To(Succeed())
 			})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
This PR fixes a flaky test in extensions/pkg/controller/common. 
Ref: https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/5687/pull-gardener-unit/1509170313273806848

Before: 
```
$  ginkgo build ./extensions/pkg/controller/common
$ stress -p 50 ./extensions/pkg/controller/common/common.test
4631 runs so far, 58 failures (1.25%)
```
After:
```
$  ginkgo build ./extensions/pkg/controller/common
$ stress -p 50 ./extensions/pkg/controller/common/common.test
6620 runs so far, 0 failures
```
This PR also cleans up usages of time.Sleep to prevent further flakes in the future.
Also it includes some minor things which was missed in #5714.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
