### PR TITLE
Eliminate usages of generated client sets in `kubernetes.Interface.Kubernetes()`

### DIFF
--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -322,25 +322,16 @@ func DeleteGrafanaByRole(ctx context.Context, k8sClient kubernetes.Interface, na
 		return fmt.Errorf("require kubernetes client")
 	}
 
-	if err := k8sClient.Client().DeleteAllOf(
-		ctx,
-		&appsv1.Deployment{},
-		client.InNamespace(namespace),
-		client.MatchingLabels{
-			"component": "grafana",
-			"role":      role,
-		},
-		client.PropagationPolicy(metav1.DeletePropagationForeground),
-	); client.IgnoreNotFound(err) != nil {
-		return err
-	}
-
 	deleteOptions := []client.DeleteAllOfOption{
 		client.InNamespace(namespace),
 		client.MatchingLabels{
 			"component": "grafana",
 			"role":      role,
 		},
+	}
+
+	if err := k8sClient.Client().DeleteAllOf(ctx, &appsv1.Deployment{}, append(deleteOptions, client.PropagationPolicy(metav1.DeletePropagationForeground))...); client.IgnoreNotFound(err) != nil {
+		return err
 	}
 
 	if err := k8sClient.Client().DeleteAllOf(ctx, &corev1.ConfigMap{}, deleteOptions...); client.IgnoreNotFound(err) != nil {

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -36,7 +36,6 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	schedulingv1 "k8s.io/api/scheduling/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -323,37 +322,49 @@ func DeleteGrafanaByRole(ctx context.Context, k8sClient kubernetes.Interface, na
 		return fmt.Errorf("require kubernetes client")
 	}
 
-	listOptions := metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("%s=%s,%s=%s", "component", "grafana", "role", role),
-	}
-
-	deletePropagation := metav1.DeletePropagationForeground
-	if err := k8sClient.Kubernetes().AppsV1().Deployments(namespace).DeleteCollection(
+	if err := k8sClient.Client().DeleteAllOf(
 		ctx,
-		metav1.DeleteOptions{
-			PropagationPolicy: &deletePropagation,
-		}, listOptions); err != nil && !apierrors.IsNotFound(err) {
+		&appsv1.Deployment{},
+		client.InNamespace(namespace),
+		client.MatchingLabels{
+			"component": "grafana",
+			"role":      role,
+		},
+		client.PropagationPolicy(metav1.DeletePropagationForeground),
+	); client.IgnoreNotFound(err) != nil {
 		return err
 	}
 
-	if err := k8sClient.Kubernetes().CoreV1().ConfigMaps(namespace).DeleteCollection(
-		ctx, metav1.DeleteOptions{}, listOptions); err != nil && !apierrors.IsNotFound(err) {
+	deleteOptions := []client.DeleteAllOfOption{
+		client.InNamespace(namespace),
+		client.MatchingLabels{
+			"component": "grafana",
+			"role":      role,
+		},
+	}
+
+	if err := k8sClient.Client().DeleteAllOf(ctx, &corev1.ConfigMap{}, deleteOptions...); client.IgnoreNotFound(err) != nil {
 		return err
 	}
 
-	if err := k8sClient.Kubernetes().ExtensionsV1beta1().Ingresses(namespace).DeleteCollection(
-		ctx, metav1.DeleteOptions{}, listOptions); err != nil && !apierrors.IsNotFound(err) {
+	if err := k8sClient.Client().DeleteAllOf(ctx, &extensionsv1beta1.Ingress{}, deleteOptions...); client.IgnoreNotFound(err) != nil {
 		return err
 	}
 
-	if err := k8sClient.Kubernetes().CoreV1().Secrets(namespace).DeleteCollection(
-		ctx, metav1.DeleteOptions{}, listOptions); err != nil && !apierrors.IsNotFound(err) {
+	if err := k8sClient.Client().DeleteAllOf(ctx, &corev1.Secret{}, deleteOptions...); client.IgnoreNotFound(err) != nil {
 		return err
 	}
 
-	if err := k8sClient.Kubernetes().CoreV1().Services(namespace).Delete(
-		ctx, fmt.Sprintf("grafana-%s", role), metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+	if err := k8sClient.Client().Delete(
+		ctx,
+		&corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "grafana-" + role,
+				Namespace: namespace,
+			}},
+	); client.IgnoreNotFound(err) != nil {
 		return err
 	}
+
 	return nil
 }

--- a/test/testmachinery/shoots/operations/worker.go
+++ b/test/testmachinery/shoots/operations/worker.go
@@ -36,7 +36,7 @@ import (
 	"fmt"
 	"time"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
 
 	"github.com/gardener/gardener/test/framework"
 
@@ -112,7 +112,8 @@ var _ = ginkgo.Describe("Shoot worker operation testing", func() {
 			ginkgo.Skip("the test requires at least 2 different worker os images")
 		}
 
-		nodesList, err := f.ShootClient.Kubernetes().CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+		nodesList := &corev1.NodeList{}
+		err := f.ShootClient.Client().List(ctx, nodesList)
 		framework.ExpectNoError(err)
 
 		nodeImages := map[string]bool{}

--- a/test/testmachinery/shoots/operations/worker.go
+++ b/test/testmachinery/shoots/operations/worker.go
@@ -112,12 +112,12 @@ var _ = ginkgo.Describe("Shoot worker operation testing", func() {
 			ginkgo.Skip("the test requires at least 2 different worker os images")
 		}
 
-		nodesList := &corev1.NodeList{}
-		err := f.ShootClient.Client().List(ctx, nodesList)
+		nodeList := &corev1.NodeList{}
+		err := f.ShootClient.Client().List(ctx, nodeList)
 		framework.ExpectNoError(err)
 
 		nodeImages := map[string]bool{}
-		for _, node := range nodesList.Items {
+		for _, node := range nodeList.Items {
 			if _, ok := nodeImages[node.Status.NodeInfo.OSImage]; !ok {
 				nodeImages[node.Status.NodeInfo.OSImage] = true
 			}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality networking cost
/kind enhancement

**What this PR does / why we need it**:
This PR eliminates the usages of generated clientsets in kubernetes.Interface.Kubernetes() wherever appropriate in favour of cached controller runtime cients.


**Which issue(s) this PR fixes**:
Fixes Part of #2414 

**Special notes for your reviewer**:


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
