### PR TITLE
Re-enable CRI migration for existing worker pools

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -293,43 +293,7 @@ func ValidateShootSpecUpdate(newSpec, oldSpec *core.ShootSpec, newObjectMeta met
 
 // ValidateProviderUpdate validates the specification of a Provider object.
 func ValidateProviderUpdate(newProvider, oldProvider *core.Provider, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newProvider.Type, oldProvider.Type, fldPath.Child("type"))...)
-	allErrs = append(allErrs, validateWorkersUpdate(newProvider.Workers, oldProvider.Workers, fldPath.Child("workers"))...)
-
-	return allErrs
-}
-
-func validateWorkersUpdate(newWorkers, oldWorkers []core.Worker, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-	oldWorkersMap := make(map[string]core.Worker)
-	for _, w := range oldWorkers {
-		oldWorkersMap[w.Name] = w
-	}
-	for i, w := range newWorkers {
-		if _, ok := oldWorkersMap[w.Name]; ok {
-			oldWorker := oldWorkersMap[w.Name]
-			allErrs = append(allErrs, validateWorkerUpdate(&w, &oldWorker, fldPath.Index(i))...)
-		}
-	}
-	return allErrs
-}
-
-func validateWorkerUpdate(newWorker, oldWorker *core.Worker, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-	allErrs = append(allErrs, validateCRIUpdate(newWorker.CRI, oldWorker.CRI, fldPath.Child("cri"))...)
-
-	return allErrs
-}
-
-func validateCRIUpdate(newCri *core.CRI, oldCri *core.CRI, fldPath *field.Path) field.ErrorList {
-	allErrs := field.ErrorList{}
-
-	if (newCri == nil && oldCri != nil) || (newCri != nil && oldCri == nil) || (newCri != nil && oldCri != nil && newCri.Name != oldCri.Name) {
-		allErrs = append(allErrs, field.Invalid(fldPath, newCri, "can't update cri configurations"))
-	}
-	return allErrs
+	return apivalidation.ValidateImmutableField(newProvider.Type, oldProvider.Type, fldPath.Child("type"))
 }
 
 // ValidateShootStatusUpdate validates the status field of a Shoot object.

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -1133,33 +1133,6 @@ var _ = Describe("Shoot Validation Tests", func() {
 					}))))
 				})
 			})
-
-			It("should not allow update cri configurations enablement", func() {
-				newShoot := prepareShootForUpdate(shoot)
-				newWorker := *shoot.Spec.Provider.Workers[0].DeepCopy()
-				newWorker.Name = "second-worker"
-				newWorker.CRI = &core.CRI{Name: core.CRINameContainerD}
-				shoot.Spec.Provider.Workers = append(shoot.Spec.Provider.Workers, newWorker)
-
-				newShoot.Spec.Provider.Workers = []core.Worker{newWorker, shoot.Spec.Provider.Workers[0]}
-				newShoot.Spec.Provider.Workers[0].CRI = nil
-				newShoot.Spec.Provider.Workers[1].CRI = &core.CRI{Name: core.CRINameContainerD}
-
-				errorList := ValidateShootUpdate(newShoot, shoot)
-
-				Expect(errorList).To(HaveLen(2))
-			})
-
-			It("should not allow update cri name", func() {
-				shoot.Spec.Provider.Workers[0].CRI = &core.CRI{Name: "test-cri"}
-				newShoot := prepareShootForUpdate(shoot)
-
-				newShoot.Spec.Provider.Workers[0].CRI = &core.CRI{Name: core.CRINameContainerD}
-
-				errorList := ValidateShootUpdate(newShoot, shoot)
-
-				Expect(errorList).To(HaveLen(1))
-			})
 		})
 
 		Context("dns section", func() {

--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -403,7 +403,7 @@ func (r *shootReconciler) runReconcileShootFlow(ctx context.Context, o *operatio
 		deployOperatingSystemConfig = g.Add(flow.Task{
 			Name:         "Deploying operating system specific configuration for shoot workers",
 			Fn:           flow.TaskFn(botanist.DeployOperatingSystemConfig).RetryUntilTimeout(defaultInterval, defaultTimeout),
-			Dependencies: flow.NewTaskIDs(deployReferencedResources, waitUntilInfrastructureReady, waitUntilControlPlaneReady, waitUntilOperatingSystemConfigReadyForMigration),
+			Dependencies: flow.NewTaskIDs(deployReferencedResources, waitUntilInfrastructureReady, waitUntilControlPlaneReady),
 		})
 		waitUntilOperatingSystemConfigReady = g.Add(flow.Task{
 			Name:         "Waiting until operating system configurations for worker nodes have been reconciled",

--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -22,7 +22,6 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
-	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/features"
@@ -37,9 +36,7 @@ import (
 	retryutils "github.com/gardener/gardener/pkg/utils/retry"
 
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // runReconcileShootFlow reconciles the Shoot cluster.
@@ -47,12 +44,11 @@ import (
 func (r *shootReconciler) runReconcileShootFlow(ctx context.Context, o *operation.Operation, operationType gardencorev1beta1.LastOperationType) *gardencorev1beta1helper.WrappedLastErrors {
 	// We create the botanists (which will do the actual work).
 	var (
-		isRestoring                    = operationType == gardencorev1beta1.LastOperationTypeRestore
-		botanist                       *botanistpkg.Botanist
-		tasksWithErrors                []string
-		isCopyOfBackupsRequired        bool
-		err                            error
-		controlPlaneExistsAndSucceeded bool
+		isRestoring             = operationType == gardencorev1beta1.LastOperationTypeRestore
+		botanist                *botanistpkg.Botanist
+		tasksWithErrors         []string
+		isCopyOfBackupsRequired bool
+		err                     error
 	)
 
 	for _, lastError := range o.Shoot.GetInfo().Status.LastErrors {
@@ -77,14 +73,6 @@ func (r *shootReconciler) runReconcileShootFlow(ctx context.Context, o *operatio
 				}
 				return retryutils.Ok()
 			})
-		}),
-		errors.ToExecute("Check whether control plane exists and is succeeded", func() error {
-			cp := &extensionsv1alpha1.ControlPlane{}
-			if err := o.K8sSeedClient.Client().Get(ctx, kutil.Key(o.Shoot.SeedNamespace, o.Shoot.GetInfo().Name), cp); client.IgnoreNotFound(err) != nil {
-				return err
-			}
-			controlPlaneExistsAndSucceeded = !apierrors.IsNotFound(err) && cp.Status.LastOperation != nil && cp.Status.LastOperation.State == gardencorev1beta1.LastOperationStateSucceeded
-			return nil
 		}),
 		errors.ToExecute("Check required extensions", func() error {
 			return botanist.WaitUntilRequiredExtensionsReady(ctx)
@@ -164,27 +152,6 @@ func (r *shootReconciler) runReconcileShootFlow(ctx context.Context, o *operatio
 			Fn:           flow.TaskFn(botanist.DeployReferencedResources).RetryUntilTimeout(defaultInterval, defaultTimeout),
 			Dependencies: flow.NewTaskIDs(deployNamespace),
 		})
-
-		// Temporary code to ensure all nodes are migrated to the new cloud-config secret names.
-		// TODO(rfranzke): Remove the below in a future version.
-		deployOperatingSystemConfigForMigration = g.Add(flow.Task{
-			Name: "Deploying operating system specific configuration for shoot workers for cloud-config secret name migration",
-			Fn: flow.TaskFn(botanist.DeployOperatingSystemConfig).
-				RetryUntilTimeout(defaultInterval, defaultTimeout).
-				DoIf(controlPlaneExistsAndSucceeded),
-			Dependencies: flow.NewTaskIDs(ensureShootStateExists, deployReferencedResources, initializeSecretsManagement, waitUntilKubeAPIServerServiceIsReady),
-		})
-		waitUntilOperatingSystemConfigReadyForMigration = g.Add(flow.Task{
-			Name:         "Waiting until operating system configurations for worker nodes have been reconciled for cloud-config secret name migration",
-			Fn:           flow.TaskFn(botanist.Shoot.Components.Extensions.OperatingSystemConfig.Wait).DoIf(controlPlaneExistsAndSucceeded),
-			Dependencies: flow.NewTaskIDs(deployOperatingSystemConfigForMigration),
-		})
-		_ = g.Add(flow.Task{
-			Name:         "Deploying managed resources for the cloud config executors for cloud-config secret name migration",
-			Fn:           flow.TaskFn(botanist.DeployManagedResourceForCloudConfigExecutor).RetryUntilTimeout(defaultInterval, defaultTimeout).DoIf(controlPlaneExistsAndSucceeded),
-			Dependencies: flow.NewTaskIDs(waitUntilOperatingSystemConfigReadyForMigration),
-		})
-
 		deployOwnerDomainDNSRecord = g.Add(flow.Task{
 			Name:         "Deploying owner domain DNS record",
 			Fn:           botanist.DeployOwnerDNSResources,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind enhancement

**What this PR does / why we need it**:
This PR reverts
- https://github.com/gardener/gardener/pull/5954
- the backwards-compatibility introduced in https://github.com/gardener/gardener/pull/5870 (for https://github.com/gardener/gardener/pull/4289)
- https://github.com/gardener/gardener/pull/5791

This enables CRI migration again for existing worker pools in shoot clusters.

**Special notes for your reviewer**:
/cc @voelzmo @ialidzhikov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
Upgrading to this Gardener version is only possible from `v1.47` (as suggested in https://github.com/gardener/gardener/blob/master/docs/deployment/version_skew_policy.md#supported-component-upgrade-order).
```
```feature user
It is now possible again to migrate the CRIs for existing worker pools in shoot clusters.
```
