### PR TITLE
Improve control plane migration integration tests

### DIFF
--- a/test/framework/shootmigrationtest.go
+++ b/test/framework/shootmigrationtest.go
@@ -29,6 +29,7 @@ import (
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/utils"
+	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 
 	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
 
@@ -71,9 +72,10 @@ type ShootMigrationConfig struct {
 
 // ShootComparisonElements contains details about Machines and Nodes that will be compared during the tests
 type ShootComparisonElements struct {
-	MachineNames []string
-	MachineNodes []string
-	NodeNames    []string
+	MachineNames   []string
+	MachineNodes   []string
+	NodeNames      []string
+	SecretsDataMap map[string]map[string][]byte
 }
 
 // NewShootMigrationTest creates a new simple shoot migration test
@@ -170,6 +172,27 @@ func (t *ShootMigrationTest) GetMachineDetails(ctx context.Context, seedClient k
 	return
 }
 
+// GetPersistedSecrets uses the seedClient to fetch the data of all Secrets that have the `persist` label key set to true
+// from the Shoot's control plane namespace
+func (t *ShootMigrationTest) GetPersistedSecrets(ctx context.Context, seedClient kubernetes.Interface) (map[string]map[string][]byte, error) {
+	secretList := &corev1.SecretList{}
+	if err := seedClient.Client().List(
+		ctx,
+		secretList,
+		client.InNamespace(t.SeedShootNamespace),
+		client.MatchingLabels(map[string]string{secretsmanager.LabelKeyPersist: secretsmanager.LabelValueTrue}),
+	); err != nil {
+		return nil, err
+	}
+
+	secretsDataMap := map[string]map[string][]byte{}
+	for _, secret := range secretList.Items {
+		secretsDataMap[secret.Name] = secret.Data
+	}
+
+	return secretsDataMap, nil
+}
+
 // PopulateBeforeMigrationComparisonElements fills the ShootMigrationTest.ComparisonElementsBeforeMigration with the necessary Machine details and Node names
 func (t *ShootMigrationTest) PopulateBeforeMigrationComparisonElements(ctx context.Context) (err error) {
 	t.ComparisonElementsBeforeMigration.MachineNames, t.ComparisonElementsBeforeMigration.MachineNodes, err = t.GetMachineDetails(ctx, t.SourceSeedClient)
@@ -177,7 +200,10 @@ func (t *ShootMigrationTest) PopulateBeforeMigrationComparisonElements(ctx conte
 		return
 	}
 	t.ComparisonElementsBeforeMigration.NodeNames, err = t.GetNodeNames(ctx, t.ShootClient)
-
+	if err != nil {
+		return
+	}
+	t.ComparisonElementsBeforeMigration.SecretsDataMap, err = t.GetPersistedSecrets(ctx, t.SourceSeedClient)
 	return
 }
 
@@ -188,7 +214,10 @@ func (t *ShootMigrationTest) PopulateAfterMigrationComparisonElements(ctx contex
 		return
 	}
 	t.ComparisonElementsAfterMigration.NodeNames, err = t.GetNodeNames(ctx, t.ShootClient)
-
+	if err != nil {
+		return
+	}
+	t.ComparisonElementsAfterMigration.SecretsDataMap, err = t.GetPersistedSecrets(ctx, t.TargetSeedClient)
 	return
 }
 
@@ -205,8 +234,18 @@ func (t *ShootMigrationTest) CompareElementsAfterMigration() error {
 	}
 	if !reflect.DeepEqual(t.ComparisonElementsAfterMigration.MachineNodes, t.ComparisonElementsAfterMigration.NodeNames) {
 		return fmt.Errorf("machine Nodes (label) %s, do not match after-migrate Nodes %s", t.ComparisonElementsAfterMigration.MachineNodes, t.ComparisonElementsAfterMigration.NodeNames)
-
 	}
+
+	differingSecrets := []string{}
+	for name, entry := range t.ComparisonElementsBeforeMigration.SecretsDataMap {
+		if !reflect.DeepEqual(entry, t.ComparisonElementsAfterMigration.SecretsDataMap[name]) {
+			differingSecrets = append(differingSecrets, name)
+		}
+	}
+	if len(differingSecrets) > 0 {
+		return fmt.Errorf("the following secrets did not have their data persisted during control plane migration: %v", differingSecrets)
+	}
+
 	return nil
 }
 
@@ -237,6 +276,11 @@ func (t *ShootMigrationTest) CheckObjectsTimestamp(ctx context.Context, mrExclud
 
 					if err := t.ShootClient.Client().Get(ctx, client.ObjectKey{Namespace: r.Namespace, Name: r.Name}, obj); err != nil {
 						return err
+					}
+
+					// Ignore immutable objects because if their data changes, they will be recreated
+					if isImmutable, ok := obj.Object["immutable"]; ok && isImmutable == true {
+						continue
 					}
 
 					creationTimestamp := obj.GetCreationTimestamp()


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/area testing
/kind enhancement test

**What this PR does / why we need it**:
After #5587 it is no longer possible to update the `shoot.Spec` and the `shoot.Spec.SeedName` at the same time. However, in the control plane migration integration tests we try to add new tolerations on shoots at the same time as changing the seedName. This PR refactors the code so that the tolerations and the `shoot.Spec.SeedName` are updated with separate `Update()` calls.

Additionally the PR includes the following:
- Secrets that have the `persist` label set to true so that they are persisted in the `ShootState` are checked so that we are sure that they are not regenerated when the control plane is recreated on the destination seed. Also objects in the shoot cluster managed by the gardener resource manager that have `immutable: true` are no longer checked to see if their creationTimestamps are after the timestamp of when the migration was triggered.
- The additional checks that are executed after the control plane migration has completed, are now only executed if the migration completed successfully.

**Which issue(s) this PR fixes**:
Fixes #5731 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
