### PR TITLE
Add workaround for switching from kube-proxy mode IPVS to IPTables.

### DIFF
--- a/pkg/operation/botanist/component/kubeproxy/kube_proxy_test.go
+++ b/pkg/operation/botanist/component/kubeproxy/kube_proxy_test.go
@@ -312,7 +312,7 @@ metadata:
   namespace: kube-system
 `
 
-			configMapCleanupScriptName = "kube-proxy-cleanup-script-a4263ada"
+			configMapCleanupScriptName = "kube-proxy-cleanup-script-56490ad9"
 			configMapCleanupScriptYAML = `apiVersion: v1
 data:
   cleanup.sh: |
@@ -322,6 +322,12 @@ data:
       echo "${KUBE_PROXY_MODE}" >"$1"
       echo "Nothing to cleanup - the mode didn't change."
       exit 0
+    fi
+
+    # Workaround kube-proxy bug when switching from ipvs to iptables mode
+    if iptables -t filter -L KUBE-NODE-PORT; then
+      echo "KUBE-NODE-PORT chain exists, flushing it..."
+      iptables -t filter -F KUBE-NODE-PORT
     fi
 
     /usr/local/bin/kube-proxy --v=2 --cleanup --config=/var/lib/kube-proxy-config/config.yaml --proxy-mode="${OLD_KUBE_PROXY_MODE}"

--- a/pkg/operation/botanist/component/kubeproxy/resources/cleanup.sh
+++ b/pkg/operation/botanist/component/kubeproxy/resources/cleanup.sh
@@ -6,5 +6,11 @@ if [ -z "${OLD_KUBE_PROXY_MODE}" ] || [ "${OLD_KUBE_PROXY_MODE}" = "${KUBE_PROXY
   exit 0
 fi
 
+# Workaround kube-proxy bug when switching from ipvs to iptables mode
+if iptables -t filter -L KUBE-NODE-PORT; then
+  echo "KUBE-NODE-PORT chain exists, flushing it..."
+  iptables -t filter -F KUBE-NODE-PORT
+fi
+
 /usr/local/bin/kube-proxy --v=2 --cleanup --config=/var/lib/kube-proxy-config/config.yaml --proxy-mode="${OLD_KUBE_PROXY_MODE}"
 echo "${KUBE_PROXY_MODE}" >"$1"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Add workaround for switching from kube-proxy mode IPVS to IPTables.

The cleanup of kube-proxy seems to be broken since v1.21 when started in IPVS mode.
This workaround flushes the iptables chain KUBE-NODE-PORT in the filter table so that
the cleanup does not fail hard, but continues as desired.

**Which issue(s) this PR fixes**:
Fixes #4599

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix kube-proxy switch from IPVS to IPTables mode.
```
