### PR TITLE
Stop using `Fatalf` logs in test framework

### DIFF
--- a/test/framework/shoot_utils.go
+++ b/test/framework/shoot_utils.go
@@ -91,7 +91,7 @@ func (f *ShootFramework) DumpState(ctx context.Context) {
 
 	if f.Shoot != nil {
 		if err := PrettyPrintObject(f.Shoot); err != nil {
-			f.Logger.Fatalf("Cannot decode shoot %s: %s", f.Shoot.GetName(), err)
+			f.Logger.Errorf("Cannot decode shoot %s: %s", f.Shoot.GetName(), err)
 		}
 
 		isRunning, err := f.IsAPIServerRunning(ctx)

--- a/test/framework/shootcreationframework.go
+++ b/test/framework/shootcreationframework.go
@@ -369,15 +369,15 @@ func (f *ShootCreationFramework) CreateShootAndWaitForCreation(ctx context.Conte
 
 	f.Logger.Infof("Creating shoot %s in namespace %s", f.Shoot.GetName(), f.ProjectNamespace)
 	if err := PrettyPrintObject(f.Shoot); err != nil {
-		f.Logger.Fatalf("Cannot decode shoot %s: %s", f.Shoot.GetName(), err)
+		f.Logger.Errorf("Cannot decode shoot %s: %s", f.Shoot.GetName(), err)
 		return err
 	}
 
 	if err := f.GardenerFramework.CreateShoot(ctx, f.Shoot); err != nil {
-		f.Logger.Fatalf("Cannot create shoot %s: %s", f.Shoot.GetName(), err.Error())
+		f.Logger.Errorf("Cannot create shoot %s: %s", f.Shoot.GetName(), err.Error())
 		shootFramework, err2 := f.NewShootFramework(ctx, f.Shoot)
 		if err2 != nil {
-			f.Logger.Fatalf("Cannot dump shoot state %s: %s", f.Shoot.GetName(), err.Error())
+			f.Logger.Errorf("Cannot dump shoot state %s: %s", f.Shoot.GetName(), err.Error())
 		} else {
 			shootFramework.DumpState(ctx)
 		}
@@ -392,14 +392,14 @@ func (f *ShootCreationFramework) CreateShootAndWaitForCreation(ctx context.Conte
 	f.shootFramework = shootFramework
 
 	if err := DownloadKubeconfig(ctx, shootFramework.GardenClient, f.ProjectNamespace, shootFramework.ShootKubeconfigSecretName(), f.Config.shootKubeconfigPath); err != nil {
-		f.Logger.Fatalf("Cannot download shoot kubeconfig: %s", err.Error())
+		f.Logger.Errorf("Cannot download shoot kubeconfig: %s", err.Error())
 		return err
 	}
 
 	if seedSecretRef := shootFramework.Seed.Spec.SecretRef; seedSecretRef == nil {
 		f.Logger.Info("seed does not have secretRef set, skip constructing seed client")
 	} else if err := DownloadKubeconfig(ctx, shootFramework.GardenClient, shootFramework.Seed.Spec.SecretRef.Namespace, shootFramework.Seed.Spec.SecretRef.Name, f.Config.seedKubeconfigPath); err != nil {
-		f.Logger.Fatalf("Cannot download seed kubeconfig: %s", err.Error())
+		f.Logger.Errorf("Cannot download seed kubeconfig: %s", err.Error())
 		return err
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:

`logger.Fatalf` basically logs an error and does `os.Exit(1)`. This is not what we want in tests.

**Which issue(s) this PR fixes**:

There were a lot of flakes in `{ci,pull}-gardener-e2e-kind` since https://github.com/gardener/gardener/pull/5774, however reporting failed to point to the test cases that actually failed, e.g.:
```
  In [ReportAfterSuite] at: autogenerated by Ginkgo
------------------------------
** Ginkgo timed out waiting for all parallel procs to report back. **
e2e (./test/e2e)
Output from proc 1:
  --- FAIL: TestE2E (960.33s)
  FAIL
Output from proc 2:
Output from proc 3:
  PASS
Output from proc 4:
  PASS
Output from proc 5:
  PASS
```
ref https://prow.gardener.cloud/view/gs/gardener-prow/logs/ci-gardener-e2e-kind/1513402774937669632

I suspect, that reporting failed because of some `Fatalf` call in the test framework. Let's fix this to see, what cases are really flaking.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
