### PR TITLE
Only download full cloud config if checksum annotation changed

### DIFF
--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/downloader/downloader.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/downloader/downloader.go
@@ -102,14 +102,18 @@ const (
 	// PathBootstrapToken is the path of a file on the shoot worker nodes in which the bootstrap token for the kubelet
 	// bootstrap is stored.
 	PathBootstrapToken = PathCredentialsDirectory + "/bootstrap-token"
-	// BootstrapTokenPlaceholder is the token that is expected to be replaced by the worker controller with the actual token
+	// BootstrapTokenPlaceholder is the token that is expected to be replaced by the worker controller with the actual
+	// token.
 	BootstrapTokenPlaceholder = "<<BOOTSTRAP_TOKEN>>"
 	// PathDownloadedCloudConfig is the path on the shoot worker nodes at which the downloaded cloud-config user-data
 	// will be stored.
 	PathDownloadedCloudConfig = PathDownloadsDirectory + "/cloud_config"
+	// PathDownloadedExecutorScript is the path on the shoot worker nodes at which the downloaded executor script will
+	// be stored.
+	PathDownloadedExecutorScript = PathDownloadsDirectory + "/execute-cloud-config.sh"
 	// PathDownloadedCloudConfigChecksum is the path on the shoot worker nodes at which the checksum of the downloaded
 	// cloud-config user-data will be stored.
-	PathDownloadedCloudConfigChecksum = PathCCDDirectory + "/downloaded_checksum"
+	PathDownloadedCloudConfigChecksum = PathDownloadsDirectory + "/execute-cloud-config-checksum"
 )
 
 // Config returns the units and the files for the OperatingSystemConfig that downloads the actual cloud-config user
@@ -122,18 +126,20 @@ const (
 func Config(cloudConfigUserDataSecretName, apiServerURL string) ([]extensionsv1alpha1.Unit, []extensionsv1alpha1.File, error) {
 	var ccdScript bytes.Buffer
 	if err := tpl.Execute(&ccdScript, map[string]string{
-		"secretName":                cloudConfigUserDataSecretName,
-		"tokenSecretName":           Name,
-		"pathCredentialsServer":     PathCredentialsServer,
-		"pathCredentialsCACert":     PathCredentialsCACert,
-		"pathCredentialsClientCert": PathCredentialsClientCert,
-		"pathCredentialsClientKey":  PathCredentialsClientKey,
-		"pathCredentialsToken":      PathCredentialsToken,
-		"pathBootstrapToken":        PathBootstrapToken,
-		"pathDownloadedChecksum":    PathDownloadedCloudConfigChecksum,
-		"annotationChecksum":        AnnotationKeyChecksum,
-		"dataKeyScript":             DataKeyScript,
-		"dataKeyToken":              resourcesv1alpha1.DataKeyToken,
+		"secretName":                   cloudConfigUserDataSecretName,
+		"tokenSecretName":              Name,
+		"pathCredentialsServer":        PathCredentialsServer,
+		"pathCredentialsCACert":        PathCredentialsCACert,
+		"pathCredentialsClientCert":    PathCredentialsClientCert,
+		"pathCredentialsClientKey":     PathCredentialsClientKey,
+		"pathCredentialsToken":         PathCredentialsToken,
+		"pathBootstrapToken":           PathBootstrapToken,
+		"pathDownloadedChecksum":       PathDownloadedCloudConfigChecksum,
+		"pathDownloadedExecutorScript": PathDownloadedExecutorScript,
+		"pathDownloadsDirectory":       PathDownloadsDirectory,
+		"annotationChecksum":           AnnotationKeyChecksum,
+		"dataKeyScript":                DataKeyScript,
+		"dataKeyToken":                 resourcesv1alpha1.DataKeyToken,
 	}); err != nil {
 		return nil, nil, err
 	}

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/downloader/downloader_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/downloader/downloader_test.go
@@ -210,27 +210,46 @@ TOKEN_SECRET_NAME="cloud-config-downloader"
 
 PATH_CLOUDCONFIG_DOWNLOADER_CLIENT_CERT="/var/lib/cloud-config-downloader/credentials/client.crt"
 PATH_CLOUDCONFIG_DOWNLOADER_CLIENT_KEY="/var/lib/cloud-config-downloader/credentials/client.key"
-PATH_BOOTSTRAP_TOKEN="/var/lib/cloud-config-downloader/credentials/bootstrap-token"
 PATH_CLOUDCONFIG_DOWNLOADER_TOKEN="/var/lib/cloud-config-downloader/credentials/token"
+PATH_BOOTSTRAP_TOKEN="/var/lib/cloud-config-downloader/credentials/bootstrap-token"
+PATH_EXECUTOR_SCRIPT="/var/lib/cloud-config-downloader/downloads/execute-cloud-config.sh"
+PATH_EXECUTOR_SCRIPT_CHECKSUM="/var/lib/cloud-config-downloader/downloads/execute-cloud-config-checksum"
+
+mkdir -p "/var/lib/cloud-config-downloader/downloads"
 
 function readSecret() {
   wget \
     -qO- \
-    --header         "Accept: application/yaml" \
     --ca-certificate "/var/lib/cloud-config-downloader/credentials/ca.crt" \
     "${@:2}" "$(cat "/var/lib/cloud-config-downloader/credentials/server")/api/v1/namespaces/kube-system/secrets/$1"
 }
 
+function readSecretFull() {
+  readSecret "$1" "--header=Accept: application/yaml" "${@:2}"
+}
+
+function readSecretMeta() {
+  readSecret "$1" "--header=Accept: application/yaml;as=PartialObjectMetadata;g=meta.k8s.io;v=v1,application/yaml;as=PartialObjectMetadata;g=meta.k8s.io;v=v1" "${@:2}"
+}
+
+function readSecretMetaWithToken() {
+  readSecretMeta "$1" "--header=Authorization: Bearer $2"
+}
+
 function readSecretWithToken() {
-  readSecret "$1" "--header=Authorization: Bearer $2"
+  readSecretFull "$1" "--header=Authorization: Bearer $2"
 }
 
 function readSecretWithClientCertificate() {
-  readSecret "$1" "--certificate=$PATH_CLOUDCONFIG_DOWNLOADER_CLIENT_CERT" "--private-key=$PATH_CLOUDCONFIG_DOWNLOADER_CLIENT_KEY"
+  readSecretFull "$1" "--certificate=$PATH_CLOUDCONFIG_DOWNLOADER_CLIENT_CERT" "--private-key=$PATH_CLOUDCONFIG_DOWNLOADER_CLIENT_KEY"
 }
 
 function extractDataKeyFromSecret() {
   echo "$1" | sed -rn "s/  $2: (.*)/\1/p" | base64 -d
+}
+
+function extractChecksumFromSecret() {
+  echo "$1" | sed -rn 's/    checksum\/data-script: (.*)/\1/p' | sed -e 's/^"//' -e 's/"$//'
 }
 
 function writeToDiskSafely() {
@@ -269,21 +288,42 @@ if [[ -z "$TOKEN" ]]; then
   echo "Token in shoot access secret $TOKEN_SECRET_NAME is empty"
   exit 1
 fi
-
 writeToDiskSafely "$TOKEN" "$PATH_CLOUDCONFIG_DOWNLOADER_TOKEN"
 
 # download and run the cloud config execution script
-if ! SECRET="$(readSecretWithToken "$SECRET_NAME" "$TOKEN")"; then
-  echo "Could not retrieve the cloud config script in secret with name $SECRET_NAME"
+if ! SECRET_META="$(readSecretMetaWithToken "$SECRET_NAME" "$TOKEN")"; then
+  echo "Could not retrieve the metadata in secret with name $SECRET_NAME"
   exit 1
 fi
+NEW_CHECKSUM="$(extractChecksumFromSecret "$SECRET_META")"
 
-CHECKSUM="$(echo "$SECRET" | sed -rn 's/    checksum\/data-script: (.*)/\1/p' | sed -e 's/^"//' -e 's/"$//')"
-echo "$CHECKSUM" > "/var/lib/cloud-config-downloader/downloaded_checksum"
+OLD_CHECKSUM="<none>"
+if [[ -f "$PATH_EXECUTOR_SCRIPT_CHECKSUM" ]]; then
+  OLD_CHECKSUM="$(cat "$PATH_EXECUTOR_SCRIPT_CHECKSUM")"
+fi
 
-SCRIPT="$(extractDataKeyFromSecret "$SECRET" "script")"
-echo "$SCRIPT" | bash
+if [[ "$NEW_CHECKSUM" != "$OLD_CHECKSUM" ]]; then
+  echo "Checksum of cloud config script has changed compared to what I had downloaded earlier (new: $NEW_CHECKSUM, old: $OLD_CHECKSUM). Fetching new script..."
 
+  if ! SECRET="$(readSecretWithToken "$SECRET_NAME" "$TOKEN")"; then
+    echo "Could not retrieve the cloud config script in secret with name $SECRET_NAME"
+    exit 1
+  fi
+
+  SCRIPT="$(extractDataKeyFromSecret "$SECRET" "script")"
+  if [[ -z "$SCRIPT" ]]; then
+    echo "Script in cloud config secret $SECRET is empty"
+    exit 1
+  fi
+
+  writeToDiskSafely "$SCRIPT" "$PATH_EXECUTOR_SCRIPT" && chmod +x "$PATH_EXECUTOR_SCRIPT"
+  writeToDiskSafely "$(extractChecksumFromSecret "$SECRET")" "$PATH_EXECUTOR_SCRIPT_CHECKSUM"
+fi
+
+# TODO(rfranzke): Delete in future release.
+rm -f "/var/lib/cloud-config-downloader/downloads/downloaded_checksum"
+
+"$PATH_EXECUTOR_SCRIPT"
 exit $?
 }
 `

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/downloader/templates/scripts/download-cloud-config.tpl.sh
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/downloader/templates/scripts/download-cloud-config.tpl.sh
@@ -10,27 +10,46 @@ TOKEN_SECRET_NAME="{{ .tokenSecretName }}"
 
 PATH_CLOUDCONFIG_DOWNLOADER_CLIENT_CERT="{{ .pathCredentialsClientCert }}"
 PATH_CLOUDCONFIG_DOWNLOADER_CLIENT_KEY="{{ .pathCredentialsClientKey }}"
-PATH_BOOTSTRAP_TOKEN="{{ .pathBootstrapToken }}"
 PATH_CLOUDCONFIG_DOWNLOADER_TOKEN="{{ .pathCredentialsToken }}"
+PATH_BOOTSTRAP_TOKEN="{{ .pathBootstrapToken }}"
+PATH_EXECUTOR_SCRIPT="{{ .pathDownloadedExecutorScript }}"
+PATH_EXECUTOR_SCRIPT_CHECKSUM="{{ .pathDownloadedChecksum }}"
+
+mkdir -p "{{ .pathDownloadsDirectory }}"
 
 function readSecret() {
   wget \
     -qO- \
-    --header         "Accept: application/yaml" \
     --ca-certificate "{{ .pathCredentialsCACert }}" \
     "${@:2}" "$(cat "{{ .pathCredentialsServer }}")/api/v1/namespaces/kube-system/secrets/$1"
 }
 
+function readSecretFull() {
+  readSecret "$1" "--header=Accept: application/yaml" "${@:2}"
+}
+
+function readSecretMeta() {
+  readSecret "$1" "--header=Accept: application/yaml;as=PartialObjectMetadata;g=meta.k8s.io;v=v1,application/yaml;as=PartialObjectMetadata;g=meta.k8s.io;v=v1" "${@:2}"
+}
+
+function readSecretMetaWithToken() {
+  readSecretMeta "$1" "--header=Authorization: Bearer $2"
+}
+
 function readSecretWithToken() {
-  readSecret "$1" "--header=Authorization: Bearer $2"
+  readSecretFull "$1" "--header=Authorization: Bearer $2"
 }
 
 function readSecretWithClientCertificate() {
-  readSecret "$1" "--certificate=$PATH_CLOUDCONFIG_DOWNLOADER_CLIENT_CERT" "--private-key=$PATH_CLOUDCONFIG_DOWNLOADER_CLIENT_KEY"
+  readSecretFull "$1" "--certificate=$PATH_CLOUDCONFIG_DOWNLOADER_CLIENT_CERT" "--private-key=$PATH_CLOUDCONFIG_DOWNLOADER_CLIENT_KEY"
 }
 
 function extractDataKeyFromSecret() {
   echo "$1" | sed -rn "s/  $2: (.*)/\1/p" | base64 -d
+}
+
+function extractChecksumFromSecret() {
+  echo "$1" | sed -rn 's/    {{ .annotationChecksum | replace "/" "\\/" }}: (.*)/\1/p' | sed -e 's/^"//' -e 's/"$//'
 }
 
 function writeToDiskSafely() {
@@ -69,20 +88,41 @@ if [[ -z "$TOKEN" ]]; then
   echo "Token in shoot access secret $TOKEN_SECRET_NAME is empty"
   exit 1
 fi
-
 writeToDiskSafely "$TOKEN" "$PATH_CLOUDCONFIG_DOWNLOADER_TOKEN"
 
 # download and run the cloud config execution script
-if ! SECRET="$(readSecretWithToken "$SECRET_NAME" "$TOKEN")"; then
-  echo "Could not retrieve the cloud config script in secret with name $SECRET_NAME"
+if ! SECRET_META="$(readSecretMetaWithToken "$SECRET_NAME" "$TOKEN")"; then
+  echo "Could not retrieve the metadata in secret with name $SECRET_NAME"
   exit 1
 fi
+NEW_CHECKSUM="$(extractChecksumFromSecret "$SECRET_META")"
 
-CHECKSUM="$(echo "$SECRET" | sed -rn 's/    {{ .annotationChecksum | replace "/" "\\/" }}: (.*)/\1/p' | sed -e 's/^"//' -e 's/"$//')"
-echo "$CHECKSUM" > "{{ .pathDownloadedChecksum }}"
+OLD_CHECKSUM="<none>"
+if [[ -f "$PATH_EXECUTOR_SCRIPT_CHECKSUM" ]]; then
+  OLD_CHECKSUM="$(cat "$PATH_EXECUTOR_SCRIPT_CHECKSUM")"
+fi
 
-SCRIPT="$(extractDataKeyFromSecret "$SECRET" "{{ .dataKeyScript }}")"
-echo "$SCRIPT" | bash
+if [[ "$NEW_CHECKSUM" != "$OLD_CHECKSUM" ]]; then
+  echo "Checksum of cloud config script has changed compared to what I had downloaded earlier (new: $NEW_CHECKSUM, old: $OLD_CHECKSUM). Fetching new script..."
 
+  if ! SECRET="$(readSecretWithToken "$SECRET_NAME" "$TOKEN")"; then
+    echo "Could not retrieve the cloud config script in secret with name $SECRET_NAME"
+    exit 1
+  fi
+
+  SCRIPT="$(extractDataKeyFromSecret "$SECRET" "{{ .dataKeyScript }}")"
+  if [[ -z "$SCRIPT" ]]; then
+    echo "Script in cloud config secret $SECRET is empty"
+    exit 1
+  fi
+
+  writeToDiskSafely "$SCRIPT" "$PATH_EXECUTOR_SCRIPT" && chmod +x "$PATH_EXECUTOR_SCRIPT"
+  writeToDiskSafely "$(extractChecksumFromSecret "$SECRET")" "$PATH_EXECUTOR_SCRIPT_CHECKSUM"
+fi
+
+# TODO(rfranzke): Delete in future release.
+rm -f "{{ .pathDownloadsDirectory }}/downloaded_checksum"
+
+"$PATH_EXECUTOR_SCRIPT"
 exit $?
 }

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/executor.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/executor.go
@@ -120,7 +120,6 @@ func Script(
 	values := map[string]interface{}{
 		"annotationKeyChecksum":                    AnnotationKeyChecksum,
 		"pathKubeletDirectory":                     kubelet.PathKubeletDirectory,
-		"pathDownloadsDirectory":                   downloader.PathDownloadsDirectory,
 		"pathBinaries":                             v1beta1constants.OperatingSystemConfigFilePathBinaries,
 		"pathBootstrapToken":                       downloader.PathBootstrapToken,
 		"pathCCDScript":                            downloader.PathCCDScript,

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/executor_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/executor_test.go
@@ -137,7 +137,7 @@ PATH_CLOUDCONFIG_DOWNLOADER_SERVER="/var/lib/cloud-config-downloader/credentials
 PATH_CLOUDCONFIG_DOWNLOADER_CA_CERT="/var/lib/cloud-config-downloader/credentials/ca.crt"
 PATH_CLOUDCONFIG="/var/lib/cloud-config-downloader/downloads/cloud_config"
 PATH_CLOUDCONFIG_OLD="${PATH_CLOUDCONFIG}.old"
-PATH_CHECKSUM="/var/lib/cloud-config-downloader/downloaded_checksum"
+PATH_CHECKSUM="/var/lib/cloud-config-downloader/downloads/execute-cloud-config-checksum"
 PATH_CCD_SCRIPT="/var/lib/cloud-config-downloader/download-cloud-config.sh"
 PATH_CCD_SCRIPT_CHECKSUM="/var/lib/cloud-config-downloader/download-cloud-config.md5"
 PATH_CCD_SCRIPT_CHECKSUM_OLD="${PATH_CCD_SCRIPT_CHECKSUM}.old"
@@ -148,7 +148,7 @@ PATH_LAST_DOWNLOADED_HYPERKUBE_IMAGE="/var/lib/cloud-config-downloader/downloads
 PATH_HYPERKUBE_IMAGE_USED_FOR_LAST_COPY_KUBELET="/opt/bin/hyperkube_image_used_for_last_copy_of_kubelet"
 PATH_HYPERKUBE_IMAGE_USED_FOR_LAST_COPY_KUBECTL="/opt/bin/hyperkube_image_used_for_last_copy_of_kubectl"
 
-mkdir -p "/var/lib/cloud-config-downloader/downloads" "/var/lib/kubelet" "$PATH_HYPERKUBE_DOWNLOADS"
+mkdir -p "/var/lib/kubelet" "$PATH_HYPERKUBE_DOWNLOADS"
 
 `
 

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/templates/scripts/execute-cloud-config.tpl.sh
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/templates/scripts/execute-cloud-config.tpl.sh
@@ -15,7 +15,7 @@ PATH_LAST_DOWNLOADED_HYPERKUBE_IMAGE="{{ .pathLastDownloadedHyperkubeImage }}"
 PATH_HYPERKUBE_IMAGE_USED_FOR_LAST_COPY_KUBELET="{{ .pathHyperKubeImageUsedForLastCopyKubelet }}"
 PATH_HYPERKUBE_IMAGE_USED_FOR_LAST_COPY_KUBECTL="{{ .pathHyperKubeImageUsedForLastCopyKubectl }}"
 
-mkdir -p "{{ .pathDownloadsDirectory }}" "{{ .pathKubeletDirectory }}" "$PATH_HYPERKUBE_DOWNLOADS"
+mkdir -p "{{ .pathKubeletDirectory }}" "$PATH_HYPERKUBE_DOWNLOADS"
 
 {{ if .kubeletDataVolume -}}
 function format-data-device() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area cost networking
/kind enhancement

**What this PR does / why we need it**:
The `cloud-config-downloader` script runs every `30s` on each shoot worker node. It reads the `cloud-config` secret in the `kube-system` namespace which contains the `executor` script and the `original` cloud config. This is about `~100kB` of traffic for each node each `30s`.
This can easily add up to quite some avoidable costs for large landscapes with a lot of shoot clusters since for > 95% of the downloads the content of the secret does not change.

In order to improve, the `cloud-config-downloader` scripts now first performs a metadata-only request for the cloud config `Secret`. It only downloads the full secret (including data containing the `executor` script) if the checksum annotation has changed.

/cc @istvanballok @vlerenc 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
In order to save network I/O and costs, the `cloud-config-downloader` script running every `30s` on each shoot worker node now first performs a metadata-only request for the cloud config `Secret`. It only downloads the full secret (including data containing the `executor` script) if the checksum annotation has changed.
```
