### PR TITLE
Introduce `maintenance.gardener.cloud/operation` annotation for `Shoot`s

### DIFF
--- a/docs/usage/shoot_maintenance.md
+++ b/docs/usage/shoot_maintenance.md
@@ -76,6 +76,19 @@ The reason is that Gardener cannot differentiate between create/update/reconcile
 ⚠️  There is one exceptional change in the shoot specification that triggers an immediate roll out which is changes to the `.spec.hibernation.enabled` field.
 If you hibernate or wake-up your shoot then Gardener gets active right away.
 
+## Shoot Operations
+
+In case you would like to perform certain [shoot operations](shoot_operations.md) (e.g., credentials rotation) during your maintenance time window, you can annotate the `Shoot` with
+
+```
+maintenance.gardener.cloud/operation=<operation>
+```
+
+This will execute the specified `<operation>` during the next maintenance reconciliation.
+Note that Gardener will remove this annotation after it has been performed in the maintenance reconciliation. 
+
+> ⚠️ This is skipped when the `Shoot`'s `.status.lastOperation.state=Failed`. Make sure to [retry](shoot_operations.md#retry-failed-reconciliation) your shoot reconciliation beforehand.
+
 ## Special Operations During Maintenance
 
 The shoot maintenance controller triggers special operations that are performed as part of the shoot reconciliation.

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -163,6 +163,9 @@ const (
 	GardenCreatedBy = "gardener.cloud/created-by"
 	// GardenerOperation is a constant for an annotation on a resource that describes a desired operation.
 	GardenerOperation = "gardener.cloud/operation"
+	// GardenerMaintenanceOperation is a constant for an annotation on a Shoot that describes a desired operation which
+	// will be performed during maintenance.
+	GardenerMaintenanceOperation = "maintenance.gardener.cloud/operation"
 	// GardenerOperationReconcile is a constant for the value of the operation annotation describing a reconcile
 	// operation.
 	GardenerOperationReconcile = "reconcile"

--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -1664,30 +1664,27 @@ func MutateShootETCDEncryptionKeyRotation(shoot *gardencorev1beta1.Shoot, f func
 // IsValidShootOperation checks whether the provided operation annotation value is valid. It returns two bools: The
 // first value specifies whether it's valid, and the second bool value specifies whether the gardener-apiserver removes
 // the annotation before the Shoot is persisted to etcd.
-func IsValidShootOperation(operation string, lastOperation *gardencorev1beta1.LastOperation) (isValid bool, removedBeforePersisted bool) {
+func IsValidShootOperation(operation string, lastOperation *gardencorev1beta1.LastOperation) (isValid bool) {
 	if lastOperation != nil && lastOperation.State == gardencorev1beta1.LastOperationStateFailed {
-		if operation == v1beta1constants.ShootOperationRetry {
-			return true, true
-		}
-	} else {
-		switch operation {
-		case v1beta1constants.GardenerOperationReconcile:
-			return true, true
-
-			// TODO(rfranzke): Handle new operation annotations introduced by
-			// - https://github.com/gardener/gardener/pull/6021
-			// - https://github.com/gardener/gardener/pull/6038
-			// once those PRs got merged.
-		case v1beta1constants.ShootOperationRotateKubeconfigCredentials,
-			v1beta1constants.ShootOperationRotateObservabilityCredentials,
-			v1beta1constants.ShootOperationRotateSSHKeypair,
-			v1beta1constants.ShootOperationRotateCAStart,
-			v1beta1constants.ShootOperationRotateCAComplete,
-			v1beta1constants.ShootOperationRotateServiceAccountKeyStart,
-			v1beta1constants.ShootOperationRotateServiceAccountKeyComplete:
-			return true, false
-		}
+		return operation == v1beta1constants.ShootOperationRetry
 	}
 
-	return false, false
+	switch operation {
+	case v1beta1constants.GardenerOperationReconcile,
+		v1beta1constants.ShootOperationRotateCredentialsStart,
+		v1beta1constants.ShootOperationRotateCredentialsComplete,
+		v1beta1constants.ShootOperationRotateKubeconfigCredentials,
+		v1beta1constants.ShootOperationRotateObservabilityCredentials,
+		v1beta1constants.ShootOperationRotateSSHKeypair,
+		v1beta1constants.ShootOperationRotateCAStart,
+		v1beta1constants.ShootOperationRotateCAComplete,
+		v1beta1constants.ShootOperationRotateServiceAccountKeyStart,
+		v1beta1constants.ShootOperationRotateServiceAccountKeyComplete,
+		v1beta1constants.ShootOperationRotateETCDEncryptionKeyStart,
+		v1beta1constants.ShootOperationRotateETCDEncryptionKeyComplete:
+		return true
+
+	default:
+		return false
+	}
 }

--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -1660,3 +1660,34 @@ func MutateShootETCDEncryptionKeyRotation(shoot *gardencorev1beta1.Shoot, f func
 
 	f(shoot.Status.Credentials.Rotation.ETCDEncryptionKey)
 }
+
+// IsValidShootOperation checks whether the provided operation annotation value is valid. It returns two bools: The
+// first value specifies whether it's valid, and the second bool value specifies whether the gardener-apiserver removes
+// the annotation before the Shoot is persisted to etcd.
+func IsValidShootOperation(operation string, lastOperation *gardencorev1beta1.LastOperation) (isValid bool, removedBeforePersisted bool) {
+	if lastOperation != nil && lastOperation.State == gardencorev1beta1.LastOperationStateFailed {
+		if operation == v1beta1constants.ShootOperationRetry {
+			return true, true
+		}
+	} else {
+		switch operation {
+		case v1beta1constants.GardenerOperationReconcile:
+			return true, true
+
+			// TODO(rfranzke): Handle new operation annotations introduced by
+			// - https://github.com/gardener/gardener/pull/6021
+			// - https://github.com/gardener/gardener/pull/6038
+			// once those PRs got merged.
+		case v1beta1constants.ShootOperationRotateKubeconfigCredentials,
+			v1beta1constants.ShootOperationRotateObservabilityCredentials,
+			v1beta1constants.ShootOperationRotateSSHKeypair,
+			v1beta1constants.ShootOperationRotateCAStart,
+			v1beta1constants.ShootOperationRotateCAComplete,
+			v1beta1constants.ShootOperationRotateServiceAccountKeyStart,
+			v1beta1constants.ShootOperationRotateServiceAccountKeyComplete:
+			return true, false
+		}
+	}
+
+	return false, false
+}

--- a/pkg/apis/core/v1beta1/helper/helper_test.go
+++ b/pkg/apis/core/v1beta1/helper/helper_test.go
@@ -2431,23 +2431,21 @@ var _ = Describe("helper", func() {
 	)
 
 	DescribeTable("#IsValidShootOperation",
-		func(operation string, lastOperation *gardencorev1beta1.LastOperation, expectedIsValid, expectedRemovedBeforePersisted bool) {
-			isValid, removedBeforePersisted := IsValidShootOperation(operation, lastOperation)
-			Expect(isValid).To(Equal(expectedIsValid))
-			Expect(removedBeforePersisted).To(Equal(expectedRemovedBeforePersisted))
+		func(operation string, lastOperation *gardencorev1beta1.LastOperation, expectedIsValid bool) {
+			Expect(IsValidShootOperation(operation, lastOperation)).To(Equal(expectedIsValid))
 		},
 
-		Entry("last operation empty", "retry", nil, false, false),
-		Entry("last operation failed, retry", "retry", &gardencorev1beta1.LastOperation{State: gardencorev1beta1.LastOperationStateFailed}, true, true),
-		Entry("last operation failed, reconcile", "reconcile", &gardencorev1beta1.LastOperation{State: gardencorev1beta1.LastOperationStateFailed}, false, false),
-		Entry("last operation not failed, reconcile", "reconcile", &gardencorev1beta1.LastOperation{}, true, true),
-		Entry("last operation not failed, rotate-kubeconfig-credentials", "rotate-kubeconfig-credentials", &gardencorev1beta1.LastOperation{}, true, false),
-		Entry("last operation not failed, rotate-observability-credentials", "rotate-observability-credentials", &gardencorev1beta1.LastOperation{}, true, false),
-		Entry("last operation not failed, rotate-ssh-keypair", "rotate-ssh-keypair", &gardencorev1beta1.LastOperation{}, true, false),
-		Entry("last operation not failed, rotate-ca-start", "rotate-ca-start", &gardencorev1beta1.LastOperation{}, true, false),
-		Entry("last operation not failed, rotate-ca-complete", "rotate-ca-complete", &gardencorev1beta1.LastOperation{}, true, false),
-		Entry("last operation not failed, rotate-serviceaccount-key-start", "rotate-serviceaccount-key-start", &gardencorev1beta1.LastOperation{}, true, false),
-		Entry("last operation not failed, rotate-serviceaccount-key-complete", "rotate-serviceaccount-key-complete", &gardencorev1beta1.LastOperation{}, true, false),
+		Entry("last operation empty", "retry", nil, false),
+		Entry("last operation failed, retry", "retry", &gardencorev1beta1.LastOperation{State: gardencorev1beta1.LastOperationStateFailed}, true),
+		Entry("last operation failed, reconcile", "reconcile", &gardencorev1beta1.LastOperation{State: gardencorev1beta1.LastOperationStateFailed}, false),
+		Entry("last operation not failed, reconcile", "reconcile", &gardencorev1beta1.LastOperation{}, true),
+		Entry("last operation not failed, rotate-kubeconfig-credentials", "rotate-kubeconfig-credentials", &gardencorev1beta1.LastOperation{}, true),
+		Entry("last operation not failed, rotate-observability-credentials", "rotate-observability-credentials", &gardencorev1beta1.LastOperation{}, true),
+		Entry("last operation not failed, rotate-ssh-keypair", "rotate-ssh-keypair", &gardencorev1beta1.LastOperation{}, true),
+		Entry("last operation not failed, rotate-ca-start", "rotate-ca-start", &gardencorev1beta1.LastOperation{}, true),
+		Entry("last operation not failed, rotate-ca-complete", "rotate-ca-complete", &gardencorev1beta1.LastOperation{}, true),
+		Entry("last operation not failed, rotate-serviceaccount-key-start", "rotate-serviceaccount-key-start", &gardencorev1beta1.LastOperation{}, true),
+		Entry("last operation not failed, rotate-serviceaccount-key-complete", "rotate-serviceaccount-key-complete", &gardencorev1beta1.LastOperation{}, true),
 	)
 })
 

--- a/pkg/registry/core/shoot/strategy.go
+++ b/pkg/registry/core/shoot/strategy.go
@@ -114,6 +114,8 @@ func mustIncreaseGeneration(oldShoot, newShoot *core.Shoot) bool {
 			mustRemoveOperationAnnotation bool
 		)
 
+		// TODO(rfranzke): After promotion and removal of `Shoot{C,S}ARotation` feature gates, consider using a function
+		//  similar to gardencorev1beta1helper.IsValidShootOperation.
 		switch lastOperation.State {
 		case core.LastOperationStateFailed:
 			if val, ok := newShoot.Annotations[v1beta1constants.GardenerOperation]; ok && val == v1beta1constants.ShootOperationRetry {

--- a/test/integration/controllermanager/shootmaintenance/maintenance_control_test.go
+++ b/test/integration/controllermanager/shootmaintenance/maintenance_control_test.go
@@ -20,7 +20,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -38,7 +37,6 @@ import (
 )
 
 var _ = Describe("Shoot Maintenance controller tests", func() {
-
 	var (
 		project      *gardencorev1beta1.Project
 		cloudProfile *gardencorev1beta1.CloudProfile
@@ -208,30 +206,6 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 			ContainElement("deployDNSRecordExternal"),
 			ContainElement("deployDNSRecordIngress"),
 		))
-	})
-
-	It("should unset the Shoot.Spec.Kubernetes.KubeAPIServer.AuditConfig.AuditPolicy.ConfigMapRef.ResourceVersion field", func() {
-		By("prepare shoot")
-		patch := client.MergeFrom(shoot.DeepCopy())
-		shoot.Spec.Kubernetes.KubeAPIServer = &gardencorev1beta1.KubeAPIServerConfig{
-			AuditConfig: &gardencorev1beta1.AuditConfig{
-				AuditPolicy: &gardencorev1beta1.AuditPolicy{
-					ConfigMapRef: &corev1.ObjectReference{
-						Name:            "auditpolicy",
-						ResourceVersion: "123456",
-					},
-				},
-			},
-		}
-		Expect(testClient.Patch(ctx, shoot, patch)).To(Succeed())
-
-		By("trigger maintenance")
-		Expect(kutil.SetAnnotationAndUpdate(ctx, testClient, shoot, v1beta1constants.GardenerOperation, v1beta1constants.ShootOperationMaintain)).To(Succeed())
-
-		waitForShootToBeMaintained(shoot)
-
-		By("ensuring resourceVersion is empty")
-		Expect(shoot.Spec.Kubernetes.KubeAPIServer.AuditConfig.AuditPolicy.ConfigMapRef.ResourceVersion).To(BeEmpty())
 	})
 
 	Describe("Machine image maintenance tests", func() {

--- a/test/integration/controllermanager/shootmaintenance/maintenance_control_test.go
+++ b/test/integration/controllermanager/shootmaintenance/maintenance_control_test.go
@@ -208,6 +208,110 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 		))
 	})
 
+	Context("operation annotations", func() {
+		var oldGeneration int64
+
+		BeforeEach(func() {
+			oldGeneration = shoot.Generation
+		})
+
+		Context("failed last operation state", func() {
+			BeforeEach(func() {
+				By("prepare shoot")
+				patch := client.MergeFrom(shoot.DeepCopy())
+				shoot.Status.LastOperation = &gardencorev1beta1.LastOperation{State: gardencorev1beta1.LastOperationStateFailed}
+				Expect(testClient.Status().Patch(ctx, shoot, patch)).To(Succeed())
+			})
+
+			It("should not set the retry operation annotation due to missing 'needs-retry-operation' annotation", func() {
+				By("trigger maintenance")
+				Expect(kutil.SetAnnotationAndUpdate(ctx, testClient, shoot, v1beta1constants.GardenerOperation, v1beta1constants.ShootOperationMaintain)).To(Succeed())
+
+				waitForShootToBeMaintained(shoot)
+
+				By("ensuring proper operation annotation handling")
+				Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
+				Expect(shoot.Generation).To(Equal(oldGeneration))
+				Expect(shoot.Annotations["gardener.cloud/operation"]).To(BeEmpty())
+			})
+
+			It("should set the retry operation annotation due to 'needs-retry-operation' annotation (implicitly increasing the generation)", func() {
+				By("prepare shoot")
+				patch := client.MergeFrom(shoot.DeepCopy())
+				metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "maintenance.shoot.gardener.cloud/needs-retry-operation", "true")
+				Expect(testClient.Patch(ctx, shoot, patch)).To(Succeed())
+
+				By("trigger maintenance")
+				Expect(kutil.SetAnnotationAndUpdate(ctx, testClient, shoot, v1beta1constants.GardenerOperation, v1beta1constants.ShootOperationMaintain)).To(Succeed())
+
+				waitForShootToBeMaintained(shoot)
+
+				By("ensuring proper operation annotation handling")
+				Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
+				Expect(shoot.Generation).To(Equal(oldGeneration + 1))
+				Expect(shoot.Annotations["gardener.cloud/operation"]).To(BeEmpty())
+				Expect(shoot.Annotations["maintenance.shoot.gardener.cloud/needs-retry-operation"]).To(BeEmpty())
+			})
+		})
+
+		Context("non-failed last operation states", func() {
+			BeforeEach(func() {
+				By("prepare shoot")
+				patch := client.MergeFrom(shoot.DeepCopy())
+				shoot.Status.LastOperation = &gardencorev1beta1.LastOperation{}
+				Expect(testClient.Status().Patch(ctx, shoot, patch)).To(Succeed())
+			})
+
+			It("should set the reconcile operation annotation (implicitly increasing the generation)", func() {
+				By("trigger maintenance")
+				Expect(kutil.SetAnnotationAndUpdate(ctx, testClient, shoot, v1beta1constants.GardenerOperation, v1beta1constants.ShootOperationMaintain)).To(Succeed())
+
+				waitForShootToBeMaintained(shoot)
+
+				By("ensuring proper operation annotation handling")
+				Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
+				Expect(shoot.Generation).To(Equal(oldGeneration + 1))
+				Expect(shoot.Annotations["gardener.cloud/operation"]).To(BeEmpty())
+			})
+
+			It("should set the maintenance operation annotation if it's valid", func() {
+				By("prepare shoot")
+				patch := client.MergeFrom(shoot.DeepCopy())
+				metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "maintenance.gardener.cloud/operation", "rotate-kubeconfig-credentials")
+				Expect(testClient.Patch(ctx, shoot, patch)).To(Succeed())
+
+				By("trigger maintenance")
+				Expect(kutil.SetAnnotationAndUpdate(ctx, testClient, shoot, v1beta1constants.GardenerOperation, v1beta1constants.ShootOperationMaintain)).To(Succeed())
+
+				waitForShootToBeMaintained(shoot)
+
+				By("ensuring proper operation annotation handling")
+				Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
+				Expect(shoot.Generation).To(Equal(oldGeneration + 1))
+				Expect(shoot.Annotations["gardener.cloud/operation"]).To(Equal("rotate-kubeconfig-credentials"))
+				Expect(shoot.Annotations["maintenance.gardener.cloud/operation"]).To(BeEmpty())
+			})
+
+			It("should not set the maintenance operation annotation if it's invalid and use the reconcile operation instead", func() {
+				By("prepare shoot")
+				patch := client.MergeFrom(shoot.DeepCopy())
+				metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "maintenance.gardener.cloud/operation", "foo-bar-does-not-exist")
+				Expect(testClient.Patch(ctx, shoot, patch)).To(Succeed())
+
+				By("trigger maintenance")
+				Expect(kutil.SetAnnotationAndUpdate(ctx, testClient, shoot, v1beta1constants.GardenerOperation, v1beta1constants.ShootOperationMaintain)).To(Succeed())
+
+				waitForShootToBeMaintained(shoot)
+
+				By("ensuring proper operation annotation handling")
+				Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
+				Expect(shoot.Generation).To(Equal(oldGeneration + 1))
+				Expect(shoot.Annotations["gardener.cloud/operation"]).To(BeEmpty())
+				Expect(shoot.Annotations["maintenance.gardener.cloud/operation"]).To(BeEmpty())
+			})
+		})
+	})
+
 	Describe("Machine image maintenance tests", func() {
 		It("Do not update Shoot machine image in maintenance time: AutoUpdate.MachineImageVersion == false && expirationDate does not apply", func() {
 			Expect(kutil.SetAnnotationAndUpdate(ctx, testClient, shoot, v1beta1constants.GardenerOperation, v1beta1constants.ShootOperationMaintain)).To(Succeed())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
While it is possible to confine `spec` update rollout to the maintenance time window, we do not offer any option to confine operation rollouts.

This PR introduces a new `maintenance.gardener.cloud/operation` annotation for `Shoot`s which can be used to confine the execution of the respective operation to the shoot cluster's maintenance time window.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
With the new `maintenance.gardener.cloud/operation` annotation for `Shoot`s it is now possible to confine the execution of the respective operation to the shoot cluster's maintenance time window.
```
