### PR TITLE
update garden cluster kubeconfig in gardenlet on CA rotation

### DIFF
--- a/cmd/gardenlet/app/gardenlet.go
+++ b/cmd/gardenlet/app/gardenlet.go
@@ -52,6 +52,7 @@ import (
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/secrets"
 
+	bootstraputil "github.com/gardener/gardener/pkg/gardenlet/bootstrap/util"
 	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/cobra"
@@ -302,6 +303,13 @@ func NewGardenlet(ctx context.Context, cfg *config.GardenletConfiguration) (*Gar
 				"To configure the Gardenlet for bootstrapping, provide the secret containing the bootstrap kubeconfig under `.gardenClientConnection.kubeconfigSecret` and also the secret name where the created kubeconfig should be stored for further use via`.gardenClientConnection.kubeconfigSecret`")
 		}
 	} else {
+		if len(cfg.GardenClientConnection.GardenClusterCACert) != 0 {
+			kubeconfigFromBootstrap, err = bootstraputil.UpdateGardenKubeconfigCAIfChanged(ctx, seedClient.Client(), kubeconfigFromBootstrap, cfg.GardenClientConnection)
+			if err != nil {
+				return nil, fmt.Errorf("error updating CA in garden cluster kubeconfig secret: %w", err)
+			}
+		}
+
 		gardenClientCertificate, err := certificate.GetCurrentCertificate(logrusLogger, kubeconfigFromBootstrap, cfg.GardenClientConnection)
 		if err != nil {
 			return nil, err

--- a/pkg/gardenlet/bootstrap/util/util_test.go
+++ b/pkg/gardenlet/bootstrap/util/util_test.go
@@ -210,6 +210,80 @@ var _ = Describe("Util", func() {
 			})
 		})
 
+		Describe("#UpdateGardenKubeconfigCAIfChanged", func() {
+			var (
+				secretReference        corev1.SecretReference
+				certClientConfig       *rest.Config
+				expectedSecret         *corev1.Secret
+				gardenClientConnection *config.GardenClientConnection
+			)
+
+			BeforeEach(func() {
+				secretReference = corev1.SecretReference{
+					Name:      "secret",
+					Namespace: "garden",
+				}
+
+				certClientConfig = &rest.Config{Host: "testhost", TLSClientConfig: rest.TLSClientConfig{
+					Insecure: false,
+					CAData:   []byte("foo"),
+				}}
+
+				expectedSecret = &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      secretReference.Name,
+						Namespace: secretReference.Namespace,
+					},
+				}
+
+				gardenClientConnection = &config.GardenClientConnection{
+					KubeconfigSecret: &secretReference,
+				}
+			})
+
+			It("should update the secret if the CA has changed", func() {
+				gardenClientConnection.GardenClusterCACert = []byte("bar")
+
+				expectedKubeconfig, err := CreateGardenletKubeconfigWithClientCertificate(certClientConfig, nil, nil)
+				Expect(err).ToNot(HaveOccurred())
+
+				updatedCertClientConfig := &rest.Config{Host: "testhost", TLSClientConfig: rest.TLSClientConfig{
+					Insecure: false,
+					CAData:   gardenClientConnection.GardenClusterCACert,
+				}}
+				expectedUpdatedKubeconfig, err := CreateGardenletKubeconfigWithClientCertificate(updatedCertClientConfig, nil, nil)
+				Expect(err).ToNot(HaveOccurred())
+
+				updatedSecret := expectedSecret.DeepCopy()
+				expectedSecret.Data = map[string][]byte{kubernetes.KubeConfig: expectedKubeconfig}
+				updatedSecret.Data = map[string][]byte{kubernetes.KubeConfig: expectedUpdatedKubeconfig}
+
+				c.EXPECT().
+					Get(ctx, kutil.Key(secretReference.Namespace, secretReference.Name), gomock.AssignableToTypeOf(&corev1.Secret{})).
+					DoAndReturn(func(_ context.Context, _ client.ObjectKey, obj *corev1.Secret) error {
+						expectedSecret.DeepCopyInto(obj)
+						return nil
+					})
+				test.EXPECTPatch(ctx, c, updatedSecret, expectedSecret, types.MergePatchType)
+
+				updatedKubeconfig, err := UpdateGardenKubeconfigCAIfChanged(ctx, c, expectedKubeconfig, gardenClientConnection)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(updatedKubeconfig).ToNot(Equal(expectedKubeconfig))
+				Expect(updatedKubeconfig).To(Equal(expectedUpdatedKubeconfig))
+			})
+
+			It("should not update the secret if the CA didn't change", func() {
+				gardenClientConnection.GardenClusterCACert = certClientConfig.CAData
+
+				expectedKubeconfig, err := CreateGardenletKubeconfigWithClientCertificate(certClientConfig, nil, nil)
+				Expect(err).ToNot(HaveOccurred())
+
+				updatedKubeconfig, err := UpdateGardenKubeconfigCAIfChanged(ctx, c, expectedKubeconfig, gardenClientConnection)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(updatedKubeconfig).To(Equal(expectedKubeconfig))
+			})
+		})
+
 		Describe("#ComputeGardenletKubeconfigWithBootstrapToken", func() {
 			var (
 				restConfig = &rest.Config{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
Before this change, the gardenlet would only create a new kubeconfig for accessing the garden cluster if it couldn't find one that had been created by a previous bootstrapping process. This way, gardenlet would not notice if the CA of the kube-apiserver changed.

Now, the bootstrapping process - which generates a new kubeconfig for accessing the garden cluster - is also triggered if an existing kubeconfig is found but its CA differs from the CA in the provided bootstrapping kubeconfig.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Gardenlet will now update its kubeconfig if `gardenClientConnection.gardenClusterCACert` is specified and contains a different CA cert than the one currently used in the kubeconfig.
```
