### PR TITLE
Switch `gardenlet` to `logr` (5)

### DIFF
--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation.go
@@ -26,20 +26,26 @@ import (
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	confighelper "github.com/gardener/gardener/pkg/gardenlet/apis/config/helper"
-	"github.com/gardener/gardener/pkg/logger"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-// FinalizerName is the name of the ControllerInstallation finalizer.
-const FinalizerName = "core.gardener.cloud/controllerinstallation"
+const (
+	finalizerName = "core.gardener.cloud/controllerinstallation"
+
+	// ControllerName is the name of this controller.
+	ControllerName = "controllerinstallation"
+)
 
 // Controller controls ControllerInstallation.
 type Controller struct {
+	log logr.Logger
+
 	reconciler     reconcile.Reconciler
 	careReconciler reconcile.Reconciler
 
@@ -54,9 +60,9 @@ type Controller struct {
 // NewController instantiates a new ControllerInstallation controller.
 func NewController(
 	ctx context.Context,
+	log logr.Logger,
 	clientMap clientmap.ClientMap,
 	config *config.GardenletConfiguration,
-	recorder record.EventRecorder,
 	identity *gardencorev1beta1.Gardener,
 	gardenNamespace *corev1.Namespace,
 	gardenClusterIdentity string,
@@ -64,6 +70,8 @@ func NewController(
 	*Controller,
 	error,
 ) {
+	log = log.WithName(ControllerName)
+
 	gardenClient, err := clientMap.GetClient(ctx, keys.ForGarden())
 	if err != nil {
 		return nil, err
@@ -75,8 +83,10 @@ func NewController(
 	}
 
 	controller := &Controller{
-		reconciler:     newReconciler(clientMap, recorder, logger.Logger, identity, gardenNamespace, gardenClusterIdentity),
-		careReconciler: newCareReconciler(clientMap, logger.Logger, config.Controllers.ControllerInstallationCare),
+		log: log,
+
+		reconciler:     newReconciler(clientMap, identity, gardenNamespace, gardenClusterIdentity),
+		careReconciler: newCareReconciler(clientMap, config.Controllers.ControllerInstallationCare),
 
 		controllerInstallationQueue:     workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "controllerinstallation"),
 		controllerInstallationCareQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "controllerinstallation-care"),
@@ -113,25 +123,24 @@ func (c *Controller) Run(ctx context.Context, workers, careWorkers int) {
 	var waitGroup sync.WaitGroup
 
 	if !cache.WaitForCacheSync(ctx.Done(), c.hasSyncedFuncs...) {
-		logger.Logger.Error("Timed out waiting for caches to sync")
+		c.log.Error(wait.ErrWaitTimeout, "Timed out waiting for caches to sync")
 		return
 	}
 
 	go func() {
 		for res := range c.workerCh {
 			c.numberOfRunningWorkers += res
-			logger.Logger.Debugf("Current number of running ControllerInstallation workers is %d", c.numberOfRunningWorkers)
 		}
 	}()
 
-	logger.Logger.Info("ControllerInstallation controller initialized.")
+	c.log.Info("ControllerInstallation controller initialized")
 
 	for i := 0; i < workers; i++ {
-		controllerutils.CreateWorker(ctx, c.controllerInstallationQueue, "ControllerInstallation", c.reconciler, &waitGroup, c.workerCh)
+		controllerutils.CreateWorker(ctx, c.controllerInstallationQueue, "ControllerInstallation", c.reconciler, &waitGroup, c.workerCh, controllerutils.WithLogger(c.log.WithName(reconcilerName)))
 	}
 
 	for i := 0; i < careWorkers; i++ {
-		controllerutils.CreateWorker(ctx, c.controllerInstallationCareQueue, "ControllerInstallation Care", c.careReconciler, &waitGroup, c.workerCh)
+		controllerutils.CreateWorker(ctx, c.controllerInstallationCareQueue, "ControllerInstallation Care", c.careReconciler, &waitGroup, c.workerCh, controllerutils.WithLogger(c.log.WithName(careReconcilerName)))
 	}
 
 	// Shutdown handling
@@ -141,10 +150,11 @@ func (c *Controller) Run(ctx context.Context, workers, careWorkers int) {
 
 	for {
 		if c.controllerInstallationQueue.Len() == 0 && c.controllerInstallationCareQueue.Len() == 0 && c.numberOfRunningWorkers == 0 {
-			logger.Logger.Debug("No running ControllerInstallation worker and no items left in the queues. Terminated ControllerInstallation controller...")
+			c.log.V(1).Info("No running ControllerInstallation worker and no items left in the queues. Terminated ControllerInstallation controller")
+
 			break
 		}
-		logger.Logger.Debugf("Waiting for %d ControllerInstallation worker(s) to finish (%d item(s) left in the queues)...", c.numberOfRunningWorkers, c.controllerInstallationQueue.Len()+c.controllerInstallationCareQueue.Len())
+		c.log.V(1).Info("Waiting for ControllerInstallation workers to finish", "numberOfRunningWorkers", c.numberOfRunningWorkers, "queueLength", c.controllerInstallationQueue.Len()+c.controllerInstallationCareQueue.Len())
 		time.Sleep(5 * time.Second)
 	}
 

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation_care_control.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation_care_control.go
@@ -21,18 +21,18 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
-	"github.com/gardener/gardener/pkg/logger"
-	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 
-	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
-	"github.com/sirupsen/logrus"
+	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -48,26 +48,22 @@ func (c *Controller) controllerInstallationCareAdd(obj interface{}) {
 
 func newCareReconciler(
 	clientMap clientmap.ClientMap,
-	l logrus.FieldLogger,
 	config *config.ControllerInstallationCareControllerConfiguration,
 ) reconcile.Reconciler {
 	return &careReconciler{
 		clientMap: clientMap,
-		logger:    l,
 		config:    config,
 	}
 }
 
 type careReconciler struct {
 	clientMap clientmap.ClientMap
-	logger    logrus.FieldLogger
 	config    *config.ControllerInstallationCareControllerConfiguration
 }
 
 func (r *careReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := logger.NewFieldLogger(r.logger, "controllerInstallation", request.Name)
+	log := logf.FromContext(ctx)
 
-	log.Debugf("[CONTROLLERINSTALLATION CARE]")
 	gardenClient, err := r.clientMap.GetClient(ctx, keys.ForGarden())
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("failed to get garden client: %w", err)
@@ -76,23 +72,27 @@ func (r *careReconciler) Reconcile(ctx context.Context, request reconcile.Reques
 	controllerInstallation := &gardencorev1beta1.ControllerInstallation{}
 	if err := gardenClient.Client().Get(ctx, request.NamespacedName, controllerInstallation); err != nil {
 		if apierrors.IsNotFound(err) {
-			log.Infof("[CONTROLLERINSTALLATION CARE] stopping care operations for ControllerInstallation since it has been deleted")
+			log.Info("Object is gone, stop reconciling")
 			return reconcile.Result{}, nil
 		}
-		log.Infof("[CONTROLLERINSTALLATION CARE] unable to retrieve object from store: %v", err)
-		return reconcile.Result{}, err
+		return reconcile.Result{}, fmt.Errorf("error retrieving object from store: %w", err)
 	}
 
 	if controllerInstallation.DeletionTimestamp != nil {
 		return reconcile.Result{}, nil
 	}
 
-	r.care(ctx, gardenClient.Client(), controllerInstallation, log)
+	r.care(ctx, log, gardenClient.Client(), controllerInstallation)
 
 	return reconcile.Result{RequeueAfter: r.config.SyncPeriod.Duration}, nil
 }
 
-func (r *careReconciler) care(ctx context.Context, gardenClient client.Client, controllerInstallation *gardencorev1beta1.ControllerInstallation, log logrus.FieldLogger) {
+func (r *careReconciler) care(
+	ctx context.Context,
+	log logr.Logger,
+	gardenClient client.Client,
+	controllerInstallation *gardencorev1beta1.ControllerInstallation,
+) {
 	// We don't return an error from this func. There is no meaningful way to handle it, because we do not want to run
 	// in the exponential backoff for the condition checks.
 	var (
@@ -102,26 +102,30 @@ func (r *careReconciler) care(ctx context.Context, gardenClient client.Client, c
 
 	defer func() {
 		if err := patchConditions(ctx, gardenClient, controllerInstallation, conditionControllerInstallationHealthy, conditionControllerInstallationInstalled); err != nil {
-			msg := fmt.Sprintf("Failed to patch ControllerInstallation status: %s", err.Error())
-			log.Error(msg)
+			log.Error(err, "Failed to patch conditions")
 		}
 	}()
 
 	seedClient, err := r.clientMap.GetClient(ctx, keys.ForSeedWithName(controllerInstallation.Spec.SeedRef.Name))
 	if err != nil {
-		msg := fmt.Sprintf("Failed to get seed client: %s", err.Error())
-		log.Error(msg)
+		log.Error(err, "Failed to get seed client")
 
+		msg := fmt.Sprintf("Failed to get seed client: %s", err.Error())
 		conditionControllerInstallationInstalled = gardencorev1beta1helper.UpdatedCondition(conditionControllerInstallationInstalled, gardencorev1beta1.ConditionUnknown, "SeedReadError", msg)
 		conditionControllerInstallationHealthy = gardencorev1beta1helper.UpdatedCondition(conditionControllerInstallationHealthy, gardencorev1beta1.ConditionUnknown, "SeedReadError", msg)
 		return
 	}
 
-	managedResource := &resourcesv1alpha1.ManagedResource{}
-	if err := seedClient.Client().Get(ctx, kutil.Key(v1beta1constants.GardenNamespace, controllerInstallation.Name), managedResource); err != nil {
-		msg := fmt.Sprintf("Failed to get ManagedResource for ControllerInstallation: %s", err.Error())
-		log.Error(msg)
+	managedResource := &resourcesv1alpha1.ManagedResource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      controllerInstallation.Name,
+			Namespace: v1beta1constants.GardenNamespace,
+		},
+	}
+	if err := seedClient.Client().Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource); err != nil {
+		log.Error(err, "Failed to get ManagedResource", "managedResource", client.ObjectKeyFromObject(managedResource))
 
+		msg := fmt.Sprintf("Failed to get ManagedResource %q: %s", client.ObjectKeyFromObject(managedResource).String(), err.Error())
 		conditionControllerInstallationInstalled = gardencorev1beta1helper.UpdatedCondition(conditionControllerInstallationInstalled, gardencorev1beta1.ConditionUnknown, "SeedReadError", msg)
 		conditionControllerInstallationHealthy = gardencorev1beta1helper.UpdatedCondition(conditionControllerInstallationHealthy, gardencorev1beta1.ConditionUnknown, "SeedReadError", msg)
 		return

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation_care_control.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation_care_control.go
@@ -36,6 +36,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
+const careReconcilerName = "care"
+
 func (c *Controller) controllerInstallationCareAdd(obj interface{}) {
 	key, err := cache.MetaNamespaceKeyFunc(obj)
 	if err != nil {

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation_control.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation_control.go
@@ -24,24 +24,23 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
 	"github.com/gardener/gardener/pkg/controllerutils"
-	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/utils"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 
-	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
-	"github.com/sirupsen/logrus"
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -53,7 +52,7 @@ const (
 func (c *Controller) controllerInstallationAdd(obj interface{}) {
 	key, err := cache.MetaNamespaceKeyFunc(obj)
 	if err != nil {
-		logger.Logger.Errorf("Couldn't get key for object %+v: %v", obj, err)
+		c.log.Error(err, "Could not get key", "obj", obj)
 		return
 	}
 	c.controllerInstallationQueue.Add(key)
@@ -79,7 +78,7 @@ func (c *Controller) controllerInstallationUpdate(oldObj, newObj interface{}) {
 func (c *Controller) controllerInstallationDelete(obj interface{}) {
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 	if err != nil {
-		logger.Logger.Errorf("Couldn't get key for object %+v: %v", obj, err)
+		c.log.Error(err, "Could not get key", "obj", obj)
 		return
 	}
 	c.controllerInstallationQueue.Add(key)
@@ -87,17 +86,13 @@ func (c *Controller) controllerInstallationDelete(obj interface{}) {
 
 func newReconciler(
 	clientMap clientmap.ClientMap,
-	recorder record.EventRecorder,
-	l logrus.FieldLogger,
 	identity *gardencorev1beta1.Gardener,
 	gardenNamespace *corev1.Namespace,
 	gardenClusterIdentity string,
 ) reconcile.Reconciler {
 	return &reconciler{
 		clientMap:             clientMap,
-		recorder:              recorder,
 		identity:              identity,
-		logger:                l,
 		gardenNamespace:       gardenNamespace,
 		gardenClusterIdentity: gardenClusterIdentity,
 	}
@@ -105,15 +100,13 @@ func newReconciler(
 
 type reconciler struct {
 	clientMap             clientmap.ClientMap
-	recorder              record.EventRecorder
-	logger                logrus.FieldLogger
 	identity              *gardencorev1beta1.Gardener
 	gardenNamespace       *corev1.Namespace
 	gardenClusterIdentity string
 }
 
 func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.logger.WithField("controllerInstallation", request.Name)
+	log := logf.FromContext(ctx)
 
 	gardenClient, err := r.clientMap.GetClient(ctx, keys.ForGarden())
 	if err != nil {
@@ -123,11 +116,10 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	controllerInstallation := &gardencorev1beta1.ControllerInstallation{}
 	if err := gardenClient.Client().Get(ctx, request.NamespacedName, controllerInstallation); err != nil {
 		if apierrors.IsNotFound(err) {
-			log.Debugf("[CONTROLLERINSTALLATION RECONCILE] skipping because ControllerInstallation has been deleted")
+			log.Info("Object is gone, stop reconciling")
 			return reconcile.Result{}, nil
 		}
-		log.Errorf("[CONTROLLERINSTALLATION RECONCILE] unable to retrieve object from store: %v", err)
-		return reconcile.Result{}, err
+		return reconcile.Result{}, fmt.Errorf("error retrieving object from store: %w", err)
 	}
 
 	if isResponsible, err := r.isResponsible(ctx, gardenClient.Client(), controllerInstallation); !isResponsible || err != nil {
@@ -135,14 +127,23 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	}
 
 	if controllerInstallation.DeletionTimestamp != nil {
-		return r.delete(ctx, gardenClient.Client(), controllerInstallation, log)
+		return r.delete(ctx, log, gardenClient.Client(), controllerInstallation)
 	}
-	return r.reconcile(ctx, gardenClient.Client(), controllerInstallation, log)
+	return r.reconcile(ctx, log, gardenClient.Client(), controllerInstallation)
 }
 
-func (r *reconciler) reconcile(ctx context.Context, gardenClient client.Client, controllerInstallation *gardencorev1beta1.ControllerInstallation, log logrus.FieldLogger) (reconcile.Result, error) {
-	if !controllerutil.ContainsFinalizer(controllerInstallation, FinalizerName) {
-		if err := controllerutils.StrategicMergePatchAddFinalizers(ctx, gardenClient, controllerInstallation, FinalizerName); err != nil {
+func (r *reconciler) reconcile(
+	ctx context.Context,
+	log logr.Logger,
+	gardenClient client.Client,
+	controllerInstallation *gardencorev1beta1.ControllerInstallation,
+) (
+	reconcile.Result,
+	error,
+) {
+	if !controllerutil.ContainsFinalizer(controllerInstallation, finalizerName) {
+		log.Info("Adding finalizer")
+		if err := controllerutils.StrategicMergePatchAddFinalizers(ctx, gardenClient, controllerInstallation, finalizerName); err != nil {
 			return reconcile.Result{}, fmt.Errorf("could not add finalizer to ControllerInstallation: %w", err)
 		}
 	}
@@ -154,7 +155,7 @@ func (r *reconciler) reconcile(ctx context.Context, gardenClient client.Client, 
 
 	defer func() {
 		if err := patchConditions(ctx, gardenClient, controllerInstallation, conditionValid, conditionInstalled); err != nil {
-			log.Errorf("Failed to patch ControllerInstallation conditions: %+v", err)
+			log.Error(err, "Failed to patch conditions")
 		}
 	}()
 
@@ -280,7 +281,15 @@ func (r *reconciler) reconcile(ctx context.Context, gardenClient client.Client, 
 	return reconcile.Result{}, nil
 }
 
-func (r *reconciler) delete(ctx context.Context, gardenClient client.Client, controllerInstallation *gardencorev1beta1.ControllerInstallation, log logrus.FieldLogger) (reconcile.Result, error) {
+func (r *reconciler) delete(
+	ctx context.Context,
+	log logr.Logger,
+	gardenClient client.Client,
+	controllerInstallation *gardencorev1beta1.ControllerInstallation,
+) (
+	reconcile.Result,
+	error,
+) {
 	var (
 		newConditions      = gardencorev1beta1helper.MergeConditions(controllerInstallation.Status.Conditions, gardencorev1beta1helper.InitCondition(gardencorev1beta1.ControllerInstallationValid), gardencorev1beta1helper.InitCondition(gardencorev1beta1.ControllerInstallationInstalled))
 		conditionValid     = newConditions[0]
@@ -289,7 +298,7 @@ func (r *reconciler) delete(ctx context.Context, gardenClient client.Client, con
 
 	defer func() {
 		if err := patchConditions(ctx, gardenClient, controllerInstallation, conditionValid, conditionInstalled); client.IgnoreNotFound(err) != nil {
-			log.Errorf("Failed to patch ControllerInstallation conditions: %+v", err)
+			log.Error(err, "Failed to patch conditions")
 		}
 	}()
 
@@ -315,11 +324,11 @@ func (r *reconciler) delete(ctx context.Context, gardenClient client.Client, con
 			Namespace: v1beta1constants.GardenNamespace,
 		},
 	}
-	err = seedClient.Client().Delete(ctx, mr)
-	if err == nil {
-		message := fmt.Sprintf("Deletion of ManagedResource %q is still pending.", controllerInstallation.Name)
-		conditionInstalled = gardencorev1beta1helper.UpdatedCondition(conditionInstalled, gardencorev1beta1.ConditionFalse, "DeletionPending", message)
-		log.Info(message)
+	if err = seedClient.Client().Delete(ctx, mr); err == nil {
+		log.Info("Deletion of ManagedResource is still pending", "managedResource", client.ObjectKeyFromObject(mr))
+
+		msg := fmt.Sprintf("Deletion of ManagedResource %q is still pending.", controllerInstallation.Name)
+		conditionInstalled = gardencorev1beta1helper.UpdatedCondition(conditionInstalled, gardencorev1beta1.ConditionFalse, "DeletionPending", msg)
 		return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
 	} else if !apierrors.IsNotFound(err) {
 		conditionInstalled = gardencorev1beta1helper.UpdatedCondition(conditionInstalled, gardencorev1beta1.ConditionFalse, "DeletionFailed", fmt.Sprintf("Deletion of ManagedResource %q failed: %+v", controllerInstallation.Name, err))
@@ -337,11 +346,11 @@ func (r *reconciler) delete(ctx context.Context, gardenClient client.Client, con
 	}
 
 	namespace := getNamespaceForControllerInstallation(controllerInstallation)
-	err = seedClient.Client().Delete(ctx, namespace)
-	if err == nil || apierrors.IsConflict(err) {
-		message := fmt.Sprintf("Deletion of Namespace %q is still pending.", namespace.Name)
-		conditionInstalled = gardencorev1beta1helper.UpdatedCondition(conditionInstalled, gardencorev1beta1.ConditionFalse, "DeletionPending", message)
-		log.Info(message)
+	if err = seedClient.Client().Delete(ctx, namespace); err == nil || apierrors.IsConflict(err) {
+		log.Info("Deletion of Namespace is still pending", "namespace", client.ObjectKeyFromObject(namespace))
+
+		msg := fmt.Sprintf("Deletion of Namespace %q is still pending.", namespace.Name)
+		conditionInstalled = gardencorev1beta1helper.UpdatedCondition(conditionInstalled, gardencorev1beta1.ConditionFalse, "DeletionPending", msg)
 		return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
 	} else if !apierrors.IsNotFound(err) {
 		conditionInstalled = gardencorev1beta1helper.UpdatedCondition(conditionInstalled, gardencorev1beta1.ConditionFalse, "DeletionFailed", fmt.Sprintf("Deletion of Namespace %q failed: %+v", namespace.Name, err))
@@ -350,7 +359,7 @@ func (r *reconciler) delete(ctx context.Context, gardenClient client.Client, con
 
 	conditionInstalled = gardencorev1beta1helper.UpdatedCondition(conditionInstalled, gardencorev1beta1.ConditionFalse, "DeletionSuccessful", "Deletion of old resources succeeded.")
 
-	return reconcile.Result{}, controllerutils.PatchRemoveFinalizers(ctx, gardenClient, controllerInstallation.DeepCopy(), FinalizerName)
+	return reconcile.Result{}, controllerutils.PatchRemoveFinalizers(ctx, gardenClient, controllerInstallation.DeepCopy(), finalizerName)
 }
 
 func patchConditions(ctx context.Context, c client.StatusClient, controllerInstallation *gardencorev1beta1.ControllerInstallation, conditions ...gardencorev1beta1.Condition) error {

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation_control.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation_control.go
@@ -45,7 +45,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-const installationTypeHelm = "helm"
+const (
+	reconcilerName       = "controllerinstallation"
+	installationTypeHelm = "helm"
+)
 
 func (c *Controller) controllerInstallationAdd(obj interface{}) {
 	key, err := cache.MetaNamespaceKeyFunc(obj)

--- a/pkg/gardenlet/controller/extensions/controllerinstallation_control.go
+++ b/pkg/gardenlet/controller/extensions/controllerinstallation_control.go
@@ -22,11 +22,9 @@ import (
 	"github.com/gardener/gardener/pkg/api/extensions"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
-	"github.com/gardener/gardener/pkg/client/kubernetes"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
 	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
-	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -42,10 +40,9 @@ const (
 )
 
 type controllerInstallationControl struct {
-	k8sGardenClient kubernetes.Interface
-	seedClient      kubernetes.Interface
-	seedName        string
-	log             *logrus.Logger
+	gardenClient client.Client
+	seedClient   client.Client
+	seedName     string
 
 	controllerInstallationQueue workqueue.RateLimitingInterface
 	lock                        *sync.RWMutex
@@ -61,7 +58,7 @@ type controllerInstallationControl struct {
 func (c *controllerInstallationControl) createExtensionRequiredReconcileFunc(kind string, newListObjFunc func() client.ObjectList) reconcile.Func {
 	return func(ctx context.Context, _ reconcile.Request) (reconcile.Result, error) {
 		listObj := newListObjFunc()
-		if err := c.seedClient.Client().List(ctx, listObj); err != nil {
+		if err := c.seedClient.List(ctx, listObj); err != nil {
 			return reconcile.Result{}, err
 		}
 
@@ -101,7 +98,7 @@ func (c *controllerInstallationControl) createExtensionRequiredReconcileFunc(kin
 		// extension kind this particular reconciler is responsible for.
 
 		controllerRegistrationList := &gardencorev1beta1.ControllerRegistrationList{}
-		if err := c.k8sGardenClient.Client().List(ctx, controllerRegistrationList); err != nil {
+		if err := c.gardenClient.List(ctx, controllerRegistrationList); err != nil {
 			return reconcile.Result{}, err
 		}
 
@@ -120,7 +117,7 @@ func (c *controllerInstallationControl) createExtensionRequiredReconcileFunc(kin
 		// the other reconciler to decide whether it is required or not.
 
 		controllerInstallationList := &gardencorev1beta1.ControllerInstallationList{}
-		if err := c.k8sGardenClient.Client().List(ctx, controllerInstallationList); err != nil {
+		if err := c.gardenClient.List(ctx, controllerInstallationList); err != nil {
 			return reconcile.Result{}, err
 		}
 
@@ -144,12 +141,12 @@ func (c *controllerInstallationControl) createExtensionRequiredReconcileFunc(kin
 // required by using the <kindToRequiredTypes> map that was computed by a separate reconciler.
 func (c *controllerInstallationControl) reconcileControllerInstallationRequired(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	controllerInstallation := &gardencorev1beta1.ControllerInstallation{}
-	if err := c.k8sGardenClient.Client().Get(ctx, req.NamespacedName, controllerInstallation); err != nil {
+	if err := c.gardenClient.Get(ctx, req.NamespacedName, controllerInstallation); err != nil {
 		return reconcile.Result{}, err
 	}
 
 	controllerRegistration := &gardencorev1beta1.ControllerRegistration{}
-	if err := c.k8sGardenClient.Client().Get(ctx, kutil.Key(controllerInstallation.Spec.RegistrationRef.Name), controllerRegistration); err != nil {
+	if err := c.gardenClient.Get(ctx, kutil.Key(controllerInstallation.Spec.RegistrationRef.Name), controllerRegistration); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -189,8 +186,7 @@ func (c *controllerInstallationControl) reconcileControllerInstallationRequired(
 		message = fmt.Sprintf("extension objects still exist in the seed: %+v", requiredKindTypes.UnsortedList())
 	}
 
-	if err := updateControllerInstallationRequiredCondition(ctx, c.k8sGardenClient.Client(), controllerInstallation, *required, message); err != nil {
-		c.log.Error(err)
+	if err := updateControllerInstallationRequiredCondition(ctx, c.gardenClient, controllerInstallation, *required, message); err != nil {
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/gardenlet/controller/extensions/controllerinstallation_control.go
+++ b/pkg/gardenlet/controller/extensions/controllerinstallation_control.go
@@ -36,6 +36,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
+const (
+	controllerInstallationReconcilerName         = "controllerinstallation"
+	controllerInstallationRequiredReconcilerName = "controllerinstallation-required"
+)
+
 type controllerInstallationControl struct {
 	k8sGardenClient kubernetes.Interface
 	seedClient      kubernetes.Interface

--- a/pkg/gardenlet/controller/extensions/extensions.go
+++ b/pkg/gardenlet/controller/extensions/extensions.go
@@ -92,8 +92,7 @@ func (c *Controller) Initialize(ctx context.Context, seedClient kubernetes.Inter
 // Initialize must be called before running the controller.
 func (c *Controller) Run(ctx context.Context, controllerInstallationWorkers, shootStateWorkers int) {
 	if !c.initialized {
-		c.log.Info("Controller is not initialized, cannot run it")
-		return
+		panic("Extensions controller is not initialized, cannot run it")
 	}
 
 	timeoutCtx, cancel := context.WithTimeout(ctx, time.Minute*2)

--- a/pkg/gardenlet/controller/extensions/extensions.go
+++ b/pkg/gardenlet/controller/extensions/extensions.go
@@ -20,22 +20,26 @@ import (
 	"sync"
 	"time"
 
-	"github.com/sirupsen/logrus"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/util/sets"
-	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/tools/record"
-	"k8s.io/client-go/util/workqueue"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/controllerutils"
+
+	"github.com/go-logr/logr"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
+
+// ControllerName is the name of this controller.
+const ControllerName = "extensions"
 
 // Controller watches the extension resources and has several control loops.
 type Controller struct {
-	log *logrus.Logger
+	log logr.Logger
 
 	initialized            bool
 	waitGroup              sync.WaitGroup
@@ -48,22 +52,27 @@ type Controller struct {
 }
 
 // NewController creates new controller that syncs extensions states to ShootState
-func NewController(gardenClient, seedClient kubernetes.Interface, seedName string, log *logrus.Logger, recorder record.EventRecorder) *Controller {
+func NewController(
+	log logr.Logger,
+	gardenClient, seedClient client.Client,
+	seedName string,
+) *Controller {
+	log = log.WithName(ControllerName)
+
 	controller := &Controller{
 		log:      log,
 		workerCh: make(chan int),
 
 		controllerArtifacts: newControllerArtifacts(),
 		controllerInstallationControl: &controllerInstallationControl{
-			k8sGardenClient:             gardenClient,
+			gardenClient:                gardenClient,
 			seedClient:                  seedClient,
 			seedName:                    seedName,
-			log:                         log,
 			controllerInstallationQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "controllerinstallation-extension-required"),
 			lock:                        &sync.RWMutex{},
 			kindToRequiredTypes:         make(map[string]sets.String),
 		},
-		shootStateControl: NewShootStateControl(gardenClient, seedClient, log, recorder),
+		shootStateControl: NewShootStateControl(gardenClient, seedClient),
 	}
 
 	return controller
@@ -83,7 +92,7 @@ func (c *Controller) Initialize(ctx context.Context, seedClient kubernetes.Inter
 // Initialize must be called before running the controller.
 func (c *Controller) Run(ctx context.Context, controllerInstallationWorkers, shootStateWorkers int) {
 	if !c.initialized {
-		c.log.Fatal("controller is not initialized")
+		c.log.Info("Controller is not initialized, cannot run it")
 		return
 	}
 
@@ -91,7 +100,7 @@ func (c *Controller) Run(ctx context.Context, controllerInstallationWorkers, sho
 	defer cancel()
 
 	if !cache.WaitForCacheSync(timeoutCtx.Done(), c.controllerArtifacts.hasSyncedFuncs...) {
-		c.log.Fatal("timeout waiting for caches to sync")
+		c.log.Error(wait.ErrWaitTimeout, "Timed out waiting for caches to sync")
 		return
 	}
 
@@ -99,7 +108,6 @@ func (c *Controller) Run(ctx context.Context, controllerInstallationWorkers, sho
 	go func() {
 		for res := range c.workerCh {
 			c.numberOfRunningWorkers += res
-			c.log.Debugf("Current number of running extension controller workers is %d", c.numberOfRunningWorkers)
 		}
 	}()
 
@@ -111,11 +119,11 @@ func (c *Controller) Run(ctx context.Context, controllerInstallationWorkers, sho
 		c.createShootStateWorkers(ctx, c.shootStateControl)
 	}
 
-	c.log.Info("Extension controller initialized.")
+	c.log.Info("Extension controller initialized")
 }
 
 func (c *Controller) createControllerInstallationWorkers(ctx context.Context, control *controllerInstallationControl) {
-	controllerutils.CreateWorker(ctx, c.controllerInstallationControl.controllerInstallationQueue, "ControllerInstallation-Required", reconcile.Func(control.reconcileControllerInstallationRequired), &c.waitGroup, c.workerCh)
+	controllerutils.CreateWorker(ctx, c.controllerInstallationControl.controllerInstallationQueue, "ControllerInstallation-Required", reconcile.Func(control.reconcileControllerInstallationRequired), &c.waitGroup, c.workerCh, controllerutils.WithLogger(c.log.WithName(controllerInstallationRequiredReconcilerName)))
 
 	for kind, artifact := range c.controllerArtifacts.controllerInstallationArtifacts {
 		workerName := fmt.Sprintf("ControllerInstallation-Extension-%s", kind)
@@ -125,16 +133,16 @@ func (c *Controller) createControllerInstallationWorkers(ctx context.Context, co
 		// In this case no event is triggered and the control function would never be executed.
 		// Eventually, the Kind would never be part of the `kindToRequiredTypes` map and no decision if the ControllerInstallation is required could be taken.
 		if _, err := controlFn(ctx, reconcile.Request{}); err != nil {
-			c.log.Errorf("Error during initial run of extension reconciliation: %v", err)
+			c.log.Error(err, "Error during initial run of extension reconciliation")
 		}
-		controllerutils.CreateWorker(ctx, artifact.queue, workerName, controlFn, &c.waitGroup, c.workerCh)
+		controllerutils.CreateWorker(ctx, artifact.queue, workerName, controlFn, &c.waitGroup, c.workerCh, controllerutils.WithLogger(c.log.WithName(controllerInstallationReconcilerName).WithValues("kind", kind)))
 	}
 }
 
 func (c *Controller) createShootStateWorkers(ctx context.Context, control *ShootStateControl) {
 	for kind, artifact := range c.controllerArtifacts.stateArtifacts {
 		workerName := fmt.Sprintf("ShootState-%s", kind)
-		controllerutils.CreateWorker(ctx, artifact.queue, workerName, control.CreateShootStateSyncReconcileFunc(kind, artifact.newObjFunc), &c.waitGroup, c.workerCh)
+		controllerutils.CreateWorker(ctx, artifact.queue, workerName, control.CreateShootStateSyncReconcileFunc(kind, artifact.newObjFunc), &c.waitGroup, c.workerCh, controllerutils.WithLogger(c.log.WithName(shootStateReconcilerName).WithValues("kind", kind)))
 	}
 }
 

--- a/pkg/gardenlet/controller/extensions/shootstate_control.go
+++ b/pkg/gardenlet/controller/extensions/shootstate_control.go
@@ -41,6 +41,8 @@ import (
 	unstructuredutils "github.com/gardener/gardener/pkg/utils/kubernetes/unstructured"
 )
 
+const shootStateReconcilerName = "shootstate"
+
 // ShootStateControl is used to update data about extensions and any resources required by them in the ShootState.
 type ShootStateControl struct {
 	k8sGardenClient kubernetes.Interface

--- a/pkg/gardenlet/controller/factory.go
+++ b/pkg/gardenlet/controller/factory.go
@@ -152,7 +152,7 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 		return fmt.Errorf("failed initializing Bastion controller: %w", err)
 	}
 
-	controllerInstallationController, err := controllerinstallationcontroller.NewController(ctx, f.clientMap, f.cfg, f.recorder, f.identity, gardenNamespace, f.gardenClusterIdentity)
+	controllerInstallationController, err := controllerinstallationcontroller.NewController(ctx, log, f.clientMap, f.cfg, f.identity, gardenNamespace, f.gardenClusterIdentity)
 	if err != nil {
 		return fmt.Errorf("failed initializing ControllerInstallation controller: %w", err)
 	}

--- a/pkg/gardenlet/controller/factory.go
+++ b/pkg/gardenlet/controller/factory.go
@@ -170,7 +170,7 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 		return fmt.Errorf("failed initializing NetworkPolicy controller: %w", err)
 	}
 
-	secretController, err := shootsecretcontroller.NewController(ctx, gardenClientSet.Client(), seedClient, logger.Logger)
+	secretController, err := shootsecretcontroller.NewController(ctx, log, gardenClientSet.Client(), seedClient)
 	if err != nil {
 		return fmt.Errorf("failed initializing Secret controller: %w", err)
 	}

--- a/pkg/gardenlet/controller/factory.go
+++ b/pkg/gardenlet/controller/factory.go
@@ -102,12 +102,12 @@ func NewGardenletControllerFactory(
 func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 	log := logf.Log.WithName("controller")
 
-	gardenClientSet, err := f.clientMap.GetClient(ctx, keys.ForGarden())
+	gardenClient, err := f.clientMap.GetClient(ctx, keys.ForGarden())
 	if err != nil {
 		return fmt.Errorf("failed to get garden client: %+v", err)
 	}
 
-	if err := addAllFieldIndexes(ctx, gardenClientSet.Cache()); err != nil {
+	if err := addAllFieldIndexes(ctx, gardenClient.Cache()); err != nil {
 		return err
 	}
 
@@ -116,7 +116,7 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 	}
 
 	// Register Seed object
-	if err := f.registerSeed(ctx, gardenClientSet.Client()); err != nil {
+	if err := f.registerSeed(ctx, gardenClient.Client()); err != nil {
 		return fmt.Errorf("failed to register the seed: %+v", err)
 	}
 
@@ -130,10 +130,9 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 	}
 
 	gardenNamespace := &corev1.Namespace{}
-	runtime.Must(gardenClientSet.Client().Get(ctx, kutil.Key(v1beta1constants.GardenNamespace), gardenNamespace))
+	runtime.Must(gardenClient.Client().Get(ctx, kutil.Key(v1beta1constants.GardenNamespace), gardenNamespace))
 
-	seedName := f.cfg.SeedConfig.Name
-	seedClient, err := f.clientMap.GetClient(ctx, keys.ForSeedWithName(seedName))
+	seedClient, err := f.clientMap.GetClient(ctx, keys.ForSeedWithName(f.cfg.SeedConfig.Name))
 	if err != nil {
 		return fmt.Errorf("failed to get seed client: %w", err)
 	}
@@ -158,7 +157,7 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 		return fmt.Errorf("failed initializing ControllerInstallation controller: %w", err)
 	}
 
-	extensionsController := extensionscontroller.NewController(gardenClientSet, seedClient, f.cfg.SeedConfig.Name, logger.Logger, f.recorder)
+	extensionsController := extensionscontroller.NewController(log, gardenClient.Client(), seedClient.Client(), f.cfg.SeedConfig.Name)
 
 	managedSeedController, err := managedseedcontroller.NewManagedSeedController(ctx, f.clientMap, f.cfg, imageVector, f.recorder, logger.Logger)
 	if err != nil {
@@ -170,7 +169,7 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 		return fmt.Errorf("failed initializing NetworkPolicy controller: %w", err)
 	}
 
-	secretController, err := shootsecretcontroller.NewController(ctx, log, gardenClientSet.Client(), seedClient)
+	secretController, err := shootsecretcontroller.NewController(ctx, log, gardenClient.Client(), seedClient)
 	if err != nil {
 		return fmt.Errorf("failed initializing Secret controller: %w", err)
 	}

--- a/pkg/gardenlet/controller/shootsecret/controller.go
+++ b/pkg/gardenlet/controller/shootsecret/controller.go
@@ -22,11 +22,11 @@ import (
 
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/controllerutils"
-	"github.com/gardener/gardener/pkg/logger"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 
-	"github.com/sirupsen/logrus"
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -35,11 +35,12 @@ import (
 
 const (
 	// ControllerName is the name of this controller.
-	ControllerName = "shoot-secret-controller"
+	ControllerName = "shootsecret"
 )
 
 // Controller controls Secret in the seed cluster and persists them in the ShootState resource.
 type Controller struct {
+	log        logr.Logger
 	reconciler reconcile.Reconciler
 
 	hasSyncedFuncs []cache.InformerSynced
@@ -51,21 +52,25 @@ type Controller struct {
 
 // NewController creates a new controller for secrets in the seed cluster which must be persisted to the ShootState in
 // the garden cluster.
-func NewController(ctx context.Context,
+func NewController(
+	ctx context.Context,
+	log logr.Logger,
 	gardenClient client.Client,
 	seedClientSet kubernetes.Interface,
-	log *logrus.Logger,
 ) (
 	*Controller,
 	error,
 ) {
+	log = log.WithName(ControllerName)
+
 	secretInformer, err := seedClientSet.Cache().GetInformer(ctx, &corev1.Secret{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Secret Informer: %w", err)
 	}
 
 	controller := &Controller{
-		reconciler:     NewReconciler(gardenClient, seedClientSet.Client(), log.WithField("controller", ControllerName)),
+		log:            log,
+		reconciler:     NewReconciler(gardenClient, seedClientSet.Client()),
 		secretQueue:    workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "Secret"),
 		workerCh:       make(chan int),
 		hasSyncedFuncs: []cache.InformerSynced{secretInformer.HasSynced},
@@ -91,7 +96,7 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 	var waitGroup sync.WaitGroup
 
 	if !cache.WaitForCacheSync(ctx.Done(), c.hasSyncedFuncs...) {
-		logger.Logger.Error("Timed out waiting for caches to sync")
+		c.log.Error(wait.ErrWaitTimeout, "Timed out waiting for caches to sync")
 		return
 	}
 
@@ -99,14 +104,13 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 	go func() {
 		for res := range c.workerCh {
 			c.numberOfRunningWorkers += res
-			logger.Logger.Debugf("Current number of running Secret workers is %d", c.numberOfRunningWorkers)
 		}
 	}()
 
-	logger.Logger.Info("Secret controller initialized.")
+	c.log.Info("Shoot Secret controller initialized")
 
 	for i := 0; i < workers; i++ {
-		controllerutils.CreateWorker(ctx, c.secretQueue, "secret", c.reconciler, &waitGroup, c.workerCh)
+		controllerutils.CreateWorker(ctx, c.secretQueue, "secret", c.reconciler, &waitGroup, c.workerCh, controllerutils.WithLogger(c.log))
 	}
 
 	// Shutdown handling
@@ -115,10 +119,10 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 
 	for {
 		if c.secretQueue.Len() == 0 && c.numberOfRunningWorkers == 0 {
-			logger.Logger.Info("No running Secret worker and no items left in the queues. Terminated Secret controller...")
+			c.log.V(1).Info("No running Shoot Secret worker and no items left in the queues. Terminated Shoot Secret controller")
 			break
 		}
-		logger.Logger.Infof("Waiting for %d Secret worker(s) to finish (%d item(s) left in the queues)...", c.numberOfRunningWorkers, c.secretQueue.Len())
+		c.log.V(1).Info("Waiting for Shoot Secret workers to finish", "numberOfRunningWorkers", c.numberOfRunningWorkers, "queueLength", c.secretQueue.Len())
 		time.Sleep(5 * time.Second)
 	}
 
@@ -128,7 +132,7 @@ func (c *Controller) Run(ctx context.Context, workers int) {
 func (c *Controller) secretAdd(obj interface{}) {
 	key, err := cache.MetaNamespaceKeyFunc(obj)
 	if err != nil {
-		logger.Logger.Errorf("Couldn't get key for object %+v: %v", obj, err)
+		c.log.Error(err, "Could not get key", "obj", obj)
 		return
 	}
 
@@ -142,9 +146,10 @@ func (c *Controller) secretUpdate(_, newObj interface{}) {
 func (c *Controller) secretDelete(obj interface{}) {
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 	if err != nil {
-		logger.Logger.Errorf("Couldn't get key for object %+v: %v", obj, err)
+		c.log.Error(err, "Could not get key", "obj", obj)
 		return
 	}
+
 	c.secretQueue.Add(key)
 }
 

--- a/test/integration/gardenlet/shoot/secret/secret_suite_test.go
+++ b/test/integration/gardenlet/shoot/secret/secret_suite_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	gardenerenvtest "github.com/gardener/gardener/pkg/envtest"
 	shootsecretcontroller "github.com/gardener/gardener/pkg/gardenlet/controller/shootsecret"
-	"github.com/gardener/gardener/pkg/logger"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -110,7 +109,7 @@ var _ = AfterSuite(func() {
 
 func addControllerToManager(mgr manager.Manager) error {
 	c, err := controller.New("shootsecret-controller", mgr, controller.Options{
-		Reconciler: shootsecretcontroller.NewReconciler(testClient, testClient, logger.AddWriter(logger.NewLogger("info", ""), GinkgoWriter)),
+		Reconciler: shootsecretcontroller.NewReconciler(testClient, testClient),
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging dev-productivity
/kind enhancement

**What this PR does / why we need it**:
- Migrate `gardenlet`'s Shoot `Secret` controller to `logr`.
- Migrate `gardenlet`'s extensions controller to `logr`.
- Migrate `gardenlet`'s `ControllerInstalaltion` controller to `logr`.

**Which issue(s) this PR fixes**:
Part of #4251

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
