### PR TITLE
Nit: make report-collector optional

### DIFF
--- a/hack/test.sh
+++ b/hack/test.sh
@@ -24,9 +24,13 @@ test_flags=
 # If running in prow, we want to generate a machine-readable output file under the location specified via $ARTIFACTS.
 # This will add a JUnit view above the build log that shows an overview over successful and failed test cases.
 if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ] ; then
-  mkdir -p "$ARTIFACTS"
-  trap "report-collector \"$ARTIFACTS/junit.xml\"" EXIT
-  test_flags="--ginkgo.junit-report=junit.xml"
+  if which report-collector &>/dev/null; then
+    mkdir -p "$ARTIFACTS"
+    trap "report-collector \"$ARTIFACTS/junit.xml\"" EXIT
+    test_flags="--ginkgo.junit-report=junit.xml"
+  else
+    echo "report-collector not found in PATH, not generating machine-readable test report"
+  fi
 fi
 
 GO111MODULE=on go test -race -timeout=2m -mod=vendor $@ $test_flags | grep -v 'no test files'


### PR DESCRIPTION
/kind bug

ref https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener-extension-shoot-oidc-service/41/pull-extension-shoot-oidc-service-unit/1519940394496823296#1:build-log.txt%3A41 (https://github.com/gardener/gardener-extension-shoot-oidc-service/pull/41)
```
> Test
ok  	github.com/gardener/gardener-extension-shoot-oidc-service/pkg/webhook/kapiserver	0.188s
/home/prow/go/src/github.com/gardener/gardener-extension-shoot-oidc-service/vendor/github.com/gardener/gardener/hack/test.sh: line 1: report-collector: command not found
make: *** [Makefile:110: test] Error 127
```

Can be easily fixed by adding `$(REPORT_COLLECTOR)` as a dependency to the `test` target, but it's always nicer to keep things optional for external parties.