### PR TITLE
Require `gnostic` in `v0.5.5`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/go-logr/logr v1.2.3
 	github.com/gogo/protobuf v1.3.2
 	github.com/golang/mock v1.6.0
-	github.com/googleapis/gnostic v0.6.9
+	github.com/googleapis/gnostic v0.5.5
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/kubernetes-csi/external-snapshotter/v2 v2.1.4
 	github.com/mholt/archiver v3.1.1+incompatible

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -235,7 +235,7 @@ github.com/google/pprof/profile
 # github.com/google/uuid v1.1.2
 ## explicit
 github.com/google/uuid
-# github.com/googleapis/gnostic v0.6.9 => github.com/googleapis/gnostic v0.5.5
+# github.com/googleapis/gnostic v0.5.5 => github.com/googleapis/gnostic v0.5.5
 ## explicit; go 1.12
 github.com/googleapis/gnostic/compiler
 github.com/googleapis/gnostic/extensions


### PR DESCRIPTION
The `require` directive was bumped to `v0.6.9` in #5986, however we replace it anyways with `v0.5.5` here https://github.com/gardener/gardener/blob/b4803b91618be93327e19664ea7e552420076af3/go.mod#L186

Without this PR, revendoring the new `gardener/gardener` version in another repository fails with:

```
go: github.com/gardener/gardener@v1.47.1-0.20220523172609-b4803b91618b requires
	github.com/googleapis/gnostic@v0.6.9: parsing go.mod:
	module declares its path as: github.com/google/gnostic
	        but was required as: github.com/googleapis/gnostic
```