### PR TITLE
Fix different memory limits when VPA enabled

### DIFF
--- a/charts/shoot-addons/charts/kubernetes-dashboard/templates/deployment-dashboard.yaml
+++ b/charts/shoot-addons/charts/kubernetes-dashboard/templates/deployment-dashboard.yaml
@@ -66,11 +66,7 @@ spec:
             cpu: 50m
             memory: 50Mi
           limits:
-          {{- if .Values.global.vpaEnabled }}
-            memory: 200Mi
-          {{- else }}
             memory: 256Mi
-          {{- end }}
       volumes:
       - name: kubernetes-dashboard-certs
         secret:

--- a/charts/shoot-addons/charts/nginx-ingress/templates/controller-deployment.yaml
+++ b/charts/shoot-addons/charts/nginx-ingress/templates/controller-deployment.yaml
@@ -137,11 +137,7 @@ spec:
               cpu: 100m
               memory: 100Mi
             limits:
-            {{- if .Values.global.vpaEnabled }}
-              memory: 400Mi
-            {{- else }}
               memory: 4Gi
-            {{- end }}
       hostNetwork: {{ .Values.controller.hostNetwork }}
     {{- if .Values.controller.nodeSelector }}
       nodeSelector:

--- a/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/deployment.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/deployment.yaml
@@ -57,11 +57,7 @@ spec:
             cpu: 10m
             memory: 5Mi
           limits:
-          {{- if .Values.global.vpaEnabled }}
-            memory: 50Mi
-          {{- else }}
             memory: 150Mi
-          {{- end }}
         ports:
         - containerPort: 9115
           protocol: TCP

--- a/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
@@ -110,11 +110,7 @@ spec:
             cpu: 50m
             memory: 50Mi
           limits:
-          {{- if .Values.global.vpaEnabled }}
-            memory: 150Mi
-          {{- else }}
             memory: 250Mi
-          {{- end }}
         volumeMounts:
         - name: host
           readOnly: true


### PR DESCRIPTION
**How to categorize this PR?**

/area auto-scaling
/kind bug

**What this PR does / why we need it**:
Fixes having different memory limits when VPA is enabled for 4 components deployed on shoot nodes: `addons-nginx-ingress-controller`, `kubernetes-dashboard`, `blackgox-exporter`, and `node-exporter`. After introducing `controlledValues: RequestsOnly` in their VPA resources with #5638, having different memory limits when VPA is enabled no longer makes sense (as limits are no longer adjusted by VPA), and can actually lead to issues in production.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```bugfix operator
`addons-nginx-ingress-controller`, `kubernetes-dashboard`, `blackgox-exporter` no longer have lower memory limits when VPA is enabled.
```
