### PR TITLE
Use networking api for ingress

### DIFF
--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -334,7 +334,7 @@ func DeleteGrafanaByRole(ctx context.Context, k8sClient kubernetes.Interface, na
 		return err
 	}
 
-	if err := k8sClient.Client().DeleteAllOf(ctx, &extensionsv1beta1.Ingress{}, deleteOptions...); client.IgnoreNotFound(err) != nil {
+	if err := k8sClient.Client().DeleteAllOf(ctx, &networkingv1.Ingress{}, deleteOptions...); client.IgnoreNotFound(err) != nil {
 		return err
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind regression

**What this PR does / why we need it**:
In PR #5754, we wrongly used `extensions/v1beta1` apiVersion for Ingress in the deletion step of the shoot. Because of this shoot is getting stuck in the deletion phase with the following error:
```
"Failed to delete Shoot cluster \"aws-i545932\": flow \"Shoot cluster deletion\" encountered task errors: [task \"Deleting Grafana in Seed\" failed: retry failed with context deadline exceeded, last error: no matches for kind \"Ingress\" in version \"extensions/v1beta1\"]" 
```
This PR fixes the issue by using correct apiVersion `networking/v1` for shoot ingress deletion.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
