### PR TITLE
Increase vpa stack memory limits

### DIFF
--- a/pkg/operation/botanist/component/vpa/admissioncontroller.go
+++ b/pkg/operation/botanist/component/vpa/admissioncontroller.go
@@ -207,7 +207,7 @@ func (v *vpa) reconcileAdmissionControllerDeployment(deployment *appsv1.Deployme
 							corev1.ResourceMemory: resource.MustParse("200Mi"),
 						},
 						Limits: corev1.ResourceList{
-							corev1.ResourceMemory: resource.MustParse("3Gi"),
+							corev1.ResourceMemory: resource.MustParse("55i"),
 						},
 					},
 					Ports: []corev1.ContainerPort{{

--- a/pkg/operation/botanist/component/vpa/admissioncontroller.go
+++ b/pkg/operation/botanist/component/vpa/admissioncontroller.go
@@ -207,7 +207,7 @@ func (v *vpa) reconcileAdmissionControllerDeployment(deployment *appsv1.Deployme
 							corev1.ResourceMemory: resource.MustParse("200Mi"),
 						},
 						Limits: corev1.ResourceList{
-							corev1.ResourceMemory: resource.MustParse("55i"),
+							corev1.ResourceMemory: resource.MustParse("5Gi"),
 						},
 					},
 					Ports: []corev1.ContainerPort{{

--- a/pkg/operation/botanist/component/vpa/recommender.go
+++ b/pkg/operation/botanist/component/vpa/recommender.go
@@ -184,7 +184,7 @@ func (v *vpa) reconcileRecommenderDeployment(deployment *appsv1.Deployment, serv
 							corev1.ResourceMemory: resource.MustParse("200Mi"),
 						},
 						Limits: corev1.ResourceList{
-							corev1.ResourceMemory: resource.MustParse("4Gi"),
+							corev1.ResourceMemory: resource.MustParse("6Gi"),
 						},
 					},
 				}},

--- a/pkg/operation/botanist/component/vpa/updater.go
+++ b/pkg/operation/botanist/component/vpa/updater.go
@@ -169,7 +169,7 @@ func (v *vpa) reconcileUpdaterDeployment(deployment *appsv1.Deployment, serviceA
 							corev1.ResourceMemory: resource.MustParse("200Mi"),
 						},
 						Limits: corev1.ResourceList{
-							corev1.ResourceMemory: resource.MustParse("4Gi"),
+							corev1.ResourceMemory: resource.MustParse("6Gi"),
 						},
 					},
 				}},

--- a/pkg/operation/botanist/component/vpa/vpa_test.go
+++ b/pkg/operation/botanist/component/vpa/vpa_test.go
@@ -505,7 +505,7 @@ var _ = Describe("VPA", func() {
 										corev1.ResourceMemory: resource.MustParse("200Mi"),
 									},
 									Limits: corev1.ResourceList{
-										corev1.ResourceMemory: resource.MustParse("4Gi"),
+										corev1.ResourceMemory: resource.MustParse("6Gi"),
 									},
 								},
 							}},
@@ -775,7 +775,7 @@ var _ = Describe("VPA", func() {
 										corev1.ResourceMemory: resource.MustParse("200Mi"),
 									},
 									Limits: corev1.ResourceList{
-										corev1.ResourceMemory: resource.MustParse("4Gi"),
+										corev1.ResourceMemory: resource.MustParse("6Gi"),
 									},
 								},
 							}},
@@ -1028,7 +1028,7 @@ var _ = Describe("VPA", func() {
 										corev1.ResourceMemory: resource.MustParse("200Mi"),
 									},
 									Limits: corev1.ResourceList{
-										corev1.ResourceMemory: resource.MustParse("3Gi"),
+										corev1.ResourceMemory: resource.MustParse("5Gi"),
 									},
 								},
 								Ports: []corev1.ContainerPort{{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement|

**What this PR does / why we need it**:

Increase memory limits for the vpa stack, because we saw certain shoots in production going over the limit.

cc: @voelzmo 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
VPA deployment memory limits have been increased. 
```
