### PR TITLE
Do not allow containers in privileged mode for the apiserver-proxy PodSecurityPolicy

### DIFF
--- a/charts/shoot-core/components/charts/apiserver-proxy/templates/psp/apiserver-proxy-psp.yaml
+++ b/charts/shoot-core/components/charts/apiserver-proxy/templates/psp/apiserver-proxy-psp.yaml
@@ -6,7 +6,7 @@ metadata:
     gardener.cloud/role: system-component
     origin: gardener
 spec:
-  privileged: true
+  privileged: false
   volumes:
   - secret
   - configMap


### PR DESCRIPTION
/area security
/kind enhancement

**What this PR does / why we need it**:
There is no need to allow a container to run in privileged mode for the apiserver-proxy PodSecurityPolicy when there is no container currently in the apiserver-proxy DaemonSet that requires to run in privileged mode.

**Which issue(s) this PR fixes**:
Indirectly part of https://github.com/gardener-security/standard-compliance/issues/3

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
