### PR TITLE
Always add default issuer to accepted issuers, add documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,7 @@
 * [Shoot Kubernetes and Operating System Versioning](usage/shoot_versions.md)
 * [Shoot Networking](usage/shoot_networking.md)
 * [Shoot Maintenance](usage/shoot_maintenance.md)
+* [Shoot `ServiceAccount` Configurations](usage/shoot_serviceaccounts.md)
 * [Shoot Status](usage/shoot_status.md)
 * [Shoot Info `ConfigMap`](usage/shoot_info_configmap.md)
 * [Shoot Updates and Upgrades](usage/shoot_updates.md)

--- a/docs/usage/shoot_serviceaccounts.md
+++ b/docs/usage/shoot_serviceaccounts.md
@@ -1,0 +1,82 @@
+# `ServiceAccount` Configurations For Shoot Clusters
+
+The `Shoot` specification allows to configure some of the settings for the handling of `ServiceAccount`s:
+
+```yaml
+apiVersion: core.gardener.cloud/v1beta1
+kind: Shoot
+spec:
+  kubernetes:
+    kubeAPIServer:
+      serviceAccountConfig:
+        issuer: foo
+        acceptedIssuers:
+        - foo1
+        - foo2
+        signingKeySecretName:
+          name: my-signing-key-secret
+        extendTokenExpiration: true
+        maxTokenExpiration: 45d
+...
+```
+
+## Issuer And Accepted Issuers
+
+The `.spec.kubernetes.kubeAPIServer.serviceAccountConfig.{issuer,acceptedIssuers}` field are translated to the `--service-account-issuer` flag for the `kube-apiserver`.
+The issuer will assert its identifier in the `iss` claim of issued tokens.
+According to the [upstream specification](https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/), values need to meet the following requirements:
+
+> This value is a string or URI. If this option is not a valid URI per the OpenID Discovery 1.0 spec, the ServiceAccountIssuerDiscovery feature will remain disabled, even if the feature gate is set to true. It is highly recommended that this value comply with the OpenID spec: https://openid.net/specs/openid-connect-discovery-1_0.html. In practice, this means that service-account-issuer must be an https URL. It is also highly recommended that this URL be capable of serving OpenID discovery documents at {service-account-issuer}/.well-known/openid-configuration.
+
+By default, Gardener uses the internal cluster domain as issuer (e.g., `https://api.foo.bar.example.com`).
+If you specify the `issuer` then this default issuer will always be part of the list of accepted issuers (you don't need to specify it yourself).
+
+⚠️ Caution: If you change from the default issuer to a custom `issuer` then all previously issued tokens are still valid/accepted.
+However, if you change from a custom `issuer` `A` to another `issuer` `B` (custom or default) then you have to add `A` to the `acceptedIssuers` so that previously issued tokens are not invalidated.
+Otherwise, the control plane components as well as system components and your workload pods might fail.
+You can remove `A` from the `acceptedIssuers` when all active tokens were issued by `B`.
+This can be ensured by using [projected token volumes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection) with a short validity, or by rolling out all pods.
+Additionally, all [`ServiceAccount` token secrets](https://kubernetes.io/docs/concepts/configuration/secret/#service-account-token-secrets) should be recreated.
+Apart from this you should wait for at least `12h` to make sure the control plane and system components receive a new token from Gardener.
+
+## Signing Key Secret
+
+The `.spec.kubernetes.kubeAPIServer.serviceAccountConfig.signingKeySecretName.name` specifies the name of `Secret` in the same namespace as the `Shoot` in the garden cluster.
+It should look as follows:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <name>
+  namespace: <namespace>
+data:
+  signing-key: base64(signing-key-pem)
+```
+
+The provided key will be used for configuring both the `--service-account-signing-key-file` and `--service-account-key-file` flags of the `kube-apiserver`.
+
+According to the [upstream specification](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection), they have the following effects:
+
+> - `--service-account-key-file`: File containing PEM-encoded x509 RSA or ECDSA private or public keys, used to verify ServiceAccount tokens. The specified file can contain multiple keys, and the flag can be specified multiple times with different files. If specified multiple times, tokens signed by any of the specified keys are considered valid by the Kubernetes API server.
+> - `--service-account-signing-key-file`: Path to the file that contains the current private key of the service account token issuer. The issuer signs issued ID tokens with this private key.
+
+Note that rotation of this key is not yet supported, hence usage is not recommended.
+By default, Gardener will generate a service account signing key for the cluster.
+
+## Token Expirations
+
+The `.spec.kubernetes.kubeAPIServer.serviceAccountConfig.extendTokenExpiration` configures the `--service-account-extend-token-expiration` flag of the `kube-apiserver`.
+It is enabled by default and has the following specification:
+
+> Turns on projected service account expiration extension during token generation, which helps safe transition from legacy token to bound service account token feature. If this flag is enabled, admission injected tokens would be extended up to 1 year to prevent unexpected failure during transition, ignoring value of service-account-max-token-expiration.
+
+The `.spec.kubernetes.kubeAPIServer.serviceAccountConfig.maxTokenExpiration` configures the `--service-account-max-token-expiration` flag of the `kube-apiserver`.
+It has the following specification:
+
+> The maximum validity duration of a token created by the service account token issuer. If an otherwise valid TokenRequest with a validity duration larger than this value is requested, a token will be issued with a validity duration of this value.
+
+⚠️ Note that the value for this field must be in the `[30d,90d]` range.
+The background for this limitation is that all Gardener components to rely on the `TokenRequest` API and the Kubernetes service account token projection feature with short-lived, auto-rotating tokens.
+Any values lower than `30d` risk impacting the SLO for shoot clusters, and any values above `90d` violate security best practices with respect to maximum validity of credentials before they must be rotated.
+Given that the field just specifies the upper bound, end-users can still use lower values for their individual workload by specifying the `.spec.volumes[].projected.sources[].serviceAccountToken.expirationSeconds` in the `PodSpec`s.

--- a/example/90-shoot.yaml
+++ b/example/90-shoot.yaml
@@ -184,7 +184,7 @@ spec:
   #     signingKeySecretName:
   #       name: my-signing-key-secret
   #     extendTokenExpiration: true
-  #     maxTokenExpiration: 1y
+  #     maxTokenExpiration: 45d
   # kubeControllerManager:
   #   nodeCIDRMaskSize: 24
   #   podEvictionTimeout: 2m0s

--- a/pkg/operation/botanist/kubeapiserver.go
+++ b/pkg/operation/botanist/kubeapiserver.go
@@ -335,7 +335,10 @@ func (b *Botanist) computeKubeAPIServerServerCertificateConfig() kubeapiserver.S
 }
 
 func (b *Botanist) computeKubeAPIServerServiceAccountConfig(ctx context.Context, config *gardencorev1beta1.KubeAPIServerConfig, externalHostname string) (kubeapiserver.ServiceAccountConfig, error) {
-	out := kubeapiserver.ServiceAccountConfig{Issuer: "https://" + externalHostname}
+	var (
+		defaultIssuer = "https://" + externalHostname
+		out           = kubeapiserver.ServiceAccountConfig{Issuer: defaultIssuer}
+	)
 
 	if config == nil || config.ServiceAccountConfig == nil {
 		return out, nil
@@ -348,6 +351,9 @@ func (b *Botanist) computeKubeAPIServerServiceAccountConfig(ctx context.Context,
 		out.Issuer = *config.ServiceAccountConfig.Issuer
 	}
 	out.AcceptedIssuers = config.ServiceAccountConfig.AcceptedIssuers
+	if out.Issuer != defaultIssuer && !utils.ValueExists(defaultIssuer, out.AcceptedIssuers) {
+		out.AcceptedIssuers = append(out.AcceptedIssuers, defaultIssuer)
+	}
 
 	if signingKeySecret := config.ServiceAccountConfig.SigningKeySecret; signingKeySecret != nil {
 		secret := &corev1.Secret{}

--- a/pkg/operation/botanist/kubeapiserver_test.go
+++ b/pkg/operation/botanist/kubeapiserver_test.go
@@ -1236,7 +1236,10 @@ var _ = Describe("KubeAPIServer", func() {
 						}
 						botanist.Shoot.SetInfo(shootCopy)
 					},
-					kubeapiserver.ServiceAccountConfig{Issuer: "issuer"},
+					kubeapiserver.ServiceAccountConfig{
+						Issuer:          "issuer",
+						AcceptedIssuers: []string{"https://api." + internalClusterDomain},
+					},
 					false,
 					Not(HaveOccurred()),
 				),
@@ -1274,7 +1277,27 @@ var _ = Describe("KubeAPIServer", func() {
 					},
 					kubeapiserver.ServiceAccountConfig{
 						Issuer:          "issuer",
-						AcceptedIssuers: []string{"issuer1", "issuer2"},
+						AcceptedIssuers: []string{"issuer1", "issuer2", "https://api." + internalClusterDomain},
+					},
+					false,
+					Not(HaveOccurred()),
+				),
+				Entry("Default Issuer is already part of AcceptedIssuers",
+					func() {
+						shootCopy := botanist.Shoot.GetInfo().DeepCopy()
+						shootCopy.Spec.Kubernetes = gardencorev1beta1.Kubernetes{
+							KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{
+								ServiceAccountConfig: &gardencorev1beta1.ServiceAccountConfig{
+									Issuer:          pointer.String("issuer"),
+									AcceptedIssuers: []string{"https://api." + internalClusterDomain},
+								},
+							},
+						}
+						botanist.Shoot.SetInfo(shootCopy)
+					},
+					kubeapiserver.ServiceAccountConfig{
+						Issuer:          "issuer",
+						AcceptedIssuers: []string{"https://api." + internalClusterDomain},
 					},
 					false,
 					Not(HaveOccurred()),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bug 

**What this PR does / why we need it**:
This PR adds the default `ServiceAccount` issuer to the list of accepted issuers as proposed in https://github.com/gardener/gardener/issues/5817#issuecomment-1108287261.
Also, it adds a new document explaining the various `ServiceAccount` configurations (and their caveats) for shoot clusters.

**Which issue(s) this PR fixes**:
Fixes #5817

/cc @acumino 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Changing the default `ServiceAccount` issuer to a custom issuer for shoot clusters is now supported.
```
```doc user
There is a [new document](https://github.com/gardener/gardener/tree/master/docs/usage/shoot_serviceaccounts.md) explaining the various configurations (and caveats) regarding the `ServiceAccount` configuration for shoot clusters.
```