### PR TITLE
Add `node_boot_time_seconds` metric

### DIFF
--- a/charts/seed-bootstrap/values.yaml
+++ b/charts/seed-bootstrap/values.yaml
@@ -130,6 +130,7 @@ allowedMetrics:
   - kubelet_volume_stats_capacity_bytes
 
   nodeExporter:
+  - node_boot_time_seconds
   - node_cpu_seconds_total
   - node_filesystem_avail_bytes
   - node_filesystem_free_bytes

--- a/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
@@ -137,6 +137,7 @@ allowedMetrics:
   - process_max_fds
   - process_open_fds
   nodeExporter:
+  - node_boot_time_seconds
   - node_cpu_seconds_total
   - node_filesystem_avail_bytes
   - node_filesystem_free_bytes


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring ops-productivity
/kind enhancement

**What this PR does / why we need it**:

Add `node_boot_time_seconds` metric to allow figuring out, when machines were booted/rebooted.
We don't have any data about this in our monitoring stack yet, so we should persist it there. Otherwise, it's impossible to figure out this information for debugging purposes if the machine is already gone.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Metrics about machine boot times are added to the monitoring stack.
```
