### PR TITLE
Ensure same order of CAs for `adminkubeconfig` subresource and `ca-cluster` secret

### DIFF
--- a/pkg/registry/core/shoot/storage/admin_kubeconfig.go
+++ b/pkg/registry/core/shoot/storage/admin_kubeconfig.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"sort"
 	"strconv"
 	"time"
 
@@ -224,9 +225,30 @@ func findNewestCACertificate(results []*gardencorev1alpha1.GardenerResourceData)
 }
 
 func getClusterCABundle(resourceDataList gardencorev1alpha1helper.GardenerResourceDataList) ([]byte, error) {
-	var caBundle []byte
+	var (
+		allCAs   = resourceDataList.Select(caCertificateSelector.Add(nameCAClusterReq))
+		caBundle []byte
+	)
 
-	for _, data := range resourceDataList.Select(caCertificateSelector.Add(nameCAClusterReq)) {
+	// Sort CAs descending based on their issued-at-time label. This ensures that the current CA is always the first so
+	// that the order in the bundle is the same as in the <shoot-name>.ca-cluster secret.
+	sort.Slice(allCAs, func(i, j int) bool {
+		issuedAtTime1, ok1 := allCAs[i].Labels[secretsmanager.LabelKeyIssuedAtTime]
+		issuedAtTime2, ok2 := allCAs[j].Labels[secretsmanager.LabelKeyIssuedAtTime]
+		if !ok1 || !ok2 {
+			return false
+		}
+
+		issuedAtUnix1, err1 := strconv.ParseInt(issuedAtTime1, 10, 64)
+		issuedAtUnix2, err2 := strconv.ParseInt(issuedAtTime2, 10, 64)
+		if err1 != nil || err2 != nil {
+			return false
+		}
+
+		return issuedAtUnix1 > issuedAtUnix2
+	})
+
+	for _, data := range allCAs {
 		cert, _, err := getCADataRaw(data)
 		if err != nil {
 			return nil, fmt.Errorf("could not fetch raw CA data for %q", data.Name)

--- a/pkg/registry/core/shoot/storage/admin_kubeconfig_test.go
+++ b/pkg/registry/core/shoot/storage/admin_kubeconfig_test.go
@@ -288,6 +288,18 @@ bW4nbZLxXHQ4e+OOPeBUXUP9V0QcE4XixdvQuslfVxjn0Ja82gdzeA==
 		It("returns error when the client certificate authority contains no certificate", func() {
 			shootState.Spec.Gardener[1].Data.Raw = []byte("{}")
 		})
+
+		It("returns error when the issued-at-time label on a CA cert secret is missing", func() {
+			shootState.Spec.Gardener = append(shootState.Spec.Gardener, gardenercore.GardenerResourceData{
+				Name: "ca-2",
+				Type: "secret",
+				Labels: map[string]string{
+					"name":             "ca",
+					"managed-by":       "secrets-manager",
+					"manager-identity": "gardenlet",
+				},
+			})
+		})
 	})
 
 	DescribeTable("request succeeds",

--- a/pkg/registry/core/shoot/storage/admin_kubeconfig_test.go
+++ b/pkg/registry/core/shoot/storage/admin_kubeconfig_test.go
@@ -362,7 +362,7 @@ bW4nbZLxXHQ4e+OOPeBUXUP9V0QcE4XixdvQuslfVxjn0Ja82gdzeA==
 
 		Entry("one client CA, one cluster CA", clientCACert1Name, clusterCACert1, nil),
 
-		Entry("one client CA, multiple cluster CA", clientCACert1Name, append(clusterCACert1, clusterCACert2...), func() {
+		Entry("one client CA, multiple cluster CA", clientCACert1Name, append(clusterCACert2, clusterCACert1...), func() {
 			shootState.Spec.Gardener = append(shootState.Spec.Gardener, gardenercore.GardenerResourceData{
 				Name: "ca-cluster-2",
 				Type: "secret",
@@ -394,7 +394,7 @@ bW4nbZLxXHQ4e+OOPeBUXUP9V0QcE4XixdvQuslfVxjn0Ja82gdzeA==
 			})
 		}),
 
-		Entry("multiple client CA (in case of rotation), multiple cluster CA", clientCACert2Name, append(clusterCACert1, clusterCACert2...), func() {
+		Entry("multiple client CA (in case of rotation), multiple cluster CA", clientCACert2Name, append(clusterCACert2, clusterCACert1...), func() {
 			shootState.Spec.Gardener = append(shootState.Spec.Gardener,
 				gardenercore.GardenerResourceData{
 					Name: "ca-client-bar",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
Today, when there are multiple CAs then the order differs between the `certificate-authority-data` in the `<shoot-name>.kubeconfig` or `ca.crt` in the `<shoot-name>.ca-cluster` secret compared to the `certificate-authority-data` in the `kubeconfig` issued via the `shoots/adminkubeconfig` subresource.

While this shouldn't matter theoretically, practically it leads to issues when `gardenctl-v2` is used. `gardenctl-v2` uses [`gardenlogin`](https://github.com/gardener/gardenlogin) which fails when trying to communicate to the shoot cluster in case there are multiple CAs (i.e., after phase 1 of the CA rotation):

```
$ ks get po
Error: failed to get ExecCredential: could not find matching auth info from shoot kubeconfig for given cluster: no matching cluster found for server https://api.my-cluster.example.com and certificate-authority-data
Usage:
  gardenlogin get-client-certificate [flags]

...

Error: failed to get ExecCredential: could not find matching auth info from shoot kubeconfig for given cluster: no matching cluster found for server https://api.my-cluster.example.com and certificate-authority-data
Unable to connect to the server: getting credentials: exec: executable kubectl failed with exit code 1
```

`gardenlogin` internally has an extra check to ensure the CA data of the `kubeconfig` issued via the `shoots/adminkubeconfig` subresource matches the CA data of the `kubeconfig` used for `gardenctl-v2`: https://github.com/gardener/gardenlogin/blob/c6814bddc4c307db6db930122563131605d3c04a/cmd/get_client_certificate.go#L411-L416

Since the order is different in the `<shoot-name>.ca-cluster` secret compared to the `certificate-authority-data` in the `kubeconfig` returned via the `shoots/adminkubeconfig`, above check fails.

There is https://github.com/gardener/gardenlogin/issues/28 to improve this check (by not depending on the order of the CAs in the bundle). However, to ensure backwards-compatibility Gardener can also always generate the same order (which is nicer and "more consistent" anyways).

**Which issue(s) this PR fixes**:
Part of #3292

**Special notes for your reviewer**:
/cc @petersutter 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
