### PR TITLE
Update envoy proxy to v1.23.1

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -302,7 +302,7 @@ images:
 - name: apiserver-proxy
   sourceRepository: github.com/envoyproxy/envoy
   repository: envoyproxy/envoy-distroless
-  tag: "v1.23.0"
+  tag: "v1.23.1"
 - name: apiserver-proxy-sidecar
   sourceRepository: github.com/gardener/apiserver-proxy
   repository: eu.gcr.io/gardener-project/gardener/apiserver-proxy

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -301,8 +301,8 @@ images:
 # API Server SNI
 - name: apiserver-proxy
   sourceRepository: github.com/envoyproxy/envoy
-  repository: envoyproxy/envoy
-  tag: "v1.21.4"
+  repository: envoyproxy/envoy-distroless
+  tag: "v1.23.0"
 - name: apiserver-proxy-sidecar
   sourceRepository: github.com/gardener/apiserver-proxy
   repository: eu.gcr.io/gardener-project/gardener/apiserver-proxy

--- a/charts/shoot-core/components/charts/apiserver-proxy/templates/_helpers.tpl
+++ b/charts/shoot-core/components/charts/apiserver-proxy/templates/_helpers.tpl
@@ -83,6 +83,8 @@ envoy.yaml: |-
                     cluster: uds_admin
             http_filters:
             - name: envoy.filters.http.router
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
 
     clusters:
     - name: kube_apiserver
@@ -108,6 +110,8 @@ envoy.yaml: |-
             version: V2
           transport_socket:
             name: envoy.transport_sockets.raw_buffer
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.transport_sockets.raw_buffer.v3.RawBuffer
       upstream_connection_options:
         tcp_keepalive:
           keepalive_time: 7200
@@ -126,6 +130,8 @@ envoy.yaml: |-
                     path: /etc/admin-uds/admin.socket
       transport_socket:
         name: envoy.transport_sockets.raw_buffer
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.transport_sockets.raw_buffer.v3.RawBuffer
 {{- end -}}
 
 {{- define "apiserver-proxy.config.name" -}}

--- a/charts/shoot-core/components/charts/apiserver-proxy/templates/apiserver-proxy-daemonset.yaml
+++ b/charts/shoot-core/components/charts/apiserver-proxy/templates/apiserver-proxy-daemonset.yaml
@@ -94,6 +94,7 @@ spec:
           capabilities:
             add:
             - NET_BIND_SERVICE
+          runAsUser: 0
         resources:
           requests:
             cpu: 20m

--- a/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server_test.go
+++ b/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server_test.go
@@ -100,7 +100,8 @@ var _ = Describe("VpnSeedServer", func() {
         port_value: 9443
     listener_filters:
     - name: "envoy.filters.listener.tls_inspector"
-      typed_config: {}
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.filters.listener.tls_inspector.v3.TlsInspector
     filter_chains:
     - transport_socket:
         name: envoy.transport_sockets.tls
@@ -163,6 +164,8 @@ var _ = Describe("VpnSeedServer", func() {
                 dns_lookup_family: V4_ONLY
                 max_hosts: 8192
           - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
           http_protocol_options:
             accept_http_10: true
           upgrade_configs:
@@ -188,12 +191,15 @@ var _ = Describe("VpnSeedServer", func() {
                   prefix: "/metrics"
                   headers:
                   - name: ":method"
-                    exact_match: GET
+                    string_match:
+                      exact: GET
                 route:
                   cluster: prometheus_stats
                   prefix_rewrite: "/stats/prometheus"
           http_filters:
           - name: envoy.filters.http.router
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
   clusters:
   - name: dynamic_forward_proxy_cluster
     connect_timeout: 20s
@@ -219,11 +225,11 @@ var _ = Describe("VpnSeedServer", func() {
         - endpoint:
             address:
               pipe:
-                path: /var/run/envoy.admin
+                path: /home/nonroot/envoy.admin
 admin:
   address:
     pipe:
-      path: /var/run/envoy.admin`,
+      path: /home/nonroot/envoy.admin`,
 			},
 		}
 
@@ -365,8 +371,8 @@ admin:
 									ImagePullPolicy: corev1.PullIfNotPresent,
 									SecurityContext: &corev1.SecurityContext{
 										Capabilities: &corev1.Capabilities{
-											Add: []corev1.Capability{
-												"NET_BIND_SERVICE",
+											Drop: []corev1.Capability{
+												"all",
 											},
 										},
 									},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Update envoy proxy to v1.23.1.

The new envoy proxy release is a bit more strict concerning the typing of its
configuration. Therefore, the config types have to be stated now explicitly.
As the envoy proxy distroless container image supports arm now, the container
image was also switched to reduce the attack surface. However, it is running
as non-root user, which required subsequent changes as well for vpn-seed-server
and apiserver-proxy.
As the switch to a non-root user showed that the capability NET_BIND_SERVICE
was not required by vpn-seed-server, all capabilities were removed from the
envoy proxy in vpn-seed-server.

**Which issue(s) this PR fixes**:
Fixes #6127.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Update envoy proxy to v1.23.1.
```

/cc @DockToFuture @acumino 