### PR TITLE
Fixes nil pointer exceptions that happen during seed deletion

### DIFF
--- a/pkg/operation/botanist/component/gardenerkubescheduler/gardener_kube_scheduler_bootstrap.go
+++ b/pkg/operation/botanist/component/gardenerkubescheduler/gardener_kube_scheduler_bootstrap.go
@@ -219,9 +219,13 @@ func Bootstrap(
 		return nil, err
 	}
 
-	caSecret, found := secretsManager.Get(v1beta1constants.SecretNameCASeed)
-	if !found {
-		return nil, fmt.Errorf("secret %q not found", v1beta1constants.SecretNameCASeed)
+	var caBundleData []byte
+	if secretsManager != nil {
+		caSecret, found := secretsManager.Get(v1beta1constants.SecretNameCASeed)
+		if !found {
+			return nil, fmt.Errorf("secret %q not found", v1beta1constants.SecretNameCASeed)
+		}
+		caBundleData = caSecret.Data[secretutils.DataKeyCertificateBundle]
 	}
 
 	scheduler, err := New(
@@ -236,7 +240,7 @@ func Bootstrap(
 				Namespace: seedAdmissionControllerNamespace,
 				Path:      pointer.String(podschedulername.WebhookPath),
 			},
-			CABundle: caSecret.Data[secretutils.DataKeyCertificateBundle],
+			CABundle: caBundleData,
 		},
 	)
 	if err != nil {

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -1099,6 +1099,20 @@ func RunDeleteSeedFlow(
 		return err
 	}
 
+	if seed.GetInfo().Status.ClusterIdentity == nil {
+		seedClusterIdentity, err := determineClusterIdentity(ctx, seedClient)
+		if err != nil {
+			return err
+		}
+
+		if err := seed.UpdateInfoStatus(ctx, gardenClient, false, func(seed *gardencorev1beta1.Seed) error {
+			seed.Status.ClusterIdentity = &seedClusterIdentity
+			return nil
+		}); err != nil {
+			return err
+		}
+	}
+
 	secretData, err := getDNSProviderSecretData(ctx, gardenClient, seed)
 	if err != nil {
 		return err


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug

**What this PR does / why we need it**:
Fixes two nil pointer exceptions that happen during deletion of `Seed` objects
1. If the reconciliation of a `Seed` errors before it has a chance to assign `seed.Status.ClusterIdentity`, and then the seed is deleted, a nil pointer exception would cause the deleiton to fail on these lines:
https://github.com/gardener/gardener/blob/a64cf673641b14692c7a1656bf67302e8c154577/pkg/operation/seed/seed.go#L1109
2. During seed deletion `gardenerkubescheduler.Bootstrap` is called with a nil `secretsManager`, but inside the Bootstrap function we still try to generate a certificate: https://github.com/gardener/gardener/blob/a64cf673641b14692c7a1656bf67302e8c154577/pkg/operation/botanist/component/gardenerkubescheduler/gardener_kube_scheduler_bootstrap.go#L222

Btw I was not sure why we add the clusterIdentity so late during the seed reconciliation, but instead of moving it I decided to just add it at the start of the deletion flow.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @rfranzke

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
3. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
