### PR TITLE
Switch `gardenlet` to `logr` (4)

### DIFF
--- a/pkg/gardenlet/controller/backupbucket/backup_bucket_controller.go
+++ b/pkg/gardenlet/controller/backupbucket/backup_bucket_controller.go
@@ -42,7 +42,7 @@ func (c *Controller) backupBucketAdd(obj interface{}) {
 
 	addAfter := controllerutils.ReconcileOncePer24hDuration(backupBucket.ObjectMeta, backupBucket.Status.ObservedGeneration, backupBucket.Status.LastOperation)
 	if addAfter > 0 {
-		c.log.V(1).Info("Scheduled next reconciliation for BackupBucket", "backupBucket", client.ObjectKeyFromObject(backupBucket), "duration", addAfter, "nextReconciliation", time.Now().Add(addAfter))
+		c.log.V(1).Info("Scheduled next reconciliation for BackupBucket", "duration", addAfter, "nextReconciliation", time.Now().Add(addAfter))
 	}
 
 	c.backupBucketQueue.AddAfter(key, addAfter)

--- a/pkg/gardenlet/controller/backupbucket/backup_bucket_controller.go
+++ b/pkg/gardenlet/controller/backupbucket/backup_bucket_controller.go
@@ -42,7 +42,7 @@ func (c *Controller) backupBucketAdd(obj interface{}) {
 
 	addAfter := controllerutils.ReconcileOncePer24hDuration(backupBucket.ObjectMeta, backupBucket.Status.ObservedGeneration, backupBucket.Status.LastOperation)
 	if addAfter > 0 {
-		c.log.V(1).Info("Scheduled next reconciliation for BackupBucket", "duration", addAfter, "nextReconciliation", time.Now().Add(addAfter))
+		log.V(1).Info("Scheduled next reconciliation for BackupBucket", "duration", addAfter, "nextReconciliation", time.Now().Add(addAfter))
 	}
 
 	c.backupBucketQueue.AddAfter(key, addAfter)

--- a/pkg/gardenlet/controller/backupentry/backup_entry.go
+++ b/pkg/gardenlet/controller/backupentry/backup_entry.go
@@ -93,7 +93,7 @@ func NewBackupEntryController(
 		log:                       log,
 		config:                    config,
 		reconciler:                newReconciler(clientMap, config, recorder),
-		migrationReconciler:       newMigrationReconciler(clientMap, config),
+		migrationReconciler:       newMigrationReconciler(gardenClient, config),
 		backupEntryInformer:       backupEntryInformer,
 		seedInformer:              seedInformer,
 		backupEntryQueue:          workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "BackupEntry"),

--- a/pkg/gardenlet/controller/backupentry/backup_entry.go
+++ b/pkg/gardenlet/controller/backupentry/backup_entry.go
@@ -28,23 +28,27 @@ import (
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	confighelper "github.com/gardener/gardener/pkg/gardenlet/apis/config/helper"
 	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
-	"github.com/gardener/gardener/pkg/logger"
 
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/pointer"
 	runtimecache "sigs.k8s.io/controller-runtime/pkg/cache"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
+// ControllerName is the name of this controller.
+const ControllerName = "backupentry"
+
 // Controller controls BackupEntries.
 type Controller struct {
-	gardenClient        client.Client
-	config              *config.GardenletConfiguration
+	log    logr.Logger
+	config *config.GardenletConfiguration
+
 	reconciler          reconcile.Reconciler
 	migrationReconciler reconcile.Reconciler
-	recorder            record.EventRecorder
 
 	backupEntryInformer       runtimecache.Informer
 	seedInformer              runtimecache.Informer
@@ -58,7 +62,18 @@ type Controller struct {
 // NewBackupEntryController takes a Kubernetes client for the Garden clusters <k8sGardenClient>, a struct
 // holding information about the acting Gardener, a <backupEntryInformer>, and a <recorder> for
 // event recording. It creates a new Gardener controller.
-func NewBackupEntryController(ctx context.Context, clientMap clientmap.ClientMap, config *config.GardenletConfiguration, recorder record.EventRecorder) (*Controller, error) {
+func NewBackupEntryController(
+	ctx context.Context,
+	log logr.Logger,
+	clientMap clientmap.ClientMap,
+	config *config.GardenletConfiguration,
+	recorder record.EventRecorder,
+) (
+	*Controller,
+	error,
+) {
+	log = log.WithName(ControllerName)
+
 	gardenClient, err := clientMap.GetClient(ctx, keys.ForGarden())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get garden client: %w", err)
@@ -75,11 +90,10 @@ func NewBackupEntryController(ctx context.Context, clientMap clientmap.ClientMap
 	}
 
 	controller := &Controller{
-		gardenClient:              gardenClient.Client(),
+		log:                       log,
 		config:                    config,
-		reconciler:                newReconciler(clientMap, recorder, logger.Logger, config),
-		migrationReconciler:       newMigrationReconciler(clientMap, logger.Logger, config),
-		recorder:                  recorder,
+		reconciler:                newReconciler(clientMap, config, recorder),
+		migrationReconciler:       newMigrationReconciler(clientMap, config),
 		backupEntryInformer:       backupEntryInformer,
 		seedInformer:              seedInformer,
 		backupEntryQueue:          workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "BackupEntry"),
@@ -88,7 +102,7 @@ func NewBackupEntryController(ctx context.Context, clientMap clientmap.ClientMap
 	}
 
 	controller.backupEntryInformer.AddEventHandler(cache.FilteringResourceEventHandler{
-		FilterFunc: controllerutils.BackupEntryFilterFunc(confighelper.SeedNameFromSeedConfig(controller.config.SeedConfig)),
+		FilterFunc: controllerutils.BackupEntryFilterFunc(confighelper.SeedNameFromSeedConfig(config.SeedConfig)),
 		Handler: cache.ResourceEventHandlerFuncs{
 			AddFunc:    controller.backupEntryAdd,
 			UpdateFunc: controller.backupEntryUpdate,
@@ -115,7 +129,7 @@ func (c *Controller) Run(ctx context.Context, workers, migrationWorkers int) {
 	var waitGroup sync.WaitGroup
 
 	if !cache.WaitForCacheSync(ctx.Done(), c.backupEntryInformer.HasSynced, c.seedInformer.HasSynced) {
-		logger.Logger.Fatal("Timed out waiting for caches to sync")
+		c.log.Error(wait.ErrWaitTimeout, "Timed out waiting for caches to sync")
 		return
 	}
 
@@ -123,18 +137,17 @@ func (c *Controller) Run(ctx context.Context, workers, migrationWorkers int) {
 	go func() {
 		for res := range c.workerCh {
 			c.numberOfRunningWorkers += res
-			logger.Logger.Debugf("Current number of running BackupEntry workers is %d", c.numberOfRunningWorkers)
 		}
 	}()
 
-	logger.Logger.Info("BackupEntry controller initialized.")
+	c.log.Info("BackupEntry controller initialized")
 
 	for i := 0; i < workers; i++ {
-		controllerutils.CreateWorker(ctx, c.backupEntryQueue, "BackupEntry", c.reconciler, &waitGroup, c.workerCh)
+		controllerutils.CreateWorker(ctx, c.backupEntryQueue, "BackupEntry", c.reconciler, &waitGroup, c.workerCh, controllerutils.WithLogger(c.log.WithName(reconcilerName)))
 	}
 	if gardenletfeatures.FeatureGate.Enabled(features.ForceRestore) && confighelper.OwnerChecksEnabledInSeedConfig(c.config.SeedConfig) {
 		for i := 0; i < migrationWorkers; i++ {
-			controllerutils.CreateWorker(ctx, c.backupEntryMigrationQueue, "BackupEntry Migration", c.migrationReconciler, &waitGroup, c.workerCh)
+			controllerutils.CreateWorker(ctx, c.backupEntryMigrationQueue, "BackupEntry Migration", c.migrationReconciler, &waitGroup, c.workerCh, controllerutils.WithLogger(c.log.WithName(migrationReconcilerName)))
 		}
 	}
 
@@ -146,10 +159,10 @@ func (c *Controller) Run(ctx context.Context, workers, migrationWorkers int) {
 	for {
 		queueLengths := c.backupEntryQueue.Len() + c.backupEntryMigrationQueue.Len()
 		if queueLengths == 0 && c.numberOfRunningWorkers == 0 {
-			logger.Logger.Info("No running BackupEntry workers and no items left in the queues. Terminated BackupEntry controller...")
+			c.log.V(1).Info("No running BackupEntry worker and no items left in the queues. Terminated BackupEntry controller")
 			break
 		}
-		logger.Logger.Infof("Waiting for %d BackupEntry worker(s) to finish (%d item(s) left in the queues)...", c.numberOfRunningWorkers, queueLengths)
+		c.log.V(1).Info("Waiting for BackupEntry workers to finish", "numberOfRunningWorkers", c.numberOfRunningWorkers, "queueLength", queueLengths)
 		time.Sleep(5 * time.Second)
 	}
 
@@ -158,6 +171,5 @@ func (c *Controller) Run(ctx context.Context, workers, migrationWorkers int) {
 
 // IsBackupEntryManagedByThisGardenlet checks if the given BackupEntry is managed by this gardenlet by comparing it with the seed name from the GardenletConfiguration.
 func IsBackupEntryManagedByThisGardenlet(backupEntry *gardencorev1beta1.BackupEntry, gc *config.GardenletConfiguration) bool {
-	seedName := confighelper.SeedNameFromSeedConfig(gc.SeedConfig)
-	return backupEntry.Spec.SeedName != nil && *backupEntry.Spec.SeedName == seedName
+	return pointer.StringDeref(backupEntry.Spec.SeedName, "") == confighelper.SeedNameFromSeedConfig(gc.SeedConfig)
 }

--- a/pkg/gardenlet/controller/backupentry/backup_entry_controller.go
+++ b/pkg/gardenlet/controller/backupentry/backup_entry_controller.go
@@ -43,7 +43,7 @@ func (c *Controller) backupEntryAdd(obj interface{}) {
 
 	addAfter := controllerutils.ReconcileOncePer24hDuration(backupEntry.ObjectMeta, backupEntry.Status.ObservedGeneration, backupEntry.Status.LastOperation)
 	if addAfter > 0 {
-		c.log.V(1).Info("Scheduled next reconciliation for BackupEntry", "duration", addAfter, "nextReconciliation", time.Now().Add(addAfter))
+		log.V(1).Info("Scheduled next reconciliation for BackupEntry", "duration", addAfter, "nextReconciliation", time.Now().Add(addAfter))
 	}
 
 	c.backupEntryQueue.AddAfter(key, addAfter)

--- a/pkg/gardenlet/controller/backupentry/backup_entry_controller.go
+++ b/pkg/gardenlet/controller/backupentry/backup_entry_controller.go
@@ -21,27 +21,29 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/controllerutils"
-	"github.com/gardener/gardener/pkg/logger"
 
 	"k8s.io/client-go/tools/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func (c *Controller) backupEntryAdd(obj interface{}) {
 	backupEntry, ok := obj.(*gardencorev1beta1.BackupEntry)
 	if !ok {
-		logger.Logger.Errorf("Couldn't convert object: %T", obj)
+		c.log.Error(fmt.Errorf("could not convert object of type %T to *gardencorev1beta1.BackupEntry", obj), "Unexpected object type", "obj", obj)
 		return
 	}
 
+	log := c.log.WithValues("backupEntry", client.ObjectKeyFromObject(backupEntry))
+
 	key, err := cache.MetaNamespaceKeyFunc(obj)
 	if err != nil {
-		logger.Logger.Errorf("Couldn't get key for object %+v: %v", obj, err)
+		log.Error(err, "Could not get key")
 		return
 	}
 
 	addAfter := controllerutils.ReconcileOncePer24hDuration(backupEntry.ObjectMeta, backupEntry.Status.ObservedGeneration, backupEntry.Status.LastOperation)
 	if addAfter > 0 {
-		logger.Logger.Infof("Scheduled next reconciliation for BackupEntry %q in %s (%s)", key, addAfter, time.Now().Add(addAfter))
+		c.log.V(1).Info("Scheduled next reconciliation for BackupEntry", "duration", addAfter, "nextReconciliation", time.Now().Add(addAfter))
 	}
 
 	c.backupEntryQueue.AddAfter(key, addAfter)
@@ -49,15 +51,15 @@ func (c *Controller) backupEntryAdd(obj interface{}) {
 
 func (c *Controller) backupEntryUpdate(_, newObj interface{}) {
 	var (
-		newBackupEntry    = newObj.(*gardencorev1beta1.BackupEntry)
-		backupEntryLogger = logger.NewFieldLogger(logger.Logger, "backupentry", fmt.Sprintf("%s/%s", newBackupEntry.Namespace, newBackupEntry.Name))
+		newBackupEntry = newObj.(*gardencorev1beta1.BackupEntry)
+		log            = c.log.WithValues("backupEntry", client.ObjectKeyFromObject(newBackupEntry))
 	)
 
 	// If the generation did not change for an update event (i.e., no changes to the .spec section have
 	// been made), we do not want to add the BackupEntry to the queue. The periodic reconciliation is handled
 	// elsewhere by adding the BackupEntry to the queue to dedicated times.
 	if newBackupEntry.Generation == newBackupEntry.Status.ObservedGeneration && !v1beta1helper.HasOperationAnnotation(newBackupEntry.ObjectMeta) {
-		backupEntryLogger.Debug("Do not need to do anything as the Update event occurred due to .status field changes")
+		log.V(1).Info("Do not need to do anything as the Update event occurred due to .status field changes")
 		return
 	}
 
@@ -67,8 +69,9 @@ func (c *Controller) backupEntryUpdate(_, newObj interface{}) {
 func (c *Controller) backupEntryDelete(obj interface{}) {
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 	if err != nil {
-		logger.Logger.Errorf("Couldn't get key for object %+v: %v", obj, err)
+		c.log.Error(err, "Could not get key", "obj", obj)
 		return
 	}
+
 	c.backupEntryQueue.Add(key)
 }

--- a/pkg/gardenlet/controller/backupentry/backup_entry_migration_controller.go
+++ b/pkg/gardenlet/controller/backupentry/backup_entry_migration_controller.go
@@ -37,6 +37,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
+const migrationReconcilerName = "migration"
+
 func (c *Controller) backupEntryMigrationAdd(obj interface{}) {
 	key, err := cache.MetaNamespaceKeyFunc(obj)
 	if err != nil {

--- a/pkg/gardenlet/controller/backupentry/backup_entry_migration_controller.go
+++ b/pkg/gardenlet/controller/backupentry/backup_entry_migration_controller.go
@@ -22,18 +22,17 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
-	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
-	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	confighelper "github.com/gardener/gardener/pkg/gardenlet/apis/config/helper"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
-	"github.com/sirupsen/logrus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -75,46 +74,34 @@ func (c *Controller) backupEntryMigrationDelete(obj interface{}) {
 // newMigrationReconciler returns an implementation of reconcile.Reconciler that forces the backup entry's restoration
 // to this seed during control plane migration if the preparation for migration in the source seed is not finished
 // after a certain grace period and is considered unlikely to succeed ("bad case" scenario).
-func newMigrationReconciler(
-	clientMap clientmap.ClientMap,
-	logger logrus.FieldLogger,
-	config *config.GardenletConfiguration,
-) reconcile.Reconciler {
+func newMigrationReconciler(gardenClient kubernetes.Interface, config *config.GardenletConfiguration) reconcile.Reconciler {
 	return &migrationReconciler{
-		clientMap: clientMap,
-		logger:    logger,
-		config:    config,
+		gardenClient: gardenClient,
+		config:       config,
 	}
 }
 
 type migrationReconciler struct {
-	clientMap clientmap.ClientMap
-	logger    logrus.FieldLogger
-	config    *config.GardenletConfiguration
+	gardenClient kubernetes.Interface
+	config       *config.GardenletConfiguration
 }
 
 func (r *migrationReconciler) Reconcile(ctx context.Context, req reconcile.Request) (result reconcile.Result, err error) {
-	log := r.logger.WithField("backupentry", req.String())
-
-	gardenClient, err := r.clientMap.GetClient(ctx, keys.ForGarden())
-	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to get garden client: %w", err)
-	}
+	log := logf.FromContext(ctx)
 
 	backupEntry := &gardencorev1beta1.BackupEntry{}
-	if err := gardenClient.Client().Get(ctx, req.NamespacedName, backupEntry); err != nil {
+	if err := r.gardenClient.Client().Get(ctx, req.NamespacedName, backupEntry); err != nil {
 		if apierrors.IsNotFound(err) {
-			log.Infof("[BACKUPENTRY MIGRATION] Skipping because BackupEntry has been deleted")
+			log.Info("Object is gone, stop reconciling")
 			return reconcile.Result{}, nil
 		}
-		log.Infof("[BACKUPENTRY MIGRATION] Unable to retrieve object from store: %+v", err)
-		return reconcile.Result{}, err
+		return reconcile.Result{}, fmt.Errorf("error retrieving object from store: %w", err)
 	}
 
 	// If the backup entry is being deleted or no longer being migrated to this seed, clear the migration start time
-	if backupEntry.DeletionTimestamp != nil || !controllerutils.BackupEntryIsBeingMigratedToSeed(ctx, gardenClient.Cache(), backupEntry, confighelper.SeedNameFromSeedConfig(r.config.SeedConfig)) {
-		log.Debugf("[BACKUPENTRY MIGRATION] Clearing migration start time")
-		if err := setMigrationStartTime(ctx, gardenClient.Client(), backupEntry, nil); err != nil {
+	if backupEntry.DeletionTimestamp != nil || !controllerutils.BackupEntryIsBeingMigratedToSeed(ctx, r.gardenClient.Cache(), backupEntry, confighelper.SeedNameFromSeedConfig(r.config.SeedConfig)) {
+		log.V(1).Info("Clearing migration start time")
+		if err := setMigrationStartTime(ctx, r.gardenClient.Client(), backupEntry, nil); err != nil {
 			return reconcile.Result{}, fmt.Errorf("could not clear migration start time: %w", err)
 		}
 
@@ -124,25 +111,25 @@ func (r *migrationReconciler) Reconcile(ctx context.Context, req reconcile.Reque
 
 	// Set the migration start time if needed
 	if backupEntry.Status.MigrationStartTime == nil {
-		log.Debugf("[BACKUPENTRY MIGRATION] Setting migration start time")
-		if err := setMigrationStartTime(ctx, gardenClient.Client(), backupEntry, &metav1.Time{Time: time.Now().UTC()}); err != nil {
+		log.V(1).Info("Setting migration start time to current time")
+		if err := setMigrationStartTime(ctx, r.gardenClient.Client(), backupEntry, &metav1.Time{Time: time.Now().UTC()}); err != nil {
 			return reconcile.Result{}, fmt.Errorf("could not set migration start time: %w", err)
 		}
 	}
 
 	// If the force-restore annotation is set or the grace period is elapsed and migration is not currently in progress,
 	// update the backup entry status to force the restoration (fallback to the "bad case" scenario)
-	log.Debugf("[BACKUPENTRY MIGRATION] Checking if the backup entry should be forcefully restored")
+	log.V(1).Info("Checking whether restoration should be forceful")
 	if hasForceRestoreAnnotation(backupEntry) || r.isGracePeriodElapsed(backupEntry) && !r.isMigrationInProgress(backupEntry) {
 
-		log.Infof("[BACKUPENTRY MIGRATION] Updating backup entry status to force restoration")
-		if err := updateStatusForRestore(ctx, gardenClient.Client(), backupEntry); err != nil {
+		log.Info("Updating status to force restoration")
+		if err := updateStatusForRestore(ctx, r.gardenClient.Client(), backupEntry); err != nil {
 			return reconcile.Result{}, fmt.Errorf("could not update backup entry status to force restoration: %w", err)
 		}
 
 		if hasForceRestoreAnnotation(backupEntry) {
-			log.Debugf("[BACKUPENTRY MIGRATION] Removing force-restore annotation")
-			if err := removeForceRestoreAnnotation(ctx, gardenClient.Client(), backupEntry); err != nil {
+			log.V(1).Info("Removing force-restore annotation")
+			if err := removeForceRestoreAnnotation(ctx, r.gardenClient.Client(), backupEntry); err != nil {
 				return reconcile.Result{}, fmt.Errorf("could not remove force-restore annotation: %w", err)
 			}
 		}

--- a/pkg/gardenlet/controller/backupentry/backup_entry_reconciler.go
+++ b/pkg/gardenlet/controller/backupentry/backup_entry_reconciler.go
@@ -44,6 +44,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
+const reconcilerName = "backupentry"
+
 // reconciler implements the reconcile.Reconcile interface for backupEntry reconciliation.
 type reconciler struct {
 	clientMap clientmap.ClientMap

--- a/pkg/gardenlet/controller/factory.go
+++ b/pkg/gardenlet/controller/factory.go
@@ -143,7 +143,7 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 		return fmt.Errorf("failed initializing BackupBucket controller: %w", err)
 	}
 
-	backupEntryController, err := backupentrycontroller.NewBackupEntryController(ctx, f.clientMap, f.cfg, f.recorder)
+	backupEntryController, err := backupentrycontroller.NewBackupEntryController(ctx, log, f.clientMap, f.cfg, f.recorder)
 	if err != nil {
 		return fmt.Errorf("failed initializing BackupEntry controller: %w", err)
 	}

--- a/pkg/operation/botanist/component/extensions/backupentry/backupentry.go
+++ b/pkg/operation/botanist/component/extensions/backupentry/backupentry.go
@@ -25,7 +25,7 @@ import (
 	"github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 
-	"github.com/sirupsen/logrus"
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -74,7 +74,7 @@ type Values struct {
 
 // New creates a new instance of Interface.
 func New(
-	logger logrus.FieldLogger,
+	log logr.Logger,
 	client client.Client,
 	values *Values,
 	waitInterval time.Duration,
@@ -82,8 +82,8 @@ func New(
 	waitTimeout time.Duration,
 ) Interface {
 	return &backupEntry{
+		log:                 log,
 		client:              client,
-		logger:              logger,
 		values:              values,
 		waitInterval:        waitInterval,
 		waitSevereThreshold: waitSevereThreshold,
@@ -99,7 +99,7 @@ func New(
 
 type backupEntry struct {
 	values              *Values
-	logger              logrus.FieldLogger
+	log                 logr.Logger
 	client              client.Client
 	waitInterval        time.Duration
 	waitSevereThreshold time.Duration
@@ -183,7 +183,7 @@ func (b *backupEntry) Wait(ctx context.Context) error {
 	return extensions.WaitUntilExtensionObjectReady(
 		ctx,
 		b.client,
-		b.logger,
+		b.log,
 		b.backupEntry,
 		extensionsv1alpha1.BackupEntryResource,
 		b.waitInterval,
@@ -198,7 +198,7 @@ func (b *backupEntry) WaitCleanup(ctx context.Context) error {
 	return extensions.WaitUntilExtensionObjectDeleted(
 		ctx,
 		b.client,
-		b.logger,
+		b.log,
 		b.backupEntry,
 		extensionsv1alpha1.BackupEntryResource,
 		b.waitInterval,

--- a/pkg/operation/botanist/component/extensions/backupentry/backupentry_test.go
+++ b/pkg/operation/botanist/component/extensions/backupentry/backupentry_test.go
@@ -19,14 +19,11 @@ import (
 	"fmt"
 	"time"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/extensions"
-	"github.com/gardener/gardener/pkg/logger"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	mocktime "github.com/gardener/gardener/pkg/mock/go/time"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
@@ -35,11 +32,12 @@ import (
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 
+	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -56,7 +54,7 @@ var _ = Describe("#BackupEntry", func() {
 		empty            *extensionsv1alpha1.BackupEntry
 		expected         *extensionsv1alpha1.BackupEntry
 		values           *backupentry.Values
-		log              logrus.FieldLogger
+		log              logr.Logger
 		fakeErr          error
 		defaultDepWaiter component.DeployMigrateWaiter
 
@@ -82,7 +80,7 @@ var _ = Describe("#BackupEntry", func() {
 		now = time.Now()
 
 		ctx = context.TODO()
-		log = logger.NewNopLogger()
+		log = logr.Discard()
 		fakeErr = fmt.Errorf("some random error")
 
 		s := runtime.NewScheme()


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Migrate `gardenlet`'s `BackupEntry` controller to `logr`. Similar to #6259.

**Which issue(s) this PR fixes**:
Part of #4251

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
