### PR TITLE
Reverse checks for invalidating clients

### DIFF
--- a/pkg/client/kubernetes/clientmap/internal/generic_clientmap.go
+++ b/pkg/client/kubernetes/clientmap/internal/generic_clientmap.go
@@ -118,7 +118,7 @@ func (cm *GenericClientMap) GetClient(ctx context.Context, key clientmap.ClientS
 				}
 				if serverVersion.GitVersion != oldVersion {
 					cm.log.Info("New server version discovered for ClientSet", "key", key.Key(), "serverVersion", serverVersion.GitVersion)
-					return true, nil
+					// client is intentionally not refreshed in this case, see https://github.com/gardener/gardener/pull/2581 for details
 				}
 
 				return false, nil

--- a/pkg/client/kubernetes/clientmap/internal/generic_clientmap_test.go
+++ b/pkg/client/kubernetes/clientmap/internal/generic_clientmap_test.go
@@ -132,6 +132,7 @@ var _ = Describe("GenericClientMap", func() {
 				// let the max refresh interval pass
 				fakeClock.Sleep(internal.MaxRefreshInterval)
 				cs.EXPECT().DiscoverVersion().Return(&version.Info{GitVersion: "1.18.1"}, nil)
+				factory.EXPECT().NewClientSet(ctx, key).Return(cs, "", nil)
 				clientSet, err := cm.GetClient(ctx, key)
 				Expect(clientSet).To(BeIdenticalTo(cs))
 				Expect(err).NotTo(HaveOccurred())
@@ -166,14 +167,13 @@ var _ = Describe("GenericClientMap", func() {
 				By("should not refresh the ClientSet as version and hash haven't changed")
 				// let the max refresh interval pass
 				fakeClock.Sleep(internal.MaxRefreshInterval)
-				cs.EXPECT().DiscoverVersion().Return(csVersion, nil)
 				factory.EXPECT().CalculateClientSetHash(ctx, key).Return("hash1", nil)
+				cs.EXPECT().DiscoverVersion().Return(csVersion, nil)
 				Expect(cm.GetClient(ctx, key)).To(BeIdenticalTo(cs))
 
 				By("should refresh the ClientSet as the hash has changed")
 				// let the max refresh interval pass again
 				fakeClock.Sleep(internal.MaxRefreshInterval)
-				cs.EXPECT().DiscoverVersion().Return(csVersion, nil)
 				factory.EXPECT().CalculateClientSetHash(ctx, key).Return("hash2", nil)
 
 				cs2 := mockkubernetes.NewMockInterface(ctrl)
@@ -189,7 +189,6 @@ var _ = Describe("GenericClientMap", func() {
 				By("should fail to get the ClientSet again because CalculateClientSetHash fails")
 				// let the max refresh interval pass again
 				fakeClock.Sleep(internal.MaxRefreshInterval)
-				cs.EXPECT().DiscoverVersion().Return(csVersion, nil)
 				factory.EXPECT().CalculateClientSetHash(ctx, key).Return("", fmt.Errorf("fake"))
 
 				clientSet, err := cm.GetClient(ctx, key)

--- a/pkg/client/kubernetes/clientmap/internal/generic_clientmap_test.go
+++ b/pkg/client/kubernetes/clientmap/internal/generic_clientmap_test.go
@@ -132,7 +132,6 @@ var _ = Describe("GenericClientMap", func() {
 				// let the max refresh interval pass
 				fakeClock.Sleep(internal.MaxRefreshInterval)
 				cs.EXPECT().DiscoverVersion().Return(&version.Info{GitVersion: "1.18.1"}, nil)
-				factory.EXPECT().NewClientSet(ctx, key).Return(cs, "", nil)
 				clientSet, err := cm.GetClient(ctx, key)
 				Expect(clientSet).To(BeIdenticalTo(cs))
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Earlier, the client was never invalidated/refreshed if the current token
was expired or invalidated because the `DiscoverVersion()` call never
succeeded (`Unauthorized`).
Now the hash of the client is checked first to ensure that a new client
is always created when the hash changed.

Also, earlier the client was not refreshed when the server version
changed (just a log statement was printed). This is now done as well.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:
Earlier, the client was never invalidated/refreshed if the current token was expired or invalidated because the `DiscoverVersion()` call never succeeded (`Unauthorized`).
Now the hash of the client is checked first to ensure that a new client is always created when the hash changed.

Also, earlier the client was not refreshed when the server version changed (just a log statement was printed). This is now done as well.

**Special notes for your reviewer**:
/cc @timebertt 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
