### PR TITLE
Fix pod security policy of node-local-dns by adding missing port.

### DIFF
--- a/pkg/operation/botanist/component/nodelocaldns/nodelocaldns.go
+++ b/pkg/operation/botanist/component/nodelocaldns/nodelocaldns.go
@@ -55,8 +55,9 @@ const (
 	// portServer is the target port used for the DNS server.
 	portServer = 8053
 	// prometheus configuration for node-local-dns
-	prometheusPort   = 9253
-	prometheusScrape = true
+	prometheusPort      = 9253
+	prometheusScrape    = true
+	prometheusErrorPort = 9353
 
 	domain            = gardencorev1beta1.DefaultDomain
 	serviceName       = "kube-dns-upstream"
@@ -172,6 +173,10 @@ func (c *nodeLocalDNS) computeResourcesData() (map[string][]byte, error) {
 					{
 						Min: prometheusPort,
 						Max: prometheusPort,
+					},
+					{
+						Min: prometheusErrorPort,
+						Max: prometheusErrorPort,
 					},
 				},
 				Privileged: true,

--- a/pkg/operation/botanist/component/nodelocaldns/nodelocaldns_test.go
+++ b/pkg/operation/botanist/component/nodelocaldns/nodelocaldns_test.go
@@ -119,6 +119,8 @@ spec:
     min: 53
   - max: 9253
     min: 9253
+  - max: 9353
+    min: 9353
   privileged: true
   runAsUser:
     rule: RunAsAny


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Fix pod security policy of node-local-dns by adding missing port.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
