### PR TITLE
Handle scaling of MCM as part of generic Worker actuator reconciliation

### DIFF
--- a/extensions/pkg/controller/controlplane/genericactuator/actuator.go
+++ b/extensions/pkg/controller/controlplane/genericactuator/actuator.go
@@ -318,7 +318,7 @@ func (a *actuator) reconcileControlPlane(
 		scaledDown = false
 	)
 
-	if extensionscontroller.IsHibernated(cluster) {
+	if extensionscontroller.IsHibernationEnabled(cluster) {
 		dep := &appsv1.Deployment{}
 		if err := a.client.Get(ctx, client.ObjectKey{Namespace: cp.Namespace, Name: v1beta1constants.DeploymentNameKubeAPIServer}, dep); client.IgnoreNotFound(err) != nil {
 			return false, fmt.Errorf("could not get deployment '%s/%s': %w", cp.Namespace, v1beta1constants.DeploymentNameKubeAPIServer, err)

--- a/extensions/pkg/controller/csimigration/reconciler.go
+++ b/extensions/pkg/controller/csimigration/reconciler.go
@@ -139,7 +139,7 @@ func (r *reconciler) reconcile(ctx context.Context, cluster *extensionsv1alpha1.
 
 		// If the shoot is hibernated then we wait until the cluster gets woken up again so that the kube-controller-manager
 		// can perform the CSI migration steps.
-		if extensionscontroller.IsHibernated(&extensionscontroller.Cluster{Shoot: shoot}) {
+		if extensionscontroller.IsHibernationEnabled(&extensionscontroller.Cluster{Shoot: shoot}) {
 			r.logger.Info("Shoot cluster is hibernated - doing nothing until it gets woken up", "csimigration", kutil.ObjectName(cluster))
 			return reconcile.Result{}, nil
 		}

--- a/extensions/pkg/controller/healthcheck/reconciler.go
+++ b/extensions/pkg/controller/healthcheck/reconciler.go
@@ -109,7 +109,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		return reconcile.Result{}, err
 	}
 
-	if extensionscontroller.IsHibernated(cluster) {
+	if extensionscontroller.IsHibernationEnabled(cluster) {
 		var conditions []condition
 		for _, healthConditionType := range r.registeredExtension.healthConditionTypes {
 			conditionBuilder, err := gardencorev1beta1helper.NewConditionBuilder(gardencorev1beta1.ConditionType(healthConditionType))

--- a/extensions/pkg/controller/worker/genericactuator/actuator_delete.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_delete.go
@@ -49,8 +49,8 @@ func (a *genericActuator) Delete(ctx context.Context, worker *extensionsv1alpha1
 	}
 
 	// Make sure machine-controller-manager is awake before deleting the machines.
-	var replicaFunc = func() (int32, error) {
-		return 1, nil
+	var replicaFunc = func() int32 {
+		return 1
 	}
 
 	// Deploy the machine-controller-manager into the cluster to make sure worker nodes can be removed.

--- a/extensions/pkg/controller/worker/genericactuator/machine_controller_manager.go
+++ b/extensions/pkg/controller/worker/genericactuator/machine_controller_manager.go
@@ -45,7 +45,7 @@ const (
 )
 
 // ReplicaCount determines the number of replicas.
-type ReplicaCount func() (int32, error)
+type ReplicaCount func() int32
 
 func (a *genericActuator) deployMachineControllerManager(ctx context.Context, logger logr.Logger, workerObj *extensionsv1alpha1.Worker, cluster *extensionscontroller.Cluster, workerDelegate WorkerDelegate, replicas ReplicaCount) error {
 	logger.Info("Deploying the machine-controller-manager")
@@ -63,10 +63,7 @@ func (a *genericActuator) deployMachineControllerManager(ctx context.Context, lo
 	}
 	mcmValues["genericTokenKubeconfigSecretName"] = extensionscontroller.GenericTokenKubeconfigSecretNameFromCluster(cluster)
 
-	replicaCount, err := replicas()
-	if err != nil {
-		return err
-	}
+	replicaCount := replicas()
 	mcmValues["replicas"] = replicaCount
 
 	if err := a.mcmSeedChart.Apply(ctx, a.chartApplier, workerObj.Namespace,


### PR DESCRIPTION
**How to categorize this PR?**

/area control-plane
/area robustness
/kind enhancement

**What this PR does / why we need it**:
~~Corrects the computation of the desired replicas for MCM when hibernation for a shoot cluster has been enabled.~~

**Which issue(s) this PR fixes**:
Fixes #5878 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
~~Enhances reconciler to compute the desired MCM replicas if the hibernation of a cluster has been enabled. This will ensure that MCM is scaled back up if required to complete the hibernation of the cluster.~~

```bugfix dependency
The generic Worker actuator now scales up machine-controller-manager Deployment when Shoot is hibernating (or waking up) and machine-controller-manager Deployment is already scaled down by external actor (dependency-watchdog).
```

```breaking dependency
The "github.com/gardener/gardener/pkg/extensions/pkg/controller.IsHibernated" func has now changed its semantics. Previously the func was returning whether the hibernation is only enabled (`.spec.hibernation.enabled=true`). Now the func is returning whether the Shoot is hibernated (`.spec.hibernation.enabled=true` and `.status.isHibernated=true`).
```