### PR TITLE
[GEP-18] Instrument CA secret generation according to specification

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
@@ -193,10 +193,10 @@ spec:
       - name: shoot-ca
         secret:
           defaultMode: 420
-          secretName: ca
+          secretName: {{ .Values.secretNameClusterCA }}
       - name: ca-etcd
         secret:
-          secretName: ca-etcd
+          secretName: {{ .Values.secretNameEtcdCA }}
       - name: etcd-client-tls
         secret:
           secretName: {{ .Values.secretNameEtcdClientCert }}
@@ -215,7 +215,7 @@ spec:
               name: {{ .Values.secretNameClientCert }}
               optional: false
           - secret:
-              name: ca
+              name: {{ .Values.secretNameClusterCA }}
               optional: false
       - name: shoot-access
         secret:

--- a/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
@@ -20,6 +20,8 @@ ingress:
   authSecretName: auth-secret-name
 
 kubernetesVersion: 1.20.1
+secretNameClusterCA: ca
+secretNameEtcdCA: ca-etcd
 secretNameEtcdClientCert: etcd-client-tls
 secretNameClientCert: prometheus
 

--- a/charts/seed-monitoring/charts/core/values.yaml
+++ b/charts/seed-monitoring/charts/core/values.yaml
@@ -14,6 +14,8 @@ prometheus:
     vpn-seed: image-repository:image-tag
   ingress:
     class: nginx
+  secretNameClusterCA: ca
+  secretNameEtcdCA: ca-etcd
   secretNameEtcdClientCert: etcd-client-tls
   secretNameClientCert: prometheus
 kube-state-metrics-seed:

--- a/extensions/pkg/controller/controlplane/genericactuator/actuator_test.go
+++ b/extensions/pkg/controller/controlplane/genericactuator/actuator_test.go
@@ -238,17 +238,17 @@ var _ = Describe("Actuator", func() {
 		checksums = map[string]string{
 			v1beta1constants.SecretNameCloudProvider: "8bafb35ff1ac60275d62e1cbd495aceb511fb354f74a20f7d06ecb48b3a68432",
 			cloudProviderConfigName:                  "08a7bc7fe8f59b055f173145e211760a83f02cf89635cef26ebb351378635606",
-			caNameControlPlane:                       "bfcf386778c8d3313168d622fc1e2d28d9b6265759e3f505e3cffa5848206dd1",
-			"cloud-controller-manager":               "48b5661ff7d535ac5cb2c3e4efc47918cc702ff0ebf84772150310ebc3c943ac",
+			caNameControlPlane:                       "5debc1c84fcd7cb944bad4b7d55ded0ff8e9a0443f479d1bfd057a0c7daf3603",
+			"cloud-controller-manager":               "e0d91e909e7d1a144ea4f31c1347286e30c968a9906d76c4667d93bc35c0e34e",
 		}
 		checksumsNoConfig = map[string]string{
 			v1beta1constants.SecretNameCloudProvider: "8bafb35ff1ac60275d62e1cbd495aceb511fb354f74a20f7d06ecb48b3a68432",
-			caNameControlPlane:                       "bfcf386778c8d3313168d622fc1e2d28d9b6265759e3f505e3cffa5848206dd1",
-			"cloud-controller-manager":               "48b5661ff7d535ac5cb2c3e4efc47918cc702ff0ebf84772150310ebc3c943ac",
+			caNameControlPlane:                       "5debc1c84fcd7cb944bad4b7d55ded0ff8e9a0443f479d1bfd057a0c7daf3603",
+			"cloud-controller-manager":               "e0d91e909e7d1a144ea4f31c1347286e30c968a9906d76c4667d93bc35c0e34e",
 		}
 		exposureChecksums = map[string]string{
-			caNameControlPlaneExposure: "3162cd2e6ef1a654fb98ca96af809d7c3341de0e2fa95b64ce8b53accaf45e57",
-			"lb-readvertiser":          "81ef59b177361b751734e9d7540331a9110428d5c58f2c5334b45ac6c4ceb39f",
+			caNameControlPlaneExposure: "8dc6feaf701d4b9fb7ecf314085a9bbb84d61fb6858d993d92d0a75deee571d1",
+			"lb-readvertiser":          "c2411522ce7468cb728995069e48a52ac7f4ffeb912ff21ca7ea730eeda03d63",
 		}
 
 		configChartValues = map[string]interface{}{
@@ -430,8 +430,8 @@ var _ = Describe("Actuator", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			expectSecretsManagedBySecretsManager(fakeClient, "wanted secrets should get created",
-				"ca-provider-test-controlplane-b01ab5b3", "ca-provider-test-controlplane-bundle-264279f5",
-				"cloud-controller-manager-87d232df",
+				"ca-provider-test-controlplane-b01ab5b3", "ca-provider-test-controlplane-bundle-275a8b6e",
+				"cloud-controller-manager-1329cb64",
 			)
 		},
 		Entry("should deploy secrets and apply charts with correct parameters", cloudProviderConfigName, checksums, []admissionregistrationv1.MutatingWebhook{{}}, true),
@@ -549,8 +549,8 @@ var _ = Describe("Actuator", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			expectSecretsManagedBySecretsManager(fakeClient, "wanted secrets should get created",
-				"ca-provider-test-controlplane-exposure-708d12fb", "ca-provider-test-controlplane-exposure-bundle-fec10245",
-				"lb-readvertiser-29ec35bb",
+				"ca-provider-test-controlplane-exposure-708d12fb", "ca-provider-test-controlplane-exposure-bundle-c830ff02",
+				"lb-readvertiser-eb3483ee",
 			)
 		},
 		Entry("should deploy secrets and apply charts with correct parameters"),

--- a/extensions/pkg/util/secret/manager/manager_test.go
+++ b/extensions/pkg/util/secret/manager/manager_test.go
@@ -252,9 +252,9 @@ var _ = Describe("SecretsManager Extension Utils", func() {
 				Expect(sm.Cleanup(ctx)).To(Succeed())
 
 				expectSecrets(fakeClient,
-					"my-extension-ca-42e0ee8a", "my-extension-ca-bundle-6b7e0c1e",
-					"my-extension-ca-2-5aab76c0", "my-extension-ca-2-bundle-a11871e1",
-					"some-server-eb130089", "some-secret-2583adfe")
+					"my-extension-ca-42e0ee8a", "my-extension-ca-bundle-b8ddbc7f",
+					"my-extension-ca-2-5aab76c0", "my-extension-ca-2-bundle-62b9412d",
+					"some-server-4b592699", "some-secret-2583adfe")
 			})
 		})
 
@@ -301,8 +301,8 @@ var _ = Describe("SecretsManager Extension Utils", func() {
 					Expect(sm.Cleanup(ctx)).To(Succeed())
 
 					expectSecrets(fakeClient,
-						"my-extension-ca-42e0ee8a", "my-extension-ca-42e0ee8a-431ab", "my-extension-ca-bundle-b5c615bd",
-						"my-extension-ca-2-5aab76c0", "my-extension-ca-2-5aab76c0-431ab", "my-extension-ca-2-bundle-27b2f0a7",
+						"my-extension-ca-42e0ee8a", "my-extension-ca-42e0ee8a-431ab", "my-extension-ca-bundle-13e1abd9",
+						"my-extension-ca-2-5aab76c0", "my-extension-ca-2-5aab76c0-431ab", "my-extension-ca-2-bundle-77d9e734",
 						"some-server-ec17c27a", "some-secret-2583adfe")
 				})
 			})
@@ -326,9 +326,9 @@ var _ = Describe("SecretsManager Extension Utils", func() {
 					Expect(sm.Cleanup(ctx)).To(Succeed())
 
 					expectSecrets(fakeClient,
-						"my-extension-ca-42e0ee8a-431ab", "my-extension-ca-bundle-6b7e0c1e",
-						"my-extension-ca-2-5aab76c0-431ab", "my-extension-ca-2-bundle-a11871e1",
-						"some-server-eb130089", "some-secret-2583adfe")
+						"my-extension-ca-42e0ee8a-431ab", "my-extension-ca-bundle-d0aec49c",
+						"my-extension-ca-2-5aab76c0-431ab", "my-extension-ca-2-bundle-c3d8dbb5",
+						"some-server-d521ae63", "some-secret-2583adfe")
 				})
 			})
 		})

--- a/pkg/operation/botanist/component/metricsserver/metrics_server.go
+++ b/pkg/operation/botanist/component/metricsserver/metrics_server.go
@@ -91,7 +91,7 @@ func (m *metricsServer) Deploy(ctx context.Context) error {
 		Name:                        secretNameServer,
 		CommonName:                  "metrics-server",
 		DNSNames:                    append([]string{serviceName}, kutil.DNSNamesForService(serviceName, metav1.NamespaceSystem)...),
-		CertType:                    secrets.ServerClientCert,
+		CertType:                    secrets.ServerCert,
 		SkipPublishingCACertificate: true,
 	}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCAMetricsServer, secretsmanager.UseCurrentCA), secretsmanager.Rotate(secretsmanager.InPlace))
 	if err != nil {

--- a/pkg/operation/botanist/monitoring.go
+++ b/pkg/operation/botanist/monitoring.go
@@ -199,6 +199,16 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 		return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameGenericTokenKubeconfig)
 	}
 
+	clusterCASecret, found := b.SecretsManager.Get(v1beta1constants.SecretNameCACluster)
+	if !found {
+		return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameCACluster)
+	}
+
+	etcdCASecret, found := b.SecretsManager.Get(v1beta1constants.SecretNameCAETCD)
+	if !found {
+		return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameCAETCD)
+	}
+
 	etcdClientSecret, found := b.SecretsManager.Get(etcd.SecretNameClient)
 	if !found {
 		return fmt.Errorf("secret %q not found", etcd.SecretNameClient)
@@ -210,6 +220,8 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 			"services": b.Shoot.Networks.Services.String(),
 		}
 		prometheusConfig = map[string]interface{}{
+			"secretNameClusterCA":      clusterCASecret.Name,
+			"secretNameEtcdCA":         etcdCASecret.Name,
 			"secretNameEtcdClientCert": etcdClientSecret.Name,
 			"secretNameClientCert":     prometheusClientSecret.Name,
 			"kubernetesVersion":        b.Shoot.GetInfo().Spec.Kubernetes.Version,

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -71,6 +71,12 @@ func (b *Botanist) lastSecretRotationStartTimes() map[string]time.Time {
 	rotation := make(map[string]time.Time)
 
 	if shootStatus := b.Shoot.GetInfo().Status; shootStatus.Credentials != nil && shootStatus.Credentials.Rotation != nil {
+		if shootStatus.Credentials.Rotation.CertificateAuthorities != nil && shootStatus.Credentials.Rotation.CertificateAuthorities.LastInitiationTime != nil {
+			for _, config := range caCertConfigurations() {
+				rotation[config.GetName()] = shootStatus.Credentials.Rotation.CertificateAuthorities.LastInitiationTime.Time
+			}
+		}
+
 		if shootStatus.Credentials.Rotation.Kubeconfig != nil && shootStatus.Credentials.Rotation.Kubeconfig.LastInitiationTime != nil {
 			rotation[kubeapiserver.SecretStaticTokenName] = shootStatus.Credentials.Rotation.Kubeconfig.LastInitiationTime.Time
 			rotation[kubeapiserver.SecretBasicAuthName] = shootStatus.Credentials.Rotation.Kubeconfig.LastInitiationTime.Time
@@ -80,9 +86,6 @@ func (b *Botanist) lastSecretRotationStartTimes() map[string]time.Time {
 			rotation[v1beta1constants.SecretNameSSHKeyPair] = shootStatus.Credentials.Rotation.SSHKeypair.LastInitiationTime.Time
 		}
 	}
-
-	// CA rotation start time is not added here for now. Otherwise, the CAs would actually get rotated already,
-	// which can only be done once all components have been adapted.
 
 	return rotation
 }

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -24,6 +24,7 @@ import (
 	gardencorev1alpha1helper "github.com/gardener/gardener/pkg/apis/core/v1alpha1/helper"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/kubeapiserver"
@@ -141,6 +142,10 @@ func (b *Botanist) caCertGenerateOptionsFor(configName string) []secretsmanager.
 	options := []secretsmanager.GenerateOption{
 		secretsmanager.Persist(),
 		secretsmanager.Rotate(secretsmanager.KeepOld),
+	}
+
+	if gardencorev1beta1helper.GetShootCARotationPhase(b.Shoot.GetInfo().Status.Credentials) == gardencorev1beta1.RotationCompleting {
+		options = append(options, secretsmanager.IgnoreOldSecrets())
 	}
 
 	if configName == v1beta1constants.SecretNameCAClient {

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -120,6 +120,10 @@ func (b *Botanist) restoreSecretsFromShootStateForSecretsManagerAdoption(ctx con
 
 func caCertConfigurations() []secretutils.ConfigInterface {
 	return []secretutils.ConfigInterface{
+		// The CommonNames for CA certificates will be overridden with the secret name by the secrets manager when
+		// generated to ensure that each CA has a unique common name. For backwards-compatibility, we still keep the
+		// CommonNames here (if we removed them then new CAs would be generated with the next shoot reconciliation
+		// without the end-user to explicitly trigger it).
 		&secretutils.CertificateSecretConfig{Name: v1beta1constants.SecretNameCACluster, CommonName: "kubernetes", CertType: secretutils.CACert},
 		&secretutils.CertificateSecretConfig{Name: v1beta1constants.SecretNameCAClient, CommonName: "kubernetes-client", CertType: secretutils.CACert},
 		&secretutils.CertificateSecretConfig{Name: v1beta1constants.SecretNameCAETCD, CommonName: "etcd", CertType: secretutils.CACert},

--- a/pkg/utils/secrets/manager/manager.go
+++ b/pkg/utils/secrets/manager/manager.go
@@ -355,3 +355,16 @@ func secretTypeForData(data map[string][]byte) corev1.SecretType {
 func unixTime(in time.Time) string {
 	return strconv.FormatInt(in.UTC().Unix(), 10)
 }
+
+func certificateSecretConfig(config secretutils.ConfigInterface) *secretutils.CertificateSecretConfig {
+	var certificateConfig *secretutils.CertificateSecretConfig
+
+	switch cfg := config.(type) {
+	case *secretutils.CertificateSecretConfig:
+		certificateConfig = cfg
+	case *secretutils.ControlPlaneSecretConfig:
+		certificateConfig = cfg.CertificateSecretConfig
+	}
+
+	return certificateConfig
+}

--- a/test/e2e/shoot/create_rotate-ca_delete.go
+++ b/test/e2e/shoot/create_rotate-ca_delete.go
@@ -17,6 +17,7 @@ package shoot
 import (
 	"context"
 	"sort"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -87,14 +88,17 @@ var _ = Describe("Shoot Tests", Label("Shoot"), func() {
 		Expect(f.Shoot.Status.Credentials.Rotation.CertificateAuthorities.Phase).To(Equal(gardencorev1beta1.RotationPrepared), "ca rotation phase should be 'Prepared'")
 
 		By("Verify CA bundle secret")
-		var caBundle []byte
+		var (
+			caBundle  []byte
+			newCACert []byte
+		)
+
 		Eventually(func(g Gomega) {
 			secret := &corev1.Secret{}
 			g.Expect(f.GardenClient.Client().Get(ctx, client.ObjectKey{Namespace: f.Shoot.Namespace, Name: gutil.ComputeShootProjectSecretName(f.Shoot.Name, gutil.ShootProjectSecretSuffixCACluster)}, secret)).To(Succeed())
-			// For now, there is only one CA cert in the bundle, as the CA is not actually rotated yet
-			// TODO: verify the old CA cert is still in there and a new is added, once the CA is actually rotated
-			g.Expect(secret.Data).To(HaveKeyWithValue("ca.crt", oldCACert))
+			g.Expect(string(secret.Data["ca.crt"])).To(ContainSubstring(string(oldCACert)))
 			caBundle = secret.Data["ca.crt"]
+			newCACert = []byte(strings.Replace(string(caBundle), string(oldCACert), "", -1))
 
 			verifyCABundleInKubeconfigSecret(ctx, g, f.GardenClient.Client(), client.ObjectKeyFromObject(f.Shoot), caBundle)
 		}).Should(Succeed(), "CA bundle should be synced to garden")
@@ -135,14 +139,10 @@ var _ = Describe("Shoot Tests", Label("Shoot"), func() {
 		}).Should(BeTrue())
 
 		By("Verify new CA secret")
-		var newCACert []byte
 		Eventually(func(g Gomega) {
 			secret := &corev1.Secret{}
 			g.Expect(f.GardenClient.Client().Get(ctx, client.ObjectKey{Namespace: f.Shoot.Namespace, Name: gutil.ComputeShootProjectSecretName(f.Shoot.Name, gutil.ShootProjectSecretSuffixCACluster)}, secret)).To(Succeed())
-			// For now, the secret will still contain the old CA cert, as the CA is not actually rotated yet
-			// TODO: verify that only the new CA cert of the bundle is kept, once the CA is actually rotated
-			g.Expect(secret.Data).To(HaveKeyWithValue("ca.crt", caBundle))
-			newCACert = secret.Data["ca.crt"]
+			g.Expect(secret.Data).To(HaveKeyWithValue("ca.crt", newCACert))
 
 			verifyCABundleInKubeconfigSecret(ctx, g, f.GardenClient.Client(), client.ObjectKeyFromObject(f.Shoot), newCACert)
 		}).Should(Succeed(), "new CA cert should be synced to garden")
@@ -161,7 +161,7 @@ var _ = Describe("Shoot Tests", Label("Shoot"), func() {
 
 func verifyCABundleInKubeconfigSecret(ctx context.Context, g Gomega, c client.Reader, shootKey client.ObjectKey, expectedBundle []byte) {
 	secret := &corev1.Secret{}
-	shootKey.Name = gutil.ComputeShootProjectSecretName(shootKey.Name, gutil.ShootProjectSecretSuffixCACluster)
+	shootKey.Name = gutil.ComputeShootProjectSecretName(shootKey.Name, gutil.ShootProjectSecretSuffixKubeconfig)
 	g.Expect(c.Get(ctx, shootKey, secret)).To(Succeed())
 	g.Expect(secret.Data).To(HaveKeyWithValue("ca.crt", expectedBundle))
 }

--- a/test/e2e/shoot/create_rotate-ca_delete.go
+++ b/test/e2e/shoot/create_rotate-ca_delete.go
@@ -98,7 +98,9 @@ var _ = Describe("Shoot Tests", Label("Shoot"), func() {
 			g.Expect(f.GardenClient.Client().Get(ctx, client.ObjectKey{Namespace: f.Shoot.Namespace, Name: gutil.ComputeShootProjectSecretName(f.Shoot.Name, gutil.ShootProjectSecretSuffixCACluster)}, secret)).To(Succeed())
 			g.Expect(string(secret.Data["ca.crt"])).To(ContainSubstring(string(oldCACert)))
 			caBundle = secret.Data["ca.crt"]
+
 			newCACert = []byte(strings.Replace(string(caBundle), string(oldCACert), "", -1))
+			Expect(newCACert).NotTo(BeEmpty())
 
 			verifyCABundleInKubeconfigSecret(ctx, g, f.GardenClient.Client(), client.ObjectKeyFromObject(f.Shoot), caBundle)
 		}).Should(Succeed(), "CA bundle should be synced to garden")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
This PR instruments the CA secret generation according to the specification outlined in [GEP-18](https://github.com/gardener/gardener/blob/master/docs/proposals/18-shoot-CA-rotation.md). Concretely,

1. CA rotation is now triggered when the `rotate-ca-start` operation annotation was set on the `Shoot`.
2. Old CA secrets are now ignored in phase 2 of the CA rotation ("`Completing`"). This will update all CA bundles to only contain the new CA and regenerate all server certificates.
3. Config checksums for the existing CA secrets are no longer ignored as soon as the first CA rotation is triggered.
4. Old seed CA secrets are now ignored when the last rotation happened `24h`+ ago.

**Which issue(s) this PR fixes**:
Part of #3292

**Special notes for your reviewer(s)**:
✅ ~Depends on #5779, hence this PR is still in draft state.~
✅ ~Depends on #5790, hence this PR is still in draft state.~

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
5. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
