### PR TITLE
Use existing API in `CentralLoggingConfig` for exposing logs to users

### DIFF
--- a/pkg/operation/botanist/component/clusterautoscaler/logging.go
+++ b/pkg/operation/botanist/component/clusterautoscaler/logging.go
@@ -39,5 +39,10 @@ const (
 
 // CentralLoggingConfiguration returns a fluent-bit parser and filter for the cluster-autoscaler logs.
 func CentralLoggingConfiguration() (component.CentralLoggingConfig, error) {
-	return component.CentralLoggingConfig{Filters: loggingFilter, Parsers: loggingParser, PodPrefix: v1beta1constants.DeploymentNameClusterAutoscaler, UserExposed: true}, nil
+	return component.CentralLoggingConfig{
+		Filters:     loggingFilter,
+		Parsers:     loggingParser,
+		UserExposed: true,
+		PodPrefixes: []string{v1beta1constants.DeploymentNameClusterAutoscaler},
+	}, nil
 }

--- a/pkg/operation/botanist/component/clusterautoscaler/logging_test.go
+++ b/pkg/operation/botanist/component/clusterautoscaler/logging_test.go
@@ -42,8 +42,8 @@ var _ = Describe("Logging", func() {
     Parser              clusterAutoscalerParser
     Reserve_Data        True
 `))
-			Expect(loggingConfig.PodPrefix).To(Equal("cluster-autoscaler"))
 			Expect(loggingConfig.UserExposed).To(BeTrue())
+			Expect(loggingConfig.PodPrefixes).To(ConsistOf("cluster-autoscaler"))
 		})
 	})
 })

--- a/pkg/operation/botanist/component/coredns/logging_test.go
+++ b/pkg/operation/botanist/component/coredns/logging_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Logging", func() {
     Parser              coreDNSParser2
     Reserve_Data        True
 `))
-			Expect(loggingConfig.PodPrefix).To(BeEmpty())
+			Expect(loggingConfig.PodPrefixes).To(BeEmpty())
 			Expect(loggingConfig.UserExposed).To(BeFalse())
 		})
 	})

--- a/pkg/operation/botanist/component/dependencywatchdog/logging_test.go
+++ b/pkg/operation/botanist/component/dependencywatchdog/logging_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Logging", func() {
     Parser              dependencyWatchdogParser
     Reserve_Data        True
 `))
-			Expect(loggingConfig.PodPrefix).To(BeEmpty())
+			Expect(loggingConfig.PodPrefixes).To(BeEmpty())
 			Expect(loggingConfig.UserExposed).To(BeFalse())
 
 		})

--- a/pkg/operation/botanist/component/etcd/logging_test.go
+++ b/pkg/operation/botanist/component/etcd/logging_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Logging", func() {
     Parser              backupRestoreParser
     Reserve_Data        True
 `))
-			Expect(loggingConfig.PodPrefix).To(BeEmpty())
+			Expect(loggingConfig.PodPrefixes).To(BeEmpty())
 			Expect(loggingConfig.UserExposed).To(BeFalse())
 		})
 	})

--- a/pkg/operation/botanist/component/hvpa/logging_test.go
+++ b/pkg/operation/botanist/component/hvpa/logging_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Logging", func() {
     Parser              hvpaParser
     Reserve_Data        True
 `))
-			Expect(loggingConfig.PodPrefix).To(BeEmpty())
+			Expect(loggingConfig.PodPrefixes).To(BeEmpty())
 			Expect(loggingConfig.UserExposed).To(BeFalse())
 		})
 	})

--- a/pkg/operation/botanist/component/kubeapiserver/logging.go
+++ b/pkg/operation/botanist/component/kubeapiserver/logging.go
@@ -77,7 +77,9 @@ const (
 // CentralLoggingConfiguration returns a fluent-bit parser and filter for the kube-apiserver logs.
 func CentralLoggingConfiguration() (component.CentralLoggingConfig, error) {
 	return component.CentralLoggingConfig{
-		Filters: fmt.Sprintf("%s\n%s\n%s\n%s", loggingFilterAPIServer, loggingFilterVPNSeed, loggingFilterAPIProxyMutator, loggingModifyFilterAPIProxyMutator),
-		Parsers: fmt.Sprintf("%s\n%s\n%s", loggingParserAPIServer, loggingParserVPNSeed, loggingParserAPIProxyMutator),
+		Filters:     fmt.Sprintf("%s\n%s\n%s\n%s", loggingFilterAPIServer, loggingFilterVPNSeed, loggingFilterAPIProxyMutator, loggingModifyFilterAPIProxyMutator),
+		Parsers:     fmt.Sprintf("%s\n%s\n%s", loggingParserAPIServer, loggingParserVPNSeed, loggingParserAPIProxyMutator),
+		UserExposed: true,
+		PodPrefixes: []string{v1beta1constants.DeploymentNameKubeAPIServer},
 	}, nil
 }

--- a/pkg/operation/botanist/component/kubeapiserver/logging_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/logging_test.go
@@ -73,8 +73,8 @@ var _ = Describe("Logging", func() {
     Match               kubernetes.*kube-apiserver*apiserver-proxy-pod-mutator*
     Copy                level    severity
 `))
-			Expect(loggingConfig.PodPrefix).To(BeEmpty())
-			Expect(loggingConfig.UserExposed).To(BeFalse())
+			Expect(loggingConfig.UserExposed).To(BeTrue())
+			Expect(loggingConfig.PodPrefixes).To(ConsistOf("kube-apiserver"))
 		})
 	})
 })

--- a/pkg/operation/botanist/component/kubecontrollermanager/logging.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/logging.go
@@ -39,5 +39,10 @@ const (
 
 // CentralLoggingConfiguration returns a fluent-bit parser and filter for the kube-controller-manager logs.
 func CentralLoggingConfiguration() (component.CentralLoggingConfig, error) {
-	return component.CentralLoggingConfig{Filters: loggingFilter, Parsers: loggingParser, PodPrefix: v1beta1constants.DeploymentNameKubeControllerManager, UserExposed: true}, nil
+	return component.CentralLoggingConfig{
+		Filters:     loggingFilter,
+		Parsers:     loggingParser,
+		UserExposed: true,
+		PodPrefixes: []string{v1beta1constants.DeploymentNameKubeControllerManager},
+	}, nil
 }

--- a/pkg/operation/botanist/component/kubecontrollermanager/logging_test.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/logging_test.go
@@ -42,8 +42,8 @@ var _ = Describe("Logging", func() {
     Parser              kubeControllerManagerParser
     Reserve_Data        True
 `))
-			Expect(loggingConfig.PodPrefix).To(Equal("kube-controller-manager"))
 			Expect(loggingConfig.UserExposed).To(BeTrue())
+			Expect(loggingConfig.PodPrefixes).To(ConsistOf("kube-controller-manager"))
 		})
 	})
 })

--- a/pkg/operation/botanist/component/kubeproxy/logging_test.go
+++ b/pkg/operation/botanist/component/kubeproxy/logging_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Logging", func() {
     Parser              kubeProxyParser
     Reserve_Data        True
 `))
-			Expect(loggingConfig.PodPrefix).To(BeEmpty())
+			Expect(loggingConfig.PodPrefixes).To(BeEmpty())
 			Expect(loggingConfig.UserExposed).To(BeFalse())
 		})
 	})

--- a/pkg/operation/botanist/component/kubescheduler/logging.go
+++ b/pkg/operation/botanist/component/kubescheduler/logging.go
@@ -39,5 +39,10 @@ const (
 
 // CentralLoggingConfiguration returns a fluent-bit parser and filter for the kube-scheduler logs.
 func CentralLoggingConfiguration() (component.CentralLoggingConfig, error) {
-	return component.CentralLoggingConfig{Filters: loggingFilter, Parsers: loggingParser, PodPrefix: v1beta1constants.DeploymentNameKubeScheduler, UserExposed: true}, nil
+	return component.CentralLoggingConfig{
+		Filters:     loggingFilter,
+		Parsers:     loggingParser,
+		UserExposed: true,
+		PodPrefixes: []string{v1beta1constants.DeploymentNameKubeScheduler},
+	}, nil
 }

--- a/pkg/operation/botanist/component/kubescheduler/logging_test.go
+++ b/pkg/operation/botanist/component/kubescheduler/logging_test.go
@@ -42,9 +42,8 @@ var _ = Describe("Logging", func() {
     Parser              kubeSchedulerParser
     Reserve_Data        True
 `))
-			Expect(loggingConfig.PodPrefix).To(Equal("kube-scheduler"))
 			Expect(loggingConfig.UserExposed).To(BeTrue())
-
+			Expect(loggingConfig.PodPrefixes).To(ConsistOf("kube-scheduler"))
 		})
 	})
 })

--- a/pkg/operation/botanist/component/metricsserver/logging_test.go
+++ b/pkg/operation/botanist/component/metricsserver/logging_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Logging", func() {
     Parser              metricsServerParser
     Reserve_Data        True
 `))
-			Expect(loggingConfig.PodPrefix).To(BeEmpty())
+			Expect(loggingConfig.PodPrefixes).To(BeEmpty())
 			Expect(loggingConfig.UserExposed).To(BeFalse())
 		})
 	})

--- a/pkg/operation/botanist/component/nodeproblemdetector/logging_test.go
+++ b/pkg/operation/botanist/component/nodeproblemdetector/logging_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Logging", func() {
     Parser              nodeProblemDetector
     Reserve_Data        True
 `))
-			Expect(loggingConfig.PodPrefix).To(BeEmpty())
+			Expect(loggingConfig.PodPrefixes).To(BeEmpty())
 			Expect(loggingConfig.UserExposed).To(BeFalse())
 		})
 	})

--- a/pkg/operation/botanist/component/seedadmissioncontroller/logging_test.go
+++ b/pkg/operation/botanist/component/seedadmissioncontroller/logging_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Logging", func() {
     Parser              gsacParser
     Reserve_Data        True
 `))
-			Expect(loggingConfig.PodPrefix).To(BeEmpty())
+			Expect(loggingConfig.PodPrefixes).To(BeEmpty())
 			Expect(loggingConfig.UserExposed).To(BeFalse())
 		})
 	})

--- a/pkg/operation/botanist/component/types.go
+++ b/pkg/operation/botanist/component/types.go
@@ -38,8 +38,8 @@ type CentralLoggingConfig struct {
 	Filters string
 	// Parser contains the parsers for specific component.
 	Parsers string
-	// PodPrefix is the prefix of the pod name.
-	PodPrefix string
 	// UserExposed defines if the component is exposed to the end-user.
 	UserExposed bool
+	// PodPrefixes is the list of prefixes of the pod names when logging config is user-exposed.
+	PodPrefixes []string
 }

--- a/pkg/operation/botanist/component/vpa/logging.go
+++ b/pkg/operation/botanist/component/vpa/logging.go
@@ -38,5 +38,10 @@ const (
 
 // CentralLoggingConfiguration returns a fluent-bit parser and filter for the VPA logs.
 func CentralLoggingConfiguration() (component.CentralLoggingConfig, error) {
-	return component.CentralLoggingConfig{Filters: loggingFilter, Parsers: loggingParser}, nil
+	return component.CentralLoggingConfig{
+		Filters:     loggingFilter,
+		Parsers:     loggingParser,
+		UserExposed: true,
+		PodPrefixes: []string{admissionController, exporter, recommender, updater},
+	}, nil
 }

--- a/pkg/operation/botanist/component/vpa/logging_test.go
+++ b/pkg/operation/botanist/component/vpa/logging_test.go
@@ -42,8 +42,8 @@ var _ = Describe("Logging", func() {
     Parser              vpaParser
     Reserve_Data        True
 `))
-			Expect(loggingConfig.PodPrefixes).To(BeEmpty())
-			Expect(loggingConfig.UserExposed).To(BeFalse())
+			Expect(loggingConfig.UserExposed).To(BeTrue())
+			Expect(loggingConfig.PodPrefixes).To(ConsistOf("vpa-admission-controller", "vpa-exporter", "vpa-recommender", "vpa-updater"))
 		})
 	})
 })

--- a/pkg/operation/botanist/component/vpa/logging_test.go
+++ b/pkg/operation/botanist/component/vpa/logging_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Logging", func() {
     Parser              vpaParser
     Reserve_Data        True
 `))
-			Expect(loggingConfig.PodPrefix).To(BeEmpty())
+			Expect(loggingConfig.PodPrefixes).To(BeEmpty())
 			Expect(loggingConfig.UserExposed).To(BeFalse())
 		})
 	})

--- a/pkg/operation/botanist/component/vpnseedserver/logging_test.go
+++ b/pkg/operation/botanist/component/vpnseedserver/logging_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Logging", func() {
     Parser              vpnSeedServerEnvoyProxyParser
     Reserve_Data        True
 `))
-			Expect(loggingConfig.PodPrefix).To(BeEmpty())
+			Expect(loggingConfig.PodPrefixes).To(BeEmpty())
 			Expect(loggingConfig.UserExposed).To(BeFalse())
 		})
 	})

--- a/pkg/operation/botanist/component/vpnshoot/logging_test.go
+++ b/pkg/operation/botanist/component/vpnshoot/logging_test.go
@@ -41,7 +41,7 @@ var _ = Describe("Logging", func() {
     Parser              vpnShootParser
     Reserve_Data        True
 `))
-			Expect(loggingConfig.PodPrefix).To(BeEmpty())
+			Expect(loggingConfig.PodPrefixes).To(BeEmpty())
 			Expect(loggingConfig.UserExposed).To(BeFalse())
 		})
 	})

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -425,10 +425,12 @@ func RunReconcileSeedFlow(
 	var (
 		loggingEnabled                    bool
 		additionalEgressIPBlocks          []string
-		filters                           = strings.Builder{}
-		parsers                           = strings.Builder{}
 		fluentBitConfigurationsOverwrites = map[string]interface{}{}
 		lokiValues                        = map[string]interface{}{}
+
+		filters               = strings.Builder{}
+		parsers               = strings.Builder{}
+		userAllowedComponents []string
 	)
 
 	loggingEnabled = gardenlethelper.IsLoggingEnabled(conf)
@@ -531,11 +533,6 @@ func RunReconcileSeedFlow(
 			metricsserver.CentralLoggingConfiguration,
 			nodeproblemdetector.CentralLoggingConfiguration,
 			vpnshoot.CentralLoggingConfiguration,
-		}
-		userAllowedComponents := []string{
-			v1beta1constants.DeploymentNameKubeAPIServer,
-			v1beta1constants.DeploymentNameVPAExporter, v1beta1constants.DeploymentNameVPARecommender,
-			v1beta1constants.DeploymentNameVPAAdmissionController,
 		}
 
 		// Fetch component specific logging configurations

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -549,7 +549,7 @@ func RunReconcileSeedFlow(
 			parsers.WriteString(fmt.Sprintln(loggingConfig.Parsers))
 
 			if loggingConfig.UserExposed {
-				userAllowedComponents = append(userAllowedComponents, loggingConfig.PodPrefix)
+				userAllowedComponents = append(userAllowedComponents, loggingConfig.PodPrefixes...)
 			}
 		}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup

**What this PR does / why we need it**:
Use existing API in `CentralLoggingConfig` for exposing logs to users and do not duplicate it centrally in `seed.go`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
