### PR TITLE
Increase VPA Recommender log level to v=3

### DIFF
--- a/pkg/operation/botanist/component/vpa/recommender.go
+++ b/pkg/operation/botanist/component/vpa/recommender.go
@@ -159,7 +159,7 @@ func (v *vpa) reconcileRecommenderDeployment(deployment *appsv1.Deployment, serv
 					ImagePullPolicy: corev1.PullIfNotPresent,
 					Command:         v.computeRecommenderCommands(),
 					Args: []string{
-						"--v=2",
+						"--v=3",
 						"--stderrthreshold=info",
 						"--pod-recommendation-min-cpu-millicores=5",
 						"--pod-recommendation-min-memory-mb=10",

--- a/pkg/operation/botanist/component/vpa/vpa_test.go
+++ b/pkg/operation/botanist/component/vpa/vpa_test.go
@@ -750,7 +750,7 @@ var _ = Describe("VPA", func() {
 								ImagePullPolicy: corev1.PullIfNotPresent,
 								Command:         []string{"./recommender"},
 								Args: []string{
-									"--v=2",
+									"--v=3",
 									"--stderrthreshold=info",
 									"--pod-recommendation-min-cpu-millicores=5",
 									"--pod-recommendation-min-memory-mb=10",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
Allows us to gather more information about e.g. [observed OOMKill events](https://github.com/kubernetes/autoscaler/blob/f47f68de3d9f044361da213a82c8758863a39f88/vertical-pod-autoscaler/pkg/recommender/input/cluster_feeder.go#L467-L470)

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Increased the VPA Recommender log level to v=3.
```
