### PR TITLE
Cleanup more legacy secrets from `ShootState`

### DIFF
--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -342,6 +342,17 @@ func (b *Botanist) GenerateAndSaveSecrets(ctx context.Context) error {
 			"vpn-seed",
 			"vpn-seed-tlsauth",
 			"vpn-seed-server",
+			"monitoring-ingress-credentials",
+			"monitoring-ingress-credentials-users",
+			"gardener-resource-manager",
+			"kube-proxy",
+			"cloud-config-downloader",
+			"kibana-tls",
+			"elasticsearch-logging-server",
+			"sg-admin-client",
+			"kibana-logging-sg-credentials",
+			"curator-sg-credentials",
+			"admin-sg-credentials",
 		} {
 			gardenerResourceDataList.Delete(name)
 		}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability security
/kind cleanup

**What this PR does / why we need it**:
This PR cleans up more legacy secrets from the `ShootState` which are no longer needed. The affected secrets were eliminated as part of the following PRs:

- https://github.com/gardener/gardener/pull/5608
- https://github.com/gardener/gardener/pull/5138
- https://github.com/gardener/gardener/pull/5099
- https://github.com/gardener/gardener/pull/5121
- https://github.com/gardener/gardener/pull/2515

**Special notes for your reviewer**:
/cc @timebertt 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
