### PR TITLE
Remove etcd-pod resource limits for old clusters (already have limits) 

### DIFF
--- a/pkg/operation/botanist/component/etcd/etcd.go
+++ b/pkg/operation/botanist/component/etcd/etcd.go
@@ -698,9 +698,13 @@ func (e *etcd) computeContainerResources(existingSts *appsv1.StatefulSet) (*core
 			v := existingSts.Spec.Template.Spec.Containers[k]
 			switch v.Name {
 			case containerNameEtcd:
-				resourcesEtcd = v.Resources.DeepCopy()
+				resourcesEtcd = &corev1.ResourceRequirements{
+					Requests: v.Resources.Requests,
+				}
 			case containerNameBackupRestore:
-				resourcesBackupRestore = v.Resources.DeepCopy()
+				resourcesBackupRestore = &corev1.ResourceRequirements{
+					Requests: v.Resources.Requests,
+				}
 			}
 		}
 	}

--- a/pkg/operation/botanist/component/etcd/etcd_test.go
+++ b/pkg/operation/botanist/component/etcd/etcd_test.go
@@ -795,7 +795,7 @@ var _ = Describe("Etcd", func() {
 			Expect(etcd.Deploy(ctx)).To(Succeed())
 		})
 
-		It("should successfully deploy (normal etcd) and keep the existing resource settings to not interfer with HVPA controller", func() {
+		It("should successfully deploy (normal etcd) and keep the existing resource request settings (but not limits) to not interfer with HVPA controller", func() {
 			oldTimeNow := TimeNow
 			defer func() { TimeNow = oldTimeNow }()
 			TimeNow = func() time.Time { return now }
@@ -820,6 +820,13 @@ var _ = Describe("Etcd", func() {
 						corev1.ResourceCPU:    resource.MustParse("7"),
 						corev1.ResourceMemory: resource.MustParse("8G"),
 					},
+				}
+
+				expectedResourcesContainerEtcd = corev1.ResourceRequirements{
+					Requests: existingResourcesContainerEtcd.Requests,
+				}
+				expectedResourcesContainerBackupRestore = corev1.ResourceRequirements{
+					Requests: existingResourcesContainerBackupRestore.Requests,
 				}
 			)
 
@@ -863,8 +870,8 @@ var _ = Describe("Etcd", func() {
 						nil,
 						"",
 						"",
-						&existingResourcesContainerEtcd,
-						&existingResourcesContainerBackupRestore,
+						&expectedResourcesContainerEtcd,
+						&expectedResourcesContainerBackupRestore,
 					)))
 				}),
 				c.EXPECT().Get(ctx, kutil.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
For etcd resources with hvpa + existing etcd stateful set, do not copy the current resource limits.
Otherwise, clusters cannot get rid of resource limits on the etcd pods. New clusters are already created without resource limits for the etcd pods.

**Which issue(s) this PR fixes**:
Fixes #



**Special notes for your reviewer**:
A change to the etcd stateful set will only happen [if this PR ](https://github.com/gardener/etcd-druid/pull/342)of the etcd-druid is also used. Otherwise, the changed etcd resource will not be transported to the etcd statefulset.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Remove resource limits from etcd resources for existing clusters. In conjunction with the etcd-druid changes in https://github.com/gardener/etcd-druid/pull/342, this can lead to a etcd-pod RESTART (!). 
```
