### PR TITLE
Differentiate the vpa metrics for the seed and control planes

### DIFF
--- a/charts/seed-bootstrap/prometheus-rules/recording-rules.rules.yaml
+++ b/charts/seed-bootstrap/prometheus-rules/recording-rules.rules.yaml
@@ -288,7 +288,7 @@ groups:
 
   # Recording rules for the sum of vpa recommendations for the entire seed
   - record: seed:vpa_status_recommendation_target:sum
-    expr: sum(vpa_status_recommendation{recommendation="target"})  by (resource)
+    expr: sum(vpa_status_recommendation{recommendation="target"}) by (resource)
 
   # Recording rules for the sum of hvpa applied recommendations for the entire seed
   - record: seed:hvpa_status_applied_vpa_recommendation_target:sum
@@ -421,11 +421,11 @@ groups:
     expr: sum(kube_pod_container_resource_limits{resource="memory", unit="byte", namespace=~"((shoot-|shoot--)(\\w.+))"})
 
   # Recording rules for the sum of vpa recommendations for all the control-planes
-  - record: seed:vpa_status_recommendation_target:sum
+  - record: seed:vpa_status_recommendation_target:sum_cp
     expr: sum(vpa_status_recommendation{recommendation="target", namespace=~"((shoot-|shoot--)(\\w.+))"}) by (resource)
 
   # Recording rules for the sum of hvpa applied recommendations for all the control-planes
-  - record: seed:hvpa_status_applied_vpa_recommendation_target:sum
+  - record: seed:hvpa_status_applied_vpa_recommendation_target:sum_cp
     expr: sum(hvpa_status_applied_vpa_recommendation{recommendation="target", namespace=~"((shoot-|shoot--)(\\w.+))"}) by (resource)
 
   # Recording rules for pod count for all the control-planes


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
Differentiate the vpa metrics for the seed and control planes

Previously, the 2 recording rules had the same name:
  `seed:hvpa_status_applied_vpa_recommendation_target:sum`
and caused a conflict because the resulting
time series had the same name and labels.

Now they are differentiated by the name suffix.

There were 2 other recording rules with the same name:
  `record: seed:hvpa_status_applied_vpa_recommendation_target:sum`
and the control plane version is similarly renamed now.

See #1863

**Which issue(s) this PR fixes**:
Fixes #6268

**Special notes for your reviewer**:

/cc @wyb1 @rickardsjp 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Differentiate the vpa metrics for the seed and control planes to avoid conflicts in prometheus when the recording rules are evaluated.
```
