### PR TITLE
Allow cilium to be used on seeds.

### DIFF
--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
@@ -785,6 +785,12 @@ var _ = Describe("KubeAPIServer", func() {
 								{
 									From: []networkingv1.NetworkPolicyPeer{
 										{PodSelector: &metav1.LabelSelector{}},
+										{
+											NamespaceSelector: &metav1.LabelSelector{},
+											PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+												"app": "istio-ingressgateway",
+											}},
+										},
 										{IPBlock: &networkingv1.IPBlock{CIDR: "0.0.0.0/0"}},
 									},
 									Ports: []networkingv1.NetworkPolicyPort{{
@@ -882,6 +888,12 @@ var _ = Describe("KubeAPIServer", func() {
 								{
 									From: []networkingv1.NetworkPolicyPeer{
 										{PodSelector: &metav1.LabelSelector{}},
+										{
+											NamespaceSelector: &metav1.LabelSelector{},
+											PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+												"app": "istio-ingressgateway",
+											}},
+										},
 										{IPBlock: &networkingv1.IPBlock{CIDR: "0.0.0.0/0"}},
 									},
 									Ports: []networkingv1.NetworkPolicyPort{{

--- a/pkg/operation/botanist/component/kubeapiserver/networkpolicies.go
+++ b/pkg/operation/botanist/component/kubeapiserver/networkpolicies.go
@@ -20,6 +20,7 @@ import (
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/controllerutils"
+	gardenletconfigv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/etcd"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/monitoring"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/vpnseedserver"
@@ -140,6 +141,14 @@ func (k *kubeAPIServer) reconcileNetworkPolicyAllowKubeAPIServer(ctx context.Con
 					From: []networkingv1.NetworkPolicyPeer{
 						// Allow all other Pods in the Seed cluster to access it.
 						{PodSelector: &metav1.LabelSelector{}},
+						// Allow all istio-ingress Pods in the Seed cluster to access it.
+						{
+							// we don't want to modify existing labels on the istio namespace
+							NamespaceSelector: &metav1.LabelSelector{},
+							PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+								v1beta1constants.LabelApp: gardenletconfigv1alpha1.DefaultIngressGatewayAppLabelValue,
+							}},
+						},
 						// kube-apiserver can be accessed from anywhere using the LoadBalancer.
 						{IPBlock: &networkingv1.IPBlock{CIDR: "0.0.0.0/0"}},
 					},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Allow cilium to be used on seeds.

Kubernetes network policies are interpreted slightly different by different CNIs.
While calico works well with IP based policies, cilium expects IP ranges to be
cluster external. This is why the network policy, which should have made it possible
for the SNI istio-ingress gateway to forward traffic to a kube-apiserver in the
shoot control plane, was not working as expected causing traffic to be dropped.
Adding the istio-ingress gateway explicitly works well with cilium.

**Which issue(s) this PR fixes**:
Fixes #4309.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Allow cilium to be used on seeds with SNI enabled.
```

/cc @DockToFuture 