### PR TITLE
Consider compatibility matrix of metrics-server

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -134,7 +134,13 @@ images:
 - name: metrics-server
   sourceRepository: github.com/kubernetes-sigs/metrics-server
   repository: k8s.gcr.io/metrics-server/metrics-server
+  tag: v0.5.2
+  targetVersion: "< 1.19"
+- name: metrics-server
+  sourceRepository: github.com/kubernetes-sigs/metrics-server
+  repository: k8s.gcr.io/metrics-server/metrics-server
   tag: v0.6.1
+  targetVersion: ">= 1.19"
 
 # Shoot core addons
 - name: vpn-shoot

--- a/pkg/operation/botanist/component/metricsserver/metrics_server.go
+++ b/pkg/operation/botanist/component/metricsserver/metrics_server.go
@@ -152,7 +152,8 @@ func (m *metricsServer) computeResourcesData(serverSecret, caSecret *corev1.Secr
 			Rules: []rbacv1.PolicyRule{
 				{
 					APIGroups: []string{""},
-					Resources: []string{"pods", "nodes", "nodes/metrics", "namespaces", "configmaps"},
+					// TODO(oliver-goetz): "nodes/stats" can be removed when we don't have to support metrics-server v0.5.x anymore
+					Resources: []string{"pods", "nodes", "nodes/metrics", "nodes/stats", "namespaces", "configmaps"},
 					Verbs:     []string{"get", "list", "watch"},
 				},
 			},

--- a/pkg/operation/botanist/component/metricsserver/metrics_server_test.go
+++ b/pkg/operation/botanist/component/metricsserver/metrics_server_test.go
@@ -118,6 +118,7 @@ rules:
   - pods
   - nodes
   - nodes/metrics
+  - nodes/stats
   - namespaces
   - configmaps
   verbs:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug
/kind regression

**What this PR does / why we need it**:
https://github.com/gardener/gardener/pull/6338 did not consider the [compatibility matrix of metrics-server](https://github.com/kubernetes-sigs/metrics-server#compatibility-matrix) which causes a regression for Kubernetes version < 1.19

This PR uses metric-server v0.5.2 for Kubernetes < v1.19 and v.0.6.1 for Kubernetes >= v1.19.
ClusterRoles are defined to support both versions of metric-server ([see breaking changes of v.0.6.0](https://github.com/kubernetes-sigs/metrics-server/releases/tag/v0.6.0))

**Which issue(s) this PR fixes**:
Fixes #6345 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
