### PR TITLE
Switch `gardenlet` to `logr` (2)

### DIFF
--- a/pkg/gardenlet/controller/factory.go
+++ b/pkg/gardenlet/controller/factory.go
@@ -165,7 +165,7 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 		return fmt.Errorf("failed initializing ManagedSeed controller: %w", err)
 	}
 
-	networkPolicyController, err := networkpolicycontroller.NewController(ctx, seedClient, logger.Logger, f.recorder, f.cfg.SeedConfig.Name)
+	networkPolicyController, err := networkpolicycontroller.NewController(ctx, log, seedClient, f.cfg.SeedConfig.Name)
 	if err != nil {
 		return fmt.Errorf("failed initializing NetworkPolicy controller: %w", err)
 	}

--- a/pkg/gardenlet/controller/factory.go
+++ b/pkg/gardenlet/controller/factory.go
@@ -148,7 +148,7 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 		return fmt.Errorf("failed initializing BackupEntry controller: %w", err)
 	}
 
-	bastionController, err := bastioncontroller.NewBastionController(ctx, f.clientMap, f.cfg)
+	bastionController, err := bastioncontroller.NewBastionController(ctx, log, f.clientMap, f.cfg)
 	if err != nil {
 		return fmt.Errorf("failed initializing Bastion controller: %w", err)
 	}

--- a/pkg/gardenlet/controller/networkpolicy/endpoints.go
+++ b/pkg/gardenlet/controller/networkpolicy/endpoints.go
@@ -17,10 +17,10 @@ package networkpolicy
 import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/networkpolicy/helper"
-	corev1 "k8s.io/api/core/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func (c *Controller) endpointAdd(_ interface{}) {
@@ -40,14 +40,14 @@ func (c *Controller) enqueueNamespaces() {
 	if err := c.seedClient.List(c.ctx, namespaces, &client.ListOptions{
 		LabelSelector: c.shootNamespaceSelector,
 	}); err != nil {
-		c.log.Errorf("Failed to enqueue namespaces to update NetworkPolicy %q - unable to list Shoot namespaces: %v", helper.AllowToSeedAPIServer, err)
+		c.log.Error(err, "Unable to list Shoot namespace for updating NetworkPolicy", "networkPolicyName", helper.AllowToSeedAPIServer)
 		return
 	}
 
 	for _, namespace := range namespaces.Items {
 		key, err := cache.MetaNamespaceKeyFunc(&namespace)
 		if err != nil {
-			c.log.Errorf("Failed to enqueue namespaces to update NetworkPolicy %q for namespace %q - couldn't get key for namespace: %v", helper.AllowToSeedAPIServer, namespace.Name, err)
+			c.log.Error(err, "Could not get key of namespace for updating NetworkPolicy", "networkPolicyName", helper.AllowToSeedAPIServer, "namespace", client.ObjectKeyFromObject(&namespace))
 			continue
 		}
 		c.namespaceQueue.Add(key)

--- a/pkg/gardenlet/controller/networkpolicy/hostnameresolver/resolver_test.go
+++ b/pkg/gardenlet/controller/networkpolicy/hostnameresolver/resolver_test.go
@@ -23,11 +23,10 @@ import (
 	"time"
 
 	"github.com/gardener/gardener/pkg/client/kubernetes/fake"
-	"github.com/gardener/gardener/pkg/logger"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/rest"
 )
@@ -43,7 +42,7 @@ type fakeLookup struct {
 	lock  sync.Mutex
 }
 
-func (f *fakeLookup) LookupHost(ctx context.Context, host string) ([]string, error) {
+func (f *fakeLookup) LookupHost(_ context.Context, _ string) ([]string, error) {
 	f.lock.Lock()
 	defer f.lock.Unlock()
 
@@ -80,7 +79,7 @@ var _ = Describe("resolver", func() {
 			lookup:        f,
 			upstreamPort:  1234,
 			refreshTicker: time.NewTicker(time.Millisecond),
-			log:           logger.NewNopLogger(),
+			log:           logr.Discard(),
 			onUpdate: func() {
 				updateCount++
 			},
@@ -195,7 +194,7 @@ var _ = Describe("CreateForCluster", func() {
 			Host: "https://foo.bar:1234",
 		}).Build()
 
-		p, err := CreateForCluster(c, logger.NewNopLogger())
+		p, err := CreateForCluster(c, logr.Discard())
 		Expect(err).NotTo(HaveOccurred())
 		Expect(p).NotTo(BeNil())
 
@@ -225,7 +224,7 @@ var _ = Describe("CreateForCluster", func() {
 			}
 		}()
 
-		p, err := CreateForCluster(c, logger.NewNopLogger())
+		p, err := CreateForCluster(c, logr.Discard())
 		Expect(err).NotTo(HaveOccurred())
 		Expect(p).NotTo(BeNil())
 
@@ -255,7 +254,7 @@ var _ = Describe("CreateForCluster", func() {
 			}
 		}()
 
-		p, err := CreateForCluster(c, logger.NewNopLogger())
+		p, err := CreateForCluster(c, logr.Discard())
 		Expect(err).NotTo(HaveOccurred())
 		Expect(p).NotTo(BeNil())
 

--- a/pkg/gardenlet/controller/networkpolicy/namespace_control.go
+++ b/pkg/gardenlet/controller/networkpolicy/namespace_control.go
@@ -21,22 +21,21 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/networkpolicy/helper"
 	"github.com/gardener/gardener/pkg/gardenlet/controller/networkpolicy/hostnameresolver"
-	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
-	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 // namespaceReconciler implements the reconcile.Reconcile interface for namespace reconciliation.
 type namespaceReconciler struct {
-	log                    *logrus.Logger
 	seedClient             client.Client
 	seedName               string
 	shootNamespaceSelector labels.Selector
@@ -45,7 +44,6 @@ type namespaceReconciler struct {
 
 // newNamespaceReconciler returns the new namespace reconciler.
 func newNamespaceReconciler(
-	seedLogger *logrus.Logger,
 	seedClient client.Client,
 	seedName string,
 	shootNamespaceSelector labels.Selector,
@@ -53,7 +51,6 @@ func newNamespaceReconciler(
 ) reconcile.Reconciler {
 	return &namespaceReconciler{
 		seedClient:             seedClient,
-		log:                    seedLogger,
 		seedName:               seedName,
 		shootNamespaceSelector: shootNamespaceSelector,
 		resolver:               resolver,
@@ -62,43 +59,46 @@ func newNamespaceReconciler(
 
 // Reconcile reconciles namespace in order to create the "allowed-to-seed-apiserver" Network Policy
 func (r *namespaceReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log := logf.FromContext(ctx)
+
 	namespace := &corev1.Namespace{}
 	if err := r.seedClient.Get(ctx, request.NamespacedName, namespace); err != nil {
-		if client.IgnoreNotFound(err) != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("Object is gone, stop reconciling")
 			return reconcile.Result{}, err
 		}
-		r.log.Debugf("namespace %q is not found, not trying to reconcile", request.Name)
-		return reconcile.Result{}, nil
+		return reconcile.Result{}, fmt.Errorf("error retrieving object from store: %w", err)
 	}
+
+	networkPolicy := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      helper.AllowToSeedAPIServer,
+			Namespace: request.Name,
+		},
+	}
+	log = log.WithValues("networkPolicy", client.ObjectKeyFromObject(networkPolicy))
 
 	// if the namespace is not the Garden or a Shoot namespace - delete the existing NetworkPolicy
 	if !(namespace.Name == v1beta1constants.GardenNamespace || r.shootNamespaceSelector.Matches(labels.Set(namespace.Labels))) {
-		policy := &networkingv1.NetworkPolicy{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      helper.AllowToSeedAPIServer,
-				Namespace: request.Name,
-			},
+		if err := r.seedClient.Delete(ctx, networkPolicy); client.IgnoreNotFound(err) != nil {
+			return reconcile.Result{}, fmt.Errorf("unable to delete NetworkPolicy %q from namespace %q: %w", networkPolicy.Name, namespace.Name, err)
 		}
-		err := r.seedClient.Delete(ctx, policy)
-		if client.IgnoreNotFound(err) != nil {
-			return reconcile.Result{}, fmt.Errorf("unable to delete NetworkPolicy %q from namespace %q: %w", policy.Name, namespace.Name, err)
-		} else if err == nil {
-			r.log.Infof("Deleting NetworkPolicy %q from namespace %q", policy.Name, namespace.Name)
-		}
+
+		log.Info("Deleted NetworkPolicy")
 		return reconcile.Result{}, nil
 	}
 
 	if namespace.DeletionTimestamp != nil {
-		r.log.Debugf("Do not update NetworkPolicy %q in namespace %q - namespace has a deletion timestamp", helper.AllowToSeedAPIServer, namespace.Name)
+		log.V(1).Info("Do not update NetworkPolicy because namespace has a deletion timestamp")
 		return reconcile.Result{}, nil
 	}
 
 	if namespace.Status.Phase != corev1.NamespaceActive {
-		r.log.Debugf("Do not update NetworkPolicy %q in namespace %q - namespace is not active", helper.AllowToSeedAPIServer, namespace.Name)
+		log.V(1).Info("Do not update NetworkPolicy because namespace is not in 'Active' phase")
 		return reconcile.Result{}, nil
 	}
 
-	r.log.Debugf("Reconciling NetworkPolicy %q in namespace %q", helper.AllowToSeedAPIServer, request.Name)
+	log.V(1).Info("Reconciling NetworkPolicy")
 
 	kubernetesEndpoints := corev1.Endpoints{}
 	kubernetesEndpointsKey := types.NamespacedName{Namespace: corev1.NamespaceDefault, Name: "kubernetes"}
@@ -108,12 +108,11 @@ func (r *namespaceReconciler) Reconcile(ctx context.Context, request reconcile.R
 
 	egressRules := helper.GetEgressRules(append(kubernetesEndpoints.Subsets, r.resolver.Subset()...)...)
 	// avoid duplicate NetworkPolicy updates
-	policy := &networkingv1.NetworkPolicy{}
-	if err := r.seedClient.Get(ctx, kutil.Key(request.Name, helper.AllowToSeedAPIServer), policy); client.IgnoreNotFound(err) != nil {
+	if err := r.seedClient.Get(ctx, client.ObjectKeyFromObject(networkPolicy), networkPolicy); client.IgnoreNotFound(err) != nil {
 		return reconcile.Result{}, err
 	}
-	if apiequality.Semantic.DeepEqual(policy.Spec.Egress, egressRules) {
-		r.log.Debugf("NetworkPolicy %q in namespace %q already up-to date", helper.AllowToSeedAPIServer, request.Name)
+	if apiequality.Semantic.DeepEqual(networkPolicy.Spec.Egress, egressRules) {
+		log.V(1).Info("Do not update NetworkPolicy because it already is up-to-date")
 		return reconcile.Result{}, nil
 	}
 
@@ -121,6 +120,6 @@ func (r *namespaceReconciler) Reconcile(ctx context.Context, request reconcile.R
 		return reconcile.Result{}, err
 	}
 
-	r.log.Infof("Successfully updated NetworkPolicy %q in namespace %q", helper.AllowToSeedAPIServer, request.Name)
+	log.Info("Successfully updated NetworkPolicy")
 	return reconcile.Result{}, nil
 }

--- a/pkg/gardenlet/controller/networkpolicy/namespaces.go
+++ b/pkg/gardenlet/controller/networkpolicy/namespaces.go
@@ -21,7 +21,7 @@ import (
 func (c *Controller) namespaceAdd(obj interface{}) {
 	key, err := cache.MetaNamespaceKeyFunc(obj)
 	if err != nil {
-		c.log.Errorf("Couldn't get key for object %+v: %v", obj, err)
+		c.log.Error(err, "Could not get key", "obj", obj)
 		return
 	}
 	c.namespaceQueue.Add(key)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Migrate `gardenlet`'s `Bastion` and `NetworkPolicy` controllers to `logr`.

**Which issue(s) this PR fixes**:
Part of #4251

**Special notes for your reviewer(s):**
✅ ~~Depends on #6259, hence it's in draft state until this PR is merged.~~

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
