### PR TITLE
Fix the PDB for the Gardener API server to allow roll outs

### DIFF
--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/poddisruptionbudget.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/poddisruptionbudget.yaml
@@ -11,7 +11,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 spec:
-  maxUnavailable: {{ sub (int .Values.global.apiserver.replicaCount) 1 }}
+  maxUnavailable: 1
   selector:
     matchLabels:
       app: gardener


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane ops-productivity
/kind bug

**What this PR does / why we need it**:
Fix the PDB for the Gardener API server to allow roll outs

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix a bug in the `PodDisruptionBudget` of the Gardener API server that was not allowing maintenance operations with the hosting cluster when the HVPA is enabled the replicas are set to 1.
```

cc @mliepold 