### PR TITLE
Remove limits carry-over for loki

### DIFF
--- a/pkg/operation/botanist/logging.go
+++ b/pkg/operation/botanist/logging.go
@@ -127,7 +127,8 @@ func (b *Botanist) DeploySeedLogging(ctx context.Context) error {
 		}
 		if len(currentResources) != 0 && currentResources["loki"] != nil {
 			lokiValues["resources"] = map[string]interface{}{
-				"loki": currentResources["loki"],
+				// Copy requests only, effectively removing limits
+				"loki": &corev1.ResourceRequirements{Requests: currentResources["loki"].Requests},
 			}
 		}
 	}

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -485,7 +485,10 @@ func RunReconcileSeedFlow(
 				}
 				if len(currentResources) != 0 && currentResources[v1beta1constants.StatefulSetNameLoki] != nil {
 					lokiValues["resources"] = map[string]interface{}{
-						v1beta1constants.StatefulSetNameLoki: currentResources[v1beta1constants.StatefulSetNameLoki],
+						// Copy requests only, effectively removing limits
+						v1beta1constants.StatefulSetNameLoki: &corev1.ResourceRequirements{
+							Requests: currentResources[v1beta1constants.StatefulSetNameLoki].Requests,
+						},
 					}
 				}
 			}


### PR DESCRIPTION
**How to categorize this PR?**
/area auto-scaling
/kind bug

**What this PR does / why we need it**:
Removes loki limit value carry-over during reconcile. After [recent transition to a fixed limit for loki/loki](https://github.com/gardener/gardener/pull/6020/files#diff-3262003ff6ffd32b33191889a6fc6f85acf0cdf9f160643ac2837c459256673bR70) carry-over is unnecessary and prevents the new limit from coming into effect on existing clusters, effectively establishing the cluster's current accidental limit as a permanent, fixed one.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug was fixed which caused current, accidental resource limit values for the loki container of the loki component, to be established as fixed limits, in place of the correct absolute limit value. 
```
