### PR TITLE
Add `skip-health-check` annotation for managed resources

### DIFF
--- a/docs/concepts/resource-manager.md
+++ b/docs/concepts/resource-manager.md
@@ -119,6 +119,10 @@ The gardener-resource-manager can manage a resource in different modes. The supp
 
 The mode for a resource can be specified with the `resources.gardener.cloud/mode` annotation. The annotation should be specified in the encoded resource manifest in the Secret that is referenced by the ManagedResource.
 
+#### Skipping health check
+
+If a resource in the ManagedResource is annotated with `resources.gardener.cloud/skip-health-check=true` then the resource will be skipped during health checks by the health controller. The ManagedResource conditions will not reflect the health condition of this resource anymore. The `ResourcesProgressing` condition will also be set to `False`.
+
 #### Resource Class
 
 By default, gardener-resource-manager controller watches for ManagedResources in all namespaces. `--namespace` flag can be specified to gardener-resource-manager binary to restrict the watch to ManagedResources in a single namespace.

--- a/pkg/apis/resources/v1alpha1/types.go
+++ b/pkg/apis/resources/v1alpha1/types.go
@@ -25,6 +25,8 @@ const (
 	// Ignore is an annotation that dictates whether a resources should be ignored during
 	// reconciliation.
 	Ignore = "resources.gardener.cloud/ignore"
+	// SkipHealthCheck is an annotation that dictates whether a resource should be ignored during health check.
+	SkipHealthCheck = "resources.gardener.cloud/skip-health-check"
 	// DeleteOnInvalidUpdate is a constant for an annotation on a resource managed by a ManagedResource. If set to
 	// true then the controller will delete the object in case it faces an "Invalid" response during an update operation.
 	DeleteOnInvalidUpdate = "resources.gardener.cloud/delete-on-invalid-update"

--- a/pkg/operation/botanist/component/seedsystem/seedsystem.go
+++ b/pkg/operation/botanist/component/seedsystem/seedsystem.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
@@ -123,6 +124,9 @@ func (s *seedSystem) addReserveExcessCapacityDeployment(registry *managedresourc
 			Name:      "reserve-excess-capacity",
 			Namespace: s.namespace,
 			Labels:    getExcessCapacityReservationLabels(),
+			Annotations: map[string]string{
+				resourcesv1alpha1.SkipHealthCheck: "true",
+			},
 		},
 		Spec: appsv1.DeploymentSpec{
 			RevisionHistoryLimit: pointer.Int32(2),

--- a/pkg/operation/botanist/component/seedsystem/seedsystem_test.go
+++ b/pkg/operation/botanist/component/seedsystem/seedsystem_test.go
@@ -55,6 +55,8 @@ var _ = Describe("SeedSystem", func() {
 		deploymentYAML = `apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    resources.gardener.cloud/skip-health-check: "true"
   creationTimestamp: null
   labels:
     app: kubernetes

--- a/pkg/resourcemanager/controller/health/health_checker.go
+++ b/pkg/resourcemanager/controller/health/health_checker.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -59,6 +60,10 @@ func CheckHealth(ctx context.Context, c client.Client, obj client.Object) (bool,
 			return false, nil
 		}
 		return false, fmt.Errorf("failed to determine GVK of object: %w", err)
+	}
+
+	if obj.GetAnnotations()[resourcesv1alpha1.SkipHealthCheck] == "true" {
+		return false, nil
 	}
 
 	// Note: we can't do client-side conversions from one version to another, because conversion code is not exported

--- a/pkg/resourcemanager/controller/health/health_checker.go
+++ b/pkg/resourcemanager/controller/health/health_checker.go
@@ -18,21 +18,20 @@ import (
 	"context"
 	"fmt"
 
-	apiextensionsinstall "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/install"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
-
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	apiextensionsinstall "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/install"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
 
 // healthCheckScheme is a dedicated healthCheckScheme for CheckHealth which contains all API types, that can be checked

--- a/pkg/resourcemanager/controller/health/progressing_reconciler.go
+++ b/pkg/resourcemanager/controller/health/progressing_reconciler.go
@@ -171,6 +171,10 @@ func (r *progressingReconciler) reconcile(ctx context.Context, log logr.Logger, 
 // CheckProgressing checks whether the given object is progressing. It returns a bool indicating whether the object is
 // progressing, a reason for it if so and an error if the check failed.
 func CheckProgressing(obj client.Object) (bool, string) {
+	if obj.GetAnnotations()[resourcesv1alpha1.SkipHealthCheck] == "true" {
+		return false, ""
+	}
+
 	switch o := obj.(type) {
 	case *appsv1.Deployment:
 		return health.IsDeploymentProgressing(o)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability 
/kind enhancement

**What this PR does / why we need it**:
This PR introduces an annotation `resources.gardener.cloud/skip-health-check`. If this annotation is set to true, then `resource-manager` will skip health check for this resource, and `ResourcesHealthy` for the MR would be `True` even if this resource is unhealthy. Also the `ResourcesProgressing` condition will be set to `False` even if the resource hasn't been fully rolled out yet (In case of statefulsets, deployments and daemonsets).

This annotation has been set to true for `reserve-excess-capacity` deployment by default, so that the seed can get `Ready` even if this pod is stuck in pending.

**Which issue(s) this PR fixes**:
Fixes #6275 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
If a resource in the `ManagedResource` is annotated with `resources.gardener.cloud/skip-health-check=true` then the resource will be skipped during health checks by the health controller. The ManagedResource conditions will not reflect the health condition of this resource anymore. The `ResourcesProgressing` condition will also be set to `False`.
```
