### PR TITLE
Always update timestamp annotation on Infrastructure and DNSRecord reconciliation

### DIFF
--- a/extensions/pkg/predicate/default.go
+++ b/extensions/pkg/predicate/default.go
@@ -83,6 +83,11 @@ var defaultControllerPredicate = predicate.Funcs{
 			return true
 		}
 
+		// If the last operation does not indicate success and the object's timestamp changes then we admit reconciliation.
+		if lastOperationNotSuccessful(e.ObjectNew) && e.ObjectOld.GetAnnotations()[v1beta1constants.GardenerTimestamp] != e.ObjectNew.GetAnnotations()[v1beta1constants.GardenerTimestamp] {
+			return true
+		}
+
 		// If none of the above conditions applies then reconciliation is not allowed.
 		return false
 	},

--- a/extensions/pkg/predicate/default_test.go
+++ b/extensions/pkg/predicate/default_test.go
@@ -15,6 +15,8 @@
 package predicate_test
 
 import (
+	"time"
+
 	. "github.com/gardener/gardener/extensions/pkg/predicate"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
@@ -32,6 +34,7 @@ var _ = Describe("Default", func() {
 			pred      predicate.Predicate
 			obj       *extensionsv1alpha1.Infrastructure
 			namespace = "shoot--foo--bar"
+			now       = time.Now()
 		)
 
 		BeforeEach(func() {
@@ -109,6 +112,20 @@ var _ = Describe("Default", func() {
 					obj.SetDeletionTimestamp(&metav1.Time{})
 					oldObj := obj.DeepCopy()
 					obj.Status.ObservedGeneration = 3
+					Expect(pred.Update(event.UpdateEvent{ObjectNew: obj, ObjectOld: oldObj})).To(BeFalse())
+				})
+
+				It("should return true when last operation has not succeeded and the timestamp changed", func() {
+					obj.Status.LastOperation = &gardencorev1beta1.LastOperation{State: gardencorev1beta1.LastOperationStateError}
+					oldObj := obj.DeepCopy()
+					obj.SetAnnotations(map[string]string{"gardener.cloud/timestamp": now.UTC().Add(time.Second).String()})
+					Expect(pred.Update(event.UpdateEvent{ObjectNew: obj, ObjectOld: oldObj})).To(BeTrue())
+				})
+
+				It("should return false when last operation has succeeded and the timestamp changed", func() {
+					obj.Status.LastOperation = &gardencorev1beta1.LastOperation{State: gardencorev1beta1.LastOperationStateSucceeded}
+					oldObj := obj.DeepCopy()
+					obj.SetAnnotations(map[string]string{"gardener.cloud/timestamp": now.UTC().Add(time.Second).String()})
 					Expect(pred.Update(event.UpdateEvent{ObjectNew: obj, ObjectOld: oldObj})).To(BeFalse())
 				})
 			})

--- a/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord.go
+++ b/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord.go
@@ -146,8 +146,8 @@ func (c *dnsRecord) deploy(ctx context.Context, operation string) (extensionsv1a
 	mutateFn := func() error {
 		if c.values.AnnotateOperation {
 			metav1.SetMetaDataAnnotation(&c.dnsRecord.ObjectMeta, v1beta1constants.GardenerOperation, operation)
-			metav1.SetMetaDataAnnotation(&c.dnsRecord.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
 		}
+		metav1.SetMetaDataAnnotation(&c.dnsRecord.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
 
 		c.dnsRecord.Spec = extensionsv1alpha1.DNSRecordSpec{
 			DefaultSpec: extensionsv1alpha1.DefaultSpec{

--- a/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord_test.go
+++ b/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord_test.go
@@ -215,8 +215,11 @@ var _ = Describe("DNSRecord", func() {
 					Kind:       extensionsv1alpha1.DNSRecordResource,
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:            name,
-					Namespace:       namespace,
+					Name:      name,
+					Namespace: namespace,
+					Annotations: map[string]string{
+						v1beta1constants.GardenerTimestamp: now.UTC().String(),
+					},
 					ResourceVersion: "1",
 				},
 				Spec: dns.Spec,

--- a/pkg/operation/botanist/component/extensions/infrastructure/infrastructure.go
+++ b/pkg/operation/botanist/component/extensions/infrastructure/infrastructure.go
@@ -135,8 +135,9 @@ func (i *infrastructure) deploy(ctx context.Context, operation string) (extensio
 	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, i.client, i.infrastructure, func() error {
 		if i.values.AnnotateOperation {
 			metav1.SetMetaDataAnnotation(&i.infrastructure.ObjectMeta, v1beta1constants.GardenerOperation, operation)
-			metav1.SetMetaDataAnnotation(&i.infrastructure.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
 		}
+
+		metav1.SetMetaDataAnnotation(&i.infrastructure.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
 
 		i.infrastructure.Spec = extensionsv1alpha1.InfrastructureSpec{
 			DefaultSpec: extensionsv1alpha1.DefaultSpec{

--- a/pkg/operation/botanist/component/extensions/infrastructure/infrastructure_test.go
+++ b/pkg/operation/botanist/component/extensions/infrastructure/infrastructure_test.go
@@ -171,7 +171,9 @@ var _ = Describe("#Interface", func() {
 
 			actual := &extensionsv1alpha1.Infrastructure{}
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(expected), actual)).To(Succeed())
-			expected.SetAnnotations(nil)
+			expected.SetAnnotations(map[string]string{
+				v1beta1constants.GardenerTimestamp: now.UTC().String(),
+			})
 			Expect(actual).To(DeepEqual(expected))
 		})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
With this PR we always update timestamp annotation for `Infrastructure` and `DNSRecord` resource.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/5914

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
The `UpdateFunc` predicate in the extensions library is modified to allow reconciliation of object on change in timestamp when the `Shoot` is in `Error` state.
```