### PR TITLE
Check kubectl context match for "gardener-local"

### DIFF
--- a/hack/local-development/dev-setup
+++ b/hack/local-development/dev-setup
@@ -22,6 +22,12 @@ EXAMPLE_DIR=$(dirname "${0}")/../../example
 source $(dirname "${0}")/common/helpers
 kubernetes_env="$(k8s_env)"
 
+# fail if context is not named "gardener-local" amd --ignore-context is not set
+if [[ "$*" != *"--ignore-context"* ]] && [[ $(kubectl config current-context) != *"gardener-local" ]]; then
+    echo "Current context is not 'gardener-local', override with '--ignore-context'"
+    exit 1
+fi
+
 # test if we are running against a Minikube, Docker or kind Kubernetes local setup
 case "${kubernetes_env}" in
     $NODELESS)


### PR DESCRIPTION
Without a context check for "gardener-local" prior to generating their local cluster, a user may inadvertently destroy a cluster that was previously being viewed.

Signed-off-by: Brian Topping <brian.topping@sap.com>

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer [Local garden cluster](https://github.com/gardener/gardener/blob/master/docs/development/getting_started_locally.md) setup will refuse to proceed if the current `kubectl` context is not "gardener-local" and the `--ignore-context` flag is not provided.

```
