### PR TITLE
Fix a nil pointer exception on webhook registration

### DIFF
--- a/extensions/pkg/webhook/cmd/options.go
+++ b/extensions/pkg/webhook/cmd/options.go
@@ -284,8 +284,10 @@ func (c *AddToManagerConfig) AddToManager(ctx context.Context, mgr manager.Manag
 			return nil, fmt.Errorf("error generating new certificates for webhook server: %w", err)
 		}
 
-		if err := extensionswebhook.InjectCABundleIntoWebhookConfig(shootWebhookConfig, caBundle); err != nil {
-			return nil, err
+		if shootWebhookConfig != nil {
+			if err := extensionswebhook.InjectCABundleIntoWebhookConfig(shootWebhookConfig, caBundle); err != nil {
+				return nil, err
+			}
 		}
 		atomicShootWebhookConfig.Store(shootWebhookConfig.DeepCopy())
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

A nil pointer occurs when locally trying to start provider extensions e.g. by using `make start`. The error occurs because a nil pointer  is passed to https://github.com/gardener/gardener/blob/8e1f67aa80bd065523e3fed808bbe463d6d5f3b8/extensions/pkg/webhook/cmd/options.go#L287 and wrapped inside the Object interface. 

AFAIK the nil pointer is produced by https://github.com/gardener/gardener/blob/8e1f67aa80bd065523e3fed808bbe463d6d5f3b8/extensions/pkg/webhook/cmd/options.go#L260 when no shoot webhooks are configured

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix developer
Fix a bug causing nil pointer exceptions when configuring the webhook server for local development
```
