### PR TITLE
Remove privilege flag from vpn-seed-server

### DIFF
--- a/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server_test.go
+++ b/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server_test.go
@@ -241,6 +241,7 @@ admin:
 		deployment = func(nodeNetwork *string) *appsv1.Deployment {
 			maxSurge := intstr.FromInt(100)
 			maxUnavailable := intstr.FromInt(0)
+			hostPathCharDev := corev1.HostPathCharDev
 			deploy := &appsv1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      DeploymentName,
@@ -297,7 +298,6 @@ admin:
 												"NET_ADMIN",
 											},
 										},
-										Privileged: pointer.Bool(true),
 									},
 									Env: []corev1.EnvVar{
 										{
@@ -341,6 +341,10 @@ admin:
 										},
 									},
 									VolumeMounts: []corev1.VolumeMount{
+										{
+											Name:      "dev-net-tun",
+											MountPath: "/dev/net/tun",
+										},
 										{
 											Name:      "certs",
 											MountPath: "/srv/secrets/vpn-server",
@@ -410,6 +414,15 @@ admin:
 							},
 							TerminationGracePeriodSeconds: pointer.Int64(30),
 							Volumes: []corev1.Volume{
+								{
+									Name: "dev-net-tun",
+									VolumeSource: corev1.VolumeSource{
+										HostPath: &corev1.HostPathVolumeSource{
+											Path: "/dev/net/tun",
+											Type: &hostPathCharDev,
+										},
+									},
+								},
 								{
 									Name: "certs",
 									VolumeSource: corev1.VolumeSource{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind cleanup

**What this PR does / why we need it**:
Remove privilege flag from vpn-seed-server.

It is not necessary for the vpn-seed-server to run as privileged container. The tun
device required for vpn operation can be mounted into the container namespace.
In case the container should run as non-root user in the future, it might help to
create a separate tun device in a privileged init container as described in
https://community.openvpn.net/openvpn/wiki/UnprivilegedUser#TUNTAPDevice .

**Which issue(s) this PR fixes**:
Partially addresses https://github.com/gardener/vpn/issues/41.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The vpn-seed-server/vpn-seed-server container no longer runs in privileged mode.
```
