### PR TITLE
Switch `gardenlet` to `logr` (8)

### DIFF
--- a/pkg/controllermanager/controller/plant/plant_health.go
+++ b/pkg/controllermanager/controller/plant/plant_health.go
@@ -20,9 +20,9 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
-	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/discovery"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -58,14 +58,11 @@ func (h *HealthChecker) CheckPlantClusterNodes(ctx context.Context, condition ga
 	return updatedCondition
 }
 
-// TODO: switch to logr once health package is migrated
-var nopLogger = logger.NewNopLogger()
-
 // CheckAPIServerAvailability checks if the API server of a Plant cluster is reachable and measure the response time.
 func (h *HealthChecker) CheckAPIServerAvailability(ctx context.Context, condition gardencorev1beta1.Condition) gardencorev1beta1.Condition {
-	return health.CheckAPIServerAvailability(ctx, condition, h.discoveryClient.RESTClient(), func(conditionType, message string) gardencorev1beta1.Condition {
+	return health.CheckAPIServerAvailability(ctx, logr.Discard(), condition, h.discoveryClient.RESTClient(), func(conditionType, message string) gardencorev1beta1.Condition {
 		return gardencorev1beta1helper.UpdatedCondition(condition, gardencorev1beta1.ConditionFalse, conditionType, message)
-	}, nopLogger)
+	})
 }
 
 func (h *HealthChecker) checkNodes(condition gardencorev1beta1.Condition, nodeList *corev1.NodeList) (gardencorev1beta1.Condition, error) {

--- a/pkg/extensions/customresources_test.go
+++ b/pkg/extensions/customresources_test.go
@@ -26,18 +26,17 @@ import (
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	. "github.com/gardener/gardener/pkg/extensions"
-	"github.com/gardener/gardener/pkg/logger"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	mocktime "github.com/gardener/gardener/pkg/mock/go/time"
 	"github.com/gardener/gardener/pkg/utils/retry"
 	retryfake "github.com/gardener/gardener/pkg/utils/retry/fake"
 	"github.com/gardener/gardener/pkg/utils/test"
 
+	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
-	"github.com/sirupsen/logrus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -48,7 +47,7 @@ import (
 var _ = Describe("extensions", func() {
 	var (
 		ctx       context.Context
-		log       logrus.FieldLogger
+		log       logr.Logger
 		ctrl      *gomock.Controller
 		mockNow   *mocktime.MockNow
 		now       time.Time
@@ -70,7 +69,7 @@ var _ = Describe("extensions", func() {
 
 	BeforeEach(func() {
 		ctx = context.TODO()
-		log = logger.NewNopLogger()
+		log = logr.Discard()
 		ctrl = gomock.NewController(GinkgoT())
 		mockNow = mocktime.NewMockNow(ctrl)
 

--- a/pkg/gardenlet/controller/backupbucket/backup_bucket_actuator.go
+++ b/pkg/gardenlet/controller/backupbucket/backup_bucket_actuator.go
@@ -99,7 +99,7 @@ func (a *actuator) Reconcile(ctx context.Context) error {
 	)
 
 	return f.Run(ctx, flow.Opts{
-		Logger:           a.log,
+		Log:              a.log,
 		ProgressReporter: flow.NewImmediateProgressReporter(a.reportBackupBucketProgress),
 	})
 }
@@ -136,7 +136,7 @@ func (a *actuator) Delete(ctx context.Context) error {
 	)
 
 	return f.Run(ctx, flow.Opts{
-		Logger:           a.log,
+		Log:              a.log,
 		ProgressReporter: flow.NewImmediateProgressReporter(a.reportBackupBucketProgress),
 	})
 }

--- a/pkg/gardenlet/controller/backupentry/backup_entry_actuator.go
+++ b/pkg/gardenlet/controller/backupentry/backup_entry_actuator.go
@@ -121,7 +121,7 @@ func (a *actuator) Reconcile(ctx context.Context) error {
 	)
 
 	return f.Run(ctx, flow.Opts{
-		Logger:           a.log,
+		Log:              a.log,
 		ProgressReporter: flow.NewImmediateProgressReporter(a.reportBackupEntryProgress),
 	})
 }
@@ -159,7 +159,7 @@ func (a *actuator) Delete(ctx context.Context) error {
 	)
 
 	return f.Run(ctx, flow.Opts{
-		Logger:           a.log,
+		Log:              a.log,
 		ProgressReporter: flow.NewImmediateProgressReporter(a.reportBackupEntryProgress),
 	})
 }
@@ -197,7 +197,7 @@ func (a *actuator) Migrate(ctx context.Context) error {
 	)
 
 	return f.Run(ctx, flow.Opts{
-		Logger:           a.log,
+		Log:              a.log,
 		ProgressReporter: flow.NewImmediateProgressReporter(a.reportBackupEntryProgress),
 	})
 }

--- a/pkg/gardenlet/controller/factory.go
+++ b/pkg/gardenlet/controller/factory.go
@@ -178,7 +178,7 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 		return fmt.Errorf("failed initializing Seed controller: %w", err)
 	}
 
-	shootController, err := shootcontroller.NewShootController(ctx, f.clientMap, logger.Logger, f.cfg, f.identity, f.gardenClusterIdentity, imageVector, f.recorder)
+	shootController, err := shootcontroller.NewShootController(ctx, log, f.clientMap, f.cfg, f.identity, f.gardenClusterIdentity, imageVector, f.recorder)
 	if err != nil {
 		return fmt.Errorf("failed initializing Shoot controller: %w", err)
 	}

--- a/pkg/gardenlet/controller/factory.go
+++ b/pkg/gardenlet/controller/factory.go
@@ -45,7 +45,6 @@ import (
 	shootcontroller "github.com/gardener/gardener/pkg/gardenlet/controller/shoot"
 	shootsecretcontroller "github.com/gardener/gardener/pkg/gardenlet/controller/shootsecret"
 	"github.com/gardener/gardener/pkg/healthz"
-	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/utils"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/pkg/utils/imagevector"

--- a/pkg/gardenlet/controller/shoot/seed_registration_control.go
+++ b/pkg/gardenlet/controller/shoot/seed_registration_control.go
@@ -40,6 +40,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
+const seedRegistrationReconcilerName = "seed-registration"
+
 func (c *Controller) seedRegistrationAdd(obj interface{}) {
 	key, err := cache.MetaNamespaceKeyFunc(obj)
 	if err != nil {

--- a/pkg/gardenlet/controller/shoot/seed_registration_control_test.go
+++ b/pkg/gardenlet/controller/shoot/seed_registration_control_test.go
@@ -22,12 +22,9 @@ import (
 	"github.com/gardener/gardener/pkg/apis/seedmanagement/encoding"
 	seedmanagementv1alpha1 "github.com/gardener/gardener/pkg/apis/seedmanagement/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
-	fakeclientmap "github.com/gardener/gardener/pkg/client/kubernetes/clientmap/fake"
-	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
 	"github.com/gardener/gardener/pkg/features"
 	configv1alpha1 "github.com/gardener/gardener/pkg/gardenlet/apis/config/v1alpha1"
 	. "github.com/gardener/gardener/pkg/gardenlet/controller/shoot"
-	gardenerlogger "github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/utils"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 
@@ -65,7 +62,6 @@ var _ = Describe("SeedRegistrationReconciler", func() {
 	BeforeEach(func() {
 		ctx = context.Background()
 		c = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).Build()
-		clientMap := fakeclientmap.NewClientMap().AddRuntimeClient(keys.ForGarden(), c)
 
 		newShoot = func(useAsSeed string) *gardencorev1beta1.Shoot {
 			var annotations map[string]string
@@ -87,7 +83,7 @@ var _ = Describe("SeedRegistrationReconciler", func() {
 		}
 		request = reconcile.Request{NamespacedName: client.ObjectKey{Namespace: namespace, Name: name}}
 
-		reconciler = NewSeedRegistrationReconciler(clientMap, record.NewFakeRecorder(1), gardenerlogger.NewNopLogger())
+		reconciler = NewSeedRegistrationReconciler(c, record.NewFakeRecorder(1))
 	})
 
 	AfterEach(func() {

--- a/pkg/gardenlet/controller/shoot/shoot.go
+++ b/pkg/gardenlet/controller/shoot/shoot.go
@@ -105,7 +105,7 @@ func NewShootController(
 
 		shootReconciler:            NewShootReconciler(clientMap, recorder, imageVector, identity, gardenClusterIdentity, config),
 		careReconciler:             NewCareReconciler(clientMap, imageVector, identity, gardenClusterIdentity, config),
-		seedRegistrationReconciler: NewSeedRegistrationReconciler(clientMap, recorder),
+		seedRegistrationReconciler: NewSeedRegistrationReconciler(gardenClient.Client(), recorder),
 		migrationReconciler:        NewMigrationReconciler(gardenClient, config),
 
 		shootCareQueue:        workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "shoot-care"),

--- a/pkg/gardenlet/controller/shoot/shoot.go
+++ b/pkg/gardenlet/controller/shoot/shoot.go
@@ -31,7 +31,8 @@ import (
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
-	"github.com/sirupsen/logrus"
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
@@ -40,13 +41,16 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
+// ControllerName is the name of this controller.
+const ControllerName = "shoot"
+
 // Controller controls Shoots.
 type Controller struct {
 	clientMap   clientmap.ClientMap
 	gardenCache runtimecache.Cache
-	logger      logrus.FieldLogger
+	log         logr.Logger
+	config      *config.GardenletConfiguration
 
-	config                     *config.GardenletConfiguration
 	shootReconciler            reconcile.Reconciler
 	careReconciler             reconcile.Reconciler
 	seedRegistrationReconciler reconcile.Reconciler
@@ -68,14 +72,16 @@ type Controller struct {
 // event recording. It creates a new Gardener controller.
 func NewShootController(
 	ctx context.Context,
+	log logr.Logger,
 	clientMap clientmap.ClientMap,
-	logger logrus.FieldLogger,
 	config *config.GardenletConfiguration,
 	identity *gardencorev1beta1.Gardener,
 	gardenClusterIdentity string,
 	imageVector imagevector.ImageVector,
 	recorder record.EventRecorder,
 ) (*Controller, error) {
+	log = log.WithName(ControllerName)
+
 	gardenClient, err := clientMap.GetClient(ctx, keys.ForGarden())
 	if err != nil {
 		return nil, err
@@ -94,13 +100,13 @@ func NewShootController(
 	shootController := &Controller{
 		clientMap:   clientMap,
 		gardenCache: gardenClient.Cache(),
-		logger:      logger,
+		log:         log,
+		config:      config,
 
-		config:                     config,
-		shootReconciler:            NewShootReconciler(clientMap, recorder, logger, imageVector, identity, gardenClusterIdentity, config),
-		careReconciler:             NewCareReconciler(clientMap, logger, imageVector, identity, gardenClusterIdentity, config),
-		seedRegistrationReconciler: NewSeedRegistrationReconciler(clientMap, recorder, logger),
-		migrationReconciler:        NewMigrationReconciler(clientMap, logger, config),
+		shootReconciler:            NewShootReconciler(clientMap, recorder, imageVector, identity, gardenClusterIdentity, config),
+		careReconciler:             NewCareReconciler(clientMap, imageVector, identity, gardenClusterIdentity, config),
+		seedRegistrationReconciler: NewSeedRegistrationReconciler(clientMap, recorder),
+		migrationReconciler:        NewMigrationReconciler(clientMap, config),
 
 		shootCareQueue:        workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "shoot-care"),
 		shootQueue:            workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "shoot"),
@@ -160,7 +166,7 @@ func (c *Controller) Run(ctx context.Context, shootWorkers, shootCareWorkers, sh
 	var waitGroup sync.WaitGroup
 
 	if !cache.WaitForCacheSync(ctx.Done(), c.hasSyncedFuncs...) {
-		c.logger.Error("Timed out waiting for caches to sync")
+		c.log.Error(wait.ErrWaitTimeout, "Timed out waiting for caches to sync")
 		return
 	}
 
@@ -168,7 +174,6 @@ func (c *Controller) Run(ctx context.Context, shootWorkers, shootCareWorkers, sh
 	go func() {
 		for res := range c.workerCh {
 			c.numberOfRunningWorkers += res
-			c.logger.Debugf("Current number of running Shoot workers is %d", c.numberOfRunningWorkers)
 		}
 	}()
 
@@ -181,9 +186,10 @@ func (c *Controller) Run(ctx context.Context, shootWorkers, shootCareWorkers, sh
 	shootFilterFunc := controllerutils.ShootFilterFunc(confighelper.SeedNameFromSeedConfig(c.config.SeedConfig))
 	shoots := &gardencorev1beta1.ShootList{}
 	if err := c.gardenCache.List(ctx, shoots); err != nil {
-		c.logger.Errorf("Failed to fetch shoots resources: %v", err.Error())
+		c.log.Error(err, "Failed to fetch shoots resources")
 		return
 	}
+
 	for _, shoot := range shoots.Items {
 		if !shootFilterFunc(&shoot) {
 			continue
@@ -199,21 +205,21 @@ func (c *Controller) Run(ctx context.Context, shootWorkers, shootCareWorkers, sh
 		}
 	}
 
-	c.logger.Info("Shoot controller initialized.")
+	c.log.Info("Shoot controller initialized")
 
 	for i := 0; i < shootWorkers; i++ {
-		controllerutils.CreateWorker(ctx, c.shootQueue, "Shoot", c.shootReconciler, &waitGroup, c.workerCh)
+		controllerutils.CreateWorker(ctx, c.shootQueue, "Shoot", c.shootReconciler, &waitGroup, c.workerCh, controllerutils.WithLogger(c.log.WithName(reconcilerName)))
 	}
 	for i := 0; i < shootCareWorkers; i++ {
-		controllerutils.CreateWorker(ctx, c.shootCareQueue, "Shoot Care", c.careReconciler, &waitGroup, c.workerCh)
+		controllerutils.CreateWorker(ctx, c.shootCareQueue, "Shoot Care", c.careReconciler, &waitGroup, c.workerCh, controllerutils.WithLogger(c.log.WithName(careReconcilerName)))
 	}
 	for i := 0; i < shootWorkers/2+1; i++ {
-		controllerutils.CreateWorker(ctx, c.shootSeedQueue, "Shooted Seeds Reconciliation", c.shootReconciler, &waitGroup, c.workerCh)
-		controllerutils.CreateWorker(ctx, c.seedRegistrationQueue, "Shooted Seeds Registration", c.seedRegistrationReconciler, &waitGroup, c.workerCh)
+		controllerutils.CreateWorker(ctx, c.shootSeedQueue, "Shooted Seeds Reconciliation", c.shootReconciler, &waitGroup, c.workerCh, controllerutils.WithLogger(c.log.WithName(reconcilerName)))
+		controllerutils.CreateWorker(ctx, c.seedRegistrationQueue, "Shooted Seeds Registration", c.seedRegistrationReconciler, &waitGroup, c.workerCh, controllerutils.WithLogger(c.log.WithName(seedRegistrationReconcilerName)))
 	}
 	if gardenletfeatures.FeatureGate.Enabled(features.ForceRestore) && confighelper.OwnerChecksEnabledInSeedConfig(c.config.SeedConfig) {
 		for i := 0; i < shootMigrationWorkers; i++ {
-			controllerutils.CreateWorker(ctx, c.shootMigrationQueue, "Shoot Migration", c.migrationReconciler, &waitGroup, c.workerCh)
+			controllerutils.CreateWorker(ctx, c.shootMigrationQueue, "Shoot Migration", c.migrationReconciler, &waitGroup, c.workerCh, controllerutils.WithLogger(c.log.WithName(migrationReconcilerName)))
 		}
 	}
 
@@ -235,10 +241,10 @@ func (c *Controller) Run(ctx context.Context, shootWorkers, shootCareWorkers, sh
 			queueLengths                = shootQueueLength + shootCareQueueLength + shootSeedQueueLength + seedRegistrationQueueLength + shootMigrationQueueLength
 		)
 		if queueLengths == 0 && c.numberOfRunningWorkers == 0 {
-			c.logger.Debug("No running Shoot worker and no items left in the queues. Terminated Shoot controller...")
+			c.log.V(1).Info("No running Shoot worker and no items left in the queues. Terminated Shoot controller")
 			break
 		}
-		c.logger.Debugf("Waiting for %d Shoot worker(s) to finish (%d item(s) left in the queues)...", c.numberOfRunningWorkers, queueLengths)
+		c.log.V(1).Info("Waiting for Shoot workers to finish", "numberOfRunningWorkers", c.numberOfRunningWorkers, "queueLengths", queueLengths)
 		time.Sleep(5 * time.Second)
 	}
 

--- a/pkg/gardenlet/controller/shoot/shoot.go
+++ b/pkg/gardenlet/controller/shoot/shoot.go
@@ -106,7 +106,7 @@ func NewShootController(
 		shootReconciler:            NewShootReconciler(clientMap, recorder, imageVector, identity, gardenClusterIdentity, config),
 		careReconciler:             NewCareReconciler(clientMap, imageVector, identity, gardenClusterIdentity, config),
 		seedRegistrationReconciler: NewSeedRegistrationReconciler(clientMap, recorder),
-		migrationReconciler:        NewMigrationReconciler(clientMap, config),
+		migrationReconciler:        NewMigrationReconciler(gardenClient, config),
 
 		shootCareQueue:        workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "shoot-care"),
 		shootQueue:            workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "shoot"),

--- a/pkg/gardenlet/controller/shoot/shoot_care_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_care_control.go
@@ -44,6 +44,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
+const careReconcilerName = "care"
+
 func (c *Controller) shootCareAdd(obj interface{}) {
 	key, err := cache.MetaNamespaceKeyFunc(obj)
 	if err != nil {

--- a/pkg/gardenlet/controller/shoot/shoot_care_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_care_control.go
@@ -34,13 +34,14 @@ import (
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 
-	"github.com/sirupsen/logrus"
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/utils/clock"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -102,7 +103,6 @@ func shootReconciliationFinishedSuccessful(oldShoot, newShoot *gardencorev1beta1
 // on shoots, e.g., health checks or garbage collection.
 func NewCareReconciler(
 	clientMap clientmap.ClientMap,
-	l logrus.FieldLogger,
 	imageVector imagevector.ImageVector,
 	identity *gardencorev1beta1.Gardener,
 	gardenClusterIdentity string,
@@ -110,7 +110,6 @@ func NewCareReconciler(
 ) reconcile.Reconciler {
 	return &careReconciler{
 		clientMap:             clientMap,
-		logger:                l,
 		imageVector:           imageVector,
 		identity:              identity,
 		gardenClusterIdentity: gardenClusterIdentity,
@@ -120,13 +119,11 @@ func NewCareReconciler(
 
 type careReconciler struct {
 	clientMap             clientmap.ClientMap
-	logger                logrus.FieldLogger
 	imageVector           imagevector.ImageVector
 	identity              *gardencorev1beta1.Gardener
 	gardenClusterIdentity string
 	config                *config.GardenletConfiguration
-
-	gardenSecrets map[string]*corev1.Secret
+	gardenSecrets         map[string]*corev1.Secret
 }
 
 func (r *careReconciler) conditionThresholdsToProgressingMapping() map[gardencorev1beta1.ConditionType]time.Duration {
@@ -166,7 +163,7 @@ func shootClientInitializer(ctx context.Context, o *operation.Operation) func() 
 	}
 }
 
-func careSetupFailure(ctx context.Context, gardenClient client.Client, shoot *gardencorev1beta1.Shoot, message string, conditions, constraints []gardencorev1beta1.Condition) error {
+func patchStatusToUnknown(ctx context.Context, gardenClient client.Client, shoot *gardencorev1beta1.Shoot, message string, conditions, constraints []gardencorev1beta1.Condition) error {
 	updatedConditions := make([]gardencorev1beta1.Condition, 0, len(conditions))
 	for _, cond := range conditions {
 		updatedConditions = append(updatedConditions, gardencorev1beta1helper.UpdatedConditionUnknownErrorMessage(cond, message))
@@ -186,7 +183,7 @@ func careSetupFailure(ctx context.Context, gardenClient client.Client, shoot *ga
 }
 
 func (r *careReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
-	log := r.logger.WithField("shoot", req.String())
+	log := logf.FromContext(ctx)
 
 	gardenClient, err := r.clientMap.GetClient(ctx, keys.ForGarden())
 	if err != nil {
@@ -196,11 +193,10 @@ func (r *careReconciler) Reconcile(ctx context.Context, req reconcile.Request) (
 	shoot := &gardencorev1beta1.Shoot{}
 	if err := gardenClient.Client().Get(ctx, req.NamespacedName, shoot); err != nil {
 		if apierrors.IsNotFound(err) {
-			log.Infof("[SHOOT CARE] Stopping care operations for Shoot since it has been deleted")
+			log.Info("Object is gone, stop reconciling")
 			return reconcile.Result{}, nil
 		}
-		log.Infof("[SHOOT CARE] unable to retrieve object from store: %+v", err)
-		return reconcile.Result{}, err
+		return reconcile.Result{}, fmt.Errorf("error retrieving object from store: %w", err)
 	}
 
 	// if shoot has not been scheduled, requeue
@@ -213,7 +209,7 @@ func (r *careReconciler) Reconcile(ctx context.Context, req reconcile.Request) (
 		return reconcile.Result{}, nil
 	}
 
-	if err := r.care(ctx, gardenClient, shoot, log); err != nil {
+	if err := r.care(ctx, log, gardenClient, shoot); err != nil {
 		return reconcile.Result{}, err
 	}
 
@@ -233,12 +229,11 @@ var (
 	NewWebhookRemediator = defaultNewWebhookRemediator
 )
 
-func (r *careReconciler) care(ctx context.Context, gardenClientSet kubernetes.Interface, shoot *gardencorev1beta1.Shoot, log logrus.FieldLogger) error {
+func (r *careReconciler) care(ctx context.Context, log logr.Logger, gardenClientSet kubernetes.Interface, shoot *gardencorev1beta1.Shoot) error {
 	careCtx, cancel := context.WithTimeout(ctx, r.config.Controllers.ShootCare.SyncPeriod.Duration)
 	defer cancel()
 
 	gardenClient := gardenClientSet.Client()
-	log.Debugf("[SHOOT CARE] Starting care")
 
 	// Initialize conditions based on the current status.
 	conditionTypes := []gardencorev1beta1.ConditionType{
@@ -265,12 +260,11 @@ func (r *careReconciler) care(ctx context.Context, gardenClientSet kubernetes.In
 
 	seedClient, err := r.clientMap.GetClient(careCtx, keys.ForSeedWithName(*shoot.Spec.SeedName))
 	if err != nil {
-		log.Errorf("seedClient cannot be constructed: %s", err.Error())
-
-		if err := careSetupFailure(ctx, gardenClient, shoot, "Precondition failed: seed client cannot be constructed", conditions, constraints); err != nil {
-			log.Error(err)
+		log.Error(err, "Could not get seed client")
+		if err := patchStatusToUnknown(ctx, gardenClient, shoot, "Precondition failed: seed client cannot be constructed", conditions, constraints); err != nil {
+			log.Error(err, "Error when trying to update the shoot status")
 		}
-		return nil
+		return nil // We do not want to run in the exponential backoff for the condition checks.
 	}
 
 	// Only read Garden secrets once because we don't rely on up-to-date secrets for health checks.
@@ -284,6 +278,7 @@ func (r *careReconciler) care(ctx context.Context, gardenClientSet kubernetes.In
 
 	o, err := NewOperation(
 		careCtx,
+		log,
 		gardenClientSet,
 		seedClient,
 		r.config,
@@ -293,24 +288,21 @@ func (r *careReconciler) care(ctx context.Context, gardenClientSet kubernetes.In
 		r.imageVector,
 		r.clientMap,
 		shoot,
-		log,
 	)
 	if err != nil {
-		log.Errorf("could not initialize a new operation: %s", err.Error())
-
-		if err := careSetupFailure(ctx, gardenClient, shoot, "Precondition failed: operation could not be initialized", conditions, constraints); err != nil {
-			log.Error(err)
+		log.Error(err, "Could not initialize a new operation")
+		if err := patchStatusToUnknown(ctx, gardenClient, shoot, "Precondition failed: operation could not be initialized", conditions, constraints); err != nil {
+			log.Error(err, "Error when trying to update the shoot status")
 		}
 		return nil // We do not want to run in the exponential backoff for the condition checks.
 	}
 
 	if err := o.InitializeSeedClients(careCtx); err != nil {
-		log.Errorf("Health checks cannot be performed: %s", err.Error())
-
-		if err := careSetupFailure(ctx, gardenClient, shoot, "Precondition failed: seed client cannot be constructed", conditions, constraints); err != nil {
-			log.Error(err)
+		log.Error(err, "Could not initialize seed clients")
+		if err := patchStatusToUnknown(ctx, gardenClient, shoot, "Precondition failed: seed client cannot be constructed", conditions, constraints); err != nil {
+			log.Error(err, "Error when trying to update the shoot status")
 		}
-		return nil
+		return nil // We do not want to run in the exponential backoff for the condition checks.
 	}
 
 	staleExtensionHealthCheckThreshold := confighelper.StaleExtensionHealthChecksThreshold(r.config.Controllers.ShootCare.StaleExtensionHealthChecks)
@@ -318,6 +310,7 @@ func (r *careReconciler) care(ctx context.Context, gardenClientSet kubernetes.In
 
 	var updatedConditions, updatedConstraints []gardencorev1beta1.Condition
 
+	// Error is ignored here since we do not want to run in the exponential backoff for the condition checks.
 	_ = flow.Parallel(
 		// Trigger health check
 		func(ctx context.Context) error {
@@ -364,9 +357,10 @@ func (r *careReconciler) care(ctx context.Context, gardenClientSet kubernetes.In
 		// correct types will be updated, and any other conditions will remain intact
 		conditions := buildShootConditions(shoot.Status.Conditions, updatedConditions, conditionTypes)
 		constraints := buildShootConditions(shoot.Status.Constraints, updatedConstraints, constraintTypes)
-		log.Debugf("[SHOOT CARE] Updating shoot status conditions and constraints")
+
+		log.V(1).Info("Updating status conditions and constraints")
 		if err := patchShootStatus(ctx, gardenClient, shoot, conditions, constraints); err != nil {
-			o.Logger.Errorf("Could not update Shoot status: %+v", err)
+			log.Error(err, "Error when trying to update the shoot status")
 			return nil // We do not want to run in the exponential backoff for the condition checks.
 		}
 	}

--- a/pkg/gardenlet/controller/shoot/shoot_care_control_types.go
+++ b/pkg/gardenlet/controller/shoot/shoot_care_control_types.go
@@ -26,7 +26,7 @@ import (
 	"github.com/gardener/gardener/pkg/operation/care"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 
-	"github.com/sirupsen/logrus"
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/clock"
@@ -87,6 +87,7 @@ var defaultNewWebhookRemediator = func(op *operation.Operation, init care.ShootC
 // NewOperationFunc is a function used to create a new `operation.Operation` instance.
 type NewOperationFunc func(
 	ctx context.Context,
+	log logr.Logger,
 	gardenClient kubernetes.Interface,
 	seedClient kubernetes.Interface,
 	config *config.GardenletConfiguration,
@@ -96,7 +97,6 @@ type NewOperationFunc func(
 	imageVector imagevector.ImageVector,
 	clientMap clientmap.ClientMap,
 	shoot *gardencorev1beta1.Shoot,
-	logger logrus.FieldLogger,
 ) (
 	*operation.Operation,
 	error,
@@ -104,6 +104,7 @@ type NewOperationFunc func(
 
 var defaultNewOperationFunc = func(
 	ctx context.Context,
+	log logr.Logger,
 	gardenClient kubernetes.Interface,
 	seedClient kubernetes.Interface,
 	config *config.GardenletConfiguration,
@@ -113,14 +114,13 @@ var defaultNewOperationFunc = func(
 	imageVector imagevector.ImageVector,
 	clientMap clientmap.ClientMap,
 	shoot *gardencorev1beta1.Shoot,
-	logger logrus.FieldLogger,
 ) (
 	*operation.Operation,
 	error,
 ) {
 	return operation.
 		NewBuilder().
-		WithLogger(logger).
+		WithLogger(log).
 		WithConfig(config).
 		WithGardenerInfo(gardenerInfo).
 		WithGardenClusterIdentity(gardenClusterIdentity).

--- a/pkg/gardenlet/controller/shoot/shoot_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control.go
@@ -1072,18 +1072,16 @@ func extensionResourceStillExists(ctx context.Context, reader client.Reader, obj
 	return true, obj.GetDeletionTimestamp() != nil, nil
 }
 
-func checkIfSeedNamespaceExistsFunc(ctx context.Context, o *operation.Operation, botanist *botanistpkg.Botanist) func() error {
-	return func() error {
-		botanist.SeedNamespaceObject = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: o.Shoot.SeedNamespace}}
-		if err := botanist.K8sSeedClient.APIReader().Get(ctx, client.ObjectKeyFromObject(botanist.SeedNamespaceObject), botanist.SeedNamespaceObject); err != nil {
-			if apierrors.IsNotFound(err) {
-				o.Logger.Info("Did not find namespace in the Seed cluster - nothing to be done", "namespace", client.ObjectKeyFromObject(o.SeedNamespaceObject))
-				return utilerrors.Cancel()
-			}
-			return err
+func checkIfSeedNamespaceExists(ctx context.Context, o *operation.Operation, botanist *botanistpkg.Botanist) error {
+	botanist.SeedNamespaceObject = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: o.Shoot.SeedNamespace}}
+	if err := botanist.K8sSeedClient.APIReader().Get(ctx, client.ObjectKeyFromObject(botanist.SeedNamespaceObject), botanist.SeedNamespaceObject); err != nil {
+		if apierrors.IsNotFound(err) {
+			o.Logger.Info("Did not find namespace in the Seed cluster - nothing to be done", "namespace", client.ObjectKeyFromObject(o.SeedNamespaceObject))
+			return utilerrors.Cancel()
 		}
-		return nil
+		return err
 	}
+	return nil
 }
 
 func shootKey(shoot *gardencorev1beta1.Shoot) string {

--- a/pkg/gardenlet/controller/shoot/shoot_control_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_delete.go
@@ -90,7 +90,9 @@ func (r *shootReconciler) runDeleteShootFlow(ctx context.Context, o *operation.O
 		}),
 		// We first check whether the namespace in the Seed cluster does exist - if it does not, then we assume that
 		// all resources have already been deleted. We can delete the Shoot resource as a consequence.
-		errors.ToExecute("Retrieve the Shoot namespace in the Seed cluster", checkIfSeedNamespaceExistsFunc(ctx, o, botanist)),
+		errors.ToExecute("Retrieve the Shoot namespace in the Seed cluster", func() error {
+			return checkIfSeedNamespaceExists(ctx, o, botanist)
+		}),
 		// We check whether the kube-apiserver deployment exists in the shoot namespace. If it does not, then we assume
 		// that it has never been deployed successfully, or that we have deleted it in a previous run because we already
 		// cleaned up. We follow that no (more) resources can have been deployed in the shoot cluster, thus there is nothing

--- a/pkg/gardenlet/controller/shoot/shoot_control_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_delete.go
@@ -628,7 +628,7 @@ func (r *shootReconciler) runDeleteShootFlow(ctx context.Context, o *operation.O
 	)
 
 	if err := f.Run(ctx, flow.Opts{
-		Logger:           o.Logger,
+		Log:              o.Logger,
 		ProgressReporter: r.newProgressReporter(o.ReportShootProgress),
 		ErrorCleaner:     o.CleanShootTaskError,
 		ErrorContext:     errorContext,

--- a/pkg/gardenlet/controller/shoot/shoot_control_delete.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_delete.go
@@ -90,17 +90,7 @@ func (r *shootReconciler) runDeleteShootFlow(ctx context.Context, o *operation.O
 		}),
 		// We first check whether the namespace in the Seed cluster does exist - if it does not, then we assume that
 		// all resources have already been deleted. We can delete the Shoot resource as a consequence.
-		errors.ToExecute("Retrieve the Shoot namespace in the Seed cluster", func() error {
-			botanist.SeedNamespaceObject = &corev1.Namespace{}
-			err := botanist.K8sSeedClient.APIReader().Get(ctx, client.ObjectKey{Name: o.Shoot.SeedNamespace}, botanist.SeedNamespaceObject)
-			if err != nil {
-				if apierrors.IsNotFound(err) {
-					o.Logger.Infof("Did not find '%s' namespace in the Seed cluster - nothing to be done", o.Shoot.SeedNamespace)
-					return errors.Cancel()
-				}
-			}
-			return err
-		}),
+		errors.ToExecute("Retrieve the Shoot namespace in the Seed cluster", checkIfSeedNamespaceExistsFunc(ctx, o, botanist)),
 		// We check whether the kube-apiserver deployment exists in the shoot namespace. If it does not, then we assume
 		// that it has never been deployed successfully, or that we have deleted it in a previous run because we already
 		// cleaned up. We follow that no (more) resources can have been deployed in the shoot cluster, thus there is nothing
@@ -643,7 +633,6 @@ func (r *shootReconciler) runDeleteShootFlow(ctx context.Context, o *operation.O
 		ErrorCleaner:     o.CleanShootTaskError,
 		ErrorContext:     errorContext,
 	}); err != nil {
-		o.Logger.Errorf("Failed to delete Shoot cluster %q: %+v", o.Shoot.GetInfo().Name, err)
 		return gardencorev1beta1helper.NewWrappedLastErrors(gardencorev1beta1helper.FormatLastErrDescription(err), flow.Errors(err))
 	}
 
@@ -653,7 +642,7 @@ func (r *shootReconciler) runDeleteShootFlow(ctx context.Context, o *operation.O
 		return gardencorev1beta1helper.NewWrappedLastErrors(gardencorev1beta1helper.FormatLastErrDescription(err), err)
 	}
 
-	o.Logger.Infof("Successfully deleted Shoot cluster %q", o.Shoot.GetInfo().Name)
+	o.Logger.Info("Successfully deleted Shoot cluster")
 	return nil
 }
 

--- a/pkg/gardenlet/controller/shoot/shoot_control_migrate.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_migrate.go
@@ -383,7 +383,7 @@ func (r *shootReconciler) runPrepareShootForMigrationFlow(ctx context.Context, o
 	)
 
 	if err := f.Run(ctx, flow.Opts{
-		Logger:           o.Logger,
+		Log:              o.Logger,
 		ProgressReporter: r.newProgressReporter(o.ReportShootProgress),
 		ErrorContext:     errorContext,
 		ErrorCleaner:     o.CleanShootTaskError,

--- a/pkg/gardenlet/controller/shoot/shoot_control_migrate.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_migrate.go
@@ -145,7 +145,9 @@ func (r *shootReconciler) runPrepareShootForMigrationFlow(ctx context.Context, o
 			}
 			return nil
 		}),
-		utilerrors.ToExecute("Retrieve the Shoot namespace in the Seed cluster", checkIfSeedNamespaceExistsFunc(ctx, o, botanist)),
+		utilerrors.ToExecute("Retrieve the Shoot namespace in the Seed cluster", func() error {
+			return checkIfSeedNamespaceExists(ctx, o, botanist)
+		}),
 		utilerrors.ToExecute("Retrieve the BackupEntry in the garden cluster", func() error {
 			backupEntry := &gardencorev1beta1.BackupEntry{}
 			err := botanist.K8sGardenClient.APIReader().Get(ctx, client.ObjectKey{Name: botanist.Shoot.BackupEntryName, Namespace: o.Shoot.GetInfo().Namespace}, backupEntry)

--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -700,7 +700,7 @@ func (r *shootReconciler) runReconcileShootFlow(ctx context.Context, o *operatio
 	f := g.Compile()
 
 	if err := f.Run(ctx, flow.Opts{
-		Logger:           o.Logger,
+		Log:              o.Logger,
 		ProgressReporter: r.newProgressReporter(o.ReportShootProgress),
 		ErrorContext:     errorContext,
 		ErrorCleaner:     o.CleanShootTaskError,

--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -705,7 +705,6 @@ func (r *shootReconciler) runReconcileShootFlow(ctx context.Context, o *operatio
 		ErrorContext:     errorContext,
 		ErrorCleaner:     o.CleanShootTaskError,
 	}); err != nil {
-		o.Logger.Errorf("Failed to %s Shoot cluster %q: %+v", utils.IifString(isRestoring, "restore", "reconcile"), o.Shoot.GetInfo().Name, err)
 		return gardencorev1beta1helper.NewWrappedLastErrors(gardencorev1beta1helper.FormatLastErrDescription(err), flow.Errors(err))
 	}
 
@@ -729,7 +728,7 @@ func (r *shootReconciler) runReconcileShootFlow(ctx context.Context, o *operatio
 		}
 	}
 
-	o.Logger.Infof("Successfully %s Shoot cluster %q", utils.IifString(isRestoring, "restored", "reconciled"), o.Shoot.GetInfo().Name)
+	o.Logger.Info("Successfully reconciled Shoot cluster", "operation", utils.IifString(isRestoring, "restored", "reconciled"))
 	return nil
 }
 

--- a/pkg/gardenlet/controller/shoot/shoot_migration_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_migration_control.go
@@ -36,6 +36,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
+const migrationReconcilerName = "migration"
+
 func (c *Controller) shootMigrationAdd(obj interface{}) {
 	key, err := cache.MetaNamespaceKeyFunc(obj)
 	if err != nil {

--- a/pkg/gardenlet/controller/shoot/shoot_migration_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_migration_control.go
@@ -21,18 +21,17 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
-	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap/keys"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
 	confighelper "github.com/gardener/gardener/pkg/gardenlet/apis/config/helper"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
-	"github.com/sirupsen/logrus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -74,46 +73,34 @@ func (c *Controller) shootMigrationDelete(obj interface{}) {
 // NewMigrationReconciler returns an implementation of reconcile.Reconciler that forces the shoot's restoration
 // to this seed during control plane migration if the preparation for migration in the source seed is not finished
 // after a certain grace period and is considered unlikely to succeed ("bad case" scenario).
-func NewMigrationReconciler(
-	clientMap clientmap.ClientMap,
-	logger logrus.FieldLogger,
-	config *config.GardenletConfiguration,
-) reconcile.Reconciler {
+func NewMigrationReconciler(gardenClient kubernetes.Interface, config *config.GardenletConfiguration) reconcile.Reconciler {
 	return &migrationReconciler{
-		clientMap: clientMap,
-		logger:    logger,
-		config:    config,
+		gardenClient: gardenClient,
+		config:       config,
 	}
 }
 
 type migrationReconciler struct {
-	clientMap clientmap.ClientMap
-	logger    logrus.FieldLogger
-	config    *config.GardenletConfiguration
+	gardenClient kubernetes.Interface
+	config       *config.GardenletConfiguration
 }
 
 func (r *migrationReconciler) Reconcile(ctx context.Context, req reconcile.Request) (result reconcile.Result, err error) {
-	log := r.logger.WithField("shoot", req.String())
-
-	gardenClient, err := r.clientMap.GetClient(ctx, keys.ForGarden())
-	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("failed to get garden client: %w", err)
-	}
+	log := logf.FromContext(ctx)
 
 	shoot := &gardencorev1beta1.Shoot{}
-	if err := gardenClient.Client().Get(ctx, req.NamespacedName, shoot); err != nil {
+	if err := r.gardenClient.Client().Get(ctx, req.NamespacedName, shoot); err != nil {
 		if apierrors.IsNotFound(err) {
-			log.Infof("[SHOOT MIGRATION] Skipping because Shoot has been deleted")
+			log.Info("Object is gone, stop reconciling")
 			return reconcile.Result{}, nil
 		}
-		log.Infof("[SHOOT MIGRATION] Unable to retrieve object from store: %+v", err)
-		return reconcile.Result{}, err
+		return reconcile.Result{}, fmt.Errorf("error retrieving object from store: %w", err)
 	}
 
 	// If the shoot is being deleted or no longer being migrated to this seed, clear the migration start time
-	if shoot.DeletionTimestamp != nil || !controllerutils.ShootIsBeingMigratedToSeed(ctx, gardenClient.Cache(), shoot, confighelper.SeedNameFromSeedConfig(r.config.SeedConfig)) {
-		log.Debugf("[SHOOT MIGRATION] Clearing migration start time")
-		if err := setMigrationStartTime(ctx, gardenClient.Client(), shoot, nil); err != nil {
+	if shoot.DeletionTimestamp != nil || !controllerutils.ShootIsBeingMigratedToSeed(ctx, r.gardenClient.Cache(), shoot, confighelper.SeedNameFromSeedConfig(r.config.SeedConfig)) {
+		log.V(1).Info("Clearing migration start time")
+		if err := setMigrationStartTime(ctx, r.gardenClient.Client(), shoot, nil); err != nil {
 			return reconcile.Result{}, fmt.Errorf("could not clear migration start time: %w", err)
 		}
 
@@ -123,25 +110,25 @@ func (r *migrationReconciler) Reconcile(ctx context.Context, req reconcile.Reque
 
 	// Set the migration start time if needed
 	if shoot.Status.MigrationStartTime == nil {
-		log.Debugf("[SHOOT MIGRATION] Setting migration start time")
-		if err := setMigrationStartTime(ctx, gardenClient.Client(), shoot, &metav1.Time{Time: time.Now().UTC()}); err != nil {
+		log.V(1).Info("Setting migration start time")
+		if err := setMigrationStartTime(ctx, r.gardenClient.Client(), shoot, &metav1.Time{Time: time.Now().UTC()}); err != nil {
 			return reconcile.Result{}, fmt.Errorf("could not set migration start time: %w", err)
 		}
 	}
 
 	// If the restore annotation is set or the grace period is elapsed and migration is not currently in progress,
 	// update the shoot status to force the restoration (fallback to the "bad case" scenario)
-	log.Debugf("[SHOOT MIGRATION] Checking if the shoot should be forcefully restored")
+	log.V(1).Info("Checking if the shoot should be forcefully restored")
 	if hasForceRestoreAnnotation(shoot) || r.isGracePeriodElapsed(shoot) && !r.isMigrationInProgress(shoot) {
 
-		log.Infof("[SHOOT MIGRATION] Updating shoot status to force restoration")
-		if err := updateStatusForRestore(ctx, gardenClient.Client(), shoot); err != nil {
+		log.Info("Updating status to force restoration")
+		if err := updateStatusForRestore(ctx, r.gardenClient.Client(), shoot); err != nil {
 			return reconcile.Result{}, fmt.Errorf("could not update shoot status to force restoration: %w", err)
 		}
 
 		if hasForceRestoreAnnotation(shoot) {
-			log.Debugf("[SHOOT MIGRATION] Removing force-restore annotation")
-			if err := removeForceRestoreAnnotation(ctx, gardenClient.Client(), shoot); err != nil {
+			log.V(1).Info("Removing force-restore annotation")
+			if err := removeForceRestoreAnnotation(ctx, r.gardenClient.Client(), shoot); err != nil {
 				return reconcile.Result{}, fmt.Errorf("could not remove force-restore annotation: %w", err)
 			}
 		}

--- a/pkg/operation/botanist/addons_test.go
+++ b/pkg/operation/botanist/addons_test.go
@@ -19,11 +19,29 @@ import (
 	"fmt"
 	"time"
 
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	cr "github.com/gardener/gardener/pkg/chartrenderer"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	fakeclientset "github.com/gardener/gardener/pkg/client/kubernetes/fake"
+	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
+	"github.com/gardener/gardener/pkg/operation"
+	. "github.com/gardener/gardener/pkg/operation/botanist"
+	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/dnsrecord"
+	mockdnsrecord "github.com/gardener/gardener/pkg/operation/botanist/component/extensions/dnsrecord/mock"
+	"github.com/gardener/gardener/pkg/operation/common"
+	"github.com/gardener/gardener/pkg/operation/garden"
+	"github.com/gardener/gardener/pkg/operation/shoot"
+	"github.com/gardener/gardener/pkg/utils/test"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+
 	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,25 +52,6 @@ import (
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
-	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	cr "github.com/gardener/gardener/pkg/chartrenderer"
-	"github.com/gardener/gardener/pkg/client/kubernetes"
-	fakeclientset "github.com/gardener/gardener/pkg/client/kubernetes/fake"
-	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
-	"github.com/gardener/gardener/pkg/logger"
-	"github.com/gardener/gardener/pkg/operation"
-	. "github.com/gardener/gardener/pkg/operation/botanist"
-	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/dnsrecord"
-	mockdnsrecord "github.com/gardener/gardener/pkg/operation/botanist/component/extensions/dnsrecord/mock"
-	"github.com/gardener/gardener/pkg/operation/common"
-	"github.com/gardener/gardener/pkg/operation/garden"
-	"github.com/gardener/gardener/pkg/operation/shoot"
-	"github.com/gardener/gardener/pkg/utils/test"
-	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
 var _ = Describe("addons", func() {
@@ -115,7 +114,7 @@ var _ = Describe("addons", func() {
 					},
 				},
 				Garden: &garden.Garden{},
-				Logger: logrus.NewEntry(logger.NewNopLogger()),
+				Logger: logr.Discard(),
 			},
 		}
 		b.Shoot.SetInfo(&gardencorev1beta1.Shoot{

--- a/pkg/operation/botanist/botanist.go
+++ b/pkg/operation/botanist/botanist.go
@@ -35,7 +35,6 @@ import (
 
 	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // DefaultInterval is the default interval for retry operations.
@@ -79,7 +78,7 @@ func New(ctx context.Context, o *operation.Operation) (*Botanist, error) {
 
 	o.SecretsManager, err = secretsmanager.New(
 		ctx,
-		logf.Log.WithName("secretsmanager"),
+		b.Logger.WithName("secretsmanager"),
 		clock.RealClock{},
 		b.K8sSeedClient.Client(),
 		b.Shoot.SeedNamespace,

--- a/pkg/operation/botanist/component/backupentry/backupentry_test.go
+++ b/pkg/operation/botanist/component/backupentry/backupentry_test.go
@@ -22,17 +22,16 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/features"
 	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
-	"github.com/gardener/gardener/pkg/logger"
 	mocktime "github.com/gardener/gardener/pkg/mock/go/time"
 	. "github.com/gardener/gardener/pkg/operation/botanist/component/backupentry"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 
+	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -48,7 +47,7 @@ var _ = Describe("BackupEntry", func() {
 		c                client.Client
 		expected         *gardencorev1beta1.BackupEntry
 		values           *Values
-		log              logrus.FieldLogger
+		log              logr.Logger
 		defaultDepWaiter Interface
 
 		mockNow *mocktime.MockNow
@@ -71,7 +70,7 @@ var _ = Describe("BackupEntry", func() {
 		mockNow = mocktime.NewMockNow(ctrl)
 
 		ctx = context.TODO()
-		log = logger.NewNopLogger()
+		log = logr.Discard()
 
 		s := runtime.NewScheme()
 		Expect(gardencorev1beta1.AddToScheme(s)).NotTo(HaveOccurred())

--- a/pkg/operation/botanist/component/etcd/etcd.go
+++ b/pkg/operation/botanist/component/etcd/etcd.go
@@ -37,7 +37,7 @@ import (
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
 
-	"github.com/sirupsen/logrus"
+	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2beta1 "k8s.io/api/autoscaling/v2beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -128,7 +128,7 @@ type Interface interface {
 // New creates a new instance of DeployWaiter for the Etcd.
 func New(
 	c client.Client,
-	logger logrus.FieldLogger,
+	log logr.Logger,
 	namespace string,
 	secretsManager secretsmanager.Interface,
 	role string,
@@ -140,11 +140,7 @@ func New(
 	caRotationPhase gardencorev1beta1.ShootCredentialsRotationPhase,
 ) Interface {
 	name := "etcd-" + role
-
-	var etcdLog logrus.FieldLogger
-	if logger != nil {
-		etcdLog = logger.WithField("etcd", client.ObjectKey{Namespace: namespace, Name: name})
-	}
+	log = log.WithValues("etcd", client.ObjectKey{Namespace: namespace, Name: name})
 
 	var (
 		nodeSpread bool
@@ -164,7 +160,7 @@ func New(
 
 	return &etcd{
 		client:                  c,
-		logger:                  etcdLog,
+		log:                     log,
 		namespace:               namespace,
 		secretsManager:          secretsManager,
 		role:                    role,
@@ -188,7 +184,7 @@ func New(
 
 type etcd struct {
 	client                  client.Client
-	logger                  logrus.FieldLogger
+	log                     logr.Logger
 	namespace               string
 	secretsManager          secretsmanager.Interface
 	role                    string

--- a/pkg/operation/botanist/component/etcd/etcd_test.go
+++ b/pkg/operation/botanist/component/etcd/etcd_test.go
@@ -24,7 +24,6 @@ import (
 	mockkubernetes "github.com/gardener/gardener/pkg/client/kubernetes/mock"
 	"github.com/gardener/gardener/pkg/features"
 	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
-	"github.com/gardener/gardener/pkg/logger"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	. "github.com/gardener/gardener/pkg/operation/botanist/component/etcd"
 	"github.com/gardener/gardener/pkg/utils/gardener"
@@ -34,14 +33,13 @@ import (
 	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
-	"github.com/go-logr/logr"
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
+	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2beta1 "k8s.io/api/autoscaling/v2beta1"
 	corev1 "k8s.io/api/core/v1"
@@ -74,7 +72,7 @@ var _ = Describe("Etcd", func() {
 		fakeClient client.Client
 		sm         secretsmanager.Interface
 		etcd       Interface
-		log        logrus.FieldLogger
+		log        logr.Logger
 
 		ctx                     = context.TODO()
 		fakeErr                 = fmt.Errorf("fake err")
@@ -660,7 +658,7 @@ var _ = Describe("Etcd", func() {
 		c = mockclient.NewMockClient(ctrl)
 		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetesscheme.Scheme).Build()
 		sm = fakesecretsmanager.New(fakeClient, testNamespace)
-		log = logger.NewNopLogger()
+		log = logr.Discard()
 
 		By("creating secrets managed outside of this package for whose secretsmanager.Get() will be called")
 		Expect(fakeClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "ca-etcd", Namespace: testNamespace}})).To(Succeed())

--- a/pkg/operation/botanist/component/etcd/monitoring_test.go
+++ b/pkg/operation/botanist/component/etcd/monitoring_test.go
@@ -21,13 +21,14 @@ import (
 	. "github.com/gardener/gardener/pkg/operation/botanist/component/etcd"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/test"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 )
 
 var _ = Describe("Monitoring", func() {
 	Describe("#ScrapeConfig", func() {
 		It("should successfully test the scrape configuration", func() {
-			etcd := New(nil, nil, testNamespace, nil, testRole, ClassNormal, nil, nil, "", nil, "")
+			etcd := New(nil, logr.Discard(), testNamespace, nil, testRole, ClassNormal, nil, nil, "", nil, "")
 			test.ScrapeConfigs(etcd, expectedScrapeConfigEtcd, expectedScrapeConfigBackupRestore)
 		})
 	})
@@ -35,7 +36,7 @@ var _ = Describe("Monitoring", func() {
 	Describe("#AlertingRules", func() {
 		Context("w/o backup", func() {
 			It("should successfully test the alerting rules (normal)", func() {
-				etcd := New(nil, nil, testNamespace, nil, testRole, ClassNormal, nil, nil, "", nil, "")
+				etcd := New(nil, logr.Discard(), testNamespace, nil, testRole, ClassNormal, nil, nil, "", nil, "")
 				test.AlertingRulesWithPromtool(
 					etcd,
 					map[string]string{fmt.Sprintf("kube-etcd3-%s.rules.yaml", testRole): expectedAlertingRulesNormalWithoutBackup},
@@ -44,7 +45,7 @@ var _ = Describe("Monitoring", func() {
 			})
 
 			It("should successfully test the alerting rules (important)", func() {
-				etcd := New(nil, nil, testNamespace, nil, testRole, ClassImportant, nil, nil, "", nil, "")
+				etcd := New(nil, logr.Discard(), testNamespace, nil, testRole, ClassImportant, nil, nil, "", nil, "")
 				test.AlertingRulesWithPromtool(
 					etcd,
 					map[string]string{fmt.Sprintf("kube-etcd3-%s.rules.yaml", testRole): expectedAlertingRulesImportantWithoutBackup},
@@ -55,7 +56,7 @@ var _ = Describe("Monitoring", func() {
 
 		Context("w/ backup", func() {
 			It("should successfully test the alerting rules (normal)", func() {
-				etcd := New(nil, nil, testNamespace, nil, testRole, ClassNormal, nil, nil, "", nil, "")
+				etcd := New(nil, logr.Discard(), testNamespace, nil, testRole, ClassNormal, nil, nil, "", nil, "")
 				etcd.SetBackupConfig(&BackupConfig{})
 				test.AlertingRulesWithPromtool(
 					etcd,
@@ -65,7 +66,7 @@ var _ = Describe("Monitoring", func() {
 			})
 
 			It("should successfully test the alerting rules (important)", func() {
-				etcd := New(nil, nil, testNamespace, nil, testRole, ClassImportant, nil, nil, "", nil, "")
+				etcd := New(nil, logr.Discard(), testNamespace, nil, testRole, ClassImportant, nil, nil, "", nil, "")
 				etcd.SetBackupConfig(&BackupConfig{})
 				test.AlertingRulesWithPromtool(
 					etcd,

--- a/pkg/operation/botanist/component/etcd/waiter.go
+++ b/pkg/operation/botanist/component/etcd/waiter.go
@@ -42,7 +42,7 @@ func (e *etcd) Wait(ctx context.Context) error {
 	return extensions.WaitUntilObjectReadyWithHealthFunction(
 		ctx,
 		e.client,
-		e.logger,
+		e.log,
 		CheckEtcdObject,
 		e.etcd,
 		"Etcd",

--- a/pkg/operation/botanist/component/etcdcopybackupstask/etcdcopybackupstask_test.go
+++ b/pkg/operation/botanist/component/etcdcopybackupstask/etcdcopybackupstask_test.go
@@ -18,20 +18,19 @@ import (
 	"context"
 	"time"
 
-	"github.com/gardener/gardener/pkg/logger"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	. "github.com/gardener/gardener/pkg/operation/botanist/component/etcdcopybackupstask"
-	"github.com/sirupsen/logrus"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/utils/pointer"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
+	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("EtcdCopyBackupsTask", func() {
@@ -39,7 +38,7 @@ var _ = Describe("EtcdCopyBackupsTask", func() {
 		ctrl *gomock.Controller
 		ctx  context.Context
 		c    *mockclient.MockClient
-		log  logrus.FieldLogger
+		log  logr.Logger
 
 		expected            *druidv1alpha1.EtcdCopyBackupsTask
 		values              *Values
@@ -52,7 +51,7 @@ var _ = Describe("EtcdCopyBackupsTask", func() {
 		ctrl = gomock.NewController(GinkgoT())
 		ctx = context.TODO()
 		c = mockclient.NewMockClient(ctrl)
-		log = logger.NewNopLogger()
+		log = logr.Discard()
 
 		expected = &druidv1alpha1.EtcdCopyBackupsTask{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/operation/botanist/component/extensions/containerruntime/containerruntime.go
+++ b/pkg/operation/botanist/component/extensions/containerruntime/containerruntime.go
@@ -28,7 +28,7 @@ import (
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/utils/flow"
 
-	"github.com/sirupsen/logrus"
+	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -66,8 +66,8 @@ type Values struct {
 
 type containerRuntime struct {
 	values              *Values
+	log                 logr.Logger
 	client              client.Client
-	logger              logrus.FieldLogger
 	waitInterval        time.Duration
 	waitSevereThreshold time.Duration
 	waitTimeout         time.Duration
@@ -77,7 +77,7 @@ type containerRuntime struct {
 
 // New creates a new instance of Interface.
 func New(
-	logger logrus.FieldLogger,
+	log logr.Logger,
 	client client.Client,
 	values *Values,
 	waitInterval time.Duration,
@@ -86,8 +86,8 @@ func New(
 ) Interface {
 	return &containerRuntime{
 		values:              values,
+		log:                 log,
 		client:              client,
-		logger:              logger,
 		waitInterval:        waitInterval,
 		waitSevereThreshold: waitSevereThreshold,
 		waitTimeout:         waitTimeout,
@@ -132,7 +132,7 @@ func (c *containerRuntime) Wait(ctx context.Context) error {
 		return extensions.WaitUntilExtensionObjectReady(
 			ctx,
 			c.client,
-			c.logger,
+			c.log,
 			cr,
 			extensionsv1alpha1.ContainerRuntimeResource,
 			c.waitInterval,
@@ -210,7 +210,7 @@ func (c *containerRuntime) waitCleanup(ctx context.Context, wantedContainerRunti
 	return extensions.WaitUntilExtensionObjectsDeleted(
 		ctx,
 		c.client,
-		c.logger,
+		c.log,
 		&extensionsv1alpha1.ContainerRuntimeList{},
 		extensionsv1alpha1.ContainerRuntimeResource,
 		c.values.Namespace,

--- a/pkg/operation/botanist/component/extensions/controlplane/controlplane.go
+++ b/pkg/operation/botanist/component/extensions/controlplane/controlplane.go
@@ -18,19 +18,18 @@ import (
 	"context"
 	"time"
 
-	"github.com/sirupsen/logrus"
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/controllerutils"
+	"github.com/gardener/gardener/pkg/extensions"
+	"github.com/gardener/gardener/pkg/operation/botanist/component"
+
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/gardener/gardener/pkg/controllerutils"
-
-	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	"github.com/gardener/gardener/pkg/extensions"
-	"github.com/gardener/gardener/pkg/operation/botanist/component"
 )
 
 const (
@@ -75,7 +74,7 @@ type Values struct {
 
 // New creates a new instance of Interface.
 func New(
-	logger logrus.FieldLogger,
+	log logr.Logger,
 	client client.Client,
 	values *Values,
 	waitInterval time.Duration,
@@ -88,8 +87,8 @@ func New(
 	}
 
 	return &controlPlane{
+		log:                 log,
 		client:              client,
-		logger:              logger,
 		values:              values,
 		waitInterval:        waitInterval,
 		waitSevereThreshold: waitSevereThreshold,
@@ -106,7 +105,7 @@ func New(
 
 type controlPlane struct {
 	values              *Values
-	logger              logrus.FieldLogger
+	log                 logr.Logger
 	client              client.Client
 	waitInterval        time.Duration
 	waitSevereThreshold time.Duration
@@ -187,7 +186,7 @@ func (c *controlPlane) Wait(ctx context.Context) error {
 	return extensions.WaitUntilExtensionObjectReady(
 		ctx,
 		c.client,
-		c.logger,
+		c.log,
 		c.controlPlane,
 		extensionsv1alpha1.ControlPlaneResource,
 		c.waitInterval,
@@ -217,7 +216,7 @@ func (c *controlPlane) WaitCleanup(ctx context.Context) error {
 	return extensions.WaitUntilExtensionObjectDeleted(
 		ctx,
 		c.client,
-		c.logger,
+		c.log,
 		c.controlPlane,
 		extensionsv1alpha1.ControlPlaneResource,
 		c.waitInterval,

--- a/pkg/operation/botanist/component/extensions/controlplane/controlplane_test.go
+++ b/pkg/operation/botanist/component/extensions/controlplane/controlplane_test.go
@@ -24,19 +24,19 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/extensions"
-	"github.com/gardener/gardener/pkg/logger"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	mocktime "github.com/gardener/gardener/pkg/mock/go/time"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/controlplane"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
+	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -54,7 +54,7 @@ var _ = Describe("ControlPlane", func() {
 		now     time.Time
 
 		ctx = context.TODO()
-		log = logger.NewNopLogger()
+		log = logr.Discard()
 
 		name                         = "test"
 		namespace                    = "testnamespace"

--- a/pkg/operation/botanist/component/extensions/dns/dnsentry.go
+++ b/pkg/operation/botanist/component/extensions/dns/dnsentry.go
@@ -25,6 +25,7 @@ import (
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
 	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -41,7 +42,7 @@ type EntryValues struct {
 
 // NewEntry creates a new instance of DeployWaiter for a specific DNSEntry.
 func NewEntry(
-	log interface{}, // TODO(rfranzke): Use logr.Logger when all usages are adapted
+	log logr.Logger,
 	client client.Client,
 	namespace string,
 	values *EntryValues,
@@ -62,7 +63,7 @@ func NewEntry(
 }
 
 type entry struct {
-	log       interface{}
+	log       logr.Logger
 	client    client.Client
 	namespace string
 	values    *EntryValues

--- a/pkg/operation/botanist/component/extensions/dns/dnsentry_test.go
+++ b/pkg/operation/botanist/component/extensions/dns/dnsentry_test.go
@@ -19,21 +19,8 @@ import (
 	"fmt"
 	"time"
 
-	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
-	"github.com/golang/mock/gomock"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"github.com/sirupsen/logrus"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/pointer"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	"github.com/gardener/gardener/pkg/logger"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	. "github.com/gardener/gardener/pkg/operation/botanist/component/extensions/dns"
@@ -41,6 +28,18 @@ import (
 	retryfake "github.com/gardener/gardener/pkg/utils/retry/fake"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+
+	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	"github.com/go-logr/logr"
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var _ = Describe("#DNSEntry", func() {
@@ -60,7 +59,7 @@ var _ = Describe("#DNSEntry", func() {
 
 		expected         *dnsv1alpha1.DNSEntry
 		vals             *EntryValues
-		log              logrus.FieldLogger
+		log              logr.Logger
 		defaultDepWaiter component.DeployWaiter
 	)
 
@@ -75,7 +74,7 @@ var _ = Describe("#DNSEntry", func() {
 			&TimeNow, func() time.Time { return now },
 		)
 		ctx = context.TODO()
-		log = logger.NewNopLogger()
+		log = logr.Discard()
 
 		scheme = runtime.NewScheme()
 		Expect(dnsv1alpha1.AddToScheme(scheme)).NotTo(HaveOccurred())

--- a/pkg/operation/botanist/component/extensions/dns/dnsprovider.go
+++ b/pkg/operation/botanist/component/extensions/dns/dnsprovider.go
@@ -18,17 +18,17 @@ import (
 	"context"
 	"time"
 
-	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
-	"github.com/sirupsen/logrus"
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	"github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+
+	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // ProviderValues contains the values used to create a DNSProvider.
@@ -51,13 +51,13 @@ type IncludeExclude struct {
 
 // NewProvider creates a new instance of DeployWaiter for a specific DNSProvider.
 func NewProvider(
-	logger logrus.FieldLogger,
+	log logr.Logger,
 	client client.Client,
 	namespace string,
 	values *ProviderValues,
 ) component.DeployWaiter {
 	return &provider{
-		logger:    logger,
+		log:       log,
 		client:    client,
 		namespace: namespace,
 		values:    values,
@@ -72,7 +72,7 @@ func NewProvider(
 }
 
 type provider struct {
-	logger    logrus.FieldLogger
+	log       logr.Logger
 	client    client.Client
 	namespace string
 	values    *ProviderValues
@@ -134,7 +134,7 @@ func (p *provider) Wait(ctx context.Context) error {
 	return extensions.WaitUntilObjectReadyWithHealthFunction(
 		ctx,
 		p.client,
-		p.logger,
+		p.log,
 		CheckDNSObject,
 		p.dnsProvider,
 		dnsv1alpha1.DNSProviderKind,

--- a/pkg/operation/botanist/component/extensions/dns/dnsprovider_test.go
+++ b/pkg/operation/botanist/component/extensions/dns/dnsprovider_test.go
@@ -19,22 +19,8 @@ import (
 	"fmt"
 	"time"
 
-	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
-	"github.com/golang/mock/gomock"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"github.com/sirupsen/logrus"
-	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/utils/pointer"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	"github.com/gardener/gardener/pkg/logger"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	. "github.com/gardener/gardener/pkg/operation/botanist/component/extensions/dns"
@@ -42,6 +28,19 @@ import (
 	retryfake "github.com/gardener/gardener/pkg/utils/retry/fake"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+
+	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	"github.com/go-logr/logr"
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var _ = Describe("#DNSProvider", func() {
@@ -63,7 +62,7 @@ var _ = Describe("#DNSProvider", func() {
 		expectedSecret   *corev1.Secret
 		expected         *dnsv1alpha1.DNSProvider
 		vals             *ProviderValues
-		log              logrus.FieldLogger
+		log              logr.Logger
 		defaultDepWaiter component.DeployWaiter
 	)
 
@@ -79,7 +78,7 @@ var _ = Describe("#DNSProvider", func() {
 		)
 
 		ctx = context.TODO()
-		log = logger.NewNopLogger()
+		log = logr.Discard()
 
 		scheme = runtime.NewScheme()
 		Expect(corev1.AddToScheme(scheme)).NotTo(HaveOccurred())

--- a/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord.go
+++ b/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord.go
@@ -27,6 +27,7 @@ import (
 	"github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -89,7 +90,7 @@ type Values struct {
 
 // New creates a new instance that implements component.DeployMigrateWaiter.
 func New(
-	log interface{}, // TODO(rfranzke): Use logr.Logger when all usages are adapted
+	log logr.Logger,
 	client client.Client,
 	values *Values,
 	waitInterval time.Duration,
@@ -120,7 +121,7 @@ func New(
 }
 
 type dnsRecord struct {
-	log                 interface{}
+	log                 logr.Logger
 	client              client.Client
 	values              *Values
 	waitInterval        time.Duration

--- a/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord_test.go
+++ b/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord_test.go
@@ -24,7 +24,6 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/extensions"
-	"github.com/gardener/gardener/pkg/logger"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	mocktime "github.com/gardener/gardener/pkg/mock/go/time"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/dnsrecord"
@@ -34,6 +33,7 @@ import (
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 
+	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -72,7 +72,7 @@ var _ = Describe("DNSRecord", func() {
 
 		ctx     = context.TODO()
 		now     = time.Now()
-		log     = logger.NewNopLogger()
+		log     = logr.Discard()
 		testErr = fmt.Errorf("test")
 
 		fakeOps *retryfake.Ops

--- a/pkg/operation/botanist/component/extensions/extension/extension.go
+++ b/pkg/operation/botanist/component/extensions/extension/extension.go
@@ -26,7 +26,7 @@ import (
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/utils/flow"
 
-	"github.com/sirupsen/logrus"
+	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -74,8 +74,8 @@ type Values struct {
 
 type extension struct {
 	values              *Values
+	log                 logr.Logger
 	client              client.Client
-	logger              logrus.FieldLogger
 	waitInterval        time.Duration
 	waitSevereThreshold time.Duration
 	waitTimeout         time.Duration
@@ -85,7 +85,7 @@ type extension struct {
 
 // New creates a new instance of Extension deployer.
 func New(
-	logger logrus.FieldLogger,
+	log logr.Logger,
 	client client.Client,
 	values *Values,
 	waitInterval time.Duration,
@@ -94,8 +94,8 @@ func New(
 ) Interface {
 	return &extension{
 		values:              values,
+		log:                 log,
 		client:              client,
-		logger:              logger,
 		waitInterval:        waitInterval,
 		waitSevereThreshold: waitSevereThreshold,
 		waitTimeout:         waitTimeout,
@@ -136,7 +136,7 @@ func (e *extension) Wait(ctx context.Context) error {
 		return extensions.WaitUntilExtensionObjectReady(
 			ctx,
 			e.client,
-			e.logger,
+			e.log,
 			ext,
 			extensionsv1alpha1.ExtensionResource,
 			e.waitInterval,
@@ -220,7 +220,7 @@ func (e *extension) waitCleanup(ctx context.Context, wantedExtensionTypes sets.S
 	return extensions.WaitUntilExtensionObjectsDeleted(
 		ctx,
 		e.client,
-		e.logger,
+		e.log,
 		&extensionsv1alpha1.ExtensionList{},
 		extensionsv1alpha1.ExtensionResource,
 		e.values.Namespace,

--- a/pkg/operation/botanist/component/extensions/extension/extension_test.go
+++ b/pkg/operation/botanist/component/extensions/extension/extension_test.go
@@ -19,11 +19,23 @@ import (
 	"fmt"
 	"time"
 
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/extensions"
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	mocktime "github.com/gardener/gardener/pkg/mock/go/time"
+	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/extension"
+	gutil "github.com/gardener/gardener/pkg/utils/gardener"
+	"github.com/gardener/gardener/pkg/utils/test"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+
+	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
 	"github.com/hashicorp/go-multierror"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/sirupsen/logrus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -31,19 +43,6 @@ import (
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
-	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	"github.com/gardener/gardener/pkg/extensions"
-	"github.com/gardener/gardener/pkg/logger"
-	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
-	mocktime "github.com/gardener/gardener/pkg/mock/go/time"
-	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/extension"
-	gutil "github.com/gardener/gardener/pkg/utils/gardener"
-	"github.com/gardener/gardener/pkg/utils/test"
-	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
 var _ = Describe("Extension", func() {
@@ -71,7 +70,7 @@ var _ = Describe("Extension", func() {
 		empty    *extensionsv1alpha1.Extension
 		expected []*extensionsv1alpha1.Extension
 		values   *extension.Values
-		log      logrus.FieldLogger
+		log      logr.Logger
 		fakeErr  = fmt.Errorf("some random error")
 
 		mockNow *mocktime.MockNow
@@ -84,7 +83,7 @@ var _ = Describe("Extension", func() {
 		now = time.Now()
 
 		ctx = context.TODO()
-		log = logger.NewNopLogger()
+		log = logr.Discard()
 
 		s := runtime.NewScheme()
 		Expect(extensionsv1alpha1.AddToScheme(s)).To(Succeed())

--- a/pkg/operation/botanist/component/extensions/infrastructure/infrastructure.go
+++ b/pkg/operation/botanist/component/extensions/infrastructure/infrastructure.go
@@ -25,7 +25,7 @@ import (
 	"github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 
-	"github.com/sirupsen/logrus"
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -81,7 +81,7 @@ type Values struct {
 
 // New creates a new instance of Interface.
 func New(
-	logger logrus.FieldLogger,
+	log logr.Logger,
 	client client.Client,
 	values *Values,
 	waitInterval time.Duration,
@@ -89,8 +89,8 @@ func New(
 	waitTimeout time.Duration,
 ) Interface {
 	return &infrastructure{
+		log:                 log,
 		client:              client,
-		logger:              logger,
 		values:              values,
 		waitInterval:        waitInterval,
 		waitSevereThreshold: waitSevereThreshold,
@@ -107,7 +107,7 @@ func New(
 
 type infrastructure struct {
 	values              *Values
-	logger              logrus.FieldLogger
+	log                 logr.Logger
 	client              client.Client
 	waitInterval        time.Duration
 	waitSevereThreshold time.Duration
@@ -191,7 +191,7 @@ func (i *infrastructure) Wait(ctx context.Context) error {
 	return extensions.WaitUntilExtensionObjectReady(
 		ctx,
 		i.client,
-		i.logger,
+		i.log,
 		i.infrastructure,
 		extensionsv1alpha1.InfrastructureResource,
 		i.waitInterval,
@@ -220,7 +220,7 @@ func (i *infrastructure) WaitCleanup(ctx context.Context) error {
 	return extensions.WaitUntilExtensionObjectDeleted(
 		ctx,
 		i.client,
-		i.logger,
+		i.log,
 		i.infrastructure,
 		extensionsv1alpha1.InfrastructureResource,
 		i.waitInterval,

--- a/pkg/operation/botanist/component/extensions/infrastructure/infrastructure_test.go
+++ b/pkg/operation/botanist/component/extensions/infrastructure/infrastructure_test.go
@@ -19,17 +19,11 @@ import (
 	"errors"
 	"time"
 
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/extensions"
-	"github.com/gardener/gardener/pkg/logger"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	mocktime "github.com/gardener/gardener/pkg/mock/go/time"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/infrastructure"
@@ -39,15 +33,19 @@ import (
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 
+	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var _ = Describe("#Interface", func() {
@@ -59,7 +57,7 @@ var _ = Describe("#Interface", func() {
 
 	var (
 		ctx     context.Context
-		log     logrus.FieldLogger
+		log     logr.Logger
 		fakeErr = errors.New("fake")
 
 		ctrl    *gomock.Controller
@@ -83,7 +81,7 @@ var _ = Describe("#Interface", func() {
 
 	BeforeEach(func() {
 		ctx = context.TODO()
-		log = logger.NewNopLogger()
+		log = logr.Discard()
 
 		ctrl = gomock.NewController(GinkgoT())
 		mockNow = mocktime.NewMockNow(ctrl)

--- a/pkg/operation/botanist/component/extensions/network/network.go
+++ b/pkg/operation/botanist/component/extensions/network/network.go
@@ -26,7 +26,7 @@ import (
 	"github.com/gardener/gardener/pkg/extensions"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 
-	"github.com/sirupsen/logrus"
+	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -63,7 +63,7 @@ type Values struct {
 
 // New creates a new instance of DeployWaiter for a Network.
 func New(
-	logger logrus.FieldLogger,
+	log logr.Logger,
 	client client.Client,
 	values *Values,
 	waitInterval time.Duration,
@@ -72,7 +72,7 @@ func New(
 ) component.DeployMigrateWaiter {
 	return &network{
 		client:              client,
-		logger:              logger,
+		log:                 log,
 		values:              values,
 		waitInterval:        waitInterval,
 		waitSevereThreshold: waitSevereThreshold,
@@ -89,7 +89,7 @@ func New(
 
 type network struct {
 	values              *Values
-	logger              logrus.FieldLogger
+	log                 logr.Logger
 	client              client.Client
 	waitInterval        time.Duration
 	waitSevereThreshold time.Duration
@@ -150,7 +150,7 @@ func (n *network) Wait(ctx context.Context) error {
 	return extensions.WaitUntilExtensionObjectReady(
 		ctx,
 		n.client,
-		n.logger,
+		n.log,
 		n.network,
 		extensionsv1alpha1.NetworkResource,
 		n.waitInterval,
@@ -165,7 +165,7 @@ func (n *network) WaitCleanup(ctx context.Context) error {
 	return extensions.WaitUntilExtensionObjectDeleted(
 		ctx,
 		n.client,
-		n.logger,
+		n.log,
 		n.network,
 		extensionsv1alpha1.NetworkResource,
 		n.waitInterval,

--- a/pkg/operation/botanist/component/extensions/network/network_test.go
+++ b/pkg/operation/botanist/component/extensions/network/network_test.go
@@ -20,23 +20,11 @@ import (
 	"net"
 	"time"
 
-	"github.com/golang/mock/gomock"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"github.com/sirupsen/logrus"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/extensions"
-	"github.com/gardener/gardener/pkg/logger"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	mocktime "github.com/gardener/gardener/pkg/mock/go/time"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
@@ -44,6 +32,17 @@ import (
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+
+	"github.com/go-logr/logr"
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var _ = Describe("#Network", func() {
@@ -63,7 +62,7 @@ var _ = Describe("#Network", func() {
 		c                client.Client
 		expected, empty  *extensionsv1alpha1.Network
 		values           *network.Values
-		log              logrus.FieldLogger
+		log              logr.Logger
 		defaultDepWaiter component.DeployMigrateWaiter
 
 		mockNow *mocktime.MockNow
@@ -80,7 +79,7 @@ var _ = Describe("#Network", func() {
 		now = time.Now()
 
 		ctx = context.TODO()
-		log = logger.NewNopLogger()
+		log = logr.Discard()
 
 		s := runtime.NewScheme()
 		Expect(extensionsv1alpha1.AddToScheme(s)).NotTo(HaveOccurred())

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig.go
@@ -40,7 +40,7 @@ import (
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 
 	"github.com/Masterminds/semver"
-	"github.com/sirupsen/logrus"
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -128,7 +128,7 @@ type OriginalValues struct {
 
 // New creates a new instance of Interface.
 func New(
-	logger logrus.FieldLogger,
+	log logr.Logger,
 	client client.Client,
 	secretsManager secretsmanager.Interface,
 	values *Values,
@@ -137,7 +137,7 @@ func New(
 	waitTimeout time.Duration,
 ) Interface {
 	osc := &operatingSystemConfig{
-		logger:              logger,
+		log:                 log,
 		client:              client,
 		secretsManager:      secretsManager,
 		values:              values,
@@ -156,7 +156,7 @@ func New(
 }
 
 type operatingSystemConfig struct {
-	logger         logrus.FieldLogger
+	log            logr.Logger
 	client         client.Client
 	secretsManager secretsmanager.Interface
 	values         *Values
@@ -237,7 +237,7 @@ func (o *operatingSystemConfig) Wait(ctx context.Context) error {
 	fns := o.forEachWorkerPoolAndPurposeTaskFn(func(ctx context.Context, osc *extensionsv1alpha1.OperatingSystemConfig, worker gardencorev1beta1.Worker, purpose extensionsv1alpha1.OperatingSystemConfigPurpose) error {
 		return extensions.WaitUntilExtensionObjectReady(ctx,
 			o.client,
-			o.logger,
+			o.log,
 			osc,
 			extensionsv1alpha1.OperatingSystemConfigResource,
 			o.waitInterval,
@@ -346,7 +346,7 @@ func (o *operatingSystemConfig) waitCleanup(ctx context.Context, wantedOSCNames 
 	return extensions.WaitUntilExtensionObjectsDeleted(
 		ctx,
 		o.client,
-		o.logger,
+		o.log,
 		&extensionsv1alpha1.OperatingSystemConfigList{},
 		extensionsv1alpha1.OperatingSystemConfigResource,
 		o.values.Namespace,

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/operatingsystemconfig_test.go
@@ -26,7 +26,6 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/extensions"
-	"github.com/gardener/gardener/pkg/logger"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	mocktime "github.com/gardener/gardener/pkg/mock/go/time"
 	. "github.com/gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig"
@@ -41,11 +40,11 @@ import (
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 
 	"github.com/Masterminds/semver"
+	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
 	"github.com/hashicorp/go-multierror"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -72,7 +71,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 
 			ctx     context.Context
 			values  *Values
-			log     logrus.FieldLogger
+			log     logr.Logger
 			fakeErr = fmt.Errorf("some random error")
 
 			mockNow *mocktime.MockNow
@@ -172,7 +171,7 @@ var _ = Describe("OperatingSystemConfig", func() {
 			now = time.Now()
 
 			ctx = context.TODO()
-			log = logger.NewNopLogger()
+			log = logr.Discard()
 
 			s := runtime.NewScheme()
 			Expect(extensionsv1alpha1.AddToScheme(s)).To(Succeed())

--- a/pkg/operation/botanist/component/extensions/worker/worker.go
+++ b/pkg/operation/botanist/component/extensions/worker/worker.go
@@ -32,7 +32,7 @@ import (
 	"github.com/gardener/gardener/pkg/utils"
 
 	"github.com/Masterminds/semver"
-	"github.com/sirupsen/logrus"
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -92,7 +92,7 @@ type Values struct {
 
 // New creates a new instance of Interface.
 func New(
-	logger logrus.FieldLogger,
+	log logr.Logger,
 	client client.Client,
 	values *Values,
 	waitInterval time.Duration,
@@ -100,8 +100,8 @@ func New(
 	waitTimeout time.Duration,
 ) Interface {
 	return &worker{
+		log:                 log,
 		client:              client,
-		logger:              logger,
 		values:              values,
 		waitInterval:        waitInterval,
 		waitSevereThreshold: waitSevereThreshold,
@@ -118,7 +118,7 @@ func New(
 
 type worker struct {
 	values              *Values
-	logger              logrus.FieldLogger
+	log                 logr.Logger
 	client              client.Client
 	waitInterval        time.Duration
 	waitSevereThreshold time.Duration
@@ -318,7 +318,7 @@ func (w *worker) Wait(ctx context.Context) error {
 	return extensions.WaitUntilExtensionObjectReady(
 		ctx,
 		w.client,
-		w.logger,
+		w.log,
 		w.worker,
 		extensionsv1alpha1.WorkerResource,
 		w.waitInterval,
@@ -348,7 +348,7 @@ func (w *worker) WaitCleanup(ctx context.Context) error {
 	return extensions.WaitUntilExtensionObjectDeleted(
 		ctx,
 		w.client,
-		w.logger,
+		w.log,
 		w.worker,
 		extensionsv1alpha1.WorkerResource,
 		w.waitInterval,

--- a/pkg/operation/botanist/component/extensions/worker/worker_test.go
+++ b/pkg/operation/botanist/component/extensions/worker/worker_test.go
@@ -24,7 +24,6 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/extensions"
-	"github.com/gardener/gardener/pkg/logger"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	mocktime "github.com/gardener/gardener/pkg/mock/go/time"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig"
@@ -35,6 +34,7 @@ import (
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 
 	"github.com/Masterminds/semver"
+	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -59,7 +59,7 @@ var _ = Describe("Worker", func() {
 		now     time.Time
 
 		ctx = context.TODO()
-		log = logger.NewNopLogger()
+		log = logr.Discard()
 
 		name                         = "test"
 		namespace                    = "testnamespace"

--- a/pkg/operation/botanist/component/kubeapiserverexposure/kube_apiserver_service_test.go
+++ b/pkg/operation/botanist/component/kubeapiserverexposure/kube_apiserver_service_test.go
@@ -17,15 +17,14 @@ package kubeapiserverexposure_test
 import (
 	"context"
 
-	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	. "github.com/gardener/gardener/pkg/operation/botanist/component/kubeapiserverexposure"
 	retryfake "github.com/gardener/gardener/pkg/utils/retry/fake"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -36,7 +35,7 @@ import (
 
 var _ = Describe("#Service", func() {
 	var (
-		log logrus.FieldLogger
+		log logr.Logger
 		ctx context.Context
 		c   client.Client
 
@@ -53,7 +52,7 @@ var _ = Describe("#Service", func() {
 	)
 
 	BeforeEach(func() {
-		log = logger.NewNopLogger()
+		log = logr.Discard()
 		ctx = context.TODO()
 
 		s := runtime.NewScheme()

--- a/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager.go
@@ -34,10 +34,10 @@ import (
 	"github.com/gardener/gardener/pkg/utils/secrets"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 	"github.com/gardener/gardener/pkg/utils/version"
+	"github.com/go-logr/logr"
 
 	"github.com/Masterminds/semver"
 	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
-	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	autoscalingv2beta1 "k8s.io/api/autoscaling/v2beta1"
@@ -96,7 +96,7 @@ type HVPAConfig struct {
 
 // New creates a new instance of DeployWaiter for the kube-controller-manager.
 func New(
-	logger logrus.FieldLogger,
+	log logr.Logger,
 	seedClient kubernetes.Interface,
 	namespace string,
 	secretsManager secretsmanager.Interface,
@@ -108,7 +108,7 @@ func New(
 	hvpaConfig *HVPAConfig,
 ) Interface {
 	return &kubeControllerManager{
-		log:            logger,
+		log:            log,
 		seedClient:     seedClient,
 		namespace:      namespace,
 		secretsManager: secretsManager,
@@ -122,7 +122,7 @@ func New(
 }
 
 type kubeControllerManager struct {
-	log            logrus.FieldLogger
+	log            logr.Logger
 	seedClient     kubernetes.Interface
 	shootClient    client.Client
 	namespace      string

--- a/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager_test.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/kube_controller_manager_test.go
@@ -25,7 +25,6 @@ import (
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	fakekubernetes "github.com/gardener/gardener/pkg/client/kubernetes/fake"
-	"github.com/gardener/gardener/pkg/logger"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	. "github.com/gardener/gardener/pkg/operation/botanist/component/kubecontrollermanager"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
@@ -38,10 +37,10 @@ import (
 
 	"github.com/Masterminds/semver"
 	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
+	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	autoscalingv2beta1 "k8s.io/api/autoscaling/v2beta1"
@@ -61,7 +60,7 @@ import (
 var _ = Describe("KubeControllerManager", func() {
 	var (
 		ctx                   = context.TODO()
-		testLogger            = logrus.NewEntry(logger.NewNopLogger())
+		testLogger            = logr.Discard()
 		ctrl                  *gomock.Controller
 		c                     *mockclient.MockClient
 		fakeClient            client.Client
@@ -791,7 +790,7 @@ subjects:
 			fakeKubernetesInterface := fakekubernetes.NewClientSetBuilder().WithAPIReader(fakeClient).WithClient(fakeClient).Build()
 
 			kubeControllerManager = New(
-				nil,
+				testLogger,
 				fakeKubernetesInterface,
 				namespace,
 				nil,

--- a/pkg/operation/botanist/component/kubecontrollermanager/monitoring_test.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/monitoring_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gardener/gardener/pkg/operation/botanist/component/test"
 
 	"github.com/Masterminds/semver"
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -30,7 +31,7 @@ var _ = Describe("Monitoring", func() {
 		func(version, expectedScrapeConfig string) {
 			semverVersion, err := semver.NewVersion(version)
 			Expect(err).NotTo(HaveOccurred())
-			kubeControllerManager := New(nil, nil, "", nil, semverVersion, "", nil, nil, nil, nil)
+			kubeControllerManager := New(logr.Discard(), nil, "", nil, semverVersion, "", nil, nil, nil, nil)
 			test.ScrapeConfigs(kubeControllerManager, expectedScrapeConfig)
 		},
 
@@ -45,7 +46,7 @@ var _ = Describe("Monitoring", func() {
 	It("should successfully test the alerting rules", func() {
 		semverVersion, err := semver.NewVersion("1.18.4")
 		Expect(err).NotTo(HaveOccurred())
-		kubeControllerManager := New(nil, nil, "", nil, semverVersion, "", nil, nil, nil, nil)
+		kubeControllerManager := New(logr.Discard(), nil, "", nil, semverVersion, "", nil, nil, nil, nil)
 
 		test.AlertingRulesWithPromtool(
 			kubeControllerManager,

--- a/pkg/operation/botanist/component/kubecontrollermanager/waiter.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/waiter.go
@@ -77,13 +77,13 @@ func (k *kubeControllerManager) WaitForControllerToBeActive(ctx context.Context)
 
 		// Check that one replica of the controller exists.
 		if len(podList.Items) != 1 {
-			k.log.Infof("Waiting for %s to have exactly one replica", v1beta1constants.DeploymentNameKubeControllerManager)
+			k.log.Info("Waiting for kube-controller-manager to have exactly one replica")
 			return retry.MinorError(fmt.Errorf("controller %s is not active", v1beta1constants.DeploymentNameKubeControllerManager))
 		}
 
 		// Check that the existing replica is not getting deleted.
 		if podList.Items[0].DeletionTimestamp != nil {
-			k.log.Infof("Waiting for a new replica of %s", v1beta1constants.DeploymentNameKubeControllerManager)
+			k.log.Info("Waiting for a new replica of kube-controller-manager")
 			return retry.MinorError(fmt.Errorf("controller %s is not active", v1beta1constants.DeploymentNameKubeControllerManager))
 		}
 
@@ -104,7 +104,7 @@ func (k *kubeControllerManager) WaitForControllerToBeActive(ctx context.Context)
 			return retry.Ok()
 		}
 
-		k.log.Infof("Waiting for %s to be active", v1beta1constants.DeploymentNameKubeControllerManager)
+		k.log.Info("Waiting for kube-controller-manager to be active")
 		return retry.MinorError(fmt.Errorf("controller %s is not active", v1beta1constants.DeploymentNameKubeControllerManager))
 	})
 }

--- a/pkg/operation/botanist/component/kubecontrollermanager/waiter_test.go
+++ b/pkg/operation/botanist/component/kubecontrollermanager/waiter_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	fakekubernetes "github.com/gardener/gardener/pkg/client/kubernetes/fake"
-	"github.com/gardener/gardener/pkg/logger"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/retry"
@@ -29,10 +28,10 @@ import (
 	"github.com/gardener/gardener/pkg/utils/test"
 
 	"github.com/Masterminds/semver"
+	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -47,7 +46,7 @@ import (
 var _ = Describe("WaiterTest", func() {
 	var (
 		ctx                   = context.TODO()
-		testLogger            = logrus.NewEntry(logger.NewNopLogger())
+		testLogger            = logr.Discard()
 		errorMsg              = "fake error"
 		fakeErr               = fmt.Errorf(errorMsg)
 		kubeControllerManager Interface

--- a/pkg/operation/botanist/component/shootsystem/shootsystem_test.go
+++ b/pkg/operation/botanist/component/shootsystem/shootsystem_test.go
@@ -32,6 +32,7 @@ import (
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 
 	"github.com/Masterminds/semver"
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -107,7 +108,7 @@ var _ = Describe("ShootSystem", func() {
 			Components: &shootpkg.Components{
 				Extensions: &shootpkg.Extensions{
 					Extension: extension.New(
-						nil,
+						logr.Discard(),
 						nil,
 						&extension.Values{
 							Extensions: extensions,

--- a/pkg/operation/botanist/dns.go
+++ b/pkg/operation/botanist/dns.go
@@ -257,7 +257,7 @@ func (b *Botanist) AdditionalDNSProviders(ctx context.Context) (map[string]compo
 			}
 
 			if *providerType == gardencore.DNSUnmanaged {
-				b.Logger.Infof("Skipping deployment of DNS provider[%d] since it specifies type %q", i, gardencore.DNSUnmanaged)
+				b.Logger.Info("Skipping deployment of DNS provider since it's of type unmanaged", "index", i)
 				continue
 			}
 

--- a/pkg/operation/botanist/dns_test.go
+++ b/pkg/operation/botanist/dns_test.go
@@ -18,11 +18,25 @@ import (
 	"context"
 	"fmt"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	cr "github.com/gardener/gardener/pkg/chartrenderer"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	fakeclientset "github.com/gardener/gardener/pkg/client/kubernetes/fake"
+	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
+	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
+	"github.com/gardener/gardener/pkg/operation"
+	mockdnsrecord "github.com/gardener/gardener/pkg/operation/botanist/component/extensions/dnsrecord/mock"
+	"github.com/gardener/gardener/pkg/operation/garden"
+	shootpkg "github.com/gardener/gardener/pkg/operation/shoot"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+
 	dnsv1alpha1 "github.com/gardener/external-dns-management/pkg/apis/dns/v1alpha1"
+	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -34,21 +48,6 @@ import (
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	cr "github.com/gardener/gardener/pkg/chartrenderer"
-	"github.com/gardener/gardener/pkg/client/kubernetes"
-	fakeclientset "github.com/gardener/gardener/pkg/client/kubernetes/fake"
-	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
-	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
-	"github.com/gardener/gardener/pkg/logger"
-	"github.com/gardener/gardener/pkg/operation"
-	mockdnsrecord "github.com/gardener/gardener/pkg/operation/botanist/component/extensions/dnsrecord/mock"
-	"github.com/gardener/gardener/pkg/operation/garden"
-	shootpkg "github.com/gardener/gardener/pkg/operation/shoot"
-	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
 var _ = Describe("dns", func() {
@@ -86,7 +85,7 @@ var _ = Describe("dns", func() {
 					SeedNamespace: seedNS,
 				},
 				Garden: &garden.Garden{},
-				Logger: logrus.NewEntry(logger.NewNopLogger()),
+				Logger: logr.Discard(),
 			},
 		}
 		b.Shoot.SetInfo(&gardencorev1beta1.Shoot{

--- a/pkg/operation/botanist/dnsrecord_test.go
+++ b/pkg/operation/botanist/dnsrecord_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	fakeclientset "github.com/gardener/gardener/pkg/client/kubernetes/fake"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
-	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/operation"
 	. "github.com/gardener/gardener/pkg/operation/botanist"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/dnsrecord"
@@ -38,10 +37,10 @@ import (
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 
+	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -147,7 +146,7 @@ var _ = Describe("dnsrecord", func() {
 					},
 				},
 				Seed:   &seed.Seed{},
-				Logger: logrus.NewEntry(logger.NewNopLogger()),
+				Logger: logr.Discard(),
 			},
 		}
 		b.Shoot.SetInfo(&gardencorev1beta1.Shoot{

--- a/pkg/operation/botanist/dnsresources_test.go
+++ b/pkg/operation/botanist/dnsresources_test.go
@@ -20,21 +20,20 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/features"
 	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
-	"github.com/gardener/gardener/pkg/operation/seed"
-	"github.com/gardener/gardener/pkg/utils/test"
-	"github.com/golang/mock/gomock"
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"github.com/sirupsen/logrus"
-	"k8s.io/utils/pointer"
-
-	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/operation"
 	. "github.com/gardener/gardener/pkg/operation/botanist"
 	mockdnsrecord "github.com/gardener/gardener/pkg/operation/botanist/component/extensions/dnsrecord/mock"
 	mockcomponent "github.com/gardener/gardener/pkg/operation/botanist/component/mock"
 	"github.com/gardener/gardener/pkg/operation/garden"
+	"github.com/gardener/gardener/pkg/operation/seed"
 	"github.com/gardener/gardener/pkg/operation/shoot"
+	"github.com/gardener/gardener/pkg/utils/test"
+
+	"github.com/go-logr/logr"
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/utils/pointer"
 )
 
 var _ = Describe("dnsrecord", func() {
@@ -108,7 +107,7 @@ var _ = Describe("dnsrecord", func() {
 						Provider: internalProvider,
 					},
 				},
-				Logger: logrus.NewEntry(logger.NewNopLogger()),
+				Logger: logr.Discard(),
 			},
 		}
 		b.Shoot.SetInfo(&gardencorev1beta1.Shoot{

--- a/pkg/operation/botanist/etcd_test.go
+++ b/pkg/operation/botanist/etcd_test.go
@@ -39,13 +39,13 @@ import (
 	"github.com/gardener/gardener/pkg/utils/test"
 
 	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
+	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
 	"github.com/hashicorp/go-multierror"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	gomegatypes "github.com/onsi/gomega/types"
-	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -138,7 +138,7 @@ var _ = Describe("Etcd", func() {
 
 						validator := &newEtcdValidator{
 							expectedClient:                  Equal(c),
-							expectedLogger:                  BeNil(),
+							expectedLogger:                  BeAssignableToTypeOf(logr.Logger{}),
 							expectedNamespace:               Equal(namespace),
 							expectedSecretsManager:          Equal(sm),
 							expectedRole:                    Equal(role),
@@ -177,7 +177,7 @@ var _ = Describe("Etcd", func() {
 
 				validator := &newEtcdValidator{
 					expectedClient:                  Equal(c),
-					expectedLogger:                  BeNil(),
+					expectedLogger:                  BeAssignableToTypeOf(logr.Logger{}),
 					expectedNamespace:               Equal(namespace),
 					expectedSecretsManager:          Equal(sm),
 					expectedRole:                    Equal(role),
@@ -208,7 +208,7 @@ var _ = Describe("Etcd", func() {
 
 				validator := &newEtcdValidator{
 					expectedClient:                  Equal(c),
-					expectedLogger:                  BeNil(),
+					expectedLogger:                  BeAssignableToTypeOf(logr.Logger{}),
 					expectedNamespace:               Equal(namespace),
 					expectedSecretsManager:          Equal(sm),
 					expectedRole:                    Equal(role),
@@ -480,7 +480,7 @@ type newEtcdValidator struct {
 
 func (v *newEtcdValidator) NewEtcd(
 	client client.Client,
-	logger logrus.FieldLogger,
+	log logr.Logger,
 	namespace string,
 	secretsManager secretsmanager.Interface,
 	role string,
@@ -492,7 +492,7 @@ func (v *newEtcdValidator) NewEtcd(
 	_ gardencorev1beta1.ShootCredentialsRotationPhase,
 ) etcd.Interface {
 	Expect(client).To(v.expectedClient)
-	Expect(logger).To(v.expectedLogger)
+	Expect(log).To(v.expectedLogger)
 	Expect(namespace).To(v.expectedNamespace)
 	Expect(secretsManager).To(v.expectedSecretsManager)
 	Expect(role).To(v.expectedRole)

--- a/pkg/operation/botanist/etcdcopybackupstask_test.go
+++ b/pkg/operation/botanist/etcdcopybackupstask_test.go
@@ -19,7 +19,6 @@ import (
 	"errors"
 	"time"
 
-	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
@@ -32,17 +31,18 @@ import (
 	seedpkg "github.com/gardener/gardener/pkg/operation/seed"
 	shootpkg "github.com/gardener/gardener/pkg/operation/shoot"
 	"github.com/gardener/gardener/pkg/utils/test"
+
+	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
+	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
-	"github.com/sirupsen/logrus"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	gomegatypes "github.com/onsi/gomega/types"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	gomegatypes "github.com/onsi/gomega/types"
 )
 
 var _ = Describe("EtcdCopyBackupsTask", func() {
@@ -105,7 +105,7 @@ var _ = Describe("EtcdCopyBackupsTask", func() {
 		It("should create a new EtcdCopyBackupsTask with correct values", func() {
 			validator := &newEtcdCopyBackupsTaskValidator{
 				expectedClient: Equal(c),
-				expectedLogger: BeNil(),
+				expectedLogger: BeAssignableToTypeOf(logr.Logger{}),
 				expectedValues: Equal(&etcdcopybackupstask.Values{
 					Name:      botanist.Shoot.GetInfo().Name,
 					Namespace: botanist.Shoot.SeedNamespace,
@@ -248,13 +248,12 @@ type newEtcdCopyBackupsTaskValidator struct {
 }
 
 func (v *newEtcdCopyBackupsTaskValidator) NewEtcdCopyBackupsTask(
-	logger logrus.FieldLogger,
+	logger logr.Logger,
 	client client.Client,
 	values *etcdcopybackupstask.Values,
 	waitInterval time.Duration,
 	waitSevereThreshold time.Duration,
 	waitTimeout time.Duration,
-
 ) etcdcopybackupstask.Interface {
 	Expect(client).To(v.expectedClient)
 	Expect(logger).To(v.expectedLogger)

--- a/pkg/operation/botanist/kubeapiserverexposure_test.go
+++ b/pkg/operation/botanist/kubeapiserverexposure_test.go
@@ -20,16 +20,15 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	fakeclientset "github.com/gardener/gardener/pkg/client/kubernetes/fake"
 	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
-	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/operation"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/operation/garden"
 	"github.com/gardener/gardener/pkg/operation/shoot"
 
+	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -68,7 +67,7 @@ var _ = Describe("KubeAPIServerExposure", func() {
 					SeedNamespace: namespace,
 				},
 				Garden: &garden.Garden{},
-				Logger: logrus.NewEntry(logger.NewNopLogger()),
+				Logger: logr.Discard(),
 			},
 		}
 		botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{})

--- a/pkg/operation/botanist/kubecontrollermanager.go
+++ b/pkg/operation/botanist/kubecontrollermanager.go
@@ -48,7 +48,7 @@ func (b *Botanist) DefaultKubeControllerManager() (kubecontrollermanager.Interfa
 	}
 
 	return kubecontrollermanager.New(
-		b.Logger.WithField("component", "kube-controller-manager"),
+		b.Logger.WithValues("component", "kube-controller-manager"),
 		b.K8sSeedClient,
 		b.Shoot.SeedNamespace,
 		b.SecretsManager,

--- a/pkg/operation/botanist/kubecontrollermanager_test.go
+++ b/pkg/operation/botanist/kubecontrollermanager_test.go
@@ -20,7 +20,6 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	mockkubernetes "github.com/gardener/gardener/pkg/client/kubernetes/mock"
-	"github.com/gardener/gardener/pkg/logger"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	"github.com/gardener/gardener/pkg/operation"
 	. "github.com/gardener/gardener/pkg/operation/botanist"
@@ -30,6 +29,7 @@ import (
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
+	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -67,7 +67,7 @@ var _ = Describe("KubeControllerManager", func() {
 		BeforeEach(func() {
 			kubernetesClient.EXPECT().Version()
 
-			botanist.Logger = logger.NewFieldLogger(logger.NewNopLogger(), "", "")
+			botanist.Logger = logr.Discard()
 			botanist.K8sSeedClient = kubernetesClient
 			botanist.Shoot = &shootpkg.Shoot{
 				Networks: &shootpkg.Networks{},

--- a/pkg/operation/botanist/namespaces.go
+++ b/pkg/operation/botanist/namespaces.go
@@ -110,7 +110,7 @@ func (b *Botanist) WaitUntilSeedNamespaceDeleted(ctx context.Context) error {
 			}
 			return retry.SevereError(err)
 		}
-		b.Logger.Infof("Waiting until the namespace '%s' has been cleaned up and deleted in the Seed cluster...", b.Shoot.SeedNamespace)
+		b.Logger.Info("Waiting until the namespace has been cleaned up and deleted in the Seed cluster", "namespaceName", b.Shoot.SeedNamespace)
 		return retry.MinorError(fmt.Errorf("namespace %q is not yet cleaned up", b.Shoot.SeedNamespace))
 	})
 }

--- a/pkg/operation/botanist/secrets_test.go
+++ b/pkg/operation/botanist/secrets_test.go
@@ -22,7 +22,6 @@ import (
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	fakeclientset "github.com/gardener/gardener/pkg/client/kubernetes/fake"
-	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/operation"
 	. "github.com/gardener/gardener/pkg/operation/botanist"
 	mocketcd "github.com/gardener/gardener/pkg/operation/botanist/component/etcd/mock"
@@ -33,12 +32,12 @@ import (
 	fakesecretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager/fake"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 
+	"github.com/go-logr/logr"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 	gomegatypes "github.com/onsi/gomega/types"
-	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -92,7 +91,7 @@ var _ = Describe("Secrets", func() {
 
 		botanist = &Botanist{
 			Operation: &operation.Operation{
-				Logger:          logrus.NewEntry(logger.NewNopLogger()),
+				Logger:          logr.Discard(),
 				K8sGardenClient: fakeGardenInterface,
 				K8sSeedClient:   fakeSeedInterface,
 				K8sShootClient:  fakeShootInterface,

--- a/pkg/operation/care/garbage_collection.go
+++ b/pkg/operation/care/garbage_collection.go
@@ -66,12 +66,10 @@ func (g *GarbageCollection) Collect(ctx context.Context) {
 	go func() {
 		defer wg.Done()
 
-		log := g.log.WithValues("shoot", client.ObjectKeyFromObject(g.shoot.GetInfo()))
-
 		shootClient, apiServerRunning, err := g.initializeShootClients()
 		if err != nil || !apiServerRunning {
 			if err != nil {
-				log.Error(err, "Could not initialize Shoot client for garbage collection")
+				g.log.Error(err, "Could not initialize Shoot client for garbage collection")
 			}
 			return
 		}

--- a/pkg/operation/care/webhook_remediation.go
+++ b/pkg/operation/care/webhook_remediation.go
@@ -27,7 +27,7 @@ import (
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/flow"
 
-	"github.com/sirupsen/logrus"
+	"github.com/go-logr/logr"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -39,7 +39,7 @@ import (
 
 // WebhookRemediation contains required information for shoot webhook remediation.
 type WebhookRemediation struct {
-	logger                 logrus.FieldLogger
+	log                    logr.Logger
 	initializeShootClients ShootClientInit
 	shoot                  *gardencorev1beta1.Shoot
 	seedNamespace          string
@@ -48,7 +48,7 @@ type WebhookRemediation struct {
 // NewWebhookRemediation creates a new instance for webhook remediation.
 func NewWebhookRemediation(op *operation.Operation, shootClientInit ShootClientInit) *WebhookRemediation {
 	return &WebhookRemediation{
-		logger:                 op.Logger,
+		log:                    op.Logger,
 		initializeShootClients: shootClientInit,
 		shoot:                  op.Shoot.GetInfo(),
 		seedNamespace:          op.Shoot.SeedNamespace,
@@ -66,8 +66,8 @@ func (r *WebhookRemediation) Remediate(ctx context.Context) error {
 	}
 
 	var (
-		logger = r.logger.WithField("shoot", client.ObjectKeyFromObject(r.shoot))
-		fns    []flow.TaskFn
+		log = r.log.WithValues("shoot", client.ObjectKeyFromObject(r.shoot))
+		fns []flow.TaskFn
 
 		notExcluded   = utils.MustNewRequirement(v1beta1constants.LabelExcludeWebhookFromRemediation, selection.NotIn, "true")
 		labelSelector = client.MatchingLabelsSelector{Selector: labels.NewSelector().Add(notExcluded)}
@@ -91,7 +91,7 @@ func (r *WebhookRemediation) Remediate(ctx context.Context) error {
 		)
 
 		for i, w := range webhookConfig.Webhooks {
-			remediate := newRemediator(logger, "ValidatingWebhookConfiguration", webhookConfig.Name, w.Name, &remediations)
+			remediate := newRemediator(log, "ValidatingWebhookConfiguration", webhookConfig.Name, w.Name, &remediations)
 
 			if mustRemediateTimeoutSeconds(w.TimeoutSeconds) {
 				mustPatch = true
@@ -140,7 +140,7 @@ func (r *WebhookRemediation) Remediate(ctx context.Context) error {
 		)
 
 		for i, w := range webhookConfig.Webhooks {
-			remediate := newRemediator(logger, "MutatingWebhookConfiguration", webhookConfig.Name, w.Name, &remediations)
+			remediate := newRemediator(log, "MutatingWebhookConfiguration", webhookConfig.Name, w.Name, &remediations)
 
 			if mustRemediateTimeoutSeconds(w.TimeoutSeconds) {
 				mustPatch = true
@@ -207,20 +207,20 @@ func mustRemediateFailurePolicy(matchers []webhookmatchers.WebhookConstraintMatc
 }
 
 type remediator struct {
-	logger            logrus.FieldLogger
+	log               logr.Logger
 	webhookConfigKind string
 	webhookConfigName string
 	webhookName       string
 	remediations      *[]string
 }
 
-func newRemediator(logger logrus.FieldLogger, webhookConfigKind, webhookConfigName, webhookName string, remediations *[]string) remediator {
+func newRemediator(log logr.Logger, webhookConfigKind, webhookConfigName, webhookName string, remediations *[]string) remediator {
 	return remediator{
-		logger: logger.WithFields(logrus.Fields{
-			"kind":    webhookConfigKind,
-			"name":    webhookConfigName,
-			"webhook": webhookName,
-		}),
+		log: log.WithValues(
+			"kind", webhookConfigKind,
+			"name", webhookConfigName,
+			"webhook", webhookName,
+		),
 		webhookConfigKind: webhookConfigKind,
 		webhookConfigName: webhookConfigName,
 		webhookName:       webhookName,
@@ -264,7 +264,7 @@ func (r *remediator) failurePolicy() *admissionregistrationv1.FailurePolicyType 
 }
 
 func (r *remediator) reportf(fieldName string, messageFmt string, args ...interface{}) {
-	r.logger.Infof("Remediating %s", fieldName)
+	r.log.Info("Remediating", "fieldName", fieldName)
 	*r.remediations = append(*r.remediations, fmt.Sprintf("%s of webhook %q was %s", fieldName, r.webhookName, fmt.Sprintf(messageFmt, args...)))
 }
 

--- a/pkg/operation/care/webhook_remediation.go
+++ b/pkg/operation/care/webhook_remediation.go
@@ -66,7 +66,6 @@ func (r *WebhookRemediation) Remediate(ctx context.Context) error {
 	}
 
 	var (
-		log = r.log.WithValues("shoot", client.ObjectKeyFromObject(r.shoot))
 		fns []flow.TaskFn
 
 		notExcluded   = utils.MustNewRequirement(v1beta1constants.LabelExcludeWebhookFromRemediation, selection.NotIn, "true")
@@ -91,7 +90,7 @@ func (r *WebhookRemediation) Remediate(ctx context.Context) error {
 		)
 
 		for i, w := range webhookConfig.Webhooks {
-			remediate := newRemediator(log, "ValidatingWebhookConfiguration", webhookConfig.Name, w.Name, &remediations)
+			remediate := newRemediator(r.log, "ValidatingWebhookConfiguration", webhookConfig.Name, w.Name, &remediations)
 
 			if mustRemediateTimeoutSeconds(w.TimeoutSeconds) {
 				mustPatch = true
@@ -140,7 +139,7 @@ func (r *WebhookRemediation) Remediate(ctx context.Context) error {
 		)
 
 		for i, w := range webhookConfig.Webhooks {
-			remediate := newRemediator(log, "MutatingWebhookConfiguration", webhookConfig.Name, w.Name, &remediations)
+			remediate := newRemediator(r.log, "MutatingWebhookConfiguration", webhookConfig.Name, w.Name, &remediations)
 
 			if mustRemediateTimeoutSeconds(w.TimeoutSeconds) {
 				mustPatch = true

--- a/pkg/operation/care/webhook_remediation_test.go
+++ b/pkg/operation/care/webhook_remediation_test.go
@@ -20,13 +20,13 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	fakekubernetes "github.com/gardener/gardener/pkg/client/kubernetes/fake"
-	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/operation"
 	"github.com/gardener/gardener/pkg/operation/botanist/matchers"
 	. "github.com/gardener/gardener/pkg/operation/care"
 	shootpkg "github.com/gardener/gardener/pkg/operation/shoot"
 	"github.com/gardener/gardener/pkg/utils/test"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
@@ -62,7 +62,7 @@ var _ = Describe("WebhookRemediation", func() {
 		shoot = &gardencorev1beta1.Shoot{}
 		seedNamespace = "shoot--foo--bar"
 		op = &operation.Operation{
-			Logger: logger.NewNopLogger(),
+			Logger: logr.Discard(),
 			Shoot: &shootpkg.Shoot{
 				SeedNamespace: seedNamespace,
 			},

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -1022,7 +1022,7 @@ func runCreateSeedFlow(
 		})
 	)
 
-	if err := g.Compile().Run(ctx, flow.Opts{Logger: log}); err != nil {
+	if err := g.Compile().Run(ctx, flow.Opts{Log: log}); err != nil {
 		return flow.Errors(err)
 	}
 
@@ -1212,7 +1212,7 @@ func RunDeleteSeedFlow(
 		})
 	)
 
-	if err := g.Compile().Run(ctx, flow.Opts{Logger: log}); err != nil {
+	if err := g.Compile().Run(ctx, flow.Opts{Log: log}); err != nil {
 		return flow.Errors(err)
 	}
 

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -88,7 +88,6 @@ import (
 	"k8s.io/utils/clock"
 	"k8s.io/utils/pointer"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // NewBuilder returns a new Builder.
@@ -242,7 +241,7 @@ func RunReconcileSeedFlow(
 
 	secretsManager, err := secretsmanager.New(
 		ctx,
-		logf.Log.WithName("secretsmanager"),
+		log.WithName("secretsmanager"),
 		clock.RealClock{},
 		seedClient,
 		v1beta1constants.GardenNamespace,

--- a/pkg/operation/types.go
+++ b/pkg/operation/types.go
@@ -31,7 +31,7 @@ import (
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 
-	"github.com/sirupsen/logrus"
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -44,7 +44,7 @@ type Builder struct {
 	gardenClusterIdentityFunc func() (string, error)
 	imageVectorFunc           func() (imagevector.ImageVector, error)
 	exposureClassFunc         func(string) (*config.ExposureClassHandler, error)
-	loggerFunc                func() (logrus.FieldLogger, error)
+	loggerFunc                func() (logr.Logger, error)
 	secretsFunc               func() (map[string]*corev1.Secret, error)
 	seedFunc                  func(context.Context) (*seed.Seed, error)
 	shootFunc                 func(context.Context, client.Reader, *garden.Garden, *seed.Seed) (*shoot.Shoot, error)
@@ -60,7 +60,7 @@ type Operation struct {
 	shootStateMutex sync.Mutex
 
 	Config                *config.GardenletConfiguration
-	Logger                logrus.FieldLogger
+	Logger                logr.Logger
 	GardenerInfo          *gardencorev1beta1.Gardener
 	GardenClusterIdentity string
 	ImageVector           imagevector.ImageVector

--- a/pkg/utils/flow/flow.go
+++ b/pkg/utils/flow/flow.go
@@ -167,7 +167,7 @@ func newExecution(flow *Flow, opts Opts) *execution {
 	}
 
 	log := logf.Log.WithName("flow").WithValues(logKeyFlow, flow.name)
-	if opts.Log != (logr.Logger{}) {
+	if opts.Log.GetSink() != nil {
 		log = opts.Log.WithValues(logKeyFlow, flow.name)
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Migrate `gardenlet`'s `Shoot` controller to `logr`.

**Which issue(s) this PR fixes**:
Part of #4251

**Special notes for your reviewer(s):**
- ✅ ~~Depends on #6265, hence it's in draft state until this PR is merged.~~
- ✅ ~~Depends on #6278, hence it's in draft state until this PR is merged.~~

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
