### PR TITLE
[GEP-18] Sign VPA server cert with current CA

### DIFF
--- a/pkg/operation/botanist/component/vpa/vpa.go
+++ b/pkg/operation/botanist/component/vpa/vpa.go
@@ -128,7 +128,7 @@ func (v *vpa) Deploy(ctx context.Context) error {
 		DNSNames:                    kutil.DNSNamesForService(admissionControllerServiceName, v.namespace),
 		CertType:                    secretutils.ServerCert,
 		SkipPublishingCACertificate: true,
-	}, secretsmanager.SignedByCA(v.values.SecretNameServerCA), secretsmanager.Rotate(secretsmanager.InPlace))
+	}, secretsmanager.SignedByCA(v.values.SecretNameServerCA, secretsmanager.UseCurrentCA), secretsmanager.Rotate(secretsmanager.InPlace))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
After #5785, server certificates which are deployed at the same time as all clients are always signed with the current CA. The VPA admission controller server certificate is of such kind as well, so let's add the configuration option.

/cc @plkokanov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
