### PR TITLE
Promote the `SecretBindingProviderValidation` feature gate to beta

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -36,7 +36,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | RotateSSHKeypairOnMaintenance                | `true`  | `Beta`  | `1.45` |        |
 | RotateSSHKeypairOnMaintenance (deprecated)   | `false` | `Beta`  | `1.48` |        |
 | CopyEtcdBackupsDuringControlPlaneMigration   | `false` | `Alpha` | `1.37` |        |
-| SecretBindingProviderValidation              | `false` | `Alpha` | `1.38` |        |
+| SecretBindingProviderValidation              | `false` | `Alpha` | `1.38` | `1.50` |
+| SecretBindingProviderValidation              | `true`  | `Beta`  | `1.51` |        |
 | ForceRestore                                 | `false` | `Alpha` | `1.39` |        |
 | DisableDNSProviderManagement                 | `false` | `Alpha` | `1.41` | `1.49` |
 | DisableDNSProviderManagement                 | `true`  | `Beta`  | `1.50` |        |

--- a/docs/deployment/secret_binding_provider_controller.md
+++ b/docs/deployment/secret_binding_provider_controller.md
@@ -23,5 +23,6 @@ A Gardener landscape operator can follow the following steps:
 
 ## Implementation History
 
-- Gardener v1.38: SecretBinding resource has a new optional field `.provider.type`. SecretBinding provider controller is disabled by default. `SecretBindingProviderValidation` feature gate of Gardener API server is disabled by default.
-- Gardener v1.42: SecretBinding provider controller is enabled by default.
+- Gardener v1.38: The SecretBinding resource has a new optional field `.provider.type`. The SecretBinding provider controller is disabled by default. The `SecretBindingProviderValidation` feature gate of Gardener API server is disabled by default.
+- Gardener v1.42: The SecretBinding provider controller is enabled by default.
+- Gardener v1.51: The `SecretBindingProviderValidation` feature gate of Gardener API server is enabled by default and the SecretBinding provider controller is disabled by default.

--- a/example/20-componentconfig-gardener-controller-manager.yaml
+++ b/example/20-componentconfig-gardener-controller-manager.yaml
@@ -14,7 +14,7 @@ controllers:
   secretBinding:
     concurrentSyncs: 5
   secretBindingProvider:
-    concurrentSyncs: 5
+    concurrentSyncs: 0
   seed:
     concurrentSyncs: 5
     syncPeriod: 30s

--- a/pkg/controllermanager/apis/config/v1alpha1/defaults.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/defaults.go
@@ -146,7 +146,7 @@ func SetDefaults_ControllerManagerConfiguration(obj *ControllerManagerConfigurat
 		obj.Controllers.SecretBindingProvider = &SecretBindingProviderControllerConfiguration{}
 	}
 	if obj.Controllers.SecretBindingProvider.ConcurrentSyncs == nil {
-		v := DefaultControllerConcurrentSyncs
+		v := 0
 		obj.Controllers.SecretBindingProvider.ConcurrentSyncs = &v
 	}
 

--- a/pkg/controllermanager/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/defaults_test.go
@@ -88,7 +88,7 @@ var _ = Describe("Defaults", func() {
 			Expect(obj.Controllers.SecretBinding.ConcurrentSyncs).To(PointTo(Equal(5)))
 			Expect(obj.Controllers.SecretBindingProvider).NotTo(BeNil())
 			Expect(obj.Controllers.SecretBindingProvider.ConcurrentSyncs).NotTo(BeNil())
-			Expect(obj.Controllers.SecretBindingProvider.ConcurrentSyncs).To(PointTo(Equal(5)))
+			Expect(obj.Controllers.SecretBindingProvider.ConcurrentSyncs).To(PointTo(Equal(0)))
 
 			Expect(obj.Controllers.Seed).NotTo(BeNil())
 			Expect(obj.Controllers.Seed.ConcurrentSyncs).NotTo(BeNil())

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -99,6 +99,7 @@ const (
 	// - enforces immutability on the provider type of a SecretBinding
 	// owner: @ialidzhikov
 	// alpha: v1.38.0
+	// beta: v1.51.0
 	SecretBindingProviderValidation featuregate.Feature = "SecretBindingProviderValidation"
 
 	// ForceRestore enables forcing the shoot's restoration to the destination seed during control plane migration
@@ -168,7 +169,7 @@ var allFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	RotateSSHKeypairOnMaintenance: {Default: false, PreRelease: featuregate.Beta},
 	WorkerPoolKubernetesVersion:   {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	CopyEtcdBackupsDuringControlPlaneMigration: {Default: false, PreRelease: featuregate.Alpha},
-	SecretBindingProviderValidation:            {Default: false, PreRelease: featuregate.Alpha},
+	SecretBindingProviderValidation:            {Default: true, PreRelease: featuregate.Beta},
 	ForceRestore:                               {Default: false, PreRelease: featuregate.Alpha},
 	DisableDNSProviderManagement:               {Default: true, PreRelease: featuregate.Beta},
 	ShootCARotation:                            {Default: false, PreRelease: featuregate.Alpha},

--- a/test/integration/scheduler/scheduler_test.go
+++ b/test/integration/scheduler/scheduler_test.go
@@ -36,11 +36,11 @@ import (
 
 var _ = Describe("Scheduler tests", func() {
 	var (
+		cloudProfile *gardencorev1beta1.CloudProfile
 		seeds        []*gardencorev1beta1.Seed
 		shoot        *gardencorev1beta1.Shoot
-		cloudProfile *gardencorev1beta1.CloudProfile
-		providerType = "provider-type"
 	)
+
 	AfterEach(func() {
 		Expect(ConfirmDeletion(ctx, testClient, shoot)).To(Succeed())
 		Expect(testClient.Delete(ctx, shoot)).To(Succeed())
@@ -49,13 +49,14 @@ var _ = Describe("Scheduler tests", func() {
 		for _, seed := range seeds {
 			Expect(testClient.Delete(ctx, seed)).To(Succeed())
 		}
-		seeds = nil
 		cloudProfile = nil
+		seeds = nil
 		shoot = nil
 
 		By("Stopping Manager")
 		mgrCancel()
 	})
+
 	Context("SameRegion Scheduling Strategy", func() {
 		BeforeEach(func() {
 			mgr := createManager(&config.ShootSchedulerConfiguration{ConcurrentSyncs: 1, Strategy: config.SameRegion})
@@ -269,7 +270,7 @@ func createShoot(shootName, providerType, cloudProfile, region string, dnsDomain
 	obj := &gardencorev1beta1.Shoot{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      shootName,
-			Namespace: "garden-dev",
+			Namespace: namespace,
 		},
 		Spec: gardencorev1beta1.ShootSpec{
 			CloudProfileName: cloudProfile,
@@ -296,7 +297,7 @@ func createShoot(shootName, providerType, cloudProfile, region string, dnsDomain
 				Type:     "some-type",
 			},
 			Kubernetes:        gardencorev1beta1.Kubernetes{Version: "1.21.1"},
-			SecretBindingName: "secret",
+			SecretBindingName: "secretbinding",
 			DNS:               &gardencorev1beta1.DNS{Domain: dnsDomain},
 		},
 	}


### PR DESCRIPTION
/kind enhancement

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/4888

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
The `SecretBindingProviderValidation` feature gate of `gardener-apiserver` is now promoted to beta and enabled by default. This enables the following validations:
- requires the provider type of a `SecretBinding` to be set (on `SecretBinding` creation)
- requires the `SecretBinding` provider type to match the `Shoot` provider type (on `Shoot` creation)
- enforces immutability on the provider type of a `SecretBinding`
```
