### PR TITLE
Fix Shoot Secret contoller that uses wrong client (gardenClient instead of seedClient)

### DIFF
--- a/pkg/gardenlet/controller/shootsecret/reconciler.go
+++ b/pkg/gardenlet/controller/shootsecret/reconciler.go
@@ -105,7 +105,7 @@ func (r *reconciler) reconcile(
 
 	if !controllerutil.ContainsFinalizer(secret, finalizerName) {
 		log.Info("Adding finalizer")
-		if err := controllerutils.AddFinalizers(ctx, r.gardenClient, secret, finalizerName); err != nil {
+		if err := controllerutils.AddFinalizers(ctx, r.seedClient, secret, finalizerName); err != nil {
 			return reconcile.Result{}, fmt.Errorf("failed to add finalizer: %w", err)
 		}
 	}


### PR DESCRIPTION
/area quality
/kind regression
/kind bug

**What this PR does / why we need it**:
After cffdb9fd10d598be614d90055ef1bf79d4e5a791 in my local setup I see enormous spam of logs of type
```
2022-07-15T12:29:05.911+0300	ERROR	controller.shootsecret	Error reconciling request	{"name": "kube-apiserver-etcd-encryption-key-80f230d7", "namespace": "shoot--foo--bar", "error": "failed to add finalizer: secrets \"kube-apiserver-etcd-encryption-key-80f230d7\" not found"}
```

It seems that in https://github.com/gardener/gardener/commit/cffdb9fd10d598be614d90055ef1bf79d4e5a791#diff-44b634a236cf0ab190845f8bb443ebfd260a5c07e49bb6ec2e09bbcaaa92ed03L99-R110 the `seedClient` was wrongly replaced by a `gardenClient`. Hence, every try to add a finalizer to the Secret is in the wrong cluster and fails with `not found` error.

**Which issue(s) this PR fixes**:
Fixes #6337

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
