### PR TITLE
Add qps and burst for the vpa-recommender for Shoots and Seeds

### DIFF
--- a/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-recommender.yaml
+++ b/charts/seed-bootstrap/charts/vpa/charts/runtime/templates/deployment-recommender.yaml
@@ -55,6 +55,8 @@ spec:
         - --pod-recommendation-min-memory-mb=10
         - --recommendation-margin-fraction={{ .Values.recommender.recommendationMarginFraction }}
         - --recommender-interval={{ .Values.recommender.interval }}
+        - --kube-api-qps=100
+        - --kube-api-burst=120
 {{- if not .Values.recommender.createServiceAccount }}
         env:
         - name: KUBERNETES_SERVICE_HOST


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
The default values for qps and burst (5/10) for the vpa-recommender are too low for large Seed clusters. 
For Seed clusters with 250 Shoots and > 3800 vpa resource, we can observe an execution latency (until Vpa recommendations are provided) of 1.17min (down from 30 minutes).

The new settings cause around 80 queries/second on the API server (up from 10 qps). To have a little buffer, a qps of 100 seems reasonable.
The increase in the request rate to the API Server of 70 qps did not seem to negatively affect the API Server.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Increase the QPS and burst values for `kube-apiserver` requests for the `vpa-recommender` of Seed and Shoot clusters to better cope with large cluster sizes.
```
