### PR TITLE
Add pre/post reconciliation/deletion hooks for the Worker resource

### DIFF
--- a/extensions/pkg/controller/worker/genericactuator/actuator_delete.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_delete.go
@@ -48,6 +48,11 @@ func (a *genericActuator) Delete(ctx context.Context, worker *extensionsv1alpha1
 		return fmt.Errorf("could not instantiate actuator context: %w", err)
 	}
 
+	// Call pre deletion hook to prepare Worker deletion.
+	if err := workerDelegate.PreDeleteHook(ctx); err != nil {
+		return fmt.Errorf("pre worker deletion hook failed: %w", err)
+	}
+
 	// Make sure machine-controller-manager is awake before deleting the machines.
 	var replicaFunc = func() int32 {
 		return 1
@@ -122,8 +127,14 @@ func (a *genericActuator) Delete(ctx context.Context, worker *extensionsv1alpha1
 	}
 
 	// Cleanup machine dependencies.
+	// TODO(dkistner) DEPRECATED: Remove in a future release.
 	if err := workerDelegate.CleanupMachineDependencies(ctx); err != nil {
 		return fmt.Errorf("failed to cleanup machine dependencies: %w", err)
+	}
+
+	// Call post deletion hook after Worker deletion has happened.
+	if err := workerDelegate.PostDeleteHook(ctx); err != nil {
+		return fmt.Errorf("post worker deletion hook failed: %w", err)
 	}
 
 	return nil

--- a/extensions/pkg/controller/worker/genericactuator/actuator_delete.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_delete.go
@@ -127,7 +127,7 @@ func (a *genericActuator) Delete(ctx context.Context, worker *extensionsv1alpha1
 	}
 
 	// Cleanup machine dependencies.
-	// TODO(dkistner) DEPRECATED: Remove in a future release.
+	// TODO(dkistner): Remove in a future release.
 	if err := workerDelegate.CleanupMachineDependencies(ctx); err != nil {
 		return fmt.Errorf("failed to cleanup machine dependencies: %w", err)
 	}

--- a/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
@@ -50,6 +50,11 @@ func (a *genericActuator) Reconcile(ctx context.Context, worker *extensionsv1alp
 		return fmt.Errorf("could not instantiate actuator context: %w", err)
 	}
 
+	// Call pre reconcilation hook to prepare Worker reconciliation.
+	if err := workerDelegate.PreReconcileHook(ctx); err != nil {
+		return fmt.Errorf("pre worker reconciliation hook failed: %w", err)
+	}
+
 	// mcmReplicaFunc returns the desired replicas for machine controller manager
 	var mcmReplicaFunc = func() int32 {
 		switch {
@@ -69,6 +74,7 @@ func (a *genericActuator) Reconcile(ctx context.Context, worker *extensionsv1alp
 	}
 
 	// Deploy machine dependencies.
+	// TODO(dkistner) DEPRECATED: Remove in a future release.
 	if err := workerDelegate.DeployMachineDependencies(ctx); err != nil {
 		return fmt.Errorf("failed to deploy machine dependencies: %w", err)
 	}
@@ -212,8 +218,14 @@ func (a *genericActuator) Reconcile(ctx context.Context, worker *extensionsv1alp
 	}
 
 	// Cleanup machine dependencies.
+	// TODO(dkistner) DEPRECATED: Remove in a future release.
 	if err := workerDelegate.CleanupMachineDependencies(ctx); err != nil {
 		return fmt.Errorf("failed to cleanup machine dependencies: %w", err)
+	}
+
+	// Call post reconcilation hook after Worker reconciliation has happened.
+	if err := workerDelegate.PostReconcileHook(ctx); err != nil {
+		return fmt.Errorf("post worker reconciliation hook failed: %w", err)
 	}
 
 	return nil

--- a/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
+++ b/extensions/pkg/controller/worker/genericactuator/actuator_reconcile.go
@@ -74,7 +74,7 @@ func (a *genericActuator) Reconcile(ctx context.Context, worker *extensionsv1alp
 	}
 
 	// Deploy machine dependencies.
-	// TODO(dkistner) DEPRECATED: Remove in a future release.
+	// TODO(dkistner): Remove in a future release.
 	if err := workerDelegate.DeployMachineDependencies(ctx); err != nil {
 		return fmt.Errorf("failed to deploy machine dependencies: %w", err)
 	}
@@ -218,7 +218,7 @@ func (a *genericActuator) Reconcile(ctx context.Context, worker *extensionsv1alp
 	}
 
 	// Cleanup machine dependencies.
-	// TODO(dkistner) DEPRECATED: Remove in a future release.
+	// TODO(dkistner): Remove in a future release.
 	if err := workerDelegate.CleanupMachineDependencies(ctx); err != nil {
 		return fmt.Errorf("failed to cleanup machine dependencies: %w", err)
 	}

--- a/extensions/pkg/controller/worker/genericactuator/interface.go
+++ b/extensions/pkg/controller/worker/genericactuator/interface.go
@@ -52,13 +52,13 @@ type WorkerDelegate interface {
 	UpdateMachineImagesStatus(context.Context) error
 
 	// DeployMachineDependencies is a hook to create external machine dependencies.
-	// DEPRECATED: Use PreReconcileHook() instead.
-	// TODO(dkistner) Remove in future release.
+	// Deprecated: Use PreReconcileHook() instead.
+	// TODO(dkistner): Remove in a future release.
 	DeployMachineDependencies(context.Context) error
 
 	// CleanupMachineDependencies is a hook to cleanup external machine dependencies.
-	// DEPRECATED: Use PostReconcileHook() and PostDeleteHook() instead.
-	// TODO(dkistner) Remove in future release.
+	// Deprecated: Use PostReconcileHook() and PostDeleteHook() instead.
+	// TODO(dkistner): Remove in a future release.
 	CleanupMachineDependencies(context.Context) error
 
 	// PreReconcileHook is a hook called at the beginning of the worker reconciliation flow.

--- a/extensions/pkg/controller/worker/genericactuator/interface.go
+++ b/extensions/pkg/controller/worker/genericactuator/interface.go
@@ -52,10 +52,23 @@ type WorkerDelegate interface {
 	UpdateMachineImagesStatus(context.Context) error
 
 	// DeployMachineDependencies is a hook to create external machine dependencies.
+	// DEPRECATED: Use PreReconcileHook() instead.
+	// TODO(dkistner) Remove in future release.
 	DeployMachineDependencies(context.Context) error
 
 	// CleanupMachineDependencies is a hook to cleanup external machine dependencies.
+	// DEPRECATED: Use PostReconcileHook() and PostDeleteHook() instead.
+	// TODO(dkistner) Remove in future release.
 	CleanupMachineDependencies(context.Context) error
+
+	// PreReconcileHook is a hook called at the beginning of the worker reconciliation flow.
+	PreReconcileHook(context.Context) error
+	// PostReconcileHook is a hook called at the end of the worker reconciliation flow.
+	PostReconcileHook(context.Context) error
+	// PreDeleteHook is a hook called at the beginning of the worker deletion flow.
+	PreDeleteHook(context.Context) error
+	// PostDeleteHook is a hook called at the end of the worker deletion flow.
+	PostDeleteHook(context.Context) error
 }
 
 // WorkerCredentialsDelegate is an interface that can optionally be implemented to be

--- a/pkg/provider-local/controller/worker/machines.go
+++ b/pkg/provider-local/controller/worker/machines.go
@@ -132,6 +132,13 @@ func (w *workerDelegate) generateMachineConfig() error {
 	return nil
 }
 
+// TODO(dkistner): DEPRECATED: Remove in future release.
 func (w *workerDelegate) DeployMachineDependencies(_ context.Context) error { return nil }
 
+// TODO(dkistner): DEPRECATED: Remove in future release.
 func (w *workerDelegate) CleanupMachineDependencies(_ context.Context) error { return nil }
+
+func (w *workerDelegate) PreReconcileHook(_ context.Context) error  { return nil }
+func (w *workerDelegate) PostReconcileHook(_ context.Context) error { return nil }
+func (w *workerDelegate) PreDeleteHook(_ context.Context) error     { return nil }
+func (w *workerDelegate) PostDeleteHook(_ context.Context) error    { return nil }

--- a/pkg/provider-local/controller/worker/machines.go
+++ b/pkg/provider-local/controller/worker/machines.go
@@ -132,10 +132,10 @@ func (w *workerDelegate) generateMachineConfig() error {
 	return nil
 }
 
-// TODO(dkistner): DEPRECATED: Remove in future release.
+// TODO(dkistner): Remove in a future release.
 func (w *workerDelegate) DeployMachineDependencies(_ context.Context) error { return nil }
 
-// TODO(dkistner): DEPRECATED: Remove in future release.
+// TODO(dkistner): Remove in a future release.
 func (w *workerDelegate) CleanupMachineDependencies(_ context.Context) error { return nil }
 
 func (w *workerDelegate) PreReconcileHook(_ context.Context) error  { return nil }


### PR DESCRIPTION
**How to categorize this PR?**
/kind enhancement

**What this PR does / why we need it**:
Extending the extension library to allow the extension worker controllers to run preparation and clean up steps before and after a worker reconciliation/deletion operation starts/ends.

- Reconciliation operation:
   - `PreReconcileHook(context.Context) error`
   - `PostReconcileHook(context.Context) error`
- Deletion operation:
  - `PreDeleteHook(context.Context) error`
  - `PostDeleteHook(context.Context) error`

Deprecation note: The functions `DeployMachineDependencies()` and `CleanupMachineDependencies()` are now deprecated. Extensions can use corresponding pre/post hook functions instead.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking dependency
Gardener extensions which contain a worker controller need to implement functions: `PreReconcileHook`, `PostReconcileHook`, `PreDeleteHook`, `PostDeleteHook`. The functions `DeployMachineDependencies` and `CleanupMachineDependencies` are now deprecated and will be removed in a future release. The logic of those deprecated functions can be moved to the respective pre/post hook functions.
```

/invite @kon-angelo 