### PR TITLE
Perform snapshot of ETCD after secrets got encrypted with new key

### DIFF
--- a/pkg/operation/botanist/kubeapiserver.go
+++ b/pkg/operation/botanist/kubeapiserver.go
@@ -334,7 +334,10 @@ func (b *Botanist) computeKubeAPIServerServerCertificateConfig() kubeapiserver.S
 	}
 }
 
-const annotationKeyNewEncryptionKeyPopulated = "credentials.gardener.cloud/new-encryption-key-populated"
+const (
+	annotationKeyNewEncryptionKeyPopulated = "credentials.gardener.cloud/new-encryption-key-populated"
+	annotationKeyEtcdSnapshotted           = "credentials.gardener.cloud/etcd-snapshotted"
+)
 
 func (b *Botanist) computeKubeAPIServerETCDEncryptionConfig(ctx context.Context) (kubeapiserver.ETCDEncryptionConfig, error) {
 	config := kubeapiserver.ETCDEncryptionConfig{

--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -36,6 +36,7 @@ import (
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 
 	"golang.org/x/time/rate"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -554,32 +555,64 @@ func (b *Botanist) DeleteOldServiceAccountSecrets(ctx context.Context) error {
 // RewriteSecretsAddLabel patches all secrets in all namespaces in the shoot clusters and adds a label whose value is
 // the name of the current ETCD encryption key secret. This function is useful for the ETCD encryption key secret
 // rotation which requires all secrets to be rewritten to ETCD so that they become encrypted with the new key.
+// After it's done, it snapshots ETCD so that we can restore backups in case we lose the cluster before the next
+// incremental snapshot is taken.
 func (b *Botanist) RewriteSecretsAddLabel(ctx context.Context) error {
 	etcdEncryptionKeySecret, found := b.SecretsManager.Get(v1beta1constants.SecretNameETCDEncryptionKey, secretsmanager.Current)
 	if !found {
 		return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameETCDEncryptionKey)
 	}
 
-	return b.rewriteSecrets(
+	if err := b.rewriteSecrets(
 		ctx,
 		utils.MustNewRequirement(labelKeyRotationKeyName, selection.NotEquals, etcdEncryptionKeySecret.Name),
 		func(objectMeta *metav1.ObjectMeta) {
 			metav1.SetMetaDataLabel(objectMeta, labelKeyRotationKeyName, etcdEncryptionKeySecret.Name)
 		},
-	)
+	); err != nil {
+		return err
+	}
+
+	// Check if we have to snapshot ETCD now that we have rewritten all secrets.
+	meta := &metav1.PartialObjectMetadata{}
+	meta.SetGroupVersionKind(appsv1.SchemeGroupVersion.WithKind("Deployment"))
+	if err := b.K8sSeedClient.Client().Get(ctx, kutil.Key(b.Shoot.SeedNamespace, v1beta1constants.DeploymentNameKubeAPIServer), meta); err != nil {
+		return err
+	}
+
+	if metav1.HasAnnotation(meta.ObjectMeta, annotationKeyEtcdSnapshotted) {
+		return nil
+	}
+
+	if err := b.SnapshotEtcd(ctx); err != nil {
+		return err
+	}
+
+	// If we have hit this point then we have snapshotted ETCD successfully. Now we can mark this step as "completed"
+	// (via an annotation) so that we do not trigger a snapshot again in a future reconciliation in case the current one
+	// fails after this step.
+	return b.patchKubeAPIServerDeploymentMeta(ctx, func(meta *metav1.PartialObjectMetadata) {
+		metav1.SetMetaDataAnnotation(&meta.ObjectMeta, annotationKeyEtcdSnapshotted, "true")
+	})
 }
 
 // RewriteSecretsRemoveLabel patches all secrets in all namespaces in the shoot clusters and removes the label whose
 // value is the name of the current ETCD encryption key secret. This function is useful for the ETCD encryption key
 // secret rotation which requires all secrets to be rewritten to ETCD so that they become encrypted with the new key.
 func (b *Botanist) RewriteSecretsRemoveLabel(ctx context.Context) error {
-	return b.rewriteSecrets(
+	if err := b.rewriteSecrets(
 		ctx,
 		utils.MustNewRequirement(labelKeyRotationKeyName, selection.Exists),
 		func(objectMeta *metav1.ObjectMeta) {
 			delete(objectMeta.Labels, labelKeyRotationKeyName)
 		},
-	)
+	); err != nil {
+		return err
+	}
+
+	return b.patchKubeAPIServerDeploymentMeta(ctx, func(meta *metav1.PartialObjectMetadata) {
+		delete(meta.Annotations, annotationKeyEtcdSnapshotted)
+	})
 }
 
 func (b *Botanist) rewriteSecrets(ctx context.Context, requirement labels.Requirement, mutateObjectMeta func(*metav1.ObjectMeta)) error {

--- a/pkg/operation/botanist/secrets_test.go
+++ b/pkg/operation/botanist/secrets_test.go
@@ -477,7 +477,7 @@ var _ = Describe("Secrets", func() {
 				ctrl.Finish()
 			})
 
-			It("should patch all secrets and add the label if not already done", func() {
+			It("should create a snapshot of ETCD and annotate kube-apiserver accordingly", func() {
 				etcdMain.EXPECT().Snapshot(ctx, gomock.Any())
 
 				Expect(botanist.SnapshotETCDAfterRewritingSecrets(ctx)).To(Succeed())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
After all `Secret`s were rewritten (i.e., encrypted with the new key), we now perform a full snapshot of ETCD. This is to make restoring from backup possible in case we lose the cluster until the next incremental snapshot would have been taken.

Similar how we "remember" that we have already populated the new key (ref https://github.com/gardener/gardener/pull/6021/commits/4af3bc44414571d7449b753345262977bf676922), with the same approach we now "remember" that we have taken a full snapshot to prevent doing it more often than necessary.

**Which issue(s) this PR fixes**:
Part of #3292

**Special notes for your reviewer**:
ETCD encryption key rotation was initially introduced with #6021.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
A full snapshot of `etcd-main` is now triggered after all `Secret` were encrypted with the new key after ETCD encryption key rotation.
```
