### PR TITLE
Deprecate the `ServiceAccount` signing key secret field

### DIFF
--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -8756,7 +8756,8 @@ Kubernetes core/v1.LocalObjectReference
 <em>(Optional)</em>
 <p>SigningKeySecret is a reference to a secret that contains an optional private key of the
 service account token issuer. The issuer will sign issued ID tokens with this private key.
-Only useful if service account tokens are also issued by another external system.</p>
+Only useful if service account tokens are also issued by another external system.
+Deprecated: This field is deprecated and will be removed in a future version of Gardener. Do not use it.</p>
 </td>
 </tr>
 <tr>

--- a/docs/usage/shoot_serviceaccounts.md
+++ b/docs/usage/shoot_serviceaccounts.md
@@ -13,6 +13,7 @@ spec:
         acceptedIssuers:
         - foo1
         - foo2
+        # Deprecated: This field is deprecated and will be removed in a future version of Gardener. Do not use it.
         signingKeySecretName:
           name: my-signing-key-secret
         extendTokenExpiration: true
@@ -40,6 +41,8 @@ Additionally, all [`ServiceAccount` token secrets](https://kubernetes.io/docs/co
 Apart from this you should wait for at least `12h` to make sure the control plane and system components receive a new token from Gardener.
 
 ## Signing Key Secret
+
+> 🚨 This field is deprecated and will be removed in a future version of Gardener. Do not use it.
 
 The `.spec.kubernetes.kubeAPIServer.serviceAccountConfig.signingKeySecretName.name` specifies the name of `Secret` in the same namespace as the `Shoot` in the garden cluster.
 It should look as follows:

--- a/example/90-shoot.yaml
+++ b/example/90-shoot.yaml
@@ -181,8 +181,6 @@ spec:
   #     acceptedIssuers:
   #     - foo1
   #     - foo2
-  #     signingKeySecretName:
-  #       name: my-signing-key-secret
   #     extendTokenExpiration: true
   #     maxTokenExpiration: 45d
   # kubeControllerManager:

--- a/pkg/apis/core/types_shoot.go
+++ b/pkg/apis/core/types_shoot.go
@@ -528,6 +528,7 @@ type ServiceAccountConfig struct {
 	// SigningKeySecret is a reference to a secret that contains an optional private key of the
 	// service account token issuer. The issuer will sign issued ID tokens with this private key.
 	// Only useful if service account tokens are also issued by another external system.
+	// Deprecated: This field is deprecated and will be removed in a future version of Gardener. Do not use it.
 	SigningKeySecret *corev1.LocalObjectReference
 	// ExtendTokenExpiration turns on projected service account expiration extension during token generation, which
 	// helps safe transition from legacy token to bound service account token feature. If this flag is enabled,

--- a/pkg/apis/core/v1alpha1/generated.proto
+++ b/pkg/apis/core/v1alpha1/generated.proto
@@ -2158,6 +2158,7 @@ message ServiceAccountConfig {
   // SigningKeySecret is a reference to a secret that contains an optional private key of the
   // service account token issuer. The issuer will sign issued ID tokens with this private key.
   // Only useful if service account tokens are also issued by another external system.
+  // Deprecated: This field is deprecated and will be removed in a future version of Gardener. Do not use it.
   // +optional
   optional k8s.io.api.core.v1.LocalObjectReference signingKeySecretName = 2;
 

--- a/pkg/apis/core/v1alpha1/types_shoot.go
+++ b/pkg/apis/core/v1alpha1/types_shoot.go
@@ -656,6 +656,7 @@ type ServiceAccountConfig struct {
 	// SigningKeySecret is a reference to a secret that contains an optional private key of the
 	// service account token issuer. The issuer will sign issued ID tokens with this private key.
 	// Only useful if service account tokens are also issued by another external system.
+	// Deprecated: This field is deprecated and will be removed in a future version of Gardener. Do not use it.
 	// +optional
 	SigningKeySecret *corev1.LocalObjectReference `json:"signingKeySecretName,omitempty" protobuf:"bytes,2,opt,name=signingKeySecretName"`
 	// ExtendTokenExpiration turns on projected service account expiration extension during token generation, which

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -2091,6 +2091,7 @@ message ServiceAccountConfig {
   // SigningKeySecret is a reference to a secret that contains an optional private key of the
   // service account token issuer. The issuer will sign issued ID tokens with this private key.
   // Only useful if service account tokens are also issued by another external system.
+  // Deprecated: This field is deprecated and will be removed in a future version of Gardener. Do not use it.
   // +optional
   optional k8s.io.api.core.v1.LocalObjectReference signingKeySecretName = 2;
 

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -668,6 +668,7 @@ type ServiceAccountConfig struct {
 	// SigningKeySecret is a reference to a secret that contains an optional private key of the
 	// service account token issuer. The issuer will sign issued ID tokens with this private key.
 	// Only useful if service account tokens are also issued by another external system.
+	// Deprecated: This field is deprecated and will be removed in a future version of Gardener. Do not use it.
 	// +optional
 	SigningKeySecret *corev1.LocalObjectReference `json:"signingKeySecretName,omitempty" protobuf:"bytes,2,opt,name=signingKeySecretName"`
 	// ExtendTokenExpiration turns on projected service account expiration extension during token generation, which

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -6747,7 +6747,7 @@ func schema_pkg_apis_core_v1alpha1_ServiceAccountConfig(ref common.ReferenceCall
 					},
 					"signingKeySecretName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "SigningKeySecret is a reference to a secret that contains an optional private key of the service account token issuer. The issuer will sign issued ID tokens with this private key. Only useful if service account tokens are also issued by another external system.",
+							Description: "SigningKeySecret is a reference to a secret that contains an optional private key of the service account token issuer. The issuer will sign issued ID tokens with this private key. Only useful if service account tokens are also issued by another external system. Deprecated: This field is deprecated and will be removed in a future version of Gardener. Do not use it.",
 							Ref:         ref("k8s.io/api/core/v1.LocalObjectReference"),
 						},
 					},
@@ -13843,7 +13843,7 @@ func schema_pkg_apis_core_v1beta1_ServiceAccountConfig(ref common.ReferenceCallb
 					},
 					"signingKeySecretName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "SigningKeySecret is a reference to a secret that contains an optional private key of the service account token issuer. The issuer will sign issued ID tokens with this private key. Only useful if service account tokens are also issued by another external system.",
+							Description: "SigningKeySecret is a reference to a secret that contains an optional private key of the service account token issuer. The issuer will sign issued ID tokens with this private key. Only useful if service account tokens are also issued by another external system. Deprecated: This field is deprecated and will be removed in a future version of Gardener. Do not use it.",
 							Ref:         ref("k8s.io/api/core/v1.LocalObjectReference"),
 						},
 					},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
This PR deprecates the configuration option to specify a user-provided signing key for `ServiceAccount`s since (a) there is no reasonable use-case nor any usage as of today, and (b) no rotation possible, hence there are security concerns.

**Special notes for your reviewer**:
This field will be deprecated now, and in a few releases it will be removed entirely from the API.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
The `.spec.kubernetes.kubeAPIServer.serviceAccountConfig.signingKeySecretName` field is deprecated now and will be removed in a future version. If you use this field for `Shoot`s make sure to recreate them as soon as possible since there is no option to migrate away from it.
```
