### PR TITLE
Skip projected token mount for gardenlet pods

### DIFF
--- a/charts/gardener/gardenlet/charts/runtime/templates/deployment.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/deployment.yaml
@@ -58,6 +58,7 @@ spec:
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         release: "{{ .Release.Name }}"
         heritage: "{{ .Release.Service }}"
+        projected-token-mount.resources.gardener.cloud/skip: "true"
         {{- if .Values.global.gardenlet.podLabels }}
 {{ toYaml .Values.global.gardenlet.podLabels | indent 8 }}
         {{- end }}

--- a/pkg/gardenlet/controller/managedseed/charttest/gardenlet_chart_test.go
+++ b/pkg/gardenlet/controller/managedseed/charttest/gardenlet_chart_test.go
@@ -64,6 +64,9 @@ var (
 	expectedLabelsWithCollectableReference = utils.MergeStringMaps(expectedLabels, map[string]string{
 		"resources.gardener.cloud/garbage-collectable-reference": "true",
 	})
+	expectedLabelsWithSkippedProjectedTokenMount = utils.MergeStringMaps(expectedLabels, map[string]string{
+		"projected-token-mount.resources.gardener.cloud/skip": "true",
+	})
 )
 
 var _ = Describe("#Gardenlet Chart Test", func() {
@@ -297,9 +300,7 @@ var _ = Describe("#Gardenlet Chart Test", func() {
 				c,
 				universalDecoder,
 				expectedGardenletConfig,
-				utils.MergeStringMaps(expectedLabels, map[string]string{
-					"resources.gardener.cloud/garbage-collectable-reference": "true",
-				}),
+				expectedLabelsWithCollectableReference,
 				cmAndSecretNameToUniqueName["gardenlet-configmap"],
 			)
 
@@ -309,7 +310,7 @@ var _ = Describe("#Gardenlet Chart Test", func() {
 				componentConfigUsesTlsServerConfig,
 				gardenClientConnectionKubeconfig,
 				seedClientConnectionKubeconfig,
-				expectedLabels,
+				expectedLabelsWithSkippedProjectedTokenMount,
 				imageVectorOverwrite,
 				componentImageVectorOverwrites,
 				cmAndSecretNameToUniqueName,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind bug

**What this PR does / why we need it**:
This PR fixed a bug which could prevent `gardenlet` pods from coming up in case the `projected-token-mount` webhook served by `gardener-resource-manager` is unavailable or broken. One example why the webhook could be broken is if a shoot used as managed seed gets hibernated for longer than `30d` (after `30d` the seed CA expires and this breaks the webhook until `gardenlet` comes up again and generates a new CA).

Given that the projected token for `gardenlet` is anyways never mounted by the webhook since it already exists, we can exclude `gardenlet` pods entirely: https://github.com/gardener/gardener/blob/36354063ffb7d173efab4db5c6999a291e8f25c0/charts/gardener/gardenlet/charts/runtime/templates/deployment.yaml#L169-L186

**Special notes for your reviewer**:
/cc @plkokanov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed which could prevent `gardenlet` pods from coming up in case the `projected-token-mount` webhook served by `gardener-resource-manager` is unavailable or broken.
```
