### PR TITLE
Switch `gardenlet` to `logr` (7)

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -39,7 +39,7 @@ issues:
   - "undeclared name: `.*`"
   - "\".*\" imported but not used"
   # allow non-capitalized messages if they start with technical terms
-  - "structured logging message should be capitalized: \"gardener-(apiserver|controller-manager)"
+  - "structured logging message should be capitalized: \"garden(er-apiserver|er-controller-manager|er-admission-controller|er-seed-admission-controller|er-resource-manager|let)"
   exclude-rules:
   - linters:
     - staticcheck

--- a/pkg/controllermanager/controller/controllerregistration/seed_control.go
+++ b/pkg/controllermanager/controller/controllerregistration/seed_control.go
@@ -27,7 +27,6 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/extensions"
-	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/operation/common"
 	gardenpkg "github.com/gardener/gardener/pkg/operation/garden"
 	shootpkg "github.com/gardener/gardener/pkg/operation/shoot"
@@ -104,8 +103,7 @@ func (r *controllerRegistrationSeedReconciler) Reconcile(ctx context.Context, re
 		return reconcile.Result{}, err
 	}
 
-	// TODO: switch to logr once ReadGardenSecrets func is migrated
-	secrets, err := gardenpkg.ReadGardenSecrets(ctx, r.gardenClient.Client(), gutil.ComputeGardenNamespace(seed.Name), logger.Logger, false)
+	secrets, err := gardenpkg.ReadGardenSecrets(ctx, log, r.gardenClient.Client(), gutil.ComputeGardenNamespace(seed.Name), false)
 	if err != nil {
 		return reconcile.Result{}, err
 	}

--- a/pkg/controllermanager/controller/factory.go
+++ b/pkg/controllermanager/controller/factory.go
@@ -46,6 +46,7 @@ import (
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 
 	"k8s.io/client-go/tools/record"
+	"k8s.io/component-base/version"
 	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -173,7 +174,8 @@ func (f *GardenControllerFactory) Run(ctx context.Context) error {
 		}
 	}
 
-	log.Info("gardener-controller-manager initialized")
+	//nolint
+	log.Info("gardener-controller-manager initialized", "version", version.Get().GitVersion)
 
 	go bastionController.Run(ctx, *f.cfg.Controllers.Bastion.ConcurrentSyncs)
 	go cloudProfileController.Run(ctx, *f.cfg.Controllers.CloudProfile.ConcurrentSyncs)

--- a/pkg/controllermanager/controller/factory.go
+++ b/pkg/controllermanager/controller/factory.go
@@ -46,7 +46,6 @@ import (
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 
 	"k8s.io/client-go/tools/record"
-	"k8s.io/component-base/version"
 	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -174,8 +173,7 @@ func (f *GardenControllerFactory) Run(ctx context.Context) error {
 		}
 	}
 
-	//nolint
-	log.Info("gardener-controller-manager initialized", "version", version.Get().GitVersion)
+	log.Info("gardener-controller-manager initialized")
 
 	go bastionController.Run(ctx, *f.cfg.Controllers.Bastion.ConcurrentSyncs)
 	go cloudProfileController.Run(ctx, *f.cfg.Controllers.CloudProfile.ConcurrentSyncs)

--- a/pkg/gardenlet/controller/factory.go
+++ b/pkg/gardenlet/controller/factory.go
@@ -57,7 +57,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/component-base/version"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -217,8 +216,7 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 
 	go extensionsController.Run(controllerCtx, *f.cfg.Controllers.ControllerInstallationRequired.ConcurrentSyncs, *f.cfg.Controllers.ShootStateSync.ConcurrentSyncs)
 
-	//nolint
-	log.Info("gardenlet initialized", "version", version.Get().GitVersion)
+	log.Info("gardenlet initialized")
 
 	// Shutdown handling
 	<-ctx.Done()

--- a/pkg/gardenlet/controller/factory.go
+++ b/pkg/gardenlet/controller/factory.go
@@ -204,7 +204,7 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 			// A NoMatchError most probably indicates that the necessary CRDs haven't been deployed to the affected seed cluster yet.
 			// This can either be the case if the seed cluster is new or if a new extension CRD was added.
 			if meta.IsNoMatchError(err) {
-				logger.Logger.Errorf("An error occurred when initializing extension controllers: %v. Will retry.", err)
+				log.Error(err, "An error occurred when initializing extension controllers, will retry")
 				return retry.MinorError(err)
 			}
 			return retry.SevereError(err)
@@ -217,14 +217,15 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 
 	go extensionsController.Run(controllerCtx, *f.cfg.Controllers.ControllerInstallationRequired.ConcurrentSyncs, *f.cfg.Controllers.ShootStateSync.ConcurrentSyncs)
 
-	logger.Logger.Infof("Gardenlet (version %s) initialized.", version.Get().GitVersion)
+	//nolint
+	log.Info("gardenlet initialized", "version", version.Get().GitVersion)
 
 	// Shutdown handling
 	<-ctx.Done()
 	cancel()
 
-	logger.Logger.Infof("I have received a stop signal and will no longer watch resources.")
-	logger.Logger.Infof("Bye Bye!")
+	log.Info("I have received a stop signal and will no longer watch resources")
+	log.Info("Bye Bye!")
 
 	return nil
 }

--- a/pkg/gardenlet/controller/factory.go
+++ b/pkg/gardenlet/controller/factory.go
@@ -174,7 +174,7 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 		return fmt.Errorf("failed initializing Secret controller: %w", err)
 	}
 
-	seedController, err := seedcontroller.NewSeedController(ctx, f.clientMap, f.healthManager, imageVector, componentImageVectors, f.identity, f.clientCertificateExpirationTimestamp, f.cfg, f.recorder)
+	seedController, err := seedcontroller.NewSeedController(ctx, log, f.clientMap, f.healthManager, imageVector, componentImageVectors, f.identity, f.clientCertificateExpirationTimestamp, f.cfg, f.recorder)
 	if err != nil {
 		return fmt.Errorf("failed initializing Seed controller: %w", err)
 	}

--- a/pkg/gardenlet/controller/seed/lease_control.go
+++ b/pkg/gardenlet/controller/seed/lease_control.go
@@ -37,6 +37,8 @@ import (
 	"github.com/gardener/gardener/pkg/healthz"
 )
 
+const leaseReconcilerName = "lease"
+
 func (c *Controller) seedLeaseAdd(obj interface{}) {
 	key, err := cache.MetaNamespaceKeyFunc(obj)
 	if err != nil {

--- a/pkg/gardenlet/controller/seed/lease_control_test.go
+++ b/pkg/gardenlet/controller/seed/lease_control_test.go
@@ -22,9 +22,18 @@ import (
 	"strings"
 	"time"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	fakeclientmap "github.com/gardener/gardener/pkg/client/kubernetes/clientmap/fake"
+	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
+	fakeclientset "github.com/gardener/gardener/pkg/client/kubernetes/fake"
+	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
+	. "github.com/gardener/gardener/pkg/gardenlet/controller/seed"
+	"github.com/gardener/gardener/pkg/healthz"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/sirupsen/logrus"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,23 +44,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	"github.com/gardener/gardener/pkg/client/kubernetes"
-	fakeclientmap "github.com/gardener/gardener/pkg/client/kubernetes/clientmap/fake"
-	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
-	fakeclientset "github.com/gardener/gardener/pkg/client/kubernetes/fake"
-	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
-	. "github.com/gardener/gardener/pkg/gardenlet/controller/seed"
-	"github.com/gardener/gardener/pkg/healthz"
-	"github.com/gardener/gardener/pkg/logger"
-	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
 var _ = Describe("LeaseReconciler", func() {
 	var (
 		ctx            context.Context
-		log            logrus.FieldLogger
 		now            metav1.Time
 		nowFunc        func() metav1.Time
 		c              client.Client
@@ -69,7 +66,6 @@ var _ = Describe("LeaseReconciler", func() {
 
 	BeforeEach(func() {
 		ctx = context.Background()
-		log = logger.NewNopLogger()
 
 		now = metav1.NewTime(time.Now().Round(time.Second))
 		nowFunc = func() metav1.Time { return now }
@@ -129,7 +125,7 @@ var _ = Describe("LeaseReconciler", func() {
 		healthManager = healthz.NewDefaultHealthz()
 		healthManager.Start()
 
-		reconciler = NewLeaseReconciler(fakeClientMap, log, healthManager, nowFunc, gardenletConf)
+		reconciler = NewLeaseReconciler(fakeClientMap, healthManager, nowFunc, gardenletConf)
 	})
 
 	AfterEach(func() {

--- a/pkg/gardenlet/controller/seed/seed.go
+++ b/pkg/gardenlet/controller/seed/seed.go
@@ -101,7 +101,7 @@ func NewSeedController(
 		leaseReconciler: NewLeaseReconciler(clientMap, healthManager, metav1.Now, config),
 		careReconciler:  NewCareReconciler(clientMap, *config.Controllers.SeedCare),
 		// TODO: move this reconciler to controller-manager and let it run once for all Seeds, no Seed specifics required here
-		extensionCheckReconciler: NewExtensionCheckReconciler(clientMap, metav1.Now),
+		extensionCheckReconciler: NewExtensionCheckReconciler(gardenClient.Client(), metav1.Now),
 
 		seedQueue:               workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "seed"),
 		seedLeaseQueue:          workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(time.Millisecond, 2*time.Second), "seed-lease"),

--- a/pkg/gardenlet/controller/seed/seed_care_control.go
+++ b/pkg/gardenlet/controller/seed/seed_care_control.go
@@ -33,7 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
-const seedCareReconcilerName = "seed-care"
+const careReconcilerName = "care"
 
 // NewCareReconciler returns an implementation of reconcile.Reconciler which is dedicated to execute care operations
 func NewCareReconciler(

--- a/pkg/gardenlet/controller/seed/seed_care_control.go
+++ b/pkg/gardenlet/controller/seed/seed_care_control.go
@@ -38,17 +38,17 @@ const careReconcilerName = "care"
 // NewCareReconciler returns an implementation of reconcile.Reconciler which is dedicated to execute care operations
 func NewCareReconciler(
 	clientMap clientmap.ClientMap,
-	seedCareControllerConfig gardenletconfig.SeedCareControllerConfiguration,
+	config gardenletconfig.SeedCareControllerConfiguration,
 ) reconcile.Reconciler {
 	return &careReconciler{
-		clientMap:                clientMap,
-		seedCareControllerConfig: seedCareControllerConfig,
+		clientMap: clientMap,
+		config:    config,
 	}
 }
 
 type careReconciler struct {
-	clientMap                clientmap.ClientMap
-	seedCareControllerConfig gardenletconfig.SeedCareControllerConfiguration
+	clientMap clientmap.ClientMap
+	config    gardenletconfig.SeedCareControllerConfiguration
 }
 
 func (r *careReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
@@ -68,11 +68,11 @@ func (r *careReconciler) Reconcile(ctx context.Context, req reconcile.Request) (
 		return reconcile.Result{}, fmt.Errorf("error retrieving object from store: %w", err)
 	}
 
-	if err := r.care(ctx, gardenClient.Client(), seed, log); err != nil {
+	if err := r.care(ctx, log, gardenClient.Client(), seed); err != nil {
 		return reconcile.Result{}, err
 	}
 
-	return reconcile.Result{RequeueAfter: r.seedCareControllerConfig.SyncPeriod.Duration}, nil
+	return reconcile.Result{RequeueAfter: r.config.SyncPeriod.Duration}, nil
 }
 
 var (
@@ -82,8 +82,13 @@ var (
 	NewHealthCheck = defaultNewHealthCheck
 )
 
-func (r *careReconciler) care(ctx context.Context, gardenClientSet client.Client, seed *gardencorev1beta1.Seed, log logr.Logger) error {
-	careCtx, cancel := context.WithTimeout(ctx, r.seedCareControllerConfig.SyncPeriod.Duration)
+func (r *careReconciler) care(
+	ctx context.Context,
+	log logr.Logger,
+	gardenClient client.Client,
+	seed *gardencorev1beta1.Seed,
+) error {
+	careCtx, cancel := context.WithTimeout(ctx, r.config.SyncPeriod.Duration)
 	defer cancel()
 
 	log.V(1).Info("Starting seed care")
@@ -101,7 +106,7 @@ func (r *careReconciler) care(ctx context.Context, gardenClientSet client.Client
 	if err != nil {
 		log.Error(err, "SeedClient cannot be constructed")
 
-		if err := careSetupFailure(ctx, gardenClientSet, seed, "Precondition failed: seed client cannot be constructed", conditions); err != nil {
+		if err := careSetupFailure(ctx, gardenClient, seed, "Precondition failed: seed client cannot be constructed", conditions); err != nil {
 			log.Error(err, "Unable to create error condition")
 		}
 
@@ -122,7 +127,7 @@ func (r *careReconciler) care(ctx context.Context, gardenClientSet client.Client
 		// correct types will be updated, and any other conditions will remain intact
 		conditions := buildSeedConditions(seed.Status.Conditions, updatedConditions, conditionTypes)
 		log.Info("Updating seed status conditions")
-		if err := patchSeedStatus(ctx, gardenClientSet, seed, conditions); err != nil {
+		if err := patchSeedStatus(ctx, gardenClient, seed, conditions); err != nil {
 			log.Error(err, "Could not update Seed status")
 			return nil // We do not want to run in the exponential backoff for the condition checks.
 		}
@@ -159,7 +164,7 @@ func patchSeedStatus(ctx context.Context, c client.StatusClient, seed *gardencor
 
 func (r *careReconciler) conditionThresholdsToProgressingMapping() map[gardencorev1beta1.ConditionType]time.Duration {
 	out := make(map[gardencorev1beta1.ConditionType]time.Duration)
-	for _, threshold := range r.seedCareControllerConfig.ConditionThresholds {
+	for _, threshold := range r.config.ConditionThresholds {
 		out[gardencorev1beta1.ConditionType(threshold.Type)] = threshold.Duration.Duration
 	}
 	return out

--- a/pkg/gardenlet/controller/seed/seed_control.go
+++ b/pkg/gardenlet/controller/seed/seed_control.go
@@ -257,11 +257,11 @@ func (r *reconciler) reconcile(ctx context.Context, log logr.Logger, gardenClien
 
 		parentLogMessage := "Can't delete Seed, because the following objects are still referencing it:"
 		if len(associatedShoots) != 0 {
-			log.Info("Cannot delete SEed because the following Shoots are still referencing it", "shoots", associatedShoots)
+			log.Info("Cannot delete Seed because the following Shoots are still referencing it", "shoots", associatedShoots)
 			r.recorder.Event(seed, corev1.EventTypeNormal, v1beta1constants.EventResourceReferenced, fmt.Sprintf("%s Shoots=%v", parentLogMessage, associatedShoots))
 		}
 		if len(associatedBackupBuckets) != 0 {
-			log.Info("Cannot delete SEed because the following BackupBuckets are still referencing it", "backupBuckets", associatedBackupBuckets)
+			log.Info("Cannot delete Seed because the following BackupBuckets are still referencing it", "backupBuckets", associatedBackupBuckets)
 			r.recorder.Event(seed, corev1.EventTypeNormal, v1beta1constants.EventResourceReferenced, fmt.Sprintf("%s BackupBuckets=%v", parentLogMessage, associatedBackupBuckets))
 		}
 
@@ -271,7 +271,7 @@ func (r *reconciler) reconcile(ctx context.Context, log logr.Logger, gardenClien
 	if !controllerutil.ContainsFinalizer(seed, gardencorev1beta1.GardenerName) {
 		log.Info("Adding finalizer")
 		if err := controllerutils.StrategicMergePatchAddFinalizers(ctx, gardenClient, seed, gardencorev1beta1.GardenerName); err != nil {
-			return fmt.Errorf("could not add finalizer to Seed: %s", err.Error())
+			return err
 		}
 	}
 

--- a/pkg/gardenlet/controller/seed/seed_control.go
+++ b/pkg/gardenlet/controller/seed/seed_control.go
@@ -47,6 +47,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
+const reconcilerName = "seed"
+
 func (c *Controller) seedAdd(obj interface{}) {
 	key, err := cache.MetaNamespaceKeyFunc(obj)
 	if err != nil {

--- a/pkg/gardenlet/controller/seed/seed_control.go
+++ b/pkg/gardenlet/controller/seed/seed_control.go
@@ -232,7 +232,7 @@ func (r *reconciler) reconcile(ctx context.Context, log logr.Logger, gardenClien
 						Namespace: seed.Spec.SecretRef.Namespace,
 					},
 				}
-				log.Info("Removing finalizer form referenced secret")
+				log.Info("Removing finalizer form referenced secret", "secret", client.ObjectKeyFromObject(secret))
 				if err := gardenClient.Get(ctx, client.ObjectKeyFromObject(secret), secret); err == nil {
 					if err := controllerutils.PatchRemoveFinalizers(ctx, gardenClient, secret, gardencorev1beta1.ExternalGardenerName); err != nil {
 						return fmt.Errorf("failed to remove finalizer from Seed secret '%s/%s': %w", secret.Namespace, secret.Name, err)
@@ -284,7 +284,7 @@ func (r *reconciler) reconcile(ctx context.Context, log logr.Logger, gardenClien
 		}
 
 		if !controllerutil.ContainsFinalizer(secret, gardencorev1beta1.ExternalGardenerName) {
-			log.Info("Adding finalizer to referenced secret")
+			log.Info("Adding finalizer to referenced secret", "secret", client.ObjectKeyFromObject(secret))
 			if err := controllerutils.StrategicMergePatchAddFinalizers(ctx, gardenClient, secret, gardencorev1beta1.ExternalGardenerName); err != nil {
 				return err
 			}

--- a/pkg/gardenlet/controller/seed/seed_control.go
+++ b/pkg/gardenlet/controller/seed/seed_control.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
@@ -27,14 +26,13 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
-	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/operation/garden"
 	seedpkg "github.com/gardener/gardener/pkg/operation/seed"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
-	"github.com/sirupsen/logrus"
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -44,6 +42,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -52,7 +51,7 @@ const reconcilerName = "seed"
 func (c *Controller) seedAdd(obj interface{}) {
 	key, err := cache.MetaNamespaceKeyFunc(obj)
 	if err != nil {
-		logger.Logger.Errorf("Couldn't get key for object %+v: %v", obj, err)
+		c.log.Error(err, "Could not get key", "obj", obj)
 		return
 	}
 	c.seedQueue.Add(key)
@@ -75,7 +74,7 @@ func (c *Controller) seedUpdate(oldObj, newObj interface{}) {
 func (c *Controller) seedDelete(obj interface{}) {
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(obj)
 	if err != nil {
-		logger.Logger.Errorf("Couldn't get key for object %+v: %v", obj, err)
+		c.log.Error(err, "Could not get key", "obj", obj)
 		return
 	}
 	c.seedQueue.Add(key)
@@ -84,7 +83,6 @@ func (c *Controller) seedDelete(obj interface{}) {
 func newReconciler(
 	clientMap clientmap.ClientMap,
 	recorder record.EventRecorder,
-	l logrus.FieldLogger,
 	imageVector imagevector.ImageVector,
 	componentImageVectors imagevector.ComponentImageVectors,
 	identity *gardencorev1beta1.Gardener,
@@ -94,7 +92,6 @@ func newReconciler(
 	return &reconciler{
 		clientMap:                            clientMap,
 		recorder:                             recorder,
-		logger:                               l,
 		imageVector:                          imageVector,
 		componentImageVectors:                componentImageVectors,
 		identity:                             identity,
@@ -106,7 +103,6 @@ func newReconciler(
 type reconciler struct {
 	clientMap                            clientmap.ClientMap
 	recorder                             record.EventRecorder
-	logger                               logrus.FieldLogger
 	imageVector                          imagevector.ImageVector
 	componentImageVectors                imagevector.ComponentImageVectors
 	identity                             *gardencorev1beta1.Gardener
@@ -115,7 +111,7 @@ type reconciler struct {
 }
 
 func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.logger.WithField("seed", request.Name)
+	log := logf.FromContext(ctx)
 
 	gardenClient, err := r.clientMap.GetClient(ctx, keys.ForGarden())
 	if err != nil {
@@ -125,7 +121,7 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	seed := &gardencorev1beta1.Seed{}
 	if err := gardenClient.Client().Get(ctx, request.NamespacedName, seed); err != nil {
 		if apierrors.IsNotFound(err) {
-			log.Debugf("[SEED RECONCILE] skipping because Seed has been deleted")
+			log.Info("Object is gone, stop reconciling")
 
 			if err := r.clientMap.InvalidateClient(keys.ForSeedWithName(request.Name)); err != nil {
 				return reconcile.Result{}, fmt.Errorf("failed to invalidate seed client: %w", err)
@@ -133,19 +129,17 @@ func (r *reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 
 			return reconcile.Result{}, nil
 		}
-		log.Errorf("[SEED RECONCILE] unable to retrieve object from store: %v", err)
-		return reconcile.Result{}, err
+		return reconcile.Result{}, fmt.Errorf("error retrieving object from store: %w", err)
 	}
 
-	if err := r.reconcile(ctx, gardenClient.Client(), seed, log); err != nil {
-		log.Errorf("error reconciling seed: %v", err)
-		return reconcile.Result{RequeueAfter: 15 * time.Second}, nil
+	if err := r.reconcile(ctx, log, gardenClient.Client(), seed); err != nil {
+		return reconcile.Result{}, err
 	}
 
 	return reconcile.Result{RequeueAfter: r.config.Controllers.Seed.SyncPeriod.Duration}, nil
 }
 
-func (r *reconciler) reconcile(ctx context.Context, gardenClient client.Client, seed *gardencorev1beta1.Seed, log logrus.FieldLogger) error {
+func (r *reconciler) reconcile(ctx context.Context, log logr.Logger, gardenClient client.Client, seed *gardencorev1beta1.Seed) error {
 	seedNamespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: gutil.ComputeGardenNamespace(seed.Name),
@@ -182,10 +176,11 @@ func (r *reconciler) reconcile(ctx context.Context, gardenClient client.Client, 
 		WithSeedObject(seed).
 		Build(ctx)
 	if err != nil {
-		message := fmt.Sprintf("Failed to create a Seed object (%s).", err.Error())
-		conditionSeedBootstrapped = gardencorev1beta1helper.UpdatedCondition(conditionSeedBootstrapped, gardencorev1beta1.ConditionUnknown, gardencorev1beta1.ConditionCheckError, message)
-		log.Error(message)
-		_ = r.patchSeedStatus(ctx, gardenClient, log, seed, "<unknown>", capacity, allocatable, conditionSeedBootstrapped)
+		log.Error(err, "Failed to create a Seed object")
+		conditionSeedBootstrapped = gardencorev1beta1helper.UpdatedCondition(conditionSeedBootstrapped, gardencorev1beta1.ConditionUnknown, gardencorev1beta1.ConditionCheckError, fmt.Sprintf("Failed to create a Seed object (%s).", err.Error()))
+		if err := r.patchSeedStatus(ctx, gardenClient, seed, "<unknown>", capacity, allocatable, conditionSeedBootstrapped); err != nil {
+			return fmt.Errorf("could not patch seed status after failed creation of Seed object: %w", err)
+		}
 		return err
 	}
 
@@ -204,46 +199,43 @@ func (r *reconciler) reconcile(ctx context.Context, gardenClient client.Client, 
 
 		if seed.Spec.Backup != nil {
 			if err := deleteBackupBucketInGarden(ctx, gardenClient, seed); err != nil {
-				log.Error(err.Error())
 				return err
 			}
 		}
 
 		associatedShoots, err := controllerutils.DetermineShootsAssociatedTo(ctx, gardenClient, seed)
 		if err != nil {
-			log.Error(err.Error())
 			return err
 		}
 
 		associatedBackupBuckets, err := controllerutils.DetermineBackupBucketAssociations(ctx, gardenClient, seed.Name)
 		if err != nil {
-			log.Error(err.Error())
 			return err
 		}
 
 		if len(associatedShoots) == 0 && len(associatedBackupBuckets) == 0 {
-			log.Info("No Shoots, ControllerInstallations or BackupBuckets are referencing the Seed. Deletion accepted.")
+			log.Info("No Shoots, ControllerInstallations or BackupBuckets are referencing the Seed, deletion accepted")
 
-			if err := seedpkg.RunDeleteSeedFlow(ctx, gardenClient, seedClientSet, seedObj, r.config.DeepCopy(), log); err != nil {
-				message := fmt.Sprintf("Failed to delete Seed Cluster (%s).", err.Error())
-				conditionSeedBootstrapped = gardencorev1beta1helper.UpdatedCondition(conditionSeedBootstrapped, gardencorev1beta1.ConditionFalse, "DebootstrapFailed", message)
-				log.Error(message)
-				_ = r.patchSeedStatus(ctx, gardenClient, log, seed, "<unknown>", capacity, allocatable, conditionSeedBootstrapped)
+			if err := seedpkg.RunDeleteSeedFlow(ctx, log, gardenClient, seedClientSet, seedObj, r.config.DeepCopy()); err != nil {
+				conditionSeedBootstrapped = gardencorev1beta1helper.UpdatedCondition(conditionSeedBootstrapped, gardencorev1beta1.ConditionFalse, "DebootstrapFailed", fmt.Sprintf("Failed to delete Seed Cluster (%s).", err.Error()))
+				if err := r.patchSeedStatus(ctx, gardenClient, seed, "<unknown>", capacity, allocatable, conditionSeedBootstrapped); err != nil {
+					return fmt.Errorf("could not patch seed status after deletion flow failed: %w", err)
+				}
 				return err
 			}
 
+			// Remove finalizer from referenced secret
 			if seed.Spec.SecretRef != nil {
-				// Remove finalizer from referenced secret
 				secret := &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      seed.Spec.SecretRef.Name,
 						Namespace: seed.Spec.SecretRef.Namespace,
 					},
 				}
-				err = gardenClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)
-				if err == nil {
-					if err2 := controllerutils.PatchRemoveFinalizers(ctx, gardenClient, secret, gardencorev1beta1.ExternalGardenerName); err2 != nil {
-						return fmt.Errorf("failed to remove finalizer from Seed secret '%s/%s': %w", secret.Namespace, secret.Name, err2)
+				log.Info("Removing finalizer form referenced secret")
+				if err := gardenClient.Get(ctx, client.ObjectKeyFromObject(secret), secret); err == nil {
+					if err := controllerutils.PatchRemoveFinalizers(ctx, gardenClient, secret, gardencorev1beta1.ExternalGardenerName); err != nil {
+						return fmt.Errorf("failed to remove finalizer from Seed secret '%s/%s': %w", secret.Namespace, secret.Name, err)
 					}
 				} else if !apierrors.IsNotFound(err) {
 					return fmt.Errorf("failed to get Seed secret '%s/%s': %w", secret.Namespace, secret.Name, err)
@@ -251,8 +243,8 @@ func (r *reconciler) reconcile(ctx context.Context, gardenClient client.Client, 
 			}
 
 			// Remove finalizer from Seed
+			log.Info("Removing finalizer")
 			if err := controllerutils.PatchRemoveFinalizers(ctx, gardenClient, seed, gardencorev1beta1.GardenerName); err != nil {
-				log.Error(err.Error())
 				return err
 			}
 
@@ -265,26 +257,21 @@ func (r *reconciler) reconcile(ctx context.Context, gardenClient client.Client, 
 
 		parentLogMessage := "Can't delete Seed, because the following objects are still referencing it:"
 		if len(associatedShoots) != 0 {
-			message := fmt.Sprintf("%s Shoots=%v", parentLogMessage, associatedShoots)
-			log.Info(message)
-			r.recorder.Event(seed, corev1.EventTypeNormal, v1beta1constants.EventResourceReferenced, message)
+			log.Info("Cannot delete SEed because the following Shoots are still referencing it", "shoots", associatedShoots)
+			r.recorder.Event(seed, corev1.EventTypeNormal, v1beta1constants.EventResourceReferenced, fmt.Sprintf("%s Shoots=%v", parentLogMessage, associatedShoots))
 		}
 		if len(associatedBackupBuckets) != 0 {
-			message := fmt.Sprintf("%s BackupBuckets=%v", parentLogMessage, associatedBackupBuckets)
-			log.Info(message)
-			r.recorder.Event(seed, corev1.EventTypeNormal, v1beta1constants.EventResourceReferenced, message)
+			log.Info("Cannot delete SEed because the following BackupBuckets are still referencing it", "backupBuckets", associatedBackupBuckets)
+			r.recorder.Event(seed, corev1.EventTypeNormal, v1beta1constants.EventResourceReferenced, fmt.Sprintf("%s BackupBuckets=%v", parentLogMessage, associatedBackupBuckets))
 		}
 
 		return errors.New("seed still has references")
 	}
 
-	log.Infof("[SEED RECONCILE]")
-
 	if !controllerutil.ContainsFinalizer(seed, gardencorev1beta1.GardenerName) {
+		log.Info("Adding finalizer")
 		if err := controllerutils.StrategicMergePatchAddFinalizers(ctx, gardenClient, seed, gardencorev1beta1.GardenerName); err != nil {
-			err = fmt.Errorf("could not add finalizer to Seed: %s", err.Error())
-			log.Error(err)
-			return err
+			return fmt.Errorf("could not add finalizer to Seed: %s", err.Error())
 		}
 	}
 
@@ -293,12 +280,12 @@ func (r *reconciler) reconcile(ctx context.Context, gardenClient client.Client, 
 	if seed.Spec.SecretRef != nil {
 		secret, err := kutil.GetSecretByReference(ctx, gardenClient, seed.Spec.SecretRef)
 		if err != nil {
-			log.Error(err.Error())
 			return err
 		}
+
 		if !controllerutil.ContainsFinalizer(secret, gardencorev1beta1.ExternalGardenerName) {
+			log.Info("Adding finalizer to referenced secret")
 			if err := controllerutils.StrategicMergePatchAddFinalizers(ctx, gardenClient, secret, gardencorev1beta1.ExternalGardenerName); err != nil {
-				log.Error(err.Error())
 				return err
 			}
 		}
@@ -308,29 +295,32 @@ func (r *reconciler) reconcile(ctx context.Context, gardenClient client.Client, 
 	seedKubernetesVersion, err := seedObj.CheckMinimumK8SVersion(seedClientSet.Version())
 	if err != nil {
 		conditionSeedBootstrapped = gardencorev1beta1helper.UpdatedCondition(conditionSeedBootstrapped, gardencorev1beta1.ConditionFalse, "K8SVersionTooOld", err.Error())
-		_ = r.patchSeedStatus(ctx, gardenClient, log, seed, seedKubernetesVersion, capacity, allocatable, conditionSeedBootstrapped)
-		log.Error(err.Error())
+		if err := r.patchSeedStatus(ctx, gardenClient, seed, "<unknown>", capacity, allocatable, conditionSeedBootstrapped); err != nil {
+			return fmt.Errorf("could not patch seed status after check for minimum Kubernetes version failed: %w", err)
+		}
 		return err
 	}
 
-	gardenSecrets, err := garden.ReadGardenSecrets(ctx, gardenClient, gutil.ComputeGardenNamespace(seed.Name), log, true)
+	gardenSecrets, err := garden.ReadGardenSecrets(ctx, log, gardenClient, gutil.ComputeGardenNamespace(seed.Name), true)
 	if err != nil {
 		conditionSeedBootstrapped = gardencorev1beta1helper.UpdatedCondition(conditionSeedBootstrapped, gardencorev1beta1.ConditionFalse, "GardenSecretsError", err.Error())
-		_ = r.patchSeedStatus(ctx, gardenClient, log, seed, seedKubernetesVersion, capacity, allocatable, conditionSeedBootstrapped)
-		log.Errorf("Reading Garden secrets failed: %+v", err)
+		if err := r.patchSeedStatus(ctx, gardenClient, seed, "<unknown>", capacity, allocatable, conditionSeedBootstrapped); err != nil {
+			return fmt.Errorf("could not patch seed status after reading garden secrets failed: %w", err)
+		}
 		return err
 	}
 
 	conditionSeedBootstrapped = gardencorev1beta1helper.UpdatedCondition(conditionSeedBootstrapped, gardencorev1beta1.ConditionProgressing, "BootstrapProgressing", "Seed cluster is currently being bootstrapped.")
-	if err = r.patchSeedStatus(ctx, gardenClient, log, seed, seedKubernetesVersion, capacity, allocatable, conditionSeedBootstrapped); err != nil {
+	if err = r.patchSeedStatus(ctx, gardenClient, seed, seedKubernetesVersion, capacity, allocatable, conditionSeedBootstrapped); err != nil {
 		return fmt.Errorf("could not update status of %s condition to %s: %w", conditionSeedBootstrapped.Type, gardencorev1beta1.ConditionProgressing, err)
 	}
 
 	// Bootstrap the Seed cluster.
-	if err := seedpkg.RunReconcileSeedFlow(ctx, gardenClient, seedClientSet, seedObj, gardenSecrets, r.imageVector, r.componentImageVectors, r.config.DeepCopy(), log); err != nil {
+	if err := seedpkg.RunReconcileSeedFlow(ctx, log, gardenClient, seedClientSet, seedObj, gardenSecrets, r.imageVector, r.componentImageVectors, r.config.DeepCopy()); err != nil {
 		conditionSeedBootstrapped = gardencorev1beta1helper.UpdatedCondition(conditionSeedBootstrapped, gardencorev1beta1.ConditionFalse, "BootstrappingFailed", err.Error())
-		_ = r.patchSeedStatus(ctx, gardenClient, log, seed, seedKubernetesVersion, capacity, allocatable, conditionSeedBootstrapped)
-		log.Errorf("Seed bootstrapping failed: %+v", err)
+		if err := r.patchSeedStatus(ctx, gardenClient, seed, "<unknown>", capacity, allocatable, conditionSeedBootstrapped); err != nil {
+			return fmt.Errorf("could not patch seed status after reconciliation flow failed: %w", err)
+		}
 		return err
 	}
 
@@ -341,7 +331,7 @@ func (r *reconciler) reconcile(ctx context.Context, gardenClient client.Client, 
 	conditionSeedSystemComponentsHealthy := gardencorev1beta1helper.GetOrInitCondition(seed.Status.Conditions, gardencorev1beta1.SeedSystemComponentsHealthy)
 	conditionSeedSystemComponentsHealthy = gardencorev1beta1helper.UpdatedCondition(conditionSeedSystemComponentsHealthy, gardencorev1beta1.ConditionProgressing, "SystemComponentsCheckProgressing", "Pending health check of system components after successful bootstrap of seed cluster.")
 	conditionSeedBootstrapped = gardencorev1beta1helper.UpdatedCondition(conditionSeedBootstrapped, gardencorev1beta1.ConditionTrue, "BootstrappingSucceeded", "Seed cluster has been bootstrapped successfully.")
-	if err = r.patchSeedStatus(ctx, gardenClient, log, seed, seedKubernetesVersion, capacity, allocatable, conditionSeedBootstrapped, conditionSeedSystemComponentsHealthy); err != nil {
+	if err = r.patchSeedStatus(ctx, gardenClient, seed, seedKubernetesVersion, capacity, allocatable, conditionSeedBootstrapped, conditionSeedSystemComponentsHealthy); err != nil {
 		return fmt.Errorf("could not update status of %s condition to %s and %s conditions to %s: %w", conditionSeedBootstrapped.Type, gardencorev1beta1.ConditionTrue, conditionSeedSystemComponentsHealthy.Type, gardencorev1beta1.ConditionProgressing, err)
 	}
 
@@ -349,7 +339,6 @@ func (r *reconciler) reconcile(ctx context.Context, gardenClient client.Client, 
 		// This should be post updating the seed is available. Since, scheduler will then mostly use
 		// same seed for deploying the backupBucket extension.
 		if err := deployBackupBucketInGarden(ctx, gardenClient, seed); err != nil {
-			log.Error(err.Error())
 			return err
 		}
 	}
@@ -360,7 +349,6 @@ func (r *reconciler) reconcile(ctx context.Context, gardenClient client.Client, 
 func (r *reconciler) patchSeedStatus(
 	ctx context.Context,
 	c client.Client,
-	log logrus.FieldLogger,
 	seed *gardencorev1beta1.Seed,
 	seedVersion string,
 	capacity, allocatable corev1.ResourceList,
@@ -376,12 +364,7 @@ func (r *reconciler) patchSeedStatus(
 	seed.Status.Capacity = capacity
 	seed.Status.Allocatable = allocatable
 
-	if err := c.Status().Patch(ctx, seed, patch); err != nil {
-		log.Errorf("Could not update the Seed status: %+v", err)
-		return err
-	}
-
-	return nil
+	return c.Status().Patch(ctx, seed, patch)
 }
 
 func deployBackupBucketInGarden(ctx context.Context, k8sGardenClient client.Client, seed *gardencorev1beta1.Seed) error {

--- a/pkg/gardenlet/controller/seed/seed_extension_control.go
+++ b/pkg/gardenlet/controller/seed/seed_extension_control.go
@@ -31,6 +31,8 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
 )
 
+const extensionCheckReconcilerName = "extension-check"
+
 func (c *Controller) controllerInstallationOfSeedAdd(obj interface{}) {
 	controllerInstallation, ok := obj.(*gardencorev1beta1.ControllerInstallation)
 	if !ok {

--- a/pkg/gardenlet/controller/seed/seed_extension_control.go
+++ b/pkg/gardenlet/controller/seed/seed_extension_control.go
@@ -18,17 +18,15 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/sirupsen/logrus"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
 	"github.com/gardener/gardener/pkg/apis/core"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
-	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
-	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 const extensionCheckReconcilerName = "extension-check"
@@ -51,44 +49,36 @@ func (c *Controller) controllerInstallationOfSeedDelete(obj interface{}) {
 
 // NewExtensionCheckReconciler creates a new reconciler that maintains the ExtensionsReady condition of Seeds
 // according to the observed changes to ControllerInstallations.
-func NewExtensionCheckReconciler(clientMap clientmap.ClientMap, l logrus.FieldLogger, nowFunc func() metav1.Time) reconcile.Reconciler {
+func NewExtensionCheckReconciler(gardenClient client.Client, nowFunc func() metav1.Time) reconcile.Reconciler {
 	return &extensionCheckReconciler{
-		clientMap: clientMap,
-		logger:    l,
-		nowFunc:   nowFunc,
+		gardenClient: gardenClient,
+		nowFunc:      nowFunc,
 	}
 }
 
 type extensionCheckReconciler struct {
-	clientMap clientmap.ClientMap
-	logger    logrus.FieldLogger
-	nowFunc   func() metav1.Time
+	gardenClient client.Client
+	nowFunc      func() metav1.Time
 }
 
 func (r *extensionCheckReconciler) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
-	log := r.logger.WithField("seed", request.Name)
-
-	gardenClient, err := r.clientMap.GetClient(ctx, keys.ForGarden())
-	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to get garden client: %w", err)
-	}
+	log := logf.FromContext(ctx)
 
 	seed := &gardencorev1beta1.Seed{}
-	if err := gardenClient.Client().Get(ctx, request.NamespacedName, seed); err != nil {
+	if err := r.gardenClient.Get(ctx, request.NamespacedName, seed); err != nil {
 		if apierrors.IsNotFound(err) {
-			log.Debugf("[SEED EXTENSION CHECK] skipping because Seed has been deleted")
+			log.Info("Object is gone, stop reconciling")
 			return reconcile.Result{}, nil
 		}
-		log.Infof("[SEED EXTENSION CHECK] unable to retrieve object from store: %v", err)
-		return reconcile.Result{}, err
+		return reconcile.Result{}, fmt.Errorf("error retrieving object from store: %w", err)
 	}
 
-	return reconcile.Result{}, r.reconcile(ctx, gardenClient.Client(), seed)
+	return reconcile.Result{}, r.reconcile(ctx, seed)
 }
 
-func (r *extensionCheckReconciler) reconcile(ctx context.Context, gardenClient client.Client, seed *gardencorev1beta1.Seed) error {
+func (r *extensionCheckReconciler) reconcile(ctx context.Context, seed *gardencorev1beta1.Seed) error {
 	controllerInstallationList := &gardencorev1beta1.ControllerInstallationList{}
-	if err := gardenClient.List(ctx, controllerInstallationList, client.MatchingFields{core.SeedRefName: seed.Name}); err != nil {
+	if err := r.gardenClient.List(ctx, controllerInstallationList, client.MatchingFields{core.SeedRefName: seed.Name}); err != nil {
 		return err
 	}
 
@@ -190,5 +180,5 @@ func (r *extensionCheckReconciler) reconcile(ctx context.Context, gardenClient c
 		return nil
 	}
 	seed.Status.Conditions = helper.MergeConditions(seed.Status.Conditions, newCondition)
-	return gardenClient.Status().Patch(ctx, seed, patch)
+	return r.gardenClient.Status().Patch(ctx, seed, patch)
 }

--- a/pkg/gardenlet/controller/seed/seed_extension_control_test.go
+++ b/pkg/gardenlet/controller/seed/seed_extension_control_test.go
@@ -18,19 +18,13 @@ import (
 	"context"
 	"time"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	fakeclientmap "github.com/gardener/gardener/pkg/client/kubernetes/clientmap/fake"
-	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
-	fakeclientset "github.com/gardener/gardener/pkg/client/kubernetes/fake"
 	. "github.com/gardener/gardener/pkg/gardenlet/controller/seed"
-	"github.com/gardener/gardener/pkg/logger"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/sirupsen/logrus"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -42,7 +36,6 @@ var _ = Describe("ExtensionCheckReconciler", func() {
 
 	var (
 		ctx                     context.Context
-		log                     logrus.FieldLogger
 		c                       client.Client
 		seed                    *gardencorev1beta1.Seed
 		controllerInstallations []*gardencorev1beta1.ControllerInstallation
@@ -56,7 +49,6 @@ var _ = Describe("ExtensionCheckReconciler", func() {
 
 	BeforeEach(func() {
 		ctx = context.Background()
-		log = logger.NewNopLogger()
 		seed = &gardencorev1beta1.Seed{
 			ObjectMeta: metav1.ObjectMeta{Name: seedName},
 		}
@@ -75,9 +67,7 @@ var _ = Describe("ExtensionCheckReconciler", func() {
 		}
 
 		c = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).WithObjects(seed).Build()
-		fakeClientSet := fakeclientset.NewClientSetBuilder().WithClient(c).Build()
-		fakeClientMap := fakeclientmap.NewClientMap().AddClient(keys.ForGarden(), fakeClientSet)
-		reconciler = NewExtensionCheckReconciler(fakeClientMap, log, nowFunc)
+		reconciler = NewExtensionCheckReconciler(c, nowFunc)
 	})
 
 	JustBeforeEach(func() {

--- a/pkg/gardenlet/controller/shoot/shoot_care_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_care_control.go
@@ -273,7 +273,7 @@ func (r *careReconciler) care(ctx context.Context, gardenClientSet kubernetes.In
 
 	// Only read Garden secrets once because we don't rely on up-to-date secrets for health checks.
 	if r.gardenSecrets == nil {
-		secrets, err := garden.ReadGardenSecrets(careCtx, gardenClient, gutil.ComputeGardenNamespace(*shoot.Spec.SeedName), log, true)
+		secrets, err := garden.ReadGardenSecrets(careCtx, log, gardenClient, gutil.ComputeGardenNamespace(*shoot.Spec.SeedName), true)
 		if err != nil {
 			return fmt.Errorf("error reading Garden secrets: %w", err)
 		}

--- a/pkg/gardenlet/controller/shoot/shoot_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control.go
@@ -310,7 +310,7 @@ func shouldPrepareShootForMigration(shoot *gardencorev1beta1.Shoot) bool {
 const taskID = "initializeOperation"
 
 func (r *shootReconciler) initializeOperation(ctx context.Context, logger logrus.FieldLogger, gardenClient kubernetes.Interface, shoot *gardencorev1beta1.Shoot, project *gardencorev1beta1.Project, cloudProfile *gardencorev1beta1.CloudProfile, seed *gardencorev1beta1.Seed) (*operation.Operation, error) {
-	gardenSecrets, err := garden.ReadGardenSecrets(ctx, gardenClient.Client(), gutil.ComputeGardenNamespace(seed.Name), logger, true)
+	gardenSecrets, err := garden.ReadGardenSecrets(ctx, logger, gardenClient.Client(), gutil.ComputeGardenNamespace(seed.Name), true)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operation/botanist/component/extensions/dns/dnsentry.go
+++ b/pkg/operation/botanist/component/extensions/dns/dnsentry.go
@@ -18,17 +18,16 @@ import (
 	"context"
 	"time"
 
-	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
-	"github.com/sirupsen/logrus"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+
+	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // EntryValues contains the values used to create a DNSEntry
@@ -42,13 +41,13 @@ type EntryValues struct {
 
 // NewEntry creates a new instance of DeployWaiter for a specific DNSEntry.
 func NewEntry(
-	logger logrus.FieldLogger,
+	log interface{}, // TODO(rfranzke): Use logr.Logger when all usages are adapted
 	client client.Client,
 	namespace string,
 	values *EntryValues,
 ) component.DeployWaiter {
 	return &entry{
-		logger:    logger,
+		log:       log,
 		client:    client,
 		namespace: namespace,
 		values:    values,
@@ -63,7 +62,7 @@ func NewEntry(
 }
 
 type entry struct {
-	logger    logrus.FieldLogger
+	log       interface{}
 	client    client.Client
 	namespace string
 	values    *EntryValues
@@ -102,7 +101,7 @@ func (e *entry) Wait(ctx context.Context) error {
 	return extensions.WaitUntilObjectReadyWithHealthFunction(
 		ctx,
 		e.client,
-		e.logger,
+		e.log,
 		CheckDNSObject,
 		e.dnsEntry,
 		dnsv1alpha1.DNSEntryKind,

--- a/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord.go
+++ b/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord.go
@@ -19,13 +19,6 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/sirupsen/logrus"
-	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/pointer"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
@@ -33,6 +26,12 @@ import (
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -90,7 +89,7 @@ type Values struct {
 
 // New creates a new instance that implements component.DeployMigrateWaiter.
 func New(
-	logger logrus.FieldLogger,
+	log interface{}, // TODO(rfranzke): Use logr.Logger when all usages are adapted
 	client client.Client,
 	values *Values,
 	waitInterval time.Duration,
@@ -98,7 +97,7 @@ func New(
 	waitTimeout time.Duration,
 ) Interface {
 	return &dnsRecord{
-		logger:              logger,
+		log:                 log,
 		client:              client,
 		values:              values,
 		waitInterval:        waitInterval,
@@ -121,7 +120,7 @@ func New(
 }
 
 type dnsRecord struct {
-	logger              logrus.FieldLogger
+	log                 interface{}
 	client              client.Client
 	values              *Values
 	waitInterval        time.Duration
@@ -251,7 +250,7 @@ func (c *dnsRecord) Wait(ctx context.Context) error {
 	return extensions.WaitUntilExtensionObjectReady(
 		ctx,
 		c.client,
-		c.logger,
+		c.log,
 		c.dnsRecord,
 		extensionsv1alpha1.DNSRecordResource,
 		c.waitInterval,
@@ -278,7 +277,7 @@ func (c *dnsRecord) WaitCleanup(ctx context.Context) error {
 	return extensions.WaitUntilExtensionObjectDeleted(
 		ctx,
 		c.client,
-		c.logger,
+		c.log,
 		c.dnsRecord,
 		extensionsv1alpha1.DNSRecordResource,
 		c.waitInterval,

--- a/pkg/operation/botanist/waiter.go
+++ b/pkg/operation/botanist/waiter.go
@@ -33,7 +33,7 @@ import (
 func (b *Botanist) WaitUntilNginxIngressServiceIsReady(ctx context.Context) error {
 	const timeout = 10 * time.Minute
 
-	loadBalancerIngress, err := kutil.WaitUntilLoadBalancerIsReady(ctx, b.K8sShootClient.Client(), metav1.NamespaceSystem, "addons-nginx-ingress-controller", timeout, b.Logger)
+	loadBalancerIngress, err := kutil.WaitUntilLoadBalancerIsReady(ctx, b.Logger, b.K8sShootClient.Client(), metav1.NamespaceSystem, "addons-nginx-ingress-controller", timeout)
 	if err != nil {
 		return err
 	}
@@ -46,7 +46,7 @@ func (b *Botanist) WaitUntilNginxIngressServiceIsReady(ctx context.Context) erro
 func (b *Botanist) WaitUntilVpnShootServiceIsReady(ctx context.Context) error {
 	const timeout = 10 * time.Minute
 
-	_, err := kutil.WaitUntilLoadBalancerIsReady(ctx, b.K8sShootClient.Client(), metav1.NamespaceSystem, "vpn-shoot", timeout, b.Logger)
+	_, err := kutil.WaitUntilLoadBalancerIsReady(ctx, b.Logger, b.K8sShootClient.Client(), metav1.NamespaceSystem, "vpn-shoot", timeout)
 	return err
 }
 

--- a/pkg/operation/garden/garden.go
+++ b/pkg/operation/garden/garden.go
@@ -205,7 +205,7 @@ func ReadGardenSecrets(
 				case logrus.FieldLogger:
 					logger.Warnf("error getting information out of default domain secret %s: %+v", secret.Name, err)
 				case logr.Logger:
-					logger.Info("Error getting information out of default domain secret", "secret", client.ObjectKeyFromObject(&secret))
+					logger.Error(err, "Error getting information out of default domain secret", "secret", client.ObjectKeyFromObject(&secret))
 				}
 
 				continue
@@ -224,7 +224,7 @@ func ReadGardenSecrets(
 				case logrus.FieldLogger:
 					logger.Warnf("error getting information out of internal domain secret %s: %+v", secret.Name, err)
 				case logr.Logger:
-					logger.Info("Error getting information out of internal domain secret", "secret", client.ObjectKeyFromObject(&secret))
+					logger.Error(err, "Error getting information out of internal domain secret", "secret", client.ObjectKeyFromObject(&secret))
 				}
 
 				continue

--- a/pkg/operation/garden/garden.go
+++ b/pkg/operation/garden/garden.go
@@ -29,6 +29,7 @@ import (
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 	"github.com/gardener/gardener/pkg/utils/version"
 
+	"github.com/go-logr/logr"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -170,7 +171,16 @@ var gardenRoleReq = utils.MustNewRequirement(v1beta1constants.GardenRole, select
 
 // ReadGardenSecrets reads the Kubernetes Secrets from the Garden cluster which are independent of Shoot clusters.
 // The Secret objects are stored on the Controller in order to pass them to created Garden objects later.
-func ReadGardenSecrets(ctx context.Context, c client.Reader, namespace string, log logrus.FieldLogger, enforceInternalDomainSecret bool) (map[string]*corev1.Secret, error) {
+func ReadGardenSecrets(
+	ctx context.Context,
+	log interface{}, // TODO(rfranzke): Use logr.Logger when all usages are adapted
+	c client.Reader,
+	namespace string,
+	enforceInternalDomainSecret bool,
+) (
+	map[string]*corev1.Secret,
+	error,
+) {
 	var (
 		logInfo                             []string
 		secretsMap                          = make(map[string]*corev1.Secret)
@@ -191,7 +201,13 @@ func ReadGardenSecrets(ctx context.Context, c client.Reader, namespace string, l
 		if secret.Labels[v1beta1constants.GardenRole] == v1beta1constants.GardenRoleDefaultDomain {
 			_, domain, _, _, _, err := gutil.GetDomainInfoFromAnnotations(secret.Annotations)
 			if err != nil {
-				log.Warnf("error getting information out of default domain secret %s: %+v", secret.Name, err)
+				switch logger := log.(type) {
+				case logrus.FieldLogger:
+					logger.Warnf("error getting information out of default domain secret %s: %+v", secret.Name, err)
+				case logr.Logger:
+					logger.Info("Error getting information out of default domain secret", "secret", client.ObjectKeyFromObject(&secret))
+				}
+
 				continue
 			}
 			defaultDomainSecret := secret
@@ -204,7 +220,13 @@ func ReadGardenSecrets(ctx context.Context, c client.Reader, namespace string, l
 		if secret.Labels[v1beta1constants.GardenRole] == v1beta1constants.GardenRoleInternalDomain {
 			_, domain, _, _, _, err := gutil.GetDomainInfoFromAnnotations(secret.Annotations)
 			if err != nil {
-				log.Warnf("error getting information out of internal domain secret %s: %+v", secret.Name, err)
+				switch logger := log.(type) {
+				case logrus.FieldLogger:
+					logger.Warnf("error getting information out of internal domain secret %s: %+v", secret.Name, err)
+				case logr.Logger:
+					logger.Info("Error getting information out of internal domain secret", "secret", client.ObjectKeyFromObject(&secret))
+				}
+
 				continue
 			}
 			internalDomainSecret := secret
@@ -299,7 +321,12 @@ func ReadGardenSecrets(ctx context.Context, c client.Reader, namespace string, l
 		return nil, fmt.Errorf("can only accept at most one global monitoring secret, but found %d", numberOfGlobalMonitoringSecrets)
 	}
 
-	log.Infof("Found secrets in namespace %q: %s", namespace, strings.Join(logInfo, ", "))
+	switch logger := log.(type) {
+	case logrus.FieldLogger:
+		logger.Infof("Found secrets in namespace %q: %s", namespace, strings.Join(logInfo, ", "))
+	case logr.Logger:
+		logger.Info("Found secrets", "namespace", namespace, "secrets", logInfo)
+	}
 
 	return secretsMap, nil
 }

--- a/pkg/operation/seed/nginxingress.go
+++ b/pkg/operation/seed/nginxingress.go
@@ -31,9 +31,9 @@ import (
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
-	"github.com/sirupsen/logrus"
 
 	"github.com/Masterminds/semver"
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/api/extensions/v1beta1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -72,7 +72,7 @@ func defaultNginxIngress(c client.Client, imageVector imagevector.ImageVector, k
 	return nginxingress.New(c, v1beta1constants.GardenNamespace, values), nil
 }
 
-func getManagedIngressDNSEntry(c client.Client, seedFQDN string, seedClusterIdentity, loadBalancerAddress string, log logrus.FieldLogger) component.DeployWaiter {
+func getManagedIngressDNSEntry(log logr.Logger, c client.Client, seedFQDN string, seedClusterIdentity, loadBalancerAddress string) component.DeployWaiter {
 	values := &dns.EntryValues{
 		Name:    "ingress",
 		DNSName: seedFQDN,
@@ -104,7 +104,7 @@ func getManagedIngressDNSOwner(k8sSeedClient client.Client, seedClusterIdentity 
 	)
 }
 
-func getManagedIngressDNSRecord(seedClient client.Client, dnsConfig gardencorev1beta1.SeedDNS, secretData map[string][]byte, seedFQDN string, loadBalancerAddress string, log logrus.FieldLogger) component.DeployMigrateWaiter {
+func getManagedIngressDNSRecord(log logr.Logger, seedClient client.Client, dnsConfig gardencorev1beta1.SeedDNS, secretData map[string][]byte, seedFQDN string, loadBalancerAddress string) component.DeployMigrateWaiter {
 	values := &dnsrecord.Values{
 		Name:                         "seed-ingress",
 		SecretName:                   "seed-ingress",

--- a/pkg/utils/kubernetes/kubernetes.go
+++ b/pkg/utils/kubernetes/kubernetes.go
@@ -26,6 +26,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/retry"
 
+	"github.com/go-logr/logr"
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	certificatesv1 "k8s.io/api/certificates/v1"
@@ -42,6 +43,7 @@ import (
 	clientcmdv1 "k8s.io/client-go/tools/clientcmd/api/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // TruncateLabelValue truncates a string at 63 characters so it's suitable for a label value.
@@ -190,27 +192,62 @@ func WaitUntilResourceDeletedWithDefaults(ctx context.Context, c client.Client, 
 
 // WaitUntilLoadBalancerIsReady waits until the given external load balancer has
 // been created (i.e., its ingress information has been updated in the service status).
-func WaitUntilLoadBalancerIsReady(ctx context.Context, c client.Client, namespace, name string, timeout time.Duration, logger logrus.FieldLogger) (string, error) {
+func WaitUntilLoadBalancerIsReady(
+	ctx context.Context,
+	log interface{}, // TODO(rfranzke): Use logr.Logger when all usages are adapted
+	c client.Client,
+	namespace, name string,
+	timeout time.Duration,
+) (
+	string,
+	error,
+) {
 	var (
 		loadBalancerIngress string
 		service             = &corev1.Service{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}
 	)
 
+	var logger interface{}
+	switch l := log.(type) {
+	case logrus.FieldLogger:
+		logger = l.WithField("service", client.ObjectKeyFromObject(service))
+	case logr.Logger:
+		logger = l.WithValues("service", client.ObjectKeyFromObject(service))
+	default:
+		logger = logf.Log.WithValues("service", client.ObjectKeyFromObject(service))
+	}
+
 	if err := retry.UntilTimeout(ctx, 5*time.Second, timeout, func(ctx context.Context) (done bool, err error) {
 		loadBalancerIngress, err = GetLoadBalancerIngress(ctx, c, service)
 		if err != nil {
-			logger.Infof("Waiting until the %s service is ready...", name)
-			// TODO(AC): This is a quite optimistic check / we should differentiate here
+			switch log := logger.(type) {
+			case logrus.FieldLogger:
+				log.Info("Waiting until service is ready")
+			case logr.Logger:
+				log.Info("Waiting until service is ready")
+			}
+
 			return retry.MinorError(fmt.Errorf("%s service is not ready: %v", name, err))
 		}
 		return retry.Ok()
 	}); err != nil {
-		logger.Errorf("error %v occurred while waiting for load balancer to be ready", err)
+		switch log := logger.(type) {
+		case logrus.FieldLogger:
+			log.Errorf("error %w occurred while waiting for load balancer to be ready", err)
+		case logr.Logger:
+			log.Error(err, "Error while waiting for load balancer to be ready")
+		}
 
 		// use API reader here, we don't want to cache all events
 		eventsErrorMessage, err2 := FetchEventMessages(ctx, c.Scheme(), c, service, corev1.EventTypeWarning, 2)
 		if err2 != nil {
-			logger.Errorf("error %v occurred while fetching events for load balancer service", err2)
+			switch log := logger.(type) {
+			case logrus.FieldLogger:
+				log.Errorf("error %v occurred while fetching events for load balancer service", err2)
+			case logr.Logger:
+				log.Error(err, "Error while fetching events for load balancer service")
+			}
+
 			return "", fmt.Errorf("'%w' occurred but could not fetch events for more information", err)
 		}
 		if eventsErrorMessage != "" {

--- a/pkg/utils/kubernetes/kubernetes.go
+++ b/pkg/utils/kubernetes/kubernetes.go
@@ -245,7 +245,7 @@ func WaitUntilLoadBalancerIsReady(
 			case logrus.FieldLogger:
 				log.Errorf("error %v occurred while fetching events for load balancer service", err2)
 			case logr.Logger:
-				log.Error(err, "Error while fetching events for load balancer service")
+				log.Error(err2, "Error while fetching events for load balancer service")
 			}
 
 			return "", fmt.Errorf("'%w' occurred but could not fetch events for more information", err)

--- a/pkg/utils/kubernetes/kubernetes_test.go
+++ b/pkg/utils/kubernetes/kubernetes_test.go
@@ -28,16 +28,15 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	fakeclientset "github.com/gardener/gardener/pkg/client/kubernetes/fake"
-	"github.com/gardener/gardener/pkg/logger"
 	mockcorev1 "github.com/gardener/gardener/pkg/mock/client-go/core/v1"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	mockio "github.com/gardener/gardener/pkg/mock/go/io"
 
+	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
-	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	certificatesv1 "k8s.io/api/certificates/v1"
 	certificatesv1beta1 "k8s.io/api/certificates/v1beta1"
@@ -817,7 +816,7 @@ var _ = Describe("kubernetes", func() {
 		var (
 			k8sShootClient kubernetes.Interface
 			key            = client.ObjectKey{Namespace: metav1.NamespaceSystem, Name: "load-balancer"}
-			logger         = logrus.NewEntry(logger.NewNopLogger())
+			logger         = logr.Discard()
 			scheme         *runtime.Scheme
 		)
 
@@ -857,7 +856,7 @@ var _ = Describe("kubernetes", func() {
 					}),
 			)
 
-			actual, err := WaitUntilLoadBalancerIsReady(ctx, k8sShootClient.Client(), metav1.NamespaceSystem, "load-balancer", 1*time.Second, logger)
+			actual, err := WaitUntilLoadBalancerIsReady(ctx, logger, k8sShootClient.Client(), metav1.NamespaceSystem, "load-balancer", 1*time.Second)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(actual).To(Equal("cluster.local"))
 		})
@@ -898,7 +897,7 @@ var _ = Describe("kubernetes", func() {
 					}),
 			)
 
-			actual, err := WaitUntilLoadBalancerIsReady(ctx, k8sShootClient.Client(), metav1.NamespaceSystem, "load-balancer", 1*time.Second, logger)
+			actual, err := WaitUntilLoadBalancerIsReady(ctx, logger, k8sShootClient.Client(), metav1.NamespaceSystem, "load-balancer", 1*time.Second)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("-> Events:\n* service-controller reported"))
 			Expect(err.Error()).To(ContainSubstring("Error syncing load balancer: an error occurred"))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Migrate `gardenlet`'s `Seed` controller to `logr`.

**Which issue(s) this PR fixes**:
Part of #4251

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
