### PR TITLE
Allow ingress traffic to shoot kube-apiserver from pods within a cilium seed

### DIFF
--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
@@ -785,13 +785,7 @@ var _ = Describe("KubeAPIServer", func() {
 							Ingress: []networkingv1.NetworkPolicyIngressRule{
 								{
 									From: []networkingv1.NetworkPolicyPeer{
-										{PodSelector: &metav1.LabelSelector{}},
-										{
-											NamespaceSelector: &metav1.LabelSelector{},
-											PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
-												"app": "istio-ingressgateway",
-											}},
-										},
+										{PodSelector: &metav1.LabelSelector{}, NamespaceSelector: &metav1.LabelSelector{}},
 										{IPBlock: &networkingv1.IPBlock{CIDR: "0.0.0.0/0"}},
 									},
 									Ports: []networkingv1.NetworkPolicyPort{{
@@ -888,13 +882,7 @@ var _ = Describe("KubeAPIServer", func() {
 							Ingress: []networkingv1.NetworkPolicyIngressRule{
 								{
 									From: []networkingv1.NetworkPolicyPeer{
-										{PodSelector: &metav1.LabelSelector{}},
-										{
-											NamespaceSelector: &metav1.LabelSelector{},
-											PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
-												"app": "istio-ingressgateway",
-											}},
-										},
+										{PodSelector: &metav1.LabelSelector{}, NamespaceSelector: &metav1.LabelSelector{}},
 										{IPBlock: &networkingv1.IPBlock{CIDR: "0.0.0.0/0"}},
 									},
 									Ports: []networkingv1.NetworkPolicyPort{{

--- a/pkg/operation/botanist/component/kubeapiserver/networkpolicies.go
+++ b/pkg/operation/botanist/component/kubeapiserver/networkpolicies.go
@@ -139,15 +139,7 @@ func (k *kubeAPIServer) reconcileNetworkPolicyAllowKubeAPIServer(ctx context.Con
 				{
 					From: []networkingv1.NetworkPolicyPeer{
 						// Allow all other Pods in the Seed cluster to access it.
-						{PodSelector: &metav1.LabelSelector{}},
-						// Allow all istio-ingress Pods in the Seed cluster to access it.
-						{
-							// we don't want to modify existing labels on the istio namespace
-							NamespaceSelector: &metav1.LabelSelector{},
-							PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
-								v1beta1constants.LabelApp: v1beta1constants.DefaultIngressGatewayAppLabelValue,
-							}},
-						},
+						{PodSelector: &metav1.LabelSelector{}, NamespaceSelector: &metav1.LabelSelector{}},
 						// kube-apiserver can be accessed from anywhere using the LoadBalancer.
 						{IPBlock: &networkingv1.IPBlock{CIDR: "0.0.0.0/0"}},
 					},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Currently it is not possible to run a seed with cilium because network traffic from a pod in the seed cluster to the kube-apiserver pod of a shoot is blocked.
This PR allows ingress traffic from all pods in the seed cluster to the kube-apiserver pod of a shoot cluster (similar to how it is done with calico).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
none
```
