### PR TITLE
Raise minimum Kubernetes cluster version to 1.20 for garden and seeds

### DIFF
--- a/charts/seed-bootstrap/charts/loki/templates/kube-rbac-proxy-ingress.yaml
+++ b/charts/seed-bootstrap/charts/loki/templates/kube-rbac-proxy-ingress.yaml
@@ -27,15 +27,10 @@ spec:
     http:
       paths:
       - backend:
-          {{- if semverCompare ">= 1.19-0" $.Capabilities.KubeVersion.GitVersion }}
           service:
             name: {{ .serviceName }}
             port:
               number: {{ .servicePort }}
-          {{- else }}
-          serviceName: {{ .serviceName }}
-          servicePort: {{ .servicePort }}
-          {{- end }}
         path: {{ .backendPath }}
         pathType: Prefix
   {{- end }}

--- a/charts/seed-bootstrap/templates/aggregate-prometheus/ingress.yaml
+++ b/charts/seed-bootstrap/templates/aggregate-prometheus/ingress.yaml
@@ -23,14 +23,9 @@ spec:
     http:
       paths:
       - backend:
-          {{- if semverCompare ">= 1.19-0" .Capabilities.KubeVersion.GitVersion }}
           service:
             name: aggregate-prometheus-web
             port:
               number: 80
-          {{- else }}
-          serviceName: aggregate-prometheus-web
-          servicePort: 80
-          {{- end }}
         path: /
         pathType: Prefix

--- a/charts/seed-bootstrap/templates/grafana/ingress.yaml
+++ b/charts/seed-bootstrap/templates/grafana/ingress.yaml
@@ -23,14 +23,9 @@ spec:
     http:
       paths:
       - backend:
-          {{- if semverCompare ">= 1.19-0" .Capabilities.KubeVersion.GitVersion }}
           service:
             name: grafana
             port:
               number: 3000
-          {{- else }}
-          serviceName: grafana
-          servicePort: 3000
-          {{- end }}
         path: /
         pathType: Prefix

--- a/charts/utils-templates/templates/_versions.tpl
+++ b/charts/utils-templates/templates/_versions.tpl
@@ -63,9 +63,5 @@ policy/v1beta1
 {{- end -}}
 
 {{- define "ingressversion" -}}
-{{- if semverCompare ">= 1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 networking.k8s.io/v1
-{{- else -}}
-networking.k8s.io/v1beta1
-{{- end -}}
 {{- end -}}

--- a/docs/usage/supported_k8s_versions.md
+++ b/docs/usage/supported_k8s_versions.md
@@ -4,13 +4,11 @@ Currently, the Gardener supports the following Kubernetes versions:
 
 ## Garden cluster version
 
-:warning: The minimum version of the garden cluster that can be used to run Gardener is **`1.17.x`**.
+The minimum version of the garden cluster that can be used to run Gardener is **`1.20.x`**.
 
 ## Seed cluster versions
 
-:warning: The minimum version of a seed cluster that can be connected to Gardener is **`1.18.x`**.
-Kubernetes `1.18` sets the common ground for several Gardener features, e.g. `SeedKubeScheduler` ([ref](https://github.com/gardener/gardener/blob/master/docs/deployment/feature_gates.md#list-of-feature-gates)).
-It also enables the Gardener code base to leverage more advanced Kubernetes features, like [Server-Side Apply](https://kubernetes.io/docs/reference/using-api/server-side-apply/), in the future.
+The minimum version of a seed cluster that can be connected to Gardener is **`1.20.x`**.
 
 ## Shoot cluster versions
 

--- a/pkg/operation/garden/garden.go
+++ b/pkg/operation/garden/garden.go
@@ -306,14 +306,14 @@ func ReadGardenSecrets(ctx context.Context, c client.Reader, namespace string, l
 
 // BootstrapCluster bootstraps the Garden cluster and deploys various required manifests.
 func BootstrapCluster(ctx context.Context, k8sGardenClient kubernetes.Interface, secretsManager secretsmanager.Interface) error {
-	// Check whether the Kubernetes version of the Garden cluster is at least 1.17 (least supported K8s version of Gardener).
-	minGardenVersion := "1.17"
-	gardenVersionOK, err := version.CompareVersions(k8sGardenClient.Version(), ">=", minGardenVersion)
+	const minKubernetesVersion = "1.20"
+
+	gardenVersionOK, err := version.CompareVersions(k8sGardenClient.Version(), ">=", minKubernetesVersion)
 	if err != nil {
 		return err
 	}
 	if !gardenVersionOK {
-		return fmt.Errorf("the Kubernetes version of the Garden cluster must be at least %s", minGardenVersion)
+		return fmt.Errorf("the Kubernetes version of the Garden cluster must be at least %s", minKubernetesVersion)
 	}
 
 	secretList := &corev1.SecretList{}

--- a/pkg/operation/garden/garden_test.go
+++ b/pkg/operation/garden/garden_test.go
@@ -189,7 +189,7 @@ var _ = Describe("Garden", func() {
 
 		BeforeEach(func() {
 			fakeGardenClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).Build()
-			k8sGardenClient = fake.NewClientSetBuilder().WithClient(fakeGardenClient).WithVersion("1.17.4").Build()
+			k8sGardenClient = fake.NewClientSetBuilder().WithClient(fakeGardenClient).WithVersion("1.20.4").Build()
 			sm = fakesecretsmanager.New(fakeGardenClient, namespace)
 		})
 
@@ -202,7 +202,7 @@ var _ = Describe("Garden", func() {
 		It("should return an error because the garden version is too low", func() {
 			k8sGardenClient = fake.NewClientSetBuilder().WithClient(fakeGardenClient).WithVersion("1.16.5").Build()
 
-			Expect(BootstrapCluster(ctx, k8sGardenClient, sm)).To(MatchError(ContainSubstring("the Kubernetes version of the Garden cluster must be at least 1.17")))
+			Expect(BootstrapCluster(ctx, k8sGardenClient, sm)).To(MatchError(ContainSubstring("the Kubernetes version of the Garden cluster must be at least 1.20")))
 		})
 
 		It("should generate a global monitoring secret because none exists yet", func() {

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -1334,15 +1334,16 @@ func (s *Seed) IngressDomain() string {
 
 // CheckMinimumK8SVersion checks whether the Kubernetes version of the Seed cluster fulfills the minimal requirements.
 func (s *Seed) CheckMinimumK8SVersion(version string) (string, error) {
-	const minSeedVersion = "1.18"
+	const minKubernetesVersion = "1.20"
 
-	seedVersionOK, err := versionutils.CompareVersions(version, ">=", minSeedVersion)
+	seedVersionOK, err := versionutils.CompareVersions(version, ">=", minKubernetesVersion)
 	if err != nil {
 		return "<unknown>", err
 	}
 	if !seedVersionOK {
-		return "<unknown>", fmt.Errorf("the Kubernetes version of the Seed cluster must be at least %s", minSeedVersion)
+		return "<unknown>", fmt.Errorf("the Kubernetes version of the Seed cluster must be at least %s", minKubernetesVersion)
 	}
+
 	return version, nil
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:
Raise minimum Kubernetes cluster version to 1.20 for garden and seeds. This allows us drop some coding that could cause issues when the credentials of seeds are rotated.

**Special notes for your reviewer**:
/cc @dguendisch @BeckerMax 

We will drop support for shoots < 1.20 end of this year.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The minimum Kubernetes version for garden and seed clusters is now `1.20`. Make sure to upgrade your clusters to at least `1.20` before deploying this Gardener version.
```
