### PR TITLE
Validate `(maintenance.)gardener.cloud/operation` annotations

### DIFF
--- a/docs/usage/shoot_maintenance.md
+++ b/docs/usage/shoot_maintenance.md
@@ -78,7 +78,7 @@ If you hibernate or wake-up your shoot then Gardener gets active right away.
 
 ## Shoot Operations
 
-In case you would like to perform certain [shoot operations](shoot_operations.md) (e.g., credentials rotation) during your maintenance time window, you can annotate the `Shoot` with
+In case you would like to perform a [shoot credential rotation](shoot_operations.md#credentials-rotation-operations) or a `reconcile` operation during your maintenance time window, you can annotate the `Shoot` with
 
 ```
 maintenance.gardener.cloud/operation=<operation>

--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -1660,31 +1660,3 @@ func MutateShootETCDEncryptionKeyRotation(shoot *gardencorev1beta1.Shoot, f func
 
 	f(shoot.Status.Credentials.Rotation.ETCDEncryptionKey)
 }
-
-// IsValidShootOperation checks whether the provided operation annotation value is valid. It returns two bools: The
-// first value specifies whether it's valid, and the second bool value specifies whether the gardener-apiserver removes
-// the annotation before the Shoot is persisted to etcd.
-func IsValidShootOperation(operation string, lastOperation *gardencorev1beta1.LastOperation) (isValid bool) {
-	if lastOperation != nil && lastOperation.State == gardencorev1beta1.LastOperationStateFailed {
-		return operation == v1beta1constants.ShootOperationRetry
-	}
-
-	switch operation {
-	case v1beta1constants.GardenerOperationReconcile,
-		v1beta1constants.ShootOperationRotateCredentialsStart,
-		v1beta1constants.ShootOperationRotateCredentialsComplete,
-		v1beta1constants.ShootOperationRotateKubeconfigCredentials,
-		v1beta1constants.ShootOperationRotateObservabilityCredentials,
-		v1beta1constants.ShootOperationRotateSSHKeypair,
-		v1beta1constants.ShootOperationRotateCAStart,
-		v1beta1constants.ShootOperationRotateCAComplete,
-		v1beta1constants.ShootOperationRotateServiceAccountKeyStart,
-		v1beta1constants.ShootOperationRotateServiceAccountKeyComplete,
-		v1beta1constants.ShootOperationRotateETCDEncryptionKeyStart,
-		v1beta1constants.ShootOperationRotateETCDEncryptionKeyComplete:
-		return true
-
-	default:
-		return false
-	}
-}

--- a/pkg/apis/core/v1beta1/helper/helper_test.go
+++ b/pkg/apis/core/v1beta1/helper/helper_test.go
@@ -2429,24 +2429,6 @@ var _ = Describe("helper", func() {
 		Entry("etcdEncryptionKey nil", &gardencorev1beta1.Shoot{Status: gardencorev1beta1.ShootStatus{Credentials: &gardencorev1beta1.ShootCredentials{Rotation: &gardencorev1beta1.ShootCredentialsRotation{}}}}, gardencorev1beta1.RotationCompleting),
 		Entry("etcdEncryptionKey non-nil", &gardencorev1beta1.Shoot{Status: gardencorev1beta1.ShootStatus{Credentials: &gardencorev1beta1.ShootCredentials{Rotation: &gardencorev1beta1.ShootCredentialsRotation{ETCDEncryptionKey: &gardencorev1beta1.ShootETCDEncryptionKeyRotation{}}}}}, gardencorev1beta1.RotationCompleting),
 	)
-
-	DescribeTable("#IsValidShootOperation",
-		func(operation string, lastOperation *gardencorev1beta1.LastOperation, expectedIsValid bool) {
-			Expect(IsValidShootOperation(operation, lastOperation)).To(Equal(expectedIsValid))
-		},
-
-		Entry("last operation empty", "retry", nil, false),
-		Entry("last operation failed, retry", "retry", &gardencorev1beta1.LastOperation{State: gardencorev1beta1.LastOperationStateFailed}, true),
-		Entry("last operation failed, reconcile", "reconcile", &gardencorev1beta1.LastOperation{State: gardencorev1beta1.LastOperationStateFailed}, false),
-		Entry("last operation not failed, reconcile", "reconcile", &gardencorev1beta1.LastOperation{}, true),
-		Entry("last operation not failed, rotate-kubeconfig-credentials", "rotate-kubeconfig-credentials", &gardencorev1beta1.LastOperation{}, true),
-		Entry("last operation not failed, rotate-observability-credentials", "rotate-observability-credentials", &gardencorev1beta1.LastOperation{}, true),
-		Entry("last operation not failed, rotate-ssh-keypair", "rotate-ssh-keypair", &gardencorev1beta1.LastOperation{}, true),
-		Entry("last operation not failed, rotate-ca-start", "rotate-ca-start", &gardencorev1beta1.LastOperation{}, true),
-		Entry("last operation not failed, rotate-ca-complete", "rotate-ca-complete", &gardencorev1beta1.LastOperation{}, true),
-		Entry("last operation not failed, rotate-serviceaccount-key-start", "rotate-serviceaccount-key-start", &gardencorev1beta1.LastOperation{}, true),
-		Entry("last operation not failed, rotate-serviceaccount-key-complete", "rotate-serviceaccount-key-complete", &gardencorev1beta1.LastOperation{}, true),
-	)
 })
 
 func timePointer(t time.Time) *metav1.Time {

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -78,8 +78,8 @@ var (
 		string(v1beta1constants.ShootOperationRotateKubeconfigCredentials),
 		string(v1beta1constants.ShootOperationRotateObservabilityCredentials),
 		string(v1beta1constants.ShootOperationRotateSSHKeypair),
-		string(v1beta1constants.ShootOperationRotateServiceAccountKeyComplete),
 		string(v1beta1constants.ShootOperationRotateServiceAccountKeyStart),
+		string(v1beta1constants.ShootOperationRotateServiceAccountKeyComplete),
 	)
 	availableShootPurposes = sets.NewString(
 		string(core.ShootPurposeEvaluation),

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -3449,6 +3449,33 @@ var _ = Describe("Shoot Validation Tests", func() {
 					},
 				}),
 			)
+
+			It("should return an error if the annotation is invalid", func() {
+				metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "gardener.cloud/operation", "foo-bar")
+				matcher := ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeNotSupported),
+					"Field": Equal("metadata.annotations[gardener.cloud/operation]"),
+				})))
+				Expect(ValidateShoot(shoot)).To(matcher)
+			})
+		})
+
+		Context("maintenance operation validation", func() {
+			It("should do nothing if the operation annotation is not set", func() {
+				Expect(ValidateShoot(shoot)).To(BeEmpty())
+			})
+			It("should return an error if the annotation is invalid", func() {
+				metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "maintenance.gardener.cloud/operation", "foo-bar")
+				matcher := ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeNotSupported),
+					"Field": Equal("metadata.annotations[maintenance.gardener.cloud/operation]"),
+				})))
+				Expect(ValidateShoot(shoot)).To(matcher)
+			})
+			It("should return nothing if annotation is valid", func() {
+				metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "maintenance.gardener.cloud/operation", "reconcile")
+				Expect(ValidateShoot(shoot)).To(BeEmpty())
+			})
 		})
 	})
 

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -2721,14 +2721,14 @@ var _ = Describe("Shoot Validation Tests", func() {
 					defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.ShootCARotation, true)()
 					defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.ShootSARotation, true)()
 
-					metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "gardener.cloud/operation", "rotate-credentials-complete")
+					metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "maintenance.gardener.cloud/operation", "rotate-credentials-complete")
 					shoot.Status = status
 
 					matcher := BeEmpty()
 					if !allowed {
 						matcher = ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 							"Type":  Equal(field.ErrorTypeForbidden),
-							"Field": Equal("metadata.annotations[gardener.cloud/operation]"),
+							"Field": Equal("metadata.annotations[maintenance.gardener.cloud/operation]"),
 						})))
 					}
 
@@ -2928,14 +2928,14 @@ var _ = Describe("Shoot Validation Tests", func() {
 			DescribeTable("starting CA rotation",
 				func(allowed bool, status core.ShootStatus) {
 					defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.ShootCARotation, true)()
-					metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "gardener.cloud/operation", "rotate-ca-start")
+					metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "maintenance.gardener.cloud/operation", "rotate-ca-start")
 					shoot.Status = status
 
 					matcher := BeEmpty()
 					if !allowed {
 						matcher = ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 							"Type":  Equal(field.ErrorTypeForbidden),
-							"Field": Equal("metadata.annotations[gardener.cloud/operation]"),
+							"Field": Equal("metadata.annotations[maintenance.gardener.cloud/operation]"),
 						})))
 					}
 
@@ -3215,14 +3215,14 @@ var _ = Describe("Shoot Validation Tests", func() {
 			DescribeTable("completing service account key rotation",
 				func(allowed bool, status core.ShootStatus) {
 					defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.ShootSARotation, true)()
-					metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "gardener.cloud/operation", "rotate-serviceaccount-key-complete")
+					metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "maintenance.gardener.cloud/operation", "rotate-serviceaccount-key-complete")
 					shoot.Status = status
 
 					matcher := BeEmpty()
 					if !allowed {
 						matcher = ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 							"Type":  Equal(field.ErrorTypeForbidden),
-							"Field": Equal("metadata.annotations[gardener.cloud/operation]"),
+							"Field": Equal("metadata.annotations[maintenance.gardener.cloud/operation]"),
 						})))
 					}
 
@@ -3281,14 +3281,14 @@ var _ = Describe("Shoot Validation Tests", func() {
 
 			DescribeTable("starting ETCD encryption key rotation",
 				func(allowed bool, status core.ShootStatus) {
-					metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "gardener.cloud/operation", "rotate-etcd-encryption-key-start")
+					metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "maintenance.gardener.cloud/operation", "rotate-etcd-encryption-key-start")
 					shoot.Status = status
 
 					matcher := BeEmpty()
 					if !allowed {
 						matcher = ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 							"Type":  Equal(field.ErrorTypeForbidden),
-							"Field": Equal("metadata.annotations[gardener.cloud/operation]"),
+							"Field": Equal("metadata.annotations[maintenance.gardener.cloud/operation]"),
 						})))
 					}
 

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -3450,7 +3450,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				}),
 			)
 
-			It("should return an error if the annotation is invalid", func() {
+			It("should return an error if the reconciliation operation annotation is invalid", func() {
 				metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "gardener.cloud/operation", "foo-bar")
 				matcher := ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeNotSupported),
@@ -3459,7 +3459,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Expect(ValidateShoot(shoot)).To(matcher)
 			})
 
-			It("should return an error if the annotation is invalid", func() {
+			It("should return an error if the maintenance operation annotation is invalid", func() {
 				metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "maintenance.gardener.cloud/operation", "foo-bar")
 				matcher := ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeNotSupported),

--- a/pkg/controllermanager/controller/shoot/shoot_maintenance_control.go
+++ b/pkg/controllermanager/controller/shoot/shoot_maintenance_control.go
@@ -396,7 +396,7 @@ func getOperation(shoot *gardencorev1beta1.Shoot) string {
 		maintenanceOperation = shoot.Annotations[v1beta1constants.GardenerMaintenanceOperation]
 	)
 
-	if gardencorev1beta1helper.IsValidShootOperation(maintenanceOperation, shoot.Status.LastOperation) {
+	if maintenanceOperation != "" {
 		operation = maintenanceOperation
 	}
 

--- a/pkg/registry/core/shoot/strategy.go
+++ b/pkg/registry/core/shoot/strategy.go
@@ -114,8 +114,7 @@ func mustIncreaseGeneration(oldShoot, newShoot *core.Shoot) bool {
 			mustRemoveOperationAnnotation bool
 		)
 
-		// TODO(rfranzke): After promotion and removal of `Shoot{C,S}ARotation` feature gates, consider using a function
-		//  similar to gardencorev1beta1helper.IsValidShootOperation.
+		// TODO(rfranzke): After promotion and removal of `Shoot{C,S}ARotation` feature gates, consider using a function.
 		switch lastOperation.State {
 		case core.LastOperationStateFailed:
 			if val, ok := newShoot.Annotations[v1beta1constants.GardenerOperation]; ok && val == v1beta1constants.ShootOperationRetry {

--- a/test/integration/controllermanager/shootmaintenance/maintenance_control_test.go
+++ b/test/integration/controllermanager/shootmaintenance/maintenance_control_test.go
@@ -20,6 +20,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -296,7 +297,8 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 				By("prepare shoot")
 				patch := client.MergeFrom(shoot.DeepCopy())
 				metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "maintenance.gardener.cloud/operation", "foo-bar-does-not-exist")
-				Expect(testClient.Patch(ctx, shoot, patch)).To(Succeed())
+				err := testClient.Patch(ctx, shoot, patch)
+				Expect(apierrors.IsInvalid(err)).To(Equal(true))
 
 				By("trigger maintenance")
 				Expect(kutil.SetAnnotationAndUpdate(ctx, testClient, shoot, v1beta1constants.GardenerOperation, v1beta1constants.ShootOperationMaintain)).To(Succeed())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
Shoot annotations `gardener.cloud/operation` and `maintenance.gardener.cloud/operation` are not checked for valid operations yet. Thus, the user does not get immediate feedback if the annotated operations are valid.
This PR adds validations for the respective annotations in apiserver.

**Which issue(s) this PR fixes**:
Fixes #6058 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
When annotating shoots with `gardener.cloud/operation` or `maintenance.gardener.cloud/operation` apiserver now validates if the respective operations are supported. 
```
