### PR TITLE
Revert "Recreate DWD deployment if needed"

### DIFF
--- a/pkg/operation/botanist/component/dependencywatchdog/bootstrap.go
+++ b/pkg/operation/botanist/component/dependencywatchdog/bootstrap.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/resourcemanager/controller/garbagecollector/references"
@@ -202,8 +201,6 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 				Name:      b.name(),
 				Namespace: b.namespace,
 				Labels:    b.getLabels(),
-				// TODO(rfranzke): Remove this in a future version. Needed due to https://github.com/gardener/gardener/issues/5973
-				Annotations: map[string]string{resourcesv1alpha1.DeleteOnInvalidUpdate: "true"},
 			},
 			Spec: appsv1.DeploymentSpec{
 				Replicas:             pointer.Int32(1),

--- a/pkg/operation/botanist/component/dependencywatchdog/bootstrap_test.go
+++ b/pkg/operation/botanist/component/dependencywatchdog/bootstrap_test.go
@@ -257,7 +257,6 @@ kind: Deployment
 metadata:
   annotations:
     ` + references.AnnotationKey(references.KindConfigMap, configMapName) + `: ` + configMapName + `
-    resources.gardener.cloud/delete-on-invalid-update: "true"
   creationTimestamp: null
   labels:
     app: ` + dwdName + `


### PR DESCRIPTION
/kind cleanup

**What this PR does / why we need it**:
Back then https://github.com/gardener/gardener/pull/5975 was introduced to tackle https://github.com/gardener/gardener/issues/5973. We should be good to clean up this as several minor releases already passed.

This reverts commit 64869baf1aa7cca708dcb174ba59b2549ecad216.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
