### PR TITLE
Make "cloud-config execution max delay seconds" configurable per `Shoot`

### DIFF
--- a/example/provider-local/shoot.yaml
+++ b/example/provider-local/shoot.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: garden-local
   annotations:
     shoot.gardener.cloud/infrastructure-cleanup-wait-period-seconds: "0"
+    shoot.gardener.cloud/cloud-config-execution-max-delay-seconds: "0"
 spec:
   seedName: local
   cloudProfileName: local

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -517,6 +517,15 @@ const (
 	// Gardener will wait for the specified time after the Infrastructure extension object has been deleted to allow
 	// controllers to gracefully cleanup everything (default behaviour is 300s).
 	AnnotationShootInfrastructureCleanupWaitPeriodSeconds = "shoot.gardener.cloud/infrastructure-cleanup-wait-period-seconds"
+	// AnnotationShootCloudConfigExecutionMaxDelaySeconds is a key for an annotation on a Shoot resource that declares
+	// the maximum delay in seconds when potentially updated cloud-config user data is executed on the worker nodes.
+	// Concretely, the cloud-config-downloader systemd service running on all worker nodes will wait for a random
+	// duration between 30s and the configured value before execution the user data (default value is 300). If set to 0
+	// then no random delay will be applied and the minimum delay (30s) applies. Any value above 1800 is ignored (in
+	// this case the default value is used).
+	// Note that changing this value only applies to new nodes. Existing nodes which already computed their individual
+	// delays will not recompute it.
+	AnnotationShootCloudConfigExecutionMaxDelaySeconds = "shoot.gardener.cloud/cloud-config-execution-max-delay-seconds"
 	// AnnotationShootForceRestore is a key for an annotation on a Shoot or BackupEntry resource to trigger a forceful restoration to a different seed.
 	AnnotationShootForceRestore = "shoot.gardener.cloud/force-restore"
 	// AnnotationReversedVPN moves the vpn-server to the seed.

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -520,9 +520,9 @@ const (
 	// AnnotationShootCloudConfigExecutionMaxDelaySeconds is a key for an annotation on a Shoot resource that declares
 	// the maximum delay in seconds when potentially updated cloud-config user data is executed on the worker nodes.
 	// Concretely, the cloud-config-downloader systemd service running on all worker nodes will wait for a random
-	// duration between 30s and the configured value before execution the user data (default value is 300). If set to 0
-	// then no random delay will be applied and the minimum delay (30s) applies. Any value above 1800 is ignored (in
-	// this case the default value is used).
+	// duration based on the configured value before executing the user data (default value is 300) plus an additional
+	// offset of 30s. If set to 0 then no random delay will be applied and the minimum delay (30s) applies. Any value
+	// above 1800 is ignored (in this case the default value is used).
 	// Note that changing this value only applies to new nodes. Existing nodes which already computed their individual
 	// delays will not recompute it.
 	AnnotationShootCloudConfigExecutionMaxDelaySeconds = "shoot.gardener.cloud/cloud-config-execution-max-delay-seconds"

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/executor.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/executor.go
@@ -70,10 +70,6 @@ const (
 	// AnnotationKeyChecksum is the key of an annotation on a shoot Node object whose value is the checksum
 	// of the last applied cloud config user data.
 	AnnotationKeyChecksum = "checksum/cloud-config-data"
-	// ExecutionMaxDelaySeconds is a constant for the maximum delay in seconds for the execution of a downloaded
-	// cloud-config user data. Each worker node will randomly select a value in [1,ExecutionMaxDelaySeconds) and always
-	// delays the execution by this number.
-	ExecutionMaxDelaySeconds = 300
 	// PathExecutionDelaySeconds is the path on the shoot worker nodes at which the randomly computed delay for the
 	// execution will be persisted.
 	PathExecutionDelaySeconds = downloader.PathCCDDirectory + "/execution_delay_seconds"
@@ -97,6 +93,7 @@ const (
 // Script returns the executor script that applies the downloaded cloud-config user-data.
 func Script(
 	cloudConfigUserData []byte,
+	cloudConfigExecutionMaxDelaySeconds int,
 	hyperkubeImage *imagevector.Image,
 	kubernetesVersion string,
 	kubeletDataVolume *gardencorev1beta1.DataVolume,
@@ -143,7 +140,7 @@ func Script(
 		"cloudConfigUserData":                      utils.EncodeBase64(cloudConfigUserData),
 		"cloudConfigDownloaderName":                downloader.Name,
 		"executionMinDelaySeconds":                 downloader.UnitRestartSeconds,
-		"executionMaxDelaySeconds":                 ExecutionMaxDelaySeconds,
+		"executionMaxDelaySeconds":                 cloudConfigExecutionMaxDelaySeconds,
 		"hyperkubeImage":                           hyperkubeImage.String(),
 		"kubernetesVersion":                        kubernetesVersion,
 		"labelWorkerKubernetesVersion":             v1beta1constants.LabelWorkerKubernetesVersion,

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/executor_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/executor_test.go
@@ -344,7 +344,11 @@ if [[ -f "/var/lib/kubelet/kubeconfig-real" ]]; then
   # and don't apply the (potentially updated) cloud-config user data. This is to spread the restarts of the systemd
   # units and to prevent too many restarts happening on the nodes at roughly the same time.
   if [[ ! -f "$PATH_EXECUTION_DELAY_SECONDS" ]]; then
-    echo $((30 + $RANDOM % 300)) > "$PATH_EXECUTION_DELAY_SECONDS"
+    if [[ "300" -gt "0" ]]; then
+      echo $((30 + $RANDOM % 300)) > "$PATH_EXECUTION_DELAY_SECONDS"
+    else
+      echo "30" > "$PATH_EXECUTION_DELAY_SECONDS"
+    fi
   fi
   execution_delay_seconds=$(cat "$PATH_EXECUTION_DELAY_SECONDS")
 

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/templates/scripts/execute-cloud-config.tpl.sh
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor/templates/scripts/execute-cloud-config.tpl.sh
@@ -212,7 +212,11 @@ if [[ -f "{{ .pathKubeletKubeconfigReal }}" ]]; then
   # and don't apply the (potentially updated) cloud-config user data. This is to spread the restarts of the systemd
   # units and to prevent too many restarts happening on the nodes at roughly the same time.
   if [[ ! -f "$PATH_EXECUTION_DELAY_SECONDS" ]]; then
-    echo $(({{ .executionMinDelaySeconds }} + $RANDOM % {{ .executionMaxDelaySeconds }})) > "$PATH_EXECUTION_DELAY_SECONDS"
+    if [[ "{{ .executionMaxDelaySeconds }}" -gt "0" ]]; then
+      echo $(({{ .executionMinDelaySeconds }} + $RANDOM % {{ .executionMaxDelaySeconds }})) > "$PATH_EXECUTION_DELAY_SECONDS"
+    else
+      echo "{{ .executionMinDelaySeconds }}" > "$PATH_EXECUTION_DELAY_SECONDS"
+    fi
   fi
   execution_delay_seconds=$(cat "$PATH_EXECUTION_DELAY_SECONDS")
 

--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -267,7 +267,15 @@ func (b *Botanist) generateCloudConfigExecutorResourcesForWorker(
 		}
 	}
 
-	executorScript, err := ExecutorScriptFn([]byte(oscDataOriginal.Content), hyperkubeImage, kubernetesVersion.String(), kubeletDataVolume, *oscDataOriginal.Command, oscDataOriginal.Units)
+	executorScript, err := ExecutorScriptFn(
+		[]byte(oscDataOriginal.Content),
+		b.Shoot.CloudConfigExecutionMaxDelaySeconds,
+		hyperkubeImage,
+		kubernetesVersion.String(),
+		kubeletDataVolume,
+		*oscDataOriginal.Command,
+		oscDataOriginal.Units,
+	)
 	if err != nil {
 		return "", nil, err
 	}

--- a/pkg/operation/botanist/worker_test.go
+++ b/pkg/operation/botanist/worker_test.go
@@ -33,6 +33,7 @@ import (
 	shootpkg "github.com/gardener/gardener/pkg/operation/shoot"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
+	"github.com/gardener/gardener/pkg/utils/test"
 
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/golang/mock/gomock"
@@ -317,13 +318,10 @@ var _ = Describe("Worker", func() {
 		})
 
 		It("should fail when the cloud-config user data script secret was not updated yet", func() {
-			oldInterval := IntervalWaitCloudConfigUpdated
-			defer func() { IntervalWaitCloudConfigUpdated = oldInterval }()
-			IntervalWaitCloudConfigUpdated = time.Millisecond
-
-			oldTimeout := TimeoutWaitCloudConfigUpdated
-			defer func() { TimeoutWaitCloudConfigUpdated = oldTimeout }()
-			TimeoutWaitCloudConfigUpdated = 5 * time.Millisecond
+			DeferCleanup(test.WithVars(
+				&IntervalWaitCloudConfigUpdated, time.Millisecond,
+				&GetTimeoutWaitCloudConfigUpdated, func(*shootpkg.Shoot) time.Duration { return 5 * time.Millisecond },
+			))
 
 			gomock.InOrder(
 				seedInterface.EXPECT().Client().Return(seedClient),
@@ -337,13 +335,10 @@ var _ = Describe("Worker", func() {
 		})
 
 		It("should fail when the cloud-config was not updated for all worker pools", func() {
-			oldInterval := IntervalWaitCloudConfigUpdated
-			defer func() { IntervalWaitCloudConfigUpdated = oldInterval }()
-			IntervalWaitCloudConfigUpdated = time.Millisecond
-
-			oldTimeout := TimeoutWaitCloudConfigUpdated
-			defer func() { TimeoutWaitCloudConfigUpdated = oldTimeout }()
-			TimeoutWaitCloudConfigUpdated = time.Millisecond
+			DeferCleanup(test.WithVars(
+				&IntervalWaitCloudConfigUpdated, time.Millisecond,
+				&GetTimeoutWaitCloudConfigUpdated, func(*shootpkg.Shoot) time.Duration { return time.Millisecond },
+			))
 
 			botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
 				Spec: gardencorev1beta1.ShootSpec{
@@ -401,13 +396,10 @@ var _ = Describe("Worker", func() {
 		})
 
 		It("should succeed when the cloud-config was updated for all worker pools", func() {
-			oldInterval := IntervalWaitCloudConfigUpdated
-			defer func() { IntervalWaitCloudConfigUpdated = oldInterval }()
-			IntervalWaitCloudConfigUpdated = time.Millisecond
-
-			oldTimeout := TimeoutWaitCloudConfigUpdated
-			defer func() { TimeoutWaitCloudConfigUpdated = oldTimeout }()
-			TimeoutWaitCloudConfigUpdated = time.Millisecond
+			DeferCleanup(test.WithVars(
+				&IntervalWaitCloudConfigUpdated, time.Millisecond,
+				&GetTimeoutWaitCloudConfigUpdated, func(*shootpkg.Shoot) time.Duration { return time.Millisecond },
+			))
 
 			botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
 				Spec: gardencorev1beta1.ShootSpec{

--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -262,15 +262,15 @@ func (b *Builder) Build(ctx context.Context, c client.Reader) (*Shoot, error) {
 	shoot.Networks = networks
 
 	shoot.NodeLocalDNSEnabled = helper.IsNodeLocalDNSEnabled(shoot.GetInfo().Spec.SystemComponents, shoot.GetInfo().Annotations)
-
 	shoot.Purpose = gardencorev1beta1helper.GetPurpose(shootObject)
 
-	// Determine backup entry name
 	backupEntryName, err := gutil.GenerateBackupEntryName(shootObject.Status.TechnicalID, shootObject.UID)
 	if err != nil {
 		return nil, err
 	}
 	shoot.BackupEntryName = backupEntryName
+
+	shoot.CloudConfigExecutionMaxDelaySeconds = 300
 
 	return shoot, nil
 }

--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -271,6 +271,16 @@ func (b *Builder) Build(ctx context.Context, c client.Reader) (*Shoot, error) {
 	shoot.BackupEntryName = backupEntryName
 
 	shoot.CloudConfigExecutionMaxDelaySeconds = 300
+	if v, ok := shootObject.Annotations[v1beta1constants.AnnotationShootCloudConfigExecutionMaxDelaySeconds]; ok {
+		seconds, err := strconv.Atoi(v)
+		if err != nil {
+			return nil, err
+		}
+
+		if seconds <= 1800 {
+			shoot.CloudConfigExecutionMaxDelaySeconds = seconds
+		}
+	}
 
 	return shoot, nil
 }

--- a/pkg/operation/shoot/types.go
+++ b/pkg/operation/shoot/types.go
@@ -79,17 +79,18 @@ type Shoot struct {
 	ExternalClusterDomain *string
 	ExternalDomain        *garden.Domain
 
-	Purpose                    gardencorev1beta1.ShootPurpose
-	WantsClusterAutoscaler     bool
-	WantsVerticalPodAutoscaler bool
-	WantsAlertmanager          bool
-	IgnoreAlerts               bool
-	HibernationEnabled         bool
-	ReversedVPNEnabled         bool
-	NodeLocalDNSEnabled        bool
-	Networks                   *Networks
-	ExposureClass              *gardencorev1alpha1.ExposureClass
-	BackupEntryName            string
+	Purpose                             gardencorev1beta1.ShootPurpose
+	WantsClusterAutoscaler              bool
+	WantsVerticalPodAutoscaler          bool
+	WantsAlertmanager                   bool
+	IgnoreAlerts                        bool
+	HibernationEnabled                  bool
+	ReversedVPNEnabled                  bool
+	NodeLocalDNSEnabled                 bool
+	Networks                            *Networks
+	ExposureClass                       *gardencorev1alpha1.ExposureClass
+	BackupEntryName                     string
+	CloudConfigExecutionMaxDelaySeconds int
 
 	Components *Components
 }

--- a/test/e2e/shoot/common.go
+++ b/test/e2e/shoot/common.go
@@ -59,6 +59,7 @@ func defaultShoot(generateName string) *gardencorev1beta1.Shoot {
 			Namespace:    projectNamespace,
 			Annotations: map[string]string{
 				v1beta1constants.AnnotationShootInfrastructureCleanupWaitPeriodSeconds: "0",
+				v1beta1constants.AnnotationShootCloudConfigExecutionMaxDelaySeconds:    "0",
 			},
 		},
 		Spec: gardencorev1beta1.ShootSpec{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity robustness
/kind enhancement

**What this PR does / why we need it**:
Earlier, the max delay seconds for the cloud-config execution was hard-coded to `300` and applied for all clusters. Now it is overridable via the new `shoot.gardener.cloud/cloud-config-execution-max-delay-seconds` annotation.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
It is now possible to override the maximum delay seconds for the cloud-config user-data execution on shoot worker nodes by specifying the `shoot.gardener.cloud/cloud-config-execution-max-delay-seconds` annotation on the `Shoot` resource (default: `300`).
```
