### PR TITLE
Upgrade kube-state-metrics to 2.5.0

### DIFF
--- a/charts/gardener/provider-local/internal/machine-controller-manager/seed/mcm-monitoring-dashboard.json
+++ b/charts/gardener/provider-local/internal/machine-controller-manager/seed/mcm-monitoring-dashboard.json
@@ -150,14 +150,14 @@
           "refId": "A"
         },
         {
-          "expr": "sum(kube_pod_container_resource_limits_cpu_cores{pod=~\"machine-controller-manager-(.+)\"}) by (pod)",
+          "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\", unit=\"core\", pod=~\"machine-controller-manager-(.+)\"}) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Limits ({{pod}})",
           "refId": "C"
         },
         {
-          "expr": "sum(kube_pod_container_resource_requests_cpu_cores{pod=~\"machine-controller-manager-(.+)\"}) by (pod)",
+          "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\", pod=~\"machine-controller-manager-(.+)\"}) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Requests ({{pod}})",
@@ -250,14 +250,14 @@
           "refId": "A"
         },
         {
-          "expr": "sum(kube_pod_container_resource_limits_memory_bytes{pod=~\"machine-controller-manager-(.+)\"}) by (pod)",
+          "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\", unit=\"byte\", pod=~\"machine-controller-manager-(.+)\"}) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Limits ({{pod}})",
           "refId": "B"
         },
         {
-          "expr": "sum(kube_pod_container_resource_requests_memory_bytes{pod=~\"machine-controller-manager-(.+)\"}) by (pod)",
+          "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\", pod=~\"machine-controller-manager-(.+)\"}) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Requests ({{pod}})",

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -112,7 +112,13 @@ images:
 - name: kube-state-metrics
   sourceRepository: github.com/kubernetes/kube-state-metrics
   repository: registry.k8s.io/kube-state-metrics/kube-state-metrics
-  tag: "v2.5.0"
+  tag: v2.1.1
+  targetVersion: "< 1.20"
+- name: kube-state-metrics
+  sourceRepository: github.com/kubernetes/kube-state-metrics
+  repository: registry.k8s.io/kube-state-metrics/kube-state-metrics
+  tag: v2.5.0
+  targetVersion: ">= 1.20"
 - name: node-exporter
   sourceRepository: github.com/prometheus/node_exporter
   repository: quay.io/prometheus/node-exporter

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -111,8 +111,8 @@ images:
   tag: v0.56.2
 - name: kube-state-metrics
   sourceRepository: github.com/kubernetes/kube-state-metrics
-  repository: quay.io/coreos/kube-state-metrics
-  tag: v1.9.7
+  repository: registry.k8s.io/kube-state-metrics/kube-state-metrics
+  tag: "v2.5.0"
 - name: node-exporter
   sourceRepository: github.com/prometheus/node_exporter
   repository: quay.io/prometheus/node-exporter

--- a/charts/seed-bootstrap/charts/kube-state-metrics/templates/deployment.yaml
+++ b/charts/seed-bootstrap/charts/kube-state-metrics/templates/deployment.yaml
@@ -33,11 +33,10 @@ spec:
       - name: kube-state-metrics
         image: {{ index .Values.global.images "kube-state-metrics" }}
         imagePullPolicy: IfNotPresent
-        command:
-        - /kube-state-metrics
+        args:
         - --port=8080
         - --telemetry-port=8081
-        - --collectors=deployments,pods,statefulsets,nodes,horizontalpodautoscalers,persistentvolumeclaims,replicasets
+        - --resources=deployments,pods,statefulsets,nodes,horizontalpodautoscalers,persistentvolumeclaims,replicasets
         ports:
         - name: metrics
           containerPort: 8080

--- a/charts/seed-bootstrap/prometheus-rules/recording-rules.rules.yaml
+++ b/charts/seed-bootstrap/prometheus-rules/recording-rules.rules.yaml
@@ -21,17 +21,17 @@ groups:
 
   # Recording rules for the sum of the requests per container
   - record: seed:kube_pod_container_resource_requests_cpu_cores:sum_by_container
-    expr: sum(kube_pod_container_resource_requests_cpu_cores) by (container)
+    expr: sum(kube_pod_container_resource_requests{resource="cpu", unit="core"}) by (container)
 
   - record: seed:kube_pod_container_resource_requests_memory_bytes:sum_by_container
-    expr: sum(kube_pod_container_resource_requests_memory_bytes) by (container)
+    expr: sum(kube_pod_container_resource_requests{resource="memory", unit="byte"}) by (container)
 
   # Recording rules for the sum of the limits per container
   - record: seed:kube_pod_container_resource_limits_cpu_cores:sum_by_container
-    expr: sum(kube_pod_container_resource_limits_cpu_cores) by (container)
+    expr: sum(kube_pod_container_resource_limits{resource="cpu", unit="core"}) by (container)
 
   - record: seed:kube_pod_container_resource_limits_memory_bytes:sum_by_container
-    expr: sum(kube_pod_container_resource_limits_memory_bytes) by (container)
+    expr: sum(kube_pod_container_resource_limits{resource="memory", unit="byte"}) by (container)
 
   # Recording rules for the sum of vpa recommendations per container
   - record: seed:vpa_status_recommendation_target:sum_by_container
@@ -56,12 +56,12 @@ groups:
   # Recording rules for the count of containers which have CPU usage below 80% of their limits, aggregated by containers.
   # How many shoots and components are not at risk of being affected (CPU-throttled or OOMKilled) if scaling (horizontally or vertically) is blocked due to any reason (bug, deliberate or wrong configuration).
   - record: seed:containers_below_cpu_limiting_threshold_total:count_by_container
-    expr: count(max(rate(container_cpu_usage_seconds_total[5m])) by (container, namespace) / max(kube_pod_container_resource_limits_cpu_cores) by (container, namespace) < 0.8) by (container)
+    expr: count(max(rate(container_cpu_usage_seconds_total[5m])) by (container, namespace) / max(kube_pod_container_resource_limits{resource="cpu", unit="core"}) by (container, namespace) < 0.8) by (container)
 
   # Recording rules for the count of containers which have memory usage below 80% of their limits, aggregated by containers.
   # How many shoots and components are not at risk of being affected (CPU-throttled or OOMKilled) if scaling (horizontally or vertically) is blocked due to any reason (bug, deliberate or wrong configuration).
   - record: seed:containers_below_memory_limiting_threshold_total:count_by_container
-    expr: count(max(container_memory_working_set_bytes) by (container, namespace) / max(kube_pod_container_resource_limits_memory_bytes) by (container, namespace) < 0.8) by (container)
+    expr: count(max(container_memory_working_set_bytes) by (container, namespace) / max(kube_pod_container_resource_limits{resource="memory", unit="byte"}) by (container, namespace) < 0.8) by (container)
 
   # Recording rules for the count of containers which have CPU usage below 100% of their VPA recommendations, aggregated by containers.
   # How many shoots and components are not affected by the observed case where VPA was not recommending higher values even when usage was consistently above the present VPA recommendation.
@@ -76,12 +76,12 @@ groups:
   # Recording rules for the count of containers which have CPU usage at or above 80% of their limits, aggregated by containers.
   # How many shoots and components are at risk of being affected (CPU-throttled or OOMKilled) if scaling (horizontally or vertically) is blocked due to any reason (bug, deliberate or wrong configuration).
   - record: seed:containers_over_cpu_limiting_threshold_total:count_by_container
-    expr: count(max(rate(container_cpu_usage_seconds_total[5m])) by (container, namespace) / max(kube_pod_container_resource_limits_cpu_cores) by (container, namespace) >= 0.8) by (container)
+    expr: count(max(rate(container_cpu_usage_seconds_total[5m])) by (container, namespace) / max(kube_pod_container_resource_limits{resource="cpu", unit="core"}) by (container, namespace) >= 0.8) by (container)
 
   # Recording rules for the count of containers which have memory usage at or above 80% of their limits, aggregated by containers.
   # How many shoots and components are at risk of being affected (CPU-throttled or OOMKilled) if scaling (horizontally or vertically) is blocked due to any reason (bug, deliberate or wrong configuration).
   - record: seed:containers_over_memory_limiting_threshold_total:count_by_container
-    expr: count(max(container_memory_working_set_bytes) by (container, namespace) / max(kube_pod_container_resource_limits_memory_bytes) by (container, namespace) >= 0.8) by (container)
+    expr: count(max(container_memory_working_set_bytes) by (container, namespace) / max(kube_pod_container_resource_limits{resource="memory", unit="byte"}) by (container, namespace) >= 0.8) by (container)
 
   # Recording rules for the count of containers which have CPU usage at or above 100% of their VPA recommendations, aggregated by containers.
   # How many shoots and components are affected by the observed case where VPA was not recommending higher values even when usage was consistently above the present VPA recommendation.
@@ -96,42 +96,42 @@ groups:
   # Recording rules for the count of containers which have CPU requests below 100% of their VPA recommendations, aggregated by containers.
   # How many shoots and components are adversely affected by any delay in scaling up (due to bugs or deliberate/wrong configuration of HPA, VPA, HVPA).
   - record: seed:containers_cpu_scale_up_pending_total:count_by_container
-    expr: count(max(kube_pod_container_resource_requests_cpu_cores) by (container, namespace) / max(vpa_status_recommendation{recommendation="target", resource="cpu"}) by (container, namespace) < 1) by (container)
+    expr: count(max(kube_pod_container_resource_requests{resource="cpu", unit="core"}) by (container, namespace) / max(vpa_status_recommendation{recommendation="target", resource="cpu"}) by (container, namespace) < 1) by (container)
 
   # Recording rules for the count of containers which have memory requests below 100% of their VPA recommendations, aggregated by containers.
   # How many shoots and components are adversely affected by any delay in scaling up (due to bugs or deliberate/wrong configuration of HPA, VPA, HVPA).
   - record: seed:containers_memory_scale_up_pending_total:count_by_container
-    expr: count(max(kube_pod_container_resource_requests_memory_bytes) by (container, namespace) / max(vpa_status_recommendation{recommendation="target", resource="memory"}) by (container, namespace) < 1) by (container)
+    expr: count(max(kube_pod_container_resource_requests{resource="memory", unit="byte"}) by (container, namespace) / max(vpa_status_recommendation{recommendation="target", resource="memory"}) by (container, namespace) < 1) by (container)
 
   # Recording rules for the count of containers which have CPU requests above 100% of their VPA recommendations, aggregated by containers.
   # How many shoots and components are costing extra resources by any delay in scaling down (due to bugs or deliberate/wrong configuration of HPA, VPA, HVPA).
   - record: seed:containers_cpu_scale_down_pending_total:count_by_container
-    expr: count(max(kube_pod_container_resource_requests_cpu_cores) by (container, namespace) / max(vpa_status_recommendation{recommendation="target", resource="cpu"}) by (container, namespace) > 1) by (container)
+    expr: count(max(kube_pod_container_resource_requests{resource="cpu", unit="core"}) by (container, namespace) / max(vpa_status_recommendation{recommendation="target", resource="cpu"}) by (container, namespace) > 1) by (container)
 
   # Recording rules for the count of containers which have memory requests at or above 100% of their VPA recommendations, aggregated by containers.
   # How many shoots and components are costing extra resources by any delay in scaling down (due to bugs or deliberate/wrong configuration of HPA, VPA, HVPA).
   - record: seed:containers_memory_scale_down_pending_total:count_by_container
-    expr: count(max(kube_pod_container_resource_requests_memory_bytes) by (container, namespace) / max(vpa_status_recommendation{recommendation="target", resource="memory"}) by (container, namespace) > 1) by (container)
+    expr: count(max(kube_pod_container_resource_requests{resource="memory", unit="byte"}) by (container, namespace) / max(vpa_status_recommendation{recommendation="target", resource="memory"}) by (container, namespace) > 1) by (container)
 
   # Recording rules for the count of containers which have CPU requests below 60% of their VPA maxAllowed configuration, aggregated by containers.
   # How many shoots are below 60% of the configured maxAllowed VPA recommendations.
   - record: seed:containers_below_cpu_max_allowed_threshold_total:count_by_container
-    expr: count(max(kube_pod_container_resource_requests_cpu_cores) by (container, namespace) / max(vpa_spec_container_resource_policy_allowed{allowed="max", resource="cpu"}) by (container, namespace) < 0.6) by (container)
+    expr: count(max(kube_pod_container_resource_requests{resource="cpu", unit="core"}) by (container, namespace) / max(vpa_spec_container_resource_policy_allowed{allowed="max", resource="cpu"}) by (container, namespace) < 0.6) by (container)
 
   # Recording rules for the count of containers which have memory requests below 60% of their VPA maxAllowed configuration, aggregated by containers.
   # How many shoots are below 60% of the configured maxAllowed VPA recommendations.
   - record: seed:containers_below_memory_max_allowed_threshold_total:count_by_container
-    expr: count(max(kube_pod_container_resource_requests_memory_bytes) by (container, namespace) / max(vpa_spec_container_resource_policy_allowed{allowed="max", resource="memory"}) by (container, namespace) < 0.6) by (container)
+    expr: count(max(kube_pod_container_resource_requests{resource="memory", unit="byte"}) by (container, namespace) / max(vpa_spec_container_resource_policy_allowed{allowed="max", resource="memory"}) by (container, namespace) < 0.6) by (container)
 
   # Recording rules for the count of containers which have CPU requests at or above 60% of their VPA maxAllowed configuration, aggregated by containers.
   # How many shoots are above 60% of the configured maxAllowed VPA recommendations. We need to know early if our end-users start getting close to the limits of the scale of the cluster that we have tested the performance so far.
   - record: seed:containers_over_cpu_max_allowed_threshold_total:count_by_container
-    expr: count(max(kube_pod_container_resource_requests_cpu_cores) by (container, namespace) / max(vpa_spec_container_resource_policy_allowed{allowed="max", resource="cpu"}) by (container, namespace) >= 0.6) by (container)
+    expr: count(max(kube_pod_container_resource_requests{resource="cpu", unit="core"}) by (container, namespace) / max(vpa_spec_container_resource_policy_allowed{allowed="max", resource="cpu"}) by (container, namespace) >= 0.6) by (container)
 
   # Recording rules for the count of containers which have memory requests at or above 60% of their VPA maxAllowed configuration, aggregated by containers.
   # How many shoots are above 60% of the configured maxAllowed VPA recommendations. We need to know early if our end-users start getting close to the limits of the scale of the cluster that we have tested the performance so far.
   - record: seed:containers_over_memory_max_allowed_threshold_total:count_by_container
-    expr: count(max(kube_pod_container_resource_requests_memory_bytes) by (container, namespace) / max(vpa_spec_container_resource_policy_allowed{allowed="max", resource="memory"}) by (container, namespace) >= 0.6) by (container)
+    expr: count(max(kube_pod_container_resource_requests{resource="memory", unit="byte"}) by (container, namespace) / max(vpa_spec_container_resource_policy_allowed{allowed="max", resource="memory"}) by (container, namespace) >= 0.6) by (container)
 
   # Recording rules for the minimum CPU usage aggregated by container
   # 1. How far down can we configure VPA minAllowed for the different components. We have some components that can be scaled down further.
@@ -149,25 +149,25 @@ groups:
   # 1. How far down can we configure VPA minAllowed for the different components. We have some components that can be scaled down further.
   # 2. Get insight into grouping components once multiple (probably dedicated) worker-pools are introduced in seed clusters.
   - record: seed:kube_pod_container_resource_requests_cpu_cores:min_by_container
-    expr: min(kube_pod_container_resource_requests_cpu_cores) by (container)
+    expr: min(kube_pod_container_resource_requests{resource="cpu", unit="core"}) by (container)
 
   # Recording rules for the minimum memory requests aggregated by container
   # 1. How far down can we configure VPA minAllowed for the different components. We have some components that can be scaled down further.
   # 2. Get insight into grouping components once multiple (probably dedicated) worker-pools are introduced in seed clusters.
   - record: seed:kube_pod_container_resource_requests_memory_bytes:min_by_container
-    expr: min(kube_pod_container_resource_requests_memory_bytes) by (container)
+    expr: min(kube_pod_container_resource_requests{resource="memory", unit="byte"}) by (container)
 
   # Recording rules for the minimum CPU limits aggregated by container
   # 1. How far down can we configure VPA minAllowed for the different components. We have some components that can be scaled down further.
   # 2. Get insight into grouping components once multiple (probably dedicated) worker-pools are introduced in seed clusters.
   - record: seed:kube_pod_container_resource_limits_cpu_cores:min_by_container
-    expr: min(kube_pod_container_resource_limits_cpu_cores) by (container)
+    expr: min(kube_pod_container_resource_limits{resource="cpu", unit="core"}) by (container)
 
   # Recording rules for the minimum memory limits aggregated by container
   # 1. How far down can we configure VPA minAllowed for the different components. We have some components that can be scaled down further.
   # 2. Get insight into grouping components once multiple (probably dedicated) worker-pools are introduced in seed clusters.
   - record: seed:kube_pod_container_resource_limits_memory_bytes:min_by_container
-    expr: min(kube_pod_container_resource_limits_memory_bytes) by (container)
+    expr: min(kube_pod_container_resource_limits{resource="memory", unit="byte"}) by (container)
 
   # Recording rules for the minimum VPA recommendations aggregated by container and resource
   # 1. How far down can we configure VPA minAllowed for the different components. We have some components that can be scaled down further.
@@ -191,25 +191,25 @@ groups:
   # 1. How far down can we configure VPA maxAllowed for the different components. We have some components (especially, the non-shoot workload) that need to be scaled up more.
   # 2. Get insight into grouping components once multiple (probably dedicated) worker-pools are introduced in seed clusters.
   - record: seed:kube_pod_container_resource_requests_cpu_cores:max_by_container
-    expr: max(kube_pod_container_resource_requests_cpu_cores) by (container)
+    expr: max(kube_pod_container_resource_requests{resource="cpu", unit="core"}) by (container)
 
   # Recording rules for the maximum memory requests aggregated by container
   # 1. How far down can we configure VPA maxAllowed for the different components. We have some components (especially, the non-shoot workload) that need to be scaled up more.
   # 2. Get insight into grouping components once multiple (probably dedicated) worker-pools are introduced in seed clusters.
   - record: seed:kube_pod_container_resource_requests_memory_bytes:max_by_container
-    expr: max(kube_pod_container_resource_requests_memory_bytes) by (container)
+    expr: max(kube_pod_container_resource_requests{resource="memory", unit="byte"}) by (container)
 
   # Recording rules for the maximum CPU limits aggregated by container
   # 1. How far down can we configure VPA maxAllowed for the different components. We have some components (especially, the non-shoot workload) that need to be scaled up more.
   # 2. Get insight into grouping components once multiple (probably dedicated) worker-pools are introduced in seed clusters.
   - record: seed:kube_pod_container_resource_limits_cpu_cores:max_by_container
-    expr: max(kube_pod_container_resource_limits_cpu_cores) by (container)
+    expr: max(kube_pod_container_resource_limits{resource="cpu", unit="core"}) by (container)
 
   # Recording rules for the maximum memory limits aggregated by container
   # 1. How far down can we configure VPA maxAllowed for the different components. We have some components (especially, the non-shoot workload) that need to be scaled up more.
   # 2. Get insight into grouping components once multiple (probably dedicated) worker-pools are introduced in seed clusters.
   - record: seed:kube_pod_container_resource_limits_memory_bytes:max_by_container
-    expr: max(kube_pod_container_resource_limits_memory_bytes) by (container)
+    expr: max(kube_pod_container_resource_limits{resource="memory", unit="byte"}) by (container)
 
   # Recording rules for the maximum VPA recommendations aggregated by container and resource
   # 1. How far down can we configure VPA maxAllowed for the different components. We have some components (especially, the non-shoot workload) that need to be scaled up more.
@@ -274,17 +274,17 @@ groups:
 
   # Recording rules for the sum of the requests in the entire seed
   - record: seed:kube_pod_container_resource_requests_cpu_cores:sum
-    expr: sum(kube_pod_container_resource_requests_cpu_cores)
+    expr: sum(kube_pod_container_resource_requests{resource="cpu", unit="core"})
 
   - record: seed:kube_pod_container_resource_requests_memory_bytes:sum
-    expr: sum(kube_pod_container_resource_requests_memory_bytes)
+    expr: sum(kube_pod_container_resource_requests{resource="memory", unit="byte"})
 
   # Recording rules for the sum of the limits in the entire seed
   - record: seed:kube_pod_container_resource_limits_cpu_cores:sum
-    expr: sum(kube_pod_container_resource_limits_cpu_cores)
+    expr: sum(kube_pod_container_resource_limits{resource="cpu", unit="core"})
 
   - record: seed:kube_pod_container_resource_limits_memory_bytes:sum
-    expr: sum(kube_pod_container_resource_limits_memory_bytes)
+    expr: sum(kube_pod_container_resource_limits{resource="memory", unit="byte"})
 
   # Recording rules for the sum of vpa recommendations for the entire seed
   - record: seed:vpa_status_recommendation_target:sum

--- a/charts/seed-bootstrap/prometheus-rules/recording-rules.rules.yaml
+++ b/charts/seed-bootstrap/prometheus-rules/recording-rules.rules.yaml
@@ -45,13 +45,13 @@ groups:
   # 1. This helps evaluate if memory-based HPA should be re-introduced at 120%. And if it is re-opened what will be the impact on the avg number of replicas per active shoot in the seed clusters.
   # 2. This helps evaluate the benefit in reducing HPA scale down stabilization period (currently, 24h) to gain better resource utilization.
   - record: seed:apiserver_containers_over_cpu_scaling_threshold_total:count_by_container
-    expr: count(sum(rate(container_cpu_usage_seconds_total{container="kube-apiserver"}[5m])) by (namespace) / sum(kube_pod_container_resource_requests_cpu_cores{container="kube-apiserver"}) by (namespace) >= 0.8)
+    expr: count(sum(rate(container_cpu_usage_seconds_total{container="kube-apiserver"}[5m])) by (namespace) / sum(kube_pod_container_resource_requests{resource="cpu", unit="core", container="kube-apiserver"}) by (namespace) >= 0.8)
 
   # Recording rules for the count of apiserver containers which have memory usage at or above 120% of their request.
   # 1. This helps evaluate if memory-based HPA should be re-introduced at 120%. And if it is re-opened what will be the impact on the avg number of replicas per active shoot in the seed clusters.
   # 2. This helps evaluate the benefit in reducing HPA scale down stabilization period (currently, 24h) to gain better resource utilization.
   - record: seed:apiserver_containers_over_memory_scaling_threshold_total:count_by_container
-    expr: count(sum(container_memory_working_set_bytes{container="kube-apiserver"}) by (namespace) / sum(kube_pod_container_resource_requests_memory_bytes{container="kube-apiserver"}) by (namespace) >= 1.2)
+    expr: count(sum(container_memory_working_set_bytes{container="kube-apiserver"}) by (namespace) / sum(kube_pod_container_resource_requests{resource="memory", unit="byte", container="kube-apiserver"}) by (namespace) >= 1.2)
 
   # Recording rules for the count of containers which have CPU usage below 80% of their limits, aggregated by containers.
   # How many shoots and components are not at risk of being affected (CPU-throttled or OOMKilled) if scaling (horizontally or vertically) is blocked due to any reason (bug, deliberate or wrong configuration).
@@ -360,22 +360,22 @@ groups:
     expr: sum(node_memory_Active_bytes)
 
   - record: seed:kube_node_status_allocatable_cpu_cores:max
-    expr: max(kube_node_status_allocatable_cpu_cores)
+    expr: max(kube_node_status_allocatable{resource="cpu",unit="core"})
 
   - record: seed:kube_node_status_allocatable_cpu_cores:sum
-    expr: sum(kube_node_status_allocatable_cpu_cores)
+    expr: sum(kube_node_status_allocatable{resource="cpu",unit="core"})
 
   - record: seed:kube_node_status_allocatable_memory_bytes:max
-    expr: max(kube_node_status_allocatable_memory_bytes)
+    expr: max(kube_node_status_allocatable{resource="memory",unit="byte"})
 
   - record: seed:kube_node_status_allocatable_memory_bytes:sum
-    expr: sum(kube_node_status_allocatable_memory_bytes)
+    expr: sum(kube_node_status_allocatable{resource="memory",unit="byte"})
 
   - record: seed:kube_node_status_allocatable_pods:max
-    expr: max(kube_node_status_allocatable_pods)
+    expr: max(kube_node_status_allocatable{resource="pods",unit="integer"})
 
   - record: seed:kube_node_status_allocatable_pods:sum
-    expr: sum(kube_node_status_allocatable_pods)
+    expr: sum(kube_node_status_allocatable{resource="pods",unit="integer"})
 
   # TODO(wyb1): Replace the following two recording rules with shoot namespaces (gardener.cloud/role=shoot label) to
   # identify the number of all shoots in the entire seed, and <no. of pods> in such a shoot namespace for the number of
@@ -408,17 +408,17 @@ groups:
 
   # Recording rules for the sum of the requests for all the control planes
   - record: seed:kube_pod_container_resource_requests_cpu_cores:sum_cp
-    expr: sum(kube_pod_container_resource_requests_cpu_cores{namespace=~"((shoot-|shoot--)(\\w.+))"})
+    expr: sum(kube_pod_container_resource_requests{resource="cpu", unit="core", namespace=~"((shoot-|shoot--)(\\w.+))"})
 
   - record: seed:kube_pod_container_resource_requests_memory_bytes:sum_cp
-    expr: sum(kube_pod_container_resource_requests_memory_bytes{namespace=~"((shoot-|shoot--)(\\w.+))"})
+    expr: sum(kube_pod_container_resource_requests{resource="memory", unit="byte", namespace=~"((shoot-|shoot--)(\\w.+))"})
 
   # Recording rules for the sum of the limits for all the control planes
   - record: seed:kube_pod_container_resource_limits_cpu_cores:sum_cp
-    expr: sum(kube_pod_container_resource_limits_cpu_cores{namespace=~"((shoot-|shoot--)(\\w.+))"})
+    expr: sum(kube_pod_container_resource_limits{resource="cpu", unit="core", namespace=~"((shoot-|shoot--)(\\w.+))"})
 
   - record: seed:kube_pod_container_resource_limits_memory_bytes:sum_cp
-    expr: sum(kube_pod_container_resource_limits_memory_bytes{namespace=~"((shoot-|shoot--)(\\w.+))"})
+    expr: sum(kube_pod_container_resource_limits{resource="memory", unit="byte", namespace=~"((shoot-|shoot--)(\\w.+))"})
 
   # Recording rules for the sum of vpa recommendations for all the control-planes
   - record: seed:vpa_status_recommendation_target:sum

--- a/charts/seed-bootstrap/values.yaml
+++ b/charts/seed-bootstrap/values.yaml
@@ -148,7 +148,7 @@ allowedMetrics:
   - kube_daemonset_status_desired_number_scheduled
   - kube_daemonset_status_number_available
   - kube_daemonset_status_number_unavailable
-  - kube_daemonset_updated_number_scheduled
+  - kube_daemonset_status_updated_number_scheduled
   - kube_deployment_metadata_generation
   - kube_deployment_spec_replicas
   - kube_deployment_status_observed_generation
@@ -156,27 +156,21 @@ allowedMetrics:
   - kube_deployment_status_replicas_available
   - kube_deployment_status_replicas_unavailable
   - kube_deployment_status_replicas_updated
-  - kube_hpa_spec_max_replicas
-  - kube_hpa_spec_min_replicas
-  - kube_hpa_status_condition
-  - kube_hpa_status_current_replicas
-  - kube_hpa_status_desired_replicas
+  - kube_horizontalpodautoscaler_spec_max_replicas
+  - kube_horizontalpodautoscaler_spec_min_replicas
+  - kube_horizontalpodautoscaler_status_current_replicas
+  - kube_horizontalpodautoscaler_status_desired_replicas
+  - kube_horizontalpodautoscaler_status_condition
   - kube_node_info
   - kube_node_labels
   - kube_node_spec_unschedulable
-  - kube_node_status_allocatable_cpu_cores
-  - kube_node_status_allocatable_memory_bytes
-  - kube_node_status_allocatable_pods
-  - kube_node_status_capacity_cpu_cores
-  - kube_node_status_capacity_memory_bytes
-  - kube_node_status_capacity_pods
+  - kube_node_status_allocatable
+  - kube_node_status_capacity
   - kube_node_status_condition
   - kube_persistentvolumeclaim_resource_requests_storage_bytes
   - kube_pod_container_info
-  - kube_pod_container_resource_limits_cpu_cores
-  - kube_pod_container_resource_limits_memory_bytes
-  - kube_pod_container_resource_requests_cpu_cores
-  - kube_pod_container_resource_requests_memory_bytes
+  - kube_pod_container_resource_limits
+  - kube_pod_container_resource_requests
   - kube_pod_container_status_restarts_total
   - kube_pod_info
   - kube_pod_labels

--- a/charts/seed-bootstrap/values.yaml
+++ b/charts/seed-bootstrap/values.yaml
@@ -143,7 +143,6 @@ allowedMetrics:
   - process_open_fds
 
   kubeStateMetrics:
-  - kube_persistentvolumeclaim_resource_requests_storage_bytes
   - kube_daemonset_metadata_generation
   - kube_daemonset_status_current_number_scheduled
   - kube_daemonset_status_desired_number_scheduled
@@ -157,6 +156,11 @@ allowedMetrics:
   - kube_deployment_status_replicas_available
   - kube_deployment_status_replicas_unavailable
   - kube_deployment_status_replicas_updated
+  - kube_hpa_spec_max_replicas
+  - kube_hpa_spec_min_replicas
+  - kube_hpa_status_condition
+  - kube_hpa_status_current_replicas
+  - kube_hpa_status_desired_replicas
   - kube_node_info
   - kube_node_labels
   - kube_node_spec_unschedulable
@@ -167,6 +171,7 @@ allowedMetrics:
   - kube_node_status_capacity_memory_bytes
   - kube_node_status_capacity_pods
   - kube_node_status_condition
+  - kube_persistentvolumeclaim_resource_requests_storage_bytes
   - kube_pod_container_info
   - kube_pod_container_resource_limits_cpu_cores
   - kube_pod_container_resource_limits_memory_bytes
@@ -184,11 +189,6 @@ allowedMetrics:
   - kube_statefulset_status_replicas_current
   - kube_statefulset_status_replicas_ready
   - kube_statefulset_status_replicas_updated
-  - kube_hpa_spec_max_replicas
-  - kube_hpa_spec_min_replicas
-  - kube_hpa_status_condition
-  - kube_hpa_status_current_replicas
-  - kube_hpa_status_desired_replicas
 
   fluentbit:
   - fluentbit_input_bytes_total

--- a/charts/seed-monitoring/charts/core/charts/kube-state-metrics-shoot/templates/deployment.yaml
+++ b/charts/seed-monitoring/charts/core/charts/kube-state-metrics-shoot/templates/deployment.yaml
@@ -33,13 +33,12 @@ spec:
       - name: kube-state-metrics
         image: {{ index .Values.images "kube-state-metrics" }}
         imagePullPolicy: IfNotPresent
-        command:
-        - /kube-state-metrics
+        args:
         - --port=8080
         - --telemetry-port=8081
         - --kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig
-        - --namespace=kube-system
-        - --collectors=daemonsets,deployments,nodes,pods,statefulsets,verticalpodautoscalers,replicasets
+        - --namespaces=kube-system
+        - --resources=daemonsets,deployments,nodes,pods,statefulsets,verticalpodautoscalers,replicasets
         volumeMounts:
         - name: kubeconfig
           mountPath: /var/run/secrets/gardener.cloud/shoot/generic-kubeconfig

--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-state-metrics.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-state-metrics.rules.yaml
@@ -37,10 +37,10 @@ groups:
       summary: No nodes available. Possibly all workloads down.
 
   - record: shoot:kube_node_status_capacity_cpu_cores:sum
-    expr: sum(kube_node_status_capacity_cpu_cores)
+    expr: sum(kube_node_status_capacity{resource="cpu",unit="core"})
 
   - record: shoot:kube_node_status_capacity_memory_bytes:sum
-    expr: sum(kube_node_status_capacity_memory_bytes)
+    expr: sum(kube_node_status_capacity{resource="memory",unit="byte"})
 
   - record: shoot:machine_types:sum
     expr: sum(kube_node_labels) by (label_beta_kubernetes_io_instance_type)

--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-state-metrics.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/kube-state-metrics.rules.yaml
@@ -47,3 +47,17 @@ groups:
 
   - record: shoot:node_operating_system:sum
     expr: sum(kube_node_info) by (os_image, kernel_version)
+
+  # Mitigation for extension dashboards.
+  # TODO(istvanballok): Remove in a future version. For more details, see https://github.com/gardener/gardener/pull/6224.
+  - record: kube_pod_container_resource_limits_cpu_cores
+    expr: kube_pod_container_resource_limits{resource="cpu", unit="core"}
+
+  - record: kube_pod_container_resource_requests_cpu_cores
+    expr: kube_pod_container_resource_requests{resource="cpu", unit="core"}
+
+  - record: kube_pod_container_resource_limits_memory_bytes
+    expr: kube_pod_container_resource_limits{resource="memory", unit="byte"}
+
+  - record: kube_pod_container_resource_requests_memory_bytes
+    expr: kube_pod_container_resource_requests{resource="memory", unit="byte"}

--- a/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
@@ -66,7 +66,7 @@ allowedMetrics:
   - kube_daemonset_status_desired_number_scheduled
   - kube_daemonset_status_number_available
   - kube_daemonset_status_number_unavailable
-  - kube_daemonset_updated_number_scheduled
+  - kube_daemonset_status_updated_number_scheduled
   - kube_deployment_metadata_generation
   - kube_deployment_spec_replicas
   - kube_deployment_status_observed_generation
@@ -77,18 +77,12 @@ allowedMetrics:
   - kube_node_info
   - kube_node_labels
   - kube_node_spec_unschedulable
-  - kube_node_status_allocatable_cpu_cores
-  - kube_node_status_allocatable_memory_bytes
-  - kube_node_status_allocatable_pods
-  - kube_node_status_capacity_cpu_cores
-  - kube_node_status_capacity_memory_bytes
-  - kube_node_status_capacity_pods
+  - kube_node_status_allocatable
+  - kube_node_status_capacity
   - kube_node_status_condition
   - kube_pod_container_info
-  - kube_pod_container_resource_limits_cpu_cores
-  - kube_pod_container_resource_limits_memory_bytes
-  - kube_pod_container_resource_requests_cpu_cores
-  - kube_pod_container_resource_requests_memory_bytes
+  - kube_pod_container_resource_limits
+  - kube_pod_container_resource_requests
   - kube_pod_container_status_restarts_total
   - kube_pod_info
   - kube_pod_labels

--- a/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
@@ -74,12 +74,6 @@ allowedMetrics:
   - kube_deployment_status_replicas_available
   - kube_deployment_status_replicas_unavailable
   - kube_deployment_status_replicas_updated
-  - kube_replicaset_metadata_generation
-  - kube_replicaset_owner
-  - kube_replicaset_spec_replicas
-  - kube_replicaset_status_observed_generation
-  - kube_replicaset_status_replicas
-  - kube_replicaset_status_ready_replicas
   - kube_node_info
   - kube_node_labels
   - kube_node_spec_unschedulable
@@ -100,6 +94,12 @@ allowedMetrics:
   - kube_pod_labels
   - kube_pod_status_phase
   - kube_pod_status_ready
+  - kube_replicaset_metadata_generation
+  - kube_replicaset_owner
+  - kube_replicaset_spec_replicas
+  - kube_replicaset_status_observed_generation
+  - kube_replicaset_status_ready_replicas
+  - kube_replicaset_status_replicas
   - kube_statefulset_metadata_generation
   - kube_statefulset_replicas
   - kube_statefulset_status_observed_generation
@@ -107,10 +107,10 @@ allowedMetrics:
   - kube_statefulset_status_replicas_current
   - kube_statefulset_status_replicas_ready
   - kube_statefulset_status_replicas_updated
+  - kube_verticalpodautoscaler_spec_updatepolicy_updatemode
+  - kube_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound
   - kube_verticalpodautoscaler_status_recommendation_containerrecommendations_target
   - kube_verticalpodautoscaler_status_recommendation_containerrecommendations_upperbound
-  - kube_verticalpodautoscaler_status_recommendation_containerrecommendations_lowerbound
-  - kube_verticalpodautoscaler_spec_updatepolicy_updatemode
   machineControllerManager:
   - mcm_workqueue_adds_total
   - mcm_workqueue_depth

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-daemonsets-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-daemonsets-dashboard.json
@@ -577,7 +577,7 @@
           "step": 40
         },
         {
-          "expr": "min(kube_daemonset_updated_number_scheduled{daemonset=\"$daemonset_name\"}) without (instance, pod)",
+          "expr": "min(kube_daemonset_status_updated_number_scheduled{daemonset=\"$daemonset_name\"}) without (instance, pod)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "updated",

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-pods-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-pods-dashboard.json
@@ -174,7 +174,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(kube_pod_container_resource_requests_memory_bytes{pod=~\"$pod\", container=~\"$container\"}) by (pod)",
+          "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\", pod=~\"$pod\", container=~\"$container\"}) by (pod)",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -184,7 +184,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(kube_pod_container_resource_limits_memory_bytes{pod=~\"$pod\", container=~\"$container\"}) by (pod)",
+          "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\", unit=\"byte\", pod=~\"$pod\", container=~\"$container\"}) by (pod)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -311,7 +311,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(kube_pod_container_resource_requests_cpu_cores{container=~\"$container\",pod=~\"$pod\"}) by (pod)",
+          "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\", container=~\"$container\",pod=~\"$pod\"}) by (pod)",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -321,7 +321,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(kube_pod_container_resource_limits_cpu_cores{container=~\"$container\",pod=~\"$pod\"}) by (pod)",
+          "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\", unit=\"core\", container=~\"$container\",pod=~\"$pod\"}) by (pod)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/vpa-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/vpa-dashboard.json
@@ -176,14 +176,14 @@
           "refId": "A"
         },
         {
-          "expr": "sum(kube_pod_container_resource_requests_memory_bytes{pod=~\"$targetName(.+)\"})",
+          "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\", pod=~\"$targetName(.+)\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "requests",
           "refId": "B"
         },
         {
-          "expr": "sum(kube_pod_container_resource_limits_memory_bytes{pod=~\"$targetName(.+)\"})",
+          "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\", unit=\"byte\", pod=~\"$targetName(.+)\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "limits",
@@ -389,14 +389,14 @@
           "refId": "A"
         },
         {
-          "expr": "sum(kube_pod_container_resource_requests_cpu_cores{pod=~\"$targetName(.+)\"}) * 1000",
+          "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\", pod=~\"$targetName(.+)\"}) * 1000",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "requests",
           "refId": "B"
         },
         {
-          "expr": "sum(kube_pod_container_resource_limits_cpu_cores{pod=~\"$targetName(.+)\"})* 1000",
+          "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\", unit=\"core\", pod=~\"$targetName(.+)\"})* 1000",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "limits",

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/vpn-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/vpn-dashboard.json
@@ -283,7 +283,7 @@
           "step": 20
         },
         {
-          "expr": "sum(kube_pod_container_resource_requests_cpu_cores{pod=~\"vpn-shoot-.*\"})",
+          "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\", pod=~\"vpn-shoot-.*\"})",
           "format": "time_series",
           "hide": false,
           "interval": "10s",
@@ -292,7 +292,7 @@
           "refId": "B"
         },
         {
-          "expr": "sum(kube_pod_container_resource_limits_cpu_cores{pod=~\"vpn-shoot-.*\"})",
+          "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\", unit=\"core\", pod=~\"vpn-shoot-.*\"})",
           "format": "time_series",
           "interval": "10s",
           "intervalFactor": 2,
@@ -399,7 +399,7 @@
           "step": 10
         },
         {
-          "expr": "sum(kube_pod_container_resource_requests_memory_bytes{pod=~\"vpn-shoot-.*\"})",
+          "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\", pod=~\"vpn-shoot-.*\"})",
           "format": "time_series",
           "hide": false,
           "interval": "10s",
@@ -408,7 +408,7 @@
           "refId": "C"
         },
         {
-          "expr": "sum(kube_pod_container_resource_limits_memory_bytes{pod=~\"vpn-shoot-.*\"})",
+          "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\", unit=\"byte\", pod=~\"vpn-shoot-.*\"})",
           "format": "time_series",
           "interval": "10s",
           "intervalFactor": 2,
@@ -528,14 +528,14 @@
           "step": 20
         },
         {
-          "expr": "kube_pod_container_resource_requests_cpu_cores{pod=~\"kube-apiserver-.*|prometheus-.*\", container=\"vpn-seed\"}",
+          "expr": "kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\", pod=~\"kube-apiserver-.*|prometheus-.*\", container=\"vpn-seed\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Requests ({{pod}}/{{container}})",
           "refId": "B"
         },
         {
-          "expr": "kube_pod_container_resource_limits_cpu_cores{pod=~\"kube-apiserver-.*|prometheus-.*\", container=\"vpn-seed\"}",
+          "expr": "kube_pod_container_resource_limits{resource=\"cpu\", unit=\"core\", pod=~\"kube-apiserver-.*|prometheus-.*\", container=\"vpn-seed\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Limits ({{pod}}/{{container}})",
@@ -642,14 +642,14 @@
           "step": 10
         },
         {
-          "expr": "kube_pod_container_resource_requests_memory_bytes{pod=~\"kube-apiserver-.*|prometheus-.*\", container=\"vpn-seed\"}",
+          "expr": "kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\", pod=~\"kube-apiserver-.*|prometheus-.*\", container=\"vpn-seed\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Request ({{pod}}/{{container}})",
           "refId": "B"
         },
         {
-          "expr": "kube_pod_container_resource_limits_memory_bytes{pod=~\"kube-apiserver-.*|prometheus-.*\", container=\"vpn-seed\"}",
+          "expr": "kube_pod_container_resource_limits{resource=\"memory\", unit=\"byte\", pod=~\"kube-apiserver-.*|prometheus-.*\", container=\"vpn-seed\"}",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Limits ({{pod}}/{{container}})",

--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/controlplane-logs-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/controlplane-logs-dashboard.json
@@ -151,7 +151,7 @@
           },
           {
             "exemplar": true,
-            "expr": "sum(kube_pod_container_resource_limits_cpu_cores{pod=~\"$pod\"}) by (pod)",
+            "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\", unit=\"core\", pod=~\"$pod\"}) by (pod)",
             "format": "time_series",
             "interval": "",
             "intervalFactor": 1,
@@ -160,7 +160,7 @@
           },
           {
             "exemplar": true,
-            "expr": "sum(kube_pod_container_resource_requests_cpu_cores{pod=~\"$pod\"}) by (pod)",
+            "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\", pod=~\"$pod\"}) by (pod)",
             "format": "time_series",
             "interval": "",
             "intervalFactor": 1,
@@ -270,7 +270,7 @@
           },
           {
             "exemplar": true,
-            "expr": "sum(kube_pod_container_resource_limits_memory_bytes{pod=~\"$pod\"}) by (pod)",
+            "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\", unit=\"byte\", pod=~\"$pod\"}) by (pod)",
             "format": "time_series",
             "interval": "",
             "intervalFactor": 1,
@@ -279,7 +279,7 @@
           },
           {
             "exemplar": true,
-            "expr": "sum(kube_pod_container_resource_requests_memory_bytes{pod=~\"$pod\"}) by (pod)",
+            "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\", pod=~\"$pod\"}) by (pod)",
             "format": "time_series",
             "interval": "",
             "intervalFactor": 1,

--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/kubernetes-control-plane-status-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/kubernetes-control-plane-status-dashboard.json
@@ -666,14 +666,14 @@
           "refId": "A"
         },
         {
-          "expr": "sum(kube_pod_container_resource_limits_cpu_cores{pod=~\"kube-apiserver-(.+)\"}) by (pod)",
+          "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\", unit=\"core\", pod=~\"kube-apiserver-(.+)\"}) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{pod}}-limits",
           "refId": "C"
         },
         {
-          "expr": "sum(kube_pod_container_resource_requests_cpu_cores{pod=~\"kube-apiserver-(.+)\"}) by (pod)",
+          "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\", pod=~\"kube-apiserver-(.+)\"}) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{pod}}-requests",
@@ -777,14 +777,14 @@
           "refId": "A"
         },
         {
-          "expr": "sum(kube_pod_container_resource_limits_memory_bytes{pod=~\"kube-apiserver-(.+)\"}) by (pod)",
+          "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\", unit=\"byte\", pod=~\"kube-apiserver-(.+)\"}) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{pod}}-limits",
           "refId": "B"
         },
         {
-          "expr": "sum(kube_pod_container_resource_requests_memory_bytes{pod=~\"kube-apiserver-(.+)\"}) by (pod)",
+          "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\", pod=~\"kube-apiserver-(.+)\"}) by (pod)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{pod}}-requests",
@@ -1432,14 +1432,14 @@
               "refId": "A"
             },
             {
-              "expr": "kube_pod_container_resource_limits_cpu_cores{pod=~\"kube-controller-manager-(.+)\"}",
+              "expr": "kube_pod_container_resource_limits{resource=\"cpu\", unit=\"core\", pod=~\"kube-controller-manager-(.+)\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "limits",
               "refId": "C"
             },
             {
-              "expr": "kube_pod_container_resource_requests_cpu_cores{pod=~\"kube-controller-manager-(.+)\"}",
+              "expr": "kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\", pod=~\"kube-controller-manager-(.+)\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "requests",
@@ -1533,14 +1533,14 @@
               "refId": "A"
             },
             {
-              "expr": "kube_pod_container_resource_limits_memory_bytes{pod=~\"kube-controller-manager-(.+)\"}",
+              "expr": "kube_pod_container_resource_limits{resource=\"memory\", unit=\"byte\", pod=~\"kube-controller-manager-(.+)\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "limits",
               "refId": "B"
             },
             {
-              "expr": "kube_pod_container_resource_requests_memory_bytes{pod=~\"kube-controller-manager-(.+)\"}",
+              "expr": "kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\", pod=~\"kube-controller-manager-(.+)\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "requests",
@@ -1736,14 +1736,14 @@
               "refId": "A"
             },
             {
-              "expr": "kube_pod_container_resource_limits_cpu_cores{pod=~\"kube-scheduler-(.+)\"}",
+              "expr": "kube_pod_container_resource_limits{resource=\"cpu\", unit=\"core\", pod=~\"kube-scheduler-(.+)\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "limits",
               "refId": "C"
             },
             {
-              "expr": "kube_pod_container_resource_requests_cpu_cores{pod=~\"kube-scheduler-(.+)\"}",
+              "expr": "kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\", pod=~\"kube-scheduler-(.+)\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "requests",
@@ -1837,14 +1837,14 @@
               "refId": "A"
             },
             {
-              "expr": "kube_pod_container_resource_limits_memory_bytes{pod=~\"kube-scheduler-(.+)\"}",
+              "expr": "kube_pod_container_resource_limits{resource=\"memory\", unit=\"byte\", pod=~\"kube-scheduler-(.+)\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "limits",
               "refId": "B"
             },
             {
-              "expr": "kube_pod_container_resource_requests_memory_bytes{pod=~\"kube-scheduler-(.+)\"}",
+              "expr": "kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\", pod=~\"kube-scheduler-(.+)\"}",
               "format": "time_series",
               "intervalFactor": 1,
               "legendFormat": "requests",

--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/node-details-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/node-details-dashboard.json
@@ -110,7 +110,7 @@
       "pluginVersion": "7.5.16",
       "targets": [
         {
-          "expr": "sum(rate(node_cpu_seconds_total{mode!=\"idle\", node=~\"$Node\"}[$__rate_interval])) / sum(kube_node_status_capacity_cpu_cores{node=~\"$Node\"}) * 100",
+          "expr": "sum(rate(node_cpu_seconds_total{mode!=\"idle\", node=~\"$Node\"}[$__rate_interval])) / sum(kube_node_status_capacity{resource=\"cpu\", unit=\"core\", node=~\"$Node\"}) * 100",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -272,7 +272,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum(kube_node_status_allocatable_cpu_cores{node=~\"$Node\"})",
+          "expr": "sum(kube_node_status_allocatable{resource=\"cpu\", unit=\"core\", node=~\"$Node\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Allocatable",
@@ -280,7 +280,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(kube_node_status_capacity_cpu_cores{node=~\"$Node\"}) - sum(rate(node_cpu_seconds_total{mode!=\"idle\", node=~\"$Node\"}[$__rate_interval]))",
+          "expr": "sum(kube_node_status_capacity{resource=\"cpu\", unit=\"core\", node=~\"$Node\"}) - sum(rate(node_cpu_seconds_total{mode!=\"idle\", node=~\"$Node\"}[$__rate_interval]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -289,7 +289,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(kube_node_status_capacity_cpu_cores{node=~\"$Node\"})",
+          "expr": "sum(kube_node_status_capacity{resource=\"cpu\", unit=\"core\", node=~\"$Node\"})",
           "format": "time_series",
           "hide": false,
           "interval": "",
@@ -400,7 +400,7 @@
           "refId": "A"
         },
         {
-          "expr": "sum(kube_node_status_allocatable_memory_bytes{node=~\"$Node\"})",
+          "expr": "sum(kube_node_status_allocatable{resource=\"memory\", unit=\"byte\", node=~\"$Node\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "Allocatable",

--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/node-pool-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/node-pool-dashboard.json
@@ -561,14 +561,14 @@
           "refId": "B"
         },
         {
-          "expr": "sum(kube_node_status_allocatable_cpu_cores) by (node) + on (node) group_right sum(kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}) by (label_worker_gardener_cloud_pool, node) - 1",
+          "expr": "sum(kube_node_status_allocatable{resource=\"cpu\", unit=\"core\"}) by (node) + on (node) group_right sum(kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}) by (label_worker_gardener_cloud_pool, node) - 1",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
           "refId": "C"
         },
         {
-          "expr": "(sum(kube_node_status_allocatable_cpu_cores) by (node) - sum(rate(node_cpu_seconds_total{mode!=\"idle\"}[$__rate_interval])) by (node)) + on (node) group_right sum(kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}) by (label_worker_gardener_cloud_pool, node) - 1",
+          "expr": "(sum(kube_node_status_allocatable{resource=\"cpu\", unit=\"core\") by (node) - sum(rate(node_cpu_seconds_total{mode!=\"idle\"}[$__rate_interval])) by (node)) + on (node) group_right sum(kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}) by (label_worker_gardener_cloud_pool, node) - 1",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
@@ -583,14 +583,14 @@
           "refId": "E"
         },
         {
-          "expr": "sum(kube_node_status_allocatable_memory_bytes) by (node) + on (node) group_right sum(kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}) by (label_worker_gardener_cloud_pool, node) - 1",
+          "expr": "sum(kube_node_status_allocatable{resource=\"memory\", unit=\"byte\"}) by (node) + on (node) group_right sum(kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}) by (label_worker_gardener_cloud_pool, node) - 1",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
           "refId": "F"
         },
         {
-          "expr": "(sum(kube_node_status_allocatable_memory_bytes) by (node) - sum(node_memory_Active_bytes) by (node)) + on (node) group_right sum(kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}) by (label_worker_gardener_cloud_pool, node) - 1",
+          "expr": "(sum(kube_node_status_allocatable{resource=\"memory\", unit=\"byte\"}) by (node) - sum(node_memory_Active_bytes) by (node)) + on (node) group_right sum(kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}) by (label_worker_gardener_cloud_pool, node) - 1",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,

--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/shoot-vpa-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/shoot-vpa-dashboard.json
@@ -94,13 +94,13 @@
           "refId": "C"
         },
         {
-          "expr": "sum(kube_pod_container_resource_requests_memory_bytes{type=\"shoot\", container=~\"$container\"}) by (container)",
+          "expr": "sum(kube_pod_container_resource_requests{resource=\"memory\", unit=\"byte\", type=\"shoot\", container=~\"$container\"}) by (container)",
           "interval": "",
           "legendFormat": "{{ container }} requests",
           "refId": "A"
         },
         {
-          "expr": "sum(kube_pod_container_resource_limits_memory_bytes{type=\"shoot\", container=~\"$container\"}) by (container)",
+          "expr": "sum(kube_pod_container_resource_limits{resource=\"memory\", unit=\"byte\", type=\"shoot\", container=~\"$container\"}) by (container)",
           "interval": "",
           "legendFormat": "{{ container }} limits",
           "refId": "B"
@@ -215,13 +215,13 @@
           "refId": "C"
         },
         {
-          "expr": "sum(kube_pod_container_resource_requests_cpu_cores{type=\"shoot\", container=~\"$container\"}) by (container)",
+          "expr": "sum(kube_pod_container_resource_requests{resource=\"cpu\", unit=\"core\", type=\"shoot\", container=~\"$container\"}) by (container)",
           "interval": "",
           "legendFormat": "{{ container }} requests",
           "refId": "A"
         },
         {
-          "expr": "sum(kube_pod_container_resource_limits_cpu_cores{type=\"shoot\", container=~\"$container\"}) by (container)",
+          "expr": "sum(kube_pod_container_resource_limits{resource=\"cpu\", unit=\"core\", type=\"shoot\", container=~\"$container\"}) by (container)",
           "interval": "",
           "legendFormat": "{{ container }} limits",
           "refId": "B"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

Upgrade kube-state-metrics to 2.5.0

Motivation:

- compatibility with the kubernetes versions
  https://github.com/kubernetes/kube-state-metrics#compatibility-matrix

- Support for the ARM architecture
  The referenced image supports both amd64 and arm64

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/cc @timuthy 
/invite @wyb1

Consider reviewing the individual commits for simplicity.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The following images are updated:
- registry.k8s.io/kube-state-metrics/kube-state-metrics: v1.9.7 -> v2.1.1 (for kubernetes < 1.20)
- registry.k8s.io/kube-state-metrics/kube-state-metrics: v1.9.7 -> v2.5.0 (for kubernetes >= 1.20)
```
