### PR TITLE
Promote `ShootMaxTokenExpiration{Validation,Overwrite}` feature gates to GA

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -43,10 +43,6 @@ The following tables are a summary of the feature gates that you can set on diff
 | DisableDNSProviderManagement                 | `false` | `Alpha` | `1.41` |        |
 | ShootCARotation                              | `false` | `Alpha` | `1.42` |        |
 | ShootSARotation                              | `false` | `Alpha` | `1.48` |        |
-| ShootMaxTokenExpirationOverwrite             | `false` | `Alpha` | `1.43` | `1.44` |
-| ShootMaxTokenExpirationOverwrite             | `true`  | `Beta`  | `1.45` |        |
-| ShootMaxTokenExpirationValidation            | `false` | `Alpha` | `1.43` | `1.45` |
-| ShootMaxTokenExpirationValidation            | `true`  | `Beta`  | `1.46` |        |
 
 ## Feature gates for graduated or deprecated features
 
@@ -78,6 +74,12 @@ The following tables are a summary of the feature gates that you can set on diff
 | DenyInvalidExtensionResources                | `false` | `Alpha`   | `1.31` | `1.41` |
 | DenyInvalidExtensionResources                | `true`  | `Beta`    | `1.42` | `1.44` |
 | DenyInvalidExtensionResources                | `true`  | `GA`      | `1.45` |        |
+| ShootMaxTokenExpirationOverwrite             | `false` | `Alpha`   | `1.43` | `1.44` |
+| ShootMaxTokenExpirationOverwrite             | `true`  | `Beta`    | `1.45` | `1.47` |
+| ShootMaxTokenExpirationOverwrite             | `true`  | `GA`      | `1.48` |        |
+| ShootMaxTokenExpirationValidation            | `false` | `Alpha`   | `1.43` | `1.45` |
+| ShootMaxTokenExpirationValidation            | `true`  | `Beta`    | `1.46` | `1.47` |
+| ShootMaxTokenExpirationValidation            | `true`  | `GA`      | `1.48` |        |
 
 ## Using a feature
 

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -159,6 +159,7 @@ const (
 	// owner: @rfranzke
 	// alpha: v1.43.0
 	// beta: v1.45.0
+	// GA: v1.48.0
 	ShootMaxTokenExpirationOverwrite featuregate.Feature = "ShootMaxTokenExpirationOverwrite"
 
 	// ShootMaxTokenExpirationValidation enables validations on Gardener API server that enforce that the value of the
@@ -169,6 +170,7 @@ const (
 	// owner: @rfranzke
 	// alpha: v1.43.0
 	// beta: v1.46.0
+	// GA: v1.48.0
 	ShootMaxTokenExpirationValidation featuregate.Feature = "ShootMaxTokenExpirationValidation"
 )
 
@@ -192,8 +194,8 @@ var allFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	DisableDNSProviderManagement:               {Default: false, PreRelease: featuregate.Alpha},
 	ShootCARotation:                            {Default: false, PreRelease: featuregate.Alpha},
 	ShootSARotation:                            {Default: false, PreRelease: featuregate.Alpha},
-	ShootMaxTokenExpirationOverwrite:           {Default: true, PreRelease: featuregate.Beta},
-	ShootMaxTokenExpirationValidation:          {Default: true, PreRelease: featuregate.Beta},
+	ShootMaxTokenExpirationOverwrite:           {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
+	ShootMaxTokenExpirationValidation:          {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 }
 
 // GetFeatures returns a feature gate map with the respective specifications. Non-existing feature gates are ignored.

--- a/pkg/registry/core/shoot/strategy_test.go
+++ b/pkg/registry/core/shoot/strategy_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Strategy", func() {
 				return shoot
 			}
 
-			DescribeTable("ShootMaxTokenExpirationOverwrite feature gate enabled",
+			DescribeTable("ShootMaxTokenExpirationOverwrite feature gate",
 				func(featureGateEnabled bool, maxTokenExpiration, expectedDuration time.Duration, shootHasDeletionTimestamp bool) {
 					defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.ShootMaxTokenExpirationOverwrite, featureGateEnabled)()
 
@@ -70,11 +70,6 @@ var _ = Describe("Strategy", func() {
 				Entry("feature gate enabled, too high value", true, 3000*time.Hour, 2160*time.Hour, false),
 				Entry("feature gate enabled, value within boundaries", true, 1000*time.Hour, 1000*time.Hour, false),
 				Entry("feature gate enabled, value out of boundaries, shoot w/ deletionTimestamp", true, 5000*time.Hour, 5000*time.Hour, true),
-
-				Entry("feature gate disabled, too low value", false, time.Hour, time.Hour, false),
-				Entry("feature gate disabled, too high value", false, 3000*time.Hour, 3000*time.Hour, false),
-				Entry("feature gate disabled, value within boundaries", false, 1000*time.Hour, 1000*time.Hour, false),
-				Entry("feature gate disabled, value out of boundaries, shoot w/ deletionTimestamp", false, 5000*time.Hour, 5000*time.Hour, true),
 			)
 		})
 	})
@@ -413,7 +408,7 @@ var _ = Describe("Strategy", func() {
 				return shoot
 			}
 
-			DescribeTable("ShootMaxTokenExpirationOverwrite feature gate enabled",
+			DescribeTable("ShootMaxTokenExpirationOverwrite feature gate",
 				func(featureGateEnabled bool, maxTokenExpiration, expectedDuration time.Duration, shootHasDeletionTimestamp bool) {
 					defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.ShootMaxTokenExpirationOverwrite, featureGateEnabled)()
 
@@ -428,11 +423,6 @@ var _ = Describe("Strategy", func() {
 				Entry("feature gate enabled, too high value", true, 3000*time.Hour, 2160*time.Hour, false),
 				Entry("feature gate enabled, value within boundaries", true, 1000*time.Hour, 1000*time.Hour, false),
 				Entry("feature gate enabled, value out of boundaries, shoot w/ deletionTimestamp", true, 5000*time.Hour, 5000*time.Hour, true),
-
-				Entry("feature gate disabled, too low value", false, time.Hour, time.Hour, false),
-				Entry("feature gate disabled, too high value", false, 3000*time.Hour, 3000*time.Hour, false),
-				Entry("feature gate disabled, value within boundaries", false, 1000*time.Hour, 1000*time.Hour, false),
-				Entry("feature gate disabled, value out of boundaries, shoot w/ deletionTimestamp", false, 5000*time.Hour, 5000*time.Hour, true),
 			)
 		})
 	})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source ops-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR promote the `ShootMaxTokenExpiration{Validation,Overwrite}` feature gates to GA and locks them to the default value.

**Special notes for your reviewer**:
Similar to #5726 and #5877.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `ShootMaxTokenExpiration{Validation,Overwrite}` feature gates have been promoted to GA and are always enabled.
```
