### PR TITLE
component:github.com/gardener/etcd-druid:Upgrade v0.8.4->v0.8.5

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -30,7 +30,7 @@ images:
 - name: etcd-druid
   sourceRepository: github.com/gardener/etcd-druid
   repository: eu.gcr.io/gardener-project/gardener/etcd-druid
-  tag: "v0.8.4"
+  tag: "v0.8.5"
 - name: dependency-watchdog
   sourceRepository: github.com/gardener/dependency-watchdog
   repository: eu.gcr.io/gardener-project/gardener/dependency-watchdog


### PR DESCRIPTION
**What this PR does / why we need it**:
Upgrade etcd-druid: v0.8.4->v0.8.5

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
cc @shafeeqes 

**Release note**:
```improvement operator github.com/gardener/etcd-druid #342 @danielfoehrKn
Do not re-use resource limits from an existing etcd  stateful set. This will cause a RESTART(!) of the etcd pod for existing clusters that currently have a resource limit set for the etcd stateful-set, but whose etcd resource does not specify a resource limit.
```
```improvement operator github.com/gardener/etcd-backup-restore #478 @plkokanov 
When the owner check fails, `etcd-backup-restore` will restart the `etcd` process right before attempting to take a final snapshot, if the owner check was previously successful.
```
