### PR TITLE
Change default value for --audit-log-path flag of gardener-apiserver …

### DIFF
--- a/charts/gardener/controlplane/values.yaml
+++ b/charts/gardener/controlplane/values.yaml
@@ -201,7 +201,7 @@ global:
         maxBackup: 5
         maxSize: 100
  #      mode: blocking
-        path: /tmp/audit/audit.log
+        path: /tmp/audit.log
  #      truncateEnabled: true
  #      truncateMaxBatchSize: 10485760
  #      truncateMaxEventSize: 102400


### PR DESCRIPTION
**How to categorize this PR?**
/area control-plane
/kind bug

**What this PR does / why we need it**:
Change default value for --audit-log-path flag of gardener-apiserver to /tmp/audit.log.

Follow up on #6184 as `k8s.io/apiserver` [expects](https://github.com/kubernetes/apiserver/blob/f9457a37879ffb63e06cceee54218aaa6cd0f6a0/pkg/server/options/audit.go#L529) the directory of the file to exist, but we cannot expect `/tmp/audit` to exist in any OCI image. I will try to reproduce and open an issue upstream for this.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
There is an option this issue to be fixed via the Dockerfile, but it is highly specific to the current default path. 

```dockerfile
RUN mkdir /tmp/audit
FROM gcr.io/distroless/static-debian11:nonroot AS test-distroless
COPY --from=builder --chown=nonroot:nonroot /tmp/audit /tmp/audit
```


@rfranzke please, remove the release notes from #6184 once this is merged.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The default value for `--audit-log-path` of Gardener API Server was changed from `/var/lib/audit.log` to `/tmp/audit.log` so that a `nonroot` user can access it without additional permissions.
```
