### PR TITLE
Nit: Improve log formatting

### DIFF
--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation_care_control.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation_care_control.go
@@ -100,7 +100,8 @@ func (r *careReconciler) care(ctx context.Context, gardenClient client.Client, c
 
 	defer func() {
 		if err := patchConditions(ctx, gardenClient, controllerInstallation, conditionControllerInstallationHealthy, conditionControllerInstallationInstalled); err != nil {
-			log.Error("Failed to patch ControllerInstallation status: %+v", err.Error())
+			msg := fmt.Sprintf("Failed to patch ControllerInstallation status: %s", err.Error())
+			log.Error(msg)
 		}
 	}()
 


### PR DESCRIPTION
/kind cleanup

Otherwise the log message is not properly formatted:
```
{"controllerInstallation":"foo-wh4rv","level":"error","msg":"Failed to patch ControllerInstallation status: %+van error on the server (\"Internal Server Error: \\\"/apis/core.gardener.cloud/v1beta1/controllerinstallations/foo-wh4rv/status\\\": Post \\\"https://host:443/apis/authorization.k8s.io/v1/subjectaccessreviews?timeout=10s\\\": context deadline exceeded\") has prevented the request from succeeding (patch controllerinstallations.core.gardener.cloud foo-wh4rv)","ts":"2022-04-21T13:13:27.187Z"}
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
