### PR TITLE
Seed prometheus: allow to overwrite scheme per annotation

### DIFF
--- a/charts/seed-bootstrap/charts/monitoring/templates/config.yaml
+++ b/charts/seed-bootstrap/charts/monitoring/templates/config.yaml
@@ -49,6 +49,11 @@ data:
         regex: garden;true;(.+)
         action: keep
       - source_labels:
+        - __meta_kubernetes_pod_annotation_prometheus_io_scheme
+        action: replace
+        target_label: __scheme__
+        regex: (https?)    
+      - source_labels:
         - __address__
         - __meta_kubernetes_pod_annotation_prometheus_io_port
         action: replace


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
Allow to overwrite the `https` scheme in the seed prometheus job `garden` by an annotation `prometheus.io/scheme: http`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
Seed prometheus: allow to overwrite scheme per annotation for job garden.
```
