### PR TITLE
[GEP-18] Adapt `gardener-seed-admission-controller` component to new secrets manager

### DIFF
--- a/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller.go
+++ b/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller.go
@@ -24,11 +24,11 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
-	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	"github.com/gardener/gardener/pkg/seedadmissioncontroller/webhooks/admission/extensioncrds"
 	"github.com/gardener/gardener/pkg/seedadmissioncontroller/webhooks/admission/extensionresources"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
+	secretutils "github.com/gardener/gardener/pkg/utils/secrets"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 
 	admissionv1 "k8s.io/api/admission/v1"
@@ -44,7 +44,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -92,19 +91,21 @@ func (g *gardenerSeedAdmissionController) Deploy(ctx context.Context) error {
 		return err
 	}
 
-	secret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      Name + "-tls",
-			Namespace: g.namespace,
-			Labels:    getLabels(),
-		},
-		Type: corev1.SecretTypeTLS,
-		Data: map[string][]byte{
-			corev1.TLSCertKey:       []byte(tlsServerCert),
-			corev1.TLSPrivateKeyKey: []byte(tlsServerKey),
-		},
+	caSecret, found := g.secretsManager.Get(v1beta1constants.SecretNameCASeed)
+	if !found {
+		return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameCASeed)
 	}
-	utilruntime.Must(kutil.MakeUnique(secret))
+
+	serverSecret, err := g.secretsManager.Generate(ctx, &secretutils.CertificateSecretConfig{
+		Name:                        Name + "-server",
+		CommonName:                  Name,
+		DNSNames:                    kutil.DNSNamesForService(Name, g.namespace),
+		CertType:                    secretutils.ServerCert,
+		SkipPublishingCACertificate: true,
+	}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCASeed, secretsmanager.UseCurrentCA), secretsmanager.Rotate(secretsmanager.InPlace))
+	if err != nil {
+		return err
+	}
 
 	var (
 		registry = managedresources.NewRegistry(kubernetes.SeedScheme, kubernetes.SeedCodec, kubernetes.SeedSerializer)
@@ -302,7 +303,7 @@ func (g *gardenerSeedAdmissionController) Deploy(ctx context.Context) error {
 							Name: volumeName,
 							VolumeSource: corev1.VolumeSource{
 								Secret: &corev1.SecretVolumeSource{
-									SecretName: secret.Name,
+									SecretName: serverSecret.Name,
 								},
 							},
 						}},
@@ -344,18 +345,14 @@ func (g *gardenerSeedAdmissionController) Deploy(ctx context.Context) error {
 			},
 		}
 
-		caBundle                       = []byte(TLSCACert)
-		validatingWebhookConfiguration = GetValidatingWebhookConfig(caBundle, service)
+		validatingWebhookConfiguration = GetValidatingWebhookConfig(caSecret.Data[secretutils.DataKeyCertificateBundle], service)
 	)
-
-	utilruntime.Must(references.InjectAnnotations(deployment))
 
 	resources, err := registry.AddAllAndSerialize(
 		serviceAccount,
 		clusterRole,
 		clusterRoleBinding,
 		service,
-		secret,
 		deployment,
 		podDisruptionBudget,
 		vpa,
@@ -549,78 +546,3 @@ func (g *gardenerSeedAdmissionController) getReplicas(ctx context.Context) (int3
 
 	return defaultReplicas, nil
 }
-
-const (
-	// TLSCACert is the of certificate authority of the
-	// seed admission controller server.
-	// TODO(mvladev) this cert is hard-coded.
-	// fix it in another PR.
-	TLSCACert = `-----BEGIN CERTIFICATE-----
-MIIC+jCCAeKgAwIBAgIUTp3XvhrWOVM8ZGe86YoXMV/UJ7AwDQYJKoZIhvcNAQEL
-BQAwFTETMBEGA1UEAxMKa3ViZXJuZXRlczAeFw0xOTAyMjcxNTM0MDBaFw0yNDAy
-MjYxNTM0MDBaMBUxEzARBgNVBAMTCmt1YmVybmV0ZXMwggEiMA0GCSqGSIb3DQEB
-AQUAA4IBDwAwggEKAoIBAQCyi0QGOcv2bTf3N8OLN97RwsgH6QAr8wSpAOrttBJg
-FnfnU2T1RHgxm7qd190WL8DChv0dZf76d6eSQ4ZrjjyArTzufb4DtPwg+VWq7XvF
-BNyn+2hf4SySkwd6k7XLhUTRx048IbByC4v+FEvmoLAwrc0d0G14ec6snD+7jO7e
-kykQ/NgAOL7P6kDs9z6+bOfgF0nGN+bmeWQqJejR0t+OyQDCx5/FMtUfEVR5QX80
-aeefgp3JFZb6fAw9KhLtdRV3FP0tz6hS+e4Sg0mwAAOqijZsV87kP5GYzjtcfA12
-lDYl/nb1GtVvvkQD49VnV7mDnl6mG3LCMNCNH6WlZNv3AgMBAAGjQjBAMA4GA1Ud
-DwEB/wQEAwIBBjAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBSFA3LvJM21d8qs
-ZVVCe6RrTT9wiTANBgkqhkiG9w0BAQsFAAOCAQEAns/EJ3yKsjtISoteQ714r2Um
-BMPyUYTTdRHD8LZMd3RykvsacF2l2y88Nz6wJcAuoUj1h8aBDP5oXVtNmFT9jybS
-TXrRvWi+aeYdb556nEA5/a94e+cb+Ck3qy/1xgQoS457AZQODisDZNBYWkAFs2Lc
-ucpcAtXJtIthVm7FjoAHYcsrY04yAiYEJLD02TjUDXg4iGOGMkVHdmhawBDBF3Aj
-esfcqFwji6JyAKFRACPowykQONFwUSom89uYESSCJFvNCk9MJmjJ2PzDUt6CypR4
-epFdd1fXLwuwn7fvPMmJqD3HtLalX1AZmPk+BI8ezfAiVcVqnTJQMXlYPpYe9A==
------END CERTIFICATE-----`
-	tlsServerCert = `-----BEGIN CERTIFICATE-----
-MIID0zCCArugAwIBAgIUaDMrqx0VRoOmGHM1afdZt39e2tMwDQYJKoZIhvcNAQEL
-BQAwFTETMBEGA1UEAxMKa3ViZXJuZXRlczAeFw0yMDAzMTYxODE4MDBaFw0zMDAz
-MTQxODE4MDBaMC0xKzApBgNVBAMTImdhcmRlbmVyLXNlZWQtYWRtaXNzaW9uLWNv
-bnRyb2xsZXIwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDFqFORLK0P
-+h2JxhyqCK850yviF0fByRqffpHfaRyfkGt33VrFXeuhGL+suTicfhzZSWMVojk/
-9R3R8FkK02Emq544o9YY5Ho/FGwlE9s1l456dW4F7oblvw7dgcRFdO6N4h/xrVab
-5qdNORnxRIZTJ3qz1ZjgcsOwjyzJwyO9PidlG6MW0qqX9Ab+g8Px0eSP2zBhqcLV
-6uGy4gYc2+RiXfKgYCsOu+HuNb4DFVediM82J0ZYzchMe5Uqp+PYiBIAH0Xqqz36
-GW9rb5O43V5R1HSVDioFrI0EkzWYLFGxol+4TRTNA4sjPXjAJFSXDr6gy6mNYqeI
-6DbThhDPMPwtAgMBAAGjggEBMIH+MA4GA1UdDwEB/wQEAwIFoDATBgNVHSUEDDAK
-BggrBgEFBQcDATAMBgNVHRMBAf8EAjAAMB0GA1UdDgQWBBQf/8Y23xQcoH8EYnWh
-yLGZ31Bk4DAfBgNVHSMEGDAWgBSFA3LvJM21d8qsZVVCe6RrTT9wiTCBiAYDVR0R
-BIGAMH6CImdhcmRlbmVyLXNlZWQtYWRtaXNzaW9uLWNvbnRyb2xsZXKCKWdhcmRl
-bmVyLXNlZWQtYWRtaXNzaW9uLWNvbnRyb2xsZXIuZ2FyZGVugi1nYXJkZW5lci1z
-ZWVkLWFkbWlzc2lvbi1jb250cm9sbGVyLmdhcmRlbi5zdmMwDQYJKoZIhvcNAQEL
-BQADggEBALEsnx+Zcv3IME/Xs82x0PAxDuIFV4ZnGPbweCZ5JKKlAtHtrq2JTYoQ
-zHbGTj2IEpzdq04RyRqY0ejD25HWeVHcAlhSLGvKKuuMznIl6e4G/Kfmg0NLwiMK
-7jsSjpNdHnJOsPg3j3iblP0ZSY8A5p12uqMzfvKPNFK62EuyqmEfI9ec6P6wNAcZ
-R3Ejum8yCcOCZlOczOH/8ZIdIC1jlFYm4Wwzm1uUgoSk240nqhuBirWqARjJNhfu
-/0HDmy6Zs/2FlRNIWuskpNIgOtMa3A277qx2O542+UhKv2jaIXtX1BnRLTCFVyDZ
-gj5593AJYDj8QFHulFeMeh5baOkksjc=
------END CERTIFICATE-----`
-	tlsServerKey = `-----BEGIN RSA PRIVATE KEY-----
-MIIEowIBAAKCAQEAxahTkSytD/odicYcqgivOdMr4hdHwckan36R32kcn5Brd91a
-xV3roRi/rLk4nH4c2UljFaI5P/Ud0fBZCtNhJqueOKPWGOR6PxRsJRPbNZeOenVu
-Be6G5b8O3YHERXTujeIf8a1Wm+anTTkZ8USGUyd6s9WY4HLDsI8sycMjvT4nZRuj
-FtKql/QG/oPD8dHkj9swYanC1erhsuIGHNvkYl3yoGArDrvh7jW+AxVXnYjPNidG
-WM3ITHuVKqfj2IgSAB9F6qs9+hlva2+TuN1eUdR0lQ4qBayNBJM1mCxRsaJfuE0U
-zQOLIz14wCRUlw6+oMupjWKniOg204YQzzD8LQIDAQABAoIBAFfUvp2qHpUU7X9F
-W4NrLIIjhkKHWcmQ1ZW+JpACI0f8YuT2pdlCLOx/FN1pyPAxUhxz8eWxGoODJmcd
-yFN5LpiCdmJw2zhgfrn9Fzk6o5Qi7psYB3X3UlZRGgfwHAlJNqAxtUQtZGkOi5VT
-JGYDrzTQPEQhTDegh7izRpG5du4mIXqkrmzTWIwPznLRmAps0fJQuQ9WIUP0iJSt
-CMLZ0898GANcdDbE8Ta3emPe3cgJjdUTyH3zMsnJT014N0zzX+e5aXcfxCwAaN+T
-fGLaQe1PV714SIhuDo+KBSJo0K0poUA8d5lNIeetl8WD0cpAKjBzpf3CvF78cT3i
-c/ZrxIECgYEAzBnDosYxuKIk8iVTe+eTRRwZsi7svaMTnmlcc6/3q5vLb3i1z5V9
-n/CEP5ZlvikhNB/Dt3WXmgprHzQN2ljnIJn2KHkR0gWe57aCbYtGxOCijvsZGUoJ
-F2iOLfTHBsnxiNP3uzjsuceCuiSD87e0bVBJon4oz6Y7eF6kzKRGFn0CgYEA9+sj
-UYtjGZfsEYChtTObC0SLXawkzAGUgJUN1NAh2w5o9Gr61Itt+SwwhqQFQhXyW50d
-+bsck3Jk6U6Hke+h9ITUB3Hnqg3KW9L8sPYPqCBT6EQ/qZPmWOKjZTyiSjO1kKx6
-+aPM4NKZttzJOcVwQU9m19dvM3xqUfXFPkCve3ECgYAHFcHfzad+NEq6CServm8z
-T/VoZQ6cyqNstVWbQnmDgIYAWZ1eFl9lBPFiT7M6da0MZSnjHXbkxwXO8Hymnr1v
-OUj9QK6orr9EZeaDLPmI7g9WjUriwNot8Ng2qi+agbobuNf5rNEy5cUY9xmJhVAD
-F21m8aAzDR81X3uzCuTP9QKBgQCu9zfZ2PF7oohsYce+Rklpzlo9JbxibcsMZCV6
-x9jc7HKN7OJRFoXqkJE+tIsxdKOynFQHZ1JnjRhCv7VV/TTjiMrK5kyE626hF2pW
-yZGLKiWNin0ThNnQaUK/s+clTxEYpWG0xTFWicsKDw/Ewd7TeOIv+k70mx298iHe
-KXCvQQKBgGdI3bZ1xxKMWDeU5QamDaOkHeZl2SacEQ+C09/O975HLfE05+gsPYDE
-+YNg06oQlO/U9tmOvyGX+Ca6yLF/XQMq62oNlp1a0oqnWlQnv57rgKrGXcv2+6sP
-LhAfbwDR/NNiimZioPeJEGPocUq21OL5RFjj2Sz5l4NYk6Mmeyfz
------END RSA PRIVATE KEY-----`
-)

--- a/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller.go
+++ b/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gardener/gardener/pkg/seedadmissioncontroller/webhooks/admission/extensionresources"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
+	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
@@ -69,18 +70,20 @@ const (
 )
 
 // New creates a new instance of DeployWaiter for the gardener-seed-admission-controller.
-func New(c client.Client, namespace string, image string) component.DeployWaiter {
+func New(c client.Client, namespace string, secretsManager secretsmanager.Interface, image string) component.DeployWaiter {
 	return &gardenerSeedAdmissionController{
-		client:    c,
-		namespace: namespace,
-		image:     image,
+		client:         c,
+		namespace:      namespace,
+		secretsManager: secretsManager,
+		image:          image,
 	}
 }
 
 type gardenerSeedAdmissionController struct {
-	client    client.Client
-	namespace string
-	image     string
+	client         client.Client
+	namespace      string
+	secretsManager secretsmanager.Interface
+	image          string
 }
 
 func (g *gardenerSeedAdmissionController) Deploy(ctx context.Context) error {

--- a/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller_suite_test.go
+++ b/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller_suite_test.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 
 	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
+	secretutils "github.com/gardener/gardener/pkg/utils/secrets"
+	"github.com/gardener/gardener/pkg/utils/test"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -29,3 +31,7 @@ func TestSeedAdmissionController(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Botanist Component SeedAdmissionController Suite")
 }
+
+var _ = BeforeSuite(func() {
+	DeferCleanup(test.WithVar(&secretutils.GenerateKey, secretutils.FakeGenerateKey))
+})

--- a/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller_test.go
+++ b/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller_test.go
@@ -25,8 +25,9 @@ import (
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	. "github.com/gardener/gardener/pkg/operation/botanist/component/seedadmissioncontroller"
-	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
+	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 
 	"github.com/golang/mock/gomock"
@@ -36,14 +37,19 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var _ = Describe("SeedAdmission", func() {
 	var (
-		ctrl          *gomock.Controller
-		c             *mockclient.MockClient
+		ctrl       *gomock.Controller
+		c          *mockclient.MockClient
+		fakeClient client.Client
+		sm         secretsmanager.Interface
+
 		seedAdmission component.DeployWaiter
 
 		ctx       = context.TODO()
@@ -51,23 +57,6 @@ var _ = Describe("SeedAdmission", func() {
 		namespace = "shoot--foo--bar"
 		image     = "gsac:v1.2.3"
 
-		secretName = "gardener-seed-admission-controller-tls-96006b7c"
-		secretYAML = `apiVersion: v1
-data:
-  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUQwekNDQXJ1Z0F3SUJBZ0lVYURNcnF4MFZSb09tR0hNMWFmZFp0MzllMnRNd0RRWUpLb1pJaHZjTkFRRUwKQlFBd0ZURVRNQkVHQTFVRUF4TUthM1ZpWlhKdVpYUmxjekFlRncweU1EQXpNVFl4T0RFNE1EQmFGdzB6TURBegpNVFF4T0RFNE1EQmFNQzB4S3pBcEJnTlZCQU1USW1kaGNtUmxibVZ5TFhObFpXUXRZV1J0YVhOemFXOXVMV052CmJuUnliMnhzWlhJd2dnRWlNQTBHQ1NxR1NJYjNEUUVCQVFVQUE0SUJEd0F3Z2dFS0FvSUJBUURGcUZPUkxLMFAKK2gySnhoeXFDSzg1MHl2aUYwZkJ5UnFmZnBIZmFSeWZrR3QzM1ZyRlhldWhHTCtzdVRpY2ZoelpTV01Wb2prLwo5UjNSOEZrSzAyRW1xNTQ0bzlZWTVIby9GR3dsRTlzMWw0NTZkVzRGN29ibHZ3N2RnY1JGZE82TjRoL3hyVmFiCjVxZE5PUm54UklaVEozcXoxWmpnY3NPd2p5ekp3eU85UGlkbEc2TVcwcXFYOUFiK2c4UHgwZVNQMnpCaHFjTFYKNnVHeTRnWWMyK1JpWGZLZ1lDc091K0h1TmI0REZWZWRpTTgySjBaWXpjaE1lNVVxcCtQWWlCSUFIMFhxcXozNgpHVzlyYjVPNDNWNVIxSFNWRGlvRnJJMEVreldZTEZHeG9sKzRUUlROQTRzalBYakFKRlNYRHI2Z3k2bU5ZcWVJCjZEYlRoaERQTVB3dEFnTUJBQUdqZ2dFQk1JSCtNQTRHQTFVZER3RUIvd1FFQXdJRm9EQVRCZ05WSFNVRUREQUsKQmdnckJnRUZCUWNEQVRBTUJnTlZIUk1CQWY4RUFqQUFNQjBHQTFVZERnUVdCQlFmLzhZMjN4UWNvSDhFWW5XaAp5TEdaMzFCazREQWZCZ05WSFNNRUdEQVdnQlNGQTNMdkpNMjFkOHFzWlZWQ2U2UnJUVDl3aVRDQmlBWURWUjBSCkJJR0FNSDZDSW1kaGNtUmxibVZ5TFhObFpXUXRZV1J0YVhOemFXOXVMV052Ym5SeWIyeHNaWEtDS1dkaGNtUmwKYm1WeUxYTmxaV1F0WVdSdGFYTnphVzl1TFdOdmJuUnliMnhzWlhJdVoyRnlaR1Z1Z2kxbllYSmtaVzVsY2kxegpaV1ZrTFdGa2JXbHpjMmx2YmkxamIyNTBjbTlzYkdWeUxtZGhjbVJsYmk1emRtTXdEUVlKS29aSWh2Y05BUUVMCkJRQURnZ0VCQUxFc254K1pjdjNJTUUvWHM4MngwUEF4RHVJRlY0Wm5HUGJ3ZUNaNUpLS2xBdEh0cnEySlRZb1EKekhiR1RqMklFcHpkcTA0UnlScVkwZWpEMjVIV2VWSGNBbGhTTEd2S0t1dU16bklsNmU0Ry9LZm1nME5Md2lNSwo3anNTanBOZEhuSk9zUGczajNpYmxQMFpTWThBNXAxMnVxTXpmdktQTkZLNjJFdXlxbUVmSTllYzZQNndOQWNaClIzRWp1bTh5Q2NPQ1psT2N6T0gvOFpJZElDMWpsRlltNFd3em0xdVVnb1NrMjQwbnFodUJpcldxQVJqSk5oZnUKLzBIRG15NlpzLzJGbFJOSVd1c2twTklnT3RNYTNBMjc3cXgyTzU0MitVaEt2MmphSVh0WDFCblJMVENGVnlEWgpnajU1OTNBSllEajhRRkh1bEZlTWVoNWJhT2trc2pjPQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0t
-  tls.key: LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlFb3dJQkFBS0NBUUVBeGFoVGtTeXREL29kaWNZY3FnaXZPZE1yNGhkSHdja2FuMzZSMzJrY241QnJkOTFhCnhWM3JvUmkvckxrNG5INGMyVWxqRmFJNVAvVWQwZkJaQ3ROaEpxdWVPS1BXR09SNlB4UnNKUlBiTlplT2VuVnUKQmU2RzViOE8zWUhFUlhUdWplSWY4YTFXbSthblRUa1o4VVNHVXlkNnM5V1k0SExEc0k4c3ljTWp2VDRuWlJ1agpGdEtxbC9RRy9vUEQ4ZEhrajlzd1lhbkMxZXJoc3VJR0hOdmtZbDN5b0dBckRydmg3alcrQXhWWG5ZalBOaWRHCldNM0lUSHVWS3FmajJJZ1NBQjlGNnFzOStobHZhMitUdU4xZVVkUjBsUTRxQmF5TkJKTTFtQ3hSc2FKZnVFMFUKelFPTEl6MTR3Q1JVbHc2K29NdXBqV0tuaU9nMjA0WVF6ekQ4TFFJREFRQUJBb0lCQUZmVXZwMnFIcFVVN1g5RgpXNE5yTElJamhrS0hXY21RMVpXK0pwQUNJMGY4WXVUMnBkbENMT3gvRk4xcHlQQXhVaHh6OGVXeEdvT0RKbWNkCnlGTjVMcGlDZG1KdzJ6aGdmcm45RnprNm81UWk3cHNZQjNYM1VsWlJHZ2Z3SEFsSk5xQXh0VVF0WkdrT2k1VlQKSkdZRHJ6VFFQRVFoVERlZ2g3aXpScEc1ZHU0bUlYcWtybXpUV0l3UHpuTFJtQXBzMGZKUXVROVdJVVAwaUpTdApDTUxaMDg5OEdBTmNkRGJFOFRhM2VtUGUzY2dKamRVVHlIM3pNc25KVDAxNE4wenpYK2U1YVhjZnhDd0FhTitUCmZHTGFRZTFQVjcxNFNJaHVEbytLQlNKbzBLMHBvVUE4ZDVsTkllZXRsOFdEMGNwQUtqQnpwZjNDdkY3OGNUM2kKYy9acnhJRUNnWUVBekJuRG9zWXh1S0lrOGlWVGUrZVRSUndac2k3c3ZhTVRubWxjYzYvM3E1dkxiM2kxejVWOQpuL0NFUDVabHZpa2hOQi9EdDNXWG1ncHJIelFOMmxqbklKbjJLSGtSMGdXZTU3YUNiWXRHeE9DaWp2c1pHVW9KCkYyaU9MZlRIQnNueGlOUDN1empzdWNlQ3VpU0Q4N2UwYlZCSm9uNG96Nlk3ZUY2a3pLUkdGbjBDZ1lFQTkrc2oKVVl0akdaZnNFWUNodFRPYkMwU0xYYXdrekFHVWdKVU4xTkFoMnc1bzlHcjYxSXR0K1N3d2hxUUZRaFh5VzUwZAorYnNjazNKazZVNkhrZStoOUlUVUIzSG5xZzNLVzlMOHNQWVBxQ0JUNkVRL3FaUG1XT0tqWlR5aVNqTzFrS3g2CithUE00TktadHR6Sk9jVndRVTltMTlkdk0zeHFVZlhGUGtDdmUzRUNnWUFIRmNIZnphZCtORXE2Q1NlcnZtOHoKVC9Wb1pRNmN5cU5zdFZXYlFubURnSVlBV1oxZUZsOWxCUEZpVDdNNmRhME1aU25qSFhia3h3WE84SHltbnIxdgpPVWo5UUs2b3JyOUVaZWFETFBtSTdnOVdqVXJpd05vdDhOZzJxaSthZ2JvYnVOZjVyTkV5NWNVWTl4bUpoVkFECkYyMW04YUF6RFI4MVgzdXpDdVRQOVFLQmdRQ3U5emZaMlBGN29vaHNZY2UrUmtscHpsbzlKYnhpYmNzTVpDVjYKeDlqYzdIS043T0pSRm9YcWtKRSt0SXN4ZEtPeW5GUUhaMUpualJoQ3Y3VlYvVFRqaU1ySzVreUU2MjZoRjJwVwp5WkdMS2lXTmluMFRoTm5RYVVLL3MrY2xUeEVZcFdHMHhURldpY3NLRHcvRXdkN1RlT0l2K2s3MG14Mjk4aUhlCktYQ3ZRUUtCZ0dkSTNiWjF4eEtNV0RlVTVRYW1EYU9rSGVabDJTYWNFUStDMDkvTzk3NUhMZkUwNStnc1BZREUKK1lOZzA2b1FsTy9VOXRtT3Z5R1grQ2E2eUxGL1hRTXE2Mm9ObHAxYTBvcW5XbFFudjU3cmdLckdYY3YyKzZzUApMaEFmYndEUi9OTmlpbVppb1BlSkVHUG9jVXEyMU9MNVJGamoyU3o1bDROWWs2TW1leWZ6Ci0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0t
-immutable: true
-kind: Secret
-metadata:
-  creationTimestamp: null
-  labels:
-    app: gardener
-    resources.gardener.cloud/garbage-collectable-reference: "true"
-    role: seed-admission-controller
-  name: ` + secretName + `
-  namespace: shoot--foo--bar
-type: kubernetes.io/tls
-`
 		clusterRoleYAML = `apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -130,8 +119,6 @@ subjects:
 		deploymentYAML = `apiVersion: apps/v1
 kind: Deployment
 metadata:
-  annotations:
-    ` + references.AnnotationKey(references.KindSecret, secretName) + `: ` + secretName + `
   creationTimestamp: null
   labels:
     app: gardener
@@ -151,8 +138,6 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      annotations:
-        ` + references.AnnotationKey(references.KindSecret, secretName) + `: ` + secretName + `
       creationTimestamp: null
       labels:
         app: gardener
@@ -209,7 +194,7 @@ spec:
       volumes:
       - name: gardener-seed-admission-controller-tls
         secret:
-          secretName: ` + secretName + `
+          secretName: gardener-seed-admission-controller-server
 status: {}
 `
 		pdbYAML = `apiVersion: policy/v1beta1
@@ -287,7 +272,6 @@ webhooks:
   - v1beta1
   - v1
   clientConfig:
-    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUMrakNDQWVLZ0F3SUJBZ0lVVHAzWHZocldPVk04WkdlODZZb1hNVi9VSjdBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd0ZURVRNQkVHQTFVRUF4TUthM1ZpWlhKdVpYUmxjekFlRncweE9UQXlNamN4TlRNME1EQmFGdzB5TkRBeQpNall4TlRNME1EQmFNQlV4RXpBUkJnTlZCQU1UQ210MVltVnlibVYwWlhNd2dnRWlNQTBHQ1NxR1NJYjNEUUVCCkFRVUFBNElCRHdBd2dnRUtBb0lCQVFDeWkwUUdPY3YyYlRmM044T0xOOTdSd3NnSDZRQXI4d1NwQU9ydHRCSmcKRm5mblUyVDFSSGd4bTdxZDE5MFdMOERDaHYwZFpmNzZkNmVTUTRacmpqeUFyVHp1ZmI0RHRQd2crVldxN1h2RgpCTnluKzJoZjRTeVNrd2Q2azdYTGhVVFJ4MDQ4SWJCeUM0ditGRXZtb0xBd3JjMGQwRzE0ZWM2c25EKzdqTzdlCmt5a1EvTmdBT0w3UDZrRHM5ejYrYk9mZ0YwbkdOK2JtZVdRcUplalIwdCtPeVFEQ3g1L0ZNdFVmRVZSNVFYODAKYWVlZmdwM0pGWmI2ZkF3OUtoTHRkUlYzRlAwdHo2aFMrZTRTZzBtd0FBT3FpalpzVjg3a1A1R1l6anRjZkExMgpsRFlsL25iMUd0VnZ2a1FENDlWblY3bURubDZtRzNMQ01OQ05INldsWk52M0FnTUJBQUdqUWpCQU1BNEdBMVVkCkR3RUIvd1FFQXdJQkJqQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01CMEdBMVVkRGdRV0JCU0ZBM0x2Sk0yMWQ4cXMKWlZWQ2U2UnJUVDl3aVRBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQW5zL0VKM3lLc2p0SVNvdGVRNzE0cjJVbQpCTVB5VVlUVGRSSEQ4TFpNZDNSeWt2c2FjRjJsMnk4OE56NndKY0F1b1VqMWg4YUJEUDVvWFZ0Tm1GVDlqeWJTClRYclJ2V2krYWVZZGI1NTZuRUE1L2E5NGUrY2IrQ2szcXkvMXhnUW9TNDU3QVpRT0Rpc0RaTkJZV2tBRnMyTGMKdWNwY0F0WEp0SXRoVm03RmpvQUhZY3NyWTA0eUFpWUVKTEQwMlRqVURYZzRpR09HTWtWSGRtaGF3QkRCRjNBagplc2ZjcUZ3amk2SnlBS0ZSQUNQb3d5a1FPTkZ3VVNvbTg5dVlFU1NDSkZ2TkNrOU1KbWpKMlB6RFV0NkN5cFI0CmVwRmRkMWZYTHd1d243ZnZQTW1KcUQzSHRMYWxYMUFabVBrK0JJOGV6ZkFpVmNWcW5USlFNWGxZUHBZZTlBPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ==
     service:
       name: gardener-seed-admission-controller
       namespace: shoot--foo--bar
@@ -315,7 +299,6 @@ webhooks:
   - v1beta1
   - v1
   clientConfig:
-    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUMrakNDQWVLZ0F3SUJBZ0lVVHAzWHZocldPVk04WkdlODZZb1hNVi9VSjdBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd0ZURVRNQkVHQTFVRUF4TUthM1ZpWlhKdVpYUmxjekFlRncweE9UQXlNamN4TlRNME1EQmFGdzB5TkRBeQpNall4TlRNME1EQmFNQlV4RXpBUkJnTlZCQU1UQ210MVltVnlibVYwWlhNd2dnRWlNQTBHQ1NxR1NJYjNEUUVCCkFRVUFBNElCRHdBd2dnRUtBb0lCQVFDeWkwUUdPY3YyYlRmM044T0xOOTdSd3NnSDZRQXI4d1NwQU9ydHRCSmcKRm5mblUyVDFSSGd4bTdxZDE5MFdMOERDaHYwZFpmNzZkNmVTUTRacmpqeUFyVHp1ZmI0RHRQd2crVldxN1h2RgpCTnluKzJoZjRTeVNrd2Q2azdYTGhVVFJ4MDQ4SWJCeUM0ditGRXZtb0xBd3JjMGQwRzE0ZWM2c25EKzdqTzdlCmt5a1EvTmdBT0w3UDZrRHM5ejYrYk9mZ0YwbkdOK2JtZVdRcUplalIwdCtPeVFEQ3g1L0ZNdFVmRVZSNVFYODAKYWVlZmdwM0pGWmI2ZkF3OUtoTHRkUlYzRlAwdHo2aFMrZTRTZzBtd0FBT3FpalpzVjg3a1A1R1l6anRjZkExMgpsRFlsL25iMUd0VnZ2a1FENDlWblY3bURubDZtRzNMQ01OQ05INldsWk52M0FnTUJBQUdqUWpCQU1BNEdBMVVkCkR3RUIvd1FFQXdJQkJqQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01CMEdBMVVkRGdRV0JCU0ZBM0x2Sk0yMWQ4cXMKWlZWQ2U2UnJUVDl3aVRBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQW5zL0VKM3lLc2p0SVNvdGVRNzE0cjJVbQpCTVB5VVlUVGRSSEQ4TFpNZDNSeWt2c2FjRjJsMnk4OE56NndKY0F1b1VqMWg4YUJEUDVvWFZ0Tm1GVDlqeWJTClRYclJ2V2krYWVZZGI1NTZuRUE1L2E5NGUrY2IrQ2szcXkvMXhnUW9TNDU3QVpRT0Rpc0RaTkJZV2tBRnMyTGMKdWNwY0F0WEp0SXRoVm03RmpvQUhZY3NyWTA0eUFpWUVKTEQwMlRqVURYZzRpR09HTWtWSGRtaGF3QkRCRjNBagplc2ZjcUZ3amk2SnlBS0ZSQUNQb3d5a1FPTkZ3VVNvbTg5dVlFU1NDSkZ2TkNrOU1KbWpKMlB6RFV0NkN5cFI0CmVwRmRkMWZYTHd1d243ZnZQTW1KcUQzSHRMYWxYMUFabVBrK0JJOGV6ZkFpVmNWcW5USlFNWGxZUHBZZTlBPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ==
     service:
       name: gardener-seed-admission-controller
       namespace: shoot--foo--bar
@@ -357,7 +340,6 @@ webhooks:
   - v1beta1
   - v1
   clientConfig:
-    caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUMrakNDQWVLZ0F3SUJBZ0lVVHAzWHZocldPVk04WkdlODZZb1hNVi9VSjdBd0RRWUpLb1pJaHZjTkFRRUwKQlFBd0ZURVRNQkVHQTFVRUF4TUthM1ZpWlhKdVpYUmxjekFlRncweE9UQXlNamN4TlRNME1EQmFGdzB5TkRBeQpNall4TlRNME1EQmFNQlV4RXpBUkJnTlZCQU1UQ210MVltVnlibVYwWlhNd2dnRWlNQTBHQ1NxR1NJYjNEUUVCCkFRVUFBNElCRHdBd2dnRUtBb0lCQVFDeWkwUUdPY3YyYlRmM044T0xOOTdSd3NnSDZRQXI4d1NwQU9ydHRCSmcKRm5mblUyVDFSSGd4bTdxZDE5MFdMOERDaHYwZFpmNzZkNmVTUTRacmpqeUFyVHp1ZmI0RHRQd2crVldxN1h2RgpCTnluKzJoZjRTeVNrd2Q2azdYTGhVVFJ4MDQ4SWJCeUM0ditGRXZtb0xBd3JjMGQwRzE0ZWM2c25EKzdqTzdlCmt5a1EvTmdBT0w3UDZrRHM5ejYrYk9mZ0YwbkdOK2JtZVdRcUplalIwdCtPeVFEQ3g1L0ZNdFVmRVZSNVFYODAKYWVlZmdwM0pGWmI2ZkF3OUtoTHRkUlYzRlAwdHo2aFMrZTRTZzBtd0FBT3FpalpzVjg3a1A1R1l6anRjZkExMgpsRFlsL25iMUd0VnZ2a1FENDlWblY3bURubDZtRzNMQ01OQ05INldsWk52M0FnTUJBQUdqUWpCQU1BNEdBMVVkCkR3RUIvd1FFQXdJQkJqQVBCZ05WSFJNQkFmOEVCVEFEQVFIL01CMEdBMVVkRGdRV0JCU0ZBM0x2Sk0yMWQ4cXMKWlZWQ2U2UnJUVDl3aVRBTkJna3Foa2lHOXcwQkFRc0ZBQU9DQVFFQW5zL0VKM3lLc2p0SVNvdGVRNzE0cjJVbQpCTVB5VVlUVGRSSEQ4TFpNZDNSeWt2c2FjRjJsMnk4OE56NndKY0F1b1VqMWg4YUJEUDVvWFZ0Tm1GVDlqeWJTClRYclJ2V2krYWVZZGI1NTZuRUE1L2E5NGUrY2IrQ2szcXkvMXhnUW9TNDU3QVpRT0Rpc0RaTkJZV2tBRnMyTGMKdWNwY0F0WEp0SXRoVm03RmpvQUhZY3NyWTA0eUFpWUVKTEQwMlRqVURYZzRpR09HTWtWSGRtaGF3QkRCRjNBagplc2ZjcUZ3amk2SnlBS0ZSQUNQb3d5a1FPTkZ3VVNvbTg5dVlFU1NDSkZ2TkNrOU1KbWpKMlB6RFV0NkN5cFI0CmVwRmRkMWZYTHd1d243ZnZQTW1KcUQzSHRMYWxYMUFabVBrK0JJOGV6ZkFpVmNWcW5USlFNWGxZUHBZZTlBPT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQ==
     service:
       name: gardener-seed-admission-controller
       namespace: shoot--foo--bar
@@ -427,8 +409,10 @@ status: {}
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
 		c = mockclient.NewMockClient(ctrl)
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetesscheme.Scheme).Build()
+		sm = fakesecretsmanager.New(fakeClient, namespace)
 
-		seedAdmission = New(c, namespace, image)
+		seedAdmission = New(c, namespace, sm, image)
 
 		managedResourceSecret = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
@@ -441,7 +425,6 @@ status: {}
 				"clusterrolebinding____gardener-seed-admission-controller.yaml":                       []byte(clusterRoleBindingYAML),
 				"deployment__shoot--foo--bar__gardener-seed-admission-controller.yaml":                []byte(deploymentYAML),
 				"poddisruptionbudget__shoot--foo--bar__gardener-seed-admission-controller.yaml":       []byte(pdbYAML),
-				"secret__shoot--foo--bar__" + secretName + ".yaml":                                    []byte(secretYAML),
 				"service__shoot--foo--bar__gardener-seed-admission-controller.yaml":                   []byte(serviceYAML),
 				"serviceaccount__shoot--foo--bar__gardener-seed-admission-controller.yaml":            []byte(serviceAccountYAML),
 				"validatingwebhookconfiguration____gardener-seed-admission-controller.yaml":           []byte(validatingWebhookConfigurationYAML),

--- a/pkg/operation/seed/components.go
+++ b/pkg/operation/seed/components.go
@@ -75,13 +75,13 @@ func defaultEtcdDruid(
 	return etcd.NewBootstrapper(c, v1beta1constants.GardenNamespace, conf, image.String(), imageVectorOverwrite), nil
 }
 
-func defaultKubeScheduler(c client.Client, imageVector imagevector.ImageVector, kubernetesVersion *semver.Version) (component.DeployWaiter, error) {
+func defaultKubeScheduler(c client.Client, imageVector imagevector.ImageVector, secretsManager secretsmanager.Interface, kubernetesVersion *semver.Version) (component.DeployWaiter, error) {
 	image, err := imageVector.FindImage(images.ImageNameKubeScheduler, imagevector.TargetVersion(kubernetesVersion.String()))
 	if err != nil {
 		return nil, err
 	}
 
-	scheduler, err := gardenerkubescheduler.Bootstrap(c, v1beta1constants.GardenNamespace, image, kubernetesVersion)
+	scheduler, err := gardenerkubescheduler.Bootstrap(c, secretsManager, v1beta1constants.GardenNamespace, image, kubernetesVersion)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operation/seed/components.go
+++ b/pkg/operation/seed/components.go
@@ -89,7 +89,7 @@ func defaultKubeScheduler(c client.Client, imageVector imagevector.ImageVector, 
 	return scheduler, nil
 }
 
-func defaultGardenerSeedAdmissionController(c client.Client, imageVector imagevector.ImageVector) (component.DeployWaiter, error) {
+func defaultGardenerSeedAdmissionController(c client.Client, imageVector imagevector.ImageVector, secretsManager secretsmanager.Interface) (component.DeployWaiter, error) {
 	image, err := imageVector.FindImage(images.ImageNameGardenerSeedAdmissionController)
 	if err != nil {
 		return nil, err
@@ -101,7 +101,7 @@ func defaultGardenerSeedAdmissionController(c client.Client, imageVector imageve
 	}
 	image = &imagevector.Image{Repository: repository, Tag: &tag}
 
-	return seedadmissioncontroller.New(c, v1beta1constants.GardenNamespace, image.String()), nil
+	return seedadmissioncontroller.New(c, v1beta1constants.GardenNamespace, secretsManager, image.String()), nil
 }
 
 func defaultGardenerResourceManager(c client.Client, imageVector imagevector.ImageVector, secretsManager secretsmanager.Interface) (component.DeployWaiter, error) {

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -1006,7 +1006,7 @@ func runCreateSeedFlow(
 	if err != nil {
 		return err
 	}
-	gardenerSeedAdmissionController, err := defaultGardenerSeedAdmissionController(seedClient, imageVector)
+	gardenerSeedAdmissionController, err := defaultGardenerSeedAdmissionController(seedClient, imageVector, secretsManager)
 	if err != nil {
 		return err
 	}
@@ -1116,7 +1116,7 @@ func RunDeleteSeedFlow(
 		dnsOwner        = getManagedIngressDNSOwner(seedClient, *seed.GetInfo().Status.ClusterIdentity)
 		dnsRecord       = getManagedIngressDNSRecord(seedClient, seed.GetInfo().Spec.DNS, secretData, seed.GetIngressFQDN("*"), "", log)
 		autoscaler      = clusterautoscaler.NewBootstrapper(seedClient, v1beta1constants.GardenNamespace)
-		gsac            = seedadmissioncontroller.New(seedClient, v1beta1constants.GardenNamespace, "")
+		gsac            = seedadmissioncontroller.New(seedClient, v1beta1constants.GardenNamespace, nil, "")
 		resourceManager = resourcemanager.New(seedClient, v1beta1constants.GardenNamespace, nil, "", resourcemanager.Values{})
 		nginxIngress    = nginxingress.New(seedClient, v1beta1constants.GardenNamespace, nginxingress.Values{})
 		etcdDruid       = etcd.NewBootstrapper(seedClient, v1beta1constants.GardenNamespace, conf, "", nil)

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -1010,7 +1010,7 @@ func runCreateSeedFlow(
 	if err != nil {
 		return err
 	}
-	kubeScheduler, err := defaultKubeScheduler(seedClient, imageVector, kubernetesVersion)
+	kubeScheduler, err := defaultKubeScheduler(seedClient, imageVector, secretsManager, kubernetesVersion)
 	if err != nil {
 		return err
 	}
@@ -1128,7 +1128,7 @@ func RunDeleteSeedFlow(
 		vpnAuthzServer  = vpnauthzserver.New(seedClient, v1beta1constants.GardenNamespace, "", 1)
 	)
 
-	scheduler, err := gardenerkubescheduler.Bootstrap(seedClient, v1beta1constants.GardenNamespace, nil, kubernetesVersion)
+	scheduler, err := gardenerkubescheduler.Bootstrap(seedClient, nil, v1beta1constants.GardenNamespace, nil, kubernetesVersion)
 	if err != nil {
 		return err
 	}

--- a/test/framework/resources/templates/block-loki-validatingwebhookconfiguration.yaml.tpl
+++ b/test/framework/resources/templates/block-loki-validatingwebhookconfiguration.yaml.tpl
@@ -9,7 +9,6 @@ webhooks:
   clientConfig:
     caBundle: {{ .CABundle }}
     service:
-    service:
       name: unreal-service
       namespace: unreal-namespace
   failurePolicy: Fail

--- a/test/testmachinery/shoots/logging/loki_tenant.go
+++ b/test/testmachinery/shoots/logging/loki_tenant.go
@@ -20,7 +20,6 @@ import (
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/controllerutils"
-	"github.com/gardener/gardener/pkg/operation/botanist/component/seedadmissioncontroller"
 	"github.com/gardener/gardener/pkg/utils"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
@@ -103,7 +102,24 @@ var _ = ginkgo.Describe("Seed logging testing", func() {
 		validatingWebhookParams := map[string]interface{}{
 			"NamespaceLabelKey":   shootNamespaceLabelKey,
 			"NamespaceLabelValue": shootNamespaceLabelValue,
-			"CABundle":            utils.EncodeBase64([]byte(seedadmissioncontroller.TLSCACert)),
+			"CABundle": utils.EncodeBase64([]byte(`-----BEGIN CERTIFICATE-----
+MIIC+jCCAeKgAwIBAgIUTp3XvhrWOVM8ZGe86YoXMV/UJ7AwDQYJKoZIhvcNAQEL
+BQAwFTETMBEGA1UEAxMKa3ViZXJuZXRlczAeFw0xOTAyMjcxNTM0MDBaFw0yNDAy
+MjYxNTM0MDBaMBUxEzARBgNVBAMTCmt1YmVybmV0ZXMwggEiMA0GCSqGSIb3DQEB
+AQUAA4IBDwAwggEKAoIBAQCyi0QGOcv2bTf3N8OLN97RwsgH6QAr8wSpAOrttBJg
+FnfnU2T1RHgxm7qd190WL8DChv0dZf76d6eSQ4ZrjjyArTzufb4DtPwg+VWq7XvF
+BNyn+2hf4SySkwd6k7XLhUTRx048IbByC4v+FEvmoLAwrc0d0G14ec6snD+7jO7e
+kykQ/NgAOL7P6kDs9z6+bOfgF0nGN+bmeWQqJejR0t+OyQDCx5/FMtUfEVR5QX80
+aeefgp3JFZb6fAw9KhLtdRV3FP0tz6hS+e4Sg0mwAAOqijZsV87kP5GYzjtcfA12
+lDYl/nb1GtVvvkQD49VnV7mDnl6mG3LCMNCNH6WlZNv3AgMBAAGjQjBAMA4GA1Ud
+DwEB/wQEAwIBBjAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQWBBSFA3LvJM21d8qs
+ZVVCe6RrTT9wiTANBgkqhkiG9w0BAQsFAAOCAQEAns/EJ3yKsjtISoteQ714r2Um
+BMPyUYTTdRHD8LZMd3RykvsacF2l2y88Nz6wJcAuoUj1h8aBDP5oXVtNmFT9jybS
+TXrRvWi+aeYdb556nEA5/a94e+cb+Ck3qy/1xgQoS457AZQODisDZNBYWkAFs2Lc
+ucpcAtXJtIthVm7FjoAHYcsrY04yAiYEJLD02TjUDXg4iGOGMkVHdmhawBDBF3Aj
+esfcqFwji6JyAKFRACPowykQONFwUSom89uYESSCJFvNCk9MJmjJ2PzDUt6CypR4
+epFdd1fXLwuwn7fvPMmJqD3HtLalX1AZmPk+BI8ezfAiVcVqnTJQMXlYPpYe9A==
+-----END CERTIFICATE-----`)),
 		}
 		err = f.RenderAndDeployTemplate(ctx, f.SeedClient, templates.BlockLokiValidatingWebhookConfiguration, validatingWebhookParams)
 		framework.ExpectNoError(err)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement
/merge squash

**What this PR does / why we need it**:
This PR drops the hard-coded certificates for `gardener-seed-admission-controller` and instead uses the new secrets manager to manage and rotate them.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/3292

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
