### PR TITLE
Enable trusted endpoints in test framework

### DIFF
--- a/test/framework/k8s_utils.go
+++ b/test/framework/k8s_utils.go
@@ -386,7 +386,7 @@ func NewClientFromServiceAccount(ctx context.Context, k8sClient kubernetes.Inter
 		Host: k8sClient.RESTConfig().Host,
 		TLSClientConfig: rest.TLSClientConfig{
 			Insecure: false,
-			CAData:   secret.Data["ca.crt"],
+			CAData:   k8sClient.RESTConfig().CAData,
 		},
 		BearerToken: string(secret.Data["token"]),
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
Currently, the test framework can't handle if the kubeconfig contains an alternative endpoint which doesn't use the same certificate as the kube-apiserver. This also includes the case that a kubeconfig is used which contains a trusted endpoint and thus no CA data at all.
This is fixed with this PR.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
