### PR TITLE
Add MaxAllowed for VPA objects

### DIFF
--- a/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager.go
@@ -185,6 +185,10 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 					corev1.ResourceCPU:    resource.MustParse("100m"),
 					corev1.ResourceMemory: resource.MustParse("100Mi"),
 				},
+				MaxAllowed: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("4"),
+					corev1.ResourceMemory: resource.MustParse("10G"),
+				},
 				ControlledValues: &controlledValues,
 			}},
 		}
@@ -194,6 +198,10 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 				MinAllowed: corev1.ResourceList{
 					corev1.ResourceCPU:    resource.MustParse("100m"),
 					corev1.ResourceMemory: resource.MustParse("100Mi"),
+				},
+				MaxAllowed: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("4"),
+					corev1.ResourceMemory: resource.MustParse("10G"),
 				},
 				ControlledValues: &controlledValues,
 			}},

--- a/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager_test.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager_test.go
@@ -277,6 +277,10 @@ var _ = Describe("KubeControllerManager", func() {
 									corev1.ResourceCPU:    resource.MustParse("100m"),
 									corev1.ResourceMemory: resource.MustParse("100Mi"),
 								},
+								MaxAllowed: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("4"),
+									corev1.ResourceMemory: resource.MustParse("10G"),
+								},
 								ControlledValues: &controlledValues,
 							}},
 						},
@@ -365,6 +369,10 @@ var _ = Describe("KubeControllerManager", func() {
 												MinAllowed: corev1.ResourceList{
 													corev1.ResourceCPU:    resource.MustParse("100m"),
 													corev1.ResourceMemory: resource.MustParse("100Mi"),
+												},
+												MaxAllowed: corev1.ResourceList{
+													corev1.ResourceCPU:    resource.MustParse("4"),
+													corev1.ResourceMemory: resource.MustParse("10G"),
 												},
 												ControlledValues: &controlledValues,
 											}},

--- a/pkg/operation/botanist/component/kubeproxy/kube_proxy_test.go
+++ b/pkg/operation/botanist/component/kubeproxy/kube_proxy_test.go
@@ -629,6 +629,9 @@ spec:
     containerPolicies:
     - containerName: '*'
       controlledValues: RequestsOnly
+      maxAllowed:
+        cpu: "4"
+        memory: 10G
   targetRef:
     apiVersion: apps/v1
     kind: DaemonSet

--- a/pkg/operation/botanist/component/kubeproxy/resources.go
+++ b/pkg/operation/botanist/component/kubeproxy/resources.go
@@ -554,7 +554,11 @@ func (k *kubeProxy) computePoolResourcesData(pool WorkerPool) (map[string][]byte
 				},
 				ResourcePolicy: &vpaautoscalingv1.PodResourcePolicy{
 					ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{{
-						ContainerName:    vpaautoscalingv1.DefaultContainerResourcePolicy,
+						ContainerName: vpaautoscalingv1.DefaultContainerResourcePolicy,
+						MaxAllowed: corev1.ResourceList{
+							corev1.ResourceCPU:    resource.MustParse("4"),
+							corev1.ResourceMemory: resource.MustParse("10G"),
+						},
 						ControlledValues: &controlledValues,
 					}},
 				},

--- a/pkg/operation/botanist/component/kubescheduler/kube_scheduler.go
+++ b/pkg/operation/botanist/component/kubescheduler/kube_scheduler.go
@@ -328,6 +328,10 @@ func (k *kubeScheduler) Deploy(ctx context.Context) error {
 						corev1.ResourceCPU:    resource.MustParse("20m"),
 						corev1.ResourceMemory: resource.MustParse("50Mi"),
 					},
+					MaxAllowed: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("4"),
+						corev1.ResourceMemory: resource.MustParse("10G"),
+					},
 					ControlledValues: &controlledValues,
 				},
 			},

--- a/pkg/operation/botanist/component/kubescheduler/kube_scheduler_test.go
+++ b/pkg/operation/botanist/component/kubescheduler/kube_scheduler_test.go
@@ -122,6 +122,10 @@ var _ = Describe("KubeScheduler", func() {
 								corev1.ResourceCPU:    resource.MustParse("20m"),
 								corev1.ResourceMemory: resource.MustParse("50Mi"),
 							},
+							MaxAllowed: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("4"),
+								corev1.ResourceMemory: resource.MustParse("10G"),
+							},
 							ControlledValues: &controlledValues,
 						},
 					},

--- a/pkg/operation/botanist/component/resourcemanager/resource_manager.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager.go
@@ -764,8 +764,12 @@ func (r *resourceManager) ensureVPA(ctx context.Context) error {
 		vpa.Spec.ResourcePolicy = &vpaautoscalingv1.PodResourcePolicy{
 			ContainerPolicies: []vpaautoscalingv1.ContainerResourcePolicy{
 				{
-					ContainerName:    vpaautoscalingv1.DefaultContainerResourcePolicy,
-					MinAllowed:       r.values.VPA.MinAllowed,
+					ContainerName: vpaautoscalingv1.DefaultContainerResourcePolicy,
+					MinAllowed:    r.values.VPA.MinAllowed,
+					MaxAllowed: corev1.ResourceList{
+						corev1.ResourceCPU:    resource.MustParse("4"),
+						corev1.ResourceMemory: resource.MustParse("10G"),
+					},
 					ControlledValues: &controlledValues,
 				},
 			},

--- a/pkg/operation/botanist/component/resourcemanager/resource_manager_test.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager_test.go
@@ -594,6 +594,10 @@ var _ = Describe("ResourceManager", func() {
 								corev1.ResourceCPU:    resource.MustParse("20m"),
 								corev1.ResourceMemory: resource.MustParse("30Mi"),
 							},
+							MaxAllowed: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("4"),
+								corev1.ResourceMemory: resource.MustParse("10G"),
+							},
 							ControlledValues: &controlledValues,
 						},
 					},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
Limits the range of maximum allowed resource requests to ensure that pods are schedulable
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
