### PR TITLE
Streamline defaulted value of ETCDConfig

### DIFF
--- a/pkg/gardenlet/apis/config/v1alpha1/defaults.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/defaults.go
@@ -88,6 +88,10 @@ func SetDefaults_GardenletConfiguration(obj *GardenletConfiguration) {
 		obj.SNI = &SNI{}
 	}
 
+	if obj.ETCDConfig == nil {
+		obj.ETCDConfig = &ETCDConfig{}
+	}
+
 	var defaultSVCName = DefaultSNIIngresServiceName
 	for i, handler := range obj.ExposureClassHandlers {
 		if obj.ExposureClassHandlers[i].SNI == nil {
@@ -478,5 +482,33 @@ func SetDefaults_Logging(obj *Logging) {
 	}
 	if obj.Loki.Garden.Storage == nil {
 		obj.Loki.Garden.Storage = &DefaultCentralLokiStorage
+	}
+}
+
+// SetDefaults_ETCDConfig sets defaults for the ETCD.
+func SetDefaults_ETCDConfig(obj *ETCDConfig) {
+	if obj.ETCDController == nil {
+		obj.ETCDController = &ETCDController{}
+	}
+	if obj.ETCDController.Workers == nil {
+		obj.ETCDController.Workers = pointer.Int64(50)
+	}
+	if obj.CustodianController == nil {
+		obj.CustodianController = &CustodianController{}
+	}
+	if obj.CustodianController.Workers == nil {
+		obj.CustodianController.Workers = pointer.Int64(10)
+	}
+	if obj.BackupCompactionController == nil {
+		obj.BackupCompactionController = &BackupCompactionController{}
+	}
+	if obj.BackupCompactionController.Workers == nil {
+		obj.BackupCompactionController.Workers = pointer.Int64(3)
+	}
+	if obj.BackupCompactionController.EnableBackupCompaction == nil {
+		obj.BackupCompactionController.EnableBackupCompaction = pointer.Bool(false)
+	}
+	if obj.BackupCompactionController.EventsThreshold == nil {
+		obj.BackupCompactionController.EventsThreshold = pointer.Int64(1000000)
 	}
 }

--- a/pkg/gardenlet/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/defaults_test.go
@@ -180,6 +180,21 @@ var _ = Describe("Defaults", func() {
 				Expect(obj.Logging.Loki.Garden.Storage).To(PointTo(Equal(resource.MustParse("100Gi"))))
 			})
 		})
+
+		Describe("#SetDefaults_ETCDConfig", func() {
+			It("should correctly default ETCDConfig configuration", func() {
+				SetObjectDefaults_GardenletConfiguration(obj)
+				Expect(obj.ETCDConfig).NotTo(BeNil())
+				Expect(obj.ETCDConfig.ETCDController).NotTo(BeNil())
+				Expect(obj.ETCDConfig.ETCDController.Workers).To(PointTo(Equal(int64(50))))
+				Expect(obj.ETCDConfig.CustodianController).NotTo(BeNil())
+				Expect(obj.ETCDConfig.CustodianController.Workers).To(PointTo(Equal(int64(10))))
+				Expect(obj.ETCDConfig.BackupCompactionController).NotTo(BeNil())
+				Expect(obj.ETCDConfig.BackupCompactionController.Workers).To(PointTo(Equal(int64(3))))
+				Expect(obj.ETCDConfig.BackupCompactionController.EnableBackupCompaction).To(PointTo(Equal(false)))
+				Expect(obj.ETCDConfig.BackupCompactionController.EventsThreshold).To(PointTo(Equal(int64(1000000))))
+			})
+		})
 	})
 
 	Describe("#SetDefaults_ManagedSeedControllerConfiguration", func() {

--- a/pkg/gardenlet/apis/config/v1alpha1/zz_generated.defaults.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/zz_generated.defaults.go
@@ -107,6 +107,9 @@ func SetObjectDefaults_GardenletConfiguration(in *GardenletConfiguration) {
 			SetDefaults_SNIIngress(in.SNI.Ingress)
 		}
 	}
+	if in.ETCDConfig != nil {
+		SetDefaults_ETCDConfig(in.ETCDConfig)
+	}
 	for i := range in.ExposureClassHandlers {
 		a := &in.ExposureClassHandlers[i]
 		if a.SNI != nil {

--- a/pkg/gardenlet/controller/managedseed/charttest/charttest.go
+++ b/pkg/gardenlet/controller/managedseed/charttest/charttest.go
@@ -810,6 +810,19 @@ func ComputeExpectedGardenletConfiguration(
 			Namespace:   pointer.String(gardenletconfigv1alpha1.DefaultSNIIngresNamespace),
 			Labels:      map[string]string{"app": "istio-ingressgateway", "istio": "ingressgateway"},
 		}},
+		ETCDConfig: &gardenletconfigv1alpha1.ETCDConfig{
+			BackupCompactionController: &gardenletconfigv1alpha1.BackupCompactionController{
+				EnableBackupCompaction: pointer.Bool(false),
+				EventsThreshold:        pointer.Int64(1000000),
+				Workers:                pointer.Int64(3),
+			},
+			CustodianController: &gardenletconfigv1alpha1.CustodianController{
+				Workers: pointer.Int64(10),
+			},
+			ETCDController: &gardenletconfigv1alpha1.ETCDController{
+				Workers: pointer.Int64(50),
+			},
+		},
 	}
 
 	if componentConfigUsesTlsServerConfig {

--- a/pkg/operation/botanist/component/etcd/bootstrap.go
+++ b/pkg/operation/botanist/component/etcd/bootstrap.go
@@ -330,26 +330,13 @@ func getDruidDeployCommands(gardenletConf *config.GardenletConfiguration) []stri
 	}
 
 	config := gardenletConf.ETCDConfig
-	if config == nil {
-		// TODO(abdasgupta): Following line to add 50 workers is only for backward compatibility. Please, remove.
-		command = append(command, "--workers=50")
-		return command
-	}
-	if config.ETCDController != nil {
-		command = append(command, "--workers="+strconv.FormatInt(pointer.Int64Deref(config.ETCDController.Workers, 50), 10))
-	}
-
-	if config.CustodianController != nil {
-		command = append(command, "--custodian-workers="+strconv.FormatInt(pointer.Int64Deref(config.CustodianController.Workers, 10), 10))
-	}
-
-	if config.BackupCompactionController != nil {
-		command = append(command, "--compaction-workers="+strconv.FormatInt(pointer.Int64Deref(config.BackupCompactionController.Workers, 3), 10))
-		command = append(command, "--enable-backup-compaction="+strconv.FormatBool(pointer.BoolDeref(config.BackupCompactionController.EnableBackupCompaction, false)))
-		command = append(command, "--etcd-events-threshold="+strconv.FormatInt(pointer.Int64Deref(config.BackupCompactionController.EventsThreshold, 1000000), 10))
-		if config.BackupCompactionController.ActiveDeadlineDuration != nil {
-			command = append(command, "--active-deadline-duration="+config.BackupCompactionController.ActiveDeadlineDuration.Duration.String())
-		}
+	command = append(command, "--workers="+strconv.FormatInt(*config.ETCDController.Workers, 10))
+	command = append(command, "--custodian-workers="+strconv.FormatInt(*config.CustodianController.Workers, 10))
+	command = append(command, "--compaction-workers="+strconv.FormatInt(*config.BackupCompactionController.Workers, 10))
+	command = append(command, "--enable-backup-compaction="+strconv.FormatBool(*config.BackupCompactionController.EnableBackupCompaction))
+	command = append(command, "--etcd-events-threshold="+strconv.FormatInt(*config.BackupCompactionController.EventsThreshold, 10))
+	if config.BackupCompactionController.ActiveDeadlineDuration != nil {
+		command = append(command, "--active-deadline-duration="+config.BackupCompactionController.ActiveDeadlineDuration.Duration.String())
 	}
 
 	return command


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind technical-debt

**What this PR does / why we need it**:
Previously ETCDConfig values were defaulted at different places like [here](https://github.com/gardener/gardener/blob/master/pkg/operation/botanist/component/etcd/bootstrap.go). Which caused inconsistencies. This PR make changes so the ETCDConfig values should be defaulted only [here](https://github.com/gardener/gardener/blob/master/pkg/gardenlet/apis/config/v1alpha1/defaults.go). Which is the desired place to default all the  `GardenletConfiguration` values.
 
**Which issue(s) this PR fixes**:
Fixes #5157

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
