### PR TITLE
Check if `issued-at-time` label is present before parsing

### DIFF
--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -1601,7 +1601,12 @@ func getIssuedAtTimeForCABundleSecret(ctx context.Context, seedClient client.Cli
 		return nil, nil
 	}
 
-	issuedAtUnix, err := strconv.ParseInt(secretList.Items[0].Labels[secretsmanager.LabelKeyIssuedAtTime], 10, 64)
+	issuedAt, ok := secretList.Items[0].Labels[secretsmanager.LabelKeyIssuedAtTime]
+	if !ok {
+		return nil, nil
+	}
+
+	issuedAtUnix, err := strconv.ParseInt(issuedAt, 10, 64)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bug

**What this PR does / why we need it**:
If the `issued-at-time` label is not present on the CA bundle secret then the `gardenlet` can fail reconciling the `Seed` with

```
ts="2022-04-27T15:15:50.219+0200" level=error msg="Seed bootstrapping failed: strconv.ParseInt: parsing \"\": invalid syntax" seed=gcp
ts="2022-04-27T15:15:50.219+0200" level=error msg="error reconciling seed: strconv.ParseInt: parsing \"\": invalid syntax" seed=gcp
```

This PR fixes this by only continuing with the auto-renewal check if the label is present.

**Special notes for your reviewer**:
Introduced with #5807 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
