### PR TITLE
Only copy existing kube-apiserver requests but not limits

### DIFF
--- a/pkg/operation/botanist/kubeapiserver.go
+++ b/pkg/operation/botanist/kubeapiserver.go
@@ -421,7 +421,8 @@ func (b *Botanist) DeployKubeAPIServer(ctx context.Context) error {
 	if deployment != nil && values.Autoscaling.HVPAEnabled {
 		for _, container := range deployment.Spec.Template.Spec.Containers {
 			if container.Name == kubeapiserver.ContainerNameKubeAPIServer {
-				b.Shoot.Components.ControlPlane.KubeAPIServer.SetAutoscalingAPIServerResources(container.Resources)
+				// Only set requests to allow limits to be removed
+				b.Shoot.Components.ControlPlane.KubeAPIServer.SetAutoscalingAPIServerResources(corev1.ResourceRequirements{Requests: container.Resources.Requests})
 				break
 			}
 		}


### PR DESCRIPTION
**How to categorize this PR?**

/area auto-scaling
/kind bug

**What this PR does / why we need it**:
Ensures that only requests but not limits of an existing `kube-aserver` deployment are copied when HVPA is enabled to allow limits to be removed from existing deployments.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```bugfix operator
Only requests but not limits of an existing `kube-apiserver` deployment are copied when HVPA is enabled to allow limits to be removed from existing deployments.
```
