### PR TITLE
Fix handling of automatic pull requests for container image updates of vpn2 repo.

### DIFF
--- a/hack/.ci/set_dependency_version
+++ b/hack/.ci/set_dependency_version
@@ -110,7 +110,7 @@ if name == 'autoscaler':
 elif name == 'vpn':
     names = ['vpn-seed', 'vpn-shoot']
 elif name == 'vpn2':
-    names = ['vpn-seed-server']
+    names = ['vpn-seed-server', 'vpn-shoot-client']
 elif name == 'external-dns-management':
     names = ['dns-controller-manager']
 elif name == 'logging':


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Fix handling of automatic pull requests for container image updates of vpn2 repo.

The vpn2 repository contains multiple container images. They need to be distinguished
so that the automatic pull request does the needful.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
