### PR TITLE
[GRM] Allow grm to read its service account token

### DIFF
--- a/pkg/operation/botanist/component/resourcemanager/resource_manager.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager.go
@@ -520,6 +520,12 @@ func (r *resourceManager) ensureDeployment(ctx context.Context) error {
 						},
 					},
 				},
+				SecurityContext: &corev1.PodSecurityContext{
+					// Workaround for https://github.com/kubernetes/kubernetes/issues/82573
+					// Fixed with https://github.com/kubernetes/kubernetes/pull/89193 starting with Kubernetes 1.19
+					// Adds the "nonroot" group as supplemental
+					FSGroup: pointer.Int64(65532),
+				},
 				ServiceAccountName: serviceAccountName,
 				Containers: []corev1.Container{
 					{

--- a/pkg/operation/botanist/component/resourcemanager/resource_manager_test.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager_test.go
@@ -466,6 +466,9 @@ var _ = Describe("ResourceManager", func() {
 									},
 								},
 							},
+							SecurityContext: &corev1.PodSecurityContext{
+								FSGroup: pointer.Int64(65532),
+							},
 							ServiceAccountName: "gardener-resource-manager",
 							Containers: []corev1.Container{
 								{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
With #6159 a regression was introduced. For k8s version < `1.19` the mounted token for the GRM has `rw------` file permissions and cannot be read by the `nonroot` user which is used by the GRM's container. This PR fixes this.
See [here](https://github.com/kubernetes/kubernetes/pull/89193) for the PR in k/k that sets the proper permissions in versions > `1.19`.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
