### PR TITLE
Forbid certain rotation operations when `Shoot` is hibernated

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -64,22 +64,22 @@ var (
 		string(corev1.ServiceExternalTrafficPolicyTypeLocal),
 	)
 	availableShootOperations = sets.NewString(
-		string(v1beta1constants.ShootOperationMaintain),
-		string(v1beta1constants.ShootOperationRetry),
+		v1beta1constants.ShootOperationMaintain,
+		v1beta1constants.ShootOperationRetry,
 	).Union(availableShootMaintenanceOperations)
 	availableShootMaintenanceOperations = sets.NewString(
-		string(v1beta1constants.GardenerOperationReconcile),
-		string(v1beta1constants.ShootOperationRotateCAStart),
-		string(v1beta1constants.ShootOperationRotateCAComplete),
-		string(v1beta1constants.ShootOperationRotateCredentialsStart),
-		string(v1beta1constants.ShootOperationRotateCredentialsComplete),
-		string(v1beta1constants.ShootOperationRotateETCDEncryptionKeyStart),
-		string(v1beta1constants.ShootOperationRotateETCDEncryptionKeyComplete),
-		string(v1beta1constants.ShootOperationRotateKubeconfigCredentials),
-		string(v1beta1constants.ShootOperationRotateObservabilityCredentials),
-		string(v1beta1constants.ShootOperationRotateSSHKeypair),
-		string(v1beta1constants.ShootOperationRotateServiceAccountKeyStart),
-		string(v1beta1constants.ShootOperationRotateServiceAccountKeyComplete),
+		v1beta1constants.GardenerOperationReconcile,
+		v1beta1constants.ShootOperationRotateCAStart,
+		v1beta1constants.ShootOperationRotateCAComplete,
+		v1beta1constants.ShootOperationRotateCredentialsStart,
+		v1beta1constants.ShootOperationRotateCredentialsComplete,
+		v1beta1constants.ShootOperationRotateETCDEncryptionKeyStart,
+		v1beta1constants.ShootOperationRotateETCDEncryptionKeyComplete,
+		v1beta1constants.ShootOperationRotateKubeconfigCredentials,
+		v1beta1constants.ShootOperationRotateObservabilityCredentials,
+		v1beta1constants.ShootOperationRotateSSHKeypair,
+		v1beta1constants.ShootOperationRotateServiceAccountKeyStart,
+		v1beta1constants.ShootOperationRotateServiceAccountKeyComplete,
 	)
 	availableShootPurposes = sets.NewString(
 		string(core.ShootPurposeEvaluation),
@@ -1737,11 +1737,11 @@ func validateShootOperation(operation, maintenanceOperation string, shoot *core.
 		allErrs = append(allErrs, field.Forbidden(fldPath, fmt.Sprintf("annotations %s and %s must not be equal", fldPathOp, fldPathMaintOp)))
 	}
 
-	if operation != "" && !availableShootOperations.Has(string(operation)) {
+	if operation != "" && !availableShootOperations.Has(operation) {
 		allErrs = append(allErrs, field.NotSupported(fldPathOp, operation, availableShootOperations.List()))
 	}
 
-	if maintenanceOperation != "" && !availableShootMaintenanceOperations.Has(string(maintenanceOperation)) {
+	if maintenanceOperation != "" && !availableShootMaintenanceOperations.Has(maintenanceOperation) {
 		allErrs = append(allErrs, field.NotSupported(fldPathMaintOp, maintenanceOperation, availableShootMaintenanceOperations.List()))
 	}
 

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -3501,22 +3501,20 @@ var _ = Describe("Shoot Validation Tests", func() {
 				}),
 			)
 
-			It("should return an error if the reconciliation operation annotation is invalid", func() {
+			It("should return an error if the operation annotation is invalid", func() {
 				metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "gardener.cloud/operation", "foo-bar")
-				matcher := ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				Expect(ValidateShoot(shoot)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeNotSupported),
 					"Field": Equal("metadata.annotations[gardener.cloud/operation]"),
-				})))
-				Expect(ValidateShoot(shoot)).To(matcher)
+				}))))
 			})
 
 			It("should return an error if the maintenance operation annotation is invalid", func() {
 				metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "maintenance.gardener.cloud/operation", "foo-bar")
-				matcher := ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				Expect(ValidateShoot(shoot)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeNotSupported),
 					"Field": Equal("metadata.annotations[maintenance.gardener.cloud/operation]"),
-				})))
-				Expect(ValidateShoot(shoot)).To(matcher)
+				}))))
 			})
 
 			It("should return an error if maintenance annotation is not allowed in this context", func() {
@@ -3527,14 +3525,13 @@ var _ = Describe("Shoot Validation Tests", func() {
 						State: core.LastOperationStateSucceeded,
 					},
 				}
-				matcher := ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				Expect(ValidateShoot(shoot)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeForbidden),
 					"Field": Equal("metadata.annotations[maintenance.gardener.cloud/operation]"),
-				})))
-				Expect(ValidateShoot(shoot)).To(matcher)
+				}))))
 			})
 
-			It("should return an error if both annotation have the same value", func() {
+			It("should return an error if both operation annotations have the same value", func() {
 				metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "gardener.cloud/operation", "rotate-etcd-encryption-key-start")
 				metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "maintenance.gardener.cloud/operation", "rotate-etcd-encryption-key-start")
 				shoot.Status = core.ShootStatus{
@@ -3543,11 +3540,10 @@ var _ = Describe("Shoot Validation Tests", func() {
 						State: core.LastOperationStateSucceeded,
 					},
 				}
-				matcher := ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				Expect(ValidateShoot(shoot)).To(ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
 					"Type":  Equal(field.ErrorTypeForbidden),
 					"Field": Equal("metadata.annotations"),
-				})))
-				Expect(ValidateShoot(shoot)).To(matcher)
+				}))))
 			})
 
 			It("should return nothing if maintenance annotation is valid", func() {
@@ -3555,7 +3551,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				Expect(ValidateShoot(shoot)).To(BeEmpty())
 			})
 
-			It("should return nothing if both annotations are valid and do not have the same value", func() {
+			It("should return nothing if both operations annotations are valid and do not have the same value", func() {
 				metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "gardener.cloud/operation", "rotate-serviceaccount-key-start")
 				metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "maintenance.gardener.cloud/operation", "rotate-etcd-encryption-key-start")
 				shoot.Status = core.ShootStatus{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind bug

**What this PR does / why we need it**:
Now it is no longer possible to perform the rotation operations requiring the shoot client when the `Shoot` itself is hibernated.

**Which issue(s) this PR fixes**:
Part of #3292

**Special notes for your reviewer**:
/cc @oliver-goetz 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
It is no longer possible to perform the following shoot operations when it is hibernated: `rotate-{credentials,etcd-encryption-key,serviceaccount-key}-{start,complete}`.
```
