### PR TITLE
Switch `gardenlet` to `logr` (1)

### DIFF
--- a/pkg/extensions/customresources.go
+++ b/pkg/extensions/customresources.go
@@ -20,13 +20,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/sirupsen/logrus"
-	autoscalingv1 "k8s.io/api/autoscaling/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	gardencorev1alpha1helper "github.com/gardener/gardener/pkg/apis/core/v1alpha1/helper"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -39,6 +32,14 @@ import (
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 	unstructuredutils "github.com/gardener/gardener/pkg/utils/kubernetes/unstructured"
 	"github.com/gardener/gardener/pkg/utils/retry"
+
+	"github.com/go-logr/logr"
+	"github.com/sirupsen/logrus"
+	autoscalingv1 "k8s.io/api/autoscaling/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // TimeNow returns the current time. Exposed for testing.
@@ -50,7 +51,7 @@ var TimeNow = time.Now
 func WaitUntilExtensionObjectReady(
 	ctx context.Context,
 	c client.Client,
-	logger logrus.FieldLogger,
+	log interface{}, // TODO(rfranzke): Use logr.Logger when all usages are adapted
 	obj extensionsv1alpha1.Object,
 	kind string,
 	interval time.Duration,
@@ -58,7 +59,7 @@ func WaitUntilExtensionObjectReady(
 	timeout time.Duration,
 	postReadyFunc func() error,
 ) error {
-	return WaitUntilObjectReadyWithHealthFunction(ctx, c, logger, health.CheckExtensionObject, obj, kind, interval, severeThreshold, timeout, postReadyFunc)
+	return WaitUntilObjectReadyWithHealthFunction(ctx, c, log, health.CheckExtensionObject, obj, kind, interval, severeThreshold, timeout, postReadyFunc)
 }
 
 // WaitUntilObjectReadyWithHealthFunction waits until the given object has become ready. It takes the health check
@@ -68,7 +69,7 @@ func WaitUntilExtensionObjectReady(
 func WaitUntilObjectReadyWithHealthFunction(
 	ctx context.Context,
 	c client.Client,
-	logger logrus.FieldLogger,
+	log interface{}, // TODO(rfranzke): Use logr.Logger when all usages are adapted
 	healthFunc health.Func,
 	obj client.Object,
 	kind string,
@@ -106,7 +107,14 @@ func WaitUntilObjectReadyWithHealthFunction(
 
 		if err := healthFunc(obj); err != nil {
 			lastObservedError = err
-			logger.WithError(err).Errorf("%s did not get ready yet", extensionKey(kind, namespace, name))
+
+			switch logger := log.(type) {
+			case logrus.FieldLogger:
+				logger.WithError(err).Errorf("%s did not get ready yet", extensionKey(kind, namespace, name))
+			case logr.Logger:
+				logger.Error(err, "Object did not get ready yet", "object", extensionKey(kind, namespace, name))
+			}
+
 			if retry.IsRetriable(err) {
 				return retry.MinorOrSevereError(retryCountUntilSevere, int(severeThreshold.Nanoseconds()/interval.Nanoseconds()), err)
 			}
@@ -202,7 +210,7 @@ func WaitUntilExtensionObjectsDeleted(
 func WaitUntilExtensionObjectDeleted(
 	ctx context.Context,
 	c client.Client,
-	logger logrus.FieldLogger,
+	log interface{}, // TODO(rfranzke): Use logr.Logger when all usages are adapted
 	obj extensionsv1alpha1.Object,
 	kind string,
 	interval time.Duration,
@@ -224,7 +232,12 @@ func WaitUntilExtensionObjectDeleted(
 		}
 
 		if lastErr := obj.GetExtensionStatus().GetLastError(); lastErr != nil {
-			logger.Errorf("%s did not get deleted yet, lastError is: %s", extensionKey(kind, namespace, name), lastErr.Description)
+			switch logger := log.(type) {
+			case logrus.FieldLogger:
+				logger.Errorf("%s did not get deleted yet, lastError is: %s", extensionKey(kind, namespace, name), lastErr.Description)
+			case logr.Logger:
+				logger.Error(fmt.Errorf(lastErr.Description), "Object did not get deleted yet", "object", extensionKey(kind, namespace, name))
+			}
 			lastObservedError = gardencorev1beta1helper.NewErrorWithCodes(errors.New(lastErr.Description), lastErr.Codes...)
 		}
 

--- a/pkg/extensions/customresources.go
+++ b/pkg/extensions/customresources.go
@@ -112,7 +112,7 @@ func WaitUntilObjectReadyWithHealthFunction(
 			case logrus.FieldLogger:
 				logger.WithError(err).Errorf("%s did not get ready yet", extensionKey(kind, namespace, name))
 			case logr.Logger:
-				logger.Error(err, "Object did not get ready yet", "object", extensionKey(kind, namespace, name))
+				logger.Error(err, "Object did not get ready yet")
 			}
 
 			if retry.IsRetriable(err) {
@@ -236,7 +236,7 @@ func WaitUntilExtensionObjectDeleted(
 			case logrus.FieldLogger:
 				logger.Errorf("%s did not get deleted yet, lastError is: %s", extensionKey(kind, namespace, name), lastErr.Description)
 			case logr.Logger:
-				logger.Error(fmt.Errorf(lastErr.Description), "Object did not get deleted yet", "object", extensionKey(kind, namespace, name))
+				logger.Error(fmt.Errorf(lastErr.Description), "Object did not get deleted yet")
 			}
 			lastObservedError = gardencorev1beta1helper.NewErrorWithCodes(errors.New(lastErr.Description), lastErr.Codes...)
 		}

--- a/pkg/gardenlet/controller/backupbucket/backup_bucket.go
+++ b/pkg/gardenlet/controller/backupbucket/backup_bucket.go
@@ -126,7 +126,7 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 	c.log.Info("BackupBucket controller initialized")
 
 	for i := 0; i < workers; i++ {
-		controllerutils.CreateWorker(ctx, c.backupBucketQueue, "backupbucket", c.reconciler, &waitGroup, c.workerCh)
+		controllerutils.CreateWorker(ctx, c.backupBucketQueue, "backupbucket", c.reconciler, &waitGroup, c.workerCh, controllerutils.WithLogger(c.log))
 	}
 
 	// Shutdown handling

--- a/pkg/gardenlet/controller/backupbucket/backup_bucket.go
+++ b/pkg/gardenlet/controller/backupbucket/backup_bucket.go
@@ -26,8 +26,9 @@ import (
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	confighelper "github.com/gardener/gardener/pkg/gardenlet/apis/config/helper"
-	"github.com/gardener/gardener/pkg/logger"
 
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
@@ -37,12 +38,15 @@ import (
 )
 
 const (
+	// ControllerName is the name of this controller.
+	ControllerName = "backupbucket"
 	// finalizerName is the backupbucket controller finalizer.
 	finalizerName = "core.gardener.cloud/backupbucket"
 )
 
 // Controller controls BackupBuckets.
 type Controller struct {
+	log          logr.Logger
 	gardenClient client.Client
 	config       *config.GardenletConfiguration
 	reconciler   reconcile.Reconciler
@@ -58,7 +62,18 @@ type Controller struct {
 // NewBackupBucketController takes a Kubernetes client for the Garden clusters <k8sGardenClient>, a struct
 // holding information about the acting Gardener, a <backupBucketInformer>, and a <recorder> for
 // event recording. It creates a new Gardener controller.
-func NewBackupBucketController(ctx context.Context, clientMap clientmap.ClientMap, config *config.GardenletConfiguration, recorder record.EventRecorder) (*Controller, error) {
+func NewBackupBucketController(
+	ctx context.Context,
+	log logr.Logger,
+	clientMap clientmap.ClientMap,
+	config *config.GardenletConfiguration,
+	recorder record.EventRecorder,
+) (
+	*Controller,
+	error,
+) {
+	log = log.WithName(ControllerName)
+
 	gardenClient, err := clientMap.GetClient(ctx, keys.ForGarden())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get garden client: %w", err)
@@ -70,6 +85,7 @@ func NewBackupBucketController(ctx context.Context, clientMap clientmap.ClientMa
 	}
 
 	controller := &Controller{
+		log:                  log,
 		gardenClient:         gardenClient.Client(),
 		config:               config,
 		reconciler:           newReconciler(clientMap, recorder, config),
@@ -96,7 +112,7 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 	var waitGroup sync.WaitGroup
 
 	if !cache.WaitForCacheSync(ctx.Done(), c.backupBucketInformer.HasSynced) {
-		logger.Logger.Fatal("Timed out waiting for BackupBucket Informer to sync")
+		c.log.Error(wait.ErrWaitTimeout, "Timed out waiting for caches to sync")
 		return
 	}
 
@@ -104,11 +120,10 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 	go func() {
 		for res := range c.workerCh {
 			c.numberOfRunningWorkers += res
-			logger.Logger.Debugf("Current number of running BackupBucket workers is %d", c.numberOfRunningWorkers)
 		}
 	}()
 
-	logger.Logger.Info("BackupBucket controller initialized.")
+	c.log.Info("BackupBucket controller initialized")
 
 	for i := 0; i < workers; i++ {
 		controllerutils.CreateWorker(ctx, c.backupBucketQueue, "backupbucket", c.reconciler, &waitGroup, c.workerCh)
@@ -120,10 +135,10 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 
 	for {
 		if c.backupBucketQueue.Len() == 0 && c.numberOfRunningWorkers == 0 {
-			logger.Logger.Info("No running BackupBucket worker and no items left in the queues. Terminated BackupBucket controller...")
+			c.log.V(1).Info("No running BackupBucket worker and no items left in the queues. Terminated BackupBucket controller")
 			break
 		}
-		logger.Logger.Infof("Waiting for %d BackupBucket worker(s) to finish (%d item(s) left in the queues)...", c.numberOfRunningWorkers, c.backupBucketQueue.Len())
+		c.log.V(1).Info("Waiting for BackupBucket workers to finish", "numberOfRunningWorkers", c.numberOfRunningWorkers, "queueLength", c.backupBucketQueue.Len())
 		time.Sleep(5 * time.Second)
 	}
 

--- a/pkg/gardenlet/controller/backupbucket/backup_bucket_reconciler.go
+++ b/pkg/gardenlet/controller/backupbucket/backup_bucket_reconciler.go
@@ -129,7 +129,7 @@ func (r *reconciler) reconcileBackupBucket(
 		return reconcile.Result{}, fmt.Errorf("failed to get seed client: %w", err)
 	}
 
-	a := newActuator(gardenClient, seedClient, backupBucket, r.logger)
+	a := newActuator(log, gardenClient, seedClient, backupBucket)
 	if err := a.Reconcile(ctx); err != nil {
 		log.Error(err, "Failed to reconcile")
 
@@ -199,7 +199,7 @@ func (r *reconciler) deleteBackupBucket(
 		return reconcile.Result{}, fmt.Errorf("failed to get seed client: %w", err)
 	}
 
-	a := newActuator(gardenClient, seedClient, backupBucket, r.logger)
+	a := newActuator(log, gardenClient, seedClient, backupBucket)
 	if err := a.Delete(ctx); err != nil {
 		log.Error(err, "Failed to delete")
 

--- a/pkg/gardenlet/controller/backupbucket/backup_bucket_reconciler.go
+++ b/pkg/gardenlet/controller/backupbucket/backup_bucket_reconciler.go
@@ -106,7 +106,7 @@ func (r *reconciler) reconcileBackupBucket(
 	}
 
 	if updateErr := updateBackupBucketStatusProcessing(ctx, gardenClient.Client(), backupBucket, "Reconciliation of Backup Bucket state in progress.", 2); updateErr != nil {
-		return reconcile.Result{}, updateErr
+		return reconcile.Result{}, fmt.Errorf("could not update status after reconciliation start: %w", updateErr)
 	}
 
 	secret, err := kutil.GetSecretByReference(ctx, gardenClient.Client(), &backupBucket.Spec.SecretRef)
@@ -138,13 +138,13 @@ func (r *reconciler) reconcileBackupBucket(
 		r.recorder.Eventf(backupBucket, corev1.EventTypeWarning, gardencorev1beta1.EventReconcileError, "%s", reconcileErr.Description)
 
 		if updateErr := updateBackupBucketStatusError(ctx, gardenClient.Client(), backupBucket, reconcileErr.Description+" Operation will be retried.", reconcileErr); updateErr != nil {
-			return reconcile.Result{}, updateErr
+			return reconcile.Result{}, fmt.Errorf("could not update status after reconciliation error: %w", updateErr)
 		}
 		return reconcile.Result{}, errors.New(reconcileErr.Description)
 	}
 
 	if updateErr := updateBackupBucketStatusSucceeded(ctx, gardenClient.Client(), backupBucket, "Backup Bucket has been successfully reconciled."); updateErr != nil {
-		return reconcile.Result{}, updateErr
+		return reconcile.Result{}, fmt.Errorf("could not update status after reconciliation success: %w", updateErr)
 	}
 
 	return reconcile.Result{}, nil
@@ -164,7 +164,7 @@ func (r *reconciler) deleteBackupBucket(
 	}
 
 	if updateErr := updateBackupBucketStatusProcessing(ctx, gardenClient.Client(), backupBucket, "Deletion of Backup Bucket in progress.", 2); updateErr != nil {
-		return reconcile.Result{}, updateErr
+		return reconcile.Result{}, fmt.Errorf("could not update status after deletion start: %w", updateErr)
 	}
 
 	backupEntryList := &gardencorev1beta1.BackupEntryList{}
@@ -202,12 +202,12 @@ func (r *reconciler) deleteBackupBucket(
 		r.recorder.Eventf(backupBucket, corev1.EventTypeWarning, gardencorev1beta1.EventDeleteError, "%s", deleteErr.Description)
 
 		if updateErr := updateBackupBucketStatusError(ctx, gardenClient.Client(), backupBucket, deleteErr.Description+" Operation will be retried.", deleteErr); updateErr != nil {
-			return reconcile.Result{}, updateErr
+			return reconcile.Result{}, fmt.Errorf("could not update status after deletion error: %w", updateErr)
 		}
 		return reconcile.Result{}, errors.New(deleteErr.Description)
 	}
 	if updateErr := updateBackupBucketStatusSucceeded(ctx, gardenClient.Client(), backupBucket, "Backup Bucket has been successfully deleted."); updateErr != nil {
-		return reconcile.Result{}, updateErr
+		return reconcile.Result{}, fmt.Errorf("could not update status after deletion success: %w", updateErr)
 	}
 
 	log.Info("Successfully deleted")

--- a/pkg/gardenlet/controller/factory.go
+++ b/pkg/gardenlet/controller/factory.go
@@ -60,6 +60,7 @@ import (
 	"k8s.io/component-base/version"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // DefaultImageVector is a constant for the path to the default image vector file.
@@ -99,6 +100,8 @@ func NewGardenletControllerFactory(
 
 // Run starts all the controllers for the Garden API group. It also performs bootstrapping tasks.
 func (f *GardenletControllerFactory) Run(ctx context.Context) error {
+	log := logf.Log.WithName("controller")
+
 	gardenClientSet, err := f.clientMap.GetClient(ctx, keys.ForGarden())
 	if err != nil {
 		return fmt.Errorf("failed to get garden client: %+v", err)
@@ -135,7 +138,7 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to get seed client: %w", err)
 	}
 
-	backupBucketController, err := backupbucketcontroller.NewBackupBucketController(ctx, f.clientMap, f.cfg, f.recorder)
+	backupBucketController, err := backupbucketcontroller.NewBackupBucketController(ctx, log, f.clientMap, f.cfg, f.recorder)
 	if err != nil {
 		return fmt.Errorf("failed initializing BackupBucket controller: %w", err)
 	}

--- a/pkg/utils/flow/flow.go
+++ b/pkg/utils/flow/flow.go
@@ -99,7 +99,7 @@ func (n *node) addTargets(taskIDs ...TaskID) {
 // are left blank and don't affect the Flow.
 type Opts struct {
 	// Logger is used to log any output during flow execution.
-	Logger interface{}
+	Logger interface{} // TODO(rfranzke): Use logr.Logger when all usages are adapted
 	// ProgressReporter is used to report the progress during flow execution.
 	ProgressReporter ProgressReporter
 	// ErrorCleaner is used to clean up a previously failed task.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Migrate `gardenlet`'s `BackupBucket` controller to `logr`.

**Which issue(s) this PR fixes**:
Part of #4251

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
