### PR TITLE
Do not rely on `kube-controller-manager` removing `Secret`s from `ServiceAccount` spec

### DIFF
--- a/pkg/operation/botanist/secrets.go
+++ b/pkg/operation/botanist/secrets.go
@@ -524,11 +524,9 @@ func (b *Botanist) DeleteOldServiceAccountSecrets(ctx context.Context) error {
 				secretsToDelete = append(secretsToDelete, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: secretReference.Name, Namespace: serviceAccount.Namespace}})
 			}
 
-			patch := client.StrategicMergeFrom(serviceAccount.DeepCopy())
+			patch := client.StrategicMergeFrom(serviceAccount.DeepCopy(), client.MergeFromWithOptimisticLock{})
 			delete(serviceAccount.Labels, labelKeyRotationKeyName)
-			// No need to remove the secret from serviceAccount.Secrets since kube-controller-manager will take care of
-			// this when the token secret gets deleted from the system. Consequently, no optimistic locking required for
-			// the patch request dropping the label.
+			serviceAccount.Secrets = []corev1.ObjectReference{serviceAccount.Secrets[0]}
 
 			// Wait until we are allowed by the limiter to not overload the kube-apiserver with too many requests.
 			if err := limiter.Wait(ctx); err != nil {

--- a/pkg/operation/botanist/secrets_test.go
+++ b/pkg/operation/botanist/secrets_test.go
@@ -376,15 +376,6 @@ var _ = Describe("Secrets", func() {
 				Expect(fakeShootClient.Get(ctx, client.ObjectKeyFromObject(sa2), sa2)).To(Succeed())
 				Expect(fakeShootClient.Get(ctx, client.ObjectKeyFromObject(sa3), sa3)).To(Succeed())
 
-				Expect(fakeShootClient.Get(ctx, client.ObjectKeyFromObject(sa3OldSecret), sa3OldSecret)).To(BeNotFoundError())
-				// mimic kube-controller-manager behaviour: In reality, when a service account token secret is deleted
-				// then KCM removes it from the ServiceAccount's `.secrets[]` list. Since no KCM is running for the
-				// test, we have to mimic it here
-				sa2.Secrets = []corev1.ObjectReference{sa2.Secrets[0]}
-				Expect(fakeShootClient.Update(ctx, sa2)).To(Succeed())
-				sa3.Secrets = []corev1.ObjectReference{sa3.Secrets[0]}
-				Expect(fakeShootClient.Update(ctx, sa3)).To(Succeed())
-
 				Expect(sa1).To(Equal(sa1Copy))
 				Expect(sa2.Secrets).To(ConsistOf(corev1.ObjectReference{Name: "sa2-token" + suffix}))
 				Expect(sa3.Labels).NotTo(HaveKey("credentials.gardener.cloud/key-name"))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bug

**What this PR does / why we need it**:
We cannot rely on `kube-controller-manager` for removing the old `Secret`s from `ServiceAccount` spec since this only works when it is up and running. In case it is down while we delete old `Secret`s (meaning it cannot observe it), it does not cleanup the `ServiceAccount` spec after it came up again.

**Which issue(s) this PR fixes**:
Part of #3292

**Special notes for your reviewer**:
- `ServiceAccount` signing key rotation was initially introduced with #5968.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug has been fixed which might cause `ServiceAccount`s to still reference old static token `Secret`s after the rotation of the `ServiceAccount` signing key.
```
