### PR TITLE
Add containerd parser

### DIFF
--- a/charts/seed-bootstrap/charts/fluent-bit/templates/_fluent-bit-config.tpl
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/_fluent-bit-config.tpl
@@ -25,7 +25,6 @@
       Tag               kubernetes.*
       Path              /var/log/containers/*.log
       Exclude_Path      *_garden_fluent-bit-*.log,*_garden_loki-*.log
-      Parser            docker
       DB                /var/log/flb_kube.db
       DB.sync           full
       read_from_head    true
@@ -33,6 +32,20 @@
       Mem_Buf_Limit     30MB
       Refresh_Interval  10
       Ignore_Older      1800s
+
+  [FILTER]
+      Name                parser
+      Match               kubernetes.*
+      Key_Name            log
+      Parser              docker
+      Reserve_Data        True
+
+  [FILTER]
+      Name                parser
+      Match               kubernetes.*
+      Key_Name            log
+      Parser              containerd
+      Reserve_Data        True
 
   [INPUT]
       Name            systemd

--- a/charts/seed-bootstrap/charts/fluent-bit/templates/_helpers.tpl
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/_helpers.tpl
@@ -182,6 +182,17 @@ parsers.conf: |-
       Decode_Field_As   escaped    log
 
   [PARSER]
+      Name        containerd
+      Format      regex
+      Regex       ^(?<time>[^ ]+) (stdout|stderr) ([^ ]*) (?<log>.*)$
+      Time_Key    time
+      Time_Format %Y-%m-%dT%H:%M:%S.%L%z
+      Time_Keep   On
+      # Command      |  Decoder | Field | Optional Action
+      # =============|==================|=================
+      Decode_Field_As   escaped    log
+
+  [PARSER]
       Name        kubeapiserverParser
       Format      regex
       Regex       ^(?<severity>\w)(?<time>\d{4} [^\s]*)\s+(?<pid>\d+)\s+(?<source>[^ \]]+)\] (?<log>.*)$


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
Add containerd filter and parser in order to parse the logs where containerd CRI is used.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
@vlvasilev 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
None
```
