### PR TITLE
[GEP-18] Advanced checks for credentials e2e test (1)

### DIFF
--- a/extensions/pkg/webhook/controlplane/genericmutator/mutator_test.go
+++ b/extensions/pkg/webhook/controlplane/genericmutator/mutator_test.go
@@ -24,7 +24,7 @@ import (
 	gcontext "github.com/gardener/gardener/extensions/pkg/webhook/context"
 	"github.com/gardener/gardener/extensions/pkg/webhook/controlplane/genericmutator"
 	mockgenericmutator "github.com/gardener/gardener/extensions/pkg/webhook/controlplane/genericmutator/mock"
-	gardencorevalpha1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
@@ -85,25 +85,25 @@ var _ = Describe("Mutator", func() {
 
 		clusterKey = client.ObjectKey{Name: namespace}
 		cluster    = &extensionscontroller.Cluster{
-			CloudProfile: &gardencorevalpha1.CloudProfile{
+			CloudProfile: &gardencorev1beta1.CloudProfile{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: gardencorevalpha1.SchemeGroupVersion.String(),
+					APIVersion: gardencorev1beta1.SchemeGroupVersion.String(),
 					Kind:       "CloudProfile",
 				},
 			},
-			Seed: &gardencorevalpha1.Seed{
+			Seed: &gardencorev1beta1.Seed{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: gardencorevalpha1.SchemeGroupVersion.String(),
+					APIVersion: gardencorev1beta1.SchemeGroupVersion.String(),
 					Kind:       "Seed",
 				},
 			},
-			Shoot: &gardencorevalpha1.Shoot{
+			Shoot: &gardencorev1beta1.Shoot{
 				TypeMeta: metav1.TypeMeta{
-					APIVersion: gardencorevalpha1.SchemeGroupVersion.String(),
+					APIVersion: gardencorev1beta1.SchemeGroupVersion.String(),
 					Kind:       "Shoot",
 				},
-				Spec: gardencorevalpha1.ShootSpec{
-					Kubernetes: gardencorevalpha1.Kubernetes{
+				Spec: gardencorev1beta1.ShootSpec{
+					Kubernetes: gardencorev1beta1.Kubernetes{
 						Version: kubernetesVersion,
 					},
 				},

--- a/hack/test-e2e-local.sh
+++ b/hack/test-e2e-local.sh
@@ -26,8 +26,10 @@ if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ]; then
   mkdir -p "$ARTIFACTS"
   ginkgo_flags="--output-dir=$ARTIFACTS --junit-report=junit.xml"
 
-  # make shoot domain accessible to test
-  printf "\n127.0.0.1 api.e2e-default.local.external.local.gardener.cloud\n127.0.0.1 api.e2e-default.local.internal.local.gardener.cloud\n" >>/etc/hosts
+  # make shoot domains accessible to test
+  for shoot in e2e-default e2e-rotate ; do
+    printf "\n127.0.0.1 api.%s.local.external.local.gardener.cloud\n127.0.0.1 api.%s.local.internal.local.gardener.cloud\n" $shoot $shoot >>/etc/hosts
+  done
 
   # dump all container logs after test execution
   trap dump_logs EXIT

--- a/test/e2e/shoot/create_rotate_delete.go
+++ b/test/e2e/shoot/create_rotate_delete.go
@@ -29,7 +29,8 @@ import (
 
 var _ = Describe("Shoot Tests", Label("Shoot"), func() {
 	f := defaultShootCreationFramework()
-	f.Shoot = defaultShoot("rotate-")
+	f.Shoot = defaultShoot("")
+	f.Shoot.Name = "e2e-rotate"
 
 	It("Create Shoot, Rotate Credentials and Delete Shoot", Label("credentials-rotation"), func() {
 		ctx, cancel := context.WithTimeout(parentCtx, 15*time.Minute)

--- a/test/e2e/shoot/create_rotate_delete.go
+++ b/test/e2e/shoot/create_rotate_delete.go
@@ -41,12 +41,15 @@ var _ = Describe("Shoot Tests", Label("Shoot"), func() {
 		f.Verify()
 
 		v := rotation.Verifiers{
+			// basic verifiers checking secrets
 			&rotation.CAVerifier{ShootCreationFramework: f},
 			&rotation.ETCDEncryptionKeyVerifier{ShootCreationFramework: f},
 			&rotation.KubeconfigVerifier{ShootCreationFramework: f},
 			&rotation.ObservabilityVerifier{ShootCreationFramework: f},
 			&rotation.ServiceAccountKeyVerifier{ShootCreationFramework: f},
 			&rotation.SSHKeypairVerifier{ShootCreationFramework: f},
+			// advanced verifiers testing things from the user's perspective
+			&rotation.ShootAccessVerifier{ShootCreationFramework: f},
 		}
 
 		v.Before(ctx)

--- a/test/e2e/shoot/create_rotate_delete.go
+++ b/test/e2e/shoot/create_rotate_delete.go
@@ -53,6 +53,13 @@ var _ = Describe("Shoot Tests", Label("Shoot"), func() {
 			&rotation.ShootAccessVerifier{ShootCreationFramework: f},
 		}
 
+		DeferCleanup(func() {
+			ctx, cancel := context.WithTimeout(parentCtx, 2*time.Minute)
+			defer cancel()
+
+			v.Cleanup(ctx)
+		})
+
 		v.Before(ctx)
 
 		By("Start credentials rotation")

--- a/test/e2e/shoot/create_rotate_delete.go
+++ b/test/e2e/shoot/create_rotate_delete.go
@@ -49,6 +49,7 @@ var _ = Describe("Shoot Tests", Label("Shoot"), func() {
 			&rotation.ServiceAccountKeyVerifier{ShootCreationFramework: f},
 			&rotation.SSHKeypairVerifier{ShootCreationFramework: f},
 			// advanced verifiers testing things from the user's perspective
+			&rotation.SecretEncryptionVerifier{ShootCreationFramework: f},
 			&rotation.ShootAccessVerifier{ShootCreationFramework: f},
 		}
 

--- a/test/e2e/shoot/internal/access.go
+++ b/test/e2e/shoot/internal/access.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+
+	authenticationv1alpha1 "github.com/gardener/gardener/pkg/apis/authentication/v1alpha1"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardenversionedcoreclientset "github.com/gardener/gardener/pkg/client/core/clientset/versioned"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	gutil "github.com/gardener/gardener/pkg/utils/gardener"
+)
+
+// CreateShootClientFromStaticTokenKubeconfig retrieves the static token kubeconfig secret and creates a shoot client.
+func CreateShootClientFromStaticTokenKubeconfig(ctx context.Context, gardenClient kubernetes.Interface, shoot *gardencorev1beta1.Shoot) (kubernetes.Interface, error) {
+	return kubernetes.NewClientFromSecret(ctx, gardenClient.Client(), shoot.Namespace, gutil.ComputeShootProjectSecretName(shoot.Name, "kubeconfig"),
+		kubernetes.WithDisabledCachedClient(),
+	)
+}
+
+// CreateShootClientFromAdminKubeconfig requests an admin kubeconfig and creates a shoot client.
+func CreateShootClientFromAdminKubeconfig(ctx context.Context, gardenClient kubernetes.Interface, shoot *gardencorev1beta1.Shoot) (kubernetes.Interface, error) {
+	versionedClient, err := gardenversionedcoreclientset.NewForConfig(gardenClient.RESTConfig())
+	if err != nil {
+		return nil, err
+	}
+
+	adminKubeconfigRequest := &authenticationv1alpha1.AdminKubeconfigRequest{
+		Spec: authenticationv1alpha1.AdminKubeconfigRequestSpec{
+			ExpirationSeconds: pointer.Int64(3600),
+		},
+	}
+	adminKubeconfig, err := versionedClient.CoreV1beta1().Shoots(shoot.GetNamespace()).CreateAdminKubeconfigRequest(ctx, shoot.GetName(), adminKubeconfigRequest, metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	return kubernetes.NewClientFromBytes(adminKubeconfig.Status.Kubeconfig, kubernetes.WithDisabledCachedClient())
+}

--- a/test/e2e/shoot/internal/rotation/certificate_authorities.go
+++ b/test/e2e/shoot/internal/rotation/certificate_authorities.go
@@ -234,6 +234,9 @@ func (v *CAVerifier) AfterCompleted(ctx context.Context) {
 	}).Should(Succeed())
 }
 
+// verifyCABundleInKubeconfigSecret asserts that the static-token kubeconfig secret contains the expected CA bundle,
+// i.e. that .data[ca.crt] is the same as in the ca-cluster secret.
+// KubeconfigVerifier takes care of asserting that the kubeconfig actually contains the same CA bundle as .data[ca.crt].
 func verifyCABundleInKubeconfigSecret(ctx context.Context, g Gomega, c client.Reader, shootKey client.ObjectKey, expectedBundle []byte) {
 	secret := &corev1.Secret{}
 	shootKey.Name = gutil.ComputeShootProjectSecretName(shootKey.Name, "kubeconfig")

--- a/test/e2e/shoot/internal/rotation/secret_encryption.go
+++ b/test/e2e/shoot/internal/rotation/secret_encryption.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rotation
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/test/e2e/shoot/internal"
+	"github.com/gardener/gardener/test/framework"
+)
+
+// SecretEncryptionVerifier creates and reads secrets in the shoot to verify correct configuration of etcd encryption.
+type SecretEncryptionVerifier struct {
+	*framework.ShootCreationFramework
+}
+
+// Before is called before the rotation is started.
+func (v *SecretEncryptionVerifier) Before(ctx context.Context) {
+	By("Verifying secret encryption before credentials rotation")
+	v.verifySecretEncryption(ctx)
+}
+
+// ExpectPreparingStatus is called while waiting for the Preparing status.
+func (v *SecretEncryptionVerifier) ExpectPreparingStatus(g Gomega) {}
+
+// AfterPrepared is called when the Shoot is in Prepared status.
+func (v *SecretEncryptionVerifier) AfterPrepared(ctx context.Context) {
+	By("Verifying secret encryption after preparing credentials rotation")
+	v.verifySecretEncryption(ctx)
+}
+
+// ExpectCompletingStatus is called while waiting for the Completing status.
+func (v *SecretEncryptionVerifier) ExpectCompletingStatus(g Gomega) {}
+
+// AfterCompleted is called when the Shoot is in Completed status.
+func (v *SecretEncryptionVerifier) AfterCompleted(ctx context.Context) {
+	By("Verifying secret encryption after credentials rotation")
+	v.verifySecretEncryption(ctx)
+}
+
+func (v *SecretEncryptionVerifier) verifySecretEncryption(ctx context.Context) {
+	var (
+		shootClient kubernetes.Interface
+		err         error
+	)
+
+	Eventually(func(g Gomega) {
+		shootClient, err = internal.CreateShootClientFromAdminKubeconfig(ctx, v.GardenClient, v.Shoot)
+		g.Expect(err).NotTo(HaveOccurred())
+	}).Should(Succeed())
+
+	Eventually(func(g Gomega) {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{GenerateName: "test-foo-", Namespace: "default"},
+			StringData: map[string]string{
+				"content": "foo",
+			},
+		}
+		g.Expect(shootClient.Client().Create(ctx, secret)).To(Succeed())
+	}).Should(Succeed(), "creating secret should succeed")
+
+	Eventually(func(g Gomega) {
+		g.Expect(shootClient.Client().List(ctx, &corev1.SecretList{})).To(Succeed())
+	}).Should(Succeed(), "reading all secrets should succeed")
+}

--- a/test/e2e/shoot/internal/rotation/shoot_access.go
+++ b/test/e2e/shoot/internal/rotation/shoot_access.go
@@ -1,0 +1,139 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rotation
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/test/e2e/shoot/internal"
+	"github.com/gardener/gardener/test/framework"
+)
+
+type clients struct {
+	staticToken, adminKubeconfig kubernetes.Interface
+}
+
+// ShootAccessVerifier uses the static token and admin kubeconfig to access the Shoot.
+type ShootAccessVerifier struct {
+	*framework.ShootCreationFramework
+
+	clientsBefore, clientsPrepared clients
+}
+
+// Before is called before the rotation is started.
+func (v *ShootAccessVerifier) Before(ctx context.Context) {
+	By("Using old static token kubeconfig with old CA to access shoot")
+	Eventually(func(g Gomega) {
+		shootClient, err := internal.CreateShootClientFromStaticTokenKubeconfig(ctx, v.GardenClient, v.Shoot)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		g.Expect(shootClient.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
+
+		v.clientsBefore.staticToken = shootClient
+	}).Should(Succeed())
+
+	By("Using admin kubeconfig with old CA to access shoot")
+	Eventually(func(g Gomega) {
+		shootClient, err := internal.CreateShootClientFromAdminKubeconfig(ctx, v.GardenClient, v.Shoot)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		g.Expect(shootClient.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
+
+		v.clientsBefore.adminKubeconfig = shootClient
+	}).Should(Succeed())
+}
+
+// ExpectPreparingStatus is called while waiting for the Preparing status.
+func (v *ShootAccessVerifier) ExpectPreparingStatus(g Gomega) {}
+
+// AfterPrepared is called when the Shoot is in Prepared status.
+func (v *ShootAccessVerifier) AfterPrepared(ctx context.Context) {
+	By("Using old static token kubeconfig with old CA to access shoot")
+	Consistently(func(g Gomega) {
+		g.Expect(v.clientsBefore.staticToken.Client().List(ctx, &corev1.NamespaceList{})).NotTo(Succeed())
+	}).Should(Succeed())
+
+	By("Using admin kubeconfig with old CA to access shoot")
+	Eventually(func(g Gomega) {
+		g.Expect(v.clientsBefore.adminKubeconfig.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
+	}).Should(Succeed())
+
+	By("Using rotated static token kubeconfig with CA bundle to access shoot")
+	Eventually(func(g Gomega) {
+		shootClient, err := internal.CreateShootClientFromStaticTokenKubeconfig(ctx, v.GardenClient, v.Shoot)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		g.Expect(shootClient.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
+
+		v.clientsPrepared.staticToken = shootClient
+	}).Should(Succeed())
+
+	By("Using admin kubeconfig with CA bundle to access shoot")
+	Eventually(func(g Gomega) {
+		shootClient, err := internal.CreateShootClientFromAdminKubeconfig(ctx, v.GardenClient, v.Shoot)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		g.Expect(shootClient.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
+
+		v.clientsPrepared.adminKubeconfig = shootClient
+	}).Should(Succeed())
+}
+
+// ExpectCompletingStatus is called while waiting for the Completing status.
+func (v *ShootAccessVerifier) ExpectCompletingStatus(g Gomega) {}
+
+// AfterCompleted is called when the Shoot is in Completed status.
+func (v *ShootAccessVerifier) AfterCompleted(ctx context.Context) {
+	By("Using old static token kubeconfig with old CA to access shoot")
+	Consistently(func(g Gomega) {
+		g.Expect(v.clientsBefore.staticToken.Client().List(ctx, &corev1.NamespaceList{})).NotTo(Succeed())
+	}).Should(Succeed())
+
+	By("Using admin kubeconfig with old CA to access shoot")
+	Consistently(func(g Gomega) {
+		g.Expect(v.clientsBefore.adminKubeconfig.Client().List(ctx, &corev1.NamespaceList{})).NotTo(Succeed())
+	}).Should(Succeed())
+
+	By("Using rotated static token kubeconfig with CA bundle to access shoot")
+	Eventually(func(g Gomega) {
+		g.Expect(v.clientsPrepared.staticToken.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
+	}).Should(Succeed())
+
+	By("Using admin kubeconfig with CA bundle to access shoot")
+	Eventually(func(g Gomega) {
+		g.Expect(v.clientsPrepared.adminKubeconfig.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
+	}).Should(Succeed())
+
+	By("Using rotated static token kubeconfig with new CA to access shoot")
+	Eventually(func(g Gomega) {
+		shootClient, err := internal.CreateShootClientFromStaticTokenKubeconfig(ctx, v.GardenClient, v.Shoot)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		g.Expect(shootClient.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
+	}).Should(Succeed())
+
+	By("Using admin kubeconfig with new CA to access shoot")
+	Eventually(func(g Gomega) {
+		shootClient, err := internal.CreateShootClientFromAdminKubeconfig(ctx, v.GardenClient, v.Shoot)
+		g.Expect(err).NotTo(HaveOccurred())
+
+		g.Expect(shootClient.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
+	}).Should(Succeed())
+}

--- a/test/e2e/shoot/internal/rotation/shoot_access.go
+++ b/test/e2e/shoot/internal/rotation/shoot_access.go
@@ -189,6 +189,11 @@ func (v *ShootAccessVerifier) AfterCompleted(ctx context.Context) {
 
 // Cleanup is passed to ginkgo.DeferCleanup.
 func (v *ShootAccessVerifier) Cleanup(ctx context.Context) {
+	if v.Config.GardenerConfig.ExistingShootName == "" {
+		// we only have to clean up if we are using an existing shoot, otherwise the shoot will be deleted
+		return
+	}
+
 	// figure out the right shoot client to use, depending on how far the test was executed
 	shootClient := v.clientsBefore.adminKubeconfig
 	if shootClient == nil {

--- a/test/e2e/shoot/internal/rotation/shoot_access.go
+++ b/test/e2e/shoot/internal/rotation/shoot_access.go
@@ -27,14 +27,14 @@ import (
 )
 
 type clients struct {
-	staticToken, adminKubeconfig kubernetes.Interface
+	staticToken, adminKubeconfig, clientCert kubernetes.Interface
 }
 
 // ShootAccessVerifier uses the static token and admin kubeconfig to access the Shoot.
 type ShootAccessVerifier struct {
 	*framework.ShootCreationFramework
 
-	clientsBefore, clientsPrepared clients
+	clientsBefore, clientsPrepared, clientsAfter clients
 }
 
 // Before is called before the rotation is started.
@@ -58,6 +58,16 @@ func (v *ShootAccessVerifier) Before(ctx context.Context) {
 
 		v.clientsBefore.adminKubeconfig = shootClient
 	}).Should(Succeed())
+
+	By("Requesting new client certificate and using it to access shoot")
+	Eventually(func(g Gomega) {
+		shootClient, err := internal.CreateShootClientFromCSR(ctx, v.clientsBefore.adminKubeconfig, "e2e-rotate-before")
+		g.Expect(err).NotTo(HaveOccurred())
+
+		g.Expect(shootClient.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
+
+		v.clientsBefore.clientCert = shootClient
+	}).Should(Succeed())
 }
 
 // ExpectPreparingStatus is called while waiting for the Preparing status.
@@ -73,6 +83,11 @@ func (v *ShootAccessVerifier) AfterPrepared(ctx context.Context) {
 	By("Using admin kubeconfig with old CA to access shoot")
 	Eventually(func(g Gomega) {
 		g.Expect(v.clientsBefore.adminKubeconfig.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
+	}).Should(Succeed())
+
+	By("Using client certificate from before rotation to access shoot")
+	Eventually(func(g Gomega) {
+		g.Expect(v.clientsBefore.clientCert.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
 	}).Should(Succeed())
 
 	By("Using rotated static token kubeconfig with CA bundle to access shoot")
@@ -94,6 +109,16 @@ func (v *ShootAccessVerifier) AfterPrepared(ctx context.Context) {
 
 		v.clientsPrepared.adminKubeconfig = shootClient
 	}).Should(Succeed())
+
+	By("Requesting new client certificate and using it to access shoot")
+	Eventually(func(g Gomega) {
+		shootClient, err := internal.CreateShootClientFromCSR(ctx, v.clientsPrepared.adminKubeconfig, "e2e-rotate-prepared")
+		g.Expect(err).NotTo(HaveOccurred())
+
+		g.Expect(shootClient.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
+
+		v.clientsPrepared.clientCert = shootClient
+	}).Should(Succeed())
 }
 
 // ExpectCompletingStatus is called while waiting for the Completing status.
@@ -111,6 +136,11 @@ func (v *ShootAccessVerifier) AfterCompleted(ctx context.Context) {
 		g.Expect(v.clientsBefore.adminKubeconfig.Client().List(ctx, &corev1.NamespaceList{})).NotTo(Succeed())
 	}).Should(Succeed())
 
+	By("Using client certificate from before rotation to access shoot")
+	Consistently(func(g Gomega) {
+		g.Expect(v.clientsBefore.clientCert.Client().List(ctx, &corev1.NamespaceList{})).NotTo(Succeed())
+	}).Should(Succeed())
+
 	By("Using rotated static token kubeconfig with CA bundle to access shoot")
 	Eventually(func(g Gomega) {
 		g.Expect(v.clientsPrepared.staticToken.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
@@ -121,12 +151,19 @@ func (v *ShootAccessVerifier) AfterCompleted(ctx context.Context) {
 		g.Expect(v.clientsPrepared.adminKubeconfig.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
 	}).Should(Succeed())
 
+	By("Using client certificate from after preparation to access shoot")
+	Eventually(func(g Gomega) {
+		g.Expect(v.clientsPrepared.clientCert.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
+	}).Should(Succeed())
+
 	By("Using rotated static token kubeconfig with new CA to access shoot")
 	Eventually(func(g Gomega) {
 		shootClient, err := internal.CreateShootClientFromStaticTokenKubeconfig(ctx, v.GardenClient, v.Shoot)
 		g.Expect(err).NotTo(HaveOccurred())
 
 		g.Expect(shootClient.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
+
+		v.clientsAfter.staticToken = shootClient
 	}).Should(Succeed())
 
 	By("Using admin kubeconfig with new CA to access shoot")
@@ -135,5 +172,38 @@ func (v *ShootAccessVerifier) AfterCompleted(ctx context.Context) {
 		g.Expect(err).NotTo(HaveOccurred())
 
 		g.Expect(shootClient.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
+
+		v.clientsAfter.adminKubeconfig = shootClient
+	}).Should(Succeed())
+
+	By("Requesting new client certificate and using it to access shoot")
+	Eventually(func(g Gomega) {
+		shootClient, err := internal.CreateShootClientFromCSR(ctx, v.clientsAfter.adminKubeconfig, "e2e-rotate-after")
+		g.Expect(err).NotTo(HaveOccurred())
+
+		g.Expect(shootClient.Client().List(ctx, &corev1.NamespaceList{})).To(Succeed())
+
+		v.clientsAfter.clientCert = shootClient
+	}).Should(Succeed())
+}
+
+// Cleanup is passed to ginkgo.DeferCleanup.
+func (v *ShootAccessVerifier) Cleanup(ctx context.Context) {
+	// figure out the right shoot client to use, depending on how far the test was executed
+	shootClient := v.clientsBefore.adminKubeconfig
+	if shootClient == nil {
+		// shoot was never successfully created or accessed, nothing to delete
+		return
+	}
+	if v.clientsPrepared.adminKubeconfig != nil {
+		shootClient = v.clientsPrepared.adminKubeconfig
+	}
+	if v.clientsAfter.adminKubeconfig != nil {
+		shootClient = v.clientsAfter.adminKubeconfig
+	}
+
+	By("Cleaning up objects in shoot from client certificate access")
+	Eventually(func(g Gomega) {
+		g.Expect(internal.CleanupObjectsFromCSRAccess(ctx, shootClient)).To(Succeed())
 	}).Should(Succeed())
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing security
/kind enhancement

**What this PR does / why we need it**:

Co-Authored-By: @rfranzke 

Adds advanced assertions for credentials rotations in the existing e2e test to increase precision/accuracy.

Basically, adds more assertions from the user's perspective, e.g. admin kubeconfig requested before rotation works after preparation but not after completion.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/3292

**Special notes for your reviewer**:

@rfranzke will continue with the second part of this task.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
