### PR TITLE
Adapt network policies to reversed vpn.

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
@@ -59,7 +59,9 @@ spec:
         role: monitoring
         networking.gardener.cloud/to-dns: allowed
         networking.gardener.cloud/to-public-networks: allowed
+{{- if not .Values.reversedVPN.enabled }}
         networking.gardener.cloud/to-shoot-networks: allowed
+{{- end }}
         networking.gardener.cloud/to-shoot-apiserver: allowed
         networking.gardener.cloud/to-seed-apiserver: allowed
     spec:

--- a/docs/development/seed_network_policies.md
+++ b/docs/development/seed_network_policies.md
@@ -23,6 +23,7 @@ In contrast to other network policies, the policy `allow-to-shoot-networks` is t
 because it is based on the network configuration in the Shoot manifest.
 It allows pods with the label `networking.gardener.cloud/to-shoot-networks=allowed` to access pods in the Shoot pod, 
 service and node CIDR range. This is used by the Shoot API Server and the prometheus pods to communicate over VPN/proxy with pods in the Shoot cluster.
+This network policy is only useful if reversed vpn is disabled as otherwise the vpn-seed-server pod in the control plane is the only pod with layer 3 routing to the shoot network.
 
 The policy `allow-to-blocked-cidrs` allows pods with the label `networking.gardener.cloud/to-blocked-cidrs=allowed` to access IPs that are explicitly blocked for all control planes in a Seed cluster (configurable via `spec.networks.blockCIDRS`). 
 This is used for instance to block the cloud provider's metadata service.

--- a/pkg/operation/botanist/component/kubeapiserver/deployment.go
+++ b/pkg/operation/botanist/component/kubeapiserver/deployment.go
@@ -214,7 +214,6 @@ func (k *kubeAPIServer) reconcileDeployment(
 						v1beta1constants.LabelNetworkPolicyToDNS:             v1beta1constants.LabelNetworkPolicyAllowed,
 						v1beta1constants.LabelNetworkPolicyToPublicNetworks:  v1beta1constants.LabelNetworkPolicyAllowed,
 						v1beta1constants.LabelNetworkPolicyToPrivateNetworks: v1beta1constants.LabelNetworkPolicyAllowed,
-						v1beta1constants.LabelNetworkPolicyToShootNetworks:   v1beta1constants.LabelNetworkPolicyAllowed,
 						v1beta1constants.LabelNetworkPolicyFromPrometheus:    v1beta1constants.LabelNetworkPolicyAllowed,
 					}),
 				},
@@ -720,6 +719,7 @@ func (k *kubeAPIServer) handleVPNSettings(
 	secretLegacyVPNSeedTLSAuth *corev1.Secret,
 ) {
 	if !k.values.VPN.ReversedVPNEnabled {
+		deployment.Spec.Template.Labels[v1beta1constants.LabelNetworkPolicyToShootNetworks] = v1beta1constants.LabelNetworkPolicyAllowed
 		deployment.Spec.Template.Spec.InitContainers = []corev1.Container{{
 			Name:  "set-iptable-rules",
 			Image: k.values.Images.AlpineIPTables,

--- a/pkg/operation/botanist/networkpolicies.go
+++ b/pkg/operation/botanist/networkpolicies.go
@@ -53,8 +53,10 @@ func (b *Botanist) DefaultNetworkPolicies(sniPhase component.Phase) (component.D
 		seedCIDRNetworks = append(seedCIDRNetworks, *v)
 	}
 
-	allCIDRNetworks := append(seedCIDRNetworks, shootCIDRNetworks...)
-	allCIDRNetworks = append(allCIDRNetworks, b.Seed.GetInfo().Spec.Networks.BlockCIDRs...)
+	allCIDRNetworks := append(seedCIDRNetworks, b.Seed.GetInfo().Spec.Networks.BlockCIDRs...)
+	if !b.Shoot.ReversedVPNEnabled {
+		allCIDRNetworks = append(allCIDRNetworks, shootCIDRNetworks...)
+	}
 
 	privateNetworkPeers, err := networkpolicies.ToNetworkPolicyPeersWithExceptions(networkpolicies.AllPrivateNetworkBlocks(), allCIDRNetworks...)
 	if err != nil {

--- a/pkg/operation/botanist/networkpolicies_test.go
+++ b/pkg/operation/botanist/networkpolicies_test.go
@@ -122,6 +122,45 @@ var _ = Describe("Networkpolicies", func() {
 		),
 
 		Entry(
+			"w/ network CIDRs with reversed vpn",
+			component.PhaseUnknown,
+			func() {
+				botanist.Shoot.GetInfo().Spec.Networking.Pods = &podCIDRShoot
+				botanist.Shoot.GetInfo().Spec.Networking.Services = &serviceCIDRShoot
+				botanist.Shoot.GetInfo().Spec.Networking.Nodes = &nodeCIDRShoot
+				botanist.Seed.GetInfo().Spec.Networks.Nodes = &nodeCIDRSeed
+				botanist.Seed.GetInfo().Spec.Networks.BlockCIDRs = blockCIDRs
+				botanist.Shoot.ReversedVPNEnabled = true
+			},
+			func(client client.Client, namespace string, values networkpolicies.Values) {
+				Expect(client).To(Equal(c))
+				Expect(namespace).To(Equal(seedNamespace))
+				Expect(values.SNIEnabled).To(BeFalse())
+				Expect(values.BlockedAddresses).To(Equal(blockCIDRs))
+				Expect(values.DenyAllTraffic).To(BeTrue())
+				Expect(values.ShootNetworkPeers).To(ConsistOf(
+					networkingv1.NetworkPolicyPeer{IPBlock: &networkingv1.IPBlock{CIDR: nodeCIDRShoot, Except: blockCIDRs}},
+					networkingv1.NetworkPolicyPeer{IPBlock: &networkingv1.IPBlock{CIDR: podCIDRShoot}},
+					networkingv1.NetworkPolicyPeer{IPBlock: &networkingv1.IPBlock{CIDR: "172.16.0.0/14"}},
+				))
+				Expect(values.PrivateNetworkPeers).To(ConsistOf(
+					networkingv1.NetworkPolicyPeer{IPBlock: &networkingv1.IPBlock{
+						CIDR:   "10.0.0.0/8",
+						Except: append([]string{podCIDRSeed, nodeCIDRSeed}, blockCIDRs...),
+					}},
+					networkingv1.NetworkPolicyPeer{IPBlock: &networkingv1.IPBlock{CIDR: "172.16.0.0/12"}},
+					networkingv1.NetworkPolicyPeer{IPBlock: &networkingv1.IPBlock{CIDR: "192.168.0.0/16"}},
+					networkingv1.NetworkPolicyPeer{IPBlock: &networkingv1.IPBlock{
+						CIDR:   "100.64.0.0/10",
+						Except: nil,
+					}},
+				))
+				Expect(values.NodeLocalIPVSAddress).To(PointTo(Equal("169.254.20.10")))
+				Expect(values.DNSServerAddress).To(PointTo(Equal("192.168.0.10")))
+			},
+		),
+
+		Entry(
 			"w/ network CIDRs",
 			component.PhaseUnknown,
 			func() {
@@ -145,7 +184,7 @@ var _ = Describe("Networkpolicies", func() {
 				Expect(values.PrivateNetworkPeers).To(ConsistOf(
 					networkingv1.NetworkPolicyPeer{IPBlock: &networkingv1.IPBlock{
 						CIDR:   "10.0.0.0/8",
-						Except: append([]string{podCIDRSeed, nodeCIDRSeed, nodeCIDRShoot}, blockCIDRs...),
+						Except: append(append([]string{podCIDRSeed, nodeCIDRSeed}, blockCIDRs...), nodeCIDRShoot),
 					}},
 					networkingv1.NetworkPolicyPeer{IPBlock: &networkingv1.IPBlock{CIDR: "172.16.0.0/12"}},
 					networkingv1.NetworkPolicyPeer{IPBlock: &networkingv1.IPBlock{CIDR: "192.168.0.0/16"}},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Adapt network policies to reversed vpn.

With reversed vpn only the vpn-seed-server pod in the cluster control plane has layer 3 routing
access to the shoot cluster. The kube-apiserver uses the vpn-seed-server as http proxy. Monitoring
utilizes kube-apiserver as another level of indirection.
This is why this change removes the annotations from kube-apiserver and prometheus in case reversed
vpn is active.
As there is basically no longer connectivity to the shoot networks it is also no longer necessary
to exclude the shoot networks from the private network range (allow-to-private-networks). This
allows additional scenarios where private IPv4 addresses are used in the shoot cluster as well as
for other services.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`NetworkPolicy/allow-to-private-networks` now allows access to networks overlapping the shoot networks in case reversed VPN is active.
```
```other operator
`kube-apiserver` and `prometheus` pods are no longer allowed to access shoot networks in case reversed VPN is active.
```

/cc @DockToFuture @MartinWeindel 