### PR TITLE
Promote `WorkerPoolKubernetesVersion` to beta

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -32,7 +32,7 @@ The following tables are a summary of the feature gates that you can set on diff
 | ReversedVPN                                  | `true`  | `Beta`  | `1.42` |        |
 | RotateSSHKeypairOnMaintenance                | `false` | `Alpha` | `1.28` | `1.44` |
 | RotateSSHKeypairOnMaintenance                | `true`  | `Beta`  | `1.45` |        |
-| WorkerPoolKubernetesVersion                  | `false` | `Alpha` | `1.35` |        |
+| WorkerPoolKubernetesVersion                  | `false` | `Alpha` | `1.35` | `1.45` |
 | WorkerPoolKubernetesVersion                  | `true`  | `Beta`  | `1.46` |        |
 | CopyEtcdBackupsDuringControlPlaneMigration   | `false` | `Alpha` | `1.37` |        |
 | SecretBindingProviderValidation              | `false` | `Alpha` | `1.38` |        |

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -33,6 +33,7 @@ The following tables are a summary of the feature gates that you can set on diff
 | RotateSSHKeypairOnMaintenance                | `false` | `Alpha` | `1.28` | `1.44` |
 | RotateSSHKeypairOnMaintenance                | `true`  | `Beta`  | `1.45` |        |
 | WorkerPoolKubernetesVersion                  | `false` | `Alpha` | `1.35` |        |
+| WorkerPoolKubernetesVersion                  | `true`  | `Beta`  | `1.46` |        |
 | CopyEtcdBackupsDuringControlPlaneMigration   | `false` | `Alpha` | `1.37` |        |
 | SecretBindingProviderValidation              | `false` | `Alpha` | `1.38` |        |
 | ForceRestore                                 | `false` | `Alpha` | `1.39` |        |

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -108,6 +108,7 @@ const (
 	// WorkerPoolKubernetesVersion allows to overwrite the Kubernetes version used for shoot clusters per worker pool.
 	// owner: @rfranzke @majst01 @mwennrich
 	// alpha: v1.35.0
+	// beta: v1.46.0
 	WorkerPoolKubernetesVersion featuregate.Feature = "WorkerPoolKubernetesVersion"
 
 	// CopyEtcdBackupsDuringControlPlaneMigration enables the copy of etcd backups from the object store of the source seed
@@ -175,7 +176,7 @@ var allFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	UseDNSRecords:                 {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	RotateSSHKeypairOnMaintenance: {Default: true, PreRelease: featuregate.Beta},
 	DenyInvalidExtensionResources: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
-	WorkerPoolKubernetesVersion:   {Default: false, PreRelease: featuregate.Alpha},
+	WorkerPoolKubernetesVersion:   {Default: true, PreRelease: featuregate.Beta},
 	CopyEtcdBackupsDuringControlPlaneMigration: {Default: false, PreRelease: featuregate.Alpha},
 	SecretBindingProviderValidation:            {Default: false, PreRelease: featuregate.Alpha},
 	ForceRestore:                               {Default: false, PreRelease: featuregate.Alpha},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:
Promote `WorkerPoolKubernetesVersion` feature gate to beta (initially introduced with #4971)

**Which issue(s) this PR fixes**:
Part of #3501

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```noteworthy operator
The `WorkerPoolKubernetesVersion` feature gate has been promoted to beta and is now enabled by default. Make sure that all provider extensions registered to your system support this feature before upgrading to this Gardener version.
```
