### PR TITLE
fix: Alert dashboard panels

### DIFF
--- a/charts/seed-bootstrap/dashboards/alerts-dashboard.json
+++ b/charts/seed-bootstrap/dashboards/alerts-dashboard.json
@@ -340,7 +340,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "count(ALERTS{alertstate=\"pending\"}) by (cluster)",
+          "expr": "count(count(ALERTS{alertstate=\"pending\"}) by (cluster))",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -429,7 +429,7 @@
       "pluginVersion": "6.3.2",
       "targets": [
         {
-          "expr": "(count(count(ALERTS) by (cluster)) / count(count(seed:container_cpu_usage_seconds_total:sum_by_pod{namespace=~\"shoot-(.+)\"}) by (namespace))) * 100",
+          "expr": "count(count(ALERTS)by(cluster)) / sum(seed:active_shoots_total:sum) * 100",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -503,7 +503,7 @@
       "tableColumn": "",
       "targets": [
         {
-          "expr": "count(count(seed:container_cpu_usage_seconds_total:sum_by_pod{namespace=~\"shoot-(.+)\"}) by (namespace))",
+          "expr": "seed:active_shoots_total:sum",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,

--- a/charts/seed-bootstrap/dashboards/alerts-dashboard.json
+++ b/charts/seed-bootstrap/dashboards/alerts-dashboard.json
@@ -429,7 +429,7 @@
       "pluginVersion": "6.3.2",
       "targets": [
         {
-          "expr": "count(count(ALERTS)by(cluster)) / sum(seed:active_shoots_total:sum) * 100",
+          "expr": "count(count(ALERTS) by (cluster)) / sum(seed:active_shoots_total:sum) * 100",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area monitoring
  /kind enhancement 
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

This PR is to fix Query of three panels in Alerts dashboard 
- Clusters with Pending Alerts
- % of Clusters with Alerts
- Clusters Total
<img width="821" alt="Screen Shot 2022-06-21 at 12 18 11" src="https://user-images.githubusercontent.com/50126000/174715183-d613afc0-1fee-4429-aff1-83bf7f2f5012.png">

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
