### PR TITLE
Fix several issues related to recent changes in `master` branch

### DIFF
--- a/charts/gardener/gardenlet/charts/runtime/templates/deployment.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/deployment.yaml
@@ -1,10 +1,10 @@
 {{- define "gardenlet.deployment.annotations" -}}
-reference.resources.gardener.cloud/config-{{ include "gardenlet.config.name" . | sha256sum | trunc 8 }}: {{ include "gardenlet.config.name" . }}
+reference.resources.gardener.cloud/configmap-{{ include "gardenlet.config.name" . | sha256sum | trunc 8 }}: {{ include "gardenlet.config.name" . }}
 {{- if .Values.global.gardenlet.imageVectorOverwrite }}
-reference.resources.gardener.cloud/config-{{ include "gardenlet.imagevector-overwrite.name" . | sha256sum | trunc 8 }}: {{ include "gardenlet.imagevector-overwrite.name" . }}
+reference.resources.gardener.cloud/configmap-{{ include "gardenlet.imagevector-overwrite.name" . | sha256sum | trunc 8 }}: {{ include "gardenlet.imagevector-overwrite.name" . }}
 {{- end }}
 {{- if .Values.global.gardenlet.componentImageVectorOverwrites }}
-reference.resources.gardener.cloud/config-{{ include "gardenlet.imagevector-overwrite-components.name" . | sha256sum | trunc 8 }}: {{ include "gardenlet.imagevector-overwrite-components.name" . }}
+reference.resources.gardener.cloud/configmap-{{ include "gardenlet.imagevector-overwrite-components.name" . | sha256sum | trunc 8 }}: {{ include "gardenlet.imagevector-overwrite-components.name" . }}
 {{- end }}
 {{- if .Values.global.gardenlet.config.gardenClientConnection.kubeconfig }}
 reference.resources.gardener.cloud/secret-{{ include "gardenlet.kubeconfig-garden.name" . | sha256sum | trunc 8 }}: {{ include "gardenlet.kubeconfig-garden.name" . }}

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -15,6 +15,8 @@
 package constants
 
 const (
+	// SecretManagerIdentityControllerManager is the identity for the secret manager used inside controller-manager.
+	SecretManagerIdentityControllerManager = "controller-manager"
 	// SecretManagerIdentityGardenlet is the identity for the secret manager used inside gardenlet.
 	SecretManagerIdentityGardenlet = "gardenlet"
 

--- a/pkg/controllermanager/controller/factory.go
+++ b/pkg/controllermanager/controller/factory.go
@@ -52,9 +52,6 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-// SecretManagerIdentityControllerManager is the identity for the secret manager used inside controller-manager.
-const SecretManagerIdentityControllerManager = "controller-manager"
-
 // GardenControllerFactory contains information relevant to controllers for the Garden API group.
 type GardenControllerFactory struct {
 	cfg       *config.ControllerManagerConfiguration
@@ -88,7 +85,7 @@ func (f *GardenControllerFactory) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to start ClientMap: %+v", err)
 	}
 
-	secretsManager, err := secretsmanager.New(ctx, logf.Log.WithName("secretsmanager"), clock.RealClock{}, gardenClientSet.Client(), v1beta1constants.GardenNamespace, SecretManagerIdentityControllerManager, nil)
+	secretsManager, err := secretsmanager.New(ctx, logf.Log.WithName("secretsmanager"), clock.RealClock{}, gardenClientSet.Client(), v1beta1constants.GardenNamespace, v1beta1constants.SecretManagerIdentityControllerManager, nil)
 	if err != nil {
 		return fmt.Errorf("failed creating new secrets manager: %w", err)
 	}

--- a/pkg/gardenlet/controller/managedseed/charttest/charttest.go
+++ b/pkg/gardenlet/controller/managedseed/charttest/charttest.go
@@ -1173,14 +1173,14 @@ func VerifyGardenletDeployment(ctx context.Context,
 
 	Expect(deployment.ObjectMeta.Labels).To(DeepEqual(expectedDeployment.ObjectMeta.Labels))
 
-	assertResourceReferenceExists(uniqueName["gardenlet-configmap"], "config-", deployment.Spec.Template.Annotations)
+	assertResourceReferenceExists(uniqueName["gardenlet-configmap"], "configmap-", deployment.Spec.Template.Annotations)
 
 	if imageVectorOverwrite != nil {
-		assertResourceReferenceExists(uniqueName["gardenlet-imagevector-overwrite"], "config-", deployment.Spec.Template.Annotations)
+		assertResourceReferenceExists(uniqueName["gardenlet-imagevector-overwrite"], "configmap-", deployment.Spec.Template.Annotations)
 	}
 
 	if componentImageVectorOverwrites != nil {
-		assertResourceReferenceExists(uniqueName["gardenlet-imagevector-overwrite-components"], "config-", deployment.Spec.Template.Annotations)
+		assertResourceReferenceExists(uniqueName["gardenlet-imagevector-overwrite-components"], "configmap-", deployment.Spec.Template.Annotations)
 	}
 
 	if componentConfigHasTLSServerConfig {

--- a/pkg/operation/botanist/etcd.go
+++ b/pkg/operation/botanist/etcd.go
@@ -130,10 +130,7 @@ func (b *Botanist) DeployEtcd(ctx context.Context) error {
 	}
 
 	// TODO(rfranzke): Remove in a future release.
-	return kutil.DeleteObjects(ctx, b.K8sSeedClient.Client(),
-		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "etcd-client-tls", Namespace: b.Shoot.SeedNamespace}},
-		&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "etcd-server-cert", Namespace: b.Shoot.SeedNamespace}},
-	)
+	return kutil.DeleteObject(ctx, b.K8sSeedClient.Client(), &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "etcd-server-cert", Namespace: b.Shoot.SeedNamespace}})
 }
 
 // WaitUntilEtcdsReady waits until both etcd-main and etcd-events are ready.

--- a/pkg/operation/botanist/etcd_test.go
+++ b/pkg/operation/botanist/etcd_test.go
@@ -314,7 +314,6 @@ var _ = Describe("Etcd", func() {
 				etcdMain.EXPECT().Deploy(ctx)
 				etcdEvents.EXPECT().Deploy(ctx)
 
-				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "etcd-client-tls", Namespace: namespace}})
 				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "etcd-server-cert", Namespace: namespace}})
 
 				Expect(botanist.DeployEtcd(ctx)).To(Succeed())
@@ -377,7 +376,6 @@ var _ = Describe("Etcd", func() {
 				expectSetOwnerCheckConfig()
 				etcdMain.EXPECT().Deploy(ctx)
 				etcdEvents.EXPECT().Deploy(ctx)
-				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "etcd-client-tls", Namespace: namespace}})
 				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "etcd-server-cert", Namespace: namespace}})
 
 				Expect(botanist.DeployEtcd(ctx)).To(Succeed())
@@ -394,7 +392,6 @@ var _ = Describe("Etcd", func() {
 				expectSetBackupConfig()
 				etcdMain.EXPECT().Deploy(ctx)
 				etcdEvents.EXPECT().Deploy(ctx)
-				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "etcd-client-tls", Namespace: namespace}})
 				c.EXPECT().Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "etcd-server-cert", Namespace: namespace}})
 
 				Expect(botanist.DeployEtcd(ctx)).To(Succeed())

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -17,6 +17,7 @@ package seed
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"regexp"
@@ -382,6 +383,8 @@ func RunReconcileSeedFlow(
 		}); err != nil {
 			return err
 		}
+	} else {
+		return errors.New("global monitoring secret not found in seed namespace")
 	}
 
 	seedImages, err := imagevector.FindImages(imageVector,

--- a/pkg/utils/secrets/manager/generate.go
+++ b/pkg/utils/secrets/manager/generate.go
@@ -400,9 +400,9 @@ func (m *manager) reconcileSecret(ctx context.Context, secret *corev1.Secret, la
 		mustPatch = true
 	}
 
-	for k, v := range labels {
-		if secret.Labels[k] != v {
-			metav1.SetMetaDataLabel(&secret.ObjectMeta, k, v)
+	for k, desired := range labels {
+		if current, ok := secret.Labels[k]; !ok || current != desired {
+			metav1.SetMetaDataLabel(&secret.ObjectMeta, k, desired)
 			mustPatch = true
 		}
 	}

--- a/pkg/utils/secrets/manager/manager.go
+++ b/pkg/utils/secrets/manager/manager.go
@@ -151,13 +151,20 @@ func (m *manager) initialize(ctx context.Context, secretNamesToTimes map[string]
 		return err
 	}
 
+	nameToNewestSecret := make(map[string]corev1.Secret, len(secretList.Items))
+
+	// Find the newest secret in system for the respective secret names. Read their existing
+	// last-rotation-initiation-time labels and store them in our internal map.
 	for _, secret := range secretList.Items {
-		// Read existing last-rotation-initiation-time labels on secrets and store them in our internal times map
-		if secret.Labels[LabelKeyLastRotationInitiationTime] != "" {
+		oldSecret, found := nameToNewestSecret[secret.Labels[LabelKeyName]]
+		if !found || oldSecret.CreationTimestamp.Time.Before(secret.CreationTimestamp.Time) {
+			nameToNewestSecret[secret.Labels[LabelKeyName]] = *secret.DeepCopy()
 			m.lastRotationInitiationTimes[secret.Labels[LabelKeyName]] = secret.Labels[LabelKeyLastRotationInitiationTime]
 		}
+	}
 
-		// Check if secret must be automatically renewed because it is about to expire
+	// Check if the secrets must be automatically renewed because they are about to expire.
+	for name, secret := range nameToNewestSecret {
 		mustRenew, err := m.mustAutoRenewSecret(secret)
 		if err != nil {
 			return err
@@ -165,7 +172,7 @@ func (m *manager) initialize(ctx context.Context, secretNamesToTimes map[string]
 
 		if mustRenew {
 			m.logger.Info("Preparing secret for automatic renewal", "secret", secret.Name, "issuedAt", secret.Labels[LabelKeyIssuedAtTime], "validUntil", secret.Labels[LabelKeyValidUntilTime])
-			m.lastRotationInitiationTimes[secret.Labels[LabelKeyName]] = unixTime(m.clock.Now())
+			m.lastRotationInitiationTimes[name] = unixTime(m.clock.Now())
 		}
 	}
 

--- a/pkg/utils/secrets/manager/manager.go
+++ b/pkg/utils/secrets/manager/manager.go
@@ -152,7 +152,7 @@ func (m *manager) initialize(ctx context.Context, secretNamesToTimes map[string]
 	}
 
 	for _, secret := range secretList.Items {
-		// Read existing last-rotatation-initiation-time labels on secrets and store them in our internal times map
+		// Read existing last-rotation-initiation-time labels on secrets and store them in our internal times map
 		if secret.Labels[LabelKeyLastRotationInitiationTime] != "" {
 			m.lastRotationInitiationTimes[secret.Labels[LabelKeyName]] = secret.Labels[LabelKeyLastRotationInitiationTime]
 		}
@@ -193,15 +193,15 @@ func (m *manager) mustAutoRenewSecret(secret corev1.Secret) (bool, error) {
 	}
 
 	var (
-		issuedAt   = time.Unix(issuedAtUnix, 0).UTC()
-		validUntil = time.Unix(validUntilUnix, 0).UTC()
-		validity   = validUntil.Sub(issuedAt)
-		now        = m.clock.Now().UTC()
+		validity    = validUntilUnix - issuedAtUnix
+		renewAtUnix = issuedAtUnix + validity*80/100
+		renewAt     = time.Unix(renewAtUnix, 0).UTC()
+		validUntil  = time.Unix(validUntilUnix, 0).UTC()
+		now         = m.clock.Now().UTC()
 	)
 
 	// Renew if 80% of the validity has been reached or if the secret expires in less than 10d.
-	return now.After(issuedAt.Add(validity*80/100)) ||
-		now.After(validUntil.Add(-10*24*time.Hour)), nil
+	return now.After(renewAt) || now.After(validUntil.Add(-10*24*time.Hour)), nil
 }
 
 func (m *manager) addToStore(name string, secret *corev1.Secret, class secretClass) error {

--- a/pkg/utils/secrets/manager/manager_test.go
+++ b/pkg/utils/secrets/manager/manager_test.go
@@ -190,6 +190,60 @@ var _ = Describe("Manager", func() {
 
 			Expect(m.lastRotationInitiationTimes).To(Equal(nameToUnixTime{"secret1": "-100"}))
 		})
+
+		It("should only consider the last rotation initiation time for the newest secret", func() {
+			secrets := []*corev1.Secret{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "secret1-1",
+						Namespace:         namespace,
+						CreationTimestamp: metav1.Time{Time: time.Date(2000, 1, 3, 1, 1, 1, 1, time.UTC)},
+						Labels: map[string]string{
+							"name":                          "secret1",
+							"managed-by":                    "secrets-manager",
+							"manager-identity":              identity,
+							"last-rotation-initiation-time": "24",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "secret1-2",
+						Namespace:         namespace,
+						CreationTimestamp: metav1.Time{Time: time.Date(2000, 1, 1, 1, 1, 1, 1, time.UTC)},
+						Labels: map[string]string{
+							"name":                          "secret1",
+							"managed-by":                    "secrets-manager",
+							"manager-identity":              identity,
+							"last-rotation-initiation-time": "12",
+						},
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "secret1-3",
+						Namespace:         namespace,
+						CreationTimestamp: metav1.Time{Time: time.Date(2000, 1, 2, 1, 1, 1, 1, time.UTC)},
+						Labels: map[string]string{
+							"name":                          "secret1",
+							"managed-by":                    "secrets-manager",
+							"manager-identity":              identity,
+							"last-rotation-initiation-time": "16",
+						},
+					},
+				},
+			}
+
+			for _, secret := range secrets {
+				Expect(fakeClient.Create(ctx, secret)).To(Succeed())
+			}
+
+			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, nil)
+			Expect(err).NotTo(HaveOccurred())
+			m = mgr.(*manager)
+
+			Expect(m.lastRotationInitiationTimes).To(Equal(nameToUnixTime{"secret1": "24"}))
+		})
 	})
 
 	Describe("#ObjectMeta", func() {

--- a/pkg/utils/secrets/manager/manager_test.go
+++ b/pkg/utils/secrets/manager/manager_test.go
@@ -178,7 +178,7 @@ var _ = Describe("Manager", func() {
 						"manager-identity":              identity,
 						"last-rotation-initiation-time": "-100",
 						"issued-at-time":                strconv.FormatInt(fakeClock.Now().Add(-24*time.Hour).Unix(), 10),
-						"valid-until-time":              strconv.FormatInt(fakeClock.Now().Add(11*24*time.Hour).Unix(), 10),
+						"valid-until-time":              strconv.FormatInt(fakeClock.Now().Add(15*365*24*time.Hour).Unix(), 10),
 					},
 				},
 			}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bug

**What this PR does / why we need it**:
This PR fixes several issues, most of them (but not all) related to the adaptions of the secrets to the new secrets manager:

1. The first commit fixes a "typo" in the reference annotations for the unique gardenlet `ConfigMap`s (introduced with #4646) which made the garbage collector part of `gardener-resource-manager` deleting them because they were not recognized as "in-use".
2. The global monitoring secret generated by `gardener-controller-manager` should always be generated if it is responsible so make sure the `Cleanup` call does not delete it with the next restart of GCM (introduced with #5608)
3. As a result out of the above, the gardenlet panics when there is no global monitoring secret, so let's rather return an error instead.
4. The old `etcd-client-tls` secret should only be deleted at the end of the reconciliation flow to make sure dependent components (`kube-apiserver`, `prometheus`) could still use it until they got deployed as well. If the flow aborts before they get deployed but after the `etcd-client-tls` secret was deleted then these pods could not start after they have been recreated.
5. There was an integer overflow in the computation for secrets that need to be auto renewed (introduced with #5679). This led to automatic renewals of CA certificates which have a long validity (`10y`).
6. Also introduced with #5679, the auto-rotation detection logic was flawed when there were multiple secrets with the same `name` label. This led to incorrectly adopted last rotation initiation times and hence to undesired behaviour.

**Special notes for your reviewer**:
/invite @timebertt 
/assign @timebertt 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
7. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
