### PR TITLE
Update coredns to v1.9.1

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -117,7 +117,7 @@ images:
 - name: coredns
   sourceRepository: github.com/coredns/coredns
   repository: coredns/coredns
-  tag: "1.8.6"
+  tag: "1.9.1"
 - name: node-local-dns
   sourceRepository: github.com/kubernetes/kubernetes/blob/master/cluster/addons/dns/nodelocaldns
   repository: k8s.gcr.io/dns/k8s-dns-node-cache


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Update coredns to v1.9.1.

With coredns v1.9.1, the kubernetes plugin of coredns does no longer support
kubernetes wildcard queries. Those are not officially part of the kubernetes
dns spec. Hence, we hopefully can drop this feature quietly.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:
Coredns wildcard support of the kubernetes plugin is described here: https://coredns.io/plugins/kubernetes/#wildcards
Removal PR: https://github.com/coredns/coredns/pull/5019

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
CoreDNS does no longer support wildcard dns queries.
```
