### PR TITLE
Add error code for misconfigured webhooks

### DIFF
--- a/docs/usage/shoot_status.md
+++ b/docs/usage/shoot_status.md
@@ -105,4 +105,4 @@ Known error codes are:
 - `ERR_CLEANUP_CLUSTER_RESOURCES` - indicates that the last error occurred due to resources in the cluster that are stuck in deletion.
 - `ERR_CONFIGURATION_PROBLEM` - indicates that the last error occurred due to a configuration problem. It is classified as a non-retryable error code.
 - `ERR_RETRYABLE_CONFIGURATION_PROBLEM` - indicates that the last error occurred due to a retryable configuration problem. "Retryable" means that the occurred error is likely to be resolved in a ungraceful manner after given period of time.
-- `ERR_USER_WEBHOOK` - indicates that the last error occurred due to misconfigured webhook.
+- `ERR_PROBLEMATIC_WEBHOOK` - indicates that the last error occurred due to a webhook not following the Kubernetes best practices (https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#best-practices-and-warnings).

--- a/docs/usage/shoot_status.md
+++ b/docs/usage/shoot_status.md
@@ -105,4 +105,4 @@ Known error codes are:
 - `ERR_CLEANUP_CLUSTER_RESOURCES` - indicates that the last error occurred due to resources in the cluster that are stuck in deletion.
 - `ERR_CONFIGURATION_PROBLEM` - indicates that the last error occurred due to a configuration problem. It is classified as a non-retryable error code.
 - `ERR_RETRYABLE_CONFIGURATION_PROBLEM` - indicates that the last error occurred due to a retryable configuration problem. "Retryable" means that the occurred error is likely to be resolved in a ungraceful manner after given period of time.
-- `ERR_USER_WEBHOOK` - indicates that the last error occured due to misconfigurred webhook.
+- `ERR_USER_WEBHOOK` - indicates that the last error occurred due to misconfigured webhook.

--- a/docs/usage/shoot_status.md
+++ b/docs/usage/shoot_status.md
@@ -105,3 +105,4 @@ Known error codes are:
 - `ERR_CLEANUP_CLUSTER_RESOURCES` - indicates that the last error occurred due to resources in the cluster that are stuck in deletion.
 - `ERR_CONFIGURATION_PROBLEM` - indicates that the last error occurred due to a configuration problem. It is classified as a non-retryable error code.
 - `ERR_RETRYABLE_CONFIGURATION_PROBLEM` - indicates that the last error occurred due to a retryable configuration problem. "Retryable" means that the occurred error is likely to be resolved in a ungraceful manner after given period of time.
+- `ERR_USER_WEBHOOK` - indicates that the last error occured due to misconfigurred webhook.

--- a/pkg/apis/core/types_common.go
+++ b/pkg/apis/core/types_common.go
@@ -47,6 +47,8 @@ const (
 	ErrorConfigurationProblem ErrorCode = "ERR_CONFIGURATION_PROBLEM"
 	// ErrorRetryableConfigurationProblem indicates that the last error occurred due to a retryable configuration problem.
 	ErrorRetryableConfigurationProblem ErrorCode = "ERR_RETRYABLE_CONFIGURATION_PROBLEM"
+	// ErorUserWebhook indicates that the last error occurred due to misconfigurred webhook.
+	ErrorUserWebhook ErrorCode = "ERR_USER_WEBHOOK"
 )
 
 // LastError indicates the last occurred error for an operation on a resource.

--- a/pkg/apis/core/types_common.go
+++ b/pkg/apis/core/types_common.go
@@ -47,7 +47,7 @@ const (
 	ErrorConfigurationProblem ErrorCode = "ERR_CONFIGURATION_PROBLEM"
 	// ErrorRetryableConfigurationProblem indicates that the last error occurred due to a retryable configuration problem.
 	ErrorRetryableConfigurationProblem ErrorCode = "ERR_RETRYABLE_CONFIGURATION_PROBLEM"
-	// ErorUserWebhook indicates that the last error occurred due to misconfigurred webhook.
+	// ErrorUserWebhook indicates that the last error occurred due to misconfigured webhook.
 	ErrorUserWebhook ErrorCode = "ERR_USER_WEBHOOK"
 )
 

--- a/pkg/apis/core/types_common.go
+++ b/pkg/apis/core/types_common.go
@@ -47,8 +47,10 @@ const (
 	ErrorConfigurationProblem ErrorCode = "ERR_CONFIGURATION_PROBLEM"
 	// ErrorRetryableConfigurationProblem indicates that the last error occurred due to a retryable configuration problem.
 	ErrorRetryableConfigurationProblem ErrorCode = "ERR_RETRYABLE_CONFIGURATION_PROBLEM"
-	// ErrorUserWebhook indicates that the last error occurred due to misconfigured webhook.
-	ErrorUserWebhook ErrorCode = "ERR_USER_WEBHOOK"
+	// ErrorProblematicWebhook indicates that the last error occurred due to a webhook not following the Kubernetes
+	// best practices (https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#best-practices-and-warnings).
+	// It is classified as a non-retryable error code.
+	ErrorProblematicWebhook ErrorCode = "ERR_PROBLEMATIC_WEBHOOK"
 )
 
 // LastError indicates the last occurred error for an operation on a resource.

--- a/pkg/apis/core/v1alpha1/types_common.go
+++ b/pkg/apis/core/v1alpha1/types_common.go
@@ -45,9 +45,10 @@ const (
 	ErrorConfigurationProblem ErrorCode = "ERR_CONFIGURATION_PROBLEM"
 	// ErrorRetryableConfigurationProblem indicates that the last error occurred due to a retryable configuration problem.
 	ErrorRetryableConfigurationProblem ErrorCode = "ERR_RETRYABLE_CONFIGURATION_PROBLEM"
-	// ErrorUserWebhook indicates that the last error occurred due to misconfigured webhook.
+	// ErrorProblematicWebhook indicates that the last error occurred due to a webhook not following the Kubernetes
+	// best practices (https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#best-practices-and-warnings).
 	// It is classified as a non-retryable error code.
-	ErrorUserWebhook ErrorCode = "ERR_USER_WEBHOOK"
+	ErrorProblematicWebhook ErrorCode = "ERR_PROBLEMATIC_WEBHOOK"
 )
 
 // LastError indicates the last occurred error for an operation on a resource.

--- a/pkg/apis/core/v1alpha1/types_common.go
+++ b/pkg/apis/core/v1alpha1/types_common.go
@@ -45,7 +45,7 @@ const (
 	ErrorConfigurationProblem ErrorCode = "ERR_CONFIGURATION_PROBLEM"
 	// ErrorRetryableConfigurationProblem indicates that the last error occurred due to a retryable configuration problem.
 	ErrorRetryableConfigurationProblem ErrorCode = "ERR_RETRYABLE_CONFIGURATION_PROBLEM"
-	// ErorUserWebhook indicates that the last error occurred due to misconfigurred webhook.
+	// ErrorUserWebhook indicates that the last error occurred due to misconfigured webhook.
 	// It is classified as a non-retryable error code.
 	ErrorUserWebhook ErrorCode = "ERR_USER_WEBHOOK"
 )

--- a/pkg/apis/core/v1alpha1/types_common.go
+++ b/pkg/apis/core/v1alpha1/types_common.go
@@ -45,6 +45,9 @@ const (
 	ErrorConfigurationProblem ErrorCode = "ERR_CONFIGURATION_PROBLEM"
 	// ErrorRetryableConfigurationProblem indicates that the last error occurred due to a retryable configuration problem.
 	ErrorRetryableConfigurationProblem ErrorCode = "ERR_RETRYABLE_CONFIGURATION_PROBLEM"
+	// ErorUserWebhook indicates that the last error occurred due to misconfigurred webhook.
+	// It is classified as a non-retryable error code.
+	ErrorUserWebhook ErrorCode = "ERR_USER_WEBHOOK"
 )
 
 // LastError indicates the last occurred error for an operation on a resource.

--- a/pkg/apis/core/v1beta1/helper/errors.go
+++ b/pkg/apis/core/v1beta1/helper/errors.go
@@ -267,7 +267,8 @@ func HasNonRetryableErrorCode(lastErrors ...gardencorev1beta1.LastError) bool {
 				code == gardencorev1beta1.ErrorInfraDependencies ||
 				code == gardencorev1beta1.ErrorInfraQuotaExceeded ||
 				code == gardencorev1beta1.ErrorInfraRateLimitsExceeded ||
-				code == gardencorev1beta1.ErrorConfigurationProblem {
+				code == gardencorev1beta1.ErrorConfigurationProblem ||
+				code == gardencorev1beta1.ErrorUserWebhook {
 				return true
 			}
 		}

--- a/pkg/apis/core/v1beta1/helper/errors.go
+++ b/pkg/apis/core/v1beta1/helper/errors.go
@@ -268,7 +268,7 @@ func HasNonRetryableErrorCode(lastErrors ...gardencorev1beta1.LastError) bool {
 				code == gardencorev1beta1.ErrorInfraQuotaExceeded ||
 				code == gardencorev1beta1.ErrorInfraRateLimitsExceeded ||
 				code == gardencorev1beta1.ErrorConfigurationProblem ||
-				code == gardencorev1beta1.ErrorUserWebhook {
+				code == gardencorev1beta1.ErrorProblematicWebhook {
 				return true
 			}
 		}

--- a/pkg/apis/core/v1beta1/types_common.go
+++ b/pkg/apis/core/v1beta1/types_common.go
@@ -45,8 +45,10 @@ const (
 	ErrorConfigurationProblem ErrorCode = "ERR_CONFIGURATION_PROBLEM"
 	// ErrorRetryableConfigurationProblem indicates that the last error occurred due to a retryable configuration problem.
 	ErrorRetryableConfigurationProblem ErrorCode = "ERR_RETRYABLE_CONFIGURATION_PROBLEM"
-	// ErrorUserWebhook indicates that the last error occurred due to misconfigured webhook.
-	ErrorUserWebhook ErrorCode = "ERR_USER_WEBHOOK"
+	// ErrorProblematicWebhook indicates that the last error occurred due to a webhook not following the Kubernetes
+	// best practices (https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#best-practices-and-warnings).
+	// It is classified as a non-retryable error code.
+	ErrorProblematicWebhook ErrorCode = "ERR_PROBLEMATIC_WEBHOOK"
 )
 
 // LastError indicates the last occurred error for an operation on a resource.

--- a/pkg/apis/core/v1beta1/types_common.go
+++ b/pkg/apis/core/v1beta1/types_common.go
@@ -45,7 +45,7 @@ const (
 	ErrorConfigurationProblem ErrorCode = "ERR_CONFIGURATION_PROBLEM"
 	// ErrorRetryableConfigurationProblem indicates that the last error occurred due to a retryable configuration problem.
 	ErrorRetryableConfigurationProblem ErrorCode = "ERR_RETRYABLE_CONFIGURATION_PROBLEM"
-	// ErorUserWebhook indicates that the last error occurred due to misconfigurred webhook.
+	// ErrorUserWebhook indicates that the last error occurred due to misconfigured webhook.
 	ErrorUserWebhook ErrorCode = "ERR_USER_WEBHOOK"
 )
 

--- a/pkg/apis/core/v1beta1/types_common.go
+++ b/pkg/apis/core/v1beta1/types_common.go
@@ -45,6 +45,8 @@ const (
 	ErrorConfigurationProblem ErrorCode = "ERR_CONFIGURATION_PROBLEM"
 	// ErrorRetryableConfigurationProblem indicates that the last error occurred due to a retryable configuration problem.
 	ErrorRetryableConfigurationProblem ErrorCode = "ERR_RETRYABLE_CONFIGURATION_PROBLEM"
+	// ErorUserWebhook indicates that the last error occurred due to misconfigurred webhook.
+	ErrorUserWebhook ErrorCode = "ERR_USER_WEBHOOK"
 )
 
 // LastError indicates the last occurred error for an operation on a resource.

--- a/pkg/operation/care/checker.go
+++ b/pkg/operation/care/checker.go
@@ -645,7 +645,7 @@ func makeWorkerLister(ctx context.Context, c client.Client, namespace string) ku
 // NewConditionOrError returns the given new condition or returns an unknown error condition if an error occurred or `newCondition` is nil.
 func NewConditionOrError(oldCondition gardencorev1beta1.Condition, newCondition *gardencorev1beta1.Condition, err error) gardencorev1beta1.Condition {
 	if err != nil || newCondition == nil {
-		return gardencorev1beta1helper.UpdatedConditionUnknownError(oldCondition, err, gardencorev1beta1helper.ExtractErrorCodes(err)...)
+		return gardencorev1beta1helper.UpdatedConditionUnknownError(oldCondition, err)
 	}
 	return *newCondition
 }

--- a/pkg/operation/care/checker.go
+++ b/pkg/operation/care/checker.go
@@ -645,7 +645,7 @@ func makeWorkerLister(ctx context.Context, c client.Client, namespace string) ku
 // NewConditionOrError returns the given new condition or returns an unknown error condition if an error occurred or `newCondition` is nil.
 func NewConditionOrError(oldCondition gardencorev1beta1.Condition, newCondition *gardencorev1beta1.Condition, err error) gardencorev1beta1.Condition {
 	if err != nil || newCondition == nil {
-		return gardencorev1beta1helper.UpdatedConditionUnknownError(oldCondition, err)
+		return gardencorev1beta1helper.UpdatedConditionUnknownError(oldCondition, err, gardencorev1beta1helper.ExtractErrorCodes(err)...)
 	}
 	return *newCondition
 }

--- a/pkg/operation/care/constraints.go
+++ b/pkg/operation/care/constraints.go
@@ -171,10 +171,11 @@ func (c *Constraint) CheckForProblematicWebhooks(ctx context.Context) (gardencor
 	for _, webhookConfig := range validatingWebhookConfigs {
 		for _, w := range webhookConfig.Webhooks {
 			if IsProblematicWebhook(w.FailurePolicy, w.ObjectSelector, w.NamespaceSelector, w.Rules, w.TimeoutSeconds) {
+				msg := buildProblematicWebhookMessage("ValidatingWebhookConfiguration", webhookConfig.Name, w.Name, w.FailurePolicy, w.TimeoutSeconds)
 				return gardencorev1beta1.ConditionFalse,
 					"ProblematicWebhooks",
-					buildProblematicWebhookMessage("ValidatingWebhookConfiguration", webhookConfig.Name, w.Name, w.FailurePolicy, w.TimeoutSeconds),
-					nil
+					msg,
+					gardencorev1beta1helper.NewErrorWithCodes(msg, gardencorev1beta1.ErrorUserWebhook)
 			}
 		}
 	}
@@ -187,10 +188,11 @@ func (c *Constraint) CheckForProblematicWebhooks(ctx context.Context) (gardencor
 	for _, webhookConfig := range mutatingWebhookConfigs {
 		for _, w := range webhookConfig.Webhooks {
 			if IsProblematicWebhook(w.FailurePolicy, w.ObjectSelector, w.NamespaceSelector, w.Rules, w.TimeoutSeconds) {
+				msg := buildProblematicWebhookMessage("MutatingWebhookConfiguration", webhookConfig.Name, w.Name, w.FailurePolicy, w.TimeoutSeconds)
 				return gardencorev1beta1.ConditionFalse,
 					"ProblematicWebhooks",
-					buildProblematicWebhookMessage("MutatingWebhookConfiguration", webhookConfig.Name, w.Name, w.FailurePolicy, w.TimeoutSeconds),
-					nil
+					msg,
+					gardencorev1beta1helper.NewErrorWithCodes(msg, gardencorev1beta1.ErrorUserWebhook)
 			}
 		}
 	}

--- a/pkg/operation/care/constraints.go
+++ b/pkg/operation/care/constraints.go
@@ -175,7 +175,7 @@ func (c *Constraint) CheckForProblematicWebhooks(ctx context.Context) (gardencor
 				return gardencorev1beta1.ConditionFalse,
 					"ProblematicWebhooks",
 					msg,
-					[]gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorUserWebhook},
+					[]gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorProblematicWebhook},
 					nil
 			}
 		}
@@ -193,7 +193,7 @@ func (c *Constraint) CheckForProblematicWebhooks(ctx context.Context) (gardencor
 				return gardencorev1beta1.ConditionFalse,
 					"ProblematicWebhooks",
 					msg,
-					[]gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorUserWebhook},
+					[]gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorProblematicWebhook},
 					nil
 			}
 		}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
In case of misconfigured webhooks , the shoot status constraints fails with reason `ProblematicWebhooks`. This PR adds the error code to reason for the failed constraint.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/5778

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
