### PR TITLE
Adapt allow-to-dns networkpolicy to also work with node local dns in cilium case

### DIFF
--- a/charts/shoot-core/components/charts/network-policies/templates/allow-to-dns.yaml
+++ b/charts/shoot-core/components/charts/network-policies/templates/allow-to-dns.yaml
@@ -20,10 +20,6 @@ spec:
     - podSelector:
         matchExpressions:
         - {key: k8s-app, operator: In, values: [kube-dns]}
-    {{- if .Values.nodeLocalDNS.enabled }}
-    - ipBlock:
-        cidr: {{ .Values.nodeLocalDNS.kubeDNSClusterIP }}/32
-    {{- end }}
     ports:
     - protocol: UDP
       port: 8053
@@ -34,6 +30,9 @@ spec:
   - to:
     - ipBlock:
         cidr: 0.0.0.0/0
+    - podSelector:
+        matchExpressions:
+        - {key: k8s-app, operator: In, values: [node-local-dns]}
     ports:
     - protocol: UDP
       port: 53

--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -30,7 +30,6 @@ import (
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/dns"
 	extensionsdnsrecord "github.com/gardener/gardener/pkg/operation/botanist/component/extensions/dnsrecord"
-	"github.com/gardener/gardener/pkg/operation/botanist/component/nodelocaldns"
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils/images"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
@@ -291,16 +290,8 @@ func (b *Botanist) generateCoreAddonsChart(ctx context.Context) (*chartrenderer.
 		blackboxExporterConfig = map[string]interface{}{}
 		networkPolicyConfig    = netpol.ShootNetworkPolicyValues{
 			Enabled: true,
-			NodeLocalDNS: netpol.NodeLocalDNSValues{
-				Enabled:          b.Shoot.NodeLocalDNSEnabled,
-				KubeDNSClusterIP: b.Shoot.Networks.CoreDNS.String(),
-			},
 		}
 	)
-
-	if b.Shoot.IPVSEnabled() {
-		networkPolicyConfig.NodeLocalDNS.KubeDNSClusterIP = nodelocaldns.IPVSAddress
-	}
 
 	nodeExporter, err := b.InjectShootShootImages(nodeExporterConfig, images.ImageNameNodeExporter)
 	if err != nil {

--- a/pkg/operation/botanist/addons/networkpolicy/shoot_network_policy.go
+++ b/pkg/operation/botanist/addons/networkpolicy/shoot_network_policy.go
@@ -18,13 +18,5 @@ package networkpolicy
 // network-policy charts used in the kube-system namespace in the Shoot
 // cluster.
 type ShootNetworkPolicyValues struct {
-	Enabled      bool               `json:"enabled,omitempty"`
-	NodeLocalDNS NodeLocalDNSValues `json:"nodeLocalDNS,omitempty"`
-}
-
-// NodeLocalDNSValues contain optional IP address of the kube-dns
-// which should be allowed in the network policies.
-type NodeLocalDNSValues struct {
-	Enabled          bool   `json:"enabled,omitempty"`
-	KubeDNSClusterIP string `json:"kubeDNSClusterIP,omitempty"`
+	Enabled bool `json:"enabled,omitempty"`
 }


### PR DESCRIPTION

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Adapt `allow-to-dns` networkpolicy to also work with node local dns in cilium case.
Furthermore an unneeded ip block was removed from the networkpolicy.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Adapt `allow-to-dns` networkpolicy to also work with node local dns in cilium case.
```
