### PR TITLE
Prevent orphaning old `ServiceAccount` secrets after signing key rotation

### DIFF
--- a/pkg/operation/botanist/secrets_test.go
+++ b/pkg/operation/botanist/secrets_test.go
@@ -377,11 +377,13 @@ var _ = Describe("Secrets", func() {
 				// mimic kube-controller-manager behaviour: In reality, when a service account token secret is deleted
 				// then KCM removes it from the ServiceAccount's `.secrets[]` list. Since no KCM is running for the
 				// test, we have to mimic it here
+				sa2.Secrets = []corev1.ObjectReference{sa2.Secrets[0]}
+				Expect(fakeShootClient.Update(ctx, sa2)).To(Succeed())
 				sa3.Secrets = []corev1.ObjectReference{sa3.Secrets[0]}
 				Expect(fakeShootClient.Update(ctx, sa3)).To(Succeed())
 
 				Expect(sa1).To(Equal(sa1Copy))
-				Expect(sa2).To(Equal(sa2Copy))
+				Expect(sa2.Secrets).To(ConsistOf(corev1.ObjectReference{Name: "sa2-token" + suffix}))
 				Expect(sa3.Labels).NotTo(HaveKey("credentials.gardener.cloud/key-name"))
 				Expect(sa3.Secrets).To(ConsistOf(corev1.ObjectReference{Name: "new-sa-secret"}))
 			})

--- a/pkg/operation/botanist/secrets_test.go
+++ b/pkg/operation/botanist/secrets_test.go
@@ -319,7 +319,7 @@ var _ = Describe("Secrets", func() {
 			}
 			sa2 = &corev1.ServiceAccount{
 				ObjectMeta: metav1.ObjectMeta{Name: "sa2", Namespace: namespace2.Name},
-				Secrets:    []corev1.ObjectReference{{Name: "sa2secret1"}},
+				Secrets:    []corev1.ObjectReference{{Name: "sa2-token" + suffix}, {Name: "sa2secret1"}},
 			}
 			sa3 = &corev1.ServiceAccount{
 				ObjectMeta: metav1.ObjectMeta{Name: "sa3", Namespace: namespace2.Name, Labels: map[string]string{"credentials.gardener.cloud/key-name": "service-account-key-current"}},
@@ -342,18 +342,15 @@ var _ = Describe("Secrets", func() {
 				Expect(fakeShootClient.Get(ctx, client.ObjectKeyFromObject(sa3), sa3)).To(Succeed())
 
 				Expect(sa1.Labels).To(HaveKeyWithValue("credentials.gardener.cloud/key-name", "service-account-key-current"))
-				Expect(sa2.Labels).To(HaveKeyWithValue("credentials.gardener.cloud/key-name", "service-account-key-current"))
+				Expect(sa2.Labels).NotTo(HaveKeyWithValue("credentials.gardener.cloud/key-name", "service-account-key-current"))
+				Expect(sa3.Labels).To(HaveKeyWithValue("credentials.gardener.cloud/key-name", "service-account-key-current"))
 				Expect(sa1.Secrets).To(ConsistOf(corev1.ObjectReference{Name: "sa1-token" + suffix}, corev1.ObjectReference{Name: "sa1secret1"}))
 				Expect(sa2.Secrets).To(ConsistOf(corev1.ObjectReference{Name: "sa2-token" + suffix}, corev1.ObjectReference{Name: "sa2secret1"}))
 				Expect(sa3.Secrets).To(ConsistOf(corev1.ObjectReference{Name: "sa3secret1"}))
 
 				sa1Secret := &corev1.Secret{}
 				Expect(fakeShootClient.Get(ctx, kutil.Key(sa1.Namespace, "sa1-token"+suffix), sa1Secret))
-				verifySATokenSecret(sa1Secret, sa1.Name)
-
-				sa2Secret := &corev1.Secret{}
-				Expect(fakeShootClient.Get(ctx, kutil.Key(sa2.Namespace, "sa2-token"+suffix), sa2Secret))
-				verifySATokenSecret(sa2Secret, sa2.Name)
+				verifyCreatedSATokenSecret(sa1Secret, sa1.Name)
 			})
 		})
 
@@ -479,8 +476,8 @@ var _ = Describe("Secrets", func() {
 })
 
 func verifyCASecret(name string, secret *corev1.Secret, dataMatcher gomegatypes.GomegaMatcher) {
-	Expect(secret.Immutable).To(PointTo(BeTrue()))
-	Expect(secret.Labels).To(And(
+	ExpectWithOffset(1, secret.Immutable).To(PointTo(BeTrue()))
+	ExpectWithOffset(1, secret.Labels).To(And(
 		HaveKeyWithValue("name", name),
 		HaveKeyWithValue("managed-by", "secrets-manager"),
 		HaveKeyWithValue("manager-identity", fakesecretsmanager.ManagerIdentity),
@@ -491,7 +488,7 @@ func verifyCASecret(name string, secret *corev1.Secret, dataMatcher gomegatypes.
 	))
 
 	if dataMatcher != nil {
-		Expect(secret.Data).To(dataMatcher)
+		ExpectWithOffset(1, secret.Data).To(dataMatcher)
 	}
 }
 
@@ -499,7 +496,7 @@ func rawData(key, value string) []byte {
 	return []byte(`{"` + key + `":"` + utils.EncodeBase64([]byte(value)) + `"}`)
 }
 
-func verifySATokenSecret(secret *corev1.Secret, serviceAccountName string) {
-	Expect(secret.Type).To(Equal(corev1.SecretTypeServiceAccountToken))
-	Expect(secret.Annotations).To(HaveKeyWithValue("kubernetes.io/service-account.name", serviceAccountName))
+func verifyCreatedSATokenSecret(secret *corev1.Secret, serviceAccountName string) {
+	ExpectWithOffset(1, secret.Type).To(Equal(corev1.SecretTypeServiceAccountToken))
+	ExpectWithOffset(1, secret.Annotations).To(HaveKeyWithValue("kubernetes.io/service-account.name", serviceAccountName))
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bug

**What this PR does / why we need it**:
This PR improves the `{CreateNew,DeleteOld}ServiceAccountSecrets` functions such that orphaning of old `ServiceAccount` secrets after signing key rotation is prevented. This can happen if the user removes the `credentials.gardener.cloud/key-name` before phase 2. Earlier, the `gardenlet` would consider `ServiceAccount`s without the proper label as "already handled" which could have led to orphaned secrets.

**Which issue(s) this PR fixes**:
Part of #3292

**Special notes for your reviewer**:
- `ServiceAccount` signing key rotation was initially introduced with #5968.
- This (manually removal of the `credentials.gardener.cloud/key-name` label) is not a concern for the ETCD encryption key rotation since this anyways is the desired behaviour in phase 2.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug has been fixed which could have caused orphaned `ServiceAccount` token `Secret`s after the rotation of the signing key.
```
