### PR TITLE
Manage autoscaler versions per k8s version

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -62,6 +62,11 @@ images:
   sourceRepository: github.com/gardener/autoscaler
   repository: eu.gcr.io/gardener-project/gardener/autoscaler/cluster-autoscaler
   tag: "v1.21.0"
+  targetVersion: "> 1.21"
+- name: cluster-autoscaler
+  sourceRepository: github.com/gardener/autoscaler
+  repository: eu.gcr.io/gardener-project/gardener/autoscaler/cluster-autoscaler
+  tag: "v1.21.0"
   targetVersion: "1.21.x"
 - name: cluster-autoscaler
   sourceRepository: github.com/gardener/autoscaler

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -72,7 +72,7 @@ images:
   sourceRepository: github.com/gardener/autoscaler
   repository: eu.gcr.io/gardener-project/gardener/autoscaler/cluster-autoscaler
   tag: "v0.19.0"
-  targetVersion: "< 1.19"
+  targetVersion: "< 1.20"
 - name: vpn-seed
   sourceRepository: github.com/gardener/vpn
   repository: eu.gcr.io/gardener-project/gardener/vpn-seed

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -61,7 +61,18 @@ images:
 - name: cluster-autoscaler
   sourceRepository: github.com/gardener/autoscaler
   repository: eu.gcr.io/gardener-project/gardener/autoscaler/cluster-autoscaler
+  tag: "v1.21.0"
+  targetVersion: "1.21.x"
+- name: cluster-autoscaler
+  sourceRepository: github.com/gardener/autoscaler
+  repository: eu.gcr.io/gardener-project/gardener/autoscaler/cluster-autoscaler
   tag: "v1.20.0"
+  targetVersion: "1.20.x"
+- name: cluster-autoscaler
+  sourceRepository: github.com/gardener/autoscaler
+  repository: eu.gcr.io/gardener-project/gardener/autoscaler/cluster-autoscaler
+  tag: "v0.19.0"
+  targetVersion: "< 1.19"
 - name: vpn-seed
   sourceRepository: github.com/gardener/vpn
   repository: eu.gcr.io/gardener-project/gardener/vpn-seed

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -62,12 +62,7 @@ images:
   sourceRepository: github.com/gardener/autoscaler
   repository: eu.gcr.io/gardener-project/gardener/autoscaler/cluster-autoscaler
   tag: "v1.21.0"
-  targetVersion: "> 1.21"
-- name: cluster-autoscaler
-  sourceRepository: github.com/gardener/autoscaler
-  repository: eu.gcr.io/gardener-project/gardener/autoscaler/cluster-autoscaler
-  tag: "v1.21.0"
-  targetVersion: "1.21.x"
+  targetVersion: ">= 1.21"
 - name: cluster-autoscaler
   sourceRepository: github.com/gardener/autoscaler
   repository: eu.gcr.io/gardener-project/gardener/autoscaler/cluster-autoscaler


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/area usability
/kind enhancement
/kind discussion

**What this PR does / why we need it**:
adds more entries to image vector for Cluster Autoscaler. We aim to deploy X.Y.* version of Cluster Autoscaler for a shoot with X.Y.* version of K8s. This is the recommendation by upstream Autoscaler as well. This change comes as a part of enabling syncing with upstream.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
* We aim to manually add a new entry to the image vector on every new minor release of `gardener/autoscaler`and remove entry for k8s version which are no longer supported by Gardener
* scale-from-zero is supported from v0.19.0 of g/autoscaler, so no issues would arise even on downgrading version of autoscaler in already running shoots with k8s<=1.19

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Cluster Autoscaler version of the same major and minor version as K8s running on the shoot, is now deployed in the control plane, starting with k8s >=1.20 shoots. For others v0.19.0 of autoscaler is deployed.
```
``` improvement user github.com/gardener/autoscaler #119 @himanshu-kun
NodeTemplate is not formed using cache in case nodegrp has minimum size zero. This is done to keep nodeTemplate updated even when instance type of nodegrp is updated.
```

``` improvement operator github.com/gardener/autoscaler #116 @himanshu-kun
cluster-autoscaler is now synced with upstream v1.21.0
```