### PR TITLE
Validate `kubeReserved` and `systemReserved` resources against Node allocatable resources

### DIFF
--- a/example/provider-local/garden/base/cloudprofile.yaml
+++ b/example/provider-local/garden/base/cloudprofile.yaml
@@ -18,7 +18,7 @@ spec:
   machineTypes:
   - cpu: "1"
     gpu: "0"
-    memory: 1Gi
+    memory: 8Gi
     name: local
   machineImages:
   - name: local

--- a/example/provider-local/garden/base/cloudprofile.yaml
+++ b/example/provider-local/garden/base/cloudprofile.yaml
@@ -15,6 +15,8 @@ spec:
     - version: 1.20.0
     - version: 1.19.0
     - version: 1.18.0
+  # These values do not represent the actual machine capacity. The actual
+  # capacity of the machine depends on your docker resource allocation. 
   machineTypes:
   - cpu: "1"
     gpu: "0"

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -967,15 +967,15 @@ func validateKubeletConfig(fldPath *field.Path, machineTypes []core.MachineType,
 
 	for _, machineType := range machineTypes {
 		if machineType.Name == workerMachineType {
-			allocatableCPU := machineType.CPU
-			allocatableMemory := machineType.Memory
+			capacityCPU := machineType.CPU
+			capacityMemory := machineType.Memory
 
-			if cmp := reservedCPU.Cmp(allocatableCPU); cmp >= 0 {
-				allErrs = append(allErrs, field.Invalid(fldPath, fmt.Sprintf("kubeReserved CPU + systemReserved CPU: %s", reservedCPU.String()), fmt.Sprintf("total reserved CPU (kubeReserved + systemReserved) cannot be more than the Node's allocatable CPU '%s'", allocatableCPU.String())))
+			if cmp := reservedCPU.Cmp(capacityCPU); cmp >= 0 {
+				allErrs = append(allErrs, field.Invalid(fldPath, fmt.Sprintf("kubeReserved CPU + systemReserved CPU: %s", reservedCPU.String()), fmt.Sprintf("total reserved CPU (kubeReserved + systemReserved) cannot be more than the Node's CPU capacity '%s'", capacityCPU.String())))
 			}
 
-			if cmp := reservedMemory.Cmp(allocatableMemory); cmp >= 0 {
-				allErrs = append(allErrs, field.Invalid(fldPath, fmt.Sprintf("kubeReserved memory + systemReserved memory: %s", reservedMemory.String()), fmt.Sprintf("total reserved memory (kubeReserved + systemReserved) cannot be more than the Node's allocatable memory '%s'", allocatableMemory.String())))
+			if cmp := reservedMemory.Cmp(capacityMemory); cmp >= 0 {
+				allErrs = append(allErrs, field.Invalid(fldPath, fmt.Sprintf("kubeReserved memory + systemReserved memory: %s", reservedMemory.String()), fmt.Sprintf("total reserved memory (kubeReserved + systemReserved) cannot be more than the Node's memory capacity '%s'", capacityMemory.String())))
 			}
 		}
 	}

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -635,22 +635,26 @@ func (c *validationContext) validateProvider(a admission.Attributes) field.Error
 		if ok, minSize := validateVolumeSize(c.cloudProfile.Spec.VolumeTypes, c.cloudProfile.Spec.MachineTypes, worker.Machine.Type, worker.Volume); !ok {
 			allErrs = append(allErrs, field.Invalid(idxPath.Child("volume", "size"), worker.Volume.VolumeSize, fmt.Sprintf("size must be >= %s", minSize)))
 		}
-
-		if worker.Kubernetes != nil && worker.Kubernetes.Version != nil {
-			oldWorkerKubernetesVersion := c.oldShoot.Spec.Kubernetes.Version
-			if oldWorker.Kubernetes != nil && oldWorker.Kubernetes.Version != nil {
-				oldWorkerKubernetesVersion = *oldWorker.Kubernetes.Version
+		if worker.Kubernetes != nil {
+			if worker.Kubernetes.Kubelet != nil {
+				allErrs = append(allErrs, validateKubeletConfig(idxPath.Child("kubernetes").Child("kubelet"), c.cloudProfile.Spec.MachineTypes, worker.Machine.Type, worker.Kubernetes.Kubelet)...)
 			}
-			ok, isDefaulted, validKubernetesVersions, versionDefault := validateKubernetesVersionConstraints(c.cloudProfile.Spec.Kubernetes.Versions, *worker.Kubernetes.Version, oldWorkerKubernetesVersion)
-			if !ok {
-				err := field.NotSupported(idxPath.Child("kubernetes", "version"), worker.Kubernetes.Version, validKubernetesVersions)
-				if isDefaulted {
-					err.Detail = fmt.Sprintf("unable to default version - couldn't find a suitable patch version for %s. Suitable patch versions have a non-expired expiration date and are no 'preview' versions. 'Preview'-classified versions have to be selected explicitly -  %s", *worker.Kubernetes.Version, err.Detail)
+			if worker.Kubernetes.Version != nil {
+				oldWorkerKubernetesVersion := c.oldShoot.Spec.Kubernetes.Version
+				if oldWorker.Kubernetes != nil && oldWorker.Kubernetes.Version != nil {
+					oldWorkerKubernetesVersion = *oldWorker.Kubernetes.Version
 				}
-				allErrs = append(allErrs, err)
-			} else if versionDefault != nil {
-				ver := versionDefault.String()
-				worker.Kubernetes.Version = &ver
+				ok, isDefaulted, validKubernetesVersions, versionDefault := validateKubernetesVersionConstraints(c.cloudProfile.Spec.Kubernetes.Versions, *worker.Kubernetes.Version, oldWorkerKubernetesVersion)
+				if !ok {
+					err := field.NotSupported(idxPath.Child("kubernetes", "version"), worker.Kubernetes.Version, validKubernetesVersions)
+					if isDefaulted {
+						err.Detail = fmt.Sprintf("unable to default version - couldn't find a suitable patch version for %s. Suitable patch versions have a non-expired expiration date and are no 'preview' versions. 'Preview'-classified versions have to be selected explicitly -  %s", *worker.Kubernetes.Version, err.Detail)
+					}
+					allErrs = append(allErrs, err)
+				} else if versionDefault != nil {
+					ver := versionDefault.String()
+					worker.Kubernetes.Version = &ver
+				}
 			}
 		}
 
@@ -928,6 +932,47 @@ top:
 	}
 
 	return false, validValues
+}
+
+func validateKubeletConfig(fldPath *field.Path, machineTypes []core.MachineType, workerMachineType string, kubeletConfig *core.KubeletConfig) field.ErrorList {
+	var allErrs field.ErrorList
+	reservedCPU := *resource.NewQuantity(0, resource.DecimalSI)
+	reservedMemory := *resource.NewQuantity(0, resource.DecimalSI)
+
+	if kubeletConfig.KubeReserved != nil {
+		if kubeletConfig.KubeReserved.CPU != nil {
+			reservedCPU.Add(*kubeletConfig.KubeReserved.CPU)
+		}
+		if kubeletConfig.KubeReserved.Memory != nil {
+			reservedMemory.Add(*kubeletConfig.KubeReserved.Memory)
+		}
+	}
+
+	if kubeletConfig.SystemReserved != nil {
+		if kubeletConfig.SystemReserved.CPU != nil {
+			reservedCPU.Add(*kubeletConfig.SystemReserved.CPU)
+		}
+		if kubeletConfig.SystemReserved.Memory != nil {
+			reservedMemory.Add(*kubeletConfig.SystemReserved.Memory)
+		}
+	}
+
+	for _, machineType := range machineTypes {
+		if machineType.Name == workerMachineType {
+			allocatableCPU := machineType.CPU
+			allocatableMemory := machineType.Memory
+
+			if cmp := reservedCPU.Cmp(allocatableCPU); cmp >= 0 {
+				allErrs = append(allErrs, field.Invalid(fldPath, fmt.Sprintf("kubeReserved CPU + systemReserved CPU: %s", reservedCPU.String()), fmt.Sprintf("total reserved CPU (kubeReserved+systemReserved) cannot be more than allocatable CPU:%s", allocatableCPU.String())))
+			}
+
+			if cmp := reservedMemory.Cmp(allocatableMemory); cmp >= 0 {
+				allErrs = append(allErrs, field.Invalid(fldPath, fmt.Sprintf("kubeReserved Memory + systemReserved Memory: %s", reservedMemory.String()), fmt.Sprintf("total reserved memory (kubeReserved+systemReserved) cannot be more than allocatable memory:%s", allocatableMemory.String())))
+			}
+		}
+	}
+
+	return allErrs
 }
 
 func validateVolumeTypes(constraints []core.VolumeType, volume, oldVolume *core.Volume, regions []core.Region, region string, zones []string) (bool, []string) {

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -1635,7 +1635,7 @@ var _ = Describe("validator", func() {
 
 					err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 				})
 
 				It("should allow creation of Shoot if both global and worker kubeletConfigs are nil", func() {
@@ -1805,7 +1805,7 @@ var _ = Describe("validator", func() {
 					Expect(err.Error()).To(ContainSubstring("total reserved memory (kubeReserved + systemReserved) cannot be more than the Node's memory capacity"))
 				})
 
-				It("should not allow creation of Shoot if systemReserved Memory is more than memory capacity", func() {
+				It("should not allow creation of Shoot if systemReserved memory is more than memory capacity", func() {
 					resource := resourceMemory2
 					resource.Add(resourceMemory2)
 					worker.Kubernetes.Kubelet.KubeReserved = nil

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -1585,6 +1585,7 @@ var _ = Describe("validator", func() {
 							Image: &core.ShootMachineImage{
 								Name: validMachineImageName,
 							},
+							Architecture: pointer.String("amd64"),
 						},
 						Minimum: 1,
 						Maximum: 1,
@@ -1608,10 +1609,11 @@ var _ = Describe("validator", func() {
 					}
 
 					machineType := core.MachineType{
-						Name:   "machine-type-kc",
-						CPU:    resource.MustParse("5"),
-						GPU:    resource.MustParse("0"),
-						Memory: resource.MustParse("5Gi"),
+						Name:         "machine-type-kc",
+						CPU:          resource.MustParse("5"),
+						GPU:          resource.MustParse("0"),
+						Memory:       resource.MustParse("5Gi"),
+						Architecture: pointer.String("amd64"),
 					}
 
 					kubeletConfig = &core.KubeletConfig{

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -1636,7 +1636,7 @@ var _ = Describe("validator", func() {
 					Expect(err).To(BeNil())
 				})
 
-				It("should not throw any errors if both global and worker kubeletConfigs are nil", func() {
+				It("should allow creation of Shoot if both global and worker kubeletConfigs are nil", func() {
 					worker.Kubernetes.Kubelet = nil
 					shoot.Spec.Provider.Workers = append(shoot.Spec.Provider.Workers, worker)
 
@@ -1644,7 +1644,7 @@ var _ = Describe("validator", func() {
 
 					err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 				})
 
 				It("should not allow creation of Shoot if reserved CPU in the global kubeletConfig is more than allocatable CPU and worker kubeletConfig is nil", func() {
@@ -1663,7 +1663,7 @@ var _ = Describe("validator", func() {
 					Expect(err.Error()).To(ContainSubstring("total reserved CPU (kubeReserved + systemReserved) cannot be more than the Node's allocatable CPU"))
 				})
 
-				It("should allow creation of Shoot if reserved CPU in the global kubeletConfig is more than allocatable CPU but the worker kubeletConfig have lesser reserved CPU", func() {
+				It("should allow creation of Shoot if reserved CPU in the global kubeletConfig is more than allocatable CPU but the worker kubeletConfig has lesser reserved CPU", func() {
 					kubeletConfig.KubeReserved.CPU = &resourceCPU2
 					kubeletConfig.SystemReserved.CPU = &resourceCPU2
 					shoot.Spec.Kubernetes.Kubelet = kubeletConfig
@@ -1674,10 +1674,10 @@ var _ = Describe("validator", func() {
 
 					err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 				})
 
-				It("should not allow creation of Shoot if reserved CPU in the global kubeletConfig is less than allocatable CPU but the worker kubeletConfig have more reserved CPU", func() {
+				It("should not allow creation of Shoot if reserved CPU in the global kubeletConfig is less than allocatable CPU but the worker kubeletConfig has more reserved CPU", func() {
 					kubeletConfig.KubeReserved.CPU = &resourceCPU1
 					kubeletConfig.SystemReserved.CPU = &resourceCPU1
 					shoot.Spec.Kubernetes.Kubelet = kubeletConfig
@@ -1767,10 +1767,10 @@ var _ = Describe("validator", func() {
 
 					err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
-					Expect(err).To(BeNil())
+					Expect(err).ToNot(HaveOccurred())
 				})
 
-				It("should not allow creation of Shoot if reserved memory in the global kubeletConfig is less than allocatable memory but the worker kubeletConfig have more reserved memory", func() {
+				It("should not allow creation of Shoot if reserved memory in the global kubeletConfig is less than allocatable memory but the worker kubeletConfig has more reserved memory", func() {
 					kubeletConfig.KubeReserved.Memory = &resourceMemory1
 					kubeletConfig.SystemReserved.Memory = &resourceMemory1
 					shoot.Spec.Kubernetes.Kubelet = kubeletConfig
@@ -1787,7 +1787,7 @@ var _ = Describe("validator", func() {
 					Expect(err.Error()).To(ContainSubstring("total reserved memory (kubeReserved + systemReserved) cannot be more than the Node's allocatable memory"))
 				})
 
-				It("should not allow creation of Shoot if kubeReserved Memory is more than allocatable Memory", func() {
+				It("should not allow creation of Shoot if kubeReserved memory is more than allocatable memory", func() {
 					resource := resourceMemory2
 					resource.Add(resourceMemory2)
 					worker.Kubernetes.Kubelet.SystemReserved = nil
@@ -1803,7 +1803,7 @@ var _ = Describe("validator", func() {
 					Expect(err.Error()).To(ContainSubstring("total reserved memory (kubeReserved + systemReserved) cannot be more than the Node's allocatable memory"))
 				})
 
-				It("should not allow creation of Shoot if systemReserved Memory is more than allocatable Memory", func() {
+				It("should not allow creation of Shoot if systemReserved Memory is more than allocatable memory", func() {
 					resource := resourceMemory2
 					resource.Add(resourceMemory2)
 					worker.Kubernetes.Kubelet.KubeReserved = nil
@@ -1819,7 +1819,7 @@ var _ = Describe("validator", func() {
 					Expect(err.Error()).To(ContainSubstring("total reserved memory (kubeReserved + systemReserved) cannot be more than the Node's allocatable memory"))
 				})
 
-				It("should not allow creation of Shoot if sum of kubeReserved and systemReserved Memory is more than allocatable Memory", func() {
+				It("should not allow creation of Shoot if sum of kubeReserved and systemReserved memory is more than allocatable memory", func() {
 					worker.Kubernetes.Kubelet.KubeReserved.Memory = &resourceMemory2
 					worker.Kubernetes.Kubelet.SystemReserved.Memory = &resourceMemory2
 
@@ -1848,7 +1848,7 @@ var _ = Describe("validator", func() {
 					Expect(err.Error()).To(ContainSubstring("total reserved CPU (kubeReserved + systemReserved) cannot be more than the Node's allocatable CPU"))
 				})
 
-				It("should not allow update of Shoot if reserved memory is more than allocatable Memory", func() {
+				It("should not allow update of Shoot if reserved memory is more than allocatable memory", func() {
 					oldShoot := shoot.DeepCopy()
 					worker.Kubernetes.Kubelet.KubeReserved.Memory = &resourceMemory2
 					worker.Kubernetes.Kubelet.SystemReserved.Memory = &resourceMemory2

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -1628,7 +1628,7 @@ var _ = Describe("validator", func() {
 					Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 				})
 
-				It("should allow creation of Shoot if reserved resources are less than allocatable resources", func() {
+				It("should allow creation of Shoot if reserved resources are less than resource capacity", func() {
 					shoot.Spec.Provider.Workers = append(shoot.Spec.Provider.Workers, worker)
 
 					attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
@@ -1649,7 +1649,7 @@ var _ = Describe("validator", func() {
 					Expect(err).ToNot(HaveOccurred())
 				})
 
-				It("should not allow creation of Shoot if reserved CPU in the global kubeletConfig is more than allocatable CPU and worker kubeletConfig is nil", func() {
+				It("should not allow creation of Shoot if reserved CPU in the global kubeletConfig is more than CPU capacity and worker kubeletConfig is nil", func() {
 					kubeletConfig.KubeReserved.CPU = &resourceCPU2
 					kubeletConfig.SystemReserved.CPU = &resourceCPU2
 					shoot.Spec.Kubernetes.Kubelet = kubeletConfig
@@ -1662,10 +1662,10 @@ var _ = Describe("validator", func() {
 					err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
 					Expect(err).To(BeForbiddenError())
-					Expect(err.Error()).To(ContainSubstring("total reserved CPU (kubeReserved + systemReserved) cannot be more than the Node's allocatable CPU"))
+					Expect(err.Error()).To(ContainSubstring("total reserved CPU (kubeReserved + systemReserved) cannot be more than the Node's CPU capacity"))
 				})
 
-				It("should allow creation of Shoot if reserved CPU in the global kubeletConfig is more than allocatable CPU but the worker kubeletConfig has lesser reserved CPU", func() {
+				It("should allow creation of Shoot if reserved CPU in the global kubeletConfig is more than CPU capacity but the worker kubeletConfig has lesser reserved CPU", func() {
 					kubeletConfig.KubeReserved.CPU = &resourceCPU2
 					kubeletConfig.SystemReserved.CPU = &resourceCPU2
 					shoot.Spec.Kubernetes.Kubelet = kubeletConfig
@@ -1679,7 +1679,7 @@ var _ = Describe("validator", func() {
 					Expect(err).ToNot(HaveOccurred())
 				})
 
-				It("should not allow creation of Shoot if reserved CPU in the global kubeletConfig is less than allocatable CPU but the worker kubeletConfig has more reserved CPU", func() {
+				It("should not allow creation of Shoot if reserved CPU in the global kubeletConfig is less than CPU capacity but the worker kubeletConfig has more reserved CPU", func() {
 					kubeletConfig.KubeReserved.CPU = &resourceCPU1
 					kubeletConfig.SystemReserved.CPU = &resourceCPU1
 					shoot.Spec.Kubernetes.Kubelet = kubeletConfig
@@ -1693,10 +1693,10 @@ var _ = Describe("validator", func() {
 					err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
 					Expect(err).To(BeForbiddenError())
-					Expect(err.Error()).To(ContainSubstring("total reserved CPU (kubeReserved + systemReserved) cannot be more than the Node's allocatable CPU"))
+					Expect(err.Error()).To(ContainSubstring("total reserved CPU (kubeReserved + systemReserved) cannot be more than the Node's CPU capacity"))
 				})
 
-				It("should not allow creation of Shoot if kubeReserved CPU is more than allocatable CPU", func() {
+				It("should not allow creation of Shoot if kubeReserved CPU is more than CPU capacity", func() {
 					resource := resourceCPU2
 					resource.Add(resourceCPU2)
 					worker.Kubernetes.Kubelet.SystemReserved = nil
@@ -1709,10 +1709,10 @@ var _ = Describe("validator", func() {
 					err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
 					Expect(err).To(BeForbiddenError())
-					Expect(err.Error()).To(ContainSubstring("total reserved CPU (kubeReserved + systemReserved) cannot be more than the Node's allocatable CPU"))
+					Expect(err.Error()).To(ContainSubstring("total reserved CPU (kubeReserved + systemReserved) cannot be more than the Node's CPU capacity"))
 				})
 
-				It("should not allow creation of Shoot if systemReserved CPU is more than allocatable CPU", func() {
+				It("should not allow creation of Shoot if systemReserved CPU is more than CPU capacity", func() {
 					resource := resourceCPU2
 					resource.Add(resourceCPU2)
 					worker.Kubernetes.Kubelet.KubeReserved = nil
@@ -1725,10 +1725,10 @@ var _ = Describe("validator", func() {
 					err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
 					Expect(err).To(BeForbiddenError())
-					Expect(err.Error()).To(ContainSubstring("total reserved CPU (kubeReserved + systemReserved) cannot be more than the Node's allocatable CPU"))
+					Expect(err.Error()).To(ContainSubstring("total reserved CPU (kubeReserved + systemReserved) cannot be more than the Node's CPU capacity"))
 				})
 
-				It("should not allow creation of Shoot if sum of kubeReserved and systemReserved CPU is more than allocatable CPU", func() {
+				It("should not allow creation of Shoot if sum of kubeReserved and systemReserved CPU is more than CPU capacity", func() {
 					worker.Kubernetes.Kubelet.KubeReserved.CPU = &resourceCPU2
 					worker.Kubernetes.Kubelet.SystemReserved.CPU = &resourceCPU2
 
@@ -1739,10 +1739,10 @@ var _ = Describe("validator", func() {
 					err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
 					Expect(err).To(BeForbiddenError())
-					Expect(err.Error()).To(ContainSubstring("total reserved CPU (kubeReserved + systemReserved) cannot be more than the Node's allocatable CPU"))
+					Expect(err.Error()).To(ContainSubstring("total reserved CPU (kubeReserved + systemReserved) cannot be more than the Node's CPU capacity"))
 				})
 
-				It("should not allow creation of Shoot if reserved memory in the global kubeletConfig is more than allocatable memory and worker kubeletConfig is nil", func() {
+				It("should not allow creation of Shoot if reserved memory in the global kubeletConfig is more than memory capacity and worker kubeletConfig is nil", func() {
 					kubeletConfig.KubeReserved.Memory = &resourceMemory2
 					kubeletConfig.SystemReserved.Memory = &resourceMemory2
 					shoot.Spec.Kubernetes.Kubelet = kubeletConfig
@@ -1755,10 +1755,10 @@ var _ = Describe("validator", func() {
 					err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
 					Expect(err).To(BeForbiddenError())
-					Expect(err.Error()).To(ContainSubstring("total reserved memory (kubeReserved + systemReserved) cannot be more than the Node's allocatable memory"))
+					Expect(err.Error()).To(ContainSubstring("total reserved memory (kubeReserved + systemReserved) cannot be more than the Node's memory capacity"))
 				})
 
-				It("should allow creation of Shoot if reserved memory in the global kubeletConfig is more than allocatable memory but the worker kubeletConfig have lesser reserved memory", func() {
+				It("should allow creation of Shoot if reserved memory in the global kubeletConfig is more than memory capacity but the worker kubeletConfig have lesser reserved memory", func() {
 					kubeletConfig.KubeReserved.Memory = &resourceMemory2
 					kubeletConfig.SystemReserved.Memory = &resourceMemory2
 					shoot.Spec.Kubernetes.Kubelet = kubeletConfig
@@ -1772,7 +1772,7 @@ var _ = Describe("validator", func() {
 					Expect(err).ToNot(HaveOccurred())
 				})
 
-				It("should not allow creation of Shoot if reserved memory in the global kubeletConfig is less than allocatable memory but the worker kubeletConfig has more reserved memory", func() {
+				It("should not allow creation of Shoot if reserved memory in the global kubeletConfig is less than memory capacity but the worker kubeletConfig has more reserved memory", func() {
 					kubeletConfig.KubeReserved.Memory = &resourceMemory1
 					kubeletConfig.SystemReserved.Memory = &resourceMemory1
 					shoot.Spec.Kubernetes.Kubelet = kubeletConfig
@@ -1786,10 +1786,10 @@ var _ = Describe("validator", func() {
 					err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
 					Expect(err).To(BeForbiddenError())
-					Expect(err.Error()).To(ContainSubstring("total reserved memory (kubeReserved + systemReserved) cannot be more than the Node's allocatable memory"))
+					Expect(err.Error()).To(ContainSubstring("total reserved memory (kubeReserved + systemReserved) cannot be more than the Node's memory capacity"))
 				})
 
-				It("should not allow creation of Shoot if kubeReserved memory is more than allocatable memory", func() {
+				It("should not allow creation of Shoot if kubeReserved memory is more than memory capacity", func() {
 					resource := resourceMemory2
 					resource.Add(resourceMemory2)
 					worker.Kubernetes.Kubelet.SystemReserved = nil
@@ -1802,10 +1802,10 @@ var _ = Describe("validator", func() {
 					err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
 					Expect(err).To(BeForbiddenError())
-					Expect(err.Error()).To(ContainSubstring("total reserved memory (kubeReserved + systemReserved) cannot be more than the Node's allocatable memory"))
+					Expect(err.Error()).To(ContainSubstring("total reserved memory (kubeReserved + systemReserved) cannot be more than the Node's memory capacity"))
 				})
 
-				It("should not allow creation of Shoot if systemReserved Memory is more than allocatable memory", func() {
+				It("should not allow creation of Shoot if systemReserved Memory is more than memory capacity", func() {
 					resource := resourceMemory2
 					resource.Add(resourceMemory2)
 					worker.Kubernetes.Kubelet.KubeReserved = nil
@@ -1818,10 +1818,10 @@ var _ = Describe("validator", func() {
 					err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
 					Expect(err).To(BeForbiddenError())
-					Expect(err.Error()).To(ContainSubstring("total reserved memory (kubeReserved + systemReserved) cannot be more than the Node's allocatable memory"))
+					Expect(err.Error()).To(ContainSubstring("total reserved memory (kubeReserved + systemReserved) cannot be more than the Node's memory capacity"))
 				})
 
-				It("should not allow creation of Shoot if sum of kubeReserved and systemReserved memory is more than allocatable memory", func() {
+				It("should not allow creation of Shoot if sum of kubeReserved and systemReserved memory is more than memory capacity", func() {
 					worker.Kubernetes.Kubelet.KubeReserved.Memory = &resourceMemory2
 					worker.Kubernetes.Kubelet.SystemReserved.Memory = &resourceMemory2
 
@@ -1832,10 +1832,10 @@ var _ = Describe("validator", func() {
 					err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
 					Expect(err).To(BeForbiddenError())
-					Expect(err.Error()).To(ContainSubstring("total reserved memory (kubeReserved + systemReserved) cannot be more than the Node's allocatable memory"))
+					Expect(err.Error()).To(ContainSubstring("total reserved memory (kubeReserved + systemReserved) cannot be more than the Node's memory capacity"))
 				})
 
-				It("should not allow update of Shoot if reserved CPU is more than allocatable CPU", func() {
+				It("should not allow update of Shoot if reserved CPU is more than CPU capacity", func() {
 					oldShoot := shoot.DeepCopy()
 					worker.Kubernetes.Kubelet.KubeReserved.CPU = &resourceCPU2
 					worker.Kubernetes.Kubelet.SystemReserved.CPU = &resourceCPU2
@@ -1847,10 +1847,10 @@ var _ = Describe("validator", func() {
 					err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
 					Expect(err).To(BeForbiddenError())
-					Expect(err.Error()).To(ContainSubstring("total reserved CPU (kubeReserved + systemReserved) cannot be more than the Node's allocatable CPU"))
+					Expect(err.Error()).To(ContainSubstring("total reserved CPU (kubeReserved + systemReserved) cannot be more than the Node's CPU capacity"))
 				})
 
-				It("should not allow update of Shoot if reserved memory is more than allocatable memory", func() {
+				It("should not allow update of Shoot if reserved memory is more than memory capacity", func() {
 					oldShoot := shoot.DeepCopy()
 					worker.Kubernetes.Kubelet.KubeReserved.Memory = &resourceMemory2
 					worker.Kubernetes.Kubelet.SystemReserved.Memory = &resourceMemory2
@@ -1862,7 +1862,7 @@ var _ = Describe("validator", func() {
 					err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
 					Expect(err).To(BeForbiddenError())
-					Expect(err.Error()).To(ContainSubstring("total reserved memory (kubeReserved + systemReserved) cannot be more than the Node's allocatable memory"))
+					Expect(err.Error()).To(ContainSubstring("total reserved memory (kubeReserved + systemReserved) cannot be more than the Node's memory capacity"))
 				})
 			})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:

This PR introduces a validation for `kubeReserved` and `systemReserved` resources against the allocatable resources of a  machine. The sum of kubeReserved and systemReserved resources (CPU, memory) for a worker should be less than the allocatable resources for the same. These reserved fields in the shoot yaml are validated against the corresponding machine type in the cloudProfile. This validation is introduced for both creation of new shoots and updation of existing shoots.

For example, now creating a shoot  with the following kubeReserved and machine type that has only 8 CPU cores (for example m5.2xlarge):
``` 
     kubeReserved:
        cpu: 9400m
        memory: 4Gi
```
gives the error:
```
Error from server (Forbidden): error when creating "90-shoot.yaml": shoots.core.gardener.cloud "shoot-aws" is forbidden: [spec.provider.workers[0].kubernetes.kubelet: Invalid value: "kubeReserved CPU + systemReserved CPU: 9400m": total reserved CPU (kubeReserved+systemReserved) cannot be more than allocatable CPU:8]
```
**Which issue(s) this PR fixes**:
Fixes #6106 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
The kubeReserved and systemReserved specs of workers are now validated against the node allocatable resources of the corresponding machine type.
```
