### PR TITLE
[release-v1.48] Automated cherry pick of #6215: [release-v1.49] Only reset conditions when resource set changes

### DIFF
--- a/pkg/resourcemanager/controller/managedresource/reconciler.go
+++ b/pkg/resourcemanager/controller/managedresource/reconciler.go
@@ -276,7 +276,7 @@ func (r *reconciler) reconcile(ctx context.Context, mr *resourcesv1alpha1.Manage
 	sortObjectReferences(newResourcesObjectReferences)
 
 	// invalidate conditions, if resources have been added/removed from the managed resource
-	if len(mr.Status.Resources) == 0 || !apiequality.Semantic.DeepEqual(mr.Status.Resources, newResourcesObjectReferences) {
+	if !apiequality.Semantic.DeepEqual(mr.Status.Resources, newResourcesObjectReferences) {
 		conditionResourcesHealthy := v1beta1helper.GetOrInitCondition(mr.Status.Conditions, resourcesv1alpha1.ResourcesHealthy)
 		conditionResourcesHealthy = v1beta1helper.UpdatedCondition(conditionResourcesHealthy, gardencorev1beta1.ConditionUnknown,
 			resourcesv1alpha1.ConditionChecksPending, "The health checks have not yet been executed for the current set of resources.")
@@ -458,6 +458,9 @@ func (r *reconciler) applyNewResources(ctx context.Context, log logr.Logger, ori
 			ErrorFormat: errorutils.NewErrorFormatFuncWithPrefix("Could not apply all new resources"),
 		}
 	)
+=======
+	newResourcesObjects = sortByKind(newResourcesObjects)
+>>>>>>> Only reset conditions when resource set changes
 
 	// get all HPA and HVPA targetRefs to check if we should prevent overwriting replicas and/or resource requirements.
 	// VPAs don't have to be checked, as they don't update the spec directly and only mutate Pods via a MutatingWebhook


### PR DESCRIPTION
/kind/bug

Cherry pick of #6215 on release-v1.48.

#6215: [release-v1.49] Only reset conditions when resource set changes

**Release Notes:**
```other operator
NONE
```