### PR TITLE
Promote feature gate `DisableDNSProviderManagement` to Beta

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -40,7 +40,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | CopyEtcdBackupsDuringControlPlaneMigration   | `false` | `Alpha` | `1.37` |        |
 | SecretBindingProviderValidation              | `false` | `Alpha` | `1.38` |        |
 | ForceRestore                                 | `false` | `Alpha` | `1.39` |        |
-| DisableDNSProviderManagement                 | `false` | `Alpha` | `1.41` |        |
+| DisableDNSProviderManagement                 | `false` | `Alpha` | `1.41` | `1.49` |
+| DisableDNSProviderManagement                 | `true`  | `Beta`  | `1.50` |        |
 | ShootCARotation                              | `false` | `Alpha` | `1.42` |        |
 | ShootSARotation                              | `false` | `Alpha` | `1.48` |        |
 | HAControlPlanes                              | `false` | `Alpha` | `1.49` |        |

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -135,10 +135,15 @@ const (
 	// alpha: v1.39.0
 	ForceRestore featuregate.Feature = "ForceRestore"
 
-	// DisableDNSProviderManagement disables management of `dns.gardener.cloud/v1alpha1.DNSProvider` resources. In this case, the `shoot-dns-service` extension will take this over if it is installed.
-	// Only supported if feature `UseDNSRecords` is set to true.
+	// DisableDNSProviderManagement disables management of `dns.gardener.cloud/v1alpha1.DNSProvider` resources.
+	// In this case, the `shoot-dns-service` extension can take this over if it is installed and following prerequisites
+	// are given:
+	// - The `shoot-dns-service` extension must be installed in a version >= `v1.20.0`.
+	// - The controller deployment of the `shoot-dns-service` sets `providerConfig.values.dnsProviderManagement.enabled=true`
+	// - Its admission controller (`gardener-extension-admission-shoot-dns-service`) is deployed on the garden cluster
 	// owner: @MartinWeindel @timuthy
 	// alpha: v1.41
+	// beta: v1.50
 	DisableDNSProviderManagement featuregate.Feature = "DisableDNSProviderManagement"
 
 	// ShootCARotation enables the automated rotation of the shoot CA certificates.
@@ -196,7 +201,7 @@ var allFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	CopyEtcdBackupsDuringControlPlaneMigration: {Default: false, PreRelease: featuregate.Alpha},
 	SecretBindingProviderValidation:            {Default: false, PreRelease: featuregate.Alpha},
 	ForceRestore:                               {Default: false, PreRelease: featuregate.Alpha},
-	DisableDNSProviderManagement:               {Default: false, PreRelease: featuregate.Alpha},
+	DisableDNSProviderManagement:               {Default: true, PreRelease: featuregate.Beta},
 	ShootCARotation:                            {Default: false, PreRelease: featuregate.Alpha},
 	ShootSARotation:                            {Default: false, PreRelease: featuregate.Alpha},
 	ShootMaxTokenExpirationOverwrite:           {Default: true, PreRelease: featuregate.GA, LockToDefault: true},

--- a/pkg/operation/botanist/dnsresources_test.go
+++ b/pkg/operation/botanist/dnsresources_test.go
@@ -18,15 +18,16 @@ import (
 	"context"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/features"
+	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 	"github.com/gardener/gardener/pkg/operation/seed"
+	"github.com/gardener/gardener/pkg/utils/test"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/sirupsen/logrus"
 	"k8s.io/utils/pointer"
 
-	"github.com/gardener/gardener/pkg/features"
-	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/operation"
 	. "github.com/gardener/gardener/pkg/operation/botanist"
@@ -34,7 +35,6 @@ import (
 	mockcomponent "github.com/gardener/gardener/pkg/operation/botanist/component/mock"
 	"github.com/gardener/gardener/pkg/operation/garden"
 	"github.com/gardener/gardener/pkg/operation/shoot"
-	"github.com/gardener/gardener/pkg/utils/test"
 )
 
 var _ = Describe("dnsrecord", func() {
@@ -134,6 +134,7 @@ var _ = Describe("dnsrecord", func() {
 
 	Describe("#DeployInternalDNSResources", func() {
 		It("should delete the DNSOwner, DNSProvider, and DNSEntry resources, and then deploy the DNSRecord resource", func() {
+			defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.DisableDNSProviderManagement, false)()
 			gomock.InOrder(
 				internalDNSOwner.EXPECT().Destroy(ctx),
 				internalDNSOwner.EXPECT().WaitCleanup(ctx),
@@ -150,6 +151,7 @@ var _ = Describe("dnsrecord", func() {
 
 	Describe("#DeployExternalDNSResources", func() {
 		It("should delete the DNSOwner and DNSEntry resources, and then deploy the DNSProvider and DNSRecord resources", func() {
+			defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.DisableDNSProviderManagement, false)()
 			gomock.InOrder(
 				externalDNSOwner.EXPECT().Destroy(ctx),
 				externalDNSOwner.EXPECT().WaitCleanup(ctx),
@@ -166,6 +168,7 @@ var _ = Describe("dnsrecord", func() {
 
 	Describe("#DeployIngressDNSResources", func() {
 		It("should delete the DNSOwner and DNSEntry resources, and then deploy the DNSRecord resource", func() {
+			defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.DisableDNSProviderManagement, false)()
 			gomock.InOrder(
 				ingressDNSOwner.EXPECT().Destroy(ctx),
 				ingressDNSOwner.EXPECT().WaitCleanup(ctx),
@@ -203,6 +206,7 @@ var _ = Describe("dnsrecord", func() {
 
 	Describe("#DestroyInternalDNSResources", func() {
 		It("should delete all internal DNS resources so that the DNS record is deleted", func() {
+			defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.DisableDNSProviderManagement, false)()
 			gomock.InOrder(
 				internalDNSEntry.EXPECT().Destroy(ctx),
 				internalDNSEntry.EXPECT().WaitCleanup(ctx),
@@ -219,6 +223,7 @@ var _ = Describe("dnsrecord", func() {
 
 	Describe("#DestroyExternalDNSResources", func() {
 		It("should delete all external DNS resources so that the DNS record is deleted", func() {
+			defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.DisableDNSProviderManagement, false)()
 			gomock.InOrder(
 				externalDNSEntry.EXPECT().Destroy(ctx),
 				externalDNSEntry.EXPECT().WaitCleanup(ctx),
@@ -232,7 +237,6 @@ var _ = Describe("dnsrecord", func() {
 			Expect(b.DestroyExternalDNSResources(ctx)).To(Succeed())
 		})
 		It("should delete all external DNS resources but DNSProvider if feature DisableDNSProviderManagement is set", func() {
-			defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.DisableDNSProviderManagement, true)()
 			gomock.InOrder(
 				externalDNSEntry.EXPECT().Destroy(ctx),
 				externalDNSEntry.EXPECT().WaitCleanup(ctx),
@@ -287,6 +291,7 @@ var _ = Describe("dnsrecord", func() {
 
 	Describe("#MigrateExternalDNSResources", func() {
 		It("should migrate or delete all external DNS resources so that the DNS record is not deleted", func() {
+			defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.DisableDNSProviderManagement, false)()
 			gomock.InOrder(
 				externalDNSOwner.EXPECT().Destroy(ctx),
 				externalDNSOwner.EXPECT().WaitCleanup(ctx),
@@ -303,6 +308,7 @@ var _ = Describe("dnsrecord", func() {
 
 	Describe("#MigrateIngressDNSResources", func() {
 		It("should migrate or delete all ingress DNS resources so that the DNS record is not deleted", func() {
+			defer test.WithFeatureGate(gardenletfeatures.FeatureGate, features.DisableDNSProviderManagement, false)()
 			gomock.InOrder(
 				ingressDNSOwner.EXPECT().Destroy(ctx),
 				ingressDNSOwner.EXPECT().WaitCleanup(ctx),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:
Promote `DisableDNSProviderManagement` feature gate to beta and is now enabled by default.

If the feature gate is enabled and you are using the Gardener extension `shoot-dns-service` make sure
- to deploy version >= `v1.20.0` 
- to set `providerConfig.values.dnsProviderManagement.enabled=true` in its [controller deployment](https://github.com/gardener/gardener-extension-shoot-dns-service/blob/master/example/controller-registration.yaml#L9)
- the shoot DNS service  admission controller (`gardener-extension-admission-shoot-dns-service`) is deployed on the garden cluster

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/5270

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```action operator
The `DisableDNSProviderManagement` feature gate has been promoted to beta and is now enabled by default. If you are using the Gardener extension `shoot-dns-service` make sure to deploy version >= `v1.20.0` and to set `providerConfig.values.dnsProviderManagement.enabled=true` in its [controller deployment](https://github.com/gardener/gardener-extension-shoot-dns-service/blob/master/example/controller-registration.yaml#L9). The shoot DNS service  admission controller (`gardener-extension-admission-shoot-dns-service`) must be deployed on the garden cluster.
```
