### PR TITLE
Enhance image vector APIs to support multi arch images

### DIFF
--- a/docs/deployment/image_vector.md
+++ b/docs/deployment/image_vector.md
@@ -13,14 +13,14 @@ images:
   repository: gcr.io/google_containers/pause-amd64
   tag: "3.0"
   version: 1.17.x
-  architecture:
+  architectures:
   - amd64
 - name: pause-container
   sourceRepository: github.com/kubernetes/kubernetes/blob/master/build/pause/Dockerfile
   repository: gcr.io/google_containers/pause-amd64
   tag: "3.1"
   version: ">= 1.18"
-  architecture:
+  architectures:
   - amd64
 ...
 ```
@@ -35,29 +35,29 @@ images:
   sourceRepository: github.com/kubernetes/kubernetes/blob/master/build/pause/Dockerfile
   repository: k8s.gcr.io/pause
   tag: "3.0"
-  architecture:
+  architectures:
   - amd64
 - name: pause-container
   sourceRepository: github.com/kubernetes/kubernetes/blob/master/build/pause/Dockerfile
   repository: k8s.gcr.io/pause
   tag: "3.0"
-  architecture:
+  architectures:
   - arm64
 - name: pause-container
   sourceRepository: github.com/kubernetes/kubernetes/blob/master/build/pause/Dockerfile
   repository: k8s.gcr.io/pause
   tag: "3.0"
-  architecture:
+  architectures:
   - amd64
   - arm64
 ...
 ```
 
-Architecture is an optional field of image. It is a list of strings specifying CPU architecture of machines on which this image can be used. The valid options for architecture field are as follow:
+Architectures is an optional field of image. It is a list of strings specifying CPU architecture of machines on which this image can be used. The valid options for architectures field are as follow:
 - `amd64` : This sepecifies image can run only on machines having CPU architecture `amd64`.
 - `arm64` : This sepecifies image can run only on machines having CPU architecture `arm64`.
 
-If image doesn't specifies any architecture then by default it is considered to support both `amd64` and `arm64` architecture.
+If image doesn't specifies any architectures then by default it is considered to support both `amd64` and `arm64` architectures.
 
 ## Overwrite image vector
 

--- a/docs/deployment/image_vector.md
+++ b/docs/deployment/image_vector.md
@@ -13,15 +13,51 @@ images:
   repository: gcr.io/google_containers/pause-amd64
   tag: "3.0"
   version: 1.17.x
+  architecture:
+  - amd64
 - name: pause-container
   sourceRepository: github.com/kubernetes/kubernetes/blob/master/build/pause/Dockerfile
   repository: gcr.io/google_containers/pause-amd64
   tag: "3.1"
   version: ">= 1.18"
+  architecture:
+  - amd64
 ...
 ```
 
 That means that the Gardenlet will use the `pause-container` in with tag `3.0` for all seed/shoot clusters with Kubernetes version `1.17.x`, and tag `3.1` for all clusters with Kubernetes `>= 1.18`.
+
+## Image Vector Architecture
+
+```yaml
+images:
+- name: pause-container
+  sourceRepository: github.com/kubernetes/kubernetes/blob/master/build/pause/Dockerfile
+  repository: k8s.gcr.io/pause
+  tag: "3.0"
+  architecture:
+  - amd64
+- name: pause-container
+  sourceRepository: github.com/kubernetes/kubernetes/blob/master/build/pause/Dockerfile
+  repository: k8s.gcr.io/pause
+  tag: "3.0"
+  architecture:
+  - arm64
+- name: pause-container
+  sourceRepository: github.com/kubernetes/kubernetes/blob/master/build/pause/Dockerfile
+  repository: k8s.gcr.io/pause
+  tag: "3.0"
+  architecture:
+  - amd64
+  - arm64
+...
+```
+
+Architecture is an optional field of image. It is a list of strings specifying CPU architecture of machines on which this image can be used. The valid options for architecture field are as follow:
+- `amd64` : This sepecifies image can run only on machines having CPU architecture `amd64`.
+- `arm64` : This sepecifies image can run only on machines having CPU architecture `arm64`.
+
+If image doesn't specifies any architecture then by default it is considered to support both `amd64` and `arm64` architecture.
 
 ## Overwrite image vector
 

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -660,6 +660,11 @@ const (
 	DNSRecordExternalName = "external"
 	// DNSRecordOwnerName is a constant for DNSRecord objects used for the owner domain name.
 	DNSRecordOwnerName = "owner"
+
+	// ArchitectureAMD64 is a constant for the 'amd64' architecture.
+	ArchitectureAMD64 = "amd64"
+	// ArchitectureARM64 is a constant for the 'arm64' architecture.
+	ArchitectureARM64 = "arm64"
 )
 
 // ControlPlaneSecretRoles contains all role values used for control plane secrets synced to the Garden cluster.

--- a/pkg/utils/imagevector/imagevector_test.go
+++ b/pkg/utils/imagevector/imagevector_test.go
@@ -35,6 +35,9 @@ var _ = Describe("imagevector", func() {
 			image1Src1VectorJSON string
 			image1Src1VectorYAML string
 
+			arm64 = "arm64"
+			amd64 = "amd64"
+
 			k8s164                         = "1.6.4"
 			k8s164WithSuffix               = "1.6.4-foo.5"
 			k8s180                         = "1.8.0"
@@ -58,6 +61,7 @@ var _ = Describe("imagevector", func() {
 
 			image1Name                                                             string
 			image1Src1, image1Src2, image1Src3, image1Src4, image1Src5, image1Src6 *ImageSource
+			image1Src1Arm64, image1Src5Arm64, image1Src5Wildcard                   *ImageSource
 
 			image2Name string
 			image2Src1 *ImageSource
@@ -65,8 +69,9 @@ var _ = Describe("imagevector", func() {
 			image3Name string
 			image3Src1 *ImageSource
 
-			image4Name                                                                         string
-			image4Src1, image4Src2, image4Src3, image4Src4, image4Src5, image4Src6, image4Src7 *ImageSource
+			image4Name                                                                          string
+			image4Src1, image4Src2, image4Src3, image4Src4, image4Src5, image4Src6, image4Src7  *ImageSource
+			image4Src1Arm64, image4Src4Arm64, image4Src5Arm64, image4Src6Arm64, image4Src7Arm64 *ImageSource
 		)
 
 		resetValues := func() {
@@ -101,6 +106,13 @@ var _ = Describe("imagevector", func() {
 				Tag:            &tag1,
 				RuntimeVersion: &greaterEquals16Smaller18,
 			}
+			image1Src1Arm64 = &ImageSource{
+				Name:           image1Name,
+				Repository:     repo1,
+				Tag:            &tag1,
+				RuntimeVersion: &greaterEquals16Smaller18,
+				Architectures:  []string{arm64},
+			}
 			image1Src2 = &ImageSource{
 				Name:           image1Name,
 				Repository:     repo1,
@@ -123,6 +135,18 @@ var _ = Describe("imagevector", func() {
 				Name:       image1Name,
 				Repository: repo1,
 				Tag:        &tag1,
+			}
+			image1Src5Arm64 = &ImageSource{
+				Name:          image1Name,
+				Repository:    repo1,
+				Tag:           &tag1,
+				Architectures: []string{arm64},
+			}
+			image1Src5Wildcard = &ImageSource{
+				Name:          image1Name,
+				Repository:    repo1,
+				Tag:           &tag1,
+				Architectures: []string{arm64, amd64},
 			}
 			image1Src6 = &ImageSource{
 				Name:           image1Name,
@@ -151,6 +175,13 @@ var _ = Describe("imagevector", func() {
 				Tag:           &tag1,
 				TargetVersion: &greaterEquals16Smaller18,
 			}
+			image4Src1Arm64 = &ImageSource{
+				Name:          image4Name,
+				Repository:    repo4,
+				Tag:           &tag1,
+				TargetVersion: &greaterEquals16Smaller18,
+				Architectures: []string{arm64},
+			}
 			image4Src2 = &ImageSource{
 				Name:          image4Name,
 				Repository:    repo4,
@@ -169,11 +200,26 @@ var _ = Describe("imagevector", func() {
 				RuntimeVersion: &greaterEquals16Smaller18,
 				TargetVersion:  &k8s113,
 			}
+			image4Src4Arm64 = &ImageSource{
+				Name:           image4Name,
+				Repository:     repo4,
+				Tag:            &tag4,
+				RuntimeVersion: &greaterEquals16Smaller18,
+				TargetVersion:  &k8s113,
+				Architectures:  []string{arm64},
+			}
 			image4Src5 = &ImageSource{
 				Name:          image4Name,
 				Repository:    repo4,
 				Tag:           &tag5,
 				TargetVersion: &equals117,
+			}
+			image4Src5Arm64 = &ImageSource{
+				Name:          image4Name,
+				Repository:    repo4,
+				Tag:           &tag5,
+				TargetVersion: &equals117,
+				Architectures: []string{arm64},
 			}
 			image4Src6 = &ImageSource{
 				Name:          image4Name,
@@ -181,11 +227,25 @@ var _ = Describe("imagevector", func() {
 				Tag:           &tag6,
 				TargetVersion: &k8s114x,
 			}
+			image4Src6Arm64 = &ImageSource{
+				Name:          image4Name,
+				Repository:    repo4,
+				Tag:           &tag6,
+				TargetVersion: &k8s114x,
+				Architectures: []string{arm64},
+			}
 			image4Src7 = &ImageSource{
 				Name:          image4Name,
 				Repository:    repo4,
 				Tag:           &tag7,
 				TargetVersion: &k8s1142,
+			}
+			image4Src7Arm64 = &ImageSource{
+				Name:          image4Name,
+				Repository:    repo4,
+				Tag:           &tag7,
+				TargetVersion: &k8s1142,
+				Architectures: []string{arm64},
 			}
 
 			image1Src1Vector = ImageVector{image1Src1}
@@ -275,26 +335,233 @@ images:
 				Expect(err).To(errorMatcher)
 			},
 
-			Entry("no entries, no match", ImageVector{}, image1Name, nil, BeNil(), HaveOccurred()),
-			Entry("single entry, match with runtime wildcard", ImageVector{image1Src1}, image1Name, nil, Equal(image1Src1.ToImage(nil)), Not(HaveOccurred())),
-			Entry("single entry, match with runtime version", ImageVector{image1Src1}, image1Name, []FindOptionFunc{k8s164RuntimeVersion}, Equal(image1Src1.ToImage(nil)), Not(HaveOccurred())),
-			Entry("single entry w/ suffix, match with runtime version", ImageVector{image1Src1}, image1Name, []FindOptionFunc{k8s164WithSuffixRuntimeVersion}, Equal(image1Src1.ToImage(nil)), Not(HaveOccurred())),
-			Entry("single entry, match with runtime and target version", ImageVector{image1Src1}, image1Name, []FindOptionFunc{k8s164RuntimeVersion, k8s164TargetVersion}, Equal(image1Src1.ToImage(&k8s164)), Not(HaveOccurred())),
-			Entry("single entry, match with runtime and non-runtime target version", ImageVector{image1Src1}, image1Name, []FindOptionFunc{k8s164RuntimeVersion, k8s180TargetVersion}, Equal(image1Src1.ToImage(&k8s180)), Not(HaveOccurred())),
-			Entry("single entry, name mismatch", ImageVector{image1Src1}, image2Name, nil, BeNil(), HaveOccurred()),
-			Entry("single entry, runtime version mismatch", ImageVector{image1Src1}, image1Name, []FindOptionFunc{k8s180RuntimeVersion}, BeNil(), HaveOccurred()),
-			Entry("single entry no runtime version, match with runtime wildcard", ImageVector{image1Src5}, image1Name, nil, Equal(image1Src5.ToImage(nil)), Not(HaveOccurred())),
-			Entry("single entry no runtime version, match with runtime version", ImageVector{image1Src5}, image1Name, []FindOptionFunc{k8s180RuntimeVersion}, Equal(image1Src5.ToImage(nil)), Not(HaveOccurred())),
-			Entry("two entries, match with runtime wildcard", ImageVector{image1Src5, image1Src1}, image1Name, []FindOptionFunc{k8s180RuntimeVersion}, Equal(image1Src5.ToImage(nil)), Not(HaveOccurred())),
-			Entry("two entries, match with runtime version", ImageVector{image1Src5, image1Src1}, image1Name, []FindOptionFunc{k8s164RuntimeVersion}, Equal(image1Src1.ToImage(nil)), Not(HaveOccurred())),
-			Entry("two entries, no runtime version, match with target version", ImageVector{image4Src1, image4Src2}, image4Name, []FindOptionFunc{k8s113TargetVersion}, Equal(image4Src2.ToImage(nil)), Not(HaveOccurred())),
-			Entry("two entries, runtime and target version, no match", ImageVector{image4Src1, image4Src4}, image4Name, []FindOptionFunc{k8s180RuntimeVersion, k8s113TargetVersion}, BeNil(), HaveOccurred()),
-			Entry("two entries, runtime and target version, no match", ImageVector{image4Src1, image4Src4}, image4Name, []FindOptionFunc{k8s164RuntimeVersion, k8s1142TargetVersion}, BeNil(), HaveOccurred()),
-			Entry("two entries, runtime and target version, match with both", ImageVector{image4Src1, image4Src4}, image4Name, []FindOptionFunc{k8s164RuntimeVersion, k8s113TargetVersion}, Equal(image4Src4.ToImage(nil)), Not(HaveOccurred())),
-			Entry("two entries, runtime and target version, match with both, prio equal match", ImageVector{image4Src1, image4Src2, image4Src3, image4Src5}, image4Name, []FindOptionFunc{k8s1170TargetVersion}, Equal(image4Src5.ToImage(nil)), Not(HaveOccurred())),
-			Entry("two entries, no runtime version, exact match with target version", ImageVector{image4Src6, image4Src7}, image4Name, []FindOptionFunc{k8s1142TargetVersion}, Equal(image4Src7.ToImage(nil)), Not(HaveOccurred())),
-			Entry("three entries, no runtime version, match with target version", ImageVector{image4Src1, image4Src2, image4Src3}, image4Name, []FindOptionFunc{k8s113TargetVersion}, Equal(image4Src2.ToImage(nil)), Not(HaveOccurred())),
-			Entry("three entries, no runtime version, match with target version", ImageVector{image4Src1, image4Src2, image4Src3}, image4Name, []FindOptionFunc{k8s1142TargetVersion}, Equal(image4Src3.ToImage(nil)), Not(HaveOccurred())),
+			Entry("no entries, no match",
+				ImageVector{},
+				image1Name, nil,
+				BeNil(), HaveOccurred()),
+
+			Entry("single entry, match with runtime wildcard",
+				ImageVector{image1Src1},
+				image1Name, nil,
+				Equal(image1Src1.ToImage(nil)), Not(HaveOccurred())),
+			Entry("single entry w/ arch, no arch opts, no runtime version opts",
+				ImageVector{image1Src1Arm64},
+				image1Name, nil,
+				BeNil(), HaveOccurred()),
+			Entry("single entry w/ arch, arch opts, no runtime version opts",
+				ImageVector{image1Src1Arm64},
+				image1Name, []FindOptionFunc{Architecture(arm64)},
+				Equal(image1Src1.ToImage(nil)), Not(HaveOccurred())),
+
+			Entry("single entry, match with runtime version",
+				ImageVector{image1Src1},
+				image1Name, []FindOptionFunc{k8s164RuntimeVersion},
+				Equal(image1Src1.ToImage(nil)), Not(HaveOccurred())),
+			Entry("single entry w/ arch, no arch opts, match with runtime version",
+				ImageVector{image1Src1Arm64},
+				image1Name, []FindOptionFunc{k8s164RuntimeVersion},
+				BeNil(), HaveOccurred()),
+			Entry("single entry w/ arch, arch opts, match with runtime version",
+				ImageVector{image1Src1Arm64},
+				image1Name, []FindOptionFunc{k8s164RuntimeVersion, Architecture(arm64)},
+				Equal(image1Src1.ToImage(nil)), Not(HaveOccurred())),
+
+			Entry("single entry w/ suffix, match with runtime version",
+				ImageVector{image1Src1},
+				image1Name, []FindOptionFunc{k8s164WithSuffixRuntimeVersion},
+				Equal(image1Src1.ToImage(nil)), Not(HaveOccurred())),
+			Entry("single entry w/ arch and suffix, no arch opts, match with runtime version",
+				ImageVector{image1Src1Arm64},
+				image1Name, []FindOptionFunc{k8s164WithSuffixRuntimeVersion},
+				BeNil(), HaveOccurred()),
+			Entry("single entry w/ arch and suffix, arch opts, match with runtime version",
+				ImageVector{image1Src1Arm64},
+				image1Name, []FindOptionFunc{k8s164WithSuffixRuntimeVersion, Architecture(arm64)},
+				Equal(image1Src1.ToImage(nil)), Not(HaveOccurred())),
+
+			Entry("single entry, match with runtime and target version",
+				ImageVector{image1Src1},
+				image1Name, []FindOptionFunc{k8s164RuntimeVersion, k8s164TargetVersion},
+				Equal(image1Src1.ToImage(&k8s164)), Not(HaveOccurred())),
+			Entry("single entry w/ arch, no arch opts, match with runtime and target version",
+				ImageVector{image1Src1Arm64},
+				image1Name, []FindOptionFunc{k8s164RuntimeVersion, k8s164TargetVersion},
+				BeNil(), HaveOccurred()),
+			Entry("single entry w/ arch, arch opts, match with runtime and target version",
+				ImageVector{image1Src1Arm64},
+				image1Name, []FindOptionFunc{k8s164RuntimeVersion, k8s164TargetVersion, Architecture(arm64)},
+				Equal(image1Src1.ToImage(&k8s164)), Not(HaveOccurred())),
+
+			Entry("single entry, match with runtime and non-runtime target version",
+				ImageVector{image1Src1},
+				image1Name, []FindOptionFunc{k8s164RuntimeVersion, k8s180TargetVersion},
+				Equal(image1Src1.ToImage(&k8s180)), Not(HaveOccurred())),
+			Entry("single entry w/ arch, no arch opts, match with runtime and non-runtime target version",
+				ImageVector{image1Src1Arm64},
+				image1Name, []FindOptionFunc{k8s164RuntimeVersion, k8s180TargetVersion},
+				BeNil(), HaveOccurred()),
+			Entry("single entry w/ arch, arch opts, match with runtime and non-runtime target version",
+				ImageVector{image1Src1Arm64},
+				image1Name, []FindOptionFunc{k8s164RuntimeVersion, k8s180TargetVersion, Architecture(arm64)},
+				Equal(image1Src1.ToImage(&k8s180)), Not(HaveOccurred())),
+
+			Entry("single entry, name mismatch",
+				ImageVector{image1Src1},
+				image2Name, nil,
+				BeNil(), HaveOccurred()),
+			Entry("single entry w/ arch, no arch opts, name mismatch",
+				ImageVector{image1Src1Arm64},
+				image2Name, nil,
+				BeNil(), HaveOccurred()),
+			Entry("single entry w/ arch, arch opts, name mismatch",
+				ImageVector{image1Src1Arm64},
+				image2Name, []FindOptionFunc{Architecture(arm64)},
+				BeNil(), HaveOccurred()),
+
+			Entry("single entry, runtime version mismatch",
+				ImageVector{image1Src1},
+				image1Name, []FindOptionFunc{k8s180RuntimeVersion},
+				BeNil(), HaveOccurred()),
+			Entry("single entry w/ arch, no arch opts, runtime version mismatch",
+				ImageVector{image1Src1Arm64},
+				image1Name, []FindOptionFunc{k8s180RuntimeVersion},
+				BeNil(), HaveOccurred()),
+			Entry("single entry w/ arch, arch opts, runtime version mismatch",
+				ImageVector{image1Src1Arm64},
+				image1Name, []FindOptionFunc{k8s180RuntimeVersion, Architecture(arm64)},
+				BeNil(), HaveOccurred()),
+
+			Entry("single entry, no runtime version, match with runtime wildcard",
+				ImageVector{image1Src5},
+				image1Name, nil,
+				Equal(image1Src5.ToImage(nil)), Not(HaveOccurred())),
+			Entry("single entry w/ arch, no arch opts, no runtime version, match with runtime wildcard",
+				ImageVector{image1Src5Arm64},
+				image1Name, nil,
+				BeNil(), HaveOccurred()),
+			Entry("single entry w/ arch, arch opts, no runtime version, match with runtime wildcard",
+				ImageVector{image1Src5Arm64},
+				image1Name, []FindOptionFunc{Architecture(arm64)},
+				Equal(image1Src5.ToImage(nil)), Not(HaveOccurred())),
+
+			Entry("single entry, no runtime version, match with runtime version",
+				ImageVector{image1Src5},
+				image1Name, []FindOptionFunc{k8s180RuntimeVersion},
+				Equal(image1Src5.ToImage(nil)), Not(HaveOccurred())),
+			Entry("single entry w/ arch, no arch opts, no runtime version, match with runtime version",
+				ImageVector{image1Src5Arm64},
+				image1Name, []FindOptionFunc{k8s180RuntimeVersion},
+				BeNil(), HaveOccurred()),
+			Entry("single entry w/ arch, arch opts, no runtime version, match with runtime version",
+				ImageVector{image1Src5Arm64},
+				image1Name, []FindOptionFunc{k8s180RuntimeVersion, Architecture(arm64)},
+				Equal(image1Src5.ToImage(nil)), Not(HaveOccurred())),
+
+			Entry("two entries + one entry w/ arch, no arch opts, match with runtime wildcard",
+				ImageVector{image1Src5, image1Src1, image1Src1Arm64},
+				image1Name, []FindOptionFunc{k8s180RuntimeVersion},
+				Equal(image1Src5.ToImage(nil)), Not(HaveOccurred())),
+			Entry("two entries + one entry w/ arch, arch opts, match with runtime wildcard",
+				ImageVector{image1Src5, image1Src1, image1Src1Arm64},
+				image1Name, []FindOptionFunc{k8s180RuntimeVersion, Architecture(arm64)},
+				Equal(image1Src5.ToImage(nil)), Not(HaveOccurred())),
+			Entry("two entries + one entry w/ arch, arch opts (wildcard), match with runtime wildcard",
+				ImageVector{image1Src5, image1Src1, image1Src1Arm64, image1Src5Wildcard},
+				image1Name, []FindOptionFunc{k8s180RuntimeVersion, Architecture(arm64)},
+				Equal(image1Src5Wildcard.ToImage(nil)), Not(HaveOccurred())),
+
+			Entry("two entries + one entry w/ arch, no arch opts, match with runtime version",
+				ImageVector{image1Src5, image1Src1, image1Src1Arm64},
+				image1Name, []FindOptionFunc{k8s164RuntimeVersion},
+				Equal(image1Src1.ToImage(nil)), Not(HaveOccurred())),
+			Entry("two entries + one entry w/ arch, arch opts, match with runtime version",
+				ImageVector{image1Src5, image1Src1, image1Src1Arm64},
+				image1Name, []FindOptionFunc{k8s164RuntimeVersion, Architecture(arm64)},
+				Equal(image1Src1Arm64.ToImage(nil)), Not(HaveOccurred())),
+
+			Entry("two entries + one entry w/ arch, no arch opts, no runtime version, match with target version",
+				ImageVector{image4Src1, image4Src2, image4Src1Arm64},
+				image4Name, []FindOptionFunc{k8s113TargetVersion},
+				Equal(image4Src2.ToImage(nil)), Not(HaveOccurred())),
+			Entry("two entries + one entry w/ arch, arch opts, no runtime version, match with runtime wildcard",
+				ImageVector{image4Src1, image4Src2, image4Src1Arm64},
+				image4Name, []FindOptionFunc{k8s113TargetVersion, Architecture(arm64)},
+				Equal(image4Src2.ToImage(nil)), Not(HaveOccurred())),
+
+			Entry("two entries + one entry w/ arch, no arch opts, runtime and target version, no match",
+				ImageVector{image4Src1, image4Src4, image1Src1Arm64},
+				image4Name, []FindOptionFunc{k8s180RuntimeVersion, k8s113TargetVersion},
+				BeNil(), HaveOccurred()),
+			Entry("two entries + one entry w/ arch, arch opts, runtime and target version, no match",
+				ImageVector{image4Src1, image4Src4, image1Src1Arm64},
+				image4Name, []FindOptionFunc{k8s180RuntimeVersion, k8s113TargetVersion, Architecture(arm64)},
+				BeNil(), HaveOccurred()),
+
+			Entry("two entries + one entry w/ arch, no arch opts, runtime and target version, no match",
+				ImageVector{image4Src1, image4Src4, image4Src1Arm64},
+				image4Name, []FindOptionFunc{k8s164RuntimeVersion, k8s1142TargetVersion},
+				BeNil(), HaveOccurred()),
+			Entry("two entries + one entry w/ arch, arch opts, runtime and target version, no match",
+				ImageVector{image4Src1, image4Src4, image4Src1Arm64},
+				image4Name, []FindOptionFunc{k8s164RuntimeVersion, k8s1142TargetVersion, Architecture(arm64)},
+				BeNil(), HaveOccurred()),
+
+			Entry("two entries + one entry w/ arch, no arch opts, runtime and target version, match with both",
+				ImageVector{image4Src1, image4Src4, image4Src1Arm64},
+				image4Name, []FindOptionFunc{k8s164RuntimeVersion, k8s113TargetVersion},
+				Equal(image4Src4.ToImage(nil)), Not(HaveOccurred())),
+			Entry("two entries + one entry w/ arch, arch opts, runtime and target version, match with runtime wildcard",
+				ImageVector{image4Src1, image4Src4, image4Src1Arm64},
+				image4Name, []FindOptionFunc{k8s164RuntimeVersion, k8s113TargetVersion, Architecture(arm64)},
+				Equal(image4Src4.ToImage(nil)), Not(HaveOccurred())),
+			Entry("two entries + two entries w/ arch, arch opts, runtime and target version, match with both",
+				ImageVector{image4Src1, image4Src4, image4Src4Arm64},
+				image4Name, []FindOptionFunc{k8s164RuntimeVersion, k8s113TargetVersion, Architecture(arm64)},
+				Equal(image4Src4Arm64.ToImage(nil)), Not(HaveOccurred())),
+
+			Entry("two entries + one entry w/ arch, no arch opts, no runtime version, exact match with target version",
+				ImageVector{image4Src6, image4Src7, image4Src6Arm64},
+				image4Name, []FindOptionFunc{k8s1142TargetVersion},
+				Equal(image4Src7.ToImage(nil)), Not(HaveOccurred())),
+			Entry("two entries + one entry w/ arch, arch opts, no runtime version, exact match with target version",
+				ImageVector{image4Src6, image4Src7, image4Src6Arm64},
+				image4Name, []FindOptionFunc{k8s1142TargetVersion, Architecture(arm64)},
+				Equal(image4Src7.ToImage(nil)), Not(HaveOccurred())),
+			Entry("two entries + two entries w/ arch, arch opts, no runtime version, exact match with target version",
+				ImageVector{image4Src6, image4Src7, image4Src6Arm64, image4Src7Arm64},
+				image4Name, []FindOptionFunc{k8s1142TargetVersion, Architecture(arm64)},
+				Equal(image4Src7Arm64.ToImage(nil)), Not(HaveOccurred())),
+
+			Entry("three entries + one entry w/ arch, no arch opts, no runtime version, match with target version",
+				ImageVector{image4Src1, image4Src2, image4Src3, image4Src1Arm64},
+				image4Name, []FindOptionFunc{k8s113TargetVersion},
+				Equal(image4Src2.ToImage(nil)), Not(HaveOccurred())),
+			Entry("three entries + one entry w/ arch, arch opts, no runtime version, match with runtime wildcard",
+				ImageVector{image4Src1, image4Src2, image4Src3, image4Src1Arm64},
+				image4Name, []FindOptionFunc{k8s113TargetVersion, Architecture(arm64)},
+				Equal(image4Src2.ToImage(nil)), Not(HaveOccurred())),
+
+			Entry("three entries + one entry w/ arch, no arch opts, no runtime version, match with target version",
+				ImageVector{image4Src1, image4Src2, image4Src3, image4Src1Arm64},
+				image4Name, []FindOptionFunc{k8s1142TargetVersion},
+				Equal(image4Src3.ToImage(nil)), Not(HaveOccurred())),
+			Entry("three entries + one entry w/ arch, arch opts, no runtime version, match with runtime wildcard",
+				ImageVector{image4Src1, image4Src2, image4Src3, image4Src1Arm64},
+				image4Name, []FindOptionFunc{k8s1142TargetVersion, Architecture(arm64)},
+				Equal(image4Src3.ToImage(nil)), Not(HaveOccurred())),
+			Entry("three entries + two entries w/ arch, arch opts, no runtime version, match with target version",
+				ImageVector{image4Src1, image4Src2, image4Src3, image4Src1Arm64, image4Src7Arm64},
+				image4Name, []FindOptionFunc{k8s1142TargetVersion, Architecture(arm64)},
+				Equal(image4Src7Arm64.ToImage(nil)), Not(HaveOccurred())),
+
+			Entry("four entries + two entries w/ arch, no arch opts, runtime and target version, match with both, prio equal match",
+				ImageVector{image4Src1, image4Src2, image4Src3, image4Src5, image4Src1Arm64, image4Src5Arm64},
+				image4Name, []FindOptionFunc{k8s1170TargetVersion},
+				Equal(image4Src5.ToImage(nil)), Not(HaveOccurred())),
+			Entry("four entries + two entries w/ arch, arch opts, runtime and target version, match with both, prio equal match",
+				ImageVector{image4Src1, image4Src2, image4Src3, image4Src5, image4Src1Arm64, image4Src5Arm64},
+				image4Name, []FindOptionFunc{k8s1170TargetVersion, Architecture(arm64)},
+				Equal(image4Src5Arm64.ToImage(nil)), Not(HaveOccurred())),
 		)
 
 		Describe("#FindImages", func() {

--- a/pkg/utils/imagevector/types.go
+++ b/pkg/utils/imagevector/types.go
@@ -22,9 +22,10 @@ package imagevector
 // in the seed cluster and act on the shoot cluster. Different versions might be used depending on the
 // seed and the shoot version.
 type ImageSource struct {
-	Name           string  `json:"name" yaml:"name"`
-	RuntimeVersion *string `json:"runtimeVersion,omitempty" yaml:"runtimeVersion,omitempty"`
-	TargetVersion  *string `json:"targetVersion,omitempty" yaml:"targetVersion,omitempty"`
+	Name           string   `json:"name" yaml:"name"`
+	RuntimeVersion *string  `json:"runtimeVersion,omitempty" yaml:"runtimeVersion,omitempty"`
+	TargetVersion  *string  `json:"targetVersion,omitempty" yaml:"targetVersion,omitempty"`
+	Architectures  []string `json:"architectures,omitempty" yaml:"architectures,omitempty"`
 
 	Repository string  `json:"repository" yaml:"repository"`
 	Tag        *string `json:"tag,omitempty" yaml:"tag,omitempty"`
@@ -53,6 +54,7 @@ type ComponentImageVectors map[string]string
 type FindOptions struct {
 	RuntimeVersion *string
 	TargetVersion  *string
+	Architecture   *string
 }
 
 // FindOptionFunc is a function that mutates FindOptions.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind enhancement

**What this PR does / why we need it**:
This PR enhances the image vector to support specifying CPU architecture supported by images. If the image doesn't have an architecture specified then it is considered a multi-arch image. The supported architecture types are `amd64`, `arm64`, and `*`, where `*` specifies that the image is multi-arch.

**Which issue(s) this PR fixes**:
Part of gardener/backlog#19

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Images in image vector now support a new field `architectures`. It is a list of CPU architecture of machines on which one image can be used. If not specified images are considered to support both `amd64` and `arm64` CPU architecture.
```
