### PR TITLE
Fix istio after update to v1.14.1.

### DIFF
--- a/pkg/operation/botanist/component/istio/charts/istio/istio-ingress/templates/deployment.yaml
+++ b/pkg/operation/botanist/component/istio/charts/istio/istio-ingress/templates/deployment.yaml
@@ -152,6 +152,10 @@ spec:
         - name: ISTIO_BOOTSTRAP_OVERRIDE
           value: /etc/istio/custom-bootstrap/custom_bootstrap.yaml
         volumeMounts:
+        - name: workload-socket
+          mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: workload-certs
+          mountPath: /var/run/secrets/workload-spiffe-credentials
         - mountPath: /etc/istio/proxy
           name: istio-envoy
         - mountPath: /var/run/secrets/istio
@@ -162,13 +166,15 @@ spec:
         - name: istio-token
           mountPath: /var/run/secrets/tokens
           readOnly: true
-        - name: ingressgatewaysdsudspath
-          mountPath: /var/run/ingress_gateway
         - name: istio-data
           mountPath: /var/lib/istio/data
         - name: podinfo
           mountPath: /etc/istio/pod
       volumes:
+      - emptyDir: {}
+        name: workload-socket
+      - emptyDir: {}
+        name: workload-certs
       - name: istiod-ca-cert
         configMap:
           name: istio-ca-root-cert
@@ -186,8 +192,6 @@ spec:
               fieldPath: metadata.annotations
       - emptyDir: {}
         name: istio-envoy
-      - name: ingressgatewaysdsudspath
-        emptyDir: {}
       - name: istio-data
         emptyDir: {}
       - name: istio-token

--- a/pkg/operation/botanist/component/istio/istiod_test.go
+++ b/pkg/operation/botanist/component/istio/istiod_test.go
@@ -1853,6 +1853,10 @@ spec:
         - name: ISTIO_BOOTSTRAP_OVERRIDE
           value: /etc/istio/custom-bootstrap/custom_bootstrap.yaml
         volumeMounts:
+        - name: workload-socket
+          mountPath: /var/run/secrets/workload-spiffe-uds
+        - name: workload-certs
+          mountPath: /var/run/secrets/workload-spiffe-credentials
         - mountPath: /etc/istio/proxy
           name: istio-envoy
         - mountPath: /var/run/secrets/istio
@@ -1863,13 +1867,15 @@ spec:
         - name: istio-token
           mountPath: /var/run/secrets/tokens
           readOnly: true
-        - name: ingressgatewaysdsudspath
-          mountPath: /var/run/ingress_gateway
         - name: istio-data
           mountPath: /var/lib/istio/data
         - name: podinfo
           mountPath: /etc/istio/pod
       volumes:
+      - emptyDir: {}
+        name: workload-socket
+      - emptyDir: {}
+        name: workload-certs
       - name: istiod-ca-cert
         configMap:
           name: istio-ca-root-cert
@@ -1887,8 +1893,6 @@ spec:
               fieldPath: metadata.annotations
       - emptyDir: {}
         name: istio-envoy
-      - name: ingressgatewaysdsudspath
-        emptyDir: {}
       - name: istio-data
         emptyDir: {}
       - name: istio-token


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
Fix istio after update to v1.14.1.

In the original change to update istio to v1.14.1 was apparently a race,
which sometimes led to istio's ingress gateway to never become ready.
Changes in the istio's SDS service now requiring write access to a new
location sometimes led to envoy hanging in status PRE_INITIALIZING.

**Which issue(s) this PR fixes**:
Fixes #6330.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
