### PR TITLE
Fix caBundle of istio's validating webhook

### DIFF
--- a/charts/istio/istio-istiod/templates/validatingwebhookconfiguration.yaml
+++ b/charts/istio/istio-istiod/templates/validatingwebhookconfiguration.yaml
@@ -3,6 +3,9 @@ kind: ValidatingWebhookConfiguration
 metadata:
   name: istiod
   labels:
+    # The istio revision is required so that the web hook is found at runtime for the caBundle update
+    # Currently, we do not set the istio revision. Hence, it is just empty.
+    istio.io/rev: ""
 {{ .Values.labels | toYaml | indent 4 }}
 webhooks:
   - name: validation.istio.io


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Fix caBundle of istio's validating web hook.

The validating web hook configuration of istio does not contain a ca bundle. This is only injected at
runtime by istio itself. Unfortunately, the logic how to identify such validating web hooks has changed
between istio 1.10 and 1.11. Starting with 1.11 the web hooks are identified using a label selector.
The label selector uses the istio.io/rev key, which should have the revision as value. We do not set
any revision as we do not work with canary deployments at the moment. Therefore, it is empty in our
case.
With the added label, the validating web hook is properly updated with the ca bundle by istio.
Please note that it is not possible to add the revision label to the set of standard istio labels as
those labels are also used as selector in the istio pilot deployment. As selectors in deployments are
immutable, we would need to delete/recreate the deployment, which seems to be unnecessary at this time.

**Which issue(s) this PR fixes**:
Fixes #5892 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing the istiod validating webhook's `clientConfig.caBundle` to be not populated is now fixed.
```
