### PR TITLE
Update container images for `nginx-ingress-controller` and `kubernetes-dashboard`

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -157,22 +157,22 @@ images:
 - name: nginx-ingress-controller
   sourceRepository: github.com/kubernetes/ingress-nginx
   repository: k8s.gcr.io/ingress-nginx/controller
-  tag: "v0.49.0"
+  tag: "v0.49.3"
   targetVersion: ">= 1.20, < 1.22"
 - name: nginx-ingress-controller
   sourceRepository: github.com/kubernetes/ingress-nginx
-  repository: k8s.gcr.io/ingress-nginx/controller
-  tag: "v1.0.0"
+  repository: k8s.gcr.io/ingress-nginx/controller-chroot
+  tag: "v1.2.0"
   targetVersion: ">= 1.22"
 - name: nginx-ingress-controller-seed
   sourceRepository: github.com/kubernetes/ingress-nginx
   repository: k8s.gcr.io/ingress-nginx/controller
-  tag: "v0.49.0"
+  tag: "v0.49.3"
   targetVersion: "< 1.22"
 - name: nginx-ingress-controller-seed
   sourceRepository: github.com/kubernetes/ingress-nginx
-  repository: k8s.gcr.io/ingress-nginx/controller
-  tag: "v1.0.0"
+  repository: k8s.gcr.io/ingress-nginx/controller-chroot
+  tag: "v1.2.0"
   targetVersion: ">= 1.22"
 - name: ingress-default-backend
   sourceRepository: github.com/gardener/ingress-default-backend

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -131,17 +131,22 @@ images:
 - name: kubernetes-dashboard
   sourceRepository: github.com/kubernetes/dashboard
   repository: kubernetesui/dashboard
-  tag: v2.0.3
-  targetVersion: "< 1.19"
+  tag: v2.2.0
+  targetVersion: "< 1.21"
 - name: kubernetes-dashboard
   sourceRepository: github.com/kubernetes/dashboard
   repository: kubernetesui/dashboard
-  tag: v2.0.4
-  targetVersion: ">= 1.19"
+  tag: v2.4.0
+  targetVersion: ">= 1.21, < 1.22"
+- name: kubernetes-dashboard
+  sourceRepository: github.com/kubernetes/dashboard
+  repository: kubernetesui/dashboard
+  tag: v2.5.1
+  targetVersion: ">= 1.22"
 - name: kubernetes-dashboard-metrics-scraper
   sourceRepository: github.com/kubernetes/dashboard
   repository: kubernetesui/metrics-scraper
-  tag: v1.0.4
+  tag: v1.0.7
 - name: nginx-ingress-controller
   sourceRepository: github.com/kubernetes/ingress-nginx
   repository: quay.io/kubernetes-ingress-controller/nginx-ingress-controller

--- a/charts/shoot-addons/charts/kubernetes-dashboard/templates/deployment-dashboard.yaml
+++ b/charts/shoot-addons/charts/kubernetes-dashboard/templates/deployment-dashboard.yaml
@@ -27,6 +27,7 @@ spec:
     spec:
       nodeSelector:
         worker.gardener.cloud/system-components: "true"
+        kubernetes.io/os: linux
       securityContext:
         allowPrivilegeEscalation: false
         readOnlyRootFilesystem: true

--- a/charts/shoot-addons/charts/kubernetes-dashboard/templates/deployment-metrics-scraper.yaml
+++ b/charts/shoot-addons/charts/kubernetes-dashboard/templates/deployment-metrics-scraper.yaml
@@ -53,6 +53,7 @@ spec:
       {{- end }}
       serviceAccountName: kubernetes-dashboard
       nodeSelector:
+        kubernetes.io/os: linux
         worker.gardener.cloud/system-components: "true"
       volumes:
       - name: tmp-volume

--- a/charts/shoot-addons/charts/nginx-ingress/templates/controller-deployment.yaml
+++ b/charts/shoot-addons/charts/nginx-ingress/templates/controller-deployment.yaml
@@ -71,6 +71,9 @@ spec:
                 - ALL
                 add:
                 - NET_BIND_SERVICE
+{{- if semverCompare ">= 1.22-0" .Capabilities.KubeVersion.GitVersion }}
+                - SYS_CHROOT
+{{- end }}
 {{- if semverCompare ">= 1.20-0" .Capabilities.KubeVersion.GitVersion }}
             runAsUser: 101
             allowPrivilegeEscalation: true

--- a/pkg/operation/botanist/component/nginxingress/nginxingress.go
+++ b/pkg/operation/botanist/component/nginxingress/nginxingress.go
@@ -553,6 +553,8 @@ func (n *nginxIngress) computeResourcesData() (map[string][]byte, error) {
 				Controller: "k8s.io/" + n.values.IngressClass,
 			},
 		}
+
+		deploymentController.Spec.Template.Spec.Containers[0].SecurityContext.Capabilities.Add = append(deploymentController.Spec.Template.Spec.Containers[0].SecurityContext.Capabilities.Add, "SYS_CHROOT")
 	}
 
 	return registry.AddAllAndSerialize(

--- a/pkg/operation/botanist/component/nginxingress/nginxingress_test.go
+++ b/pkg/operation/botanist/component/nginxingress/nginxingress_test.go
@@ -462,15 +462,15 @@ spec:
         - --election-id=ingress-controller-seed-leader
         - --update-status=true
         - --annotations-prefix=nginx.ingress.kubernetes.io
-        - --configmap=` + namespace + `/` + configMapName + ``
+        - --configmap=` + namespace + `/` + configMapName
 
 				if version.ConstraintK8sGreaterEqual122.Check(kubernetesVersion) {
 					out += `
         - --ingress-class=` + v1beta1constants.SeedNginxIngressClass122 + `
-        - --controller-class=k8s.io/` + v1beta1constants.SeedNginxIngressClass122 + ``
+        - --controller-class=k8s.io/` + v1beta1constants.SeedNginxIngressClass122
 				} else {
 					out += `
-        - --ingress-class=` + v1beta1constants.SeedNginxIngressClass + ``
+        - --ingress-class=` + v1beta1constants.SeedNginxIngressClass
 				}
 
 				out += `
@@ -523,7 +523,14 @@ spec:
           allowPrivilegeEscalation: true
           capabilities:
             add:
-            - NET_BIND_SERVICE
+            - NET_BIND_SERVICE`
+
+				if version.ConstraintK8sGreaterEqual122.Check(kubernetesVersion) {
+					out += `
+            - SYS_CHROOT`
+				}
+
+				out += `
             drop:
             - ALL
           runAsUser: 101


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:
This PR bumps the container images for `nginx-ingress-controller` and `kubernetes-dashboard`

- `nginx-ingress-controller`:
  - `0.49.0` -> `0.49.3` for seeds and shoots < 1.22
  - `1.0.0` -> `1.2.0` for seeds and shoots >= 1.22
- `kubernetes-dashboard`:
  - `2.0.3`/`2.0.4` -> `2.2.0` for shoots < 1.21
  - `2.0.4` -> `2.4.0` for shoots = 1.21
  - `2.0.4` -> `2.5.1` for shoots >= 1.22
- `kubernetes-dashboard-metrics-scraper`:
  - `1.0.4` -> `1.0.7` for all shoots

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other user
The version of the `nginx-ingress-controller` addon has been bumped to `0.49.3` for shoots < 1.22, and to `1.2.0` for shoots >= 1.22. The version of the `kubernetes-dashboard` has been bumped to `2.2.0` for shoots < 1.21, to `2.4.0` for shoots = 1.21, and to `2.5.1` for shoots >= 1.22. The version of the `kubernetes-dashboard-metrics-scraper` has been bumped to `1.0.7` for all shoots.
```
```other user
The version of the `nginx-ingress-controller` addon has been bumped to `0.49.3` for seeds < 1.22, and to `1.2.0` for seeds >= 1.22.
```