### PR TITLE
Allow spec changes on `shoots/binding` update strategy

### DIFF
--- a/pkg/registry/core/shoot/strategy.go
+++ b/pkg/registry/core/shoot/strategy.go
@@ -265,10 +265,7 @@ func (shootBindingStrategy) PrepareForUpdate(ctx context.Context, obj, old runti
 	newShoot := obj.(*core.Shoot)
 	oldShoot := old.(*core.Shoot)
 
-	seedName := newShoot.Spec.SeedName
-	newShoot.Spec = oldShoot.Spec
 	newShoot.Status = oldShoot.Status
-	newShoot.Spec.SeedName = seedName
 
 	if !apiequality.Semantic.DeepEqual(oldShoot.Spec, newShoot.Spec) {
 		newShoot.Generation = oldShoot.Generation + 1


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind bug

**What this PR does / why we need it**:
With #6179, in the `shoots/binding` strategy, we used to replace any spec changes to shoot with the oldSpec itself. This was to prevent updates to any other fields than `.spec.seedName`. But this caused the changes by the `ShootDNS` admission plugin to shoot spec to be reverted. Anyways, the binding subresource can only be updated by operators, so we can safely allow simultaneous spec changes. This PR removes this `newShoot.Spec=oldShoot.Spec` handling from binding strategy.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @plkokanov @rfranzke 
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
