### PR TITLE
Bump up logging images

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -220,11 +220,11 @@ images:
 - name: fluent-bit
   sourceRepository: github.com/fluent/fluent-bit
   repository: fluent/fluent-bit
-  tag: "1.9.3"
+  tag: "1.9.6"
 - name: fluent-bit-plugin-installer
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/fluent-bit-to-loki
-  tag: "v0.40.0"
+  tag: "v0.41.0"
 - name: loki
   sourceRepository: github.com/grafana/loki
   repository: grafana/loki
@@ -232,11 +232,11 @@ images:
 - name: loki-curator
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/loki-curator
-  tag: "v0.40.0"
+  tag: "v0.41.0"
 - name: kube-rbac-proxy
   sourceRepository: github.com/brancz/kube-rbac-proxy
   repository: quay.io/brancz/kube-rbac-proxy
-  tag: v0.12.0
+  tag: v0.13.0
 - name: promtail
   sourceRepository: github.com/grafana/loki
   repository: "docker.io/grafana/promtail"
@@ -244,7 +244,7 @@ images:
 - name: telegraf
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/telegraf-iptables
-  tag: "v0.40.0"
+  tag: "v0.41.0"
 
 # VPA
 - name: vpa-admission-controller


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
This PR bump ups following logging container images:
1. fluent-bit                     1.9.3 -> 1.9.6
2. fluent-bit-to-loki        v0.40.0 -> v0.41.0
3. loki-curator                v0.40.0 -> v0.41.0
4. kube-rbac-proxy       v0.12.0 -> v0.13.0
5. telegraf                       v0.40.0 -> v0.41.0


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other  operator
The following images are updated:
- `fluent/fluent-bit`: `1.9.3` -> `1.9.6`
- `eu.gcr.io/gardener-project/gardener/fluent-bit-to-loki`: `v0.40.0` -> `v0.41.1`
- `eu.gcr.io/gardener-project/gardener/loki-curator`: `v0.40.0` -> `v0.41.0`
- `quay.io/brancz/kube-rbac-proxy`: `v0.12.0` -> `v0.13.0`
- `eu.gcr.io/gardener-project/gardener/telegraf-iptables`: `v0.40.0` -> `v0.41.0`
```