### PR TITLE
Update metrics-server to v0.6.1

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -134,7 +134,7 @@ images:
 - name: metrics-server
   sourceRepository: github.com/kubernetes-sigs/metrics-server
   repository: k8s.gcr.io/metrics-server/metrics-server
-  tag: v0.5.1
+  tag: v0.6.1
 
 # Shoot core addons
 - name: vpn-shoot

--- a/pkg/operation/botanist/component/metricsserver/metrics_server.go
+++ b/pkg/operation/botanist/component/metricsserver/metrics_server.go
@@ -152,7 +152,7 @@ func (m *metricsServer) computeResourcesData(serverSecret, caSecret *corev1.Secr
 			Rules: []rbacv1.PolicyRule{
 				{
 					APIGroups: []string{""},
-					Resources: []string{"pods", "nodes", "nodes/stats", "namespaces", "configmaps"},
+					Resources: []string{"pods", "nodes", "nodes/metrics", "namespaces", "configmaps"},
 					Verbs:     []string{"get", "list", "watch"},
 				},
 			},

--- a/pkg/operation/botanist/component/metricsserver/metrics_server_test.go
+++ b/pkg/operation/botanist/component/metricsserver/metrics_server_test.go
@@ -117,7 +117,7 @@ rules:
   resources:
   - pods
   - nodes
-  - nodes/stats
+  - nodes/metrics
   - namespaces
   - configmaps
   verbs:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
Mitigate CVE findings.

**Special notes for your reviewer**:
ClusterRole `system:metrics-server` was adapted according to breaking changes mentioned in [release notes of v0.6.0](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.6.0)

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other dependency
`metric-server` image is updated to `v0.6.1`
```
