### PR TITLE
Drop legacy client certificate for Prometheus

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
@@ -111,6 +111,8 @@ spec:
             cpu: 50m
             memory: 350Mi
         volumeMounts:
+        - mountPath: /etc/prometheus/seed
+          name: shoot-ca
         - mountPath: /srv/kubernetes/etcd/ca
           name: ca-etcd
         - mountPath: /srv/kubernetes/etcd/client
@@ -124,10 +126,6 @@ spec:
         - mountPath: /var/prometheus/data
           name: prometheus-db
           subPath: prometheus-
-        # TODO(rfranzke): Delete this in a future release once all monitoring configurations of extensions have been
-        # adapted.
-        - mountPath: /etc/prometheus/seed
-          name: prometheus-client-cert
         - name: shoot-access
           mountPath: /var/run/secrets/gardener.cloud/shoot/token
           readOnly: true
@@ -191,29 +189,10 @@ spec:
           defaultMode: 420
           name: prometheus-rules
       - name: shoot-ca
-        secret:
-          defaultMode: 420
-          secretName: {{ .Values.secretNameClusterCA }}
-      - name: ca-etcd
-        secret:
-          secretName: {{ .Values.secretNameEtcdCA }}
-      - name: etcd-client-tls
-        secret:
-          secretName: {{ .Values.secretNameEtcdClientCert }}
-      # TODO(rfranzke): Delete this in a future release once all monitoring configurations of extensions have been
-      #	adapted.
-      - name: prometheus-client-cert
         projected:
           defaultMode: 420
           sources:
-          - secret:
-              items:
-              - key: tls.crt
-                path: prometheus.crt
-              - key: tls.key
-                path: prometheus.key
-              name: {{ .Values.secretNameClientCert }}
-              optional: false
+          # For backwards-compatibility, we make the CA bundle available under both ca.crt and bundle.crt keys.
           - secret:
               name: {{ .Values.secretNameClusterCA }}
               items:
@@ -222,6 +201,12 @@ spec:
               - key: bundle.crt
                 path: ca.crt
               optional: false
+      - name: ca-etcd
+        secret:
+          secretName: {{ .Values.secretNameEtcdCA }}
+      - name: etcd-client-tls
+        secret:
+          secretName: {{ .Values.secretNameEtcdClientCert }}
       - name: shoot-access
         secret:
           secretName: shoot-access-prometheus

--- a/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
@@ -23,7 +23,6 @@ kubernetesVersion: 1.20.1
 secretNameClusterCA: ca
 secretNameEtcdCA: ca-etcd
 secretNameEtcdClientCert: etcd-client-tls
-secretNameClientCert: prometheus
 
 reversedVPN:
   enabled: false

--- a/charts/seed-monitoring/charts/core/values.yaml
+++ b/charts/seed-monitoring/charts/core/values.yaml
@@ -17,7 +17,6 @@ prometheus:
   secretNameClusterCA: ca
   secretNameEtcdCA: ca-etcd
   secretNameEtcdClientCert: etcd-client-tls
-  secretNameClientCert: prometheus
 kube-state-metrics-seed:
   replicas: 1
   images:

--- a/pkg/operation/botanist/monitoring.go
+++ b/pkg/operation/botanist/monitoring.go
@@ -183,18 +183,6 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 		return err
 	}
 
-	// TODO(rfranzke): Delete this in a future release once all monitoring configurations of extensions have been
-	// adapted and some migration grace period has passed.
-	prometheusClientSecret, err := b.SecretsManager.Generate(ctx, &secrets.CertificateSecretConfig{
-		Name:         "prometheus",
-		CommonName:   "gardener.cloud:monitoring:prometheus",
-		Organization: []string{"gardener.cloud:monitoring"},
-		CertType:     secrets.ClientCert,
-	}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCAClient), secretsmanager.Rotate(secretsmanager.InPlace))
-	if err != nil {
-		return err
-	}
-
 	genericTokenKubeconfigSecret, found := b.SecretsManager.Get(v1beta1constants.SecretNameGenericTokenKubeconfig)
 	if !found {
 		return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameGenericTokenKubeconfig)
@@ -224,7 +212,6 @@ func (b *Botanist) DeploySeedMonitoring(ctx context.Context) error {
 			"secretNameClusterCA":      clusterCASecret.Name,
 			"secretNameEtcdCA":         etcdCASecret.Name,
 			"secretNameEtcdClientCert": etcdClientSecret.Name,
-			"secretNameClientCert":     prometheusClientSecret.Name,
 			"kubernetesVersion":        b.Shoot.GetInfo().Spec.Kubernetes.Version,
 			"nodeLocalDNS": map[string]interface{}{
 				"enabled": b.Shoot.NodeLocalDNSEnabled,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
This PR drops the (deprecated) legacy client certificate for Prometheus. It was deprecated as part of #5008, however kept for a while to give extension developers time to adapt their scrape configurations.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/4661
Part of https://github.com/gardener/gardener/issues/4878

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking developer
The deprecated client certificate for Prometheus has been dropped. Extensions still relying on it must now adapt their scrape configurations according to the [documentation](https://github.com/gardener/gardener/blob/master/docs/extensions/logging-and-monitoring.md#extensions-monitoring-integration).
```
