### PR TITLE
[GEP-18] Add a new constraint in `.status.constraints` for `Shoot`s whose CAs are expiring in less than `1y`

### DIFF
--- a/docs/usage/shoot_status.md
+++ b/docs/usage/shoot_status.md
@@ -92,6 +92,12 @@ As of today, the same checks as in the `HibernationPossible` constraint are bein
 There is no further action being performed on this constraint's status (maintenance is still being performed).
 It is meant to make the user aware of potential problems that might occur due to his configurations.
 
+**`CACertificateValiditiesAcceptable`**:
+
+This constraints indicates that there is at least one CA certificate which expires in less than `1y`.
+It will not be added to the `.status.constraints` if there is no such CA certificate.
+However, if it's visible, then a [credentials rotation operation](shoot_credentials_rotation.md#certificate-authorities) should be considered.
+
 ### Last Operation
 
 The Shoot status holds information about the last operation that is performed on the Shoot. The last operation field reflects overall progress and the tasks that are currently being executed. Allowed operation types are `Create`, `Reconcile`, `Delete`, `Migrate` and `Restore`. Allowed operation states are `Processing`, `Succeeded`, `Error`, `Failed`, `Pending` and `Aborted`. An operation in `Error` state is an operation that will be retried for a configurable amount of time (`controllers.shoot.retryDuration` field in `GardenletConfiguration`, defaults to `12h`). If the operation cannot complete successfully for the configured retry duration, it will be marked as `Failed`. An operation in `Failed` state is an operation that won't be retried automatically (to retry such an operation, see [Retry failed operation](https://github.com/gardener/gardener/blob/master/docs/usage/shoot_operations.md#retry-failed-operation)).

--- a/pkg/apis/core/v1beta1/types_shoot.go
+++ b/pkg/apis/core/v1beta1/types_shoot.go
@@ -1461,6 +1461,9 @@ const (
 	// ShootMaintenancePreconditionsSatisfied is a constant for a condition type indicating whether all preconditions
 	// for a shoot maintenance operation are satisfied.
 	ShootMaintenancePreconditionsSatisfied ConditionType = "MaintenancePreconditionsSatisfied"
+	// ShootCACertificateValiditiesAcceptable is a constant for a condition type indicating that the validities of all
+	// CA certificates is long enough.
+	ShootCACertificateValiditiesAcceptable ConditionType = "CACertificateValiditiesAcceptable"
 )
 
 // ShootPurpose is a type alias for string.

--- a/pkg/gardenlet/controller/shoot/shoot_care_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_care_control.go
@@ -38,6 +38,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/clock"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -253,6 +254,7 @@ func (r *careReconciler) care(ctx context.Context, gardenClientSet kubernetes.In
 	constraintTypes := []gardencorev1beta1.ConditionType{
 		gardencorev1beta1.ShootHibernationPossible,
 		gardencorev1beta1.ShootMaintenancePreconditionsSatisfied,
+		gardencorev1beta1.ShootCACertificateValiditiesAcceptable,
 	}
 	var constraints []gardencorev1beta1.Condition
 	for _, constr := range constraintTypes {
@@ -328,7 +330,7 @@ func (r *careReconciler) care(ctx context.Context, gardenClientSet kubernetes.In
 		},
 		// Trigger constraint checks
 		func(ctx context.Context) error {
-			constraint := NewConstraintCheck(o, initializeShootClients)
+			constraint := NewConstraintCheck(clock.RealClock{}, o, initializeShootClients)
 			updatedConstraints = constraint.Check(
 				ctx,
 				constraints,

--- a/pkg/gardenlet/controller/shoot/shoot_care_control_test.go
+++ b/pkg/gardenlet/controller/shoot/shoot_care_control_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -539,7 +540,7 @@ func (c resultingConstraintFunc) Check(_ context.Context, constraints []gardenco
 }
 
 func constraintCheckFunc(fn resultingConstraintFunc) NewConstraintCheckFunc {
-	return func(op *operation.Operation, init care.ShootClientInit) ConstraintCheck {
+	return func(clock clock.Clock, op *operation.Operation, init care.ShootClientInit) ConstraintCheck {
 		return fn
 	}
 }
@@ -606,6 +607,11 @@ func consistOfConstraintsInUnknownStatus(message string) types.GomegaMatcher {
 		}),
 		MatchFields(IgnoreExtras, Fields{
 			"Type":    Equal(gardencorev1beta1.ShootMaintenancePreconditionsSatisfied),
+			"Status":  Equal(gardencorev1beta1.ConditionUnknown),
+			"Message": Equal(message),
+		}),
+		MatchFields(IgnoreExtras, Fields{
+			"Type":    Equal(gardencorev1beta1.ShootCACertificateValiditiesAcceptable),
 			"Status":  Equal(gardencorev1beta1.ConditionUnknown),
 			"Message": Equal(message),
 		}),

--- a/pkg/gardenlet/controller/shoot/shoot_care_control_types.go
+++ b/pkg/gardenlet/controller/shoot/shoot_care_control_types.go
@@ -29,6 +29,7 @@ import (
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/clock"
 )
 
 // HealthCheck is an interface used to perform health checks.
@@ -50,11 +51,11 @@ type ConstraintCheck interface {
 }
 
 // NewConstraintCheckFunc is a function used to create a new instance for performing constraint checks.
-type NewConstraintCheckFunc func(op *operation.Operation, init care.ShootClientInit) ConstraintCheck
+type NewConstraintCheckFunc func(clock clock.Clock, op *operation.Operation, init care.ShootClientInit) ConstraintCheck
 
 // defaultNewConstraintCheck is the default function to create a new instance for performing constraint checks.
-var defaultNewConstraintCheck = func(op *operation.Operation, init care.ShootClientInit) ConstraintCheck {
-	return care.NewConstraint(op, init)
+var defaultNewConstraintCheck = func(clock clock.Clock, op *operation.Operation, init care.ShootClientInit) ConstraintCheck {
+	return care.NewConstraint(clock, op, init)
 }
 
 // GarbageCollector is an interface used to perform garbage collection.

--- a/pkg/operation/care/constraints.go
+++ b/pkg/operation/care/constraints.go
@@ -17,6 +17,9 @@ package care
 import (
 	"context"
 	"fmt"
+	"strconv"
+	"strings"
+	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
@@ -26,12 +29,16 @@ import (
 	"github.com/gardener/gardener/pkg/operation/botanist/matchers"
 	"github.com/gardener/gardener/pkg/operation/shoot"
 	"github.com/gardener/gardener/pkg/utils"
+	secretutils "github.com/gardener/gardener/pkg/utils/secrets"
+	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 
 	"github.com/sirupsen/logrus"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -60,16 +67,20 @@ func shootControlPlaneNotRunningConstraints(conditions ...gardencorev1beta1.Cond
 type Constraint struct {
 	shoot *shoot.Shoot
 
+	seedClient             client.Client
 	initializeShootClients ShootClientInit
 	shootClient            client.Client
 
 	logger logrus.FieldLogger
+	clock  clock.Clock
 }
 
 // NewConstraint returns a new constraint instance.
-func NewConstraint(op *operation.Operation, shootClientInit ShootClientInit) *Constraint {
+func NewConstraint(clock clock.Clock, op *operation.Operation, shootClientInit ShootClientInit) *Constraint {
 	return &Constraint{
+		clock:                  clock,
 		shoot:                  op.Shoot,
+		seedClient:             op.K8sSeedClient.Client(),
 		initializeShootClients: shootClientInit,
 		logger:                 op.Logger,
 	}
@@ -94,16 +105,33 @@ func (c *Constraint) constraintsChecks(
 		return shootHibernatedConstraints(constraints...)
 	}
 
-	var hibernationPossibleConstraint, maintenancePreconditionsSatisfiedConstraint gardencorev1beta1.Condition
+	var (
+		// required constraints (always present in .status.constraints)
+		hibernationPossibleConstraint, maintenancePreconditionsSatisfiedConstraint gardencorev1beta1.Condition
+		// optional constraints (not always present in .status.constraints)
+		caCertificateValidityExpiringConstraint = gardencorev1beta1.Condition{Type: gardencorev1beta1.ShootCACertificateValiditiesAcceptable}
+	)
+
 	for _, cons := range constraints {
 		switch cons.Type {
 		case gardencorev1beta1.ShootHibernationPossible:
 			hibernationPossibleConstraint = cons
 		case gardencorev1beta1.ShootMaintenancePreconditionsSatisfied:
 			maintenancePreconditionsSatisfiedConstraint = cons
+		case gardencorev1beta1.ShootCACertificateValiditiesAcceptable:
+			caCertificateValidityExpiringConstraint = cons
 		}
 	}
 
+	// Check constraints not depending on the shoot's kube-apiserver to be up and running
+	status, reason, message, errorCodes, err := c.CheckIfCACertificateValiditiesAcceptable(ctx)
+	if err != nil {
+		caCertificateValidityExpiringConstraint = NewConditionOrError(caCertificateValidityExpiringConstraint, nil, err)
+	} else {
+		caCertificateValidityExpiringConstraint = gardencorev1beta1helper.UpdatedCondition(caCertificateValidityExpiringConstraint, status, reason, message, errorCodes...)
+	}
+
+	// Now check constraints depending on the shoot's kube-apiserver to be up and running
 	shootClient, apiServerRunning, err := c.initializeShootClients()
 	if err != nil {
 		message := fmt.Sprintf("Could not initialize Shoot client for constraints check: %+v", err)
@@ -111,11 +139,17 @@ func (c *Constraint) constraintsChecks(
 		hibernationPossibleConstraint = gardencorev1beta1helper.UpdatedConditionUnknownErrorMessage(hibernationPossibleConstraint, message)
 		maintenancePreconditionsSatisfiedConstraint = gardencorev1beta1helper.UpdatedConditionUnknownErrorMessage(maintenancePreconditionsSatisfiedConstraint, message)
 
-		return []gardencorev1beta1.Condition{hibernationPossibleConstraint, maintenancePreconditionsSatisfiedConstraint}
+		return filterOptionalConstraints(
+			[]gardencorev1beta1.Condition{hibernationPossibleConstraint, maintenancePreconditionsSatisfiedConstraint},
+			[]gardencorev1beta1.Condition{caCertificateValidityExpiringConstraint},
+		)
 	}
 	if !apiServerRunning {
 		// don't check constraints if API server has already been deleted or has not been created yet
-		return shootControlPlaneNotRunningConstraints(hibernationPossibleConstraint, maintenancePreconditionsSatisfiedConstraint)
+		return filterOptionalConstraints(
+			shootControlPlaneNotRunningConstraints(hibernationPossibleConstraint, maintenancePreconditionsSatisfiedConstraint),
+			[]gardencorev1beta1.Condition{caCertificateValidityExpiringConstraint},
+		)
 	}
 	c.shootClient = shootClient.Client()
 
@@ -128,7 +162,10 @@ func (c *Constraint) constraintsChecks(
 		maintenancePreconditionsSatisfiedConstraint = gardencorev1beta1helper.UpdatedCondition(maintenancePreconditionsSatisfiedConstraint, status, reason, message, errorCodes...)
 	}
 
-	return []gardencorev1beta1.Condition{hibernationPossibleConstraint, maintenancePreconditionsSatisfiedConstraint}
+	return filterOptionalConstraints(
+		[]gardencorev1beta1.Condition{hibernationPossibleConstraint, maintenancePreconditionsSatisfiedConstraint},
+		[]gardencorev1beta1.Condition{caCertificateValidityExpiringConstraint},
+	)
 }
 
 func getValidatingWebhookConfigurations(ctx context.Context, client client.Client) ([]admissionregistrationv1.ValidatingWebhookConfiguration, error) {
@@ -150,6 +187,59 @@ func getMutatingWebhookConfigurations(ctx context.Context, c client.Client) ([]a
 		return nil, err
 	}
 	return mutatingWebhookConfigs.Items, nil
+}
+
+// CheckIfCACertificateValiditiesAcceptable checks whether there are CA certificates which are expiring in less than a
+// year.
+func (c *Constraint) CheckIfCACertificateValiditiesAcceptable(ctx context.Context) (gardencorev1beta1.ConditionStatus, string, string, []gardencorev1beta1.ErrorCode, error) {
+	// CA certificates are valid for 10y, so let's only consider those certificates problematic which are valid for less
+	// than 1y.
+	const minimumValidity = 24 * time.Hour * 365
+
+	secretList := &corev1.SecretList{}
+	if err := c.seedClient.List(ctx, secretList, client.InNamespace(c.shoot.SeedNamespace), client.MatchingLabels{
+		secretsmanager.LabelKeyManagedBy:       secretsmanager.LabelValueSecretsManager,
+		secretsmanager.LabelKeyManagerIdentity: v1beta1constants.SecretManagerIdentityGardenlet,
+		secretsmanager.LabelKeyPersist:         secretsmanager.LabelValueTrue,
+	}); err != nil {
+		return "", "", "", nil, fmt.Errorf("could not list secrets in shoot namespace in seed to check for expiring CA certificates: %w", err)
+	}
+
+	expiringCACertificates := make(map[string]time.Time, len(secretList.Items))
+	for _, secret := range secretList.Items {
+		if secret.Data[secretutils.DataKeyCertificateCA] == nil || secret.Data[secretutils.DataKeyPrivateKeyCA] == nil {
+			continue
+		}
+
+		validUntilUnix, err := strconv.ParseInt(secret.Labels[secretsmanager.LabelKeyValidUntilTime], 10, 64)
+		if err != nil {
+			return "", "", "", nil, fmt.Errorf("could not parse %s label from secret %q: %w", secretsmanager.LabelKeyValidUntilTime, secret.Name, err)
+		}
+		validUntil := time.Unix(validUntilUnix, 0).UTC()
+
+		if validUntil.Sub(c.clock.Now().UTC()) < minimumValidity {
+			expiringCACertificates[secret.Labels[secretsmanager.LabelKeyName]] = validUntil
+		}
+	}
+
+	if len(expiringCACertificates) > 0 {
+		var msgs []string
+		for name, validUntil := range expiringCACertificates {
+			msgs = append(msgs, fmt.Sprintf("%q (expiring at %s)", name, validUntil))
+		}
+
+		return gardencorev1beta1.ConditionFalse,
+			"ExpiringCACertificates",
+			fmt.Sprintf("Some CA certificates are expiring in less than %s, you should rotate them: %s", minimumValidity, strings.Join(msgs, ", ")),
+			nil,
+			nil
+	}
+
+	return gardencorev1beta1.ConditionTrue,
+		"NoExpiringCACertificates",
+		fmt.Sprintf("All CA certificates are still valid for at least %s.", minimumValidity),
+		nil,
+		nil
 }
 
 // CheckForProblematicWebhooks checks the Shoot for problematic webhooks which could prevent shoot worker nodes from
@@ -274,4 +364,17 @@ func IsProblematicWebhook(
 
 func wasRemediatedByGardener(annotations map[string]string) bool {
 	return annotations[v1beta1constants.GardenerWarning] != ""
+}
+
+func filterOptionalConstraints(required, optional []gardencorev1beta1.Condition) []gardencorev1beta1.Condition {
+	var out []gardencorev1beta1.Condition
+	out = append(out, required...)
+
+	for _, constraint := range optional {
+		if constraint.Status != gardencorev1beta1.ConditionTrue {
+			out = append(out, constraint)
+		}
+	}
+
+	return out
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
This PR adds a new optional constraint to the `.status.constraints` of `Shoot`s.
It is only visible when there is at least one CA certificate which expires in less than `1y` as a "warning"/reminder that a rotation should be performed.

FYI @gardener/dashboard-maintainers 

**Which issue(s) this PR fixes**:
Part of #3292

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
In case at least one shoot cluster CA certificate is about to expire in less than `1y`, a new constraint of type `CACertificateValiditiesAcceptable` will be visible in the `.status.constraints` to make end-users aware that a rotation should be performed.
```
