### PR TITLE
Use multi-arch image of `nginx`, `curl`, `alpine`, `busybox` and `k8s-example-web-app` for tests

### DIFF
--- a/test/framework/k8s_utils.go
+++ b/test/framework/k8s_utils.go
@@ -480,7 +480,7 @@ func DeployRootPod(ctx context.Context, c client.Client, namespace string, noden
 			Containers: []corev1.Container{
 				{
 					Name:  "root-container",
-					Image: "eu.gcr.io/gardener-project/3rd/busybox:1.29.2",
+					Image: "eu.gcr.io/gardener-project/3rd/busybox:1.29.3",
 					Command: []string{
 						"sleep",
 						"10000000",

--- a/test/framework/resources/templates/guestbook-app.yaml.tpl
+++ b/test/framework/resources/templates/guestbook-app.yaml.tpl
@@ -15,7 +15,7 @@ spec:
         app: guestbook
     spec:
       containers:
-      - image: eu.gcr.io/gardener-project/test/k8s-example-web-app:0.2.0
+      - image: eu.gcr.io/gardener-project/test/k8s-example-web-app:0.3.0
         name: guestbook
         ports:
         - containerPort: 8080

--- a/test/framework/resources/templates/network-nginx-daemonset.yaml.tpl
+++ b/test/framework/resources/templates/network-nginx-daemonset.yaml.tpl
@@ -14,11 +14,11 @@ spec:
         app: net-nginx
     spec:
       containers:
-      - image: eu.gcr.io/gardener-project/3rd/nginx:1.17.5
+      - image: eu.gcr.io/gardener-project/3rd/nginx:1.17.6
         name: net-nginx
         ports:
         - containerPort: 80
-      - image: eu.gcr.io/gardener-project/3rd/curlimages/curl:7.67.0
+      - image: eu.gcr.io/gardener-project/3rd/curlimages/curl:7.70.0
         name: net-curl
         command: ["sh", "-c"]
         args: ["sleep 300"]

--- a/test/framework/resources/templates/simple-load-deployment.yaml.tpl
+++ b/test/framework/resources/templates/simple-load-deployment.yaml.tpl
@@ -14,7 +14,7 @@ spec:
         app: load
     spec:
       containers:
-      - image: eu.gcr.io/gardener-project/3rd/alpine:3.15
+      - image: eu.gcr.io/gardener-project/3rd/alpine:3.16.1
         name: load
         command: ["sh", "-c"]
         {{ if .nodeName }}

--- a/test/framework/resources/templates/vpntunnel-copy.yaml.tpl
+++ b/test/framework/resources/templates/vpntunnel-copy.yaml.tpl
@@ -17,7 +17,7 @@ spec:
         app: {{ .AppLabel }}
     spec:
       initContainers:
-      - image: eu.gcr.io/gardener-project/3rd/alpine:3.15
+      - image: eu.gcr.io/gardener-project/3rd/alpine:3.16.1
         name: data-generator
         command:
         - dd
@@ -28,7 +28,7 @@ spec:
         volumeMounts:
         - name: source-data
           mountPath: /data
-      - image: eu.gcr.io/gardener-project/3rd/alpine:3.15
+      - image: eu.gcr.io/gardener-project/3rd/alpine:3.16.1
         name: install-kubectl
         command:
         - /bin/sh
@@ -40,7 +40,7 @@ spec:
         - name: source-data
           mountPath: /data
       containers:
-      - image: eu.gcr.io/gardener-project/3rd/busybox:1.29.2
+      - image: eu.gcr.io/gardener-project/3rd/busybox:1.29.3
         name: source-container
         command:
         - sleep
@@ -53,7 +53,7 @@ spec:
           mountPath: /data
         - name: kubecfg
           mountPath: /secret
-      - image: eu.gcr.io/gardener-project/3rd/busybox:1.29.2
+      - image: eu.gcr.io/gardener-project/3rd/busybox:1.29.3
         name: target-container
         command:
         - sleep

--- a/test/framework/resources/templates/vpntunnel.yaml.tpl
+++ b/test/framework/resources/templates/vpntunnel.yaml.tpl
@@ -17,7 +17,7 @@ spec:
         app: {{ .AppLabel }}
     spec:
       containers:
-      - image: eu.gcr.io/gardener-project/3rd/curlimages/curl:7.67.0
+      - image: eu.gcr.io/gardener-project/3rd/curlimages/curl:7.70.0
         name: net-curl
         args:
           - /bin/sh


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind enhancement

**What this PR does / why we need it**:
This PR updates the test images (except the redis image) to use multi-arch image.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/backlog/issues/19

**Special notes for your reviewer**:
~~Depends on https://github.wdf.sap.corp/kubernetes/guestbook/pull/3~~

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
