### PR TITLE
Cleanup `Clock` attribute from `CertificateSecretConfig`

### DIFF
--- a/pkg/registry/core/shoot/storage/admin_kubeconfig.go
+++ b/pkg/registry/core/shoot/storage/admin_kubeconfig.go
@@ -43,7 +43,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/selection"
-	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/authentication/user"
 	genericapirequest "k8s.io/apiserver/pkg/endpoints/request"
@@ -54,7 +53,6 @@ import (
 type AdminKubeconfigREST struct {
 	shootStateStorage    getter
 	shootStorage         getter
-	clock                clock.Clock
 	maxExpirationSeconds int64
 }
 
@@ -147,7 +145,6 @@ func (r *AdminKubeconfigREST) Create(ctx context.Context, name string, obj runti
 				CertType:     secrets.ClientCert,
 				Validity:     &validity,
 				SigningCA:    clientCACertificate,
-				Clock:        r.clock,
 			},
 		}
 	)

--- a/pkg/registry/core/shoot/storage/admin_kubeconfig_test.go
+++ b/pkg/registry/core/shoot/storage/admin_kubeconfig_test.go
@@ -26,6 +26,8 @@ import (
 	authenticationapi "github.com/gardener/gardener/pkg/apis/authentication"
 	gardenercore "github.com/gardener/gardener/pkg/apis/core"
 	"github.com/gardener/gardener/pkg/utils"
+	secretutils "github.com/gardener/gardener/pkg/utils/secrets"
+	"github.com/gardener/gardener/pkg/utils/test"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -218,12 +220,13 @@ bW4nbZLxXHQ4e+OOPeBUXUP9V0QcE4XixdvQuslfVxjn0Ja82gdzeA==
 		akcREST = &AdminKubeconfigREST{
 			shootStorage:      shootGetter,
 			shootStateStorage: shootStateGetter,
-			clock:             clock.NewFakeClock(time.Unix(10, 0)),
 		}
 
 		ctx = request.WithUser(context.Background(), &user.DefaultInfo{
 			Name: userName,
 		})
+
+		DeferCleanup(test.WithVar(&secretutils.Clock, clock.NewFakeClock(time.Unix(10, 0))))
 	})
 
 	Context("request fails", func() {

--- a/pkg/registry/core/shoot/storage/storage.go
+++ b/pkg/registry/core/shoot/storage/storage.go
@@ -23,7 +23,6 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/util/clock"
 	"k8s.io/apiserver/pkg/registry/generic"
 	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/apiserver/pkg/registry/rest"
@@ -54,7 +53,6 @@ func NewStorage(optsGetter generic.RESTOptionsGetter, shootStateStore *genericre
 	s.AdminKubeconfig = &AdminKubeconfigREST{
 		shootStateStorage:    shootStateStore,
 		shootStorage:         shootRest,
-		clock:                clock.RealClock{},
 		maxExpirationSeconds: int64(max.Seconds()),
 	}
 

--- a/pkg/utils/secrets/certificate.go
+++ b/pkg/utils/secrets/certificate.go
@@ -26,8 +26,6 @@ import (
 	"time"
 
 	"github.com/gardener/gardener/pkg/utils"
-
-	"k8s.io/apimachinery/pkg/util/clock"
 )
 
 // CertType is a string alias for certificate types.
@@ -76,8 +74,6 @@ type CertificateSecretConfig struct {
 
 	Validity                    *time.Duration
 	SkipPublishingCACertificate bool
-
-	Clock clock.Clock
 }
 
 // Certificate contains the private key, and the certificate. It does also contain the CA certificate
@@ -207,12 +203,8 @@ func LoadCertificate(name string, privateKeyPEM, certificatePEM []byte) (*Certif
 // or both, depending on the <certType> value. If <isCACert> is true, then a CA certificate is being created.
 // The certificates a valid for 10 years.
 func (s *CertificateSecretConfig) generateCertificateTemplate() *x509.Certificate {
-	clock := Clock
-	if s.Clock != nil {
-		clock = s.Clock
-	}
+	now := Clock.Now()
 
-	now := clock.Now()
 	expiration := now.AddDate(10, 0, 0) // + 10 years
 	if s.Validity != nil {
 		expiration = now.Add(*s.Validity)

--- a/pkg/utils/secrets/manager/generate_test.go
+++ b/pkg/utils/secrets/manager/generate_test.go
@@ -361,8 +361,9 @@ var _ = Describe("Generate", func() {
 			})
 
 			It("should maintain the lifetime labels (w/o custom validity)", func() {
+				DeferCleanup(test.WithVar(&secretutils.Clock, fakeClock))
+
 				By("generating new secret")
-				config.Clock = fakeClock
 				secret, err := m.Generate(ctx, config)
 				Expect(err).NotTo(HaveOccurred())
 
@@ -378,8 +379,9 @@ var _ = Describe("Generate", func() {
 			})
 
 			It("should maintain the lifetime labels (w/ custom validity which is ignored for certificates)", func() {
+				DeferCleanup(test.WithVar(&secretutils.Clock, fakeClock))
+
 				By("generating new secret")
-				config.Clock = fakeClock
 				secret, err := m.Generate(ctx, config, Validity(time.Hour))
 				Expect(err).NotTo(HaveOccurred())
 
@@ -478,13 +480,14 @@ var _ = Describe("Generate", func() {
 			})
 
 			It("should maintain the lifetime labels (w/o custom validity)", func() {
+				DeferCleanup(test.WithVar(&secretutils.Clock, fakeClock))
+
 				By("generating new CA secret")
 				caSecret, err := m.Generate(ctx, caConfig)
 				Expect(err).NotTo(HaveOccurred())
 				expectSecretWasCreated(ctx, fakeClient, caSecret)
 
 				By("generating new server secret")
-				serverConfig.Clock = fakeClock
 				serverSecret, err := m.Generate(ctx, serverConfig, SignedByCA(caName))
 				Expect(err).NotTo(HaveOccurred())
 				expectSecretWasCreated(ctx, fakeClient, serverSecret)
@@ -501,13 +504,14 @@ var _ = Describe("Generate", func() {
 			})
 
 			It("should maintain the lifetime labels (w/ custom validity which is ignored for certificates)", func() {
+				DeferCleanup(test.WithVar(&secretutils.Clock, fakeClock))
+
 				By("generating new CA secret")
 				caSecret, err := m.Generate(ctx, caConfig)
 				Expect(err).NotTo(HaveOccurred())
 				expectSecretWasCreated(ctx, fakeClient, caSecret)
 
 				By("generating new server secret")
-				serverConfig.Clock = fakeClock
 				serverSecret, err := m.Generate(ctx, serverConfig, SignedByCA(caName), Validity(time.Hour))
 				Expect(err).NotTo(HaveOccurred())
 				expectSecretWasCreated(ctx, fakeClient, serverSecret)
@@ -640,13 +644,14 @@ var _ = Describe("Generate", func() {
 			})
 
 			It("should also accept ControlPlaneSecretConfigs", func() {
+				DeferCleanup(test.WithVar(&secretutils.Clock, fakeClock))
+
 				By("generating new CA secret")
 				caSecret, err := m.Generate(ctx, caConfig)
 				Expect(err).NotTo(HaveOccurred())
 				expectSecretWasCreated(ctx, fakeClient, caSecret)
 
 				By("generating new control plane secret")
-				serverConfig.Clock = fakeClock
 				serverConfig.Validity = utils.DurationPtr(1337 * time.Minute)
 				controlPlaneSecretConfig := &secretutils.ControlPlaneSecretConfig{
 					Name:                    "control-plane-secret",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:
Cleanup `Clock` attribute from `CertificateSecretConfig`.
There already is `secrets.Clock` which is also used in other secret config structs, so let's harmonize this.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
