### PR TITLE
Remove GA-ed `WorkerPoolKubernetesVersion` feature gate

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -92,7 +92,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | ShootMaxTokenExpirationValidation            | `true`  | `Removed` | `1.51` |        |
 | WorkerPoolKubernetesVersion                  | `false` | `Alpha`   | `1.35` | `1.45` |
 | WorkerPoolKubernetesVersion                  | `true`  | `Beta`    | `1.46` | `1.49` |
-| WorkerPoolKubernetesVersion                  | `true`  | `GA`      | `1.50` |        |
+| WorkerPoolKubernetesVersion                  | `true`  | `GA`      | `1.50` | `1.51` |
+| WorkerPoolKubernetesVersion                  | `true`  | `Removed` | `1.51` |        |
 
 ## Using a feature
 

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -93,7 +93,7 @@ The following tables are a summary of the feature gates that you can set on diff
 | WorkerPoolKubernetesVersion                  | `false` | `Alpha`   | `1.35` | `1.45` |
 | WorkerPoolKubernetesVersion                  | `true`  | `Beta`    | `1.46` | `1.49` |
 | WorkerPoolKubernetesVersion                  | `true`  | `GA`      | `1.50` | `1.51` |
-| WorkerPoolKubernetesVersion                  | `true`  | `Removed` | `1.51` |        |
+| WorkerPoolKubernetesVersion                  | `true`  | `Removed` | `1.52` |        |
 
 ## Using a feature
 

--- a/docs/usage/worker_pool_k8s_versions.md
+++ b/docs/usage/worker_pool_k8s_versions.md
@@ -2,8 +2,6 @@
 
 Since Gardener `v1.36`, worker pools can have different Kubernetes versions specified than the control plane.
 
-It must be enabled by setting the featureGate `WorkerPoolKubernetesVersion: true` in the gardenlet's component configuration.
-
 In earlier Gardener versions all worker pools inherited the Kubernetes version of the control plane. Once the Kubernetes version of the control plane was modified, all worker pools have been updated as well (either by rolling the nodes in case of a minor version change, or in-place for patch version changes).
 
 In order to gracefully perform Kubernetes upgrades (triggering a rolling update of the nodes) with workloads sensitive to restarts (e.g., those dealing with lots of data), it might be required to be able to gradually perform the upgrade process.

--- a/example/90-shoot.yaml
+++ b/example/90-shoot.yaml
@@ -68,7 +68,7 @@ spec:
     #   effect: NoSchedule
     # caBundle: <some-ca-bundle-to-be-installed-to-all-nodes-in-this-pool>
     # kubernetes:
-    #   version: 1.14.3 # This can only be specified if the WorkerPoolKubernetesVersion feature gate is enabled.
+    #   version: 1.14.3
     #   kubelet:
     #     cpuCFSQuota: true
     #     failSwapOn: true

--- a/example/gardener-local/controlplane/values.yaml
+++ b/example/gardener-local/controlplane/values.yaml
@@ -157,7 +157,6 @@ global:
         policy: ""
     featureGates:
       SeedChange: true
-      WorkerPoolKubernetesVersion: true
       ShootCARotation: true
       ShootSARotation: true
     resources: {}

--- a/hack/local-development/start-apiserver
+++ b/hack/local-development/start-apiserver
@@ -58,7 +58,6 @@ apiserver_flags="
   --tls-cert-file $TLS_CERT_FILE \
   --tls-private-key-file $TLS_KEY_FILE \
   --feature-gates SeedChange=true \
-  --feature-gates WorkerPoolKubernetesVersion=true \
   --feature-gates ShootCARotation=true \
   --feature-gates ShootSARotation=true \
   --shoot-admin-kubeconfig-max-expiration=1h \

--- a/pkg/apiserver/features/features.go
+++ b/pkg/apiserver/features/features.go
@@ -25,7 +25,6 @@ import (
 func RegisterFeatureGates() {
 	utilruntime.Must(utilfeature.DefaultMutableFeatureGate.Add(features.GetFeatures(
 		features.SeedChange,
-		features.WorkerPoolKubernetesVersion,
 		features.SecretBindingProviderValidation,
 		features.ShootCARotation,
 		features.ShootSARotation,

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -73,13 +73,6 @@ const (
 	// beta: v1.42.0
 	ReversedVPN featuregate.Feature = "ReversedVPN"
 
-	// WorkerPoolKubernetesVersion allows to overwrite the Kubernetes version used for shoot clusters per worker pool.
-	// owner: @rfranzke @majst01 @mwennrich
-	// alpha: v1.35.0
-	// beta: v1.46.0
-	// GA: v1.50.0
-	WorkerPoolKubernetesVersion featuregate.Feature = "WorkerPoolKubernetesVersion"
-
 	// CopyEtcdBackupsDuringControlPlaneMigration enables the copy of etcd backups from the object store of the source seed
 	// to the object store of the destination seed during control plane migration.
 	// owner: @plkokanov
@@ -132,14 +125,13 @@ const (
 )
 
 var allFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	HVPA:                        {Default: false, PreRelease: featuregate.Alpha},
-	HVPAForShootedSeed:          {Default: false, PreRelease: featuregate.Alpha},
-	ManagedIstio:                {Default: true, PreRelease: featuregate.Beta},
-	APIServerSNI:                {Default: true, PreRelease: featuregate.Beta},
-	SeedChange:                  {Default: false, PreRelease: featuregate.Alpha},
-	SeedKubeScheduler:           {Default: false, PreRelease: featuregate.Alpha},
-	ReversedVPN:                 {Default: true, PreRelease: featuregate.Beta},
-	WorkerPoolKubernetesVersion: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
+	HVPA:               {Default: false, PreRelease: featuregate.Alpha},
+	HVPAForShootedSeed: {Default: false, PreRelease: featuregate.Alpha},
+	ManagedIstio:       {Default: true, PreRelease: featuregate.Beta},
+	APIServerSNI:       {Default: true, PreRelease: featuregate.Beta},
+	SeedChange:         {Default: false, PreRelease: featuregate.Alpha},
+	SeedKubeScheduler:  {Default: false, PreRelease: featuregate.Alpha},
+	ReversedVPN:        {Default: true, PreRelease: featuregate.Beta},
 	CopyEtcdBackupsDuringControlPlaneMigration: {Default: false, PreRelease: featuregate.Alpha},
 	SecretBindingProviderValidation:            {Default: true, PreRelease: featuregate.Beta},
 	ForceRestore:                               {Default: false, PreRelease: featuregate.Alpha},

--- a/test/integration/controllermanager/shoot/maintenance/maintenance_suite_test.go
+++ b/test/integration/controllermanager/shoot/maintenance/maintenance_suite_test.go
@@ -62,7 +62,6 @@ var _ = BeforeSuite(func() {
 		GardenerAPIServer: &envtest.GardenerAPIServer{
 			Args: []string{
 				"--disable-admission-plugins=ResourceReferenceManager,ExtensionValidator,ShootQuotaValidator,ShootValidator,ShootTolerationRestriction",
-				"--feature-gates=WorkerPoolKubernetesVersion=true",
 			},
 		},
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:
This PR removes the GA-ed  `WorkerPoolKubernetesVersion` feature gate (promoted to GA with #6166).

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/3501

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The GA-ed `WorkerPoolKubernetesVersion` feature gate is now removed.
```
