### PR TITLE
Update apiserver-proxy to v0.4.0 and adapt dependency script so that automatic pull requests should do the right thing.

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -272,8 +272,8 @@ images:
 - name: apiserver-proxy-sidecar
   sourceRepository: github.com/gardener/apiserver-proxy
   repository: eu.gcr.io/gardener-project/gardener/apiserver-proxy
-  tag: "v0.3.0"
+  tag: "v0.4.0"
 - name: apiserver-proxy-pod-webhook
   sourceRepository: github.com/gardener/apiserver-proxy
   repository: eu.gcr.io/gardener-project/gardener/apiserver-proxy-pod-webhook
-  tag: "v0.3.0"
+  tag: "v0.4.0"

--- a/hack/.ci/set_dependency_version
+++ b/hack/.ci/set_dependency_version
@@ -119,6 +119,8 @@ elif name == 'etcd-custom-image':
     names = ['etcd']
 elif name == 'egress-filter-refresher':
     names = ['egress-filter-blackholer', 'egress-filter-firewaller']
+elif name == 'apiserver-proxy':
+    names = ['apiserver-proxy-sidecar', 'apiserver-proxy-pod-webhook']
 else:
     names = [name]
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Update apiserver-proxy to v0.4.0 and adapt dependency script so that automatic pull requests should do the right thing.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
