### PR TITLE
Add more contributors as reviewers

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -7,15 +7,27 @@ aliases:
   - BeckerMax
   - ialidzhikov
   - kris94
+  - oliver-goetz
   - plkokanov
   - rfranzke
   - shafeeqes
   - timebertt
   - timuthy
+  - abdasgupta
+  - danielfoehrKn
+  - DockToFuture
+  - istvanballok
+  - Kristian-ZH
+  - petersutter
+  - ScheererJ
+  - shreyas-s-rao
+  - vlvasilev
+  - voelzmo
+  - vpnachev
+  - wyb1
   gardener-approvers:
   - acumino
   - ary1992
-  - BeckerMax
   - ialidzhikov
   - kris94
   - plkokanov


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:

We want to encourage more of our contributors to review PRs, especially in areas where they are more knowledgable than the current set of reviewers/approvers.
We often explicitly invite them to review PRs in their areas of expertise. So their feedback in form of `/lgtm` should also be counted as a successful review for fulfilling the auto-merge requirements by tide, instead of the bot telling them they are not [allowed to add LGTM](https://github.com/gardener/gardener/pull/5934#issuecomment-1118711843).
The list of reviewers can of course be augmented/adapted according to the team/contributor situation.

cc @oliver-goetz @abdasgupta @danielfoehrKn @DockToFuture @istvanballok @Kristian-ZH @ScheererJ @shreyas-s-rao @vlvasilev @voelzmo @vpnachev @wyb1 @petersutter 