### PR TITLE
Add dashboard for node-local-dns operational errors.

### DIFF
--- a/charts/seed-monitoring/charts/grafana/dashboards/dns/node-local-dns-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/dns/node-local-dns-dashboard.json
@@ -1428,6 +1428,114 @@
         "align": false,
         "alignLevel": null
       }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "description": "Number of errors occurred during node cache operation",
+      "editable": true,
+      "error": false,
+      "fieldConfig": {
+        "defaults": {
+          "links": []
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "grid": {},
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 51
+      },
+      "hiddenSeries": false,
+      "id": 28,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sort": "current",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.4",
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(coredns_nodecache_setup_errors_total{pod=~\"$pod\"}[$__rate_interval])) by (errortype)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "Type: {{errortype}}",
+          "refId": "A",
+          "step": 60
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Node Cache Errors",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "cumulative"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:99",
+          "format": "pps",
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:100",
+          "format": "pps",
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
     }
   ],
   "schemaVersion": 27,

--- a/pkg/operation/botanist/component/nodelocaldns/monitoring_test.go
+++ b/pkg/operation/botanist/component/nodelocaldns/monitoring_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Monitoring", func() {
 	})
 
 	It("should successfully test the scrape config", func() {
-		test.ScrapeConfigs(component, expectedScrapeConfig)
+		test.ScrapeConfigs(component, expectedScrapeConfig, expectedErrorScrapeConfig)
 	})
 })
 
@@ -73,5 +73,44 @@ metric_relabel_configs:
 - source_labels: [ __name__ ]
   action: keep
   regex: ^(coredns_build_info|coredns_cache_entries|coredns_cache_hits_total|coredns_cache_misses_total|coredns_dns_request_duration_seconds_count|coredns_dns_request_duration_seconds_bucket|coredns_dns_responses_total|coredns_forward_requests_total|coredns_forward_responses_total|coredns_kubernetes_dns_programming_duration_seconds_bucket|coredns_kubernetes_dns_programming_duration_seconds_count|coredns_kubernetes_dns_programming_duration_seconds_sum|process_max_fds|process_open_fds)$
+`
+	expectedErrorScrapeConfig = `job_name: node-local-dns-errors
+scheme: https
+tls_config:
+  ca_file: /etc/prometheus/seed/ca.crt
+authorization:
+  type: Bearer
+  credentials_file: /var/run/secrets/gardener.cloud/shoot/token/token
+honor_labels: false
+kubernetes_sd_configs:
+- role: pod
+  api_server: https://kube-apiserver:443
+  tls_config:
+    ca_file: /etc/prometheus/seed/ca.crt
+  authorization:
+    type: Bearer
+    credentials_file: /var/run/secrets/gardener.cloud/shoot/token/token
+relabel_configs:
+- source_labels:
+  - __meta_kubernetes_pod_name
+  action: keep
+  regex: node-local.*
+- source_labels:
+  - __meta_kubernetes_pod_container_name
+  - __meta_kubernetes_pod_container_port_name
+  action: keep
+  regex: node-cache;errormetrics
+- source_labels: [ __meta_kubernetes_pod_name ]
+  target_label: pod
+- target_label: __address__
+  replacement: kube-apiserver:443
+- source_labels: [__meta_kubernetes_pod_name,__meta_kubernetes_pod_container_port_number]
+  regex: (.+);(.+)
+  target_label: __metrics_path__
+  replacement: /api/v1/namespaces/kube-system/pods/${1}:${2}/proxy/metrics
+metric_relabel_configs:
+- source_labels: [ __name__ ]
+  action: keep
+  regex: ^(coredns_nodecache_setup_errors_total)$
 `
 )

--- a/pkg/operation/botanist/component/nodelocaldns/nodelocaldns.go
+++ b/pkg/operation/botanist/component/nodelocaldns/nodelocaldns.go
@@ -55,8 +55,9 @@ const (
 	// portServer is the target port used for the DNS server.
 	portServer = 8053
 	// prometheus configuration for node-local-dns
-	prometheusPort   = 9253
-	prometheusScrape = true
+	prometheusPort      = 9253
+	prometheusScrape    = true
+	prometheusErrorPort = 9353
 
 	domain            = gardencorev1beta1.DefaultDomain
 	serviceName       = "kube-dns-upstream"
@@ -409,6 +410,11 @@ ip6.arpa:53 {
 									{
 										ContainerPort: int32(prometheusPort),
 										Name:          "metrics",
+										Protocol:      corev1.ProtocolTCP,
+									},
+									{
+										ContainerPort: int32(prometheusErrorPort),
+										Name:          "errormetrics",
 										Protocol:      corev1.ProtocolTCP,
 									},
 								},

--- a/pkg/operation/botanist/component/nodelocaldns/nodelocaldns_test.go
+++ b/pkg/operation/botanist/component/nodelocaldns/nodelocaldns_test.go
@@ -62,13 +62,14 @@ var _ = Describe("NodeLocalDNS", func() {
 		managedResource       *resourcesv1alpha1.ManagedResource
 		managedResourceSecret *corev1.Secret
 
-		ipvsAddress       = "169.254.20.10"
-		labelKey          = "k8s-app"
-		labelValue        = "node-local-dns"
-		prometheusPort    = 9253
-		prometheusScrape  = true
-		livenessProbePort = 8080
-		configMapHash     string
+		ipvsAddress         = "169.254.20.10"
+		labelKey            = "k8s-app"
+		labelValue          = "node-local-dns"
+		prometheusPort      = 9253
+		prometheusErrorPort = 9353
+		prometheusScrape    = true
+		livenessProbePort   = 8080
+		configMapHash       string
 	)
 
 	BeforeEach(func() {
@@ -353,6 +354,11 @@ status:
 											{
 												ContainerPort: int32(prometheusPort),
 												Name:          "metrics",
+												Protocol:      corev1.ProtocolTCP,
+											},
+											{
+												ContainerPort: int32(prometheusErrorPort),
+												Name:          "errormetrics",
 												Protocol:      corev1.ProtocolTCP,
 											},
 										},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
Add dashboard for node-local-dns operational errors.

Node-local-dns may run into a number of issues at runtime, e.g. due to the xtables
lock being held by another process. These errors are now also available via metrics
in prometheus and exposed via a dashboard in grafana.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Additional dashboard for node-local-dns errors.
```
