### PR TITLE
Deflake managedresource controller integration test

### DIFF
--- a/pkg/resourcemanager/controller/managedresource/add.go
+++ b/pkg/resourcemanager/controller/managedresource/add.go
@@ -66,6 +66,9 @@ type ControllerConfig struct {
 	GarbageCollectorActivated bool
 
 	TargetCluster cluster.Cluster
+
+	// only used for testing, defaults to 5 seconds
+	RequeueAfterOnDeletionPending time.Duration
 }
 
 // AddToManagerWithOptions adds the controller to a Manager with the given config.
@@ -84,6 +87,8 @@ func AddToManagerWithOptions(mgr manager.Manager, conf ControllerConfig) error {
 				syncPeriod:                conf.SyncPeriod,
 				clusterID:                 conf.ClusterID,
 				garbageCollectorActivated: conf.GarbageCollectorActivated,
+
+				requeueAfterOnDeletionPending: conf.RequeueAfterOnDeletionPending,
 			},
 		),
 		RecoverPanic: true,
@@ -153,6 +158,8 @@ func (o *ControllerOptions) Complete() error {
 		ClassFilter:          managerpredicate.NewClassFilter(o.resourceClass),
 		AlwaysUpdate:         o.alwaysUpdate,
 		ClusterID:            o.clusterID,
+
+		RequeueAfterOnDeletionPending: 5 * time.Second,
 	}
 	return nil
 }

--- a/pkg/resourcemanager/controller/managedresource/reconciler.go
+++ b/pkg/resourcemanager/controller/managedresource/reconciler.go
@@ -78,6 +78,8 @@ type reconciler struct {
 	garbageCollectorActivated bool
 
 	clusterID string
+
+	requeueAfterOnDeletionPending time.Duration
 }
 
 // InjectClient injects a client into the reconciler.
@@ -318,7 +320,7 @@ func (r *reconciler) reconcile(ctx context.Context, mr *resourcesv1alpha1.Manage
 		}
 
 		if deletionPending {
-			return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+			return ctrl.Result{RequeueAfter: r.requeueAfterOnDeletionPending}, nil
 		} else {
 			return ctrl.Result{}, err
 		}
@@ -403,7 +405,7 @@ func (r *reconciler) delete(ctx context.Context, mr *resourcesv1alpha1.ManagedRe
 			}
 
 			if deletionPending {
-				return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
+				return ctrl.Result{RequeueAfter: r.requeueAfterOnDeletionPending}, nil
 			} else {
 				return ctrl.Result{}, err
 			}

--- a/test/integration/resourcemanager/health/health_suite_test.go
+++ b/test/integration/resourcemanager/health/health_suite_test.go
@@ -44,10 +44,8 @@ func TestHealthController(t *testing.T) {
 	RunSpecs(t, "Health Controller Integration Test Suite")
 }
 
-const (
-	// testID is used for generating test namespace names and other IDs
-	testID = "health-controller-test"
-)
+// testID is used for generating test namespace names and other IDs
+const testID = "health-controller-test"
 
 var (
 	ctx       = context.Background()
@@ -55,7 +53,6 @@ var (
 	log       logr.Logger
 
 	testEnv    *envtest.Environment
-	testScheme *runtime.Scheme
 	testClient client.Client
 
 	testNamespace *corev1.Namespace
@@ -85,7 +82,7 @@ var _ = BeforeSuite(func() {
 	})
 
 	By("creating test client")
-	testScheme = runtime.NewScheme()
+	testScheme := runtime.NewScheme()
 	Expect(resourcemanagercmd.AddToSourceScheme(testScheme)).To(Succeed())
 	Expect(resourcemanagercmd.AddToTargetScheme(testScheme)).To(Succeed())
 
@@ -99,7 +96,8 @@ var _ = BeforeSuite(func() {
 			GenerateName: testID + "-",
 		},
 	}
-	Expect(testClient.Create(ctx, testNamespace)).To(Or(Succeed(), BeAlreadyExistsError()))
+	Expect(testClient.Create(ctx, testNamespace)).To(Succeed())
+	log.Info("Created Namespace for test", "namespaceName", testNamespace.Name)
 
 	DeferCleanup(func() {
 		By("deleting test namespace")

--- a/test/integration/resourcemanager/managedresource/resource_suite_test.go
+++ b/test/integration/resourcemanager/managedresource/resource_suite_test.go
@@ -133,7 +133,10 @@ var _ = BeforeSuite(func() {
 	filter = predicate.NewClassFilter(managerpredicate.DefaultClass)
 	Expect(managedresource.AddToManagerWithOptions(mgr, managedresource.ControllerConfig{
 		MaxConcurrentWorkers: 5,
-		SyncPeriod:           500 * time.Millisecond, // gotta go fast during tests
+
+		// gotta go fast during tests
+		SyncPeriod:                    500 * time.Millisecond,
+		RequeueAfterOnDeletionPending: 50 * time.Millisecond,
 
 		ClassFilter:   filter,
 		TargetCluster: targetClusterOpts.Completed().Cluster,

--- a/test/integration/resourcemanager/managedresource/resource_suite_test.go
+++ b/test/integration/resourcemanager/managedresource/resource_suite_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package reconciler_test
+package managedresource_test
 
 import (
 	"context"

--- a/test/integration/resourcemanager/managedresource/resource_test.go
+++ b/test/integration/resourcemanager/managedresource/resource_test.go
@@ -25,6 +25,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllerutils"
+	"github.com/gardener/gardener/pkg/utils"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -38,83 +39,108 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const (
-	secretName    = "test-secret"
-	configMapName = "test-configmap"
-	dataKey       = "configmap.yaml"
-)
-
 var _ = Describe("ManagedResource controller tests", func() {
+	const dataKey = "configmap.yaml"
+
 	var (
+		// resourceName is used as a base name for all resources in the current test case
+		resourceName string
+		objectKey    client.ObjectKey
+
 		secretForManagedResource *corev1.Secret
 		managedResource          *resourcesv1alpha1.ManagedResource
 
 		configMap *corev1.ConfigMap
 	)
 
-	Context("create, update and delete operations", func() {
-		BeforeEach(func() {
-			configMap = &corev1.ConfigMap{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: corev1.SchemeGroupVersion.String(),
-					Kind:       "ConfigMap",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      configMapName,
-					Namespace: testNamespace.Name,
-				},
-			}
+	BeforeEach(func() {
+		// use unique resource names specific to test case
+		// If we use the same names for all test cases, failing cases will cause cascading failures because of AlreadyExistsErrors.
+		// We want to avoid cascading failures because they are distracting from the actual root failure, and we want to
+		// test all cases in a clean environment to make sure we don't have any unintended dependencies between test code.
+		// We could also use GenerateName for this purpose, but then we would need an extra call to update the name of the
+		// marshalled ConfigMap in the already created Secret.
+		resourceName = "test-" + utils.ComputeSHA256Hex([]byte(CurrentSpecReport().LeafNodeLocation.String()))[:8]
+		objectKey = client.ObjectKey{Namespace: testNamespace.Name, Name: resourceName}
 
-			secretForManagedResource = &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      secretName,
-					Namespace: testNamespace.Name,
-				},
-				Data: secretDataForObject(configMap, dataKey),
-			}
+		configMap = &corev1.ConfigMap{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: corev1.SchemeGroupVersion.String(),
+				Kind:       "ConfigMap",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resourceName,
+				Namespace: testNamespace.Name,
+			},
+		}
 
-			managedResource = &resourcesv1alpha1.ManagedResource{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-managedresource",
-					Namespace: testNamespace.Name,
-				},
-				Spec: resourcesv1alpha1.ManagedResourceSpec{
-					Class:      pointer.String(filter.ResourceClass()),
-					SecretRefs: []corev1.LocalObjectReference{{Name: secretForManagedResource.Name}},
-				},
-			}
-		})
+		secretForManagedResource = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resourceName,
+				Namespace: testNamespace.Name,
+			},
+			Data: secretDataForObject(configMap, dataKey),
+		}
 
-		AfterEach(func() {
-			Expect(testClient.Delete(ctx, managedResource)).To(Or(Succeed(), BeNotFoundError()))
-			Eventually(func(g Gomega) {
-				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(BeNotFoundError())
-				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)).To(BeNotFoundError())
+		managedResource = &resourcesv1alpha1.ManagedResource{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resourceName,
+				Namespace: testNamespace.Name,
+			},
+			Spec: resourcesv1alpha1.ManagedResourceSpec{
+				Class:      pointer.String(filter.ResourceClass()),
+				SecretRefs: []corev1.LocalObjectReference{{Name: secretForManagedResource.Name}},
+			},
+		}
+	})
+
+	JustBeforeEach(func() {
+		if secretForManagedResource != nil {
+			By("creating Secret for test")
+			log.Info("Creating Secret for test", "secret", objectKey)
+			Expect(testClient.Create(ctx, secretForManagedResource)).To(Succeed())
+		}
+
+		By("creating ManagedResource for test")
+		log.Info("Creating ManagedResource for test", "managedResource", objectKey)
+		Expect(testClient.Create(ctx, managedResource)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		By("deleting ManagedResource")
+		Expect(testClient.Delete(ctx, managedResource)).To(Or(Succeed(), BeNotFoundError()))
+
+		Eventually(func(g Gomega) {
+			g.Expect(testClient.Get(ctx, objectKey, &resourcesv1alpha1.ManagedResource{})).To(BeNotFoundError(), "ManagedResource should get released")
+			g.Expect(testClient.Get(ctx, objectKey, &corev1.ConfigMap{})).To(BeNotFoundError(), "managed ConfigMap should get deleted")
+		}).Should(Succeed())
+
+		if secretForManagedResource != nil {
+			By("deleting Secret")
+			Expect(testClient.Delete(ctx, secretForManagedResource)).To(Or(Succeed(), BeNotFoundError()))
+		}
+	})
+
+	Describe("create managed resource", func() {
+		It("should successfully create the resources and maintain proper status conditions", func() {
+			Eventually(func() error {
+				return testClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)
 			}).Should(Succeed())
 
-			Expect(testClient.Delete(ctx, secretForManagedResource)).To(Or(Succeed(), BeNotFoundError()))
+			Eventually(func(g Gomega) []gardencorev1beta1.Condition {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
+				return managedResource.Status.Conditions
+			}).Should(
+				containCondition(ofType(resourcesv1alpha1.ResourcesApplied), withStatus(gardencorev1beta1.ConditionTrue), withReason(resourcesv1alpha1.ConditionApplySucceeded)),
+			)
 		})
 
-		Context("create managed resource", func() {
-			It("should successfully create the resources and maintain proper status conditions", func() {
-				Expect(testClient.Create(ctx, secretForManagedResource)).To(Succeed())
-				Expect(testClient.Create(ctx, managedResource)).To(Succeed())
-
-				Eventually(func() error {
-					return testClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)
-				}).Should(Succeed())
-
-				Eventually(func(g Gomega) []gardencorev1beta1.Condition {
-					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
-					return managedResource.Status.Conditions
-				}).Should(
-					containCondition(ofType(resourcesv1alpha1.ResourcesApplied), withStatus(gardencorev1beta1.ConditionTrue), withReason(resourcesv1alpha1.ConditionApplySucceeded)),
-				)
+		Context("missing secret", func() {
+			BeforeEach(func() {
+				secretForManagedResource = nil
 			})
 
 			It("should fail to create the resource due to missing secret reference", func() {
-				Expect(testClient.Create(ctx, managedResource)).To(Succeed())
-
 				Eventually(func(g Gomega) []gardencorev1beta1.Condition {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 					return managedResource.Status.Conditions
@@ -122,14 +148,15 @@ var _ = Describe("ManagedResource controller tests", func() {
 					containCondition(ofType(resourcesv1alpha1.ResourcesApplied), withStatus(gardencorev1beta1.ConditionFalse), withReason("CannotReadSecret")),
 				)
 			})
+		})
 
-			It("should fail to create the resource due to incorrect object", func() {
+		Context("missing TypeMeta in object", func() {
+			BeforeEach(func() {
 				newConfigMap := &corev1.ConfigMap{}
 				secretForManagedResource.Data = secretDataForObject(newConfigMap, dataKey)
+			})
 
-				Expect(testClient.Create(ctx, secretForManagedResource)).To(Succeed())
-				Expect(testClient.Create(ctx, managedResource)).To(Succeed())
-
+			It("should fail to create the resource due to incorrect object", func() {
 				Eventually(func(g Gomega) []gardencorev1beta1.Condition {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 					return managedResource.Status.Conditions
@@ -137,16 +164,48 @@ var _ = Describe("ManagedResource controller tests", func() {
 					containCondition(ofType(resourcesv1alpha1.ResourcesApplied), withStatus(gardencorev1beta1.ConditionFalse), withReason(resourcesv1alpha1.ConditionApplyFailed)),
 				)
 			})
+		})
+	})
 
-			It("should correctly set the condition ResourceApplied to Progressing", func() {
+	Describe("update managed resource", func() {
+		const newDataKey = "secret.yaml"
+		var newResource *corev1.Secret
+
+		BeforeEach(func() {
+			newResource = &corev1.Secret{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: corev1.SchemeGroupVersion.String(),
+					Kind:       "Secret",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      resourceName + "-new",
+					Namespace: testNamespace.Name,
+				},
+				Data: map[string][]byte{
+					"entry": []byte("value"),
+				},
+				Type: corev1.SecretTypeOpaque,
+			}
+		})
+
+		JustBeforeEach(func() {
+			Eventually(func(g Gomega) []gardencorev1beta1.Condition {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
+				return managedResource.Status.Conditions
+			}).Should(
+				containCondition(ofType(resourcesv1alpha1.ResourcesApplied), withStatus(gardencorev1beta1.ConditionTrue), withReason(resourcesv1alpha1.ConditionApplySucceeded)),
+			)
+		})
+
+		Describe("resource set changes", func() {
+			BeforeEach(func() {
 				// this finalizer is added to prolong the deletion of the resource so that we can
 				// observe the controller successfully setting ResourceApplied condition to Progressing
 				configMap.Finalizers = append(configMap.Finalizers, "kubernetes")
 				secretForManagedResource.Data = secretDataForObject(configMap, dataKey)
+			})
 
-				Expect(testClient.Create(ctx, secretForManagedResource)).To(Succeed())
-				Expect(testClient.Create(ctx, managedResource)).To(Succeed())
-
+			It("should correctly set the condition ResourceApplied to Progressing", func() {
 				Eventually(func(g Gomega) []gardencorev1beta1.Condition {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 					return managedResource.Status.Conditions
@@ -160,7 +219,7 @@ var _ = Describe("ManagedResource controller tests", func() {
 						Kind:       "ConfigMap",
 					},
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "new-configmap",
+						Name:      resourceName + "-new",
 						Namespace: testNamespace.Name,
 					},
 				}
@@ -182,38 +241,8 @@ var _ = Describe("ManagedResource controller tests", func() {
 			})
 		})
 
-		Context("update managed resource", func() {
-			const newDataKey = "secret.yaml"
-			var newResource *corev1.Secret
-
-			BeforeEach(func() {
-				newResource = &corev1.Secret{
-					TypeMeta: metav1.TypeMeta{
-						APIVersion: corev1.SchemeGroupVersion.String(),
-						Kind:       "Secret",
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "update-test-secret",
-						Namespace: testNamespace.Name,
-					},
-					Data: map[string][]byte{
-						"entry": []byte("value"),
-					},
-					Type: corev1.SecretTypeOpaque,
-				}
-
-				Expect(testClient.Create(ctx, secretForManagedResource)).To(Succeed())
-				Expect(testClient.Create(ctx, managedResource)).To(Succeed())
-
-				Eventually(func(g Gomega) []gardencorev1beta1.Condition {
-					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
-					return managedResource.Status.Conditions
-				}).Should(
-					containCondition(ofType(resourcesv1alpha1.ResourcesApplied), withStatus(gardencorev1beta1.ConditionTrue), withReason(resourcesv1alpha1.ConditionApplySucceeded)),
-				)
-			})
-
-			It("should successfully create a new resource when the secret referenced by the managed resource is updated with data containing the new resource", func() {
+		Describe("new resource added", func() {
+			It("should successfully create a new resource", func() {
 				Expect(testClient.Get(ctx, client.ObjectKeyFromObject(secretForManagedResource), secretForManagedResource)).To(Or(Succeed(), BeNoMatchError()))
 				secretForManagedResource.Data[newDataKey] = secretDataForObject(newResource, newDataKey)[newDataKey]
 				Expect(testClient.Update(ctx, secretForManagedResource)).To(Succeed())
@@ -231,10 +260,27 @@ var _ = Describe("ManagedResource controller tests", func() {
 				)
 			})
 
+			It("should fail to update the managed resource if a new incorrect resource is added", func() {
+				newResource.TypeMeta = metav1.TypeMeta{}
+
+				Expect(testClient.Get(ctx, client.ObjectKeyFromObject(secretForManagedResource), secretForManagedResource)).To(Or(Succeed(), BeNoMatchError()))
+				secretForManagedResource.Data[newDataKey] = secretDataForObject(newResource, newDataKey)[newDataKey]
+				Expect(testClient.Update(ctx, secretForManagedResource)).To(Succeed())
+
+				Eventually(func(g Gomega) []gardencorev1beta1.Condition {
+					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
+					return managedResource.Status.Conditions
+				}).Should(
+					containCondition(ofType(resourcesv1alpha1.ResourcesApplied), withStatus(gardencorev1beta1.ConditionFalse), withReason(resourcesv1alpha1.ConditionApplyFailed)),
+				)
+			})
+		})
+
+		Describe("new secret reference", func() {
 			It("should successfully update the managed resource with a new secret reference", func() {
 				newSecretForManagedResource := &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "new-secret",
+						Name:      resourceName + "-new-resource",
 						Namespace: testNamespace.Name,
 					},
 					Data: secretDataForObject(newResource, dataKey),
@@ -256,100 +302,43 @@ var _ = Describe("ManagedResource controller tests", func() {
 					containCondition(ofType(resourcesv1alpha1.ResourcesApplied), withStatus(gardencorev1beta1.ConditionTrue), withReason(resourcesv1alpha1.ConditionApplySucceeded)),
 				)
 			})
-
-			It("should fail to update the managed resource if a new incorrect resource is added to the secret referenced by the managed resource", func() {
-				newResource.TypeMeta = metav1.TypeMeta{}
-
-				Expect(testClient.Get(ctx, client.ObjectKeyFromObject(secretForManagedResource), secretForManagedResource)).To(Or(Succeed(), BeNoMatchError()))
-				secretForManagedResource.Data[newDataKey] = secretDataForObject(newResource, newDataKey)[newDataKey]
-				Expect(testClient.Update(ctx, secretForManagedResource)).To(Succeed())
-
-				Eventually(func(g Gomega) []gardencorev1beta1.Condition {
-					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
-					return managedResource.Status.Conditions
-				}).Should(
-					containCondition(ofType(resourcesv1alpha1.ResourcesApplied), withStatus(gardencorev1beta1.ConditionFalse), withReason(resourcesv1alpha1.ConditionApplyFailed)),
-				)
-			})
-		})
-
-		Context("delete managed resource", func() {
-			BeforeEach(func() {
-				Expect(testClient.Create(ctx, secretForManagedResource)).To(Succeed())
-				Expect(testClient.Create(ctx, managedResource)).To(Succeed())
-
-				patch := client.MergeFrom(managedResource.DeepCopy())
-				managedResource.SetFinalizers([]string{"test-finalizer"})
-				Expect(testClient.Patch(ctx, managedResource, patch)).To(Succeed())
-			})
-
-			JustAfterEach(func() {
-				patch := client.MergeFrom(managedResource.DeepCopy())
-				controllerutil.RemoveFinalizer(managedResource, "test-finalizer")
-				Expect(testClient.Patch(ctx, managedResource, patch))
-			})
-
-			It("should set ManagedResource to unhealthy", func() {
-				Expect(testClient.Delete(ctx, managedResource)).To(Succeed())
-
-				Eventually(func(g Gomega) []gardencorev1beta1.Condition {
-					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
-					return managedResource.Status.Conditions
-				}).Should(
-					containCondition(ofType(resourcesv1alpha1.ResourcesHealthy), withStatus(gardencorev1beta1.ConditionFalse), withReason(resourcesv1alpha1.ConditionDeletionPending)),
-					containCondition(ofType(resourcesv1alpha1.ResourcesProgressing), withStatus(gardencorev1beta1.ConditionTrue), withReason(resourcesv1alpha1.ConditionDeletionPending)),
-				)
-			})
 		})
 	})
 
-	Context("Resource class", func() {
-		BeforeEach(func() {
-			configMap = &corev1.ConfigMap{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: corev1.SchemeGroupVersion.String(),
-					Kind:       "ConfigMap",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      configMapName,
-					Namespace: testNamespace.Name,
-				},
-			}
-
-			secretForManagedResource = &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      secretName,
-					Namespace: testNamespace.Name,
-				},
-				Data: secretDataForObject(configMap, dataKey),
-			}
-
-			managedResource = &resourcesv1alpha1.ManagedResource{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-managedresource",
-					Namespace: testNamespace.Name,
-				},
-				Spec: resourcesv1alpha1.ManagedResourceSpec{
-					Class:      pointer.String("test"),
-					SecretRefs: []corev1.LocalObjectReference{{Name: secretForManagedResource.Name}},
-				},
-			}
+	Describe("delete managed resource", func() {
+		JustBeforeEach(func() {
+			// add finalizer to prolong deletion of ManagedResource after resource-manager removed its finalizer
+			patch := client.MergeFrom(managedResource.DeepCopy())
+			managedResource.SetFinalizers([]string{"test-finalizer"})
+			Expect(testClient.Patch(ctx, managedResource, patch)).To(Succeed())
 		})
 
-		AfterEach(func() {
-			Expect(testClient.Delete(ctx, managedResource)).To(Or(Succeed(), BeNotFoundError()))
-			Eventually(func(g Gomega) {
-				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(BeNotFoundError())
-				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)).To(BeNotFoundError())
-			}).Should(Succeed())
+		JustAfterEach(func() {
+			patch := client.MergeFrom(managedResource.DeepCopy())
+			controllerutil.RemoveFinalizer(managedResource, "test-finalizer")
+			Expect(testClient.Patch(ctx, managedResource, patch))
+		})
 
-			Expect(testClient.Delete(ctx, secretForManagedResource)).To(Or(Succeed(), BeNotFoundError()))
+		It("should set ManagedResource to unhealthy", func() {
+			By("deleting ManagedResource")
+			Expect(testClient.Delete(ctx, managedResource)).To(Succeed())
+
+			Eventually(func(g Gomega) []gardencorev1beta1.Condition {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
+				return managedResource.Status.Conditions
+			}).Should(
+				containCondition(ofType(resourcesv1alpha1.ResourcesHealthy), withStatus(gardencorev1beta1.ConditionFalse), withReason(resourcesv1alpha1.ConditionDeletionPending)),
+				containCondition(ofType(resourcesv1alpha1.ResourcesProgressing), withStatus(gardencorev1beta1.ConditionTrue), withReason(resourcesv1alpha1.ConditionDeletionPending)),
+			)
+		})
+	})
+
+	Describe("Resource class", func() {
+		BeforeEach(func() {
+			managedResource.Spec.Class = pointer.String("test")
 		})
 
 		It("should not reconcile ManagedResource of any other class except the default class", func() {
-			Expect(testClient.Create(ctx, secretForManagedResource)).To(Succeed())
-			Expect(testClient.Create(ctx, managedResource)).To(Succeed())
-
 			Consistently(func() error {
 				return testClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)
 			}).Should(BeNotFoundError())
@@ -357,61 +346,18 @@ var _ = Describe("ManagedResource controller tests", func() {
 			Consistently(func(g Gomega) []gardencorev1beta1.Condition {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 				return managedResource.Status.Conditions
-			}).ShouldNot(
-				containCondition(ofType(resourcesv1alpha1.ResourcesApplied)),
-			)
+			}).Should(BeEmpty())
 		})
 	})
 
-	Context("Reconciliation Modes/Annotations", func() {
-		BeforeEach(func() {
-			configMap = &corev1.ConfigMap{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: corev1.SchemeGroupVersion.String(),
-					Kind:       "ConfigMap",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      configMapName,
-					Namespace: testNamespace.Name,
-				},
-			}
-
-			secretForManagedResource = &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      secretName,
-					Namespace: testNamespace.Name,
-				},
-			}
-
-			managedResource = &resourcesv1alpha1.ManagedResource{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-managedresource",
-					Namespace: testNamespace.Name,
-				},
-				Spec: resourcesv1alpha1.ManagedResourceSpec{
-					Class:      pointer.String(filter.ResourceClass()),
-					SecretRefs: []corev1.LocalObjectReference{{Name: secretForManagedResource.Name}},
-				},
-			}
-
-			DeferCleanup(func() {
-				Expect(testClient.Delete(ctx, managedResource)).To(Or(Succeed(), BeNotFoundError()))
-				Eventually(func(g Gomega) {
-					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(BeNotFoundError())
-				}).Should(Succeed())
-
-				Expect(testClient.Delete(ctx, secretForManagedResource)).To(Or(Succeed(), BeNotFoundError()))
-			})
-		})
-
-		Context("Ignore Mode", func() {
-			It("should not update/re-apply resources having ignore mode annotation and remove them from the ManagedResource status", func() {
+	Describe("Reconciliation Modes/Annotations", func() {
+		Describe("Ignore Mode", func() {
+			BeforeEach(func() {
 				configMap.SetAnnotations(map[string]string{resourcesv1alpha1.Mode: resourcesv1alpha1.ModeIgnore})
 				secretForManagedResource.Data = secretDataForObject(configMap, dataKey)
+			})
 
-				Expect(testClient.Create(ctx, secretForManagedResource)).To(Succeed())
-				Expect(testClient.Create(ctx, managedResource)).To(Succeed())
-
+			It("should not update/re-apply resources having ignore mode annotation and remove them from the ManagedResource status", func() {
 				Eventually(func(g Gomega) []gardencorev1beta1.Condition {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 					return managedResource.Status.Conditions
@@ -425,29 +371,17 @@ var _ = Describe("ManagedResource controller tests", func() {
 			})
 		})
 
-		Context("Delete On Invalid Update", func() {
+		Describe("Delete On Invalid Update", func() {
 			var originalUID types.UID
 
 			BeforeEach(func() {
-				configMap = &corev1.ConfigMap{
-					TypeMeta: metav1.TypeMeta{
-						APIVersion: corev1.SchemeGroupVersion.String(),
-						Kind:       "ConfigMap",
-					},
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      configMapName,
-						Namespace: testNamespace.Name,
-					},
-				}
-
 				configMap.SetAnnotations(map[string]string{resourcesv1alpha1.DeleteOnInvalidUpdate: "true"})
 				// provoke invalid update by trying to update an immutable configmap's data
 				configMap.Immutable = pointer.Bool(true)
 				secretForManagedResource.Data = secretDataForObject(configMap, dataKey)
+			})
 
-				Expect(testClient.Create(ctx, secretForManagedResource)).To(Succeed())
-				Expect(testClient.Create(ctx, managedResource)).To(Succeed())
-
+			JustBeforeEach(func() {
 				Eventually(func(g Gomega) []gardencorev1beta1.Condition {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 					return managedResource.Status.Conditions
@@ -491,21 +425,23 @@ var _ = Describe("ManagedResource controller tests", func() {
 			})
 		})
 
-		Context("Keep Object", func() {
+		Describe("Keep Object", func() {
 			BeforeEach(func() {
 				configMap.SetAnnotations(map[string]string{resourcesv1alpha1.KeepObject: "true"})
-
 				secretForManagedResource.Data = secretDataForObject(configMap, dataKey)
+			})
 
-				Expect(testClient.Create(ctx, secretForManagedResource)).To(Succeed())
-				Expect(testClient.Create(ctx, managedResource)).To(Succeed())
-
+			JustBeforeEach(func() {
 				Eventually(func(g Gomega) []gardencorev1beta1.Condition {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 					return managedResource.Status.Conditions
 				}).Should(
 					containCondition(ofType(resourcesv1alpha1.ResourcesApplied), withStatus(gardencorev1beta1.ConditionTrue), withReason(resourcesv1alpha1.ConditionApplySucceeded)),
 				)
+			})
+
+			JustAfterEach(func() {
+				Expect(testClient.Delete(ctx, configMap)).To(Or(Succeed(), BeNotFoundError()))
 			})
 
 			It("should keep the object in case it is removed from the MangedResource", func() {
@@ -525,25 +461,24 @@ var _ = Describe("ManagedResource controller tests", func() {
 			})
 
 			It("should keep the object even after deletion of ManagedResource", func() {
+				By("deleting ManagedResource")
 				Expect(testClient.Delete(ctx, managedResource)).To(Or(Succeed(), BeNotFoundError()))
+
 				Eventually(func(g Gomega) {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(BeNotFoundError())
 				}).Should(Succeed())
 
-				Expect(testClient.Delete(ctx, secretForManagedResource)).To(Or(Succeed(), BeNotFoundError()))
 				Expect(testClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)).To(Succeed())
 			})
 		})
 
-		Context("Ignore", func() {
-			It("should not revert any manual update on resource managed by ManagedResource when resource itself has ignore annotation", func() {
+		Describe("Ignore on Resource", func() {
+			BeforeEach(func() {
 				configMap.SetAnnotations(map[string]string{resourcesv1alpha1.Ignore: "true"})
-
 				secretForManagedResource.Data = secretDataForObject(configMap, dataKey)
+			})
 
-				Expect(testClient.Create(ctx, secretForManagedResource)).To(Succeed())
-				Expect(testClient.Create(ctx, managedResource)).To(Succeed())
-
+			It("should not revert any manual update to managed resource", func() {
 				Eventually(func(g Gomega) []gardencorev1beta1.Condition {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 					return managedResource.Status.Conditions
@@ -552,7 +487,6 @@ var _ = Describe("ManagedResource controller tests", func() {
 				)
 
 				Expect(testClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)).To(Succeed())
-
 				configMap.Data = map[string]string{"foo": "bar"}
 				Expect(testClient.Update(ctx, configMap)).To(Succeed())
 
@@ -568,11 +502,10 @@ var _ = Describe("ManagedResource controller tests", func() {
 					return configMap.Data
 				}).Should(HaveKeyWithValue("foo", "bar"))
 			})
+		})
 
-			It("should not revert any manual update on the resources when the ManagedResource has ignore annotation", func() {
-				Expect(testClient.Create(ctx, secretForManagedResource)).To(Succeed())
-				Expect(testClient.Create(ctx, managedResource)).To(Succeed())
-
+		Describe("Ignore on ManagedResource", func() {
+			It("should not revert any manual update to the resources", func() {
 				Eventually(func(g Gomega) []gardencorev1beta1.Condition {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 					return managedResource.Status.Conditions
@@ -603,215 +536,189 @@ var _ = Describe("ManagedResource controller tests", func() {
 				}).Should(HaveKeyWithValue("foo", "bar"))
 			})
 		})
-	})
 
-	Context("Preserve Replica/Resource", func() {
-		var (
-			defaultPodTemplateSpec *corev1.PodTemplateSpec
-			deployment             *appsv1.Deployment
-		)
+		Describe("Preserve Replica/Resource", func() {
+			var (
+				defaultPodTemplateSpec *corev1.PodTemplateSpec
+				deployment             *appsv1.Deployment
+			)
 
-		BeforeEach(func() {
-			defaultPodTemplateSpec = &corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"foo": "bar"},
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name:  "foo-container",
-							Image: "foo",
+			BeforeEach(func() {
+				defaultPodTemplateSpec = &corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{"foo": "bar"},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "foo-container",
+								Image: "foo",
+								Resources: corev1.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("25m"),
+										corev1.ResourceMemory: resource.MustParse("25Mi"),
+									},
+									Limits: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("50m"),
+										corev1.ResourceMemory: resource.MustParse("50Mi"),
+									},
+								},
+							},
 						},
 					},
-				},
-			}
+				}
 
-			deployment = &appsv1.Deployment{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: appsv1.SchemeGroupVersion.String(),
-					Kind:       "Deployment",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-deploy",
-					Namespace: testNamespace.Name,
-				},
-				Spec: appsv1.DeploymentSpec{
-					Selector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{"foo": "bar"},
+				deployment = &appsv1.Deployment{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: appsv1.SchemeGroupVersion.String(),
+						Kind:       "Deployment",
 					},
-					Replicas: pointer.Int32Ptr(1),
-					Template: *defaultPodTemplateSpec,
-				},
-			}
-
-			secretForManagedResource = &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      secretName,
-					Namespace: testNamespace.Name,
-				},
-			}
-
-			managedResource = &resourcesv1alpha1.ManagedResource{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-managedresource",
-					Namespace: testNamespace.Name,
-				},
-				Spec: resourcesv1alpha1.ManagedResourceSpec{
-					Class:      pointer.String(filter.ResourceClass()),
-					SecretRefs: []corev1.LocalObjectReference{{Name: secretForManagedResource.Name}},
-				},
-			}
-		})
-
-		AfterEach(func() {
-			Expect(testClient.Delete(ctx, managedResource)).To(Or(Succeed(), BeNotFoundError()))
-
-			// wait for finalizer to be added
-			Eventually(func(g Gomega) []string {
-				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)).To(Succeed())
-				return deployment.Finalizers
-			}).Should(ConsistOf("foregroundDeletion"))
-
-			// remove finalizer so the deployment can be deleted
-			Expect(controllerutils.PatchRemoveFinalizers(ctx, testClient, deployment, "foregroundDeletion")).To(BeNil())
-
-			Eventually(func(g Gomega) {
-				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)).To(BeNotFoundError())
-				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(BeNotFoundError())
-			}).Should(Succeed())
-
-			Expect(testClient.Delete(ctx, secretForManagedResource)).To(Or(Succeed(), BeNotFoundError()))
-		})
-
-		Context("Preserve Replicas", func() {
-			It("should not preserve changes in the number of replicas if the resource don't have preserve-replicas annotation", func() {
-				secretForManagedResource.Data = secretDataForObject(deployment, "deployment.yaml")
-
-				Expect(testClient.Create(ctx, secretForManagedResource)).To(Succeed())
-				Expect(testClient.Create(ctx, managedResource)).To(Succeed())
-
-				Eventually(func(g Gomega) []gardencorev1beta1.Condition {
-					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
-					return managedResource.Status.Conditions
-				}).Should(
-					containCondition(ofType(resourcesv1alpha1.ResourcesApplied), withStatus(gardencorev1beta1.ConditionTrue), withReason(resourcesv1alpha1.ConditionApplySucceeded)),
-				)
-
-				Expect(testClient.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)).To(Succeed())
-				updatedDeployment := deployment.DeepCopy()
-				updatedDeployment.Spec.Replicas = pointer.Int32Ptr(5)
-				Expect(testClient.Update(ctx, updatedDeployment)).To(Succeed())
-
-				Eventually(func(g Gomega) int32 {
-					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)).To(Succeed())
-					return *deployment.Spec.Replicas
-				}).Should(BeEquivalentTo(1))
-			})
-
-			It("should preserve changes in the number of replicas if the resource has preserve-replicas annotation", func() {
-				deployment.SetAnnotations(map[string]string{resourcesv1alpha1.PreserveReplicas: "true"})
-				secretForManagedResource.Data = secretDataForObject(deployment, "deployment.yaml")
-
-				Expect(testClient.Create(ctx, secretForManagedResource)).To(Succeed())
-				Expect(testClient.Create(ctx, managedResource)).To(Succeed())
-
-				Eventually(func(g Gomega) []gardencorev1beta1.Condition {
-					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
-					return managedResource.Status.Conditions
-				}).Should(
-					containCondition(ofType(resourcesv1alpha1.ResourcesApplied), withStatus(gardencorev1beta1.ConditionTrue), withReason(resourcesv1alpha1.ConditionApplySucceeded)),
-				)
-
-				Expect(testClient.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)).To(Succeed())
-				updatedDeployment := deployment.DeepCopy()
-				updatedDeployment.Spec.Replicas = pointer.Int32Ptr(5)
-				Expect(testClient.Update(ctx, updatedDeployment)).To(Succeed())
-
-				Consistently(func(g Gomega) int32 {
-					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)).To(Succeed())
-					return *deployment.Spec.Replicas
-				}).Should(BeEquivalentTo(5))
-			})
-		})
-
-		Context("Preserve Resources", func() {
-			var (
-				newPodTemplateSpec *corev1.PodTemplateSpec
-			)
-			BeforeEach(func() {
-				defaultPodTemplateSpec.Spec.Containers[0].Resources = corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("25m"),
-						corev1.ResourceMemory: resource.MustParse("25Mi"),
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      resourceName,
+						Namespace: testNamespace.Name,
 					},
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("50m"),
-						corev1.ResourceMemory: resource.MustParse("50Mi"),
+					Spec: appsv1.DeploymentSpec{
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"foo": "bar"},
+						},
+						Replicas: pointer.Int32Ptr(1),
+						Template: *defaultPodTemplateSpec,
 					},
 				}
 
-				deployment.Spec.Template = *defaultPodTemplateSpec
-
-				newPodTemplateSpec = defaultPodTemplateSpec.DeepCopy()
-				newPodTemplateSpec.Spec.Containers[0].Resources = corev1.ResourceRequirements{
-					Requests: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("35m"),
-						corev1.ResourceMemory: resource.MustParse("35Mi"),
-					},
-					Limits: corev1.ResourceList{
-						corev1.ResourceCPU:    resource.MustParse("60m"),
-						corev1.ResourceMemory: resource.MustParse("60Mi"),
-					},
-				}
+				secretForManagedResource.Data = secretDataForObject(deployment, "deployment.yaml")
 			})
 
-			It("should not preserve changes in resource requests and limits in Pod if the resource doesn't have preserve-resources annotation", func() {
-				secretForManagedResource.Data = secretDataForObject(deployment, "deployment.yaml")
+			AfterEach(func() {
+				By("deleting ManagedResource")
+				Expect(testClient.Delete(ctx, managedResource)).To(Or(Succeed(), BeNotFoundError()))
 
-				Expect(testClient.Create(ctx, secretForManagedResource)).To(Succeed())
-				Expect(testClient.Create(ctx, managedResource)).To(Succeed())
-
-				Eventually(func(g Gomega) []gardencorev1beta1.Condition {
-					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
-					return managedResource.Status.Conditions
-				}).Should(
-					containCondition(ofType(resourcesv1alpha1.ResourcesApplied), withStatus(gardencorev1beta1.ConditionTrue), withReason(resourcesv1alpha1.ConditionApplySucceeded)),
-				)
-
-				Expect(testClient.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)).To(Succeed())
-				updatedDeployment := deployment.DeepCopy()
-				updatedDeployment.Spec.Template = *newPodTemplateSpec
-				Expect(testClient.Update(ctx, updatedDeployment)).To(Succeed())
-
-				Eventually(func(g Gomega) corev1.ResourceRequirements {
+				// wait for finalizer to be added
+				Eventually(func(g Gomega) []string {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)).To(Succeed())
-					return deployment.Spec.Template.Spec.Containers[0].Resources
-				}).Should(DeepEqual(defaultPodTemplateSpec.Spec.Containers[0].Resources))
+					return deployment.Finalizers
+				}).Should(ConsistOf("foregroundDeletion"))
+
+				// remove finalizer so the deployment can be deleted
+				Expect(controllerutils.PatchRemoveFinalizers(ctx, testClient, deployment, "foregroundDeletion")).To(BeNil())
+
+				Eventually(func(g Gomega) {
+					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)).To(BeNotFoundError())
+				}).Should(Succeed())
 			})
 
-			It("should preserve changes in resource requests and limits in Pod if the resource has preserve-resources annotation", func() {
-				deployment.SetAnnotations(map[string]string{resourcesv1alpha1.PreserveResources: "true"})
-				secretForManagedResource.Data = secretDataForObject(deployment, "deployment.yaml")
+			Describe("Preserve Replicas", func() {
+				Context("resource doesn't have preserve-replicas annotation", func() {
+					It("should not preserve changes in the number of replicas", func() {
+						Eventually(func(g Gomega) []gardencorev1beta1.Condition {
+							g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
+							return managedResource.Status.Conditions
+						}).Should(
+							containCondition(ofType(resourcesv1alpha1.ResourcesApplied), withStatus(gardencorev1beta1.ConditionTrue), withReason(resourcesv1alpha1.ConditionApplySucceeded)),
+						)
 
-				Expect(testClient.Create(ctx, secretForManagedResource)).To(Succeed())
-				Expect(testClient.Create(ctx, managedResource)).To(Succeed())
+						Expect(testClient.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)).To(Succeed())
+						updatedDeployment := deployment.DeepCopy()
+						updatedDeployment.Spec.Replicas = pointer.Int32Ptr(5)
+						Expect(testClient.Update(ctx, updatedDeployment)).To(Succeed())
 
-				Eventually(func(g Gomega) []gardencorev1beta1.Condition {
-					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
-					return managedResource.Status.Conditions
-				}).Should(
-					containCondition(ofType(resourcesv1alpha1.ResourcesApplied), withStatus(gardencorev1beta1.ConditionTrue), withReason(resourcesv1alpha1.ConditionApplySucceeded)),
-				)
+						Eventually(func(g Gomega) int32 {
+							g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)).To(Succeed())
+							return *deployment.Spec.Replicas
+						}).Should(BeEquivalentTo(1))
+					})
+				})
 
-				Expect(testClient.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)).To(Succeed())
-				updatedDeployment := deployment.DeepCopy()
-				updatedDeployment.Spec.Template = *newPodTemplateSpec
-				Expect(testClient.Update(ctx, updatedDeployment)).To(Succeed())
+				Context("resource has preserve-replicas annotation", func() {
+					BeforeEach(func() {
+						deployment.SetAnnotations(map[string]string{resourcesv1alpha1.PreserveReplicas: "true"})
+						secretForManagedResource.Data = secretDataForObject(deployment, "deployment.yaml")
+					})
 
-				Eventually(func(g Gomega) corev1.ResourceRequirements {
-					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)).To(Succeed())
-					return deployment.Spec.Template.Spec.Containers[0].Resources
-				}).ShouldNot(DeepEqual(defaultPodTemplateSpec.Spec.Containers[0].Resources))
+					It("should preserve changes in the number of replicas if the resource", func() {
+						Eventually(func(g Gomega) []gardencorev1beta1.Condition {
+							g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
+							return managedResource.Status.Conditions
+						}).Should(
+							containCondition(ofType(resourcesv1alpha1.ResourcesApplied), withStatus(gardencorev1beta1.ConditionTrue), withReason(resourcesv1alpha1.ConditionApplySucceeded)),
+						)
+
+						Expect(testClient.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)).To(Succeed())
+						updatedDeployment := deployment.DeepCopy()
+						updatedDeployment.Spec.Replicas = pointer.Int32Ptr(5)
+						Expect(testClient.Update(ctx, updatedDeployment)).To(Succeed())
+
+						Consistently(func(g Gomega) int32 {
+							g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)).To(Succeed())
+							return *deployment.Spec.Replicas
+						}).Should(BeEquivalentTo(5))
+					})
+				})
+			})
+
+			Describe("Preserve Resources", func() {
+				var newPodTemplateSpec *corev1.PodTemplateSpec
+
+				BeforeEach(func() {
+					newPodTemplateSpec = defaultPodTemplateSpec.DeepCopy()
+					newPodTemplateSpec.Spec.Containers[0].Resources = corev1.ResourceRequirements{
+						Requests: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("35m"),
+							corev1.ResourceMemory: resource.MustParse("35Mi"),
+						},
+						Limits: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("60m"),
+							corev1.ResourceMemory: resource.MustParse("60Mi"),
+						},
+					}
+				})
+
+				Context("resource doesn't have preserve-resources annotation", func() {
+					It("should not preserve changes in resource requests and limits in Pod", func() {
+						Eventually(func(g Gomega) []gardencorev1beta1.Condition {
+							g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
+							return managedResource.Status.Conditions
+						}).Should(
+							containCondition(ofType(resourcesv1alpha1.ResourcesApplied), withStatus(gardencorev1beta1.ConditionTrue), withReason(resourcesv1alpha1.ConditionApplySucceeded)),
+						)
+
+						Expect(testClient.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)).To(Succeed())
+						updatedDeployment := deployment.DeepCopy()
+						updatedDeployment.Spec.Template = *newPodTemplateSpec
+						Expect(testClient.Update(ctx, updatedDeployment)).To(Succeed())
+
+						Eventually(func(g Gomega) corev1.ResourceRequirements {
+							g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)).To(Succeed())
+							return deployment.Spec.Template.Spec.Containers[0].Resources
+						}).Should(DeepEqual(defaultPodTemplateSpec.Spec.Containers[0].Resources))
+					})
+				})
+
+				Context("resource has preserve-resources annotation", func() {
+					BeforeEach(func() {
+						deployment.SetAnnotations(map[string]string{resourcesv1alpha1.PreserveResources: "true"})
+						secretForManagedResource.Data = secretDataForObject(deployment, "deployment.yaml")
+					})
+
+					It("should preserve changes in resource requests and limits in Pod", func() {
+						Eventually(func(g Gomega) []gardencorev1beta1.Condition {
+							g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
+							return managedResource.Status.Conditions
+						}).Should(
+							containCondition(ofType(resourcesv1alpha1.ResourcesApplied), withStatus(gardencorev1beta1.ConditionTrue), withReason(resourcesv1alpha1.ConditionApplySucceeded)),
+						)
+
+						Expect(testClient.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)).To(Succeed())
+						updatedDeployment := deployment.DeepCopy()
+						updatedDeployment.Spec.Template = *newPodTemplateSpec
+						Expect(testClient.Update(ctx, updatedDeployment)).To(Succeed())
+
+						Eventually(func(g Gomega) corev1.ResourceRequirements {
+							g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)).To(Succeed())
+							return deployment.Spec.Template.Spec.Containers[0].Resources
+						}).ShouldNot(DeepEqual(defaultPodTemplateSpec.Spec.Containers[0].Resources))
+					})
+				})
 			})
 		})
 	})

--- a/test/integration/resourcemanager/managedresource/resource_test.go
+++ b/test/integration/resourcemanager/managedresource/resource_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package reconciler_test
+package managedresource_test
 
 import (
 	"encoding/json"

--- a/test/integration/resourcemanager/managedresource/resource_test.go
+++ b/test/integration/resourcemanager/managedresource/resource_test.go
@@ -728,10 +728,10 @@ var _ = Describe("ManagedResource controller tests", func() {
 						deployment.Spec.Template = *newPodTemplateSpec
 						Expect(testClient.Patch(ctx, deployment, patch)).To(Succeed())
 
-						Eventually(func(g Gomega) corev1.ResourceRequirements {
+						Consistently(func(g Gomega) corev1.ResourceRequirements {
 							g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(deployment), deployment)).To(Succeed())
 							return deployment.Spec.Template.Spec.Containers[0].Resources
-						}).ShouldNot(DeepEqual(defaultPodTemplateSpec.Spec.Containers[0].Resources))
+						}).Should(DeepEqual(newPodTemplateSpec.Spec.Containers[0].Resources))
 					})
 				})
 			})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing dev-productivity
/kind flake cleanup

**What this PR does / why we need it**:

Fixes several flakes in the managedresource controller integration test, that were caused by changes in https://github.com/gardener/gardener/pull/5904.
In essence, the test cases were not able to cater with faster reconcile cycles, which resulted in conflicts, race conditions, etc. After lowering the sync period in https://github.com/gardener/gardener/pull/5904 to speed up the integration test these problems surfaced in CI. Previously we were just lucky / they were unlikely to surface because of the high sync period and long wait timeouts.

In order to reproduce, debug and fix the flakes, I had to rework the test suite significantly, so that it can be executed in parallel against an existing cluster.
I simplified and enhanced the test code significantly along the way, as well as fixed a wrongful test case for the `DeleteOnInvalidUpdate` annotation.

**Which issue(s) this PR fixes**:

Fixes 4 kinds of flakes:

- flake 1: `should not reconcile ManagedResource of any other class except the default class`, observed in https://prow.gardener.cloud/view/gs/gardener-prow/logs/ci-gardener-integration/1522509775537967104
  - fixed by the refactoring to use dedicated resource names per test case
- flake 2: `should set ManagedResource to unhealthy`, observed in https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/5935/pull-gardener-integration/1522480867149090816 and https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/5938/pull-gardener-integration/1523470537722957824
- flake 3: different test failures caused by conflicts errors, observed in https://prow.gardener.cloud/view/gs/gardener-prow/logs/ci-gardener-integration/1522992965088186368 and https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/5926/pull-gardener-integration/1523542805262110720
- flake 4: deletion times out because of constant requeue on pending deletion, observed locally

With this PR, the test suite looks much more stable:
```
$ make kind-up
$ export USE_EXISTING_CLUSTER=true
$ export GOMEGA_DEFAULT_EVENTUALLY_TIMEOUT=5s GOMEGA_DEFAULT_EVENTUALLY_POLLING_INTERVAL=200ms GOMEGA_DEFAULT_CONSISTENTLY_DURATION=5s GOMEGA_DEFAULT_CONSISTENTLY_POLLING_INTERVAL=200ms
$ cd ./test/integration/resourcemanager/managedresource && ginkgo build . && stress -p 32 ./managedresource.test
...
16m40s: 452 runs so far, 0 failures
```

**Special notes for your reviewer**:

The first 6 commits focus on reworking the test suite to make flakes reproducible with `stress` and `USE_EXISTING_CLUSTER=true`.
The last 3 commits fix individual flakes mentioned above.
