### PR TITLE
Disable calico backend for shoots in local e2e tests

### DIFF
--- a/example/provider-local/shoot.yaml
+++ b/example/provider-local/shoot.yaml
@@ -15,6 +15,7 @@ spec:
     providerConfig:
       apiVersion: calico.networking.extensions.gardener.cloud/v1alpha1
       kind: NetworkConfig
+      backend: none
       typha:
         enabled: false
   provider:

--- a/test/e2e/shoot/common.go
+++ b/test/e2e/shoot/common.go
@@ -71,7 +71,7 @@ func defaultShoot(generateName string) *gardencorev1beta1.Shoot {
 			},
 			Networking: gardencorev1beta1.Networking{
 				Type:           "calico",
-				ProviderConfig: &runtime.RawExtension{Raw: []byte(`{"apiVersion":"calico.networking.extensions.gardener.cloud/v1alpha1","kind":"NetworkConfig","typha":{"enabled":false}}`)},
+				ProviderConfig: &runtime.RawExtension{Raw: []byte(`{"apiVersion":"calico.networking.extensions.gardener.cloud/v1alpha1","kind":"NetworkConfig","typha":{"enabled":false},"backend":"none"}`)},
 			},
 			Provider: gardencorev1beta1.Provider{
 				Type: "local",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
After #5774, the e2e tests are quite flaky because the `calico-kube-controllers` pod often has connectivity issues to the shoot cluster's `kube-apiserver`.

<img width="1913" alt="image" src="https://user-images.githubusercontent.com/19169361/162751240-3c7e8b45-2f2d-4f48-bc8a-77ba0d1a2a7c.png">

For now, let's fix the flaky behaviour by setting the `backend=none` which prevents `calico-kube-controllers` from being deployed in the first place.

**Special notes for your reviewer**:
/cc @timebertt 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
