### PR TITLE
[provider-local] Add support for `PersistentVolumeClaim`s in local shoot clusters

### DIFF
--- a/charts/gardener/provider-local/internal/shoot-storageclasses/Chart.yaml
+++ b/charts/gardener/provider-local/internal/shoot-storageclasses/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: A Helm chart for storageclasses that should be installed to the shoot
+name: shoot-storageclasses
+version: 0.1.0

--- a/charts/gardener/provider-local/internal/shoot-storageclasses/templates/storageclasses.yaml
+++ b/charts/gardener/provider-local/internal/shoot-storageclasses/templates/storageclasses.yaml
@@ -1,0 +1,9 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: standard
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: rancher.io/local-path
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer

--- a/charts/gardener/provider-local/internal/shoot-system-components/Chart.yaml
+++ b/charts/gardener/provider-local/internal/shoot-system-components/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: An umbrella chart for control plane resources in the Shoot cluster
+name: shoot-system-components
+version: 0.1.0

--- a/charts/gardener/provider-local/internal/shoot-system-components/charts/local-path-provisioner/Chart.yaml
+++ b/charts/gardener/provider-local/internal/shoot-system-components/charts/local-path-provisioner/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: Helm chart for local-path-provisioner
+name: local-path-provisioner
+version: 0.1.0

--- a/charts/gardener/provider-local/internal/shoot-system-components/charts/local-path-provisioner/templates/clusterrole.yaml
+++ b/charts/gardener/provider-local/internal/shoot-system-components/charts/local-path-provisioner/templates/clusterrole.yaml
@@ -1,0 +1,38 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: local-path-provisioner
+rules:
+- apiGroups:
+    - ""
+  resources:
+    - nodes
+    - persistentvolumeclaims
+    - configmaps
+  verbs:
+    - get
+    - list
+    - watch
+- apiGroups:
+    - ""
+  resources:
+    - endpoints
+    - persistentvolumes
+    - pods
+  verbs:
+    - '*'
+- apiGroups:
+    - ""
+  resources:
+    - events
+  verbs:
+    - create
+    - patch
+- apiGroups:
+    - storage.k8s.io
+  resources:
+    - storageclasses
+  verbs:
+    - get
+    - list
+    - watch

--- a/charts/gardener/provider-local/internal/shoot-system-components/charts/local-path-provisioner/templates/clusterrolebinding.yaml
+++ b/charts/gardener/provider-local/internal/shoot-system-components/charts/local-path-provisioner/templates/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: local-path-provisioner
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: local-path-provisioner
+subjects:
+- kind: ServiceAccount
+  name: local-path-provisioner-service-account
+  namespace: kube-system

--- a/charts/gardener/provider-local/internal/shoot-system-components/charts/local-path-provisioner/templates/configmap.yaml
+++ b/charts/gardener/provider-local/internal/shoot-system-components/charts/local-path-provisioner/templates/configmap.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-path-config
+  namespace: kube-system
+data:
+  config.json: |-
+    {
+      "nodePathMap":[{
+          "node":"DEFAULT_PATH_FOR_NON_LISTED_NODES",
+          "paths":["/var/lib/local-path-provisioner"]
+      }]
+    }
+  helperPod.yaml: |-
+    apiVersion: v1
+    kind: Pod
+    metadata:
+      name: helper-pod
+    spec:
+      containers:
+      - name: helper-pod
+        image: {{ index .Values.images "local-path-helper" }}
+        imagePullPolicy: IfNotPresent
+  setup: |-
+    #!/bin/sh
+    set -eu
+    mkdir -m 0777 -p "$VOL_DIR"
+  teardown: |-
+    #!/bin/sh
+    set -eu
+    rm -rf "$VOL_DIR"

--- a/charts/gardener/provider-local/internal/shoot-system-components/charts/local-path-provisioner/templates/deployment.yaml
+++ b/charts/gardener/provider-local/internal/shoot-system-components/charts/local-path-provisioner/templates/deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: local-path-provisioner
+  namespace: kube-system
+spec:
+  replicas: 1
+  revisionHistoryLimit: 2
+  selector:
+    matchLabels:
+      app: local-path-provisioner
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: local-path-provisioner
+    spec:
+      serviceAccountName: local-path-provisioner-service-account
+      containers:
+        - name: local-path-provisioner
+          image: {{ index .Values.images "local-path-provisioner" }}
+          imagePullPolicy: IfNotPresent
+          command:
+            - local-path-provisioner
+            - --debug
+            - start
+            - --helper-image
+            - {{ index .Values.images "local-path-helper" }}
+            - --config
+            - /etc/config/config.json
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.namespace
+          volumeMounts:
+            - mountPath: /etc/config/
+              name: config-volume
+      volumes:
+        - configMap:
+            defaultMode: 420
+            name: local-path-config
+          name: config-volume

--- a/charts/gardener/provider-local/internal/shoot-system-components/charts/local-path-provisioner/templates/serviceaccount.yaml
+++ b/charts/gardener/provider-local/internal/shoot-system-components/charts/local-path-provisioner/templates/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: local-path-provisioner-service-account
+  namespace: kube-system
+automountServiceAccountToken: false

--- a/charts/gardener/provider-local/internal/shoot-system-components/charts/local-path-provisioner/values.yaml
+++ b/charts/gardener/provider-local/internal/shoot-system-components/charts/local-path-provisioner/values.yaml
@@ -1,0 +1,3 @@
+images:
+  local-path-provisioner: image-repository:image-tag
+  local-path-helper: image-repository:image-tag

--- a/charts/gardener/provider-local/internal/shoot-system-components/requirements.yaml
+++ b/charts/gardener/provider-local/internal/shoot-system-components/requirements.yaml
@@ -1,0 +1,4 @@
+dependencies:
+- name: local-path-provisioner
+  repository: http://localhost:10191
+  version: 0.1.0

--- a/pkg/provider-local/controller/controlplane/add.go
+++ b/pkg/provider-local/controller/controlplane/add.go
@@ -51,7 +51,7 @@ type AddOptions struct {
 func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 	return controlplane.Add(mgr, controlplane.AddArgs{
 		Actuator: genericactuator.NewActuator(local.Name, getSecretConfigs, nil, nil, nil, nil, nil, controlPlaneShootChart,
-			nil, nil, nil, NewValuesProvider(), extensionscontroller.ChartRendererFactoryFunc(util.NewChartRendererForShoot),
+			nil, storageClassChart, nil, NewValuesProvider(), extensionscontroller.ChartRendererFactoryFunc(util.NewChartRendererForShoot),
 			imagevector.ImageVector(), "", opts.ShootWebhookConfig, mgr.GetWebhookServer().Port, logger),
 		ControllerOptions: opts.Controller,
 		Predicates:        controlplane.DefaultPredicates(opts.IgnoreOperationAnnotation),

--- a/pkg/provider-local/controller/controlplane/add.go
+++ b/pkg/provider-local/controller/controlplane/add.go
@@ -50,7 +50,7 @@ type AddOptions struct {
 // The opts.Reconciler is being set with a newly instantiated actuator.
 func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) error {
 	return controlplane.Add(mgr, controlplane.AddArgs{
-		Actuator: genericactuator.NewActuator(local.Name, getSecretConfigs, nil, nil, nil, nil, nil, nil,
+		Actuator: genericactuator.NewActuator(local.Name, getSecretConfigs, nil, nil, nil, nil, nil, controlPlaneShootChart,
 			nil, nil, nil, NewValuesProvider(), extensionscontroller.ChartRendererFactoryFunc(util.NewChartRendererForShoot),
 			imagevector.ImageVector(), "", opts.ShootWebhookConfig, mgr.GetWebhookServer().Port, logger),
 		ControllerOptions: opts.Controller,

--- a/pkg/provider-local/controller/controlplane/valuesprovider.go
+++ b/pkg/provider-local/controller/controlplane/valuesprovider.go
@@ -15,11 +15,14 @@
 package controlplane
 
 import (
+	"path/filepath"
 	"time"
 
 	"github.com/gardener/gardener/extensions/pkg/controller/controlplane/genericactuator"
 	extensionssecretsmanager "github.com/gardener/gardener/extensions/pkg/util/secret/manager"
+	localimagevector "github.com/gardener/gardener/pkg/provider-local/imagevector"
 	"github.com/gardener/gardener/pkg/provider-local/local"
+	"github.com/gardener/gardener/pkg/utils/chart"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	secretutils "github.com/gardener/gardener/pkg/utils/secrets"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
@@ -75,3 +78,19 @@ func getSecretConfigs(namespace string) []extensionssecretsmanager.SecretConfigW
 		},
 	}
 }
+
+var (
+	controlPlaneShootChart = &chart.Chart{
+		Name: "shoot-system-components",
+		Path: filepath.Join(local.InternalChartsPath, "shoot-system-components"),
+		SubCharts: []*chart.Chart{
+			{
+				Name: "local-path-provisioner",
+				Images: []string{
+					localimagevector.ImageNameLocalPathProvisioner,
+					localimagevector.ImageNameLocalPathHelper,
+				},
+			},
+		},
+	}
+)

--- a/pkg/provider-local/controller/controlplane/valuesprovider.go
+++ b/pkg/provider-local/controller/controlplane/valuesprovider.go
@@ -93,4 +93,9 @@ var (
 			},
 		},
 	}
+
+	storageClassChart = &chart.Chart{
+		Name: "shoot-storageclasses",
+		Path: filepath.Join(local.InternalChartsPath, "shoot-storageclasses"),
+	}
 )

--- a/pkg/provider-local/controller/worker/machine_controller_manager.go
+++ b/pkg/provider-local/controller/worker/machine_controller_manager.go
@@ -16,7 +16,6 @@ package worker
 
 import (
 	"context"
-	"fmt"
 	"path/filepath"
 
 	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
@@ -28,7 +27,6 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	rbacv1 "k8s.io/api/rbac/v1"
 )
 
 var (
@@ -49,10 +47,6 @@ var (
 	mcmShootChart = &chart.Chart{
 		Name: local.MachineControllerManagerName,
 		Path: filepath.Join(local.InternalChartsPath, local.MachineControllerManagerName, "shoot"),
-		Objects: []*chart.Object{
-			{Type: &rbacv1.ClusterRole{}, Name: fmt.Sprintf("extensions.gardener.cloud:%s:%s", local.Name, local.MachineControllerManagerName)},
-			{Type: &rbacv1.ClusterRoleBinding{}, Name: fmt.Sprintf("extensions.gardener.cloud:%s:%s", local.Name, local.MachineControllerManagerName)},
-		},
 	}
 )
 

--- a/pkg/provider-local/imagevector/images.go
+++ b/pkg/provider-local/imagevector/images.go
@@ -21,6 +21,10 @@ package imagevector
 const (
 	// ImageNameKindnet is a constant for an image in the image vector with name 'kindnet'.
 	ImageNameKindnet = "kindnet"
+	// ImageNameLocalPathHelper is a constant for an image in the image vector with name 'local-path-helper'.
+	ImageNameLocalPathHelper = "local-path-helper"
+	// ImageNameLocalPathProvisioner is a constant for an image in the image vector with name 'local-path-provisioner'.
+	ImageNameLocalPathProvisioner = "local-path-provisioner"
 	// ImageNameMachineControllerManager is a constant for an image in the image vector with name 'machine-controller-manager'.
 	ImageNameMachineControllerManager = "machine-controller-manager"
 	// ImageNameMachineControllerManagerProviderLocal is a constant for an image in the image vector with name 'machine-controller-manager-provider-local'.

--- a/pkg/provider-local/imagevector/images.yaml
+++ b/pkg/provider-local/imagevector/images.yaml
@@ -11,3 +11,11 @@ images:
   sourceRepository: github.com/kubernetes-sigs/kind
   repository: docker.io/kindest/kindnetd
   tag: v20210326-1e038dc5
+- name: local-path-provisioner
+  sourceRepository: github.com/kubernetes-sigs/kind/tree/main/images/local-path-provisioner
+  repository: docker.io/kindest/local-path-provisioner
+  tag: v0.0.22-kind.0
+- name: local-path-helper
+  sourceRepository: github.com/kubernetes-sigs/kind/tree/main/images/local-path-helper
+  repository: docker.io/kindest/local-path-helper
+  tag: v20220512-507ff70b


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bug

**What this PR does / why we need it**:
This PR adds support for `PersistentVolumeClaim`s for local shoot clusters by making the `ControlPlane` controller

- deploying the `local-path-provisioner`
  Similar to what kind does to provide PVCs, the `ControlPlane` controller of `provider-local` now deploys the `local-path-provisioner` (see https://github.com/rancher/local-path-provisioner) with the exact same manifests/configuration.
  Note that the name of the `ServiceAccount` and `ConfigMap` are hard-coded in the `local-path-provisioner` code, so they cannot be renamed (I tried just naming them `local-path-provisioner` like all the other resources).
- deploying a `StorageClass`
  Again, same `StorageClass` like in kind.

On the way, I cleaned up the definition of the `mcmShootChart` in `provider-local`.

You can test creating a PVC for a local shoot with the following manifest:

```yaml
---
kind: PersistentVolumeClaim
apiVersion: v1
metadata:
  name: task-pv-claim
spec:
  accessModes:
  - ReadWriteOnce
  resources:
    requests:
      storage: 20Gi
---
kind: Pod
apiVersion: v1
metadata:
  name: task-pv-pod
spec:
  volumes:
  - name: task-pv-storage
    persistentVolumeClaim:
      claimName: task-pv-claim
  containers:
  - name: task-pv-container
    image: nginx
    ports:
      - containerPort: 80
        name: "http-server"
    volumeMounts:
      - mountPath: "/usr/share/nginx/html"
        name: task-pv-storage
```

**Special notes for your reviewer**:
/cc @timebertt

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
NONE
```