### PR TITLE
Add serviceaccountmanager permissions to administratos

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
@@ -87,6 +87,8 @@ aggregationRule:
       gardener.cloud/role: admin
   - matchLabels:
       gardener.cloud/role: project-member
+  - matchLabels:
+      gardener.cloud/role: project-serviceaccountmanager
 rules: []
 
 # Cluster role granting viewer permissions for the resources in the gardener API group


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
Add serviceaccountmanager permissions to administratos

cc @donistz @dimityrmirchev 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Gardener landscape administrators are now provided with `serviceaccountmanager` permissions, i.e. they can manage service accounts and issue tokens for them.
```
