### PR TITLE
Allow updates to the `extensions.BackupEntry.Spec.Region` field

### DIFF
--- a/pkg/apis/extensions/validation/backupentry.go
+++ b/pkg/apis/extensions/validation/backupentry.go
@@ -75,7 +75,6 @@ func ValidateBackupEntrySpecUpdate(new, old *extensionsv1alpha1.BackupEntrySpec,
 	}
 
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Type, old.Type, fldPath.Child("type"))...)
-	allErrs = append(allErrs, apivalidation.ValidateImmutableField(new.Region, old.Region, fldPath.Child("region"))...)
 
 	return allErrs
 }

--- a/pkg/apis/extensions/validation/backupentry_test.go
+++ b/pkg/apis/extensions/validation/backupentry_test.go
@@ -93,26 +93,39 @@ var _ = Describe("BackupEntry validation tests", func() {
 			}))))
 		})
 
-		It("should prevent updating the type or region", func() {
+		It("should prevent updating the type", func() {
 			newBackupEntry := prepareBackupEntryForUpdate(be)
 			newBackupEntry.Spec.Type = "changed-type"
-			newBackupEntry.Spec.Region = "changed-region"
-			newBackupEntry.Spec.BucketName = "changed-bucket-name"
 
 			errorList := ValidateBackupEntryUpdate(newBackupEntry, be)
 
 			Expect(errorList).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 				"Type":  Equal(field.ErrorTypeInvalid),
 				"Field": Equal("spec.type"),
-			})), PointTo(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeInvalid),
-				"Field": Equal("spec.region"),
 			}))))
 		})
 
 		It("should allow updating the name of the referenced secret", func() {
 			newBackupEntry := prepareBackupEntryForUpdate(be)
 			newBackupEntry.Spec.SecretRef.Name = "changed-secretref-name"
+
+			errorList := ValidateBackupEntryUpdate(newBackupEntry, be)
+
+			Expect(errorList).To(BeEmpty())
+		})
+
+		It("should allow updating the name of the backup bucket", func() {
+			newBackupEntry := prepareBackupEntryForUpdate(be)
+			newBackupEntry.Spec.BucketName = "changed-bucket-name"
+
+			errorList := ValidateBackupEntryUpdate(newBackupEntry, be)
+
+			Expect(errorList).To(BeEmpty())
+		})
+
+		It("should allow updating the region", func() {
+			newBackupEntry := prepareBackupEntryForUpdate(be)
+			newBackupEntry.Spec.Region = "changed-region"
 
 			errorList := ValidateBackupEntryUpdate(newBackupEntry, be)
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind enhancement

**What this PR does / why we need it**:
Makes it possible to update the `extensions.BackupEntry.Spec.Region` field which is necessary when performing control plane migrations between seeds in different regions when the `CopyEtcdBackupsDuringControlPlaneMigration` feature gate is enabled.

This is necessary because the backup entry reconciler in `gardenlet` in the destination seed can reconcile the corresponding `core.BackupEntry` and deploy the `extensions.BackupEntry` resource in the destination seed before the shoot reconciler has started to reconcile the `Shoot` resource.

Basically the following series of events happens:
1. Control plane migration is triggered
2. Near the end, of the `Migrate` phase the `core.BackupEntry.Spec.SeedName` is changed to point to the destination seed
3. The backup entry controller in `gardenlet` in the source seed sees the change and migrates the `core.BackupEntry`. At the end of the operation it sets the `core.BackupEntry.Status.SeedName` field to nil.
4. The backup entry controller in the destination seed will see this change, and since the `core.BackupEntry` is now accepted by its filter func, the update to the `Status.SeedName` is treated as an `Add` event (will call the backup entry controller's [backupEntryAdd](https://github.com/gardener/gardener/blob/8f819ffab82898c65be19a4376aeec3b5627c3ba/pkg/gardenlet/controller/backupentry/backup_entry_controller.go#L29) function). This immediately adds the `core.BackupEntry` to the reconciliation queue.

All of this can happen before the following step: https://github.com/gardener/gardener/blob/8f819ffab82898c65be19a4376aeec3b5627c3ba/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go#L226-L230

**Which issue(s) this PR fixes**:
Fixes #6034 

**Special notes for your reviewer**:
Since we already allow changes to the bucket name I thought that it would be ok to also allow changes to the region. 
The other option would be to add a bit more complex logic in the [`backupEntryAdd`](https://github.com/gardener/gardener/blob/8f819ffab82898c65be19a4376aeec3b5627c3ba/pkg/gardenlet/controller/backupentry/backup_entry_controller.go#L29) method of the backup entry controller, so that it is not enqueued immediately in some cases (after backup entry migration), but I think this might introduce more complexity and issues.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
3. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Updates to the `extensions.BackupEntry.Spec.Region` field are now allowed.
```
