### PR TITLE
Set kubeconfig rotation details in shootstatus to nil when `enableStaticTokenKubeconfig` is set to false

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control.go
@@ -817,6 +817,10 @@ func (r *shootReconciler) patchShootStatusOperationSuccess(
 		})
 	}
 
+	if pointer.BoolEqual(shoot.Spec.Kubernetes.EnableStaticTokenKubeconfig, pointer.Bool(false)) {
+		shoot.Status.Credentials.Rotation.Kubeconfig = nil
+	}
+
 	return gardenClient.Status().Patch(ctx, shoot, patch)
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
Currently when `shoot.spec.kubernetes.enableStaticTokenKubeconfig` is set to `true` and user annotates the shoot with `gardener.cloud/operation=rotate-kubeconfig-credentials` the `.status.credentials.rotation.kubeconfig` gets set in ShootStatus.
```
Credentials:
    Rotation:
      Kubeconfig:
        Last Completion Time:  2022-04-28T06:18:05Z
        Last Initiation Time:  2022-04-28T06:16:36Z
```
Even if the user later sets `enableStaticTokenKubeconfig` to false, `.status.credentials.rotation.kubeconfig` still contains the rotation details. This is not the desirable behaviour.

This PR will set the `.status.credentials.rotation.kubeconfig` field in the shootstatus to `nil` when `enableStaticTokenKubeconfig` is later set to false after rotation of kubeconfig.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Introduced with https://github.com/gardener/gardener/pull/5649

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
