### PR TITLE
[GEP-18] Auto-rotate seed cluster CA certificate every `30d`

### DIFF
--- a/pkg/operation/botanist/component/metricsserver/metrics_server.go
+++ b/pkg/operation/botanist/component/metricsserver/metrics_server.go
@@ -93,7 +93,7 @@ func (m *metricsServer) Deploy(ctx context.Context) error {
 		DNSNames:                    append([]string{serviceName}, kutil.DNSNamesForService(serviceName, metav1.NamespaceSystem)...),
 		CertType:                    secrets.ServerClientCert,
 		SkipPublishingCACertificate: true,
-	}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCAMetricsServer), secretsmanager.Rotate(secretsmanager.InPlace))
+	}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCAMetricsServer, secretsmanager.UseCurrentCA), secretsmanager.Rotate(secretsmanager.InPlace))
 	if err != nil {
 		return err
 	}

--- a/pkg/operation/botanist/component/resourcemanager/resource_manager.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager.go
@@ -472,7 +472,7 @@ func (r *resourceManager) ensureDeployment(ctx context.Context) error {
 		DNSNames:                    kutil.DNSNamesForService(serviceName, r.namespace),
 		CertType:                    secrets.ServerCert,
 		SkipPublishingCACertificate: true,
-	}, secretsmanager.SignedByCA(r.values.SecretNameServerCA), secretsmanager.Rotate(secretsmanager.InPlace))
+	}, secretsmanager.SignedByCA(r.values.SecretNameServerCA, secretsmanager.UseCurrentCA), secretsmanager.Rotate(secretsmanager.InPlace))
 	if err != nil {
 		return err
 	}

--- a/pkg/operation/botanist/logging.go
+++ b/pkg/operation/botanist/logging.go
@@ -85,12 +85,13 @@ func (b *Botanist) DeploySeedLogging(ctx context.Context) error {
 
 	if b.isShootNodeLoggingEnabled() {
 		ingressTLSSecret, err := b.SecretsManager.Generate(ctx, &secrets.CertificateSecretConfig{
-			Name:         "loki-tls",
-			CommonName:   b.ComputeLokiHost(),
-			Organization: []string{"gardener.cloud:monitoring:ingress"},
-			DNSNames:     b.ComputeLokiHosts(),
-			CertType:     secrets.ServerCert,
-			Validity:     &ingressTLSCertificateValidity,
+			Name:                        "loki-tls",
+			CommonName:                  b.ComputeLokiHost(),
+			Organization:                []string{"gardener.cloud:monitoring:ingress"},
+			DNSNames:                    b.ComputeLokiHosts(),
+			CertType:                    secrets.ServerCert,
+			Validity:                    &ingressTLSCertificateValidity,
+			SkipPublishingCACertificate: true,
 		}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCACluster))
 		if err != nil {
 			return err

--- a/pkg/operation/botanist/monitoring.go
+++ b/pkg/operation/botanist/monitoring.go
@@ -163,12 +163,13 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 		prometheusIngressTLSSecretName = b.ControlPlaneWildcardCert.GetName()
 	} else {
 		ingressTLSSecret, err := b.SecretsManager.Generate(ctx, &secrets.CertificateSecretConfig{
-			Name:         "prometheus-tls",
-			CommonName:   "prometheus",
-			Organization: []string{"gardener.cloud:monitoring:ingress"},
-			DNSNames:     b.ComputePrometheusHosts(),
-			CertType:     secrets.ServerCert,
-			Validity:     &ingressTLSCertificateValidity,
+			Name:                        "prometheus-tls",
+			CommonName:                  "prometheus",
+			Organization:                []string{"gardener.cloud:monitoring:ingress"},
+			DNSNames:                    b.ComputePrometheusHosts(),
+			CertType:                    secrets.ServerCert,
+			Validity:                    &ingressTLSCertificateValidity,
+			SkipPublishingCACertificate: true,
 		}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCACluster))
 		if err != nil {
 			return err
@@ -396,12 +397,13 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 			alertManagerIngressTLSSecretName = b.ControlPlaneWildcardCert.GetName()
 		} else {
 			ingressTLSSecret, err := b.SecretsManager.Generate(ctx, &secrets.CertificateSecretConfig{
-				Name:         "alertmanager-tls",
-				CommonName:   "alertmanager",
-				Organization: []string{"gardener.cloud:monitoring:ingress"},
-				DNSNames:     b.ComputeAlertManagerHosts(),
-				CertType:     secrets.ServerCert,
-				Validity:     &ingressTLSCertificateValidity,
+				Name:                        "alertmanager-tls",
+				CommonName:                  "alertmanager",
+				Organization:                []string{"gardener.cloud:monitoring:ingress"},
+				DNSNames:                    b.ComputeAlertManagerHosts(),
+				CertType:                    secrets.ServerCert,
+				Validity:                    &ingressTLSCertificateValidity,
+				SkipPublishingCACertificate: true,
 			}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCACluster))
 			if err != nil {
 				return err
@@ -492,12 +494,13 @@ func (b *Botanist) DeploySeedGrafana(ctx context.Context) error {
 		ingressTLSSecretName = b.ControlPlaneWildcardCert.GetName()
 	} else {
 		ingressTLSSecret, err := b.SecretsManager.Generate(ctx, &secrets.CertificateSecretConfig{
-			Name:         "grafana-tls",
-			CommonName:   "grafana",
-			Organization: []string{"gardener.cloud:monitoring:ingress"},
-			DNSNames:     b.ComputeGrafanaHosts(),
-			CertType:     secrets.ServerCert,
-			Validity:     &ingressTLSCertificateValidity,
+			Name:                        "grafana-tls",
+			CommonName:                  "grafana",
+			Organization:                []string{"gardener.cloud:monitoring:ingress"},
+			DNSNames:                    b.ComputeGrafanaHosts(),
+			CertType:                    secrets.ServerCert,
+			Validity:                    &ingressTLSCertificateValidity,
+			SkipPublishingCACertificate: true,
 		}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCACluster))
 		if err != nil {
 			return err

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -154,7 +154,7 @@ func (b *Botanist) restoreSecretsFromShootStateForSecretsManagerAdoption(ctx con
 
 func (b *Botanist) generateCertificateAuthorities(ctx context.Context) error {
 	for _, config := range b.wantedCertificateAuthorities() {
-		if _, err := b.SecretsManager.Generate(ctx, config, secretsmanager.Persist(), secretsmanager.Rotate(secretsmanager.KeepOld)); err != nil {
+		if _, err := b.SecretsManager.Generate(ctx, config, secretsmanager.Persist(), secretsmanager.Rotate(secretsmanager.KeepOld), secretsmanager.IgnoreConfigChecksumForCASecretName()); err != nil {
 			return err
 		}
 	}
@@ -281,7 +281,7 @@ func (b *Botanist) fetchCertificateAuthoritiesForLegacySecretsManager(ctx contex
 	cas := make(map[string]*secretutils.Certificate)
 
 	for _, config := range b.wantedCertificateAuthorities() {
-		secret, err := b.SecretsManager.Generate(ctx, config, secretsmanager.Persist(), secretsmanager.Rotate(secretsmanager.KeepOld))
+		secret, err := b.SecretsManager.Generate(ctx, config, secretsmanager.Persist(), secretsmanager.Rotate(secretsmanager.KeepOld), secretsmanager.IgnoreConfigChecksumForCASecretName())
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -700,24 +700,26 @@ func RunReconcileSeedFlow(
 		prometheusIngressTLSSecretName = wildcardCert.GetName()
 	} else {
 		grafanaIngressTLSSecret, err := secretsManager.Generate(ctx, &secretutils.CertificateSecretConfig{
-			Name:         "grafana-tls",
-			CommonName:   "grafana",
-			Organization: []string{"gardener.cloud:monitoring:ingress"},
-			DNSNames:     []string{seed.GetIngressFQDN(grafanaPrefix)},
-			CertType:     secretutils.ServerCert,
-			Validity:     &ingressTLSCertificateValidity,
+			Name:                        "grafana-tls",
+			CommonName:                  "grafana",
+			Organization:                []string{"gardener.cloud:monitoring:ingress"},
+			DNSNames:                    []string{seed.GetIngressFQDN(grafanaPrefix)},
+			CertType:                    secretutils.ServerCert,
+			Validity:                    &ingressTLSCertificateValidity,
+			SkipPublishingCACertificate: true,
 		}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCASeed))
 		if err != nil {
 			return err
 		}
 
 		prometheusIngressTLSSecret, err := secretsManager.Generate(ctx, &secretutils.CertificateSecretConfig{
-			Name:         "aggregate-prometheus-tls",
-			CommonName:   "prometheus",
-			Organization: []string{"gardener.cloud:monitoring:ingress"},
-			DNSNames:     []string{seed.GetIngressFQDN(prometheusPrefix)},
-			CertType:     secretutils.ServerCert,
-			Validity:     &ingressTLSCertificateValidity,
+			Name:                        "aggregate-prometheus-tls",
+			CommonName:                  "prometheus",
+			Organization:                []string{"gardener.cloud:monitoring:ingress"},
+			DNSNames:                    []string{seed.GetIngressFQDN(prometheusPrefix)},
+			CertType:                    secretutils.ServerCert,
+			Validity:                    &ingressTLSCertificateValidity,
+			SkipPublishingCACertificate: true,
 		}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCASeed))
 		if err != nil {
 			return err

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -247,10 +247,12 @@ func RunReconcileSeedFlow(
 	}
 
 	// Deploy dedicated CA certificate for seed cluster.
+	validity := 30 * 24 * time.Hour
 	if _, err := secretsManager.Generate(ctx, &secretutils.CertificateSecretConfig{
 		Name:       v1beta1constants.SecretNameCASeed,
 		CommonName: "kubernetes",
 		CertType:   secretutils.CACert,
+		Validity:   &validity,
 	}, secretsmanager.Rotate(secretsmanager.KeepOld)); err != nil {
 		return err
 	}

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -943,7 +943,11 @@ func RunReconcileSeedFlow(
 		return err
 	}
 
-	return runCreateSeedFlow(ctx, gardenClient, seedClient, kubernetesVersion, secretsManager, imageVector, imageVectorOverwrites, seed, conf, log, anySNI)
+	if err := runCreateSeedFlow(ctx, gardenClient, seedClient, kubernetesVersion, secretsManager, imageVector, imageVectorOverwrites, seed, conf, log, anySNI); err != nil {
+		return err
+	}
+
+	return secretsManager.Cleanup(ctx)
 }
 
 func runCreateSeedFlow(

--- a/pkg/utils/secrets/manager/fake/fake_manager.go
+++ b/pkg/utils/secrets/manager/fake/fake_manager.go
@@ -71,7 +71,7 @@ func (m *fakeManager) Generate(ctx context.Context, config secretutils.ConfigInt
 		return nil, err
 	}
 
-	objectMeta, err := secretsmanager.ObjectMeta(m.namespace, ManagerIdentity, config, "", nil, nil, &options.Persist, nil)
+	objectMeta, err := secretsmanager.ObjectMeta(m.namespace, ManagerIdentity, config, true, "", nil, nil, &options.Persist, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/utils/secrets/manager/generate.go
+++ b/pkg/utils/secrets/manager/generate.go
@@ -469,10 +469,44 @@ func (o *GenerateOptions) ApplyOptions(manager Interface, configInterface secret
 	return nil
 }
 
+// SignedByCAOption is some configuration that modifies options for a SignedByCA request.
+type SignedByCAOption interface {
+	// ApplyToOptions applies this configuration to the given options.
+	ApplyToOptions(*SignedByCAOptions)
+}
+
+// SignedByCAOptions are options for SignedByCA calls.
+type SignedByCAOptions struct {
+	// UseCurrentCA specifies whether the certificate should always be signed by the current CA. This option does only
+	// take effect for server certificates since they are signed by the old CA by default (if it exists). Client
+	// certificates are always signed by the current CA.
+	UseCurrentCA bool
+}
+
+// ApplyOptions applies the given update options on these options, and then returns itself (for convenient chaining).
+func (o *SignedByCAOptions) ApplyOptions(opts []SignedByCAOption) *SignedByCAOptions {
+	for _, opt := range opts {
+		opt.ApplyToOptions(o)
+	}
+	return o
+}
+
+// UseCurrentCA sets the UseCurrentCA field to 'true' in the SignedByCAOptions.
+var UseCurrentCA = useCurrentCAOption{}
+
+type useCurrentCAOption struct{}
+
+func (useCurrentCAOption) ApplyToOptions(options *SignedByCAOptions) {
+	options.UseCurrentCA = true
+}
+
 // SignedByCA returns a function which sets the 'SigningCA' field in case the ConfigInterface provided to the
 // Generate request is a CertificateSecretConfig. Additionally, in such case it stores a checksum of the signing
 // CA in the options.
-func SignedByCA(name string) GenerateOption {
+func SignedByCA(name string, opts ...SignedByCAOption) GenerateOption {
+	signedByCAOptions := &SignedByCAOptions{}
+	signedByCAOptions.ApplyOptions(opts)
+
 	return func(m Interface, config secretutils.ConfigInterface, options *GenerateOptions) error {
 		mgr, ok := m.(*manager)
 		if !ok {
@@ -497,7 +531,7 @@ func SignedByCA(name string) GenerateOption {
 		// Client certificates are always renewed immediately (hence, signed with the current CA), while server
 		// certificates are signed with the old CA until they don't exist anymore in the internal store.
 		secret := secrets.current
-		if certificateConfig.CertType == secretutils.ServerCert && secrets.old != nil {
+		if certificateConfig.CertType == secretutils.ServerCert && !signedByCAOptions.UseCurrentCA && secrets.old != nil {
 			secret = *secrets.old
 		}
 

--- a/pkg/utils/secrets/manager/generate.go
+++ b/pkg/utils/secrets/manager/generate.go
@@ -53,7 +53,17 @@ func (m *manager) Generate(ctx context.Context, config secretutils.ConfigInterfa
 		validUntilTime = pointer.String(unixTime(m.clock.Now().Add(options.Validity)))
 	}
 
-	objectMeta, err := ObjectMeta(m.namespace, m.identity, config, m.lastRotationInitiationTimes[config.GetName()], validUntilTime, options.signingCAChecksum, &options.Persist, bundleFor)
+	objectMeta, err := ObjectMeta(
+		m.namespace,
+		m.identity,
+		config,
+		options.IgnoreConfigChecksumForCASecretName,
+		m.lastRotationInitiationTimes[config.GetName()],
+		validUntilTime,
+		options.signingCAChecksum,
+		&options.Persist,
+		bundleFor,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -432,6 +442,9 @@ type GenerateOptions struct {
 	IgnoreOldSecrets bool
 	// Validity specifies for how long the secret should be valid.
 	Validity time.Duration
+	// IgnoreConfigChecksumForCASecretName specifies whether the secret config checksum should be ignored when
+	// computing the secret name for CA secrets.
+	IgnoreConfigChecksumForCASecretName bool
 
 	signingCAChecksum *string
 	isBundleSecret    bool
@@ -528,6 +541,15 @@ func IgnoreOldSecrets() GenerateOption {
 func Validity(v time.Duration) GenerateOption {
 	return func(_ Interface, _ secretutils.ConfigInterface, options *GenerateOptions) error {
 		options.Validity = v
+		return nil
+	}
+}
+
+// IgnoreConfigChecksumForCASecretName returns a function which sets the 'IgnoreConfigChecksumForCASecretName' field to
+// true.
+func IgnoreConfigChecksumForCASecretName() GenerateOption {
+	return func(_ Interface, _ secretutils.ConfigInterface, options *GenerateOptions) error {
+		options.IgnoreConfigChecksumForCASecretName = true
 		return nil
 	}
 }

--- a/pkg/utils/secrets/manager/generate_test.go
+++ b/pkg/utils/secrets/manager/generate_test.go
@@ -246,6 +246,7 @@ var _ = Describe("Generate", func() {
 				By("generating new secret")
 				secret, err := m.Generate(ctx, config)
 				Expect(err).NotTo(HaveOccurred())
+				Expect(secret.Name).To(Equal(name + "-cb09286a"))
 				expectSecretWasCreated(ctx, fakeClient, secret)
 
 				By("finding created bundle secret")
@@ -297,6 +298,14 @@ var _ = Describe("Generate", func() {
 					HaveKeyWithValue("issued-at-time", strconv.FormatInt(fakeClock.Now().Unix(), 10)),
 					HaveKeyWithValue("valid-until-time", strconv.FormatInt(fakeClock.Now().AddDate(10, 0, 0).Unix(), 10)),
 				))
+			})
+
+			It("should generate a new CA secret and ignore the config checksum for its name", func() {
+				By("generating new secret")
+				secret, err := m.Generate(ctx, config, IgnoreConfigChecksumForCASecretName())
+				Expect(err).NotTo(HaveOccurred())
+				expectSecretWasCreated(ctx, fakeClient, secret)
+				Expect(secret.Name).To(Equal(name))
 			})
 
 			It("should rotate a CA secret and add old and new to the corresponding bundle", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
This PR changes the validity of the seed cluster CA certificate to `30d`. After #5679, this will trigger regular auto-rotation of the CA and the signed secrets.

Along the way, the secrets manager was improved to also (optionally) include the config checksum into the secret name for CA secrets. 

**Which issue(s) this PR fixes**:
Part of #3292

**Special notes for your reviewer**:
/cc @timebertt 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
The seed cluster CA certificate is now auto-rotated each `30d`.
```
