### PR TITLE
Handle cluster-autoscaler Deployment in generic controlplane mutator

### DIFF
--- a/extensions/pkg/webhook/controlplane/genericmutator/mock/mocks.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/mock/mocks.go
@@ -70,6 +70,20 @@ func (mr *MockEnsurerMockRecorder) EnsureAdditionalUnits(arg0, arg1, arg2, arg3 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureAdditionalUnits", reflect.TypeOf((*MockEnsurer)(nil).EnsureAdditionalUnits), arg0, arg1, arg2, arg3)
 }
 
+// EnsureClusterAutoscalerDeployment mocks base method.
+func (m *MockEnsurer) EnsureClusterAutoscalerDeployment(arg0 context.Context, arg1 context0.GardenContext, arg2, arg3 *v1.Deployment) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "EnsureClusterAutoscalerDeployment", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// EnsureClusterAutoscalerDeployment indicates an expected call of EnsureClusterAutoscalerDeployment.
+func (mr *MockEnsurerMockRecorder) EnsureClusterAutoscalerDeployment(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnsureClusterAutoscalerDeployment", reflect.TypeOf((*MockEnsurer)(nil).EnsureClusterAutoscalerDeployment), arg0, arg1, arg2, arg3)
+}
+
 // EnsureETCD mocks base method.
 func (m *MockEnsurer) EnsureETCD(arg0 context.Context, arg1 context0.GardenContext, arg2, arg3 *v1alpha1.Etcd) error {
 	m.ctrl.T.Helper()

--- a/extensions/pkg/webhook/controlplane/genericmutator/mutator.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/mutator.go
@@ -56,6 +56,9 @@ type Ensurer interface {
 	// EnsureKubeSchedulerDeployment ensures that the kube-scheduler deployment conforms to the provider requirements.
 	// "old" might be "nil" and must always be checked.
 	EnsureKubeSchedulerDeployment(ctx context.Context, gctx gcontext.GardenContext, new, old *appsv1.Deployment) error
+	// EnsureClusterAutoscalerDeployment ensures that the cluster-autoscaler deployment conforms to the provider requirements.
+	// "old" might be "nil" and must always be checked.
+	EnsureClusterAutoscalerDeployment(ctx context.Context, gctx gcontext.GardenContext, new, old *appsv1.Deployment) error
 	// EnsureETCD ensures that the etcds conform to the respective provider requirements.
 	// "old" might be "nil" and must always be checked.
 	EnsureETCD(ctx context.Context, gctx gcontext.GardenContext, new, old *druidv1alpha1.Etcd) error
@@ -164,6 +167,9 @@ func (m *mutator) Mutate(ctx context.Context, new, old client.Object) error {
 		case v1beta1constants.DeploymentNameKubeScheduler:
 			extensionswebhook.LogMutation(m.logger, x.Kind, x.Namespace, x.Name)
 			return m.ensurer.EnsureKubeSchedulerDeployment(ctx, gctx, x, oldDep)
+		case v1beta1constants.DeploymentNameClusterAutoscaler:
+			extensionswebhook.LogMutation(m.logger, x.Kind, x.Namespace, x.Name)
+			return m.ensurer.EnsureClusterAutoscalerDeployment(ctx, gctx, x, oldDep)
 		case v1beta1constants.DeploymentNameVPNSeedServer:
 			extensionswebhook.LogMutation(m.logger, x.Kind, x.Namespace, x.Name)
 			return m.ensurer.EnsureVPNSeedServerDeployment(ctx, gctx, x, oldDep)

--- a/extensions/pkg/webhook/controlplane/genericmutator/mutator_test.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/mutator_test.go
@@ -227,6 +227,21 @@ var _ = Describe("Mutator", func() {
 				},
 			),
 			Entry(
+				"EnsureClusterAutoscalerDeployment with a cluster-autoscaler deployment",
+				func() {
+					new = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameClusterAutoscaler}}
+					ensurer.EXPECT().EnsureClusterAutoscalerDeployment(context.TODO(), gomock.Any(), new, old).Return(nil)
+				},
+			),
+			Entry(
+				"EnsureClusterAutoscalerDeployment with a cluster-autoscaler deployment and existing deployment",
+				func() {
+					new = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameClusterAutoscaler}}
+					old = new.DeepCopyObject().(client.Object)
+					ensurer.EXPECT().EnsureClusterAutoscalerDeployment(context.TODO(), gomock.Any(), new, old).Return(nil)
+				},
+			),
+			Entry(
 				"EnsureVPNSeedServerDeployment with a vpn-seed-server deployment",
 				func() {
 					new = &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.DeploymentNameVPNSeedServer}}

--- a/extensions/pkg/webhook/controlplane/genericmutator/noopensurer.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/noopensurer.go
@@ -52,6 +52,11 @@ func (e *NoopEnsurer) EnsureKubeSchedulerDeployment(ctx context.Context, gctx gc
 	return nil
 }
 
+// EnsureClusterAutoscalerDeployment ensures that the cluster-autoscaler deployment conforms to the provider requirements.
+func (e *NoopEnsurer) EnsureClusterAutoscalerDeployment(ctx context.Context, gctx gcontext.GardenContext, new, old *appsv1.Deployment) error {
+	return nil
+}
+
 // EnsureETCD ensures that the etcd stateful sets conform to the provider requirements.
 func (e *NoopEnsurer) EnsureETCD(ctx context.Context, gctx gcontext.GardenContext, new, old *druidv1alpha1.Etcd) error {
 	return nil


### PR DESCRIPTION
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
When our [forked cluster-autoscaler](https://github.com/gardener/autoscaler) adopts a version of the upstream cluster-autoscaler that contains https://github.com/kubernetes/autoscaler/pull/4539 (or any of its backports) we have to specify the CSI feature gates for the cluster-autoscaler Deployment. As the CSI feature gates are different for the different cloud providers we have to enhance the generic controlplane mutator and allow provider extensions to mutate the cluster-autoscaler Deployment in order to add the CSI feature gates.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/5064

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
Provider extensions using the generic `controlplane` mutator webhook can now mutate the `cluster-autoscaler` Deployment by implementing the `EnsureClusterAutoscalerDeployment` function. This is required in the context of https://github.com/kubernetes/autoscaler/issues/4517 - cluster-autoscaler supports `--feature-gates` flag and provider extensions have to mutate the cluster-autoscaler Deployment to add the CSI related feature flags to it.
```
