### PR TITLE
Support kubernetes.default.svc.cluster.local in the provider-local setup

### DIFF
--- a/docs/extensions/provider-local.md
+++ b/docs/extensions/provider-local.md
@@ -118,7 +118,7 @@ This controller reconciles `Services` of type `LoadBalancer` in the local `Seed`
 Since the local Kubernetes clusters used as Seed clusters typically don't support such services, this controller sets the `.status.ingress.loadBalancer.ip[0]` to the IP of the host.
 It makes important LoadBalancer Services (e.g. `istio-ingress/istio-ingressgateway` and `garden/nginx-ingress-controller`) available to the host by setting `spec.ports[].nodePort` to well-known ports that are mapped to `hostPorts` in the kind cluster configuration.
 
-If the `--apiserver-sni-enabled` flag is set to `true` (default), `istio-ingress/istio-ingressgateway` is set to be exposed on `nodePort` `30433` by this controller. Otherwise, the `kube-apiserver` `Service` in the shoot namespaces in the seed cluster needs to be patched to be exposed on `30443` by the [Control Plane Exposure Webhook](#control-plane-exposure).
+If the `--apiserver-sni-enabled` flag is set to `true` (default), `istio-ingress/istio-ingressgateway` is set to be exposed on `nodePort` `30433` for https and `nodePort` `31443` for the proxy protocol by this controller. Otherwise, the `kube-apiserver` `Service` in the shoot namespaces in the seed cluster needs to be patched to be exposed on `30443` by the [Control Plane Exposure Webhook](#control-plane-exposure).
 
 #### ETCD Backups
 This controller reconciles the `BackuBucket` and `BackupEntry` of the shoot allowing the `etcd-backup-restore` to create and copy backups using the `local` provider functionality. The backups are stored on the host file system. This is achieved by mounting that directory to the `etcd-backup-restore` container.

--- a/example/gardener-local/kind/cluster-local.yaml
+++ b/example/gardener-local/kind/cluster-local.yaml
@@ -7,6 +7,9 @@ nodes:
   # istio-ingressgateway
   - containerPort: 30443
     hostPort: 443
+  # istio-ingressgateway, proxy protocol
+  - containerPort: 31443
+    hostPort: 8443
   # etcd (for gardener-apiserver)
   - containerPort: 32379
     hostPort: 32379

--- a/example/gardener-local/kind/cluster-skaffold.yaml
+++ b/example/gardener-local/kind/cluster-skaffold.yaml
@@ -7,6 +7,9 @@ nodes:
   # istio-ingressgateway
   - containerPort: 30443
     hostPort: 443
+  # istio-ingressgateway, proxy protocol
+  - containerPort: 31443
+    hostPort: 8443
   # etcd (for gardener-apiserver)
   - containerPort: 32379
     hostPort: 32379

--- a/pkg/provider-local/controller/service/reconciler.go
+++ b/pkg/provider-local/controller/service/reconciler.go
@@ -60,6 +60,8 @@ func (r *reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			switch {
 			case key == keyIstioIngressGateway && servicePort.Name == "tcp":
 				service.Spec.Ports[i].NodePort = 30443
+			case key == keyIstioIngressGateway && servicePort.Name == "proxy":
+				service.Spec.Ports[i].NodePort = 31443
 			case key == keyNginxIngress && servicePort.Name == "https":
 				service.Spec.Ports[i].NodePort = 30448
 			}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

Support kubernetes.default.svc.cluster.local in the provider-local setup

**Special notes for your reviewer**:

Expose the istio-ingressgateway's proxy protocol in the provider-local
setup. This enables to access the shoot's api server via the
kubernetes.default.svc.cluster.local service in a pod inside
the shoot cluster.

For details, please refer to the SNI GEP:
https://github.com/gardener/gardener/blob/master/docs/proposals/08-shoot-apiserver-via-sni.md

To test it:


```
kubectl run --kubeconfig=/tmp/kubeconfig-shoot-local.yaml -it alpine --image=alpine --restart=Never --rm

apk add curl
curl -k https://kubernetes.default.svc.cluster.local
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Support `kubernetes.default.svc.cluster.local` in the provider-local setup
```
