### PR TITLE
Add projected service account tokens also for init containers.

### DIFF
--- a/pkg/resourcemanager/webhook/projectedtokenmount/handler.go
+++ b/pkg/resourcemanager/webhook/projectedtokenmount/handler.go
@@ -105,6 +105,9 @@ func (h *handler) Handle(ctx context.Context, req admission.Request) admission.R
 	for i := range pod.Spec.Containers {
 		pod.Spec.Containers[i].VolumeMounts = append(pod.Spec.Containers[i].VolumeMounts, getVolumeMount())
 	}
+	for i := range pod.Spec.InitContainers {
+		pod.Spec.InitContainers[i].VolumeMounts = append(pod.Spec.InitContainers[i].VolumeMounts, getVolumeMount())
+	}
 
 	// Workaround https://github.com/kubernetes/kubernetes/issues/82573 - this got fixed with
 	// https://github.com/kubernetes/kubernetes/pull/89193 starting with Kubernetes 1.19, however, we don't know to

--- a/pkg/resourcemanager/webhook/projectedtokenmount/handler_test.go
+++ b/pkg/resourcemanager/webhook/projectedtokenmount/handler_test.go
@@ -81,6 +81,7 @@ var _ = Describe("Handler", func() {
 			Spec: corev1.PodSpec{
 				ServiceAccountName: serviceAccountName,
 				Containers:         []corev1.Container{{}, {}},
+				InitContainers:     []corev1.Container{{}},
 			},
 		}
 		serviceAccount = &corev1.ServiceAccount{
@@ -322,6 +323,17 @@ var _ = Describe("Handler", func() {
 					jsonpatch.JsonPatchOperation{
 						Operation: "add",
 						Path:      "/spec/containers/1/volumeMounts",
+						Value: []interface{}{
+							map[string]interface{}{
+								"name":      "kube-api-access-gardener",
+								"readOnly":  true,
+								"mountPath": "/var/run/secrets/kubernetes.io/serviceaccount",
+							},
+						},
+					},
+					jsonpatch.JsonPatchOperation{
+						Operation: "add",
+						Path:      "/spec/initContainers/0/volumeMounts",
 						Value: []interface{}{
 							map[string]interface{}{
 								"name":      "kube-api-access-gardener",


### PR DESCRIPTION

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:
Add projected service account tokens also for init containers.

In case the webhook for auto-mounting projected service account tokens is used,
it now also adds the tokens to the init containers. Previously, init containers
did not get the service account tokens and therefore may have lost access to the
kube-apiserver.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:
An example of an init container that might loose its service account token prior to this change is the calico extension as its init container requires a token, which is used for later CNI operations.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The webhook for auto-mounting projected service account tokens now also considers init containers.
```
