### PR TITLE
Improve WebhookConstraintMatchers for namespaces

### DIFF
--- a/pkg/operation/botanist/matchers/matcher.go
+++ b/pkg/operation/botanist/matchers/matcher.go
@@ -77,10 +77,9 @@ var (
 		{GVR: corev1.SchemeGroupVersion.WithResource("nodes"), ClusterScoped: true},
 		{GVR: corev1.SchemeGroupVersion.WithResource("nodes"), ClusterScoped: true, Subresource: "status"},
 
-		// needed when cluster is migrating to a version which adds the "kube-node-lease" namespace
-		{GVR: corev1.SchemeGroupVersion.WithResource("namespaces"), ClusterScoped: true},
-		{GVR: corev1.SchemeGroupVersion.WithResource("namespaces"), ClusterScoped: true, Subresource: "status"},
-		{GVR: corev1.SchemeGroupVersion.WithResource("namespaces"), ClusterScoped: true, Subresource: "finalize"},
+		// needed for gardener-resource-manager to update "kube-system" namespace labels
+		{GVR: corev1.SchemeGroupVersion.WithResource("namespaces"), ClusterScoped: true, ObjectLabels: kubeSystemLabels},
+		{GVR: corev1.SchemeGroupVersion.WithResource("namespaces"), ClusterScoped: true, ObjectLabels: kubeSystemLabels, Subresource: "status"},
 
 		{GVR: appsv1.SchemeGroupVersion.WithResource("controllerrevisions"), NamespaceLabels: kubeSystemLabels},
 		{GVR: appsv1.SchemeGroupVersion.WithResource("daemonsets"), NamespaceLabels: kubeSystemLabels},

--- a/pkg/operation/botanist/matchers/matcher.go
+++ b/pkg/operation/botanist/matchers/matcher.go
@@ -78,8 +78,8 @@ var (
 		{GVR: corev1.SchemeGroupVersion.WithResource("nodes"), ClusterScoped: true, Subresource: "status"},
 
 		// needed for gardener-resource-manager to update "kube-system" namespace labels
-		{GVR: corev1.SchemeGroupVersion.WithResource("namespaces"), ClusterScoped: true, ObjectLabels: kubeSystemLabels},
-		{GVR: corev1.SchemeGroupVersion.WithResource("namespaces"), ClusterScoped: true, ObjectLabels: kubeSystemLabels, Subresource: "status"},
+		{GVR: corev1.SchemeGroupVersion.WithResource("namespaces"), ClusterScoped: true, ObjectLabels: kubeSystemLabels, NamespaceLabels: kubeSystemLabels},
+		{GVR: corev1.SchemeGroupVersion.WithResource("namespaces"), ClusterScoped: true, ObjectLabels: kubeSystemLabels, NamespaceLabels: kubeSystemLabels, Subresource: "status"},
 
 		{GVR: appsv1.SchemeGroupVersion.WithResource("controllerrevisions"), NamespaceLabels: kubeSystemLabels},
 		{GVR: appsv1.SchemeGroupVersion.WithResource("daemonsets"), NamespaceLabels: kubeSystemLabels},
@@ -231,6 +231,11 @@ func (w *WebhookConstraintMatcher) Match(
 	rm := ruleMatcher{rule: r, gvr: w.GVR, subresource: w.Subresource}
 	if !w.ClusterScoped {
 		rm.namespace = "dummy"
+	}
+
+	// namespaceSelector can be used to select namespace objects (although the namespace is cluster-scoped resource)
+	if w.GVR == namespaceResource {
+		return matchObj && matchNS && rm.Matches()
 	}
 
 	return matchObj && (w.ClusterScoped || matchNS) && rm.Matches()

--- a/pkg/operation/care/constraints_test.go
+++ b/pkg/operation/care/constraints_test.go
@@ -218,6 +218,32 @@ var _ = Describe("#IsProblematicWebhook", func() {
 			))
 		}
 
+		namespacesTestTables = func(gvr schema.GroupVersionResource) {
+			var (
+				problematic = []TableEntry{
+					Entry("objectSelector matching purpose", webhookTestCase{
+						objectSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"gardener.cloud/purpose": "kube-system"}},
+					}),
+				}
+				notProblematic = []TableEntry{
+					Entry("objectSelector not matching purpose", webhookTestCase{
+						objectSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{Key: "gardener.cloud/purpose", Operator: metav1.LabelSelectorOpNotIn, Values: []string{"kube-system"}},
+							},
+						},
+					}),
+					Entry("not matching objectSelector", webhookTestCase{
+						objectSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"foo": "bar"}},
+					}),
+				}
+			)
+
+			commonTests(gvr, problematic, notProblematic)
+		}
+
 		kubeSystemNamespaceTables = func(gvr schema.GroupVersionResource) {
 			commonTests(gvr, kubeSystemNamespaceProblematic, kubeSystemNamespaceNotProblematic)
 		}
@@ -237,9 +263,8 @@ var _ = Describe("#IsProblematicWebhook", func() {
 	withoutSelectorsTables(corev1.SchemeGroupVersion.WithResource("services/status"))
 	withoutSelectorsTables(corev1.SchemeGroupVersion.WithResource("nodes"))
 	withoutSelectorsTables(corev1.SchemeGroupVersion.WithResource("nodes/status"))
-	withoutSelectorsTables(corev1.SchemeGroupVersion.WithResource("namespaces"))
-	withoutSelectorsTables(corev1.SchemeGroupVersion.WithResource("namespaces/status"))
-	withoutSelectorsTables(corev1.SchemeGroupVersion.WithResource("namespaces/finalize"))
+	namespacesTestTables(corev1.SchemeGroupVersion.WithResource("namespaces"))
+	namespacesTestTables(corev1.SchemeGroupVersion.WithResource("namespaces/status"))
 
 	kubeSystemNamespaceTables(appsv1.SchemeGroupVersion.WithResource("controllerrevisions"))
 	kubeSystemNamespaceTables(appsv1.SchemeGroupVersion.WithResource("daemonsets"))

--- a/pkg/operation/care/constraints_test.go
+++ b/pkg/operation/care/constraints_test.go
@@ -221,12 +221,27 @@ var _ = Describe("#IsProblematicWebhook", func() {
 		namespacesTestTables = func(gvr schema.GroupVersionResource) {
 			var (
 				problematic = []TableEntry{
+					Entry("namespaceSelector matching purpose", webhookTestCase{
+						namespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"gardener.cloud/purpose": "kube-system"}},
+					}),
 					Entry("objectSelector matching purpose", webhookTestCase{
 						objectSelector: &metav1.LabelSelector{
 							MatchLabels: map[string]string{"gardener.cloud/purpose": "kube-system"}},
 					}),
 				}
 				notProblematic = []TableEntry{
+					Entry("namespaceSelector not matching purpose", webhookTestCase{
+						namespaceSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{Key: "gardener.cloud/purpose", Operator: metav1.LabelSelectorOpNotIn, Values: []string{"kube-system"}},
+							},
+						},
+					}),
+					Entry("not matching namespaceSelector", webhookTestCase{
+						namespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"foo": "bar"}},
+					}),
 					Entry("objectSelector not matching purpose", webhookTestCase{
 						objectSelector: &metav1.LabelSelector{
 							MatchExpressions: []metav1.LabelSelectorRequirement{
@@ -237,6 +252,18 @@ var _ = Describe("#IsProblematicWebhook", func() {
 					Entry("not matching objectSelector", webhookTestCase{
 						objectSelector: &metav1.LabelSelector{
 							MatchLabels: map[string]string{"foo": "bar"}},
+					}),
+					Entry("matching objectSelector, not matching namespaceSelector", webhookTestCase{
+						objectSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"gardener.cloud/purpose": "kube-system"}},
+						namespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"foo": "bar"}},
+					}),
+					Entry("matching namespaceSelector, not matching objectSelector", webhookTestCase{
+						objectSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"foo": "bar"}},
+						namespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"gardener.cloud/purpose": "kube-system"}},
 					}),
 				}
 			)


### PR DESCRIPTION
/area ops-productivity
/kind enhancement

Currently a webhook for namespaces that properly ignores the `kube-system` namespace is still considered as problematic webhook:

```yaml
  failurePolicy: Fail
  matchPolicy: Exact
  name: check-ignore-label.gatekeeper.sh
  namespaceSelector: {}
  objectSelector:
    matchExpressions:
    - key: gardener.cloud/purpose
      operator: NotIn
      values:
      - kube-system
  rules:
  - apiGroups:
    - ""
    apiVersions:
    - '*'
    operations:
    - CREATE
    - UPDATE
    resources:
    - namespaces
```

This PR adapts the constraints to do not consider any webhook for namespace as problematic but only webhooks for namespace selecting the `kube-system` namespace.

Fixes #5956

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
A corner case in gardenlet's logic about detection of misconfigured webhook is addressed. Previously a webhook for namespaces that properly ignores the kube-system namespace was wrongly considered as "problematic". 
```
