### PR TITLE
Remove gardenlet memory limit

### DIFF
--- a/charts/gardener/gardenlet/values.yaml
+++ b/charts/gardener/gardenlet/values.yaml
@@ -14,8 +14,6 @@ global:
       requests:
         cpu: 100m
         memory: 100Mi
-      limits:
-        memory: 512Mi
   # podAnnotations: # YAML formated annotations used for pod template
   # podLabels: # YAML formated labels used for pod template
     additionalVolumes: []

--- a/pkg/gardenlet/controller/managedseed/charttest/charttest.go
+++ b/pkg/gardenlet/controller/managedseed/charttest/charttest.go
@@ -954,9 +954,6 @@ func ComputeExpectedGardenletDeploymentSpec(
 							FailureThreshold:    3,
 						},
 						Resources: corev1.ResourceRequirements{
-							Limits: corev1.ResourceList{
-								corev1.ResourceMemory: resource.MustParse("512Mi"),
-							},
 							Requests: corev1.ResourceList{
 								corev1.ResourceCPU:    resource.MustParse("100m"),
 								corev1.ResourceMemory: resource.MustParse("100Mi"),
@@ -1030,9 +1027,15 @@ func ComputeExpectedGardenletDeploymentSpec(
 			}
 
 			if value, ok := deploymentConfiguration.Resources.Limits[corev1.ResourceCPU]; ok {
+				if deployment.Template.Spec.Containers[0].Resources.Limits == nil {
+					deployment.Template.Spec.Containers[0].Resources.Limits = map[corev1.ResourceName]resource.Quantity{}
+				}
 				deployment.Template.Spec.Containers[0].Resources.Limits[corev1.ResourceCPU] = value
 			}
 			if value, ok := deploymentConfiguration.Resources.Limits[corev1.ResourceMemory]; ok {
+				if deployment.Template.Spec.Containers[0].Resources.Limits == nil {
+					deployment.Template.Spec.Containers[0].Resources.Limits = map[corev1.ResourceName]resource.Quantity{}
+				}
 				deployment.Template.Spec.Containers[0].Resources.Limits[corev1.ResourceMemory] = value
 			}
 		}


### PR DESCRIPTION
**How to categorize this PR?**
/area auto-scaling
/area robustness
/kind enhancement

**What this PR does / why we need it**:
Removes gardenlet memory limit according to measured usage to prevent OOMKills due to reaching the limits.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
This is an urgent fix to alleviate immediate pain. Will be followed by comprehensive research of what other memory limits need to be removed.

**Release note**:
```other operator
Gardenlet memory limit was removed, according to measured usage, to prevent OOMKills due to reaching the limits.
```
