### PR TITLE
Switch `gardenlet` to `logr` (3)

### DIFF
--- a/cmd/gardenlet/app/gardenlet.go
+++ b/cmd/gardenlet/app/gardenlet.go
@@ -288,9 +288,9 @@ func NewGardenlet(ctx context.Context, cfg *config.GardenletConfiguration) (*Gar
 		return nil, err
 	}
 
-	boostrapLog := log.WithName("bootstrap")
+	bootstrapLog := log.WithName("bootstrap")
 	if cfg.GardenClientConnection.KubeconfigSecret != nil {
-		kubeconfigFromBootstrap, csrName, seedName, err = getOrBootstrapKubeconfig(ctx, boostrapLog, seedClientForBootstrap.Client(), cfg)
+		kubeconfigFromBootstrap, csrName, seedName, err = getOrBootstrapKubeconfig(ctx, bootstrapLog, seedClientForBootstrap.Client(), cfg)
 		if err != nil {
 			return nil, err
 		}
@@ -306,13 +306,13 @@ func NewGardenlet(ctx context.Context, cfg *config.GardenletConfiguration) (*Gar
 		}
 	} else {
 		if len(cfg.GardenClientConnection.GardenClusterCACert) != 0 {
-			kubeconfigFromBootstrap, err = bootstraputil.UpdateGardenKubeconfigCAIfChanged(ctx, boostrapLog, seedClientForBootstrap.Client(), kubeconfigFromBootstrap, cfg.GardenClientConnection)
+			kubeconfigFromBootstrap, err = bootstraputil.UpdateGardenKubeconfigCAIfChanged(ctx, bootstrapLog, seedClientForBootstrap.Client(), kubeconfigFromBootstrap, cfg.GardenClientConnection)
 			if err != nil {
 				return nil, fmt.Errorf("error updating CA in garden cluster kubeconfig secret: %w", err)
 			}
 		}
 
-		gardenClientCertificate, err := certificate.GetCurrentCertificate(boostrapLog, kubeconfigFromBootstrap, cfg.GardenClientConnection)
+		gardenClientCertificate, err := certificate.GetCurrentCertificate(bootstrapLog, kubeconfigFromBootstrap, cfg.GardenClientConnection)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/gardenlet/bootstrap/certificate/certificate_rotation_test.go
+++ b/pkg/gardenlet/bootstrap/certificate/certificate_rotation_test.go
@@ -21,10 +21,10 @@ import (
 	"net"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/sirupsen/logrus"
 	certificatesv1 "k8s.io/api/certificates/v1"
 	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -43,7 +43,6 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
 	"github.com/gardener/gardener/pkg/client/kubernetes/mock"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
-	"github.com/gardener/gardener/pkg/logger"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	"github.com/gardener/gardener/pkg/utils"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -53,7 +52,7 @@ import (
 
 var _ = Describe("Certificates", func() {
 	var (
-		log logrus.FieldLogger = logger.NewNopLogger()
+		log = logr.Discard()
 
 		ctx       context.Context
 		ctxCancel context.CancelFunc

--- a/pkg/utils/kubernetes/kubernetes.go
+++ b/pkg/utils/kubernetes/kubernetes.go
@@ -130,6 +130,14 @@ func ObjectMetaFromKey(key client.ObjectKey) metav1.ObjectMeta {
 	return ObjectMeta(key.Namespace, key.Name)
 }
 
+// ObjectKeyFromSecretRef returns an ObjectKey for the given SecretReference.
+func ObjectKeyFromSecretRef(ref corev1.SecretReference) client.ObjectKey {
+	return client.ObjectKey{
+		Namespace: ref.Namespace,
+		Name:      ref.Name,
+	}
+}
+
 // WaitUntilResourceDeleted deletes the given resource and then waits until it has been deleted. It respects the
 // given interval and timeout.
 func WaitUntilResourceDeleted(ctx context.Context, c client.Client, obj client.Object, interval time.Duration) error {

--- a/pkg/utils/kubernetes/kubernetes_test.go
+++ b/pkg/utils/kubernetes/kubernetes_test.go
@@ -106,6 +106,12 @@ var _ = Describe("kubernetes", func() {
 		})
 	})
 
+	Describe("#ObjectKeyFromSecretRef", func() {
+		It("should return an ObjectKey with namespace and name set", func() {
+			Expect(ObjectKeyFromSecretRef(corev1.SecretReference{Namespace: namespace, Name: name})).To(Equal(client.ObjectKey{Namespace: namespace, Name: name}))
+		})
+	})
+
 	DescribeTable("#SetMetaDataLabel",
 		func(labels map[string]string, key, value string, expectedLabels map[string]string) {
 			original := &metav1.ObjectMeta{Labels: labels}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Migrate `gardenlet`'s certificate bootstrap and rotation to `logr`.

**Which issue(s) this PR fixes**:
Part of #4251

**Special notes for your reviewer(s):**
✅ ~~Depends on #6259, hence it's in draft state until this PR is merged.~~

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
