### PR TITLE
Revert "Apply resources in sorted order in managedresource controller (#5822)

### DIFF
--- a/pkg/resourcemanager/controller/managedresource/reconciler.go
+++ b/pkg/resourcemanager/controller/managedresource/reconciler.go
@@ -52,6 +52,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -418,8 +419,13 @@ func (r *Reconciler) delete(ctx context.Context, mr *resourcesv1alpha1.ManagedRe
 }
 
 func (r *Reconciler) applyNewResources(ctx context.Context, origin string, newResourcesObjects []object, labelsToInject map[string]string, equivalences Equivalences) error {
-
-	newResourcesObjects = sortByKind(newResourcesObjects)
+	var (
+		results   = make(chan error)
+		wg        sync.WaitGroup
+		errorList = &multierror.Error{
+			ErrorFormat: errorutils.NewErrorFormatFuncWithPrefix("Could not apply all new resources"),
+		}
+	)
 
 	// get all HPA and HVPA targetRefs to check if we should prevent overwriting replicas and/or resource requirements.
 	// VPAs don't have to be checked, as they don't update the spec directly and only mutate Pods via a MutatingWebhook
@@ -429,55 +435,75 @@ func (r *Reconciler) applyNewResources(ctx context.Context, origin string, newRe
 		return fmt.Errorf("failed to compute all HPA and HVPA target ref object keys: %w", err)
 	}
 
-	for _, obj := range newResourcesObjects {
-		var (
-			current            = obj.obj.DeepCopy()
-			resource           = unstructuredToString(obj.obj)
-			scaledHorizontally = isScaled(obj.obj, horizontallyScaledObjects, equivalences)
-			scaledVertically   = isScaled(obj.obj, verticallyScaledObjects, equivalences)
-		)
+	for _, o := range newResourcesObjects {
+		wg.Add(1)
 
-		r.log.Info("Applying", "resource", resource)
+		go func(obj object) {
+			defer wg.Done()
 
-		if operationResult, err := controllerutils.TypedCreateOrUpdate(ctx, r.targetClient, r.targetScheme, current, r.alwaysUpdate, func() error {
-			metadata, err := meta.Accessor(obj.obj)
-			if err != nil {
-				return fmt.Errorf("error getting metadata of object %q: %s", resource, err)
-			}
+			var (
+				current            = obj.obj.DeepCopy()
+				resource           = unstructuredToString(obj.obj)
+				scaledHorizontally = isScaled(obj.obj, horizontallyScaledObjects, equivalences)
+				scaledVertically   = isScaled(obj.obj, verticallyScaledObjects, equivalences)
+			)
 
-			// if the ignore annotation is set to false, do nothing (ignore the resource)
-			if ignore(metadata) {
-				annotations := current.GetAnnotations()
-				delete(annotations, descriptionAnnotation)
-				current.SetAnnotations(annotations)
-				return nil
-			}
+			r.log.Info("Applying", "resource", resource)
 
-			if err := injectLabels(obj.obj, labelsToInject); err != nil {
-				return fmt.Errorf("error injecting labels into object %q: %s", resource, err)
-			}
+			results <- retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+				if operationResult, err := controllerutils.TypedCreateOrUpdate(ctx, r.targetClient, r.targetScheme, current, r.alwaysUpdate, func() error {
+					metadata, err := meta.Accessor(obj.obj)
+					if err != nil {
+						return fmt.Errorf("error getting metadata of object %q: %s", resource, err)
+					}
 
-			return merge(origin, obj.obj, current, obj.forceOverwriteLabels, obj.oldInformation.Labels, obj.forceOverwriteAnnotations, obj.oldInformation.Annotations, scaledHorizontally, scaledVertically)
-		}); err != nil {
-			if apierrors.IsConflict(err) {
-				r.log.Info("Conflict while applying object", "object", resource, "err", err)
-				// return conflict error directly, so that the update will be retried
-				return err
-			}
+					// if the ignore annotation is set to false, do nothing (ignore the resource)
+					if ignore(metadata) {
+						annotations := current.GetAnnotations()
+						delete(annotations, descriptionAnnotation)
+						current.SetAnnotations(annotations)
+						return nil
+					}
 
-			if apierrors.IsInvalid(err) && operationResult == controllerutil.OperationResultUpdated && deleteOnInvalidUpdate(current) {
-				if deleteErr := r.targetClient.Delete(ctx, current); client.IgnoreNotFound(deleteErr) != nil {
-					return fmt.Errorf("error deleting object %q after 'invalid' update error: %s", resource, deleteErr)
+					if err := injectLabels(obj.obj, labelsToInject); err != nil {
+						return fmt.Errorf("error injecting labels into object %q: %s", resource, err)
+					}
+
+					return merge(origin, obj.obj, current, obj.forceOverwriteLabels, obj.oldInformation.Labels, obj.forceOverwriteAnnotations, obj.oldInformation.Annotations, scaledHorizontally, scaledVertically)
+				}); err != nil {
+					if apierrors.IsConflict(err) {
+						r.log.Info("Conflict while applying object", "object", resource, "err", err)
+						// return conflict error directly, so that the update will be retried
+						return err
+					}
+
+					if apierrors.IsInvalid(err) && operationResult == controllerutil.OperationResultUpdated && deleteOnInvalidUpdate(current) {
+						if deleteErr := r.targetClient.Delete(ctx, current); client.IgnoreNotFound(deleteErr) != nil {
+							return fmt.Errorf("error deleting object %q after 'invalid' update error: %s", resource, deleteErr)
+						}
+						// return error directly, so that the create after delete will be retried
+						return fmt.Errorf("deleted object %q because of 'invalid' update error and 'delete-on-invalid-update' annotation on object (%s)", resource, err)
+					}
+
+					return fmt.Errorf("error during apply of object %q: %s", resource, err)
 				}
-				// return error directly, so that the create after delete will be retried
-				return fmt.Errorf("deleted object %q because of 'invalid' update error and 'delete-on-invalid-update' annotation on object (%s)", resource, err)
-			}
+				return nil
+			})
+		}(o)
+	}
 
-			return fmt.Errorf("error during apply of object %q: %s", resource, err)
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	for err := range results {
+		if err != nil {
+			errorList = multierror.Append(errorList, err)
 		}
 	}
 
-	return nil
+	return errorList.ErrorOrNil()
 }
 
 func (r *Reconciler) origin(mr *resourcesv1alpha1.ManagedResource) string {

--- a/pkg/resourcemanager/controller/managedresource/sort.go
+++ b/pkg/resourcemanager/controller/managedresource/sort.go
@@ -18,7 +18,6 @@ import (
 	"sort"
 
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
-	chartrenderer "github.com/gardener/gardener/pkg/chartrenderer"
 )
 
 var _ = sort.Interface(referenceSorter{})
@@ -57,61 +56,4 @@ func (r referenceSorter) Less(i, j int) bool {
 func (r referenceSorter) Swap(i, j int) {
 	r.keys[i], r.keys[j] = r.keys[j], r.keys[i]
 	r.refs[i], r.refs[j] = r.refs[j], r.refs[i]
-}
-
-type kindSorter struct {
-	ordering map[string]int
-	objects  []object
-}
-
-func newKindSorter(obj []object, s chartrenderer.SortOrder) *kindSorter {
-	o := make(map[string]int, len(s))
-	for v, k := range s {
-		o[k] = v
-	}
-
-	return &kindSorter{
-		objects:  obj,
-		ordering: o,
-	}
-}
-
-func (k *kindSorter) Len() int { return len(k.objects) }
-
-func (k *kindSorter) Swap(i, j int) { k.objects[i], k.objects[j] = k.objects[j], k.objects[i] }
-
-func (k *kindSorter) Less(i, j int) bool {
-	a := k.objects[i]
-	b := k.objects[j]
-	first, aok := k.ordering[a.oldInformation.Kind]
-	second, bok := k.ordering[b.oldInformation.Kind]
-
-	if !aok && !bok {
-		// if both are unknown then sort alphabetically by kind and name
-		if a.oldInformation.Kind != b.oldInformation.Kind {
-			return a.oldInformation.Kind < b.oldInformation.Kind
-		}
-		return a.oldInformation.Name < b.oldInformation.Name
-	}
-
-	// unknown kind is last
-	if !aok {
-		return false
-	}
-	if !bok {
-		return true
-	}
-
-	// if same kind sub sort alphanumeric
-	if first == second {
-		return a.oldInformation.Name < b.oldInformation.Name
-	}
-	// sort different kinds
-	return first < second
-}
-func sortByKind(resourceObject []object) []object {
-	ordering := chartrenderer.InstallOrder
-	ks := newKindSorter(resourceObject, ordering)
-	sort.Sort(ks)
-	return ks.objects
 }

--- a/pkg/resourcemanager/controller/managedresource/sort_test.go
+++ b/pkg/resourcemanager/controller/managedresource/sort_test.go
@@ -22,132 +22,86 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-var _ = Describe("Sorter", func() {
-	Describe("Reference sorter", func() {
-		var refs, refsBase []resourcesv1alpha1.ObjectReference
+var _ = Describe("Reference sorter", func() {
+	var refs, refsBase []resourcesv1alpha1.ObjectReference
 
-		BeforeEach(func() {
-			refsBase = []resourcesv1alpha1.ObjectReference{
-				{
-					ObjectReference: corev1.ObjectReference{
-						APIVersion: "v1",
-						Kind:       "ConfigMap",
-						Name:       "foo",
-						Namespace:  "bar",
-					},
+	BeforeEach(func() {
+		refsBase = []resourcesv1alpha1.ObjectReference{
+			{
+				ObjectReference: corev1.ObjectReference{
+					APIVersion: "v1",
+					Kind:       "ConfigMap",
+					Name:       "foo",
+					Namespace:  "bar",
 				},
-				{
-					ObjectReference: corev1.ObjectReference{
-						APIVersion: "apps/v1",
-						Kind:       "Deployment",
-						Name:       "nginx",
-						Namespace:  "web",
-					},
+			},
+			{
+				ObjectReference: corev1.ObjectReference{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Name:       "nginx",
+					Namespace:  "web",
 				},
-			}
+			},
+		}
 
-			// copy refs for assertions, as referenceSorter is sorting in-place
-			refs = append(refsBase[:0:0], refsBase...)
+		// copy refs for assertions, as referenceSorter is sorting in-place
+		refs = append(refsBase[:0:0], refsBase...)
+	})
+
+	Describe("#sortObjectReferences", func() {
+		It("should correctly sort refs", func() {
+			sortObjectReferences(refs)
+			Expect(refs).To(Equal(refsBase))
 		})
-
-		Describe("#sortObjectReferences", func() {
-			It("should correctly sort refs", func() {
-				sortObjectReferences(refs)
-				Expect(refs).To(Equal(refsBase))
-			})
-			It("should correctly sort refs (inverted order)", func() {
-				refs[0], refs[1] = refs[1], refs[0]
-				sortObjectReferences(refs)
-				Expect(refs).To(Equal(refsBase))
-			})
-		})
-
-		Describe("#newReferenceSorter", func() {
-			var sorter referenceSorter
-
-			BeforeEach(func() {
-				sorter = newReferenceSorter(refs).(referenceSorter)
-			})
-
-			It("should return the correct length", func() {
-				Expect(sorter.Len()).To(BeEquivalentTo(len(refsBase)))
-			})
-
-			It("should return the correct length (nil slice)", func() {
-				sorter = newReferenceSorter(nil).(referenceSorter)
-				Expect(sorter.Len()).To(BeEquivalentTo(0))
-			})
-
-			It("should calculate the correct keys for refs", func() {
-				Expect(refs).To(Equal([]resourcesv1alpha1.ObjectReference{
-					refsBase[0],
-					refsBase[1],
-				}))
-				Expect(sorter.keys).To(Equal([]string{
-					"/ConfigMap/bar/foo",
-					"apps/Deployment/web/nginx",
-				}))
-			})
-
-			It("should correctly compare refs", func() {
-				Expect(sorter.Less(0, 1)).To(BeTrue())
-			})
-
-			It("should correctly swap refs and keys", func() {
-				sorter.Swap(0, 1)
-				Expect(refs).To(Equal([]resourcesv1alpha1.ObjectReference{
-					refsBase[1],
-					refsBase[0],
-				}))
-				Expect(sorter.keys).To(Equal([]string{
-					"apps/Deployment/web/nginx",
-					"/ConfigMap/bar/foo",
-				}))
-			})
+		It("should correctly sort refs (inverted order)", func() {
+			refs[0], refs[1] = refs[1], refs[0]
+			sortObjectReferences(refs)
+			Expect(refs).To(Equal(refsBase))
 		})
 	})
 
-	Describe("Kind sorter", func() {
-		var obj, objBase []object
+	Describe("#newReferenceSorter", func() {
+		var sorter referenceSorter
 
 		BeforeEach(func() {
-			objBase = []object{
-				{
-					oldInformation: resourcesv1alpha1.ObjectReference{
-						ObjectReference: corev1.ObjectReference{
-							APIVersion: "v1",
-							Kind:       "ConfigMap",
-							Name:       "foo",
-							Namespace:  "bar",
-						},
-					},
-				},
-				{
-					oldInformation: resourcesv1alpha1.ObjectReference{
-						ObjectReference: corev1.ObjectReference{
-							APIVersion: "apps/v1",
-							Kind:       "Deployment",
-							Name:       "nginx",
-							Namespace:  "web",
-						},
-					},
-				},
-			}
-
-			// copy refs for assertions, as kindSorter is sorting in-place
-			obj = append(obj[:0:0], objBase...)
+			sorter = newReferenceSorter(refs).(referenceSorter)
 		})
 
-		Describe("#sortObjectReferences", func() {
-			It("should correctly sort refs", func() {
-				sortByKind(obj)
-				Expect(obj).To(Equal(objBase))
-			})
-			It("should correctly sort refs (inverted order)", func() {
-				obj[0], obj[1] = obj[1], obj[0]
-				sortByKind(obj)
-				Expect(obj).To(Equal(objBase))
-			})
+		It("should return the correct length", func() {
+			Expect(sorter.Len()).To(BeEquivalentTo(len(refsBase)))
+		})
+
+		It("should return the correct length (nil slice)", func() {
+			sorter = newReferenceSorter(nil).(referenceSorter)
+			Expect(sorter.Len()).To(BeEquivalentTo(0))
+		})
+
+		It("should calculate the correct keys for refs", func() {
+			Expect(refs).To(Equal([]resourcesv1alpha1.ObjectReference{
+				refsBase[0],
+				refsBase[1],
+			}))
+			Expect(sorter.keys).To(Equal([]string{
+				"/ConfigMap/bar/foo",
+				"apps/Deployment/web/nginx",
+			}))
+		})
+
+		It("should correctly compare refs", func() {
+			Expect(sorter.Less(0, 1)).To(BeTrue())
+		})
+
+		It("should correctly swap refs and keys", func() {
+			sorter.Swap(0, 1)
+			Expect(refs).To(Equal([]resourcesv1alpha1.ObjectReference{
+				refsBase[1],
+				refsBase[0],
+			}))
+			Expect(sorter.keys).To(Equal([]string{
+				"apps/Deployment/web/nginx",
+				"/ConfigMap/bar/foo",
+			}))
 		})
 	})
 })


### PR DESCRIPTION
/area control-plane
/kind bug

This reverts commit 052739856f9f90110d81c97791ee0bf4d9fcf434.

The sorting functionality introduced with 052739856f9f90110d81c97791ee0bf4d9fcf434 does not properly sort the resources and tries to apply for example a VerticalPodAutoscaler before a ClusterRoleBInding resource. And on Shoot creation the VerticalPodAutoscaler fails to be created as the CRDs are still missing and this blocks important RBAC to be created which is the reason the Shoot creation to fail.

Fixes https://github.com/gardener/gardener/issues/5893


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
