### PR TITLE
Prevent writing newlines to nodename file

### DIFF
--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/executor_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/executor_test.go
@@ -303,11 +303,11 @@ fi
 
 # Try to find Node object for this machine if already registered to the cluster.
 NODENAME=
-if [[ -s "/var/lib/kubelet/nodename" ]]; then
+if [[ -s "/var/lib/kubelet/nodename" ]] && [[ ! -z "$(cat "/var/lib/kubelet/nodename")" ]]; then
   NODENAME="$(cat "/var/lib/kubelet/nodename")"
 elif [[ -f "/var/lib/kubelet/kubeconfig-real" ]]; then
   NODENAME="$(/opt/bin/kubectl --kubeconfig="/var/lib/kubelet/kubeconfig-real" get nodes -l "kubernetes.io/hostname=$(hostname | tr '[:upper:]' '[:lower:]')" -o go-template="{{ if .items }}{{ (index .items 0).metadata.name }}{{ end }}")"
-  echo "$NODENAME" > "/var/lib/kubelet/nodename"
+  echo -n "$NODENAME" > "/var/lib/kubelet/nodename"
 fi
 
 # Check if node is annotated with information about to-be-restarted systemd services

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/templates/scripts/execute-cloud-config.tpl.sh
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/templates/scripts/execute-cloud-config.tpl.sh
@@ -173,11 +173,11 @@ fi
 
 # Try to find Node object for this machine if already registered to the cluster.
 NODENAME=
-if [[ -s "{{ .pathNodeName }}" ]]; then
+if [[ -s "{{ .pathNodeName }}" ]] && [[ ! -z "$(cat "{{ .pathNodeName }}")" ]]; then
   NODENAME="$(cat "{{ .pathNodeName }}")"
 elif [[ -f "{{ .pathKubeletKubeconfigReal }}" ]]; then
   {{`NODENAME="$(`}}{{ .pathBinaries }}{{`/kubectl --kubeconfig="`}}{{ .pathKubeletKubeconfigReal }}{{`" get nodes -l "kubernetes.io/hostname=$(hostname | tr '[:upper:]' '[:lower:]')" -o go-template="{{ if .items }}{{ (index .items 0).metadata.name }}{{ end }}")"`}}
-  echo "$NODENAME" > "{{ .pathNodeName }}"
+  echo -n "$NODENAME" > "{{ .pathNodeName }}"
 fi
 
 # Check if node is annotated with information about to-be-restarted systemd services


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
When fetching the node name fails then the `NODENAME` variable is empty. However, a newline is written to the `/var/lib/kubelet/nodename` file:

```
$ echo "" > /tmp/foo
$ ls -l /tmp/foo
-rw-r--r-- 1 rfranzke rfranzke 1 Apr  7 09:06 /tmp/foo
$ [[ -s /tmp/foo ]] && echo "nothing to be done"
nothing to be done
```

However, when preventing `echo` from writing a trailing newline, the `[[ -s ... ]]` condition works as expected:

```
$ echo -n "" > /tmp/bar
$ ls -l /tmp/bar
-rw-r--r-- 1 rfranzke rfranzke 0 Apr  7 09:08 /tmp/bar
$ [[ -s /tmp/bar ]] && echo "nothing to be done"
# no output here!
```

**Special notes for your reviewer**:
/cc @vpnachev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
An issue preventing nodes from updating their downloaded cloud config checksum annotation has been fixed.
```
