### PR TITLE
Eliminate `causer` interface in favour of errors.Unwrap

### DIFF
--- a/pkg/utils/errors/errors.go
+++ b/pkg/utils/errors/errors.go
@@ -30,7 +30,7 @@ func (w *withSuppressed) Error() string {
 	return fmt.Sprintf("%s, suppressed: %s", w.cause.Error(), w.suppressed.Error())
 }
 
-func (w *withSuppressed) Cause() error {
+func (w *withSuppressed) Unwrap() error {
 	return w.cause
 }
 
@@ -38,7 +38,7 @@ func (w *withSuppressed) Format(s fmt.State, verb rune) {
 	switch verb {
 	case 'v':
 		if s.Flag('+') {
-			_, _ = fmt.Fprintf(s, "%+v\nsuppressed: %+v", w.Cause(), w.suppressed)
+			_, _ = fmt.Fprintf(s, "%+v\nsuppressed: %+v", w.Unwrap(), w.suppressed)
 			return
 		}
 		fallthrough
@@ -100,11 +100,6 @@ func (t *reconciliationError) ErrorID() string {
 
 func (t *reconciliationError) Unwrap() error {
 	return t.error
-}
-
-// Cause implements the causer interface and returns the underlying error
-func (t *reconciliationError) Cause() error {
-	return t.Unwrap()
 }
 
 // GetID returns the ID of the error if possible.

--- a/pkg/utils/errors/errors.go
+++ b/pkg/utils/errors/errors.go
@@ -82,7 +82,7 @@ func WithSuppressed(err, suppressed error) error {
 	}
 }
 
-// reconciliationError implements ErrorIDer and Causer
+// reconciliationError implements ErrorIDer
 type reconciliationError struct {
 	error
 	errorID string

--- a/pkg/utils/errors/unwrap.go
+++ b/pkg/utils/errors/unwrap.go
@@ -18,15 +18,15 @@ import "errors"
 
 // Unwrap unwraps and returns the root error. Multiple wrappings via `fmt.Errorf` implementations are properly taken into account.
 func Unwrap(err error) error {
-	var udone bool
+	var done bool
 
-	for !udone {
+	for !done {
 		if err == nil || errors.Unwrap(err) == nil {
 			// this most likely is the root error
-			udone = true
+			done = true
 		} else {
 			err = errors.Unwrap(err)
-			udone = false
+			done = false
 		}
 	}
 

--- a/pkg/utils/errors/unwrap.go
+++ b/pkg/utils/errors/unwrap.go
@@ -16,29 +16,17 @@ package errors
 
 import "errors"
 
-type causer interface {
-	Cause() error
-}
-
-// Unwrap unwraps and returns the root error. Multiple wrappings either via `fmt.Errorf` or via `causer` implementations are properly taken into account.
+// Unwrap unwraps and returns the root error. Multiple wrappings via `fmt.Errorf` implementations are properly taken into account.
 func Unwrap(err error) error {
-	var cdone, udone bool
+	var udone bool
 
-	for !(udone && cdone) {
+	for !udone {
 		if err == nil || errors.Unwrap(err) == nil {
 			// this most likely is the root error
 			udone = true
 		} else {
 			err = errors.Unwrap(err)
 			udone = false
-		}
-
-		if cause, ok := err.(causer); !ok {
-			// this most likely is the root cause error
-			cdone = true
-		} else {
-			err = cause.Cause()
-			cdone = false
 		}
 	}
 

--- a/pkg/utils/flow/flow.go
+++ b/pkg/utils/flow/flow.go
@@ -379,7 +379,7 @@ func (f *flowCanceled) Error() string {
 		f.name, f.cause, f.taskErrors)
 }
 
-func (f *flowCanceled) Cause() error {
+func (f *flowCanceled) Unwrap() error {
 	return f.cause
 }
 
@@ -387,7 +387,7 @@ func (f *flowFailed) Error() string {
 	return fmt.Sprintf("flow %q encountered task errors: %v", f.name, f.taskErrors)
 }
 
-func (f *flowFailed) Cause() error {
+func (f *flowFailed) Unwrap() error {
 	return &multierror.Error{Errors: f.taskErrors}
 }
 

--- a/pkg/utils/retry/retry.go
+++ b/pkg/utils/retry/retry.go
@@ -113,18 +113,13 @@ type Error struct {
 	err      error
 }
 
-// Cause implements Causer.
-func (e *Error) Cause() error {
+// Unwrap implements the Unwrap function
+// https://golang.org/pkg/errors/#Unwrap
+func (e *Error) Unwrap() error {
 	if e.err != nil {
 		return e.err
 	}
 	return e.ctxError
-}
-
-// Unwrap implements the Unwrap function
-// https://golang.org/pkg/errors/#Unwrap
-func (e *Error) Unwrap() error {
-	return e.err
 }
 
 // Error implements error.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind cleanup technical-debt

**What this PR does / why we need it**:
Eliminate caused interface and rather use Golang`s native error unwrapping. Ref : https://pkg.go.dev/errors
**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/6211

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
