### PR TITLE
Allow projected volumes in the vpn-shoot PSP

### DIFF
--- a/pkg/operation/botanist/component/vpnshoot/vpnshoot.go
+++ b/pkg/operation/botanist/component/vpnshoot/vpnshoot.go
@@ -368,6 +368,7 @@ func (v *vpnShoot) computeResourcesData(secretCAVPN, secretVPNShoot *corev1.Secr
 				Volumes: []policyv1beta1.FSType{
 					"secret",
 					"emptyDir",
+					"projected",
 				},
 				AllowedCapabilities: []corev1.Capability{
 					"NET_ADMIN",

--- a/pkg/operation/botanist/component/vpnshoot/vpnshoot_test.go
+++ b/pkg/operation/botanist/component/vpnshoot/vpnshoot_test.go
@@ -191,6 +191,7 @@ spec:
   volumes:
   - secret
   - emptyDir
+  - projected
 `
 			clusterRolePSPYAML = `apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
/area quality
/kind bug

https://github.com/gardener/gardener/pull/5691 adds a new projected volume to the vpn-shoot Pod spec:

https://github.com/gardener/gardener/blob/09e7c0528ba4dafa09e5ff53c5ae2b773b864cab/pkg/operation/botanist/component/vpnshoot/vpnshoot.go#L632-L669

The corresponding PodSecurityPolicy has to be adapted as well.

```
$ k -n kube-system describe rs vpn-shoot-58fd79f94c

  Warning  FailedCreate  115s (x6 over 4m38s)    replicaset-controller  Error creating: pods "vpn-shoot-58fd79f94c-" is forbidden: PodSecurityPolicy: unable to admit pod: [spec.containers[0].securityContext.privileged: Invalid value: true: Privileged containers are not allowed spec.containers[0].securityContext.capabilities.add: Invalid value: "NET_ADMIN": capability may not be added spec.volumes[0]: Invalid value: "projected": projected volumes are not allowed to be used]
```

<img width="863" alt="Screenshot 2022-04-02 at 19 11 31" src="https://user-images.githubusercontent.com/9372594/161391602-8e186305-4dd8-4ab1-bf2d-a01177e80ba3.png">

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
