### PR TITLE
Fixes the blackbox-exporter PDB for k8s < 1.21

### DIFF
--- a/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/pdb.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/pdb.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1
+apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: blackbox-exporter


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:
The `policy/v1` api version is only available after k8s 1.21. Currently using `policy/v1beta1` is ok for all k8s versions that we support. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

I saw that in our `_version.tpl` file the following is defined:
```
{{- define "poddisruptionbudgetversion" -}}
policy/v1beta1
{{- end -}}
```
but it is not used anywhere.

Perhaps we could add something like this in the future wherever pdbs are used:
```
{{- define "poddisruptionbudgetversion" -}}
{{- if semverCompare ">= 1.21-0" .Capabilities.KubeVersion.GitVersion -}}
policy/v1
{{- else -}}
policy/v1beta1
{{- end -}}
{{- end -}}
```

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
