### PR TITLE
Revert "Allow passing custom REST configuration settings to extension shoot clients (#6113)"

### DIFF
--- a/extensions/pkg/controller/csimigration/reconciler.go
+++ b/extensions/pkg/controller/csimigration/reconciler.go
@@ -144,7 +144,7 @@ func (r *reconciler) reconcile(ctx context.Context, cluster *extensionsv1alpha1.
 			return reconcile.Result{}, nil
 		}
 
-		_, shootClient, err := NewClientForShoot(ctx, r.client, cluster.Name, client.Options{}, util.RESTOptions{})
+		_, shootClient, err := NewClientForShoot(ctx, r.client, cluster.Name, client.Options{})
 		if err != nil {
 			return reconcile.Result{}, err
 		}

--- a/extensions/pkg/controller/csimigration/reconciler_test.go
+++ b/extensions/pkg/controller/csimigration/reconciler_test.go
@@ -31,7 +31,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/gardener/gardener/extensions/pkg/util"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
@@ -148,7 +147,7 @@ var _ = Describe("reconciler", func() {
 
 				oldNewClientForShoot := NewClientForShoot
 				defer func() { NewClientForShoot = oldNewClientForShoot }()
-				NewClientForShoot = func(_ context.Context, _ client.Client, _ string, _ client.Options, _ util.RESTOptions) (*rest.Config, client.Client, error) {
+				NewClientForShoot = func(_ context.Context, _ client.Client, _ string, _ client.Options) (*rest.Config, client.Client, error) {
 					return nil, shootClient, nil
 				}
 
@@ -178,7 +177,7 @@ var _ = Describe("reconciler", func() {
 
 				oldNewClientForShoot := NewClientForShoot
 				defer func() { NewClientForShoot = oldNewClientForShoot }()
-				NewClientForShoot = func(_ context.Context, _ client.Client, _ string, _ client.Options, _ util.RESTOptions) (*rest.Config, client.Client, error) {
+				NewClientForShoot = func(_ context.Context, _ client.Client, _ string, _ client.Options) (*rest.Config, client.Client, error) {
 					return nil, shootClient, nil
 				}
 

--- a/extensions/pkg/controller/healthcheck/config/types.go
+++ b/extensions/pkg/controller/healthcheck/config/types.go
@@ -14,11 +14,7 @@
 
 package config
 
-import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/gardener/gardener/extensions/pkg/util"
-)
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 // HealthCheckConfig contains the health check controller configuration.
 type HealthCheckConfig struct {
@@ -27,6 +23,4 @@ type HealthCheckConfig struct {
 	// already running on them).
 	// defaults to 30 sec
 	SyncPeriod metav1.Duration
-	// ShootRESTOptions allow overwriting certain default settings of the shoot rest.Client
-	ShootRESTOptions util.RESTOptions
 }

--- a/extensions/pkg/controller/healthcheck/controller.go
+++ b/extensions/pkg/controller/healthcheck/controller.go
@@ -19,7 +19,6 @@ import (
 
 	healthcheckconfig "github.com/gardener/gardener/extensions/pkg/controller/healthcheck/config"
 	extensionspredicate "github.com/gardener/gardener/extensions/pkg/predicate"
-	"github.com/gardener/gardener/extensions/pkg/util"
 	"github.com/gardener/gardener/pkg/api/extensions"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllerutils/mapper"
@@ -54,8 +53,6 @@ type AddArgs struct {
 	Type string
 	// SyncPeriod is the duration how often the registered extension is being reconciled
 	SyncPeriod metav1.Duration
-	// ShootRESTOptions allow overwriting certain default settings of the shoot rest.Client
-	ShootRESTOptions util.RESTOptions
 	// registeredExtension is the registered extensions that the HealthCheck Controller watches and writes HealthConditions for.
 	// The Gardenlet reads the conditions on the extension Resource.
 	// Through this mechanism, the extension can contribute to the Shoot's HealthStatus.
@@ -104,7 +101,6 @@ func DefaultRegistration(extensionType string, kind schema.GroupVersionKind, get
 		Predicates:              predicates,
 		Type:                    extensionType,
 		SyncPeriod:              opts.HealthCheckConfig.SyncPeriod,
-		ShootRESTOptions:        opts.HealthCheckConfig.ShootRESTOptions,
 		GetExtensionObjListFunc: getExtensionObjListFunc,
 	}
 
@@ -112,7 +108,7 @@ func DefaultRegistration(extensionType string, kind schema.GroupVersionKind, get
 		return err
 	}
 
-	healthCheckActuator := NewActuator(args.Type, args.GetExtensionGroupVersionKind().Kind, getExtensionObjFunc, healthChecks, args.ShootRESTOptions)
+	healthCheckActuator := NewActuator(args.Type, args.GetExtensionGroupVersionKind().Kind, getExtensionObjFunc, healthChecks)
 	return Register(mgr, args, healthCheckActuator)
 }
 

--- a/extensions/pkg/controller/healthcheck/healthcheck_actuator.go
+++ b/extensions/pkg/controller/healthcheck/healthcheck_actuator.go
@@ -48,18 +48,16 @@ type Actuator struct {
 	extensionKind       string
 	getExtensionObjFunc GetExtensionObjectFunc
 	healthChecks        []ConditionTypeToHealthCheck
-	shootRESTOptions    util.RESTOptions
 }
 
 // NewActuator creates a new Actuator.
-func NewActuator(provider, extensionKind string, getExtensionObjFunc GetExtensionObjectFunc, healthChecks []ConditionTypeToHealthCheck, shootRESTOptions util.RESTOptions) HealthCheckActuator {
+func NewActuator(provider, extensionKind string, getExtensionObjFunc GetExtensionObjectFunc, healthChecks []ConditionTypeToHealthCheck) HealthCheckActuator {
 	return &Actuator{
 		healthChecks:        healthChecks,
 		getExtensionObjFunc: getExtensionObjFunc,
 		provider:            provider,
 		extensionKind:       extensionKind,
 		logger:              log.Log.WithName(fmt.Sprintf("%s-%s-healthcheck-actuator", provider, extensionKind)),
-		shootRESTOptions:    shootRESTOptions,
 	}
 }
 
@@ -121,7 +119,7 @@ func (a *Actuator) ExecuteHealthCheckFunctions(ctx context.Context, request type
 		if _, ok := check.(ShootClient); ok {
 			if shootClient == nil {
 				var err error
-				_, shootClient, err = util.NewClientForShoot(ctx, a.seedClient, request.Namespace, client.Options{}, a.shootRESTOptions)
+				_, shootClient, err = util.NewClientForShoot(ctx, a.seedClient, request.Namespace, client.Options{})
 				if err != nil {
 					// don't return here, as we might have started some goroutines already to prevent leakage
 					channel <- channelResult{

--- a/extensions/pkg/util/shoot_clients.go
+++ b/extensions/pkg/util/shoot_clients.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"time"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/chartrenderer"
@@ -31,8 +30,6 @@ import (
 	"k8s.io/apimachinery/pkg/version"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/util/flowcontrol"
-	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
@@ -71,36 +68,13 @@ func NewShootClients(c client.Client, clientset kubernetes.Interface, gardenerCl
 	}
 }
 
-// RESTOptions define a subset of optional parameters for a rest.Client
-type RESTOptions struct {
-	// QPS indicates the maximum QPS to the master from this client.
-	QPS *float32
-	// Maximum burst for throttle.
-	Burst *int
-	// Rate limiter for limiting connections to the master from this client. If present overwrites QPS/Burst
-	RateLimiter flowcontrol.RateLimiter
-	// The maximum length of time to wait before giving up on a server request. A value of zero means no timeout.
-	Timeout *time.Duration
-}
-
-// ApplyRESTOptions applies RESTOptions to the given rest.Config
-func ApplyRESTOptions(restConfig *rest.Config, restOptions RESTOptions) *rest.Config {
-	restConfig.QPS = pointer.Float32Deref(restOptions.QPS, restConfig.QPS)
-	restConfig.Burst = pointer.IntDeref(restOptions.Burst, restConfig.Burst)
-	restConfig.Timeout = pointer.DurationDeref(restOptions.Timeout, restConfig.Timeout)
-	if restOptions.RateLimiter != nil {
-		restConfig.RateLimiter = restOptions.RateLimiter
-	}
-	return restConfig
-}
-
 // NewClientForShoot returns the rest config and the client for the given shoot namespace. It first looks to use the "internal" kubeconfig
 // (the one with in-cluster address) as in-cluster traffic is free of charge. If it cannot find that, then it fallbacks to the "external" kubeconfig
 // (the one with external DNS name or load balancer address) and this usually translates to egress traffic costs.
 // However, if the environment variable GARDENER_SHOOT_CLIENT=external, then it *only* checks for the external endpoint,
 // i.e. v1beta1constants.SecretNameGardener. This is useful when connecting from outside the seed cluster on which the shoot kube-apiserver
 // is running.
-func NewClientForShoot(ctx context.Context, c client.Client, namespace string, opts client.Options, restOptions RESTOptions) (*rest.Config, client.Client, error) {
+func NewClientForShoot(ctx context.Context, c client.Client, namespace string, opts client.Options) (*rest.Config, client.Client, error) {
 	var (
 		gardenerSecret = &corev1.Secret{}
 		err            error
@@ -121,7 +95,6 @@ func NewClientForShoot(ctx context.Context, c client.Client, namespace string, o
 	if err != nil {
 		return nil, nil, err
 	}
-	ApplyRESTOptions(shootRESTConfig, restOptions)
 
 	if opts.Mapper == nil {
 		mapper, err := apiutil.NewDynamicRESTMapper(shootRESTConfig, apiutil.WithLazyDiscovery)
@@ -140,12 +113,11 @@ func NewClientForShoot(ctx context.Context, c client.Client, namespace string, o
 
 // NewClientsForShoot is a utility function that creates a new clientset and a chart applier for the shoot cluster.
 // It uses the 'gardener' secret in the given shoot namespace. It also returns the Kubernetes version of the cluster.
-func NewClientsForShoot(ctx context.Context, c client.Client, namespace string, opts client.Options, restOptions RESTOptions) (ShootClients, error) {
-	shootRESTConfig, shootClient, err := NewClientForShoot(ctx, c, namespace, opts, restOptions)
+func NewClientsForShoot(ctx context.Context, c client.Client, namespace string, opts client.Options) (ShootClients, error) {
+	shootRESTConfig, shootClient, err := NewClientForShoot(ctx, c, namespace, opts)
 	if err != nil {
 		return nil, err
 	}
-	ApplyRESTOptions(shootRESTConfig, restOptions)
 	shootClientset, err := kubernetes.NewForConfig(shootRESTConfig)
 	if err != nil {
 		return nil, err

--- a/extensions/pkg/webhook/handler_shootclient.go
+++ b/extensions/pkg/webhook/handler_shootclient.go
@@ -122,7 +122,7 @@ func (h *handlerShootClient) Handle(ctx context.Context, req admission.Request) 
 			return fmt.Errorf("could not find shoot namespace for webhook request")
 		}
 
-		_, shootClient, err := util.NewClientForShoot(ctx, h.client, shootNamespace, client.Options{}, util.RESTOptions{})
+		_, shootClient, err := util.NewClientForShoot(ctx, h.client, shootNamespace, client.Options{})
 		if err != nil {
 			return fmt.Errorf("could not create shoot client: %w", err)
 		}

--- a/pkg/provider-local/controller/healthcheck/add.go
+++ b/pkg/provider-local/controller/healthcheck/add.go
@@ -24,13 +24,11 @@ import (
 	"github.com/gardener/gardener/extensions/pkg/controller/healthcheck/worker"
 	genericworkeractuator "github.com/gardener/gardener/extensions/pkg/controller/worker/genericactuator"
 	extensionspredicate "github.com/gardener/gardener/extensions/pkg/predicate"
-	"github.com/gardener/gardener/extensions/pkg/util"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/provider-local/local"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -40,14 +38,7 @@ var (
 	defaultSyncPeriod = time.Second * 30
 	// DefaultAddOptions are the default DefaultAddArgs for AddToManager.
 	DefaultAddOptions = healthcheck.DefaultAddArgs{
-		HealthCheckConfig: healthcheckconfig.HealthCheckConfig{
-			SyncPeriod: metav1.Duration{Duration: defaultSyncPeriod},
-			// Increase default QPS and Burst by factor 10 as a configuration example of custom REST options for shoot clients
-			ShootRESTOptions: util.RESTOptions{
-				QPS:   pointer.Float32(50),
-				Burst: pointer.Int(100),
-			},
-		},
+		HealthCheckConfig: healthcheckconfig.HealthCheckConfig{SyncPeriod: metav1.Duration{Duration: defaultSyncPeriod}},
 	}
 )
 


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
This reverts commit fd3b120dd1e3ed35f3c94f165af724e60d5ef05b.

While trying to vendor `gardener/gardener@v1.50.0` we see a build error coming from the changes in #6113.
```
$ make install
> Install
# github.com/gardener/gardener-extension-provider-aws/pkg/apis/config
pkg/apis/config/zz_generated.deepcopy.go:43:8: (*in).DeepCopyInto undefined (type *"github.com/gardener/gardener/extensions/pkg/controller/healthcheck/config".HealthCheckConfig has no field or method DeepCopyInto)
make: *** [install] Error 2
```

It looks like we don't have deepcopies generated for `github.com/gardener/gardener/extensions/pkg/controller/healthcheck/config` and `github.com/gardener/gardener/extensions/pkg/controller/healthcheck/config/v1alpha1`. 
Provider extensions use the `HealthCheckConfig` type in their types and the deepcopy generated code relies the `HealthCheckConfig` type to have a deepcopies generated as well.
With @acumino we tried to generate deepcopy for the corresponding pkg but for unknown reasons we don't manage to generate the deepcopy for the internal type - ref https://github.com/ialidzhikov/gardener/commit/ff52d908a1ae9c541d870cc9a000850cfdcdf89a.
#6113 also has the conceptual flaw that the `util.RESTOptions` type has a field of type `flowcontrol.RateLimiter` which is interface and does not make sense in the scenario of the extensions where the HealthCheckConfig type is part of the ComponentConfig of the extensions. And #6113 didn't add the new field to the v1alpha1 type (ref https://github.com/gardener/gardener/pull/6247).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix dependency
The recent changes to the "github.com/gardener/gardener/extensions/pkg/controller/healthcheck/config".HealthCheckConfig type that added client configuration settings are now reverted.
```
