### PR TITLE
Promote `ShootMaxTokenExpirationValidation` feature gate to beta

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -41,7 +41,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | ShootCARotation                              | `false` | `Alpha` | `1.42` |        |
 | ShootMaxTokenExpirationOverwrite             | `false` | `Alpha` | `1.43` | `1.44` |
 | ShootMaxTokenExpirationOverwrite             | `true`  | `Beta`  | `1.45` |        |
-| ShootMaxTokenExpirationValidation            | `false` | `Alpha` | `1.43` |        |
+| ShootMaxTokenExpirationValidation            | `false` | `Alpha` | `1.43` | `1.45` |
+| ShootMaxTokenExpirationValidation            | `true`  | `Beta`  | `1.46` |        |
 
 ## Feature gates for graduated or deprecated features
 

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -160,6 +160,7 @@ const (
 	// Only enable this after ShootMaxTokenExpirationOverwrite is enabled and all shoots got updated accordingly.
 	// owner: @rfranzke
 	// alpha: v1.43.0
+	// beta: v1.46.0
 	ShootMaxTokenExpirationValidation featuregate.Feature = "ShootMaxTokenExpirationValidation"
 )
 
@@ -183,7 +184,7 @@ var allFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	DisableDNSProviderManagement:               {Default: false, PreRelease: featuregate.Alpha},
 	ShootCARotation:                            {Default: false, PreRelease: featuregate.Alpha},
 	ShootMaxTokenExpirationOverwrite:           {Default: true, PreRelease: featuregate.Beta},
-	ShootMaxTokenExpirationValidation:          {Default: false, PreRelease: featuregate.Alpha},
+	ShootMaxTokenExpirationValidation:          {Default: true, PreRelease: featuregate.Beta},
 }
 
 // GetFeatures returns a feature gate map with the respective specifications. Non-existing feature gates are ignored.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source ops-productivity
/kind enhancement

**What this PR does / why we need it**:
Similar to #5726: Promote `ShootMaxTokenExpirationValidation` feature gate to beta.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `ShootMaxTokenExpirationValidation` feature gate has been promoted to beta and is now enabled by default.
```
