### PR TITLE
Switch test framework debug logs to info

### DIFF
--- a/test/framework/commonframework.go
+++ b/test/framework/commonframework.go
@@ -19,10 +19,11 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/gardener/gardener/pkg/logger"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
+
+	"github.com/gardener/gardener/pkg/logger"
 )
 
 var commonCfg *CommonConfig
@@ -139,7 +140,7 @@ func mergeCommonConfigs(base, overwrite *CommonConfig) *CommonConfig {
 func RegisterCommonFrameworkFlags() *CommonConfig {
 	newCfg := &CommonConfig{}
 
-	flag.StringVar(&newCfg.LogLevel, "verbose", "", "verbosity level, when set, logging level will be DEBUG")
+	flag.StringVar(&newCfg.LogLevel, "verbose", logger.InfoLevel, "verbosity level (defaults to info)")
 	flag.BoolVar(&newCfg.DisableStateDump, "disable-dump", false, "Disable the state dump if a test fails")
 
 	commonCfg = newCfg

--- a/test/framework/gardener_utils.go
+++ b/test/framework/gardener_utils.go
@@ -214,7 +214,7 @@ func (f *GardenerFramework) UpdateShoot(ctx context.Context, shoot *gardencorev1
 		}
 
 		if err := f.GardenClient.Client().Update(ctx, updatedShoot); err != nil {
-			f.Logger.Debugf("unable to update shoot %s: %s", updatedShoot.Name, err.Error())
+			f.Logger.Infof("unable to update shoot %s: %s", updatedShoot.Name, err.Error())
 			return retry.MinorError(err)
 		}
 		*shoot = *updatedShoot
@@ -318,8 +318,7 @@ func (f *GardenerFramework) WaitForShootToBeCreated(ctx context.Context, shoot *
 // WaitForShootToBeDeleted waits for the shoot to be deleted
 func (f *GardenerFramework) WaitForShootToBeDeleted(ctx context.Context, shoot *gardencorev1beta1.Shoot) error {
 	return retry.UntilTimeout(ctx, 30*time.Second, 60*time.Minute, func(ctx context.Context) (done bool, err error) {
-		updatedShoot := &gardencorev1beta1.Shoot{}
-		err = f.GardenClient.Client().Get(ctx, client.ObjectKey{Namespace: shoot.Namespace, Name: shoot.Name}, updatedShoot)
+		err = f.GardenClient.Client().Get(ctx, client.ObjectKey{Namespace: shoot.Namespace, Name: shoot.Name}, shoot)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				return retry.Ok()
@@ -327,10 +326,9 @@ func (f *GardenerFramework) WaitForShootToBeDeleted(ctx context.Context, shoot *
 			f.Logger.Infof("Error while waiting for shoot to be deleted: %s", err.Error())
 			return retry.MinorError(err)
 		}
-		*shoot = *updatedShoot
 		f.Logger.Infof("waiting for shoot %s to be deleted", shoot.Name)
 		if shoot.Status.LastOperation != nil {
-			f.Logger.Debugf("%d%%: Shoot state: %s, Description: %s", shoot.Status.LastOperation.Progress, shoot.Status.LastOperation.State, shoot.Status.LastOperation.Description)
+			f.Logger.Infof("%d%%: Shoot state: %s, Description: %s", shoot.Status.LastOperation.Progress, shoot.Status.LastOperation.State, shoot.Status.LastOperation.Description)
 		}
 		return retry.MinorError(fmt.Errorf("shoot %q still exists", shoot.Name))
 	})
@@ -339,20 +337,18 @@ func (f *GardenerFramework) WaitForShootToBeDeleted(ctx context.Context, shoot *
 // WaitForShootToBeReconciled waits for the shoot to be successfully reconciled
 func (f *GardenerFramework) WaitForShootToBeReconciled(ctx context.Context, shoot *gardencorev1beta1.Shoot) error {
 	return retry.UntilTimeout(ctx, 30*time.Second, 60*time.Minute, func(ctx context.Context) (done bool, err error) {
-		newShoot := &gardencorev1beta1.Shoot{}
-		err = f.GardenClient.Client().Get(ctx, client.ObjectKey{Namespace: shoot.Namespace, Name: shoot.Name}, newShoot)
+		err = f.GardenClient.Client().Get(ctx, client.ObjectKey{Namespace: shoot.Namespace, Name: shoot.Name}, shoot)
 		if err != nil {
 			f.Logger.Infof("Error while waiting for shoot to be reconciled: %s", err.Error())
 			return retry.MinorError(err)
 		}
-		shoot = newShoot
 		completed, msg := ShootReconciliationSuccessful(shoot)
 		if completed {
 			return retry.Ok()
 		}
 		f.Logger.Infof("Shoot %s not yet reconciled successfully (%s)", shoot.Name, msg)
-		if newShoot.Status.LastOperation != nil {
-			f.Logger.Debugf("%d%%: Shoot State: %s, Description: %s", shoot.Status.LastOperation.Progress, shoot.Status.LastOperation.State, shoot.Status.LastOperation.Description)
+		if shoot.Status.LastOperation != nil {
+			f.Logger.Infof("%d%%: Shoot State: %s, Description: %s", shoot.Status.LastOperation.Progress, shoot.Status.LastOperation.State, shoot.Status.LastOperation.Description)
 		}
 		return retry.MinorError(fmt.Errorf("shoot %q was not successfully reconciled", shoot.Name))
 	})
@@ -487,7 +483,7 @@ func (f *GardenerFramework) CreateSeed(ctx context.Context, seed *gardencorev1be
 			return retry.SevereError(err)
 		}
 		if err != nil {
-			f.Logger.Debugf("unable to create seed %s: %s", seed.Name, err.Error())
+			f.Logger.Infof("unable to create seed %s: %s", seed.Name, err.Error())
 			return retry.MinorError(err)
 		}
 		return retry.Ok()
@@ -562,7 +558,7 @@ func (f *GardenerFramework) CreateManagedSeed(ctx context.Context, managedSeed *
 			return retry.SevereError(err)
 		}
 		if err != nil {
-			f.Logger.Debugf("Could not create managed seed %s: %s", managedSeed.Name, err.Error())
+			f.Logger.Infof("Could not create managed seed %s: %s", managedSeed.Name, err.Error())
 			return retry.MinorError(err)
 		}
 		return retry.Ok()
@@ -580,7 +576,7 @@ func (f *GardenerFramework) WaitForManagedSeedToBeCreated(ctx context.Context, m
 	return retry.UntilTimeout(ctx, 30*time.Second, 60*time.Minute, func(ctx context.Context) (done bool, err error) {
 		err = f.GardenClient.Client().Get(ctx, client.ObjectKeyFromObject(managedSeed), managedSeed)
 		if err != nil {
-			f.Logger.Debugf("Could not get managed seed %s: %s", managedSeed.Name, err.Error())
+			f.Logger.Infof("Could not get managed seed %s: %s", managedSeed.Name, err.Error())
 			return retry.MinorError(err)
 		}
 		err = health.CheckManagedSeed(managedSeed)
@@ -597,7 +593,7 @@ func (f *GardenerFramework) DeleteManagedSeed(ctx context.Context, managedSeed *
 	err := retry.UntilTimeout(ctx, 20*time.Second, 5*time.Minute, func(ctx context.Context) (done bool, err error) {
 		err = f.GardenClient.Client().Delete(ctx, managedSeed)
 		if err != nil {
-			f.Logger.Debugf("Could not delete managed seed %s: %s", managedSeed.Name, err.Error())
+			f.Logger.Infof("Could not delete managed seed %s: %s", managedSeed.Name, err.Error())
 			return retry.MinorError(err)
 		}
 		return retry.Ok()
@@ -618,7 +614,7 @@ func (f *GardenerFramework) WaitForManagedSeedToBeDeleted(ctx context.Context, m
 			if apierrors.IsNotFound(err) {
 				return retry.Ok()
 			}
-			f.Logger.Debugf("Could not get managed seed %s: %s", managedSeed.Name, err.Error())
+			f.Logger.Infof("Could not get managed seed %s: %s", managedSeed.Name, err.Error())
 			return retry.MinorError(err)
 		}
 		return retry.MinorError(fmt.Errorf("managed seed %s still exists", managedSeed.Name))

--- a/test/testmachinery/system/complete_reconcile/gardener_reconcile_test.go
+++ b/test/testmachinery/system/complete_reconcile/gardener_reconcile_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Shoot reconciliation testing", func() {
 			shoots := &gardencorev1beta1.ShootList{}
 			err := f.GardenClient.Client().List(ctx, shoots)
 			if err != nil {
-				f.Logger.Debug(err.Error())
+				f.Logger.Info(err.Error())
 				return retry.MinorError(err)
 			}
 
@@ -71,13 +71,13 @@ var _ = Describe("Shoot reconciliation testing", func() {
 				// check if the last acted gardener version is the current version,
 				// to determine if the updated gardener version reconciled the shoot.
 				if shoot.Status.Gardener.Version != *gardenerVersion {
-					f.Logger.Debugf("last acted gardener version %s does not match current gardener version %s", shoot.Status.Gardener.Version, *gardenerVersion)
+					f.Logger.Infof("last acted gardener version %s does not match current gardener version %s", shoot.Status.Gardener.Version, *gardenerVersion)
 					continue
 				}
 				if completed, msg := framework.ShootReconciliationSuccessful(&shoot); completed {
 					reconciledShoots++
 				} else {
-					f.Logger.Debugf("Shoot %s not yet reconciled successfully (%s)", shoot.Name, msg)
+					f.Logger.Infof("Shoot %s not yet reconciled successfully (%s)", shoot.Name, msg)
 				}
 
 			}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:

Functions using retry mechanics with high timeouts (>1m) should log more information if things are not successful to help debugging test failures.
The framework's logger uses info level by default, so switch the logs to info level.

Related to https://github.com/gardener/gardener/issues/6016

/cc @oliver-goetz 