### PR TITLE
Change some of the Gardener components' base images to distroless

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,11 @@ RUN make install EFFECTIVE_VERSION=$EFFECTIVE_VERSION
 ############# base
 FROM alpine:3.15.4 AS base
 
-#############      apiserver     #############
-FROM base AS apiserver
+############# distroless-static
+FROM gcr.io/distroless/static-debian11:nonroot as distroless-static
 
-RUN apk add --update tzdata
+#############      apiserver     #############
+FROM distroless-static AS apiserver
 
 COPY --from=builder /go/bin/gardener-apiserver /gardener-apiserver
 
@@ -23,9 +24,7 @@ WORKDIR /
 ENTRYPOINT ["/gardener-apiserver"]
 
 ############# controller-manager #############
-FROM base AS controller-manager
-
-RUN apk add --update tzdata
+FROM distroless-static AS controller-manager
 
 COPY --from=builder /go/bin/gardener-controller-manager /gardener-controller-manager
 COPY charts /charts
@@ -35,7 +34,7 @@ WORKDIR /
 ENTRYPOINT ["/gardener-controller-manager"]
 
 ############# scheduler #############
-FROM base AS scheduler
+FROM distroless-static AS scheduler
 
 COPY --from=builder /go/bin/gardener-scheduler /gardener-scheduler
 
@@ -56,7 +55,7 @@ WORKDIR /
 ENTRYPOINT ["/gardenlet"]
 
 ############# admission-controller #############
-FROM base AS admission-controller
+FROM distroless-static AS admission-controller
 
 COPY --from=builder /go/bin/gardener-admission-controller /gardener-admission-controller
 
@@ -65,7 +64,7 @@ WORKDIR /
 ENTRYPOINT ["/gardener-admission-controller"]
 
 ############# seed-admission-controller #############
-FROM base AS seed-admission-controller
+FROM distroless-static AS seed-admission-controller
 
 COPY --from=builder /go/bin/gardener-seed-admission-controller /gardener-seed-admission-controller
 
@@ -74,7 +73,7 @@ WORKDIR /
 ENTRYPOINT ["/gardener-seed-admission-controller"]
 
 ############# resource-manager #############
-FROM base AS resource-manager
+FROM distroless-static AS resource-manager
 
 COPY --from=builder /go/bin/gardener-resource-manager /gardener-resource-manager
 

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -7,6 +7,9 @@ ENV GOTRACEBACK=single
 
 RUN apk add --update tzdata
 
+############# distroless-static
+FROM gcr.io/distroless/static-debian11:nonroot as distroless-static
+
 ############# builder-base #############
 FROM golang:1.18.1 AS builder-base
 
@@ -44,7 +47,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     -ldflags="$(cat /tmp/build-flags)" \
     -o /gardener-apiserver ./cmd/gardener-apiserver
 
-FROM base AS apiserver
+FROM distroless-static AS apiserver
 
 COPY --from=builder-apiserver /gardener-apiserver /gardener-apiserver
 ENTRYPOINT ["/gardener-apiserver"]
@@ -64,7 +67,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     -ldflags="$(cat /tmp/build-flags)" \
     -o /gardener-controller-manager ./cmd/gardener-controller-manager
 
-FROM base AS controller-manager
+FROM distroless-static AS controller-manager
 
 COPY --from=builder-controller-manager /gardener-controller-manager /gardener-controller-manager
 ENTRYPOINT ["/gardener-controller-manager"]
@@ -84,7 +87,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     -ldflags="$(cat /tmp/build-flags)" \
     -o /gardener-scheduler ./cmd/gardener-scheduler
 
-FROM base AS scheduler
+FROM distroless-static AS scheduler
 
 COPY --from=builder-scheduler /gardener-scheduler /gardener-scheduler
 ENTRYPOINT ["/gardener-scheduler"]
@@ -104,7 +107,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     -ldflags="$(cat /tmp/build-flags)" \
     -o /gardener-admission-controller ./cmd/gardener-admission-controller
 
-FROM base AS admission-controller
+FROM distroless-static AS admission-controller
 
 COPY --from=builder-admission-controller /gardener-admission-controller /gardener-admission-controller
 ENTRYPOINT ["/gardener-admission-controller"]
@@ -124,7 +127,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     -ldflags="$(cat /tmp/build-flags)" \
     -o /gardener-resource-manager ./cmd/gardener-resource-manager
 
-FROM base AS resource-manager
+FROM distroless-static AS resource-manager
 
 COPY --from=builder-resource-manager /gardener-resource-manager /gardener-resource-manager
 ENTRYPOINT ["/gardener-resource-manager"]
@@ -144,7 +147,7 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     -ldflags="$(cat /tmp/build-flags)" \
     -o /gardener-seed-admission-controller ./cmd/gardener-seed-admission-controller
 
-FROM base AS seed-admission-controller
+FROM distroless-static AS seed-admission-controller
 
 COPY --from=builder-seed-admission-controller /gardener-seed-admission-controller /gardener-seed-admission-controller
 ENTRYPOINT ["/gardener-seed-admission-controller"]

--- a/charts/gardener/controlplane/charts/application/templates/service-apiserver.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/service-apiserver.yaml
@@ -19,7 +19,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 8443
 ---
 apiVersion: v1
 kind: Endpoints

--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
@@ -246,7 +246,7 @@ spec:
         - --request-timeout={{ .Values.global.apiserver.requests.timeout }}
         {{- end }}
         {{- end }}
-        - --secure-port=443
+        - --secure-port=8443
         {{- if .Values.global.apiserver.shootAdminKubeconfigMaxExpiration }}
         - --shoot-admin-kubeconfig-max-expiration={{ .Values.global.apiserver.shootAdminKubeconfigMaxExpiration }}
         {{- end }}
@@ -276,7 +276,7 @@ spec:
           httpGet:
             scheme: HTTPS
             path: /livez
-            port: 443
+            port: 8443
           initialDelaySeconds: {{ .Values.global.apiserver.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.global.apiserver.livenessProbe.periodSeconds }}
           successThreshold: {{ .Values.global.apiserver.livenessProbe.successThreshold }}
@@ -286,7 +286,7 @@ spec:
           httpGet:
             scheme: HTTPS
             path: /readyz
-            port: 443
+            port: 8443
           initialDelaySeconds: {{ .Values.global.apiserver.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.global.apiserver.readinessProbe.periodSeconds }}
           successThreshold: {{ .Values.global.apiserver.readinessProbe.successThreshold }}

--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/service.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/service.yaml
@@ -22,5 +22,5 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 443
+    targetPort: 8443
 {{- end }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source security
/kind enhancement

**What this PR does / why we need it**:
This PR changes the base image to some of the Gardener's components from alpine to [distroless](https://github.com/GoogleContainerTools/distroless). It changes the default user that is executing the binaries from root to a nonroot user. This will help reduce the attack surface of the images.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
- `tzdata` is preinstalled in the distroless base image.
- debian11 is hardcoded as a version so that we do not receive any unexpected changes when debian12 is released.
- Gardenlet remains with alpine since it has a [dependency](https://github.com/gardener/gardener/blob/c422d3f50f5f07e2a5fdffd796655131598e6778/pkg/utils/secrets/vpn_tlsauth.go#L76) to `openvpn` binary. I am not sure if this will still be needed when we deprecate the non reversed VPN.
- Gardener API Server secure port is changed to 8443 so that it can be run as nonroot and avoid setting additional capabilities to that binary. See [here](https://github.com/kubernetes/kubernetes/blob/f33ca2306548719e5116b53fccfc278bffb809a8/build/server-image/kube-apiserver/Dockerfile#L24) for example.
- There are several more usages of alpine in this repository but they will be separately evaluated.
- Shells are removed from these images. For debugging purposes [ephemeral containers](https://kubernetes.io/docs/concepts/workloads/pods/ephemeral-containers/) can be used.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
`gardener-apiserver`, `gardener-controller-manager`, `gardener-scheduler`, `gardener-admission-controller`, `gardener-seed-admission-controller` and `gardener-resource-manager` are now using `gcr.io/distroless/static-debian11:nonroot` instead of versions of `alpine` as a base image.
```
