### PR TITLE
Allow to inject special cases

### DIFF
--- a/hack/.ci/set_dependency_version
+++ b/hack/.ci/set_dependency_version
@@ -14,7 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import pathlib
+import sys
 
 import util
 
@@ -103,9 +105,16 @@ class ImagesParser(object):
         )
 
 
+# optionally load special cases from first argument given as JSON
+injectedSpecialCases = {}
+if len(sys.argv) == 2:
+    injectedSpecialCases = json.loads(sys.argv[1])
+
 # handle special cases
 name = dependency_name.split('/')[-1]
-if name == 'autoscaler':
+if name in injectedSpecialCases:
+    names = injectedSpecialCases[name]
+elif name == 'autoscaler':
     names = ['cluster-autoscaler']
 elif name == 'vpn':
     names = ['vpn-seed', 'vpn-shoot']


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
If an extension has some special dependency name resolution, the script `hack/.ci/set_dependency_version` need to be adjusted. To avoid such nasty changes, it is now optionally possible to specify the special cases as an argument in JSON format:

```json
{
   "name1": ["mapped-name1a", "mapped-name1b"],
   "name2": ["mapped-name2"]
}
```

Example:
```bash
"$(dirname $0)"/../vendor/github.com/gardener/gardener/hack/.ci/set_dependency_version '{"network-problem-detector": ["network-problem-detector-agent", "network-problem-detector-controller"]}'
```

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
See #5905 #5918
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```

/invite @ialidzhikov 