### PR TITLE
[GEP-18] Introduce dedicated client CA for shoot clusters

### DIFF
--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -23,6 +23,9 @@ const (
 	// SecretNameCACluster is a constant for the name of a Kubernetes secret object that contains the CA
 	// certificate of a shoot cluster.
 	SecretNameCACluster = "ca"
+	// SecretNameCAClient is a constant for the name of a Kubernetes secret object that contains the client CA
+	// certificate of a shoot cluster.
+	SecretNameCAClient = "ca-client"
 	// SecretNameCAETCD is a constant for the name of a Kubernetes secret object that contains the CA
 	// certificate of the etcd of a shoot cluster.
 	SecretNameCAETCD = "ca-etcd"

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
@@ -85,6 +85,7 @@ var _ = Describe("KubeAPIServer", func() {
 		secretNameStaticToken            = "kube-apiserver-static-token-c069a0e6"
 		secretNameCA                     = "CA-secret"
 		secretChecksumCA                 = "12345"
+		secretNameCAClient               = "ca-client"
 		secretNameCAEtcd                 = "ca-etcd"
 		secretNameCAFrontProxy           = "CAFrontProxy-secret"
 		secretChecksumCAFrontProxy       = "12345"
@@ -1395,6 +1396,7 @@ rules:
 					Expect(deployment.Annotations).To(Equal(map[string]string{
 						"reference.resources.gardener.cloud/secret-a709ce3a":    secretNameServiceAccountKey,
 						"reference.resources.gardener.cloud/secret-71fba891":    secretNameCA,
+						"reference.resources.gardener.cloud/secret-17c26aa4":    secretNameCAClient,
 						"reference.resources.gardener.cloud/secret-e01f5645":    secretNameCAEtcd,
 						"reference.resources.gardener.cloud/secret-9282d44f":    secretNameCAFrontProxy,
 						"reference.resources.gardener.cloud/secret-389fbba5":    secretNameEtcd,
@@ -1445,6 +1447,7 @@ rules:
 						"checksum/secret-" + secretNameCAFrontProxy:             secretChecksumCAFrontProxy,
 						"reference.resources.gardener.cloud/secret-a709ce3a":    secretNameServiceAccountKey,
 						"reference.resources.gardener.cloud/secret-71fba891":    secretNameCA,
+						"reference.resources.gardener.cloud/secret-17c26aa4":    secretNameCAClient,
 						"reference.resources.gardener.cloud/secret-e01f5645":    secretNameCAEtcd,
 						"reference.resources.gardener.cloud/secret-9282d44f":    secretNameCAFrontProxy,
 						"reference.resources.gardener.cloud/secret-389fbba5":    secretNameEtcd,
@@ -1742,7 +1745,7 @@ rules:
 							"--audit-log-maxsize=100",
 							"--audit-log-maxbackup=5",
 							"--authorization-mode=Node,RBAC",
-							"--client-ca-file=/srv/kubernetes/ca/ca.crt",
+							"--client-ca-file=/srv/kubernetes/ca-client/bundle.crt",
 							"--enable-aggregator-routing=true",
 							"--enable-bootstrap-token-auth=true",
 							"--http2-max-streams-per-connection=1000",
@@ -1805,6 +1808,10 @@ rules:
 							corev1.VolumeMount{
 								Name:      "ca",
 								MountPath: "/srv/kubernetes/ca",
+							},
+							corev1.VolumeMount{
+								Name:      "ca-client",
+								MountPath: "/srv/kubernetes/ca-client",
 							},
 							corev1.VolumeMount{
 								Name:      "ca-etcd",
@@ -1870,6 +1877,14 @@ rules:
 								VolumeSource: corev1.VolumeSource{
 									Secret: &corev1.SecretVolumeSource{
 										SecretName: secretNameCA,
+									},
+								},
+							},
+							corev1.Volume{
+								Name: "ca-client",
+								VolumeSource: corev1.VolumeSource{
+									Secret: &corev1.SecretVolumeSource{
+										SecretName: secretNameCAClient,
 									},
 								},
 							},

--- a/pkg/operation/botanist/component/kubeapiserver/secrets.go
+++ b/pkg/operation/botanist/component/kubeapiserver/secrets.go
@@ -325,7 +325,7 @@ func (k *kubeAPIServer) reconcileSecretLegacyVPNSeed(ctx context.Context) (*core
 		Name:       secretNameLegacyVPNSeed,
 		CommonName: UserNameVPNSeed,
 		CertType:   secretutils.ClientCert,
-	}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCACluster), secretsmanager.Rotate(secretsmanager.InPlace))
+	}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCAClient), secretsmanager.Rotate(secretsmanager.InPlace))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager_test.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager_test.go
@@ -512,6 +512,10 @@ var _ = Describe("KubeControllerManager", func() {
 													MountPath: "/srv/kubernetes/ca",
 												},
 												{
+													Name:      "ca-client",
+													MountPath: "/srv/kubernetes/ca-client",
+												},
+												{
 													Name:      "service-account-key",
 													MountPath: "/srv/kubernetes/service-account-key",
 												},
@@ -528,6 +532,14 @@ var _ = Describe("KubeControllerManager", func() {
 											VolumeSource: corev1.VolumeSource{
 												Secret: &corev1.SecretVolumeSource{
 													SecretName: "ca",
+												},
+											},
+										},
+										{
+											Name: "ca-client",
+											VolumeSource: corev1.VolumeSource{
+												Secret: &corev1.SecretVolumeSource{
+													SecretName: "ca-client-current",
 												},
 											},
 										},
@@ -806,8 +818,8 @@ func commandForKubernetesVersion(
 	command = append(command,
 		fmt.Sprintf("--cluster-cidr=%s", podNetwork.String()),
 		fmt.Sprintf("--cluster-name=%s", clusterName),
-		"--cluster-signing-cert-file=/srv/kubernetes/ca/ca.crt",
-		"--cluster-signing-key-file=/srv/kubernetes/ca/ca.key",
+		"--cluster-signing-cert-file=/srv/kubernetes/ca-client/ca.crt",
+		"--cluster-signing-key-file=/srv/kubernetes/ca-client/ca.key",
 	)
 
 	if k8sVersionGreaterEqual119, _ := versionutils.CompareVersions(version, ">=", "1.19"); k8sVersionGreaterEqual119 {

--- a/pkg/operation/botanist/component/kubescheduler/kube_scheduler.go
+++ b/pkg/operation/botanist/component/kubescheduler/kube_scheduler.go
@@ -132,9 +132,9 @@ func (k *kubeScheduler) Deploy(ctx context.Context) error {
 		return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameGenericTokenKubeconfig)
 	}
 
-	clientCASecret, found := k.secretsManager.Get(v1beta1constants.SecretNameCACluster)
+	clientCASecret, found := k.secretsManager.Get(v1beta1constants.SecretNameCAClient)
 	if !found {
-		return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameCACluster)
+		return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameCAClient)
 	}
 
 	componentConfigYAML, err := k.computeComponentConfig()

--- a/pkg/operation/botanist/component/kubescheduler/kube_scheduler_test.go
+++ b/pkg/operation/botanist/component/kubescheduler/kube_scheduler_test.go
@@ -67,7 +67,7 @@ var _ = Describe("KubeScheduler", func() {
 		configEmpty *gardencorev1beta1.KubeSchedulerConfig
 		configFull  = &gardencorev1beta1.KubeSchedulerConfig{KubernetesConfig: gardencorev1beta1.KubernetesConfig{FeatureGates: map[string]bool{"Foo": true, "Bar": false, "Baz": false}}, KubeMaxPDVols: pointer.String("23")}
 
-		secretNameClientCA = "ca"
+		secretNameClientCA = "ca-client"
 		secretNameServer   = "kube-scheduler-server"
 
 		genericTokenKubeconfigSecretName = "generic-token-kubeconfig"

--- a/pkg/operation/botanist/monitoring.go
+++ b/pkg/operation/botanist/monitoring.go
@@ -189,7 +189,7 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 		CommonName:   "gardener.cloud:monitoring:prometheus",
 		Organization: []string{"gardener.cloud:monitoring"},
 		CertType:     secrets.ClientCert,
-	}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCACluster), secretsmanager.Rotate(secretsmanager.InPlace))
+	}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCAClient), secretsmanager.Rotate(secretsmanager.InPlace))
 	if err != nil {
 		return err
 	}

--- a/pkg/operation/botanist/resource_manager.go
+++ b/pkg/operation/botanist/resource_manager.go
@@ -220,7 +220,7 @@ func (b *Botanist) reconcileGardenerResourceManagerBootstrapKubeconfigSecret(ctx
 			APIServerHost: b.Shoot.ComputeInClusterAPIServerAddress(true),
 			CAData:        caBundleSecret.Data[secretutils.DataKeyCertificateBundle],
 		}},
-	}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCACluster))
+	}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCAClient))
 }
 
 func (b *Botanist) waitUntilGardenerResourceManagerBootstrapped(ctx context.Context) error {

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -153,6 +153,16 @@ func (b *Botanist) restoreSecretsFromShootStateForSecretsManagerAdoption(ctx con
 }
 
 func (b *Botanist) generateCertificateAuthorities(ctx context.Context) error {
+	// TODO(rfranzke): Move this client CA secret configuration to the b.wantedCertificateAuthorities() function in a
+	//  future release.
+	if _, err := b.SecretsManager.Generate(ctx, &secretutils.CertificateSecretConfig{
+		Name:       v1beta1constants.SecretNameCAClient,
+		CommonName: "client",
+		CertType:   secretutils.CACert,
+	}, secretsmanager.Persist(), secretsmanager.Rotate(secretsmanager.KeepOld)); err != nil {
+		return err
+	}
+
 	for _, config := range b.wantedCertificateAuthorities() {
 		if _, err := b.SecretsManager.Generate(ctx, config, secretsmanager.Persist(), secretsmanager.Rotate(secretsmanager.KeepOld), secretsmanager.IgnoreConfigChecksumForCASecretName()); err != nil {
 			return err

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -157,7 +157,7 @@ func (b *Botanist) generateCertificateAuthorities(ctx context.Context) error {
 	//  future release.
 	if _, err := b.SecretsManager.Generate(ctx, &secretutils.CertificateSecretConfig{
 		Name:       v1beta1constants.SecretNameCAClient,
-		CommonName: "client",
+		CommonName: "kubernetes-client",
 		CertType:   secretutils.CACert,
 	}, secretsmanager.Persist(), secretsmanager.Rotate(secretsmanager.KeepOld)); err != nil {
 		return err

--- a/pkg/registry/core/shoot/storage/admin_kubeconfig.go
+++ b/pkg/registry/core/shoot/storage/admin_kubeconfig.go
@@ -119,9 +119,12 @@ func (r *AdminKubeconfigREST) Create(ctx context.Context, name string, obj runti
 
 	resourceDataList := gardencorev1alpha1helper.GardenerResourceDataList(shootState.Spec.Gardener)
 
-	ca := resourceDataList.Get(v1beta1constants.SecretNameCACluster)
+	ca := resourceDataList.Get(v1beta1constants.SecretNameCAClient)
 	if ca == nil {
-		return nil, errors.NewInternalError(fmt.Errorf("certificate authority not yet provisioned"))
+		ca = resourceDataList.Get(v1beta1constants.SecretNameCACluster)
+		if ca == nil {
+			return nil, errors.NewInternalError(fmt.Errorf("certificate authority not yet provisioned"))
+		}
 	}
 
 	data := make(map[string][]byte)

--- a/pkg/registry/core/shoot/storage/admin_kubeconfig_test.go
+++ b/pkg/registry/core/shoot/storage/admin_kubeconfig_test.go
@@ -114,7 +114,7 @@ lIwEl8tStnO9u1JUK4w1e+lC37zI2v5k4WMQmJcolUEMwmZjnCR/
 			Spec: gardenercore.ShootStateSpec{
 				Gardener: []gardenercore.GardenerResourceData{
 					{
-						Name: "ca",
+						Name: "ca-client",
 						Type: "secret",
 						Data: runtime.RawExtension{
 							Raw: caRaw,

--- a/pkg/utils/secrets/manager/generate.go
+++ b/pkg/utils/secrets/manager/generate.go
@@ -141,6 +141,15 @@ func (m *manager) keepExistingSecretsIfNeeded(ctx context.Context, configName st
 	existingSecret := &corev1.Secret{}
 
 	switch configName {
+	case "ca-client":
+		if err := m.client.Get(ctx, kutil.Key(m.namespace, "ca"), existingSecret); err != nil {
+			if !apierrors.IsNotFound(err) {
+				return nil, err
+			}
+			return newData, nil
+		}
+		return existingSecret.Data, nil
+
 	case "kube-apiserver-basic-auth", "observability-ingress", "observability-ingress-users":
 		oldSecretName := configName
 		if configName == "observability-ingress" {

--- a/pkg/utils/secrets/manager/generate.go
+++ b/pkg/utils/secrets/manager/generate.go
@@ -142,6 +142,9 @@ func (m *manager) keepExistingSecretsIfNeeded(ctx context.Context, configName st
 
 	switch configName {
 	case "ca-client":
+		// TODO(rfranzke): Drop this code before promoting the ShootCARotation feature gate to beta. Otherwise, the
+		//  cluster CA will still be used as client CA during the first shoot CA certificate rotation since the `ca`
+		//  secret will still exist. This code is only very temporary to ensure all shoots get a `ca-client` secret.
 		if err := m.client.Get(ctx, kutil.Key(m.namespace, "ca"), existingSecret); err != nil {
 			if !apierrors.IsNotFound(err) {
 				return nil, err

--- a/pkg/utils/secrets/manager/generate_test.go
+++ b/pkg/utils/secrets/manager/generate_test.go
@@ -1091,7 +1091,7 @@ FskcKs088h3kZh8sc8pG25SCwKdEXXh7ufO3aYtEbViSAQbqIixNVdRO
 				BeforeEach(func() {
 					config = &secretutils.CertificateSecretConfig{
 						Name:       "ca-client",
-						CommonName: "client",
+						CommonName: "kubernetes-client",
 						CertType:   secretutils.CACert,
 					}
 				})

--- a/pkg/utils/secrets/manager/generate_test.go
+++ b/pkg/utils/secrets/manager/generate_test.go
@@ -1059,6 +1059,77 @@ resources:
 					Expect(secret.Data).To(Equal(oldData))
 				})
 			})
+
+			Context("ca-client", func() {
+				var (
+					caClusterKey = []byte(`-----BEGIN RSA PRIVATE KEY-----
+...
+-----END RSA PRIVATE KEY-----
+`)
+					caClusterCert = []byte(`-----BEGIN CERTIFICATE-----
+MIIC9jCCAd6gAwIBAgIUEoEOCJXk3WYh/R86QU6tl21Inc4wDQYJKoZIhvcNAQEL
+BQAwEzERMA8GA1UEAxMIZ2FyZGVuZXIwHhcNMjExMDE4MTMwNzAwWhcNMjYxMDE3
+MTMwNzAwWjATMREwDwYDVQQDEwhnYXJkZW5lcjCCASIwDQYJKoZIhvcNAQEBBQAD
+ggEPADCCAQoCggEBAN/p2ouZ/IEN1AcSeZcStVqovo5Z27ZMFYBVTbcTd3L1oKhh
+KuO7Z8UORXZJKUX313CqMRE9DeB0FoDOeiOUFxn41Cz+efI7FxxYKi1CqZOPWl4d
+Ihrsh2+wsbxgIUEVDIMO//HBE9pugqn9DTuwpg2EjT67gXttJgLyOcNkeQPE6V2y
+jlAoYxJuOLWt/Np82qqAOnioZS2yDvzwXrAFCFK1tqSAt9A8W+p/XgWTTqdWPF9W
+HOjzFg+Ux+VyasSCM2Cchot14/HwH3SBVXvi0SnPjpNeuQqDlQAEqnruMOIOObVw
+swOcXn5dFck+7vrCCdJnOKIZ+WO+DrngMcOvkc8CAwEAAaNCMEAwDgYDVR0PAQH/
+BAQDAgEGMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0OBBYEFGpfM5/ePMXpslUv/A/K
+6yjQUjMjMA0GCSqGSIb3DQEBCwUAA4IBAQCAUA+e4JuaEDz2gvIAleemuQ/9ylFq
+/XmzevAjqXSndKmkMTwOxvPWAA3xLJjvowZy0i5tPA/hFh5gIknReL4kGINGnCaL
+50ZbcClvlm1ClqUw97S0qBNZQP4xGa3ChkpKERs8liXu613xNqIgib1+0FtfTvGm
+qSHwwAI6pMbxxzYBFftp0YLBjpwDHZOhBAQcVPtld8Cce/Md6bNMNgqtTkDVWRXV
+TrZURcfizB5ipQRgOCiXaX/U0qxYWbG0Xrrvt869wNnl8DKfx5YtdCeHhT74Go0A
+FskcKs088h3kZh8sc8pG25SCwKdEXXh7ufO3aYtEbViSAQbqIixNVdRO
+-----END CERTIFICATE-----
+`)
+					config *secretutils.CertificateSecretConfig
+				)
+
+				BeforeEach(func() {
+					config = &secretutils.CertificateSecretConfig{
+						Name:       "ca-client",
+						CommonName: "client",
+						CertType:   secretutils.CACert,
+					}
+				})
+
+				It("should generate a new CA certificate if the cluster CA does not exist", func() {
+					By("generating secret")
+					secret, err := m.Generate(ctx, config)
+					Expect(err).NotTo(HaveOccurred())
+
+					By("verifying new CA certificate was generated")
+					Expect(secret.Data[secretutils.DataKeyCertificateCA]).NotTo(Equal(caClusterCert))
+					Expect(secret.Data[secretutils.DataKeyPrivateKeyCA]).NotTo(Equal(caClusterKey))
+				})
+
+				It("should use the cluster CA certificate if cluster CA exists", func() {
+					By("creating cluster CA secret")
+					existingSecret := &corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "ca",
+							Namespace: namespace,
+						},
+						Type: corev1.SecretTypeOpaque,
+						Data: map[string][]byte{
+							"ca.crt": caClusterCert,
+							"ca.key": caClusterKey,
+						},
+					}
+					Expect(fakeClient.Create(ctx, existingSecret)).To(Succeed())
+
+					By("generating secret")
+					secret, err := m.Generate(ctx, config)
+					Expect(err).NotTo(HaveOccurred())
+
+					By("verifying cluster CA certificate is used")
+					Expect(secret.Data[secretutils.DataKeyCertificateCA]).To(Equal(caClusterCert))
+					Expect(secret.Data[secretutils.DataKeyPrivateKeyCA]).To(Equal(caClusterKey))
+				})
+			})
 		})
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
This PR introduces a dedicated client CA for shoot clusters as suggested in [GEP-18](https://github.com/gardener/gardener/blob/master/docs/proposals/18-shoot-CA-rotation.md).

For existing clusters, the new `ca-client` secret will have the same content like the `ca` secret for backwards-compatibility reasons.
For new clusters, the `ca-client` secret will be different from the `ca` secret.

The `kube-apiserver` always uses the client CA bundle containing the current and potential old client CA certificates. The `kube-controller-manager` always uses the current client CA certificate to ensure new client certificates are always signed with the most recent client CA certificate.

**Which issue(s) this PR fixes**:
Part of #3292

**Special notes for your reviewer**:
/cc @timebertt 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy user
Newly created shoot clusters now get a dedicated CA certificate which is used for signing client certificates. Note that this client CA is different from the cluster CA. For existing clusters, the client CA is the same like the cluster CA to ensure backwards compatibility.
```
