### PR TITLE
Fix contorlplane migration integration test

### DIFF
--- a/test/framework/gardener_utils.go
+++ b/test/framework/gardener_utils.go
@@ -60,10 +60,8 @@ func (f *GardenerFramework) GetSeed(ctx context.Context, seedName string) (*gard
 		return seed, nil, nil
 	}
 
-	seedClient, err := kubernetes.NewClientFromSecret(ctx, f.GardenClient.Client(), seedSecretRef.Namespace, seedSecretRef.Name, kubernetes.WithClientOptions(
-		client.Options{
-			Scheme: kubernetes.SeedScheme,
-		}),
+	seedClient, err := kubernetes.NewClientFromSecret(ctx, f.GardenClient.Client(), seedSecretRef.Namespace, seedSecretRef.Name,
+		kubernetes.WithClientOptions(client.Options{Scheme: kubernetes.SeedScheme}),
 		kubernetes.WithDisabledCachedClient(),
 	)
 	if err != nil {

--- a/test/framework/gardenerframework.go
+++ b/test/framework/gardenerframework.go
@@ -88,10 +88,8 @@ func NewGardenerFrameworkFromConfig(cfg *GardenerConfig) *GardenerFramework {
 func (f *GardenerFramework) BeforeEach() {
 	f.GardenerFrameworkConfig = mergeGardenerConfig(f.GardenerFrameworkConfig, gardenerCfg)
 	validateGardenerConfig(f.GardenerFrameworkConfig)
-	gardenClient, err := kubernetes.NewClientFromFile("", f.GardenerFrameworkConfig.GardenerKubeconfig, kubernetes.WithClientOptions(
-		client.Options{
-			Scheme: kubernetes.GardenScheme,
-		}),
+	gardenClient, err := kubernetes.NewClientFromFile("", f.GardenerFrameworkConfig.GardenerKubeconfig,
+		kubernetes.WithClientOptions(client.Options{Scheme: kubernetes.GardenScheme}),
 		kubernetes.WithAllowedUserFields([]string{kubernetes.AuthTokenFile}),
 		kubernetes.WithDisabledCachedClient(),
 	)

--- a/test/framework/k8s_utils.go
+++ b/test/framework/k8s_utils.go
@@ -393,10 +393,7 @@ func NewClientFromServiceAccount(ctx context.Context, k8sClient kubernetes.Inter
 
 	return kubernetes.NewWithConfig(
 		kubernetes.WithRESTConfig(serviceAccountConfig),
-		kubernetes.WithClientOptions(
-			client.Options{
-				Scheme: kubernetes.GardenScheme,
-			}),
+		kubernetes.WithClientOptions(client.Options{Scheme: kubernetes.GardenScheme}),
 		kubernetes.WithDisabledCachedClient(),
 	)
 }

--- a/test/framework/shootframework.go
+++ b/test/framework/shootframework.go
@@ -210,10 +210,8 @@ func (f *ShootFramework) AddShoot(ctx context.Context, shootName, shootNamespace
 
 	if !f.GardenerFrameworkConfig.SkipAccessingShoot {
 		if err := retry.UntilTimeout(ctx, k8sClientInitPollInterval, k8sClientInitTimeout, func(ctx context.Context) (bool, error) {
-			shootClient, err = kubernetes.NewClientFromSecret(ctx, f.GardenClient.Client(), shoot.Namespace, shoot.Name+"."+gutil.ShootProjectSecretSuffixKubeconfig, kubernetes.WithClientOptions(
-				client.Options{
-					Scheme: kubernetes.ShootScheme,
-				}),
+			shootClient, err = kubernetes.NewClientFromSecret(ctx, f.GardenClient.Client(), shoot.Namespace, shoot.Name+"."+gutil.ShootProjectSecretSuffixKubeconfig,
+				kubernetes.WithClientOptions(client.Options{Scheme: kubernetes.ShootScheme}),
 				kubernetes.WithDisabledCachedClient(),
 			)
 			if err != nil {

--- a/test/testmachinery/system/shoot_cp_migration/migrate_test.go
+++ b/test/testmachinery/system/shoot_cp_migration/migrate_test.go
@@ -134,9 +134,10 @@ func initShootAndClient(ctx context.Context, t *ShootMigrationTest) (err error) 
 		}
 		t.GardenerFramework.Logger.Info("Shoot kubeconfig secret was fetched successfully")
 
-		t.ShootClient, err = kubernetes.NewClientFromSecret(ctx, t.GardenerFramework.GardenClient.Client(), kubecfgSecret.Namespace, kubecfgSecret.Name, kubernetes.WithClientOptions(client.Options{
-			Scheme: kubernetes.ShootScheme,
-		}))
+		t.ShootClient, err = kubernetes.NewClientFromSecret(ctx, t.GardenerFramework.GardenClient.Client(), kubecfgSecret.Namespace, kubecfgSecret.Name,
+			kubernetes.WithClientOptions(client.Options{Scheme: kubernetes.ShootScheme}),
+			kubernetes.WithDisabledCachedClient(),
+		)
 	}
 	t.Shoot = *shoot
 	return


### PR DESCRIPTION
/area control-plane-migration
/area testing
/kind bug

Currently the test always fails with:
```
2022-05-01 18:17:33  In [JustBeforeEach] at: /src/test/testmachinery/system/shoot_cp_migration/migrate_test.go:95
2022-05-01 18:17:33  The Shoot CP Migration preparation steps failed with: the cache is not started, can not read objects
```

https://github.com/gardener/gardener/pull/5752 didn't adapt the CP migration test.

With this PR:
```
Ran 1 of 1 Specs in 809.964 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestCPMigrationApplications (809.96s)
PASS
ok  	github.com/gardener/gardener/test/testmachinery/system/shoot_cp_migration	810.862s
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
An issue causing the controlplane migration integration tests to always fail is now fixed.
```
