### PR TITLE
Add `ResourcesProgressing` condition to `ManagedResources`

### DIFF
--- a/cmd/gardener-resource-manager/app/app.go
+++ b/cmd/gardener-resource-manager/app/app.go
@@ -105,7 +105,9 @@ func NewResourceManagerCommand() *cobra.Command {
 				if err := resourceControllerOpts.Completed().ApplyDefaultClusterId(ctx, log, sourceClientOpts.Completed().RESTConfig); err != nil {
 					return err
 				}
+				healthControllerOpts.Completed().ClusterID = resourceControllerOpts.Completed().ClusterID
 				healthControllerOpts.Completed().TargetCluster = targetClusterOpts.Completed().Cluster
+				healthControllerOpts.Completed().TargetCacheDisabled = targetClusterOpts.Completed().DisableCachedClient
 				gcControllerOpts.Completed().TargetCluster = targetClusterOpts.Completed().Cluster
 				tokenInvalidatorControllerOpts.Completed().TargetCluster = targetClusterOpts.Completed().Cluster
 				tokenRequestorControllerOpts.Completed().TargetCluster = targetClusterOpts.Completed().Cluster

--- a/example/resource-manager/10-crd-resources.gardener.cloud_managedresources.yaml
+++ b/example/resource-manager/10-crd-resources.gardener.cloud_managedresources.yaml
@@ -31,6 +31,11 @@ spec:
       jsonPath: .status.conditions[?(@.type=="ResourcesHealthy")].status
       name: Healthy
       type: string
+    - description: Indicates whether some resources are still progressing to be rolled
+        out.
+      jsonPath: .status.conditions[?(@.type=="ResourcesProgressing")].status
+      name: Progressing
+      type: string
     - description: creation timestamp
       jsonPath: .metadata.creationTimestamp
       name: Age

--- a/example/seed-crds/10-crd-resources.gardener.cloud_managedresources.yaml
+++ b/example/seed-crds/10-crd-resources.gardener.cloud_managedresources.yaml
@@ -31,6 +31,11 @@ spec:
       jsonPath: .status.conditions[?(@.type=="ResourcesHealthy")].status
       name: Healthy
       type: string
+    - description: Indicates whether some resources are still progressing to be rolled
+        out.
+      jsonPath: .status.conditions[?(@.type=="ResourcesProgressing")].status
+      name: Progressing
+      type: string
     - description: creation timestamp
       jsonPath: .metadata.creationTimestamp
       name: Age

--- a/pkg/apis/resources/v1alpha1/helper/helper.go
+++ b/pkg/apis/resources/v1alpha1/helper/helper.go
@@ -1,0 +1,62 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helper
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+)
+
+// ClusterIDSeparator separates clusterID and ManagedResource key in an origin value.
+const ClusterIDSeparator = ":"
+
+// OriginForManagedResource encodes clusterID and ManagedResource key into an origin value.
+func OriginForManagedResource(clusterID string, mr *resourcesv1alpha1.ManagedResource) string {
+	if clusterID != "" {
+		return clusterID + ClusterIDSeparator + mr.Namespace + string(types.Separator) + mr.Name
+	}
+	return mr.Namespace + string(types.Separator) + mr.Name
+}
+
+// SplitOrigin returns the clusterID and ManagedResource key encoded in an origin value.
+func SplitOrigin(origin string) (string, types.NamespacedName, error) {
+	var (
+		parts     = strings.Split(origin, ClusterIDSeparator)
+		clusterID string
+		key       string
+	)
+	switch len(parts) {
+	case 1:
+		// no clusterID
+		key = parts[0]
+	case 2:
+		// clusterID and key
+		clusterID = parts[0]
+		key = parts[1]
+	default:
+		return "", types.NamespacedName{}, fmt.Errorf("unexpected origin format: %q", origin)
+	}
+
+	parts = strings.Split(key, string(types.Separator))
+	if len(parts) != 2 {
+		return "", types.NamespacedName{}, fmt.Errorf("unexpected origin format: %q", origin)
+	}
+
+	return clusterID, types.NamespacedName{Namespace: parts[0], Name: parts[1]}, nil
+}

--- a/pkg/apis/resources/v1alpha1/helper/helper_suite_test.go
+++ b/pkg/apis/resources/v1alpha1/helper/helper_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helper_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestHelper(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Resources API Helper Suite")
+}

--- a/pkg/apis/resources/v1alpha1/helper/helper_test.go
+++ b/pkg/apis/resources/v1alpha1/helper/helper_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helper_test
+
+import (
+	"k8s.io/apimachinery/pkg/types"
+
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	. "github.com/gardener/gardener/pkg/apis/resources/v1alpha1/helper"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Origin", func() {
+	const (
+		clusterID = "test"
+		name      = "bar"
+		namespace = "foo"
+	)
+	var managedResource *resourcesv1alpha1.ManagedResource
+
+	BeforeEach(func() {
+		managedResource = &resourcesv1alpha1.ManagedResource{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: namespace,
+			},
+		}
+	})
+
+	Describe("#OriginForManagedResource", func() {
+		It("should return the ManagedResource key without clusterID", func() {
+			Expect(OriginForManagedResource("", managedResource)).To(Equal(namespace + "/" + name))
+		})
+
+		It("should return the ManagedResource key with clusterID", func() {
+			Expect(OriginForManagedResource(clusterID, managedResource)).To(Equal(clusterID + ":" + namespace + "/" + name))
+		})
+	})
+
+	Describe("#SplitOrigin", func() {
+		It("should complain about invalid format", func() {
+			_, _, err := SplitOrigin("id:foo")
+			Expect(err).To(MatchError(ContainSubstring("unexpected origin format")))
+			_, _, err = SplitOrigin("id:foo:bar")
+			Expect(err).To(MatchError(ContainSubstring("unexpected origin format")))
+			_, _, err = SplitOrigin("foo")
+			Expect(err).To(MatchError(ContainSubstring("unexpected origin format")))
+			_, _, err = SplitOrigin("id/foo/bar")
+			Expect(err).To(MatchError(ContainSubstring("unexpected origin format")))
+		})
+
+		It("should return the ManagedResource key and clusterID", func() {
+			id, key, err := SplitOrigin(clusterID + ":" + namespace + "/" + name)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(id).To(Equal(clusterID))
+			Expect(key).To(Equal(types.NamespacedName{Namespace: namespace, Name: name}))
+		})
+
+		It("should return the ManagedResource key and empty clusterID", func() {
+			id, key, err := SplitOrigin(namespace + "/" + name)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(id).To(BeEmpty())
+			Expect(key).To(Equal(types.NamespacedName{Namespace: namespace, Name: name}))
+		})
+	})
+})

--- a/pkg/apis/resources/v1alpha1/types.go
+++ b/pkg/apis/resources/v1alpha1/types.go
@@ -215,4 +215,7 @@ const (
 	// ConditionHealthChecksPending indicates that the `ResourcesHealthy` condition is `Unknown`,
 	// because the health checks have not been completely executed yet for the current set of resources.
 	ConditionHealthChecksPending = "HealthChecksPending"
+	// ConditionProgressingChecksPending indicates that the `ResourcesProgressing` condition is `Unknown`,
+	// because the checks have not been completely executed yet for the current set of resources.
+	ConditionProgressingChecksPending = "ChecksPending"
 )

--- a/pkg/apis/resources/v1alpha1/types.go
+++ b/pkg/apis/resources/v1alpha1/types.go
@@ -46,6 +46,10 @@ const (
 	// true then the controller will keep the resource requests and limits in Pod templates (e.g. in a
 	// DeploymentSpec) during updates to the resource. This applies for all containers.
 	PreserveResources = "resources.gardener.cloud/preserve-resources"
+	// OriginAnnotation is a constant for an annotation on a resource managed by a ManagedResource.
+	// It is set by the ManagedResource controller to the key of the owning ManagedResource, optionally prefixed with the
+	// clusterID.
+	OriginAnnotation = "resources.gardener.cloud/origin"
 
 	// StaticTokenSkip is a constant for a label on a ServiceAccount which indicates that this ServiceAccount should not
 	// be considered by this controller.

--- a/pkg/apis/resources/v1alpha1/types.go
+++ b/pkg/apis/resources/v1alpha1/types.go
@@ -212,6 +212,9 @@ const (
 	// ReleaseOfOrphanedResourcesFailed indicates that the `ResourcesApplied` condition is `False`,
 	// because the release of orphaned resources failed.
 	ReleaseOfOrphanedResourcesFailed = "ReleaseOfOrphanedResourcesFailed"
+	// ConditionManagedResourceIgnored indicates that the ManagedResource's conditions are not checked,
+	// because the ManagedResource is marked to be ignored.
+	ConditionManagedResourceIgnored = "ManagedResourceIgnored"
 	// ConditionHealthChecksPending indicates that the `ResourcesHealthy` condition is `Unknown`,
 	// because the health checks have not been completely executed yet for the current set of resources.
 	ConditionHealthChecksPending = "HealthChecksPending"

--- a/pkg/apis/resources/v1alpha1/types.go
+++ b/pkg/apis/resources/v1alpha1/types.go
@@ -215,10 +215,7 @@ const (
 	// ConditionManagedResourceIgnored indicates that the ManagedResource's conditions are not checked,
 	// because the ManagedResource is marked to be ignored.
 	ConditionManagedResourceIgnored = "ManagedResourceIgnored"
-	// ConditionHealthChecksPending indicates that the `ResourcesHealthy` condition is `Unknown`,
-	// because the health checks have not been completely executed yet for the current set of resources.
-	ConditionHealthChecksPending = "HealthChecksPending"
-	// ConditionProgressingChecksPending indicates that the `ResourcesProgressing` condition is `Unknown`,
-	// because the checks have not been completely executed yet for the current set of resources.
-	ConditionProgressingChecksPending = "ChecksPending"
+	// ConditionChecksPending indicates that the `ResourcesProgressing` condition is `Unknown`,
+	// because the condition checks have not been completely executed yet for the current set of resources.
+	ConditionChecksPending = "ChecksPending"
 )

--- a/pkg/apis/resources/v1alpha1/types.go
+++ b/pkg/apis/resources/v1alpha1/types.go
@@ -105,6 +105,7 @@ const (
 // +kubebuilder:printcolumn:name="Class",type=string,JSONPath=`.spec.class`,description="The class identifies which resource manager is responsible for this ManagedResource."
 // +kubebuilder:printcolumn:name="Applied",type=string,JSONPath=`.status.conditions[?(@.type=="ResourcesApplied")].status`,description=" Indicates whether all resources have been applied."
 // +kubebuilder:printcolumn:name="Healthy",type=string,JSONPath=`.status.conditions[?(@.type=="ResourcesHealthy")].status`,description="Indicates whether all resources are healthy."
+// +kubebuilder:printcolumn:name="Progressing",type=string,JSONPath=`.status.conditions[?(@.type=="ResourcesProgressing")].status`,description="Indicates whether some resources are still progressing to be rolled out."
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`,description="creation timestamp"
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
@@ -184,6 +185,8 @@ const (
 	ResourcesApplied gardencorev1beta1.ConditionType = "ResourcesApplied"
 	// ResourcesHealthy is a condition type that indicates whether all resources are present and healthy.
 	ResourcesHealthy gardencorev1beta1.ConditionType = "ResourcesHealthy"
+	// ResourcesProgressing is a condition type that indicates whether some resources are still progressing to be rolled out.
+	ResourcesProgressing gardencorev1beta1.ConditionType = "ResourcesProgressing"
 )
 
 // These are well-known reasons for Conditions.

--- a/pkg/operation/botanist/component/extensions/crds/templates/crd-resources.gardener.cloud_managedresources.yaml
+++ b/pkg/operation/botanist/component/extensions/crds/templates/crd-resources.gardener.cloud_managedresources.yaml
@@ -33,6 +33,11 @@ spec:
       jsonPath: .status.conditions[?(@.type=="ResourcesHealthy")].status
       name: Healthy
       type: string
+    - description: Indicates whether some resources are still progressing to be rolled
+        out.
+      jsonPath: .status.conditions[?(@.type=="ResourcesProgressing")].status
+      name: Progressing
+      type: string
     - description: creation timestamp
       jsonPath: .metadata.creationTimestamp
       name: Age

--- a/pkg/resourcemanager/cmd/target.go
+++ b/pkg/resourcemanager/cmd/target.go
@@ -76,7 +76,8 @@ type TargetClusterOptions struct {
 // Before the first usage, Start and WaitForCacheSync should be called to ensure that the cache is running
 // and has been populated successfully.
 type TargetClusterConfig struct {
-	Cluster cluster.Cluster
+	Cluster             cluster.Cluster
+	DisableCachedClient bool
 }
 
 // AddFlags adds the needed command line flags to the given FlagSet.
@@ -127,7 +128,7 @@ func (o *TargetClusterOptions) Complete() error {
 		return fmt.Errorf("could not instantiate target cluster: %w", err)
 	}
 
-	o.config = &TargetClusterConfig{Cluster: cl}
+	o.config = &TargetClusterConfig{Cluster: cl, DisableCachedClient: o.disableCachedClient}
 	return nil
 }
 

--- a/pkg/resourcemanager/controller/garbagecollector/add.go
+++ b/pkg/resourcemanager/controller/garbagecollector/add.go
@@ -31,7 +31,7 @@ import (
 )
 
 // ControllerName is the name of the controller.
-const ControllerName = "garbage_collector"
+const ControllerName = "garbage-collector"
 
 // defaultControllerConfig is the default config for the controller.
 var defaultControllerConfig ControllerConfig

--- a/pkg/resourcemanager/controller/garbagecollector/reconciler.go
+++ b/pkg/resourcemanager/controller/garbagecollector/reconciler.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"time"
 
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
 	errorutils "github.com/gardener/gardener/pkg/utils/errors"
 
@@ -44,17 +46,14 @@ type reconciler struct {
 	minimumObjectLifetime time.Duration
 }
 
-func (r *reconciler) InjectLogger(l logr.Logger) error {
-	r.log = l.WithName(ControllerName)
-	return nil
-}
-
 func (r *reconciler) Reconcile(reconcileCtx context.Context, _ reconcile.Request) (reconcile.Result, error) {
+	log := logf.FromContext(reconcileCtx)
+
 	ctx, cancel := context.WithTimeout(reconcileCtx, time.Minute)
 	defer cancel()
 
-	r.log.Info("Starting garbage collection")
-	defer r.log.Info("Garbage collection finished")
+	log.Info("Starting garbage collection")
+	defer log.Info("Garbage collection finished")
 
 	var (
 		labels                  = client.MatchingLabels{references.LabelKeyGarbageCollectable: references.LabelValueGarbageCollectable}
@@ -135,7 +134,7 @@ func (r *reconciler) Reconcile(reconcileCtx context.Context, _ reconcile.Request
 				return
 			}
 
-			r.log.Info("Delete resource",
+			log.Info("Delete resource",
 				"kind", objId.kind,
 				"namespace", objId.namespace,
 				"name", objId.name,

--- a/pkg/resourcemanager/controller/health/add.go
+++ b/pkg/resourcemanager/controller/health/add.go
@@ -37,7 +37,6 @@ import (
 
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	resourceshelper "github.com/gardener/gardener/pkg/apis/resources/v1alpha1/helper"
-	predicateutils "github.com/gardener/gardener/pkg/controllerutils/predicate"
 	managerpredicate "github.com/gardener/gardener/pkg/resourcemanager/predicate"
 )
 
@@ -179,10 +178,7 @@ var healthControllerPredicates = []predicate.Predicate{
 		managerpredicate.ConditionStatusChanged(resourcesv1alpha1.ResourcesApplied, managerpredicate.DefaultConditionChange),
 		managerpredicate.NoLongerIgnored(),
 	),
-	predicate.Or(
-		managerpredicate.NotIgnored(),
-		predicateutils.IsDeleting(),
-	),
+	managerpredicate.NotIgnored(),
 }
 
 func mapToOriginManagedResource(log logr.Logger, clusterID string) handler.MapFunc {
@@ -221,4 +217,8 @@ var progressingStatusChanged = predicate.Funcs{
 	},
 	DeleteFunc:  func(_ event.DeleteEvent) bool { return false },
 	GenericFunc: func(_ event.GenericEvent) bool { return false },
+}
+
+func isIgnored(obj client.Object) bool {
+	return obj.GetAnnotations()[resourcesv1alpha1.Ignore] == "true"
 }

--- a/pkg/resourcemanager/controller/health/add.go
+++ b/pkg/resourcemanager/controller/health/add.go
@@ -99,7 +99,7 @@ func AddToManagerWithOptions(mgr manager.Manager, conf ControllerConfig) error {
 		For(&resourcesv1alpha1.ManagedResource{}, builder.WithPredicates(append(healthControllerPredicates, &conf.ClassFilter)...))
 
 	if !conf.TargetCacheDisabled {
-		// Watch relevant objects for Progressing condition in oder to immediately update the condition as soon as there is
+		// Watch relevant objects for Progressing condition in order to immediately update the condition as soon as there is
 		// a change on managed resources.
 		// If the target cache is disabled (e.g. for Shoots), we don't want to watch workload objects (Deployment, DaemonSet,
 		// StatefulSet) because this would cache all of them in the entire cluster. This can potentially be a lot of objects

--- a/pkg/resourcemanager/controller/health/add.go
+++ b/pkg/resourcemanager/controller/health/add.go
@@ -18,9 +18,10 @@ import (
 	"fmt"
 	"time"
 
-	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
-	predicateutils "github.com/gardener/gardener/pkg/controllerutils/predicate"
-	managerpredicate "github.com/gardener/gardener/pkg/resourcemanager/predicate"
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/types"
@@ -33,6 +34,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	resourceshelper "github.com/gardener/gardener/pkg/apis/resources/v1alpha1/helper"
+	predicateutils "github.com/gardener/gardener/pkg/controllerutils/predicate"
+	managerpredicate "github.com/gardener/gardener/pkg/resourcemanager/predicate"
 )
 
 // ControllerName is the name of the health controller.
@@ -82,6 +88,47 @@ func AddToManagerWithOptions(mgr manager.Manager, conf ControllerConfig) error {
 	); err != nil {
 		return fmt.Errorf("unable to watch ManagedResources: %w", err)
 	}
+
+	// setup reconciler for progressing condition
+	log := mgr.GetLogger().WithName("controller").WithName(progressingReconcilerName)
+
+	b := builder.ControllerManagedBy(mgr).Named(progressingReconcilerName).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: conf.MaxConcurrentWorkers,
+			RecoverPanic:            true,
+		}).
+		For(&resourcesv1alpha1.ManagedResource{}, builder.WithPredicates(append(healthControllerPredicates, &conf.ClassFilter)...))
+
+	if !conf.TargetCacheDisabled {
+		// Watch relevant objects for Progressing condition in oder to immediately update the condition as soon as there is
+		// a change on managed resources.
+		// If the target cache is disabled (e.g. for Shoots), we don't want to watch workload objects (Deployment, DaemonSet,
+		// StatefulSet) because this would cache all of them in the entire cluster. This can potentially be a lot of objects
+		// in Shoot clusters, because they are controlled by the end user. In this case, we rely on periodic syncs only.
+		// If we want to have immediate updates for managed resources in Shoots in the future as well, we could consider
+		// adding labels to managed resources and watch them explicitly.
+		b.Watches(
+			&source.Kind{Type: &appsv1.Deployment{}}, handler.EnqueueRequestsFromMapFunc(mapToOriginManagedResource(log, conf.ClusterID)),
+			builder.WithPredicates(progressingStatusChanged),
+		).Watches(
+			&source.Kind{Type: &appsv1.StatefulSet{}}, handler.EnqueueRequestsFromMapFunc(mapToOriginManagedResource(log, conf.ClusterID)),
+			builder.WithPredicates(progressingStatusChanged),
+		).Watches(
+			&source.Kind{Type: &appsv1.DaemonSet{}}, handler.EnqueueRequestsFromMapFunc(mapToOriginManagedResource(log, conf.ClusterID)),
+			builder.WithPredicates(progressingStatusChanged),
+		)
+	}
+
+	if err := b.Complete(&progressingReconciler{
+		client:       mgr.GetClient(),
+		targetClient: conf.TargetCluster.GetClient(),
+		targetScheme: conf.TargetCluster.GetScheme(),
+		classFilter:  &conf.ClassFilter,
+		syncPeriod:   conf.SyncPeriod,
+	}); err != nil {
+		return fmt.Errorf("unable to setup progressing reconciler: %w", err)
+	}
+
 	return nil
 }
 
@@ -136,4 +183,42 @@ var healthControllerPredicates = []predicate.Predicate{
 		managerpredicate.NotIgnored(),
 		predicateutils.IsDeleting(),
 	),
+}
+
+func mapToOriginManagedResource(log logr.Logger, clusterID string) handler.MapFunc {
+	return func(obj client.Object) []reconcile.Request {
+		origin, ok := obj.GetAnnotations()[resourcesv1alpha1.OriginAnnotation]
+		if !ok {
+			return nil
+		}
+
+		originClusterID, key, err := resourceshelper.SplitOrigin(origin)
+		if err != nil {
+			log.Error(err, "Failed to parse origin of object", "object", obj, "origin", origin)
+			return nil
+		}
+
+		if originClusterID != clusterID {
+			// object isn't managed by this resource-manager instance
+			return nil
+		}
+
+		return []reconcile.Request{{NamespacedName: key}}
+	}
+}
+
+var progressingStatusChanged = predicate.Funcs{
+	CreateFunc: func(_ event.CreateEvent) bool { return false },
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		if e.ObjectOld.GetResourceVersion() == e.ObjectNew.GetResourceVersion() {
+			// periodic cache resync, enqueue
+			return true
+		}
+
+		oldProgressing, _ := CheckProgressing(e.ObjectOld)
+		newProgressing, _ := CheckProgressing(e.ObjectNew)
+		return oldProgressing != newProgressing
+	},
+	DeleteFunc:  func(_ event.DeleteEvent) bool { return false },
+	GenericFunc: func(_ event.GenericEvent) bool { return false },
 }

--- a/pkg/resourcemanager/controller/health/add.go
+++ b/pkg/resourcemanager/controller/health/add.go
@@ -36,7 +36,7 @@ import (
 )
 
 // ControllerName is the name of the health controller.
-const ControllerName = "health-controller"
+const ControllerName = "health"
 
 // defaultControllerConfig is the default config for the controller.
 var defaultControllerConfig ControllerConfig

--- a/pkg/resourcemanager/controller/health/health_checker.go
+++ b/pkg/resourcemanager/controller/health/health_checker.go
@@ -47,7 +47,7 @@ func init() {
 
 // CheckHealth checks whether the given object is healthy.
 // It returns a bool indicating whether the object was actually checked and an error if any health check failed.
-func CheckHealth(ctx context.Context, c client.Client, obj runtime.Object) (bool, error) {
+func CheckHealth(ctx context.Context, c client.Client, obj client.Object) (bool, error) {
 	// We must not rely on TypeMeta to be set in objects as decoder clears apiVersion and kind fields, see
 	// https://github.com/kubernetes/kubernetes/issues/80609 and https://github.com/gardener/gardener/issues/5357#issuecomment-1040150204.
 	// Instead of using GetObjectKind(), we use a scheme to figure out the GroupVersionKind which works for both typed

--- a/pkg/resourcemanager/controller/health/health_checker_test.go
+++ b/pkg/resourcemanager/controller/health/health_checker_test.go
@@ -44,7 +44,7 @@ var _ = Describe("CheckHealth", func() {
 		ctx context.Context
 		c   client.Client
 
-		healthy, unhealthy runtime.Object
+		healthy, unhealthy client.Object
 		gvk                schema.GroupVersionKind
 	)
 

--- a/pkg/resourcemanager/controller/health/health_reconciler.go
+++ b/pkg/resourcemanager/controller/health/health_reconciler.go
@@ -69,6 +69,11 @@ func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, fmt.Errorf("could not fetch ManagedResource: %w", err)
 	}
 
+	if isIgnored(mr) {
+		log.Info("Skipping health checks since ManagedResource is ignored")
+		return ctrl.Result{}, nil
+	}
+
 	// Check responsibility
 	if _, responsible := r.classFilter.Active(mr); !responsible {
 		log.Info("Stopping health checks as the responsibility changed")

--- a/pkg/resourcemanager/controller/health/health_reconciler.go
+++ b/pkg/resourcemanager/controller/health/health_reconciler.go
@@ -37,7 +37,6 @@ import (
 )
 
 type reconciler struct {
-	log          logr.Logger
 	client       client.Client
 	targetClient client.Client
 	targetScheme *runtime.Scheme

--- a/pkg/resourcemanager/controller/health/progressing_reconciler.go
+++ b/pkg/resourcemanager/controller/health/progressing_reconciler.go
@@ -1,0 +1,178 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package health
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/resourcemanager/predicate"
+	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
+)
+
+const progressingReconcilerName = "progressing"
+
+type progressingReconciler struct {
+	client       client.Client
+	targetClient client.Client
+	targetScheme *runtime.Scheme
+	classFilter  *predicate.ClassFilter
+	syncPeriod   time.Duration
+}
+
+func (r *progressingReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	log := logf.FromContext(ctx)
+
+	// timeout for all calls (e.g. status updates), give status updates a bit of headroom if checks
+	// themselves run into timeouts, so that we will still update the status with that timeout error
+	var cancel context.CancelFunc
+	ctx, cancel = context.WithTimeout(ctx, 2*time.Minute)
+	defer cancel()
+
+	mr := &resourcesv1alpha1.ManagedResource{}
+	if err := r.client.Get(ctx, req.NamespacedName, mr); err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("Stopping checks for ManagedResource, as it has been deleted")
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("could not fetch ManagedResource: %w", err)
+	}
+
+	// Check responsibility
+	if _, responsible := r.classFilter.Active(mr); !responsible {
+		log.Info("Stopping checks as the responsibility changed")
+		return ctrl.Result{}, nil
+	}
+
+	if !mr.DeletionTimestamp.IsZero() {
+		log.Info("Stopping checks for ManagedResource, as it is marked for deletion")
+		return ctrl.Result{}, nil
+	}
+
+	// skip checks until ManagedResource has been reconciled completely successfully to prevent updating status while
+	// resource controller is still applying the resources (this would lead to a myriad of conflicts)
+	conditionResourcesApplied := v1beta1helper.GetCondition(mr.Status.Conditions, resourcesv1alpha1.ResourcesApplied)
+	if conditionResourcesApplied == nil || conditionResourcesApplied.Status == gardencorev1beta1.ConditionProgressing || conditionResourcesApplied.Status == gardencorev1beta1.ConditionFalse {
+		log.Info("Skipping checks for ManagedResource, as it is has not been reconciled successfully yet")
+		return ctrl.Result{RequeueAfter: r.syncPeriod}, nil
+	}
+
+	return r.reconcile(ctx, log, mr)
+}
+
+func (r *progressingReconciler) reconcile(ctx context.Context, log logr.Logger, mr *resourcesv1alpha1.ManagedResource) (ctrl.Result, error) {
+	log.V(1).Info("Starting ManagedResource progressing checks")
+	// don't block workers if calls timeout for some reason
+	checkCtx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+
+	conditionResourcesProgressing := v1beta1helper.GetOrInitCondition(mr.Status.Conditions, resourcesv1alpha1.ResourcesProgressing)
+
+	for _, ref := range mr.Status.Resources {
+		// only Deployment, StatefulSet and DaemonSet are considered for Progressing condition
+		if ref.GroupVersionKind().Group != appsv1.GroupName {
+			continue
+		}
+
+		var obj client.Object
+		switch ref.Kind {
+		case "Deployment":
+			obj = &appsv1.Deployment{}
+		case "StatefulSet":
+			obj = &appsv1.StatefulSet{}
+		case "DaemonSet":
+			obj = &appsv1.DaemonSet{}
+		default:
+			continue
+		}
+
+		var (
+			objectKey = client.ObjectKey{Namespace: ref.Namespace, Name: ref.Name}
+			objectLog = log.WithValues("object", objectKey, "objectGVK", ref.GroupVersionKind())
+		)
+
+		if err := r.targetClient.Get(checkCtx, objectKey, obj); err != nil {
+			if apierrors.IsNotFound(err) {
+				// missing objects already handled by health controller, skip
+				continue
+			}
+			return ctrl.Result{}, err
+		}
+
+		if progressing, description := CheckProgressing(obj); progressing {
+			var (
+				reason  = ref.Kind + "Progressing"
+				message = fmt.Sprintf("%s %q is progressing: %s", ref.Kind, objectKey.String(), description)
+			)
+
+			objectLog.Info("ManagedResource rollout is progressing, detected progressing object", "status", "progressing", "reason", reason, "message", message)
+
+			conditionResourcesProgressing = v1beta1helper.UpdatedCondition(conditionResourcesProgressing, gardencorev1beta1.ConditionTrue, reason, message)
+			if err := updateConditions(ctx, r.client, mr, conditionResourcesProgressing); err != nil {
+				return ctrl.Result{}, fmt.Errorf("could not update the ManagedResource status: %w", err)
+			}
+
+			return ctrl.Result{RequeueAfter: r.syncPeriod}, nil
+		}
+	}
+
+	b, err := v1beta1helper.NewConditionBuilder(resourcesv1alpha1.ResourcesProgressing)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	var needsUpdate bool
+	conditionResourcesProgressing, needsUpdate = b.WithOldCondition(conditionResourcesProgressing).
+		WithStatus(gardencorev1beta1.ConditionFalse).WithReason("ResourcesRolledOut").
+		WithMessage("All resources have been fully rolled out.").
+		Build()
+
+	if needsUpdate {
+		log.Info("ManagedResource has been fully rolled out", "status", "rolled out")
+		if err := updateConditions(ctx, r.client, mr, conditionResourcesProgressing); err != nil {
+			return ctrl.Result{}, fmt.Errorf("could not update the ManagedResource status: %w", err)
+		}
+	}
+
+	return ctrl.Result{RequeueAfter: r.syncPeriod}, nil
+}
+
+// CheckProgressing checks whether the given object is progressing. It returns a bool indicating whether the object is
+// progressing, a reason for it if so and an error if the check failed.
+func CheckProgressing(obj client.Object) (bool, string) {
+	switch o := obj.(type) {
+	case *appsv1.Deployment:
+		return health.IsDeploymentProgressing(o)
+	case *appsv1.StatefulSet:
+		return health.IsStatefulSetProgressing(o)
+	case *appsv1.DaemonSet:
+		return health.IsDaemonSetProgressing(o)
+	}
+
+	return false, ""
+}

--- a/pkg/resourcemanager/controller/health/progressing_reconciler.go
+++ b/pkg/resourcemanager/controller/health/progressing_reconciler.go
@@ -75,15 +75,16 @@ func (r *progressingReconciler) Reconcile(ctx context.Context, req reconcile.Req
 	}
 
 	if !mr.DeletionTimestamp.IsZero() {
-		log.Info("Stopping checks for ManagedResource, as it is marked for deletion")
+		log.Info("Stopping checks for ManagedResource as it is marked for deletion")
 		return ctrl.Result{}, nil
 	}
 
 	// skip checks until ManagedResource has been reconciled completely successfully to prevent updating status while
-	// resource controller is still applying the resources (this would lead to a myriad of conflicts)
+	// resource controller is still applying the resources (this might lead to wrongful results inconsistent with the
+	// actual set of applied resources and causes a myriad of conflicts)
 	conditionResourcesApplied := v1beta1helper.GetCondition(mr.Status.Conditions, resourcesv1alpha1.ResourcesApplied)
 	if conditionResourcesApplied == nil || conditionResourcesApplied.Status == gardencorev1beta1.ConditionProgressing || conditionResourcesApplied.Status == gardencorev1beta1.ConditionFalse {
-		log.Info("Skipping checks for ManagedResource, as it is has not been reconciled successfully yet")
+		log.Info("Skipping checks for ManagedResource as the resources were not applied yet")
 		return ctrl.Result{RequeueAfter: r.syncPeriod}, nil
 	}
 

--- a/pkg/resourcemanager/controller/health/progressing_reconciler.go
+++ b/pkg/resourcemanager/controller/health/progressing_reconciler.go
@@ -63,6 +63,11 @@ func (r *progressingReconciler) Reconcile(ctx context.Context, req reconcile.Req
 		return ctrl.Result{}, fmt.Errorf("could not fetch ManagedResource: %w", err)
 	}
 
+	if isIgnored(mr) {
+		log.Info("Skipping checks since ManagedResource is ignored")
+		return ctrl.Result{}, nil
+	}
+
 	// Check responsibility
 	if _, responsible := r.classFilter.Active(mr); !responsible {
 		log.Info("Stopping checks as the responsibility changed")

--- a/pkg/resourcemanager/controller/health/reconciler.go
+++ b/pkg/resourcemanager/controller/health/reconciler.go
@@ -51,12 +51,6 @@ func (r *reconciler) InjectClient(c client.Client) error {
 	return nil
 }
 
-// InjectLogger injects a logger into the reconciler.
-func (r *reconciler) InjectLogger(l logr.Logger) error {
-	r.log = l.WithName(ControllerName)
-	return nil
-}
-
 // Reconcile performs health checks.
 func (r *reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)

--- a/pkg/resourcemanager/controller/managedresource/add.go
+++ b/pkg/resourcemanager/controller/managedresource/add.go
@@ -101,8 +101,13 @@ func AddToManagerWithOptions(mgr manager.Manager, conf ControllerConfig) error {
 			managerpredicate.HasOperationAnnotation(),
 			managerpredicate.ConditionStatusChanged(resourcesv1alpha1.ResourcesHealthy, managerpredicate.ConditionChangedToUnhealthy),
 			managerpredicate.NoLongerIgnored(),
+			// we need to reconcile once if the ManagedResource got marked as ignored in order to update the conditions
+			managerpredicate.GotMarkedAsIgnored(),
 		),
+		// TODO: refactor this predicate chain into a single predicate.Funcs that can be properly tested as a whole
 		predicate.Or(
+			// Added again here, as otherwise NotIgnored would filter this add/update event out
+			managerpredicate.GotMarkedAsIgnored(),
 			managerpredicate.NotIgnored(),
 			predicateutils.IsDeleting(),
 		),

--- a/pkg/resourcemanager/controller/managedresource/add.go
+++ b/pkg/resourcemanager/controller/managedresource/add.go
@@ -42,7 +42,7 @@ import (
 )
 
 // ControllerName is the name of the managedresource controller.
-const ControllerName = "resource-controller"
+const ControllerName = "resource"
 
 // defaultControllerConfig is the default config for the controller.
 var defaultControllerConfig ControllerConfig

--- a/pkg/resourcemanager/controller/managedresource/add.go
+++ b/pkg/resourcemanager/controller/managedresource/add.go
@@ -75,7 +75,7 @@ func AddToManagerWithOptions(mgr manager.Manager, conf ControllerConfig) error {
 		MaxConcurrentReconciles: conf.MaxConcurrentWorkers,
 		Reconciler: reconcilerutils.OperationAnnotationWrapper(
 			func() client.Object { return &resourcesv1alpha1.ManagedResource{} },
-			&Reconciler{
+			&reconciler{
 				targetClient:              conf.TargetCluster.GetClient(),
 				targetRESTMapper:          conf.TargetCluster.GetRESTMapper(),
 				targetScheme:              conf.TargetCluster.GetScheme(),

--- a/pkg/resourcemanager/controller/managedresource/merger.go
+++ b/pkg/resourcemanager/controller/managedresource/merger.go
@@ -36,8 +36,6 @@ const (
 	descriptionAnnotation     = "resources.gardener.cloud/description"
 	descriptionAnnotationText = `DO NOT EDIT - This resource is managed by gardener-resource-manager.
 Any modifications are discarded and the resource is returned to the original state.`
-
-	originAnnotation = "resources.gardener.cloud/origin"
 )
 
 // merge merges the values of the `desired` object into the `current` object while preserving `current`'s important
@@ -89,7 +87,7 @@ func merge(origin string, desired, current *unstructured.Unstructured, forceOver
 	}
 
 	ann[descriptionAnnotation] = descriptionAnnotationText
-	ann[originAnnotation] = origin
+	ann[resourcesv1alpha1.OriginAnnotation] = origin
 	newObject.SetAnnotations(ann)
 
 	// keep status of old object if it is set and not empty

--- a/pkg/resourcemanager/controller/managedresource/merger_test.go
+++ b/pkg/resourcemanager/controller/managedresource/merger_test.go
@@ -31,6 +31,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 )
 
 var _ = Describe("merger", func() {
@@ -1115,7 +1117,7 @@ func addAnnotations(origin string, obj *unstructured.Unstructured) {
 		ann = make(map[string]string, 1)
 	}
 	ann[descriptionAnnotation] = descriptionAnnotationText
-	ann[originAnnotation] = origin
+	ann[v1alpha1.OriginAnnotation] = origin
 	obj.SetAnnotations(ann)
 }
 

--- a/pkg/resourcemanager/controller/managedresource/reconciler.go
+++ b/pkg/resourcemanager/controller/managedresource/reconciler.go
@@ -277,10 +277,10 @@ func (r *reconciler) reconcile(ctx context.Context, mr *resourcesv1alpha1.Manage
 	if len(mr.Status.Resources) == 0 || !apiequality.Semantic.DeepEqual(mr.Status.Resources, newResourcesObjectReferences) {
 		conditionResourcesHealthy := v1beta1helper.GetOrInitCondition(mr.Status.Conditions, resourcesv1alpha1.ResourcesHealthy)
 		conditionResourcesHealthy = v1beta1helper.UpdatedCondition(conditionResourcesHealthy, gardencorev1beta1.ConditionUnknown,
-			resourcesv1alpha1.ConditionHealthChecksPending, "The health checks have not yet been executed for the current set of resources.")
+			resourcesv1alpha1.ConditionChecksPending, "The health checks have not yet been executed for the current set of resources.")
 		conditionResourcesProgressing := v1beta1helper.GetOrInitCondition(mr.Status.Conditions, resourcesv1alpha1.ResourcesProgressing)
 		conditionResourcesProgressing = v1beta1helper.UpdatedCondition(conditionResourcesProgressing, gardencorev1beta1.ConditionUnknown,
-			resourcesv1alpha1.ConditionProgressingChecksPending, "Checks have not yet been executed for the current set of resources.")
+			resourcesv1alpha1.ConditionChecksPending, "Checks have not yet been executed for the current set of resources.")
 
 		reason := resourcesv1alpha1.ConditionApplyProgressing
 		msg := "The resources are currently being reconciled."
@@ -423,12 +423,13 @@ func (r *reconciler) delete(ctx context.Context, mr *resourcesv1alpha1.ManagedRe
 }
 
 func (r *reconciler) updateConditionsForIgnoredManagedResource(ctx context.Context, mr *resourcesv1alpha1.ManagedResource) error {
+	message := "ManagedResource is marked to be ignored."
 	conditionResourcesApplied := v1beta1helper.GetOrInitCondition(mr.Status.Conditions, resourcesv1alpha1.ResourcesApplied)
-	conditionResourcesApplied = v1beta1helper.UpdatedCondition(conditionResourcesApplied, gardencorev1beta1.ConditionTrue, resourcesv1alpha1.ConditionManagedResourceIgnored, "ManagedResource is marked to be ignored.")
+	conditionResourcesApplied = v1beta1helper.UpdatedCondition(conditionResourcesApplied, gardencorev1beta1.ConditionTrue, resourcesv1alpha1.ConditionManagedResourceIgnored, message)
 	conditionResourcesHealthy := v1beta1helper.GetOrInitCondition(mr.Status.Conditions, resourcesv1alpha1.ResourcesHealthy)
-	conditionResourcesHealthy = v1beta1helper.UpdatedCondition(conditionResourcesHealthy, gardencorev1beta1.ConditionTrue, resourcesv1alpha1.ConditionManagedResourceIgnored, "ManagedResource is marked to be ignored.")
+	conditionResourcesHealthy = v1beta1helper.UpdatedCondition(conditionResourcesHealthy, gardencorev1beta1.ConditionTrue, resourcesv1alpha1.ConditionManagedResourceIgnored, message)
 	conditionResourcesProgressing := v1beta1helper.GetOrInitCondition(mr.Status.Conditions, resourcesv1alpha1.ResourcesProgressing)
-	conditionResourcesProgressing = v1beta1helper.UpdatedCondition(conditionResourcesProgressing, gardencorev1beta1.ConditionFalse, resourcesv1alpha1.ConditionManagedResourceIgnored, "ManagedResource is marked to be ignored.")
+	conditionResourcesProgressing = v1beta1helper.UpdatedCondition(conditionResourcesProgressing, gardencorev1beta1.ConditionFalse, resourcesv1alpha1.ConditionManagedResourceIgnored, message)
 
 	oldMr := mr.DeepCopy()
 	mr.Status.Conditions = v1beta1helper.MergeConditions(mr.Status.Conditions, conditionResourcesApplied, conditionResourcesHealthy, conditionResourcesProgressing)

--- a/pkg/resourcemanager/controller/managedresource/reconciler.go
+++ b/pkg/resourcemanager/controller/managedresource/reconciler.go
@@ -274,6 +274,9 @@ func (r *Reconciler) reconcile(ctx context.Context, mr *resourcesv1alpha1.Manage
 		conditionResourcesHealthy := v1beta1helper.GetOrInitCondition(mr.Status.Conditions, resourcesv1alpha1.ResourcesHealthy)
 		conditionResourcesHealthy = v1beta1helper.UpdatedCondition(conditionResourcesHealthy, gardencorev1beta1.ConditionUnknown,
 			resourcesv1alpha1.ConditionHealthChecksPending, "The health checks have not yet been executed for the current set of resources.")
+		conditionResourcesProgressing := v1beta1helper.GetOrInitCondition(mr.Status.Conditions, resourcesv1alpha1.ResourcesProgressing)
+		conditionResourcesProgressing = v1beta1helper.UpdatedCondition(conditionResourcesProgressing, gardencorev1beta1.ConditionUnknown,
+			resourcesv1alpha1.ConditionProgressingChecksPending, "Checks have not yet been executed for the current set of resources.")
 
 		reason := resourcesv1alpha1.ConditionApplyProgressing
 		msg := "The resources are currently being reconciled."
@@ -285,7 +288,7 @@ func (r *Reconciler) reconcile(ctx context.Context, mr *resourcesv1alpha1.Manage
 		}
 		conditionResourcesApplied = v1beta1helper.UpdatedCondition(conditionResourcesApplied, gardencorev1beta1.ConditionProgressing, reason, msg)
 
-		if err := updateConditions(ctx, r.client, mr, conditionResourcesHealthy, conditionResourcesApplied); err != nil {
+		if err := updateConditions(ctx, r.client, mr, conditionResourcesHealthy, conditionResourcesProgressing, conditionResourcesApplied); err != nil {
 			return ctrl.Result{}, fmt.Errorf("could not update the ManagedResource status: %w", err)
 		}
 	}

--- a/pkg/resourcemanager/controller/rootcapublisher/reconciler.go
+++ b/pkg/resourcemanager/controller/rootcapublisher/reconciler.go
@@ -18,13 +18,13 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -41,7 +41,6 @@ const (
 type reconciler struct {
 	targetClient client.Client
 	rootCA       string
-	log          logr.Logger
 }
 
 // NewReconciler is constructor only used in tests.
@@ -52,13 +51,8 @@ func NewReconciler(cl client.Client, rootCA string) *reconciler {
 	}
 }
 
-func (r *reconciler) InjectLogger(l logr.Logger) error {
-	r.log = l.WithName(ControllerName)
-	return nil
-}
-
 func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	log := r.log.WithValues("rootcapublisher", req)
+	log := logf.FromContext(ctx)
 
 	namespace := &corev1.Namespace{}
 	if err := r.targetClient.Get(ctx, req.NamespacedName, namespace); err != nil {

--- a/pkg/resourcemanager/controller/rootcapublisher/reconciler_test.go
+++ b/pkg/resourcemanager/controller/rootcapublisher/reconciler_test.go
@@ -20,7 +20,6 @@ import (
 
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	. "github.com/gardener/gardener/pkg/resourcemanager/controller/rootcapublisher"
-	"github.com/go-logr/logr"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
@@ -35,7 +34,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 )
 
 var _ = Describe("Reconciler", func() {
@@ -58,7 +56,6 @@ var _ = Describe("Reconciler", func() {
 			Build()
 
 		ctrl = NewReconciler(fakeClient, rootCA)
-		Expect(inject.LoggerInto(logr.Discard(), ctrl)).To(BeTrue())
 
 		namespace = &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
@@ -130,7 +127,6 @@ var _ = Describe("Reconciler", func() {
 					mockClient = mockclient.NewMockClient(mockCtrl)
 
 					ctrl = NewReconciler(mockClient, rootCA)
-					Expect(inject.LoggerInto(logr.Discard(), ctrl)).To(BeTrue())
 				})
 
 				AfterEach(func() {

--- a/pkg/resourcemanager/controller/secret/add.go
+++ b/pkg/resourcemanager/controller/secret/add.go
@@ -31,7 +31,7 @@ import (
 )
 
 // ControllerName is the name of the secret controller.
-const ControllerName = "secret-controller"
+const ControllerName = "secret"
 
 // defaultControllerConfig is the default config for the controller.
 var defaultControllerConfig ControllerConfig

--- a/pkg/resourcemanager/controller/secret/reconciler_test.go
+++ b/pkg/resourcemanager/controller/secret/reconciler_test.go
@@ -18,13 +18,6 @@ import (
 	"context"
 	"fmt"
 
-	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
-	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
-	secretcontroller "github.com/gardener/gardener/pkg/resourcemanager/controller/secret"
-	"github.com/gardener/gardener/pkg/resourcemanager/predicate"
-	"github.com/gardener/gardener/pkg/utils/test"
-	"github.com/go-logr/logr"
-
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -37,6 +30,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	secretcontroller "github.com/gardener/gardener/pkg/resourcemanager/controller/secret"
+	"github.com/gardener/gardener/pkg/resourcemanager/predicate"
+	"github.com/gardener/gardener/pkg/utils/test"
 )
 
 var _ = Describe("SecretReconciler", func() {
@@ -60,7 +59,6 @@ var _ = Describe("SecretReconciler", func() {
 		r = &secretcontroller.Reconciler{ClassFilter: classFilter}
 
 		Expect(inject.ClientInto(c, r)).To(BeTrue())
-		Expect(inject.LoggerInto(logr.Discard(), r)).To(BeTrue())
 
 		secret = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/utils/kubernetes/health/replicaset_test.go
+++ b/pkg/utils/kubernetes/health/replicaset_test.go
@@ -15,6 +15,8 @@
 package health_test
 
 import (
+	"k8s.io/utils/pointer"
+
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -24,24 +26,22 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ = Describe("Replicaset", func() {
-	Context("CheckReplicaSet", func() {
-		DescribeTable("replicasets",
-			func(rs *appsv1.ReplicaSet, matcher types.GomegaMatcher) {
-				err := health.CheckReplicaSet(rs)
-				Expect(err).To(matcher)
-			},
-			Entry("not observed at latest version", &appsv1.ReplicaSet{
-				ObjectMeta: metav1.ObjectMeta{Generation: 1},
-			}, HaveOccurred()),
-			Entry("not enough ready replicas", &appsv1.ReplicaSet{
-				Spec:   appsv1.ReplicaSetSpec{Replicas: replicas(2)},
-				Status: appsv1.ReplicaSetStatus{ReadyReplicas: 1},
-			}, HaveOccurred()),
-			Entry("healthy", &appsv1.ReplicaSet{
-				Spec:   appsv1.ReplicaSetSpec{Replicas: replicas(2)},
-				Status: appsv1.ReplicaSetStatus{ReadyReplicas: 2},
-			}, BeNil()),
-		)
-	})
+var _ = Describe("ReplicaSet", func() {
+	DescribeTable("CheckReplicaSet",
+		func(rs *appsv1.ReplicaSet, matcher types.GomegaMatcher) {
+			err := health.CheckReplicaSet(rs)
+			Expect(err).To(matcher)
+		},
+		Entry("not observed at latest version", &appsv1.ReplicaSet{
+			ObjectMeta: metav1.ObjectMeta{Generation: 1},
+		}, HaveOccurred()),
+		Entry("not enough ready replicas", &appsv1.ReplicaSet{
+			Spec:   appsv1.ReplicaSetSpec{Replicas: pointer.Int32(2)},
+			Status: appsv1.ReplicaSetStatus{ReadyReplicas: 1},
+		}, HaveOccurred()),
+		Entry("healthy", &appsv1.ReplicaSet{
+			Spec:   appsv1.ReplicaSetSpec{Replicas: pointer.Int32(2)},
+			Status: appsv1.ReplicaSetStatus{ReadyReplicas: 2},
+		}, BeNil()),
+	)
 })

--- a/pkg/utils/kubernetes/health/replicationcontroller_test.go
+++ b/pkg/utils/kubernetes/health/replicationcontroller_test.go
@@ -15,6 +15,8 @@
 package health_test
 
 import (
+	"k8s.io/utils/pointer"
+
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -24,24 +26,22 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ = Describe("Replicationcontroller", func() {
-	Context("CheckReplicationController", func() {
-		DescribeTable("replicationcontroller",
-			func(rc *corev1.ReplicationController, matcher types.GomegaMatcher) {
-				err := health.CheckReplicationController(rc)
-				Expect(err).To(matcher)
-			},
-			Entry("not observed at latest version", &corev1.ReplicationController{
-				ObjectMeta: metav1.ObjectMeta{Generation: 1},
-			}, HaveOccurred()),
-			Entry("not enough ready replicas", &corev1.ReplicationController{
-				Spec:   corev1.ReplicationControllerSpec{Replicas: replicas(2)},
-				Status: corev1.ReplicationControllerStatus{ReadyReplicas: 1},
-			}, HaveOccurred()),
-			Entry("healthy", &corev1.ReplicationController{
-				Spec:   corev1.ReplicationControllerSpec{Replicas: replicas(2)},
-				Status: corev1.ReplicationControllerStatus{ReadyReplicas: 2},
-			}, BeNil()),
-		)
-	})
+var _ = Describe("ReplicationController", func() {
+	DescribeTable("CheckReplicationController",
+		func(rc *corev1.ReplicationController, matcher types.GomegaMatcher) {
+			err := health.CheckReplicationController(rc)
+			Expect(err).To(matcher)
+		},
+		Entry("not observed at latest version", &corev1.ReplicationController{
+			ObjectMeta: metav1.ObjectMeta{Generation: 1},
+		}, HaveOccurred()),
+		Entry("not enough ready replicas", &corev1.ReplicationController{
+			Spec:   corev1.ReplicationControllerSpec{Replicas: pointer.Int32(2)},
+			Status: corev1.ReplicationControllerStatus{ReadyReplicas: 1},
+		}, HaveOccurred()),
+		Entry("healthy", &corev1.ReplicationController{
+			Spec:   corev1.ReplicationControllerSpec{Replicas: pointer.Int32(2)},
+			Status: corev1.ReplicationControllerStatus{ReadyReplicas: 2},
+		}, BeNil()),
+	)
 })

--- a/pkg/utils/kubernetes/health/statefulset_test.go
+++ b/pkg/utils/kubernetes/health/statefulset_test.go
@@ -15,6 +15,8 @@
 package health_test
 
 import (
+	"k8s.io/utils/pointer"
+
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -24,14 +26,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ = Describe("Statefulset", func() {
-	DescribeTable("statefulsets",
+var _ = Describe("StatefulSet", func() {
+	DescribeTable("CheckStatefulSet",
 		func(statefulSet *appsv1.StatefulSet, matcher types.GomegaMatcher) {
 			err := health.CheckStatefulSet(statefulSet)
 			Expect(err).To(matcher)
 		},
 		Entry("healthy", &appsv1.StatefulSet{
-			Spec:   appsv1.StatefulSetSpec{Replicas: replicas(1)},
+			Spec:   appsv1.StatefulSetSpec{Replicas: pointer.Int32(1)},
 			Status: appsv1.StatefulSetStatus{CurrentReplicas: 1, ReadyReplicas: 1},
 		}, BeNil()),
 		Entry("healthy with nil replicas", &appsv1.StatefulSet{
@@ -41,12 +43,60 @@ var _ = Describe("Statefulset", func() {
 			ObjectMeta: metav1.ObjectMeta{Generation: 1},
 		}, HaveOccurred()),
 		Entry("not enough ready replicas", &appsv1.StatefulSet{
-			Spec:   appsv1.StatefulSetSpec{Replicas: replicas(2)},
+			Spec:   appsv1.StatefulSetSpec{Replicas: pointer.Int32(2)},
 			Status: appsv1.StatefulSetStatus{ReadyReplicas: 1},
 		}, HaveOccurred()),
 	)
-})
 
-func replicas(i int32) *int32 {
-	return &i
-}
+	Describe("IsStatefulSetProgressing", func() {
+		var (
+			statefulSet *appsv1.StatefulSet
+		)
+
+		BeforeEach(func() {
+			statefulSet = &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Generation: 42,
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: pointer.Int32(3),
+				},
+				Status: appsv1.StatefulSetStatus{
+					ObservedGeneration: 42,
+					UpdatedReplicas:    3,
+				},
+			}
+		})
+
+		It("should return false if it is fully rolled out", func() {
+			progressing, reason := health.IsStatefulSetProgressing(statefulSet)
+			Expect(progressing).To(BeFalse())
+			Expect(reason).To(Equal("StatefulSet is fully rolled out"))
+		})
+
+		It("should return true if observedGeneration is outdated", func() {
+			statefulSet.Status.ObservedGeneration--
+
+			progressing, reason := health.IsStatefulSetProgressing(statefulSet)
+			Expect(progressing).To(BeTrue())
+			Expect(reason).To(Equal("observed generation outdated (41/42)"))
+		})
+
+		It("should return true if replicas still need to be updated", func() {
+			statefulSet.Status.UpdatedReplicas--
+
+			progressing, reason := health.IsStatefulSetProgressing(statefulSet)
+			Expect(progressing).To(BeTrue())
+			Expect(reason).To(Equal("2 of 3 replica(s) have been updated"))
+		})
+
+		It("should return true if replica still needs to be updated (spec.replicas=null)", func() {
+			statefulSet.Spec.Replicas = nil
+			statefulSet.Status.UpdatedReplicas = 0
+
+			progressing, reason := health.IsStatefulSetProgressing(statefulSet)
+			Expect(progressing).To(BeTrue())
+			Expect(reason).To(Equal("0 of 1 replica(s) have been updated"))
+		})
+	})
+})

--- a/test/integration/resourcemanager/health/health_suite_test.go
+++ b/test/integration/resourcemanager/health/health_suite_test.go
@@ -45,9 +45,8 @@ func TestHealthController(t *testing.T) {
 }
 
 const (
-	// testID is used for generating test namespace names
-	testID        = "health-controller-test"
-	testFinalizer = "gardener.cloud/" + testID
+	// testID is used for generating test namespace names and other IDs
+	testID = "health-controller-test"
 )
 
 var (

--- a/test/integration/resourcemanager/health/health_test.go
+++ b/test/integration/resourcemanager/health/health_test.go
@@ -369,11 +369,13 @@ var _ = Describe("Health controller tests", func() {
 				Expect(testClient.Create(ctx, deployment)).To(Succeed())
 				deployment.Status = *deploymentStatus
 				Expect(testClient.Status().Update(ctx, deployment)).To(Succeed())
+
 				statefulSet = generateStatefulSetTestResource(managedResource.Name)
 				statefulSetStatus := statefulSet.Status.DeepCopy()
 				Expect(testClient.Create(ctx, statefulSet)).To(Succeed())
 				statefulSet.Status = *statefulSetStatus
 				Expect(testClient.Status().Update(ctx, statefulSet)).To(Succeed())
+
 				daemonSet = generateDaemonSetTestResource(managedResource.Name)
 				daemonSetStatus := daemonSet.Status.DeepCopy()
 				Expect(testClient.Create(ctx, daemonSet)).To(Succeed())

--- a/test/integration/resourcemanager/health/health_test.go
+++ b/test/integration/resourcemanager/health/health_test.go
@@ -129,31 +129,6 @@ var _ = Describe("Health controller tests", func() {
 		})
 	})
 
-	Context("ManagedResource in deletion", func() {
-		JustBeforeEach(func() {
-			By("marking ManagedResource for deletion")
-			patch := client.MergeFrom(managedResource.DeepCopy())
-			managedResource.SetFinalizers([]string{testFinalizer})
-			Expect(testClient.Patch(ctx, managedResource, patch)).To(Succeed())
-			Expect(testClient.Delete(ctx, managedResource)).To(Or(Succeed(), BeNotFoundError()))
-
-			DeferCleanup(func() {
-				patch = client.MergeFrom(managedResource.DeepCopy())
-				managedResource.SetFinalizers(nil)
-				Expect(testClient.Patch(ctx, managedResource, patch))
-			})
-		})
-
-		It("sets ManagedResource to unhealthy", func() {
-			Eventually(func(g Gomega) []gardencorev1beta1.Condition {
-				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
-				return managedResource.Status.Conditions
-			}).Should(
-				containCondition(ofType(resourcesv1alpha1.ResourcesHealthy), withStatus(gardencorev1beta1.ConditionFalse), withReason(resourcesv1alpha1.ConditionDeletionPending)),
-			)
-		})
-	})
-
 	Context("resources not applied yet", func() {
 		It("does not touch ManagedResource if it has not been applied yet", func() {
 			Consistently(func(g Gomega) []gardencorev1beta1.Condition {

--- a/test/integration/resourcemanager/health/health_test.go
+++ b/test/integration/resourcemanager/health/health_test.go
@@ -19,6 +19,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gstruct"
 	gomegatypes "github.com/onsi/gomega/types"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
@@ -75,10 +76,11 @@ var _ = Describe("Health controller tests", func() {
 				return managedResource.Status.Conditions
 			}).ShouldNot(
 				containCondition(ofType(resourcesv1alpha1.ResourcesHealthy)),
+				containCondition(ofType(resourcesv1alpha1.ResourcesProgressing)),
 			)
 		})
 
-		It("sets ManagedResource to healthy if it is responsible now", func() {
+		It("checks ManagedResource again if it is responsible now", func() {
 			By("update ManagedResource to default class")
 			patch := client.MergeFrom(managedResource.DeepCopy())
 			managedResource.Spec.Class = nil
@@ -89,6 +91,7 @@ var _ = Describe("Health controller tests", func() {
 				return managedResource.Status.Conditions
 			}).Should(
 				containCondition(ofType(resourcesv1alpha1.ResourcesHealthy), withStatus(gardencorev1beta1.ConditionTrue)),
+				containCondition(ofType(resourcesv1alpha1.ResourcesProgressing), withStatus(gardencorev1beta1.ConditionFalse)),
 			)
 		})
 	})
@@ -111,10 +114,11 @@ var _ = Describe("Health controller tests", func() {
 				return managedResource.Status.Conditions
 			}).ShouldNot(
 				containCondition(ofType(resourcesv1alpha1.ResourcesHealthy)),
+				containCondition(ofType(resourcesv1alpha1.ResourcesProgressing)),
 			)
 		})
 
-		It("sets ManagedResource to healthy if it no longer ignored", func() {
+		It("checks ManagedResource again if it is no longer ignored", func() {
 			By("update ManagedResource and remove ignore annotation")
 			patch := client.MergeFrom(managedResource.DeepCopy())
 			delete(managedResource.Annotations, resourcesv1alpha1.Ignore)
@@ -125,6 +129,7 @@ var _ = Describe("Health controller tests", func() {
 				return managedResource.Status.Conditions
 			}).Should(
 				containCondition(ofType(resourcesv1alpha1.ResourcesHealthy), withStatus(gardencorev1beta1.ConditionTrue)),
+				containCondition(ofType(resourcesv1alpha1.ResourcesProgressing), withStatus(gardencorev1beta1.ConditionFalse)),
 			)
 		})
 	})
@@ -136,6 +141,7 @@ var _ = Describe("Health controller tests", func() {
 				return managedResource.Status.Conditions
 			}).ShouldNot(
 				containCondition(ofType(resourcesv1alpha1.ResourcesHealthy)),
+				containCondition(ofType(resourcesv1alpha1.ResourcesProgressing)),
 			)
 		})
 
@@ -149,6 +155,7 @@ var _ = Describe("Health controller tests", func() {
 				return managedResource.Status.Conditions
 			}).ShouldNot(
 				containCondition(ofType(resourcesv1alpha1.ResourcesHealthy)),
+				containCondition(ofType(resourcesv1alpha1.ResourcesProgressing)),
 			)
 		})
 
@@ -162,11 +169,12 @@ var _ = Describe("Health controller tests", func() {
 				return managedResource.Status.Conditions
 			}).ShouldNot(
 				containCondition(ofType(resourcesv1alpha1.ResourcesHealthy)),
+				containCondition(ofType(resourcesv1alpha1.ResourcesProgressing)),
 			)
 		})
 	})
 
-	Context("resources applied", func() {
+	Describe("Health Reconciler", func() {
 		JustBeforeEach(func() {
 			By("set ManagedResource to be applied successfully")
 			patch := client.MergeFrom(managedResource.DeepCopy())
@@ -296,6 +304,174 @@ var _ = Describe("Health controller tests", func() {
 			})
 		})
 	})
+
+	Describe("Progressing Reconciler", func() {
+		JustBeforeEach(func() {
+			By("set ManagedResource to be applied successfully")
+			patch := client.MergeFrom(managedResource.DeepCopy())
+			setCondition(managedResource, resourcesv1alpha1.ResourcesApplied, gardencorev1beta1.ConditionTrue)
+			Expect(testClient.Status().Patch(ctx, managedResource, patch)).To(Succeed())
+		})
+
+		It("sets Progressing to false as it does not contain any resources of interest", func() {
+			By("add resources to ManagedResource status")
+			patch := client.MergeFrom(managedResource.DeepCopy())
+			managedResource.Status.Resources = []resourcesv1alpha1.ObjectReference{{
+				ObjectReference: corev1.ObjectReference{
+					APIVersion: "v1",
+					Kind:       "ConfigMap",
+					Namespace:  testNamespace.Name,
+					Name:       "non-existing",
+				},
+			}}
+			Expect(testClient.Status().Patch(ctx, managedResource, patch)).To(Succeed())
+
+			Eventually(func(g Gomega) []gardencorev1beta1.Condition {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
+				return managedResource.Status.Conditions
+			}).Should(
+				containCondition(ofType(resourcesv1alpha1.ResourcesProgressing), withStatus(gardencorev1beta1.ConditionFalse), withReason("ResourcesRolledOut")),
+			)
+		})
+
+		It("ignores missing resources", func() {
+			By("add resources to ManagedResource status")
+			patch := client.MergeFrom(managedResource.DeepCopy())
+			managedResource.Status.Resources = []resourcesv1alpha1.ObjectReference{{
+				ObjectReference: corev1.ObjectReference{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Namespace:  testNamespace.Name,
+					Name:       "non-existing",
+				},
+			}}
+			Expect(testClient.Status().Patch(ctx, managedResource, patch)).To(Succeed())
+
+			Eventually(func(g Gomega) []gardencorev1beta1.Condition {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
+				return managedResource.Status.Conditions
+			}).Should(
+				containCondition(ofType(resourcesv1alpha1.ResourcesProgressing), withStatus(gardencorev1beta1.ConditionFalse), withReason("ResourcesRolledOut")),
+			)
+		})
+
+		Context("with existing resources", func() {
+			var (
+				deployment  *appsv1.Deployment
+				statefulSet *appsv1.StatefulSet
+				daemonSet   *appsv1.DaemonSet
+			)
+
+			JustBeforeEach(func() {
+				By("create test resources")
+				deployment = generateDeploymentTestResource(managedResource.Name)
+				deploymentStatus := deployment.Status.DeepCopy()
+				Expect(testClient.Create(ctx, deployment)).To(Succeed())
+				deployment.Status = *deploymentStatus
+				Expect(testClient.Status().Update(ctx, deployment)).To(Succeed())
+				statefulSet = generateStatefulSetTestResource(managedResource.Name)
+				statefulSetStatus := statefulSet.Status.DeepCopy()
+				Expect(testClient.Create(ctx, statefulSet)).To(Succeed())
+				statefulSet.Status = *statefulSetStatus
+				Expect(testClient.Status().Update(ctx, statefulSet)).To(Succeed())
+				daemonSet = generateDaemonSetTestResource(managedResource.Name)
+				daemonSetStatus := daemonSet.Status.DeepCopy()
+				Expect(testClient.Create(ctx, daemonSet)).To(Succeed())
+				daemonSet.Status = *daemonSetStatus
+				Expect(testClient.Status().Update(ctx, daemonSet)).To(Succeed())
+
+				DeferCleanup(func() {
+					By("delete test resources")
+					Expect(testClient.Delete(ctx, deployment)).To(Or(Succeed(), BeNotFoundError()))
+					Expect(testClient.Delete(ctx, statefulSet)).To(Or(Succeed(), BeNotFoundError()))
+					Expect(testClient.Delete(ctx, daemonSet)).To(Or(Succeed(), BeNotFoundError()))
+				})
+
+				By("add resources to ManagedResource status")
+				patch := client.MergeFrom(managedResource.DeepCopy())
+				managedResource.Status.Resources = []resourcesv1alpha1.ObjectReference{
+					{
+						ObjectReference: corev1.ObjectReference{
+							APIVersion: "apps/v1",
+							Kind:       "Deployment",
+							Namespace:  deployment.Namespace,
+							Name:       deployment.Name,
+						},
+					},
+					{
+						ObjectReference: corev1.ObjectReference{
+							APIVersion: "apps/v1",
+							Kind:       "StatefulSet",
+							Namespace:  statefulSet.Namespace,
+							Name:       statefulSet.Name,
+						},
+					},
+					{
+						ObjectReference: corev1.ObjectReference{
+							APIVersion: "apps/v1",
+							Kind:       "DaemonSet",
+							Namespace:  daemonSet.Namespace,
+							Name:       daemonSet.Name,
+						},
+					},
+				}
+				Expect(testClient.Status().Patch(ctx, managedResource, patch)).To(Succeed())
+			})
+
+			It("sets Progressing to false as all resources have been fully rolled out", func() {
+				Eventually(func(g Gomega) []gardencorev1beta1.Condition {
+					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
+					return managedResource.Status.Conditions
+				}).Should(
+					containCondition(ofType(resourcesv1alpha1.ResourcesProgressing), withStatus(gardencorev1beta1.ConditionFalse), withReason("ResourcesRolledOut")),
+				)
+			})
+
+			It("sets Progressing to true as Deployment is not fully rolled out", func() {
+				patch := client.MergeFrom(deployment.DeepCopy())
+				deployment.Status.Conditions = []appsv1.DeploymentCondition{{
+					Type:    appsv1.DeploymentProgressing,
+					Status:  corev1.ConditionFalse,
+					Reason:  "ProgressDeadlineExceeded",
+					Message: `ReplicaSet "nginx-946d57896" has timed out progressing.`,
+				}}
+				Expect(testClient.Status().Patch(ctx, deployment, patch)).To(Succeed())
+
+				Eventually(func(g Gomega) []gardencorev1beta1.Condition {
+					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
+					return managedResource.Status.Conditions
+				}).Should(
+					containCondition(ofType(resourcesv1alpha1.ResourcesProgressing), withStatus(gardencorev1beta1.ConditionTrue), withReason("DeploymentProgressing")),
+				)
+			})
+
+			It("sets Progressing to true as StatefulSet is not fully rolled out", func() {
+				patch := client.MergeFrom(statefulSet.DeepCopy())
+				statefulSet.Status.UpdatedReplicas--
+				Expect(testClient.Status().Patch(ctx, statefulSet, patch)).To(Succeed())
+
+				Eventually(func(g Gomega) []gardencorev1beta1.Condition {
+					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
+					return managedResource.Status.Conditions
+				}).Should(
+					containCondition(ofType(resourcesv1alpha1.ResourcesProgressing), withStatus(gardencorev1beta1.ConditionTrue), withReason("StatefulSetProgressing")),
+				)
+			})
+
+			It("sets Progressing to true as DaemonSet is not fully rolled out", func() {
+				patch := client.MergeFrom(daemonSet.DeepCopy())
+				daemonSet.Status.UpdatedNumberScheduled--
+				Expect(testClient.Status().Patch(ctx, daemonSet, patch)).To(Succeed())
+
+				Eventually(func(g Gomega) []gardencorev1beta1.Condition {
+					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
+					return managedResource.Status.Conditions
+				}).Should(
+					containCondition(ofType(resourcesv1alpha1.ResourcesProgressing), withStatus(gardencorev1beta1.ConditionTrue), withReason("DaemonSetProgressing")),
+				)
+			})
+		})
+	})
 })
 
 func setCondition(managedResource *resourcesv1alpha1.ManagedResource, conditionType gardencorev1beta1.ConditionType, status gardencorev1beta1.ConditionStatus) {
@@ -345,6 +521,99 @@ func generatePodTestResource(name string) *corev1.Pod {
 			// set to non-existing node, so that no kubelet will interfere when testing against existing cluster, so that we
 			// solely control the pod's status
 			NodeName: "non-existing",
+		},
+	}
+}
+
+func generateDeploymentTestResource(name string) *appsv1.Deployment {
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       name,
+			Namespace:  testNamespace.Name,
+			Generation: 42,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: pointer.Int32(1),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"test": "foo",
+				},
+			},
+			Template: generatePodTemplate(),
+		},
+		Status: appsv1.DeploymentStatus{
+			ObservedGeneration: 42,
+			Conditions: []appsv1.DeploymentCondition{{
+				Type:    appsv1.DeploymentProgressing,
+				Status:  corev1.ConditionTrue,
+				Reason:  "NewReplicaSetAvailable",
+				Message: `ReplicaSet "test-foo-abcdef" has successfully progressed.`,
+			}},
+		},
+	}
+}
+
+func generateStatefulSetTestResource(name string) *appsv1.StatefulSet {
+	return &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       name,
+			Namespace:  testNamespace.Name,
+			Generation: 42,
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: pointer.Int32(1),
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"test": "foo",
+				},
+			},
+			Template: generatePodTemplate(),
+		},
+		Status: appsv1.StatefulSetStatus{
+			ObservedGeneration: 42,
+			Replicas:           1,
+			CurrentReplicas:    1,
+			UpdatedReplicas:    1,
+		},
+	}
+}
+
+func generateDaemonSetTestResource(name string) *appsv1.DaemonSet {
+	return &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       name,
+			Namespace:  testNamespace.Name,
+			Generation: 42,
+		},
+		Spec: appsv1.DaemonSetSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"test": "foo",
+				},
+			},
+			Template: generatePodTemplate(),
+		},
+		Status: appsv1.DaemonSetStatus{
+			ObservedGeneration:     42,
+			DesiredNumberScheduled: 1,
+			CurrentNumberScheduled: 1,
+			UpdatedNumberScheduled: 1,
+		},
+	}
+}
+
+func generatePodTemplate() corev1.PodTemplateSpec {
+	return corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{
+			Labels: map[string]string{
+				"test": "foo",
+			},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "test",
+				Image: "ubuntu",
+			}},
 		},
 	}
 }

--- a/test/integration/resourcemanager/managedresource/reconciler_suite_test.go
+++ b/test/integration/resourcemanager/managedresource/reconciler_suite_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/managedresource"
@@ -100,9 +101,11 @@ var _ = BeforeSuite(func() {
 	By("registering controller")
 	filter = predicate.NewClassFilter(managerpredicate.DefaultClass)
 	Expect(managedresource.AddToManagerWithOptions(mgr, managedresource.ControllerConfig{
-		MaxConcurrentWorkers: 1,
-		TargetCluster:        mgr,
-		ClassFilter:          filter,
+		MaxConcurrentWorkers: 5,
+		SyncPeriod:           500 * time.Millisecond, // gotta go fast during tests
+
+		TargetCluster: mgr,
+		ClassFilter:   filter,
 	})).To(Succeed())
 
 	By("starting manager")

--- a/test/integration/resourcemanager/managedresource/reconciler_test.go
+++ b/test/integration/resourcemanager/managedresource/reconciler_test.go
@@ -17,14 +17,12 @@ package reconciler_test
 import (
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/onsi/gomega/gstruct"
 	gomegatypes "github.com/onsi/gomega/types"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardenerv1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllerutils"
@@ -97,7 +95,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 			Eventually(func(g Gomega) {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(BeNotFoundError())
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)).To(BeNotFoundError())
-			}, time.Minute, 5*time.Second).Should(Succeed())
+			}).Should(Succeed())
 
 			Expect(testClient.Delete(ctx, secretForManagedResource)).To(Or(Succeed(), BeNotFoundError()))
 		})
@@ -109,13 +107,13 @@ var _ = Describe("ManagedResource controller tests", func() {
 
 				Eventually(func() error {
 					return testClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)
-				}, time.Minute, time.Second).Should(Succeed())
+				}).Should(Succeed())
 
 				Eventually(func(g Gomega) bool {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 					condition := gardenerv1beta1helper.GetCondition(managedResource.Status.Conditions, resourcesv1alpha1.ResourcesApplied)
 					return condition != nil && condition.Status == gardencorev1beta1.ConditionTrue
-				}, time.Minute, time.Second).Should(BeTrue())
+				}).Should(BeTrue())
 			})
 
 			It("should fail to create the resource due to missing secret reference", func() {
@@ -125,7 +123,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 					condition := gardenerv1beta1helper.GetCondition(managedResource.Status.Conditions, resourcesv1alpha1.ResourcesApplied)
 					return condition != nil && condition.Status == gardencorev1beta1.ConditionFalse && condition.Reason == "CannotReadSecret"
-				}, 30*time.Second, time.Second).Should(BeTrue())
+				}).Should(BeTrue())
 			})
 
 			It("should fail to create the resource due to incorrect object", func() {
@@ -142,7 +140,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 					condition := gardenerv1beta1helper.GetCondition(managedResource.Status.Conditions, resourcesv1alpha1.ResourcesApplied)
 					return condition != nil && condition.Status == gardencorev1beta1.ConditionFalse
-				}, 30*time.Second, time.Second).Should(BeTrue())
+				}).Should(BeTrue())
 			})
 
 			It("should correctly set the condition ResourceApplied to Progressing", func() {
@@ -162,7 +160,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 					condition := gardenerv1beta1helper.GetCondition(managedResource.Status.Conditions, resourcesv1alpha1.ResourcesApplied)
 					return condition != nil && condition.Status == gardencorev1beta1.ConditionTrue
-				}, time.Minute, time.Second).Should(BeTrue())
+				}).Should(BeTrue())
 
 				newConfigMapName := "new-configmap"
 				newConfigMap := &corev1.ConfigMap{
@@ -186,7 +184,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 					condition := gardenerv1beta1helper.GetCondition(managedResource.Status.Conditions, resourcesv1alpha1.ResourcesApplied)
 					return condition != nil && condition.Status == gardencorev1beta1.ConditionProgressing
-				}, time.Minute, time.Second).Should(BeTrue())
+				}).Should(BeTrue())
 
 				Expect(testClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)).To(Or(Succeed(), BeNoMatchError()))
 				configMap.Finalizers = []string{}
@@ -231,7 +229,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 					condition := gardenerv1beta1helper.GetCondition(managedResource.Status.Conditions, resourcesv1alpha1.ResourcesApplied)
 					return condition != nil && condition.Status == gardencorev1beta1.ConditionTrue
-				}, time.Minute, time.Second).Should(BeTrue())
+				}).Should(BeTrue())
 			})
 
 			It("should successfully create a new resource when the secret referenced by the managed resource is updated with data containing the new resource", func() {
@@ -243,13 +241,13 @@ var _ = Describe("ManagedResource controller tests", func() {
 				Eventually(func(g Gomega) {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)).To(Succeed())
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(newResource), newResource)).To(Succeed())
-				}, time.Minute, 5*time.Second).Should(Succeed())
+				}).Should(Succeed())
 
 				Eventually(func(g Gomega) bool {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 					condition := gardenerv1beta1helper.GetCondition(managedResource.Status.Conditions, resourcesv1alpha1.ResourcesApplied)
 					return condition != nil && condition.Status == gardencorev1beta1.ConditionTrue
-				}, time.Minute, time.Second).Should(BeTrue())
+				}).Should(BeTrue())
 			})
 
 			It("should successfully update the managed resource with a new secret reference", func() {
@@ -275,22 +273,20 @@ var _ = Describe("ManagedResource controller tests", func() {
 					Data: data,
 				}
 
-				managedResource.Spec.SecretRefs = append(managedResource.Spec.SecretRefs, corev1.LocalObjectReference{Name: newSecretForManagedResource.Name})
-				metav1.SetMetaDataAnnotation(&managedResource.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
-
 				Expect(testClient.Create(ctx, newSecretForManagedResource)).To(Succeed())
+				managedResource.Spec.SecretRefs = append(managedResource.Spec.SecretRefs, corev1.LocalObjectReference{Name: newSecretForManagedResource.Name})
 				Expect(testClient.Update(ctx, managedResource)).To(Succeed())
 
 				Eventually(func(g Gomega) {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)).To(Succeed())
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(newConfigMap), newConfigMap)).To(Succeed())
-				}, time.Minute, 5*time.Second).Should(Succeed())
+				}).Should(Succeed())
 
 				Eventually(func(g Gomega) bool {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 					condition := gardenerv1beta1helper.GetCondition(managedResource.Status.Conditions, resourcesv1alpha1.ResourcesApplied)
 					return condition != nil && condition.Status == gardencorev1beta1.ConditionTrue
-				}, time.Minute, time.Second).Should(BeTrue())
+				}).Should(BeTrue())
 			})
 
 			It("should fail to update the managed resource if a new incorrect resource is added to the secret referenced by the managed resource", func() {
@@ -306,7 +302,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 					condition := gardenerv1beta1helper.GetCondition(managedResource.Status.Conditions, resourcesv1alpha1.ResourcesApplied)
 					return condition != nil && condition.Status == gardencorev1beta1.ConditionFalse
-				}, time.Minute, time.Second).Should(BeTrue())
+				}).Should(BeTrue())
 			})
 		})
 
@@ -380,7 +376,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 			Eventually(func(g Gomega) {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(BeNotFoundError())
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)).To(BeNotFoundError())
-			}, time.Minute, 5*time.Second).Should(Succeed())
+			}).Should(Succeed())
 
 			Expect(testClient.Delete(ctx, secretForManagedResource)).To(Or(Succeed(), BeNotFoundError()))
 		})
@@ -434,7 +430,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 				Expect(testClient.Delete(ctx, managedResource)).To(Or(Succeed(), BeNotFoundError()))
 				Eventually(func(g Gomega) {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(BeNotFoundError())
-				}, time.Minute, 5*time.Second).Should(Succeed())
+				}).Should(Succeed())
 
 				Expect(testClient.Delete(ctx, secretForManagedResource)).To(Or(Succeed(), BeNotFoundError()))
 			})
@@ -457,7 +453,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 					condition := gardenerv1beta1helper.GetCondition(managedResource.Status.Conditions, resourcesv1alpha1.ResourcesApplied)
 					return condition != nil && condition.Status == gardencorev1beta1.ConditionTrue
-				}, time.Minute, time.Second).Should(BeTrue())
+				}).Should(BeTrue())
 
 				Consistently(func(g Gomega) {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)).To(BeNotFoundError())
@@ -484,7 +480,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 					condition := gardenerv1beta1helper.GetCondition(managedResource.Status.Conditions, resourcesv1alpha1.ResourcesApplied)
 					return condition != nil && condition.Status == gardencorev1beta1.ConditionTrue
-				}, time.Minute, time.Second).Should(BeTrue())
+				}).Should(BeTrue())
 			})
 
 			It("should not delete the resource on valid update", func() {
@@ -498,13 +494,13 @@ var _ = Describe("ManagedResource controller tests", func() {
 
 				Eventually(func(g Gomega) {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)).To(Succeed())
-				}, time.Minute, 5*time.Second).Should(Succeed())
+				}).Should(Succeed())
 
 				Eventually(func(g Gomega) bool {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 					condition := gardenerv1beta1helper.GetCondition(managedResource.Status.Conditions, resourcesv1alpha1.ResourcesApplied)
 					return condition != nil && condition.Status == gardencorev1beta1.ConditionTrue
-				}, time.Minute, time.Second).Should(BeTrue())
+				}).Should(BeTrue())
 			})
 
 			It("should delete the resource on invalid update", func() {
@@ -521,7 +517,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 					condition := gardenerv1beta1helper.GetCondition(managedResource.Status.Conditions, resourcesv1alpha1.ResourcesApplied)
 					return condition != nil && condition.Status == gardencorev1beta1.ConditionFalse
-				}, time.Minute, time.Second).Should(BeTrue())
+				}).Should(BeTrue())
 
 				Consistently(func(g Gomega) {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)).To(BeNotFoundError())
@@ -548,20 +544,18 @@ var _ = Describe("ManagedResource controller tests", func() {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 					condition := gardenerv1beta1helper.GetCondition(managedResource.Status.Conditions, resourcesv1alpha1.ResourcesApplied)
 					return condition != nil && condition.Status == gardencorev1beta1.ConditionTrue
-				}, time.Minute, time.Second).Should(BeTrue())
+				}).Should(BeTrue())
 			})
 
 			It("should keep the object in case it is removed from the MangedResource", func() {
 				managedResource.Spec.SecretRefs = []corev1.LocalObjectReference{}
-				metav1.SetMetaDataAnnotation(&managedResource.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
-
 				Expect(testClient.Update(ctx, managedResource)).To(Succeed())
 
 				Eventually(func(g Gomega) bool {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 					condition := gardenerv1beta1helper.GetCondition(managedResource.Status.Conditions, resourcesv1alpha1.ResourcesApplied)
 					return condition != nil && condition.Status == gardencorev1beta1.ConditionTrue
-				}, time.Minute, time.Second).Should(BeTrue())
+				}).Should(BeTrue())
 
 				Consistently(func(g Gomega) {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)).To(Succeed())
@@ -572,7 +566,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 				Expect(testClient.Delete(ctx, managedResource)).To(Or(Succeed(), BeNotFoundError()))
 				Eventually(func(g Gomega) {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(BeNotFoundError())
-				}, time.Minute, 5*time.Second).Should(Succeed())
+				}).Should(Succeed())
 
 				Expect(testClient.Delete(ctx, secretForManagedResource)).To(Or(Succeed(), BeNotFoundError()))
 				Expect(testClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)).To(Succeed())
@@ -596,7 +590,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 					condition := gardenerv1beta1helper.GetCondition(managedResource.Status.Conditions, resourcesv1alpha1.ResourcesApplied)
 					return condition != nil && condition.Status == gardencorev1beta1.ConditionTrue
-				}, time.Minute, time.Second).Should(BeTrue())
+				}).Should(BeTrue())
 
 				Expect(testClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)).To(Succeed())
 
@@ -607,7 +601,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 					condition := gardenerv1beta1helper.GetCondition(managedResource.Status.Conditions, resourcesv1alpha1.ResourcesApplied)
 					return condition != nil && condition.Status == gardencorev1beta1.ConditionTrue
-				}, time.Minute, time.Second).Should(BeTrue())
+				}).Should(BeTrue())
 
 				Consistently(func(g Gomega) bool {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)).To(Succeed())
@@ -623,7 +617,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 					condition := gardenerv1beta1helper.GetCondition(managedResource.Status.Conditions, resourcesv1alpha1.ResourcesApplied)
 					return condition != nil && condition.Status == gardencorev1beta1.ConditionTrue
-				}, time.Minute, time.Second).Should(BeTrue())
+				}).Should(BeTrue())
 
 				Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 				managedResource.SetAnnotations(map[string]string{resourcesv1alpha1.Ignore: "true"})
@@ -637,7 +631,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 					condition := gardenerv1beta1helper.GetCondition(managedResource.Status.Conditions, resourcesv1alpha1.ResourcesApplied)
 					return condition != nil && condition.Status == gardencorev1beta1.ConditionTrue
-				}, time.Minute, time.Second).Should(BeTrue())
+				}).Should(BeTrue())
 
 				Consistently(func(g Gomega) bool {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)).To(Succeed())
@@ -707,7 +701,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 			Eventually(func(g Gomega) bool {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)).To(Succeed())
 				return deployment.Finalizers != nil && len(deployment.Finalizers) == 1
-			}, time.Minute, time.Second).Should(BeTrue())
+			}).Should(BeTrue())
 
 			// remove finalizer so the deployment can be deleted
 			Expect(controllerutils.PatchRemoveFinalizers(ctx, testClient, deployment, "foregroundDeletion")).To(BeNil())
@@ -715,7 +709,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 			Eventually(func(g Gomega) {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)).To(BeNotFoundError())
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(BeNotFoundError())
-			}, time.Minute, 5*time.Second).Should(Succeed())
+			}).Should(Succeed())
 
 			Expect(testClient.Delete(ctx, secretForManagedResource)).To(Or(Succeed(), BeNotFoundError()))
 		})
@@ -734,20 +728,17 @@ var _ = Describe("ManagedResource controller tests", func() {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 					condition := gardenerv1beta1helper.GetCondition(managedResource.Status.Conditions, resourcesv1alpha1.ResourcesApplied)
 					return condition != nil && condition.Status == gardencorev1beta1.ConditionTrue
-				}, time.Minute, time.Second).Should(BeTrue())
+				}).Should(BeTrue())
 
 				Expect(testClient.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)).To(Succeed())
 				updatedDeployment := deployment.DeepCopy()
 				updatedDeployment.Spec.Replicas = pointer.Int32Ptr(5)
 				Expect(testClient.Update(ctx, updatedDeployment)).To(Succeed())
 
-				metav1.SetMetaDataAnnotation(&managedResource.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
-				Expect(testClient.Update(ctx, managedResource)).To(Succeed())
-
 				Eventually(func(g Gomega) bool {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)).To(Succeed())
 					return *deployment.Spec.Replicas == int32(1)
-				}, time.Minute, time.Second).Should(BeTrue())
+				}).Should(BeTrue())
 			})
 
 			It("should preserve changes in the number of replicas if the resource has preserve-replicas annotation", func() {
@@ -764,15 +755,12 @@ var _ = Describe("ManagedResource controller tests", func() {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 					condition := gardenerv1beta1helper.GetCondition(managedResource.Status.Conditions, resourcesv1alpha1.ResourcesApplied)
 					return condition != nil && condition.Status == gardencorev1beta1.ConditionTrue
-				}, time.Minute, time.Second).Should(BeTrue())
+				}).Should(BeTrue())
 
 				Expect(testClient.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)).To(Succeed())
 				updatedDeployment := deployment.DeepCopy()
 				updatedDeployment.Spec.Replicas = pointer.Int32Ptr(5)
 				Expect(testClient.Update(ctx, updatedDeployment)).To(Succeed())
-
-				metav1.SetMetaDataAnnotation(&managedResource.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
-				Expect(testClient.Update(ctx, managedResource)).To(Succeed())
 
 				Consistently(func(g Gomega) bool {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)).To(Succeed())
@@ -825,20 +813,17 @@ var _ = Describe("ManagedResource controller tests", func() {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 					condition := gardenerv1beta1helper.GetCondition(managedResource.Status.Conditions, resourcesv1alpha1.ResourcesApplied)
 					return condition != nil && condition.Status == gardencorev1beta1.ConditionTrue
-				}, time.Minute, time.Second).Should(BeTrue())
+				}).Should(BeTrue())
 
 				Expect(testClient.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)).To(Succeed())
 				updatedDeployment := deployment.DeepCopy()
 				updatedDeployment.Spec.Template = *newPodTemplateSpec
 				Expect(testClient.Update(ctx, updatedDeployment)).To(Succeed())
 
-				metav1.SetMetaDataAnnotation(&managedResource.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
-				Expect(testClient.Update(ctx, managedResource)).To(Succeed())
-
 				Eventually(func(g Gomega) bool {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)).To(Succeed())
 					return compareResource(deployment.Spec.Template.Spec.Containers[0].Resources, defaultPodTemplateSpec.Spec.Containers[0].Resources)
-				}, time.Minute, time.Second).Should(BeTrue())
+				}).Should(BeTrue())
 			})
 
 			It("should preserve changes in resource requests and limits in Pod if the resource has preserve-resources annotation", func() {
@@ -855,15 +840,12 @@ var _ = Describe("ManagedResource controller tests", func() {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 					condition := gardenerv1beta1helper.GetCondition(managedResource.Status.Conditions, resourcesv1alpha1.ResourcesApplied)
 					return condition != nil && condition.Status == gardencorev1beta1.ConditionTrue
-				}, time.Minute, time.Second).Should(BeTrue())
+				}).Should(BeTrue())
 
 				Expect(testClient.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)).To(Succeed())
 				updatedDeployment := deployment.DeepCopy()
 				updatedDeployment.Spec.Template = *newPodTemplateSpec
 				Expect(testClient.Update(ctx, updatedDeployment)).To(Succeed())
-
-				metav1.SetMetaDataAnnotation(&managedResource.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
-				Expect(testClient.Update(ctx, managedResource)).To(Succeed())
 
 				Consistently(func(g Gomega) bool {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)).To(Succeed())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:

Add `ResourcesProgressing` condition to `ManagedResources` (first step of https://github.com/gardener/gardener/issues/5850#issuecomment-1108251803).
Will be read by the seed care controller soon, but can also be used waiting for `ManagedResources` targeting shoots to be fully rolled out later on.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/5850

**Special notes for your reviewer**:

I improved a few things along the way:

- Harmonize logging across all resource-manager controllers (ref https://github.com/gardener/gardener/issues/4251)
- Move condition update on deletion to resource controller to prevent unneeded conflicts between controllers
- Speed up resource controller integration test (ref https://github.com/gardener/gardener/issues/4805, https://github.com/gardener/gardener/pull/5610 etc.)
- Improve conditions handling for ignored ManagedResources (previously health checks continued to be executed even if `ManagedResource` was marked as ignored, ref https://github.com/gardener/gardener/pull/5556)

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
The status of `ManagedResources` now contains a new condition of type `ResourcesProgressing` which can be used to detect whether updates to managed resources have been fully rolled out.
```
