### PR TITLE
Remove labels from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,7 +1,6 @@
 ---
 name: Bug Report
 about: Report a bug encountered while operating Gardener
-labels: kind/bug
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,7 +1,6 @@
 ---
 name: Enhancement Request
 about: Suggest an enhancement to the Gardener project
-labels: kind/enhancement
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/flaking-test.md
+++ b/.github/ISSUE_TEMPLATE/flaking-test.md
@@ -2,7 +2,6 @@
 name: Flaking Test
 about: Report flaky tests or jobs in Gardener CI
 title: "[Flaky Test] FLAKING TEST/SUITE"
-labels: kind/flake
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/support.md
+++ b/.github/ISSUE_TEMPLATE/support.md
@@ -1,7 +1,6 @@
 ---
 name: Support Request
 about: Support request or question relating to Gardener
-labels: kind/question
 
 ---
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup

**What this PR does / why we need it**:

Remove labels from issue templates, authors are asked to use the `/kind` command anyways.
Prevents github from adding default labels (e.g. `kind/bug`) if author specified non-default labels (e.g. `kind/regression`).

