### PR TITLE
Switch default backend to `k8s.gcr.io/defaultbackend-amd64:1.5`

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -191,9 +191,9 @@ images:
   tag: "v1.2.0"
   targetVersion: ">= 1.22"
 - name: ingress-default-backend
-  sourceRepository: github.com/gardener/ingress-default-backend
-  repository: eu.gcr.io/gardener-project/gardener/ingress-default-backend
-  tag: "0.10.0"
+  sourceRepository: https://github.com/kubernetes/ingress-gce
+  repository: k8s.gcr.io/defaultbackend-amd64
+  tag: "1.5"
 
 # Miscellaenous
 - name: alpine

--- a/charts/shoot-addons/charts/nginx-ingress/templates/default-backend-deployment.yaml
+++ b/charts/shoot-addons/charts/nginx-ingress/templates/default-backend-deployment.yaml
@@ -48,7 +48,7 @@ spec:
           {{- end }}
           livenessProbe:
             httpGet:
-              path: /healthy
+              path: /healthz
               port: 8080
               scheme: HTTP
             initialDelaySeconds: 30

--- a/pkg/operation/botanist/component/nginxingress/nginxingress.go
+++ b/pkg/operation/botanist/component/nginxingress/nginxingress.go
@@ -357,7 +357,7 @@ func (n *nginxIngress) computeResourcesData() (map[string][]byte, error) {
 							LivenessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{
-										Path:   "/healthy",
+										Path:   "/healthz",
 										Port:   intstr.FromInt(int(containerPortBackend)),
 										Scheme: corev1.URISchemeHTTP,
 									},

--- a/pkg/operation/botanist/component/nginxingress/nginxingress_test.go
+++ b/pkg/operation/botanist/component/nginxingress/nginxingress_test.go
@@ -389,7 +389,7 @@ spec:
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
-            path: /healthy
+            path: /healthz
             port: 8080
             scheme: HTTP
           initialDelaySeconds: 30


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:
We decided to deprecate `github.com/gardener/ingress-default-backend`, so let's switch to the open-source/community-maintained `k8s.gcr.io/defaultbackend-amd64:1.5` instead.

**Special notes for your reviewer**:
/cc @holgerkoser @petersutter @grolu 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The ingress default backend has been switched to `k8s.gcr.io/defaultbackend-amd64:1.5`.
```
