### PR TITLE
Improve default machine image selection for worker pool having machine of CPU architecture `arm64`

### DIFF
--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -623,11 +623,11 @@ func (c *validationContext) validateProvider(a admission.Attributes) field.Error
 
 		idxPath := path.Child("workers").Index(i)
 		if ok, validMachineTypes := validateMachineTypes(c.cloudProfile.Spec.MachineTypes, worker.Machine, oldWorker.Machine, c.cloudProfile.Spec.Regions, c.shoot.Spec.Region, worker.Zones); !ok {
-			detail := fmt.Sprintf("machine type '%s' does not support CPU architecture '%s', supported machine types of CPU architecture '%s' are: %+v", worker.Machine.Type, *worker.Machine.Architecture, *worker.Machine.Architecture, validMachineTypes)
+			detail := fmt.Sprintf("machine type '%s' does not support CPU architecture '%s' or is unavailable in at least one zone, supported machine types are: %+v", worker.Machine.Type, *worker.Machine.Architecture, validMachineTypes)
 			allErrs = append(allErrs, field.Invalid(idxPath.Child("machine", "type"), worker.Machine.Type, detail))
 		}
 		if ok, validMachineImages := validateMachineImagesConstraints(c.cloudProfile.Spec.MachineImages, worker.Machine, oldWorker.Machine); !ok {
-			detail := fmt.Sprintf("machine image '%s' does not support CPU architecture '%s', valid machine images that supports CPU architecture '%s' are: %+v", worker.Machine.Image, *worker.Machine.Architecture, *worker.Machine.Architecture, validMachineImages)
+			detail := fmt.Sprintf("machine image '%s' does not support CPU architecture '%s' or is expired, valid machine images are: %+v", worker.Machine.Image, *worker.Machine.Architecture, validMachineImages)
 			allErrs = append(allErrs, field.Invalid(idxPath.Child("machine", "image"), worker.Machine.Image, detail))
 		} else {
 			allErrs = append(allErrs, validateContainerRuntimeConstraints(c.cloudProfile.Spec.MachineImages, worker, oldWorker, idxPath.Child("cri"))...)
@@ -1117,8 +1117,8 @@ func getDefaultMachineImage(machineImages []core.MachineImage, imageName string,
 	} else {
 		//select the first image which support the required architecture type
 		for _, machineImage := range machineImages {
-			for _, verison := range machineImage.Versions {
-				if slices.Contains(verison.Architectures, *arch) {
+			for _, version := range machineImage.Versions {
+				if slices.Contains(version.Architectures, *arch) {
 					defaultImage = &machineImage
 					break
 				}
@@ -1128,7 +1128,7 @@ func getDefaultMachineImage(machineImages []core.MachineImage, imageName string,
 			}
 		}
 		if defaultImage == nil {
-			return nil, fmt.Errorf("image name %q is not supported", imageName)
+			return nil, fmt.Errorf("no valid machine image found that support architecture `%s`", *arch)
 		}
 	}
 

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -1640,9 +1640,7 @@ var _ = Describe("validator", func() {
 
 					attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 
-					err := admissionHandler.Admit(context.TODO(), attrs, nil)
-
-					Expect(err).ToNot(HaveOccurred())
+					Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
 				})
 
 				It("should allow creation of Shoot if both global and worker kubeletConfigs are nil", func() {
@@ -1651,9 +1649,7 @@ var _ = Describe("validator", func() {
 
 					attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 
-					err := admissionHandler.Admit(context.TODO(), attrs, nil)
-
-					Expect(err).ToNot(HaveOccurred())
+					Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
 				})
 
 				It("should not allow creation of Shoot if reserved CPU in the global kubeletConfig is more than CPU capacity and worker kubeletConfig is nil", func() {
@@ -1681,9 +1677,7 @@ var _ = Describe("validator", func() {
 
 					attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 
-					err := admissionHandler.Admit(context.TODO(), attrs, nil)
-
-					Expect(err).ToNot(HaveOccurred())
+					Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
 				})
 
 				It("should not allow creation of Shoot if reserved CPU in the global kubeletConfig is less than CPU capacity but the worker kubeletConfig has more reserved CPU", func() {
@@ -1774,9 +1768,7 @@ var _ = Describe("validator", func() {
 
 					attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 
-					err := admissionHandler.Admit(context.TODO(), attrs, nil)
-
-					Expect(err).ToNot(HaveOccurred())
+					Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
 				})
 
 				It("should not allow creation of Shoot if reserved memory in the global kubeletConfig is less than memory capacity but the worker kubeletConfig has more reserved memory", func() {
@@ -2060,9 +2052,7 @@ var _ = Describe("validator", func() {
 						Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 						attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 
-						err := admissionHandler.Admit(context.TODO(), attrs, nil)
-
-						Expect(err).NotTo(HaveOccurred())
+						Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
 						Expect(shoot.Spec.Provider.Workers[0].Machine.Image).To(Equal(&core.ShootMachineImage{
 							Name:    imageName1,
 							Version: latestNonExpiredVersion,
@@ -2086,9 +2076,7 @@ var _ = Describe("validator", func() {
 						Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 						attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 
-						err := admissionHandler.Admit(context.TODO(), attrs, nil)
-
-						Expect(err).NotTo(HaveOccurred())
+						Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
 						Expect(shoot.Spec.Provider.Workers[0].Machine.Image).To(Equal(&core.ShootMachineImage{
 							Name:    imageName1,
 							Version: latestNonExpiredVersion,
@@ -2152,9 +2140,7 @@ var _ = Describe("validator", func() {
 						Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 						attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 
-						err := admissionHandler.Admit(context.TODO(), attrs, nil)
-
-						Expect(err).NotTo(HaveOccurred())
+						Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
 					})
 
 					It("should reject unsupported CRI", func() {
@@ -2390,9 +2376,7 @@ var _ = Describe("validator", func() {
 						Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 						attrs := admission.NewAttributesRecord(newShoot, &shoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
 
-						err := admissionHandler.Admit(context.TODO(), attrs, nil)
-
-						Expect(err).NotTo(HaveOccurred())
+						Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
 						Expect(*newShoot).To(Equal(shoot))
 					})
 
@@ -2407,9 +2391,7 @@ var _ = Describe("validator", func() {
 						Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 						attrs := admission.NewAttributesRecord(newShoot, &shoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
 
-						err := admissionHandler.Admit(context.TODO(), attrs, nil)
-
-						Expect(err).NotTo(HaveOccurred())
+						Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
 						Expect(*newShoot).To(Equal(shoot))
 					})
 
@@ -2425,9 +2407,7 @@ var _ = Describe("validator", func() {
 						Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 						attrs := admission.NewAttributesRecord(newShoot, &shoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
 
-						err := admissionHandler.Admit(context.TODO(), attrs, nil)
-
-						Expect(err).NotTo(HaveOccurred())
+						Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
 						Expect(newShoot.Spec.Provider.Workers[0].Machine.Image).To(Equal(&core.ShootMachineImage{
 							Name:    imageName1,
 							Version: nonExpiredVersion2,
@@ -2451,9 +2431,7 @@ var _ = Describe("validator", func() {
 						Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 						attrs := admission.NewAttributesRecord(newShoot, &shoot, core.Kind("Shoot").WithVersion("version"), newShoot.Namespace, newShoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.CreateOptions{}, false, nil)
 
-						err := admissionHandler.Admit(context.TODO(), attrs, nil)
-
-						Expect(err).NotTo(HaveOccurred())
+						Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
 						Expect(newShoot.Spec.Provider.Workers[0]).To(Equal(shoot.Spec.Provider.Workers[0]))
 						Expect(newShoot.Spec.Provider.Workers[1].Machine.Image).To(Equal(&core.ShootMachineImage{
 							Name:    imageName1,
@@ -2486,9 +2464,7 @@ var _ = Describe("validator", func() {
 						Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 						attrs := admission.NewAttributesRecord(newShoot, &shoot, core.Kind("Shoot").WithVersion("version"), newShoot.Namespace, newShoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.CreateOptions{}, false, nil)
 
-						err := admissionHandler.Admit(context.TODO(), attrs, nil)
-
-						Expect(err).NotTo(HaveOccurred())
+						Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
 						Expect(newShoot.Spec.Provider.Workers[0]).To(Equal(shoot.Spec.Provider.Workers[0]))
 						Expect(newShoot.Spec.Provider.Workers[1].Machine.Image).To(Equal(&core.ShootMachineImage{
 							Name:    imageName2,
@@ -2511,9 +2487,7 @@ var _ = Describe("validator", func() {
 						Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 						attrs := admission.NewAttributesRecord(newShoot, &shoot, core.Kind("Shoot").WithVersion("version"), newShoot.Namespace, newShoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.CreateOptions{}, false, nil)
 
-						err := admissionHandler.Admit(context.TODO(), attrs, nil)
-
-						Expect(err).NotTo(HaveOccurred())
+						Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
 						Expect(newShoot.Spec.Provider.Workers[0].Machine.Image).To(Equal(&core.ShootMachineImage{
 							Name:    imageName1,
 							Version: nonExpiredVersion1,
@@ -2535,9 +2509,7 @@ var _ = Describe("validator", func() {
 						Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 						attrs := admission.NewAttributesRecord(newShoot, &shoot, core.Kind("Shoot").WithVersion("version"), newShoot.Namespace, newShoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.CreateOptions{}, false, nil)
 
-						err := admissionHandler.Admit(context.TODO(), attrs, nil)
-
-						Expect(err).NotTo(HaveOccurred())
+						Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
 						Expect(newShoot.Spec.Provider.Workers[0]).To(Equal(shoot.Spec.Provider.Workers[0]))
 						Expect(newShoot.Spec.Provider.Workers[1].Machine.Image).To(Equal(&core.ShootMachineImage{
 							Name:    imageName2,
@@ -2561,9 +2533,7 @@ var _ = Describe("validator", func() {
 						Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 						attrs := admission.NewAttributesRecord(newShoot, &shoot, core.Kind("Shoot").WithVersion("version"), newShoot.Namespace, newShoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.CreateOptions{}, false, nil)
 
-						err := admissionHandler.Admit(context.TODO(), attrs, nil)
-
-						Expect(err).NotTo(HaveOccurred())
+						Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
 						Expect(newShoot.Spec.Provider.Workers[0].Machine.Image).To(Equal(&core.ShootMachineImage{
 							Name:    imageName2,
 							Version: latestNonExpiredVersion,
@@ -2587,9 +2557,7 @@ var _ = Describe("validator", func() {
 						Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 						attrs := admission.NewAttributesRecord(newShoot, &shoot, core.Kind("Shoot").WithVersion("version"), newShoot.Namespace, newShoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.CreateOptions{}, false, nil)
 
-						err := admissionHandler.Admit(context.TODO(), attrs, nil)
-
-						Expect(err).NotTo(HaveOccurred())
+						Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
 						Expect(newShoot.Spec.Provider.Workers[0].Machine.Image).To(Equal(&core.ShootMachineImage{
 							Name:    imageName2,
 							Version: nonExpiredVersion2,
@@ -2624,7 +2592,10 @@ var _ = Describe("validator", func() {
 
 					err := admissionHandler.Admit(context.TODO(), attrs, nil)
 
-					Expect(err).To(BeForbiddenError())
+					Expect(err).To(MatchError(And(
+						ContainSubstring("spec.provider.workers[0].machine.type: Invalid value"),
+						ContainSubstring("spec.provider.workers[0].machine.image: Invalid value"),
+					)))
 				})
 			})
 
@@ -2738,9 +2709,7 @@ var _ = Describe("validator", func() {
 					Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 					attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.UpdateOptions{}, false, nil)
 
-					err := admissionHandler.Admit(context.TODO(), attrs, nil)
-
-					Expect(err).ToNot(HaveOccurred())
+					Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
 				})
 
 				It("should reject due to wrong volume size (volume type constraint)", func() {
@@ -2897,9 +2866,7 @@ var _ = Describe("validator", func() {
 					Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 					attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Update, &metav1.CreateOptions{}, false, nil)
 
-					err := admissionHandler.Admit(context.TODO(), attrs, nil)
-
-					Expect(err).ToNot(HaveOccurred())
+					Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
 				})
 
 				It("admits new clusters using other apiVersion than 'internal'", func() {
@@ -2962,9 +2929,7 @@ var _ = Describe("validator", func() {
 					Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
 					attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, nil)
 
-					err := admissionHandler.Admit(context.TODO(), attrs, nil)
-
-					Expect(err).ToNot(HaveOccurred())
+					Expect(admissionHandler.Admit(context.TODO(), attrs, nil)).To(Succeed())
 				})
 			})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind enhancement

**What this PR does / why we need it**:
This PR improves default machine image selection for worker pool having machine of CPU architecture `arm64`. Also improves the validation message for machine type and machine image of shoot.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/backlog/issues/19

**Special notes for your reviewer**:
/cc @rfranzke 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The machine image defaulting does now work based on the CPU architecture of the machine in a given worker pool.
```
