### PR TITLE
Replace `utils.IsTrue` with `pointer.BoolDeref`

### DIFF
--- a/cmd/gardener-admission-controller/app/gardener_admission_controller.go
+++ b/cmd/gardener-admission-controller/app/gardener_admission_controller.go
@@ -21,18 +21,6 @@ import (
 	goruntime "runtime"
 	"time"
 
-	"github.com/spf13/cobra"
-	"github.com/spf13/pflag"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/component-base/version"
-	"k8s.io/component-base/version/verflag"
-	"sigs.k8s.io/controller-runtime/pkg/healthz"
-	runtimelog "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
-
 	"github.com/gardener/gardener/pkg/admissioncontroller/apis/config"
 	configv1alpha1 "github.com/gardener/gardener/pkg/admissioncontroller/apis/config/v1alpha1"
 	configvalidation "github.com/gardener/gardener/pkg/admissioncontroller/apis/config/validation"
@@ -47,7 +35,19 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	gardenerhealthz "github.com/gardener/gardener/pkg/healthz"
 	"github.com/gardener/gardener/pkg/server/routes"
-	"github.com/gardener/gardener/pkg/utils"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/component-base/version"
+	"k8s.io/component-base/version/verflag"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
+	runtimelog "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
 )
 
 const (
@@ -197,7 +197,7 @@ func (o *options) run(ctx context.Context) error {
 	server.Register(auditpolicy.WebhookPath, &webhook.Admission{Handler: auditpolicy.New(runtimelog.Log.WithName(auditpolicy.HandlerName))})
 	server.Register(internaldomainsecret.WebhookPath, &webhook.Admission{Handler: internaldomainsecret.New(runtimelog.Log.WithName(internaldomainsecret.HandlerName))})
 
-	if utils.IsTrue(o.config.Server.EnableDebugHandlers) {
+	if pointer.BoolDeref(o.config.Server.EnableDebugHandlers, false) {
 		log.Info("Registering debug handlers")
 		server.Register(seedauthorizergraph.DebugHandlerPath, seedauthorizergraph.NewDebugHandler(graph))
 	}

--- a/pkg/apis/seedmanagement/validation/managedseed.go
+++ b/pkg/apis/seedmanagement/validation/managedseed.go
@@ -31,6 +31,7 @@ import (
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	metav1validation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/pointer"
 )
 
 // ValidateManagedSeed validates a ManagedSeed object.
@@ -199,7 +200,7 @@ func validateGardenlet(gardenlet *seedmanagement.Gardenlet, fldPath *field.Path,
 		}
 
 		// Validate gardenlet config
-		allErrs = append(allErrs, validateGardenletConfiguration(gardenletConfig, helper.GetBootstrap(gardenlet.Bootstrap), utils.IsTrue(gardenlet.MergeWithParent), configPath, inTemplate)...)
+		allErrs = append(allErrs, validateGardenletConfiguration(gardenletConfig, helper.GetBootstrap(gardenlet.Bootstrap), pointer.BoolDeref(gardenlet.MergeWithParent, false), configPath, inTemplate)...)
 	}
 
 	if gardenlet.Bootstrap != nil {

--- a/pkg/controllermanager/controller/shoot/shoot_maintenance_control.go
+++ b/pkg/controllermanager/controller/shoot/shoot_maintenance_control.go
@@ -28,7 +28,6 @@ import (
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/logger"
-	"github.com/gardener/gardener/pkg/utils"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
@@ -40,6 +39,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -215,11 +215,11 @@ func (r *shootMaintenanceReconciler) reconcile(ctx context.Context, shoot *garde
 		v1beta1constants.ShootTaskDeployDNSRecordIngress,
 	)
 
-	if utils.IsTrue(r.config.EnableShootControlPlaneRestarter) {
+	if pointer.BoolDeref(r.config.EnableShootControlPlaneRestarter, false) {
 		controllerutils.AddTasks(shoot.Annotations, v1beta1constants.ShootTaskRestartControlPlanePods)
 	}
 
-	if utils.IsTrue(r.config.EnableShootCoreAddonRestarter) {
+	if pointer.BoolDeref(r.config.EnableShootCoreAddonRestarter, false) {
 		controllerutils.AddTasks(shoot.Annotations, v1beta1constants.ShootTaskRestartCoreAddons)
 	}
 

--- a/pkg/gardenlet/controller/managedseed/managedseed_actuator.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_actuator.go
@@ -47,6 +47,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -365,7 +366,7 @@ func (a *actuator) deployGardenlet(
 		seed,
 		gardenletConfig,
 		v1alpha1helper.GetBootstrap(managedSeed.Spec.Gardenlet.Bootstrap),
-		utils.IsTrue(managedSeed.Spec.Gardenlet.MergeWithParent),
+		pointer.BoolDeref(managedSeed.Spec.Gardenlet.MergeWithParent, false),
 		shoot,
 	)
 	if err != nil {
@@ -392,7 +393,7 @@ func (a *actuator) deleteGardenlet(
 		seed,
 		gardenletConfig,
 		v1alpha1helper.GetBootstrap(managedSeed.Spec.Gardenlet.Bootstrap),
-		utils.IsTrue(managedSeed.Spec.Gardenlet.MergeWithParent),
+		pointer.BoolDeref(managedSeed.Spec.Gardenlet.MergeWithParent, false),
 		shoot,
 	)
 	if err != nil {

--- a/pkg/operation/botanist/component/etcd/waiter.go
+++ b/pkg/operation/botanist/component/etcd/waiter.go
@@ -21,10 +21,10 @@ import (
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/extensions"
-	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/retry"
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -83,7 +83,7 @@ func CheckEtcdObject(obj client.Object) error {
 		return fmt.Errorf("gardener operation %q is not yet picked up by etcd-druid", op)
 	}
 
-	if !utils.IsTrue(etcd.Status.Ready) {
+	if !pointer.BoolDeref(etcd.Status.Ready, false) {
 		return fmt.Errorf("is not ready yet")
 	}
 

--- a/pkg/operation/botanist/extension.go
+++ b/pkg/operation/botanist/extension.go
@@ -21,9 +21,9 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/extension"
-	"github.com/gardener/gardener/pkg/utils"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
 )
 
 // DefaultExtension creates the default deployer for the Extension custom resources.
@@ -102,7 +102,7 @@ func mergeExtensions(registrations []gardencorev1beta1.ControllerRegistration, e
 	// Extensions defined in Shoot resource.
 	for _, extension := range extensions {
 		if obj, ok := typeToExtension[extension.Type]; ok {
-			if utils.IsTrue(extension.Disabled) {
+			if pointer.BoolDeref(extension.Disabled, false) {
 				delete(requiredExtensions, extension.Type)
 				continue
 			}

--- a/pkg/operation/botanist/namespaces.go
+++ b/pkg/operation/botanist/namespaces.go
@@ -27,13 +27,13 @@ import (
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/namespaces"
-	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/retry"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -131,14 +131,14 @@ func (b *Botanist) getShootRequiredExtensionTypes(ctx context.Context) (sets.Str
 	types := sets.String{}
 	for _, reg := range controllerRegistrationList.Items {
 		for _, res := range reg.Spec.Resources {
-			if res.Kind == extensionsv1alpha1.ExtensionResource && utils.IsTrue(res.GloballyEnabled) {
+			if res.Kind == extensionsv1alpha1.ExtensionResource && pointer.BoolDeref(res.GloballyEnabled, false) {
 				types.Insert(res.Type)
 			}
 		}
 	}
 
 	for _, extension := range b.Shoot.GetInfo().Spec.Extensions {
-		if utils.IsTrue(extension.Disabled) {
+		if pointer.BoolDeref(extension.Disabled, false) {
 			types.Delete(extension.Type)
 		} else {
 			types.Insert(extension.Type)

--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -21,12 +21,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/Masterminds/semver"
-	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/sets"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	"github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -42,10 +36,16 @@ import (
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/operation/garden"
-	"github.com/gardener/gardener/pkg/utils"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/version"
+
+	"github.com/Masterminds/semver"
+	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // NewBuilder returns a new Builder.
@@ -619,7 +619,7 @@ func ComputeRequiredExtensions(shoot *gardencorev1beta1.Shoot, seed *gardencorev
 	for _, extension := range shoot.Spec.Extensions {
 		id := gardenerextensions.Id(extensionsv1alpha1.ExtensionResource, extension.Type)
 
-		if utils.IsTrue(extension.Disabled) {
+		if pointer.BoolDeref(extension.Disabled, false) {
 			disabledExtensions.Insert(id)
 		} else {
 			requiredExtensions.Insert(id)

--- a/pkg/utils/kubernetes/health/etcd.go
+++ b/pkg/utils/kubernetes/health/etcd.go
@@ -17,15 +17,14 @@ package health
 import (
 	"fmt"
 
-	"github.com/gardener/gardener/pkg/utils"
-
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
+	"k8s.io/utils/pointer"
 )
 
 // CheckEtcd checks whether the given Etcd is healthy.
 // A Etcd is considered healthy if its ready field in status is true.
 func CheckEtcd(etcd *druidv1alpha1.Etcd) error {
-	if !utils.IsTrue(etcd.Status.Ready) {
+	if !pointer.BoolDeref(etcd.Status.Ready, false) {
 		return fmt.Errorf("etcd %q is not ready yet", etcd.Name)
 	}
 	return nil

--- a/pkg/utils/miscellaneous.go
+++ b/pkg/utils/miscellaneous.go
@@ -120,11 +120,6 @@ func TestEmail(email string) bool {
 	return match
 }
 
-// IsTrue returns true if the passed bool pointer is not nil and true.
-func IsTrue(value *bool) bool {
-	return value != nil && *value
-}
-
 // IDForKeyWithOptionalValue returns an identifier for the given key + optional value.
 func IDForKeyWithOptionalValue(key string, value *string) string {
 	v := ""

--- a/pkg/utils/miscellaneous_test.go
+++ b/pkg/utils/miscellaneous_test.go
@@ -19,7 +19,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	gomegatypes "github.com/onsi/gomega/types"
 	"k8s.io/utils/pointer"
 )
 
@@ -60,15 +59,6 @@ var _ = Describe("utils", func() {
 			}))
 		})
 	})
-
-	DescribeTable("#IsTrue",
-		func(value *bool, matcher gomegatypes.GomegaMatcher) {
-			Expect(IsTrue(value)).To(matcher)
-		},
-		Entry("nil", nil, BeFalse()),
-		Entry("false", pointer.Bool(false), BeFalse()),
-		Entry("true", pointer.Bool(true), BeTrue()),
-	)
 
 	DescribeTable("#IDForKeyWithOptionalValue",
 		func(key string, value *string, expectation string) {

--- a/plugin/pkg/shoot/dns/admission.go
+++ b/plugin/pkg/shoot/dns/admission.go
@@ -255,7 +255,7 @@ func (d *DNS) Admit(ctx context.Context, a admission.Attributes, o admission.Obj
 func checkFunctionlessDNSProviders(a admission.Attributes, shoot *core.Shoot) error {
 	dns := shoot.Spec.DNS
 	for _, provider := range dns.Providers {
-		if !utils.IsTrue(provider.Primary) && (provider.Type == nil || provider.SecretName == nil) {
+		if !pointer.BoolDeref(provider.Primary, false) && (provider.Type == nil || provider.SecretName == nil) {
 			fieldErr := field.Required(field.NewPath("spec", "dns", "providers"), "non-primary DNS providers in .spec.dns.providers must specify a `type` and `secretName`")
 			return apierrors.NewInvalid(a.GetKind().GroupKind(), shoot.Name, field.ErrorList{fieldErr})
 		}

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -33,7 +33,6 @@ import (
 	corev1alpha1listers "github.com/gardener/gardener/pkg/client/core/listers/core/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/features"
-	"github.com/gardener/gardener/pkg/utils"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 	cidrvalidation "github.com/gardener/gardener/pkg/utils/validation/cidr"
@@ -51,6 +50,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/admission"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
+	"k8s.io/utils/pointer"
 )
 
 const (
@@ -545,7 +545,7 @@ func (c *validationContext) addMetadataAnnotations(a admission.Attributes) {
 	}
 
 	if c.shoot.Spec.Maintenance != nil &&
-		utils.IsTrue(c.shoot.Spec.Maintenance.ConfineSpecUpdateRollout) &&
+		pointer.BoolDeref(c.shoot.Spec.Maintenance.ConfineSpecUpdateRollout, false) &&
 		!apiequality.Semantic.DeepEqual(c.oldShoot.Spec, c.shoot.Spec) &&
 		c.shoot.Status.LastOperation != nil &&
 		c.shoot.Status.LastOperation.State == core.LastOperationStateFailed {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:
This PR replaces the duplicative implementation `utils.IsTrue` with `pointer.BoolDeref`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
