### PR TITLE
Promote DenyInvalidExtensionResources feature gate to GA

### DIFF
--- a/cmd/gardener-seed-admission-controller/app/gardener_seed_admission_controller.go
+++ b/cmd/gardener-seed-admission-controller/app/gardener_seed_admission_controller.go
@@ -92,8 +92,6 @@ type Options struct {
 	Port int
 	// ServerCertDir is the path to server TLS cert and key.
 	ServerCertDir string
-	// AllowInvalidExtensionResources causes the seed-admission-controller to allow invalid extension resources.
-	AllowInvalidExtensionResources bool
 	// MetricsBindAddress is the TCP address that the controller should bind to
 	// for serving prometheus metrics.
 	// It can be set to "0" to disable the metrics serving.
@@ -112,7 +110,6 @@ func (o *Options) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.BindAddress, "bind-address", "0.0.0.0", "Address to bind to")
 	fs.IntVar(&o.Port, "port", 9443, "Webhook server port")
 	fs.StringVar(&o.ServerCertDir, "tls-cert-dir", "", "Directory with server TLS certificate and key (must contain a tls.crt and tls.key file)")
-	fs.BoolVar(&o.AllowInvalidExtensionResources, "allow-invalid-extension-resources", false, "Allow invalid extension resources")
 	fs.StringVar(&o.MetricsBindAddress, "metrics-bind-address", ":8080", "Bind address for the metrics server")
 	fs.StringVar(&o.HealthBindAddress, "health-bind-address", ":8081", "Bind address for the health server")
 	fs.BoolVar(&o.EnableProfiling, "profiling", false, "Enable profiling via web interface host:port/debug/pprof/")
@@ -186,7 +183,7 @@ func (o *Options) Run(ctx context.Context) error {
 
 	server.Register(extensioncrds.WebhookPath, &webhook.Admission{Handler: extensioncrds.New(runtimelog.Log.WithName(extensioncrds.HandlerName))})
 	server.Register(podschedulername.WebhookPath, &webhook.Admission{Handler: admission.HandlerFunc(podschedulername.DefaultShootControlPlanePodsSchedulerName)})
-	server.Register(extensionresources.WebhookPath, &webhook.Admission{Handler: extensionresources.New(runtimelog.Log.WithName(extensionresources.HandlerName), o.AllowInvalidExtensionResources)})
+	server.Register(extensionresources.WebhookPath, &webhook.Admission{Handler: extensionresources.New(runtimelog.Log.WithName(extensionresources.HandlerName))})
 
 	log.Info("Starting manager")
 	if err := mgr.Start(ctx); err != nil {

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -31,8 +31,6 @@ The following tables are a summary of the feature gates that you can set on diff
 | ReversedVPN                                  | `false` | `Alpha` | `1.22` | `1.41` |
 | ReversedVPN                                  | `true`  | `Beta`  | `1.42` |        |
 | RotateSSHKeypairOnMaintenance                | `false` | `Alpha` | `1.28` |        |
-| DenyInvalidExtensionResources                | `false` | `Alpha` | `1.31` | `1.41` |
-| DenyInvalidExtensionResources                | `true`  | `Beta`  | `1.42` |        |
 | WorkerPoolKubernetesVersion                  | `false` | `Alpha` | `1.35` |        |
 | CopyEtcdBackupsDuringControlPlaneMigration   | `false` | `Alpha` | `1.37` |        |
 | SecretBindingProviderValidation              | `false` | `Alpha` | `1.38` |        |
@@ -70,6 +68,9 @@ The following tables are a summary of the feature gates that you can set on diff
 | CachedRuntimeClients                         | `false` | `Alpha`   | `1.7`  | `1.33` |
 | CachedRuntimeClients                         | `true`  | `Beta`    | `1.34` | `1.44` |
 | CachedRuntimeClients                         | `true`  | `GA`      | `1.45` |        |
+| DenyInvalidExtensionResources                | `false` | `Alpha`   | `1.31` | `1.41` |
+| DenyInvalidExtensionResources                | `true`  | `Beta`    | `1.42` | `1.44` |
+| DenyInvalidExtensionResources                | `true`  | `GA`      | `1.45` |        |
 
 ## Using a feature
 

--- a/example/20-componentconfig-gardenlet.yaml
+++ b/example/20-componentconfig-gardenlet.yaml
@@ -114,7 +114,6 @@ featureGates:
   APIServerSNI: true
   SeedKubeScheduler: false
   ReversedVPN: true
-  DenyInvalidExtensionResources: true
   CopyEtcdBackupsDuringControlPlaneMigration: false
   ForceRestore: false
   DisableDNSProviderManagement: false

--- a/example/gardener-local/gardenlet/values.yaml
+++ b/example/gardener-local/gardenlet/values.yaml
@@ -44,7 +44,6 @@ global:
         APIServerSNI: true
         SeedKubeScheduler: false
         ReversedVPN: true
-        DenyInvalidExtensionResources: true
         ShootCARotation: true
       seedConfig:
         apiVersion: core.gardener.cloud/v1beta1

--- a/hack/local-development/start-seed-admission-controller
+++ b/hack/local-development/start-seed-admission-controller
@@ -26,5 +26,4 @@ GO111MODULE=on \
       -ldflags "$(./hack/get-build-ld-flags.sh)" \
       "$(dirname $0)"/../../cmd/gardener-seed-admission-controller/main.go \
       --kubeconfig="${KUBECONFIG:-$kubeconfig}" \
-      --tls-cert-dir="$(dirname $0)/../../example/seed-admission-controller" \
-      --allow-invalid-extension-resources=false
+      --tls-cert-dir="$(dirname $0)/../../example/seed-admission-controller"

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -101,6 +101,7 @@ const (
 	// owner: @stoyanr
 	// alpha: v1.31.0
 	// beta: v1.42.0
+	// GA: v1.45.0
 	DenyInvalidExtensionResources featuregate.Feature = "DenyInvalidExtensionResources"
 
 	// WorkerPoolKubernetesVersion allows to overwrite the Kubernetes version used for shoot clusters per worker pool.
@@ -172,7 +173,7 @@ var allFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	AdminKubeconfigRequest:        {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	UseDNSRecords:                 {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	RotateSSHKeypairOnMaintenance: {Default: false, PreRelease: featuregate.Alpha},
-	DenyInvalidExtensionResources: {Default: true, PreRelease: featuregate.Beta},
+	DenyInvalidExtensionResources: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	WorkerPoolKubernetesVersion:   {Default: false, PreRelease: featuregate.Alpha},
 	CopyEtcdBackupsDuringControlPlaneMigration: {Default: false, PreRelease: featuregate.Alpha},
 	SecretBindingProviderValidation:            {Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller.go
+++ b/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller.go
@@ -23,8 +23,6 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	"github.com/gardener/gardener/pkg/features"
-	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	"github.com/gardener/gardener/pkg/seedadmissioncontroller/webhooks/admission/extensioncrds"
@@ -249,7 +247,6 @@ func (g *gardenerSeedAdmissionController) Deploy(ctx context.Context) error {
 								"/gardener-seed-admission-controller",
 								fmt.Sprintf("--port=%d", port),
 								fmt.Sprintf("--tls-cert-dir=%s", volumeMountPath),
-								fmt.Sprintf("--allow-invalid-extension-resources=%t", !gardenletfeatures.FeatureGate.Enabled(features.DenyInvalidExtensionResources)),
 								fmt.Sprintf("--metrics-bind-address=:%d", metricsPort),
 								fmt.Sprintf("--health-bind-address=:%d", healthPort),
 							},

--- a/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller_test.go
+++ b/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller_test.go
@@ -173,7 +173,6 @@ spec:
         - /gardener-seed-admission-controller
         - --port=10250
         - --tls-cert-dir=/srv/gardener-seed-admission-controller
-        - --allow-invalid-extension-resources=false
         - --metrics-bind-address=:8080
         - --health-bind-address=:8081
         image: ` + image + `

--- a/pkg/seedadmissioncontroller/webhooks/admission/extensionresources/admission_test.go
+++ b/pkg/seedadmissioncontroller/webhooks/admission/extensionresources/admission_test.go
@@ -239,7 +239,7 @@ var _ = Describe("handler", func() {
 			decoder, err = admission.NewDecoder(kubernetes.SeedScheme)
 			Expect(err).NotTo(HaveOccurred())
 
-			handler = extensionresources.New(logger, false)
+			handler = extensionresources.New(logger)
 			Expect(admission.InjectDecoderInto(decoder, handler)).To(BeTrue())
 
 			request = nil

--- a/test/integration/seedadmissioncontroller/seedadmission_suite_test.go
+++ b/test/integration/seedadmissioncontroller/seedadmission_suite_test.go
@@ -91,7 +91,7 @@ var _ = BeforeSuite(func() {
 	server := mgr.GetWebhookServer()
 	server.Register(extensioncrds.WebhookPath, &webhook.Admission{Handler: extensioncrds.New(logger)})
 	server.Register(podschedulername.WebhookPath, &webhook.Admission{Handler: admission.HandlerFunc(podschedulername.DefaultShootControlPlanePodsSchedulerName)})
-	server.Register(extensionresources.WebhookPath, &webhook.Admission{Handler: extensionresources.New(logger, true)})
+	server.Register(extensionresources.WebhookPath, &webhook.Admission{Handler: extensionresources.New(logger)})
 
 	go func() {
 		defer GinkgoRecover()


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
The `DenyInvalidExtensionResources` feature gate for seed-admission-controller has been promoted to `GA`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `DenyInvalidExtensionResources` feature gate in the `seed-admission-controller` has been promoted to GA and can no longer be disabled.
```

@stoyanr