### PR TITLE
Validate shoot default dns even if shoot's seed spec is not specified

### DIFF
--- a/plugin/pkg/shoot/dns/admission.go
+++ b/plugin/pkg/shoot/dns/admission.go
@@ -161,7 +161,7 @@ func (d *DNS) Admit(ctx context.Context, a admission.Attributes, o admission.Obj
 	specPath := field.NewPath("spec")
 	// If shoot uses deafult domain validate domain even though shoot can be assigned to seed
 	// having dns disabled
-	if !helper.ShootUsesUnmanagedDNS(shoot) {
+	if shoot.Spec.DNS != nil && !helper.ShootUsesUnmanagedDNS(shoot) {
 		if err := assignDefaultDomainIfNeeded(a, shoot, d.projectLister, defaultDomains); err != nil {
 			return err
 		}
@@ -230,6 +230,10 @@ func (d *DNS) Admit(ctx context.Context, a admission.Attributes, o admission.Obj
 	// Generate a Shoot domain if none is configured (at this point in time we know that the chosen seed does
 	// not disable DNS.
 	if !helper.ShootUsesUnmanagedDNS(shoot) {
+		if err := assignDefaultDomainIfNeeded(a, shoot, d.projectLister, defaultDomains); err != nil {
+			return err
+		}
+
 		if shoot.Spec.DNS == nil || shoot.Spec.DNS.Domain == nil {
 			fieldErr := field.Required(specPath.Child("DNS"), fmt.Sprintf("shoot domain field .spec.dns.domain must be set if provider != %s and assigned to a seed which does not disable DNS", core.DNSUnmanaged))
 			return apierrors.NewInvalid(a.GetKind().GroupKind(), shoot.Name, field.ErrorList{fieldErr})

--- a/plugin/pkg/shoot/dns/admission.go
+++ b/plugin/pkg/shoot/dns/admission.go
@@ -369,8 +369,7 @@ func checkDefaultDomainFormat(a admission.Attributes, shoot *core.Shoot, project
 		return apierrors.NewInternalError(err)
 	}
 
-	var shootDomain *string
-	shootDomain = shoot.Spec.DNS.Domain
+	shootDomain := shoot.Spec.DNS.Domain
 
 	for _, domain := range defaultDomains {
 		if shootDomain != nil && strings.HasSuffix(*shootDomain, "."+domain) {

--- a/plugin/pkg/shoot/dns/admission.go
+++ b/plugin/pkg/shoot/dns/admission.go
@@ -161,7 +161,7 @@ func (d *DNS) Admit(ctx context.Context, a admission.Attributes, o admission.Obj
 	specPath := field.NewPath("spec")
 	// If shoot uses deafult domain validate domain even though shoot can be assigned to seed
 	// having dns disabled
-	if shoot.Spec.DNS != nil && !helper.ShootUsesUnmanagedDNS(shoot) {
+	if shoot.Spec.DNS != nil && shoot.Spec.DNS.Domain != nil && !helper.ShootUsesUnmanagedDNS(shoot) {
 		if err := checkDefaultDomainFormat(a, shoot, d.projectLister, defaultDomains); err != nil {
 			return err
 		}
@@ -372,7 +372,7 @@ func checkDefaultDomainFormat(a admission.Attributes, shoot *core.Shoot, project
 	shootDomain := shoot.Spec.DNS.Domain
 
 	for _, domain := range defaultDomains {
-		if shootDomain != nil && strings.HasSuffix(*shootDomain, "."+domain) {
+		if strings.HasSuffix(*shootDomain, "."+domain) {
 			// Check that the specified domain matches the pattern for default domains, especially in order
 			// to prevent shoots from "stealing" domain names for shoots in other projects
 			if len(shoot.GenerateName) > 0 && (len(shoot.Name) == 0 || strings.HasPrefix(shoot.Name, shoot.GenerateName)) {

--- a/plugin/pkg/shoot/dns/admission_test.go
+++ b/plugin/pkg/shoot/dns/admission_test.go
@@ -201,6 +201,7 @@ var _ = Describe("dns", func() {
 			shootCopy.Spec.DNS = nil
 			shootBefore := shootCopy.DeepCopy()
 
+			Expect(coreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&project)).To(Succeed())
 			Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(seedCopy)).To(Succeed())
 			attrs := admission.NewAttributesRecord(shootCopy, nil, core.Kind("Shoot").WithVersion("version"), shootCopy.Namespace, shootCopy.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 
@@ -676,7 +677,7 @@ var _ = Describe("dns", func() {
 
 				err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
-				Expect(err).To(Not(HaveOccurred()))
+				Expect(err).To(HaveOccurred())
 			})
 
 			It("should reject because no domain was configured for the shoot and project is missing", func() {
@@ -796,7 +797,7 @@ var _ = Describe("dns", func() {
 
 					err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
-					Expect(err).To(Not(HaveOccurred()))
+					Expect(err).To(HaveOccurred())
 				})
 			})
 		})

--- a/plugin/pkg/shoot/dns/admission_test.go
+++ b/plugin/pkg/shoot/dns/admission_test.go
@@ -666,7 +666,7 @@ var _ = Describe("dns", func() {
 				Expect(err).To(HaveOccurred())
 			})
 
-			It("should not reject shoots using a non compliant default domain on updates", func() {
+			It("should reject shoots using a non compliant default domain on updates", func() {
 				shootDomain := fmt.Sprintf("%s.other-project.%s", shoot.Name, domain)
 				shoot.Spec.DNS.Domain = &shootDomain
 
@@ -786,7 +786,7 @@ var _ = Describe("dns", func() {
 					Expect(err).To(HaveOccurred())
 				})
 
-				It("should not reject shoots using a non compliant default domain on updates", func() {
+				It("should reject shoots using a non compliant default domain on updates", func() {
 					shootDomain := fmt.Sprintf("%s.other-project.%s", shoot.Name, domain)
 					shoot.Spec.DNS.Domain = &shootDomain
 

--- a/test/integration/controllermanager/shootmaintenance/maintenance_control_test.go
+++ b/test/integration/controllermanager/shootmaintenance/maintenance_control_test.go
@@ -40,6 +40,7 @@ import (
 var _ = Describe("Shoot Maintenance controller tests", func() {
 
 	var (
+		project      *gardencorev1beta1.Project
 		cloudProfile *gardencorev1beta1.CloudProfile
 		shoot        *gardencorev1beta1.Shoot
 
@@ -63,6 +64,17 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 	)
 
 	BeforeEach(func() {
+		By("create project")
+		project = &gardencorev1beta1.Project{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "dev",
+			},
+			Spec: gardencorev1beta1.ProjectSpec{
+				Namespace: pointer.String("garden-dev"),
+			},
+		}
+		Expect(testClient.Create(ctx, project)).To(Succeed())
+
 		By("create cloud profile")
 		cloudProfile = &gardencorev1beta1.CloudProfile{
 			ObjectMeta: metav1.ObjectMeta{
@@ -177,6 +189,9 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 
 		logger.Infof("Delete CloudProfile %s", cloudProfile.Name)
 		Expect(testClient.Delete(ctx, cloudProfile)).To(Succeed())
+
+		logger.Infof("Delete Project %s", project.Name)
+		Expect(deleteProject(ctx, testClient, project)).To(Succeed())
 	})
 
 	It("should add task annotations", func() {

--- a/test/integration/controllermanager/shootmaintenance/utils_test.go
+++ b/test/integration/controllermanager/shootmaintenance/utils_test.go
@@ -156,3 +156,11 @@ func deleteShoot(ctx context.Context, gardenClient client.Client, shoot *gardenc
 	}
 	return client.IgnoreNotFound(gardenClient.Delete(ctx, shoot))
 }
+
+func deleteProject(ctx context.Context, gardenClient client.Client, project *gardencorev1beta1.Project) error {
+	err := gutil.ConfirmDeletion(ctx, gardenClient, project)
+	if err != nil {
+		return err
+	}
+	return client.IgnoreNotFound(gardenClient.Delete(ctx, project))
+}

--- a/test/integration/controllermanager/shootretry/shootretry_control_test.go
+++ b/test/integration/controllermanager/shootretry/shootretry_control_test.go
@@ -30,6 +30,7 @@ import (
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -46,11 +47,23 @@ var _ = Describe("Shoot retry controller tests", func() {
 	var (
 		ctx = context.Background()
 
+		project   *gardencorev1beta1.Project
 		namespace *corev1.Namespace
 		shoot     *gardencorev1beta1.Shoot
 	)
 
 	BeforeEach(func() {
+		By("create project")
+		project = &gardencorev1beta1.Project{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "dev",
+			},
+			Spec: gardencorev1beta1.ProjectSpec{
+				Namespace: pointer.String("garden-dev"),
+			},
+		}
+		Expect(testClient.Create(ctx, project)).To(Succeed())
+
 		By("create shoot namespace")
 		namespace = &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{Name: "garden-dev"},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity security
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #5808

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
