### PR TITLE
Improve maintenance controller to filter image based on architecture

### DIFF
--- a/test/integration/controllermanager/shoot/maintenance/maintenance_test.go
+++ b/test/integration/controllermanager/shoot/maintenance/maintenance_test.go
@@ -44,9 +44,20 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 		shoot        *gardencorev1beta1.Shoot
 
 		// Test Machine Image
-		highestShootMachineImage gardencorev1beta1.ShootMachineImage
-		testMachineImageVersion  = "0.0.1-beta"
-		testMachineImage         = gardencorev1beta1.ShootMachineImage{
+		machineImageName                = "foo-image"
+		highestAMD64MachineImageVersion = "1.1.1"
+		highestAMD64MachineImage        = gardencorev1beta1.ShootMachineImage{
+			Name:    machineImageName,
+			Version: &highestAMD64MachineImageVersion,
+		}
+		highestARM64MachineImageVersion = "1.2.0"
+		highestARM64MachineImage        = gardencorev1beta1.ShootMachineImage{
+			Name:    machineImageName,
+			Version: &highestARM64MachineImageVersion,
+		}
+		testMachineImageVersion = "0.0.1-beta"
+		testMachineImage        = gardencorev1beta1.ShootMachineImage{
+			Name:    machineImageName,
 			Version: &testMachineImageVersion,
 		}
 
@@ -93,21 +104,30 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 				},
 				MachineImages: []gardencorev1beta1.MachineImage{
 					{
-						Name: "foo-image",
+						Name: machineImageName,
 						Versions: []gardencorev1beta1.MachineImageVersion{
 							{
 								ExpirableVersion: gardencorev1beta1.ExpirableVersion{
-									Version:        "1.1.1",
+									Version:        highestAMD64MachineImageVersion,
 									Classification: &supportedClassification,
 								},
 								CRI: []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
 							},
 							{
 								ExpirableVersion: gardencorev1beta1.ExpirableVersion{
+									Version:        highestARM64MachineImageVersion,
+									Classification: &supportedClassification,
+								},
+								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+								Architectures: []string{"arm64"},
+							},
+							{
+								ExpirableVersion: gardencorev1beta1.ExpirableVersion{
 									Version:        testMachineImageVersion,
 									Classification: &deprecatedClassification,
 								},
-								CRI: []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+								CRI:           []gardencorev1beta1.CRI{{Name: gardencorev1beta1.CRINameDocker}},
+								Architectures: []string{"amd64", "arm64"},
 							},
 						},
 					},
@@ -138,15 +158,22 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 					Type: "foo-provider",
 					Workers: []gardencorev1beta1.Worker{
 						{
-							Name:    "cpu-worker",
+							Name:    "cpu-worker1",
 							Minimum: 2,
 							Maximum: 2,
 							Machine: gardencorev1beta1.Machine{
-								Image: &gardencorev1beta1.ShootMachineImage{
-									Name:    "foo-image",
-									Version: pointer.String("1.1.1"),
-								},
-								Type: "large",
+								Image: &testMachineImage,
+								Type:  "large",
+							},
+						},
+						{
+							Name:    "cpu-worker2",
+							Minimum: 2,
+							Maximum: 2,
+							Machine: gardencorev1beta1.Machine{
+								Image:        &testMachineImage,
+								Type:         "large",
+								Architecture: pointer.String("arm64"),
 							},
 						},
 					},
@@ -171,15 +198,8 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 		}
 		log = log.WithValues("shoot", client.ObjectKeyFromObject(shoot))
 
-		// remember highest version of the image.
-		highestShootMachineImage = *shoot.Spec.Provider.Workers[0].Machine.Image
 		// set dummy kubernetes version to shoot
 		shoot.Spec.Kubernetes.Version = testKubernetesVersionLowPatchLowMinor.Version
-		// set shoot MachineImage version to testMachineImage
-		shoot.Spec.Provider.Workers[0].Machine.Image.Version = testMachineImage.Version
-		// remember the test machine image
-		// also required to know for which image name the test versions should be added to the CloudProfile
-		testMachineImage = *shoot.Spec.Provider.Workers[0].Machine.Image
 		Expect(testClient.Create(ctx, shoot)).To(Succeed())
 	})
 
@@ -318,8 +338,9 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 	Describe("Machine image maintenance tests", func() {
 		It("Do not update Shoot machine image in maintenance time: AutoUpdate.MachineImageVersion == false && expirationDate does not apply", func() {
 			Expect(kutil.SetAnnotationAndUpdate(ctx, testClient, shoot, v1beta1constants.GardenerOperation, v1beta1constants.ShootOperationMaintain)).To(Succeed())
+			expectedMachineImages := []gardencorev1beta1.ShootMachineImage{testMachineImage, testMachineImage}
 
-			Expect(waitForExpectedMachineImageMaintenance(ctx, log, testClient, shoot, testMachineImage, false, time.Now().Add(time.Second*10))).To(Succeed())
+			Expect(waitForExpectedMachineImageMaintenance(ctx, log, testClient, shoot, expectedMachineImages, false, time.Now().Add(time.Second*10))).To(Succeed())
 		})
 
 		It("Shoot machine image must be updated in maintenance time: AutoUpdate.MachineImageVersion == true && expirationDate does not apply", func() {
@@ -327,10 +348,11 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 			patch := client.MergeFrom(shoot.DeepCopy())
 			shoot.Spec.Maintenance.AutoUpdate.MachineImageVersion = true
 			Expect(testClient.Patch(ctx, shoot, patch)).To(Succeed())
+			expectedMachineImages := []gardencorev1beta1.ShootMachineImage{highestAMD64MachineImage, highestARM64MachineImage}
 
 			Expect(kutil.SetAnnotationAndUpdate(ctx, testClient, shoot, v1beta1constants.GardenerOperation, v1beta1constants.ShootOperationMaintain)).To(Succeed())
 
-			Expect(waitForExpectedMachineImageMaintenance(ctx, log, testClient, shoot, highestShootMachineImage, true, time.Now().Add(time.Second*20))).To(Succeed())
+			Expect(waitForExpectedMachineImageMaintenance(ctx, log, testClient, shoot, expectedMachineImages, true, time.Now().Add(time.Second*20))).To(Succeed())
 		})
 
 		It("Shoot machine image must be updated in maintenance time: AutoUpdate.MachineImageVersion == false && expirationDate applies", func() {
@@ -339,7 +361,8 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 
 			Expect(kutil.SetAnnotationAndUpdate(ctx, testClient, shoot, v1beta1constants.GardenerOperation, v1beta1constants.ShootOperationMaintain)).To(Succeed())
 
-			Expect(waitForExpectedMachineImageMaintenance(ctx, log, testClient, shoot, highestShootMachineImage, true, time.Now().Add(time.Minute*1))).To(Succeed())
+			expectedMachineImages := []gardencorev1beta1.ShootMachineImage{highestAMD64MachineImage, highestARM64MachineImage}
+			Expect(waitForExpectedMachineImageMaintenance(ctx, log, testClient, shoot, expectedMachineImages, true, time.Now().Add(time.Minute*1))).To(Succeed())
 		})
 	})
 

--- a/test/integration/controllermanager/shoot/maintenance/utils_test.go
+++ b/test/integration/controllermanager/shoot/maintenance/utils_test.go
@@ -16,20 +16,15 @@ package maintenance_test
 
 import (
 	"context"
-	"fmt"
-	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 
-	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -45,75 +40,6 @@ func waitForShootToBeMaintained(shoot *gardencorev1beta1.Shoot) {
 		g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
 		return shoot.ObjectMeta.Annotations[v1beta1constants.GardenerOperation] == v1beta1constants.ShootOperationMaintain
 	}).Should(BeFalse())
-}
-
-// WaitForExpectedMachineImageMaintenance polls a shoot until the given deadline is exceeded. Checks if the shoot's machine image  equals the targetImage and if an image update is required.
-func waitForExpectedMachineImageMaintenance(ctx context.Context, log logr.Logger, gardenClient client.Client, s *gardencorev1beta1.Shoot, targetMachineImages []gardencorev1beta1.ShootMachineImage, imageUpdateRequired bool, deadline time.Time) error {
-	return wait.PollImmediateUntil(2*time.Second, func() (bool, error) {
-		shoot := &gardencorev1beta1.Shoot{}
-		err := gardenClient.Get(ctx, client.ObjectKey{Namespace: s.Namespace, Name: s.Name}, shoot)
-		if err != nil {
-			return false, err
-		}
-
-		nameVersions := make(map[string]string)
-		shootMaintained := false
-		for idx, worker := range shoot.Spec.Provider.Workers {
-			if worker.Machine.Image.Version != nil {
-				nameVersions[worker.Machine.Image.Name] = *worker.Machine.Image.Version
-			}
-			if worker.Machine.Image != nil && imageUpdateRequired {
-				if apiequality.Semantic.DeepEqual(*worker.Machine.Image, targetMachineImages[idx]) {
-					shootMaintained = true
-				} else {
-					shootMaintained = false
-				}
-			}
-		}
-
-		if shootMaintained {
-			log.Info("Shoot maintained properly, received machine image version update")
-			return true, nil
-		}
-
-		now := time.Now()
-		nowIsAfterDeadline := now.After(deadline)
-		if nowIsAfterDeadline && imageUpdateRequired {
-			return false, fmt.Errorf("shoot did not get the expected machine image maintenance. Deadline exceeded. ")
-		} else if nowIsAfterDeadline && !imageUpdateRequired {
-			log.Info("Shoot maintained properly, did no receive machine image version update")
-			return true, nil
-		}
-		log.Info("Shoot has workers which might require a machine image version update", "poolNameToVersion", nameVersions, "updateRequired", imageUpdateRequired, "deadline", deadline.Sub(now))
-		return false, nil
-	}, ctx.Done())
-}
-
-// WaitForExpectedKubernetesVersionMaintenance polls a shoot until the given deadline is exceeded. Checks if the shoot's kubernetes version equals the targetVersion and if an kubernetes version update is required.
-func waitForExpectedKubernetesVersionMaintenance(ctx context.Context, log logr.Logger, gardenClient client.Client, s *gardencorev1beta1.Shoot, targetVersion string, kubernetesVersionUpdateRequired bool, deadline time.Time) error {
-	return wait.PollImmediateUntil(2*time.Second, func() (bool, error) {
-		shoot := &gardencorev1beta1.Shoot{}
-		err := gardenClient.Get(ctx, client.ObjectKey{Namespace: s.Namespace, Name: s.Name}, shoot)
-		if err != nil {
-			return false, err
-		}
-
-		if shoot.Spec.Kubernetes.Version == targetVersion && kubernetesVersionUpdateRequired {
-			log.Info("Shoot maintained properly, received Kubernetes version update")
-			return true, nil
-		}
-
-		now := time.Now()
-		nowIsAfterDeadline := now.After(deadline)
-		if nowIsAfterDeadline && kubernetesVersionUpdateRequired {
-			return false, fmt.Errorf("shoot did not get the expected kubernetes version maintenance. Deadline exceeded. ")
-		} else if nowIsAfterDeadline && !kubernetesVersionUpdateRequired {
-			log.Info("Shoot maintained properly, did no receive Kubernetes version update")
-			return true, nil
-		}
-		log.Info("Shoot has might require a Kubernetes version update to the target version", "currentVersion", shoot.Spec.Kubernetes.Version, "targetVersion", targetVersion, "updateRequired", kubernetesVersionUpdateRequired, "deadline", deadline.Sub(now))
-		return false, nil
-	}, ctx.Done())
 }
 
 // PatchCloudProfileForMachineImageMaintenance patches the images of the Cloud Profile


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind enhancement

**What this PR does / why we need it**:
This PR enhances the maintenance controller to filter machine images specific to the worker pool machine's CPU architecture.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/backlog/issues/19

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
The `Shoot` maintenance controller has been enhanced to auto-update the machine image of the worker pool in a `Shoot` based on the CPU architecture of the machines.
```
