### PR TITLE
Fix GRM not scaled up after a failed hibernation attempt

### DIFF
--- a/pkg/operation/botanist/kubecontrollermanager.go
+++ b/pkg/operation/botanist/kubecontrollermanager.go
@@ -66,7 +66,7 @@ func (b *Botanist) DefaultKubeControllerManager() (kubecontrollermanager.Interfa
 
 // DeployKubeControllerManager deploys the Kubernetes Controller Manager.
 func (b *Botanist) DeployKubeControllerManager(ctx context.Context) error {
-	replicaCount, err := b.determineControllerReplicas(ctx, v1beta1constants.DeploymentNameKubeControllerManager, 1)
+	replicaCount, err := b.determineControllerReplicas(ctx, v1beta1constants.DeploymentNameKubeControllerManager, 1, true)
 	if err != nil {
 		return err
 	}

--- a/pkg/operation/botanist/resource_manager.go
+++ b/pkg/operation/botanist/resource_manager.go
@@ -101,7 +101,7 @@ func (b *Botanist) DeployGardenerResourceManager(ctx context.Context) error {
 	var secrets resourcemanager.Secrets
 
 	if b.Shoot.Components.ControlPlane.ResourceManager.GetReplicas() == nil {
-		replicaCount, err := b.determineControllerReplicas(ctx, v1beta1constants.DeploymentNameGardenerResourceManager, 3)
+		replicaCount, err := b.determineControllerReplicas(ctx, v1beta1constants.DeploymentNameGardenerResourceManager, 3, false)
 		if err != nil {
 			return err
 		}

--- a/pkg/operation/botanist/resource_manager_test.go
+++ b/pkg/operation/botanist/resource_manager_test.go
@@ -182,7 +182,7 @@ var _ = Describe("ResourceManager", func() {
 
 					gomock.InOrder(
 						resourceManager.EXPECT().GetReplicas(),
-						c.EXPECT().Get(ctx, kutil.Key(seedNamespace, "gardener-resource-manager"), gomock.AssignableToTypeOf(&appsv1.Deployment{})),
+						kubeAPIServer.EXPECT().GetAutoscalingReplicas().Return(pointer.Int32(0)),
 						resourceManager.EXPECT().SetReplicas(pointer.Int32(0)),
 					)
 				})
@@ -238,8 +238,8 @@ var _ = Describe("ResourceManager", func() {
 				BeforeEach(func() {
 					gomock.InOrder(
 						resourceManager.EXPECT().GetReplicas(),
-						c.EXPECT().Get(ctx, kutil.Key(seedNamespace, "gardener-resource-manager"), gomock.AssignableToTypeOf(&appsv1.Deployment{})),
-						resourceManager.EXPECT().SetReplicas(pointer.Int32(0)),
+						kubeAPIServer.EXPECT().GetAutoscalingReplicas().Return(pointer.Int32(1)),
+						resourceManager.EXPECT().SetReplicas(pointer.Int32(3)),
 						resourceManager.EXPECT().GetReplicas().Return(pointer.Int32(3)),
 
 						// ensure bootstrapping prerequisites are not met
@@ -359,8 +359,8 @@ var _ = Describe("ResourceManager", func() {
 
 						gomock.InOrder(
 							resourceManager.EXPECT().GetReplicas(),
-							c.EXPECT().Get(ctx, kutil.Key(seedNamespace, "gardener-resource-manager"), gomock.AssignableToTypeOf(&appsv1.Deployment{})),
-							resourceManager.EXPECT().SetReplicas(pointer.Int32(0)),
+							kubeAPIServer.EXPECT().GetAutoscalingReplicas().Return(pointer.Int32(1)),
+							resourceManager.EXPECT().SetReplicas(pointer.Int32(3)),
 							resourceManager.EXPECT().GetReplicas().Return(pointer.Int32(3)),
 						)
 					})
@@ -370,13 +370,12 @@ var _ = Describe("ResourceManager", func() {
 
 				Context("shoot is in the process of being woken-up", func() {
 					BeforeEach(func() {
-						kubeAPIServer.EXPECT().GetAutoscalingReplicas().Return(pointer.Int32(1)).AnyTimes()
-
 						botanist.Shoot.HibernationEnabled = false
 						botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{Status: gardencorev1beta1.ShootStatus{IsHibernated: true}})
 
 						gomock.InOrder(
 							resourceManager.EXPECT().GetReplicas(),
+							kubeAPIServer.EXPECT().GetAutoscalingReplicas().Return(pointer.Int32(1)),
 							resourceManager.EXPECT().SetReplicas(pointer.Int32(3)),
 							resourceManager.EXPECT().GetReplicas().Return(pointer.Int32(3)),
 						)


### PR DESCRIPTION
/area control-plane
/kind bug

Fixes #5872

**Special notes for your reviewer**:
A change to consider is https://github.com/gardener/gardener/pull/2518.
For KCM when the Shoot is being reconciled with `.spec.hibernation.enabled=.status.isHibernated`, we want to keep the current replicas as it is controlled by dependency-watchdog.
While for GRM when the Shoot is reconciled with `.spec.hibernation.enabled=.status.isHibernated=false` we always want to scale up GRM.

I tested the following cases:
- Create hibernated Shoot and delete it afterwards
- Delete hibernated Shoot
- Hibernate existing Shoot and wake it up
- The case from https://github.com/gardener/gardener/pull/5874

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing gardener-resource-manager to not be scaled up (and afterwards the Shoot reconciliation to be stuck) after a failed hibernation attempt is now fixed.
```
