### PR TITLE
Fixed typos

### DIFF
--- a/docs/usage/worker_pool_k8s_versions.md
+++ b/docs/usage/worker_pool_k8s_versions.md
@@ -10,7 +10,7 @@ In order to gracefully perform Kubernetes upgrades (triggering a rolling update 
 In such cases, the Kubernetes version for the worker pools can be pinned (`.spec.provider.workers[].kubernetes.version`) while the control plane Kubernetes version (`.spec.kubernetes.version`) is updated.
 This results in the nodes being untouched while the control plane is upgraded. 
 Now a new worker pool (with the version equal to the control plane version) can be added.
-Administrators can then reschedule their workloads to the new worekr pool according to their upgrade requirements and processes.
+Administrators can then reschedule their workloads to the new worker pool according to their upgrade requirements and processes.
 
 ## Example Usage in a `Shoot`
 
@@ -26,10 +26,10 @@ spec:
     - name: data2
 ```
 
-- If `.kubernetes.version` is not specified in a worker pool then the Kubernetes version of the kubelet is inherited from the control plane (`.spec.kubernetes.version`), i.e., in above example the `data2` pool will use `1.20.1`.
+- If `.kubernetes.version` is not specified in a worker pool, then the Kubernetes version of the kubelet is inherited from the control plane (`.spec.kubernetes.version`), i.e., in the above example, the `data2` pool will use `1.20.1`.
 - If `.kubernetes.version` is specified in a worker pool then it must meet the following constraints:
   - It must be at most two minor versions lower than the control plane version.
-  - If it was not specified before then no downgrade is possible (you cannot set it to `1.19.1` while `.spec.kubernetes.version` is already `1.20.1`). The "two minor version skew" is only possible if the worker pool version is set to control plane version and then the control plane was updated gradually two minor versions.
+  - If it was not specified before, then no downgrade is possible (you cannot set it to `1.19.1` while `.spec.kubernetes.version` is already `1.20.1`). The "two minor version skew" is only possible if the worker pool version is set to control plane version and then the control plane was updated gradually two minor versions.
   - If the version is removed from the worker pool, only one minor version difference is allowed to the control plane (you cannot upgrade a pool from version `1.18.0` to `1.20.0` in one go).
 
-Automatic updates of Kubernetes versions (see [this document](shoot_maintenance.md#automatic-version-updates)) also apply to worker pool Kubernetes versions.
+Automatic updates of Kubernetes versions (see [Shoot Maintenance](shoot_maintenance.md#automatic-version-updates)) also apply to worker pool Kubernetes versions.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area documentation
/kind enhancement

**What this PR does / why we need it**:
This PR fixes some minor typos in the Worker Pools topic. 
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```doc developer
NONE
```
