### PR TITLE
Nit: Fix the scheduling profile name in the docs

### DIFF
--- a/docs/usage/shoot_scheduling_profiles.md
+++ b/docs/usage/shoot_scheduling_profiles.md
@@ -61,7 +61,7 @@ spec:
   # ...
   kubernetes:
     kubeScheduler:
-      profile: "default" # or "bin-packing"
+      profile: "balanced" # or "bin-packing"
 ```
 
 ## Custom scheduling profiles


### PR DESCRIPTION
The allowed values are `balanced` and `bin-packing`. This PR addresses the typo - by `default` I had in mind `balanced`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
