### PR TITLE
Add Prometheus scrape configuration for `gardener-resource-manager`

### DIFF
--- a/pkg/operation/botanist/component/resourcemanager/mock/mocks.go
+++ b/pkg/operation/botanist/component/resourcemanager/mock/mocks.go
@@ -35,6 +35,21 @@ func (m *MockInterface) EXPECT() *MockInterfaceMockRecorder {
 	return m.recorder
 }
 
+// AlertingRules mocks base method.
+func (m *MockInterface) AlertingRules() (map[string]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AlertingRules")
+	ret0, _ := ret[0].(map[string]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AlertingRules indicates an expected call of AlertingRules.
+func (mr *MockInterfaceMockRecorder) AlertingRules() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AlertingRules", reflect.TypeOf((*MockInterface)(nil).AlertingRules))
+}
+
 // Deploy mocks base method.
 func (m *MockInterface) Deploy(arg0 context.Context) error {
 	m.ctrl.T.Helper()
@@ -75,6 +90,21 @@ func (m *MockInterface) GetReplicas() *int32 {
 func (mr *MockInterfaceMockRecorder) GetReplicas() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReplicas", reflect.TypeOf((*MockInterface)(nil).GetReplicas))
+}
+
+// ScrapeConfigs mocks base method.
+func (m *MockInterface) ScrapeConfigs() ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ScrapeConfigs")
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ScrapeConfigs indicates an expected call of ScrapeConfigs.
+func (mr *MockInterfaceMockRecorder) ScrapeConfigs() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScrapeConfigs", reflect.TypeOf((*MockInterface)(nil).ScrapeConfigs))
 }
 
 // SetReplicas mocks base method.

--- a/pkg/operation/botanist/component/resourcemanager/monitoring.go
+++ b/pkg/operation/botanist/component/resourcemanager/monitoring.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourcemanager
+
+import (
+	"bytes"
+	"strings"
+	"text/template"
+
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+)
+
+const (
+	monitoringPrometheusJobName = "resourcemanager"
+
+	monitoringMetricGo                      = "go_.+"
+	monitoringMetricWorkQueue               = "workqueue_.+"
+	monitoringMetricControllerRuntime       = "controller_runtime_.+"
+	monitoringMetricRestClientRequestsTotal = "rest_client_requests_total"
+)
+
+var (
+	monitoringAllowedMetrics = []string{
+		monitoringMetricGo,
+		monitoringMetricWorkQueue,
+		monitoringMetricControllerRuntime,
+		monitoringMetricRestClientRequestsTotal,
+	}
+
+	monitoringScrapeConfigTmpl = `job_name: ` + monitoringPrometheusJobName + `
+honor_labels: false
+kubernetes_sd_configs:
+- role: endpoints
+  namespaces:
+    names: [{{ .namespace }}]
+relabel_configs:
+- source_labels:
+  - __meta_kubernetes_service_name
+  - __meta_kubernetes_endpoint_port_name
+  action: keep
+  regex: ` + serviceName + `;` + metricsPortName + `
+- action: labelmap
+  regex: __meta_kubernetes_service_label_(.+)
+- source_labels: [ __meta_kubernetes_pod_name ]
+  target_label: pod
+metric_relabel_configs:
+- source_labels: [ __name__ ]
+  action: keep
+  regex: ^(` + strings.Join(monitoringAllowedMetrics, "|") + `)$
+`
+
+	monitoringScrapeConfigTemplate *template.Template
+)
+
+func init() {
+	var err error
+
+	monitoringScrapeConfigTemplate, err = template.New("monitoring-scrape-config").Parse(monitoringScrapeConfigTmpl)
+	utilruntime.Must(err)
+}
+
+// ScrapeConfigs returns the scrape configurations for Prometheus.
+func (c *resourceManager) ScrapeConfigs() ([]string, error) {
+	var scrapeConfig bytes.Buffer
+
+	if err := monitoringScrapeConfigTemplate.Execute(&scrapeConfig, map[string]interface{}{"namespace": c.namespace}); err != nil {
+		return nil, err
+	}
+
+	return []string{scrapeConfig.String()}, nil
+}
+
+// AlertingRules returns the alerting rules for AlertManager.
+func (c *resourceManager) AlertingRules() (map[string]string, error) {
+	return nil, nil
+}

--- a/pkg/operation/botanist/component/resourcemanager/monitoring.go
+++ b/pkg/operation/botanist/component/resourcemanager/monitoring.go
@@ -16,29 +16,16 @@ package resourcemanager
 
 import (
 	"bytes"
-	"strings"
 	"text/template"
 
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
 
 const (
-	monitoringPrometheusJobName = "resourcemanager"
-
-	monitoringMetricGo                      = "go_.+"
-	monitoringMetricWorkQueue               = "workqueue_.+"
-	monitoringMetricControllerRuntime       = "controller_runtime_.+"
-	monitoringMetricRestClientRequestsTotal = "rest_client_requests_total"
+	monitoringPrometheusJobName = "gardener-resource-manager"
 )
 
 var (
-	monitoringAllowedMetrics = []string{
-		monitoringMetricGo,
-		monitoringMetricWorkQueue,
-		monitoringMetricControllerRuntime,
-		monitoringMetricRestClientRequestsTotal,
-	}
-
 	monitoringScrapeConfigTmpl = `job_name: ` + monitoringPrometheusJobName + `
 honor_labels: false
 kubernetes_sd_configs:
@@ -55,10 +42,8 @@ relabel_configs:
   regex: __meta_kubernetes_service_label_(.+)
 - source_labels: [ __meta_kubernetes_pod_name ]
   target_label: pod
-metric_relabel_configs:
-- source_labels: [ __name__ ]
-  action: keep
-  regex: ^(` + strings.Join(monitoringAllowedMetrics, "|") + `)$
+- source_labels: [ __meta_kubernetes_namespace ]
+  target_label: namespace
 `
 
 	monitoringScrapeConfigTemplate *template.Template

--- a/pkg/operation/botanist/component/resourcemanager/monitoring_test.go
+++ b/pkg/operation/botanist/component/resourcemanager/monitoring_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 var _ = Describe("Monitoring", func() {
-	resourceManager := New(nil, "", nil, "", Values{})
+	resourceManager := New(nil, "shoot--foo--bar", nil, "", Values{})
 
 	Describe("#ScrapeConfig", func() {
 		It("should successfully test the scrape configuration", func() {
@@ -32,12 +32,12 @@ var _ = Describe("Monitoring", func() {
 })
 
 const (
-	expectedScrapeConfig = `job_name: resourcemanager
+	expectedScrapeConfig = `job_name: gardener-resource-manager
 honor_labels: false
 kubernetes_sd_configs:
 - role: endpoints
   namespaces:
-    names: []
+    names: [shoot--foo--bar]
 relabel_configs:
 - source_labels:
   - __meta_kubernetes_service_name
@@ -48,9 +48,7 @@ relabel_configs:
   regex: __meta_kubernetes_service_label_(.+)
 - source_labels: [ __meta_kubernetes_pod_name ]
   target_label: pod
-metric_relabel_configs:
-- source_labels: [ __name__ ]
-  action: keep
-  regex: ^(go_.+|workqueue_.+|controller_runtime_.+|rest_client_requests_total)$
+- source_labels: [ __meta_kubernetes_namespace ]
+  target_label: namespace
 `
 )

--- a/pkg/operation/botanist/component/resourcemanager/monitoring_test.go
+++ b/pkg/operation/botanist/component/resourcemanager/monitoring_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resourcemanager_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+
+	. "github.com/gardener/gardener/pkg/operation/botanist/component/resourcemanager"
+	"github.com/gardener/gardener/pkg/operation/botanist/component/test"
+)
+
+var _ = Describe("Monitoring", func() {
+	resourceManager := New(nil, "", nil, "", Values{})
+
+	Describe("#ScrapeConfig", func() {
+		It("should successfully test the scrape configuration", func() {
+			test.ScrapeConfigs(resourceManager, expectedScrapeConfig)
+		})
+	})
+})
+
+const (
+	expectedScrapeConfig = `job_name: resourcemanager
+honor_labels: false
+kubernetes_sd_configs:
+- role: endpoints
+  namespaces:
+    names: []
+relabel_configs:
+- source_labels:
+  - __meta_kubernetes_service_name
+  - __meta_kubernetes_endpoint_port_name
+  action: keep
+  regex: gardener-resource-manager;metrics
+- action: labelmap
+  regex: __meta_kubernetes_service_label_(.+)
+- source_labels: [ __meta_kubernetes_pod_name ]
+  target_label: pod
+metric_relabel_configs:
+- source_labels: [ __name__ ]
+  action: keep
+  regex: ^(go_.+|workqueue_.+|controller_runtime_.+|rest_client_requests_total)$
+`
+)

--- a/pkg/operation/botanist/component/resourcemanager/resource_manager.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager.go
@@ -67,6 +67,7 @@ const (
 	clusterRoleName    = "gardener-resource-manager-seed"
 	roleName           = "gardener-resource-manager"
 	serviceAccountName = "gardener-resource-manager"
+	metricsPortName    = "metrics"
 	containerName      = v1beta1constants.DeploymentNameGardenerResourceManager
 	healthPort         = 8081
 	metricsPort        = 8080
@@ -129,6 +130,7 @@ var (
 // Interface contains functions for a gardener-resource-manager deployer.
 type Interface interface {
 	component.DeployWaiter
+	component.MonitoringComponent
 	// GetReplicas gets the Replicas field in the Values.
 	GetReplicas() *int32
 	// SetReplicas sets the Replicas field in the Values.
@@ -392,9 +394,8 @@ func (r *resourceManager) emptyRoleBindingInWatchedNamespace() *rbacv1.RoleBindi
 
 func (r *resourceManager) ensureService(ctx context.Context) error {
 	const (
-		healthPortName  = "health"
-		metricsPortName = "metrics"
-		serverPortName  = "server"
+		healthPortName = "health"
+		serverPortName = "server"
 	)
 
 	// TODO(rfranzke): This can be removed in a future version.

--- a/pkg/operation/botanist/monitoring.go
+++ b/pkg/operation/botanist/monitoring.go
@@ -97,6 +97,7 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 		b.Shoot.Components.SystemComponents.CoreDNS,
 		b.Shoot.Components.SystemComponents.KubeProxy,
 		b.Shoot.Components.SystemComponents.VPNShoot,
+		b.Shoot.Components.ControlPlane.ResourceManager,
 	}
 
 	if b.Shoot.NodeLocalDNSEnabled {

--- a/pkg/operation/botanist/monitoring.go
+++ b/pkg/operation/botanist/monitoring.go
@@ -94,10 +94,10 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 		b.Shoot.Components.ControlPlane.KubeAPIServer,
 		b.Shoot.Components.ControlPlane.KubeScheduler,
 		b.Shoot.Components.ControlPlane.KubeControllerManager,
+		b.Shoot.Components.ControlPlane.ResourceManager,
 		b.Shoot.Components.SystemComponents.CoreDNS,
 		b.Shoot.Components.SystemComponents.KubeProxy,
 		b.Shoot.Components.SystemComponents.VPNShoot,
-		b.Shoot.Components.ControlPlane.ResourceManager,
 	}
 
 	if b.Shoot.NodeLocalDNSEnabled {

--- a/pkg/operation/botanist/monitoring_test.go
+++ b/pkg/operation/botanist/monitoring_test.go
@@ -32,6 +32,7 @@ import (
 	mockkubecontrollermanager "github.com/gardener/gardener/pkg/operation/botanist/component/kubecontrollermanager/mock"
 	mockkubeproxy "github.com/gardener/gardener/pkg/operation/botanist/component/kubeproxy/mock"
 	mockkubescheduler "github.com/gardener/gardener/pkg/operation/botanist/component/kubescheduler/mock"
+	mockresourcemanager "github.com/gardener/gardener/pkg/operation/botanist/component/resourcemanager/mock"
 	mockvpnshoot "github.com/gardener/gardener/pkg/operation/botanist/component/vpnshoot/mock"
 	gardenpkg "github.com/gardener/gardener/pkg/operation/garden"
 	seedpkg "github.com/gardener/gardener/pkg/operation/seed"
@@ -79,6 +80,7 @@ var _ = Describe("Monitoring", func() {
 		mockCoreDNS               *mockcoredns.MockInterface
 		mockKubeProxy             *mockkubeproxy.MockInterface
 		mockVPNShoot              *mockvpnshoot.MockInterface
+		mockResourceManager       *mockresourcemanager.MockInterface
 
 		botanist *Botanist
 
@@ -116,6 +118,7 @@ var _ = Describe("Monitoring", func() {
 		mockCoreDNS = mockcoredns.NewMockInterface(ctrl)
 		mockKubeProxy = mockkubeproxy.NewMockInterface(ctrl)
 		mockVPNShoot = mockvpnshoot.NewMockInterface(ctrl)
+		mockResourceManager = mockresourcemanager.NewMockInterface(ctrl)
 
 		botanist = &Botanist{
 			Operation: &operation.Operation{
@@ -141,6 +144,7 @@ var _ = Describe("Monitoring", func() {
 							KubeAPIServer:         mockKubeAPIServer,
 							KubeScheduler:         mockKubeScheduler,
 							KubeControllerManager: mockKubeControllerManager,
+							ResourceManager:       mockResourceManager,
 						},
 						SystemComponents: &shootpkg.SystemComponents{
 							CoreDNS:   mockCoreDNS,
@@ -198,6 +202,8 @@ var _ = Describe("Monitoring", func() {
 			mockKubeProxy.EXPECT().AlertingRules()
 			mockVPNShoot.EXPECT().ScrapeConfigs()
 			mockVPNShoot.EXPECT().AlertingRules()
+			mockResourceManager.EXPECT().ScrapeConfigs()
+			mockResourceManager.EXPECT().AlertingRules()
 		})
 
 		It("should delete the legacy ingress secrets", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Part of #5547

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
