### PR TITLE
Do not run loki/telegraf in privileged mode

### DIFF
--- a/charts/seed-bootstrap/charts/loki/templates/statefulset.yaml
+++ b/charts/seed-bootstrap/charts/loki/templates/statefulset.yaml
@@ -75,7 +75,6 @@ spec:
             capabilities:
               add:
               - NET_ADMIN
-            privileged: true
           ports:
           - name: telegraf
             containerPort: {{ .Values.telegraf.port }}


### PR DESCRIPTION
/area security
/kind enhancement

**What this PR does / why we need it**:
It seems that the loki/telegraf container does not need to run in privileged mode. We checked that it works as expected in non-privileged mode as well.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener-security/standard-compliance/issues/3

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The loki/telegraf container no longer runs in privileged mode.
```
