### PR TITLE
Fix disabling of seed VPA

### DIFF
--- a/pkg/operation/botanist/component/vpa/vpa.go
+++ b/pkg/operation/botanist/component/vpa/vpa.go
@@ -92,6 +92,9 @@ type Values struct {
 	// resources (like Deployment, Service, etc.) are being deployed directly (with the client). All other application-
 	// related resources (like RBAC roles, CRD, etc.) are deployed as part of a ManagedResource.
 	ClusterType clusterType
+	// Enabled specifies if VPA is enabled. If VPA is not enabled and the cluster type is "seed", only vpa-exporter
+	// is deployed.
+	Enabled bool
 	// SecretNameServerCA is the name of the server CA secret.
 	SecretNameServerCA string
 
@@ -134,12 +137,15 @@ func (v *vpa) Deploy(ctx context.Context) error {
 	}
 	v.serverSecretName = serverSecret.Name
 
-	allResources := mergeResourceConfigs(
-		v.admissionControllerResourceConfigs(),
-		v.recommenderResourceConfigs(),
-		v.updaterResourceConfigs(),
-		v.generalResourceConfigs(),
-	)
+	var allResources resourceConfigs
+	if v.values.Enabled {
+		allResources = mergeResourceConfigs(
+			v.admissionControllerResourceConfigs(),
+			v.recommenderResourceConfigs(),
+			v.updaterResourceConfigs(),
+			v.generalResourceConfigs(),
+		)
+	}
 
 	if v.values.ClusterType == ClusterTypeSeed {
 		allResources = mergeResourceConfigs(allResources, v.exporterResourceConfigs())

--- a/pkg/operation/botanist/vpa.go
+++ b/pkg/operation/botanist/vpa.go
@@ -81,6 +81,7 @@ func (b *Botanist) DefaultVerticalPodAutoscaler() (component.DeployWaiter, error
 		b.SecretsManager,
 		vpa.Values{
 			ClusterType:         vpa.ClusterTypeShoot,
+			Enabled:             true,
 			SecretNameServerCA:  v1beta1constants.SecretNameCACluster,
 			AdmissionController: valuesAdmissionController,
 			Exporter:            valuesExporter,

--- a/pkg/operation/seed/components.go
+++ b/pkg/operation/seed/components.go
@@ -241,7 +241,7 @@ func defaultDependencyWatchdogs(
 	return
 }
 
-func defaultVerticalPodAutoscaler(c client.Client, imageVector imagevector.ImageVector, secretsManager secretsmanager.Interface) (component.DeployWaiter, error) {
+func defaultVerticalPodAutoscaler(c client.Client, imageVector imagevector.ImageVector, secretsManager secretsmanager.Interface, enabled bool) (component.DeployWaiter, error) {
 	imageAdmissionController, err := imageVector.FindImage(images.ImageNameVpaAdmissionController)
 	if err != nil {
 		return nil, err
@@ -268,6 +268,7 @@ func defaultVerticalPodAutoscaler(c client.Client, imageVector imagevector.Image
 		secretsManager,
 		vpa.Values{
 			ClusterType:        vpa.ClusterTypeSeed,
+			Enabled:            enabled,
 			SecretNameServerCA: v1beta1constants.SecretNameCASeed,
 			AdmissionController: vpa.ValuesAdmissionController{
 				Image:    imageAdmissionController.String(),

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -270,12 +270,6 @@ func RunReconcileSeedFlow(
 		if _, err := seedClient.RESTMapper().RESTMapping(vpaGK); err != nil {
 			return fmt.Errorf("VPA is required for seed cluster: %s", err)
 		}
-
-		vpa := vpa.New(seedClient, v1beta1constants.GardenNamespace, nil, vpa.Values{ClusterType: vpa.ClusterTypeSeed})
-
-		if err := component.OpDestroyAndWait(vpa).Destroy(ctx); err != nil {
-			return err
-		}
 	}
 
 	const (
@@ -947,7 +941,7 @@ func RunReconcileSeedFlow(
 		return err
 	}
 
-	if err := runCreateSeedFlow(ctx, gardenClient, seedClient, kubernetesVersion, secretsManager, imageVector, imageVectorOverwrites, seed, conf, log, anySNI); err != nil {
+	if err := runCreateSeedFlow(ctx, gardenClient, seedClient, kubernetesVersion, secretsManager, imageVector, imageVectorOverwrites, seed, conf, log, anySNI, vpaEnabled); err != nil {
 		return err
 	}
 
@@ -965,7 +959,7 @@ func runCreateSeedFlow(
 	seed *Seed,
 	conf *config.GardenletConfiguration,
 	log logrus.FieldLogger,
-	anySNI bool,
+	anySNI, vpaEnabled bool,
 ) error {
 	secretData, err := getDNSProviderSecretData(ctx, gardenClient, seed)
 	if err != nil {
@@ -1018,7 +1012,7 @@ func runCreateSeedFlow(
 	if err != nil {
 		return err
 	}
-	vpa, err := defaultVerticalPodAutoscaler(seedClient, imageVector, secretsManager)
+	vpa, err := defaultVerticalPodAutoscaler(seedClient, imageVector, secretsManager, vpaEnabled)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**How to categorize this PR?**

/area auto-scaling
/kind bug

**What this PR does / why we need it**:
Ensures that the seed VPA is properly destroyed when the corresponding seed setting is false, fixing the previous issue introduced with #5745.

**Which issue(s) this PR fixes**:
Fixes #5810 

**Special notes for your reviewer**:

**Release note**:

```bugfix operator
NONE
```
