### PR TITLE
Check workspace location in generator scripts

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -18,6 +18,14 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# Friendly reminder if workspace location is not in $GOPATH
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+if [ "${SCRIPT_DIR}" != "$(realpath $GOPATH)/src/github.com/gardener/gardener/hack" ]; then
+  echo "'hack/update-codegen.sh' script does not work correctly if your workspace is outside GOPATH"
+  echo "Please check https://github.com/gardener/gardener/blob/master/docs/development/local_setup.md#get-the-sources"
+  exit 1
+fi
+
 # We need to explicitly pass GO111MODULE=off to k8s.io/code-generator as it is significantly slower otherwise,
 # see https://github.com/kubernetes/code-generator/issues/100.
 export GO111MODULE=off

--- a/hack/update-protobuf.sh
+++ b/hack/update-protobuf.sh
@@ -18,6 +18,14 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# Friendly reminder if workspace location is not in $GOPATH
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+if [ "${SCRIPT_DIR}" != "$(realpath $GOPATH)/src/github.com/gardener/gardener/hack" ]; then
+  echo "'hack/update-protobuf.sh' script does not work correctly if your workspace is outside GOPATH"
+  echo "Please check https://github.com/gardener/gardener/blob/master/docs/development/local_setup.md#get-the-sources"
+  exit 1
+fi
+
 # We need to explicitly pass GO111MODULE=off to k8s.io/code-generator as it is significantly slower otherwise,
 # see https://github.com/kubernetes/code-generator/issues/100.
 export GO111MODULE=off


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
`hack/update-codegen.sh` and `hack/update-protobuf.sh` scripts do not work correctly if the workspace is outside $GOPATH as referenced [in documentation](https://github.com/gardener/gardener/blob/master/docs/development/local_setup.md#get-the-sources).
With this PR the scripts check their location before they start running. This could avoid confusing, because gardener uses modules and most dev tools are working outside $GOPATH too.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
