### PR TITLE
fix webhook certificate reconciler in case no SeedWebhookConfig is there

### DIFF
--- a/extensions/pkg/webhook/certificates/reconciler.go
+++ b/extensions/pkg/webhook/certificates/reconciler.go
@@ -176,10 +176,12 @@ func (r *reconciler) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	}
 	log.Info("Generated webhook server cert", "serverSecretName", serverSecret.Name)
 
-	if err := r.reconcileSeedWebhookConfig(ctx, caBundleSecret); err != nil {
-		return reconcile.Result{}, fmt.Errorf("error reconciling seed webhook config: %w", err)
+	if r.SeedWebhookConfig != nil {
+		if err := r.reconcileSeedWebhookConfig(ctx, caBundleSecret); err != nil {
+			return reconcile.Result{}, fmt.Errorf("error reconciling seed webhook config: %w", err)
+		}
+		log.Info("Updated seed webhook config with new CA bundle", "webhookConfig", r.SeedWebhookConfig)
 	}
-	log.Info("Updated seed webhook config with new CA bundle", "webhookConfig", r.SeedWebhookConfig)
 
 	if r.ShootWebhookConfig != nil {
 		// update shoot webhook config object (in memory) with the freshly created CA bundle which is also used by the


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind bug

**What this PR does / why we need it**:
The PR fixes the webhook certificate reconciler. When no SeedWebhookConfig is there the reconcileSeedWebhookConfig 
 function panic'ed.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
A bug has been fixed which prevented extension controllers to register shoot webhooks only (w/o any seed webhooks).
```
