### PR TITLE
Add ShootRESTOptions field to v1alpha1

### DIFF
--- a/extensions/pkg/controller/healthcheck/config/v1alpha1/types.go
+++ b/extensions/pkg/controller/healthcheck/config/v1alpha1/types.go
@@ -14,7 +14,10 @@
 
 package v1alpha1
 
-import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+import (
+	"github.com/gardener/gardener/extensions/pkg/util"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
 
 // HealthCheckConfig contains the health check controller configuration.
 type HealthCheckConfig struct {
@@ -23,4 +26,6 @@ type HealthCheckConfig struct {
 	// already running on them).
 	// defaults to 30 sec
 	SyncPeriod metav1.Duration `json:"syncPeriod"`
+	// ShootRESTOptions allow overwriting certain default settings of the shoot rest.Client
+	ShootRESTOptions util.RESTOptions `json:"shootRESTOptions"`
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind regression

**What this PR does / why we need it**:
#6113 added a new filed `ShootRESTOptions` but it was not added to v1alpha1.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @rfranzke @oliver-goetz 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
