### PR TITLE
Promote `ShootMaxTokenExpirationOverwrite` feature gate to beta

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -41,7 +41,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | ForceRestore                                 | `false` | `Alpha` | `1.39` |        |
 | DisableDNSProviderManagement                 | `false` | `Alpha` | `1.41` |        |
 | ShootCARotation                              | `false` | `Alpha` | `1.42` |        |
-| ShootMaxTokenExpirationOverwrite             | `false` | `Alpha` | `1.43` |        |
+| ShootMaxTokenExpirationOverwrite             | `false` | `Alpha` | `1.43` | `1.44` |
+| ShootMaxTokenExpirationOverwrite             | `true`  | `Beta`  | `1.45` |        |
 | ShootMaxTokenExpirationValidation            | `false` | `Alpha` | `1.43` |        |
 
 ## Feature gates for graduated or deprecated features

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -147,6 +147,7 @@ const (
 	// before persisting the object to etcd.
 	// owner: @rfranzke
 	// alpha: v1.43.0
+	// beta: v1.45.0
 	ShootMaxTokenExpirationOverwrite featuregate.Feature = "ShootMaxTokenExpirationOverwrite"
 
 	// ShootMaxTokenExpirationValidation enables validations on Gardener API server that enforce that the value of the
@@ -178,7 +179,7 @@ var allFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	ForceRestore:                               {Default: false, PreRelease: featuregate.Alpha},
 	DisableDNSProviderManagement:               {Default: false, PreRelease: featuregate.Alpha},
 	ShootCARotation:                            {Default: false, PreRelease: featuregate.Alpha},
-	ShootMaxTokenExpirationOverwrite:           {Default: false, PreRelease: featuregate.Alpha},
+	ShootMaxTokenExpirationOverwrite:           {Default: true, PreRelease: featuregate.Beta},
 	ShootMaxTokenExpirationValidation:          {Default: false, PreRelease: featuregate.Alpha},
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source ops-productivity
/kind enhancement

**What this PR does / why we need it**:
Promote `ShootMaxTokenExpirationOverwrite` feature gate to beta.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `ShootMaxTokenExpirationOverwrite` feature gate has been promoted to beta and is now enabled by default.
```
