### PR TITLE
(Re-)bootstrap GRM when its token expired

### DIFF
--- a/pkg/operation/botanist/resource_manager.go
+++ b/pkg/operation/botanist/resource_manager.go
@@ -191,7 +191,8 @@ func (b *Botanist) mustBootstrapGardenerResourceManager(ctx context.Context) (bo
 
 	if conditionApplied := v1beta1helper.GetCondition(managedResource.Status.Conditions, resourcesv1alpha1.ResourcesApplied); conditionApplied != nil &&
 		conditionApplied.Status == gardencorev1beta1.ConditionFalse &&
-		strings.Contains(conditionApplied.Message, `forbidden: User "system:serviceaccount:kube-system:gardener-resource-manager" cannot`) {
+		(strings.Contains(conditionApplied.Message, `forbidden: User "system:serviceaccount:kube-system:gardener-resource-manager" cannot`) ||
+			strings.Contains(conditionApplied.Message, ": Unauthorized")) {
 		return true, nil // ServiceAccount lost access.
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:
In case the `gardener-resource-manager` token got invalidated then `gardenlet` can now rebootstrap it. For example, in such case the `ManagedResource`s' `Applied` condition could look as follows:

```yaml
conditions:
  - lastTransitionTime: "2022-05-11T15:58:27Z"
    lastUpdateTime: "2022-05-11T15:58:27Z"
    message: 'failed to compute all HPA and HVPA target ref object keys: failed to
      list all HPAs: Unauthorized'
    reason: ApplyFailed
    status: "False"
    type: ResourcesApplied
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```improvement operator
`gardener-resource-manager` is now (re-)bootstrapped in case its token got invalidated.
```
