### PR TITLE
[GEP-18] Add client warnings for `Shoot`s when credentials rotation is due

### DIFF
--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
@@ -247,6 +247,12 @@ spec:
         {{- end }}
         {{- end }}
         - --secure-port=443
+        {{- if .Values.global.apiserver.shootAdminKubeconfigMaxExpiration }}
+        - --shoot-admin-kubeconfig-max-expiration={{ .Values.global.apiserver.shootAdminKubeconfigMaxExpiration }}
+        {{- end }}
+        {{- if .Values.global.apiserver.shootCredentialsRotationInterval }}
+        - --shoot-credentials-rotation-interval={{ .Values.global.apiserver.shootCredentialsRotationInterval }}
+        {{- end }}
         {{- if .Values.global.apiserver.shutdownDelayDuration }}
         - --shutdown-delay-duration={{ .Values.global.apiserver.shutdownDelayDuration }}
         {{- end }}

--- a/charts/gardener/controlplane/values.yaml
+++ b/charts/gardener/controlplane/values.yaml
@@ -134,6 +134,8 @@ global:
       enabled: false
       expirationSeconds: 43200
       audience: ""
+  # shootAdminKubeconfigMaxExpiration: 24h
+  # shootCredentialsRotationInterval: 2160h
     vpa: false
     hvpa:
       enabled: false

--- a/pkg/api/core/shoot/shoot_suite_test.go
+++ b/pkg/api/core/shoot/shoot_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shoot_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestShoot(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "API Core Shoot Suite")
+}

--- a/pkg/api/core/shoot/shoot_suite_test.go
+++ b/pkg/api/core/shoot/shoot_suite_test.go
@@ -17,11 +17,14 @@ package shoot_test
 import (
 	"testing"
 
+	"github.com/gardener/gardener/pkg/apiserver/features"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
 func TestShoot(t *testing.T) {
+	features.RegisterFeatureGates()
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "API Core Shoot Suite")
 }

--- a/pkg/api/core/shoot/warnings.go
+++ b/pkg/api/core/shoot/warnings.go
@@ -1,0 +1,137 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shoot
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/gardener/gardener/pkg/apis/core"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+)
+
+// GetWarnings returns warnings for the provided shoot.
+func GetWarnings(_ context.Context, shoot, oldShoot *core.Shoot, credentialsRotationInterval time.Duration) []string {
+	if shoot == nil {
+		return nil
+	}
+
+	var warnings []string
+
+	if pointer.BoolDeref(shoot.Spec.Kubernetes.EnableStaticTokenKubeconfig, true) {
+		warnings = append(warnings, "you should consider disabling the static token kubeconfig, see https://github.com/gardener/gardener/blob/master/docs/usage/shoot_access.md for details")
+	}
+
+	if oldShoot != nil {
+		warnings = append(warnings, getWarningsForDueCredentialsRotations(shoot, credentialsRotationInterval)...)
+		warnings = append(warnings, getWarningsForIncompleteCredentialsRotation(shoot, credentialsRotationInterval)...)
+	}
+
+	return warnings
+}
+
+func getWarningsForDueCredentialsRotations(shoot *core.Shoot, credentialsRotationInterval time.Duration) []string {
+	if !isOldEnough(shoot.CreationTimestamp.Time, credentialsRotationInterval) {
+		return nil
+	}
+
+	if shoot.Status.Credentials == nil || shoot.Status.Credentials.Rotation == nil {
+		return []string{"you should consider rotating the shoot credentials, see https://github.com/gardener/gardener/blob/master/docs/usage/shoot_credentials_rotation.md#gardener-provided-credentials for details"}
+	}
+
+	var (
+		rotation = shoot.Status.Credentials.Rotation
+		warnings []string
+	)
+
+	if rotation.CertificateAuthorities == nil || initiationDue(rotation.CertificateAuthorities.LastInitiationTime, credentialsRotationInterval) {
+		warnings = append(warnings, "you should consider rotating the certificate authorities, see https://github.com/gardener/gardener/blob/master/docs/usage/shoot_credentials_rotation.md#certificate-authorities for details")
+	}
+
+	if rotation.ETCDEncryptionKey == nil || initiationDue(rotation.ETCDEncryptionKey.LastInitiationTime, credentialsRotationInterval) {
+		warnings = append(warnings, "you should consider rotating the ETCD encryption key, see https://github.com/gardener/gardener/blob/master/docs/usage/shoot_credentials_rotation.md#etcd-encryption-key for details")
+	}
+
+	if pointer.BoolDeref(shoot.Spec.Kubernetes.EnableStaticTokenKubeconfig, true) &&
+		(rotation.Kubeconfig == nil || initiationDue(rotation.Kubeconfig.LastInitiationTime, credentialsRotationInterval)) {
+		warnings = append(warnings, "you should consider rotating the static token kubeconfig, see https://github.com/gardener/gardener/blob/master/docs/usage/shoot_credentials_rotation.md#kubeconfig for details")
+	}
+
+	if (shoot.Spec.Purpose == nil || *shoot.Spec.Purpose != core.ShootPurposeTesting) &&
+		(rotation.Observability == nil || initiationDue(rotation.Observability.LastInitiationTime, credentialsRotationInterval)) {
+		warnings = append(warnings, "you should consider rotating the observability passwords, see https://github.com/gardener/gardener/blob/master/docs/usage/shoot_credentials_rotation.md#observability-passwords-for-grafana for details")
+	}
+
+	if rotation.ServiceAccountKey == nil || initiationDue(rotation.ServiceAccountKey.LastInitiationTime, credentialsRotationInterval) {
+		warnings = append(warnings, "you should consider rotating the ServiceAccount token signing key, see https://github.com/gardener/gardener/blob/master/docs/usage/shoot_credentials_rotation.md#serviceaccount-token-signing-key for details")
+	}
+
+	if rotation.SSHKeypair == nil || initiationDue(rotation.SSHKeypair.LastInitiationTime, credentialsRotationInterval) {
+		warnings = append(warnings, "you should consider rotating the SSH keypair, see https://github.com/gardener/gardener/blob/master/docs/usage/shoot_credentials_rotation.md#ssh-key-pair-for-worker-nodes for details")
+	}
+
+	return warnings
+}
+
+func getWarningsForIncompleteCredentialsRotation(shoot *core.Shoot, credentialsRotationInterval time.Duration) []string {
+	if shoot.Status.Credentials == nil || shoot.Status.Credentials.Rotation == nil {
+		return nil
+	}
+
+	var (
+		warnings                      []string
+		recommendedCompletionInterval = credentialsRotationInterval / 3
+		rotation                      = shoot.Status.Credentials.Rotation
+	)
+
+	// Only consider credentials for which completion must be triggered explicitly by the user. Credentials which are
+	// rotated in "one phase" are excluded.
+	if rotation.CertificateAuthorities != nil && completionDue(rotation.CertificateAuthorities.LastInitiationTime, rotation.CertificateAuthorities.LastCompletionTime, recommendedCompletionInterval) {
+		warnings = append(warnings, completionWarning("certificate authorities", recommendedCompletionInterval))
+	}
+	if rotation.ETCDEncryptionKey != nil && completionDue(rotation.ETCDEncryptionKey.LastInitiationTime, rotation.ETCDEncryptionKey.LastCompletionTime, recommendedCompletionInterval) {
+		warnings = append(warnings, completionWarning("ETCD encryption key", recommendedCompletionInterval))
+	}
+	if rotation.ServiceAccountKey != nil && completionDue(rotation.ServiceAccountKey.LastInitiationTime, rotation.ServiceAccountKey.LastCompletionTime, recommendedCompletionInterval) {
+		warnings = append(warnings, completionWarning("ServiceAccount token signing key", recommendedCompletionInterval))
+	}
+
+	return warnings
+}
+
+func initiationDue(lastInitiationTime *metav1.Time, threshold time.Duration) bool {
+	return lastInitiationTime == nil || isOldEnough(lastInitiationTime.Time, threshold)
+}
+
+func completionDue(lastInitiationTime, lastCompletionTime *metav1.Time, threshold time.Duration) bool {
+	if lastInitiationTime == nil {
+		return false
+	}
+	if lastCompletionTime != nil && lastCompletionTime.Time.UTC().After(lastInitiationTime.Time.UTC()) {
+		return false
+	}
+	return isOldEnough(lastInitiationTime.Time, threshold)
+}
+
+func isOldEnough(t time.Time, threshold time.Duration) bool {
+	return t.UTC().Add(threshold).Before(time.Now().UTC())
+}
+
+func completionWarning(credentials string, recommendedCompletionInterval time.Duration) string {
+	return fmt.Sprintf("the %s rotation was initiated more than %s ago and should be completed", credentials, recommendedCompletionInterval)
+}

--- a/pkg/api/core/shoot/warnings_test.go
+++ b/pkg/api/core/shoot/warnings_test.go
@@ -1,0 +1,276 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package shoot_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/gardener/gardener/pkg/api/core/shoot"
+	"github.com/gardener/gardener/pkg/apis/core"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	gomegatypes "github.com/onsi/gomega/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+)
+
+var _ = Describe("Warnings", func() {
+	Describe("#GetWarnings", func() {
+		var (
+			ctx                         = context.TODO()
+			shoot                       *core.Shoot
+			credentialsRotationInterval = time.Hour
+		)
+
+		BeforeEach(func() {
+			shoot = &core.Shoot{
+				Spec: core.ShootSpec{
+					Kubernetes: core.Kubernetes{
+						EnableStaticTokenKubeconfig: pointer.Bool(false),
+					},
+				},
+			}
+		})
+
+		It("should return nil when shoot is nil", func() {
+			Expect(GetWarnings(ctx, nil, nil, credentialsRotationInterval)).To(BeEmpty())
+		})
+
+		It("should return nil when shoot does not have any problematic configuration", func() {
+			Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(BeEmpty())
+		})
+
+		It("should return a warning when static token kubeconfig is nil", func() {
+			shoot.Spec.Kubernetes.EnableStaticTokenKubeconfig = nil
+			Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(ContainElement(ContainSubstring("you should consider disabling the static token kubeconfig")))
+		})
+
+		It("should return a warning when static token kubeconfig is explicitly enabled", func() {
+			shoot.Spec.Kubernetes.EnableStaticTokenKubeconfig = pointer.Bool(true)
+			Expect(GetWarnings(ctx, shoot, nil, credentialsRotationInterval)).To(ContainElement(ContainSubstring("you should consider disabling the static token kubeconfig")))
+		})
+
+		Context("credentials rotation", func() {
+			BeforeEach(func() {
+				shoot.CreationTimestamp = metav1.Time{Time: time.Now().Add(-credentialsRotationInterval * 2)}
+			})
+
+			It("should not return a warning when credentials rotation is due in case shoot is too young", func() {
+				shoot.CreationTimestamp = metav1.Now()
+				Expect(GetWarnings(ctx, shoot, shoot, credentialsRotationInterval)).To(BeEmpty())
+			})
+
+			It("should return a warning when credentials rotation is due", func() {
+				Expect(GetWarnings(ctx, shoot, shoot, credentialsRotationInterval)).To(ContainElement(ContainSubstring("you should consider rotating the shoot credentials")))
+			})
+
+			DescribeTable("warnings for specific credentials rotations",
+				func(matcher gomegatypes.GomegaMatcher, mutateShoot func(*core.Shoot), mutateRotation func(rotation *core.ShootCredentialsRotation)) {
+					if mutateShoot != nil {
+						mutateShoot(shoot)
+					}
+
+					rotation := &core.ShootCredentialsRotation{
+						CertificateAuthorities: &core.ShootCARotation{},
+						Kubeconfig:             &core.ShootKubeconfigRotation{},
+						SSHKeypair:             &core.ShootSSHKeypairRotation{},
+						Observability:          &core.ShootObservabilityRotation{},
+						ServiceAccountKey:      &core.ShootServiceAccountKeyRotation{},
+						ETCDEncryptionKey:      &core.ShootETCDEncryptionKeyRotation{},
+					}
+					mutateRotation(rotation)
+					shoot.Status.Credentials = &core.ShootCredentials{Rotation: rotation}
+
+					Expect(GetWarnings(ctx, shoot, shoot, credentialsRotationInterval)).To(matcher)
+				},
+
+				Entry("ca nil", ContainElement(ContainSubstring("you should consider rotating the certificate authorities")), nil,
+					func(rotation *core.ShootCredentialsRotation) {
+						rotation.CertificateAuthorities = nil
+					},
+				),
+				Entry("ca last initiated too long ago", ContainElement(ContainSubstring("you should consider rotating the certificate authorities")), nil,
+					func(rotation *core.ShootCredentialsRotation) {
+						rotation.CertificateAuthorities.LastInitiationTime = &metav1.Time{Time: time.Now().Add(-credentialsRotationInterval * 2)}
+					},
+				),
+				Entry("ca last initiated not too long ago", Not(ContainElement(ContainSubstring("you should consider rotating the certificate authorities"))), nil,
+					func(rotation *core.ShootCredentialsRotation) {
+						rotation.CertificateAuthorities.LastInitiationTime = &metav1.Time{Time: time.Now().Add(-credentialsRotationInterval / 2)}
+					},
+				),
+				Entry("ca completion is due (never completed yet)", ContainElement(ContainSubstring("the certificate authorities rotation was initiated more than")), nil,
+					func(rotation *core.ShootCredentialsRotation) {
+						rotation.CertificateAuthorities.LastInitiationTime = &metav1.Time{Time: time.Now().Add(-credentialsRotationInterval / 2)}
+						rotation.CertificateAuthorities.LastCompletionTime = nil
+					},
+				),
+				Entry("ca completion is due (current rotation not completed)", ContainElement(ContainSubstring("the certificate authorities rotation was initiated more than")), nil,
+					func(rotation *core.ShootCredentialsRotation) {
+						rotation.CertificateAuthorities.LastInitiationTime = &metav1.Time{Time: time.Now().Add(-credentialsRotationInterval / 2)}
+						rotation.CertificateAuthorities.LastCompletionTime = &metav1.Time{Time: time.Now().Add(-credentialsRotationInterval)}
+					},
+				),
+				Entry("ca completion is not due (current rotation not completed)", Not(ContainElement(ContainSubstring("the certificate authorities rotation was initiated more than"))), nil,
+					func(rotation *core.ShootCredentialsRotation) {
+						rotation.CertificateAuthorities.LastInitiationTime = &metav1.Time{Time: time.Now().Add(-credentialsRotationInterval / 2)}
+						rotation.CertificateAuthorities.LastCompletionTime = &metav1.Time{Time: time.Now().Add(-credentialsRotationInterval / 3)}
+					},
+				),
+
+				Entry("etcdEncryptionKey nil", ContainElement(ContainSubstring("you should consider rotating the ETCD encryption key")), nil,
+					func(rotation *core.ShootCredentialsRotation) {
+						rotation.ETCDEncryptionKey = nil
+					},
+				),
+				Entry("etcdEncryptionKey last initiated too long ago", ContainElement(ContainSubstring("you should consider rotating the ETCD encryption key")), nil,
+					func(rotation *core.ShootCredentialsRotation) {
+						rotation.ETCDEncryptionKey.LastInitiationTime = &metav1.Time{Time: time.Now().Add(-credentialsRotationInterval * 2)}
+					},
+				),
+				Entry("etcdEncryptionKey last initiated not too long ago", Not(ContainElement(ContainSubstring("you should consider rotating the ETCD encryption key"))), nil,
+					func(rotation *core.ShootCredentialsRotation) {
+						rotation.ETCDEncryptionKey.LastInitiationTime = &metav1.Time{Time: time.Now().Add(-credentialsRotationInterval / 2)}
+					},
+				),
+				Entry("etcdEncryptionKey completion is due (never completed yet)", ContainElement(ContainSubstring("the ETCD encryption key rotation was initiated more than")), nil,
+					func(rotation *core.ShootCredentialsRotation) {
+						rotation.ETCDEncryptionKey.LastInitiationTime = &metav1.Time{Time: time.Now().Add(-credentialsRotationInterval / 2)}
+						rotation.ETCDEncryptionKey.LastCompletionTime = nil
+					},
+				),
+				Entry("etcdEncryptionKey completion is due (current rotation not completed)", ContainElement(ContainSubstring("the ETCD encryption key rotation was initiated more than")), nil,
+					func(rotation *core.ShootCredentialsRotation) {
+						rotation.ETCDEncryptionKey.LastInitiationTime = &metav1.Time{Time: time.Now().Add(-credentialsRotationInterval / 2)}
+						rotation.ETCDEncryptionKey.LastCompletionTime = &metav1.Time{Time: time.Now().Add(-credentialsRotationInterval)}
+					},
+				),
+				Entry("etcdEncryptionKey completion is not due (current rotation not completed)", Not(ContainElement(ContainSubstring("the ETCD encryption key rotation was initiated more than"))), nil,
+					func(rotation *core.ShootCredentialsRotation) {
+						rotation.ETCDEncryptionKey.LastInitiationTime = &metav1.Time{Time: time.Now().Add(-credentialsRotationInterval / 2)}
+						rotation.ETCDEncryptionKey.LastCompletionTime = &metav1.Time{Time: time.Now().Add(-credentialsRotationInterval / 3)}
+					},
+				),
+
+				Entry("kubeconfig nil", ContainElement(ContainSubstring("you should consider rotating the static token kubeconfig")),
+					func(shoot *core.Shoot) {
+						shoot.Spec.Kubernetes.EnableStaticTokenKubeconfig = pointer.Bool(true)
+					},
+					func(rotation *core.ShootCredentialsRotation) {
+						rotation.Kubeconfig = nil
+					},
+				),
+				Entry("kubeconfig last initiated too long ago", ContainElement(ContainSubstring("you should consider rotating the static token kubeconfig")),
+					func(shoot *core.Shoot) {
+						shoot.Spec.Kubernetes.EnableStaticTokenKubeconfig = pointer.Bool(true)
+					},
+					func(rotation *core.ShootCredentialsRotation) {
+						rotation.Kubeconfig.LastInitiationTime = &metav1.Time{Time: time.Now().Add(-credentialsRotationInterval * 2)}
+					},
+				),
+				Entry("kubeconfig last initiated too long ago but disabled", Not(ContainElement(ContainSubstring("you should consider rotating the static token kubeconfig"))),
+					func(shoot *core.Shoot) {
+						shoot.Spec.Kubernetes.EnableStaticTokenKubeconfig = pointer.Bool(false)
+					},
+					func(rotation *core.ShootCredentialsRotation) {
+						rotation.Kubeconfig.LastInitiationTime = &metav1.Time{Time: time.Now().Add(-credentialsRotationInterval * 2)}
+					},
+				),
+				Entry("kubeconfig last initiated not too long ago", Not(ContainElement(ContainSubstring("you should consider rotating the static token kubeconfig"))), nil,
+					func(rotation *core.ShootCredentialsRotation) {
+						rotation.Kubeconfig.LastInitiationTime = &metav1.Time{Time: time.Now().Add(-credentialsRotationInterval / 2)}
+					},
+				),
+
+				Entry("observability nil", ContainElement(ContainSubstring("you should consider rotating the observability passwords")), nil,
+					func(rotation *core.ShootCredentialsRotation) {
+						rotation.Observability = nil
+					},
+				),
+				Entry("observability last initiated too long ago", ContainElement(ContainSubstring("you should consider rotating the observability passwords")), nil,
+					func(rotation *core.ShootCredentialsRotation) {
+						rotation.Observability.LastInitiationTime = &metav1.Time{Time: time.Now().Add(-credentialsRotationInterval * 2)}
+					},
+				),
+				Entry("observability last initiated too long ago but shoot purpose is testing", Not(ContainElement(ContainSubstring("you should consider rotating the observability passwords"))),
+					func(shoot *core.Shoot) {
+						p := core.ShootPurposeTesting
+						shoot.Spec.Purpose = &p
+					},
+					func(rotation *core.ShootCredentialsRotation) {
+						rotation.Observability.LastInitiationTime = &metav1.Time{Time: time.Now().Add(-credentialsRotationInterval * 2)}
+					},
+				),
+				Entry("observability last initiated not too long ago", Not(ContainElement(ContainSubstring("you should consider rotating the observability passwords"))), nil,
+					func(rotation *core.ShootCredentialsRotation) {
+						rotation.Observability.LastInitiationTime = &metav1.Time{Time: time.Now().Add(-credentialsRotationInterval / 2)}
+					},
+				),
+
+				Entry("serviceAccountKey nil", ContainElement(ContainSubstring("you should consider rotating the ServiceAccount token signing key")), nil,
+					func(rotation *core.ShootCredentialsRotation) {
+						rotation.ServiceAccountKey = nil
+					},
+				),
+				Entry("serviceAccountKey last initiated too long ago", ContainElement(ContainSubstring("you should consider rotating the ServiceAccount token signing key")), nil,
+					func(rotation *core.ShootCredentialsRotation) {
+						rotation.ServiceAccountKey.LastInitiationTime = &metav1.Time{Time: time.Now().Add(-credentialsRotationInterval * 2)}
+					},
+				),
+				Entry("serviceAccountKey last initiated not too long ago", Not(ContainElement(ContainSubstring("you should consider rotating the ServiceAccount token signing key"))), nil,
+					func(rotation *core.ShootCredentialsRotation) {
+						rotation.ServiceAccountKey.LastInitiationTime = &metav1.Time{Time: time.Now().Add(-credentialsRotationInterval / 2)}
+					},
+				),
+				Entry("serviceAccountKey completion is due (never completed yet)", ContainElement(ContainSubstring("the ServiceAccount token signing key rotation was initiated more than")), nil,
+					func(rotation *core.ShootCredentialsRotation) {
+						rotation.ServiceAccountKey.LastInitiationTime = &metav1.Time{Time: time.Now().Add(-credentialsRotationInterval / 2)}
+						rotation.ServiceAccountKey.LastCompletionTime = nil
+					},
+				),
+				Entry("serviceAccountKey completion is due (current rotation not completed)", ContainElement(ContainSubstring("the ServiceAccount token signing key rotation was initiated more than")), nil,
+					func(rotation *core.ShootCredentialsRotation) {
+						rotation.ServiceAccountKey.LastInitiationTime = &metav1.Time{Time: time.Now().Add(-credentialsRotationInterval / 2)}
+						rotation.ServiceAccountKey.LastCompletionTime = &metav1.Time{Time: time.Now().Add(-credentialsRotationInterval)}
+					},
+				),
+				Entry("serviceAccountKey completion is not due (current rotation not completed)", Not(ContainElement(ContainSubstring("the ServiceAccount token signing key rotation was initiated more than"))), nil,
+					func(rotation *core.ShootCredentialsRotation) {
+						rotation.ServiceAccountKey.LastInitiationTime = &metav1.Time{Time: time.Now().Add(-credentialsRotationInterval / 2)}
+						rotation.ServiceAccountKey.LastCompletionTime = &metav1.Time{Time: time.Now().Add(-credentialsRotationInterval / 3)}
+					},
+				),
+
+				Entry("sshKeypair nil", ContainElement(ContainSubstring("you should consider rotating the SSH keypair")), nil,
+					func(rotation *core.ShootCredentialsRotation) {
+						rotation.SSHKeypair = nil
+					},
+				),
+				Entry("sshKeypair last initiated too long ago", ContainElement(ContainSubstring("you should consider rotating the SSH keypair")), nil,
+					func(rotation *core.ShootCredentialsRotation) {
+						rotation.SSHKeypair.LastInitiationTime = &metav1.Time{Time: time.Now().Add(-credentialsRotationInterval * 2)}
+					},
+				),
+				Entry("sshKeypair last initiated not too long ago", Not(ContainElement(ContainSubstring("you should consider rotating the SSH keypair"))), nil,
+					func(rotation *core.ShootCredentialsRotation) {
+						rotation.SSHKeypair.LastInitiationTime = &metav1.Time{Time: time.Now().Add(-credentialsRotationInterval / 2)}
+					},
+				),
+			)
+		})
+	})
+})

--- a/pkg/api/core/shoot/warnings_test.go
+++ b/pkg/api/core/shoot/warnings_test.go
@@ -20,11 +20,14 @@ import (
 
 	. "github.com/gardener/gardener/pkg/api/core/shoot"
 	"github.com/gardener/gardener/pkg/apis/core"
+	"github.com/gardener/gardener/pkg/features"
+	"github.com/gardener/gardener/pkg/utils/test"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/utils/pointer"
 )
 
@@ -80,6 +83,9 @@ var _ = Describe("Warnings", func() {
 
 			DescribeTable("warnings for specific credentials rotations",
 				func(matcher gomegatypes.GomegaMatcher, mutateShoot func(*core.Shoot), mutateRotation func(rotation *core.ShootCredentialsRotation)) {
+					defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.ShootCARotation, true)()
+					defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.ShootSARotation, true)()
+
 					if mutateShoot != nil {
 						mutateShoot(shoot)
 					}

--- a/pkg/registry/core/rest/storage_core.go
+++ b/pkg/registry/core/rest/storage_core.go
@@ -45,6 +45,7 @@ import (
 // StorageProvider contains configurations related to the core resources.
 type StorageProvider struct {
 	AdminKubeconfigMaxExpiration time.Duration
+	CredentialsRotationInterval  time.Duration
 }
 
 // NewRESTStorage creates a new API group info object and registers the v1alpha1 core storage.
@@ -108,7 +109,7 @@ func (p StorageProvider) v1alpha1Storage(restOptionsGetter generic.RESTOptionsGe
 	shootStateStorage := shootstatestore.NewStorage(restOptionsGetter)
 	storage["shootstates"] = shootStateStorage.ShootState
 
-	shootStorage := shootstore.NewStorage(restOptionsGetter, shootStateStorage.ShootState.Store, p.AdminKubeconfigMaxExpiration)
+	shootStorage := shootstore.NewStorage(restOptionsGetter, shootStateStorage.ShootState.Store, p.AdminKubeconfigMaxExpiration, p.CredentialsRotationInterval)
 	storage["shoots"] = shootStorage.Shoot
 	storage["shoots/status"] = shootStorage.Status
 
@@ -161,7 +162,7 @@ func (p StorageProvider) v1beta1Storage(restOptionsGetter generic.RESTOptionsGet
 	storage["seeds"] = seedStorage.Seed
 	storage["seeds/status"] = seedStorage.Status
 
-	shootStorage := shootstore.NewStorage(restOptionsGetter, shootstatestore.NewStorage(restOptionsGetter).ShootState.Store, p.AdminKubeconfigMaxExpiration)
+	shootStorage := shootstore.NewStorage(restOptionsGetter, shootstatestore.NewStorage(restOptionsGetter).ShootState.Store, p.AdminKubeconfigMaxExpiration, p.CredentialsRotationInterval)
 	storage["shoots"] = shootStorage.Shoot
 	storage["shoots/status"] = shootStorage.Status
 

--- a/pkg/registry/core/shoot/strategy.go
+++ b/pkg/registry/core/shoot/strategy.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/gardener/gardener/pkg/api"
+	"github.com/gardener/gardener/pkg/api/core/shoot"
 	"github.com/gardener/gardener/pkg/apis/core"
 	"github.com/gardener/gardener/pkg/apis/core/helper"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
@@ -208,13 +209,13 @@ func (shootStrategy) AllowUnconditionalUpdate() bool {
 }
 
 // WarningsOnCreate returns warnings to the client performing a create.
-func (shootStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
-	return nil
+func (s shootStrategy) WarningsOnCreate(ctx context.Context, obj runtime.Object) []string {
+	return shoot.GetWarnings(ctx, obj.(*core.Shoot), nil, s.credentialsRotationInterval)
 }
 
 // WarningsOnUpdate returns warnings to the client performing the update.
-func (shootStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
-	return nil
+func (s shootStrategy) WarningsOnUpdate(ctx context.Context, obj, old runtime.Object) []string {
+	return shoot.GetWarnings(ctx, obj.(*core.Shoot), old.(*core.Shoot), s.credentialsRotationInterval)
 }
 
 type shootStatusStrategy struct {

--- a/pkg/registry/core/shoot/strategy.go
+++ b/pkg/registry/core/shoot/strategy.go
@@ -42,13 +42,17 @@ import (
 type shootStrategy struct {
 	runtime.ObjectTyper
 	names.NameGenerator
+
+	credentialsRotationInterval time.Duration
 }
 
-// Strategy defines the storage strategy for Shoots.
-var Strategy = shootStrategy{api.Scheme, names.SimpleNameGenerator}
+// NewStrategy returns a new storage strategy for Shoots.
+func NewStrategy(credentialsRotationInterval time.Duration) shootStrategy {
+	return shootStrategy{api.Scheme, names.SimpleNameGenerator, credentialsRotationInterval}
+}
 
 // Strategy should implement rest.RESTCreateUpdateStrategy
-var _ rest.RESTCreateUpdateStrategy = Strategy
+var _ rest.RESTCreateUpdateStrategy = shootStrategy{}
 
 func (shootStrategy) NamespaceScoped() bool {
 	return true
@@ -217,8 +221,10 @@ type shootStatusStrategy struct {
 	shootStrategy
 }
 
-// StatusStrategy defines the storage strategy for the status subresource of Shoots.
-var StatusStrategy = shootStatusStrategy{Strategy}
+// NewStatusStrategy returns a new storage strategy for the status subresource of Shoots.
+func NewStatusStrategy() shootStatusStrategy {
+	return shootStatusStrategy{NewStrategy(0)}
+}
 
 func (shootStatusStrategy) PrepareForUpdate(ctx context.Context, obj, old runtime.Object) {
 	newShoot := obj.(*core.Shoot)

--- a/pkg/registry/core/shoot/strategy.go
+++ b/pkg/registry/core/shoot/strategy.go
@@ -242,6 +242,14 @@ func (shootStatusStrategy) ValidateUpdate(ctx context.Context, obj, old runtime.
 	return validation.ValidateShootStatusUpdate(obj.(*core.Shoot).Status, old.(*core.Shoot).Status)
 }
 
+func (shootStatusStrategy) WarningsOnCreate(_ context.Context, _ runtime.Object) []string {
+	return nil
+}
+
+func (shootStatusStrategy) WarningsOnUpdate(_ context.Context, _, _ runtime.Object) []string {
+	return nil
+}
+
 // ToSelectableFields returns a field set that represents the object
 // TODO: fields are not labels, and the validation rules for them do not apply.
 func ToSelectableFields(shoot *core.Shoot) fields.Set {

--- a/pkg/registry/core/shoot/strategy_test.go
+++ b/pkg/registry/core/shoot/strategy_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Strategy", func() {
 					defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.ShootMaxTokenExpirationOverwrite, featureGateEnabled)()
 
 					shoot := newShoot(maxTokenExpiration, shootHasDeletionTimestamp)
-					shootregistry.Strategy.PrepareForCreate(context.TODO(), shoot)
+					shootregistry.NewStrategy(0).PrepareForCreate(context.TODO(), shoot)
 					Expect(shoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.MaxTokenExpiration.Duration).To(Equal(expectedDuration))
 				},
 
@@ -92,7 +92,7 @@ var _ = Describe("Strategy", func() {
 						mutateNewShoot(newShoot)
 					}
 
-					shootregistry.Strategy.PrepareForUpdate(context.TODO(), newShoot, oldShoot)
+					shootregistry.NewStrategy(0).PrepareForUpdate(context.TODO(), newShoot, oldShoot)
 
 					expectedGeneration := oldShoot.Generation
 					if shouldIncreaseGeneration {
@@ -140,7 +140,7 @@ var _ = Describe("Strategy", func() {
 							mutateNewShoot(newShoot)
 						}
 
-						shootregistry.Strategy.PrepareForUpdate(context.TODO(), newShoot, oldShoot)
+						shootregistry.NewStrategy(0).PrepareForUpdate(context.TODO(), newShoot, oldShoot)
 
 						expectedGeneration := oldShoot.Generation
 						if shouldIncreaseGeneration {
@@ -278,7 +278,7 @@ var _ = Describe("Strategy", func() {
 					newShoot := oldShoot.DeepCopy()
 					newShoot.Annotations = map[string]string{v1beta1constants.GardenerOperation: operationAnnotation}
 
-					shootregistry.Strategy.PrepareForUpdate(context.TODO(), newShoot, oldShoot)
+					shootregistry.NewStrategy(0).PrepareForUpdate(context.TODO(), newShoot, oldShoot)
 
 					expectedGeneration := oldShoot.Generation
 					if shouldIncreaseGeneration {
@@ -462,7 +462,7 @@ var _ = Describe("Strategy", func() {
 					shoot := newShoot(maxTokenExpiration, shootHasDeletionTimestamp)
 					oldShoot := shoot.DeepCopy()
 
-					shootregistry.Strategy.PrepareForUpdate(context.TODO(), shoot, oldShoot)
+					shootregistry.NewStrategy(0).PrepareForUpdate(context.TODO(), shoot, oldShoot)
 					Expect(shoot.Spec.Kubernetes.KubeAPIServer.ServiceAccountConfig.MaxTokenExpiration.Duration).To(Equal(expectedDuration))
 				},
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
There are now client warnings for `Shoot` resources when credentials rotation is due. For example:

```
Warning: you should consider rotating the shoot credentials, see https://github.com/gardener/gardener/blob/master/docs/usage/shoot_credentials_rotation.md#gardener-provided-credentials for details
shoot.core.gardener.cloud/local patched
```

**Which issue(s) this PR fixes**:
Part of #3292

**Special notes for your reviewer**:
On the way, I also introduced a warning when the static token kubeconfig is used (cc @ary1992 @donistz) like this:

```
Warning: you should consider disabling the static token kubeconfig, see https://github.com/gardener/gardener/blob/master/docs/usage/shoot_access.md for details
shoot.core.gardener.cloud/local patched
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
There are now client warnings for `Shoot` resources when credentials rotation is due or when the static token kubeconfig is used.
```
