### PR TITLE
Introduce option to remediate problematic shoot webhooks

### DIFF
--- a/charts/gardener/gardenlet/charts/runtime/templates/_helpers.tpl
+++ b/charts/gardener/gardenlet/charts/runtime/templates/_helpers.tpl
@@ -169,6 +169,7 @@ config.yaml: |
       {{- if .Values.global.gardenlet.config.controllers.shootCare.conditionThresholds }}
 {{ toYaml .Values.global.gardenlet.config.controllers.shootCare.conditionThresholds | indent 6 }}
       {{- end }}
+      webhookRemediatorEnabled: {{ required ".Values.global.gardenlet.config.controllers.shootCare.webhookRemediatorEnabled is required" .Values.global.gardenlet.config.controllers.shootCare.webhookRemediatorEnabled }}
     seedCare:
       syncPeriod: {{ required ".Values.global.gardenlet.config.controllers.seedCare.syncPeriod is required" .Values.global.gardenlet.config.controllers.seedCare.syncPeriod }}
       conditionThresholds:

--- a/charts/gardener/gardenlet/values.yaml
+++ b/charts/gardener/gardenlet/values.yaml
@@ -105,6 +105,7 @@ global:
             duration: 1m
           - type: EveryNodeReady
             duration: 5m
+          webhookRemediatorEnabled: false
         seedCare:
           syncPeriod: 30s
           conditionThresholds:

--- a/charts/shoot-core/components/charts/apiserver-proxy/templates/apiserver-proxy-pod-mutatingwebhook.yaml
+++ b/charts/shoot-core/components/charts/apiserver-proxy/templates/apiserver-proxy-pod-mutatingwebhook.yaml
@@ -10,6 +10,7 @@ metadata:
   labels:
     gardener.cloud/role: system-component
     origin: gardener
+    remediation.webhook.shoot.gardener.cloud/exclude: true
 webhooks:
 - admissionReviewVersions:
   - v1beta1

--- a/docs/usage/shoot_status.md
+++ b/docs/usage/shoot_status.md
@@ -76,6 +76,15 @@ namespaceSelector:
 If the Shoot still has webhooks with either `failurePolicy={Fail,nil}` or `failurePolicy=Ignore && timeoutSeconds>15` that act on [critical resources](https://github.com/gardener/gardener/blob/master/pkg/operation/botanist/matchers/matcher.go#L60) in the `kube-system` namespace, Gardener will set the `HibernationPossible` to `False` indicating, that the Shoot can probably not be woken up again after hibernation without manual intervention of the Gardener Operator.
 `gardener-apiserver` will prevent any Shoot with the `HibernationPossible` constraint set to `False` from being hibernated, that is via manual hibernation as well as scheduled hibernation.
 
+> By setting `.controllers.shootCare.webhookRemediatorEnabled=true` in the gardenlet configuration, the auto-remediation of webhooks not following the best practices can be turned on in the shoot clusters.
+> Concretely, missing `namespaceSelector`s or `objectSelector`s will be added and too high `timeoutSeconds` will be lowered.
+> In some cases, the `failurePolicy` will be set from `Fail` to `Ignore`.
+> Gardenlet will also add an annotation to make it visible to end-users that their webhook configurations were mutated and should be fixed by them in the first place.
+> Note that all of this is no perfect solution and just done on a best effort basis.
+> Only the owner of the webhook can know whether it indeed is problematic and configured correctly.
+> 
+> Webhooks labeled with `remediation.webhook.shoot.gardener.cloud/exclude=true` will be excluded from auto-remediation.
+
 **`MaintenancePreconditionsSatisfied`**:
 
 This constraint indicates whether all preconditions for a safe maintenance operation are satisfied (see also [this document](shoot_maintenance.md) for more information about what happens during a shoot maintenance).

--- a/example/20-componentconfig-gardenlet.yaml
+++ b/example/20-componentconfig-gardenlet.yaml
@@ -57,6 +57,7 @@ controllers:
       duration: 1m
     - type: EveryNodeReady
       duration: 5m
+    webhookRemediatorEnabled: false
   seedCare:
     syncPeriod: 30s
     conditionThresholds:

--- a/extensions/pkg/webhook/registration.go
+++ b/extensions/pkg/webhook/registration.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"strings"
 
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/utils/kubernetes"
 
@@ -109,15 +110,21 @@ func BuildWebhookConfigs(webhooks []*Webhook, c client.Client, namespace, provid
 	// webhook config
 	if len(seedWebhooks) > 0 {
 		seedWebhookConfig = &admissionregistrationv1.MutatingWebhookConfiguration{
-			ObjectMeta: metav1.ObjectMeta{Name: NamePrefix + providerName},
-			Webhooks:   seedWebhooks,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   NamePrefix + providerName,
+				Labels: map[string]string{v1beta1constants.LabelExcludeWebhookFromRemediation: "true"},
+			},
+			Webhooks: seedWebhooks,
 		}
 	}
 
 	if len(shootWebhooks) > 0 {
 		shootWebhookConfig = &admissionregistrationv1.MutatingWebhookConfiguration{
-			ObjectMeta: metav1.ObjectMeta{Name: NamePrefix + providerName + NameSuffixShoot},
-			Webhooks:   shootWebhooks,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   NamePrefix + providerName + NameSuffixShoot,
+				Labels: map[string]string{v1beta1constants.LabelExcludeWebhookFromRemediation: "true"},
+			},
+			Webhooks: shootWebhooks,
 		}
 	}
 

--- a/extensions/pkg/webhook/registration_test.go
+++ b/extensions/pkg/webhook/registration_test.go
@@ -139,7 +139,8 @@ var _ = Describe("Registration", func() {
 
 				Expect(seedWebhookConfig).To(Equal(&admissionregistrationv1.MutatingWebhookConfiguration{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "gardener-extension-" + providerName,
+						Name:   "gardener-extension-" + providerName,
+						Labels: map[string]string{"remediation.webhook.shoot.gardener.cloud/exclude": "true"},
 					},
 					Webhooks: []admissionregistrationv1.MutatingWebhook{
 						{
@@ -183,7 +184,8 @@ var _ = Describe("Registration", func() {
 
 				Expect(shootWebhookConfig).To(Equal(&admissionregistrationv1.MutatingWebhookConfiguration{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "gardener-extension-" + providerName + "-shoot",
+						Name:   "gardener-extension-" + providerName + "-shoot",
+						Labels: map[string]string{"remediation.webhook.shoot.gardener.cloud/exclude": "true"},
 					},
 					Webhooks: []admissionregistrationv1.MutatingWebhook{
 						{

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -163,6 +163,8 @@ const (
 	GardenerPurpose = "gardener.cloud/purpose"
 	// GardenerDescription is a constant for a key in an annotation describing what the resource is used for.
 	GardenerDescription = "gardener.cloud/description"
+	// GardenerWarning is a constant for a key in an annotation containing a warning message.
+	GardenerWarning = "gardener.cloud/warning"
 
 	// GardenCreatedBy is the key for an annotation of a Shoot cluster whose value indicates contains the username
 	// of the user that created the resource.
@@ -301,6 +303,10 @@ const (
 	ShootStatus = "shoot.gardener.cloud/status"
 	// FailedShootNeedsRetryOperation is a constant for an annotation on a Shoot in a failed state indicating that a retry operation should be triggered during the next maintenance time window.
 	FailedShootNeedsRetryOperation = "maintenance.shoot.gardener.cloud/needs-retry-operation"
+	// LabelExcludeWebhookFromRemediation is a constant for a label on a webhook in the shoot which makes it being
+	// excluded from automatic remediation.
+	LabelExcludeWebhookFromRemediation = "remediation.webhook.shoot.gardener.cloud/exclude"
+
 	// ShootTasks is a constant for an annotation on a Shoot which states that certain tasks should be done.
 	ShootTasks = "shoot.gardener.cloud/tasks"
 	// ShootTaskDeployInfrastructure is a name for a Shoot's infrastructure deployment task. It indicates that the

--- a/pkg/gardenlet/apis/config/types.go
+++ b/pkg/gardenlet/apis/config/types.go
@@ -270,6 +270,10 @@ type ShootCareControllerConfiguration struct {
 	StaleExtensionHealthChecks *StaleExtensionHealthChecks
 	// ConditionThresholds defines the condition threshold per condition type.
 	ConditionThresholds []ConditionThreshold
+	// WebhookRemediatorEnabled specifies whether the remediator for webhooks not following the Kubernetes best
+	// practices (https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#best-practices-and-warnings)
+	// is enabled.
+	WebhookRemediatorEnabled *bool
 }
 
 // SeedCareControllerConfiguration defines the configuration of the SeedCare

--- a/pkg/gardenlet/apis/config/v1alpha1/types.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/types.go
@@ -338,6 +338,11 @@ type ShootCareControllerConfiguration struct {
 	// ConditionThresholds defines the condition threshold per condition type.
 	// +optional
 	ConditionThresholds []ConditionThreshold `json:"conditionThresholds,omitempty"`
+	// WebhookRemediatorEnabled specifies whether the remediator for webhooks not following the Kubernetes best
+	// practices (https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#best-practices-and-warnings)
+	// is enabled.
+	// +optional
+	WebhookRemediatorEnabled *bool `json:"webhookRemediatorEnabled,omitempty"`
 }
 
 // SeedCareControllerConfiguration defines the configuration of the SeedCare

--- a/pkg/gardenlet/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/zz_generated.conversion.go
@@ -1604,6 +1604,7 @@ func autoConvert_v1alpha1_ShootCareControllerConfiguration_To_config_ShootCareCo
 	out.SyncPeriod = (*v1.Duration)(unsafe.Pointer(in.SyncPeriod))
 	out.StaleExtensionHealthChecks = (*config.StaleExtensionHealthChecks)(unsafe.Pointer(in.StaleExtensionHealthChecks))
 	out.ConditionThresholds = *(*[]config.ConditionThreshold)(unsafe.Pointer(&in.ConditionThresholds))
+	out.WebhookRemediatorEnabled = (*bool)(unsafe.Pointer(in.WebhookRemediatorEnabled))
 	return nil
 }
 
@@ -1617,6 +1618,7 @@ func autoConvert_config_ShootCareControllerConfiguration_To_v1alpha1_ShootCareCo
 	out.SyncPeriod = (*v1.Duration)(unsafe.Pointer(in.SyncPeriod))
 	out.StaleExtensionHealthChecks = (*StaleExtensionHealthChecks)(unsafe.Pointer(in.StaleExtensionHealthChecks))
 	out.ConditionThresholds = *(*[]ConditionThreshold)(unsafe.Pointer(&in.ConditionThresholds))
+	out.WebhookRemediatorEnabled = (*bool)(unsafe.Pointer(in.WebhookRemediatorEnabled))
 	return nil
 }
 

--- a/pkg/gardenlet/apis/config/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/gardenlet/apis/config/v1alpha1/zz_generated.deepcopy.go
@@ -1178,6 +1178,11 @@ func (in *ShootCareControllerConfiguration) DeepCopyInto(out *ShootCareControlle
 		*out = make([]ConditionThreshold, len(*in))
 		copy(*out, *in)
 	}
+	if in.WebhookRemediatorEnabled != nil {
+		in, out := &in.WebhookRemediatorEnabled, &out.WebhookRemediatorEnabled
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/gardenlet/apis/config/zz_generated.deepcopy.go
+++ b/pkg/gardenlet/apis/config/zz_generated.deepcopy.go
@@ -1178,6 +1178,11 @@ func (in *ShootCareControllerConfiguration) DeepCopyInto(out *ShootCareControlle
 		*out = make([]ConditionThreshold, len(*in))
 		copy(*out, *in)
 	}
+	if in.WebhookRemediatorEnabled != nil {
+		in, out := &in.WebhookRemediatorEnabled, &out.WebhookRemediatorEnabled
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/gardenlet/controller/managedseed/charttest/charttest.go
+++ b/pkg/gardenlet/controller/managedseed/charttest/charttest.go
@@ -732,6 +732,7 @@ func ComputeExpectedGardenletConfiguration(
 						},
 					},
 				},
+				WebhookRemediatorEnabled: pointer.Bool(false),
 			},
 			SeedCare: &gardenletconfigv1alpha1.SeedCareControllerConfiguration{
 				SyncPeriod: &metav1.Duration{

--- a/pkg/gardenlet/controller/managedseed/charttest/gardenlet_chart_test.go
+++ b/pkg/gardenlet/controller/managedseed/charttest/gardenlet_chart_test.go
@@ -364,17 +364,17 @@ var _ = Describe("#Gardenlet Chart Test", func() {
 				ValidateGardenletChartVPA(ctx, c)
 			}
 		},
-		Entry("verify the default values for the Gardenlet chart & the Gardenlet component config", nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-0b01bd7b"}),
+		Entry("verify the default values for the Gardenlet chart & the Gardenlet component config", nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-11b5c474"}),
 		Entry("verify Gardenlet with component config with TLS server configuration", pointer.String("dummy cert content"), pointer.String("dummy key content"), nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{
-			"gardenlet-configmap": "gardenlet-configmap-6601486f",
+			"gardenlet-configmap": "gardenlet-configmap-3a989e8d",
 			"gardenlet-cert":      "gardenlet-cert-4a9a9f55",
 		}),
 		Entry("verify Gardenlet with component config having the Garden client connection kubeconfig set", nil, nil, pointer.String("dummy garden kubeconfig"), nil, nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{
-			"gardenlet-configmap":         "gardenlet-configmap-9e193dad",
+			"gardenlet-configmap":         "gardenlet-configmap-0701c430",
 			"gardenlet-kubeconfig-garden": "gardenlet-kubeconfig-garden-8c9ae097",
 		}),
 		Entry("verify Gardenlet with component config having the Seed client connection kubeconfig set", nil, nil, nil, pointer.String("dummy seed kubeconfig"), nil, nil, nil, nil, nil, nil, nil, nil, map[string]string{
-			"gardenlet-configmap":       "gardenlet-configmap-e2207f45",
+			"gardenlet-configmap":       "gardenlet-configmap-814ecbd5",
 			"gardenlet-kubeconfig-seed": "gardenlet-kubeconfig-seed-662d92ae",
 		}),
 		Entry("verify Gardenlet with component config having a Bootstrap kubeconfig set", nil, nil, nil, nil, &corev1.SecretReference{
@@ -384,7 +384,7 @@ var _ = Describe("#Gardenlet Chart Test", func() {
 			Name:      "gardenlet-kubeconfig",
 			Namespace: gardencorev1beta1constants.GardenNamespace,
 		}, pointer.String("dummy bootstrap kubeconfig"), nil, nil, nil, nil, nil, map[string]string{
-			"gardenlet-configmap": "gardenlet-configmap-ef09dd3b",
+			"gardenlet-configmap": "gardenlet-configmap-71aa4ff5",
 		}),
 		Entry("verify that the SeedConfig is set in the component config Config Map", nil, nil, nil, nil, nil, nil, nil,
 			&gardenletconfigv1alpha1.SeedConfig{
@@ -393,23 +393,23 @@ var _ = Describe("#Gardenlet Chart Test", func() {
 						Name: "sweet-seed",
 					},
 				},
-			}, nil, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-0147f710"}),
+			}, nil, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-c4a9a671"}),
 		Entry("verify deployment with image vector override", nil, nil, nil, nil, nil, nil, nil, nil, nil, pointer.String("dummy-override-content"), nil, nil, map[string]string{
-			"gardenlet-configmap":             "gardenlet-configmap-0b01bd7b",
+			"gardenlet-configmap":             "gardenlet-configmap-11b5c474",
 			"gardenlet-imagevector-overwrite": "gardenlet-imagevector-overwrite-32ecb769",
 		}),
 		Entry("verify deployment with component image vector override", nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, pointer.String("dummy-override-content"), nil, map[string]string{
-			"gardenlet-configmap":                        "gardenlet-configmap-0b01bd7b",
+			"gardenlet-configmap":                        "gardenlet-configmap-11b5c474",
 			"gardenlet-imagevector-overwrite-components": "gardenlet-imagevector-overwrite-components-53f94952",
 		}),
 
 		Entry("verify deployment with replica count", nil, nil, nil, nil, nil, nil, nil, nil, &seedmanagement.GardenletDeployment{
 			ReplicaCount: pointer.Int32(2),
-		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-0b01bd7b"}),
+		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-11b5c474"}),
 
 		Entry("verify deployment with service account", nil, nil, nil, nil, nil, nil, nil, nil, &seedmanagement.GardenletDeployment{
 			ServiceAccountName: pointer.String("ax"),
-		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-0b01bd7b"}),
+		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-11b5c474"}),
 
 		Entry("verify deployment with resources", nil, nil, nil, nil, nil, nil, nil, nil, &seedmanagement.GardenletDeployment{
 			Resources: &corev1.ResourceRequirements{
@@ -421,19 +421,19 @@ var _ = Describe("#Gardenlet Chart Test", func() {
 					corev1.ResourceMemory: resource.MustParse("25Mi"),
 				},
 			},
-		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-0b01bd7b"}),
+		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-11b5c474"}),
 
 		Entry("verify deployment with pod labels", nil, nil, nil, nil, nil, nil, nil, nil, &seedmanagement.GardenletDeployment{
 			PodLabels: map[string]string{
 				"x": "y",
 			},
-		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-0b01bd7b"}),
+		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-11b5c474"}),
 
 		Entry("verify deployment with pod annotations", nil, nil, nil, nil, nil, nil, nil, nil, &seedmanagement.GardenletDeployment{
 			PodAnnotations: map[string]string{
 				"x": "y",
 			},
-		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-0b01bd7b"}),
+		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-11b5c474"}),
 
 		Entry("verify deployment with additional volumes", nil, nil, nil, nil, nil, nil, nil, nil, &seedmanagement.GardenletDeployment{
 			AdditionalVolumes: []corev1.Volume{
@@ -442,7 +442,7 @@ var _ = Describe("#Gardenlet Chart Test", func() {
 					VolumeSource: corev1.VolumeSource{},
 				},
 			},
-		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-0b01bd7b"}),
+		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-11b5c474"}),
 
 		Entry("verify deployment with additional volume mounts", nil, nil, nil, nil, nil, nil, nil, nil, &seedmanagement.GardenletDeployment{
 			AdditionalVolumeMounts: []corev1.VolumeMount{
@@ -450,7 +450,7 @@ var _ = Describe("#Gardenlet Chart Test", func() {
 					Name: "a",
 				},
 			},
-		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-0b01bd7b"}),
+		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-11b5c474"}),
 
 		Entry("verify deployment with env variables", nil, nil, nil, nil, nil, nil, nil, nil, &seedmanagement.GardenletDeployment{
 			Env: []corev1.EnvVar{
@@ -459,14 +459,14 @@ var _ = Describe("#Gardenlet Chart Test", func() {
 					Value: "XY",
 				},
 			},
-		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-0b01bd7b"}),
+		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-11b5c474"}),
 
 		Entry("verify deployment with VPA enabled", nil, nil, nil, nil, nil, nil, nil, nil, &seedmanagement.GardenletDeployment{
 			VPA: pointer.Bool(true),
-		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-0b01bd7b"}),
-		Entry("verify Gardenlet RBACs when ManagedIstio is enabled", nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, map[string]bool{string(features.ManagedIstio): true}, map[string]string{"gardenlet-configmap": "gardenlet-configmap-54683e34"}),
-		Entry("verify Gardenlet RBACs when APIServerSNI is enabled", nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, map[string]bool{string(features.APIServerSNI): true}, map[string]string{"gardenlet-configmap": "gardenlet-configmap-1d6aa849"}),
-		Entry("verify Gardenlet RBACs when APIServerSNI is disabled", nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, map[string]bool{string(features.APIServerSNI): false}, map[string]string{"gardenlet-configmap": "gardenlet-configmap-6ad60277"}),
+		}, nil, nil, nil, map[string]string{"gardenlet-configmap": "gardenlet-configmap-11b5c474"}),
+		Entry("verify Gardenlet RBACs when ManagedIstio is enabled", nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, map[string]bool{string(features.ManagedIstio): true}, map[string]string{"gardenlet-configmap": "gardenlet-configmap-6d53f972"}),
+		Entry("verify Gardenlet RBACs when APIServerSNI is enabled", nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, map[string]bool{string(features.APIServerSNI): true}, map[string]string{"gardenlet-configmap": "gardenlet-configmap-fba13c38"}),
+		Entry("verify Gardenlet RBACs when APIServerSNI is disabled", nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, map[string]bool{string(features.APIServerSNI): false}, map[string]string{"gardenlet-configmap": "gardenlet-configmap-5dc34cd2"}),
 	)
 })
 

--- a/pkg/gardenlet/controller/shoot/shoot_care_control_types.go
+++ b/pkg/gardenlet/controller/shoot/shoot_care_control_types.go
@@ -70,6 +70,19 @@ var defaultNewGarbageCollector = func(op *operation.Operation, init care.ShootCl
 	return care.NewGarbageCollection(op, init)
 }
 
+// WebhookRemediator is an interface used to perform webhook remediation.
+type WebhookRemediator interface {
+	Remediate(ctx context.Context) error
+}
+
+// NewWebhookRemediatorFunc is a function used to create a new instance to perform webhook remediation.
+type NewWebhookRemediatorFunc func(op *operation.Operation, init care.ShootClientInit) WebhookRemediator
+
+// defaultNewWebhookRemediator is the default function to create a new instance to perform webhook remediation.
+var defaultNewWebhookRemediator = func(op *operation.Operation, init care.ShootClientInit) WebhookRemediator {
+	return care.NewWebhookRemediation(op, init)
+}
+
 // NewOperationFunc is a function used to create a new `operation.Operation` instance.
 type NewOperationFunc func(
 	ctx context.Context,

--- a/pkg/operation/botanist/component/resourcemanager/resource_manager.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager.go
@@ -832,7 +832,9 @@ func (r *resourceManager) ensureMutatingWebhookConfiguration(ctx context.Context
 	}
 
 	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, r.client, mutatingWebhookConfiguration, func() error {
-		mutatingWebhookConfiguration.Labels = appLabel()
+		mutatingWebhookConfiguration.Labels = utils.MergeStringMaps(appLabel(), map[string]string{
+			v1beta1constants.LabelExcludeWebhookFromRemediation: "true",
+		})
 		mutatingWebhookConfiguration.Webhooks = GetMutatingWebhookConfigurationWebhooks(r.buildWebhookNamespaceSelector(), secretServerCA, r.buildWebhookClientConfig)
 		return nil
 	})

--- a/pkg/operation/botanist/component/resourcemanager/resource_manager_test.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager_test.go
@@ -682,7 +682,10 @@ var _ = Describe("ResourceManager", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "gardener-resource-manager",
 				Namespace: deployNamespace,
-				Labels:    map[string]string{"app": "gardener-resource-manager"},
+				Labels: map[string]string{
+					"app": "gardener-resource-manager",
+					"remediation.webhook.shoot.gardener.cloud/exclude": "true",
+				},
 			},
 			Webhooks: []admissionregistrationv1.MutatingWebhook{
 				{

--- a/pkg/operation/botanist/component/vpa/general.go
+++ b/pkg/operation/botanist/component/vpa/general.go
@@ -17,10 +17,12 @@ package vpa
 import (
 	"fmt"
 
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 )
 
@@ -182,6 +184,7 @@ func (v *vpa) reconcileGeneralMutatingWebhookConfiguration(mutatingWebhookConfig
 		clientConfig.URL = pointer.String(fmt.Sprintf("https://%s.%s:%d", admissionControllerServiceName, v.namespace, admissionControllerServicePort))
 	}
 
+	metav1.SetMetaDataLabel(&mutatingWebhookConfiguration.ObjectMeta, v1beta1constants.LabelExcludeWebhookFromRemediation, "true")
 	mutatingWebhookConfiguration.Webhooks = []admissionregistrationv1.MutatingWebhook{{
 		Name:                    "vpa.k8s.io",
 		AdmissionReviewVersions: []string{"v1"},

--- a/pkg/operation/botanist/component/vpa/vpa_test.go
+++ b/pkg/operation/botanist/component/vpa/vpa_test.go
@@ -1332,7 +1332,8 @@ var _ = Describe("VPA", func() {
 				Kind:       "MutatingWebhookConfiguration",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "vpa-webhook-config-target",
+				Name:   "vpa-webhook-config-target",
+				Labels: map[string]string{"remediation.webhook.shoot.gardener.cloud/exclude": "true"},
 			},
 			Webhooks: []admissionregistrationv1.MutatingWebhook{{
 				Name:                    "vpa.k8s.io",

--- a/pkg/operation/botanist/matchers/matcher.go
+++ b/pkg/operation/botanist/matchers/matcher.go
@@ -189,8 +189,8 @@ type WebhookConstraintMatcher struct {
 	GVR             schema.GroupVersionResource
 	Subresource     string
 	ClusterScoped   bool
-	ObjectLabels    labels.Labels
-	NamespaceLabels labels.Labels
+	ObjectLabels    labels.Set
+	NamespaceLabels labels.Set
 }
 
 // Match rule with objLabelSelector and namespaceLabelSelector if

--- a/pkg/operation/care/constraints.go
+++ b/pkg/operation/care/constraints.go
@@ -178,6 +178,14 @@ func (c *Constraint) CheckForProblematicWebhooks(ctx context.Context) (gardencor
 					nil
 			}
 		}
+
+		if wasRemediatedByGardener(webhookConfig.Annotations) {
+			return gardencorev1beta1.ConditionFalse,
+				"RemediatedWebhooks",
+				fmt.Sprintf("ValidatingWebhookConfiguration %q is problematic and was remediated by Gardener (please check its annotations for details).", webhookConfig.Name),
+				[]gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorProblematicWebhook},
+				nil
+		}
 	}
 
 	mutatingWebhookConfigs, err := getMutatingWebhookConfigurations(ctx, c.shootClient)
@@ -195,6 +203,14 @@ func (c *Constraint) CheckForProblematicWebhooks(ctx context.Context) (gardencor
 					[]gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorProblematicWebhook},
 					nil
 			}
+		}
+
+		if wasRemediatedByGardener(webhookConfig.Annotations) {
+			return gardencorev1beta1.ConditionFalse,
+				"RemediatedWebhooks",
+				fmt.Sprintf("MutatingWebhookConfiguration %q is problematic and was remediated by Gardener (please check its annotations for details).", webhookConfig.Name),
+				[]gardencorev1beta1.ErrorCode{gardencorev1beta1.ErrorProblematicWebhook},
+				nil
 		}
 	}
 
@@ -261,4 +277,8 @@ func IsProblematicWebhook(
 	}
 
 	return false
+}
+
+func wasRemediatedByGardener(annotations map[string]string) bool {
+	return annotations[v1beta1constants.GardenerWarning] != ""
 }

--- a/pkg/operation/care/constraints.go
+++ b/pkg/operation/care/constraints.go
@@ -27,7 +27,6 @@ import (
 	"github.com/gardener/gardener/pkg/operation/shoot"
 	"github.com/gardener/gardener/pkg/utils"
 
-	"github.com/Masterminds/semver"
 	"github.com/sirupsen/logrus"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -139,7 +138,7 @@ func (c *Constraint) constraintsChecks(
 	return []gardencorev1beta1.Condition{hibernationPossibleConstraint, maintenancePreconditionsSatisfiedConstraint}
 }
 
-func getValidatingWebhookConfigurations(ctx context.Context, client client.Client, k8sVersion *semver.Version) ([]admissionregistrationv1.ValidatingWebhookConfiguration, error) {
+func getValidatingWebhookConfigurations(ctx context.Context, client client.Client) ([]admissionregistrationv1.ValidatingWebhookConfiguration, error) {
 	validatingWebhookConfigs := &admissionregistrationv1.ValidatingWebhookConfigurationList{}
 	if err := client.List(ctx, validatingWebhookConfigs); err != nil {
 		return nil, err
@@ -152,7 +151,7 @@ var (
 	labelSelectorNotResourceManager = labels.NewSelector().Add(notResourceManager)
 )
 
-func getMutatingWebhookConfigurations(ctx context.Context, c client.Client, k8sVersion *semver.Version) ([]admissionregistrationv1.MutatingWebhookConfiguration, error) {
+func getMutatingWebhookConfigurations(ctx context.Context, c client.Client) ([]admissionregistrationv1.MutatingWebhookConfiguration, error) {
 	mutatingWebhookConfigs := &admissionregistrationv1.MutatingWebhookConfigurationList{}
 	if err := c.List(ctx, mutatingWebhookConfigs, client.MatchingLabelsSelector{Selector: labelSelectorNotResourceManager}); err != nil {
 		return nil, err
@@ -163,7 +162,7 @@ func getMutatingWebhookConfigurations(ctx context.Context, c client.Client, k8sV
 // CheckForProblematicWebhooks checks the Shoot for problematic webhooks which could prevent shoot worker nodes from
 // joining the cluster.
 func (c *Constraint) CheckForProblematicWebhooks(ctx context.Context) (gardencorev1beta1.ConditionStatus, string, string, []gardencorev1beta1.ErrorCode, error) {
-	validatingWebhookConfigs, err := getValidatingWebhookConfigurations(ctx, c.shootClient, c.shoot.KubernetesVersion)
+	validatingWebhookConfigs, err := getValidatingWebhookConfigurations(ctx, c.shootClient)
 	if err != nil {
 		return "", "", "", nil, fmt.Errorf("could not get ValidatingWebhookConfigurations of Shoot cluster to check for problematic webhooks: %w", err)
 	}
@@ -181,7 +180,7 @@ func (c *Constraint) CheckForProblematicWebhooks(ctx context.Context) (gardencor
 		}
 	}
 
-	mutatingWebhookConfigs, err := getMutatingWebhookConfigurations(ctx, c.shootClient, c.shoot.KubernetesVersion)
+	mutatingWebhookConfigs, err := getMutatingWebhookConfigurations(ctx, c.shootClient)
 	if err != nil {
 		return "", "", "", nil, fmt.Errorf("could not get MutatingWebhookConfigurations of Shoot cluster to check for problematic webhooks: %w", err)
 	}

--- a/pkg/operation/care/webhook_remediation.go
+++ b/pkg/operation/care/webhook_remediation.go
@@ -16,11 +16,24 @@ package care
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/operation"
+	"github.com/gardener/gardener/pkg/operation/botanist/matchers"
+	"github.com/gardener/gardener/pkg/utils"
+	"github.com/gardener/gardener/pkg/utils/flow"
 
 	"github.com/sirupsen/logrus"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // WebhookRemediation contains required information for shoot webhook remediation.
@@ -28,18 +41,270 @@ type WebhookRemediation struct {
 	logger                 logrus.FieldLogger
 	initializeShootClients ShootClientInit
 	shoot                  *gardencorev1beta1.Shoot
+	seedNamespace          string
 }
 
 // NewWebhookRemediation creates a new instance for webhook remediation.
 func NewWebhookRemediation(op *operation.Operation, shootClientInit ShootClientInit) *WebhookRemediation {
 	return &WebhookRemediation{
 		logger:                 op.Logger,
-		shoot:                  op.Shoot.GetInfo(),
 		initializeShootClients: shootClientInit,
+		shoot:                  op.Shoot.GetInfo(),
+		seedNamespace:          op.Shoot.SeedNamespace,
 	}
 }
 
 // Remediate mutates shoot webhooks not following the best practices documented by Kubernetes.
 func (r *WebhookRemediation) Remediate(ctx context.Context) error {
-	return nil
+	shootClient, apiServerRunning, err := r.initializeShootClients()
+	if err != nil {
+		return err
+	}
+	if !apiServerRunning {
+		return nil
+	}
+
+	var (
+		logger = r.logger.WithField("shoot", client.ObjectKeyFromObject(r.shoot))
+		fns    []flow.TaskFn
+
+		notExcluded   = utils.MustNewRequirement(v1beta1constants.LabelExcludeWebhookFromRemediation, selection.NotIn, "true")
+		labelSelector = client.MatchingLabelsSelector{Selector: labels.NewSelector().Add(notExcluded)}
+	)
+
+	validatingWebhookConfigs := &admissionregistrationv1.ValidatingWebhookConfigurationList{}
+	if err := shootClient.Client().List(ctx, validatingWebhookConfigs, labelSelector); err != nil {
+		return fmt.Errorf("could not get ValidatingWebhookConfigurations of Shoot cluster to remediate problematic webhooks: %w", err)
+	}
+
+	for _, config := range validatingWebhookConfigs.Items {
+		if strings.Contains(config.Annotations[resourcesv1alpha1.OriginAnnotation], r.seedNamespace) {
+			continue
+		}
+
+		var (
+			webhookConfig = config.DeepCopy()
+			mustPatch     bool
+			patch         = client.StrategicMergeFrom(webhookConfig.DeepCopy())
+			remediations  []string
+		)
+
+		for i, w := range webhookConfig.Webhooks {
+			remediate := newRemediator(logger, "ValidatingWebhookConfiguration", webhookConfig.Name, w.Name, &remediations)
+
+			if mustRemediateTimeoutSeconds(w.TimeoutSeconds) {
+				mustPatch = true
+				webhookConfig.Webhooks[i].TimeoutSeconds = remediate.timeoutSeconds()
+			}
+
+			if mustRemediate, matcher := mustRemediateSelector(w.FailurePolicy, w.Rules, w.ObjectSelector, w.NamespaceSelector); mustRemediate {
+				mustPatch = true
+
+				if matcher.NamespaceLabels == nil && matcher.ObjectLabels == nil {
+					// If the matcher has neither namespaceLabels nor objectLabels then our only option for remediation
+					// is setting the failurePolicy to 'Ignore'.
+					webhookConfig.Webhooks[i].FailurePolicy = remediate.failurePolicy()
+				} else {
+					matchExpressions := remediate.selector(matcher)
+
+					if matcher.ClusterScoped {
+						// If a rule was matched for a cluster-scoped resource then we can remediate by extending the
+						// objectSelector so that our resources are getting excluded.
+						webhookConfig.Webhooks[i].ObjectSelector = extendSelector(webhookConfig.Webhooks[i].ObjectSelector, matchExpressions...)
+					} else {
+						// If a rule was matched for a namespace-scoped resource then we can remediate by extending the
+						// namespaceSelector so that our resources are getting excluded.
+						webhookConfig.Webhooks[i].NamespaceSelector = extendSelector(webhookConfig.Webhooks[i].NamespaceSelector, matchExpressions...)
+					}
+				}
+			}
+		}
+
+		if mustPatch {
+			fns = append(fns, newPatchFunc(shootClient.Client(), webhookConfig, patch, remediations))
+		}
+	}
+
+	mutatingWebhookConfigs := &admissionregistrationv1.MutatingWebhookConfigurationList{}
+	if err := shootClient.Client().List(ctx, mutatingWebhookConfigs, labelSelector); err != nil {
+		return fmt.Errorf("could not get MutatingWebhookConfigurations of Shoot cluster to remediate problematic webhooks: %w", err)
+	}
+
+	for _, config := range mutatingWebhookConfigs.Items {
+		if strings.Contains(config.Annotations[resourcesv1alpha1.OriginAnnotation], r.seedNamespace) {
+			continue
+		}
+
+		var (
+			webhookConfig = config.DeepCopy()
+			mustPatch     bool
+			patch         = client.StrategicMergeFrom(webhookConfig.DeepCopy())
+			remediations  []string
+		)
+
+		for i, w := range webhookConfig.Webhooks {
+			remediate := newRemediator(logger, "MutatingWebhookConfiguration", webhookConfig.Name, w.Name, &remediations)
+
+			if mustRemediateTimeoutSeconds(w.TimeoutSeconds) {
+				mustPatch = true
+				webhookConfig.Webhooks[i].TimeoutSeconds = remediate.timeoutSeconds()
+			}
+
+			if mustRemediate, matcher := mustRemediateSelector(w.FailurePolicy, w.Rules, w.ObjectSelector, w.NamespaceSelector); mustRemediate {
+				mustPatch = true
+
+				if matcher.NamespaceLabels == nil && matcher.ObjectLabels == nil {
+					// If the matcher has neither namespaceLabels nor objectLabels then our only option for remediation
+					// is setting the failurePolicy to 'Ignore'.
+					webhookConfig.Webhooks[i].FailurePolicy = remediate.failurePolicy()
+				} else {
+					matchExpressions := remediate.selector(matcher)
+
+					if matcher.ClusterScoped {
+						// If a rule was matched for a cluster-scoped resource then we can remediate by extending the
+						// objectSelector so that our resources are getting excluded.
+						webhookConfig.Webhooks[i].ObjectSelector = extendSelector(webhookConfig.Webhooks[i].ObjectSelector, matchExpressions...)
+					} else {
+						// If a rule was matched for a namespace-scoped resource then we can remediate by extending the
+						// namespaceSelector so that our resources are getting excluded.
+						webhookConfig.Webhooks[i].NamespaceSelector = extendSelector(webhookConfig.Webhooks[i].NamespaceSelector, matchExpressions...)
+					}
+				}
+			}
+		}
+
+		if mustPatch {
+			fns = append(fns, newPatchFunc(shootClient.Client(), webhookConfig, patch, remediations))
+		}
+	}
+
+	return flow.Parallel(fns...)(ctx)
+}
+
+func mustRemediateTimeoutSeconds(timeoutSeconds *int32) bool {
+	return timeoutSeconds == nil || *timeoutSeconds > WebhookMaximumTimeoutSecondsNotProblematic
+}
+
+func mustRemediateSelector(
+	failurePolicy *admissionregistrationv1.FailurePolicyType,
+	rules []admissionregistrationv1.RuleWithOperations,
+	objectSelector, namespaceSelector *metav1.LabelSelector,
+) (
+	bool,
+	matchers.WebhookConstraintMatcher,
+) {
+	if failurePolicy == nil || *failurePolicy != admissionregistrationv1.Ignore {
+		for _, rule := range rules {
+			for _, matcher := range matchers.WebhookConstraintMatchers {
+				if matcher.Match(rule, objectSelector, namespaceSelector) {
+					return true, matcher
+				}
+			}
+		}
+	}
+	return false, matchers.WebhookConstraintMatcher{}
+}
+
+type remediator struct {
+	logger            logrus.FieldLogger
+	webhookConfigKind string
+	webhookConfigName string
+	webhookName       string
+	remediations      *[]string
+}
+
+func newRemediator(logger logrus.FieldLogger, webhookConfigKind, webhookConfigName, webhookName string, remediations *[]string) remediator {
+	return remediator{
+		logger: logger.WithFields(logrus.Fields{
+			"kind":    webhookConfigKind,
+			"name":    webhookConfigName,
+			"webhook": webhookName,
+		}),
+		webhookConfigKind: webhookConfigKind,
+		webhookConfigName: webhookConfigName,
+		webhookName:       webhookName,
+		remediations:      remediations,
+	}
+}
+
+func (r *remediator) timeoutSeconds() *int32 {
+	var timeoutSeconds int32 = WebhookMaximumTimeoutSecondsNotProblematic
+
+	r.logger.Info("Remediating timeout seconds")
+	*r.remediations = append(*r.remediations, fmt.Sprintf("timeoutSeconds of webhook %q was set to %d", r.webhookName, WebhookMaximumTimeoutSecondsNotProblematic))
+
+	return pointer.Int32(timeoutSeconds)
+}
+
+func (r *remediator) selector(matcher matchers.WebhookConstraintMatcher) []metav1.LabelSelectorRequirement {
+	var (
+		selectorFieldName = "namespaceSelector"
+		matcherLabels     = matcher.NamespaceLabels
+	)
+
+	if matcher.ClusterScoped {
+		selectorFieldName = "objectSelector"
+		matcherLabels = matcher.ObjectLabels
+	}
+
+	selectorExtensions := make([]metav1.LabelSelectorRequirement, 0, len(matcherLabels))
+	for k, v := range matcherLabels {
+		selectorExtensions = append(selectorExtensions, metav1.LabelSelectorRequirement{
+			Key:      k,
+			Operator: metav1.LabelSelectorOpNotIn,
+			Values:   []string{v},
+		})
+	}
+
+	r.logger.Infof("Remediating %s", selectorFieldName)
+	*r.remediations = append(*r.remediations, fmt.Sprintf("%s of webhook %q was extended with %s", selectorFieldName, r.webhookName, selectorExtensions))
+
+	return selectorExtensions
+}
+
+func (r *remediator) failurePolicy() *admissionregistrationv1.FailurePolicyType {
+	ignore := admissionregistrationv1.Ignore
+
+	r.logger.Info("Remediating failurePolicy")
+	*r.remediations = append(*r.remediations, fmt.Sprintf("failurePolicy of webhook %q was set to %s", r.webhookName, ignore))
+
+	return &ignore
+}
+
+func newPatchFunc(shootClient client.Client, webhookConfig client.Object, patch client.Patch, remediations []string) func(context.Context) error {
+	annotations := webhookConfig.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string, 1)
+	}
+
+	annotations[v1beta1constants.GardenerWarning] = "ATTENTION: This webhook configuration has been modified by " +
+		"Gardener since it does not follow the best practices recommended by Kubernetes " +
+		"(https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#best-practices-and-warnings) " +
+		"and might interfere with the cluster operations. Please make sure to follow these recommendations to prevent " +
+		"future interventions. When you are done, please remove this annotation. See also " +
+		"https://github.com/gardener/gardener/blob/master/docs/usage/shoot_status.md#constraints for further information.\n" +
+		"The following modifications have been made:\n" +
+		strings.Join(addHyphenPrefix(remediations), "\n")
+	webhookConfig.SetAnnotations(annotations)
+
+	return func(ctx context.Context) error {
+		return shootClient.Patch(ctx, webhookConfig, patch)
+	}
+}
+
+func addHyphenPrefix(list []string) []string {
+	out := make([]string, 0, len(list))
+	for _, v := range list {
+		out = append(out, "- "+v)
+	}
+	return out
+}
+
+func extendSelector(selector *metav1.LabelSelector, requirements ...metav1.LabelSelectorRequirement) *metav1.LabelSelector {
+	if selector == nil {
+		selector = &metav1.LabelSelector{}
+	}
+
+	selector.MatchExpressions = append(selector.MatchExpressions, requirements...)
+	return selector
 }

--- a/pkg/operation/care/webhook_remediation.go
+++ b/pkg/operation/care/webhook_remediation.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package care
+
+import (
+	"context"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/operation"
+
+	"github.com/sirupsen/logrus"
+)
+
+// WebhookRemediation contains required information for shoot webhook remediation.
+type WebhookRemediation struct {
+	logger                 logrus.FieldLogger
+	initializeShootClients ShootClientInit
+	shoot                  *gardencorev1beta1.Shoot
+}
+
+// NewWebhookRemediation creates a new instance for webhook remediation.
+func NewWebhookRemediation(op *operation.Operation, shootClientInit ShootClientInit) *WebhookRemediation {
+	return &WebhookRemediation{
+		logger:                 op.Logger,
+		shoot:                  op.Shoot.GetInfo(),
+		initializeShootClients: shootClientInit,
+	}
+}
+
+// Remediate mutates shoot webhooks not following the best practices documented by Kubernetes.
+func (r *WebhookRemediation) Remediate(ctx context.Context) error {
+	return nil
+}

--- a/pkg/operation/care/webhook_remediation.go
+++ b/pkg/operation/care/webhook_remediation.go
@@ -199,7 +199,9 @@ func mustRemediateSelectors(matchers []webhookmatchers.WebhookConstraintMatcher)
 
 func mustRemediateFailurePolicy(matchers []webhookmatchers.WebhookConstraintMatcher) bool {
 	for _, matcher := range matchers {
-		return matcher.NamespaceLabels == nil && matcher.ObjectLabels == nil
+		if matcher.NamespaceLabels == nil && matcher.ObjectLabels == nil {
+			return true
+		}
 	}
 	return false
 }

--- a/pkg/operation/care/webhook_remediation_test.go
+++ b/pkg/operation/care/webhook_remediation_test.go
@@ -147,6 +147,11 @@ var _ = Describe("WebhookRemediation", func() {
 				})
 
 				It("failurePolicy", func() {
+					defer test.WithVar(&matchers.WebhookConstraintMatchers, []matchers.WebhookConstraintMatcher{
+						{GVR: corev1.SchemeGroupVersion.WithResource("foobars")},
+						{GVR: corev1.SchemeGroupVersion.WithResource("barfoos"), ObjectLabels: map[string]string{"foo": "bar"}},
+					})()
+
 					validatingWebhookConfiguration.Webhooks = []admissionregistrationv1.ValidatingWebhook{{
 						Name:          "some-webhook.example.com",
 						FailurePolicy: &fail,
@@ -154,7 +159,7 @@ var _ = Describe("WebhookRemediation", func() {
 							Rule: admissionregistrationv1.Rule{
 								APIGroups:   []string{""},
 								APIVersions: []string{"v1"},
-								Resources:   []string{"endpoints"},
+								Resources:   []string{"foobars", "barfoos"},
 							},
 							Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
 						}},
@@ -294,6 +299,11 @@ var _ = Describe("WebhookRemediation", func() {
 				})
 
 				It("failurePolicy", func() {
+					defer test.WithVar(&matchers.WebhookConstraintMatchers, []matchers.WebhookConstraintMatcher{
+						{GVR: corev1.SchemeGroupVersion.WithResource("foobars")},
+						{GVR: corev1.SchemeGroupVersion.WithResource("barfoos"), ObjectLabels: map[string]string{"foo": "bar"}},
+					})()
+
 					mutatingWebhookConfiguration.Webhooks = []admissionregistrationv1.MutatingWebhook{{
 						Name:          "some-webhook.example.com",
 						FailurePolicy: &fail,
@@ -301,7 +311,7 @@ var _ = Describe("WebhookRemediation", func() {
 							Rule: admissionregistrationv1.Rule{
 								APIGroups:   []string{""},
 								APIVersions: []string{"v1"},
-								Resources:   []string{"endpoints"},
+								Resources:   []string{"foobars", "barfoos"},
 							},
 							Operations: []admissionregistrationv1.OperationType{admissionregistrationv1.Create},
 						}},

--- a/pkg/operation/care/webhook_remediation_test.go
+++ b/pkg/operation/care/webhook_remediation_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package care_test
+
+import (
+	"context"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	fakekubernetes "github.com/gardener/gardener/pkg/client/kubernetes/fake"
+	"github.com/gardener/gardener/pkg/logger"
+	"github.com/gardener/gardener/pkg/operation"
+	. "github.com/gardener/gardener/pkg/operation/care"
+	shootpkg "github.com/gardener/gardener/pkg/operation/shoot"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("WebhookRemediation", func() {
+	var (
+		ctx = context.TODO()
+
+		fakeClient              client.Client
+		fakeKubernetesInterface kubernetes.Interface
+		shootClientInit         func() (kubernetes.Interface, bool, error)
+
+		shoot *gardencorev1beta1.Shoot
+		op    *operation.Operation
+
+		remediator *WebhookRemediation
+	)
+
+	BeforeEach(func() {
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.ShootScheme).Build()
+		fakeKubernetesInterface = fakekubernetes.NewClientSetBuilder().WithClient(fakeClient).Build()
+		shootClientInit = func() (kubernetes.Interface, bool, error) {
+			return fakeKubernetesInterface, true, nil
+		}
+
+		shoot = &gardencorev1beta1.Shoot{}
+		op = &operation.Operation{
+			Logger: logger.NewNopLogger(),
+			Shoot:  &shootpkg.Shoot{},
+		}
+		op.Shoot.SetInfo(shoot)
+
+		remediator = NewWebhookRemediation(op, shootClientInit)
+	})
+
+	Describe("#Remediate", func() {
+		It("should remediate the problematic webhooks", func() {
+			Expect(remediator.Remediate(ctx)).To(Succeed())
+		})
+	})
+})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR introduces the possibility to remediate problematic webhooks in the shoot clusters by setting `.controllers.shootCare.webhookRemediatorEnabled=true` in the `gardenlet`'s configuration file (disabled by default).

This introduces another routine as part of the shoot care controllers which works as follows (for both `{Validating,Mutating}WebhookConfiguration`s):

1. All webhooks with `timeoutSeconds > 15s` will be changed to `timeoutSeconds=15s`.
2. If there are `rules` which are matched by our [`WebhookConstraintsMatcher`](https://github.com/gardener/gardener/blob/fe30e53b5e5e728e17bfc86d3f8e097373932349/pkg/operation/botanist/matchers/matcher.go#L58-L175) then
   1. the `failurePolicy` will be set to `Ignore` if the matched resource has neither `namespaceLabels` or `objectLabels` that we could set to exclude our critical namespaces/objects from being matched.
   2. the `namespaceSelector` will be extended with the matched resource's `namespaceLabels` (negated) if the resource is not cluster-scoped.
   3. the `objectSelector` will be extended with the matched resource's `objectLabels` (negated) if the resource is cluster-scoped.

In addition, a new annotation `gardener.cloud/warning` is written to the respective webhook configuration explaining what happened and which changes were applied by Gardener to remediate the problematic configuration.

Note that the constraints will continue to have `False` status even if webhooks were remediated so that end-users become aware that something is wrong and they should take a look.

**Which issue(s) this PR fixes**:
Fixes #3244

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
4. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
You can now make the `gardenlet` remediate problematic webhooks in shoot clusters by setting  `.controllers.shootCare.webhookRemediatorEnabled=true` in its configuration file.
```
