### PR TITLE
Update the Logging images version due to security compliance

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -192,11 +192,11 @@ images:
 - name: fluent-bit
   sourceRepository: github.com/fluent/fluent-bit
   repository: fluent/fluent-bit
-  tag: "1.8.7"
+  tag: "1.9.3"
 - name: fluent-bit-plugin-installer
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/fluent-bit-to-loki
-  tag: "v0.39.0"
+  tag: "v0.40.0"
 - name: loki
   sourceRepository: github.com/grafana/loki
   repository: grafana/loki
@@ -204,11 +204,11 @@ images:
 - name: loki-curator
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/loki-curator
-  tag: "v0.39.0"
+  tag: "v0.40.0"
 - name: kube-rbac-proxy
   sourceRepository: github.com/brancz/kube-rbac-proxy
   repository: quay.io/brancz/kube-rbac-proxy
-  tag: v0.8.0
+  tag: v0.12.0
 - name: promtail
   sourceRepository: github.com/grafana/loki
   repository: "docker.io/grafana/promtail"
@@ -216,7 +216,7 @@ images:
 - name: telegraf
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/telegraf-iptables
-  tag: "v0.39.0"
+  tag: "v0.40.0"
 
 # VPA
 - name: vpa-admission-controller

--- a/charts/seed-bootstrap/charts/fluent-bit/templates/_fluent-bit-config.tpl
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/_fluent-bit-config.tpl
@@ -108,6 +108,7 @@
       DynamicHostSuffix .svc:3100/loki/api/v1/push
       DynamicHostRegex ^shoot-
       DynamicTenant user gardenuser user
+      HostnameKeyValue nodename ${NODE_NAME}
       MaxRetries 3
       Timeout 10s
       MinBackoff 30s
@@ -139,6 +140,7 @@
       DropSingleKey false
       RemoveKeys kubernetes,stream,hostname,unit
       LabelMapPath /fluent-bit/etc/systemd_label_map.json
+      HostnameKeyValue nodename ${NODE_NAME}
       MaxRetries 3
       Timeout 10s
       MinBackoff 30s


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
`flunet-bit` image is updated from `1.8.7` to `1.9.3`.
`kube-rbac-proxy` image is updated from `v0.8.0` to `v0.12.0`.
The base image of `telegraf-iptables` is updated from `telegraf:1.18.0-alpine` to `telegraf:1.22.3-alpine`.
The base image of `fluent-bit-plugin` is updated from `alpine:3.12.3` to `alpine:3.15.4`

Fluent-bit adds the name of the node in the log stream.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Seed log processor images `fluent-bit` is updated from `1.8.7` to `1.9.3`.
Shoot Loki side car `kube-rbac-proxy` image is updated from `v0.8.0` to `v0.12.0`.
Shoot Loki side car `telegraf-iptables` base image is updated from `1.18.0-alpine` to `1.22.3-alpine`.
Seed log processor plugin `fluent-bit-plugin` base image is updated from `alpine:3.12.3` to `alpine:3.15.4`
```

```other operator
The name of the seed node is added to the log stream.
```