### PR TITLE
Consider `ResourcesProgressing` condition of `ManagedResources` during seed health checks

### DIFF
--- a/pkg/operation/care/health_check_test.go
+++ b/pkg/operation/care/health_check_test.go
@@ -506,6 +506,21 @@ var _ = Describe("health check", func() {
 			},
 			false,
 			PointTo(beConditionWithStatusAndMsg(gardencorev1beta1.ConditionFalse, gardencorev1beta1.OutdatedStatusError, "outdated"))),
+		Entry("unknown condition status with reason and message",
+			[]gardencorev1beta1.Condition{
+				{
+					Type:   resourcesv1alpha1.ResourcesApplied,
+					Status: gardencorev1beta1.ConditionTrue,
+				},
+				{
+					Type:    resourcesv1alpha1.ResourcesHealthy,
+					Status:  gardencorev1beta1.ConditionUnknown,
+					Reason:  "Unknown",
+					Message: "bar is unknown",
+				},
+			},
+			true,
+			PointTo(beConditionWithStatusAndMsg(gardencorev1beta1.ConditionFalse, "Unknown", "bar is unknown"))),
 	)
 
 	Describe("#CheckClusterNodes", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
When evaluating the status of the SeedSystemComponentsHealthy condition the `resourcesv1alpha1.ResourcesProgressing` condition of managed resource is now also considered.

**Which issue(s) this PR fixes**:
Part of #5850

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
When evaluationg the `SeedSystemComponentsHealthy` condition, the `ResourcesProgressing` condition of `ManagedResource`s is now also considered.
```
