### PR TITLE
Prevent updates of existing nodes when CRI name in `ShootSpec` gets changed

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -22,6 +22,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/features"
@@ -36,7 +37,9 @@ import (
 	retryutils "github.com/gardener/gardener/pkg/utils/retry"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // runReconcileShootFlow reconciles the Shoot cluster.
@@ -44,11 +47,12 @@ import (
 func (r *shootReconciler) runReconcileShootFlow(ctx context.Context, o *operation.Operation, operationType gardencorev1beta1.LastOperationType) *gardencorev1beta1helper.WrappedLastErrors {
 	// We create the botanists (which will do the actual work).
 	var (
-		isRestoring             = operationType == gardencorev1beta1.LastOperationTypeRestore
-		botanist                *botanistpkg.Botanist
-		tasksWithErrors         []string
-		isCopyOfBackupsRequired bool
-		err                     error
+		isRestoring                    = operationType == gardencorev1beta1.LastOperationTypeRestore
+		botanist                       *botanistpkg.Botanist
+		tasksWithErrors                []string
+		isCopyOfBackupsRequired        bool
+		err                            error
+		controlPlaneExistsAndSucceeded bool
 	)
 
 	for _, lastError := range o.Shoot.GetInfo().Status.LastErrors {
@@ -73,6 +77,14 @@ func (r *shootReconciler) runReconcileShootFlow(ctx context.Context, o *operatio
 				}
 				return retryutils.Ok()
 			})
+		}),
+		errors.ToExecute("Check whether control plane exists and is succeeded", func() error {
+			cp := &extensionsv1alpha1.ControlPlane{}
+			if err := o.K8sSeedClient.Client().Get(ctx, kutil.Key(o.Shoot.SeedNamespace, o.Shoot.GetInfo().Name), cp); client.IgnoreNotFound(err) != nil {
+				return err
+			}
+			controlPlaneExistsAndSucceeded = !apierrors.IsNotFound(err) && cp.Status.LastOperation != nil && cp.Status.LastOperation.State == gardencorev1beta1.LastOperationStateSucceeded
+			return nil
 		}),
 		errors.ToExecute("Check required extensions", func() error {
 			return botanist.WaitUntilRequiredExtensionsReady(ctx)
@@ -158,6 +170,27 @@ func (r *shootReconciler) runReconcileShootFlow(ctx context.Context, o *operatio
 			Fn:           flow.TaskFn(botanist.DeployReferencedResources).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(deployNamespace),
 		})
+
+		// Temporary code to ensure all nodes are migrated to the new cloud-config secret names.
+		// TODO(rfranzke): Remove the below in a future version.
+		deployOperatingSystemConfigForMigration = g.Add(flow.Task{
+			Name: "Deploying operating system specific configuration for shoot workers for cloud-config secret name migration",
+			Fn: flow.TaskFn(botanist.DeployOperatingSystemConfig).
+				RetryUntilTimeout(defaultInterval, defaultTimeout).
+				DoIf(controlPlaneExistsAndSucceeded),
+			Dependencies: flow.NewTaskIDs(ensureShootStateExists, deployReferencedResources, initializeSecretsManagement, waitUntilKubeAPIServerServiceIsReady),
+		})
+		waitUntilOperatingSystemConfigReadyForMigration = g.Add(flow.Task{
+			Name:         "Waiting until operating system configurations for worker nodes have been reconciled for cloud-config secret name migration",
+			Fn:           flow.TaskFn(botanist.Shoot.Components.Extensions.OperatingSystemConfig.Wait).DoIf(controlPlaneExistsAndSucceeded),
+			Dependencies: flow.NewTaskIDs(deployOperatingSystemConfigForMigration),
+		})
+		_ = g.Add(flow.Task{
+			Name:         "Deploying managed resources for the cloud config executors for cloud-config secret name migration",
+			Fn:           flow.TaskFn(botanist.DeployManagedResourceForCloudConfigExecutor).RetryUntilTimeout(defaultInterval, defaultTimeout).DoIf(controlPlaneExistsAndSucceeded),
+			Dependencies: flow.NewTaskIDs(waitUntilOperatingSystemConfigReadyForMigration),
+		})
+
 		deployOwnerDomainDNSRecord = g.Add(flow.Task{
 			Name:         "Deploying owner domain DNS record",
 			Fn:           botanist.DeployOwnerDNSResources,

--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -39,7 +39,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // runReconcileShootFlow reconciles the Shoot cluster.
@@ -80,10 +79,14 @@ func (r *shootReconciler) runReconcileShootFlow(ctx context.Context, o *operatio
 		}),
 		errors.ToExecute("Check whether control plane exists and is succeeded", func() error {
 			cp := &extensionsv1alpha1.ControlPlane{}
-			if err := o.K8sSeedClient.Client().Get(ctx, kutil.Key(o.Shoot.SeedNamespace, o.Shoot.GetInfo().Name), cp); client.IgnoreNotFound(err) != nil {
+			if err := o.K8sSeedClient.Client().Get(ctx, kutil.Key(o.Shoot.SeedNamespace, o.Shoot.GetInfo().Name), cp); err != nil {
+				if apierrors.IsNotFound(err) {
+					controlPlaneExistsAndSucceeded = false
+					return nil
+				}
 				return err
 			}
-			controlPlaneExistsAndSucceeded = !apierrors.IsNotFound(err) && cp.Status.LastOperation != nil && cp.Status.LastOperation.State == gardencorev1beta1.LastOperationStateSucceeded
+			controlPlaneExistsAndSucceeded = cp.Status.LastOperation != nil && cp.Status.LastOperation.State == gardencorev1beta1.LastOperationStateSucceeded
 			return nil
 		}),
 		errors.ToExecute("Check required extensions", func() error {

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -376,7 +376,7 @@ func (o *operatingSystemConfig) getWantedOSCNames() (sets.String, error) {
 			if err != nil {
 				return nil, err
 			}
-			wantedOSCNames.Insert(Key(worker.Name, kubernetesVersion) + keySuffix(worker.Machine.Image.Name, purpose))
+			wantedOSCNames.Insert(Key(worker.Name, kubernetesVersion, worker.CRI) + keySuffix(worker.Machine.Image.Name, purpose))
 		}
 	}
 
@@ -397,7 +397,7 @@ func (o *operatingSystemConfig) forEachWorkerPoolAndPurpose(fn func(*extensionsv
 			if err != nil {
 				return err
 			}
-			oscName := Key(worker.Name, kubernetesVersion) + keySuffix(worker.Machine.Image.Name, purpose)
+			oscName := Key(worker.Name, kubernetesVersion, worker.CRI) + keySuffix(worker.Machine.Image.Name, purpose)
 
 			osc, ok := o.oscs[oscName]
 			if !ok {
@@ -497,7 +497,7 @@ func (o *operatingSystemConfig) newDeployer(osc *extensionsv1alpha1.OperatingSys
 		osc:                     osc,
 		worker:                  worker,
 		purpose:                 purpose,
-		key:                     Key(worker.Name, kubernetesVersion),
+		key:                     Key(worker.Name, kubernetesVersion, worker.CRI),
 		apiServerURL:            o.values.APIServerURL,
 		caBundle:                caBundle,
 		clusterCASecretName:     clusterCASecret.Name,
@@ -693,14 +693,22 @@ func (d *deployer) deploy(ctx context.Context, operation string) (extensionsv1al
 	return d.osc, err
 }
 
-// Key returns the key that can be used as secret name based on the provided worker name and Kubernetes version.
-func Key(workerName string, kubernetesVersion *semver.Version) string {
+// Key returns the key that can be used as secret name based on the provided worker name, Kubernetes version and CRI configuration.
+func Key(workerName string, kubernetesVersion *semver.Version, criConfig *gardencorev1beta1.CRI) string {
 	if kubernetesVersion == nil {
 		return ""
 	}
 
-	kubernetesMajorMinorVersion := fmt.Sprintf("%d.%d", kubernetesVersion.Major(), kubernetesVersion.Minor())
-	return fmt.Sprintf("cloud-config-%s-%s", workerName, utils.ComputeSHA256Hex([]byte(kubernetesMajorMinorVersion))[:5])
+	var (
+		kubernetesMajorMinorVersion = fmt.Sprintf("%d.%d", kubernetesVersion.Major(), kubernetesVersion.Minor())
+		criName                     gardencorev1beta1.CRIName
+	)
+
+	if criConfig != nil && criConfig.Name != gardencorev1beta1.CRINameDocker {
+		criName = criConfig.Name
+	}
+
+	return fmt.Sprintf("cloud-config-%s-%s", workerName, utils.ComputeSHA256Hex([]byte(kubernetesMajorMinorVersion + string(criName)))[:5])
 }
 
 func keySuffix(machineImageName string, purpose extensionsv1alpha1.OperatingSystemConfigPurpose) string {

--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -253,7 +253,7 @@ func (b *Botanist) generateCloudConfigExecutorResourcesForWorker(
 	}
 	var (
 		registry   = managedresources.NewRegistry(kubernetes.ShootScheme, kubernetes.ShootCodec, kubernetes.ShootSerializer)
-		secretName = operatingsystemconfig.Key(worker.Name, kubernetesVersion)
+		secretName = operatingsystemconfig.Key(worker.Name, kubernetesVersion, worker.CRI)
 	)
 
 	var kubeletDataVolume *gardencorev1beta1.DataVolume

--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -181,12 +181,12 @@ func (b *Botanist) DeployManagedResourceForCloudConfigExecutor(ctx context.Conte
 			return err
 		}
 
-		secretName, data, err := b.generateCloudConfigExecutorResourcesForWorker(worker, oscData.Original, hyperkubeImage)
+		secretNames, data, err := b.generateCloudConfigExecutorResourcesForWorker(worker, oscData.Original, hyperkubeImage)
 		if err != nil {
 			return err
 		}
 
-		cloudConfigExecutorSecretNames = append(cloudConfigExecutorSecretNames, secretName)
+		cloudConfigExecutorSecretNames = append(cloudConfigExecutorSecretNames, secretNames...)
 		managedResourceSecretNameToData[fmt.Sprintf("shoot-cloud-config-execution-%s", worker.Name)] = data
 	}
 
@@ -243,17 +243,18 @@ func (b *Botanist) generateCloudConfigExecutorResourcesForWorker(
 	oscDataOriginal operatingsystemconfig.Data,
 	hyperkubeImage *imagevector.Image,
 ) (
-	string,
+	[]string,
 	map[string][]byte,
 	error,
 ) {
 	kubernetesVersion, err := v1beta1helper.CalculateEffectiveKubernetesVersion(b.Shoot.KubernetesVersion, worker.Kubernetes)
 	if err != nil {
-		return "", nil, err
+		return nil, nil, err
 	}
 	var (
-		registry   = managedresources.NewRegistry(kubernetes.ShootScheme, kubernetes.ShootCodec, kubernetes.ShootSerializer)
-		secretName = operatingsystemconfig.Key(worker.Name, kubernetesVersion, worker.CRI)
+		registry    = managedresources.NewRegistry(kubernetes.ShootScheme, kubernetes.ShootCodec, kubernetes.ShootSerializer)
+		secretName  = operatingsystemconfig.Key(worker.Name, kubernetesVersion, worker.CRI)
+		secretNames = []string{secretName}
 	)
 
 	var kubeletDataVolume *gardencorev1beta1.DataVolume
@@ -269,13 +270,23 @@ func (b *Botanist) generateCloudConfigExecutorResourcesForWorker(
 
 	executorScript, err := ExecutorScriptFn([]byte(oscDataOriginal.Content), hyperkubeImage, kubernetesVersion.String(), kubeletDataVolume, *oscDataOriginal.Command, oscDataOriginal.Units)
 	if err != nil {
-		return "", nil, err
+		return nil, nil, err
 	}
 
-	resources, err := registry.AddAllAndSerialize(executor.Secret(secretName, metav1.NamespaceSystem, worker.Name, executorScript))
-	if err != nil {
-		return "", nil, err
+	if err := registry.Add(executor.Secret(secretName, metav1.NamespaceSystem, worker.Name, executorScript)); err != nil {
+		return nil, nil, err
 	}
 
-	return secretName, resources, nil
+	// TODO(rfranzke): Remove this legacySecretName in a future release.
+	// Since we changed the logic of the Key function to incorporate the CRI name for
+	// https://github.com/gardener/gardener/issues/4415, the name of the secret changes. To make existing nodes
+	// update to the new secret name, we need to also create the legacy secret name and point it to the new secret.
+	if legacySecretName := operatingsystemconfig.Key(worker.Name, kubernetesVersion, nil); legacySecretName != secretName {
+		if err := registry.Add(executor.Secret(legacySecretName, metav1.NamespaceSystem, worker.Name, executorScript)); err != nil {
+			return nil, nil, err
+		}
+		secretNames = append(secretNames, legacySecretName)
+	}
+
+	return secretNames, registry.SerializedObjects(), nil
 }

--- a/pkg/operation/botanist/operatingsystemconfig_test.go
+++ b/pkg/operation/botanist/operatingsystemconfig_test.go
@@ -209,14 +209,14 @@ var _ = Describe("operatingsystemconfig", func() {
 			worker1OriginalContent = "w1content"
 			worker1OriginalCommand = "/foo"
 			worker1OriginalUnits   = []string{"w1u1", "w1u2"}
-			worker1Key             = operatingsystemconfig.Key(worker1Name, semver.MustParse(kubernetesVersion))
+			worker1Key             = operatingsystemconfig.Key(worker1Name, semver.MustParse(kubernetesVersion), nil)
 
 			worker2Name                  = "worker2"
 			worker2OriginalContent       = "w2content"
 			worker2OriginalCommand       = "/bar"
 			worker2OriginalUnits         = []string{"w2u2", "w2u2", "w2u3"}
 			worker2KubernetesVersion     = "4.5.6"
-			worker2Key                   = operatingsystemconfig.Key(worker2Name, semver.MustParse(worker2KubernetesVersion))
+			worker2Key                   = operatingsystemconfig.Key(worker2Name, semver.MustParse(worker2KubernetesVersion), nil)
 			worker2KubeletDataVolumeName = "vol"
 
 			workerNameToOperatingSystemConfigMaps = map[string]*operatingsystemconfig.OperatingSystemConfigs{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind enhancement

**What this PR does / why we need it**:
Earlier, when the `cri.name` of a worker pool in the `ShootSpec` was changed, existing nodes were updated (i.e., the container runtime was exchanged "in-place") which caused significant disruption to running workload. See https://github.com/gardener/gardener/issues/4415 for the details.

This PR contains two commits:
1. Cherry-pick of #4289
2. Logic for backwards-compatibility to prevent regressions like #4390

The basic idea is outlined in https://github.com/gardener/gardener/issues/4415#issuecomment-1111036368 and https://github.com/gardener/gardener/issues/4415#issuecomment-1111048061. With the next release (v1.48) after this PR got released (v1.46), the second commit as well as #5791 will both be reverted which then will allow "smooth" container runtime updates as initially desired.

**Which issue(s) this PR fixes**:
Fixes #4415

**Special notes for your reviewer**:
Follow-up of #5273
/cc @vpnachev @voelzmo @BeckerMax 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
3. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
