### PR TITLE
Switch `gardenlet` to `logr` (6)

### DIFF
--- a/pkg/gardenlet/controller/factory.go
+++ b/pkg/gardenlet/controller/factory.go
@@ -159,7 +159,7 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 
 	extensionsController := extensionscontroller.NewController(log, gardenClient.Client(), seedClient.Client(), f.cfg.SeedConfig.Name)
 
-	managedSeedController, err := managedseedcontroller.NewManagedSeedController(ctx, f.clientMap, f.cfg, imageVector, f.recorder, logger.Logger)
+	managedSeedController, err := managedseedcontroller.NewManagedSeedController(ctx, log, f.clientMap, f.cfg, imageVector, f.recorder)
 	if err != nil {
 		return fmt.Errorf("failed initializing ManagedSeed controller: %w", err)
 	}

--- a/pkg/gardenlet/controller/managedseed/managedseed_actuator.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_actuator.go
@@ -33,14 +33,13 @@ import (
 	"github.com/gardener/gardener/pkg/controllerutils"
 	configv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	bootstraputil "github.com/gardener/gardener/pkg/gardenlet/bootstrap/util"
-	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/operation/common"
 	"github.com/gardener/gardener/pkg/utils"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
 	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
-	"github.com/sirupsen/logrus"
+	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -54,9 +53,9 @@ import (
 // Actuator acts upon ManagedSeed resources.
 type Actuator interface {
 	// Reconcile reconciles ManagedSeed creation or update.
-	Reconcile(context.Context, *seedmanagementv1alpha1.ManagedSeed) (*seedmanagementv1alpha1.ManagedSeedStatus, bool, error)
+	Reconcile(context.Context, logr.Logger, *seedmanagementv1alpha1.ManagedSeed) (*seedmanagementv1alpha1.ManagedSeedStatus, bool, error)
 	// Delete reconciles ManagedSeed deletion.
-	Delete(context.Context, *seedmanagementv1alpha1.ManagedSeed) (*seedmanagementv1alpha1.ManagedSeedStatus, bool, bool, error)
+	Delete(context.Context, logr.Logger, *seedmanagementv1alpha1.ManagedSeed) (*seedmanagementv1alpha1.ManagedSeedStatus, bool, bool, error)
 }
 
 // actuator is a concrete implementation of Actuator.
@@ -65,29 +64,36 @@ type actuator struct {
 	clientMap    clientmap.ClientMap
 	vp           ValuesHelper
 	recorder     record.EventRecorder
-	logger       *logrus.Logger
 }
 
 // newActuator creates a new Actuator with the given clients, ValuesHelper, and logger.
-func newActuator(gardenClient kubernetes.Interface, clientMap clientmap.ClientMap, vp ValuesHelper, recorder record.EventRecorder, logger *logrus.Logger) Actuator {
+func newActuator(gardenClient kubernetes.Interface, clientMap clientmap.ClientMap, vp ValuesHelper, recorder record.EventRecorder) Actuator {
 	return &actuator{
 		gardenClient: gardenClient,
 		clientMap:    clientMap,
 		vp:           vp,
 		recorder:     recorder,
-		logger:       logger,
 	}
 }
 
 // Reconcile reconciles ManagedSeed creation or update.
-func (a *actuator) Reconcile(ctx context.Context, ms *seedmanagementv1alpha1.ManagedSeed) (status *seedmanagementv1alpha1.ManagedSeedStatus, wait bool, err error) {
+func (a *actuator) Reconcile(
+	ctx context.Context,
+	log logr.Logger,
+	ms *seedmanagementv1alpha1.ManagedSeed,
+) (
+	status *seedmanagementv1alpha1.ManagedSeedStatus,
+	wait bool,
+	err error,
+) {
 	// Initialize status
 	status = ms.Status.DeepCopy()
 	status.ObservedGeneration = ms.Generation
 
 	defer func() {
 		if err != nil {
-			a.reconcileErrorEventf(ms, err.Error())
+			log.Error(err, "Error during reconciliation")
+			a.recorder.Eventf(ms, corev1.EventTypeWarning, gardencorev1beta1.EventReconcileError, err.Error())
 			updateCondition(status, seedmanagementv1alpha1.ManagedSeedSeedRegistered, gardencorev1beta1.ConditionFalse, gardencorev1beta1.EventReconcileError, err.Error())
 		}
 	}()
@@ -100,18 +106,21 @@ func (a *actuator) Reconcile(ctx context.Context, ms *seedmanagementv1alpha1.Man
 
 	// Check if shoot is reconciled and update ShootReconciled condition
 	if !shootReconciled(shoot) {
-		a.reconcilingInfoEventf(ms, "Waiting for shoot %s to be reconciled", kutil.ObjectName(shoot))
-		updateCondition(status, seedmanagementv1alpha1.ManagedSeedShootReconciled, gardencorev1beta1.ConditionFalse, gardencorev1beta1.EventReconciling,
-			fmt.Sprintf("Waiting for shoot %s to be reconciled", kutil.ObjectName(shoot)))
+		log.Info("Waiting for shoot to be reconciled", "shoot", client.ObjectKeyFromObject(shoot))
+
+		msg := fmt.Sprintf("Waiting for shoot %q to be reconciled", client.ObjectKeyFromObject(shoot).String())
+		a.recorder.Event(ms, corev1.EventTypeNormal, gardencorev1beta1.EventReconciling, msg)
+		updateCondition(status, seedmanagementv1alpha1.ManagedSeedShootReconciled, gardencorev1beta1.ConditionFalse, gardencorev1beta1.EventReconciling, msg)
+
 		return status, true, nil
 	}
 	updateCondition(status, seedmanagementv1alpha1.ManagedSeedShootReconciled, gardencorev1beta1.ConditionTrue, gardencorev1beta1.EventReconciled,
-		fmt.Sprintf("Shoot %s has been reconciled", kutil.ObjectName(shoot)))
+		fmt.Sprintf("Shoot %q has been reconciled", client.ObjectKeyFromObject(shoot).String()))
 
 	// Get shoot client
 	shootClient, err := a.clientMap.GetClient(ctx, keys.ForShoot(shoot))
 	if err != nil {
-		return status, false, fmt.Errorf("could not get shoot client for shoot %s: %w", kutil.ObjectName(shoot), err)
+		return status, false, fmt.Errorf("could not get shoot client for shoot %s: %w", client.ObjectKeyFromObject(shoot).String(), err)
 	}
 
 	// Extract seed template and gardenlet config
@@ -126,20 +135,23 @@ func (a *actuator) Reconcile(ctx context.Context, ms *seedmanagementv1alpha1.Man
 	}
 
 	// Create or update garden namespace in the shoot
-	a.reconcilingInfoEventf(ms, "Creating or updating garden namespace in shoot %s", kutil.ObjectName(shoot))
+	log.Info("Ensuring garden namespace in shoot", "shoot", client.ObjectKeyFromObject(shoot))
+	a.recorder.Eventf(ms, corev1.EventTypeNormal, gardencorev1beta1.EventReconciling, "Ensuring garden namespace in shoot %q", client.ObjectKeyFromObject(shoot).String())
 	if err := a.ensureGardenNamespace(ctx, shootClient.Client()); err != nil {
-		return status, false, fmt.Errorf("could not create or update garden namespace in shoot %s: %w", kutil.ObjectName(shoot), err)
+		return status, false, fmt.Errorf("could not create or update garden namespace in shoot %s: %w", client.ObjectKeyFromObject(shoot).String(), err)
 	}
 
 	// Create or update seed secrets
-	a.reconcilingInfoEventf(ms, "Creating or updating seed %s secrets", ms.Name)
+	log.Info("Reconciling seed secrets")
+	a.recorder.Event(ms, corev1.EventTypeNormal, gardencorev1beta1.EventReconciling, "Reconciling seed secrets")
 	if err := a.createOrUpdateSeedSecrets(ctx, &seedTemplate.Spec, ms, shoot); err != nil {
 		return status, false, fmt.Errorf("could not create or update seed %s secrets: %w", ms.Name, err)
 	}
 
 	if ms.Spec.SeedTemplate != nil {
 		// Create or update seed
-		a.reconcilingInfoEventf(ms, "Creating or updating seed %s", ms.Name)
+		log.Info("Reconciling seed object", "seedName", ms.Name)
+		a.recorder.Eventf(ms, corev1.EventTypeNormal, gardencorev1beta1.EventReconciling, "Reconciling seed object %q", ms.Name)
 		if err := a.createOrUpdateSeed(ctx, ms); err != nil {
 			return status, false, fmt.Errorf("could not create or update seed %s: %w", ms.Name, err)
 		}
@@ -150,10 +162,12 @@ func (a *actuator) Reconcile(ctx context.Context, ms *seedmanagementv1alpha1.Man
 		}
 
 		// Deploy gardenlet into the shoot, it will register the seed automatically
-		a.reconcilingInfoEventf(ms, "Deploying gardenlet into shoot %s", kutil.ObjectName(shoot))
-		if err := a.deployGardenlet(ctx, shootClient, ms, seed, gardenletConfig, shoot); err != nil {
-			return status, false, fmt.Errorf("could not deploy gardenlet into shoot %s: %w", kutil.ObjectName(shoot), err)
+		log.Info("Deploying gardenlet into shoot", "shoot", client.ObjectKeyFromObject(shoot))
+		a.recorder.Eventf(ms, corev1.EventTypeNormal, gardencorev1beta1.EventReconciling, "Deploying gardenlet into shoot %q", client.ObjectKeyFromObject(shoot).String())
+		if err := a.deployGardenlet(ctx, log, shootClient, ms, seed, gardenletConfig, shoot); err != nil {
+			return status, false, fmt.Errorf("could not deploy gardenlet into shoot %s: %w", client.ObjectKeyFromObject(shoot).String(), err)
 		}
+
 		if err := bootstraputil.DeleteNonUniqueGardenletSecretsAndCms(ctx, shootClient.Client()); err != nil {
 			return status, false, fmt.Errorf("could not delete legacy non-unique secrets and configmaps %s: %w", ms.Name, err)
 		}
@@ -165,14 +179,23 @@ func (a *actuator) Reconcile(ctx context.Context, ms *seedmanagementv1alpha1.Man
 }
 
 // Delete reconciles ManagedSeed deletion.
-func (a *actuator) Delete(ctx context.Context, ms *seedmanagementv1alpha1.ManagedSeed) (status *seedmanagementv1alpha1.ManagedSeedStatus, wait, removeFinalizer bool, err error) {
+func (a *actuator) Delete(
+	ctx context.Context,
+	log logr.Logger,
+	ms *seedmanagementv1alpha1.ManagedSeed,
+) (
+	status *seedmanagementv1alpha1.ManagedSeedStatus,
+	wait, removeFinalizer bool,
+	err error,
+) {
 	// Initialize status
 	status = ms.Status.DeepCopy()
 	status.ObservedGeneration = ms.Generation
 
 	defer func() {
 		if err != nil {
-			a.deleteErrorEventf(ms, err.Error())
+			log.Error(err, "Error during deletion")
+			a.recorder.Eventf(ms, corev1.EventTypeWarning, gardencorev1beta1.EventDeleteError, err.Error())
 			updateCondition(status, seedmanagementv1alpha1.ManagedSeedSeedRegistered, gardencorev1beta1.ConditionFalse, gardencorev1beta1.EventDeleteError, err.Error())
 		}
 	}()
@@ -190,7 +213,7 @@ func (a *actuator) Delete(ctx context.Context, ms *seedmanagementv1alpha1.Manage
 	// Get shoot client
 	shootClient, err := a.clientMap.GetClient(ctx, keys.ForShoot(shoot))
 	if err != nil {
-		return status, false, false, fmt.Errorf("could not get shoot client for shoot %s: %w", kutil.ObjectName(shoot), err)
+		return status, false, false, fmt.Errorf("could not get shoot client for shoot %s: %w", client.ObjectKeyFromObject(shoot).String(), err)
 	}
 
 	// Extract seed template and gardenlet config
@@ -207,13 +230,16 @@ func (a *actuator) Delete(ctx context.Context, ms *seedmanagementv1alpha1.Manage
 
 	if seed != nil {
 		if seed.DeletionTimestamp == nil {
-			a.deletingInfoEventf(ms, "Deleting seed %s", ms.Name)
+			log.Info("Deleting seed", "seed", client.ObjectKey{Name: ms.Name})
+			a.recorder.Eventf(ms, corev1.EventTypeNormal, gardencorev1beta1.EventDeleting, "Deleting seed %s", ms.Name)
 			if err := a.deleteSeed(ctx, ms); err != nil {
 				return status, false, false, fmt.Errorf("could not delete seed %s: %w", ms.Name, err)
 			}
 		} else {
-			a.deletingInfoEventf(ms, "Waiting for seed %s to be deleted", ms.Name)
+			log.Info("Waiting for seed to be deleted", "seed", client.ObjectKey{Name: ms.Name}.String())
+			a.recorder.Eventf(ms, corev1.EventTypeNormal, gardencorev1beta1.EventDeleting, "Waiting for seed %q to be deleted", ms.Name)
 		}
+
 		return status, false, false, nil
 	}
 
@@ -221,17 +247,21 @@ func (a *actuator) Delete(ctx context.Context, ms *seedmanagementv1alpha1.Manage
 		// Delete gardenlet from the shoot if it still exists and is not already deleting
 		gardenletDeployment, err := a.getGardenletDeployment(ctx, shootClient)
 		if err != nil {
-			return status, false, false, fmt.Errorf("could not get gardenlet deployment in shoot %s: %w", kutil.ObjectName(shoot), err)
+			return status, false, false, fmt.Errorf("could not get gardenlet deployment in shoot %s: %w", client.ObjectKeyFromObject(shoot).String(), err)
 		}
+
 		if gardenletDeployment != nil {
 			if gardenletDeployment.DeletionTimestamp == nil {
-				a.deletingInfoEventf(ms, "Deleting gardenlet from shoot %s", kutil.ObjectName(shoot))
-				if err := a.deleteGardenlet(ctx, shootClient, ms, seed, gardenletConfig, shoot); err != nil {
-					return status, false, false, fmt.Errorf("could delete gardenlet from shoot %s: %w", kutil.ObjectName(shoot), err)
+				log.Info("Deleting gardenlet from shoot", "shoot", client.ObjectKeyFromObject(shoot))
+				a.recorder.Eventf(ms, corev1.EventTypeNormal, gardencorev1beta1.EventDeleting, "Deleting gardenlet from shoot %q", client.ObjectKeyFromObject(shoot).String())
+				if err := a.deleteGardenlet(ctx, log, shootClient, ms, seed, gardenletConfig, shoot); err != nil {
+					return status, false, false, fmt.Errorf("could delete gardenlet from shoot %s: %w", client.ObjectKeyFromObject(shoot).String(), err)
 				}
 			} else {
-				a.deletingInfoEventf(ms, "Waiting for gardenlet to be deleted from shoot %s", kutil.ObjectName(shoot))
+				log.Info("Waiting for gardenlet to be deleted from shoot", "shoot", client.ObjectKeyFromObject(shoot))
+				a.recorder.Eventf(ms, corev1.EventTypeNormal, gardencorev1beta1.EventDeleting, "Waiting for gardenlet to be deleted from shoot %q", client.ObjectKeyFromObject(shoot).String())
 			}
+
 			return status, true, false, nil
 		}
 	}
@@ -241,32 +271,40 @@ func (a *actuator) Delete(ctx context.Context, ms *seedmanagementv1alpha1.Manage
 	if err != nil {
 		return status, false, false, fmt.Errorf("could not get seed %s secrets: %w", ms.Name, err)
 	}
+
 	if secret != nil || backupSecret != nil {
 		if (secret != nil && secret.DeletionTimestamp == nil) || (backupSecret != nil && backupSecret.DeletionTimestamp == nil) {
-			a.deletingInfoEventf(ms, "Deleting seed %s secrets", ms.Name)
+			log.Info("Deleting seed secrets")
+			a.recorder.Event(ms, corev1.EventTypeNormal, gardencorev1beta1.EventDeleting, "Deleting seed secrets")
 			if err := a.deleteSeedSecrets(ctx, &seedTemplate.Spec, ms); err != nil {
 				return status, false, false, fmt.Errorf("could not delete seed %s secrets: %w", ms.Name, err)
 			}
 		} else {
-			a.deletingInfoEventf(ms, "Waiting for seed %s secrets to be deleted", ms.Name)
+			log.Info("Waiting for seed secrets to be deleted")
+			a.recorder.Event(ms, corev1.EventTypeNormal, gardencorev1beta1.EventDeleting, "Waiting for seed secrets to be deleted")
 		}
+
 		return status, true, false, nil
 	}
 
 	// Delete garden namespace from the shoot if it still exists and is not already deleting
 	gardenNamespace, err := a.getGardenNamespace(ctx, shootClient)
 	if err != nil {
-		return status, false, false, fmt.Errorf("could not check if garden namespace exists in shoot %s: %w", kutil.ObjectName(shoot), err)
+		return status, false, false, fmt.Errorf("could not check if garden namespace exists in shoot %s: %w", client.ObjectKeyFromObject(shoot).String(), err)
 	}
+
 	if gardenNamespace != nil {
 		if gardenNamespace.DeletionTimestamp == nil {
-			a.deletingInfoEventf(ms, "Deleting garden namespace from shoot %s", kutil.ObjectName(shoot))
+			log.Info("Deleting garden namespace from shoot", "shoot", client.ObjectKeyFromObject(shoot))
+			a.recorder.Eventf(ms, corev1.EventTypeNormal, gardencorev1beta1.EventDeleting, "Deleting garden namespace from shoot %q", client.ObjectKeyFromObject(shoot).String())
 			if err := a.deleteGardenNamespace(ctx, shootClient); err != nil {
-				return status, false, false, fmt.Errorf("could not delete garden namespace from shoot %s: %w", kutil.ObjectName(shoot), err)
+				return status, false, false, fmt.Errorf("could not delete garden namespace from shoot %s: %w", client.ObjectKeyFromObject(shoot).String(), err)
 			}
 		} else {
-			a.deletingInfoEventf(ms, "Waiting for garden namespace to be deleted from shoot %s", kutil.ObjectName(shoot))
+			log.Info("Waiting for garden namespace to be deleted from shoot", "shoot", client.ObjectKeyFromObject(shoot))
+			a.recorder.Eventf(ms, corev1.EventTypeNormal, gardencorev1beta1.EventDeleting, "Waiting for garden namespace to be deleted from shoot %q", client.ObjectKeyFromObject(shoot).String())
 		}
+
 		return status, true, false, nil
 	}
 
@@ -352,6 +390,7 @@ func (a *actuator) getSeed(ctx context.Context, managedSeed *seedmanagementv1alp
 
 func (a *actuator) deployGardenlet(
 	ctx context.Context,
+	log logr.Logger,
 	shootClient kubernetes.Interface,
 	managedSeed *seedmanagementv1alpha1.ManagedSeed,
 	seed *gardencorev1beta1.Seed,
@@ -361,6 +400,7 @@ func (a *actuator) deployGardenlet(
 	// Prepare gardenlet chart values
 	values, err := a.prepareGardenletChartValues(
 		ctx,
+		log,
 		shootClient,
 		managedSeed,
 		seed,
@@ -392,6 +432,7 @@ func (a *actuator) deployGardenlet(
 
 func (a *actuator) deleteGardenlet(
 	ctx context.Context,
+	log logr.Logger,
 	shootClient kubernetes.Interface,
 	managedSeed *seedmanagementv1alpha1.ManagedSeed,
 	seed *gardencorev1beta1.Seed,
@@ -401,6 +442,7 @@ func (a *actuator) deleteGardenlet(
 	// Prepare gardenlet chart values
 	values, err := a.prepareGardenletChartValues(
 		ctx,
+		log,
 		shootClient,
 		managedSeed,
 		seed,
@@ -610,6 +652,7 @@ func (a *actuator) seedIngressDNSEntryExists(ctx context.Context, seedClient kub
 
 func (a *actuator) prepareGardenletChartValues(
 	ctx context.Context,
+	log logr.Logger,
 	shootClient kubernetes.Interface,
 	managedSeed *seedmanagementv1alpha1.ManagedSeed,
 	seed *gardencorev1beta1.Seed,
@@ -642,7 +685,7 @@ func (a *actuator) prepareGardenletChartValues(
 	if bootstrap == seedmanagementv1alpha1.BootstrapNone {
 		a.removeBootstrapConfigFromGardenClientConnection(gardenletConfig.GardenClientConnection)
 	} else {
-		bootstrapKubeconfig, err = a.prepareGardenClientConnectionWithBootstrap(ctx, shootClient, gardenletConfig.GardenClientConnection, managedSeed, seed, bootstrap)
+		bootstrapKubeconfig, err = a.prepareGardenClientConnectionWithBootstrap(ctx, log, shootClient, gardenletConfig.GardenClientConnection, managedSeed, seed, bootstrap)
 		if err != nil {
 			return nil, err
 		}
@@ -700,6 +743,7 @@ func ensureGardenletEnvironment(deployment *seedmanagementv1alpha1.GardenletDepl
 
 func (a *actuator) prepareGardenClientConnectionWithBootstrap(
 	ctx context.Context,
+	log logr.Logger,
 	shootClient kubernetes.Interface,
 	gcc *configv1alpha1.GardenClientConnection,
 	managedSeed *seedmanagementv1alpha1.ManagedSeed,
@@ -725,7 +769,9 @@ func (a *actuator) prepareGardenClientConnectionWithBootstrap(
 		}
 	} else if managedSeed.Annotations[v1beta1constants.GardenerOperation] == v1beta1constants.GardenerOperationRenewKubeconfig {
 		// Also remove the kubeconfig if the renew-kubeconfig operation annotation is set on the ManagedSeed resource.
-		a.reconcilingInfoEventf(managedSeed, "Renewing gardenlet kubeconfig secret due to '%s=%s' annotation", v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationRenewKubeconfig)
+		log.Info("Renewing gardenlet kubeconfig secret due to operation annotation")
+		a.recorder.Event(managedSeed, corev1.EventTypeNormal, gardencorev1beta1.EventReconciling, "Renewing gardenlet kubeconfig secret due to operation annotation")
+
 		if err := kutil.DeleteSecretByReference(ctx, shootClient.Client(), gcc.KubeconfigSecret); err != nil {
 			return "", err
 		}
@@ -825,30 +871,6 @@ func (a *actuator) prepareGardenClientRestConfig(address *string, caCert []byte)
 		}
 	}
 	return gardenClientRestConfig
-}
-
-func (a *actuator) reconcilingInfoEventf(ms *seedmanagementv1alpha1.ManagedSeed, fmt string, args ...interface{}) {
-	a.recorder.Eventf(ms, corev1.EventTypeNormal, gardencorev1beta1.EventReconciling, fmt, args...)
-	a.getLogger(ms).Infof(fmt, args...)
-}
-
-func (a *actuator) deletingInfoEventf(ms *seedmanagementv1alpha1.ManagedSeed, fmt string, args ...interface{}) {
-	a.recorder.Eventf(ms, corev1.EventTypeNormal, gardencorev1beta1.EventDeleting, fmt, args...)
-	a.getLogger(ms).Infof(fmt, args...)
-}
-
-func (a *actuator) reconcileErrorEventf(ms *seedmanagementv1alpha1.ManagedSeed, fmt string, args ...interface{}) {
-	a.recorder.Eventf(ms, corev1.EventTypeWarning, gardencorev1beta1.EventReconcileError, fmt, args...)
-	a.getLogger(ms).Errorf(fmt, args...)
-}
-
-func (a *actuator) deleteErrorEventf(ms *seedmanagementv1alpha1.ManagedSeed, fmt string, args ...interface{}) {
-	a.recorder.Eventf(ms, corev1.EventTypeWarning, gardencorev1beta1.EventDeleteError, fmt, args...)
-	a.getLogger(ms).Errorf(fmt, args...)
-}
-
-func (a *actuator) getLogger(ms *seedmanagementv1alpha1.ManagedSeed) *logrus.Entry {
-	return logger.NewFieldLogger(a.logger, "managedSeed", kutil.ObjectName(ms))
 }
 
 func shootReconciled(shoot *gardencorev1beta1.Shoot) bool {

--- a/pkg/gardenlet/controller/managedseed/managedseed_controller_test.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_controller_test.go
@@ -20,9 +20,9 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
-	gardenerlogger "github.com/gardener/gardener/pkg/logger"
 	mockworkqueue "github.com/gardener/gardener/pkg/mock/client-go/util/workqueue"
 
+	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -42,7 +42,8 @@ var _ = Describe("Controller", func() {
 
 		queue *mockworkqueue.MockRateLimitingInterface
 
-		c *Controller
+		log logr.Logger
+		c   *Controller
 
 		managedSeed *seedmanagementv1alpha1.ManagedSeed
 
@@ -60,7 +61,9 @@ var _ = Describe("Controller", func() {
 
 		queue = mockworkqueue.NewMockRateLimitingInterface(ctrl)
 
+		log = logr.Discard()
 		c = &Controller{
+			log:              log,
 			managedSeedQueue: queue,
 			config: &config.GardenletConfiguration{
 				Controllers: &config.GardenletControllerConfiguration{
@@ -70,7 +73,6 @@ var _ = Describe("Controller", func() {
 					},
 				},
 			},
-			logger: gardenerlogger.NewNopLogger(),
 		}
 
 		managedSeed = &seedmanagementv1alpha1.ManagedSeed{
@@ -130,7 +132,6 @@ var _ = Describe("Controller", func() {
 				queue.EXPECT().Add(key)
 				c.managedSeedAdd(managedSeed)
 			})
-
 		})
 
 		It("should add the object to the queue with a jittered delay because the object generation and observed generation are equal", func() {
@@ -140,7 +141,6 @@ var _ = Describe("Controller", func() {
 
 			c.managedSeedAdd(managedSeed)
 		})
-
 	})
 
 	Describe("#managedSeedUpdate", func() {
@@ -180,7 +180,6 @@ var _ = Describe("Controller", func() {
 				c.managedSeedUpdate(nil, managedSeed)
 			})
 		})
-
 	})
 
 	Describe("#managedSeedDelete", func() {

--- a/pkg/gardenlet/controller/managedseed/managedseed_predicates.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_predicates.go
@@ -15,11 +15,10 @@
 package managedseed
 
 import (
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
-	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func (c *Controller) filterSeed(obj, _, controller client.Object, deleted bool) bool {
@@ -33,7 +32,7 @@ func (c *Controller) filterSeed(obj, _, controller client.Object, deleted bool) 
 	}
 
 	if ms.DeletionTimestamp != nil && deleted {
-		c.logger.Debugf("Managed seed %s is deleting and seed %s no longer exists", kutil.ObjectName(ms), kutil.ObjectName(seed))
+		c.log.V(1).Info("ManagedSeed is deleting and seed no longer exists", "managedSeed", client.ObjectKeyFromObject(ms), "seed", client.ObjectKeyFromObject(seed))
 		return true
 	}
 	return false

--- a/pkg/gardenlet/controller/managedseed/managedseed_predicates.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_predicates.go
@@ -32,7 +32,7 @@ func (c *Controller) filterSeed(obj, _, controller client.Object, deleted bool) 
 	}
 
 	if ms.DeletionTimestamp != nil && deleted {
-		c.log.V(1).Info("ManagedSeed is deleting and seed no longer exists", "managedSeed", client.ObjectKeyFromObject(ms), "seed", client.ObjectKeyFromObject(seed))
+		c.log.V(1).Info("ManagedSeed is deleting and seed no longer exists", "managedSeed", client.ObjectKeyFromObject(ms), "seedName", seed.Name)
 		return true
 	}
 	return false

--- a/pkg/gardenlet/controller/managedseed/managedseed_reconciler.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_reconciler.go
@@ -23,13 +23,13 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
-	"github.com/gardener/gardener/pkg/logger"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
-	"github.com/sirupsen/logrus"
+	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -38,40 +38,46 @@ type reconciler struct {
 	gardenClient kubernetes.Interface
 	actuator     Actuator
 	cfg          *config.ManagedSeedControllerConfiguration
-	logger       *logrus.Logger
 }
 
 // newReconciler creates a new ManagedSeed reconciler with the given parameters.
-func newReconciler(gardenClient kubernetes.Interface, actuator Actuator, cfg *config.ManagedSeedControllerConfiguration, logger *logrus.Logger) reconcile.Reconciler {
+func newReconciler(gardenClient kubernetes.Interface, actuator Actuator, cfg *config.ManagedSeedControllerConfiguration) reconcile.Reconciler {
 	return &reconciler{
 		gardenClient: gardenClient,
 		actuator:     actuator,
 		cfg:          cfg,
-		logger:       logger,
 	}
 }
 
 func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	log := logf.FromContext(ctx)
+
 	ms := &seedmanagementv1alpha1.ManagedSeed{}
 	if err := r.gardenClient.Client().Get(ctx, request.NamespacedName, ms); err != nil {
 		if apierrors.IsNotFound(err) {
-			r.logger.Debugf("Skipping ManagedSeed %s because it has been deleted", request.NamespacedName)
+			log.Info("Object is gone, stop reconciling")
 			return reconcile.Result{}, nil
 		}
-		r.logger.Errorf("Could not get ManagedSeed %s from store: %+v", request.NamespacedName, err)
-		return reconcile.Result{}, err
+		return reconcile.Result{}, fmt.Errorf("error retrieving object from store: %w", err)
 	}
 
 	if ms.DeletionTimestamp != nil {
-		return r.delete(ctx, ms)
+		return r.delete(ctx, log, ms)
 	}
-	return r.reconcile(ctx, ms)
+	return r.reconcile(ctx, log, ms)
 }
 
-func (r *reconciler) reconcile(ctx context.Context, ms *seedmanagementv1alpha1.ManagedSeed) (result reconcile.Result, err error) {
+func (r *reconciler) reconcile(
+	ctx context.Context,
+	log logr.Logger,
+	ms *seedmanagementv1alpha1.ManagedSeed,
+) (
+	result reconcile.Result,
+	err error,
+) {
 	// Ensure gardener finalizer
 	if !controllerutil.ContainsFinalizer(ms, gardencorev1beta1.GardenerName) {
-		r.getLogger(ms).Debug("Adding finalizer")
+		log.Info("Adding finalizer")
 		if err := controllerutils.StrategicMergePatchAddFinalizers(ctx, r.gardenClient.Client(), ms, gardencorev1beta1.GardenerName); err != nil {
 			return reconcile.Result{}, fmt.Errorf("could not add finalizer to ManagedSeed: %w", err)
 		}
@@ -87,12 +93,12 @@ func (r *reconciler) reconcile(ctx context.Context, ms *seedmanagementv1alpha1.M
 	}()
 
 	// Reconcile creation or update
-	r.getLogger(ms).Debug("Reconciling creation or update")
+	log.V(1).Info("Reconciling")
 	var wait bool
-	if status, wait, err = r.actuator.Reconcile(ctx, ms); err != nil {
+	if status, wait, err = r.actuator.Reconcile(ctx, log, ms); err != nil {
 		return reconcile.Result{}, fmt.Errorf("could not reconcile ManagedSeed %s creation or update: %w", kutil.ObjectName(ms), err)
 	}
-	r.getLogger(ms).Debug("Creation or update reconciled")
+	log.V(1).Info("Reconciliation finished")
 
 	// If waiting, requeue after WaitSyncPeriod
 	if wait {
@@ -103,10 +109,17 @@ func (r *reconciler) reconcile(ctx context.Context, ms *seedmanagementv1alpha1.M
 	return reconcile.Result{RequeueAfter: r.cfg.SyncPeriod.Duration}, nil
 }
 
-func (r *reconciler) delete(ctx context.Context, ms *seedmanagementv1alpha1.ManagedSeed) (result reconcile.Result, err error) {
+func (r *reconciler) delete(
+	ctx context.Context,
+	log logr.Logger,
+	ms *seedmanagementv1alpha1.ManagedSeed,
+) (
+	result reconcile.Result,
+	err error,
+) {
 	// Check gardener finalizer
 	if !controllerutil.ContainsFinalizer(ms, gardencorev1beta1.GardenerName) {
-		r.getLogger(ms).Debug("Skipping as it does not have a finalizer")
+		log.V(1).Info("Skipping deletion as object does not have a finalizer")
 		return reconcile.Result{}, nil
 	}
 
@@ -123,11 +136,11 @@ func (r *reconciler) delete(ctx context.Context, ms *seedmanagementv1alpha1.Mana
 	}()
 
 	// Reconcile deletion
-	r.getLogger(ms).Debug("Reconciling deletion")
-	if status, wait, removeFinalizer, err = r.actuator.Delete(ctx, ms); err != nil {
+	log.V(1).Info("Deletion")
+	if status, wait, removeFinalizer, err = r.actuator.Delete(ctx, log, ms); err != nil {
 		return reconcile.Result{}, fmt.Errorf("could not reconcile ManagedSeed %s deletion: %w", kutil.ObjectName(ms), err)
 	}
-	r.getLogger(ms).Debug("Deletion reconciled")
+	log.V(1).Info("Deletion finished")
 
 	// If waiting, requeue after WaitSyncPeriod
 	if wait {
@@ -136,7 +149,7 @@ func (r *reconciler) delete(ctx context.Context, ms *seedmanagementv1alpha1.Mana
 
 	// Remove gardener finalizer if requested by the actuator
 	if removeFinalizer {
-		r.getLogger(ms).Debug("Removing finalizer")
+		log.Info("Removing finalizer")
 		if err := controllerutils.PatchRemoveFinalizers(ctx, r.gardenClient.Client(), ms, gardencorev1beta1.GardenerName); err != nil {
 			return reconcile.Result{}, fmt.Errorf("could not remove gardener finalizer: %w", err)
 		}
@@ -145,10 +158,6 @@ func (r *reconciler) delete(ctx context.Context, ms *seedmanagementv1alpha1.Mana
 
 	// Return success result
 	return reconcile.Result{RequeueAfter: r.cfg.SyncPeriod.Duration}, nil
-}
-
-func (r *reconciler) getLogger(ms *seedmanagementv1alpha1.ManagedSeed) *logrus.Entry {
-	return logger.NewFieldLogger(r.logger, "managedSeed", kutil.ObjectName(ms))
 }
 
 func (r *reconciler) updateStatus(ctx context.Context, ms *seedmanagementv1alpha1.ManagedSeed, status *seedmanagementv1alpha1.ManagedSeedStatus) error {

--- a/pkg/gardenlet/controller/managedseed/managedseed_reconciler_test.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_reconciler_test.go
@@ -23,10 +23,10 @@ import (
 	mockkubernetes "github.com/gardener/gardener/pkg/client/kubernetes/mock"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	mockmanagedseed "github.com/gardener/gardener/pkg/gardenlet/controller/managedseed/mock"
-	gardenerlogger "github.com/gardener/gardener/pkg/logger"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
+	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -79,7 +79,7 @@ var _ = Describe("Reconciler", func() {
 			WaitSyncPeriod: &metav1.Duration{Duration: waitSyncPeriod},
 		}
 
-		reconciler = newReconciler(gardenClient, actuator, cfg, gardenerlogger.NewNopLogger())
+		reconciler = newReconciler(gardenClient, actuator, cfg)
 
 		ctx = context.TODO()
 		request = reconcile.Request{NamespacedName: kutil.Key(namespace, name)}
@@ -150,7 +150,7 @@ var _ = Describe("Reconciler", func() {
 			It("should reconcile the ManagedSeed creation or update, and update the status (no wait)", func() {
 				expectGetManagedSeed()
 				managedSeed.Finalizers = []string{gardencorev1beta1.GardenerName}
-				actuator.EXPECT().Reconcile(ctx, managedSeed).Return(status, false, nil)
+				actuator.EXPECT().Reconcile(ctx, gomock.AssignableToTypeOf(logr.Logger{}), managedSeed).Return(status, false, nil)
 				expectPatchManagedSeedStatus(func(ms *seedmanagementv1alpha1.ManagedSeed) {
 					Expect(&ms.Status).To(Equal(status))
 				})
@@ -163,7 +163,7 @@ var _ = Describe("Reconciler", func() {
 			It("should reconcile the ManagedSeed creation or update, and update the status (wait)", func() {
 				expectGetManagedSeed()
 				managedSeed.Finalizers = []string{gardencorev1beta1.GardenerName}
-				actuator.EXPECT().Reconcile(ctx, managedSeed).Return(status, true, nil)
+				actuator.EXPECT().Reconcile(ctx, gomock.AssignableToTypeOf(logr.Logger{}), managedSeed).Return(status, true, nil)
 				expectPatchManagedSeedStatus(func(ms *seedmanagementv1alpha1.ManagedSeed) {
 					Expect(&ms.Status).To(Equal(status))
 				})
@@ -183,7 +183,7 @@ var _ = Describe("Reconciler", func() {
 
 			It("should reconcile the ManagedSeed deletion and update the status (no wait)", func() {
 				expectGetManagedSeed()
-				actuator.EXPECT().Delete(ctx, managedSeed).Return(status, false, false, nil)
+				actuator.EXPECT().Delete(ctx, gomock.AssignableToTypeOf(logr.Logger{}), managedSeed).Return(status, false, false, nil)
 				expectPatchManagedSeedStatus(func(ms *seedmanagementv1alpha1.ManagedSeed) {
 					Expect(&ms.Status).To(Equal(status))
 				})
@@ -195,7 +195,7 @@ var _ = Describe("Reconciler", func() {
 
 			It("should reconcile the ManagedSeed deletion and update the status (wait)", func() {
 				expectGetManagedSeed()
-				actuator.EXPECT().Delete(ctx, managedSeed).Return(status, true, false, nil)
+				actuator.EXPECT().Delete(ctx, gomock.AssignableToTypeOf(logr.Logger{}), managedSeed).Return(status, true, false, nil)
 				expectPatchManagedSeedStatus(func(ms *seedmanagementv1alpha1.ManagedSeed) {
 					Expect(&ms.Status).To(Equal(status))
 				})
@@ -207,7 +207,7 @@ var _ = Describe("Reconciler", func() {
 
 			It("should reconcile the ManagedSeed deletion, remove the finalizer, and not update the status", func() {
 				expectGetManagedSeed()
-				actuator.EXPECT().Delete(ctx, managedSeed).Return(status, false, true, nil)
+				actuator.EXPECT().Delete(ctx, gomock.AssignableToTypeOf(logr.Logger{}), managedSeed).Return(status, false, true, nil)
 				expectPatchManagedSeed(func(ms *seedmanagementv1alpha1.ManagedSeed) {
 					Expect(ms.Finalizers).To(BeEmpty())
 				})

--- a/pkg/gardenlet/controller/managedseed/managedseed_valueshelper.go
+++ b/pkg/gardenlet/controller/managedseed/managedseed_valueshelper.go
@@ -18,8 +18,6 @@ import (
 	"os"
 	"strings"
 
-	"k8s.io/utils/pointer"
-
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
@@ -30,6 +28,7 @@ import (
 	"github.com/gardener/gardener/pkg/utils/secrets"
 
 	"k8s.io/component-base/version"
+	"k8s.io/utils/pointer"
 )
 
 // ValuesHelper provides methods for merging GardenletDeployment and GardenletConfiguration with parent,

--- a/pkg/gardenlet/controller/managedseed/mock/mocks.go
+++ b/pkg/gardenlet/controller/managedseed/mock/mocks.go
@@ -11,6 +11,7 @@ import (
 	v1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	v1alpha10 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
+	logr "github.com/go-logr/logr"
 	gomock "github.com/golang/mock/gomock"
 )
 
@@ -38,9 +39,9 @@ func (m *MockActuator) EXPECT() *MockActuatorMockRecorder {
 }
 
 // Delete mocks base method.
-func (m *MockActuator) Delete(arg0 context.Context, arg1 *v1alpha1.ManagedSeed) (*v1alpha1.ManagedSeedStatus, bool, bool, error) {
+func (m *MockActuator) Delete(arg0 context.Context, arg1 logr.Logger, arg2 *v1alpha1.ManagedSeed) (*v1alpha1.ManagedSeedStatus, bool, bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", arg0, arg1)
+	ret := m.ctrl.Call(m, "Delete", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*v1alpha1.ManagedSeedStatus)
 	ret1, _ := ret[1].(bool)
 	ret2, _ := ret[2].(bool)
@@ -49,15 +50,15 @@ func (m *MockActuator) Delete(arg0 context.Context, arg1 *v1alpha1.ManagedSeed) 
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockActuatorMockRecorder) Delete(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockActuatorMockRecorder) Delete(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockActuator)(nil).Delete), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockActuator)(nil).Delete), arg0, arg1, arg2)
 }
 
 // Reconcile mocks base method.
-func (m *MockActuator) Reconcile(arg0 context.Context, arg1 *v1alpha1.ManagedSeed) (*v1alpha1.ManagedSeedStatus, bool, error) {
+func (m *MockActuator) Reconcile(arg0 context.Context, arg1 logr.Logger, arg2 *v1alpha1.ManagedSeed) (*v1alpha1.ManagedSeedStatus, bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Reconcile", arg0, arg1)
+	ret := m.ctrl.Call(m, "Reconcile", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*v1alpha1.ManagedSeedStatus)
 	ret1, _ := ret[1].(bool)
 	ret2, _ := ret[2].(error)
@@ -65,9 +66,9 @@ func (m *MockActuator) Reconcile(arg0 context.Context, arg1 *v1alpha1.ManagedSee
 }
 
 // Reconcile indicates an expected call of Reconcile.
-func (mr *MockActuatorMockRecorder) Reconcile(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockActuatorMockRecorder) Reconcile(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reconcile", reflect.TypeOf((*MockActuator)(nil).Reconcile), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reconcile", reflect.TypeOf((*MockActuator)(nil).Reconcile), arg0, arg1, arg2)
 }
 
 // MockValuesHelper is a mock of ValuesHelper interface.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Migrate `gardenlet`'s `ManagedSeed` controller to `logr`.

**Which issue(s) this PR fixes**:
Part of #4251

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
