### PR TITLE
Use `client-ca` for signing vpn-seed certificates

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
@@ -203,8 +203,20 @@ spec:
       # TODO(rfranzke): Delete this in a future release once all monitoring configurations of extensions have been
       #	adapted.
       - name: prometheus-client-cert
-        secret:
-          secretName: {{ .Values.secretNameClientCert }}
+        projected:
+          defaultMode: 420
+          sources:
+          - secret:
+              items:
+              - key: tls.crt
+                path: prometheus.crt
+              - key: tls.key
+                path: prometheus.key
+              name: {{ .Values.secretNameClientCert }}
+              optional: false
+          - secret:
+              name: ca
+              optional: false
       - name: shoot-access
         secret:
           secretName: shoot-access-prometheus

--- a/pkg/operation/botanist/component/kubeapiserver/deployment.go
+++ b/pkg/operation/botanist/component/kubeapiserver/deployment.go
@@ -740,7 +740,7 @@ func (k *kubeAPIServer) handleVPNSettings(
 				},
 				{
 					Name:  "APISERVER_AUTH_MODE_CLIENT_CERT_CA",
-					Value: volumeMountPathVPNSeed + "/" + secrets.DataKeyCertificateCA,
+					Value: volumeMountPathCA + "/" + secrets.DataKeyCertificateCA,
 				},
 				{
 					Name:  "APISERVER_AUTH_MODE_CLIENT_CERT_CRT",
@@ -784,6 +784,10 @@ func (k *kubeAPIServer) handleVPNSettings(
 				{
 					Name:      volumeNameVPNSeedTLSAuth,
 					MountPath: volumeMountPathVPNSeedTLSAuth,
+				},
+				{
+					Name:      volumeNameCA,
+					MountPath: volumeMountPathCA,
 				},
 			},
 		}

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
@@ -1566,7 +1566,7 @@ rules:
 							},
 							{
 								Name:  "APISERVER_AUTH_MODE_CLIENT_CERT_CA",
-								Value: "/srv/secrets/vpn-seed/ca.crt",
+								Value: "/srv/kubernetes/ca/ca.crt",
 							},
 							{
 								Name:  "APISERVER_AUTH_MODE_CLIENT_CERT_CRT",
@@ -1614,6 +1614,10 @@ rules:
 							{
 								Name:      "vpn-seed-tlsauth",
 								MountPath: "/srv/secrets/tlsauth",
+							},
+							{
+								Name:      "ca",
+								MountPath: "/srv/kubernetes/ca",
 							},
 						},
 					}))

--- a/pkg/operation/botanist/component/vpnshoot/vpnshoot.go
+++ b/pkg/operation/botanist/component/vpnshoot/vpnshoot.go
@@ -154,7 +154,7 @@ func (v *vpnShoot) Deploy(ctx context.Context) error {
 			CertType:                    secretutils.ServerCert,
 			SkipPublishingCACertificate: true,
 		}
-		signingCA = v1beta1constants.SecretNameCACluster
+		signingCA = v1beta1constants.SecretNameCAClient
 	}
 
 	secretCA, found := v.secretsManager.Get(signingCA)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/kind regression

**What this PR does / why we need it**:
The kube-apiserver was moved to use `client-ca` in this #5779. but the `vpn-seed` was still using cluster ca to sign its certificate because of this it was not able to communicate with kube-apiserver leading to following error in kube-apiserver
```
E0421 11:47:34.287614       1 authentication.go:104] Unable to authenticate the request due to an error: x509: certificate
signed by unknown authority
E0421 11:47:34.996896       1 authentication.go:104] Unable to authenticate the request due to an error: x509: certificate
signed by unknown authority
```
This PR fixes the issue by using `client-ca` to sign `vpn-seed` certificates.

Apart from the above it also mounts cluster ca in `vpn-seed` which is needed for `vpn-shoot`.

**Which issue(s) this PR fixes**:
Fixes #5839

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
