### PR TITLE
Ensure that shoot node network and seed service network do not overlap.

### DIFF
--- a/pkg/utils/validation/cidr/disjoint.go
+++ b/pkg/utils/validation/cidr/disjoint.go
@@ -35,6 +35,9 @@ func ValidateNetworkDisjointedness(fldPath *field.Path, shootNodes, shootPods, s
 	if shootNodes != nil && seedNodes != nil && NetworksIntersect(*shootNodes, *seedNodes) {
 		allErrs = append(allErrs, field.Invalid(pathNodes, *shootNodes, "shoot node network intersects with seed node network"))
 	}
+	if shootNodes != nil && NetworksIntersect(*shootNodes, seedServices) {
+		allErrs = append(allErrs, field.Invalid(pathNodes, *shootNodes, "shoot node network intersects with seed service network"))
+	}
 	if shootNodes != nil && NetworksIntersect(*shootNodes, v1beta1constants.DefaultVpnRange) {
 		allErrs = append(allErrs, field.Invalid(pathNodes, *shootNodes, fmt.Sprintf("shoot node network intersects with default vpn network (%s)", v1beta1constants.DefaultVpnRange)))
 	}

--- a/pkg/utils/validation/cidr/disjoint_test.go
+++ b/pkg/utils/validation/cidr/disjoint_test.go
@@ -36,7 +36,7 @@ var _ = Describe("utils", func() {
 			var (
 				podsCIDR     = "10.242.128.0/17"
 				servicesCIDR = "10.242.0.0/17"
-				nodesCIDR    = "10.241.0.0/16"
+				nodesCIDR    = "10.243.0.0/16"
 			)
 
 			errorList := ValidateNetworkDisjointedness(
@@ -135,7 +135,7 @@ var _ = Describe("utils", func() {
 			var (
 				podsCIDR     = "192.168.123.0/24"
 				servicesCIDR = "10.242.0.0/17"
-				nodesCIDR    = "10.241.0.0/16"
+				nodesCIDR    = "10.243.0.0/16"
 			)
 
 			errorList := ValidateNetworkDisjointedness(
@@ -158,7 +158,7 @@ var _ = Describe("utils", func() {
 			var (
 				podsCIDR     = "10.242.128.0/17"
 				servicesCIDR = "192.168.123.64/26"
-				nodesCIDR    = "10.241.0.0/16"
+				nodesCIDR    = "10.243.0.0/16"
 			)
 
 			errorList := ValidateNetworkDisjointedness(
@@ -204,7 +204,7 @@ var _ = Describe("utils", func() {
 			var (
 				podsCIDR     = seedNodesCIDR
 				servicesCIDR = seedNodesCIDR
-				nodesCIDR    = "10.241.0.0/16"
+				nodesCIDR    = "10.243.0.0/16"
 			)
 
 			errorList := ValidateNetworkDisjointedness(
@@ -225,6 +225,29 @@ var _ = Describe("utils", func() {
 				"Field": Equal("[].services"),
 			})),
 			))
+		})
+
+		It("should fail due to seed service network and shoot node network overlap", func() {
+			var (
+				podsCIDR     = "10.242.128.0/17"
+				servicesCIDR = "10.242.0.0/17"
+				nodesCIDR    = "10.241.0.0/16"
+			)
+
+			errorList := ValidateNetworkDisjointedness(
+				field.NewPath(""),
+				&nodesCIDR,
+				&podsCIDR,
+				&servicesCIDR,
+				&seedNodesCIDR,
+				seedPodsCIDR,
+				seedServicesCIDR,
+			)
+
+			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":  Equal(field.ErrorTypeInvalid),
+				"Field": Equal("[].nodes"),
+			}))))
 		})
 	})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area robustness
/kind bug

**What this PR does / why we need it**:
Ensure that shoot node network and seed service network do not overlap.

The SNI implementation in Gardener using apiserver-proxy 'leaks' the cluster
ip of the kube-apiserver in the seed into all shoot nodes. As the ip is locally
assigned it can easily cause issues if the shoot node network overlaps with the
seed service network.
This change adds the corresponding validation and adapts the tests.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The shoot node network is no longer allowed to overlap with the seed service network.
```
