### PR TITLE
Deflake watchdog test

### DIFF
--- a/extensions/pkg/controller/common/checkerwatchdog.go
+++ b/extensions/pkg/controller/common/checkerwatchdog.go
@@ -89,29 +89,23 @@ func (w *checkerWatchdog) Start(ctx context.Context) {
 			resultRequested := false
 			select {
 			case <-ctx.Done():
-				w.logger.V(2).Info("Context done")
 				return
 			case reset := <-w.timerChan:
-				w.logger.V(2).Info("Stopping timer")
 				// Stop the timer, then reset it if a reset was requested
 				// Timers are not concurrency safe, therefore all timer updates are performed here
 				timer.Stop()
 				if reset {
-					w.logger.V(2).Info("Resetting timer")
 					timer.Reset(w.interval)
 				}
 				continue
 			case <-w.resultChan:
-				w.logger.V(2).Info("Result requested")
 				resultRequested = true
 				// If the last result is not older than w.interval, use it
 				if !w.clock.Now().After(w.resultTime.Add(w.interval)) {
-					w.logger.V(2).Info("Using last result")
 					w.resultReadyChan <- struct{}{}
 					continue
 				}
 			case <-timer.C():
-				w.logger.V(2).Info("Timer expired")
 				timer.Reset(w.interval)
 			}
 

--- a/extensions/pkg/controller/common/checkerwatchdog_test.go
+++ b/extensions/pkg/controller/common/checkerwatchdog_test.go
@@ -19,9 +19,7 @@ import (
 	"errors"
 	"time"
 
-	"go.uber.org/zap/zapcore"
-	logzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
-
+	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -50,7 +48,7 @@ var _ = Describe("CheckerWatchdog", func() {
 		checker = &fakeChecker{called: make(chan struct{}, 2)} // we expect 2 calls in every test case
 		fakeClock = clock.NewFakeClock(time.Now())
 		ctx = context.TODO()
-		watchdog = NewCheckerWatchdog(checker, interval, timeout, fakeClock, logzap.New(logzap.Level(zapcore.DebugLevel*2), logzap.WriteTo(GinkgoWriter)))
+		watchdog = NewCheckerWatchdog(checker, interval, timeout, fakeClock, logr.Discard())
 	})
 
 	AfterEach(func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:

Deflakes the watchdog test by fixing the issue described in https://github.com/gardener/gardener/issues/5836#issuecomment-1114687900.

**Which issue(s) this PR fixes**:
Fixes #https://github.com/gardener/gardener/issues/5836

