### PR TITLE
Update `OWNERS`

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,7 +1,0 @@
-# gardener maintainers
-*                @gardener/gardener-maintainers
-
-# test machinery related directory maintainers
-/.test-defs                    @gardener/gardener-maintainers @gardener/test-infra-maintainers
-/test/testmachinery            @gardener/gardener-maintainers @gardener/test-infra-maintainers
-/extensions/test/testmachinery @gardener/gardener-maintainers @gardener/test-infra-maintainers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -10,7 +10,6 @@ aliases:
   - plkokanov
   - rfranzke
   - shafeeqes
-  - stoyanr
   - timebertt
   - timuthy
   gardener-approvers:
@@ -22,7 +21,6 @@ aliases:
   - plkokanov
   - rfranzke
   - shafeeqes
-  - stoyanr
   - timebertt
   - timuthy
   testmachinery-maintainers:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup

**What this PR does / why we need it**:

- Drop `CODEOWNERS` – we rely on prow's `OWNERS` now, no need for GitHub's `CODEOWNERS` anymore
- stoyanr left the team :( 

