### PR TITLE
Write the blackbox exporter scrape probe logs also to stdout

### DIFF
--- a/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/deployment.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/deployment.yaml
@@ -51,6 +51,7 @@ spec:
         image: {{ index .Values.images "blackbox-exporter" }}
         args:
         - --config.file=/etc/blackbox_exporter/blackbox.yaml
+        - --log.level=debug
         imagePullPolicy: IfNotPresent
         resources:
           requests:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

Previously, the blackbox exporter wrote logs to stdout on the info level.

The logs of the scrape probes, e.g. regarding the requests to check the
connectivity to the k8s api server, were not logged to stdout.
They were available for operators only via port-forwarding to the web UI
of the blackbox exporter on port 9115.

After this change, the probe logs are also written to stdout so that
when operators are looking for the reason of probe failures, they
can more conveniently check it with `k logs blackbox-exporter-...` instead
of port-forwarding to the component.

Note that the blackbox exporter UI has 2 minor advantages
when checking the logs:
- The blackbox exporter UI allows to check the logs and metrics of
  individual scrape probe runs separately. Operators have to rely on the
  timestamp of the logs in the stdout stream to keep logs from different
  scrape runs apart.
- The caller attribute of the logs is masked in stdout, main.go:211 is
  reported for each log line. (Not really relevant for our use case.)
  See https://github.com/prometheus/blackbox_exporter/blob/d26fcc665935e962ba9ce331d3dc82babe0627c4/main.go#L211

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

cc @dguendisch, @wyb1, @rickardsjp 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The blackbox exporter scrape probe logs are also written to stdout
```
