### PR TITLE
Properly `Unwrap` errors from flow when construction `lastErrors`

### DIFF
--- a/pkg/apis/core/v1beta1/helper/errors.go
+++ b/pkg/apis/core/v1beta1/helper/errors.go
@@ -46,11 +46,6 @@ func (e *ErrorWithCodes) Codes() []gardencorev1beta1.ErrorCode {
 	return e.codes
 }
 
-// Unwrap rettieves the error from ErrorWithCodes.
-func (e *ErrorWithCodes) Unwrap() error {
-	return e.err
-}
-
 // Error returns the error message.
 func (e *ErrorWithCodes) Error() string {
 	return e.err.Error()

--- a/pkg/apis/core/v1beta1/helper/errors.go
+++ b/pkg/apis/core/v1beta1/helper/errors.go
@@ -46,6 +46,11 @@ func (e *ErrorWithCodes) Codes() []gardencorev1beta1.ErrorCode {
 	return e.codes
 }
 
+// Unwrap rettieves the error from ErrorWithCodes.
+func (e *ErrorWithCodes) Unwrap() error {
+	return e.err
+}
+
 // Error returns the error message.
 func (e *ErrorWithCodes) Error() string {
 	return e.err.Error()
@@ -226,7 +231,7 @@ func NewWrappedLastErrors(description string, err error) *WrappedLastErrors {
 		lastErrors = append(lastErrors, *LastErrorWithTaskID(
 			partError.Error(),
 			utilerrors.GetID(partError),
-			DeprecatedDetermineErrorCodes(utilerrors.Unwrap(partError))...))
+			DeprecatedDetermineErrorCodes(partError)...))
 	}
 
 	return &WrappedLastErrors{

--- a/pkg/utils/errors/errors.go
+++ b/pkg/utils/errors/errors.go
@@ -98,9 +98,13 @@ func (t *reconciliationError) ErrorID() string {
 	return t.errorID
 }
 
+func (t *reconciliationError) Unwrap() error {
+	return t.error
+}
+
 // Cause implements the causer interface and returns the underlying error
 func (t *reconciliationError) Cause() error {
-	return t.error
+	return t.Unwrap()
 }
 
 // GetID returns the ID of the error if possible.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
After #5625, the assignment of the `ERR_CLEANUP_CLUSTER_RESOURCES` error code is broken because now that `Unwrap` got implemented for this `struct`, https://github.com/gardener/gardener/blob/bdd5621e4e882be510d08ae01bc1f7774803efbb/pkg/apis/core/v1beta1/helper/errors.go#L227-L241 only provides the unwrapped error to the `DeprecatedDetermineErrorCodes` function. However, it should rather provide the `Coder` error so that the error codes can be extracted.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed which prevented the assignment of the `ERR_CLEANUP_CLUSTER_RESOURCES` error code to `Shoot`s.
```
