### PR TITLE
Adapt `gardenlet` to use priority class `gardener-system-critical`

### DIFF
--- a/charts/gardener/gardenlet/charts/runtime/templates/deployment.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/deployment.yaml
@@ -63,7 +63,7 @@ spec:
 {{ toYaml .Values.global.gardenlet.podLabels | indent 8 }}
         {{- end }}
     spec:
-      priorityClassName: gardenlet
+      priorityClassName: gardener-system-critical
       {{- if not .Values.global.gardenlet.config.seedClientConnection.kubeconfig }}
       serviceAccountName: {{ required ".Values.global.gardenlet.serviceAccountName is required" .Values.global.gardenlet.serviceAccountName }}
       {{- else }}

--- a/charts/gardener/gardenlet/charts/runtime/templates/priorityclass.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/priorityclass.yaml
@@ -2,6 +2,8 @@ apiVersion: {{ include "priorityclassversion" . }}
 kind: PriorityClass
 metadata:
   name: gardener-system-critical
+  annotations:
+    resources.gardener.cloud/mode: Ignore # TODO(kris94) remove in future release
 value: 999998950
 globalDefault: false
 description: "This class is used to ensure that the gardenlet and some seed system components has a high priority and is not preempted in favor of other pods."

--- a/charts/gardener/gardenlet/charts/runtime/templates/priorityclass.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/priorityclass.yaml
@@ -1,7 +1,7 @@
 apiVersion: {{ include "priorityclassversion" . }}
 kind: PriorityClass
 metadata:
-  name: gardenlet
-value: 1000000000
+  name: gardener-system-critical
+value: 999998950
 globalDefault: false
-description: "This class is used to ensure that the gardenlet has a high priority and is not preempted in favor of other pods."
+description: "This class is used to ensure that the gardenlet and some seed system components has a high priority and is not preempted in favor of other pods."

--- a/cmd/gardenlet/app/gardenlet.go
+++ b/cmd/gardenlet/app/gardenlet.go
@@ -61,7 +61,6 @@ import (
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
 	eventsv1 "k8s.io/api/events/v1"
-	schedulingv1 "k8s.io/api/scheduling/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -71,7 +70,6 @@ import (
 	"k8s.io/component-base/version"
 	"k8s.io/component-base/version/verflag"
 	"k8s.io/utils/clock"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	runtimelog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	bootstraputil "github.com/gardener/gardener/pkg/gardenlet/bootstrap/util"
@@ -421,10 +419,6 @@ func NewGardenlet(ctx context.Context, cfg *config.GardenletConfiguration) (*Gar
 	var certificateManager *certificate.Manager
 	if cfg.GardenClientConnection.KubeconfigSecret != nil {
 		certificateManager = certificate.NewCertificateManager(log, clientMap, seedClientForBootstrap.Client(), cfg)
-	}
-
-	if err := client.IgnoreNotFound(seedClient.Client().Delete(ctx, &schedulingv1.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: "gardenlet"}})); err != nil {
-		return nil, fmt.Errorf("unable to delete Gardenlet's old PriorityClass: %w", err)
 	}
 
 	return &Gardenlet{

--- a/pkg/gardenlet/controller/factory.go
+++ b/pkg/gardenlet/controller/factory.go
@@ -53,6 +53,7 @@ import (
 	"github.com/gardener/gardener/pkg/utils/retry"
 
 	corev1 "k8s.io/api/core/v1"
+	schedulingv1 "k8s.io/api/scheduling/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/runtime"
@@ -136,6 +137,10 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 	seedClient, err := f.clientMap.GetClient(ctx, keys.ForSeedWithName(seedName))
 	if err != nil {
 		return fmt.Errorf("failed to get seed client: %w", err)
+	}
+
+	if err := client.IgnoreNotFound(seedClient.Client().Delete(ctx, &schedulingv1.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: "gardenlet"}})); err != nil {
+		return fmt.Errorf("unable to delete Gardenlet's old PriorityClass: %w", err)
 	}
 
 	backupBucketController, err := backupbucketcontroller.NewBackupBucketController(ctx, log, f.clientMap, f.cfg, f.recorder)

--- a/pkg/gardenlet/controller/managedseed/charttest/charttest.go
+++ b/pkg/gardenlet/controller/managedseed/charttest/charttest.go
@@ -96,13 +96,13 @@ func ValidateGardenletChartPriorityClass(ctx context.Context, c client.Client) {
 		priorityClass,
 	)).ToNot(HaveOccurred())
 	Expect(priorityClass.GlobalDefault).To(Equal(false))
-	Expect(priorityClass.Value).To(Equal(int32(1000000000)))
+	Expect(priorityClass.Value).To(Equal(int32(999998950)))
 }
 
 func getEmptyPriorityClass() *schedulingv1.PriorityClass {
 	return &schedulingv1.PriorityClass{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "gardenlet",
+			Name: "gardener-system-critical",
 		},
 	}
 }
@@ -956,7 +956,7 @@ func ComputeExpectedGardenletDeploymentSpec(
 				Labels: expectedLabels,
 			},
 			Spec: corev1.PodSpec{
-				PriorityClassName:  "gardenlet",
+				PriorityClassName:  "gardener-system-critical",
 				ServiceAccountName: "gardenlet",
 				Containers: []corev1.Container{
 					{

--- a/pkg/operation/botanist/component/seedsystem/seedsystem.go
+++ b/pkg/operation/botanist/component/seedsystem/seedsystem.go
@@ -162,7 +162,6 @@ var gardenletManagedPriorityClasses = []struct {
 	value       int32
 	description string
 }{
-	{v1beta1constants.PriorityClassNameSeedSystemCritical, 999998950, "PriorityClass for Seed system components"},
 	{v1beta1constants.PriorityClassNameSeedSystem900, 999998900, "PriorityClass for Seed system components"},
 	{v1beta1constants.PriorityClassNameSeedSystem800, 999998800, "PriorityClass for Seed system components"},
 	{v1beta1constants.PriorityClassNameSeedSystem700, 999998700, "PriorityClass for Seed system components"},

--- a/pkg/operation/botanist/component/seedsystem/seedsystem_test.go
+++ b/pkg/operation/botanist/component/seedsystem/seedsystem_test.go
@@ -149,7 +149,7 @@ status: {}
 		})
 
 		It("should successfully deploy the resources", func() {
-			Expect(managedResourceSecret.Data).To(HaveLen(13))
+			Expect(managedResourceSecret.Data).To(HaveLen(12))
 			Expect(string(managedResourceSecret.Data["deployment__"+namespace+"__reserve-excess-capacity.yaml"])).To(Equal(deploymentYAML))
 			expectPriorityClasses(managedResourceSecret.Data)
 		})
@@ -263,7 +263,6 @@ func expectPriorityClasses(data map[string][]byte) {
 		value       int32
 		description string
 	}{
-		{"gardener-system-critical", 999998950, "PriorityClass for Seed system components"},
 		{"gardener-system-900", 999998900, "PriorityClass for Seed system components"},
 		{"gardener-system-800", 999998800, "PriorityClass for Seed system components"},
 		{"gardener-system-700", 999998700, "PriorityClass for Seed system components"},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
This PR removes the custom priority class from the gardenlet charts and adapts it to use priorityClass `gardener-system-critical` as part of #5634
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Gardenlet now uses PriorityClass: gardener-system-critical
```
