### PR TITLE
Use optimistic locking for reconciling shoot access secret

### DIFF
--- a/pkg/resourcemanager/controller/secret/reconciler_test.go
+++ b/pkg/resourcemanager/controller/secret/reconciler_test.go
@@ -305,7 +305,7 @@ var _ = Describe("SecretReconciler", func() {
 
 			secretAfter := secret.DeepCopy()
 			secretAfter.SetFinalizers(nil)
-			test.EXPECTPatchWithOptimisticLock(gomock.Any(), c, secretAfter, secret)
+			test.EXPECTPatchWithOptimisticLock(gomock.Any(), c, secretAfter, secret, types.MergePatchType)
 
 			res, err := r.Reconcile(ctx, secretReq)
 			Expect(err).NotTo(HaveOccurred())
@@ -339,7 +339,7 @@ var _ = Describe("SecretReconciler", func() {
 
 			secretAfter := secret.DeepCopy()
 			secretAfter.SetFinalizers(nil)
-			test.EXPECTPatchWithOptimisticLock(gomock.Any(), c, secretAfter, secret)
+			test.EXPECTPatchWithOptimisticLock(gomock.Any(), c, secretAfter, secret, types.MergePatchType)
 
 			res, err := r.Reconcile(ctx, secretReq)
 			Expect(err).NotTo(HaveOccurred())
@@ -373,7 +373,7 @@ var _ = Describe("SecretReconciler", func() {
 
 			secretAfter := secret.DeepCopy()
 			secretAfter.SetFinalizers(nil)
-			test.EXPECTPatchWithOptimisticLock(gomock.Any(), c, secretAfter, secret, fmt.Errorf("fake"))
+			test.EXPECTPatchWithOptimisticLock(gomock.Any(), c, secretAfter, secret, types.MergePatchType, fmt.Errorf("fake"))
 
 			res, err := r.Reconcile(ctx, secretReq)
 			Expect(err).To(MatchError(ContainSubstring("fake")))

--- a/pkg/utils/gardener/shoot.go
+++ b/pkg/utils/gardener/shoot.go
@@ -335,7 +335,11 @@ func (s *ShootAccessSecret) Reconcile(ctx context.Context, c client.Client) erro
 		}
 
 		return nil
-	})
+	},
+		// The token-requestor might concurrently update the kubeconfig secret key to populate the token.
+		// Hence, we need to use optimistic locking here to ensure we don't accidentally overwrite the concurrent update.
+		// ref https://github.com/gardener/gardener/issues/6092#issuecomment-1156244514
+		client.MergeFromWithOptimisticLock{})
 	return err
 }
 

--- a/pkg/utils/test/test.go
+++ b/pkg/utils/test/test.go
@@ -197,8 +197,16 @@ func EXPECTPatch(ctx interface{}, c *mockclient.MockClient, expectedObj, mergeFr
 
 // EXPECTPatchWithOptimisticLock is a helper function for a GoMock call with the mock client
 // expecting a merge patch with optimistic lock.
-func EXPECTPatchWithOptimisticLock(ctx interface{}, c *mockclient.MockClient, expectedObj, mergeFrom client.Object, rets ...interface{}) *gomock.Call {
-	expectedPatch := client.MergeFromWithOptions(mergeFrom, client.MergeFromWithOptimisticLock{})
+func EXPECTPatchWithOptimisticLock(ctx interface{}, c *mockclient.MockClient, expectedObj, mergeFrom client.Object, patchType types.PatchType, rets ...interface{}) *gomock.Call {
+	var expectedPatch client.Patch
+
+	switch patchType {
+	case types.MergePatchType:
+		expectedPatch = client.MergeFromWithOptions(mergeFrom, client.MergeFromWithOptimisticLock{})
+	case types.StrategicMergePatchType:
+		expectedPatch = client.StrategicMergeFrom(mergeFrom.DeepCopyObject().(client.Object), client.MergeFromWithOptimisticLock{})
+	}
+
 	return expectPatch(ctx, c, expectedObj, expectedPatch, rets...)
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug

**What this PR does / why we need it**:

Use optimistic locking for reconciling shoot access secret in gardenlet

**Which issue(s) this PR fixes**:

Hopefully, this fixes the remaining few instances of https://github.com/gardener/gardener/issues/6092, see https://github.com/gardener/gardener/issues/6092#issuecomment-1156244514.

**Special notes for your reviewer**:

/milestone v1.49

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
