### PR TITLE
Promote `Shoot{C,S}ARotation` feature gates to beta

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -38,8 +38,10 @@ The following tables are a summary of the feature gates that you can set on diff
 | ForceRestore                                 | `false` | `Alpha` | `1.39` |        |
 | DisableDNSProviderManagement                 | `false` | `Alpha` | `1.41` | `1.49` |
 | DisableDNSProviderManagement                 | `true`  | `Beta`  | `1.50` |        |
-| ShootCARotation                              | `false` | `Alpha` | `1.42` |        |
-| ShootSARotation                              | `false` | `Alpha` | `1.48` |        |
+| ShootCARotation                              | `false` | `Alpha` | `1.42` | `1.50` |
+| ShootCARotation                              | `true`  | `Beta`  | `1.51` |        |
+| ShootSARotation                              | `false` | `Alpha` | `1.48` | `1.50` |
+| ShootSARotation                              | `true`  | `Beta`  | `1.51` |        |
 | HAControlPlanes                              | `false` | `Alpha` | `1.49` |        |
 
 ## Feature gates for graduated or deprecated features

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -116,11 +116,13 @@ const (
 	// ShootCARotation enables the automated rotation of the shoot CA certificates.
 	// owner: @rfranzke
 	// alpha: v1.42.0
+	// beta: v1.51.0
 	ShootCARotation featuregate.Feature = "ShootCARotation"
 
 	// ShootSARotation enables the automated rotation of the shoot service account signing key.
 	// owner: @rfranzke
 	// alpha: v1.48.0
+	// beta: v1.51.0
 	ShootSARotation featuregate.Feature = "ShootSARotation"
 
 	// HAControlPlanes allows shoot control planes to be run in high availability mode.
@@ -142,8 +144,8 @@ var allFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	SecretBindingProviderValidation:            {Default: true, PreRelease: featuregate.Beta},
 	ForceRestore:                               {Default: false, PreRelease: featuregate.Alpha},
 	DisableDNSProviderManagement:               {Default: true, PreRelease: featuregate.Beta},
-	ShootCARotation:                            {Default: false, PreRelease: featuregate.Alpha},
-	ShootSARotation:                            {Default: false, PreRelease: featuregate.Alpha},
+	ShootCARotation:                            {Default: true, PreRelease: featuregate.Beta},
+	ShootSARotation:                            {Default: true, PreRelease: featuregate.Beta},
 	HAControlPlanes:                            {Default: false, PreRelease: featuregate.Alpha},
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security open-source
/kind enhancement

**What this PR does / why we need it**:
Promote `Shoot{C,S}ARotation` feature gates to beta.

**Which issue(s) this PR fixes**:
Part of #3292

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The `ShootCARotation` and `ShootSARotation` feature gates have been promoted to beta and are now enabled by default. Make sure that all provider extensions registered to your system support these features before upgrading to this Gardener version.
```
