### PR TITLE
Recreate DWD deployment if needed

### DIFF
--- a/pkg/operation/botanist/component/dependencywatchdog/bootstrap.go
+++ b/pkg/operation/botanist/component/dependencywatchdog/bootstrap.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
@@ -201,6 +202,8 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 				Name:      b.name(),
 				Namespace: b.namespace,
 				Labels:    b.getLabels(),
+				// TODO(rfranzke): Remove this in a future version. Needed due to https://github.com/gardener/gardener/issues/5973
+				Annotations: map[string]string{resourcesv1alpha1.DeleteOnInvalidUpdate: "true"},
 			},
 			Spec: appsv1.DeploymentSpec{
 				Replicas:             pointer.Int32(1),

--- a/pkg/operation/botanist/component/dependencywatchdog/bootstrap_test.go
+++ b/pkg/operation/botanist/component/dependencywatchdog/bootstrap_test.go
@@ -257,6 +257,7 @@ kind: Deployment
 metadata:
   annotations:
     ` + references.AnnotationKey(references.KindConfigMap, configMapName) + `: ` + configMapName + `
+    resources.gardener.cloud/delete-on-invalid-update: "true"
   creationTimestamp: null
   labels:
     app: ` + dwdName + `


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind regression

**What this PR does / why we need it**:
https://github.com/gardener/gardener/pull/5937 introduces a change to dependency-watchdog-endpoint Deployment `spec.selector`. This field is actually immutable. Hence, existing Seed cannot get ready with:
```
{"level":"error","msg":"seed is not yet ready: condition \"SeedSystemComponentsHealthy\" has invalid status False (expected True) due to ApplyFailed: Could not apply all new resources: 1 error occurred: error during apply of object \"apps/v1/Deployment/garden/dependency-watchdog-endpoint\": Deployment.apps \"dependency-watchdog-endpoint\" is invalid: spec.selector: Invalid value: v1.LabelSelector{MatchLabels:map[string]string{\"app\":\"dependency-watchdog-endpoint\"}, MatchExpressions:[]v1.LabelSelectorRequirement(nil)}: field is immutable","op
```

This PR makes GRM delete the `Deployment` if the update is invalid to recreate it with the new selector.

**Which issue(s) this PR fixes**:
Fixes #5973

**Special notes for your reviewer**:
/cc @ialidzhikov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
