### PR TITLE
Properly select CA secrets by labels

### DIFF
--- a/pkg/apis/core/v1alpha1/helper/shootstate_list.go
+++ b/pkg/apis/core/v1alpha1/helper/shootstate_list.go
@@ -18,6 +18,7 @@ import (
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/labels"
 )
 
 // ExtensionResourceStateList is a list of ExtensionResourceStates
@@ -84,6 +85,19 @@ func (g *GardenerResourceDataList) Get(name string) *gardencorev1alpha1.Gardener
 		}
 	}
 	return nil
+}
+
+// Select uses the provided label selector to find data entries with matching labels.
+func (g *GardenerResourceDataList) Select(labelSelector labels.Selector) []*gardencorev1alpha1.GardenerResourceData {
+	var results []*gardencorev1alpha1.GardenerResourceData
+
+	for _, resourceDataEntry := range *g {
+		if labelSelector.Matches(labels.Set(resourceDataEntry.Labels)) {
+			results = append(results, resourceDataEntry.DeepCopy())
+		}
+	}
+
+	return results
 }
 
 // Upsert inserts a new element or updates an existing one

--- a/pkg/registry/core/shoot/storage/admin_kubeconfig_test.go
+++ b/pkg/registry/core/shoot/storage/admin_kubeconfig_test.go
@@ -49,18 +49,10 @@ var _ = Describe("Admin Kubeconfig", func() {
 		shootGetter      *fakeGetter
 		ctx              context.Context
 		obj              *authenticationapi.AdminKubeconfigRequest
-		caCert           []byte
-		caKey            []byte
 		createValidation registryrest.ValidateObjectFunc
-	)
 
-	const (
-		name      = "test"
-		userName  = "foo"
-		namespace = "baz"
-	)
-	BeforeEach(func() {
-		caCert = []byte(`-----BEGIN CERTIFICATE-----
+		caCert1Name = "minikubeCA"
+		caCert1     = []byte(`-----BEGIN CERTIFICATE-----
 MIIDBjCCAe6gAwIBAgIBATANBgkqhkiG9w0BAQsFADAVMRMwEQYDVQQDEwptaW5p
 a3ViZUNBMB4XDTIxMDMyNTE0MjczN1oXDTMxMDMyNDE0MjczN1owFTETMBEGA1UE
 AxMKbWluaWt1YmVDQTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALsW
@@ -79,7 +71,7 @@ OnM7+5534rkP8/eIX58QFcVibjM34BfqNQgHW5vFXobYoIX2wfMysLZVESYQdU9P
 C3KRaS8COePkaiH/NUjuIjyTXzhvJqmFbH730vABpcKi01eQMMjtRkPlWIEqUHoG
 QbU6uberp2QAQA==
 -----END CERTIFICATE-----`)
-		caKey = []byte(`-----BEGIN RSA PRIVATE KEY-----
+		caKey1 = []byte(`-----BEGIN RSA PRIVATE KEY-----
 MIIEowIBAAKCAQEAuxbyNToBQ/W31anrE5MBiGOsQ8aLE/6IKP1xJfleRKGlU1g1
 6bAKqkM0560oAC0VAySlyjWKx+4Hzvps1j79sLlgKtimvOWNL4RgBv794P9qFRGd
 dfLT3J8GsZMy+vq2LwEvkOqUOqEe7ex6QgxJ52twKzXR0NySCXiWCGhFKgJp3f8s
@@ -107,17 +99,77 @@ AIOz/jD6sCJ6KPr1L6mJ5w4mDX1UmjCKy3Kz4xfqxPEbMvPDTL+9TWFSlAuNtHGC
 lIwEl8tStnO9u1JUK4w1e+lC37zI2v5k4WMQmJcolUEMwmZjnCR/
 -----END RSA PRIVATE KEY-----`)
 
-		caRaw := []byte(`{"ca.crt":"` + utils.EncodeBase64(caCert) + `","ca.key":"` + utils.EncodeBase64(caKey) + `"}`)
+		caCert2Name = "new-minikube-ca"
+		caCert2     = []byte(`-----BEGIN CERTIFICATE-----
+MIIDBDCCAeygAwIBAgIUXutuW//tcCBAR2BKjz1N9xNosNwwDQYJKoZIhvcNAQEL
+BQAwGjEYMBYGA1UEAxMPbmV3LW1pbmlrdWJlLWNhMB4XDTIyMDQxMjA3MDcwMFoX
+DTI3MDQxMTA3MDcwMFowGjEYMBYGA1UEAxMPbmV3LW1pbmlrdWJlLWNhMIIBIjAN
+BgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsiOi5NGvtPtJLD4FfMUne1KcgtKs
+o91WdriOJWF6mfWiB2fnbMS8EaKaU4AMXyrQpn6neZTDXeH5DOXhiQqvczRr5B4u
+/SD+OXLhdrzNaIpYc7DNhbT41DdG0F+ZiNQao0rQJrvw7pcR6D+CzqMmLk34Q4VU
+h0e2nXSqNS4S/0coKUomL1eMSHpMqJVGTQhlWHDU7xMyOZ2t5TleHBI+OhfXAMyV
+iEcaZUeengV73RoX+ycAYb5tjZOwk0GlolQxYl4rnjro2c2i5ezK8F+xdfkbCL/D
+NfUGg01JBfCc1Yb3DtOpTaQcnnwFyJjQX8aPMTtDbT/4JZsHujZdRKU9yQIDAQAB
+o0IwQDAOBgNVHQ8BAf8EBAMCAQYwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4EFgQU
++8T3UU5pFUA8jFwy4pLioRxg1IgwDQYJKoZIhvcNAQELBQADggEBAELa5wEx7CAX
+y98v2iDAQ4uXNIrVZFp3zAgL1Rvtivf85Vz6+aQMSflJG8Ftk205PbUPhcvMrdFi
+NdC9mGZ1K+QoyAIP+cU6zDVhzH73Vjlg/JyMa8kRFaqJMAnExGKNuzu4Ox742XKH
+ej+WbykRbnB3t/Fvw4WrA0ZhQip/314SOyF71xDHGfBQrJYItGEB7kIriTOUL0Or
+Eh1pkuxLBmO/iz4iAMaaG5JuVlPtDEYLX1kBx/aPh9sjgw28AWvlA1L/HawmXLsR
+Yg+zBuGRGSu1IfIIwjshOGmsz+jaTM0SEZ5AtbmOl1gvGSgj8Ylod+Qb7gXBxBO8
+yUsW6+ksN+o=
+-----END CERTIFICATE-----`)
+		caKey2 = []byte(`-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEAsiOi5NGvtPtJLD4FfMUne1KcgtKso91WdriOJWF6mfWiB2fn
+bMS8EaKaU4AMXyrQpn6neZTDXeH5DOXhiQqvczRr5B4u/SD+OXLhdrzNaIpYc7DN
+hbT41DdG0F+ZiNQao0rQJrvw7pcR6D+CzqMmLk34Q4VUh0e2nXSqNS4S/0coKUom
+L1eMSHpMqJVGTQhlWHDU7xMyOZ2t5TleHBI+OhfXAMyViEcaZUeengV73RoX+ycA
+Yb5tjZOwk0GlolQxYl4rnjro2c2i5ezK8F+xdfkbCL/DNfUGg01JBfCc1Yb3DtOp
+TaQcnnwFyJjQX8aPMTtDbT/4JZsHujZdRKU9yQIDAQABAoIBAQCacqVHyLmTq478
+qeVuES2zEaQbFPeTt1LA6jBsHoECvWI3E5IlzsjUbWtqXAnd9SwkPomLszxTyJl6
+4lDR1Y7azqeAh97rntBsFLuAjB93tQMNg0wd0hMvQ6HFBi4C4QsbasDf5HD3G8nt
+2CrcZ72xxe4q9I2eIMIm8ECmjQTxiFiVf89TRz5Y+63IniId9Gh7WKmDR59sS31I
+aEVRVRS9934tdkKx3TJd4Hmb1SNusvnx8wiTfi12nVjgVtYLLzPkd18I58wNvyj/
+BE4iyiM4AqzQBqgEjc8Hw6YeR3Mwu6zyA0u7g3pXHhO4JL/eOpxWY6DAVlOt+WWC
+ZkhGxs0lAoGBAN8GgPKVOX9x75CPv44ATfbZ5g7qmT5wrhHIlcF/1B1Q0xvZsrmn
+2Hax96EINk93osWaiKAWoVIt0mHuoE2k5TK1cazI+DatyuXgU+3ngxoI7SPK95w2
+EcXTKkFGgz5/WU2XWgYRdDy2gzb3XTlygPael+pjWYb5bRQjw6hALwQHAoGBAMx6
+MWcX9FmeHvjBjXRyxz4xehqv8iXnMKIghAfCTD0zQ4OTGher5mVVCcWncKB8s/c7
+5mIaKfTaoGgfVeGlrBeGLSeDWoHQMdWP1ZBMchNKpzZ9OXU2QmYrkUzFPJGTUSJe
+sKLLYD2R+vwWGra508rJBKQKMnmIf7MLacB6lVuvAoGAJ/HoQoqLo9HqUIAOlQZk
+8GOSmvVVwSM5aiH9AI0+lomVZhWVtz7ivE+fxI3N/Gm3E6Fb+yBSgH+IgNXWjFGO
+Y4iv9XyBSHnUL1wAbEnc51rV7mU5+BaPFFl/5fUVKKpyej0zeIbDxOQDmGKxpcpm
+YsWA/BATRuOBr+u/7XChex0CgYBdGG0RsPhRLQqQ2x6aG//WsxQSvnSTCTU9O2yh
+U7b+Ti644uqISH13OUZftSI0D1Koh58Wny7nCfrqLQoe2B0IANDiIo28eJuXzgq/
+ze5KFj0XM+BLG08T0VYwC8TNyrKv4UiudcX1glcxGqdC9kwVEXyJaxMb/ieVzuZw
++d6yhQKBgQCyR66MFetyEffnbxHng3WIG4MzJj7Bn5IewQiKe6yWgrS4xMxoUywx
+xdiQxdLMPqh48D9u+bwt+roq66lt1kcF0mvIUgEYXhaPj/9moG8cfgmbmF9tsm08
+bW4nbZLxXHQ4e+OOPeBUXUP9V0QcE4XixdvQuslfVxjn0Ja82gdzeA==
+-----END RSA PRIVATE KEY-----`)
+	)
 
+	const (
+		name      = "test"
+		userName  = "foo"
+		namespace = "baz"
+	)
+
+	BeforeEach(func() {
 		shootState = &gardenercore.ShootState{
 			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
 			Spec: gardenercore.ShootStateSpec{
 				Gardener: []gardenercore.GardenerResourceData{
 					{
-						Name: "ca-client",
+						Name: "ca-client-foo",
 						Type: "secret",
+						Labels: map[string]string{
+							"name":             "ca-client",
+							"managed-by":       "secrets-manager",
+							"manager-identity": "gardenlet",
+							"issued-at-time":   "0",
+						},
 						Data: runtime.RawExtension{
-							Raw: caRaw,
+							Raw: []byte(`{"ca.crt":"` + utils.EncodeBase64(caCert1) + `","ca.key":"` + utils.EncodeBase64(caKey1) + `"}`),
 						},
 					},
 				},
@@ -214,8 +266,12 @@ lIwEl8tStnO9u1JUK4w1e+lC37zI2v5k4WMQmJcolUEMwmZjnCR/
 		})
 	})
 
-	Context("request succeeds", func() {
-		AfterEach(func() {
+	DescribeTable("request succeeds",
+		func(expectedIssuerName string, expectedCACert []byte, prepEnv func()) {
+			if prepEnv != nil {
+				prepEnv()
+			}
+
 			actual, err := akcREST.Create(ctx, name, obj, nil, nil)
 
 			Expect(err).ToNot(HaveOccurred())
@@ -234,14 +290,14 @@ lIwEl8tStnO9u1JUK4w1e+lC37zI2v5k4WMQmJcolUEMwmZjnCR/
 					Name: "baz--test-external",
 					Cluster: configv1.Cluster{
 						Server:                   "https://foo.bar.external:9443",
-						CertificateAuthorityData: caCert,
+						CertificateAuthorityData: expectedCACert,
 					},
 				},
 				configv1.NamedCluster{
 					Name: "baz--test-internal",
 					Cluster: configv1.Cluster{
 						Server:                   "https://foo.bar.internal:9443",
-						CertificateAuthorityData: caCert,
+						CertificateAuthorityData: expectedCACert,
 					},
 				},
 			))
@@ -277,15 +333,59 @@ lIwEl8tStnO9u1JUK4w1e+lC37zI2v5k4WMQmJcolUEMwmZjnCR/
 			Expect(cert.Subject.Organization).To(ConsistOf("system:masters"))
 			Expect(cert.NotAfter.Unix()).To(Equal(akcr.Status.ExpirationTimestamp.Time.Unix())) // certificates do not have nano seconds in them
 			Expect(cert.NotBefore.UTC()).To(Equal(time.Unix(10, 0).UTC()))
-		})
+			Expect(cert.Issuer.CommonName).To(Equal(expectedIssuerName))
+		},
 
-		It("ca is stored as secret data type", func() {})
+		Entry("one client ca", caCert1Name, caCert1, nil),
 
-		It("ca is stored as certificate data type", func() {
+		Entry("multiple client ca (in case of rotation)", caCert2Name, caCert2, func() {
+			shootState.Spec.Gardener = append(shootState.Spec.Gardener, gardenercore.GardenerResourceData{
+				Name: "ca-client-bar",
+				Type: "secret",
+				Labels: map[string]string{
+					"name":             "ca-client",
+					"managed-by":       "secrets-manager",
+					"manager-identity": "gardenlet",
+					"issued-at-time":   "1",
+				},
+				Data: runtime.RawExtension{
+					Raw: []byte(`{"ca.crt":"` + utils.EncodeBase64(caCert2) + `","ca.key":"` + utils.EncodeBase64(caKey2) + `"}`),
+				},
+			})
+		}),
+
+		Entry("no client ca, one cluster ca", caCert1Name, caCert1, func() {
+			shootState.Spec.Gardener[0].Labels["name"] = "ca"
+		}),
+
+		Entry("one client ca, one cluster ca", caCert1Name, caCert1, func() {
+			shootState.Spec.Gardener = append(shootState.Spec.Gardener, gardenercore.GardenerResourceData{
+				Name: "ca-new",
+				Type: "secret",
+				Labels: map[string]string{
+					"name":             "ca",
+					"managed-by":       "secrets-manager",
+					"manager-identity": "gardenlet",
+					"issued-at-time":   "1",
+				},
+				Data: runtime.RawExtension{
+					Raw: []byte(`{"ca.crt":"` + utils.EncodeBase64(caCert2) + `","ca.key":"` + utils.EncodeBase64(caKey2) + `"}`),
+				},
+			})
+		}),
+
+		Entry("legacy ca is stored as certificate data type", caCert1Name, caCert1, func() {
+			shootState.Spec.Gardener[0].Name = "ca"
+			shootState.Spec.Gardener[0].Labels = nil
+		}),
+
+		Entry("legacy ca is stored as certificate data type", caCert1Name, caCert1, func() {
+			shootState.Spec.Gardener[0].Name = "ca"
+			shootState.Spec.Gardener[0].Labels = nil
 			shootState.Spec.Gardener[0].Type = "certificate"
-			shootState.Spec.Gardener[0].Data.Raw = []byte(`{"certificate":"` + utils.EncodeBase64(caCert) + `","privateKey":"` + utils.EncodeBase64(caKey) + `"}`)
-		})
-	})
+			shootState.Spec.Gardener[0].Data.Raw = []byte(`{"certificate":"` + utils.EncodeBase64(caCert1) + `","privateKey":"` + utils.EncodeBase64(caKey1) + `"}`)
+		}),
+	)
 })
 
 type fakeGetter struct {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind regression

**What this PR does / why we need it**:
The client CA introduced with #5779 does never have a constant name (`ca-client`) but always a name including the config checksum (`ca-client-<some-hash>`). Hence, the code trying to retrieve the client CA for the `shoots/adminkubeconfig` subresource is failing and falls back to the cluster CA (`ca`). Consequently, client certificate are issued by the wrong CA since the cluster CA is no longer used for verifying client certificates.

Now, we properly select the client CA via the secrets manager labels. If this fails we try the same with the cluster CA, and only if this fails as well we fall back to the constant cluster CA name (`ca`).

**Which issue(s) this PR fixes**:
Fixes #5847

**Special notes for your reviewer**:
/milestone v1.45
/cc @acumino 

This is basically a modified cherry-pick of https://github.com/gardener/gardener/pull/5790/commits/b9ffff2baf3b9e36b331c060dbf2a0f4b967791a.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
