### PR TITLE
Update/remove memory limits. Disable limit autoscaling.

### DIFF
--- a/charts/istio/istio-istiod/templates/deployment.yaml
+++ b/charts/istio/istio-istiod/templates/deployment.yaml
@@ -97,8 +97,6 @@ spec:
           requests:
             cpu: 250m
             memory: 256Mi
-          limits:
-            memory: 2048Mi
         securityContext:
           capabilities:
             drop:

--- a/charts/seed-bootstrap/charts/hvpa/templates/controller-deployment.yaml
+++ b/charts/seed-bootstrap/charts/hvpa/templates/controller-deployment.yaml
@@ -40,8 +40,6 @@ spec:
           - --metrics-addr=:9569
           - --v=2
         resources:
-          limits:
-            memory: 1000Mi
           requests:
             cpu: 50m
             memory: 500Mi

--- a/charts/seed-bootstrap/charts/loki/templates/hvpa.yaml
+++ b/charts/seed-bootstrap/charts/loki/templates/hvpa.yaml
@@ -68,6 +68,7 @@ spec:
         resourcePolicy:
           containerPolicies:
             - containerName: loki
+              controlledValues: RequestsOnly
               maxAllowed:
                 memory: {{ .Values.hvpa.maxAllowed.memory }}
                 cpu:  "{{ .Values.hvpa.maxAllowed.cpu }}"

--- a/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager.go
@@ -610,7 +610,8 @@ func (k *kubeControllerManager) computeResourceRequirements(ctx context.Context)
 	}
 
 	if len(existingDeployment.Spec.Template.Spec.Containers) > 0 {
-		return existingDeployment.Spec.Template.Spec.Containers[0].Resources, nil
+		// Copy requests only, effectively removing limits
+		return corev1.ResourceRequirements{Requests: existingDeployment.Spec.Template.Spec.Containers[0].Resources.Requests}, nil
 	}
 
 	return defaultResources, nil

--- a/pkg/operation/botanist/component/vpnauthzserver/external_authz_server.go
+++ b/pkg/operation/botanist/component/vpnauthzserver/external_authz_server.go
@@ -144,9 +144,6 @@ func (a *authzServer) Deploy(ctx context.Context) error {
 									corev1.ResourceCPU:    resource.MustParse("100m"),
 									corev1.ResourceMemory: resource.MustParse("100Mi"),
 								},
-								Limits: corev1.ResourceList{
-									corev1.ResourceMemory: resource.MustParse("500Mi"),
-								},
 							},
 						},
 					},

--- a/pkg/operation/botanist/component/vpnauthzserver/external_authz_server_test.go
+++ b/pkg/operation/botanist/component/vpnauthzserver/external_authz_server_test.go
@@ -173,9 +173,6 @@ var _ = Describe("ExtAuthzServer", func() {
 										corev1.ResourceCPU:    resource.MustParse("100m"),
 										corev1.ResourceMemory: resource.MustParse("100Mi"),
 									},
-									Limits: corev1.ResourceList{
-										corev1.ResourceMemory: resource.MustParse("500Mi"),
-									},
 								},
 							},
 						},


### PR DESCRIPTION
**How to categorize this PR?**
/area auto-scaling
/area robustness
/kind enhancement

**What this PR does / why we need it**:
Improves stability by updating and removing various components' memory limits and disabling limit autoscaling.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Includes only mid-and-higher priority improvements. Lower priority limit scaling improvements will be addressed by a separate change set.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Memory limits of various components were updated, based on measured usage, to prevent OOMKills due to reaching the limits. Limit scaling was disabled to prevent limit downscaling during periods of load system load.
```
