### PR TITLE
Adjust the path to the shoot CA certificate in the blackbox exporter

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/blackbox-exporter-config.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/blackbox-exporter-config.yaml
@@ -23,7 +23,7 @@ data:
             Accept: "*/*"
             Accept-Language: "en-US"
           tls_config:
-            ca_file: "/var/run/secrets/shoot-ca/ca.crt"
+            ca_file: "/var/run/secrets/shoot-ca/bundle.crt"
             server_name: {{ .Values.shoot.apiserverServerName }}
           bearer_token_file: /var/run/secrets/gardener.cloud/shoot/token/token
           preferred_ip_protocol: "ip4"


### PR DESCRIPTION
**How to categorize this PR?**

/area monitoring
/kind bug

**What this PR does / why we need it**:

The blackbox exporter, which is running as a sidecar of the prometheus
in the shoot control plane namespace is used to probe the shoot api server
via its external endpoint. See the red path in the documentation:
https://github.com/gardener/gardener/blob/dc1abd68d3e04679cf810d86086611cbbefa0a66/docs/monitoring/connectivity.md

The TLS connection to the api server does not work which results in
false positive alerts: "ApiServerNotReachable".

The underlying error message is:

```
unable to load specified CA cert /var/run/secrets/shoot-ca/ca.crt:
  open /var/run/secrets/shoot-ca/ca.crt: no such file or directory
```

The blackbox exporter does not have access to the CA certificate that
it needs to verify the certificate of the shoot API server, and hence
the TLS connection fails.

This issue is related to the CA rotation epic, which introduced a different
name for the certificate to support the rotation process.

The path is pointing to this volume:
https://github.com/gardener/gardener/blob/dc1abd68d3e04679cf810d86086611cbbefa0a66/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml#L196
where the file name changed from "ca.crt" to "bundle.crt".

<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix a blackbox exporter configuration issue (path to shoot CA) that resulted in false positive "ApiServerNotReachable" alerts
```
