### PR TITLE
Use strategic merge for patching `ShootState.Spec.Gardener`

### DIFF
--- a/pkg/gardenlet/controller/shootsecret/reconciler.go
+++ b/pkg/gardenlet/controller/shootsecret/reconciler.go
@@ -106,7 +106,7 @@ func (r *reconciler) reconcile(
 		return reconcile.Result{}, err
 	}
 
-	patch := client.MergeFromWithOptions(shootState.DeepCopy(), client.MergeFromWithOptimisticLock{})
+	patch := client.StrategicMergeFrom(shootState.DeepCopy())
 
 	dataList := gardencorev1alpha1helper.GardenerResourceDataList(shootState.Spec.Gardener)
 	dataList.Upsert(&gardencorev1alpha1.GardenerResourceData{
@@ -135,7 +135,7 @@ func (r *reconciler) delete(
 	} else {
 		log.Info("Removing Secret from ShootState and releasing its finalizer")
 
-		patch := client.MergeFromWithOptions(shootState.DeepCopy(), client.MergeFromWithOptimisticLock{})
+		patch := client.StrategicMergeFrom(shootState.DeepCopy())
 
 		dataList := gardencorev1alpha1helper.GardenerResourceDataList(shootState.Spec.Gardener)
 		dataList.Delete(secret.Name)

--- a/pkg/operation/operation.go
+++ b/pkg/operation/operation.go
@@ -565,7 +565,7 @@ func (o *Operation) SaveGardenerResourceDataInShootState(ctx context.Context, f 
 
 	shootState := o.GetShootState().DeepCopy()
 	original := shootState.DeepCopy()
-	patch := client.MergeFromWithOptions(original, client.MergeFromWithOptimisticLock{})
+	patch := client.StrategicMergeFrom(original)
 
 	if err := f(&shootState.Spec.Gardener); err != nil {
 		return err

--- a/pkg/operation/operation_test.go
+++ b/pkg/operation/operation_test.go
@@ -19,6 +19,8 @@ import (
 	"errors"
 	"time"
 
+	"k8s.io/apimachinery/pkg/types"
+
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	gardencorev1alpha1helper "github.com/gardener/gardener/pkg/apis/core/v1alpha1/helper"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -263,7 +265,7 @@ var _ = Describe("operation", func() {
 
 			shootState := o.GetShootState().DeepCopy()
 			shootState.Spec.Gardener = gardenerResourceList
-			test.EXPECTPatchWithOptimisticLock(ctx, k8sGardenRuntimeClient, shootState, o.GetShootState())
+			test.EXPECTPatch(ctx, k8sGardenRuntimeClient, shootState, o.GetShootState(), types.StrategicMergePatchType)
 
 			Expect(
 				o.SaveGardenerResourceDataInShootState(


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement

**What this PR does / why we need it**:

Previously, gardenlet used json merge patch + optimistic locking for patching `ShootState.Spec.Gardener`.
In (not so rare cases) the gardenlet secrets controller, needs to add or delete a bunch of secrets in the shootstate at the same time, e.g. during step `Cleaning no longer required secrets` in credentials rotation phase `Completing`.
Because of optimisitic locking and concurrent modifications in different workers of the controller, this leads to conflicts, exponential backoff and potentially even client-side rate-limiting. Also, ShootStates are uncached, so this causes quite some unnecessary API requests and network data transfer.

With this PR, gardenlet uses strategic merge patches for operating on `ShootState.Spec.Gardener` without optimistic locking, which avoids all conflicts.

**Which issue(s) this PR fixes**:
I suspect that this is a contributing factor to https://github.com/gardener/gardener/issues/6081.
However, I'm not sure if it will deflake the test entirely.
Nevertheless, this is a valuable improvement anyways.

**Special notes for your reviewer**:

Example: creating 10 secrets with label `persist=true` in bulk and deleting them afterwards.

Before this PR:
```
$ kcf /tmp/bulk-secrets.yaml
secret/test-secret-68g42 created
...

$ k -n shoot--local--local delete secret -l managed-by=secrets-manager,manager-identity=test
secret "test-secret-64vb8" deleted
...

$ cat dev/gardenlet-kind.log | grep 'Error syncing secret'
ts="2022-06-09T08:30:06.282+0200" level=info msg="Error syncing secret shoot--local--local/test-secret-68g42: Operation cannot be fulfilled on shootstates.core.gardener.cloud \"local\": the object has been modified; please apply your changes to the latest version and try again"
...

$ cat dev/gardenlet-kind.log | grep 'Error syncing secret' | wc -l
137
```

With this PR:
```
$ kcf /tmp/bulk-secrets.yaml
...

$ k -n shoot--local--local delete secret -l managed-by=secrets-manager,manager-identity=test
...

$ cat dev/gardenlet-kind.log | grep 'Error syncing secret' | wc -l
0
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
