### PR TITLE
Do not consider shoots with deletion timestamp when `ShootMaxTokenExpiration{Overwrite,Validation}` is enabled

### DIFF
--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -1743,6 +1743,19 @@ var _ = Describe("Shoot Validation Tests", func() {
 						"Field": Equal("spec.kubernetes.kubeAPIServer.serviceAccountConfig.maxTokenExpiration"),
 					}))))
 				})
+
+				It("should accept values for the max token duration out of boundaries when deletion timestamp is set", func() {
+					defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.ShootMaxTokenExpirationValidation, true)()
+
+					shoot.DeletionTimestamp = &metav1.Time{}
+					shoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig = &core.ServiceAccountConfig{
+						MaxTokenExpiration: &metav1.Duration{Duration: 5000 * time.Hour},
+					}
+
+					errorList := ValidateShoot(shoot)
+
+					Expect(errorList).To(BeEmpty())
+				})
 			})
 
 			It("should not allow too specify the 'extend' flag if kubernetes is lower than 1.19", func() {

--- a/pkg/registry/core/shoot/strategy.go
+++ b/pkg/registry/core/shoot/strategy.go
@@ -82,7 +82,8 @@ func (shootStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Obje
 }
 
 func overwriteMaxTokenExpiration(shoot *core.Shoot) {
-	if shoot.Spec.Kubernetes.KubeAPIServer != nil &&
+	if shoot.DeletionTimestamp == nil &&
+		shoot.Spec.Kubernetes.KubeAPIServer != nil &&
 		shoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig != nil &&
 		shoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.MaxTokenExpiration != nil {
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
Do not consider shoots with deletion timestamp when `ShootMaxTokenExpiration{Overwrite,Validation}` is enabled (ref #5550). Otherwise, shoots which already have a deletion timestamp at the time when the feature gates are enabled can get stuck in deletion because `gardenlet` is unable to remove its finalizer. This is because the `gardener-apiserver` tries to patch the spec (`.spec.kubernetes.kubeAPIServer.serviceAccountConfig.maxTokenExpiration`) which is not allowed when a deletion timestamp is set.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed which can result in `Shoot`s stuck in deletion when the `ShootMaxTokenExpiration{Overwrite,Validation}` feature gates are enabled.
```
