### PR TITLE
Improve the CPU and memory usage calculation on the Node Details dashboard

### DIFF
--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/node-details-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/node-details-dashboard.json
@@ -107,7 +107,7 @@
         "showThresholdMarkers": true,
         "text": {}
       },
-      "pluginVersion": "7.5.4",
+      "pluginVersion": "7.5.16",
       "targets": [
         {
           "expr": "sum(rate(node_cpu_seconds_total{mode!=\"idle\", node=~\"$Node\"}[$__rate_interval])) / sum(kube_node_status_allocatable_cpu_cores{node=~\"$Node\"}) * 100",
@@ -195,7 +195,7 @@
         "showThresholdMarkers": true,
         "text": {}
       },
-      "pluginVersion": "7.5.4",
+      "pluginVersion": "7.5.16",
       "targets": [
         {
           "expr": "sum(node_memory_Active_bytes{node=~\"$Node\"}) / sum(kube_node_status_allocatable_memory_bytes{node=~\"$Node\"}) * 100",
@@ -253,7 +253,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.4",
+      "pluginVersion": "7.5.16",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -373,7 +373,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.4",
+      "pluginVersion": "7.5.16",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -497,7 +497,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.4",
+      "pluginVersion": "7.5.16",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -613,7 +613,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.4",
+      "pluginVersion": "7.5.16",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -739,7 +739,7 @@
         "alertThreshold": false
       },
       "percentage": false,
-      "pluginVersion": "7.5.4",
+      "pluginVersion": "7.5.16",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -872,7 +872,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.4",
+      "pluginVersion": "7.5.16",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -996,7 +996,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.4",
+      "pluginVersion": "7.5.16",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",

--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/node-details-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/node-details-dashboard.json
@@ -110,7 +110,7 @@
       "pluginVersion": "7.5.16",
       "targets": [
         {
-          "expr": "sum(rate(node_cpu_seconds_total{mode!=\"idle\", node=~\"$Node\"}[$__rate_interval])) / sum(kube_node_status_allocatable_cpu_cores{node=~\"$Node\"}) * 100",
+          "expr": "sum(rate(node_cpu_seconds_total{mode!=\"idle\", node=~\"$Node\"}[$__rate_interval])) / sum(kube_node_status_capacity_cpu_cores{node=~\"$Node\"}) * 100",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -198,7 +198,7 @@
       "pluginVersion": "7.5.16",
       "targets": [
         {
-          "expr": "sum(node_memory_Active_bytes{node=~\"$Node\"}) / sum(kube_node_status_allocatable_memory_bytes{node=~\"$Node\"}) * 100",
+          "expr": "sum((node_memory_MemTotal_bytes{node=~\"$Node\"} - node_memory_MemAvailable_bytes{node=~\"$Node\"}) / node_memory_MemTotal_bytes{node=~\"$Node\"}) * 100",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -268,7 +268,7 @@
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "CPU",
+          "legendFormat": "Used",
           "refId": "A"
         },
         {
@@ -280,12 +280,22 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(kube_node_status_allocatable_cpu_cores{node=~\"$Node\"}) - sum(rate(node_cpu_seconds_total{mode!=\"idle\", node=~\"$Node\"}[$__rate_interval]))",
+          "expr": "sum(kube_node_status_capacity_cpu_cores{node=~\"$Node\"}) - sum(rate(node_cpu_seconds_total{mode!=\"idle\", node=~\"$Node\"}[$__rate_interval]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
           "legendFormat": "Idle",
           "refId": "C"
+        },
+        {
+          "exemplar": true,
+          "expr": "sum(kube_node_status_capacity_cpu_cores{node=~\"$Node\"})",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Total",
+          "refId": "D"
         }
       ],
       "thresholds": [],
@@ -383,10 +393,10 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(node_memory_Active_bytes{node=~\"$Node\"})",
+          "expr": "node_memory_MemTotal_bytes{node=~\"$Node\"} - node_memory_MemAvailable_bytes{node=~\"$Node\"}",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "Current",
+          "legendFormat": "Used (Total - Available)",
           "refId": "A"
         },
         {
@@ -397,11 +407,21 @@
           "refId": "B"
         },
         {
-          "expr": "sum(kube_node_status_allocatable_memory_bytes{node=~\"$Node\"}) - sum(node_memory_Active_bytes{node=~\"$Node\"})",
+          "expr": "node_memory_MemAvailable_bytes{node=~\"$Node\"}",
           "format": "time_series",
           "intervalFactor": 1,
-          "legendFormat": "Unused",
+          "legendFormat": "Available",
           "refId": "C"
+        },
+        {
+          "exemplar": true,
+          "expr": "node_memory_MemTotal_bytes{node=~\"$Node\"}",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Total",
+          "refId": "D"
         }
       ],
       "thresholds": [],


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

Change the way the memory and CPU usage on the node is calculated

Previously, the memory usage was calculated based on the
allocatable and active memory metrics.
Now it is calculated based on the total and available memory metrics.

It turns out that the (total - available) metric is a better indication
of memory pressure. When the available memory approaches 0, the system
will experience OOM.

The CPU usage was also adjusted to use the total capacity instead of the
allocatable capacity.

See #6031.

cc @danielfoehrKn 

**Special notes for your reviewer**:

<img width="300" alt="image" src="https://user-images.githubusercontent.com/23032437/174305042-56ff3b43-ac67-4fe3-b340-e5aa0de747d2.png">

I suggest reviewing the diff of the individual commits.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Improve the CPU and memory usage calculation on the Node Details dashboard
```
