### PR TITLE
[controller-manager] Add documentation and integration test for `CloudProfile` controller

### DIFF
--- a/docs/concepts/controller-manager.md
+++ b/docs/concepts/controller-manager.md
@@ -8,6 +8,12 @@ This document explains the various functionalities of the Gardener Controller Ma
 
 ## Control Loops
 
+### [`CloudProfile` Controller](../../pkg/controllermanager/controller/cloudprofile)
+
+`CloudProfile`s are essential when it comes to reconciling `Shoot`s since they contain constraints (like valid machine types, Kubernetes versions, or machine images) and sometimes also some global configuration for the respective environment (typically via provider-specific configuration in `.spec.providerConfig`).
+
+Consequently, to ensure that `CloudProfile`s in-use are always present in the system until the last referring `Shoot` gets deleted, the controller adds a finalizer which is only released when there is no `Shoot` referencing the `CloudProfile` anymore.
+
 ### `Project` Controller
 
 This controller consists out of three reconciliation loops:

--- a/pkg/controllermanager/controller/add.go
+++ b/pkg/controllermanager/controller/add.go
@@ -26,7 +26,7 @@ import (
 // AddControllersToManager adds all controller-manager controllers to the given manager.
 func AddControllersToManager(mgr manager.Manager, cfg *config.ControllerManagerConfiguration) error {
 	if err := (&cloudprofile.Reconciler{
-		Config: cfg.Controllers.CloudProfile,
+		Config: *cfg.Controllers.CloudProfile,
 	}).AddToManager(mgr); err != nil {
 		return fmt.Errorf("failed adding CloudProfile controller: %w", err)
 	}

--- a/pkg/controllermanager/controller/cloudprofile/add.go
+++ b/pkg/controllermanager/controller/cloudprofile/add.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudprofile
+
+import (
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+// ControllerName is the name of this controller.
+const ControllerName = "cloudprofile"
+
+// AddToManager adds Reconciler to the given manager.
+func (r *Reconciler) AddToManager(mgr manager.Manager) error {
+	if r.Client == nil {
+		r.Client = mgr.GetClient()
+	}
+	if r.Recorder == nil {
+		r.Recorder = mgr.GetEventRecorderFor(ControllerName + "-controller")
+	}
+
+	return builder.
+		ControllerManagedBy(mgr).
+		Named(ControllerName).
+		For(&gardencorev1beta1.CloudProfile{}).
+		WithOptions(controller.Options{
+			MaxConcurrentReconciles: *r.Config.ConcurrentSyncs,
+			RecoverPanic:            true,
+		}).
+		Complete(r)
+}

--- a/pkg/controllermanager/controller/cloudprofile/add.go
+++ b/pkg/controllermanager/controller/cloudprofile/add.go
@@ -15,6 +15,8 @@
 package cloudprofile
 
 import (
+	"k8s.io/utils/pointer"
+
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -39,7 +41,7 @@ func (r *Reconciler) AddToManager(mgr manager.Manager) error {
 		Named(ControllerName).
 		For(&gardencorev1beta1.CloudProfile{}).
 		WithOptions(controller.Options{
-			MaxConcurrentReconciles: *r.Config.ConcurrentSyncs,
+			MaxConcurrentReconciles: pointer.IntDeref(r.Config.ConcurrentSyncs, 0),
 			RecoverPanic:            true,
 		}).
 		Complete(r)

--- a/pkg/controllermanager/controller/cloudprofile/reconciler.go
+++ b/pkg/controllermanager/controller/cloudprofile/reconciler.go
@@ -36,7 +36,7 @@ import (
 // Reconciler reconciles CloudProfiles.
 type Reconciler struct {
 	Client   client.Client
-	Config   *config.CloudProfileControllerConfiguration
+	Config   config.CloudProfileControllerConfiguration
 	Recorder record.EventRecorder
 }
 

--- a/pkg/controllermanager/controller/cloudprofile/reconciler.go
+++ b/pkg/controllermanager/controller/cloudprofile/reconciler.go
@@ -22,12 +22,9 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/client-go/tools/record"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -36,34 +33,11 @@ import (
 	"github.com/gardener/gardener/pkg/controllerutils"
 )
 
-// ControllerName is the name of this controller.
-const ControllerName = "cloudprofile"
-
 // Reconciler reconciles CloudProfiles.
 type Reconciler struct {
-	Config *config.CloudProfileControllerConfiguration
-
 	Client   client.Client
+	Config   *config.CloudProfileControllerConfiguration
 	Recorder record.EventRecorder
-}
-
-// AddToManager adds Reconciler to the given manager.
-func (r *Reconciler) AddToManager(mgr manager.Manager) error {
-	if r.Client == nil {
-		r.Client = mgr.GetClient()
-	}
-	if r.Recorder == nil {
-		r.Recorder = mgr.GetEventRecorderFor(ControllerName + "-controller")
-	}
-
-	return builder.ControllerManagedBy(mgr).
-		Named(ControllerName).
-		For(&gardencorev1beta1.CloudProfile{}).
-		WithOptions(controller.Options{
-			MaxConcurrentReconciles: *r.Config.ConcurrentSyncs,
-			RecoverPanic:            true,
-		}).
-		Complete(r)
 }
 
 // Reconcile performs the main reconciliation logic.

--- a/test/integration/controllermanager/cloudprofile/cloudprofile_suite_test.go
+++ b/test/integration/controllermanager/cloudprofile/cloudprofile_suite_test.go
@@ -107,7 +107,7 @@ var _ = BeforeSuite(func() {
 
 	By("registering controller")
 	Expect((&cloudprofilecontroller.Reconciler{
-		Config: &config.CloudProfileControllerConfiguration{
+		Config: config.CloudProfileControllerConfiguration{
 			ConcurrentSyncs: pointer.Int(5),
 		},
 	}).AddToManager(mgr)).To(Succeed())

--- a/test/integration/controllermanager/cloudprofile/cloudprofile_suite_test.go
+++ b/test/integration/controllermanager/cloudprofile/cloudprofile_suite_test.go
@@ -1,0 +1,127 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudprofile_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
+	cloudprofilecontroller "github.com/gardener/gardener/pkg/controllermanager/controller/cloudprofile"
+	gardenerenvtest "github.com/gardener/gardener/pkg/envtest"
+	"github.com/gardener/gardener/pkg/logger"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	"k8s.io/utils/pointer"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+func TestCloudProfileController(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "CloudProfile Controller Integration Test Suite")
+}
+
+// testID is used for generating test namespace names and other IDs
+const testID = "cloudprofile-controller-test"
+
+var (
+	ctx = context.Background()
+	log logr.Logger
+
+	restConfig *rest.Config
+	testEnv    *gardenerenvtest.GardenerTestEnvironment
+	testClient client.Client
+
+	testNamespace *corev1.Namespace
+)
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)))
+	log = logf.Log.WithName(testID)
+
+	By("starting test environment")
+	testEnv = &gardenerenvtest.GardenerTestEnvironment{
+		GardenerAPIServer: &gardenerenvtest.GardenerAPIServer{
+			Args: []string{"--disable-admission-plugins=ResourceReferenceManager,ExtensionValidator,ShootBinding,ShootDNS,ShootQuotaValidator,ShootTolerationRestriction,ShootValidator"},
+		},
+	}
+
+	var err error
+	restConfig, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(restConfig).NotTo(BeNil())
+
+	DeferCleanup(func() {
+		By("stopping test environment")
+		Expect(testEnv.Stop()).To(Succeed())
+	})
+
+	By("creating test clients")
+	testClient, err = client.New(restConfig, client.Options{Scheme: kubernetes.GardenScheme})
+	Expect(err).NotTo(HaveOccurred())
+
+	By("creating test namespace")
+	testNamespace = &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			// create dedicated namespace for each test run, so that we can run multiple tests concurrently for stress tests
+			GenerateName: testID + "-",
+		},
+	}
+	Expect(testClient.Create(ctx, testNamespace)).To(Succeed())
+	log.Info("Created Namespace for test", "namespaceName", testNamespace.Name)
+
+	DeferCleanup(func() {
+		By("deleting test namespace")
+		Expect(testClient.Delete(ctx, testNamespace)).To(Or(Succeed(), BeNotFoundError()))
+	})
+
+	By("setting up manager")
+	mgr, err := manager.New(restConfig, manager.Options{
+		Scheme:             kubernetes.GardenScheme,
+		MetricsBindAddress: "0",
+		Namespace:          testNamespace.Name,
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	By("registering controller")
+	Expect((&cloudprofilecontroller.Reconciler{
+		Config: &config.CloudProfileControllerConfiguration{
+			ConcurrentSyncs: pointer.Int(5),
+		},
+	}).AddToManager(mgr)).To(Succeed())
+
+	By("starting manager")
+	mgrContext, mgrCancel := context.WithCancel(ctx)
+
+	go func() {
+		defer GinkgoRecover()
+		Expect(mgr.Start(mgrContext)).To(Succeed())
+	}()
+
+	DeferCleanup(func() {
+		By("stopping manager")
+		mgrCancel()
+	})
+})

--- a/test/integration/controllermanager/cloudprofile/cloudprofile_test.go
+++ b/test/integration/controllermanager/cloudprofile/cloudprofile_test.go
@@ -128,7 +128,7 @@ var _ = Describe("CloudProfile controller tests", func() {
 			By("Delete CloudProfile")
 			Expect(testClient.Delete(ctx, cloudProfile)).To(Succeed())
 
-			By("Ensure finalizer got removed")
+			By("Ensure CloudProfile is released")
 			Eventually(func() error {
 				return testClient.Get(ctx, client.ObjectKeyFromObject(cloudProfile), cloudProfile)
 			}).Should(BeNotFoundError())
@@ -148,8 +148,8 @@ var _ = Describe("CloudProfile controller tests", func() {
 		})
 
 		It("should add the finalizer and not release it on deletion since there still is a referencing shoot", func() {
-			By("Ensure finalizer got removed")
-			Eventually(func() error {
+			By("Ensure CloudProfile is not released")
+			Consistently(func() error {
 				return testClient.Get(ctx, client.ObjectKeyFromObject(cloudProfile), cloudProfile)
 			}).Should(Succeed())
 		})
@@ -159,7 +159,7 @@ var _ = Describe("CloudProfile controller tests", func() {
 			Expect(gardener.ConfirmDeletion(ctx, testClient, shoot)).To(Succeed())
 			Expect(testClient.Delete(ctx, shoot)).To(Succeed())
 
-			By("Ensure finalizer got removed")
+			By("Ensure CloudProfile is released")
 			Eventually(func() error {
 				return testClient.Get(ctx, client.ObjectKeyFromObject(cloudProfile), cloudProfile)
 			}).Should(BeNotFoundError())

--- a/test/integration/controllermanager/cloudprofile/cloudprofile_test.go
+++ b/test/integration/controllermanager/cloudprofile/cloudprofile_test.go
@@ -1,0 +1,168 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudprofile_test
+
+import (
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/utils"
+	"github.com/gardener/gardener/pkg/utils/gardener"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("CloudProfile controller tests", func() {
+	var (
+		resourceName string
+
+		cloudProfile *gardencorev1beta1.CloudProfile
+		shoot        *gardencorev1beta1.Shoot
+	)
+
+	BeforeEach(func() {
+		resourceName = "test-" + utils.ComputeSHA256Hex([]byte(CurrentSpecReport().LeafNodeLocation.String()))[:8]
+
+		cloudProfile = &gardencorev1beta1.CloudProfile{
+			ObjectMeta: metav1.ObjectMeta{Name: resourceName},
+			Spec: gardencorev1beta1.CloudProfileSpec{
+				Type: "some-provider",
+				Kubernetes: gardencorev1beta1.KubernetesSettings{
+					Versions: []gardencorev1beta1.ExpirableVersion{{Version: "1.2.3"}},
+				},
+				MachineImages: []gardencorev1beta1.MachineImage{
+					{
+						Name: "some-image",
+						Versions: []gardencorev1beta1.MachineImageVersion{
+							{ExpirableVersion: gardencorev1beta1.ExpirableVersion{Version: "4.5.6"}},
+						},
+					},
+				},
+				MachineTypes: []gardencorev1beta1.MachineType{{
+					Name:   "some-type",
+					CPU:    resource.MustParse("1"),
+					GPU:    resource.MustParse("0"),
+					Memory: resource.MustParse("1Gi"),
+				}},
+				Regions: []gardencorev1beta1.Region{
+					{Name: "some-region"},
+				},
+			},
+		}
+		shoot = &gardencorev1beta1.Shoot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      resourceName,
+				Namespace: testNamespace.Name,
+			},
+			Spec: gardencorev1beta1.ShootSpec{
+				CloudProfileName:  cloudProfile.Name,
+				SecretBindingName: "my-provider-account",
+				Region:            "foo-region",
+				Provider: gardencorev1beta1.Provider{
+					Type: cloudProfile.Spec.Type,
+					Workers: []gardencorev1beta1.Worker{
+						{
+							Name:    "cpu-worker",
+							Minimum: 2,
+							Maximum: 2,
+							Machine: gardencorev1beta1.Machine{Type: "large"},
+						},
+					},
+				},
+				Kubernetes: gardencorev1beta1.Kubernetes{Version: "1.21.1"},
+				Networking: gardencorev1beta1.Networking{Type: "foo-networking"},
+			},
+		}
+	})
+
+	JustBeforeEach(func() {
+		By("Create CloudProfile")
+		Expect(testClient.Create(ctx, cloudProfile)).To(Succeed())
+		log.Info("Created CloudProfile for test", "cloudProfile", client.ObjectKeyFromObject(cloudProfile))
+
+		DeferCleanup(func() {
+			By("Delete CloudProfile")
+			Expect(client.IgnoreNotFound(testClient.Delete(ctx, cloudProfile))).To(Succeed())
+		})
+
+		if shoot != nil {
+			By("Create Shoot")
+			Expect(testClient.Create(ctx, shoot)).To(Succeed())
+			log.Info("Created shoot for test", "shoot", client.ObjectKeyFromObject(shoot))
+
+			DeferCleanup(func() {
+				By("Delete Shoot")
+				Expect(client.IgnoreNotFound(gardener.ConfirmDeletion(ctx, testClient, shoot))).To(Succeed())
+				Expect(client.IgnoreNotFound(testClient.Delete(ctx, shoot))).To(Succeed())
+			})
+		}
+	})
+
+	Context("no shoot referencing the CloudProfile", func() {
+		BeforeEach(func() {
+			shoot = nil
+		})
+
+		It("should add the finalizer and release it on deletion", func() {
+			By("Ensure finalizer got added")
+			Eventually(func(g Gomega) {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(cloudProfile), cloudProfile)).To(Succeed())
+				g.Expect(cloudProfile.Finalizers).To(ConsistOf("gardener"))
+			}).Should(Succeed())
+
+			By("Delete CloudProfile")
+			Expect(testClient.Delete(ctx, cloudProfile)).To(Succeed())
+
+			By("Ensure finalizer got removed")
+			Eventually(func() error {
+				return testClient.Get(ctx, client.ObjectKeyFromObject(cloudProfile), cloudProfile)
+			}).Should(BeNotFoundError())
+		})
+	})
+
+	Context("shoots referencing the CloudProfile", func() {
+		JustBeforeEach(func() {
+			By("Ensure finalizer got added")
+			Eventually(func(g Gomega) {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(cloudProfile), cloudProfile)).To(Succeed())
+				g.Expect(cloudProfile.Finalizers).To(ConsistOf("gardener"))
+			}).Should(Succeed())
+
+			By("Delete CloudProfile")
+			Expect(testClient.Delete(ctx, cloudProfile)).To(Succeed())
+		})
+
+		It("should add the finalizer and not release it on deletion since there still is a referencing shoot", func() {
+			By("Ensure finalizer got removed")
+			Eventually(func() error {
+				return testClient.Get(ctx, client.ObjectKeyFromObject(cloudProfile), cloudProfile)
+			}).Should(Succeed())
+		})
+
+		It("should add the finalizer and release it on deletion after the shoot got deleted", func() {
+			By("Delete Shoot")
+			Expect(gardener.ConfirmDeletion(ctx, testClient, shoot)).To(Succeed())
+			Expect(testClient.Delete(ctx, shoot)).To(Succeed())
+
+			By("Ensure finalizer got removed")
+			Eventually(func() error {
+				return testClient.Get(ctx, client.ObjectKeyFromObject(cloudProfile), cloudProfile)
+			}).Should(BeNotFoundError())
+		})
+	})
+})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity scalability
/kind enhancement

**What this PR does / why we need it**:
- Add documentation and integration test for `CloudProfile` controller after it got refactored to `controller-runtime` with #6333.
- Move `AddToManager` function into dedicated `add.go` file (like in #6358).
- ~~Cleanup legacy migration coding from https://github.com/gardener/gardener/pull/4500~~ ➡️  https://github.com/gardener/gardener/issues/6375

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/4251

**Special notes for your reviewer**:
Generally, we want to follow this cookbook while refactoring existing controllers, however we only decided about this after #6333 got merged:

1. Add documentation
2. Add integration test based on `envtest`
3. Switch controller to `controller-runtime`

Hence, this PR is now adding the left-overs.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
4. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
NONE
```