### PR TITLE
Fix `make test` and `make test-integration` for M1 Macbooks

### DIFF
--- a/hack/test-integration.sh
+++ b/hack/test-integration.sh
@@ -26,8 +26,15 @@ if ! command -v setup-envtest &> /dev/null ; then
   exit 1
 fi
 
+ARCH=
+# if using M1 macbook, use amd64 architecture build, as suggested in
+# https://github.com/kubernetes-sigs/controller-runtime/issues/1657#issuecomment-988484517
+if [[ $(uname) == 'Darwin' && $(uname -m) == 'arm64' ]]; then
+  ARCH='--arch=amd64'
+fi
+
 # --use-env allows overwriting the envtest tools path via the KUBEBUILDER_ASSETS env var just like it was before
-export KUBEBUILDER_ASSETS="$(setup-envtest use --use-env -p path ${ENVTEST_K8S_VERSION})"
+export KUBEBUILDER_ASSETS="$(setup-envtest ${ARCH} use --use-env -p path ${ENVTEST_K8S_VERSION})"
 echo "using envtest tools installed at '$KUBEBUILDER_ASSETS'"
 
 echo "> Integration Tests"

--- a/hack/tools/install-promtool.sh
+++ b/hack/tools/install-promtool.sh
@@ -21,9 +21,9 @@ echo "> Installing promtool"
 TOOLS_BIN_DIR=${TOOLS_BIN_DIR:-$(dirname $0)/bin}
 
 platform=$(uname -s | tr '[:upper:]' '[:lower:]')
-version="2.24.1"
+version="2.34.0"
 case $(uname -m) in
-  aarch64)
+  aarch64 | arm64)
     arch="arm64"
     ;;
   x86_64)


### PR DESCRIPTION
Signed-off-by: Shreyas Rao <shreyas.sriganesh.rao@sap.com>

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
This PR fixes the targets `make test` and `make test-integration` for M1 Macbooks

**Which issue(s) this PR fixes**:
Fixes #5800 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Fix `make test` and `make test-integration` for M1 Macbooks
```
