### PR TITLE
[GEP-18] Use old CA for signing the `kube-apiserver`'s client certificate for `kubelet`

### DIFF
--- a/pkg/operation/botanist/component/kubeapiserver/secrets.go
+++ b/pkg/operation/botanist/component/kubeapiserver/secrets.go
@@ -273,7 +273,7 @@ func (k *kubeAPIServer) reconcileSecretKubeletClient(ctx context.Context) (*core
 		CommonName:                  userName,
 		CertType:                    secretutils.ClientCert,
 		SkipPublishingCACertificate: true,
-	}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCAKubelet), secretsmanager.Rotate(secretsmanager.InPlace))
+	}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCAKubelet, secretsmanager.UseOldCA), secretsmanager.Rotate(secretsmanager.InPlace))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
Similar to how https://github.com/gardener/gardener/pull/5785/commits/8e00a27181b3222c8f939307e96faf9af82573da#diff-7e9c32e4003f71573a8f109fc5a54bbc36ff8f510a875f144989c5a53190e0be introduced the option to sign server certificates with the current CA, this PR introduces the option to sign client certificates with the old CA.

This is needed for the `kube-apiserver-kubelet` client certificate which is used when `kube-apiserver` talks to `kubelet`s in order to fetch logs, forward ports, etc. Since the `kube-apiserver` is deployed before the `kubelet` in the `Shoot` reconciliation flow, regenerating the client certificate with the current CA shortly breaks the ability of `kube-apiserver` to talk to `kubelet`s (until all `kubelet`s got updated with the new CA bundle).

**Which issue(s) this PR fixes**:
Part of #3292

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
