### PR TITLE
Enable removal of CA data from gardenlet kubeconfig

### DIFF
--- a/docs/deployment/deploy_gardenlet_manually.md
+++ b/docs/deployment/deploy_gardenlet_manually.md
@@ -299,6 +299,10 @@ We refer to the global configuration values as _gardenlet configuration_ in the 
         namespace: garden
     ```
 
+### Updating the garden cluster CA
+
+The kubeconfig created by the gardenlet in step 4 will not be recreated, as long as it exists, even if a new bootstrap kubeconfig is provided. To enable rotation of the garden cluster CA certificate, new certificates can be given in the `gardenClientConnection.gardenClusterCACert` field. If the certificate given there differs from the one currently in the gardenlet kubeconfig secret, it will be updated. To remove the CA completely - when switching to a publicly trusted endpoint - this field can be set to either `none` or `null`.
+
 ## Automatically register shoot cluster as a seed cluster
 
 A seed cluster can either be registered by manually creating

--- a/docs/deployment/deploy_gardenlet_manually.md
+++ b/docs/deployment/deploy_gardenlet_manually.md
@@ -301,7 +301,7 @@ We refer to the global configuration values as _gardenlet configuration_ in the 
 
 ### Updating the garden cluster CA
 
-The kubeconfig created by the gardenlet in step 4 will not be recreated, as long as it exists, even if a new bootstrap kubeconfig is provided. To enable rotation of the garden cluster CA certificate, new certificates can be given in the `gardenClientConnection.gardenClusterCACert` field. If the certificate given there differs from the one currently in the gardenlet kubeconfig secret, it will be updated. To remove the CA completely - when switching to a publicly trusted endpoint - this field can be set to either `none` or `null`.
+The kubeconfig created by the gardenlet in step 4 will not be recreated as long as it exists, even if a new bootstrap kubeconfig is provided. To enable rotation of the garden cluster CA certificate, a new bundle can be provided via the `gardenClientConnection.gardenClusterCACert` field. If the provided bundle differs from the one currently in the gardenlet's kubeconfig secret then it will be updated. To remove the CA completely (e.g. when switching to a publicly trusted endpoint) this field can be set to either `none` or `null`.
 
 ## Automatically register shoot cluster as a seed cluster
 

--- a/pkg/gardenlet/bootstrap/util/util.go
+++ b/pkg/gardenlet/bootstrap/util/util.go
@@ -138,6 +138,10 @@ func UpdateGardenKubeconfigCAIfChanged(ctx context.Context, seedClient client.Cl
 		return kubeconfig, nil
 	}
 
+	if bytes.Equal(gardenClientConnection.GardenClusterCACert, []byte("none")) || bytes.Equal(gardenClientConnection.GardenClusterCACert, []byte("null")) {
+		gardenClientConnection.GardenClusterCACert = []byte{}
+	}
+
 	// extract data from existing kubeconfig and reuse UpdateGardenKubeconfigSecret function
 	return UpdateGardenKubeconfigSecret(ctx, &rest.Config{
 		Host: curCluster.Server,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
With #5735 the possibility of changing the CA bundle in the gardenlet kubeconfig secret has been added. However, since `gardenClientConnection.gardenClusterCACert` is an optional field and will be ignored, if it is empty, there is currently no way of completely removing the CA data from the kubeconfig. This is interesting if one switches to an apiserver endpoint which uses publicly trusted certificates. In this case, the CA is not required anymore in the kubeconfig.

This PR enhances the logic from #5735: if the `gardenClientConnection.gardenClusterCACert` field is not empty, but contains either `none` or `null`, any CA data currently specified in the gardenlet kubeconfig secret will be removed.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
It is now possible to remove the CA bundle from the gardenlet kubeconfig by setting `gardenClientConnection.gardenClusterCACert` to either `none` or `null`.
```
