### PR TITLE
Properly maintain `valid-until-time` label on `Secret`s managed by secrets manager

### DIFF
--- a/extensions/pkg/util/secret/manager/manager_test.go
+++ b/extensions/pkg/util/secret/manager/manager_test.go
@@ -345,7 +345,7 @@ func createOldCASecrets(c client.Client, cluster *extensionscontroller.Cluster, 
 	for _, caConfig := range caConfigs {
 		secretData, err := caConfig.Config.Generate()
 		Expect(err).NotTo(HaveOccurred(), caConfig.Config.GetName())
-		secretMeta, err := secretsmanager.ObjectMeta(cluster.ObjectMeta.Name, testIdentity, caConfig.Config, false, "", nil, nil, nil, nil)
+		secretMeta, err := secretsmanager.ObjectMeta(cluster.ObjectMeta.Name, testIdentity, caConfig.Config, false, "", nil, nil, nil)
 		Expect(err).NotTo(HaveOccurred(), caConfig.Config.GetName())
 
 		dataMap := secretData.SecretData()

--- a/pkg/utils/secrets/manager/fake/fake_manager.go
+++ b/pkg/utils/secrets/manager/fake/fake_manager.go
@@ -71,7 +71,7 @@ func (m *fakeManager) Generate(ctx context.Context, config secretutils.ConfigInt
 		return nil, err
 	}
 
-	objectMeta, err := secretsmanager.ObjectMeta(m.namespace, ManagerIdentity, config, true, "", nil, nil, &options.Persist, nil)
+	objectMeta, err := secretsmanager.ObjectMeta(m.namespace, ManagerIdentity, config, true, "", nil, &options.Persist, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/utils/secrets/manager/manager.go
+++ b/pkg/utils/secrets/manager/manager.go
@@ -284,7 +284,6 @@ func ObjectMeta(
 	config secretutils.ConfigInterface,
 	ignoreConfigChecksumForCASecretName bool,
 	lastRotationInitiationTime string,
-	validUntilTime *string,
 	signingCAChecksum *string,
 	persist *bool,
 	bundleFor *string,
@@ -307,10 +306,6 @@ func ObjectMeta(
 
 	if signingCAChecksum != nil {
 		labels[LabelKeyChecksumSigningCA] = *signingCAChecksum
-	}
-
-	if validUntilTime != nil {
-		labels[LabelKeyValidUntilTime] = *validUntilTime
 	}
 
 	if persist != nil && *persist {

--- a/pkg/utils/secrets/manager/manager_test.go
+++ b/pkg/utils/secrets/manager/manager_test.go
@@ -303,7 +303,7 @@ var _ = Describe("Manager", func() {
 			func(ignoreChecksum bool, expectedName string, lastRotationInitiationTime string) {
 				config := &secretutils.CertificateSecretConfig{Name: configName}
 
-				meta, err := ObjectMeta(namespace, "test", config, ignoreChecksum, lastRotationInitiationTime, nil, nil, nil, nil)
+				meta, err := ObjectMeta(namespace, "test", config, ignoreChecksum, lastRotationInitiationTime, nil, nil, nil)
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(meta).To(Equal(metav1.ObjectMeta{
@@ -326,13 +326,13 @@ var _ = Describe("Manager", func() {
 		)
 
 		DescribeTable("check different label options",
-			func(nameInfix string, signingCAChecksum *string, validUntilTime *string, persist *bool, bundleFor *string, extraLabels map[string]string) {
+			func(nameInfix string, signingCAChecksum *string, persist *bool, bundleFor *string, extraLabels map[string]string) {
 				config := &secretutils.CertificateSecretConfig{
 					Name:      configName,
 					SigningCA: &secretutils.Certificate{},
 				}
 
-				meta, err := ObjectMeta(namespace, "test", config, false, lastRotationInitiationTime, validUntilTime, signingCAChecksum, persist, bundleFor)
+				meta, err := ObjectMeta(namespace, "test", config, false, lastRotationInitiationTime, signingCAChecksum, persist, bundleFor)
 				Expect(err).NotTo(HaveOccurred())
 
 				labels := map[string]string{
@@ -350,11 +350,10 @@ var _ = Describe("Manager", func() {
 				}))
 			},
 
-			Entry("no extras", "a9c2fcb9", nil, nil, nil, nil, nil),
-			Entry("with signing ca checksum", "a11a0b2d", pointer.String("checksum"), nil, nil, nil, map[string]string{"checksum-of-signing-ca": "checksum"}),
-			Entry("with valid until time", "a9c2fcb9", nil, pointer.String("validuntil"), nil, nil, map[string]string{"valid-until-time": "validuntil"}),
-			Entry("with persist", "a9c2fcb9", nil, nil, pointer.Bool(true), nil, map[string]string{"persist": "true"}),
-			Entry("with bundleFor", "a9c2fcb9", nil, nil, nil, pointer.String("bundle-origin"), map[string]string{"bundle-for": "bundle-origin"}),
+			Entry("no extras", "a9c2fcb9", nil, nil, nil, nil),
+			Entry("with signing ca checksum", "a11a0b2d", pointer.String("checksum"), nil, nil, map[string]string{"checksum-of-signing-ca": "checksum"}),
+			Entry("with persist", "a9c2fcb9", nil, pointer.Bool(true), nil, map[string]string{"persist": "true"}),
+			Entry("with bundleFor", "a9c2fcb9", nil, nil, pointer.String("bundle-origin"), map[string]string{"bundle-for": "bundle-origin"}),
 		)
 	})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bug

**What this PR does / why we need it**:
Earlier, each invocation of the secrets manager's `Generate` function has overwritten the `valid-until-time` on the secret based on the current time because of https://github.com/gardener/gardener/blob/a59e5dbfa51d3ddee06aeb5b0a76182d519425d4/pkg/utils/secrets/manager/generate.go#L51-L54

Now the `valid-until-time` label is properly maintained. This means:

- another invocation of `Generate` with the same validity does no longer overwrite the existing `valid-until-time`
- another invocation of `Generate` with a different validity does recompute the `valid-until-time` based on the `issued-at-time`. If the new `valid-until-time` is now in the
  - future then nothing else happens (the label value just got updated).
  - past then the next instantiation of the secrets manager will auto-rotate this secret.
- another invocation of `Generate` without any validity removes the existing `valid-until-time` label.

**Which issue(s) this PR fixes**:
Related to #5992

**Special notes for your reviewer**:
/cc @kris94 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A custom validity of secrets is now properly respected. Earlier, it was overwritten and regenerated in each reconciliation which technically led to the situation in which such secrets were never auto-rotated when their intentional validity was expired.
```
