### PR TITLE
Introduce well-known and fine-granular `PriorityClasses` managed by gardenlet

### DIFF
--- a/charts/seed-bootstrap/templates/priorityclass-shoot-controlplane.yaml
+++ b/charts/seed-bootstrap/templates/priorityclass-shoot-controlplane.yaml
@@ -1,8 +1,0 @@
----
-apiVersion: {{ include "priorityclassversion" . }}
-kind: PriorityClass
-metadata:
-  name: {{ .Values.priorityClassName }}
-value: 100
-globalDefault: false
-description: "This class is used to ensure priority scheduling for some of shoot's control plane pods."

--- a/charts/seed-bootstrap/values.yaml
+++ b/charts/seed-bootstrap/values.yaml
@@ -1,5 +1,3 @@
-priorityClassName: foo
-
 prometheus:
   resources:
     prometheus:

--- a/docs/README.md
+++ b/docs/README.md
@@ -112,6 +112,7 @@
 * [Extending the Monitoring Stack](development/monitoring-stack.md)
 * [How to create log parser for container into fluent-bit](development/log_parsers.md)
 * [Network Policies in the Seed Cluster](development/seed_network_policies.md)
+* [`PriorityClasses` in Gardener Clusters](development/priority-classes.md)
 
 ## Extensions
 

--- a/docs/development/priority-classes.md
+++ b/docs/development/priority-classes.md
@@ -1,0 +1,48 @@
+# `PriorityClasses` in Gardener Clusters
+
+Gardener makes use of [`PriorityClasses`](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/) to improve overall robustness of the system.
+In order to benefit from the full potential of `PriorityClasses`, gardenlet manages a set of well-known `PriorityClasses` with fine-granular priority values.
+
+All components of the system should use these well-known `PriorityClasses` instead of creating and using separate ones with arbitrary values, which would compromise the overall goal of using `PriorityClasses` in the first place.
+Gardenlet manages the well-known `PriorityClasses` listed in this document, so that third parties (e.g., gardener extensions) can rely on them to be present when deploying components to Seed and Shoot clusters.
+
+The listed well-known `PriorityClasses` follow this rough concept:
+
+- Values are close to the maximum that can be declared by the user. This is important to ensure that Shoot system components have higher priority than the workload deployed by end-users.
+- Values have a bit of headroom in between to ensure flexibility when the need for intermediate priority values arises.
+- Values of `PriorityClasses` created on Seed clusters are lower than the ones on Shoots to ensure that Shoot system components have higher priority than Seed components, if the Seed is backed by a Shoot (`ManagedSeed`), e.g. `coredns` should have higher priority than `gardenlet`.
+- Names simply include the last digits of the value to minimize confusion caused by many (similar) names like `critical`, `importance-high`, etc.
+
+
+## `PriorityClasses` for Shoot System Components
+
+| Name                                              | Priority   | Associated Components (Examples)                                                                                            |
+|---------------------------------------------------|------------|-----------------------------------------------------------------------------------------------------------------------------|
+| `system-node-critical` (created by Kubernetes)    | 2000001000 | `calico-node`, `kube-proxy`, `apiserver-proxy`, `csi-driver`, `egress-filter-applier`                                       |
+| `system-cluster-critical` (created by Kubernetes) | 2000000000 | `calico-typha`, `calico-kube-controllers`, `coredns`, `vpn-shoot`                                                           |
+| `gardener-shoot-system-900`                       | 999999900  | `node-problem-detector`                                                                                                     |
+| `gardener-shoot-system-800`                       | 999999800  | `calico-typha-horizontal-autoscaler`, `calico-typha-vertical-autoscaler`                                                    |
+| `gardener-shoot-system-700`                       | 999999700  | `blackbox-exporter`, `node-exporter`                                                                                        |
+| `gardener-shoot-system-600`                       | 999999600  | `addons-nginx-ingress-controller`, `addons-nginx-ingress-k8s-backend`, `kubernetes-dashboard`, `kubernetes-metrics-scraper` |
+
+
+## `PriorityClasses` for Seed System Components
+
+| Name                               | Priority  | Associated Components (Examples)                                                                                                                                                          |
+|------------------------------------|-----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `gardener-system-critical`         | 999998950 | `gardenlet`, `gardener-resource-manager`, `istio-ingressgateway`, `istiod`                                                                                                                |
+| `gardener-system-900`              | 999998900 | Extensions, `gardener-seed-admission-controller`, `reversed-vpn-auth-server`                                                                                                              |
+| `gardener-system-800`              | 999998800 | `dependency-watchdog-endpoint`, `dependency-watchdog-probe`, `etcd-druid`, `(auditlog-)mutator`, `vpa-admission-controller`                                                               |
+| `gardener-system-700`              | 999998700 | `auditlog-seed-controller`, `hvpa-controller`, `vpa-recommender`, `vpa-updater`                                                                                                           |
+| `gardener-system-600`              | 999998600 | `aggregate-alertmanager`, `alertmanager`, `fluent-bit`, `grafana`, `kube-state-metrics`, `nginx-ingress-controller`, `nginx-k8s-backend`, `prometheus`, `seed-prometheus`, `vpa-exporter` |
+| `gardener-reserve-excess-capacity` | -5        | `reserve-excess-capacity` ([ref](https://github.com/gardener/gardener/pull/6135))                                                                                                         |
+
+## `PriorityClasses` for Shoot Control Plane Components
+
+| Name                  | Priority  | Associated Components (Examples)                                                                                                                                        |
+|-----------------------|-----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `gardener-system-500` | 999998500 | `etcd-events`, `etcd-main`, `kube-apiserver`                                                                                                                            |
+| `gardener-system-400` | 999998400 | `gardener-resource-manager`                                                                                                                                             |
+| `gardener-system-300` | 999998300 | `cloud-controller-manager`, `cluster-autoscaler`, `csi-driver-controller`, `kube-controller-manager`, `kube-scheduler`, `machine-controller-manager`, `vpn-seed-server` |
+| `gardener-system-200` | 999998200 | `csi-snapshot-controller`, `csi-snapshot-validation`, `cert-controller-manager`, `shoot-dns-service`, `vpa-admission-controller`, `vpa-recommender`, `vpa-updater`      |
+| `gardener-system-100` | 999998100 | `alertmanager`, `grafana-operators`, `grafana-users`, `kube-state-metrics`, `prometheus`, `loki`                                                                        |

--- a/docs/development/priority-classes.md
+++ b/docs/development/priority-classes.md
@@ -46,3 +46,7 @@ The listed well-known `PriorityClasses` follow this rough concept:
 | `gardener-system-300` | 999998300 | `cloud-controller-manager`, `cluster-autoscaler`, `csi-driver-controller`, `kube-controller-manager`, `kube-scheduler`, `machine-controller-manager`, `vpn-seed-server` |
 | `gardener-system-200` | 999998200 | `csi-snapshot-controller`, `csi-snapshot-validation`, `cert-controller-manager`, `shoot-dns-service`, `vpa-admission-controller`, `vpa-recommender`, `vpa-updater`      |
 | `gardener-system-100` | 999998100 | `alertmanager`, `grafana-operators`, `grafana-users`, `kube-state-metrics`, `prometheus`, `loki`                                                                        |
+
+There is also a legacy `PriorityClass` called `gardener-shoot-controlplane` with value `100`.
+This `PriorityClass` is deprecated and will be removed in a future release.
+Make sure to migrate all your components to the above listed fine-granular `PriorityClasses`.

--- a/docs/development/priority-classes.md
+++ b/docs/development/priority-classes.md
@@ -4,7 +4,7 @@ Gardener makes use of [`PriorityClasses`](https://kubernetes.io/docs/concepts/sc
 In order to benefit from the full potential of `PriorityClasses`, gardenlet manages a set of well-known `PriorityClasses` with fine-granular priority values.
 
 All components of the system should use these well-known `PriorityClasses` instead of creating and using separate ones with arbitrary values, which would compromise the overall goal of using `PriorityClasses` in the first place.
-Gardenlet manages the well-known `PriorityClasses` listed in this document, so that third parties (e.g., gardener extensions) can rely on them to be present when deploying components to Seed and Shoot clusters.
+Gardenlet manages the well-known `PriorityClasses` listed in this document, so that third parties (e.g., Gardener extensions) can rely on them to be present when deploying components to Seed and Shoot clusters.
 
 The listed well-known `PriorityClasses` follow this rough concept:
 

--- a/docs/extensions/conventions.md
+++ b/docs/extensions/conventions.md
@@ -6,6 +6,11 @@ Some of these extensions might need to create global resources in the seed (e.g.
 
 Consequently, this page should help answering some general questions that might come up when it comes to developing an extension.
 
+## `PriorityClasses`
+
+Extensions are not supposed to create and use self-defined `PriorityClasses`.
+Instead, they can and should rely on well-known [`PriorityClasses`](../development/priority-classes.md) managed by gardenlet.
+
 ## Is there a naming scheme for (global) resources?
 
 As there is no formal process to validate non-existence of conflicts between two extensions please follow these naming schemes when creating resources (especially, when creating global resources, but it's in general a good idea for most created resources):

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -603,9 +603,6 @@ const (
 	// being referenced by at least one other resource (e.g. a SecretBinding is still referenced by a Shoot)
 	EventResourceReferenced = "ResourceReferenced"
 
-	// PriorityClassNameShootControlPlane is the name of a priority class for critical pods of a shoot control plane.
-	PriorityClassNameShootControlPlane = "gardener-shoot-controlplane"
-
 	// ReferencedResourcesPrefix is the prefix used when copying referenced resources to the Shoot namespace in the Seed,
 	// to avoid naming collisions with resources managed by Gardener.
 	ReferencedResourcesPrefix = "ref-"
@@ -721,4 +718,7 @@ const (
 	// PriorityClassNameShootControlPlane100 is the name of a PriorityClass for Shoot control plane components.
 	// Please consider the documentation in https://github.com/gardener/gardener/blob/master/docs/development/priority-classes.md
 	PriorityClassNameShootControlPlane100 = "gardener-system-100"
+	// PriorityClassNameShootControlPlane is the name of a PriorityClass for Shoot control plane components.
+	// Deprecated: this PriorityClass will be removed in a future version, use the fine-granular PriorityClasses above instead.
+	PriorityClassNameShootControlPlane = "gardener-shoot-controlplane"
 )

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -671,3 +671,54 @@ var ControlPlaneSecretRoles = []string{
 	GardenRoleSSHKeyPair,
 	GardenRoleMonitoring,
 }
+
+// constants for well-known PriorityClass names
+const (
+	// PriorityClassNameShootSystem900 is the name of a PriorityClass for Shoot system components.
+	// Please consider the documentation in https://github.com/gardener/gardener/blob/master/docs/development/priority-classes.md
+	PriorityClassNameShootSystem900 = "gardener-shoot-system-900"
+	// PriorityClassNameShootSystem800 is the name of a PriorityClass for Shoot system components.
+	// Please consider the documentation in https://github.com/gardener/gardener/blob/master/docs/development/priority-classes.md
+	PriorityClassNameShootSystem800 = "gardener-shoot-system-800"
+	// PriorityClassNameShootSystem700 is the name of a PriorityClass for Shoot system components.
+	// Please consider the documentation in https://github.com/gardener/gardener/blob/master/docs/development/priority-classes.md
+	PriorityClassNameShootSystem700 = "gardener-shoot-system-700"
+	// PriorityClassNameShootSystem600 is the name of a PriorityClass for Shoot system components.
+	// Please consider the documentation in https://github.com/gardener/gardener/blob/master/docs/development/priority-classes.md
+	PriorityClassNameShootSystem600 = "gardener-shoot-system-600"
+
+	// PriorityClassNameSeedSystemCritical is the name of a PriorityClass for Seed system components.
+	// Please consider the documentation in https://github.com/gardener/gardener/blob/master/docs/development/priority-classes.md
+	PriorityClassNameSeedSystemCritical = "gardener-system-critical"
+	// PriorityClassNameSeedSystem900 is the name of a PriorityClass for Seed system components.
+	// Please consider the documentation in https://github.com/gardener/gardener/blob/master/docs/development/priority-classes.md
+	PriorityClassNameSeedSystem900 = "gardener-system-900"
+	// PriorityClassNameSeedSystem800 is the name of a PriorityClass for Seed system components.
+	// Please consider the documentation in https://github.com/gardener/gardener/blob/master/docs/development/priority-classes.md
+	PriorityClassNameSeedSystem800 = "gardener-system-800"
+	// PriorityClassNameSeedSystem700 is the name of a PriorityClass for Seed system components.
+	// Please consider the documentation in https://github.com/gardener/gardener/blob/master/docs/development/priority-classes.md
+	PriorityClassNameSeedSystem700 = "gardener-system-700"
+	// PriorityClassNameSeedSystem600 is the name of a PriorityClass for Seed system components.
+	// Please consider the documentation in https://github.com/gardener/gardener/blob/master/docs/development/priority-classes.md
+	PriorityClassNameSeedSystem600 = "gardener-system-600"
+	// PriorityClassNameReserveExcessCapacity is the name of a PriorityClass for reserving excess capacity on a Seed cluster.
+	// Please consider the documentation in https://github.com/gardener/gardener/blob/master/docs/development/priority-classes.md
+	PriorityClassNameReserveExcessCapacity = "gardener-reserve-excess-capacity"
+
+	// PriorityClassNameShootControlPlane500 is the name of a PriorityClass for Shoot control plane components.
+	// Please consider the documentation in https://github.com/gardener/gardener/blob/master/docs/development/priority-classes.md
+	PriorityClassNameShootControlPlane500 = "gardener-system-500"
+	// PriorityClassNameShootControlPlane400 is the name of a PriorityClass for Shoot control plane components.
+	// Please consider the documentation in https://github.com/gardener/gardener/blob/master/docs/development/priority-classes.md
+	PriorityClassNameShootControlPlane400 = "gardener-system-400"
+	// PriorityClassNameShootControlPlane300 is the name of a PriorityClass for Shoot control plane components.
+	// Please consider the documentation in https://github.com/gardener/gardener/blob/master/docs/development/priority-classes.md
+	PriorityClassNameShootControlPlane300 = "gardener-system-300"
+	// PriorityClassNameShootControlPlane200 is the name of a PriorityClass for Shoot control plane components.
+	// Please consider the documentation in https://github.com/gardener/gardener/blob/master/docs/development/priority-classes.md
+	PriorityClassNameShootControlPlane200 = "gardener-system-200"
+	// PriorityClassNameShootControlPlane100 is the name of a PriorityClass for Shoot control plane components.
+	// Please consider the documentation in https://github.com/gardener/gardener/blob/master/docs/development/priority-classes.md
+	PriorityClassNameShootControlPlane100 = "gardener-system-100"
+)

--- a/pkg/operation/botanist/component/seedsystem/seedsystem.go
+++ b/pkg/operation/botanist/component/seedsystem/seedsystem.go
@@ -173,6 +173,8 @@ var gardenletManagedPriorityClasses = []struct {
 	{v1beta1constants.PriorityClassNameShootControlPlane300, 999998300, "PriorityClass for Shoot control plane components"},
 	{v1beta1constants.PriorityClassNameShootControlPlane200, 999998200, "PriorityClass for Shoot control plane components"},
 	{v1beta1constants.PriorityClassNameShootControlPlane100, 999998100, "PriorityClass for Shoot control plane components"},
+	// TODO: remove this in a future release once all components have been migrated to the other fine-granular PriorityClasses.
+	{v1beta1constants.PriorityClassNameShootControlPlane, 100, "DEPRECATED PriorityClass for Shoot control plane components"},
 }
 
 func addPriorityClasses(registry *managedresources.Registry) error {

--- a/pkg/operation/botanist/component/seedsystem/seedsystem.go
+++ b/pkg/operation/botanist/component/seedsystem/seedsystem.go
@@ -105,66 +105,91 @@ func (s *seedSystem) computeResourcesData() (map[string][]byte, error) {
 	)
 
 	if s.values.ReserveExcessCapacity.Enabled {
-		if err := s.addReserveExcessCapacityResources(registry); err != nil {
+		if err := s.addReserveExcessCapacityDeployment(registry); err != nil {
 			return nil, err
 		}
+	}
+
+	if err := addPriorityClasses(registry); err != nil {
+		return nil, err
 	}
 
 	return registry.SerializedObjects(), nil
 }
 
-func (s *seedSystem) addReserveExcessCapacityResources(registry *managedresources.Registry) error {
-	var (
-		priorityClass = &schedulingv1.PriorityClass{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "gardener-reserve-excess-capacity",
-			},
-			Value:         -5,
-			GlobalDefault: false,
-			Description:   "This class is used to reserve excess resource capacity on a cluster",
-		}
-		deployment = &appsv1.Deployment{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "reserve-excess-capacity",
-				Namespace: s.namespace,
-				Labels:    getExcessCapacityReservationLabels(),
-			},
-			Spec: appsv1.DeploymentSpec{
-				RevisionHistoryLimit: pointer.Int32(2),
-				Replicas:             desiredExcessCapacity(),
-				Selector:             &metav1.LabelSelector{MatchLabels: getExcessCapacityReservationLabels()},
-				Template: corev1.PodTemplateSpec{
-					ObjectMeta: metav1.ObjectMeta{
-						Labels: getExcessCapacityReservationLabels(),
-					},
-					Spec: corev1.PodSpec{
-						TerminationGracePeriodSeconds: pointer.Int64(5),
-						Containers: []corev1.Container{{
-							Name:            "pause-container",
-							Image:           s.values.ReserveExcessCapacity.Image,
-							ImagePullPolicy: corev1.PullIfNotPresent,
-							Resources: corev1.ResourceRequirements{
-								Requests: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("2"),
-									corev1.ResourceMemory: resource.MustParse("6Gi"),
-								},
-								Limits: corev1.ResourceList{
-									corev1.ResourceCPU:    resource.MustParse("2"),
-									corev1.ResourceMemory: resource.MustParse("6Gi"),
-								},
+func (s *seedSystem) addReserveExcessCapacityDeployment(registry *managedresources.Registry) error {
+	return registry.Add(&appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "reserve-excess-capacity",
+			Namespace: s.namespace,
+			Labels:    getExcessCapacityReservationLabels(),
+		},
+		Spec: appsv1.DeploymentSpec{
+			RevisionHistoryLimit: pointer.Int32(2),
+			Replicas:             desiredExcessCapacity(),
+			Selector:             &metav1.LabelSelector{MatchLabels: getExcessCapacityReservationLabels()},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: getExcessCapacityReservationLabels(),
+				},
+				Spec: corev1.PodSpec{
+					TerminationGracePeriodSeconds: pointer.Int64(5),
+					Containers: []corev1.Container{{
+						Name:            "pause-container",
+						Image:           s.values.ReserveExcessCapacity.Image,
+						ImagePullPolicy: corev1.PullIfNotPresent,
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("2"),
+								corev1.ResourceMemory: resource.MustParse("6Gi"),
 							},
-						}},
-						PriorityClassName: priorityClass.Name,
-					},
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("2"),
+								corev1.ResourceMemory: resource.MustParse("6Gi"),
+							},
+						},
+					}},
+					PriorityClassName: v1beta1constants.PriorityClassNameReserveExcessCapacity,
 				},
 			},
-		}
-	)
+		},
+	})
+}
 
-	return registry.Add(
-		priorityClass,
-		deployment,
-	)
+// remember to update docs/development/priority-classes.md when making changes here
+var gardenletManagedPriorityClasses = []struct {
+	name        string
+	value       int32
+	description string
+}{
+	{v1beta1constants.PriorityClassNameSeedSystemCritical, 999998950, "PriorityClass for Seed system components"},
+	{v1beta1constants.PriorityClassNameSeedSystem900, 999998900, "PriorityClass for Seed system components"},
+	{v1beta1constants.PriorityClassNameSeedSystem800, 999998800, "PriorityClass for Seed system components"},
+	{v1beta1constants.PriorityClassNameSeedSystem700, 999998700, "PriorityClass for Seed system components"},
+	{v1beta1constants.PriorityClassNameSeedSystem600, 999998600, "PriorityClass for Seed system components"},
+	{v1beta1constants.PriorityClassNameReserveExcessCapacity, -5, "PriorityClass for reserving excess capacity on a Seed cluster"},
+	{v1beta1constants.PriorityClassNameShootControlPlane500, 999998500, "PriorityClass for Shoot control plane components"},
+	{v1beta1constants.PriorityClassNameShootControlPlane400, 999998400, "PriorityClass for Shoot control plane components"},
+	{v1beta1constants.PriorityClassNameShootControlPlane300, 999998300, "PriorityClass for Shoot control plane components"},
+	{v1beta1constants.PriorityClassNameShootControlPlane200, 999998200, "PriorityClass for Shoot control plane components"},
+	{v1beta1constants.PriorityClassNameShootControlPlane100, 999998100, "PriorityClass for Shoot control plane components"},
+}
+
+func addPriorityClasses(registry *managedresources.Registry) error {
+	for _, class := range gardenletManagedPriorityClasses {
+		if err := registry.Add(&schedulingv1.PriorityClass{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: class.name,
+			},
+			Description:   class.description,
+			GlobalDefault: false,
+			Value:         class.value,
+		}); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func getExcessCapacityReservationLabels() map[string]string {

--- a/pkg/operation/botanist/component/seedsystem/seedsystem_test.go
+++ b/pkg/operation/botanist/component/seedsystem/seedsystem_test.go
@@ -149,7 +149,7 @@ status: {}
 		})
 
 		It("should successfully deploy the resources", func() {
-			Expect(managedResourceSecret.Data).To(HaveLen(12))
+			Expect(managedResourceSecret.Data).To(HaveLen(13))
 			Expect(string(managedResourceSecret.Data["deployment__"+namespace+"__reserve-excess-capacity.yaml"])).To(Equal(deploymentYAML))
 			expectPriorityClasses(managedResourceSecret.Data)
 		})
@@ -274,6 +274,7 @@ func expectPriorityClasses(data map[string][]byte) {
 		{"gardener-system-300", 999998300, "PriorityClass for Shoot control plane components"},
 		{"gardener-system-200", 999998200, "PriorityClass for Shoot control plane components"},
 		{"gardener-system-100", 999998100, "PriorityClass for Shoot control plane components"},
+		{"gardener-shoot-controlplane", 100, "DEPRECATED PriorityClass for Shoot control plane components"},
 	}
 
 	for _, pc := range expected {

--- a/pkg/operation/botanist/component/seedsystem/seedsystem_test.go
+++ b/pkg/operation/botanist/component/seedsystem/seedsystem_test.go
@@ -16,6 +16,7 @@ package seedsystem_test
 
 import (
 	"context"
+	"strconv"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
@@ -30,9 +31,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -53,14 +52,6 @@ var _ = Describe("SeedSystem", func() {
 		managedResource       *resourcesv1alpha1.ManagedResource
 		managedResourceSecret *corev1.Secret
 
-		priorityClassYAML = `apiVersion: scheduling.k8s.io/v1
-description: This class is used to reserve excess resource capacity on a cluster
-kind: PriorityClass
-metadata:
-  creationTimestamp: null
-  name: gardener-reserve-excess-capacity
-value: -5
-`
 		deploymentYAML = `apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -128,8 +119,8 @@ status: {}
 
 	Describe("#Deploy", func() {
 		JustBeforeEach(func() {
-			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: resourcesv1alpha1.SchemeGroupVersion.Group, Resource: "managedresources"}, managedResource.Name)))
-			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), managedResourceSecret)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: corev1.SchemeGroupVersion.Group, Resource: "secrets"}, managedResourceSecret.Name)))
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(BeNotFoundError())
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), managedResourceSecret)).To(BeNotFoundError())
 
 			Expect(component.Deploy(ctx)).To(Succeed())
 
@@ -158,9 +149,9 @@ status: {}
 		})
 
 		It("should successfully deploy the resources", func() {
-			Expect(managedResourceSecret.Data).To(HaveLen(2))
-			Expect(string(managedResourceSecret.Data["priorityclass____gardener-reserve-excess-capacity.yaml"])).To(Equal(priorityClassYAML))
+			Expect(managedResourceSecret.Data).To(HaveLen(12))
 			Expect(string(managedResourceSecret.Data["deployment__"+namespace+"__reserve-excess-capacity.yaml"])).To(Equal(deploymentYAML))
+			expectPriorityClasses(managedResourceSecret.Data)
 		})
 	})
 
@@ -174,8 +165,8 @@ status: {}
 
 			Expect(component.Destroy(ctx)).To(Succeed())
 
-			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: resourcesv1alpha1.SchemeGroupVersion.Group, Resource: "managedresources"}, managedResource.Name)))
-			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), managedResourceSecret)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: corev1.SchemeGroupVersion.Group, Resource: "secrets"}, managedResourceSecret.Name)))
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(BeNotFoundError())
+			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), managedResourceSecret)).To(BeNotFoundError())
 		})
 	})
 
@@ -265,3 +256,35 @@ status: {}
 		})
 	})
 })
+
+func expectPriorityClasses(data map[string][]byte) {
+	expected := []struct {
+		name        string
+		value       int32
+		description string
+	}{
+		{"gardener-system-critical", 999998950, "PriorityClass for Seed system components"},
+		{"gardener-system-900", 999998900, "PriorityClass for Seed system components"},
+		{"gardener-system-800", 999998800, "PriorityClass for Seed system components"},
+		{"gardener-system-700", 999998700, "PriorityClass for Seed system components"},
+		{"gardener-system-600", 999998600, "PriorityClass for Seed system components"},
+		{"gardener-reserve-excess-capacity", -5, "PriorityClass for reserving excess capacity on a Seed cluster"},
+		{"gardener-system-500", 999998500, "PriorityClass for Shoot control plane components"},
+		{"gardener-system-400", 999998400, "PriorityClass for Shoot control plane components"},
+		{"gardener-system-300", 999998300, "PriorityClass for Shoot control plane components"},
+		{"gardener-system-200", 999998200, "PriorityClass for Shoot control plane components"},
+		{"gardener-system-100", 999998100, "PriorityClass for Shoot control plane components"},
+	}
+
+	for _, pc := range expected {
+		ExpectWithOffset(1, data).To(HaveKeyWithValue("priorityclass____"+pc.name+".yaml", []byte(`apiVersion: scheduling.k8s.io/v1
+description: `+pc.description+`
+kind: PriorityClass
+metadata:
+  creationTimestamp: null
+  name: `+pc.name+`
+value: `+strconv.FormatInt(int64(pc.value), 10)+`
+`),
+		))
+	}
+}

--- a/pkg/operation/common/utils.go
+++ b/pkg/operation/common/utils.go
@@ -16,7 +16,6 @@ package common
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math/big"
 	"net"
@@ -134,30 +133,6 @@ func DeleteSeedLoggingStack(ctx context.Context, k8sClient client.Client) error 
 	}
 
 	return DeleteLoki(ctx, k8sClient, v1beta1constants.GardenNamespace)
-}
-
-// DeleteReserveExcessCapacity deletes the deployment and priority class for excess capacity
-func DeleteReserveExcessCapacity(ctx context.Context, k8sClient client.Client) error {
-	if k8sClient == nil {
-		return errors.New("must provide non-nil kubernetes client to common.DeleteReserveExcessCapacity")
-	}
-
-	deploy := &appsv1.Deployment{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "reserve-excess-capacity",
-			Namespace: v1beta1constants.GardenNamespace,
-		},
-	}
-	if err := k8sClient.Delete(ctx, deploy); client.IgnoreNotFound(err) != nil {
-		return err
-	}
-
-	priorityClass := &schedulingv1.PriorityClass{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "gardener-reserve-excess-capacity",
-		},
-	}
-	return client.IgnoreNotFound(k8sClient.Delete(ctx, priorityClass))
 }
 
 // DeleteAlertmanager deletes all resources of the Alertmanager in a given namespace.

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -668,12 +668,6 @@ func RunReconcileSeedFlow(
 		}
 	}
 
-	if !seed.GetInfo().Spec.Settings.ExcessCapacityReservation.Enabled {
-		if err := common.DeleteReserveExcessCapacity(ctx, seedClient); client.IgnoreNotFound(err) != nil {
-			return err
-		}
-	}
-
 	var (
 		applierOptions          = kubernetes.CopyApplierOptions(kubernetes.DefaultMergeFuncs)
 		retainStatusInformation = func(new, old *unstructured.Unstructured) {

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -767,7 +767,6 @@ func RunReconcileSeedFlow(
 	}
 
 	values := kubernetes.Values(map[string]interface{}{
-		"priorityClassName": v1beta1constants.PriorityClassNameShootControlPlane,
 		"global": map[string]interface{}{
 			"ingressClass": ingressClass,
 			"images":       imagevector.ImageMapToValues(seedImages),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:

Performs the first steps towards fine-granular `PriorityClasses` as proposed in https://github.com/gardener/gardener/issues/5634#issuecomment-1156512839:

- define and document well-known PriorityClasses
- manage them in gardenlet for Seed and Shoots
- deprecates `gardener-shoot-controlplane`

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/5634

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking dependency
Gardenlet now manages fine-granular `PriorityClasses` that are supposed to be used by all components in order to improve the overall robustness of the system.
- Find out more in the related [documentation](https://github.com/gardener/gardener/blob/master/docs/development/priority-classes.md).
- Extensions need to migrate all their extension controller pods as well as their shoot control plane and shoot system components to the newly defined `PriorityClasses` and drop custom ones.
- Legacy `PriorityClass` `gardener-shoot-controlplane` is deprecated and will be removed in a future release.
```
