### PR TITLE
Exclude optional addons from compliance scans

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -158,42 +158,48 @@ images:
   repository: kubernetesui/dashboard
   tag: v2.2.0
   targetVersion: "< 1.21"
-- name: kubernetes-dashboard
-  sourceRepository: github.com/kubernetes/dashboard
-  repository: kubernetesui/dashboard
-  tag: v2.4.0
-  targetVersion: ">= 1.21, < 1.22"
-- name: kubernetes-dashboard
-  sourceRepository: github.com/kubernetes/dashboard
-  repository: kubernetesui/dashboard
-  tag: v2.5.1
-  targetVersion: ">= 1.22"
-- name: kubernetes-dashboard-metrics-scraper
-  sourceRepository: github.com/kubernetes/dashboard
-  repository: kubernetesui/metrics-scraper
-  tag: v1.0.7
-- name: nginx-ingress-controller
-  sourceRepository: github.com/kubernetes/ingress-nginx
-  repository: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
-  tag: "0.22.0"
-  targetVersion: "< 1.20"
-  labels:
+  labels: &optionalAddonLabels
   - name: cloud.gardener.cnudie/dso/scanning-hints/binary_id/v1
     value:
       policy: skip
       comment: >
         not deployed as part of gardener infrastructure. Offered to users for development
         purposes only, accompanied w/ warning that no support be provided.
+- name: kubernetes-dashboard
+  sourceRepository: github.com/kubernetes/dashboard
+  repository: kubernetesui/dashboard
+  tag: v2.4.0
+  targetVersion: ">= 1.21, < 1.22"
+  labels: *optionalAddonLabels
+- name: kubernetes-dashboard
+  sourceRepository: github.com/kubernetes/dashboard
+  repository: kubernetesui/dashboard
+  tag: v2.5.1
+  targetVersion: ">= 1.22"
+  labels: *optionalAddonLabels
+- name: kubernetes-dashboard-metrics-scraper
+  sourceRepository: github.com/kubernetes/dashboard
+  repository: kubernetesui/metrics-scraper
+  tag: v1.0.7
+  labels: *optionalAddonLabels
+- name: nginx-ingress-controller
+  sourceRepository: github.com/kubernetes/ingress-nginx
+  repository: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
+  tag: "0.22.0"
+  targetVersion: "< 1.20"
+  labels: *optionalAddonLabels
 - name: nginx-ingress-controller
   sourceRepository: github.com/kubernetes/ingress-nginx
   repository: k8s.gcr.io/ingress-nginx/controller
   tag: "v0.49.3"
   targetVersion: ">= 1.20, < 1.22"
+  labels: *optionalAddonLabels
 - name: nginx-ingress-controller
   sourceRepository: github.com/kubernetes/ingress-nginx
   repository: k8s.gcr.io/ingress-nginx/controller-chroot
   tag: "v1.2.1"
   targetVersion: ">= 1.22"
+  labels: *optionalAddonLabels
 
 # Miscellaenous
 - name: alpine

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -35,6 +35,20 @@ images:
   sourceRepository: github.com/gardener/dependency-watchdog
   repository: eu.gcr.io/gardener-project/gardener/dependency-watchdog
   tag: "v0.7.2"
+- name: nginx-ingress-controller-seed
+  sourceRepository: github.com/kubernetes/ingress-nginx
+  repository: k8s.gcr.io/ingress-nginx/controller
+  tag: "v0.49.3"
+  targetVersion: "< 1.22"
+- name: nginx-ingress-controller-seed
+  sourceRepository: github.com/kubernetes/ingress-nginx
+  repository: k8s.gcr.io/ingress-nginx/controller-chroot
+  tag: "v1.2.1"
+  targetVersion: ">= 1.22"
+- name: ingress-default-backend
+  sourceRepository: https://github.com/kubernetes/ingress-gce
+  repository: k8s.gcr.io/defaultbackend-amd64
+  tag: "1.5"
 
 # Seed controlplane
 #   hyperkube is used for kubectl + kubelet binaries on the worker nodes
@@ -180,20 +194,6 @@ images:
   repository: k8s.gcr.io/ingress-nginx/controller-chroot
   tag: "v1.2.1"
   targetVersion: ">= 1.22"
-- name: nginx-ingress-controller-seed
-  sourceRepository: github.com/kubernetes/ingress-nginx
-  repository: k8s.gcr.io/ingress-nginx/controller
-  tag: "v0.49.3"
-  targetVersion: "< 1.22"
-- name: nginx-ingress-controller-seed
-  sourceRepository: github.com/kubernetes/ingress-nginx
-  repository: k8s.gcr.io/ingress-nginx/controller-chroot
-  tag: "v1.2.1"
-  targetVersion: ">= 1.22"
-- name: ingress-default-backend
-  sourceRepository: https://github.com/kubernetes/ingress-gce
-  repository: k8s.gcr.io/defaultbackend-amd64
-  tag: "1.5"
 
 # Miscellaenous
 - name: alpine


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area compliance
/kind enhancement

**What this PR does / why we need it**:
This prevents us being bothered for vulnerabilities find in optional addons which are not recommended/usable for productive shoot clusters anyways.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
