### PR TITLE
Fixes token invalidation in cloud-config-downloader

### DIFF
--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/downloader/downloader_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/downloader/downloader_test.go
@@ -235,7 +235,7 @@ function extractDataKeyFromSecret() {
   echo "$1" | sed -rn "s/  $2: (.*)/\1/p" | base64 -d
 }
 
-function saveToDiskSafely() {
+function writeToDiskSafely() {
   local data="$1"
   local file_path="$2"
 
@@ -272,7 +272,7 @@ if [[ -z "$TOKEN" ]]; then
   exit 1
 fi
 
-saveToDiskSafely "$TOKEN" "$PATH_CLOUDCONFIG_DOWNLOADER_TOKEN"
+writeToDiskSafely "$TOKEN" "$PATH_CLOUDCONFIG_DOWNLOADER_TOKEN"
 
 # download and run the cloud config execution script
 if ! SECRET="$(readSecretWithToken "$SECRET_NAME" "$TOKEN")"; then

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/downloader/templates/scripts/download-cloud-config.tpl.sh
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/downloader/templates/scripts/download-cloud-config.tpl.sh
@@ -33,6 +33,17 @@ function extractDataKeyFromSecret() {
   echo "$1" | sed -rn "s/  $2: (.*)/\1/p" | base64 -d
 }
 
+function saveToDiskSafely() {
+  local data="$1"
+  local file_path="$2"
+
+  if echo "$data" > "$file_path.tmp" && ( [[ ! -f "$file_path" ]] || ! diff "$file_path" "$file_path.tmp">/dev/null ); then
+    mv "$file_path.tmp" "$file_path"
+  elif [[ -f "$file_path.tmp" ]]; then
+    rm -f "$file_path.tmp"
+  fi
+}
+
 # download shoot access token for cloud-config-downloader
 if [[ -f "$PATH_CLOUDCONFIG_DOWNLOADER_TOKEN" ]]; then
   if ! SECRET="$(readSecretWithToken "$TOKEN_SECRET_NAME" "$(cat "$PATH_CLOUDCONFIG_DOWNLOADER_TOKEN")")"; then
@@ -58,7 +69,8 @@ if [[ -z "$TOKEN" ]]; then
   echo "Token in shoot access secret $TOKEN_SECRET_NAME is empty"
   exit 1
 fi
-echo "$TOKEN" > "$PATH_CLOUDCONFIG_DOWNLOADER_TOKEN"
+
+saveToDiskSafely "$TOKEN" "$PATH_CLOUDCONFIG_DOWNLOADER_TOKEN"
 
 # download and run the cloud config execution script
 if ! SECRET="$(readSecretWithToken "$SECRET_NAME" "$TOKEN")"; then

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/downloader/templates/scripts/download-cloud-config.tpl.sh
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/downloader/templates/scripts/download-cloud-config.tpl.sh
@@ -33,7 +33,7 @@ function extractDataKeyFromSecret() {
   echo "$1" | sed -rn "s/  $2: (.*)/\1/p" | base64 -d
 }
 
-function saveToDiskSafely() {
+function writeToDiskSafely() {
   local data="$1"
   local file_path="$2"
 
@@ -70,7 +70,7 @@ if [[ -z "$TOKEN" ]]; then
   exit 1
 fi
 
-saveToDiskSafely "$TOKEN" "$PATH_CLOUDCONFIG_DOWNLOADER_TOKEN"
+writeToDiskSafely "$TOKEN" "$PATH_CLOUDCONFIG_DOWNLOADER_TOKEN"
 
 # download and run the cloud config execution script
 if ! SECRET="$(readSecretWithToken "$SECRET_NAME" "$TOKEN")"; then


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug

**What this PR does / why we need it**:
Fixes a possible issue that could cause the cloud-config-downloader token to be invalidated if there any problems with the root file system of the node. 
Basically instead of directly trying to write the token data into the file specified for the token, the data will first be written to a temporary file. If that succeeds and the contents of the temporary file differ from the token file or the token file has still not been created, the temporary file will be `mv`-ed to the token file. Otherwise (if the contents are the same) the temporary file will be removed.

I managed to reproduce the error locally by writing creating a very large file and then trying to `echo` some content into another file. The `echo` commands fills the file until there is not enough space on the device and then exists before filling in the entire data. Echoing to a temp file and then using `mv` as suggested in the issue prevents this.

**Which issue(s) this PR fixes**:
Fixes #5674 

**Special notes for your reviewer**:
I have not yet tested this with an actual shoot yet.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed an issue that could cause the cloud-config-downloader to invalidate its credentials token if the node that it is currently running on has issues with the file system where the credentials token is stored (for example when the node runs out of disk space).
```
