### PR TITLE
managedseed_actuator: Clean up ineffective `updateCondition` call

### DIFF
--- a/pkg/gardenlet/controller/managedseed/managedseed_actuator.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_actuator.go
@@ -107,10 +107,6 @@ func (a *actuator) Reconcile(ctx context.Context, ms *seedmanagementv1alpha1.Man
 	updateCondition(status, seedmanagementv1alpha1.ManagedSeedShootReconciled, gardencorev1beta1.ConditionTrue, gardencorev1beta1.EventReconciled,
 		fmt.Sprintf("Shoot %s has been reconciled", kutil.ObjectName(shoot)))
 
-	// Update SeedRegistered condition
-	updateCondition(status, seedmanagementv1alpha1.ManagedSeedSeedRegistered, gardencorev1beta1.ConditionProgressing, gardencorev1beta1.EventReconciling,
-		fmt.Sprintf("Registering seed %s", ms.Name))
-
 	// Get shoot client
 	shootClient, err := a.clientMap.GetClient(ctx, keys.ForShoot(shoot))
 	if err != nil {

--- a/pkg/gardenlet/controller/managedseed/managedseed_actuator_test.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_actuator_test.go
@@ -1046,12 +1046,12 @@ var _ = Describe("Utils", func() {
 		var (
 			otherEnvDeployment = &seedmanagementv1alpha1.GardenletDeployment{
 				Env: []corev1.EnvVar{
-					corev1.EnvVar{Name: "TEST_VAR", Value: "TEST_VALUE"},
+					{Name: "TEST_VAR", Value: "TEST_VALUE"},
 				},
 			}
 			kubernetesServiceHostEnvDeployment = &seedmanagementv1alpha1.GardenletDeployment{
 				Env: []corev1.EnvVar{
-					corev1.EnvVar{Name: kubernetesServiceHost, Value: preserveDomain},
+					{Name: kubernetesServiceHost, Value: preserveDomain},
 				},
 			}
 


### PR DESCRIPTION
/area quality
/kind enhancement

If I see correctly the in-memory condition update that sets `SeedRegistered` condition to `Processing` in

https://github.com/gardener/gardener/blob/b37eee51d34be2810f2f7d8062d4a07250dd784b/pkg/gardenlet/controller/managedseed/managedseed_actuator.go#L110-L112

is not effective.

1. If no errors occurs the `Processing` `updateCondition` call is overwritten by the following `updateCondition` call that sets the condition to `True` https://github.com/gardener/gardener/blob/b37eee51d34be2810f2f7d8062d4a07250dd784b/pkg/gardenlet/controller/managedseed/managedseed_actuator.go#L165-L166


2. If error occurs meanwhile in https://github.com/gardener/gardener/blob/b37eee51d34be2810f2f7d8062d4a07250dd784b/pkg/gardenlet/controller/managedseed/managedseed_actuator.go#L114-L163 then the `Processing` `updateCondition` call is overwritten by https://github.com/gardener/gardener/blob/b37eee51d34be2810f2f7d8062d4a07250dd784b/pkg/gardenlet/controller/managedseed/managedseed_actuator.go#L87-L92.

To my understanding of the code, currently it is not possible the `Reconcile` func to return a status that is `Processing` - it will be always overwritten by one of the 2 existing exit scenarios described above.

As described above https://github.com/gardener/gardener/issues/4796, this `updateCondition` call to  `Processing` is causing the `Last(Transition|Update)Time` to be updated.

**Which issue(s) this PR fixes**:
Fixes #4796

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
An issue causing the `lastTransitionTime` and `lastUpdateTime` of the `SeedRegistered` condition of a `ManagedSeed` to be unnecessary updated on each reconciliation is now fixed.
```
