### PR TITLE
Switch controller-manager to logr (5)

### DIFF
--- a/pkg/controllermanager/controller/plant/plant_health.go
+++ b/pkg/controllermanager/controller/plant/plant_health.go
@@ -58,6 +58,7 @@ func (h *HealthChecker) CheckPlantClusterNodes(ctx context.Context, condition ga
 	return updatedCondition
 }
 
+// TODO: switch to logr once health package is migrated
 var nopLogger = logger.NewNopLogger()
 
 // CheckAPIServerAvailability checks if the API server of a Plant cluster is reachable and measure the response time.

--- a/pkg/controllermanager/controller/shoot/shoot.go
+++ b/pkg/controllermanager/controller/shoot/shoot.go
@@ -109,7 +109,7 @@ func NewShootController(
 		shootRetryReconciler:       NewShootRetryReconciler(logger.Logger, gardenClient.Client(), config.Controllers.ShootRetry),
 		shootConditionsReconciler:  NewShootConditionsReconciler(logger.Logger, gardenClient.Client()),
 		shootStatusLabelReconciler: NewShootStatusLabelReconciler(logger.Logger, gardenClient.Client()),
-		shootRefReconciler:         NewShootReferenceReconciler(logger.Logger, gardenClient),
+		shootRefReconciler:         NewShootReferenceReconciler(gardenClient.Client()),
 
 		shootMaintenanceQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "shoot-maintenance"),
 		shootQuotaQueue:       workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "shoot-quota"),
@@ -224,7 +224,7 @@ func (c *Controller) Run(
 		controllerutils.CreateWorker(ctx, c.shootHibernationQueue, "Shoot Hibernation", c.shootHibernationReconciler, &waitGroup, c.workerCh, controllerutils.WithLogger(c.log.WithName(shootHibernationReconcilerName)))
 	}
 	for i := 0; i < shootReferenceWorkers; i++ {
-		controllerutils.CreateWorker(ctx, c.shootReferenceQueue, "ShootReference", c.shootRefReconciler, &waitGroup, c.workerCh)
+		controllerutils.CreateWorker(ctx, c.shootReferenceQueue, "Shoot Reference", c.shootRefReconciler, &waitGroup, c.workerCh, controllerutils.WithLogger(c.log.WithName(referenceReconcilerName)))
 	}
 	for i := 0; i < shootRetryWorkers; i++ {
 		controllerutils.CreateWorker(ctx, c.shootRetryQueue, "Shoot Retry", c.shootRetryReconciler, &waitGroup, c.workerCh)

--- a/pkg/controllermanager/controller/shoot/shoot.go
+++ b/pkg/controllermanager/controller/shoot/shoot.go
@@ -108,7 +108,7 @@ func NewShootController(
 		shootQuotaReconciler:       NewShootQuotaReconciler(gardenClient.Client(), config.Controllers.ShootQuota),
 		shootRetryReconciler:       NewShootRetryReconciler(gardenClient.Client(), config.Controllers.ShootRetry),
 		shootConditionsReconciler:  NewShootConditionsReconciler(gardenClient.Client()),
-		shootStatusLabelReconciler: NewShootStatusLabelReconciler(logger.Logger, gardenClient.Client()),
+		shootStatusLabelReconciler: NewShootStatusLabelReconciler(gardenClient.Client()),
 		shootRefReconciler:         NewShootReferenceReconciler(gardenClient.Client()),
 
 		shootMaintenanceQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "shoot-maintenance"),
@@ -236,7 +236,7 @@ func (c *Controller) Run(
 		controllerutils.CreateWorker(ctx, c.shootConditionsQueue, "Shoot Conditions", c.shootConditionsReconciler, &waitGroup, c.workerCh, controllerutils.WithLogger(c.log.WithName(conditionsReconcilerName)))
 	}
 	for i := 0; i < shootStatusLabelWorkers; i++ {
-		controllerutils.CreateWorker(ctx, c.shootStatusLabelQueue, "Shoot Status Label", c.shootStatusLabelReconciler, &waitGroup, c.workerCh)
+		controllerutils.CreateWorker(ctx, c.shootStatusLabelQueue, "Shoot Status Label", c.shootStatusLabelReconciler, &waitGroup, c.workerCh, controllerutils.WithLogger(c.log.WithName(statusLabelReconcilerName)))
 	}
 
 	// Shutdown handling

--- a/pkg/controllermanager/controller/shoot/shoot.go
+++ b/pkg/controllermanager/controller/shoot/shoot.go
@@ -106,7 +106,7 @@ func NewShootController(
 
 		shootHibernationReconciler: NewShootHibernationReconciler(gardenClient.Client(), config.Controllers.ShootHibernation, recorder, clock.RealClock{}),
 		shootMaintenanceReconciler: NewShootMaintenanceReconciler(gardenClient.Client(), config.Controllers.ShootMaintenance, recorder),
-		shootQuotaReconciler:       NewShootQuotaReconciler(logger.Logger, gardenClient.Client(), config.Controllers.ShootQuota),
+		shootQuotaReconciler:       NewShootQuotaReconciler(gardenClient.Client(), config.Controllers.ShootQuota),
 		shootRetryReconciler:       NewShootRetryReconciler(logger.Logger, gardenClient.Client(), config.Controllers.ShootRetry),
 		shootConditionsReconciler:  NewShootConditionsReconciler(logger.Logger, gardenClient.Client()),
 		shootStatusLabelReconciler: NewShootStatusLabelReconciler(logger.Logger, gardenClient.Client()),
@@ -219,7 +219,7 @@ func (c *Controller) Run(
 		controllerutils.CreateWorker(ctx, c.shootMaintenanceQueue, "Shoot Maintenance", c.shootMaintenanceReconciler, &waitGroup, c.workerCh, controllerutils.WithLogger(c.log.WithName(maintenanceReconcilerName)))
 	}
 	for i := 0; i < shootQuotaWorkers; i++ {
-		controllerutils.CreateWorker(ctx, c.shootQuotaQueue, "Shoot Quota", c.shootQuotaReconciler, &waitGroup, c.workerCh)
+		controllerutils.CreateWorker(ctx, c.shootQuotaQueue, "Shoot Quota", c.shootQuotaReconciler, &waitGroup, c.workerCh, controllerutils.WithLogger(c.log.WithName(quotaReconcilerName)))
 	}
 	for i := 0; i < shootHibernationWorkers; i++ {
 		controllerutils.CreateWorker(ctx, c.shootHibernationQueue, "Shoot Hibernation", c.shootHibernationReconciler, &waitGroup, c.workerCh, controllerutils.WithLogger(logf.Log.WithName(shootHibernationReconcilerName)))

--- a/pkg/controllermanager/controller/shoot/shoot.go
+++ b/pkg/controllermanager/controller/shoot/shoot.go
@@ -105,7 +105,7 @@ func NewShootController(
 		log:    log,
 
 		shootHibernationReconciler: NewShootHibernationReconciler(gardenClient.Client(), config.Controllers.ShootHibernation, recorder, clock.RealClock{}),
-		shootMaintenanceReconciler: NewShootMaintenanceReconciler(logger.Logger, gardenClient.Client(), config.Controllers.ShootMaintenance, recorder),
+		shootMaintenanceReconciler: NewShootMaintenanceReconciler(gardenClient.Client(), config.Controllers.ShootMaintenance, recorder),
 		shootQuotaReconciler:       NewShootQuotaReconciler(logger.Logger, gardenClient.Client(), config.Controllers.ShootQuota),
 		shootRetryReconciler:       NewShootRetryReconciler(logger.Logger, gardenClient.Client(), config.Controllers.ShootRetry),
 		shootConditionsReconciler:  NewShootConditionsReconciler(logger.Logger, gardenClient.Client()),
@@ -216,7 +216,7 @@ func (c *Controller) Run(
 	c.log.Info("Shoot controller initialized")
 
 	for i := 0; i < shootMaintenanceWorkers; i++ {
-		controllerutils.CreateWorker(ctx, c.shootMaintenanceQueue, "Shoot Maintenance", c.shootMaintenanceReconciler, &waitGroup, c.workerCh)
+		controllerutils.CreateWorker(ctx, c.shootMaintenanceQueue, "Shoot Maintenance", c.shootMaintenanceReconciler, &waitGroup, c.workerCh, controllerutils.WithLogger(c.log.WithName(maintenanceReconcilerName)))
 	}
 	for i := 0; i < shootQuotaWorkers; i++ {
 		controllerutils.CreateWorker(ctx, c.shootQuotaQueue, "Shoot Quota", c.shootQuotaReconciler, &waitGroup, c.workerCh)

--- a/pkg/controllermanager/controller/shoot/shoot.go
+++ b/pkg/controllermanager/controller/shoot/shoot.go
@@ -31,7 +31,6 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
 	"github.com/gardener/gardener/pkg/controllerutils"
-	"github.com/gardener/gardener/pkg/logger"
 	kutils "github.com/gardener/gardener/pkg/utils/kubernetes"
 
 	"k8s.io/client-go/tools/cache"
@@ -152,9 +151,6 @@ func NewShootController(
 		AddFunc: shootController.shootConditionsAdd,
 	})
 
-	// TODO: switch to logr once kutils package is migrated
-	logrusLogger := logger.Logger.WithField("logger", "controller."+ControllerName)
-
 	// Add event handler for seeds that are registered via managed seeds referencing shoots
 	seedInformer.AddEventHandler(&kutils.ControlledResourceEventHandler{
 		ControllerTypes: []kutils.ControllerType{
@@ -180,7 +176,7 @@ func NewShootController(
 		ControllerPredicateFactory: kutils.ControllerPredicateFactoryFunc(FilterSeedForShootConditions),
 		Enqueuer:                   kutils.EnqueuerFunc(func(obj client.Object) { shootController.shootConditionsAdd(obj) }),
 		Scheme:                     kubernetes.GardenScheme,
-		Logger:                     logrusLogger,
+		Logger:                     log,
 	})
 
 	shootInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{

--- a/pkg/controllermanager/controller/shoot/shoot.go
+++ b/pkg/controllermanager/controller/shoot/shoot.go
@@ -106,7 +106,7 @@ func NewShootController(
 		shootHibernationReconciler: NewShootHibernationReconciler(gardenClient.Client(), config.Controllers.ShootHibernation, recorder, clock.RealClock{}),
 		shootMaintenanceReconciler: NewShootMaintenanceReconciler(gardenClient.Client(), config.Controllers.ShootMaintenance, recorder),
 		shootQuotaReconciler:       NewShootQuotaReconciler(gardenClient.Client(), config.Controllers.ShootQuota),
-		shootRetryReconciler:       NewShootRetryReconciler(logger.Logger, gardenClient.Client(), config.Controllers.ShootRetry),
+		shootRetryReconciler:       NewShootRetryReconciler(gardenClient.Client(), config.Controllers.ShootRetry),
 		shootConditionsReconciler:  NewShootConditionsReconciler(logger.Logger, gardenClient.Client()),
 		shootStatusLabelReconciler: NewShootStatusLabelReconciler(logger.Logger, gardenClient.Client()),
 		shootRefReconciler:         NewShootReferenceReconciler(gardenClient.Client()),
@@ -227,7 +227,7 @@ func (c *Controller) Run(
 		controllerutils.CreateWorker(ctx, c.shootReferenceQueue, "Shoot Reference", c.shootRefReconciler, &waitGroup, c.workerCh, controllerutils.WithLogger(c.log.WithName(referenceReconcilerName)))
 	}
 	for i := 0; i < shootRetryWorkers; i++ {
-		controllerutils.CreateWorker(ctx, c.shootRetryQueue, "Shoot Retry", c.shootRetryReconciler, &waitGroup, c.workerCh)
+		controllerutils.CreateWorker(ctx, c.shootRetryQueue, "Shoot Retry", c.shootRetryReconciler, &waitGroup, c.workerCh, controllerutils.WithLogger(c.log.WithName(retryReconcilerName)))
 	}
 	for i := 0; i < shootConditionsWorkers; i++ {
 		controllerutils.CreateWorker(ctx, c.shootConditionsQueue, "Shoot Conditions", c.shootConditionsReconciler, &waitGroup, c.workerCh)

--- a/pkg/controllermanager/controller/shoot/shoot.go
+++ b/pkg/controllermanager/controller/shoot/shoot.go
@@ -40,7 +40,6 @@ import (
 	"k8s.io/utils/clock"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -222,7 +221,7 @@ func (c *Controller) Run(
 		controllerutils.CreateWorker(ctx, c.shootQuotaQueue, "Shoot Quota", c.shootQuotaReconciler, &waitGroup, c.workerCh, controllerutils.WithLogger(c.log.WithName(quotaReconcilerName)))
 	}
 	for i := 0; i < shootHibernationWorkers; i++ {
-		controllerutils.CreateWorker(ctx, c.shootHibernationQueue, "Shoot Hibernation", c.shootHibernationReconciler, &waitGroup, c.workerCh, controllerutils.WithLogger(logf.Log.WithName(shootHibernationReconcilerName)))
+		controllerutils.CreateWorker(ctx, c.shootHibernationQueue, "Shoot Hibernation", c.shootHibernationReconciler, &waitGroup, c.workerCh, controllerutils.WithLogger(c.log.WithName(shootHibernationReconcilerName)))
 	}
 	for i := 0; i < shootReferenceWorkers; i++ {
 		controllerutils.CreateWorker(ctx, c.shootReferenceQueue, "ShootReference", c.shootRefReconciler, &waitGroup, c.workerCh)

--- a/pkg/gardenlet/controller/managedseed/managedseed.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed.go
@@ -20,6 +20,8 @@ import (
 	"sync"
 	"time"
 
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	gardencorev1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
@@ -132,7 +134,8 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 			ControllerPredicateFactory: kutils.ControllerPredicateFactoryFunc(c.filterSeed),
 			Enqueuer:                   kutils.EnqueuerFunc(func(obj client.Object) { c.managedSeedAdd(obj) }),
 			Scheme:                     kubernetes.GardenScheme,
-			Logger:                     c.logger,
+			// TODO: switch to passed logr once this controller is migrated
+			Logger: logf.Log.WithName("controller").WithName("managedseed"),
 		},
 	})
 

--- a/pkg/utils/kubernetes/eventhandler.go
+++ b/pkg/utils/kubernetes/eventhandler.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/sirupsen/logrus"
+	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -87,7 +87,7 @@ type ControlledResourceEventHandler struct {
 	// Scheme is used to resolve types to their GroupKinds.
 	Scheme *runtime.Scheme
 	// Logger is used to log messages.
-	Logger logrus.FieldLogger
+	Logger logr.Logger
 }
 
 // ControllerType contains information about a controller type.
@@ -283,8 +283,11 @@ func (h *ControlledResourceEventHandler) getControllerByRef(namespace string, co
 }
 
 func (h *ControlledResourceEventHandler) logEnqueue(controller, obj client.Object, eventType string) {
-	h.Logger.Debugf("Enqueueing %s %s due to %s event on %s %s", h.getLastControllerKind(), ObjectName(controller),
-		eventType, h.getObjectKind(obj), ObjectName(obj))
+	h.Logger.V(1).Info("Enqueuing controlling object due to change to controlled object",
+		"controllingKind", h.getLastControllerKind(), "controllingObject", client.ObjectKeyFromObject(controller),
+		"controlledKind", h.getObjectKind(obj), "controlledObject", client.ObjectKeyFromObject(obj),
+		"eventType", eventType,
+	)
 }
 
 func (h *ControlledResourceEventHandler) getGroupKind(ct *ControllerType) (*schema.GroupKind, error) {

--- a/pkg/utils/kubernetes/eventhandler_test.go
+++ b/pkg/utils/kubernetes/eventhandler_test.go
@@ -17,10 +17,11 @@ package kubernetes_test
 import (
 	"context"
 
+	"github.com/go-logr/logr"
+
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	gardencorev1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
-	gardenerlogger "github.com/gardener/gardener/pkg/logger"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	mockpredicate "github.com/gardener/gardener/pkg/mock/controller-runtime/predicate"
 	. "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -79,7 +80,7 @@ var _ = Describe("eventhandler", func() {
 			ControllerPredicateFactory: cpf,
 			Enqueuer:                   enqueuer,
 			Scheme:                     scheme,
-			Logger:                     gardenerlogger.NewNopLogger(),
+			Logger:                     logr.Discard(),
 		}
 
 		set = &seedmanagementv1alpha1.ManagedSeedSet{

--- a/test/integration/controllermanager/shoot/hibernation/hibernation_suite_test.go
+++ b/test/integration/controllermanager/shoot/hibernation/hibernation_suite_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package shoot_test
+package hibernation_test
 
 import (
 	"context"

--- a/test/integration/controllermanager/shoot/hibernation/hibernation_test.go
+++ b/test/integration/controllermanager/shoot/hibernation/hibernation_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package shoot_test
+package hibernation_test
 
 import (
 	"context"

--- a/test/integration/controllermanager/shoot/maintenance/maintenance_suite_test.go
+++ b/test/integration/controllermanager/shoot/maintenance/maintenance_suite_test.go
@@ -12,36 +12,44 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package shoot_test
+package maintenance_test
 
 import (
 	"context"
 	"testing"
 
-	"github.com/gardener/gardener/pkg/client/kubernetes"
-	"github.com/gardener/gardener/pkg/envtest"
-	"github.com/gardener/gardener/test/framework"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	logzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	controllermanagerfeatures "github.com/gardener/gardener/pkg/controllermanager/features"
+	"github.com/gardener/gardener/pkg/envtest"
+	log "github.com/gardener/gardener/pkg/logger"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	"github.com/gardener/gardener/test/framework"
 )
 
-func TestShootRetry(t *testing.T) {
+func TestShootMaintenance(t *testing.T) {
+	controllermanagerfeatures.RegisterFeatureGates()
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Shoot Retry Controller Integration Test Suite")
+	RunSpecs(t, "Shoot Maintenance Controller Integration Test Suite")
 }
 
 var (
+	logger *logrus.Logger
+
 	ctx        = context.Background()
 	testEnv    *envtest.GardenerTestEnvironment
 	restConfig *rest.Config
 	mgrCancel  context.CancelFunc
-
 	testClient client.Client
 )
 
@@ -51,7 +59,10 @@ var _ = BeforeSuite(func() {
 	By("starting test environment")
 	testEnv = &envtest.GardenerTestEnvironment{
 		GardenerAPIServer: &envtest.GardenerAPIServer{
-			Args: []string{"--disable-admission-plugins=ResourceReferenceManager,ExtensionValidator,ShootQuotaValidator,ShootValidator,ShootTolerationRestriction"},
+			Args: []string{
+				"--disable-admission-plugins=ResourceReferenceManager,ExtensionValidator,ShootQuotaValidator,ShootValidator,ShootTolerationRestriction",
+				"--feature-gates=WorkerPoolKubernetesVersion=true",
+			},
 		},
 	}
 	var err error
@@ -61,6 +72,8 @@ var _ = BeforeSuite(func() {
 	testClient, err = client.New(restConfig, client.Options{Scheme: kubernetes.GardenScheme})
 	Expect(err).ToNot(HaveOccurred())
 
+	logger = log.AddWriter(log.NewLogger("", ""), GinkgoWriter)
+
 	By("setup manager")
 	mgr, err := manager.New(restConfig, manager.Options{
 		Scheme:             kubernetes.GardenScheme,
@@ -68,8 +81,7 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
-	err = addShootRetryControllerToManager(mgr)
-	Expect(err).ToNot(HaveOccurred())
+	Expect(addShootMaintenanceControllerToManager(mgr)).To(Succeed())
 
 	var mgrContext context.Context
 	mgrContext, mgrCancel = context.WithCancel(ctx)
@@ -77,9 +89,14 @@ var _ = BeforeSuite(func() {
 	By("start manager")
 	go func() {
 		defer GinkgoRecover()
-		err := mgr.Start(mgrContext)
-		Expect(err).ToNot(HaveOccurred())
+		Expect(mgr.Start(mgrContext)).To(Succeed())
 	}()
+
+	By("create shoot namespace")
+	namespace := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: "garden-dev"},
+	}
+	Expect(testClient.Create(ctx, namespace)).To(Or(Succeed(), BeAlreadyExistsError()))
 })
 
 var _ = AfterSuite(func() {

--- a/test/integration/controllermanager/shoot/maintenance/maintenance_test.go
+++ b/test/integration/controllermanager/shoot/maintenance/maintenance_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package shoot_maintenance_test
+package maintenance_test
 
 import (
 	"strings"

--- a/test/integration/controllermanager/shoot/maintenance/utils_test.go
+++ b/test/integration/controllermanager/shoot/maintenance/utils_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package shoot_maintenance_test
+package maintenance_test
 
 import (
 	"context"

--- a/test/integration/controllermanager/shoot/retry/retry_suite_test.go
+++ b/test/integration/controllermanager/shoot/retry/retry_suite_test.go
@@ -12,44 +12,36 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package shoot_maintenance_test
+package retry_test
 
 import (
 	"context"
 	"testing"
 
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/envtest"
+	"github.com/gardener/gardener/test/framework"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/sirupsen/logrus"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	logzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-
-	"github.com/gardener/gardener/pkg/client/kubernetes"
-	controllermanagerfeatures "github.com/gardener/gardener/pkg/controllermanager/features"
-	"github.com/gardener/gardener/pkg/envtest"
-	log "github.com/gardener/gardener/pkg/logger"
-	. "github.com/gardener/gardener/pkg/utils/test/matchers"
-	"github.com/gardener/gardener/test/framework"
 )
 
-func TestShootMaintenance(t *testing.T) {
-	controllermanagerfeatures.RegisterFeatureGates()
+func TestShootRetry(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Shoot Maintenance Controller Integration Test Suite")
+	RunSpecs(t, "Shoot Retry Controller Integration Test Suite")
 }
 
 var (
-	logger *logrus.Logger
-
 	ctx        = context.Background()
 	testEnv    *envtest.GardenerTestEnvironment
 	restConfig *rest.Config
 	mgrCancel  context.CancelFunc
+
 	testClient client.Client
 )
 
@@ -59,10 +51,7 @@ var _ = BeforeSuite(func() {
 	By("starting test environment")
 	testEnv = &envtest.GardenerTestEnvironment{
 		GardenerAPIServer: &envtest.GardenerAPIServer{
-			Args: []string{
-				"--disable-admission-plugins=ResourceReferenceManager,ExtensionValidator,ShootQuotaValidator,ShootValidator,ShootTolerationRestriction",
-				"--feature-gates=WorkerPoolKubernetesVersion=true",
-			},
+			Args: []string{"--disable-admission-plugins=ResourceReferenceManager,ExtensionValidator,ShootQuotaValidator,ShootValidator,ShootTolerationRestriction"},
 		},
 	}
 	var err error
@@ -72,8 +61,6 @@ var _ = BeforeSuite(func() {
 	testClient, err = client.New(restConfig, client.Options{Scheme: kubernetes.GardenScheme})
 	Expect(err).ToNot(HaveOccurred())
 
-	logger = log.AddWriter(log.NewLogger("", ""), GinkgoWriter)
-
 	By("setup manager")
 	mgr, err := manager.New(restConfig, manager.Options{
 		Scheme:             kubernetes.GardenScheme,
@@ -81,7 +68,8 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
-	Expect(addShootMaintenanceControllerToManager(mgr)).To(Succeed())
+	err = addShootRetryControllerToManager(mgr)
+	Expect(err).ToNot(HaveOccurred())
 
 	var mgrContext context.Context
 	mgrContext, mgrCancel = context.WithCancel(ctx)
@@ -89,14 +77,9 @@ var _ = BeforeSuite(func() {
 	By("start manager")
 	go func() {
 		defer GinkgoRecover()
-		Expect(mgr.Start(mgrContext)).To(Succeed())
+		err := mgr.Start(mgrContext)
+		Expect(err).ToNot(HaveOccurred())
 	}()
-
-	By("create shoot namespace")
-	namespace := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{Name: "garden-dev"},
-	}
-	Expect(testClient.Create(ctx, namespace)).To(Or(Succeed(), BeAlreadyExistsError()))
 })
 
 var _ = AfterSuite(func() {

--- a/test/integration/controllermanager/shoot/retry/retry_test.go
+++ b/test/integration/controllermanager/shoot/retry/retry_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package shoot_test
+package retry_test
 
 import (
 	"context"

--- a/test/integration/controllermanager/shootmaintenance/maintenance_control_test.go
+++ b/test/integration/controllermanager/shootmaintenance/maintenance_control_test.go
@@ -472,13 +472,13 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 
 func addShootMaintenanceControllerToManager(mgr manager.Manager) error {
 	recorder := mgr.GetEventRecorderFor("shoot-maintenance-controller")
-	concurrentSyncs := 1
+	cfg := config.ShootMaintenanceControllerConfiguration{ConcurrentSyncs: pointer.Int(1)}
 
 	c, err := controller.New(
 		"shoot-maintenance-controller",
 		mgr,
 		controller.Options{
-			Reconciler: shootcontroller.NewShootMaintenanceReconciler(logger, testClient, config.ShootMaintenanceControllerConfiguration{ConcurrentSyncs: &concurrentSyncs}, recorder),
+			Reconciler: shootcontroller.NewShootMaintenanceReconciler(testClient, cfg, recorder),
 		},
 	)
 	if err != nil {

--- a/test/integration/controllermanager/shootretry/shootretry_control_test.go
+++ b/test/integration/controllermanager/shootretry/shootretry_control_test.go
@@ -22,7 +22,6 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
 	"github.com/gardener/gardener/pkg/controllermanager/controller/shoot"
-	"github.com/gardener/gardener/pkg/logger"
 	retryutils "github.com/gardener/gardener/pkg/utils/retry"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 
@@ -144,7 +143,7 @@ func addShootRetryControllerToManager(mgr manager.Manager) error {
 		"shoot-retry-controller",
 		mgr,
 		controller.Options{
-			Reconciler: shoot.NewShootRetryReconciler(logger.NewNopLogger(), testClient, &config.ShootRetryControllerConfiguration{RetryPeriod: &metav1.Duration{Duration: retryPeriod}}),
+			Reconciler: shoot.NewShootRetryReconciler(testClient, &config.ShootRetryControllerConfiguration{RetryPeriod: &metav1.Duration{Duration: retryPeriod}}),
 		},
 	)
 	if err != nil {

--- a/test/integration/gardenlet/shoot/secret/secret_suite_test.go
+++ b/test/integration/gardenlet/shoot/secret/secret_suite_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package shootsecret_test
+package secret_test
 
 import (
 	"context"
@@ -62,7 +62,7 @@ var _ = BeforeSuite(func() {
 	testEnv = &gardenerenvtest.GardenerTestEnvironment{
 		Environment: &envtest.Environment{
 			CRDInstallOptions: envtest.CRDInstallOptions{
-				Paths: []string{filepath.Join("..", "..", "..", "..", "example", "seed-crds", "10-crd-extensions.gardener.cloud_clusters.yaml")},
+				Paths: []string{filepath.Join("..", "..", "..", "..", "..", "example", "seed-crds", "10-crd-extensions.gardener.cloud_clusters.yaml")},
 			},
 			ErrorIfCRDPathMissing: true,
 		},

--- a/test/integration/gardenlet/shoot/secret/secret_test.go
+++ b/test/integration/gardenlet/shoot/secret/secret_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package shootsecret_test
+package secret_test
 
 import (
 	"encoding/json"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging dev-productivity
/kind enhancement

**What this PR does / why we need it**:

Continuation of https://github.com/gardener/gardener/pull/5488
Migrate controller-manager shoot controller to logr.
This was the last one in controller-manager, meaning it is fully migrated now.

**Which issue(s) this PR fixes**:
Part of #4251

**Special notes for your reviewer**:

We have to keep instantiating `logger.Logger` in controller-manager for now, as there are a few minor usages in helper funcs shared with gardenlet. 
We can drop this, once they have been switched as well.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
