### PR TITLE
Extend `serviceaccountmanager` docu to cover kubectl 1.24

### DIFF
--- a/docs/usage/project_namespace_access.md
+++ b/docs/usage/project_namespace_access.md
@@ -13,7 +13,12 @@ kubectl -n project-abc create sa robot-user
 ### Request a token for a Service Account
 A token for the "robot-user" `ServiceAccount` can be requested via the [TokenRequest API](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-request-v1/) in several ways:
 
-- using `kubectl`
+- using `kubectl` >= v1.24
+```bash
+kubectl -n project-abc create token robot-user --duration=3600s
+```
+
+- using `kubectl` < v1.24
 ```bash
 cat <<EOF | kubectl create -f - --raw /api/v1/namespaces/project-abc/serviceaccounts/robot-user/token
 {
@@ -24,11 +29,6 @@ cat <<EOF | kubectl create -f - --raw /api/v1/namespaces/project-abc/serviceacco
   }
 }
 EOF
-```
-
-- using `kubectl` v1.24 or later
-```bash
-kubectl -n project-abc create token robot-user --duration=3600s
 ```
 
 - directly calling the Kubernetes HTTP API

--- a/docs/usage/project_namespace_access.md
+++ b/docs/usage/project_namespace_access.md
@@ -11,9 +11,9 @@ kubectl -n project-abc create sa robot-user
 ```
 
 ### Request a token for a Service Account
-A token for the "robot-user" `ServiceAccount` can be requested via the [TokenRequest API](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-request-v1/).
+A token for the "robot-user" `ServiceAccount` can be requested via the [TokenRequest API](https://kubernetes.io/docs/reference/kubernetes-api/authentication-resources/token-request-v1/) in several ways:
 
-The request can be made with `kubectl`
+- using `kubectl`
 ```bash
 cat <<EOF | kubectl create -f - --raw /api/v1/namespaces/project-abc/serviceaccounts/robot-user/token
 {
@@ -25,7 +25,13 @@ cat <<EOF | kubectl create -f - --raw /api/v1/namespaces/project-abc/serviceacco
 }
 EOF
 ```
-or alternatively by directly calling the Kubernetes HTTP API
+
+- using `kubectl` v1.24 or later
+```bash
+kubectl -n project-abc create token robot-user --duration=3600s
+```
+
+- directly calling the Kubernetes HTTP API
 ```bash
 curl -X POST https://api.gardener/api/v1/namespaces/project-abc/serviceaccounts/robot-user/token \
     -H "Authorization: Bearer <auth-token>" \


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
This PR extends the documentation for the `serviceaccountmanager` role so that it covers the `kubectl create token` command introduced in `kubectl` v1.24

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
