### PR TITLE
[ci:component:github.com/gardener/etcd-druid:v0.8.2->v0.8.3]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -30,7 +30,7 @@ images:
 - name: etcd-druid
   sourceRepository: github.com/gardener/etcd-druid
   repository: eu.gcr.io/gardener-project/gardener/etcd-druid
-  tag: "v0.8.2"
+  tag: "v0.8.3"
 - name: dependency-watchdog
   sourceRepository: github.com/gardener/dependency-watchdog
   repository: eu.gcr.io/gardener-project/gardener/dependency-watchdog


### PR DESCRIPTION
**How to categorize this PR?**

/area TODO
/kind TODO

**What this PR does / why we need it**:
Upgrade the etcd-druid image from v0.8.2 to v0.8.3

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
``` bugfix operator [gardener/etcd-backup-restore#467](https://github.com/gardener/etcd-backup-restore/pull/467),  @ishan16696
Throw Fatal error to avoid edge case potential deadlocks.
```
```others operator ([gardener/etcd-backup-restore#470](https://github.com/gardener/etcd-backup-restore/pull/470) @abdasgupta 
ETCD won't restart from the PVC if it is wrongly mounted to the pod
```
