### PR TITLE
Increase timeouts in `create_update_delete` e2e test

### DIFF
--- a/test/e2e/shoot/create_update_delete.go
+++ b/test/e2e/shoot/create_update_delete.go
@@ -49,7 +49,7 @@ var _ = Describe("Shoot Tests", Label("Shoot"), func() {
 
 	It("Create, Update, Delete", Label("simple"), func() {
 		By("Create Shoot")
-		ctx, cancel := context.WithTimeout(parentCtx, 15*time.Minute)
+		ctx, cancel := context.WithTimeout(parentCtx, 20*time.Minute)
 		defer cancel()
 		Expect(f.CreateShootAndWaitForCreation(ctx, false)).To(Succeed())
 		f.Verify()
@@ -63,13 +63,15 @@ var _ = Describe("Shoot Tests", Label("Shoot"), func() {
 		}).Should(Succeed())
 
 		By("Update Shoot")
+		ctx, cancel = context.WithTimeout(parentCtx, 20*time.Minute)
+		defer cancel()
 		shootupdatesuite.RunTest(ctx, &framework.ShootFramework{
 			GardenerFramework: f.GardenerFramework,
 			Shoot:             f.Shoot,
 		}, nil, nil)
 
 		By("Delete Shoot")
-		ctx, cancel = context.WithTimeout(parentCtx, 15*time.Minute)
+		ctx, cancel = context.WithTimeout(parentCtx, 20*time.Minute)
 		defer cancel()
 		Expect(f.DeleteShootAndWaitForDeletion(ctx, f.Shoot)).To(Succeed())
 	})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
After #6166, the simple "create/update/delete" e2e test requires more time since it runs with 3 worker pools that have to be rolled out.
Also, there was no new timeout context created after the initial shoot creation succeeded.

/cc @timebertt 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
