### PR TITLE
Increase Loki memory limit to 3Gi

### DIFF
--- a/charts/seed-bootstrap/charts/loki/values.yaml
+++ b/charts/seed-bootstrap/charts/loki/values.yaml
@@ -51,7 +51,8 @@ replicas: 1
 resources:
   loki:
     limits:
-      memory: 10Gi
+# TODO(vlvasilev): After fixing the following issue https://github.com/gardener/gardener/issues/5757, set the memory limit to 10Gi.
+      memory: 3Gi
     requests:
       cpu: 200m
       memory: 300Mi
@@ -110,7 +111,7 @@ hvpa:
   enabled: false
   maxAllowed:
     cpu: 800m
-    memory: 2G
+    memory: 3Gi
   minAllowed:
     cpu: 200m
     memory: 300M


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
With this PR the Loki memory limit is increased to 3Gi

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Loki memory limit is increased to 3Gi.
```
