### PR TITLE
Deploy the metrics server to the kind cluster (local development setup)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -273,6 +273,7 @@ endif
 	docker exec gardener-local$(TARGET_SUFFIX)-control-plane sh -c "sysctl fs.inotify.max_user_instances=8192" # workaround https://kind.sigs.k8s.io/docs/user/known-issues/#pod-errors-due-to-too-many-open-files
 	cp $(KUBECONFIG) $(REPO_ROOT)/example/provider-local/seed-kind$(TARGET_SUFFIX)/base/kubeconfig
 	kubectl apply -k $(REPO_ROOT)/example/gardener-local/calico --server-side
+	kubectl apply -k $(REPO_ROOT)/example/gardener-local/metrics-server --server-side
 
 kind-down kind2-down: $(KIND)
 	$(KIND) delete cluster --name gardener-local$(TARGET_SUFFIX)

--- a/example/gardener-local/metrics-server/kustomization.yaml
+++ b/example/gardener-local/metrics-server/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+- https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.6.1/components.yaml
+
+patches:
+- path: metrics-deployment_patch.json
+  target:
+    group: apps
+    version: v1
+    kind: Deployment
+    name: metrics-server

--- a/example/gardener-local/metrics-server/metrics-deployment_patch.json
+++ b/example/gardener-local/metrics-server/metrics-deployment_patch.json
@@ -1,0 +1,7 @@
+[
+  {
+    "op": "add",
+    "path": "/spec/template/spec/containers/0/args/-",
+    "value": "--kubelet-insecure-tls"
+  }
+]


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

Deploy the metrics server to the kind cluster

This allows one to use `k top pods` and lets the vpa recommender
calculate recommendations.

See https://github.com/kubernetes-sigs/kind/issues/398

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
