### PR TITLE
Revert 'Allow changing container runtime on existing workers'

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -293,7 +293,45 @@ func ValidateShootSpecUpdate(newSpec, oldSpec *core.ShootSpec, newObjectMeta met
 
 // ValidateProviderUpdate validates the specification of a Provider object.
 func ValidateProviderUpdate(newProvider, oldProvider *core.Provider, fldPath *field.Path) field.ErrorList {
-	return apivalidation.ValidateImmutableField(newProvider.Type, oldProvider.Type, fldPath.Child("type"))
+	allErrs := field.ErrorList{}
+
+	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newProvider.Type, oldProvider.Type, fldPath.Child("type"))...)
+	allErrs = append(allErrs, ValidateWorkersUpdate(newProvider.Workers, oldProvider.Workers, fldPath.Child("workers"))...)
+
+	return allErrs
+}
+
+// ValidateWorkersUpdate validates the specification of a Provider object.
+func ValidateWorkersUpdate(newWorkers, oldWorkers []core.Worker, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	oldWorkersMap := make(map[string]core.Worker)
+	for _, w := range oldWorkers {
+		oldWorkersMap[w.Name] = w
+	}
+	for i, w := range newWorkers {
+		if _, ok := oldWorkersMap[w.Name]; ok {
+			oldWorker := oldWorkersMap[w.Name]
+			allErrs = append(allErrs, ValidateWorkerUpdate(&w, &oldWorker, fldPath.Index(i))...)
+		}
+	}
+	return allErrs
+}
+
+// ValidateWorkerUpdate validates the specification of a Provider object.
+func ValidateWorkerUpdate(newWorker, oldWorker *core.Worker, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	allErrs = append(allErrs, validateCRIUpdate(newWorker.CRI, oldWorker.CRI, fldPath.Child("cri"))...)
+
+	return allErrs
+}
+
+func validateCRIUpdate(newCri *core.CRI, oldCri *core.CRI, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	if (newCri == nil && oldCri != nil) || (newCri != nil && oldCri == nil) || (newCri != nil && oldCri != nil && newCri.Name != oldCri.Name) {
+		allErrs = append(allErrs, field.Invalid(fldPath, newCri, "can't update cri configurations"))
+	}
+	return allErrs
 }
 
 // ValidateShootStatusUpdate validates the status field of a Shoot object.

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -252,7 +252,7 @@ func ValidateShootSpecUpdate(newSpec, oldSpec *core.ShootSpec, newObjectMeta met
 	allErrs = append(allErrs, validateDNSUpdate(newSpec.DNS, oldSpec.DNS, seedGotAssigned, fldPath.Child("dns"))...)
 	allErrs = append(allErrs, validateKubernetesVersionUpdate(newSpec.Kubernetes.Version, oldSpec.Kubernetes.Version, fldPath.Child("kubernetes", "version"))...)
 	allErrs = append(allErrs, validateKubeControllerManagerUpdate(newSpec.Kubernetes.KubeControllerManager, oldSpec.Kubernetes.KubeControllerManager, fldPath.Child("kubernetes", "kubeControllerManager"))...)
-	allErrs = append(allErrs, validateProviderUpdate(&newSpec.Provider, &oldSpec.Provider, fldPath.Child("provider"))...)
+	allErrs = append(allErrs, ValidateProviderUpdate(&newSpec.Provider, &oldSpec.Provider, fldPath.Child("provider"))...)
 
 	for i, newWorker := range newSpec.Provider.Workers {
 		oldWorker := newWorker
@@ -291,7 +291,8 @@ func ValidateShootSpecUpdate(newSpec, oldSpec *core.ShootSpec, newObjectMeta met
 	return allErrs
 }
 
-func validateProviderUpdate(newProvider, oldProvider *core.Provider, fldPath *field.Path) field.ErrorList {
+// ValidateProviderUpdate validates the specification of a Provider object.
+func ValidateProviderUpdate(newProvider, oldProvider *core.Provider, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newProvider.Type, oldProvider.Type, fldPath.Child("type"))...)

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -252,7 +252,7 @@ func ValidateShootSpecUpdate(newSpec, oldSpec *core.ShootSpec, newObjectMeta met
 	allErrs = append(allErrs, validateDNSUpdate(newSpec.DNS, oldSpec.DNS, seedGotAssigned, fldPath.Child("dns"))...)
 	allErrs = append(allErrs, validateKubernetesVersionUpdate(newSpec.Kubernetes.Version, oldSpec.Kubernetes.Version, fldPath.Child("kubernetes", "version"))...)
 	allErrs = append(allErrs, validateKubeControllerManagerUpdate(newSpec.Kubernetes.KubeControllerManager, oldSpec.Kubernetes.KubeControllerManager, fldPath.Child("kubernetes", "kubeControllerManager"))...)
-	allErrs = append(allErrs, ValidateProviderUpdate(&newSpec.Provider, &oldSpec.Provider, fldPath.Child("provider"))...)
+	allErrs = append(allErrs, validateProviderUpdate(&newSpec.Provider, &oldSpec.Provider, fldPath.Child("provider"))...)
 
 	for i, newWorker := range newSpec.Provider.Workers {
 		oldWorker := newWorker
@@ -291,18 +291,16 @@ func ValidateShootSpecUpdate(newSpec, oldSpec *core.ShootSpec, newObjectMeta met
 	return allErrs
 }
 
-// ValidateProviderUpdate validates the specification of a Provider object.
-func ValidateProviderUpdate(newProvider, oldProvider *core.Provider, fldPath *field.Path) field.ErrorList {
+func validateProviderUpdate(newProvider, oldProvider *core.Provider, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newProvider.Type, oldProvider.Type, fldPath.Child("type"))...)
-	allErrs = append(allErrs, ValidateWorkersUpdate(newProvider.Workers, oldProvider.Workers, fldPath.Child("workers"))...)
+	allErrs = append(allErrs, validateWorkersUpdate(newProvider.Workers, oldProvider.Workers, fldPath.Child("workers"))...)
 
 	return allErrs
 }
 
-// ValidateWorkersUpdate validates the specification of a Provider object.
-func ValidateWorkersUpdate(newWorkers, oldWorkers []core.Worker, fldPath *field.Path) field.ErrorList {
+func validateWorkersUpdate(newWorkers, oldWorkers []core.Worker, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	oldWorkersMap := make(map[string]core.Worker)
 	for _, w := range oldWorkers {
@@ -311,14 +309,13 @@ func ValidateWorkersUpdate(newWorkers, oldWorkers []core.Worker, fldPath *field.
 	for i, w := range newWorkers {
 		if _, ok := oldWorkersMap[w.Name]; ok {
 			oldWorker := oldWorkersMap[w.Name]
-			allErrs = append(allErrs, ValidateWorkerUpdate(&w, &oldWorker, fldPath.Index(i))...)
+			allErrs = append(allErrs, validateWorkerUpdate(&w, &oldWorker, fldPath.Index(i))...)
 		}
 	}
 	return allErrs
 }
 
-// ValidateWorkerUpdate validates the specification of a Provider object.
-func ValidateWorkerUpdate(newWorker, oldWorker *core.Worker, fldPath *field.Path) field.ErrorList {
+func validateWorkerUpdate(newWorker, oldWorker *core.Worker, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 	allErrs = append(allErrs, validateCRIUpdate(newWorker.CRI, oldWorker.CRI, fldPath.Child("cri"))...)
 

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -1133,6 +1133,33 @@ var _ = Describe("Shoot Validation Tests", func() {
 					}))))
 				})
 			})
+
+			It("should not allow update cri configurations enablement", func() {
+				newShoot := prepareShootForUpdate(shoot)
+				newWorker := *shoot.Spec.Provider.Workers[0].DeepCopy()
+				newWorker.Name = "second-worker"
+				newWorker.CRI = &core.CRI{Name: core.CRINameContainerD}
+				shoot.Spec.Provider.Workers = append(shoot.Spec.Provider.Workers, newWorker)
+
+				newShoot.Spec.Provider.Workers = []core.Worker{newWorker, shoot.Spec.Provider.Workers[0]}
+				newShoot.Spec.Provider.Workers[0].CRI = nil
+				newShoot.Spec.Provider.Workers[1].CRI = &core.CRI{Name: core.CRINameContainerD}
+
+				errorList := ValidateShootUpdate(newShoot, shoot)
+
+				Expect(errorList).To(HaveLen(2))
+			})
+
+			It("should not allow update cri name", func() {
+				shoot.Spec.Provider.Workers[0].CRI = &core.CRI{Name: "test-cri"}
+				newShoot := prepareShootForUpdate(shoot)
+
+				newShoot.Spec.Provider.Workers[0].CRI = &core.CRI{Name: core.CRINameContainerD}
+
+				errorList := ValidateShootUpdate(newShoot, shoot)
+
+				Expect(errorList).To(HaveLen(1))
+			})
 		})
 
 		Context("dns section", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
After #5273 got closed:
Reverts https://github.com/gardener/gardener/pull/4171, to stop people from switching their container runtime on existing worker pools while https://github.com/gardener/gardener/issues/4415 is still open. This is only temporary, until the issue is fixed – afterwards we can safely allow updating the container runtime again.

**Which issue(s) this PR fixes**:
This is a bandaid for https://github.com/gardener/gardener/issues/4415. An actual fix should follow.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Temporarily no longer allow changing container runtime on existing workers due to an open bug: [#4415](https://github.com/gardener/gardener/issues/4415).
```
