### PR TITLE
Fixed monitoring of node local dns.

### DIFF
--- a/pkg/operation/botanist/component/nodelocaldns/monitoring.go
+++ b/pkg/operation/botanist/component/nodelocaldns/monitoring.go
@@ -62,10 +62,20 @@ var (
 	// TODO: Replace below hard-coded paths to Prometheus certificates once its deployment has been refactored.
 	monitoringScrapeConfig = `job_name: ` + monitoringPrometheusJobName + `
 scheme: https
+tls_config:
+  ca_file: /etc/prometheus/seed/ca.crt
+authorization:
+  type: Bearer
+  credentials_file: /var/run/secrets/gardener.cloud/shoot/token/token
 honor_labels: false
 kubernetes_sd_configs:
 - role: pod
   api_server: https://` + v1beta1constants.DeploymentNameKubeAPIServer + `:` + strconv.Itoa(kubeapiserver.Port) + `
+  tls_config:
+    ca_file: /etc/prometheus/seed/ca.crt
+  authorization:
+    type: Bearer
+    credentials_file: /var/run/secrets/gardener.cloud/shoot/token/token
 relabel_configs:
 - source_labels:
   - __meta_kubernetes_pod_name

--- a/pkg/operation/botanist/component/nodelocaldns/monitoring_test.go
+++ b/pkg/operation/botanist/component/nodelocaldns/monitoring_test.go
@@ -37,10 +37,20 @@ var _ = Describe("Monitoring", func() {
 const (
 	expectedScrapeConfig = `job_name: node-local-dns
 scheme: https
+tls_config:
+  ca_file: /etc/prometheus/seed/ca.crt
+authorization:
+  type: Bearer
+  credentials_file: /var/run/secrets/gardener.cloud/shoot/token/token
 honor_labels: false
 kubernetes_sd_configs:
 - role: pod
   api_server: https://kube-apiserver:443
+  tls_config:
+    ca_file: /etc/prometheus/seed/ca.crt
+  authorization:
+    type: Bearer
+    credentials_file: /var/run/secrets/gardener.cloud/shoot/token/token
 relabel_configs:
 - source_labels:
   - __meta_kubernetes_pod_name


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area monitoring
/kind bug

**What this PR does / why we need it**:
Fixed monitoring of node local dns.

The migration from the helm charts to the go based deployment broke the monitoring
of node local dns as the credentials were not provided. Now, they are added again
analogously to the coredns monitoring.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Monitoring dashboards of node local dns should work again.
```
