### PR TITLE
gardener-kube-scheduler: Support K8s 1.24 Seeds

### DIFF
--- a/pkg/operation/botanist/component/gardenerkubescheduler/gardener_kube_scheduler_bootstrap.go
+++ b/pkg/operation/botanist/component/gardenerkubescheduler/gardener_kube_scheduler_bootstrap.go
@@ -183,7 +183,10 @@ func Bootstrap(
 			},
 		}
 		config, err = schedulerconfigv22.NewConfigurator(Name, Name, schedulerConfig)
-	case version.ConstraintK8sEqual123.Check(seedVersion):
+	case version.ConstraintK8sEqual123.Check(seedVersion),
+		// There aren't any significant changes in the kube-scheduler config types between 1.23 and 1.24,
+		// that's why the 1.23 types are used for 1.24 as well.
+		version.ConstraintK8sEqual124.Check(seedVersion):
 		schedulerConfig := &schedulerconfigv23v1beta3.KubeSchedulerConfiguration{
 			Profiles: []schedulerconfigv23v1beta3.KubeSchedulerProfile{
 				{

--- a/pkg/operation/botanist/component/gardenerkubescheduler/gardener_kube_scheduler_bootstrap_test.go
+++ b/pkg/operation/botanist/component/gardenerkubescheduler/gardener_kube_scheduler_bootstrap_test.go
@@ -249,6 +249,17 @@ var _ = Describe("Bootstrap", func() {
 					Expect(config).To(Equal(expectedV23Config))
 				})
 			})
+			Context("v1.24", func() {
+				BeforeEach(func() {
+					version, err = semver.NewVersion("1.24.0")
+					Expect(err).ToNot(HaveOccurred())
+					configMapDataHash = "4ac487c7"
+				})
+
+				It("has correct config", func() {
+					Expect(config).To(Equal(expectedV24Config))
+				})
+			})
 		})
 	})
 })
@@ -396,4 +407,6 @@ profiles:
       - name: NodeResourcesBalancedAllocation
   schedulerName: gardener-shoot-controlplane-scheduler
 `
+
+	expectedV24Config = expectedV23Config
 )

--- a/pkg/utils/version/version.go
+++ b/pkg/utils/version/version.go
@@ -55,6 +55,8 @@ var (
 	ConstraintK8sEqual123 *semver.Constraints
 	// ConstraintK8sGreaterEqual123 is a version constraint for versions >= 1.23.
 	ConstraintK8sGreaterEqual123 *semver.Constraints
+	// ConstraintK8sEqual124 is a version constraint for versions == 1.24.
+	ConstraintK8sEqual124 *semver.Constraints
 	// ConstraintK8sLess124 is a version constraint for versions < 1.24.
 	ConstraintK8sLess124 *semver.Constraints
 )
@@ -93,6 +95,8 @@ func init() {
 	ConstraintK8sEqual123, err = semver.NewConstraint("1.23.x")
 	utilruntime.Must(err)
 	ConstraintK8sGreaterEqual123, err = semver.NewConstraint(">= 1.23")
+	utilruntime.Must(err)
+	ConstraintK8sEqual124, err = semver.NewConstraint("1.24.x")
 	utilruntime.Must(err)
 	ConstraintK8sLess124, err = semver.NewConstraint("< 1.24")
 	utilruntime.Must(err)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement

**What this PR does / why we need it**:
As there aren't any significant changes in the kube-scheduler config between 1.23 and 1.24, I decided to reuse the 1.23 types for 1.24 as well (instead of duplicating the upstream pkgs for 1.24 under `./third_party`).

To check the changes in the kube-scheduler types between 1.23 and 1.24:
```
git diff release-1.23..release-1.24 ./staging/src/k8s.io/kube-scheduler/config
```

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/4741
Part of #5912 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
`SeedKubeScheduler`: `gardenlet` does now support the `SeedKubeScheduler` feature gate to be enabled for K8s `1.24` Seed clusters.
```
