### PR TITLE
Promote `RotateSSHKeypairOnMaintenance` feature gate to beta

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -30,7 +30,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | SeedKubeScheduler                            | `false` | `Alpha` | `1.15` |        |
 | ReversedVPN                                  | `false` | `Alpha` | `1.22` | `1.41` |
 | ReversedVPN                                  | `true`  | `Beta`  | `1.42` |        |
-| RotateSSHKeypairOnMaintenance                | `false` | `Alpha` | `1.28` |        |
+| RotateSSHKeypairOnMaintenance                | `false` | `Alpha` | `1.28` | `1.44` |
+| RotateSSHKeypairOnMaintenance                | `true`  | `Beta`  | `1.45` |        |
 | WorkerPoolKubernetesVersion                  | `false` | `Alpha` | `1.35` |        |
 | CopyEtcdBackupsDuringControlPlaneMigration   | `false` | `Alpha` | `1.37` |        |
 | SecretBindingProviderValidation              | `false` | `Alpha` | `1.38` |        |

--- a/example/20-componentconfig-gardener-controller-manager.yaml
+++ b/example/20-componentconfig-gardener-controller-manager.yaml
@@ -82,4 +82,4 @@ debugging:
   enableProfiling: false
   enableContentionProfiling: false
 featureGates:
-  RotateSSHKeypairOnMaintenance: false
+  RotateSSHKeypairOnMaintenance: true

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -95,6 +95,7 @@ const (
 	// RotateSSHKeypairOnMaintenance enables SSH keypair rotation in the maintenance controller of the gardener-controller-manager.
 	// owner: @petersutter
 	// alpha: v1.28.0
+	// beta: v1.45.0
 	RotateSSHKeypairOnMaintenance featuregate.Feature = "RotateSSHKeypairOnMaintenance"
 
 	// DenyInvalidExtensionResources causes the seed-admission-controller to deny invalid extension resources (instead of just logging validation errors).
@@ -172,7 +173,7 @@ var allFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	ReversedVPN:                   {Default: true, PreRelease: featuregate.Beta},
 	AdminKubeconfigRequest:        {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	UseDNSRecords:                 {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
-	RotateSSHKeypairOnMaintenance: {Default: false, PreRelease: featuregate.Alpha},
+	RotateSSHKeypairOnMaintenance: {Default: true, PreRelease: featuregate.Beta},
 	DenyInvalidExtensionResources: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	WorkerPoolKubernetesVersion:   {Default: false, PreRelease: featuregate.Alpha},
 	CopyEtcdBackupsDuringControlPlaneMigration: {Default: false, PreRelease: featuregate.Alpha},

--- a/test/integration/controllermanager/shootmaintenance/utils_test.go
+++ b/test/integration/controllermanager/shootmaintenance/utils_test.go
@@ -43,7 +43,7 @@ func waitForShootToBeMaintained(shoot *gardencorev1beta1.Shoot) {
 	By("waiting for shoot to be maintained")
 	Eventually(func(g Gomega) bool {
 		g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
-		return metav1.HasAnnotation(shoot.ObjectMeta, v1beta1constants.GardenerOperation)
+		return shoot.ObjectMeta.Annotations[v1beta1constants.GardenerOperation] == v1beta1constants.ShootOperationMaintain
 	}).Should(BeFalse())
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind enhancement

**What this PR does / why we need it**:
`RotateSSHKeypairOnMaintenance` feature gate in gardener-controller-manager has been promoted to `beta`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`RotateSSHKeypairOnMaintenance` feature gate in gardener-controller-manager has been promoted to `beta` and is now enabled by default.
```

cc @ialidzhikov @petersutter 