### PR TITLE
Deprecate `ManagedIstio` and `APIServerSNI` feature gates and `ShootDNS` seed setting

### DIFF
--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -8071,7 +8071,8 @@ SeedSettingShootDNS
 </td>
 <td>
 <em>(Optional)</em>
-<p>ShootDNS controls the shoot DNS settings for the seed.</p>
+<p>ShootDNS controls the shoot DNS settings for the seed.
+Deprecated: This field is deprecated and will be removed in a future version of Gardener. Do not use it.</p>
 </td>
 </tr>
 <tr>

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -24,8 +24,10 @@ The following tables are a summary of the feature gates that you can set on diff
 | HVPAForShootedSeed                           | `false` | `Alpha` | `0.32` |        |
 | ManagedIstio                                 | `false` | `Alpha` | `1.5`  | `1.18` |
 | ManagedIstio                                 | `true`  | `Beta`  | `1.19` |        |
+| ManagedIstio (deprecated)                    | `true`  | `Beta`  | `1.48` |        |
 | APIServerSNI                                 | `false` | `Alpha` | `1.7`  | `1.18` |
 | APIServerSNI                                 | `true`  | `Beta`  | `1.19` |        |
+| APIServerSNI (deprecated)                    | `true`  | `Beta`  | `1.48` |        |
 | SeedChange                                   | `false` | `Alpha` | `1.12` |        |
 | SeedKubeScheduler                            | `false` | `Alpha` | `1.15` |        |
 | ReversedVPN                                  | `false` | `Alpha` | `1.22` | `1.41` |
@@ -116,8 +118,8 @@ A *General Availability* (GA) feature is also referred to as a *stable* feature.
 | ------------------------------------------ | ---------------------------------------------------------------- |  -----------|
 | HVPA                                       | `gardenlet`                                                      | Enables simultaneous horizontal and vertical scaling in Seed Clusters. |
 | HVPAForShootedSeed                         | `gardenlet`                                                      | Enables simultaneous horizontal and vertical scaling in managed seed (aka "shooted seed") clusters. |
-| ManagedIstio                               | `gardenlet`                                                      | Enables a Gardener-tailored [Istio](https://istio.io) in each Seed cluster. Disable this feature if Istio is already installed in the cluster. Istio is not automatically removed if this feature is disabled. See the [detailed documentation](../usage/istio.md) for more information. |
-| APIServerSNI                               | `gardenlet`                                                      | Enables only one LoadBalancer to be used for every Shoot cluster API server in a Seed. Enable this feature when `ManagedIstio` is enabled or Istio is manually deployed in Seed cluster. See [GEP-8](../proposals/08-shoot-apiserver-via-sni.md) for more details. |
+| ManagedIstio (deprecated)                  | `gardenlet`                                                      | Enables a Gardener-tailored [Istio](https://istio.io) in each Seed cluster. Disable this feature if Istio is already installed in the cluster. Istio is not automatically removed if this feature is disabled. See the [detailed documentation](../usage/istio.md) for more information. |
+| APIServerSNI (deprecated)                  | `gardenlet`                                                      | Enables only one LoadBalancer to be used for every Shoot cluster API server in a Seed. Enable this feature when `ManagedIstio` is enabled or Istio is manually deployed in Seed cluster. See [GEP-8](../proposals/08-shoot-apiserver-via-sni.md) for more details. |
 | CachedRuntimeClients                       | `gardener-controller-manager`, `gardenlet`                       | Enables a cache in the controller-runtime clients, that Gardener components use. The feature gate can be specified for gardenlet and gardener-controller-manager (and gardener-scheduler for the versions `< 1.29`). |
 | SeedChange                                 | `gardener-apiserver`                                             | Enables updating the `spec.seedName` field during shoot validation from a non-empty value in order to trigger shoot control plane migration. |
 | SeedKubeScheduler                          | `gardenlet`                                                      | Adds custom `kube-scheduler` in `gardener-kube-scheduler` namespace. It schedules [pods with scheduler name](../concepts/seed-admission-controller.md#mutating-webhooks) `gardener-kube-scheduler` on Nodes with higher resource utilization. It requires Seed cluster with kubernetes version `1.18` or higher. |

--- a/docs/usage/istio.md
+++ b/docs/usage/istio.md
@@ -6,7 +6,7 @@
 
 When enabled in gardenlet the `ManagedIstio` feature gate can be used to deploy a Gardener-tailored Istio installation in Seed clusters. It's main usage is to enable features such as [Shoot API server SNI](../proposals/08-shoot-apiserver-via-sni.md). This feature should not be enabled on a Seed cluster where Istio is already deployed.
 
-However, this feature gate is deprecated, turned off by default and will be removed in a future version of Gardener.
+However, this feature gate is deprecated, turned on by default and will be removed in a future version of Gardener.
 This means that Gardener will unconditionally deploy Istio with its desired configuration to seed clusters.
 Consequently, existing/bring-your-own Istio deployments will no longer be supported.
 

--- a/docs/usage/istio.md
+++ b/docs/usage/istio.md
@@ -6,6 +6,10 @@
 
 When enabled in gardenlet the `ManagedIstio` feature gate can be used to deploy a Gardener-tailored Istio installation in Seed clusters. It's main usage is to enable features such as [Shoot API server SNI](../proposals/08-shoot-apiserver-via-sni.md). This feature should not be enabled on a Seed cluster where Istio is already deployed.
 
+However, this feature gate is deprecated, turned off by default and will be removed in a future version of Gardener.
+This means that Gardener will unconditionally deploy Istio with its desired configuration to seed clusters.
+Consequently, existing/bring-your-own Istio deployments will no longer be supported.
+
 ## Prerequisites
 
 - Third-party JWT is used, therefore each Seed cluster where this feature is enabled must have [Service Account Token Volume Projection](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#service-account-token-volume-projection) enabled.

--- a/example/50-seed.yaml
+++ b/example/50-seed.yaml
@@ -67,6 +67,7 @@ spec:
       enabled: true # this seed will deploy excess-capacity-reservation pods
     scheduling:
       visible: true # the gardener-scheduler will consider this seed for shoots
+    # Deprecated: This field (`shootDNS`) is deprecated and will be removed in a future version of Gardener. Do not use it.
     shootDNS:
       enabled: true # all shoots on this seed will use DNS, if disabled they'll just use the plain IPs/hostnames
   # loadBalancerServices:

--- a/pkg/apis/core/types_seed.go
+++ b/pkg/apis/core/types_seed.go
@@ -201,6 +201,7 @@ type SeedSettings struct {
 	// Scheduling controls settings for scheduling decisions for the seed.
 	Scheduling *SeedSettingScheduling
 	// ShootDNS controls the shoot DNS settings for the seed.
+	// Deprecated: This field is deprecated and will be removed in a future version of Gardener. Do not use it.
 	ShootDNS *SeedSettingShootDNS
 	// LoadBalancerServices controls certain settings for services of type load balancer that are created in the seed.
 	LoadBalancerServices *SeedSettingLoadBalancerServices

--- a/pkg/apis/core/v1alpha1/generated.proto
+++ b/pkg/apis/core/v1alpha1/generated.proto
@@ -2020,6 +2020,7 @@ message SeedSettings {
   optional SeedSettingScheduling scheduling = 2;
 
   // ShootDNS controls the shoot DNS settings for the seed.
+  // Deprecated: This field is deprecated and will be removed in a future version of Gardener. Do not use it.
   // +optional
   optional SeedSettingShootDNS shootDNS = 3;
 

--- a/pkg/apis/core/v1alpha1/types_seed.go
+++ b/pkg/apis/core/v1alpha1/types_seed.go
@@ -213,6 +213,7 @@ type SeedSettings struct {
 	// +optional
 	Scheduling *SeedSettingScheduling `json:"scheduling,omitempty" protobuf:"bytes,2,opt,name=scheduling"`
 	// ShootDNS controls the shoot DNS settings for the seed.
+	// Deprecated: This field is deprecated and will be removed in a future version of Gardener. Do not use it.
 	// +optional
 	ShootDNS *SeedSettingShootDNS `json:"shootDNS,omitempty" protobuf:"bytes,3,opt,name=shootDNS"`
 	// LoadBalancerServices controls certain settings for services of type load balancer that are created in the seed.

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -1938,6 +1938,7 @@ message SeedSettings {
   optional SeedSettingScheduling scheduling = 2;
 
   // ShootDNS controls the shoot DNS settings for the seed.
+  // Deprecated: This field is deprecated and will be removed in a future version of Gardener. Do not use it.
   // +optional
   optional SeedSettingShootDNS shootDNS = 3;
 

--- a/pkg/apis/core/v1beta1/types_seed.go
+++ b/pkg/apis/core/v1beta1/types_seed.go
@@ -230,6 +230,7 @@ type SeedSettings struct {
 	// +optional
 	Scheduling *SeedSettingScheduling `json:"scheduling,omitempty" protobuf:"bytes,2,opt,name=scheduling"`
 	// ShootDNS controls the shoot DNS settings for the seed.
+	// Deprecated: This field is deprecated and will be removed in a future version of Gardener. Do not use it.
 	// +optional
 	ShootDNS *SeedSettingShootDNS `json:"shootDNS,omitempty" protobuf:"bytes,3,opt,name=shootDNS"`
 	// LoadBalancerServices controls certain settings for services of type load balancer that are created in the seed.

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -43,6 +43,7 @@ const (
 	// owner @ScheererJ @DockToFuture
 	// alpha: v1.5.0
 	// beta: v1.19.0
+	// deprecated: v1.48.0
 	ManagedIstio featuregate.Feature = "ManagedIstio"
 
 	// APIServerSNI allows to use only one LoadBalancer in the Seed cluster
@@ -52,6 +53,7 @@ const (
 	// owner @ScheererJ @DockToFuture
 	// alpha: v1.7.0
 	// beta: v1.19.0
+	// deprecated: v1.48.0
 	APIServerSNI featuregate.Feature = "APIServerSNI"
 
 	// CachedRuntimeClients enables a cache in the controller-runtime clients, that Gardener uses.

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -6431,7 +6431,7 @@ func schema_pkg_apis_core_v1alpha1_SeedSettings(ref common.ReferenceCallback) co
 					},
 					"shootDNS": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ShootDNS controls the shoot DNS settings for the seed.",
+							Description: "ShootDNS controls the shoot DNS settings for the seed. Deprecated: This field is deprecated and will be removed in a future version of Gardener. Do not use it.",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1alpha1.SeedSettingShootDNS"),
 						},
 					},
@@ -13489,7 +13489,7 @@ func schema_pkg_apis_core_v1beta1_SeedSettings(ref common.ReferenceCallback) com
 					},
 					"shootDNS": {
 						SchemaProps: spec.SchemaProps{
-							Description: "ShootDNS controls the shoot DNS settings for the seed.",
+							Description: "ShootDNS controls the shoot DNS settings for the seed. Deprecated: This field is deprecated and will be removed in a future version of Gardener. Do not use it.",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1beta1.SeedSettingShootDNS"),
 						},
 					},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
This PR deprecate the `ManagedIstio` and `APIServerSNI` feature gates since they will be "unconditionally" enabled in a future version of Gardener. Rationales:

- `ManagedIstio`: The feature is pretty stable meanwhile and the introduction of the feature gate was wrong in the first place (the purpose was to allow operators to bring their own Istio deployment to seed cluster, so a configuration option would have been more appropriate).
- `APIServerSNI`: Same here, pretty stable meanwhile and depending on `ManagedIstio` anyways.

As a result, the seed setting for disabling DNS for shoots gets deprecated as well (pretty-much unused anyways).

All of this is a prerequisite for dropping the legacy VPN solution and rely only on `ReversedVPN` which itself depends on `ManagedIstio`, `APIServerSNI` and DNS.

/cc @shafeeqes 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The `ManagedIstio` and `APIServerSNI` feature gates are now deprecated. They are already turned on by default and will be removed in a future version of Gardener. If you don't use them yet, turn them on now so to ensure a smooth migration to the future Gardener release.
```
```breaking operator
The seed setting for disabling DNS for shoots is now deprecated and will be removed in a future version of Gardener. Make sure to recreate your shoot clusters on such seeds with DNS enabled.
```
