### PR TITLE
Add CA rotation support for multi-node etcd clusters

### DIFF
--- a/cmd/gardener-extension-provider-local/app/app.go
+++ b/cmd/gardener-extension-provider-local/app/app.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"time"
 
+	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 	"github.com/gardener/gardener/extensions/pkg/controller"
 	controllercmd "github.com/gardener/gardener/extensions/pkg/controller/cmd"
 	"github.com/gardener/gardener/extensions/pkg/controller/controlplane/genericactuator"
@@ -220,6 +221,9 @@ func NewControllerManagerCommand(ctx context.Context) *cobra.Command {
 				return fmt.Errorf("could not update manager scheme: %w", err)
 			}
 			if err := dnsv1alpha1.AddToScheme(scheme); err != nil {
+				return fmt.Errorf("could not update manager scheme: %w", err)
+			}
+			if err := druidv1alpha1.AddToScheme(scheme); err != nil {
 				return fmt.Errorf("could not update manager scheme: %w", err)
 			}
 			// add common meta types to schema for controller-runtime to use v1.ListOptions

--- a/example/20-componentconfig-gardener-scheduler.yaml
+++ b/example/20-componentconfig-gardener-scheduler.yaml
@@ -25,7 +25,7 @@ debugging:
   enableProfiling: false
   enableContentionProfiling: false
 featureGates:
-  HAControlPlanes: false
+  HAControlPlanes: true
 #schedulers:
 #  backupBucket:
 #    concurrentSyncs: 5 # defaults to 5

--- a/example/20-componentconfig-gardenlet.yaml
+++ b/example/20-componentconfig-gardenlet.yaml
@@ -125,7 +125,7 @@ featureGates:
   DisableDNSProviderManagement: false
   ShootCARotation: true
   ShootSARotation: true
-  HAControlPlanes: false
+  HAControlPlanes: true
 # seedConfig:
 #   metadata:
 #     name: my-seed

--- a/example/gardener-local/controlplane/values.yaml
+++ b/example/gardener-local/controlplane/values.yaml
@@ -258,6 +258,12 @@ global:
           port: 2718
     resources: {}
 
+  # Gardener scheduler configuration values
+  scheduler:
+    config:
+      featureGates:
+        HAControlPlanes: true
+
   # General system configuration
   internalDomain:
     provider: local

--- a/example/gardener-local/gardenlet/values.yaml
+++ b/example/gardener-local/gardenlet/values.yaml
@@ -47,6 +47,7 @@ global:
         ShootCARotation: true
         ShootSARotation: true
         CopyEtcdBackupsDuringControlPlaneMigration: true
+        HAControlPlanes: true
       logging:
         enabled: true
         loki:

--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -29,6 +29,7 @@ import (
 	"github.com/gardener/gardener/pkg/operation"
 	botanistpkg "github.com/gardener/gardener/pkg/operation/botanist"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
+	"github.com/gardener/gardener/pkg/operation/botanist/component/etcd"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/kubeapiserver"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/errors"
@@ -99,14 +100,23 @@ func (r *shootReconciler) runReconcileShootFlow(ctx context.Context, o *operatio
 		kubeProxyEnabled                = gardencorev1beta1helper.KubeProxyEnabled(o.Shoot.GetInfo().Spec.Kubernetes.KubeProxy)
 		shootControlPlaneLoggingEnabled = botanist.Shoot.IsShootControlPlaneLoggingEnabled(botanist.Config)
 		deployKubeAPIServerTaskTimeout  = defaultTimeout
+		deployEtcdTaskTimeout           = defaultTimeout
+		deployEtcdTaskInterval          = defaultInterval
 	)
 
-	// During the 'Preparing' phase of ETCD encryption key rotation, the `kube-apiserver` is deployed twice. Also, the
-	// `botanist.DeployKubeAPIServer` function calls the `Wait` method after the first deployment. Hence, we should use
+	// During the 'Preparing' phase of different rotation operations, components are deployed twice. Also, the
+	// different deployment functions call the `Wait` method after the first deployment. Hence, we should use
 	// the respective timeout in this case instead of the (too short) default timeout to prevent undesired and confusing
 	// errors in the reconciliation flow.
 	if gardencorev1beta1helper.GetShootETCDEncryptionKeyRotationPhase(o.Shoot.GetInfo().Status.Credentials) == gardencorev1beta1.RotationPreparing {
 		deployKubeAPIServerTaskTimeout = kubeapiserver.TimeoutWaitForDeployment
+	}
+
+	if gardenletfeatures.FeatureGate.Enabled(features.HAControlPlanes) &&
+		metav1.HasAnnotation(o.Shoot.GetInfo().ObjectMeta, v1beta1constants.ShootAlphaControlPlaneHighAvailability) &&
+		gardencorev1beta1helper.GetShootCARotationPhase(o.Shoot.GetInfo().Status.Credentials) == gardencorev1beta1.RotationPreparing {
+		deployEtcdTaskTimeout = etcd.DefaultTimeout
+		deployEtcdTaskInterval = 1 * time.Minute
 	}
 
 	var (
@@ -261,7 +271,7 @@ func (r *shootReconciler) runReconcileShootFlow(ctx context.Context, o *operatio
 		})
 		deployETCD = g.Add(flow.Task{
 			Name:         "Deploying main and events etcd",
-			Fn:           flow.TaskFn(botanist.DeployEtcd).RetryUntilTimeout(defaultInterval, defaultTimeout),
+			Fn:           flow.TaskFn(botanist.DeployEtcd).RetryUntilTimeout(deployEtcdTaskInterval, deployEtcdTaskTimeout),
 			Dependencies: flow.NewTaskIDs(initializeSecretsManagement, deployCloudProviderSecret, waitUntilBackupEntryInGardenReconciled, waitUntilEtcdBackupsCopied),
 		})
 		_ = g.Add(flow.Task{

--- a/pkg/operation/botanist/component/etcd/etcd.go
+++ b/pkg/operation/botanist/component/etcd/etcd.go
@@ -813,9 +813,6 @@ func (e *etcd) Snapshot(ctx context.Context, podExecutor kubernetes.PodExecutor)
 	if len(podsList.Items) == 0 {
 		return fmt.Errorf("didn't find any pods for selector: %v", etcdMainSelector)
 	}
-	if len(podsList.Items) > 1 {
-		return fmt.Errorf("multiple ETCD Pods found. Pod list found: %v", podsList.Items)
-	}
 
 	_, err := podExecutor.Execute(
 		e.namespace,

--- a/pkg/operation/botanist/component/etcd/etcd.go
+++ b/pkg/operation/botanist/component/etcd/etcd.go
@@ -120,6 +120,9 @@ type Interface interface {
 	SetOwnerCheckConfig(config *OwnerCheckConfig)
 	// Scale scales the etcd resource to the given replica count.
 	Scale(context.Context, int32) error
+	// RolloutPeerCA gets the peer CA and patches the
+	// related `etcd` resource to use this new CA for peer communication.
+	RolloutPeerCA(context.Context) error
 }
 
 // New creates a new instance of DeployWaiter for the Etcd.
@@ -134,6 +137,7 @@ func New(
 	replicas *int32,
 	storageCapacity string,
 	defragmentationSchedule *string,
+	caRotationPhase gardencorev1beta1.ShootCredentialsRotationPhase,
 ) Interface {
 	name := "etcd-" + role
 
@@ -171,6 +175,7 @@ func New(
 		defragmentationSchedule: defragmentationSchedule,
 		nodeSpread:              nodeSpread,
 		zoneSpread:              zoneSpread,
+		caRotationPhase:         caRotationPhase,
 
 		etcd: &druidv1alpha1.Etcd{
 			ObjectMeta: metav1.ObjectMeta{
@@ -200,6 +205,7 @@ type etcd struct {
 	backupConfig     *BackupConfig
 	hvpaConfig       *HVPAConfig
 	ownerCheckConfig *OwnerCheckConfig
+	caRotationPhase  gardencorev1beta1.ShootCredentialsRotationPhase
 }
 
 func (e *etcd) Deploy(ctx context.Context) error {
@@ -301,25 +307,12 @@ func (e *etcd) Deploy(ctx context.Context) error {
 
 	// add peer certs if shoot has HA control plane
 	var (
-		etcdPeerCASecret *corev1.Secret
-		peerServerSecret *corev1.Secret
+		etcdPeerCASecretName string
+		peerServerSecretName string
 	)
-	if e.nodeSpread {
-		etcdPeerCASecret, found = e.secretsManager.Get(v1beta1constants.SecretNameCAETCDPeer)
-		if !found {
-			return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameCAETCDPeer)
-		}
 
-		peerServerSecret, err = e.secretsManager.Generate(ctx, &secretutils.CertificateSecretConfig{
-			Name:                        secretNamePrefixPeerServer + e.role,
-			CommonName:                  "etcd-server",
-			DNSNames:                    e.peerServiceDNSNames(),
-			CertType:                    secretutils.ServerClientCert,
-			SkipPublishingCACertificate: true,
-		}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCAETCDPeer), secretsmanager.Rotate(secretsmanager.InPlace))
-		if err != nil {
-			return err
-		}
+	if etcdPeerCASecretName, peerServerSecretName, err = e.handlePeerCertificates(ctx); err != nil {
+		return err
 	}
 
 	// add pod anti-affinity rules for etcd if shoot has a HA control plane
@@ -526,14 +519,14 @@ func (e *etcd) Deploy(ctx context.Context) error {
 			e.etcd.Spec.Etcd.PeerUrlTLS = &druidv1alpha1.TLSConfig{
 				TLSCASecretRef: druidv1alpha1.SecretReference{
 					SecretReference: corev1.SecretReference{
-						Name:      etcdPeerCASecret.Name,
-						Namespace: etcdPeerCASecret.Namespace,
+						Name:      etcdPeerCASecretName,
+						Namespace: e.namespace,
 					},
 					DataKey: pointer.String(secretutils.DataKeyCertificateBundle),
 				},
 				ServerTLSSecretRef: corev1.SecretReference{
-					Name:      peerServerSecret.Name,
-					Namespace: peerServerSecret.Namespace,
+					Name:      peerServerSecretName,
+					Namespace: e.namespace,
 				},
 			}
 		}
@@ -896,6 +889,44 @@ func (e *etcd) Scale(ctx context.Context, replicas int32) error {
 	return e.client.Patch(ctx, etcdObj, patch)
 }
 
+func (e *etcd) RolloutPeerCA(ctx context.Context) error {
+	if !e.nodeSpread {
+		return nil
+	}
+
+	etcdPeerCASecret, found := e.secretsManager.Get(v1beta1constants.SecretNameCAETCDPeer)
+	if !found {
+		return fmt.Errorf("secret %q not found", v1beta1constants.SecretNameCAETCDPeer)
+	}
+
+	_, err := controllerutils.GetAndCreateOrMergePatch(ctx, e.client, e.etcd, func() error {
+		e.etcd.Annotations = map[string]string{
+			v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
+			v1beta1constants.GardenerTimestamp: TimeNow().UTC().String(),
+		}
+
+		var dataKey *string
+		if e.etcd.Spec.Etcd.PeerUrlTLS != nil {
+			dataKey = e.etcd.Spec.Etcd.PeerUrlTLS.TLSCASecretRef.DataKey
+		}
+
+		if e.etcd.Spec.Etcd.PeerUrlTLS == nil {
+			e.etcd.Spec.Etcd.PeerUrlTLS = &druidv1alpha1.TLSConfig{}
+		}
+
+		e.etcd.Spec.Etcd.PeerUrlTLS.TLSCASecretRef = druidv1alpha1.SecretReference{
+			SecretReference: corev1.SecretReference{
+				Name:      etcdPeerCASecret.Name,
+				Namespace: etcdPeerCASecret.Namespace,
+			},
+			DataKey: dataKey,
+		}
+		return nil
+	})
+
+	return err
+}
+
 func (e *etcd) podLabelSelector() labels.Selector {
 	app, _ := labels.NewRequirement(v1beta1constants.LabelApp, selection.Equals, []string{LabelAppValue})
 	role, _ := labels.NewRequirement(v1beta1constants.LabelRole, selection.Equals, []string{e.role})
@@ -962,6 +993,40 @@ func (e *etcd) computeFullSnapshotSchedule(existingEtcd *druidv1alpha1.Etcd) *st
 		fullSnapshotSchedule = existingEtcd.Spec.Backup.FullSnapshotSchedule
 	}
 	return fullSnapshotSchedule
+}
+
+func (e *etcd) handlePeerCertificates(ctx context.Context) (caSecretName, peerSecretName string, err error) {
+	if !e.nodeSpread {
+		return
+	}
+
+	etcdPeerCASecret, found := e.secretsManager.Get(v1beta1constants.SecretNameCAETCDPeer)
+	if !found {
+		err = fmt.Errorf("secret %q not found", v1beta1constants.SecretNameCAETCDPeer)
+		return
+	}
+
+	var singedByCAOption []secretsmanager.SignedByCAOption
+
+	if e.caRotationPhase == gardencorev1beta1.RotationPreparing {
+		singedByCAOption = append(singedByCAOption, secretsmanager.UseCurrentCA)
+	}
+
+	peerServerSecret, err := e.secretsManager.Generate(ctx, &secretutils.CertificateSecretConfig{
+		Name:                        secretNamePrefixPeerServer + e.role,
+		CommonName:                  "etcd-server",
+		DNSNames:                    e.peerServiceDNSNames(),
+		CertType:                    secretutils.ServerClientCert,
+		SkipPublishingCACertificate: true,
+	}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCAETCDPeer, singedByCAOption...), secretsmanager.Rotate(secretsmanager.InPlace))
+	if err != nil {
+		err = fmt.Errorf("secret %q not found", v1beta1constants.SecretNameCAETCDPeer)
+		return
+	}
+
+	caSecretName = etcdPeerCASecret.Name
+	peerSecretName = peerServerSecret.Name
+	return
 }
 
 // BackupConfig contains information for configuring the backup-restore sidecar so that it takes regularly backups of

--- a/pkg/operation/botanist/component/etcd/etcd_test.go
+++ b/pkg/operation/botanist/component/etcd/etcd_test.go
@@ -1427,6 +1427,10 @@ var _ = Describe("Etcd", func() {
 							"etcd-test-client.shoot--test--test",
 							"etcd-test-client.shoot--test--test.svc",
 							"etcd-test-client.shoot--test--test.svc.cluster.local",
+							"*.etcd-test-peer",
+							"*.etcd-test-peer.shoot--test--test",
+							"*.etcd-test-peer.shoot--test--test.svc",
+							"*.etcd-test-peer.shoot--test--test.svc.cluster.local",
 						},
 						CertType:                    secretutils.ServerClientCert,
 						SkipPublishingCACertificate: true,
@@ -1436,7 +1440,6 @@ var _ = Describe("Etcd", func() {
 					createExpectations(v1beta1constants.ShootAlphaControlPlaneHighAvailabilitySingleZone, clientCASecret.Name, clientSecret.Name, serverSecret.Name, peerCASecret.Name, peerServerSecret.Name)
 
 					Expect(etcd.Deploy(ctx)).To(Succeed())
-
 				})
 			})
 
@@ -1629,29 +1632,6 @@ var _ = Describe("Etcd", func() {
 				)
 
 				Expect(etcd.Snapshot(ctx, podExecutor)).To(MatchError(ContainSubstring("didn't find any pods")))
-			})
-
-			It("should return an error when the pod list is too large", func() {
-				podList := &corev1.PodList{
-					Items: []corev1.Pod{
-						{},
-						{},
-					},
-				}
-
-				c.EXPECT().List(
-					ctx,
-					gomock.AssignableToTypeOf(&corev1.PodList{}),
-					client.InNamespace(testNamespace),
-					client.MatchingLabelsSelector{Selector: selector},
-				).DoAndReturn(
-					func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
-						podList.DeepCopyInto(list.(*corev1.PodList))
-						return nil
-					},
-				)
-
-				Expect(etcd.Snapshot(ctx, podExecutor)).To(MatchError(ContainSubstring("multiple ETCD Pods found")))
 			})
 
 			It("should return an error when the execution command fails", func() {

--- a/pkg/operation/botanist/component/etcd/etcd_test.go
+++ b/pkg/operation/botanist/component/etcd/etcd_test.go
@@ -34,6 +34,7 @@ import (
 	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	"github.com/go-logr/logr"
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
@@ -53,9 +54,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	vpaautoscalingv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
 	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
+	testclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 var _ = Describe("Etcd", func() {
@@ -265,6 +268,11 @@ var _ = Describe("Etcd", func() {
 			existingResourcesContainerEtcd *corev1.ResourceRequirements,
 			existingResourcesContainerBackupRestore *corev1.ResourceRequirements,
 			haOption *string,
+			caSecretName string,
+			clientSecretName string,
+			serverSecretName string,
+			peerCASecretName *string,
+			peerServerSecretName *string,
 		) *druidv1alpha1.Etcd {
 
 			defragSchedule := defragmentationSchedule
@@ -330,17 +338,17 @@ var _ = Describe("Etcd", func() {
 						ClientUrlTLS: &druidv1alpha1.TLSConfig{
 							TLSCASecretRef: druidv1alpha1.SecretReference{
 								SecretReference: corev1.SecretReference{
-									Name:      secretNameCA,
+									Name:      caSecretName,
 									Namespace: testNamespace,
 								},
 								DataKey: pointer.String("bundle.crt"),
 							},
 							ServerTLSSecretRef: corev1.SecretReference{
-								Name:      secretNameServer,
+								Name:      serverSecretName,
 								Namespace: testNamespace,
 							},
 							ClientTLSSecretRef: corev1.SecretReference{
-								Name:      secretNameClient,
+								Name:      clientSecretName,
 								Namespace: testNamespace,
 							},
 						},
@@ -354,17 +362,17 @@ var _ = Describe("Etcd", func() {
 						TLS: &druidv1alpha1.TLSConfig{
 							TLSCASecretRef: druidv1alpha1.SecretReference{
 								SecretReference: corev1.SecretReference{
-									Name:      secretNameCA,
+									Name:      caSecretName,
 									Namespace: testNamespace,
 								},
 								DataKey: pointer.String("bundle.crt"),
 							},
 							ServerTLSSecretRef: corev1.SecretReference{
-								Name:      secretNameServer,
+								Name:      serverSecretName,
 								Namespace: testNamespace,
 							},
 							ClientTLSSecretRef: corev1.SecretReference{
-								Name:      secretNameClient,
+								Name:      clientSecretName,
 								Namespace: testNamespace,
 							},
 						},
@@ -439,6 +447,23 @@ var _ = Describe("Etcd", func() {
 							},
 						},
 					},
+				}
+			}
+
+			if pointer.StringDeref(peerServerSecretName, "") != "" {
+				obj.Spec.Etcd.PeerUrlTLS.ServerTLSSecretRef = corev1.SecretReference{
+					Name:      *peerServerSecretName,
+					Namespace: testNamespace,
+				}
+			}
+
+			if pointer.StringDeref(peerCASecretName, "") != "" {
+				obj.Spec.Etcd.PeerUrlTLS.TLSCASecretRef = druidv1alpha1.SecretReference{
+					SecretReference: corev1.SecretReference{
+						Name:      *peerCASecretName,
+						Namespace: testNamespace,
+					},
+					DataKey: pointer.String(secretutils.DataKeyCertificateBundle),
 				}
 			}
 
@@ -639,7 +664,7 @@ var _ = Describe("Etcd", func() {
 
 		By("creating secrets managed outside of this package for whose secretsmanager.Get() will be called")
 		Expect(fakeClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "ca-etcd", Namespace: testNamespace}})).To(Succeed())
-		etcd = New(c, log, testNamespace, sm, testRole, class, annotations, replicas, storageCapacity, &defragmentationSchedule)
+		etcd = New(c, log, testNamespace, sm, testRole, class, annotations, replicas, storageCapacity, &defragmentationSchedule, "")
 	})
 
 	AfterEach(func() {
@@ -777,7 +802,11 @@ var _ = Describe("Etcd", func() {
 						nil,
 						nil,
 						nil,
-					)))
+						secretNameCA,
+						secretNameClient,
+						secretNameServer,
+						nil,
+						nil)))
 				}),
 				c.EXPECT().Get(ctx, kutil.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
@@ -797,7 +826,7 @@ var _ = Describe("Etcd", func() {
 				existingReplicas int32 = 245
 			)
 
-			etcd = New(c, log, testNamespace, sm, testRole, class, annotations, nil, storageCapacity, &defragmentationSchedule)
+			etcd = New(c, log, testNamespace, sm, testRole, class, annotations, nil, storageCapacity, &defragmentationSchedule, "")
 			setHVPAConfig()
 
 			gomock.InOrder(
@@ -833,7 +862,11 @@ var _ = Describe("Etcd", func() {
 						nil,
 						nil,
 						nil,
-					)))
+						secretNameCA,
+						secretNameClient,
+						secretNameServer,
+						nil,
+						nil)))
 				}),
 				c.EXPECT().Get(ctx, kutil.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
@@ -853,7 +886,7 @@ var _ = Describe("Etcd", func() {
 				existingReplicas int32 = 245
 			)
 
-			etcd = New(c, log, testNamespace, sm, testRole, class, annotations, nil, storageCapacity, &defragmentationSchedule)
+			etcd = New(c, log, testNamespace, sm, testRole, class, annotations, nil, storageCapacity, &defragmentationSchedule, "")
 			setHVPAConfig()
 
 			gomock.InOrder(
@@ -894,7 +927,11 @@ var _ = Describe("Etcd", func() {
 						nil,
 						nil,
 						nil,
-					)))
+						secretNameCA,
+						secretNameClient,
+						secretNameServer,
+						nil,
+						nil)))
 				}),
 				c.EXPECT().Get(ctx, kutil.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
@@ -952,7 +989,11 @@ var _ = Describe("Etcd", func() {
 						nil,
 						nil,
 						nil,
-					)))
+						secretNameCA,
+						secretNameClient,
+						secretNameServer,
+						nil,
+						nil)))
 				}),
 				c.EXPECT().Get(ctx, kutil.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
@@ -1041,7 +1082,11 @@ var _ = Describe("Etcd", func() {
 						&expectedResourcesContainerEtcd,
 						&expectedResourcesContainerBackupRestore,
 						nil,
-					)))
+						secretNameCA,
+						secretNameClient,
+						secretNameServer,
+						nil,
+						nil)))
 				}),
 				c.EXPECT().Get(ctx, kutil.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
 				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
@@ -1068,7 +1113,7 @@ var _ = Describe("Etcd", func() {
 
 				replicas = pointer.Int32Ptr(1)
 
-				etcd = New(c, log, testNamespace, sm, testRole, class, annotations, replicas, storageCapacity, &defragmentationSchedule)
+				etcd = New(c, log, testNamespace, sm, testRole, class, annotations, replicas, storageCapacity, &defragmentationSchedule, "")
 				newSetHVPAConfigFunc(updateMode)()
 
 				gomock.InOrder(
@@ -1090,7 +1135,11 @@ var _ = Describe("Etcd", func() {
 							nil,
 							nil,
 							nil,
-						)))
+							secretNameCA,
+							secretNameClient,
+							secretNameServer,
+							nil,
+							nil)))
 					}),
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
@@ -1139,7 +1188,11 @@ var _ = Describe("Etcd", func() {
 							nil,
 							nil,
 							nil,
-						)))
+							secretNameCA,
+							secretNameClient,
+							secretNameServer,
+							nil,
+							nil)))
 					}),
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, hvpaName), gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{})),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&hvpav1alpha1.Hvpa{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
@@ -1194,7 +1247,11 @@ var _ = Describe("Etcd", func() {
 							nil,
 							nil,
 							nil,
-						)
+							secretNameCA,
+							secretNameClient,
+							secretNameServer,
+							nil,
+							nil)
 						expobj.Status.Etcd = &druidv1alpha1.CrossVersionObjectReference{}
 
 						Expect(obj).To(DeepEqual(expobj))
@@ -1210,9 +1267,12 @@ var _ = Describe("Etcd", func() {
 		})
 
 		Context("when HA setup is configured", func() {
-			var zoneAnnotations map[string]string
+			var (
+				zoneAnnotations map[string]string
+				rotationPhase   gardencorev1beta1.ShootCredentialsRotationPhase
+			)
 
-			createExpectations := func(haOption string) {
+			createExpectations := func(haOption string, caSecretName, clientSecretName, serverSecretName, peerCASecretName, peerServerSecretName string) {
 				gomock.InOrder(
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
 					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&appsv1.StatefulSet{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")),
@@ -1225,7 +1285,18 @@ var _ = Describe("Etcd", func() {
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&networkingv1.NetworkPolicy{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(peerNetworkPolicy))
 					}),
-					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})),
+					c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).DoAndReturn(
+						func(_ context.Context, _ client.ObjectKey, etcd *druidv1alpha1.Etcd) error {
+							if peerServerSecretName != "" {
+								etcd.Spec.Etcd.PeerUrlTLS = &druidv1alpha1.TLSConfig{
+									ServerTLSSecretRef: corev1.SecretReference{
+										Name:      peerServerSecretName,
+										Namespace: testNamespace,
+									},
+								}
+							}
+							return nil
+						}),
 					c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).Do(func(ctx context.Context, obj client.Object, _ client.Patch, _ ...client.PatchOption) {
 						Expect(obj).To(DeepEqual(etcdObjFor(
 							class,
@@ -1236,6 +1307,11 @@ var _ = Describe("Etcd", func() {
 							nil,
 							nil,
 							pointer.String(haOption),
+							caSecretName,
+							clientSecretName,
+							serverSecretName,
+							&peerCASecretName,
+							&peerServerSecretName,
 						)))
 					}),
 					c.EXPECT().Delete(ctx, &hvpav1alpha1.Hvpa{ObjectMeta: metav1.ObjectMeta{Name: "etcd-" + testRole, Namespace: testNamespace}}),
@@ -1248,7 +1324,120 @@ var _ = Describe("Etcd", func() {
 			})
 
 			JustBeforeEach(func() {
-				etcd = New(c, log, testNamespace, sm, testRole, class, zoneAnnotations, replicas, storageCapacity, &defragmentationSchedule)
+				etcd = New(c, log, testNamespace, sm, testRole, class, zoneAnnotations, replicas, storageCapacity, &defragmentationSchedule, rotationPhase)
+			})
+
+			Context("when CA rotation phase is in `Preparing` state", func() {
+				var (
+					clientCASecret *corev1.Secret
+					peerCASecret   *corev1.Secret
+				)
+
+				BeforeEach(func() {
+					zoneAnnotations = map[string]string{
+						v1beta1constants.ShootAlphaControlPlaneHighAvailability: v1beta1constants.ShootAlphaControlPlaneHighAvailabilitySingleZone,
+					}
+					rotationPhase = gardencorev1beta1.RotationPreparing
+
+					secretNamesToTimes := map[string]time.Time{}
+
+					// A "real" SecretsManager is needed here because in further tests we want to differentiate
+					// between what was issued by the old and new CAs.
+					var err error
+					sm, err = secretsmanager.New(
+						ctx,
+						logr.New(logf.NullLogSink{}),
+						testclock.NewFakeClock(time.Now()),
+						fakeClient,
+						testNamespace,
+						"",
+						secretsmanager.Config{
+							SecretNamesToTimes: secretNamesToTimes,
+						})
+					Expect(err).ToNot(HaveOccurred())
+
+					// Create new etcd CA
+					_, err = sm.Generate(ctx,
+						&secretutils.CertificateSecretConfig{Name: v1beta1constants.SecretNameCAETCD, CommonName: "etcd", CertType: secretutils.CACert})
+					Expect(err).ToNot(HaveOccurred())
+
+					// Create new peer CA
+					_, err = sm.Generate(ctx,
+						&secretutils.CertificateSecretConfig{Name: v1beta1constants.SecretNameCAETCDPeer, CommonName: "etcd-peer", CertType: secretutils.CACert})
+					Expect(err).ToNot(HaveOccurred())
+
+					// Set time to trigger CA rotation
+					secretNamesToTimes[v1beta1constants.SecretNameCAETCDPeer] = now
+
+					// Rotate CA
+					_, err = sm.Generate(ctx,
+						&secretutils.CertificateSecretConfig{Name: v1beta1constants.SecretNameCAETCDPeer, CommonName: "etcd-peer", CertType: secretutils.CACert},
+						secretsmanager.Rotate(secretsmanager.KeepOld))
+					Expect(err).ToNot(HaveOccurred())
+
+					var ok bool
+					clientCASecret, ok = sm.Get(v1beta1constants.SecretNameCAETCD)
+					Expect(ok).To(BeTrue())
+
+					peerCASecret, ok = sm.Get(v1beta1constants.SecretNameCAETCDPeer)
+					Expect(ok).To(BeTrue())
+
+					DeferCleanup(func() {
+						rotationPhase = ""
+					})
+				})
+
+				It("should successfully deploy", func() {
+					oldTimeNow := TimeNow
+					defer func() { TimeNow = oldTimeNow }()
+					TimeNow = func() time.Time { return now }
+
+					peerServerSecret, err := sm.Generate(ctx, &secretutils.CertificateSecretConfig{
+						Name:       "etcd-peer-server-" + testRole,
+						CommonName: "etcd-server",
+						DNSNames: []string{
+							"etcd-test-peer",
+							"etcd-test-peer.shoot--test--test",
+							"etcd-test-peer.shoot--test--test.svc",
+							"etcd-test-peer.shoot--test--test.svc.cluster.local",
+							"*.etcd-test-peer",
+							"*.etcd-test-peer.shoot--test--test",
+							"*.etcd-test-peer.shoot--test--test.svc",
+							"*.etcd-test-peer.shoot--test--test.svc.cluster.local",
+						},
+						CertType:                    secretutils.ServerClientCert,
+						SkipPublishingCACertificate: true,
+					}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCAETCDPeer, secretsmanager.UseCurrentCA), secretsmanager.Rotate(secretsmanager.InPlace))
+					Expect(err).ToNot(HaveOccurred())
+
+					clientSecret, err := sm.Generate(ctx, &secretutils.CertificateSecretConfig{
+						Name:                        SecretNameClient,
+						CommonName:                  "etcd-client",
+						CertType:                    secretutils.ClientCert,
+						SkipPublishingCACertificate: true,
+					}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCAETCD), secretsmanager.Rotate(secretsmanager.InPlace))
+					Expect(err).ToNot(HaveOccurred())
+
+					serverSecret, err := sm.Generate(ctx, &secretutils.CertificateSecretConfig{
+						Name:       "etcd-server-" + testRole,
+						CommonName: "etcd-server",
+						DNSNames: []string{
+							"etcd-test-local",
+							"etcd-test-client",
+							"etcd-test-client.shoot--test--test",
+							"etcd-test-client.shoot--test--test.svc",
+							"etcd-test-client.shoot--test--test.svc.cluster.local",
+						},
+						CertType:                    secretutils.ServerClientCert,
+						SkipPublishingCACertificate: true,
+					}, secretsmanager.SignedByCA(v1beta1constants.SecretNameCAETCD), secretsmanager.Rotate(secretsmanager.InPlace))
+					Expect(err).ToNot(HaveOccurred())
+
+					createExpectations(v1beta1constants.ShootAlphaControlPlaneHighAvailabilitySingleZone, clientCASecret.Name, clientSecret.Name, serverSecret.Name, peerCASecret.Name, peerServerSecret.Name)
+
+					Expect(etcd.Deploy(ctx)).To(Succeed())
+
+				})
 			})
 
 			Context("when configured for single-zone", func() {
@@ -1263,7 +1452,7 @@ var _ = Describe("Etcd", func() {
 					defer func() { TimeNow = oldTimeNow }()
 					TimeNow = func() time.Time { return now }
 
-					createExpectations(v1beta1constants.ShootAlphaControlPlaneHighAvailabilitySingleZone)
+					createExpectations(v1beta1constants.ShootAlphaControlPlaneHighAvailabilitySingleZone, secretNameCA, secretNameClient, secretNameServer, secretNamePeerCA, secretNameServerPeer)
 
 					Expect(etcd.Deploy(ctx)).To(Succeed())
 				})
@@ -1281,7 +1470,7 @@ var _ = Describe("Etcd", func() {
 					defer func() { TimeNow = oldTimeNow }()
 					TimeNow = func() time.Time { return now }
 
-					createExpectations(v1beta1constants.ShootAlphaControlPlaneHighAvailabilityMultiZone)
+					createExpectations(v1beta1constants.ShootAlphaControlPlaneHighAvailabilityMultiZone, secretNameCA, secretNameClient, secretNameServer, secretNamePeerCA, secretNameServerPeer)
 
 					Expect(etcd.Deploy(ctx)).To(Succeed())
 				})
@@ -1606,6 +1795,73 @@ var _ = Describe("Etcd", func() {
 			)
 
 			Expect(etcd.Scale(ctx, 1)).Should(MatchError(`etcd object still has operation annotation set`))
+		})
+	})
+
+	Describe("#RolloutPeerCA", func() {
+		var zoneAnnotations map[string]string
+
+		BeforeEach(func() {
+			zoneAnnotations = map[string]string{}
+		})
+
+		JustBeforeEach(func() {
+			etcd = New(c, log, testNamespace, sm, testRole, class, zoneAnnotations, replicas, storageCapacity, &defragmentationSchedule, "")
+		})
+
+		Context("when HA control-plane is not requested", func() {
+			It("should do nothing and succeed without expectations", func() {
+				Expect(etcd.RolloutPeerCA(ctx)).To(Succeed())
+			})
+		})
+
+		Context("when HA control-plane is requested", func() {
+			BeforeEach(func() {
+				Expect(gardenletfeatures.FeatureGate.Set(fmt.Sprintf("%s=true", features.HAControlPlanes))).To(Succeed())
+				zoneAnnotations[v1beta1constants.ShootAlphaControlPlaneHighAvailability] = v1beta1constants.ShootAlphaControlPlaneHighAvailabilityMultiZone
+				DeferCleanup(test.WithVar(&TimeNow, func() time.Time { return now }))
+			})
+
+			It("should patch the etcd resource with the new peer CA secret name", func() {
+				Expect(fakeClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "ca-etcd-peer", Namespace: testNamespace}})).To(Succeed())
+
+				c.EXPECT().Get(ctx, kutil.Key(testNamespace, etcdName), gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{})).Return(apierrors.NewNotFound(schema.GroupResource{}, "")).DoAndReturn(func(ctx context.Context, _ client.ObjectKey, obj client.Object) error {
+					(&druidv1alpha1.Etcd{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      etcdName,
+							Namespace: testNamespace,
+						},
+						Spec: druidv1alpha1.EtcdSpec{
+							Etcd: druidv1alpha1.EtcdConfig{
+								PeerUrlTLS: &druidv1alpha1.TLSConfig{
+									TLSCASecretRef: druidv1alpha1.SecretReference{
+										SecretReference: corev1.SecretReference{
+											Name:      "old-ca",
+											Namespace: testNamespace,
+										},
+										DataKey: pointer.String(secretutils.DataKeyCertificateBundle),
+									},
+								},
+							},
+						},
+					}).DeepCopyInto(obj.(*druidv1alpha1.Etcd))
+					return nil
+				})
+
+				c.EXPECT().Patch(ctx, gomock.AssignableToTypeOf(&druidv1alpha1.Etcd{}), gomock.Any()).DoAndReturn(
+					func(_ context.Context, obj *druidv1alpha1.Etcd, patch client.Patch, _ ...client.PatchOption) error {
+						data, err := patch.Data(obj)
+						Expect(err).ToNot(HaveOccurred())
+						Expect(string(data)).To(Equal("{\"metadata\":{\"annotations\":{\"gardener.cloud/operation\":\"reconcile\",\"gardener.cloud/timestamp\":\"0001-01-01 00:00:00 +0000 UTC\"}},\"spec\":{\"etcd\":{\"peerUrlTls\":{\"tlsCASecretRef\":{\"name\":\"ca-etcd-peer\"}}}}}"))
+						return nil
+					})
+
+				Expect(etcd.RolloutPeerCA(ctx)).To(Succeed())
+			})
+
+			It("should fail because CA cannot be found", func() {
+				Expect(etcd.RolloutPeerCA(ctx)).To(MatchError("secret \"ca-etcd-peer\" not found"))
+			})
 		})
 	})
 })

--- a/pkg/operation/botanist/component/etcd/mock/mocks.go
+++ b/pkg/operation/botanist/component/etcd/mock/mocks.go
@@ -95,6 +95,20 @@ func (mr *MockInterfaceMockRecorder) Get(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockInterface)(nil).Get), arg0)
 }
 
+// RolloutPeerCA mocks base method.
+func (m *MockInterface) RolloutPeerCA(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RolloutPeerCA", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RolloutPeerCA indicates an expected call of RolloutPeerCA.
+func (mr *MockInterfaceMockRecorder) RolloutPeerCA(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RolloutPeerCA", reflect.TypeOf((*MockInterface)(nil).RolloutPeerCA), arg0)
+}
+
 // Scale mocks base method.
 func (m *MockInterface) Scale(arg0 context.Context, arg1 int32) error {
 	m.ctrl.T.Helper()

--- a/pkg/operation/botanist/component/etcd/monitoring_test.go
+++ b/pkg/operation/botanist/component/etcd/monitoring_test.go
@@ -27,7 +27,7 @@ import (
 var _ = Describe("Monitoring", func() {
 	Describe("#ScrapeConfig", func() {
 		It("should successfully test the scrape configuration", func() {
-			etcd := New(nil, nil, testNamespace, nil, testRole, ClassNormal, nil, nil, "", nil)
+			etcd := New(nil, nil, testNamespace, nil, testRole, ClassNormal, nil, nil, "", nil, "")
 			test.ScrapeConfigs(etcd, expectedScrapeConfigEtcd, expectedScrapeConfigBackupRestore)
 		})
 	})
@@ -35,7 +35,7 @@ var _ = Describe("Monitoring", func() {
 	Describe("#AlertingRules", func() {
 		Context("w/o backup", func() {
 			It("should successfully test the alerting rules (normal)", func() {
-				etcd := New(nil, nil, testNamespace, nil, testRole, ClassNormal, nil, nil, "", nil)
+				etcd := New(nil, nil, testNamespace, nil, testRole, ClassNormal, nil, nil, "", nil, "")
 				test.AlertingRulesWithPromtool(
 					etcd,
 					map[string]string{fmt.Sprintf("kube-etcd3-%s.rules.yaml", testRole): expectedAlertingRulesNormalWithoutBackup},
@@ -44,7 +44,7 @@ var _ = Describe("Monitoring", func() {
 			})
 
 			It("should successfully test the alerting rules (important)", func() {
-				etcd := New(nil, nil, testNamespace, nil, testRole, ClassImportant, nil, nil, "", nil)
+				etcd := New(nil, nil, testNamespace, nil, testRole, ClassImportant, nil, nil, "", nil, "")
 				test.AlertingRulesWithPromtool(
 					etcd,
 					map[string]string{fmt.Sprintf("kube-etcd3-%s.rules.yaml", testRole): expectedAlertingRulesImportantWithoutBackup},
@@ -55,7 +55,7 @@ var _ = Describe("Monitoring", func() {
 
 		Context("w/ backup", func() {
 			It("should successfully test the alerting rules (normal)", func() {
-				etcd := New(nil, nil, testNamespace, nil, testRole, ClassNormal, nil, nil, "", nil)
+				etcd := New(nil, nil, testNamespace, nil, testRole, ClassNormal, nil, nil, "", nil, "")
 				etcd.SetBackupConfig(&BackupConfig{})
 				test.AlertingRulesWithPromtool(
 					etcd,
@@ -65,7 +65,7 @@ var _ = Describe("Monitoring", func() {
 			})
 
 			It("should successfully test the alerting rules (important)", func() {
-				etcd := New(nil, nil, testNamespace, nil, testRole, ClassImportant, nil, nil, "", nil)
+				etcd := New(nil, nil, testNamespace, nil, testRole, ClassImportant, nil, nil, "", nil, "")
 				etcd.SetBackupConfig(&BackupConfig{})
 				test.AlertingRulesWithPromtool(
 					etcd,

--- a/pkg/operation/botanist/component/etcd/waiter_test.go
+++ b/pkg/operation/botanist/component/etcd/waiter_test.go
@@ -89,7 +89,7 @@ var _ = Describe("#Wait", func() {
 			&retry.UntilTimeout, waiter.UntilTimeout,
 		)
 
-		etcd = New(c, log, testNamespace, sm, testRole, ClassNormal, nil, pointer.Int32Ptr(1), "12Gi", pointer.String("abcd"))
+		etcd = New(c, log, testNamespace, sm, testRole, ClassNormal, nil, pointer.Int32Ptr(1), "12Gi", pointer.String("abcd"), "")
 		etcd.SetHVPAConfig(&HVPAConfig{
 			Enabled: true,
 			MaintenanceTimeWindow: gardencorev1beta1.MaintenanceTimeWindow{

--- a/pkg/operation/botanist/etcd_test.go
+++ b/pkg/operation/botanist/etcd_test.go
@@ -485,10 +485,11 @@ func (v *newEtcdValidator) NewEtcd(
 	secretsManager secretsmanager.Interface,
 	role string,
 	class etcd.Class,
-	annotations map[string]string,
+	_ map[string]string,
 	replicas *int32,
 	storageCapacity string,
 	defragmentationSchedule *string,
+	_ gardencorev1beta1.ShootCredentialsRotationPhase,
 ) etcd.Interface {
 	Expect(client).To(v.expectedClient)
 	Expect(logger).To(v.expectedLogger)

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -116,7 +116,11 @@ func (b *Builder) WithSeedObjectFrom(gardenClient client.Reader, seedName string
 
 // Build initializes a new Seed object.
 func (b *Builder) Build(ctx context.Context) (*Seed, error) {
-	seed := &Seed{}
+	seed := &Seed{
+		components: &Components{
+			dns: &DNS{},
+		},
+	}
 
 	seedObject, err := b.seedObjectFunc(ctx)
 	if err != nil {
@@ -854,15 +858,10 @@ func runCreateSeedFlow(
 	log logrus.FieldLogger,
 	sniEnabledOrInUse, hvpaEnabled, vpaEnabled bool,
 ) error {
-	secretData, err := getDNSProviderSecretData(ctx, gardenClient, seed)
-	if err != nil {
-		return err
-	}
-
 	// setup for flow graph
 	var (
-		istio                      component.DeployWaiter
-		ingressLoadBalancerAddress string
+		istio component.DeployWaiter
+		err   error
 	)
 
 	if gardenletfeatures.FeatureGate.Enabled(features.ManagedIstio) {
@@ -871,30 +870,6 @@ func runCreateSeedFlow(
 			return err
 		}
 	}
-
-	if gardencorev1beta1helper.SeedUsesNginxIngressController(seed.GetInfo()) {
-		providerConfig, err := getConfig(seed)
-		if err != nil {
-			return err
-		}
-		nginxIngress, err := defaultNginxIngress(seedClient, imageVector, kubernetesVersion, ingressClass, providerConfig)
-		if err != nil {
-			return err
-		}
-
-		if err = component.OpWaiter(nginxIngress).Deploy(ctx); err != nil {
-			return err
-		}
-
-		ingressLoadBalancerAddress, err = kutil.WaitUntilLoadBalancerIsReady(ctx, seedClient, v1beta1constants.GardenNamespace, "nginx-ingress-controller", time.Minute, log)
-		if err != nil {
-			return err
-		}
-	}
-
-	dnsEntry := getManagedIngressDNSEntry(seedClient, seed.GetIngressFQDN("*"), *seed.GetInfo().Status.ClusterIdentity, ingressLoadBalancerAddress, log)
-	dnsOwner := getManagedIngressDNSOwner(seedClient, *seed.GetInfo().Status.ClusterIdentity)
-	dnsRecord := getManagedIngressDNSRecord(seedClient, seed.GetInfo().Spec.DNS, secretData, seed.GetIngressFQDN("*"), ingressLoadBalancerAddress, log)
 
 	networkPolicies, err := defaultNetworkPolicies(seedClient, seed.GetInfo(), sniEnabledOrInUse)
 	if err != nil {
@@ -945,17 +920,25 @@ func runCreateSeedFlow(
 			Name: "Ensuring network policies",
 			Fn:   networkPolicies.Deploy,
 		})
+		nginxLBReady = g.Add(flow.Task{
+			Name: "Waiting until nginx ingress LoadBalancer is ready",
+			Fn: func(ctx context.Context) error {
+				return waitUntilNginxIngressServiceIsReady(ctx, seed, gardenClient, seedClient, imageVector, kubernetesVersion, log)
+			},
+		})
 		_ = g.Add(flow.Task{
 			Name: "Deploying managed ingress DNS record",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return deployDNSResources(ctx, dnsEntry, dnsOwner, dnsRecord, deployDNSProviderTask(seedClient, seed.GetInfo().Spec.DNS), destroyDNSProviderTask(seedClient))
+				return deployDNSResources(ctx, seed, deployDNSProviderTask(seedClient, seed.GetInfo().Spec.DNS), destroyDNSProviderTask(seedClient))
 			}).DoIf(managedIngress(seed)),
+			Dependencies: flow.NewTaskIDs(nginxLBReady),
 		})
 		_ = g.Add(flow.Task{
 			Name: "Destroying managed ingress DNS record (if existing)",
 			Fn: flow.TaskFn(func(ctx context.Context) error {
-				return destroyDNSResources(ctx, dnsEntry, dnsOwner, dnsRecord, destroyDNSProviderTask(seedClient))
+				return destroyDNSResources(ctx, seed, destroyDNSProviderTask(seedClient))
 			}).DoIf(!managedIngress(seed)),
+			Dependencies: flow.NewTaskIDs(nginxLBReady),
 		})
 		_ = g.Add(flow.Task{
 			Name: "Deploying cluster-identity",
@@ -1044,9 +1027,9 @@ func RunDeleteSeedFlow(
 		return err
 	}
 
-	istioIngressGateway := []istio.IngressGateway{istio.IngressGateway{
-		Namespace: *conf.SNI.Ingress.Namespace,
-	}}
+	istioIngressGateway := []istio.IngressGateway{
+		{Namespace: *conf.SNI.Ingress.Namespace},
+	}
 
 	// Add for each ExposureClass handler in the config an own Ingress Gateway.
 	for _, handler := range conf.ExposureClassHandlers {
@@ -1055,11 +1038,14 @@ func RunDeleteSeedFlow(
 		})
 	}
 
+	seed.components.dns = &DNS{
+		entry:  getManagedIngressDNSEntry(seedClient, seed.GetIngressFQDN("*"), *seed.GetInfo().Status.ClusterIdentity, "", log),
+		owner:  getManagedIngressDNSOwner(seedClient, *seed.GetInfo().Status.ClusterIdentity),
+		record: getManagedIngressDNSRecord(seedClient, seed.GetInfo().Spec.DNS, secretData, seed.GetIngressFQDN("*"), "", log),
+	}
+
 	// setup for flow graph
 	var (
-		dnsEntry        = getManagedIngressDNSEntry(seedClient, seed.GetIngressFQDN("*"), *seed.GetInfo().Status.ClusterIdentity, "", log)
-		dnsOwner        = getManagedIngressDNSOwner(seedClient, *seed.GetInfo().Status.ClusterIdentity)
-		dnsRecord       = getManagedIngressDNSRecord(seedClient, seed.GetInfo().Spec.DNS, secretData, seed.GetIngressFQDN("*"), "", log)
 		autoscaler      = clusterautoscaler.NewBootstrapper(seedClient, v1beta1constants.GardenNamespace)
 		gsac            = seedadmissioncontroller.New(seedClient, v1beta1constants.GardenNamespace, nil, "")
 		hvpa            = hvpa.New(seedClient, v1beta1constants.GardenNamespace, hvpa.Values{})
@@ -1087,7 +1073,7 @@ func RunDeleteSeedFlow(
 		destroyDNSRecord = g.Add(flow.Task{
 			Name: "Destroying managed ingress DNS record (if existing)",
 			Fn: func(ctx context.Context) error {
-				return destroyDNSResources(ctx, dnsEntry, dnsOwner, dnsRecord, destroyDNSProviderTask(seedClient))
+				return destroyDNSResources(ctx, seed, destroyDNSProviderTask(seedClient))
 			},
 		})
 		noControllerInstallations = g.Add(flow.Task{
@@ -1191,48 +1177,48 @@ func RunDeleteSeedFlow(
 	return nil
 }
 
-func deployDNSResources(ctx context.Context, dnsEntry, dnsOwner component.DeployWaiter, dnsRecord component.DeployMigrateWaiter, deployDNSProviderTask, destroyDNSProviderTask flow.TaskFn) error {
-	if err := dnsOwner.Destroy(ctx); err != nil {
+func deployDNSResources(ctx context.Context, seed *Seed, deployDNSProviderTask, destroyDNSProviderTask flow.TaskFn) error {
+	if err := seed.components.dns.owner.Destroy(ctx); err != nil {
 		return err
 	}
-	if err := dnsOwner.WaitCleanup(ctx); err != nil {
+	if err := seed.components.dns.owner.WaitCleanup(ctx); err != nil {
 		return err
 	}
 	if err := destroyDNSProviderTask(ctx); err != nil {
 		return err
 	}
-	if err := dnsEntry.Destroy(ctx); err != nil {
+	if err := seed.components.dns.entry.Destroy(ctx); err != nil {
 		return err
 	}
-	if err := dnsEntry.WaitCleanup(ctx); err != nil {
+	if err := seed.components.dns.entry.WaitCleanup(ctx); err != nil {
 		return err
 	}
-	if err := dnsRecord.Deploy(ctx); err != nil {
+	if err := seed.components.dns.record.Deploy(ctx); err != nil {
 		return err
 	}
-	return dnsRecord.Wait(ctx)
+	return seed.components.dns.record.Wait(ctx)
 }
 
-func destroyDNSResources(ctx context.Context, dnsEntry, dnsOwner, dnsRecord component.DeployWaiter, destroyDNSProviderTask flow.TaskFn) error {
-	if err := dnsEntry.Destroy(ctx); err != nil {
+func destroyDNSResources(ctx context.Context, seed *Seed, destroyDNSProviderTask flow.TaskFn) error {
+	if err := seed.components.dns.entry.Destroy(ctx); err != nil {
 		return err
 	}
-	if err := dnsEntry.WaitCleanup(ctx); err != nil {
+	if err := seed.components.dns.entry.WaitCleanup(ctx); err != nil {
 		return err
 	}
 	if err := destroyDNSProviderTask(ctx); err != nil {
 		return err
 	}
-	if err := dnsOwner.Destroy(ctx); err != nil {
+	if err := seed.components.dns.owner.Destroy(ctx); err != nil {
 		return err
 	}
-	if err := dnsOwner.WaitCleanup(ctx); err != nil {
+	if err := seed.components.dns.owner.WaitCleanup(ctx); err != nil {
 		return err
 	}
-	if err := dnsRecord.Destroy(ctx); err != nil {
+	if err := seed.components.dns.record.Destroy(ctx); err != nil {
 		return err
 	}
-	return dnsRecord.WaitCleanup(ctx)
+	return seed.components.dns.record.WaitCleanup(ctx)
 }
 
 func ensureNoControllerInstallations(c client.Client, seedName string) func(ctx context.Context) error {
@@ -1521,4 +1507,38 @@ func ResizeOrDeleteLokiDataVolumeIfStorageNotTheSame(ctx context.Context, k8sCli
 
 	lokiSts := &appsv1.StatefulSet{ObjectMeta: metav1.ObjectMeta{Name: v1beta1constants.StatefulSetNameLoki, Namespace: v1beta1constants.GardenNamespace}}
 	return client.IgnoreNotFound(k8sClient.Delete(ctx, lokiSts))
+}
+
+func waitUntilNginxIngressServiceIsReady(ctx context.Context, seed *Seed, gardenClient, seedClient client.Client, imageVector imagevector.ImageVector, kubernetesVersion *semver.Version, log logrus.FieldLogger) error {
+	secretData, err := getDNSProviderSecretData(ctx, gardenClient, seed)
+	if err != nil {
+		return err
+	}
+
+	var ingressLoadBalancerAddress string
+	if gardencorev1beta1helper.SeedUsesNginxIngressController(seed.GetInfo()) {
+		providerConfig, err := getConfig(seed)
+		if err != nil {
+			return err
+		}
+		nginxIngress, err := defaultNginxIngress(seedClient, imageVector, kubernetesVersion, ingressClass, providerConfig)
+		if err != nil {
+			return err
+		}
+
+		if err = component.OpWaiter(nginxIngress).Deploy(ctx); err != nil {
+			return err
+		}
+
+		ingressLoadBalancerAddress, err = kutil.WaitUntilLoadBalancerIsReady(ctx, seedClient, v1beta1constants.GardenNamespace, "nginx-ingress-controller", time.Minute, log)
+		if err != nil {
+			return err
+		}
+	}
+
+	seed.components.dns.entry = getManagedIngressDNSEntry(seedClient, seed.GetIngressFQDN("*"), *seed.GetInfo().Status.ClusterIdentity, ingressLoadBalancerAddress, log)
+	seed.components.dns.owner = getManagedIngressDNSOwner(seedClient, *seed.GetInfo().Status.ClusterIdentity)
+	seed.components.dns.record = getManagedIngressDNSRecord(seedClient, seed.GetInfo().Spec.DNS, secretData, seed.GetIngressFQDN("*"), ingressLoadBalancerAddress, log)
+
+	return nil
 }

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -923,7 +923,7 @@ func runCreateSeedFlow(
 		nginxLBReady = g.Add(flow.Task{
 			Name: "Waiting until nginx ingress LoadBalancer is ready",
 			Fn: func(ctx context.Context) error {
-				return waitUntilNginxIngressServiceIsReady(ctx, seed, gardenClient, seedClient, imageVector, kubernetesVersion, log)
+				return waitForNginxIngressServiceAndCreateDNSComponents(ctx, seed, gardenClient, seedClient, imageVector, kubernetesVersion, log)
 			},
 		})
 		_ = g.Add(flow.Task{
@@ -1509,7 +1509,7 @@ func ResizeOrDeleteLokiDataVolumeIfStorageNotTheSame(ctx context.Context, k8sCli
 	return client.IgnoreNotFound(k8sClient.Delete(ctx, lokiSts))
 }
 
-func waitUntilNginxIngressServiceIsReady(ctx context.Context, seed *Seed, gardenClient, seedClient client.Client, imageVector imagevector.ImageVector, kubernetesVersion *semver.Version, log logrus.FieldLogger) error {
+func waitForNginxIngressServiceAndCreateDNSComponents(ctx context.Context, seed *Seed, gardenClient, seedClient client.Client, imageVector imagevector.ImageVector, kubernetesVersion *semver.Version, log logrus.FieldLogger) error {
 	secretData, err := getDNSProviderSecretData(ctx, gardenClient, seed)
 	if err != nil {
 		return err

--- a/pkg/operation/seed/types.go
+++ b/pkg/operation/seed/types.go
@@ -20,6 +20,7 @@ import (
 	"sync/atomic"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/operation/botanist/component"
 )
 
 // Builder is an object that builds Seed objects.
@@ -33,4 +34,18 @@ type Seed struct {
 	infoMutex sync.Mutex
 
 	LoadBalancerServiceAnnotations map[string]string
+
+	components *Components
+}
+
+// Components contains different components deployed in the Seed cluster.
+type Components struct {
+	dns *DNS
+}
+
+// DNS contains all necessary DNS components for the Seed cluster.
+type DNS struct {
+	entry  component.DeployWaiter
+	owner  component.DeployWaiter
+	record component.DeployMigrateWaiter
 }

--- a/pkg/provider-local/webhook/controlplane/add.go
+++ b/pkg/provider-local/webhook/controlplane/add.go
@@ -15,6 +15,7 @@
 package controlplane
 
 import (
+	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	"github.com/gardener/gardener/extensions/pkg/webhook/controlplane"
 	"github.com/gardener/gardener/extensions/pkg/webhook/controlplane/genericmutator"
@@ -38,7 +39,10 @@ func AddToManager(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
 	return controlplane.New(mgr, controlplane.Args{
 		Kind:     controlplane.KindShoot,
 		Provider: local.Type,
-		Types:    []extensionswebhook.Type{{Obj: &extensionsv1alpha1.OperatingSystemConfig{}}},
-		Mutator:  genericmutator.NewMutator(NewEnsurer(logger), oscutils.NewUnitSerializer(), kubelet.NewConfigCodec(fciCodec), fciCodec, logger),
+		Types: []extensionswebhook.Type{
+			{Obj: &druidv1alpha1.Etcd{}},
+			{Obj: &extensionsv1alpha1.OperatingSystemConfig{}},
+		},
+		Mutator: genericmutator.NewMutator(NewEnsurer(logger), oscutils.NewUnitSerializer(), kubelet.NewConfigCodec(fciCodec), fciCodec, logger),
 	})
 }

--- a/pkg/provider-local/webhook/controlplane/ensurer.go
+++ b/pkg/provider-local/webhook/controlplane/ensurer.go
@@ -17,6 +17,7 @@ package controlplane
 import (
 	"context"
 
+	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 	gcontext "github.com/gardener/gardener/extensions/pkg/webhook/context"
 	"github.com/gardener/gardener/extensions/pkg/webhook/controlplane/genericmutator"
 
@@ -40,5 +41,12 @@ type ensurer struct {
 
 func (e *ensurer) EnsureKubeletConfiguration(_ context.Context, _ gcontext.GardenContext, _ *semver.Version, newObj, _ *kubeletconfigv1beta1.KubeletConfiguration) error {
 	newObj.FailSwapOn = pointer.Bool(false)
+	return nil
+}
+
+func (e *ensurer) EnsureETCD(_ context.Context, _ gcontext.GardenContext, newObj, _ *druidv1alpha1.Etcd) error {
+	// Remove any affinities from etcd's spec because in the local setup we only have one node,
+	// so that pod (anti-) affinities can't apply here.
+	newObj.Spec.SchedulingConstraints.Affinity = nil
 	return nil
 }

--- a/test/e2e/shoot/create_rotate_delete.go
+++ b/test/e2e/shoot/create_rotate_delete.go
@@ -24,18 +24,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/test/e2e/shoot/internal/rotation"
 )
 
 var _ = Describe("Shoot Tests", Label("Shoot"), func() {
+	// TODO(timuthy): enable rotation for HA shoots as soon as data consistency issue in multi-node etcd is solved.
 	f := defaultShootCreationFramework()
 	f.Shoot = defaultShoot("")
 	f.Shoot.Name = "e2e-rotate"
-	f.Shoot.Annotations = utils.MergeStringMaps(f.Shoot.Annotations, map[string]string{
-		// Use a single zone HA control plane because we don't know if there is a multi-AZ seed available.
-		v1beta1constants.ShootAlphaControlPlaneHighAvailability: v1beta1constants.ShootAlphaControlPlaneHighAvailabilitySingleZone,
-	})
 
 	It("Create Shoot, Rotate Credentials and Delete Shoot", Label("credentials-rotation"), func() {
 		ctx, cancel := context.WithTimeout(parentCtx, 20*time.Minute)

--- a/test/e2e/shoot/create_rotate_delete.go
+++ b/test/e2e/shoot/create_rotate_delete.go
@@ -24,6 +24,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/test/e2e/shoot/internal/rotation"
 )
 
@@ -31,6 +32,10 @@ var _ = Describe("Shoot Tests", Label("Shoot"), func() {
 	f := defaultShootCreationFramework()
 	f.Shoot = defaultShoot("")
 	f.Shoot.Name = "e2e-rotate"
+	f.Shoot.Annotations = utils.MergeStringMaps(f.Shoot.Annotations, map[string]string{
+		// Use a single zone HA control plane because we don't know if there is a multi-AZ seed available.
+		v1beta1constants.ShootAlphaControlPlaneHighAvailability: v1beta1constants.ShootAlphaControlPlaneHighAvailabilitySingleZone,
+	})
 
 	It("Create Shoot, Rotate Credentials and Delete Shoot", Label("credentials-rotation"), func() {
 		ctx, cancel := context.WithTimeout(parentCtx, 15*time.Minute)

--- a/test/e2e/shoot/create_rotate_delete.go
+++ b/test/e2e/shoot/create_rotate_delete.go
@@ -38,7 +38,7 @@ var _ = Describe("Shoot Tests", Label("Shoot"), func() {
 	})
 
 	It("Create Shoot, Rotate Credentials and Delete Shoot", Label("credentials-rotation"), func() {
-		ctx, cancel := context.WithTimeout(parentCtx, 10*time.Minute)
+		ctx, cancel := context.WithTimeout(parentCtx, 20*time.Minute)
 		defer cancel()
 
 		By("Create Shoot")
@@ -92,7 +92,7 @@ var _ = Describe("Shoot Tests", Label("Shoot"), func() {
 		v.AfterPrepared(ctx)
 
 		By("Complete credentials rotation")
-		ctx, cancel = context.WithTimeout(parentCtx, 10*time.Minute)
+		ctx, cancel = context.WithTimeout(parentCtx, 20*time.Minute)
 		defer cancel()
 
 		patch = client.MergeFrom(f.Shoot.DeepCopy())
@@ -116,7 +116,7 @@ var _ = Describe("Shoot Tests", Label("Shoot"), func() {
 		v.AfterCompleted(ctx)
 
 		By("Delete Shoot")
-		ctx, cancel = context.WithTimeout(parentCtx, 15*time.Minute)
+		ctx, cancel = context.WithTimeout(parentCtx, 20*time.Minute)
 		defer cancel()
 		Expect(f.DeleteShootAndWaitForDeletion(ctx, f.Shoot)).To(Succeed())
 	})

--- a/test/e2e/shoot/create_rotate_delete.go
+++ b/test/e2e/shoot/create_rotate_delete.go
@@ -38,7 +38,7 @@ var _ = Describe("Shoot Tests", Label("Shoot"), func() {
 	})
 
 	It("Create Shoot, Rotate Credentials and Delete Shoot", Label("credentials-rotation"), func() {
-		ctx, cancel := context.WithTimeout(parentCtx, 15*time.Minute)
+		ctx, cancel := context.WithTimeout(parentCtx, 10*time.Minute)
 		defer cancel()
 
 		By("Create Shoot")
@@ -68,7 +68,7 @@ var _ = Describe("Shoot Tests", Label("Shoot"), func() {
 		v.Before(ctx)
 
 		By("Start credentials rotation")
-		ctx, cancel = context.WithTimeout(parentCtx, 10*time.Minute)
+		ctx, cancel = context.WithTimeout(parentCtx, 20*time.Minute)
 		defer cancel()
 
 		patch := client.MergeFrom(f.Shoot.DeepCopy())

--- a/test/e2e/shoot/internal/rotation/certificate_authorities.go
+++ b/test/e2e/shoot/internal/rotation/certificate_authorities.go
@@ -54,7 +54,6 @@ var allGardenletCAs = []string{
 	caCluster,
 	caClient,
 	caETCD,
-	caETCDPeer,
 	caFrontProxy,
 	caKubelet,
 	caMetricsServer,
@@ -65,7 +64,6 @@ const (
 	caCluster       = "ca"
 	caClient        = "ca-client"
 	caETCD          = "ca-etcd"
-	caETCDPeer      = "ca-etcd-peer"
 	caFrontProxy    = "ca-front-proxy"
 	caKubelet       = "ca-kubelet"
 	caMetricsServer = "ca-metrics-server"

--- a/test/e2e/shoot/internal/rotation/certificate_authorities.go
+++ b/test/e2e/shoot/internal/rotation/certificate_authorities.go
@@ -54,6 +54,7 @@ var allGardenletCAs = []string{
 	caCluster,
 	caClient,
 	caETCD,
+	caETCDPeer,
 	caFrontProxy,
 	caKubelet,
 	caMetricsServer,
@@ -64,6 +65,7 @@ const (
 	caCluster       = "ca"
 	caClient        = "ca-client"
 	caETCD          = "ca-etcd"
+	caETCDPeer      = "ca-etcd-peer"
 	caFrontProxy    = "ca-front-proxy"
 	caKubelet       = "ca-kubelet"
 	caMetricsServer = "ca-metrics-server"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area high-availability
/area security
/kind enhancement

**What this PR does / why we need it**:
Mutli-node etcd clusters need a special handling to make the CA rotation work because etcd's peer communication certificates are used as server and client certificates likewise. Thus the following steps are required if CA rotation happens:

1. CA rotation in `Preparing` phase:
1.1 Change etcd spec to use new bundle CA secret (contains old and new CA).
1.2 Wait until all etcd pods are ready to ensure every member knows both CAs.
1.3 Change etcd spec to use server/client certificate signed by the new CA.
1.4 Wait until all etcd pods are ready to ensure every member uses the new certificate. While rolling out, members with the old certificate can still communicate to other members because all parties accept the new and old CA.

2. CA rotation in `Completing` phase:
2.1 Change etcd spec to use new bundle CA (only contains new CA).
2.2 Wait until all etcd pods are ready to ensure every member only knows and accepts the new CA.

Thanks for the input @rfranzke, @shafeeqes and @timebertt.

**Which issue(s) this PR fixes**:
Part of #3292

**Special notes for your reviewer**:
PR is still a draft because I'm working on additional unit tests.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
A disruption free CA rotation is now being supported for HA shoot clusters.
```
