### PR TITLE
Use `--kubeconfig` flag for VPA recommender and updater

### DIFF
--- a/pkg/operation/botanist/component/vpa/admissioncontroller.go
+++ b/pkg/operation/botanist/component/vpa/admissioncontroller.go
@@ -269,7 +269,7 @@ func (v *vpa) reconcileAdmissionControllerDeployment(deployment *appsv1.Deployme
 		})
 	}
 
-	v.injectAPIServerConnectionSpec(deployment, admissionController, serviceAccountName, nil)
+	v.injectAPIServerConnectionSpec(deployment, admissionController, serviceAccountName)
 }
 
 func (v *vpa) reconcileAdmissionControllerVPA(vpa *vpaautoscalingv1.VerticalPodAutoscaler, deployment *appsv1.Deployment) {

--- a/pkg/operation/botanist/component/vpa/admissioncontroller.go
+++ b/pkg/operation/botanist/component/vpa/admissioncontroller.go
@@ -21,7 +21,6 @@ import (
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/kubeapiserver"
 	"github.com/gardener/gardener/pkg/utils"
-	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	secretutils "github.com/gardener/gardener/pkg/utils/secrets"
 
@@ -270,7 +269,7 @@ func (v *vpa) reconcileAdmissionControllerDeployment(deployment *appsv1.Deployme
 		})
 	}
 
-	v.injectAPIServerConnectionSpec(deployment, admissionController, serviceAccountName, v.genericTokenKubeconfigSecretName)
+	v.injectAPIServerConnectionSpec(deployment, admissionController, serviceAccountName, nil)
 }
 
 func (v *vpa) reconcileAdmissionControllerVPA(vpa *vpaautoscalingv1.VerticalPodAutoscaler, deployment *appsv1.Deployment) {
@@ -300,10 +299,8 @@ func (v *vpa) reconcileAdmissionControllerVPA(vpa *vpaautoscalingv1.VerticalPodA
 }
 
 func (v *vpa) computeAdmissionControllerCommands() []string {
+	// TODO(shafeeqes): add --kubeconfig flag also, after https://github.com/kubernetes/autoscaler/issues/4844 is fixed.
 	out := []string{"./admission-controller"}
 
-	if v.values.ClusterType == ClusterTypeShoot {
-		out = append(out, "--kubeconfig="+gutil.PathGenericKubeconfig)
-	}
 	return out
 }

--- a/pkg/operation/botanist/component/vpa/recommender.go
+++ b/pkg/operation/botanist/component/vpa/recommender.go
@@ -199,7 +199,7 @@ func (v *vpa) reconcileRecommenderDeployment(deployment *appsv1.Deployment, serv
 		})
 	}
 
-	v.injectAPIServerConnectionSpec(deployment, recommender, serviceAccountName, v.genericTokenKubeconfigSecretName)
+	v.injectAPIServerConnectionSpec(deployment, recommender, serviceAccountName)
 }
 
 func (v *vpa) reconcileRecommenderVPA(vpa *vpaautoscalingv1.VerticalPodAutoscaler, deployment *appsv1.Deployment) {

--- a/pkg/operation/botanist/component/vpa/updater.go
+++ b/pkg/operation/botanist/component/vpa/updater.go
@@ -184,7 +184,7 @@ func (v *vpa) reconcileUpdaterDeployment(deployment *appsv1.Deployment, serviceA
 		})
 	}
 
-	v.injectAPIServerConnectionSpec(deployment, updater, serviceAccountName, v.genericTokenKubeconfigSecretName)
+	v.injectAPIServerConnectionSpec(deployment, updater, serviceAccountName)
 }
 
 func (v *vpa) reconcileUpdaterVPA(vpa *vpaautoscalingv1.VerticalPodAutoscaler, deployment *appsv1.Deployment) {

--- a/pkg/operation/botanist/component/vpa/vpa.go
+++ b/pkg/operation/botanist/component/vpa/vpa.go
@@ -398,7 +398,7 @@ func mergeResourceConfigs(configsLists ...resourceConfigs) resourceConfigs {
 	return out
 }
 
-func (v *vpa) injectAPIServerConnectionSpec(deployment *appsv1.Deployment, name string, serviceAccountName, genericTokenKubeconfigSecretName *string) {
+func (v *vpa) injectAPIServerConnectionSpec(deployment *appsv1.Deployment, name string, serviceAccountName *string) {
 	if serviceAccountName != nil {
 		deployment.Spec.Template.Spec.ServiceAccountName = *serviceAccountName
 
@@ -415,9 +415,9 @@ func (v *vpa) injectAPIServerConnectionSpec(deployment *appsv1.Deployment, name 
 	} else {
 		deployment.Spec.Template.Spec.AutomountServiceAccountToken = pointer.Bool(false)
 
-		// TODO(shafeeqes): Adapt admssion-controller to use kubeconfig too, after https://github.com/kubernetes/autoscaler/issues/4844 is fixed.
-		if genericTokenKubeconfigSecretName != nil {
-			utilruntime.Must(gutil.InjectGenericKubeconfig(deployment, *genericTokenKubeconfigSecretName, gutil.GetShootAccessSecretName(deployment.Name)))
+		// TODO(shafeeqes): Adapt admission-controller to use kubeconfig too, after https://github.com/kubernetes/autoscaler/issues/4844 is fixed.
+		if name != admissionController {
+			utilruntime.Must(gutil.InjectGenericKubeconfig(deployment, *v.genericTokenKubeconfigSecretName, gutil.SecretNamePrefixShootAccess+deployment.Name))
 		} else {
 			deployment.Spec.Template.Spec.Containers[0].Env = append(deployment.Spec.Template.Spec.Containers[0].Env,
 				corev1.EnvVar{

--- a/pkg/operation/botanist/component/vpa/vpa.go
+++ b/pkg/operation/botanist/component/vpa/vpa.go
@@ -17,12 +17,15 @@ package vpa
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
+	"github.com/gardener/gardener/pkg/operation/botanist/component/kubeapiserver"
 	"github.com/gardener/gardener/pkg/utils"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -412,8 +415,58 @@ func (v *vpa) injectAPIServerConnectionSpec(deployment *appsv1.Deployment, name 
 	} else {
 		deployment.Spec.Template.Spec.AutomountServiceAccountToken = pointer.Bool(false)
 
+		// TODO(shafeeqes): Adapt admssion-controller to use kubeconfig too, after https://github.com/kubernetes/autoscaler/issues/4844 is fixed.
 		if genericTokenKubeconfigSecretName != nil {
 			utilruntime.Must(gutil.InjectGenericKubeconfig(deployment, *genericTokenKubeconfigSecretName, gutil.GetShootAccessSecretName(deployment.Name)))
+		} else {
+			deployment.Spec.Template.Spec.Containers[0].Env = append(deployment.Spec.Template.Spec.Containers[0].Env,
+				corev1.EnvVar{
+					Name:  "KUBERNETES_SERVICE_HOST",
+					Value: v1beta1constants.DeploymentNameKubeAPIServer,
+				},
+				corev1.EnvVar{
+					Name:  "KUBERNETES_SERVICE_PORT",
+					Value: strconv.Itoa(kubeapiserver.Port),
+				},
+			)
+			deployment.Spec.Template.Spec.Volumes = append(deployment.Spec.Template.Spec.Volumes, corev1.Volume{
+				Name: "shoot-access",
+				VolumeSource: corev1.VolumeSource{
+					Projected: &corev1.ProjectedVolumeSource{
+						DefaultMode: pointer.Int32(420),
+						Sources: []corev1.VolumeProjection{
+							{
+								Secret: &corev1.SecretProjection{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: v.caSecretName,
+									},
+									Items: []corev1.KeyToPath{{
+										Key:  secretutils.DataKeyCertificateBundle,
+										Path: "ca.crt",
+									}},
+								},
+							},
+							{
+								Secret: &corev1.SecretProjection{
+									LocalObjectReference: corev1.LocalObjectReference{
+										Name: gutil.SecretNamePrefixShootAccess + name,
+									},
+									Items: []corev1.KeyToPath{{
+										Key:  resourcesv1alpha1.DataKeyToken,
+										Path: "token",
+									}},
+									Optional: pointer.Bool(false),
+								},
+							},
+						},
+					},
+				},
+			})
+			deployment.Spec.Template.Spec.Containers[0].VolumeMounts = append(deployment.Spec.Template.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{
+				Name:      "shoot-access",
+				MountPath: "/var/run/secrets/kubernetes.io/serviceaccount",
+				ReadOnly:  true,
+			})
 		}
 	}
 }

--- a/pkg/utils/gardener/shoot.go
+++ b/pkg/utils/gardener/shoot.go
@@ -236,19 +236,23 @@ type ShootAccessSecret struct {
 // with for the given name and namespace. If not already done, the name will be prefixed with the
 // SecretNamePrefixShootAccess. The ServiceAccountName field will be defaulted with the name.
 func NewShootAccessSecret(name, namespace string) *ShootAccessSecret {
-	if !strings.HasPrefix(name, SecretNamePrefixShootAccess) {
-		name = SecretNamePrefixShootAccess + name
-	}
-
 	return &ShootAccessSecret{
 		Secret: &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
+				Name:      GetShootAccessSecretName(name),
 				Namespace: namespace,
 			},
 		},
 		ServiceAccountName: strings.TrimPrefix(name, SecretNamePrefixShootAccess),
 	}
+}
+
+// GetShootAccessSecretName returns the name for the ShootAccessSecret with SecretNamePrefixShootAccess.
+func GetShootAccessSecretName(name string) string {
+	if !strings.HasPrefix(name, SecretNamePrefixShootAccess) {
+		return SecretNamePrefixShootAccess + name
+	}
+	return name
 }
 
 // WithNameOverride sets the ObjectMeta.Name field of the *corev1.Secret inside the ShootAccessSecret.

--- a/pkg/utils/gardener/shoot.go
+++ b/pkg/utils/gardener/shoot.go
@@ -236,23 +236,19 @@ type ShootAccessSecret struct {
 // with for the given name and namespace. If not already done, the name will be prefixed with the
 // SecretNamePrefixShootAccess. The ServiceAccountName field will be defaulted with the name.
 func NewShootAccessSecret(name, namespace string) *ShootAccessSecret {
+	if !strings.HasPrefix(name, SecretNamePrefixShootAccess) {
+		name = SecretNamePrefixShootAccess + name
+	}
+
 	return &ShootAccessSecret{
 		Secret: &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      GetShootAccessSecretName(name),
+				Name:      name,
 				Namespace: namespace,
 			},
 		},
 		ServiceAccountName: strings.TrimPrefix(name, SecretNamePrefixShootAccess),
 	}
-}
-
-// GetShootAccessSecretName returns the name for the ShootAccessSecret with SecretNamePrefixShootAccess.
-func GetShootAccessSecretName(name string) string {
-	if !strings.HasPrefix(name, SecretNamePrefixShootAccess) {
-		return SecretNamePrefixShootAccess + name
-	}
-	return name
 }
 
 // WithNameOverride sets the ObjectMeta.Name field of the *corev1.Secret inside the ShootAccessSecret.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind cleanup

**What this PR does / why we need it**:
With #5716, it's now possible to use `--kubeconfig` flag to pass the generic-token-kubeconfig to the components.
This PR adapts the same for VPA recommender and updater.
Admission controller is not included in this PR because of https://github.com/kubernetes/autoscaler/issues/4844.
 
**Which issue(s) this PR fixes**:
Fixes #5824 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
