### PR TITLE
Adapt the `kube-apiserver` and `kube-controller-manager` to use the appropriate `PriorityClasses`

### DIFF
--- a/pkg/operation/botanist/component/kubeapiserver/deployment.go
+++ b/pkg/operation/botanist/component/kubeapiserver/deployment.go
@@ -230,7 +230,7 @@ func (k *kubeAPIServer) reconcileDeployment(
 						},
 					},
 					AutomountServiceAccountToken:  pointer.Bool(false),
-					PriorityClassName:             v1beta1constants.PriorityClassNameShootControlPlane,
+					PriorityClassName:             v1beta1constants.PriorityClassNameShootControlPlane500,
 					DNSPolicy:                     corev1.DNSClusterFirst,
 					RestartPolicy:                 corev1.RestartPolicyAlways,
 					SchedulerName:                 corev1.DefaultSchedulerName,

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
@@ -1595,7 +1595,7 @@ rules:
 						}},
 					},
 				}))
-				Expect(deployment.Spec.Template.Spec.PriorityClassName).To(Equal("gardener-shoot-controlplane"))
+				Expect(deployment.Spec.Template.Spec.PriorityClassName).To(Equal("gardener-system-500"))
 				Expect(deployment.Spec.Template.Spec.AutomountServiceAccountToken).To(PointTo(BeFalse()))
 				Expect(deployment.Spec.Template.Spec.DNSPolicy).To(Equal(corev1.DNSClusterFirst))
 				Expect(deployment.Spec.Template.Spec.RestartPolicy).To(Equal(corev1.RestartPolicyAlways))

--- a/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager.go
@@ -255,6 +255,7 @@ func (k *kubeControllerManager) Deploy(ctx context.Context) error {
 			},
 			Spec: corev1.PodSpec{
 				AutomountServiceAccountToken: pointer.Bool(false),
+				PriorityClassName:            v1beta1constants.PriorityClassNameShootControlPlane300,
 				Containers: []corev1.Container{
 					{
 						Name:            containerName,

--- a/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager_test.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager_test.go
@@ -470,6 +470,7 @@ var _ = Describe("KubeControllerManager", func() {
 								},
 								Spec: corev1.PodSpec{
 									AutomountServiceAccountToken: pointer.Bool(false),
+									PriorityClassName:            v1beta1constants.PriorityClassNameShootControlPlane300,
 									Containers: []corev1.Container{
 										{
 											Name:            "kube-controller-manager",


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
This PR adapts  he kube-apiserver and kube-controller-manager to use PriorityClasses`gardener-system-500` and  `gardener-system-300` as part of #5634
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
