### PR TITLE
Allow projected volumes for node-local-dns

### DIFF
--- a/pkg/operation/botanist/component/nodelocaldns/nodelocaldns.go
+++ b/pkg/operation/botanist/component/nodelocaldns/nodelocaldns.go
@@ -189,6 +189,7 @@ func (c *nodeLocalDNS) computeResourcesData() (map[string][]byte, error) {
 					"secret",
 					"hostPath",
 					"configMap",
+					"projected",
 				},
 			},
 		}

--- a/pkg/operation/botanist/component/nodelocaldns/nodelocaldns_test.go
+++ b/pkg/operation/botanist/component/nodelocaldns/nodelocaldns_test.go
@@ -131,6 +131,7 @@ spec:
   - secret
   - hostPath
   - configMap
+  - projected
 `
 			clusterRoleYAML = `apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
/area quality
/kind bug

Currently when privileged containers are not allowed, the node-local-dns DaemonSet fails to create a Pod with:
```
  Warning  FailedCreate      70s (x4 over 73s)    daemonset-controller  Error creating: pods "node-local-dns-" is forbidden: unable to validate against any pod security policy: [spec.securityContext.hostNetwork: Invalid value: true: Host network is not allowed to be used spec.volumes[0]: Invalid value: "hostPath": hostPath volumes are not allowed to be used spec.containers[0].securityContext.privileged: Invalid value: true: Privileged containers are not allowed spec.containers[0].hostPort: Invalid value: 53: Host port 53 is not allowed to be used. Allowed ports: [] spec.containers[0].hostPort: Invalid value: 53: Host port 53 is not allowed to be used. Allowed ports: [] spec.containers[0].hostPort: Invalid value: 9253: Host port 9253 is not allowed to be used. Allowed ports: [] spec.volumes[3]: Invalid value: "projected": projected volumes are not allowed to be used]
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
An issue causing Pod creation to fail for the node-local-dns DaemonSet when privileged containers are not allowed is now fixed.
```
