### PR TITLE
Drop `operation.*CheckSum` functions

### DIFF
--- a/pkg/operation/botanist/monitoring.go
+++ b/pkg/operation/botanist/monitoring.go
@@ -291,19 +291,6 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 	}
 	prometheusConfig["networks"] = networks
 
-	var (
-		prometheusImages = []string{
-			images.ImageNamePrometheus,
-			images.ImageNameConfigmapReloader,
-			images.ImageNameBlackboxExporter,
-		}
-		podAnnotations = map[string]interface{}{
-			"checksum/secret-prometheus": b.LoadCheckSum("prometheus"),
-		}
-	)
-
-	prometheusConfig["podAnnotations"] = podAnnotations
-
 	// Add remotewrite to prometheus when enabled
 	if b.Config.Monitoring != nil &&
 		b.Config.Monitoring.Shoot != nil &&
@@ -345,7 +332,7 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 		prometheusConfig["externalLabels"] = b.Config.Monitoring.Shoot.ExternalLabels
 	}
 
-	prometheus, err := b.InjectSeedShootImages(prometheusConfig, prometheusImages...)
+	prometheus, err := b.InjectSeedShootImages(prometheusConfig, images.ImageNamePrometheus, images.ImageNameConfigmapReloader, images.ImageNameBlackboxExporter)
 	if err != nil {
 		return err
 	}

--- a/pkg/operation/botanist/vpnseedserver_test.go
+++ b/pkg/operation/botanist/vpnseedserver_test.go
@@ -121,7 +121,7 @@ var _ = Describe("VPNSeedServer", func() {
 			fakeErr = fmt.Errorf("fake err")
 
 			secretNameDH     = v1beta1constants.GardenRoleOpenVPNDiffieHellman
-			secretChecksumDH = "9012"
+			secretChecksumDH = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 
 			namespaceUID = types.UID("1234")
 		)
@@ -129,7 +129,6 @@ var _ = Describe("VPNSeedServer", func() {
 		BeforeEach(func() {
 			vpnSeedServer = mockvpnseedserver.NewMockInterface(ctrl)
 
-			botanist.StoreCheckSum(secretNameDH, secretChecksumDH)
 			botanist.StoreSecret(secretNameDH, &corev1.Secret{})
 			botanist.Shoot = &shootpkg.Shoot{
 				Components: &shootpkg.Components{
@@ -151,7 +150,7 @@ var _ = Describe("VPNSeedServer", func() {
 			}
 			botanist.SeedNamespaceObject = &corev1.Namespace{
 				ObjectMeta: metav1.ObjectMeta{
-					UID: types.UID("1234"),
+					UID: "1234",
 				},
 			}
 		})

--- a/pkg/operation/botanist/vpnshoot.go
+++ b/pkg/operation/botanist/vpnshoot.go
@@ -17,8 +17,6 @@ package botanist
 import (
 	"context"
 
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/vpnseedserver"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/vpnshoot"
 	"github.com/gardener/gardener/pkg/utils/images"
@@ -79,14 +77,8 @@ func (b *Botanist) DeployVPNShoot(ctx context.Context) error {
 	secrets := vpnshoot.Secrets{}
 
 	if !b.Shoot.ReversedVPNEnabled {
-		checkSumDH := diffieHellmanKeyChecksum
-		openvpnDiffieHellmanSecret := map[string][]byte{"dh2048.pem": []byte(DefaultDiffieHellmanKey)}
-		if dh := b.LoadSecret(v1beta1constants.GardenRoleOpenVPNDiffieHellman); dh != nil {
-			openvpnDiffieHellmanSecret = dh.Data
-			checkSumDH = b.LoadCheckSum(v1beta1constants.GardenRoleOpenVPNDiffieHellman)
-		}
-
-		secrets.DH = &component.Secret{Name: v1beta1constants.GardenRoleOpenVPNDiffieHellman, Checksum: checkSumDH, Data: openvpnDiffieHellmanSecret}
+		dhSecret := b.getDiffieHellmanSecret()
+		secrets.DH = &dhSecret
 	}
 
 	b.Shoot.Components.SystemComponents.VPNShoot.SetSecrets(secrets)

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -691,35 +691,6 @@ func (o *Operation) UpdateAdvertisedAddresses(ctx context.Context) error {
 	})
 }
 
-// StoreCheckSum stores the passed checksum under the given key from the operation. Calling this function is thread-safe.
-func (o *Operation) StoreCheckSum(key, value string) {
-	o.checkSumsMutex.Lock()
-	defer o.checkSumsMutex.Unlock()
-
-	if o.checkSums == nil {
-		o.checkSums = make(map[string]string)
-	}
-
-	o.checkSums[key] = value
-}
-
-// LoadCheckSum loads the checksum value under the given key from the operation. Calling this function is thread-safe.
-func (o *Operation) LoadCheckSum(key string) string {
-	o.checkSumsMutex.RLock()
-	defer o.checkSumsMutex.RUnlock()
-
-	val := o.checkSums[key]
-	return val
-}
-
-// DeleteCheckSum deletes the checksum entry under the given key from the operation. Calling this function is thread-safe.
-func (o *Operation) DeleteCheckSum(key string) {
-	o.checkSumsMutex.Lock()
-	defer o.checkSumsMutex.Unlock()
-
-	delete(o.checkSums, key)
-}
-
 // StoreSecret stores the passed secret under the given key from the operation. Calling this function is thread-safe.
 func (o *Operation) StoreSecret(key string, secret *corev1.Secret) {
 	o.secretsMutex.Lock()

--- a/pkg/operation/types.go
+++ b/pkg/operation/types.go
@@ -52,9 +52,6 @@ type Builder struct {
 
 // Operation contains all data required to perform an operation on a Shoot cluster.
 type Operation struct {
-	checkSumsMutex sync.RWMutex
-	checkSums      map[string]string
-
 	secrets        map[string]*corev1.Secret
 	secretsMutex   sync.RWMutex
 	SecretsManager secretsmanager.Interface


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bug

**What this PR does / why we need it**:
This PR drops the `operation.*CheckSum` functions since the `operation.checkSums` map is no longer used after #5790.

**Which issue(s) this PR fixes**:
Fixes #5865

**Special notes for your reviewer**:
/cc @ialidzhikov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
