### PR TITLE
Switch back the istiod PriorityClass name to `istiod`

### DIFF
--- a/pkg/operation/botanist/component/istio/istiod.go
+++ b/pkg/operation/botanist/component/istio/istiod.go
@@ -189,7 +189,7 @@ func (i *istiod) generateIstiodChart() (*chartrenderer.RenderedChart, error) {
 		"trustDomain":       i.values.TrustDomain,
 		"labels":            map[string]interface{}{"app": "istiod", "istio": "pilot"},
 		"deployNamespace":   false,
-		"priorityClassName": "istio",
+		"priorityClassName": "istiod",
 		"ports":             map[string]interface{}{"https": 10250},
 		"image":             i.values.Image,
 	})

--- a/pkg/operation/botanist/component/istio/istiod_test.go
+++ b/pkg/operation/botanist/component/istio/istiod_test.go
@@ -387,7 +387,7 @@ spec:
 apiVersion: scheduling.k8s.io/v1
 kind: PriorityClass
 metadata:
-  name: istio
+  name: istiod
 value: 1000000000
 globalDefault: false
 description: "This class is used to ensure that istiod has a high priority and is not preempted in favor of other pods."
@@ -801,7 +801,7 @@ spec:
       - name: config-volume
         configMap:
           name: istio
-      priorityClassName: istio
+      priorityClassName: istiod
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind cleanup

**What this PR does / why we need it**:
Before #5946 the istiod PriorityClass name was `istiod`. 

With #5946 it gets changed to `istio`:

```
$ k get priorityclasses.scheduling.k8s.io | grep istio
istio                                        1000000000   false            3d18h
istio-ingressgateway                         1000000000   false            88d
istiod                                       1000000000   false            88d
```

Let's switch back to the old PriorityClass name. 

Otherwise in my local setup the PriorityClass name change caused transient issues of type:
```
{"level":"error","msg":"seed is not yet ready: condition \"SeedSystemComponentsHealthy\" has invalid status False (expected True) due to DeploymentUnhealthy: Deployment \"istio-system/istiod\" is unhealthy: condition \"ReplicaFailure\" has invalid status True (expected False) due to FailedCreate: pods \"istiod-c45cc6957-\" is forbidden: no PriorityClass with name istio was found","operation":"reconcile","shoot":"garden-foo/bar","ts":"2022-06-27T12:21:11.232+0300"}
```

which get resolved on its own after some time.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
