### PR TITLE
Deprecate `RotateSSHKeypairOnMaintenance` feature gate

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -32,6 +32,7 @@ The following tables are a summary of the feature gates that you can set on diff
 | ReversedVPN                                  | `true`  | `Beta`  | `1.42` |        |
 | RotateSSHKeypairOnMaintenance                | `false` | `Alpha` | `1.28` | `1.44` |
 | RotateSSHKeypairOnMaintenance                | `true`  | `Beta`  | `1.45` |        |
+| RotateSSHKeypairOnMaintenance (deprecated)   | `false` | `Beta`  | `1.48` |        |
 | WorkerPoolKubernetesVersion                  | `false` | `Alpha` | `1.35` | `1.45` |
 | WorkerPoolKubernetesVersion                  | `true`  | `Beta`  | `1.46` |        |
 | CopyEtcdBackupsDuringControlPlaneMigration   | `false` | `Alpha` | `1.37` |        |
@@ -123,7 +124,7 @@ A *General Availability* (GA) feature is also referred to as a *stable* feature.
 | ReversedVPN                                | `gardenlet`                                                      | Reverses the connection setup of the vpn tunnel between the Seed and the Shoot cluster(s). It allows Seed and Shoot clusters to be in different networks with only direct access in one direction (Shoot -> Seed). In addition to that, it reduces the amount of load balancers required, i.e. no load balancers are required for the vpn tunnel anymore. It requires `APIServerSNI` and kubernetes version `1.18` or higher to work. Details can be found in [GEP-14](../proposals/14-reversed-cluster-vpn.md). |
 | AdminKubeconfigRequest                     | `gardener-apiserver`                                             | Enables the `AdminKubeconfigRequest` endpoint on Shoot resources. See [GEP-16](../proposals/16-adminkubeconfig-subresource.md) for more details. |
 | UseDNSRecords                              | `gardener-apiserver`, `gardener-controller-manager`, `gardenlet` | Enables using `DNSRecord` resources for Gardener DNS records instead of `DNSProvider`, `DNSEntry`, and `DNSOwner` resources. See [Contract: `DNSRecord` resources](../extensions/dnsrecord.md) for more details. |
-| RotateSSHKeypairOnMaintenance              | `gardener-controller-manager`                                    | Enables SSH keypair rotation in the maintenance controller of the gardener-controller-manager. Details can be found in [GEP-15](../proposals/15-manage-bastions-and-ssh-key-pair-rotation.md). |
+| RotateSSHKeypairOnMaintenance (deprecated) | `gardener-controller-manager`                                    | Enables SSH keypair rotation in the maintenance controller of the gardener-controller-manager. Details can be found in [GEP-15](../proposals/15-manage-bastions-and-ssh-key-pair-rotation.md). |
 | DenyInvalidExtensionResources              | `gardenlet`                                                      | Causes the `seed-admission-controller` to deny invalid extension resources, instead of just logging validation errors. |
 | WorkerPoolKubernetesVersion                | `gardener-apiserver`                                             | Allows to overwrite the Kubernetes version used for shoot clusters per worker pool (see [this document](../usage/worker_pool_k8s_versions.md)) |
 | CopyEtcdBackupsDuringControlPlaneMigration | `gardenlet`                                                      | Enables the copy of etcd backups from the object store of the source seed to the object store of the destination seed during control plane migration. |

--- a/docs/usage/shoot_credentials_rotation.md
+++ b/docs/usage/shoot_credentials_rotation.md
@@ -162,6 +162,7 @@ kubectl -n <shoot-namespace> annotate shoot <shoot-name> gardener.cloud/operatio
 The old key is stored in a `Secret` with name `<shoot-name>.ssh-keypair.old` in the project namespace in the garden cluster and has the same data keys as the regular `Secret`.
 
 > Note that the SSH keypairs for shoot clusters are rotated automatically during maintenance time window when the `RotateSSHKeypairOnMaintenance` feature gate is enabled.
+However, this feature gate is deprecated, turned off by default and will be removed in a future version of Gardener.
 
 ## ETCD Encryption Key
 

--- a/example/20-componentconfig-gardener-controller-manager.yaml
+++ b/example/20-componentconfig-gardener-controller-manager.yaml
@@ -81,5 +81,3 @@ server:
 debugging:
   enableProfiling: false
   enableContentionProfiling: false
-featureGates:
-  RotateSSHKeypairOnMaintenance: true

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -96,6 +96,7 @@ const (
 	// owner: @petersutter
 	// alpha: v1.28.0
 	// beta: v1.45.0
+	// deprecated: v1.48.0
 	RotateSSHKeypairOnMaintenance featuregate.Feature = "RotateSSHKeypairOnMaintenance"
 
 	// DenyInvalidExtensionResources causes the seed-admission-controller to deny invalid extension resources (instead of just logging validation errors).
@@ -175,7 +176,7 @@ var allFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	ReversedVPN:                   {Default: true, PreRelease: featuregate.Beta},
 	AdminKubeconfigRequest:        {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	UseDNSRecords:                 {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
-	RotateSSHKeypairOnMaintenance: {Default: true, PreRelease: featuregate.Beta},
+	RotateSSHKeypairOnMaintenance: {Default: false, PreRelease: featuregate.Beta},
 	DenyInvalidExtensionResources: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	WorkerPoolKubernetesVersion:   {Default: true, PreRelease: featuregate.Beta},
 	CopyEtcdBackupsDuringControlPlaneMigration: {Default: false, PreRelease: featuregate.Alpha},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
This PR deprecate the `RotateSSHKeypairOnMaintenance` feature gate and turns it off by default so that it can be removed in a future version of Gardener. The rationale behind it is that it's asymmetric (we don't auto-rotate any similar end-user facing credentials and don't plan to do so).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `RotateSSHKeypairOnMaintenance` feature gate is now deprecated and disabled by default. It will be removed in a future version of Gardener. If you rely on it then you can implement an equivalent workflow by annotating `Shoot`s with `gardener.cloud/operation=rotate-ssh-keypair` during their respective maintenance time windows.
```
