### PR TITLE
Allow cluster-autoscaler to watch `csidrivers` and `csistoragecapacities`

### DIFF
--- a/pkg/operation/botanist/component/clusterautoscaler/cluster_autoscaler.go
+++ b/pkg/operation/botanist/component/clusterautoscaler/cluster_autoscaler.go
@@ -424,7 +424,7 @@ func (c *clusterAutoscaler) computeShootResourcesData(serviceAccountName string)
 				},
 				{
 					APIGroups: []string{"storage.k8s.io"},
-					Resources: []string{"storageclasses", "csinodes"},
+					Resources: []string{"storageclasses", "csinodes", "csidrivers", "csistoragecapacities"},
 					Verbs:     []string{"watch", "list", "get"},
 				},
 				{

--- a/pkg/operation/botanist/component/clusterautoscaler/cluster_autoscaler_test.go
+++ b/pkg/operation/botanist/component/clusterautoscaler/cluster_autoscaler_test.go
@@ -404,6 +404,8 @@ rules:
   resources:
   - storageclasses
   - csinodes
+  - csidrivers
+  - csistoragecapacities
   verbs:
   - watch
   - list


### PR DESCRIPTION
/area auto-scaling
/kind bug

Currently the cluster-autoscaler fails to watch `csidrivers` and `csistoragecapacities`:
```
E0529 13:42:31.452741       1 reflector.go:138] k8s.io/client-go/informers/factory.go:134: Failed to watch *v1beta1.CSIStorageCapacity: failed to list *v1beta1.CSIStorageCapacity: csistoragecapacities.storage.k8s.io is forbidden: User "system:serviceaccount:kube-system:cluster-autoscaler" cannot list resource "csistoragecapacities" in API group "storage.k8s.io" at the cluster scope
E0529 13:42:38.400407       1 reflector.go:138] k8s.io/client-go/informers/factory.go:134: Failed to watch *v1.CSIDriver: failed to list *v1.CSIDriver: csidrivers.storage.k8s.io is forbidden: User "system:serviceaccount:kube-system:cluster-autoscaler" cannot list resource "csidrivers" in API group "storage.k8s.io" at the cluster scope
```

```
$ k -n shoot--foo--bar logs cluster-autoscaler-54594ddc56-hksd5 | grep 'forbidden' | wc -l
1372
```

The cluster-autoscaler runs the scheduler plugins as part of its simulations.  The `VolumeBinding` plugin is requiring watch permissions for `csidrivers` and `csistoragecapacities`:

https://github.com/kubernetes/kubernetes/blob/a24eb09a399262c1acc8b4c30e97143cedaad3cc/pkg/scheduler/framework/plugins/volumebinding/volume_binding.go#L354-L359

The upstream cluster-autoscaler ClusterRole also includes the same rules:
```yaml
  # ...
  - apiGroups:
    - storage.k8s.io
    resources:
    - storageclasses
    - csinodes
    - csidrivers
    - csistoragecapacities
    verbs:
    - watch
    - list
    - get
  # ...
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue preventing the cluster-autoscaler to watch `csidrivers` and `csistoragecapacities` is now fixed.
```
