### PR TITLE
Upgrade github.com/gardener/autoscaler

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -61,18 +61,18 @@ images:
 - name: cluster-autoscaler
   sourceRepository: github.com/gardener/autoscaler
   repository: eu.gcr.io/gardener-project/gardener/autoscaler/cluster-autoscaler
-  tag: "v1.21.0"
-  targetVersion: ">= 1.21"
+  tag: "v1.22.1"
+  targetVersion: ">= 1.22"
 - name: cluster-autoscaler
   sourceRepository: github.com/gardener/autoscaler
   repository: eu.gcr.io/gardener-project/gardener/autoscaler/cluster-autoscaler
-  tag: "v1.20.0"
-  targetVersion: "1.20.x"
+  tag: "v1.21.1"
+  targetVersion: "1.21.x"
 - name: cluster-autoscaler
   sourceRepository: github.com/gardener/autoscaler
   repository: eu.gcr.io/gardener-project/gardener/autoscaler/cluster-autoscaler
-  tag: "v0.19.0"
-  targetVersion: "< 1.20"
+  tag: "v1.20.1"
+  targetVersion: "<= 1.20"
 - name: vpn-seed
   sourceRepository: github.com/gardener/vpn
   repository: eu.gcr.io/gardener-project/gardener/vpn-seed


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement

**Special notes for your reviewer**:
- gardener/cluster-autoscaler@v0.19.0 is no longer used
- gardener/cluster-autoscaler@v1.20.1 K8s <= 1.20. This is done because both v0.19.0 and v1.20.0 sync kubernetes/cluster-autoscaler 1.20 only.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The following images are updated:
- `eu.gcr.io/gardener-project/gardener/autoscaler/cluster-autoscaler:` `v0.19.0` -> `v1.20.1` (for Kubernetes `< 1.20`)
- `eu.gcr.io/gardener-project/gardener/autoscaler/cluster-autoscaler:` `v1.20.0` -> `v1.20.1` (for Kubernetes `1.20`)
- `eu.gcr.io/gardener-project/gardener/autoscaler/cluster-autoscaler:` `v1.21.0` -> `v1.21.1 `(for Kubernetes `1.21`)
- `eu.gcr.io/gardener-project/gardener/autoscaler/cluster-autoscaler`: `v1.21.0` -> `v1.22.1` (for Kubernetes `>= 1.22`)
```
