### PR TITLE
Keep all the memory metrics in the seed prometheus

### DIFF
--- a/charts/seed-bootstrap/values.yaml
+++ b/charts/seed-bootstrap/values.yaml
@@ -138,7 +138,7 @@ allowedMetrics:
   - node_load1
   - node_load5
   - node_load15
-  - node_memory_Active_bytes
+  - node_memory_.+
   - node_nf_conntrack_entries
   - node_nf_conntrack_entries_limit
   - process_max_fds

--- a/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
@@ -145,7 +145,7 @@ allowedMetrics:
   - node_load1
   - node_load15
   - node_load5
-  - node_memory_Active_bytes
+  - node_memory_.+
   - node_nf_conntrack_entries
   - node_nf_conntrack_entries_limit
   - node_scrape_collector_duration_seconds


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

Keep all the memory metrics in the seed and shoot prometheus

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

The meminfo collector of the node exporter exposes
the fields of the `/proc/meminfo` as metrics.

See https://github.com/prometheus/node_exporter/blob/c6e1a5b74277557045f0620e6d37259a291cb03b/collector/meminfo_linux.go#L33-L75

Previously, we kept a single metric:

>      Active: Memory that has been used more recently and usually not
>              reclaimed unless absolutely necessary.

See https://www.kernel.org/doc/Documentation/filesystems/proc.txt

and we noticed that the other fields could be also useful to
understand the memory usage of a node.

We shall list all the metrics in the allow list individually for consistency,
but for now I think using a regular expression is more concise
and reflects the intent to capture all of them.

<details>
<summary>List of the 50 metrics with documentation</summary>

```
$ curl -s localhost:16909/metrics | grep '# HELP node_memory' | nl
     1	# HELP node_memory_Active_anon_bytes Memory information field Active_anon_bytes.
     2	# HELP node_memory_Active_bytes Memory information field Active_bytes.
     3	# HELP node_memory_Active_file_bytes Memory information field Active_file_bytes.
     4	# HELP node_memory_AnonHugePages_bytes Memory information field AnonHugePages_bytes.
     5	# HELP node_memory_AnonPages_bytes Memory information field AnonPages_bytes.
     6	# HELP node_memory_Bounce_bytes Memory information field Bounce_bytes.
     7	# HELP node_memory_Buffers_bytes Memory information field Buffers_bytes.
     8	# HELP node_memory_Cached_bytes Memory information field Cached_bytes.
     9	# HELP node_memory_CommitLimit_bytes Memory information field CommitLimit_bytes.
    10	# HELP node_memory_Committed_AS_bytes Memory information field Committed_AS_bytes.
    11	# HELP node_memory_DirectMap1G_bytes Memory information field DirectMap1G_bytes.
    12	# HELP node_memory_DirectMap2M_bytes Memory information field DirectMap2M_bytes.
    13	# HELP node_memory_DirectMap4k_bytes Memory information field DirectMap4k_bytes.
    14	# HELP node_memory_Dirty_bytes Memory information field Dirty_bytes.
    15	# HELP node_memory_FileHugePages_bytes Memory information field FileHugePages_bytes.
    16	# HELP node_memory_FilePmdMapped_bytes Memory information field FilePmdMapped_bytes.
    17	# HELP node_memory_HugePages_Free Memory information field HugePages_Free.
    18	# HELP node_memory_HugePages_Rsvd Memory information field HugePages_Rsvd.
    19	# HELP node_memory_HugePages_Surp Memory information field HugePages_Surp.
    20	# HELP node_memory_HugePages_Total Memory information field HugePages_Total.
    21	# HELP node_memory_Hugepagesize_bytes Memory information field Hugepagesize_bytes.
    22	# HELP node_memory_Hugetlb_bytes Memory information field Hugetlb_bytes.
    23	# HELP node_memory_Inactive_anon_bytes Memory information field Inactive_anon_bytes.
    24	# HELP node_memory_Inactive_bytes Memory information field Inactive_bytes.
    25	# HELP node_memory_Inactive_file_bytes Memory information field Inactive_file_bytes.
    26	# HELP node_memory_KReclaimable_bytes Memory information field KReclaimable_bytes.
    27	# HELP node_memory_KernelStack_bytes Memory information field KernelStack_bytes.
    28	# HELP node_memory_Mapped_bytes Memory information field Mapped_bytes.
    29	# HELP node_memory_MemAvailable_bytes Memory information field MemAvailable_bytes.
    30	# HELP node_memory_MemFree_bytes Memory information field MemFree_bytes.
    31	# HELP node_memory_MemTotal_bytes Memory information field MemTotal_bytes.
    32	# HELP node_memory_Mlocked_bytes Memory information field Mlocked_bytes.
    33	# HELP node_memory_NFS_Unstable_bytes Memory information field NFS_Unstable_bytes.
    34	# HELP node_memory_PageTables_bytes Memory information field PageTables_bytes.
    35	# HELP node_memory_Percpu_bytes Memory information field Percpu_bytes.
    36	# HELP node_memory_SReclaimable_bytes Memory information field SReclaimable_bytes.
    37	# HELP node_memory_SUnreclaim_bytes Memory information field SUnreclaim_bytes.
    38	# HELP node_memory_ShmemHugePages_bytes Memory information field ShmemHugePages_bytes.
    39	# HELP node_memory_ShmemPmdMapped_bytes Memory information field ShmemPmdMapped_bytes.
    40	# HELP node_memory_Shmem_bytes Memory information field Shmem_bytes.
    41	# HELP node_memory_Slab_bytes Memory information field Slab_bytes.
    42	# HELP node_memory_SwapCached_bytes Memory information field SwapCached_bytes.
    43	# HELP node_memory_SwapFree_bytes Memory information field SwapFree_bytes.
    44	# HELP node_memory_SwapTotal_bytes Memory information field SwapTotal_bytes.
    45	# HELP node_memory_Unevictable_bytes Memory information field Unevictable_bytes.
    46	# HELP node_memory_VmallocChunk_bytes Memory information field VmallocChunk_bytes.
    47	# HELP node_memory_VmallocTotal_bytes Memory information field VmallocTotal_bytes.
    48	# HELP node_memory_VmallocUsed_bytes Memory information field VmallocUsed_bytes.
    49	# HELP node_memory_WritebackTmp_bytes Memory information field WritebackTmp_bytes.
    50	# HELP node_memory_Writeback_bytes Memory information field Writeback_bytes.
```

```
    MemTotal: Total usable ram (i.e. physical ram minus a few reserved
              bits and the kernel binary code)
     MemFree: The sum of LowFree+HighFree
MemAvailable: An estimate of how much memory is available for starting new
              applications, without swapping. Calculated from MemFree,
              SReclaimable, the size of the file LRU lists, and the low
              watermarks in each zone.
              The estimate takes into account that the system needs some
              page cache to function well, and that not all reclaimable
              slab will be reclaimable, due to items being in use. The
              impact of those factors will vary from system to system.
     Buffers: Relatively temporary storage for raw disk blocks
              shouldn't get tremendously large (20MB or so)
      Cached: in-memory cache for files read from the disk (the
              pagecache).  Doesn't include SwapCached
  SwapCached: Memory that once was swapped out, is swapped back in but
              still also is in the swapfile (if memory is needed it
              doesn't need to be swapped out AGAIN because it is already
              in the swapfile. This saves I/O)
      Active: Memory that has been used more recently and usually not
              reclaimed unless absolutely necessary.
    Inactive: Memory which has been less recently used.  It is more
              eligible to be reclaimed for other purposes
   HighTotal:
    HighFree: Highmem is all memory above ~860MB of physical memory
              Highmem areas are for use by userspace programs, or
              for the pagecache.  The kernel must use tricks to access
              this memory, making it slower to access than lowmem.
    LowTotal:
     LowFree: Lowmem is memory which can be used for everything that
              highmem can be used for, but it is also available for the
              kernel's use for its own data structures.  Among many
              other things, it is where everything from the Slab is
              allocated.  Bad things happen when you're out of lowmem.
   SwapTotal: total amount of swap space available
    SwapFree: Memory which has been evicted from RAM, and is temporarily
              on the disk
       Dirty: Memory which is waiting to get written back to the disk
   Writeback: Memory which is actively being written back to the disk
   AnonPages: Non-file backed pages mapped into userspace page tables
HardwareCorrupted: The amount of RAM/memory in KB, the kernel identifies as
	      corrupted.
AnonHugePages: Non-file backed huge pages mapped into userspace page tables
      Mapped: files which have been mmaped, such as libraries
       Shmem: Total memory used by shared memory (shmem) and tmpfs
ShmemHugePages: Memory used by shared memory (shmem) and tmpfs allocated
              with huge pages
ShmemPmdMapped: Shared memory mapped into userspace with huge pages
KReclaimable: Kernel allocations that the kernel will attempt to reclaim
              under memory pressure. Includes SReclaimable (below), and other
              direct allocations with a shrinker.
        Slab: in-kernel data structures cache
SReclaimable: Part of Slab, that might be reclaimed, such as caches
  SUnreclaim: Part of Slab, that cannot be reclaimed on memory pressure
  PageTables: amount of memory dedicated to the lowest level of page
              tables.
NFS_Unstable: NFS pages sent to the server, but not yet committed to stable
	      storage
      Bounce: Memory used for block device "bounce buffers"
WritebackTmp: Memory used by FUSE for temporary writeback buffers
 CommitLimit: Based on the overcommit ratio ('vm.overcommit_ratio'),
              this is the total amount of  memory currently available to
              be allocated on the system. This limit is only adhered to
              if strict overcommit accounting is enabled (mode 2 in
              'vm.overcommit_memory').
              The CommitLimit is calculated with the following formula:
              CommitLimit = ([total RAM pages] - [total huge TLB pages]) *
                             overcommit_ratio / 100 + [total swap pages]
              For example, on a system with 1G of physical RAM and 7G
              of swap with a `vm.overcommit_ratio` of 30 it would
              yield a CommitLimit of 7.3G.
              For more details, see the memory overcommit documentation
              in vm/overcommit-accounting.
Committed_AS: The amount of memory presently allocated on the system.
              The committed memory is a sum of all of the memory which
              has been allocated by processes, even if it has not been
              "used" by them as of yet. A process which malloc()'s 1G
              of memory, but only touches 300M of it will show up as
	      using 1G. This 1G is memory which has been "committed" to
              by the VM and can be used at any time by the allocating
              application. With strict overcommit enabled on the system
              (mode 2 in 'vm.overcommit_memory'),allocations which would
              exceed the CommitLimit (detailed above) will not be permitted.
              This is useful if one needs to guarantee that processes will
              not fail due to lack of memory once that memory has been
              successfully allocated.
VmallocTotal: total size of vmalloc memory area
 VmallocUsed: amount of vmalloc area which is used
VmallocChunk: largest contiguous block of vmalloc area which is free
      Percpu: Memory allocated to the percpu allocator used to back percpu
              allocations. This stat excludes the cost of metadata.
```
</details>

If we gain more experience which of these metrics are useful,
we shall replace the regular expression and list them explicitly.

The seed prometheus is the one in the garden ns.
The shoot prometheus is in the control plane.
https://gardener.cloud/docs/gardener/monitoring/

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Keep all the memory metrics in the seed prometheus
```
