### PR TITLE
Update the supported values in the usage text of the `--leader-election-resource-lock` flag

### DIFF
--- a/extensions/pkg/controller/cmd/options.go
+++ b/extensions/pkg/controller/cmd/options.go
@@ -202,7 +202,7 @@ func (m *ManagerOptions) AddFlags(fs *pflag.FlagSet) {
 
 	fs.BoolVar(&m.LeaderElection, LeaderElectionFlag, m.LeaderElection, "Whether to use leader election or not when running this controller manager.")
 	fs.StringVar(&m.LeaderElectionResourceLock, LeaderElectionResourceLockFlag, defaultLeaderElectionResourceLock, "Which resource type to use for leader election. "+
-		"Supported options are 'endpoints', 'configmaps', 'leases', 'endpointsleases' and 'configmapsleases'.")
+		"Supported options are 'leases', 'endpointsleases' and 'configmapsleases'.")
 	fs.StringVar(&m.LeaderElectionID, LeaderElectionIDFlag, m.LeaderElectionID, "The leader election id to use.")
 	fs.StringVar(&m.LeaderElectionNamespace, LeaderElectionNamespaceFlag, m.LeaderElectionNamespace, "The namespace to do leader election in.")
 	fs.StringVar(&m.WebhookServerHost, WebhookServerHostFlag, m.WebhookServerHost, "The webhook server host.")

--- a/pkg/resourcemanager/cmd/manager.go
+++ b/pkg/resourcemanager/cmd/manager.go
@@ -66,7 +66,7 @@ type ManagerConfig struct {
 func (o *ManagerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&o.leaderElection, "leader-election", true, "enable or disable leader election")
 	fs.StringVar(&o.leaderElectionResourceLock, "leader-election-resource-lock", resourcelock.LeasesResourceLock, "Which resource type to use for leader election. "+
-		"Supported options are 'endpoints', 'configmaps', 'leases', 'endpointsleases' and 'configmapsleases'.")
+		"Supported options are 'leases', 'endpointsleases' and 'configmapsleases'.")
 	fs.StringVar(&o.leaderElectionNamespace, "leader-election-namespace", "", "namespace for leader election")
 	fs.DurationVar(&o.leaderElectionLeaseDuration, "leader-election-lease-duration", 15*time.Second, "lease duration for leader election")
 	fs.DurationVar(&o.leaderElectionRenewDeadline, "leader-election-renew-deadline", 10*time.Second, "renew deadline for leader election")


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:
After https://github.com/gardener/gardener/pull/6101 (with K8s dependencies >= 1.24) it is no longer supported to specify `endpoints` or `configmaps` as leader election resource lock (ref https://github.com/kubernetes/kubernetes/pull/106852).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
