### PR TITLE
Add referenced secret checksum as condition for `ManagedResource` health check

### DIFF
--- a/docs/api-reference/resources.md
+++ b/docs/api-reference/resources.md
@@ -341,6 +341,18 @@ int64
 <p>Resources is a list of objects that have been created.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>secretChecksum</code></br>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>SecretChecksum is the checksum of referenced secret&rsquo;s data.</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="resources.gardener.cloud/v1alpha1.ObjectReference">ObjectReference

--- a/docs/api-reference/resources.md
+++ b/docs/api-reference/resources.md
@@ -343,14 +343,14 @@ int64
 </tr>
 <tr>
 <td>
-<code>secretChecksum</code></br>
+<code>secretsChecksum</code></br>
 <em>
 string
 </em>
 </td>
 <td>
 <em>(Optional)</em>
-<p>SecretChecksum is the checksum of referenced secret&rsquo;s data.</p>
+<p>SecretsChecksum is the checksum of referenced secrets data.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/api-reference/resources.md
+++ b/docs/api-reference/resources.md
@@ -343,14 +343,14 @@ int64
 </tr>
 <tr>
 <td>
-<code>secretsChecksum</code></br>
+<code>secretsDataChecksum</code></br>
 <em>
 string
 </em>
 </td>
 <td>
 <em>(Optional)</em>
-<p>SecretsChecksum is the checksum of referenced secrets data.</p>
+<p>SecretsDataChecksum is the checksum of referenced secrets data.</p>
 </td>
 </tr>
 </tbody>

--- a/example/resource-manager/10-crd-resources.gardener.cloud_managedresources.yaml
+++ b/example/resource-manager/10-crd-resources.gardener.cloud_managedresources.yaml
@@ -225,6 +225,10 @@ spec:
                       type: string
                   type: object
                 type: array
+              secretChecksum:
+                description: SecretChecksum is the checksum of referenced secret's
+                  data.
+                type: string
             type: object
         type: object
     served: true

--- a/example/resource-manager/10-crd-resources.gardener.cloud_managedresources.yaml
+++ b/example/resource-manager/10-crd-resources.gardener.cloud_managedresources.yaml
@@ -225,8 +225,8 @@ spec:
                       type: string
                   type: object
                 type: array
-              secretChecksum:
-                description: SecretChecksum is the checksum of referenced secret's
+              secretsChecksum:
+                description: SecretsChecksum is the checksum of referenced secrets
                   data.
                 type: string
             type: object

--- a/example/resource-manager/10-crd-resources.gardener.cloud_managedresources.yaml
+++ b/example/resource-manager/10-crd-resources.gardener.cloud_managedresources.yaml
@@ -225,8 +225,8 @@ spec:
                       type: string
                   type: object
                 type: array
-              secretsChecksum:
-                description: SecretsChecksum is the checksum of referenced secrets
+              secretsDataChecksum:
+                description: SecretsDataChecksum is the checksum of referenced secrets
                   data.
                 type: string
             type: object

--- a/example/seed-crds/10-crd-resources.gardener.cloud_managedresources.yaml
+++ b/example/seed-crds/10-crd-resources.gardener.cloud_managedresources.yaml
@@ -225,6 +225,10 @@ spec:
                       type: string
                   type: object
                 type: array
+              secretChecksum:
+                description: SecretChecksum is the checksum of referenced secret's
+                  data.
+                type: string
             type: object
         type: object
     served: true

--- a/example/seed-crds/10-crd-resources.gardener.cloud_managedresources.yaml
+++ b/example/seed-crds/10-crd-resources.gardener.cloud_managedresources.yaml
@@ -225,8 +225,8 @@ spec:
                       type: string
                   type: object
                 type: array
-              secretChecksum:
-                description: SecretChecksum is the checksum of referenced secret's
+              secretsChecksum:
+                description: SecretsChecksum is the checksum of referenced secrets
                   data.
                 type: string
             type: object

--- a/example/seed-crds/10-crd-resources.gardener.cloud_managedresources.yaml
+++ b/example/seed-crds/10-crd-resources.gardener.cloud_managedresources.yaml
@@ -225,8 +225,8 @@ spec:
                       type: string
                   type: object
                 type: array
-              secretsChecksum:
-                description: SecretsChecksum is the checksum of referenced secrets
+              secretsDataChecksum:
+                description: SecretsDataChecksum is the checksum of referenced secrets
                   data.
                 type: string
             type: object

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -546,6 +546,9 @@ const (
 	AnnotationNodeLocalDNSForceTcpToClusterDns = "alpha.featuregates.shoot.gardener.cloud/node-local-dns-force-tcp-to-cluster-dns"
 	// AnnotationNodeLocalDNSForceTcpToUpstreamDns enforces upgrade to tcp connections for communication between node local and upstream dns.
 	AnnotationNodeLocalDNSForceTcpToUpstreamDns = "alpha.featuregates.shoot.gardener.cloud/node-local-dns-force-tcp-to-upstream-dns"
+	// AnnotationManagedResourceSecretChecksum is a key for an annotation on a Managed Resource containing checksum for the secrets
+	// referenced by managed resource.
+	AnnotationManagedResourceSecretChecksum = "checksum/secret-data"
 
 	// AnnotationShootAPIServerSNIPodInjector is the key for an annotation of a Shoot cluster whose value indicates
 	// if pod injection of 'KUBERNETES_SERVICE_HOST' environment variable should happen for clusters where APIServerSNI

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -546,9 +546,6 @@ const (
 	AnnotationNodeLocalDNSForceTcpToClusterDns = "alpha.featuregates.shoot.gardener.cloud/node-local-dns-force-tcp-to-cluster-dns"
 	// AnnotationNodeLocalDNSForceTcpToUpstreamDns enforces upgrade to tcp connections for communication between node local and upstream dns.
 	AnnotationNodeLocalDNSForceTcpToUpstreamDns = "alpha.featuregates.shoot.gardener.cloud/node-local-dns-force-tcp-to-upstream-dns"
-	// AnnotationManagedResourceSecretChecksum is a key for an annotation on a Managed Resource containing checksum for the secrets
-	// referenced by managed resource.
-	AnnotationManagedResourceSecretChecksum = "checksum/secret-data"
 
 	// AnnotationShootAPIServerSNIPodInjector is the key for an annotation of a Shoot cluster whose value indicates
 	// if pod injection of 'KUBERNETES_SERVICE_HOST' environment variable should happen for clusters where APIServerSNI

--- a/pkg/apis/resources/v1alpha1/types.go
+++ b/pkg/apis/resources/v1alpha1/types.go
@@ -169,6 +169,9 @@ type ManagedResourceStatus struct {
 	// Resources is a list of objects that have been created.
 	// +optional
 	Resources []ObjectReference `json:"resources,omitempty"`
+	// SecretChecksum is the checksum of referenced secret's data.
+	// +optional
+	SecretChecksum string `json:"secretChecksum,omitempty"`
 }
 
 // ObjectReference is a reference to another object.

--- a/pkg/apis/resources/v1alpha1/types.go
+++ b/pkg/apis/resources/v1alpha1/types.go
@@ -169,9 +169,9 @@ type ManagedResourceStatus struct {
 	// Resources is a list of objects that have been created.
 	// +optional
 	Resources []ObjectReference `json:"resources,omitempty"`
-	// SecretsChecksum is the checksum of referenced secrets data.
+	// SecretsDataChecksum is the checksum of referenced secrets data.
 	// +optional
-	SecretsChecksum string `json:"secretsChecksum,omitempty"`
+	SecretsDataChecksum *string `json:"secretsDataChecksum,omitempty"`
 }
 
 // ObjectReference is a reference to another object.

--- a/pkg/apis/resources/v1alpha1/types.go
+++ b/pkg/apis/resources/v1alpha1/types.go
@@ -169,9 +169,9 @@ type ManagedResourceStatus struct {
 	// Resources is a list of objects that have been created.
 	// +optional
 	Resources []ObjectReference `json:"resources,omitempty"`
-	// SecretChecksum is the checksum of referenced secret's data.
+	// SecretsChecksum is the checksum of referenced secrets data.
 	// +optional
-	SecretChecksum string `json:"secretChecksum,omitempty"`
+	SecretsChecksum string `json:"secretsChecksum,omitempty"`
 }
 
 // ObjectReference is a reference to another object.

--- a/pkg/apis/resources/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/resources/v1alpha1/zz_generated.deepcopy.go
@@ -170,6 +170,11 @@ func (in *ManagedResourceStatus) DeepCopyInto(out *ManagedResourceStatus) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.SecretsDataChecksum != nil {
+		in, out := &in.SecretsDataChecksum, &out.SecretsDataChecksum
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/operation/botanist/component/extensions/crds/templates/crd-resources.gardener.cloud_managedresources.yaml
+++ b/pkg/operation/botanist/component/extensions/crds/templates/crd-resources.gardener.cloud_managedresources.yaml
@@ -227,8 +227,8 @@ spec:
                       type: string
                   type: object
                 type: array
-              secretChecksum:
-                description: SecretChecksum is the checksum of referenced secret's
+              secretsChecksum:
+                description: SecretsChecksum is the checksum of referenced secrets
                   data.
                 type: string
             type: object

--- a/pkg/operation/botanist/component/extensions/crds/templates/crd-resources.gardener.cloud_managedresources.yaml
+++ b/pkg/operation/botanist/component/extensions/crds/templates/crd-resources.gardener.cloud_managedresources.yaml
@@ -227,8 +227,8 @@ spec:
                       type: string
                   type: object
                 type: array
-              secretsChecksum:
-                description: SecretsChecksum is the checksum of referenced secrets
+              secretsDataChecksum:
+                description: SecretsDataChecksum is the checksum of referenced secrets
                   data.
                 type: string
             type: object

--- a/pkg/operation/botanist/component/extensions/crds/templates/crd-resources.gardener.cloud_managedresources.yaml
+++ b/pkg/operation/botanist/component/extensions/crds/templates/crd-resources.gardener.cloud_managedresources.yaml
@@ -227,6 +227,10 @@ spec:
                       type: string
                   type: object
                 type: array
+              secretChecksum:
+                description: SecretChecksum is the checksum of referenced secret's
+                  data.
+                type: string
             type: object
         type: object
     served: true

--- a/test/integration/resourcemanager/managedresource/resource_test.go
+++ b/test/integration/resourcemanager/managedresource/resource_test.go
@@ -244,11 +244,11 @@ var _ = Describe("ManagedResource controller tests", func() {
 				Eventually(func(g Gomega) []gardencorev1beta1.Condition {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 					return managedResource.Status.Conditions
-				}).Should(
+				}).Should(And(
 					containCondition(ofType(resourcesv1alpha1.ResourcesApplied), withStatus(gardencorev1beta1.ConditionProgressing), withReason(resourcesv1alpha1.ConditionDeletionPending)),
 					containCondition(ofType(resourcesv1alpha1.ResourcesHealthy), withStatus(gardencorev1beta1.ConditionUnknown), withReason(resourcesv1alpha1.ConditionChecksPending)),
 					containCondition(ofType(resourcesv1alpha1.ResourcesProgressing), withStatus(gardencorev1beta1.ConditionUnknown), withReason(resourcesv1alpha1.ConditionChecksPending)),
-				)
+				))
 
 				patch = client.MergeFrom(configMap.DeepCopy())
 				controllerutil.RemoveFinalizer(configMap, testFinalizer)
@@ -270,11 +270,11 @@ var _ = Describe("ManagedResource controller tests", func() {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 					g.Expect(managedResource.Status.SecretsDataChecksum).NotTo(Equal(checksumBefore))
 					return managedResource.Status.Conditions
-				}).Should(
+				}).Should(And(
 					containCondition(ofType(resourcesv1alpha1.ResourcesApplied), withStatus(gardencorev1beta1.ConditionTrue), withReason(resourcesv1alpha1.ConditionApplySucceeded)),
 					containCondition(ofType(resourcesv1alpha1.ResourcesHealthy), withStatus(gardencorev1beta1.ConditionUnknown), withReason(resourcesv1alpha1.ConditionChecksPending)),
 					containCondition(ofType(resourcesv1alpha1.ResourcesProgressing), withStatus(gardencorev1beta1.ConditionUnknown), withReason(resourcesv1alpha1.ConditionChecksPending)),
-				)
+				))
 
 				Consistently(func(g Gomega) map[string]string {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)).To(Succeed())
@@ -296,11 +296,11 @@ var _ = Describe("ManagedResource controller tests", func() {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 					g.Expect(managedResource.Status.SecretsDataChecksum).NotTo(Equal(checksumBefore))
 					return managedResource.Status.Conditions
-				}).Should(
+				}).Should(And(
 					containCondition(ofType(resourcesv1alpha1.ResourcesApplied), withStatus(gardencorev1beta1.ConditionTrue), withReason(resourcesv1alpha1.ConditionApplySucceeded)),
 					containCondition(ofType(resourcesv1alpha1.ResourcesHealthy), withStatus(gardencorev1beta1.ConditionUnknown), withReason(resourcesv1alpha1.ConditionChecksPending)),
 					containCondition(ofType(resourcesv1alpha1.ResourcesProgressing), withStatus(gardencorev1beta1.ConditionUnknown), withReason(resourcesv1alpha1.ConditionChecksPending)),
-				)
+				))
 
 				Eventually(func(g Gomega) {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)).To(Succeed())
@@ -347,11 +347,11 @@ var _ = Describe("ManagedResource controller tests", func() {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 					g.Expect(managedResource.Status.SecretsDataChecksum).NotTo(Equal(checksumBefore))
 					return managedResource.Status.Conditions
-				}).Should(
+				}).Should(And(
 					containCondition(ofType(resourcesv1alpha1.ResourcesApplied), withStatus(gardencorev1beta1.ConditionTrue), withReason(resourcesv1alpha1.ConditionApplySucceeded)),
 					containCondition(ofType(resourcesv1alpha1.ResourcesHealthy), withStatus(gardencorev1beta1.ConditionUnknown), withReason(resourcesv1alpha1.ConditionChecksPending)),
 					containCondition(ofType(resourcesv1alpha1.ResourcesProgressing), withStatus(gardencorev1beta1.ConditionUnknown), withReason(resourcesv1alpha1.ConditionChecksPending)),
-				)
+				))
 
 				Eventually(func(g Gomega) {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)).To(Succeed())
@@ -391,11 +391,11 @@ var _ = Describe("ManagedResource controller tests", func() {
 			Eventually(func(g Gomega) []gardencorev1beta1.Condition {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 				return managedResource.Status.Conditions
-			}).Should(
+			}).Should(And(
 				containCondition(ofType(resourcesv1alpha1.ResourcesApplied), withStatus(gardencorev1beta1.ConditionProgressing), withReason(resourcesv1alpha1.ConditionDeletionPending)),
 				containCondition(ofType(resourcesv1alpha1.ResourcesHealthy), withStatus(gardencorev1beta1.ConditionFalse), withReason(resourcesv1alpha1.ConditionDeletionPending)),
 				containCondition(ofType(resourcesv1alpha1.ResourcesProgressing), withStatus(gardencorev1beta1.ConditionTrue), withReason(resourcesv1alpha1.ConditionDeletionPending)),
-			)
+			))
 		})
 	})
 
@@ -587,11 +587,11 @@ var _ = Describe("ManagedResource controller tests", func() {
 				Eventually(func(g Gomega) []gardencorev1beta1.Condition {
 					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 					return managedResource.Status.Conditions
-				}).Should(
+				}).Should(And(
 					containCondition(ofType(resourcesv1alpha1.ResourcesApplied), withStatus(gardencorev1beta1.ConditionTrue), withReason(resourcesv1alpha1.ConditionManagedResourceIgnored)),
 					containCondition(ofType(resourcesv1alpha1.ResourcesHealthy), withStatus(gardencorev1beta1.ConditionTrue), withReason(resourcesv1alpha1.ConditionManagedResourceIgnored)),
 					containCondition(ofType(resourcesv1alpha1.ResourcesProgressing), withStatus(gardencorev1beta1.ConditionFalse), withReason(resourcesv1alpha1.ConditionManagedResourceIgnored)),
-				)
+				))
 
 				patch = client.MergeFrom(configMap.DeepCopy())
 				configMap.Data = map[string]string{"foo": "bar"}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness ops-productivity
/kind bug

**What this PR does / why we need it**:
Earlier due to race condition there was a possibility for SeedSystemComponentsHealthy condition becoming True right after it has been set to Progressing due to a race condition.
To fix this race condition we are now calculating the checksum for data of reference secrets by managed resource. And storing the checksum in the `.Status.SecretDataChecksum` field. During every reconciliation of managed resource currently calculated checksum is compared with the `.Status.SecretDataChecksum `. Change in calculated checksum means there is a change in the referenced secrets data (i.e change in the resource managed by managed resource). This will result in setting the `ResourcesHealthy` and `ResourcesProgressing` condition to `Unknown`.


**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/6084

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Health checks of `ManagedResources` are more reliable now when updating resources in the referenced secrets.
```
