### PR TITLE
Do not exit early when a webhook has `failurePolicy=Ignore`

### DIFF
--- a/pkg/operation/care/webhook_remediation.go
+++ b/pkg/operation/care/webhook_remediation.go
@@ -99,7 +99,7 @@ func (r *WebhookRemediation) Remediate(ctx context.Context) error {
 			}
 
 			if w.FailurePolicy != nil && *w.FailurePolicy == admissionregistrationv1.Ignore {
-				return nil
+				continue
 			}
 
 			matchers := getMatchingRules(w.Rules, w.ObjectSelector, w.NamespaceSelector)
@@ -148,7 +148,7 @@ func (r *WebhookRemediation) Remediate(ctx context.Context) error {
 			}
 
 			if w.FailurePolicy != nil && *w.FailurePolicy == admissionregistrationv1.Ignore {
-				return nil
+				continue
 			}
 
 			matchers := getMatchingRules(w.Rules, w.ObjectSelector, w.NamespaceSelector)

--- a/pkg/operation/care/webhook_remediation_test.go
+++ b/pkg/operation/care/webhook_remediation_test.go
@@ -146,6 +146,21 @@ var _ = Describe("WebhookRemediation", func() {
 					Expect(validatingWebhookConfiguration.Webhooks[0].TimeoutSeconds).To(Equal(pointer.Int32(15)))
 				})
 
+				It("timeoutSeconds when failurePolicy=Ignore", func() {
+					validatingWebhookConfiguration.Webhooks = []admissionregistrationv1.ValidatingWebhook{{
+						Name:           "some-webhook.example.com",
+						TimeoutSeconds: pointer.Int32(30),
+						FailurePolicy:  &ignore,
+					}}
+					Expect(fakeClient.Create(ctx, validatingWebhookConfiguration)).To(Succeed())
+
+					Expect(remediator.Remediate(ctx)).To(Succeed())
+
+					Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(validatingWebhookConfiguration), validatingWebhookConfiguration)).To(Succeed())
+					Expect(validatingWebhookConfiguration.Annotations).To(HaveKey("gardener.cloud/warning"))
+					Expect(validatingWebhookConfiguration.Webhooks[0].TimeoutSeconds).To(Equal(pointer.Int32(15)))
+				})
+
 				It("failurePolicy", func() {
 					defer test.WithVar(&matchers.WebhookConstraintMatchers, []matchers.WebhookConstraintMatcher{
 						{GVR: corev1.SchemeGroupVersion.WithResource("foobars")},
@@ -288,6 +303,21 @@ var _ = Describe("WebhookRemediation", func() {
 					mutatingWebhookConfiguration.Webhooks = []admissionregistrationv1.MutatingWebhook{{
 						Name:           "some-webhook.example.com",
 						TimeoutSeconds: pointer.Int32(30),
+					}}
+					Expect(fakeClient.Create(ctx, mutatingWebhookConfiguration)).To(Succeed())
+
+					Expect(remediator.Remediate(ctx)).To(Succeed())
+
+					Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(mutatingWebhookConfiguration), mutatingWebhookConfiguration)).To(Succeed())
+					Expect(mutatingWebhookConfiguration.Annotations).To(HaveKey("gardener.cloud/warning"))
+					Expect(mutatingWebhookConfiguration.Webhooks[0].TimeoutSeconds).To(Equal(pointer.Int32(15)))
+				})
+
+				It("timeoutSeconds when failurePolicy=Ignore", func() {
+					mutatingWebhookConfiguration.Webhooks = []admissionregistrationv1.MutatingWebhook{{
+						Name:           "some-webhook.example.com",
+						TimeoutSeconds: pointer.Int32(30),
+						FailurePolicy:  &ignore,
 					}}
 					Expect(fakeClient.Create(ctx, mutatingWebhookConfiguration)).To(Succeed())
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind bug

**What this PR does / why we need it**:
Without this, automatic remediation of webhooks is prevented/aborted in case there is at least one webhook with `failurePolicy=Ignore`.

**Special notes for your reviewer**:
Feature initially introduced with #6090.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed which prevented automatic remediation of webhooks in case there was at least one webhook with `failurePolicy=Ignore`.
```
