### PR TITLE
Jitter for the shootretry controller

### DIFF
--- a/charts/gardener/controlplane/charts/runtime/templates/controller-manager/configmap-componentconfig.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/controller-manager/configmap-componentconfig.yaml
@@ -124,6 +124,9 @@ data:
         {{- if .Values.global.controller.config.controllers.shootRetry.retryPeriod }}
         retryPeriod: {{ .Values.global.controller.config.controllers.shootRetry.retryPeriod }}
         {{- end }}
+        {{- if .Values.global.controller.config.controllers.shootRetry.retryJitterPeriod }}
+        retryJitterPeriod: {{ .Values.global.controller.config.controllers.shootRetry.retryJitterPeriod }}
+        {{- end }}
       managedSeedSet:
         concurrentSyncs: {{ required ".Values.global.controller.config.controllers.managedSeedSet.concurrentSyncs is required" .Values.global.controller.config.controllers.managedSeedSet.concurrentSyncs }}
         {{- if .Values.global.controller.config.controllers.managedSeedSet.maxShootRetries }}

--- a/charts/gardener/controlplane/values.yaml
+++ b/charts/gardener/controlplane/values.yaml
@@ -404,6 +404,7 @@ global:
         shootRetry:
           concurrentSyncs: 5
           retryPeriod: 10m
+          retryJitterPeriod: 5m
         managedSeedSet:
           concurrentSyncs: 5
           syncPeriod: 30m

--- a/pkg/controllermanager/apis/config/types.go
+++ b/pkg/controllermanager/apis/config/types.go
@@ -277,6 +277,10 @@ type ShootRetryControllerConfiguration struct {
 	ConcurrentSyncs *int
 	// RetryPeriod is the retry period for retrying failed Shoots that match certain criterion.
 	RetryPeriod *metav1.Duration
+	// RetryJitterPeriod is a jitter duration for the reconciler retry that can be used to distribute the retries randomly.
+	// If its value is greater than 0 then the shoot will not be retried with the configured retry period but a random
+	// duration between 0 and the configured value will be added. It is defaulted to 5m.
+	RetryJitterPeriod *metav1.Duration
 }
 
 // ShootConditionsControllerConfiguration defines the configuration of the

--- a/pkg/controllermanager/apis/config/v1alpha1/defaults.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/defaults.go
@@ -281,6 +281,9 @@ func SetDefaults_ShootRetryControllerConfiguration(obj *ShootRetryControllerConf
 	if obj.RetryPeriod == nil {
 		obj.RetryPeriod = &metav1.Duration{Duration: 10 * time.Minute}
 	}
+	if obj.RetryJitterPeriod == nil {
+		obj.RetryJitterPeriod = &metav1.Duration{Duration: 5 * time.Minute}
+	}
 }
 
 // SetDefaults_ManagedSeedSetControllerConfiguration sets defaults for the given ManagedSeedSetControllerConfiguration.

--- a/pkg/controllermanager/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/defaults_test.go
@@ -209,6 +209,7 @@ var _ = Describe("Defaults", func() {
 
 			SetDefaults_ShootRetryControllerConfiguration(obj)
 			Expect(obj.RetryPeriod).To(PointTo(Equal(metav1.Duration{Duration: 10 * time.Minute})))
+			Expect(obj.RetryJitterPeriod).To(PointTo(Equal(metav1.Duration{Duration: 5 * time.Minute})))
 		})
 	})
 

--- a/pkg/controllermanager/apis/config/v1alpha1/types.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/types.go
@@ -334,7 +334,8 @@ type ShootRetryControllerConfiguration struct {
 	// RetryJitterPeriod is a jitter duration for the reconciler retry that can be used to distribute the retries randomly.
 	// If its value is greater than 0 then the shoot will not be retried with the configured retry period but a random
 	// duration between 0 and the configured value will be added. It is defaulted to 5m.
-	RetryJitterPeriod *metav1.Duration
+	// +optional
+	RetryJitterPeriod *metav1.Duration `json:"retryJitterPeriod,omitempty"`
 }
 
 // ShootConditionsControllerConfiguration defines the configuration of the

--- a/pkg/controllermanager/apis/config/v1alpha1/types.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/types.go
@@ -331,6 +331,10 @@ type ShootRetryControllerConfiguration struct {
 	// Defaults to 10m.
 	// +optional
 	RetryPeriod *metav1.Duration `json:"retryPeriod,omitempty"`
+	// RetryJitterPeriod is a jitter duration for the reconciler retry that can be used to distribute the retries randomly.
+	// If its value is greater than 0 then the shoot will not be retried with the configured retry period but a random
+	// duration between 0 and the configured value will be added. It is defaulted to 5m.
+	RetryJitterPeriod *metav1.Duration
 }
 
 // ShootConditionsControllerConfiguration defines the configuration of the

--- a/pkg/controllermanager/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/zz_generated.conversion.go
@@ -999,6 +999,7 @@ func Convert_config_ShootReferenceControllerConfiguration_To_v1alpha1_ShootRefer
 func autoConvert_v1alpha1_ShootRetryControllerConfiguration_To_config_ShootRetryControllerConfiguration(in *ShootRetryControllerConfiguration, out *config.ShootRetryControllerConfiguration, s conversion.Scope) error {
 	out.ConcurrentSyncs = (*int)(unsafe.Pointer(in.ConcurrentSyncs))
 	out.RetryPeriod = (*v1.Duration)(unsafe.Pointer(in.RetryPeriod))
+	out.RetryJitterPeriod = (*v1.Duration)(unsafe.Pointer(in.RetryJitterPeriod))
 	return nil
 }
 
@@ -1010,6 +1011,7 @@ func Convert_v1alpha1_ShootRetryControllerConfiguration_To_config_ShootRetryCont
 func autoConvert_config_ShootRetryControllerConfiguration_To_v1alpha1_ShootRetryControllerConfiguration(in *config.ShootRetryControllerConfiguration, out *ShootRetryControllerConfiguration, s conversion.Scope) error {
 	out.ConcurrentSyncs = (*int)(unsafe.Pointer(in.ConcurrentSyncs))
 	out.RetryPeriod = (*v1.Duration)(unsafe.Pointer(in.RetryPeriod))
+	out.RetryJitterPeriod = (*v1.Duration)(unsafe.Pointer(in.RetryJitterPeriod))
 	return nil
 }
 

--- a/pkg/controllermanager/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -712,6 +712,11 @@ func (in *ShootRetryControllerConfiguration) DeepCopyInto(out *ShootRetryControl
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.RetryJitterPeriod != nil {
+		in, out := &in.RetryJitterPeriod, &out.RetryJitterPeriod
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controllermanager/apis/config/zz_generated.deepcopy.go
+++ b/pkg/controllermanager/apis/config/zz_generated.deepcopy.go
@@ -714,6 +714,11 @@ func (in *ShootRetryControllerConfiguration) DeepCopyInto(out *ShootRetryControl
 		*out = new(v1.Duration)
 		**out = **in
 	}
+	if in.RetryJitterPeriod != nil {
+		in, out := &in.RetryJitterPeriod, &out.RetryJitterPeriod
+		*out = new(v1.Duration)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controllermanager/controller/shoot/shoot_retry_control.go
+++ b/pkg/controllermanager/controller/shoot/shoot_retry_control.go
@@ -94,7 +94,7 @@ func (r *shootRetryReconciler) Reconcile(ctx context.Context, request reconcile.
 
 	mustRetry, requeueAfter := mustRetryNow(shoot, *r.config.RetryPeriod, r.config.RetryJitterPeriod)
 	if !mustRetry {
-		shootLogger.Infof("[SHOOT RETRY] Scheduled retry in %s", requeueAfter.Round(time.Minute))
+		shootLogger.Infof("[SHOOT RETRY] Scheduled retry in %s", requeueAfter.Round(time.Second))
 		return reconcile.Result{RequeueAfter: requeueAfter}, nil
 	}
 
@@ -122,7 +122,7 @@ func isShootFailed(shoot *gardencorev1beta1.Shoot) bool {
 		shoot.Generation == shoot.Status.ObservedGeneration
 }
 
-func mustRetryNow(shoot *gardencorev1beta1.Shoot, retryPeriod metav1.Duration, syncJitterPeriod *metav1.Duration) (bool, time.Duration) {
+func mustRetryNow(shoot *gardencorev1beta1.Shoot, retryPeriod metav1.Duration, jitterPeriod *metav1.Duration) (bool, time.Duration) {
 	if shoot.Status.LastOperation == nil {
 		return false, 0
 	}
@@ -136,5 +136,5 @@ func mustRetryNow(shoot *gardencorev1beta1.Shoot, retryPeriod metav1.Duration, s
 		return true, 0
 	}
 
-	return false, lastReconciliationPlusRetryPeriod.Add(utils.RandomDurationWithMetaDuration(syncJitterPeriod)).Sub(now)
+	return false, lastReconciliationPlusRetryPeriod.Add(utils.RandomDurationWithMetaDuration(jitterPeriod)).Sub(now)
 }

--- a/pkg/controllermanager/controller/shoot/shoot_retry_control.go
+++ b/pkg/controllermanager/controller/shoot/shoot_retry_control.go
@@ -24,6 +24,7 @@ import (
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
 	gardenlogger "github.com/gardener/gardener/pkg/logger"
+	"github.com/gardener/gardener/pkg/utils"
 
 	"github.com/sirupsen/logrus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -91,7 +92,7 @@ func (r *shootRetryReconciler) Reconcile(ctx context.Context, request reconcile.
 		return reconcile.Result{}, nil
 	}
 
-	mustRetry, requeueAfter := mustRetryNow(shoot, *r.config.RetryPeriod)
+	mustRetry, requeueAfter := mustRetryNow(shoot, *r.config.RetryPeriod, r.config.RetryJitterPeriod)
 	if !mustRetry {
 		shootLogger.Infof("[SHOOT RETRY] Scheduled retry in %s", requeueAfter.Round(time.Minute))
 		return reconcile.Result{RequeueAfter: requeueAfter}, nil
@@ -121,11 +122,10 @@ func isShootFailed(shoot *gardencorev1beta1.Shoot) bool {
 		shoot.Generation == shoot.Status.ObservedGeneration
 }
 
-func mustRetryNow(shoot *gardencorev1beta1.Shoot, retryPeriod metav1.Duration) (bool, time.Duration) {
+func mustRetryNow(shoot *gardencorev1beta1.Shoot, retryPeriod metav1.Duration, syncJitterPeriod *metav1.Duration) (bool, time.Duration) {
 	if shoot.Status.LastOperation == nil {
 		return false, 0
 	}
-
 	var (
 		lastReconciliation                = shoot.Status.LastOperation.LastUpdateTime.Time.UTC()
 		lastReconciliationPlusRetryPeriod = lastReconciliation.Add(retryPeriod.Duration)
@@ -136,5 +136,5 @@ func mustRetryNow(shoot *gardencorev1beta1.Shoot, retryPeriod metav1.Duration) (
 		return true, 0
 	}
 
-	return false, lastReconciliationPlusRetryPeriod.Sub(now)
+	return false, lastReconciliationPlusRetryPeriod.Add(utils.RandomDurationWithMetaDuration(syncJitterPeriod)).Sub(now)
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
This PR  incorporates a random jitter duration on top of the configured retry period, similar to how we already do it for other controllers such as the `managed seed controller`
**Which issue(s) this PR fixes**:
Fixes #6017

**Special notes for your reviewer**:
Full description and more details are in the issue.
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other other
The shoot retry controller now have a jitter duration that is added on top of the retry period for retrying failed shoots.
```
