### PR TITLE
Adds support for v1beta1 CronJobs in resource manager

### DIFF
--- a/charts/utils-templates/templates/_versions.tpl
+++ b/charts/utils-templates/templates/_versions.tpl
@@ -35,7 +35,11 @@ scheduling.k8s.io/v1
 {{- end -}}
 
 {{- define "cronjobversion" -}}
+{{- if semverCompare ">= 1.21-0" .Capabilities.KubeVersion.GitVersion -}}
+batch/v1
+{{- else -}}
 batch/v1beta1
+{{- end -}}
 {{- end -}}
 
 {{- define "hpaversion" -}}

--- a/pkg/resourcemanager/controller/managedresource/merger.go
+++ b/pkg/resourcemanager/controller/managedresource/merger.go
@@ -15,6 +15,7 @@
 package managedresource
 
 import (
+	"fmt"
 	"strings"
 
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
@@ -22,6 +23,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -222,6 +224,33 @@ func mergeJob(scheme *runtime.Scheme, oldObj, newObj runtime.Object, preserveRes
 }
 
 func mergeCronJob(scheme *runtime.Scheme, oldObj, newObj runtime.Object, preserveResources bool) error {
+	switch newObj.GetObjectKind().GroupVersionKind().Version {
+	case batchv1beta1.SchemeGroupVersion.Version:
+		return mergeV1beta1CronJob(scheme, oldObj, newObj, preserveResources)
+	case batchv1.SchemeGroupVersion.Version:
+		return mergeV1CronJob(scheme, oldObj, newObj, preserveResources)
+	default:
+		return fmt.Errorf("cannot merge objects with gvk: %s", newObj.GetObjectKind().GroupVersionKind().String())
+	}
+}
+
+func mergeV1beta1CronJob(scheme *runtime.Scheme, oldObj, newObj runtime.Object, preserveResources bool) error {
+	oldCronJob := &batchv1beta1.CronJob{}
+	if err := scheme.Convert(oldObj, oldCronJob, nil); err != nil {
+		return err
+	}
+
+	newCronJob := &batchv1beta1.CronJob{}
+	if err := scheme.Convert(newObj, newCronJob, nil); err != nil {
+		return err
+	}
+
+	mergePodTemplate(&oldCronJob.Spec.JobTemplate.Spec.Template, &newCronJob.Spec.JobTemplate.Spec.Template, preserveResources)
+
+	return scheme.Convert(newCronJob, newObj, nil)
+}
+
+func mergeV1CronJob(scheme *runtime.Scheme, oldObj, newObj runtime.Object, preserveResources bool) error {
 	oldCronJob := &batchv1.CronJob{}
 	if err := scheme.Convert(oldObj, oldCronJob, nil); err != nil {
 		return err


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement bug

**What this PR does / why we need it**:
Adds support for v1beta1 CronJobs in the resource manager. 
Previously trying to deploy a `ManagedResource` that included a v1beta1 `CronJob` would fail due to the following conversions: https://github.com/gardener/gardener/blob/256b46794f44b193a40e58f8035a8905b202ff7a/pkg/resourcemanager/controller/managedresource/merger.go#L224-L238
as there was no check whether the incoming object was a v1beta1 or v1 `CronJob` and conversions between apis cannot be done automatically on the client (check [this comment](https://github.com/gardener/gardener/issues/5443#issuecomment-1040469802))

**Which issue(s) this PR fixes**:
Fixes #5443 

**Special notes for your reviewer**:
Not sure if `usability` is the correct area here.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Gardener resource manager can now properly deploy v1beta1 `CronJobs` if they are part of a `ManagedResource`'s referenced `Secret`
```
