### PR TITLE
[GEP-18] Make shoot webhook reconciliation generic

### DIFF
--- a/cmd/gardener-extension-provider-local/app/app.go
+++ b/cmd/gardener-extension-provider-local/app/app.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/gardener/gardener/extensions/pkg/controller"
 	controllercmd "github.com/gardener/gardener/extensions/pkg/controller/cmd"
+	"github.com/gardener/gardener/extensions/pkg/controller/controlplane/genericactuator"
 	"github.com/gardener/gardener/extensions/pkg/controller/operatingsystemconfig/oscommon"
 	"github.com/gardener/gardener/extensions/pkg/controller/worker"
 	webhookcmd "github.com/gardener/gardener/extensions/pkg/webhook/cmd"
@@ -157,7 +158,13 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 
 		controllerSwitches = ControllerSwitchOptions()
 		webhookSwitches    = WebhookSwitchOptions()
-		webhookOptions     = webhookcmd.NewAddToManagerOptions(local.Name, local.Type, webhookServerOptions, webhookSwitches)
+		webhookOptions     = webhookcmd.NewAddToManagerOptions(
+			local.Name,
+			genericactuator.ShootWebhooksResourceName,
+			genericactuator.ShootWebhookNamespaceSelector(local.Type),
+			webhookServerOptions,
+			webhookSwitches,
+		)
 
 		aggOption = controllercmd.NewOptionAggregator(
 			restOpts,

--- a/extensions/pkg/webhook/certificates/add.go
+++ b/extensions/pkg/webhook/certificates/add.go
@@ -37,7 +37,10 @@ func AddCertificateManagementToManager(
 	clock clock.Clock,
 	seedWebhookConfig, shootWebhookConfig *admissionregistrationv1.MutatingWebhookConfiguration,
 	atomicShootWebhookConfig *atomic.Value,
-	extensionName, providerType, namespace, mode, url string,
+	extensionName string,
+	shootWebhookManagedResourceName string,
+	shootNamespaceSelector map[string]string,
+	namespace, mode, url string,
 ) error {
 	var (
 		identity         = "gardener-extension-" + extensionName + "-webhook"
@@ -48,19 +51,20 @@ func AddCertificateManagementToManager(
 	// first, add reconciler that manages the certificates and injects them into webhook configs
 	// (only running in the leader or once if no secrets have been generated yet)
 	if err := (&reconciler{
-		Clock:                    clock,
-		SyncPeriod:               DefaultSyncPeriod,
-		SeedWebhookConfig:        seedWebhookConfig,
-		ShootWebhookConfig:       shootWebhookConfig,
-		AtomicShootWebhookConfig: atomicShootWebhookConfig,
-		CASecretName:             caSecretName,
-		ServerSecretName:         serverSecretName,
-		Namespace:                namespace,
-		Identity:                 identity,
-		ProviderName:             extensionName,
-		ProviderType:             providerType,
-		Mode:                     mode,
-		URL:                      url,
+		Clock:                           clock,
+		SyncPeriod:                      DefaultSyncPeriod,
+		SeedWebhookConfig:               seedWebhookConfig,
+		ShootWebhookConfig:              shootWebhookConfig,
+		AtomicShootWebhookConfig:        atomicShootWebhookConfig,
+		CASecretName:                    caSecretName,
+		ServerSecretName:                serverSecretName,
+		Namespace:                       namespace,
+		Identity:                        identity,
+		ExtensionName:                   extensionName,
+		ShootWebhookManagedResourceName: shootWebhookManagedResourceName,
+		ShootNamespaceSelector:          shootNamespaceSelector,
+		Mode:                            mode,
+		URL:                             url,
 	}).AddToManager(ctx, mgr); err != nil {
 		return fmt.Errorf("failed to add webhook server certificate reconciler: %w", err)
 	}

--- a/extensions/pkg/webhook/certificates/reconciler.go
+++ b/extensions/pkg/webhook/certificates/reconciler.go
@@ -20,8 +20,8 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/gardener/gardener/extensions/pkg/controller/controlplane/genericactuator"
 	"github.com/gardener/gardener/extensions/pkg/webhook"
+	extensionswebhookshoot "github.com/gardener/gardener/extensions/pkg/webhook/shoot"
 	"github.com/gardener/gardener/pkg/utils/kubernetes"
 	secretutils "github.com/gardener/gardener/pkg/utils/secrets"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
@@ -69,8 +69,12 @@ type reconciler struct {
 	Namespace string
 	// Identity of the secrets manager used for managing the secret.
 	Identity string
-	// Name and provider type of the extension.
-	ProviderName, ProviderType string
+	// Name of the extension.
+	ExtensionName string
+	// ShootWebhookManagedResourceName is the name of the ManagedResource containing the raw extensionswebhookshoot webhook config.
+	ShootWebhookManagedResourceName string
+	// ShootNamespaceSelector is a label selector for extensionswebhookshoot namespaces relevant to the extension.
+	ShootNamespaceSelector map[string]string
 	// Mode is the webhook client config mode.
 	Mode string
 	// URL is the URL that is used to register the webhooks in Kubernetes.
@@ -186,8 +190,8 @@ func (r *reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 		r.AtomicShootWebhookConfig.Store(r.ShootWebhookConfig.DeepCopy())
 
 		// reconcile all shoot webhook configs with the freshly created CA bundle
-		if err := genericactuator.ReconcileShootWebhooksForAllNamespaces(ctx, r.client, r.ProviderName, r.ProviderType, r.serverPort, r.ShootWebhookConfig); err != nil {
-			return reconcile.Result{}, fmt.Errorf("error reconciling all shoot webhook configs: %w", err)
+		if err := extensionswebhookshoot.ReconcileWebhooksForAllNamespaces(ctx, r.client, r.ExtensionName, r.ShootWebhookManagedResourceName, r.ShootNamespaceSelector, r.serverPort, r.ShootWebhookConfig); err != nil {
+			return reconcile.Result{}, fmt.Errorf("error reconciling all extensionswebhookshoot webhook configs: %w", err)
 		}
 		log.Info("Updated all shoot webhook configs with new CA bundle", "webhookConfig", r.ShootWebhookConfig)
 	}
@@ -247,7 +251,7 @@ func (r *reconciler) generateWebhookCA(ctx context.Context, sm secretsmanager.In
 
 func (r *reconciler) generateWebhookServerCert(ctx context.Context, sm secretsmanager.Interface) (*corev1.Secret, error) {
 	// use current CA for signing server cert to prevent mismatches when dropping the old CA from the webhook config
-	return sm.Generate(ctx, getWebhookServerCertConfig(r.ServerSecretName, r.Namespace, r.ProviderName, r.Mode, r.URL),
+	return sm.Generate(ctx, getWebhookServerCertConfig(r.ServerSecretName, r.Namespace, r.ExtensionName, r.Mode, r.URL),
 		secretsmanager.SignedByCA(r.CASecretName, secretsmanager.UseCurrentCA))
 }
 

--- a/extensions/pkg/webhook/certificates/reconciler.go
+++ b/extensions/pkg/webhook/certificates/reconciler.go
@@ -191,7 +191,7 @@ func (r *reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 
 		// reconcile all shoot webhook configs with the freshly created CA bundle
 		if err := extensionswebhookshoot.ReconcileWebhooksForAllNamespaces(ctx, r.client, r.ExtensionName, r.ShootWebhookManagedResourceName, r.ShootNamespaceSelector, r.serverPort, r.ShootWebhookConfig); err != nil {
-			return reconcile.Result{}, fmt.Errorf("error reconciling all extensionswebhookshoot webhook configs: %w", err)
+			return reconcile.Result{}, fmt.Errorf("error reconciling all shoot webhook configs: %w", err)
 		}
 		log.Info("Updated all shoot webhook configs with new CA bundle", "webhookConfig", r.ShootWebhookConfig)
 	}

--- a/extensions/pkg/webhook/shoot/networkpolicy.go
+++ b/extensions/pkg/webhook/shoot/networkpolicy.go
@@ -29,14 +29,14 @@ import (
 )
 
 // GetNetworkPolicyMeta returns the network policy object with filled meta data.
-func GetNetworkPolicyMeta(namespace, providerName string) *networkingv1.NetworkPolicy {
-	return &networkingv1.NetworkPolicy{ObjectMeta: kutil.ObjectMeta(namespace, "gardener-extension-"+providerName)}
+func GetNetworkPolicyMeta(namespace, extensionName string) *networkingv1.NetworkPolicy {
+	return &networkingv1.NetworkPolicy{ObjectMeta: kutil.ObjectMeta(namespace, "gardener-extension-"+extensionName)}
 }
 
-// EnsureNetworkPolicy ensures that the required network policy that allows the kube-apiserver running in the given namespace
-// to talk to the extension webhook is installed.
-func EnsureNetworkPolicy(ctx context.Context, c client.Client, namespace, providerName string, port int) error {
-	networkPolicy := GetNetworkPolicyMeta(namespace, providerName)
+// EnsureNetworkPolicy ensures that the required network policy that allows the kube-apiserver running in the given
+// namespace to talk to the extension webhook is installed.
+func EnsureNetworkPolicy(ctx context.Context, c client.Client, namespace, extensionName string, port int) error {
+	networkPolicy := GetNetworkPolicyMeta(namespace, extensionName)
 
 	policyPort := intstr.FromInt(port)
 	policyProtocol := corev1.ProtocolTCP
@@ -56,13 +56,12 @@ func EnsureNetworkPolicy(ctx context.Context, c client.Client, namespace, provid
 						{
 							NamespaceSelector: &metav1.LabelSelector{
 								MatchLabels: map[string]string{
-									v1beta1constants.LabelControllerRegistrationName: providerName,
-									v1beta1constants.GardenRole:                      v1beta1constants.GardenRoleExtension,
+									v1beta1constants.GardenRole: v1beta1constants.GardenRoleExtension,
 								},
 							},
 							PodSelector: &metav1.LabelSelector{
 								MatchLabels: map[string]string{
-									"app.kubernetes.io/name": "gardener-extension-" + providerName,
+									"app.kubernetes.io/name": "gardener-extension-" + extensionName,
 								},
 							},
 						},

--- a/extensions/pkg/webhook/shoot/networkpolicy_test.go
+++ b/extensions/pkg/webhook/shoot/networkpolicy_test.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shoot_test
+
+import (
+	"context"
+
+	. "github.com/gardener/gardener/extensions/pkg/webhook/shoot"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("NetworkPolicy", func() {
+	var (
+		ctx           = context.TODO()
+		fakeClient    client.Client
+		namespace     = "extension-foo-bar"
+		extensionName = "provider-test"
+		serverPort    = 1337
+	)
+
+	BeforeEach(func() {
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(scheme.Scheme).Build()
+	})
+
+	Describe("#EnsureNetworkPolicy", func() {
+		It("should reconcile the correct network policy", func() {
+			Expect(EnsureNetworkPolicy(ctx, fakeClient, namespace, extensionName, serverPort)).To(Succeed())
+
+			networkPolicy := &networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: "gardener-extension-" + extensionName}}
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(networkPolicy), networkPolicy)).To(Succeed())
+
+			port := intstr.FromInt(serverPort)
+			protocol := corev1.ProtocolTCP
+
+			Expect(networkPolicy.Spec).To(DeepEqual(networkingv1.NetworkPolicySpec{
+				PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
+				Egress: []networkingv1.NetworkPolicyEgressRule{
+					{
+						Ports: []networkingv1.NetworkPolicyPort{
+							{
+								Port:     &port,
+								Protocol: &protocol,
+							},
+						},
+						To: []networkingv1.NetworkPolicyPeer{
+							{
+								NamespaceSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										v1beta1constants.GardenRole: v1beta1constants.GardenRoleExtension,
+									},
+								},
+								PodSelector: &metav1.LabelSelector{
+									MatchLabels: map[string]string{
+										"app.kubernetes.io/name": "gardener-extension-" + extensionName,
+									},
+								},
+							},
+						},
+					},
+				},
+				PodSelector: metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						v1beta1constants.LabelApp:  v1beta1constants.LabelKubernetes,
+						v1beta1constants.LabelRole: v1beta1constants.LabelAPIServer,
+					},
+				},
+			}))
+		})
+	})
+})

--- a/extensions/pkg/webhook/shoot/shoot_suite_test.go
+++ b/extensions/pkg/webhook/shoot/shoot_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shoot_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestShoot(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Extensions Webhook Shoot Suite")
+}

--- a/extensions/pkg/webhook/shoot/webhook.go
+++ b/extensions/pkg/webhook/shoot/webhook.go
@@ -1,0 +1,117 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shoot
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gardener/gardener/extensions/pkg/controller"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/extensions"
+	"github.com/gardener/gardener/pkg/utils"
+	"github.com/gardener/gardener/pkg/utils/flow"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/managedresources"
+
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ReconcileWebhookConfig deploys the shoot webhook configuration, i.e., a network policy to allow the
+// kube-apiserver to talk to the extension, and a managed resource that contains the MutatingWebhookConfiguration.
+func ReconcileWebhookConfig(
+	ctx context.Context,
+	c client.Client,
+	namespace string,
+	extensionName string,
+	managedResourceName string,
+	serverPort int,
+	shootWebhookConfig *admissionregistrationv1.MutatingWebhookConfiguration,
+	cluster *controller.Cluster,
+) error {
+	if err := EnsureNetworkPolicy(ctx, c, namespace, extensionName, serverPort); err != nil {
+		return fmt.Errorf("could not create or update network policy for shoot webhooks in namespace '%s': %w", namespace, err)
+	}
+
+	if cluster.Shoot == nil {
+		return fmt.Errorf("no shoot found in cluster resource")
+	}
+
+	data, err := managedresources.
+		NewRegistry(kubernetes.ShootScheme, kubernetes.ShootCodec, kubernetes.ShootSerializer).
+		AddAllAndSerialize(shootWebhookConfig)
+	if err != nil {
+		return err
+	}
+
+	if err := managedresources.Create(ctx, c, namespace, managedResourceName, false, "", data, nil, nil, nil); err != nil {
+		return fmt.Errorf("could not create or update managed resource '%s/%s' containing shoot webhooks: %w", namespace, managedResourceName, err)
+	}
+
+	return nil
+}
+
+// ReconcileWebhooksForAllNamespaces reconciles the shoot webhooks in all shoot namespaces of the given
+// provider type. This is necessary in case the webhook port is changed (otherwise, the network policy would only be
+// updated again as part of the ControlPlane reconciliation which might only happen in the next 24h).
+func ReconcileWebhooksForAllNamespaces(
+	ctx context.Context,
+	c client.Client,
+	extensionName string,
+	managedResourceName string,
+	shootNamespaceSelector map[string]string,
+	port int,
+	shootWebhookConfig *admissionregistrationv1.MutatingWebhookConfiguration,
+) error {
+	namespaceList := &corev1.NamespaceList{}
+	if err := c.List(ctx, namespaceList, client.MatchingLabels(utils.MergeStringMaps(map[string]string{
+		v1beta1constants.GardenRole: v1beta1constants.GardenRoleShoot,
+	}, shootNamespaceSelector))); err != nil {
+		return err
+	}
+
+	fns := make([]flow.TaskFn, 0, len(namespaceList.Items))
+
+	for _, namespace := range namespaceList.Items {
+		var (
+			networkPolicy     = GetNetworkPolicyMeta(namespace.Name, extensionName)
+			namespaceName     = namespace.Name
+			networkPolicyName = networkPolicy.Name
+		)
+
+		fns = append(fns, func(ctx context.Context) error {
+			if err := c.Get(ctx, kutil.Key(namespaceName, networkPolicyName), &networkingv1.NetworkPolicy{}); err != nil {
+				if !errors.IsNotFound(err) {
+					return err
+				}
+				return nil
+			}
+
+			cluster, err := extensions.GetCluster(ctx, c, namespaceName)
+			if err != nil {
+				return err
+			}
+
+			return ReconcileWebhookConfig(ctx, c, namespaceName, extensionName, managedResourceName, port, shootWebhookConfig.DeepCopy(), cluster)
+		})
+	}
+
+	return flow.Parallel(fns...)(ctx)
+}

--- a/extensions/pkg/webhook/shoot/webhook_test.go
+++ b/extensions/pkg/webhook/shoot/webhook_test.go
@@ -223,16 +223,16 @@ webhooks:
 
 func expectWebhookConfigReconciliation(ctx context.Context, fakeClient client.Client, namespace, managedResourceName string, shootWebhookConfigRaw map[string][]byte) {
 	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: managedResourceName, Namespace: namespace}}
-	Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
-	Expect(secret.Type).To(Equal(corev1.SecretTypeOpaque))
-	Expect(secret.Data).To(Equal(shootWebhookConfigRaw))
+	ExpectWithOffset(1, fakeClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
+	ExpectWithOffset(1, secret.Type).To(Equal(corev1.SecretTypeOpaque))
+	ExpectWithOffset(1, secret.Data).To(Equal(shootWebhookConfigRaw))
 
 	managedResource := &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: managedResourceName, Namespace: namespace}}
-	Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
-	Expect(managedResource.Spec).To(DeepEqual(resourcesv1alpha1.ManagedResourceSpec{SecretRefs: []corev1.LocalObjectReference{{Name: managedResourceName}}}))
+	ExpectWithOffset(1, fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
+	ExpectWithOffset(1, managedResource.Spec).To(DeepEqual(resourcesv1alpha1.ManagedResourceSpec{SecretRefs: []corev1.LocalObjectReference{{Name: managedResourceName}}}))
 }
 
 func expectNoWebhookConfigReconciliation(ctx context.Context, fakeClient client.Client, namespace, managedResourceName string) {
-	Expect(fakeClient.Get(ctx, kutil.Key(namespace, managedResourceName), &corev1.Secret{})).To(BeNotFoundError())
-	Expect(fakeClient.Get(ctx, kutil.Key(namespace, managedResourceName), &resourcesv1alpha1.ManagedResource{})).To(BeNotFoundError())
+	ExpectWithOffset(1, fakeClient.Get(ctx, kutil.Key(namespace, managedResourceName), &corev1.Secret{})).To(BeNotFoundError())
+	ExpectWithOffset(1, fakeClient.Get(ctx, kutil.Key(namespace, managedResourceName), &resourcesv1alpha1.ManagedResource{})).To(BeNotFoundError())
 }

--- a/extensions/pkg/webhook/shoot/webhook_test.go
+++ b/extensions/pkg/webhook/shoot/webhook_test.go
@@ -1,0 +1,238 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shoot_test
+
+import (
+	"context"
+	"errors"
+
+	"github.com/gardener/gardener/extensions/pkg/controller"
+	. "github.com/gardener/gardener/extensions/pkg/webhook/shoot"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+
+	"github.com/hashicorp/go-multierror"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("Webhook", func() {
+	var (
+		ctx        = context.TODO()
+		fakeClient client.Client
+
+		shootWebhookConfig    *admissionregistrationv1.MutatingWebhookConfiguration
+		shootWebhookConfigRaw map[string][]byte
+
+		extensionName       = "provider-test"
+		managedResourceName = "extension-provider-test-shoot-webhooks"
+		serverPort          = 1337
+	)
+
+	BeforeEach(func() {
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+
+		shootWebhookConfig = &admissionregistrationv1.MutatingWebhookConfiguration{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: extensionName,
+			},
+			Webhooks: []admissionregistrationv1.MutatingWebhook{{
+				Name: "some-webhook",
+			}},
+		}
+		shootWebhookConfigRaw = map[string][]byte{"mutatingwebhookconfiguration____provider-test.yaml": []byte(`apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  creationTimestamp: null
+  name: provider-test
+webhooks:
+- admissionReviewVersions: null
+  clientConfig: {}
+  name: some-webhook
+  sideEffects: null
+`)}
+	})
+
+	Describe("#ReconcileWebhookConfig", func() {
+		var (
+			cluster   *controller.Cluster
+			namespace = "extension-foo-bar"
+		)
+
+		BeforeEach(func() {
+			cluster = &controller.Cluster{Shoot: &gardencorev1beta1.Shoot{}}
+		})
+
+		It("should reconcile the shoot webhook config", func() {
+			Expect(ReconcileWebhookConfig(ctx, fakeClient, namespace, extensionName, managedResourceName, serverPort, shootWebhookConfig, cluster)).To(Succeed())
+			expectWebhookConfigReconciliation(ctx, fakeClient, namespace, managedResourceName, shootWebhookConfigRaw)
+		})
+	})
+
+	Describe("#ReconcileWebhooksForAllNamespaces", func() {
+		var (
+			networkPolicyName      = "gardener-extension-" + extensionName
+			extensionType          = "test"
+			shootNamespaceSelector = map[string]string{"networking.shoot.gardener.cloud/provider": extensionType}
+
+			namespace1 *corev1.Namespace
+			namespace2 *corev1.Namespace
+			namespace3 *corev1.Namespace
+			namespace4 *corev1.Namespace
+			namespace5 *corev1.Namespace
+
+			networkPolicy3 *networkingv1.NetworkPolicy
+			networkPolicy4 *networkingv1.NetworkPolicy
+
+			cluster3 *extensionsv1alpha1.Cluster
+			cluster4 *extensionsv1alpha1.Cluster
+		)
+
+		BeforeEach(func() {
+			namespace1 = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "namespace1",
+				},
+			}
+			namespace2 = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "namespace2",
+					Labels: map[string]string{
+						"gardener.cloud/role":                      "shoot",
+						"networking.shoot.gardener.cloud/provider": "foo",
+					},
+				},
+			}
+			namespace3 = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "namespace3",
+					Labels: map[string]string{
+						"gardener.cloud/role":                      "shoot",
+						"networking.shoot.gardener.cloud/provider": extensionType,
+					},
+				},
+			}
+			namespace4 = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "namespace4",
+					Labels: map[string]string{
+						"gardener.cloud/role":                      "shoot",
+						"networking.shoot.gardener.cloud/provider": extensionType,
+					},
+				},
+			}
+			namespace5 = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "namespace5",
+					Labels: map[string]string{
+						"gardener.cloud/role":                      "shoot",
+						"networking.shoot.gardener.cloud/provider": extensionType,
+					},
+				},
+			}
+
+			Expect(fakeClient.Create(ctx, namespace1)).To(Succeed())
+			Expect(fakeClient.Create(ctx, namespace2)).To(Succeed())
+			Expect(fakeClient.Create(ctx, namespace3)).To(Succeed())
+			Expect(fakeClient.Create(ctx, namespace4)).To(Succeed())
+			Expect(fakeClient.Create(ctx, namespace5)).To(Succeed())
+
+			networkPolicy3 = &networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Namespace: namespace3.Name, Name: networkPolicyName}}
+			networkPolicy4 = &networkingv1.NetworkPolicy{ObjectMeta: metav1.ObjectMeta{Namespace: namespace4.Name, Name: networkPolicyName}}
+
+			Expect(fakeClient.Create(ctx, networkPolicy3)).To(Succeed())
+			Expect(fakeClient.Create(ctx, networkPolicy4)).To(Succeed())
+
+			cluster3 = &extensionsv1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: namespace3.Name},
+				Spec: extensionsv1alpha1.ClusterSpec{
+					Shoot: runtime.RawExtension{
+						Object: &gardencorev1beta1.Shoot{},
+					},
+				},
+			}
+			cluster4 = &extensionsv1alpha1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{Name: namespace4.Name},
+				Spec: extensionsv1alpha1.ClusterSpec{
+					Shoot: runtime.RawExtension{
+						Object: &gardencorev1beta1.Shoot{},
+					},
+				},
+			}
+
+			Expect(fakeClient.Create(ctx, cluster3)).To(Succeed())
+			Expect(fakeClient.Create(ctx, cluster4)).To(Succeed())
+		})
+
+		It("should reconcile the webhook config for namespace3 and namespace4", func() {
+			Expect(ReconcileWebhooksForAllNamespaces(ctx, fakeClient, extensionName, managedResourceName, shootNamespaceSelector, serverPort, shootWebhookConfig)).To(Succeed())
+
+			expectNoWebhookConfigReconciliation(ctx, fakeClient, namespace1.Name, managedResourceName)
+			expectNoWebhookConfigReconciliation(ctx, fakeClient, namespace2.Name, managedResourceName)
+			expectWebhookConfigReconciliation(ctx, fakeClient, namespace3.Name, managedResourceName, shootWebhookConfigRaw)
+			expectWebhookConfigReconciliation(ctx, fakeClient, namespace4.Name, managedResourceName, shootWebhookConfigRaw)
+			expectNoWebhookConfigReconciliation(ctx, fakeClient, namespace5.Name, managedResourceName)
+		})
+
+		It("should return an error because cluster for namespace3 is missing", func() {
+			Expect(fakeClient.Delete(ctx, cluster3)).To(Succeed())
+
+			err := ReconcileWebhooksForAllNamespaces(ctx, fakeClient, extensionName, managedResourceName, shootNamespaceSelector, serverPort, shootWebhookConfig)
+
+			Expect(err).To(BeAssignableToTypeOf(&multierror.Error{}))
+			Expect(err.(*multierror.Error).Errors).To(ConsistOf(Equal(apierrors.NewNotFound(schema.GroupResource{Group: extensionsv1alpha1.SchemeGroupVersion.Group, Resource: "clusters"}, namespace3.Name))))
+		})
+
+		It("should return an error because cluster for namespace4 is does not contain shoot", func() {
+			patch := client.MergeFrom(cluster4.DeepCopy())
+			cluster4.Spec.Shoot = runtime.RawExtension{}
+			Expect(fakeClient.Patch(ctx, cluster4, patch)).To(Succeed())
+
+			err := ReconcileWebhooksForAllNamespaces(ctx, fakeClient, extensionName, managedResourceName, shootNamespaceSelector, serverPort, shootWebhookConfig)
+
+			Expect(err).To(BeAssignableToTypeOf(&multierror.Error{}))
+			Expect(err.(*multierror.Error).Errors).To(ConsistOf(Equal(errors.New("no shoot found in cluster resource"))))
+		})
+	})
+})
+
+func expectWebhookConfigReconciliation(ctx context.Context, fakeClient client.Client, namespace, managedResourceName string, shootWebhookConfigRaw map[string][]byte) {
+	secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: managedResourceName, Namespace: namespace}}
+	Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
+	Expect(secret.Type).To(Equal(corev1.SecretTypeOpaque))
+	Expect(secret.Data).To(Equal(shootWebhookConfigRaw))
+
+	managedResource := &resourcesv1alpha1.ManagedResource{ObjectMeta: metav1.ObjectMeta{Name: managedResourceName, Namespace: namespace}}
+	Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
+	Expect(managedResource.Spec).To(DeepEqual(resourcesv1alpha1.ManagedResourceSpec{SecretRefs: []corev1.LocalObjectReference{{Name: managedResourceName}}}))
+}
+
+func expectNoWebhookConfigReconciliation(ctx context.Context, fakeClient client.Client, namespace, managedResourceName string) {
+	Expect(fakeClient.Get(ctx, kutil.Key(namespace, managedResourceName), &corev1.Secret{})).To(BeNotFoundError())
+	Expect(fakeClient.Get(ctx, kutil.Key(namespace, managedResourceName), &resourcesv1alpha1.ManagedResource{})).To(BeNotFoundError())
+}


### PR DESCRIPTION
Co-Authored-By: Tim Ebert <tim.ebert@sap.com>

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security usability 
/kind enhancement

**What this PR does / why we need it**:
Earlier, the code was designed to only work for provider extensions. However, nowadays there are also other extension with shoot webhooks (cilium, shoot-oidc-service) which should work out of the box with the generic library coding.
Hence, this PR make the shoot webhook reconciliation generic so that it can be used in different extension contexts.

**Which issue(s) this PR fixes**:
Part of #3292
Follow-up of #6003

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
