### PR TITLE
Add missing flow task dependency for `OperatingSystemConfig` deployment

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -403,7 +403,7 @@ func (r *shootReconciler) runReconcileShootFlow(ctx context.Context, o *operatio
 		deployOperatingSystemConfig = g.Add(flow.Task{
 			Name:         "Deploying operating system specific configuration for shoot workers",
 			Fn:           flow.TaskFn(botanist.DeployOperatingSystemConfig).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			Dependencies: flow.NewTaskIDs(deployReferencedResources, waitUntilInfrastructureReady, waitUntilControlPlaneReady),
+			Dependencies: flow.NewTaskIDs(deployReferencedResources, waitUntilInfrastructureReady, waitUntilControlPlaneReady, waitUntilOperatingSystemConfigReadyForMigration),
 		})
 		waitUntilOperatingSystemConfigReady = g.Add(flow.Task{
 			Name:         "Waiting until operating system configurations for worker nodes have been reconciled",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind bug

**What this PR does / why we need it**:
After #5870, there are two `OperatingSystemConfig` deployment tasks in the shoot reconciliation flow. However, the second deployment task was not depending on the first one which could lead to race conditions causing the following error messages in `gardenlet`:

```
ts="2022-05-11T13:30:07.450+0200" level=error msg="OperatingSystemConfig shoot--local--local/cloud-config-local-b3bcf-local-original did not get ready yet" error="object's \"gardener.cloud/timestamp\" annotation is not \"2022-05-11 11:29:31.971893 +0000 UTC\" but \"2022-05-11 11:29:32.493372 +0000 UTC\"" operation=reconcile shoot=garden-local/local
```

This is coming from https://github.com/gardener/gardener/blob/a2fbe8e0b209c9090326dd63f33e1937db39758f/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go#L180-L184 which waits for the proper timestamp. However, the timestamp was already changed in the meantime by the second deployment task in https://github.com/gardener/gardener/blob/a2fbe8e0b209c9090326dd63f33e1937db39758f/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go#L403-L407

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
