### PR TITLE
[GEP-18] Fix basic auth secret migration for secrets without CSV data

### DIFF
--- a/pkg/utils/secrets/manager/generate.go
+++ b/pkg/utils/secrets/manager/generate.go
@@ -146,10 +146,15 @@ func (m *manager) keepExistingSecretsIfNeeded(ctx context.Context, configName st
 			return newData, nil
 		}
 
-		existingBasicAuth, err := secretutils.LoadBasicAuthFromCSV("", existingSecret.Data[secretutils.DataKeyCSV])
-		if err != nil {
-			return nil, err
+		existingPassword, ok := existingSecret.Data[secretutils.DataKeyPassword]
+		if !ok {
+			existingBasicAuth, err := secretutils.LoadBasicAuthFromCSV("", existingSecret.Data[secretutils.DataKeyCSV])
+			if err != nil {
+				return nil, err
+			}
+			existingPassword = []byte(existingBasicAuth.Password)
 		}
+
 		newBasicAuth, err := secretutils.LoadBasicAuthFromCSV("", newData[secretutils.DataKeyCSV])
 		if err != nil {
 			return nil, err
@@ -159,7 +164,7 @@ func (m *manager) keepExistingSecretsIfNeeded(ctx context.Context, configName st
 			newBasicAuth.Format = secretutils.BasicAuthFormatNormal
 		}
 
-		newBasicAuth.Password = existingBasicAuth.Password
+		newBasicAuth.Password = string(existingPassword)
 		return newBasicAuth.SecretData(), nil
 
 	case "kube-apiserver-static-token":

--- a/pkg/utils/secrets/manager/generate_test.go
+++ b/pkg/utils/secrets/manager/generate_test.go
@@ -661,6 +661,36 @@ resources:
 					Expect(basicAuth.Password).To(Equal(oldPassword))
 					Expect(secret.Data).To(And(HaveKey("username"), HaveKey("password"), HaveKey("auth")))
 				})
+
+				It("should keep the existing password if old secret still exists (w/o CSV)", func() {
+					oldBasicAuth := &secretutils.BasicAuth{
+						Format:   secretutils.BasicAuthFormatNormal,
+						Username: userName,
+						Password: oldPassword,
+					}
+
+					By("creating existing secret with old password")
+					existingSecret := &corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "monitoring-ingress-credentials",
+							Namespace: namespace,
+						},
+						Type: corev1.SecretTypeOpaque,
+						Data: oldBasicAuth.SecretData(),
+					}
+					delete(existingSecret.Data, secretutils.DataKeyCSV)
+					Expect(fakeClient.Create(ctx, existingSecret)).To(Succeed())
+
+					By("generating secret")
+					secret, err := m.Generate(ctx, config)
+					Expect(err).NotTo(HaveOccurred())
+
+					By("verifying old password was kept")
+					basicAuth, err := secretutils.LoadBasicAuthFromCSV("", secret.Data[secretutils.DataKeyCSV])
+					Expect(err).NotTo(HaveOccurred())
+					Expect(basicAuth.Password).To(Equal(oldPassword))
+					Expect(secret.Data).To(And(HaveKey("username"), HaveKey("password"), HaveKey("auth")))
+				})
 			})
 
 			Context("shoot monitoring ingress credentials (users)", func() {
@@ -706,6 +736,36 @@ resources:
 						Type: corev1.SecretTypeOpaque,
 						Data: oldBasicAuth.SecretData(),
 					}
+					Expect(fakeClient.Create(ctx, existingSecret)).To(Succeed())
+
+					By("generating secret")
+					secret, err := m.Generate(ctx, config)
+					Expect(err).NotTo(HaveOccurred())
+
+					By("verifying old password was kept")
+					basicAuth, err := secretutils.LoadBasicAuthFromCSV("", secret.Data[secretutils.DataKeyCSV])
+					Expect(err).NotTo(HaveOccurred())
+					Expect(basicAuth.Password).To(Equal(oldPassword))
+					Expect(secret.Data).To(And(HaveKey("username"), HaveKey("password"), HaveKey("auth")))
+				})
+
+				It("should keep the existing password if old secret still exists (w/o CSV)", func() {
+					oldBasicAuth := &secretutils.BasicAuth{
+						Format:   secretutils.BasicAuthFormatNormal,
+						Username: userName,
+						Password: oldPassword,
+					}
+
+					By("creating existing secret with old password")
+					existingSecret := &corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "monitoring-ingress-credentials-users",
+							Namespace: namespace,
+						},
+						Type: corev1.SecretTypeOpaque,
+						Data: oldBasicAuth.SecretData(),
+					}
+					delete(existingSecret.Data, secretutils.DataKeyCSV)
 					Expect(fakeClient.Create(ctx, existingSecret)).To(Succeed())
 
 					By("generating secret")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bug

**What this PR does / why we need it**:
With #5608 we are migrating the `monitoring-ingress-credentials{-users}` secrets from the legacy secrets management to the new secrets manager. However, for existing shoot clusters which were created a long time ago, the existing secrets do not have the `.data["basic_auth.csv"]` key (this was only introduced with #353). Hence, the migration failed with

```
Flow "Shoot cluster reconciliation" encountered task errors: [task
"Reconciling Grafana for Shoot in Seed for the logging stack" failed:
retry failed with context deadline exceeded, last error: invalid CSV for
loading basic auth data:  task "Deploying Shoot monitoring stack in Seed"
failed: retry failed with context deadline exceeded, last error: secret
"observability-ingress" not found]
```

**Special notes for your reviewer**:
/cc @timebertt @ialidzhikov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed which prevented the migration of existing basic auth secrets without CSV data to the new secrets manager.
```
