### PR TITLE
Update gardenlet's base image to alpine:3.16.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ARG EFFECTIVE_VERSION
 RUN make install EFFECTIVE_VERSION=$EFFECTIVE_VERSION
 
 ############# base
-FROM alpine:3.15.4 AS base
+FROM alpine:3.16.0 AS base
 
 ############# distroless-static
 FROM gcr.io/distroless/static-debian11:nonroot as distroless-static

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,5 +1,5 @@
 ############# base
-FROM alpine:3.15.4 AS base
+FROM alpine:3.16.0 AS base
 
 # Define GOTRACEBACK to mark this container as using the Go language runtime
 # for `skaffold debug` (https://skaffold.dev/docs/workflows/debug/).


### PR DESCRIPTION
/area security
/kind enhancement

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
gardenlet's base image is updated from `alpine:3.15.4` to `alpine:3.16.0`.
```
