### PR TITLE
Secure port of gapi-server can now be configured through the helm chart

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/service-apiserver.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/service-apiserver.yaml
@@ -19,7 +19,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 8443
+    targetPort: {{ .Values.global.apiserver.securePort | default 8443 }}
 ---
 apiVersion: v1
 kind: Endpoints

--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/deployment.yaml
@@ -246,7 +246,7 @@ spec:
         - --request-timeout={{ .Values.global.apiserver.requests.timeout }}
         {{- end }}
         {{- end }}
-        - --secure-port=8443
+        - --secure-port={{ .Values.global.apiserver.securePort | default 8443 }}
         {{- if .Values.global.apiserver.shootAdminKubeconfigMaxExpiration }}
         - --shoot-admin-kubeconfig-max-expiration={{ .Values.global.apiserver.shootAdminKubeconfigMaxExpiration }}
         {{- end }}
@@ -276,7 +276,7 @@ spec:
           httpGet:
             scheme: HTTPS
             path: /livez
-            port: 8443
+            port: {{ .Values.global.apiserver.securePort | default 8443 }}
           initialDelaySeconds: {{ .Values.global.apiserver.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.global.apiserver.livenessProbe.periodSeconds }}
           successThreshold: {{ .Values.global.apiserver.livenessProbe.successThreshold }}
@@ -286,7 +286,7 @@ spec:
           httpGet:
             scheme: HTTPS
             path: /readyz
-            port: 8443
+            port: {{ .Values.global.apiserver.securePort | default 8443 }}
           initialDelaySeconds: {{ .Values.global.apiserver.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.global.apiserver.readinessProbe.periodSeconds }}
           successThreshold: {{ .Values.global.apiserver.readinessProbe.successThreshold }}

--- a/charts/gardener/controlplane/charts/runtime/templates/apiserver/service.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/apiserver/service.yaml
@@ -22,5 +22,5 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 8443
+    targetPort: {{ .Values.global.apiserver.securePort | default 8443 }}
 {{- end }}

--- a/charts/gardener/controlplane/values.yaml
+++ b/charts/gardener/controlplane/values.yaml
@@ -4,6 +4,7 @@ global:
     enabled: true
     serviceEnabled: true
     replicaCount: 1
+    securePort: 8443
     serviceAccountName: gardener-apiserver
     image:
       repository: eu.gcr.io/gardener-project/gardener/apiserver


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
The `--secure-port` flag of the Gardener API Server can now be configured through the helm chart by setting `.Values.global.apiserver.securePort`. The default value is 8443. The service exposing the Gardener API Server deployment will continue to listen on port 443.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The `--secure-port` flag of the Gardener API Server can now be configured through the helm chart by setting `.Values.global.apiserver.securePort`. The default value is `8443`. The service exposing the Gardener API Server deployment will continue to listen on port `443`.
```
