### PR TITLE
Change the Loki fsGroupChangePolicy from Always to OnRootMismatch

### DIFF
--- a/charts/seed-bootstrap/charts/loki/templates/statefulset.yaml
+++ b/charts/seed-bootstrap/charts/loki/templates/statefulset.yaml
@@ -37,6 +37,7 @@ spec:
       automountServiceAccountToken: false
       securityContext:
         fsGroup: 10001
+        fsGroupChangePolicy: "OnRootMismatch"
       priorityClassName: {{ .Values.priorityClass.name }}
       containers:
 {{- if .Values.rbacSidecarEnabled }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
Our colleague @hendrikKahl found out that moving the Loki pod from one node to another leads to Loki being stuck in the ContainerCreation state for a too long time. Sometimes up to 40 minutes.
From the `kubelet` logs he noticed that the `kubelet` is trying to change the ownership of all the files in the Loki PD which takes too much time, because of their count(normally between 1 and 2 million).
According to the documentation Kubernetes always try to do that unless specified otherwise.
So Kahl has made some tests with `fsGroupChangePolicy="OnRootMissmatch"`.
From the test, it looks like the Loki is able to run for up to 3 minutes.
I tested it myself and also saw that logs are reachable via Grafana.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Loki StatefulSet fsGroupChangePolicy is changed from "Always" to "OnRootMissmatch" in order to increase the Loki pod creation when moved from one node to another
```
