### PR TITLE
Add e2e test for unprivileged shoot clusters

### DIFF
--- a/test/e2e/shoot/create_and_delete_hibernated.go
+++ b/test/e2e/shoot/create_and_delete_hibernated.go
@@ -32,7 +32,7 @@ var _ = Describe("Shoot Tests", Label("Shoot"), func() {
 		Enabled: pointer.Bool(true),
 	}
 
-	It("Create and Delete Hibernated Shoot", func() {
+	It("Create and Delete Hibernated Shoot", Label("hibernated"), func() {
 		By("Create Shoot")
 		ctx, cancel := context.WithTimeout(parentCtx, 15*time.Minute)
 		defer cancel()

--- a/test/e2e/shoot/create_and_delete_unprivileged.go
+++ b/test/e2e/shoot/create_and_delete_unprivileged.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shoot
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/utils/pointer"
+)
+
+var _ = Describe("Shoot Tests", Label("Shoot"), func() {
+	f := defaultShootCreationFramework()
+	f.Shoot = defaultShoot("unpriv-")
+	f.Shoot.Spec.Kubernetes.AllowPrivilegedContainers = pointer.Bool(false)
+
+	It("Create and Delete Unprivileged Shoot", Label("unprivileged"), func() {
+		By("Create Shoot")
+		ctx, cancel := context.WithTimeout(parentCtx, 15*time.Minute)
+		defer cancel()
+		Expect(f.CreateShootAndWaitForCreation(ctx, false)).To(Succeed())
+		f.Verify()
+
+		By("Delete Shoot")
+		ctx, cancel = context.WithTimeout(parentCtx, 15*time.Minute)
+		defer cancel()
+		Expect(f.DeleteShootAndWaitForDeletion(ctx, f.Shoot)).To(Succeed())
+	})
+})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality dev-productivity
/kind test

**What this PR does / why we need it**:
This PR adds a new e2e test which sets `.spec.kubernetes.allowPrivilegedContainers=false` to catch regressions caused by https://github.com/gardener/gardener/pull/5691 (fixed by #5722).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
