### PR TITLE
Apply resources in sorted order in managedresource controller

### DIFF
--- a/pkg/resourcemanager/controller/managedresource/reconciler.go
+++ b/pkg/resourcemanager/controller/managedresource/reconciler.go
@@ -52,7 +52,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/yaml"
-	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -419,13 +418,6 @@ func (r *Reconciler) delete(ctx context.Context, mr *resourcesv1alpha1.ManagedRe
 }
 
 func (r *Reconciler) applyNewResources(ctx context.Context, origin string, newResourcesObjects []object, labelsToInject map[string]string, equivalences Equivalences) error {
-	var (
-		results   = make(chan error)
-		wg        sync.WaitGroup
-		errorList = &multierror.Error{
-			ErrorFormat: errorutils.NewErrorFormatFuncWithPrefix("Could not apply all new resources"),
-		}
-	)
 
 	newResourcesObjects = sortByKind(newResourcesObjects)
 
@@ -437,75 +429,55 @@ func (r *Reconciler) applyNewResources(ctx context.Context, origin string, newRe
 		return fmt.Errorf("failed to compute all HPA and HVPA target ref object keys: %w", err)
 	}
 
-	for _, o := range newResourcesObjects {
-		wg.Add(1)
+	for _, obj := range newResourcesObjects {
+		var (
+			current            = obj.obj.DeepCopy()
+			resource           = unstructuredToString(obj.obj)
+			scaledHorizontally = isScaled(obj.obj, horizontallyScaledObjects, equivalences)
+			scaledVertically   = isScaled(obj.obj, verticallyScaledObjects, equivalences)
+		)
 
-		go func(obj object) {
-			defer wg.Done()
+		r.log.Info("Applying", "resource", resource)
 
-			var (
-				current            = obj.obj.DeepCopy()
-				resource           = unstructuredToString(obj.obj)
-				scaledHorizontally = isScaled(obj.obj, horizontallyScaledObjects, equivalences)
-				scaledVertically   = isScaled(obj.obj, verticallyScaledObjects, equivalences)
-			)
+		if operationResult, err := controllerutils.TypedCreateOrUpdate(ctx, r.targetClient, r.targetScheme, current, r.alwaysUpdate, func() error {
+			metadata, err := meta.Accessor(obj.obj)
+			if err != nil {
+				return fmt.Errorf("error getting metadata of object %q: %s", resource, err)
+			}
 
-			r.log.Info("Applying", "resource", resource)
-
-			results <- retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-				if operationResult, err := controllerutils.TypedCreateOrUpdate(ctx, r.targetClient, r.targetScheme, current, r.alwaysUpdate, func() error {
-					metadata, err := meta.Accessor(obj.obj)
-					if err != nil {
-						return fmt.Errorf("error getting metadata of object %q: %s", resource, err)
-					}
-
-					// if the ignore annotation is set to false, do nothing (ignore the resource)
-					if ignore(metadata) {
-						annotations := current.GetAnnotations()
-						delete(annotations, descriptionAnnotation)
-						current.SetAnnotations(annotations)
-						return nil
-					}
-
-					if err := injectLabels(obj.obj, labelsToInject); err != nil {
-						return fmt.Errorf("error injecting labels into object %q: %s", resource, err)
-					}
-
-					return merge(origin, obj.obj, current, obj.forceOverwriteLabels, obj.oldInformation.Labels, obj.forceOverwriteAnnotations, obj.oldInformation.Annotations, scaledHorizontally, scaledVertically)
-				}); err != nil {
-					if apierrors.IsConflict(err) {
-						r.log.Info("Conflict while applying object", "object", resource, "err", err)
-						// return conflict error directly, so that the update will be retried
-						return err
-					}
-
-					if apierrors.IsInvalid(err) && operationResult == controllerutil.OperationResultUpdated && deleteOnInvalidUpdate(current) {
-						if deleteErr := r.targetClient.Delete(ctx, current); client.IgnoreNotFound(deleteErr) != nil {
-							return fmt.Errorf("error deleting object %q after 'invalid' update error: %s", resource, deleteErr)
-						}
-						// return error directly, so that the create after delete will be retried
-						return fmt.Errorf("deleted object %q because of 'invalid' update error and 'delete-on-invalid-update' annotation on object (%s)", resource, err)
-					}
-
-					return fmt.Errorf("error during apply of object %q: %s", resource, err)
-				}
+			// if the ignore annotation is set to false, do nothing (ignore the resource)
+			if ignore(metadata) {
+				annotations := current.GetAnnotations()
+				delete(annotations, descriptionAnnotation)
+				current.SetAnnotations(annotations)
 				return nil
-			})
-		}(o)
-	}
+			}
 
-	go func() {
-		wg.Wait()
-		close(results)
-	}()
+			if err := injectLabels(obj.obj, labelsToInject); err != nil {
+				return fmt.Errorf("error injecting labels into object %q: %s", resource, err)
+			}
 
-	for err := range results {
-		if err != nil {
-			errorList = multierror.Append(errorList, err)
+			return merge(origin, obj.obj, current, obj.forceOverwriteLabels, obj.oldInformation.Labels, obj.forceOverwriteAnnotations, obj.oldInformation.Annotations, scaledHorizontally, scaledVertically)
+		}); err != nil {
+			if apierrors.IsConflict(err) {
+				r.log.Info("Conflict while applying object", "object", resource, "err", err)
+				// return conflict error directly, so that the update will be retried
+				return err
+			}
+
+			if apierrors.IsInvalid(err) && operationResult == controllerutil.OperationResultUpdated && deleteOnInvalidUpdate(current) {
+				if deleteErr := r.targetClient.Delete(ctx, current); client.IgnoreNotFound(deleteErr) != nil {
+					return fmt.Errorf("error deleting object %q after 'invalid' update error: %s", resource, deleteErr)
+				}
+				// return error directly, so that the create after delete will be retried
+				return fmt.Errorf("deleted object %q because of 'invalid' update error and 'delete-on-invalid-update' annotation on object (%s)", resource, err)
+			}
+
+			return fmt.Errorf("error during apply of object %q: %s", resource, err)
 		}
 	}
 
-	return errorList.ErrorOrNil()
+	return nil
 }
 
 func (r *Reconciler) origin(mr *resourcesv1alpha1.ManagedResource) string {

--- a/pkg/resourcemanager/controller/managedresource/reconciler.go
+++ b/pkg/resourcemanager/controller/managedresource/reconciler.go
@@ -427,6 +427,8 @@ func (r *Reconciler) applyNewResources(ctx context.Context, origin string, newRe
 		}
 	)
 
+	newResourcesObjects = sortByKind(newResourcesObjects)
+
 	// get all HPA and HVPA targetRefs to check if we should prevent overwriting replicas and/or resource requirements.
 	// VPAs don't have to be checked, as they don't update the spec directly and only mutate Pods via a MutatingWebhook
 	// and therefore don't interfere with the resource manager.

--- a/pkg/resourcemanager/controller/managedresource/sort.go
+++ b/pkg/resourcemanager/controller/managedresource/sort.go
@@ -18,7 +18,7 @@ import (
 	"sort"
 
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
-	. "github.com/gardener/gardener/pkg/chartrenderer"
+	chartrenderer "github.com/gardener/gardener/pkg/chartrenderer"
 )
 
 var _ = sort.Interface(referenceSorter{})
@@ -64,7 +64,7 @@ type kindSorter struct {
 	objects  []object
 }
 
-func newKindSorter(obj []object, s SortOrder) *kindSorter {
+func newKindSorter(obj []object, s chartrenderer.SortOrder) *kindSorter {
 	o := make(map[string]int, len(s))
 	for v, k := range s {
 		o[k] = v
@@ -110,7 +110,7 @@ func (k *kindSorter) Less(i, j int) bool {
 	return first < second
 }
 func sortByKind(resourceObject []object) []object {
-	ordering := InstallOrder
+	ordering := chartrenderer.InstallOrder
 	ks := newKindSorter(resourceObject, ordering)
 	sort.Sort(ks)
 	return ks.objects

--- a/pkg/resourcemanager/controller/managedresource/sort_test.go
+++ b/pkg/resourcemanager/controller/managedresource/sort_test.go
@@ -22,86 +22,132 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-var _ = Describe("Reference sorter", func() {
-	var refs, refsBase []resourcesv1alpha1.ObjectReference
-
-	BeforeEach(func() {
-		refsBase = []resourcesv1alpha1.ObjectReference{
-			{
-				ObjectReference: corev1.ObjectReference{
-					APIVersion: "v1",
-					Kind:       "ConfigMap",
-					Name:       "foo",
-					Namespace:  "bar",
-				},
-			},
-			{
-				ObjectReference: corev1.ObjectReference{
-					APIVersion: "apps/v1",
-					Kind:       "Deployment",
-					Name:       "nginx",
-					Namespace:  "web",
-				},
-			},
-		}
-
-		// copy refs for assertions, as referenceSorter is sorting in-place
-		refs = append(refsBase[:0:0], refsBase...)
-	})
-
-	Describe("#sortObjectReferences", func() {
-		It("should correctly sort refs", func() {
-			sortObjectReferences(refs)
-			Expect(refs).To(Equal(refsBase))
-		})
-		It("should correctly sort refs (inverted order)", func() {
-			refs[0], refs[1] = refs[1], refs[0]
-			sortObjectReferences(refs)
-			Expect(refs).To(Equal(refsBase))
-		})
-	})
-
-	Describe("#newReferenceSorter", func() {
-		var sorter referenceSorter
+var _ = Describe("Sorter", func() {
+	Describe("Reference sorter", func() {
+		var refs, refsBase []resourcesv1alpha1.ObjectReference
 
 		BeforeEach(func() {
-			sorter = newReferenceSorter(refs).(referenceSorter)
+			refsBase = []resourcesv1alpha1.ObjectReference{
+				{
+					ObjectReference: corev1.ObjectReference{
+						APIVersion: "v1",
+						Kind:       "ConfigMap",
+						Name:       "foo",
+						Namespace:  "bar",
+					},
+				},
+				{
+					ObjectReference: corev1.ObjectReference{
+						APIVersion: "apps/v1",
+						Kind:       "Deployment",
+						Name:       "nginx",
+						Namespace:  "web",
+					},
+				},
+			}
+
+			// copy refs for assertions, as referenceSorter is sorting in-place
+			refs = append(refsBase[:0:0], refsBase...)
 		})
 
-		It("should return the correct length", func() {
-			Expect(sorter.Len()).To(BeEquivalentTo(len(refsBase)))
+		Describe("#sortObjectReferences", func() {
+			It("should correctly sort refs", func() {
+				sortObjectReferences(refs)
+				Expect(refs).To(Equal(refsBase))
+			})
+			It("should correctly sort refs (inverted order)", func() {
+				refs[0], refs[1] = refs[1], refs[0]
+				sortObjectReferences(refs)
+				Expect(refs).To(Equal(refsBase))
+			})
 		})
 
-		It("should return the correct length (nil slice)", func() {
-			sorter = newReferenceSorter(nil).(referenceSorter)
-			Expect(sorter.Len()).To(BeEquivalentTo(0))
+		Describe("#newReferenceSorter", func() {
+			var sorter referenceSorter
+
+			BeforeEach(func() {
+				sorter = newReferenceSorter(refs).(referenceSorter)
+			})
+
+			It("should return the correct length", func() {
+				Expect(sorter.Len()).To(BeEquivalentTo(len(refsBase)))
+			})
+
+			It("should return the correct length (nil slice)", func() {
+				sorter = newReferenceSorter(nil).(referenceSorter)
+				Expect(sorter.Len()).To(BeEquivalentTo(0))
+			})
+
+			It("should calculate the correct keys for refs", func() {
+				Expect(refs).To(Equal([]resourcesv1alpha1.ObjectReference{
+					refsBase[0],
+					refsBase[1],
+				}))
+				Expect(sorter.keys).To(Equal([]string{
+					"/ConfigMap/bar/foo",
+					"apps/Deployment/web/nginx",
+				}))
+			})
+
+			It("should correctly compare refs", func() {
+				Expect(sorter.Less(0, 1)).To(BeTrue())
+			})
+
+			It("should correctly swap refs and keys", func() {
+				sorter.Swap(0, 1)
+				Expect(refs).To(Equal([]resourcesv1alpha1.ObjectReference{
+					refsBase[1],
+					refsBase[0],
+				}))
+				Expect(sorter.keys).To(Equal([]string{
+					"apps/Deployment/web/nginx",
+					"/ConfigMap/bar/foo",
+				}))
+			})
+		})
+	})
+
+	Describe("Kind sorter", func() {
+		var obj, objBase []object
+
+		BeforeEach(func() {
+			objBase = []object{
+				{
+					oldInformation: resourcesv1alpha1.ObjectReference{
+						ObjectReference: corev1.ObjectReference{
+							APIVersion: "v1",
+							Kind:       "ConfigMap",
+							Name:       "foo",
+							Namespace:  "bar",
+						},
+					},
+				},
+				{
+					oldInformation: resourcesv1alpha1.ObjectReference{
+						ObjectReference: corev1.ObjectReference{
+							APIVersion: "apps/v1",
+							Kind:       "Deployment",
+							Name:       "nginx",
+							Namespace:  "web",
+						},
+					},
+				},
+			}
+
+			// copy refs for assertions, as referenceSorter is sorting in-place
+			obj = append(obj[:0:0], objBase...)
 		})
 
-		It("should calculate the correct keys for refs", func() {
-			Expect(refs).To(Equal([]resourcesv1alpha1.ObjectReference{
-				refsBase[0],
-				refsBase[1],
-			}))
-			Expect(sorter.keys).To(Equal([]string{
-				"/ConfigMap/bar/foo",
-				"apps/Deployment/web/nginx",
-			}))
-		})
-
-		It("should correctly compare refs", func() {
-			Expect(sorter.Less(0, 1)).To(BeTrue())
-		})
-
-		It("should correctly swap refs and keys", func() {
-			sorter.Swap(0, 1)
-			Expect(refs).To(Equal([]resourcesv1alpha1.ObjectReference{
-				refsBase[1],
-				refsBase[0],
-			}))
-			Expect(sorter.keys).To(Equal([]string{
-				"apps/Deployment/web/nginx",
-				"/ConfigMap/bar/foo",
-			}))
+		Describe("#sortObjectReferences", func() {
+			It("should correctly sort refs", func() {
+				sortByKind(obj)
+				Expect(obj).To(Equal(objBase))
+			})
+			It("should correctly sort refs (inverted order)", func() {
+				obj[0], obj[1] = obj[1], obj[0]
+				sortByKind(obj)
+				Expect(obj).To(Equal(objBase))
+			})
 		})
 	})
 })

--- a/pkg/resourcemanager/controller/managedresource/sort_test.go
+++ b/pkg/resourcemanager/controller/managedresource/sort_test.go
@@ -134,7 +134,7 @@ var _ = Describe("Sorter", func() {
 				},
 			}
 
-			// copy refs for assertions, as referenceSorter is sorting in-place
+			// copy refs for assertions, as kindSorter is sorting in-place
 			obj = append(obj[:0:0], objBase...)
 		})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
Previously `ManagedResource` controller applied all the resources in parallel. This can cause problem for ex -
```
Deployments applied before ServiceAccounts, 
In this scenario, if a ServiceAccount specifies automountServiceAccountToken=false then the Pods should not get a token volume, however, in rare cases, such wrong order can lead to such undesired situations.
```
This PR adds a sorter that sorts all the resources which are applied by the resource manager based on their kind, therefore, restricting similar scenario's as described above.

**Which issue(s) this PR fixes**:
Fixes #5585

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
