### PR TITLE
seed care: Check for the hvpa ManagedResource only when the HVPA feature gate is enabled

### DIFF
--- a/pkg/operation/care/care_suite_test.go
+++ b/pkg/operation/care/care_suite_test.go
@@ -17,11 +17,14 @@ package care_test
 import (
 	"testing"
 
+	"github.com/gardener/gardener/pkg/gardenlet/features"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
 func TestValidator(t *testing.T) {
+	features.RegisterFeatureGates()
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Care Suite")
 }

--- a/pkg/operation/care/seed_health.go
+++ b/pkg/operation/care/seed_health.go
@@ -51,7 +51,6 @@ var requiredManagedResourcesSeed = sets.NewString(
 	clusterautoscaler.ManagedResourceControlName,
 	seedsystem.ManagedResourceName,
 	vpa.ManagedResourceControlName,
-	hvpa.ManagedResourceName,
 )
 
 // SeedHealth contains information needed to execute health checks for seed.
@@ -96,6 +95,9 @@ func (h *SeedHealth) checkSeedSystemComponents(
 
 	if gardenletfeatures.FeatureGate.Enabled(features.ManagedIstio) {
 		managedResources = append(managedResources, istio.ManagedResourceControlName)
+	}
+	if gardenletfeatures.FeatureGate.Enabled(features.HVPA) {
+		managedResources = append(managedResources, hvpa.ManagedResourceName)
 	}
 	if gardencorev1beta1helper.SeedSettingDependencyWatchdogEndpointEnabled(h.seed.Spec.Settings) {
 		managedResources = append(managedResources, dependencywatchdog.ManagedResourceDependencyWatchdogEndpoint)


### PR DESCRIPTION
/area control-plane
/kind bug

**What this PR does / why we need it**:
The `hvpa` ManagedResource should be a required one only when the HVPA feature gate is enabled. Currently when the HVPA feature gate is not enabled:
```yaml
  - lastTransitionTime: "2022-06-23T11:05:18Z"
    lastUpdateTime: "2022-06-23T11:05:18Z"
    message: ManagedResource.resources.gardener.cloud "hvpa" not found
    reason: ResourceNotFound
    status: "False"
    type: SeedSystemComponentsHealthy
```

Introduced with https://github.com/gardener/gardener/pull/6133.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
