### PR TITLE
Cleanup utility functions

### DIFF
--- a/extensions/pkg/webhook/certificates/certificates.go
+++ b/extensions/pkg/webhook/certificates/certificates.go
@@ -23,8 +23,9 @@ import (
 	"time"
 
 	"github.com/gardener/gardener/extensions/pkg/webhook"
-	"github.com/gardener/gardener/pkg/utils"
 	secretutils "github.com/gardener/gardener/pkg/utils/secrets"
+
+	"k8s.io/utils/pointer"
 )
 
 // GenerateUnmanagedCertificates generates a one-off CA and server cert for a webhook server. The server certificate and
@@ -32,7 +33,7 @@ import (
 func GenerateUnmanagedCertificates(providerName, certDir, mode, url string) ([]byte, error) {
 	caConfig := getWebhookCAConfig(providerName)
 	// we want to use a long validity here, because we don't auto-renew certificates
-	caConfig.Validity = utils.DurationPtr(10 * 365 * 24 * time.Hour) // 10y
+	caConfig.Validity = pointer.Duration(10 * 365 * 24 * time.Hour) // 10y
 
 	caCert, err := caConfig.GenerateCertificate()
 	if err != nil {

--- a/pkg/gardenlet/controller/shoot/seed_registration_control_test.go
+++ b/pkg/gardenlet/controller/shoot/seed_registration_control_test.go
@@ -28,6 +28,7 @@ import (
 	configv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	. "github.com/gardener/gardener/pkg/gardenlet/controller/shoot"
 	gardenerlogger "github.com/gardener/gardener/pkg/logger"
+	"github.com/gardener/gardener/pkg/utils"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -208,7 +209,7 @@ var _ = Describe("SeedRegistrationReconciler", func() {
 										},
 									},
 									Volume: &gardencorev1beta1.SeedVolume{
-										MinimumSize: quantityPtr(resource.MustParse("20Gi")),
+										MinimumSize: utils.QuantityPtr(resource.MustParse("20Gi")),
 									},
 									Settings: &gardencorev1beta1.SeedSettings{
 										ExcessCapacityReservation: &gardencorev1beta1.SeedSettingExcessCapacityReservation{
@@ -354,7 +355,7 @@ var _ = Describe("SeedRegistrationReconciler", func() {
 													},
 												},
 												Volume: &gardencorev1beta1.SeedVolume{
-													MinimumSize: quantityPtr(resource.MustParse("20Gi")),
+													MinimumSize: utils.QuantityPtr(resource.MustParse("20Gi")),
 												},
 												Settings: &gardencorev1beta1.SeedSettings{
 													ExcessCapacityReservation: &gardencorev1beta1.SeedSettingExcessCapacityReservation{
@@ -421,7 +422,5 @@ func rawExtension(cfg *configv1alpha1.GardenletConfiguration) runtime.RawExtensi
 	re.Object = nil
 	return *re
 }
-
-func quantityPtr(v resource.Quantity) *resource.Quantity { return &v }
 
 func bootstrapPtr(v seedmanagementv1alpha1.Bootstrap) *seedmanagementv1alpha1.Bootstrap { return &v }

--- a/pkg/operation/botanist/resource_manager.go
+++ b/pkg/operation/botanist/resource_manager.go
@@ -27,7 +27,6 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/resourcemanager"
-	"github.com/gardener/gardener/pkg/utils"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/pkg/utils/images"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
@@ -65,13 +64,13 @@ func (b *Botanist) DefaultResourceManager() (resourcemanager.Interface, error) {
 		AlwaysUpdate:                         pointer.Bool(true),
 		ClusterIdentity:                      b.Seed.GetInfo().Status.ClusterIdentity,
 		ConcurrentSyncs:                      pointer.Int32(20),
-		HealthSyncPeriod:                     utils.DurationPtr(time.Minute),
+		HealthSyncPeriod:                     pointer.Duration(time.Minute),
 		MaxConcurrentHealthWorkers:           pointer.Int32(10),
 		MaxConcurrentTokenInvalidatorWorkers: pointer.Int32(5),
 		MaxConcurrentTokenRequestorWorkers:   pointer.Int32(5),
 		MaxConcurrentRootCAPublisherWorkers:  pointer.Int32(5),
 		SecretNameServerCA:                   v1beta1constants.SecretNameCACluster,
-		SyncPeriod:                           utils.DurationPtr(time.Minute),
+		SyncPeriod:                           pointer.Duration(time.Minute),
 		TargetDiffersFromSourceCluster:       true,
 		TargetDisableCache:                   pointer.Bool(true),
 		Version:                              semver.MustParse(b.K8sSeedClient.Version()),
@@ -213,7 +212,7 @@ func (b *Botanist) reconcileGardenerResourceManagerBootstrapKubeconfigSecret(ctx
 			CommonName:                  "gardener.cloud:system:gardener-resource-manager",
 			Organization:                []string{user.SystemPrivilegedGroup},
 			CertType:                    secretutils.ClientCert,
-			Validity:                    utils.DurationPtr(10 * time.Minute),
+			Validity:                    pointer.Duration(10 * time.Minute),
 			SkipPublishingCACertificate: true,
 		},
 		KubeConfigRequests: []secretutils.KubeConfigRequest{{

--- a/pkg/operation/seed/components.go
+++ b/pkg/operation/seed/components.go
@@ -38,7 +38,6 @@ import (
 	"github.com/gardener/gardener/pkg/operation/botanist/component/vpa"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/vpnauthzserver"
 	"github.com/gardener/gardener/pkg/operation/common"
-	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/images"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
@@ -120,11 +119,11 @@ func defaultGardenerResourceManager(c client.Client, seedClientVersion string, i
 		ConcurrentSyncs:                      pointer.Int32(20),
 		MaxConcurrentTokenInvalidatorWorkers: pointer.Int32(5),
 		MaxConcurrentRootCAPublisherWorkers:  pointer.Int32(5),
-		HealthSyncPeriod:                     utils.DurationPtr(time.Minute),
+		HealthSyncPeriod:                     pointer.Duration(time.Minute),
 		Replicas:                             pointer.Int32(3),
 		ResourceClass:                        pointer.String(v1beta1constants.SeedResourceManagerClass),
 		SecretNameServerCA:                   v1beta1constants.SecretNameCASeed,
-		SyncPeriod:                           utils.DurationPtr(time.Hour),
+		SyncPeriod:                           pointer.Duration(time.Hour),
 		Version:                              semver.MustParse(seedClientVersion),
 		VPA: &resourcemanager.VPAConfig{
 			MinAllowed: corev1.ResourceList{

--- a/pkg/utils/miscellaneous.go
+++ b/pkg/utils/miscellaneous.go
@@ -134,11 +134,6 @@ func QuantityPtr(q resource.Quantity) *resource.Quantity {
 	return &q
 }
 
-// DurationPtr returns a time.Duration pointer to its argument.
-func DurationPtr(d time.Duration) *time.Duration {
-	return &d
-}
-
 // Indent indents the given string with the given number of spaces.
 func Indent(str string, spaces int) string {
 	return strings.ReplaceAll(str, "\n", "\n"+strings.Repeat(" ", spaces))

--- a/pkg/utils/secrets/manager/generate_test.go
+++ b/pkg/utils/secrets/manager/generate_test.go
@@ -19,7 +19,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/gardener/gardener/pkg/utils"
 	secretutils "github.com/gardener/gardener/pkg/utils/secrets"
 	"github.com/gardener/gardener/pkg/utils/test"
 
@@ -31,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
 	testclock "k8s.io/utils/clock/testing"
+	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -652,7 +652,7 @@ var _ = Describe("Generate", func() {
 				expectSecretWasCreated(ctx, fakeClient, caSecret)
 
 				By("generating new control plane secret")
-				serverConfig.Validity = utils.DurationPtr(1337 * time.Minute)
+				serverConfig.Validity = pointer.Duration(1337 * time.Minute)
 				controlPlaneSecretConfig := &secretutils.ControlPlaneSecretConfig{
 					Name:                    "control-plane-secret",
 					CertificateSecretConfig: serverConfig,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:
This PR cleans up the duplicative `utils.DurationPtr` function (already exists with `pointer.Duration`).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
