### PR TITLE
[HA] Prefer non-zonal seeds for non-zonal shoots 

### DIFF
--- a/docs/concepts/scheduler.md
+++ b/docs/concepts/scheduler.md
@@ -37,8 +37,9 @@ The following **sequence** describes the steps involved to determine a seed cand
    * whose capacity for shoots would not be exceeded if the shoot is scheduled onto the seed, see [Ensuring seeds capacity for shoots is not exceeded](#ensuring-seeds-capacity-for-shoots-is-not-exceeded)
    * which are labelled with `seed.gardener.cloud/multi-zonal` if feature gate `HAControlPlanes` is turned on and shoot requests a high available control plane.
 1. Apply active [strategy](#strategies) e.g., _Minimal Distance strategy_
-1. Choose least utilized seed, i.e., the one with the least number of shoot control planes, will be the winner and written to the `.spec.seedName` field of the `Shoot`.
-
+1. Determine scores for seeds. The one with the least score will be the winner:
+   * Assign a smaller score to seeds which host less shoot clusters.
+   * Prefer non-zonal seed clusters for shoot clusters which don't require a zonal control-plane.
 ## Configuration
 
 The Gardener Scheduler configuration has to be supplied on startup. It is a mandatory and also the only available flag.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area high-availability
/kind enhancement

**What this PR does / why we need it**:
This PR enhances the Gardener Scheduler in a way that it prefers non-zonal seed clusters for non-zonal shoot clusters. Earlier, even zonal seed clusters were considered for "normal" shoots which makes it especially problematic if Gardeners introduce the HA feature (#5741) to their landscape with new seeds and then those special zonal seeds will get overloaded by non-zonal shoot clusters.

The scheduler now only picks a zonal seed for a non-zonal shoot as a last resort. Smaller setups benefit from this behavior as they don't need to create extra non-zonal seeds.

**Special notes for your reviewer**:
/cc @unmarshall @shreyas-s-rao

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
With the shoot HA feature in Gardener, the Gardener Scheduler prefers non-zonal seed clusters for non-zonal shoot clusters. This preserves capacity on seeds which are required to run zonal shoot clusters.
```
