### PR TITLE
add annotation to renew gardenlet kubeconfig secret to ManagedSeed

### DIFF
--- a/docs/usage/managed_seed.md
+++ b/docs/usage/managed_seed.md
@@ -45,6 +45,8 @@ For an example that uses non-default configuration, see [55-managed-seed-gardenl
 
 To have the `ManagedSeed` controller renew the gardenlet's kubeconfig secret, annotate the `ManagedSeed` with `gardener.cloud/operation=renew-kubeconfig`. This will trigger a reconciliation during which the kubeconfig secret is deleted and the bootstrapping is performed again.
 
+It is also possible to trigger the renewal on the secret directly, see [here](../concepts/gardenlet.md#rotate-certificates-using-bootstrap-kubeconfig).
+
 ## Creating a Seed from a Template
 
 To register a shoot as a seed from a template without deploying `gardenlet` to the shoot using a default configuration, create a `ManagedSeed` resource similar to the following:

--- a/docs/usage/managed_seed.md
+++ b/docs/usage/managed_seed.md
@@ -43,7 +43,7 @@ For an example that uses non-default configuration, see [55-managed-seed-gardenl
 
 ### Renewing the Gardenlet Kubeconfig Secret
 
-To have the `ManagedSeed` controller renew the gardenlet's kubeconfig secret, annotate the `ManagedSeed` with `gardener.cloud/operation=renew-kubeconfig`. This will trigger a reconciliation during which the kubeconfig secret is deleted and the bootstrapping is performed again.
+In order to making the `ManagedSeed` controller renew the gardenlet's kubeconfig secret, annotate the `ManagedSeed` with `gardener.cloud/operation=renew-kubeconfig`. This will trigger a reconciliation during which the kubeconfig secret is deleted and the bootstrapping is performed again (during which gardenlet obtains a new client certificate).
 
 It is also possible to trigger the renewal on the secret directly, see [here](../concepts/gardenlet.md#rotate-certificates-using-bootstrap-kubeconfig).
 

--- a/docs/usage/managed_seed.md
+++ b/docs/usage/managed_seed.md
@@ -43,7 +43,7 @@ For an example that uses non-default configuration, see [55-managed-seed-gardenl
 
 ### Renewing the Gardenlet Kubeconfig Secret
 
-To have the `ManagedSeed` controller renew the gardenlet's kubeconfig secret, annotate the `ManagedSeed` with `gardener.cloud/operation=renew-kubeconfig`. This will trigger a reconcile during which the kubeconfig secret is deleted and the bootstrapping is performed again.
+To have the `ManagedSeed` controller renew the gardenlet's kubeconfig secret, annotate the `ManagedSeed` with `gardener.cloud/operation=renew-kubeconfig`. This will trigger a reconciliation during which the kubeconfig secret is deleted and the bootstrapping is performed again.
 
 ## Creating a Seed from a Template
 

--- a/docs/usage/managed_seed.md
+++ b/docs/usage/managed_seed.md
@@ -41,6 +41,10 @@ spec:
 
 For an example that uses non-default configuration, see [55-managed-seed-gardenlet.yaml](../../example/55-managedseed-gardenlet.yaml)
 
+### Renewing the Gardenlet Kubeconfig Secret
+
+To have the `ManagedSeed` controller renew the gardenlet's kubeconfig secret, annotate the `ManagedSeed` with `gardener.cloud/operation=renew-kubeconfig`. This will trigger a reconcile during which the kubeconfig secret is deleted and the bootstrapping is performed again.
+
 ## Creating a Seed from a Template
 
 To register a shoot as a seed from a template without deploying `gardenlet` to the shoot using a default configuration, create a `ManagedSeed` resource similar to the following:

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -178,6 +178,8 @@ const (
 	// GardenerOperationKeepalive is a constant for the value of the operation annotation describing an
 	// operation that extends the lifetime of the object having the operation annotation.
 	GardenerOperationKeepalive = "keepalive"
+	// GardenerOperationRenewKubeconfig is a constant for the value of the operation annotation to renew the gardenlet's kubeconfig secret.
+	GardenerOperationRenewKubeconfig = "renew-kubeconfig"
 
 	// DeprecatedGardenRole is the key for an annotation on a Kubernetes object indicating what it is used for.
 	//

--- a/pkg/gardenlet/controller/managedseed/managedseed.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed.go
@@ -49,8 +49,6 @@ const (
 	// GardenletDefaultKubeconfigBootstrapSecretName is the default name for the field in the Gardenlet component configuration
 	// .gardenClientConnection.BootstrapKubeconfig.Name
 	GardenletDefaultKubeconfigBootstrapSecretName = "gardenlet-kubeconfig-bootstrap"
-	// GardenerOperationRenewKubeconfig is the value for the operation annotation to renew the gardenlet's kubeconfig secret.
-	GardenerOperationRenewKubeconfig = "renew-kubeconfig"
 )
 
 // Controller controls ManagedSeeds.

--- a/pkg/gardenlet/controller/managedseed/managedseed.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed.go
@@ -49,6 +49,8 @@ const (
 	// GardenletDefaultKubeconfigBootstrapSecretName is the default name for the field in the Gardenlet component configuration
 	// .gardenClientConnection.BootstrapKubeconfig.Name
 	GardenletDefaultKubeconfigBootstrapSecretName = "gardenlet-kubeconfig-bootstrap"
+	// GardenerOperationRenewKubeconfig is the value for the operation annotation to renew the gardenlet's kubeconfig secret.
+	GardenerOperationRenewKubeconfig = "renew-kubeconfig"
 )
 
 // Controller controls ManagedSeeds.

--- a/pkg/gardenlet/controller/managedseed/managedseed_actuator.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_actuator.go
@@ -713,9 +713,9 @@ func (a *actuator) prepareGardenClientConnectionWithBootstrap(
 		if err := kutil.DeleteSecretByReference(ctx, shootClient.Client(), gcc.KubeconfigSecret); err != nil {
 			return "", err
 		}
-	} else if managedSeed.Annotations[v1beta1constants.GardenerOperation] == GardenerOperationRenewKubeconfig {
+	} else if managedSeed.Annotations[v1beta1constants.GardenerOperation] == v1beta1constants.GardenerOperationRenewKubeconfig {
 		// Also remove the kubeconfig if the renew-kubeconfig operation annotation is set on the ManagedSeed resource.
-		a.reconcilingInfoEventf(managedSeed, "Renewing gardenlet kubeconfig secret due to '%s=%s' annotation", v1beta1constants.GardenerOperation, GardenerOperationRenewKubeconfig)
+		a.reconcilingInfoEventf(managedSeed, "Renewing gardenlet kubeconfig secret due to '%s=%s' annotation", v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationRenewKubeconfig)
 		if err := kutil.DeleteSecretByReference(ctx, shootClient.Client(), gcc.KubeconfigSecret); err != nil {
 			return "", err
 		}

--- a/pkg/gardenlet/controller/managedseed/managedseed_actuator.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_actuator.go
@@ -719,9 +719,9 @@ func (a *actuator) prepareGardenClientConnectionWithBootstrap(
 		if err := kutil.DeleteSecretByReference(ctx, shootClient.Client(), gcc.KubeconfigSecret); err != nil {
 			return "", err
 		}
-		old := managedSeed.DeepCopy()
+		patch := client.MergeFrom(managedSeed.DeepCopy())
 		delete(managedSeed.Annotations, v1beta1constants.GardenerOperation)
-		if err := shootClient.Client().Patch(ctx, managedSeed, client.MergeFrom(old)); err != nil {
+		if err := shootClient.Client().Patch(ctx, managedSeed, patch); err != nil {
 			return "", err
 		}
 	} else {

--- a/pkg/gardenlet/controller/managedseed/managedseed_actuator.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_actuator.go
@@ -719,8 +719,9 @@ func (a *actuator) prepareGardenClientConnectionWithBootstrap(
 		if err := kutil.DeleteSecretByReference(ctx, shootClient.Client(), gcc.KubeconfigSecret); err != nil {
 			return "", err
 		}
+		old := managedSeed.DeepCopy()
 		delete(managedSeed.Annotations, v1beta1constants.GardenerOperation)
-		if err := shootClient.Client().Update(ctx, managedSeed); err != nil {
+		if err := shootClient.Client().Patch(ctx, managedSeed, client.MergeFrom(old)); err != nil {
 			return "", err
 		}
 	} else {

--- a/pkg/gardenlet/controller/managedseed/managedseed_actuator_test.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_actuator_test.go
@@ -759,11 +759,11 @@ var _ = Describe("Actuator", func() {
 			It("should create the garden namespace and seed secrets, and deploy gardenlet (with bootstrap, non-expired gardenlet client cert, and renew-kubeconfig annotation)", func() {
 				seed.Status.ClientCertificateExpirationTimestamp = &metav1.Time{Time: time.Now().Add(time.Hour)}
 				managedSeed.Annotations = map[string]string{
-					v1beta1constants.GardenerOperation: GardenerOperationRenewKubeconfig,
+					v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationRenewKubeconfig,
 				}
 
 				expectGetShoot()
-				recorder.EXPECT().Eventf(managedSeed, corev1.EventTypeNormal, gardencorev1beta1.EventReconciling, "Renewing gardenlet kubeconfig secret due to '%s=%s' annotation", v1beta1constants.GardenerOperation, GardenerOperationRenewKubeconfig)
+				recorder.EXPECT().Eventf(managedSeed, corev1.EventTypeNormal, gardencorev1beta1.EventReconciling, "Renewing gardenlet kubeconfig secret due to '%s=%s' annotation", v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationRenewKubeconfig)
 				expectDeleteKubeconfigSecret()
 				shc.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeed{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
 					Expect(patch.Data(o)).To(BeEquivalentTo(`{"metadata":{"annotations":null}}`))

--- a/pkg/gardenlet/controller/managedseed/managedseed_actuator_test.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_actuator_test.go
@@ -756,6 +756,49 @@ var _ = Describe("Actuator", func() {
 				Expect(wait).To(Equal(false))
 			})
 
+			It("should create the garden namespace and seed secrets, and deploy gardenlet (with bootstrap, non-expired gardenlet client cert, and renew-kubeconfig annotation)", func() {
+				seed.Status.ClientCertificateExpirationTimestamp = &metav1.Time{Time: time.Now().Add(time.Hour)}
+				managedSeed.Annotations = map[string]string{
+					v1beta1constants.GardenerOperation: GardenerOperationRenewKubeconfig,
+				}
+
+				expectGetShoot()
+				recorder.EXPECT().Eventf(managedSeed, corev1.EventTypeNormal, gardencorev1beta1.EventReconciling, "Renewing gardenlet kubeconfig secret due to '%s=%s' annotation", v1beta1constants.GardenerOperation, GardenerOperationRenewKubeconfig)
+				expectDeleteKubeconfigSecret()
+				shc.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&seedmanagementv1alpha1.ManagedSeed{}), gomock.Any()).DoAndReturn(func(_ context.Context, o client.Object, patch client.Patch, opts ...client.PatchOption) error {
+					Expect(patch.Data(o)).To(BeEquivalentTo(`{"metadata":{"annotations":null}}`))
+					return nil
+				})
+				expectGetSeed(true)
+				expectCheckSeedSpec()
+				recorder.EXPECT().Eventf(managedSeed, corev1.EventTypeNormal, gardencorev1beta1.EventReconciling, "Creating or updating garden namespace in shoot %s", kutil.ObjectName(shoot))
+				expectCreateGardenNamespace()
+				recorder.EXPECT().Eventf(managedSeed, corev1.EventTypeNormal, gardencorev1beta1.EventReconciling, "Creating or updating seed %s secrets", name)
+				expectCreateSeedSecrets()
+				recorder.EXPECT().Eventf(managedSeed, corev1.EventTypeNormal, gardencorev1beta1.EventReconciling, "Deploying gardenlet into shoot %s", kutil.ObjectName(shoot))
+				expectMergeWithParent()
+				expectPrepareGardenClientConnection(false)
+				expectGetGardenletChartValues(true)
+				expectApplyGardenletChart()
+				expectLegacySecretDeletion()
+
+				status, wait, err := actuator.Reconcile(ctx, managedSeed)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(status.Conditions).To(ConsistOf(
+					MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(seedmanagementv1alpha1.ManagedSeedShootReconciled),
+						"Status": Equal(gardencorev1beta1.ConditionTrue),
+						"Reason": Equal(gardencorev1beta1.EventReconciled),
+					}),
+					MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(seedmanagementv1alpha1.ManagedSeedSeedRegistered),
+						"Status": Equal(gardencorev1beta1.ConditionTrue),
+						"Reason": Equal(gardencorev1beta1.EventReconciled),
+					}),
+				))
+				Expect(wait).To(Equal(false))
+			})
+
 			It("should create the garden namespace and seed secrets, and deploy gardenlet (without bootstrap)", func() {
 				managedSeed.Spec.Gardenlet.Bootstrap = bootstrapPtr(seedmanagementv1alpha1.BootstrapNone)
 

--- a/pkg/registry/seedmanagement/managedseed/strategy.go
+++ b/pkg/registry/seedmanagement/managedseed/strategy.go
@@ -22,7 +22,6 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement/validation"
-	"github.com/gardener/gardener/pkg/gardenlet/controller/managedseed"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -91,7 +90,7 @@ func mustIncreaseGeneration(oldManagedSeed, newManagedSeed *seedmanagement.Manag
 	}
 
 	// The operation annotation was added with value "renew-kubeconfig"
-	if kutil.HasMetaDataAnnotation(&newManagedSeed.ObjectMeta, v1beta1constants.GardenerOperation, managedseed.GardenerOperationRenewKubeconfig) {
+	if kutil.HasMetaDataAnnotation(&newManagedSeed.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationRenewKubeconfig) {
 		return true
 	}
 

--- a/pkg/registry/seedmanagement/managedseed/strategy.go
+++ b/pkg/registry/seedmanagement/managedseed/strategy.go
@@ -22,6 +22,7 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement"
 	"github.com/gardener/gardener/pkg/apis/seedmanagement/validation"
+	"github.com/gardener/gardener/pkg/gardenlet/controller/managedseed"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -86,6 +87,11 @@ func mustIncreaseGeneration(oldManagedSeed, newManagedSeed *seedmanagement.Manag
 	// The operation annotation was added with value "reconcile"
 	if kutil.HasMetaDataAnnotation(&newManagedSeed.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile) {
 		delete(newManagedSeed.Annotations, v1beta1constants.GardenerOperation)
+		return true
+	}
+
+	// The operation annotation was added with value "renew-kubeconfig"
+	if kutil.HasMetaDataAnnotation(&newManagedSeed.ObjectMeta, v1beta1constants.GardenerOperation, managedseed.GardenerOperationRenewKubeconfig) {
 		return true
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
The kubeconfig secret of a gardenlet created by a `ManagedSeed` resource is currently only renewed if the validity of its client certificate has expired.
This PR introduces an annotation `gardener.cloud/operation=renew-kubeconfig` which can be used on the `ManagedSeed` resource to trigger the kubeconfig bootstrapping again. The procedure is the same as for an expired certificate, just that it can be triggered 'from the outside' now.

**Which issue(s) this PR fixes**:
This is required for CA rotation on the garden cluster, as that invalidates the client certificates before their expiration date.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
A `ManagedSeed` can now be annotated with `gardener.cloud/operation=renew-kubeconfig` to recreate the gardenlet's kubeconfig secret.
```
