### PR TITLE
[GEP-18] Prevent automatic shoot CA rotation caused by approaching expiration time or config change

### DIFF
--- a/extensions/pkg/util/secret/manager/manager.go
+++ b/extensions/pkg/util/secret/manager/manager.go
@@ -46,7 +46,10 @@ type SecretConfigWithOptions struct {
 // - keeps old CA secrets during CA rotation
 // - removes old CA secrets on Cleanup() if cluster.shoot.status.credentials.rotation.certificateAuthorities.phase == Completing
 func SecretsManagerForCluster(ctx context.Context, logger logr.Logger, clock clock.Clock, c client.Client, cluster *extensionscontroller.Cluster, identity string, secretConfigs []SecretConfigWithOptions) (secretsmanager.Interface, error) {
-	sm, err := secretsmanager.New(ctx, logger, clock, c, cluster.ObjectMeta.Name, identity, lastSecretRotationStartTimesFromCluster(cluster, secretConfigs))
+	sm, err := secretsmanager.New(ctx, logger, clock, c, cluster.ObjectMeta.Name, identity, secretsmanager.Rotation{
+		NoCASecretAutoRotation: true,
+		SecretNamesToTimes:     lastSecretRotationStartTimesFromCluster(cluster, secretConfigs),
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/extensions/pkg/util/secret/manager/manager.go
+++ b/extensions/pkg/util/secret/manager/manager.go
@@ -46,9 +46,9 @@ type SecretConfigWithOptions struct {
 // - keeps old CA secrets during CA rotation
 // - removes old CA secrets on Cleanup() if cluster.shoot.status.credentials.rotation.certificateAuthorities.phase == Completing
 func SecretsManagerForCluster(ctx context.Context, logger logr.Logger, clock clock.Clock, c client.Client, cluster *extensionscontroller.Cluster, identity string, secretConfigs []SecretConfigWithOptions) (secretsmanager.Interface, error) {
-	sm, err := secretsmanager.New(ctx, logger, clock, c, cluster.ObjectMeta.Name, identity, secretsmanager.Rotation{
-		NoCASecretAutoRotation: true,
-		SecretNamesToTimes:     lastSecretRotationStartTimesFromCluster(cluster, secretConfigs),
+	sm, err := secretsmanager.New(ctx, logger, clock, c, cluster.ObjectMeta.Name, identity, secretsmanager.Config{
+		CASecretAutoRotation: false,
+		SecretNamesToTimes:   lastSecretRotationStartTimesFromCluster(cluster, secretConfigs),
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/controllermanager/controller/factory.go
+++ b/pkg/controllermanager/controller/factory.go
@@ -85,7 +85,7 @@ func (f *GardenControllerFactory) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to start ClientMap: %+v", err)
 	}
 
-	secretsManager, err := secretsmanager.New(ctx, logf.Log.WithName("secretsmanager"), clock.RealClock{}, gardenClientSet.Client(), v1beta1constants.GardenNamespace, v1beta1constants.SecretManagerIdentityControllerManager, nil)
+	secretsManager, err := secretsmanager.New(ctx, logf.Log.WithName("secretsmanager"), clock.RealClock{}, gardenClientSet.Client(), v1beta1constants.GardenNamespace, v1beta1constants.SecretManagerIdentityControllerManager, secretsmanager.Rotation{})
 	if err != nil {
 		return fmt.Errorf("failed creating new secrets manager: %w", err)
 	}

--- a/pkg/controllermanager/controller/factory.go
+++ b/pkg/controllermanager/controller/factory.go
@@ -85,7 +85,7 @@ func (f *GardenControllerFactory) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to start ClientMap: %+v", err)
 	}
 
-	secretsManager, err := secretsmanager.New(ctx, logf.Log.WithName("secretsmanager"), clock.RealClock{}, gardenClientSet.Client(), v1beta1constants.GardenNamespace, v1beta1constants.SecretManagerIdentityControllerManager, secretsmanager.Rotation{})
+	secretsManager, err := secretsmanager.New(ctx, logf.Log.WithName("secretsmanager"), clock.RealClock{}, gardenClientSet.Client(), v1beta1constants.GardenNamespace, v1beta1constants.SecretManagerIdentityControllerManager, secretsmanager.Config{})
 	if err != nil {
 		return fmt.Errorf("failed creating new secrets manager: %w", err)
 	}

--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -83,9 +83,9 @@ func New(ctx context.Context, o *operation.Operation) (*Botanist, error) {
 		b.K8sSeedClient.Client(),
 		b.Shoot.SeedNamespace,
 		v1beta1constants.SecretManagerIdentityGardenlet,
-		secretsmanager.Rotation{
-			NoCASecretAutoRotation: true,
-			SecretNamesToTimes:     b.lastSecretRotationStartTimes(),
+		secretsmanager.Config{
+			CASecretAutoRotation: false,
+			SecretNamesToTimes:   b.lastSecretRotationStartTimes(),
 		},
 	)
 	if err != nil {

--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -83,7 +83,10 @@ func New(ctx context.Context, o *operation.Operation) (*Botanist, error) {
 		b.K8sSeedClient.Client(),
 		b.Shoot.SeedNamespace,
 		v1beta1constants.SecretManagerIdentityGardenlet,
-		b.lastSecretRotationStartTimes(),
+		secretsmanager.Rotation{
+			NoCASecretAutoRotation: true,
+			SecretNamesToTimes:     b.lastSecretRotationStartTimes(),
+		},
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -242,7 +242,7 @@ func RunReconcileSeedFlow(
 		seedClient,
 		v1beta1constants.GardenNamespace,
 		v1beta1constants.SecretManagerIdentityGardenlet,
-		secretsmanager.Rotation{NoCASecretAutoRotation: false},
+		secretsmanager.Config{CASecretAutoRotation: true},
 	)
 	if err != nil {
 		return err

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -242,7 +242,7 @@ func RunReconcileSeedFlow(
 		seedClient,
 		v1beta1constants.GardenNamespace,
 		v1beta1constants.SecretManagerIdentityGardenlet,
-		nil,
+		secretsmanager.Rotation{NoCASecretAutoRotation: false},
 	)
 	if err != nil {
 		return err

--- a/pkg/utils/secrets/manager/cleanup_test.go
+++ b/pkg/utils/secrets/manager/cleanup_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Cleanup", func() {
 	BeforeEach(func() {
 		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetesscheme.Scheme).Build()
 
-		mgr, err := New(ctx, logr.Discard(), clock.RealClock{}, fakeClient, namespace, testIdentity, Rotation{})
+		mgr, err := New(ctx, logr.Discard(), clock.RealClock{}, fakeClient, namespace, testIdentity, Config{})
 		Expect(err).NotTo(HaveOccurred())
 		m = mgr.(*manager)
 	})

--- a/pkg/utils/secrets/manager/cleanup_test.go
+++ b/pkg/utils/secrets/manager/cleanup_test.go
@@ -46,7 +46,7 @@ var _ = Describe("Cleanup", func() {
 	BeforeEach(func() {
 		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetesscheme.Scheme).Build()
 
-		mgr, err := New(ctx, logr.Discard(), clock.RealClock{}, fakeClient, namespace, testIdentity, nil)
+		mgr, err := New(ctx, logr.Discard(), clock.RealClock{}, fakeClient, namespace, testIdentity, Rotation{})
 		Expect(err).NotTo(HaveOccurred())
 		m = mgr.(*manager)
 	})

--- a/pkg/utils/secrets/manager/generate_test.go
+++ b/pkg/utils/secrets/manager/generate_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Generate", func() {
 	BeforeEach(func() {
 		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetesscheme.Scheme).Build()
 
-		mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, nil)
+		mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Rotation{})
 		Expect(err).NotTo(HaveOccurred())
 		m = mgr.(*manager)
 	})
@@ -147,7 +147,7 @@ var _ = Describe("Generate", func() {
 				expectSecretWasCreated(ctx, fakeClient, secret)
 
 				By("changing last rotation initiation time and generate again")
-				mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, map[string]time.Time{name: time.Now()})
+				mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Rotation{SecretNamesToTimes: map[string]time.Time{name: time.Now()}})
 				Expect(err).NotTo(HaveOccurred())
 				m = mgr.(*manager)
 
@@ -335,7 +335,7 @@ var _ = Describe("Generate", func() {
 				oldBundleSecret := secretInfos.bundle.obj
 
 				By("changing secret config and generate again")
-				mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, map[string]time.Time{name: time.Now()})
+				mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Rotation{SecretNamesToTimes: map[string]time.Time{name: time.Now()}})
 				Expect(err).NotTo(HaveOccurred())
 				m = mgr.(*manager)
 
@@ -445,7 +445,7 @@ var _ = Describe("Generate", func() {
 				expectSecretWasCreated(ctx, fakeClient, serverSecret)
 
 				By("rotating CA")
-				mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, map[string]time.Time{name: time.Now()})
+				mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Rotation{SecretNamesToTimes: map[string]time.Time{name: time.Now()}})
 				Expect(err).NotTo(HaveOccurred())
 				m = mgr.(*manager)
 
@@ -474,7 +474,7 @@ var _ = Describe("Generate", func() {
 				expectSecretWasCreated(ctx, fakeClient, serverSecret)
 
 				By("rotating CA")
-				mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, map[string]time.Time{caName: time.Now()})
+				mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Rotation{SecretNamesToTimes: map[string]time.Time{caName: time.Now()}})
 				Expect(err).NotTo(HaveOccurred())
 				m = mgr.(*manager)
 
@@ -532,7 +532,7 @@ var _ = Describe("Generate", func() {
 				expectSecretWasCreated(ctx, fakeClient, clientSecret)
 
 				By("rotating CA")
-				mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, map[string]time.Time{caName: time.Now()})
+				mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Rotation{SecretNamesToTimes: map[string]time.Time{caName: time.Now()}})
 				Expect(err).NotTo(HaveOccurred())
 				m = mgr.(*manager)
 

--- a/pkg/utils/secrets/manager/generate_test.go
+++ b/pkg/utils/secrets/manager/generate_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Generate", func() {
 	BeforeEach(func() {
 		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetesscheme.Scheme).Build()
 
-		mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Rotation{})
+		mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Config{})
 		Expect(err).NotTo(HaveOccurred())
 		m = mgr.(*manager)
 	})
@@ -147,7 +147,7 @@ var _ = Describe("Generate", func() {
 				expectSecretWasCreated(ctx, fakeClient, secret)
 
 				By("changing last rotation initiation time and generate again")
-				mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Rotation{SecretNamesToTimes: map[string]time.Time{name: time.Now()}})
+				mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Config{SecretNamesToTimes: map[string]time.Time{name: time.Now()}})
 				Expect(err).NotTo(HaveOccurred())
 				m = mgr.(*manager)
 
@@ -335,7 +335,7 @@ var _ = Describe("Generate", func() {
 				oldBundleSecret := secretInfos.bundle.obj
 
 				By("changing secret config and generate again")
-				mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Rotation{SecretNamesToTimes: map[string]time.Time{name: time.Now()}})
+				mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Config{SecretNamesToTimes: map[string]time.Time{name: time.Now()}})
 				Expect(err).NotTo(HaveOccurred())
 				m = mgr.(*manager)
 
@@ -445,7 +445,7 @@ var _ = Describe("Generate", func() {
 				expectSecretWasCreated(ctx, fakeClient, serverSecret)
 
 				By("rotating CA")
-				mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Rotation{SecretNamesToTimes: map[string]time.Time{name: time.Now()}})
+				mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Config{SecretNamesToTimes: map[string]time.Time{name: time.Now()}})
 				Expect(err).NotTo(HaveOccurred())
 				m = mgr.(*manager)
 
@@ -474,7 +474,7 @@ var _ = Describe("Generate", func() {
 				expectSecretWasCreated(ctx, fakeClient, serverSecret)
 
 				By("rotating CA")
-				mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Rotation{SecretNamesToTimes: map[string]time.Time{caName: time.Now()}})
+				mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Config{SecretNamesToTimes: map[string]time.Time{caName: time.Now()}})
 				Expect(err).NotTo(HaveOccurred())
 				m = mgr.(*manager)
 
@@ -503,7 +503,7 @@ var _ = Describe("Generate", func() {
 				expectSecretWasCreated(ctx, fakeClient, clientSecret)
 
 				By("rotating CA")
-				mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, map[string]time.Time{caName: time.Now()})
+				mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Config{SecretNamesToTimes: map[string]time.Time{caName: time.Now()}})
 				Expect(err).NotTo(HaveOccurred())
 				m = mgr.(*manager)
 
@@ -532,7 +532,7 @@ var _ = Describe("Generate", func() {
 				expectSecretWasCreated(ctx, fakeClient, clientSecret)
 
 				By("rotating CA")
-				mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Rotation{SecretNamesToTimes: map[string]time.Time{caName: time.Now()}})
+				mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Config{SecretNamesToTimes: map[string]time.Time{caName: time.Now()}})
 				Expect(err).NotTo(HaveOccurred())
 				m = mgr.(*manager)
 

--- a/pkg/utils/secrets/manager/manager_test.go
+++ b/pkg/utils/secrets/manager/manager_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Manager", func() {
 		})
 
 		It("should create a new instance w/ empty last rotation initiation times map", func() {
-			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Rotation{})
+			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Config{})
 			Expect(err).NotTo(HaveOccurred())
 			m = mgr.(*manager)
 
@@ -59,7 +59,7 @@ var _ = Describe("Manager", func() {
 		})
 
 		It("should create a new instance w/ provided last rotation initiation times", func() {
-			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Rotation{SecretNamesToTimes: map[string]time.Time{"foo": fakeClock.Now()}})
+			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Config{SecretNamesToTimes: map[string]time.Time{"foo": fakeClock.Now()}})
 			Expect(err).NotTo(HaveOccurred())
 			m = mgr.(*manager)
 
@@ -81,7 +81,7 @@ var _ = Describe("Manager", func() {
 			}
 			Expect(fakeClient.Create(ctx, existingSecret)).To(Succeed())
 
-			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Rotation{SecretNamesToTimes: map[string]time.Time{"secret1": fakeClock.Now()}})
+			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Config{SecretNamesToTimes: map[string]time.Time{"secret1": fakeClock.Now()}})
 			Expect(err).NotTo(HaveOccurred())
 			m = mgr.(*manager)
 
@@ -103,7 +103,7 @@ var _ = Describe("Manager", func() {
 			}
 			Expect(fakeClient.Create(ctx, existingSecret)).To(Succeed())
 
-			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Rotation{SecretNamesToTimes: map[string]time.Time{"foo": fakeClock.Now()}})
+			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Config{SecretNamesToTimes: map[string]time.Time{"foo": fakeClock.Now()}})
 			Expect(err).NotTo(HaveOccurred())
 			m = mgr.(*manager)
 
@@ -132,7 +132,7 @@ var _ = Describe("Manager", func() {
 			}
 			Expect(fakeClient.Create(ctx, existingSecret)).To(Succeed())
 
-			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Rotation{})
+			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Config{})
 			Expect(err).NotTo(HaveOccurred())
 			m = mgr.(*manager)
 
@@ -158,7 +158,7 @@ var _ = Describe("Manager", func() {
 			}
 			Expect(fakeClient.Create(ctx, existingSecret)).To(Succeed())
 
-			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Rotation{})
+			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Config{})
 			Expect(err).NotTo(HaveOccurred())
 			m = mgr.(*manager)
 
@@ -184,7 +184,7 @@ var _ = Describe("Manager", func() {
 			}
 			Expect(fakeClient.Create(ctx, existingSecret)).To(Succeed())
 
-			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Rotation{})
+			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Config{})
 			Expect(err).NotTo(HaveOccurred())
 			m = mgr.(*manager)
 
@@ -238,7 +238,7 @@ var _ = Describe("Manager", func() {
 				Expect(fakeClient.Create(ctx, secret)).To(Succeed())
 			}
 
-			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Rotation{})
+			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Config{})
 			Expect(err).NotTo(HaveOccurred())
 			m = mgr.(*manager)
 
@@ -272,18 +272,18 @@ var _ = Describe("Manager", func() {
 				Expect(fakeClient.Create(ctx, existingSecret)).To(Succeed())
 			})
 
-			It("should create a new instance and auto-renew the CA secret because NoCASecretAutoRotation=false", func() {
+			It("should create a new instance and auto-renew the CA secret because CASecretAutoRotation=true", func() {
 				fakeClock = clock.NewFakeClock(time.Date(2000, 1, 1, 1, 1, 1, 1, time.UTC))
 
-				mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Rotation{NoCASecretAutoRotation: false})
+				mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Config{CASecretAutoRotation: true})
 				Expect(err).NotTo(HaveOccurred())
 				m = mgr.(*manager)
 
 				Expect(m.lastRotationInitiationTimes).To(Equal(nameToUnixTime{"secret1": strconv.FormatInt(fakeClock.Now().Unix(), 10)}))
 			})
 
-			It("should create a new instance and NOT auto-renew the CA secret because NoCASecretAutoRotation=true", func() {
-				mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Rotation{NoCASecretAutoRotation: true})
+			It("should create a new instance and NOT auto-renew the CA secret because CASecretAutoRotation=false", func() {
+				mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Config{CASecretAutoRotation: false})
 				Expect(err).NotTo(HaveOccurred())
 				m = mgr.(*manager)
 

--- a/pkg/utils/secrets/manager/manager_test.go
+++ b/pkg/utils/secrets/manager/manager_test.go
@@ -51,7 +51,7 @@ var _ = Describe("Manager", func() {
 		})
 
 		It("should create a new instance w/ empty last rotation initiation times map", func() {
-			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, nil)
+			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Rotation{})
 			Expect(err).NotTo(HaveOccurred())
 			m = mgr.(*manager)
 
@@ -59,7 +59,7 @@ var _ = Describe("Manager", func() {
 		})
 
 		It("should create a new instance w/ provided last rotation initiation times", func() {
-			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, map[string]time.Time{"foo": fakeClock.Now()})
+			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Rotation{SecretNamesToTimes: map[string]time.Time{"foo": fakeClock.Now()}})
 			Expect(err).NotTo(HaveOccurred())
 			m = mgr.(*manager)
 
@@ -81,7 +81,7 @@ var _ = Describe("Manager", func() {
 			}
 			Expect(fakeClient.Create(ctx, existingSecret)).To(Succeed())
 
-			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, map[string]time.Time{"secret1": fakeClock.Now()})
+			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Rotation{SecretNamesToTimes: map[string]time.Time{"secret1": fakeClock.Now()}})
 			Expect(err).NotTo(HaveOccurred())
 			m = mgr.(*manager)
 
@@ -103,7 +103,7 @@ var _ = Describe("Manager", func() {
 			}
 			Expect(fakeClient.Create(ctx, existingSecret)).To(Succeed())
 
-			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, map[string]time.Time{"foo": fakeClock.Now()})
+			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Rotation{SecretNamesToTimes: map[string]time.Time{"foo": fakeClock.Now()}})
 			Expect(err).NotTo(HaveOccurred())
 			m = mgr.(*manager)
 
@@ -132,7 +132,7 @@ var _ = Describe("Manager", func() {
 			}
 			Expect(fakeClient.Create(ctx, existingSecret)).To(Succeed())
 
-			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, nil)
+			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Rotation{})
 			Expect(err).NotTo(HaveOccurred())
 			m = mgr.(*manager)
 
@@ -158,7 +158,7 @@ var _ = Describe("Manager", func() {
 			}
 			Expect(fakeClient.Create(ctx, existingSecret)).To(Succeed())
 
-			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, nil)
+			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Rotation{})
 			Expect(err).NotTo(HaveOccurred())
 			m = mgr.(*manager)
 
@@ -184,7 +184,7 @@ var _ = Describe("Manager", func() {
 			}
 			Expect(fakeClient.Create(ctx, existingSecret)).To(Succeed())
 
-			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, nil)
+			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Rotation{})
 			Expect(err).NotTo(HaveOccurred())
 			m = mgr.(*manager)
 
@@ -238,11 +238,57 @@ var _ = Describe("Manager", func() {
 				Expect(fakeClient.Create(ctx, secret)).To(Succeed())
 			}
 
-			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, nil)
+			mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Rotation{})
 			Expect(err).NotTo(HaveOccurred())
 			m = mgr.(*manager)
 
 			Expect(m.lastRotationInitiationTimes).To(Equal(nameToUnixTime{"secret1": "24"}))
+		})
+
+		Context("ca secrets which are about to expire (at most 10d left until expiration)", func() {
+			var existingSecret *corev1.Secret
+
+			BeforeEach(func() {
+				fakeClock = clock.NewFakeClock(time.Date(2000, 1, 1, 1, 1, 1, 1, time.UTC))
+
+				existingSecret = &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "secret1",
+						Namespace: namespace,
+						Labels: map[string]string{
+							"name":                          "secret1",
+							"managed-by":                    "secrets-manager",
+							"manager-identity":              identity,
+							"last-rotation-initiation-time": "-100",
+							"issued-at-time":                strconv.FormatInt(fakeClock.Now().Add(-24*time.Hour).Unix(), 10),
+							"valid-until-time":              strconv.FormatInt(fakeClock.Now().Add(24*time.Hour).Unix(), 10),
+						},
+					},
+					Data: map[string][]byte{
+						"ca.crt": []byte("foo"),
+						"ca.key": []byte("foo"),
+					},
+				}
+				Expect(fakeClient.Create(ctx, existingSecret)).To(Succeed())
+			})
+
+			It("should create a new instance and auto-renew the CA secret because NoCASecretAutoRotation=false", func() {
+				fakeClock = clock.NewFakeClock(time.Date(2000, 1, 1, 1, 1, 1, 1, time.UTC))
+
+				mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Rotation{NoCASecretAutoRotation: false})
+				Expect(err).NotTo(HaveOccurred())
+				m = mgr.(*manager)
+
+				Expect(m.lastRotationInitiationTimes).To(Equal(nameToUnixTime{"secret1": strconv.FormatInt(fakeClock.Now().Unix(), 10)}))
+			})
+
+			It("should create a new instance and NOT auto-renew the CA secret because NoCASecretAutoRotation=true", func() {
+				mgr, err := New(ctx, logr.Discard(), fakeClock, fakeClient, namespace, identity, Rotation{NoCASecretAutoRotation: true})
+				Expect(err).NotTo(HaveOccurred())
+				m = mgr.(*manager)
+
+				Expect(m.lastRotationInitiationTimes).To(Equal(nameToUnixTime{"secret1": "-100"}))
+			})
 		})
 	})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
This PR allows to configure whether CA secrets should be considered for auto-rotation. While the `Seed` controller makes use of this to auto-rotate the CA each `30d` (ref #5785), the `Shoot` controller disables this feature since CA rotation shall only be initiated via the respective operation annotations.

**Which issue(s) this PR fixes**:
Part of #3292

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
