### PR TITLE
Fix cluster autoscaler permissions

### DIFF
--- a/pkg/operation/botanist/component/clusterautoscaler/cluster_autoscaler.go
+++ b/pkg/operation/botanist/component/clusterautoscaler/cluster_autoscaler.go
@@ -475,10 +475,15 @@ func (c *clusterAutoscaler) computeShootResourcesData(serviceAccountName string)
 			},
 			Rules: []rbacv1.PolicyRule{
 				{
+					APIGroups: []string{""},
+					Resources: []string{"configmaps"},
+					Verbs:     []string{"watch", "list", "get", "create"},
+				},
+				{
 					APIGroups:     []string{""},
 					Resources:     []string{"configmaps"},
 					ResourceNames: []string{"cluster-autoscaler-status"},
-					Verbs:         []string{"delete", "get", "update", "create"},
+					Verbs:         []string{"delete", "update"},
 				},
 			},
 		}

--- a/pkg/operation/botanist/component/clusterautoscaler/cluster_autoscaler.go
+++ b/pkg/operation/botanist/component/clusterautoscaler/cluster_autoscaler.go
@@ -409,7 +409,7 @@ func (c *clusterAutoscaler) computeShootResourcesData(serviceAccountName string)
 				},
 				{
 					APIGroups: []string{""},
-					Resources: []string{"pods", "services", "replicationcontrollers", "persistentvolumeclaims", "persistentvolumes"},
+					Resources: []string{"namespaces", "pods", "services", "replicationcontrollers", "persistentvolumeclaims", "persistentvolumes"},
 					Verbs:     []string{"watch", "list", "get"},
 				},
 				{
@@ -446,11 +446,6 @@ func (c *clusterAutoscaler) computeShootResourcesData(serviceAccountName string)
 				{
 					APIGroups: []string{"batch"},
 					Resources: []string{"jobs", "cronjobs"},
-					Verbs:     []string{"get", "list", "watch"},
-				},
-				{
-					APIGroups: []string{""},
-					Resources: []string{"namespaces"},
 					Verbs:     []string{"get", "list", "watch"},
 				},
 			},

--- a/pkg/operation/botanist/component/clusterautoscaler/cluster_autoscaler.go
+++ b/pkg/operation/botanist/component/clusterautoscaler/cluster_autoscaler.go
@@ -388,7 +388,7 @@ func (c *clusterAutoscaler) computeShootResourcesData(serviceAccountName string)
 				},
 				{
 					APIGroups: []string{""},
-					Resources: []string{"pods/eviction", "configmaps"},
+					Resources: []string{"pods/eviction"},
 					Verbs:     []string{"create"},
 				},
 				{
@@ -426,12 +426,6 @@ func (c *clusterAutoscaler) computeShootResourcesData(serviceAccountName string)
 					APIGroups: []string{"storage.k8s.io"},
 					Resources: []string{"storageclasses", "csinodes", "csidrivers", "csistoragecapacities"},
 					Verbs:     []string{"watch", "list", "get"},
-				},
-				{
-					APIGroups:     []string{""},
-					Resources:     []string{"configmaps"},
-					ResourceNames: []string{"cluster-autoscaler-status"},
-					Verbs:         []string{"delete", "get", "update"},
 				},
 				{
 					APIGroups: []string{"coordination.k8s.io"},
@@ -472,10 +466,44 @@ func (c *clusterAutoscaler) computeShootResourcesData(serviceAccountName string)
 				Namespace: metav1.NamespaceSystem,
 			}},
 		}
+
+		role = &rbacv1.Role{
+			TypeMeta: metav1.TypeMeta{},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "gardener.cloud:target:cluster-autoscaler",
+				Namespace: metav1.NamespaceSystem,
+			},
+			Rules: []rbacv1.PolicyRule{
+				{
+					APIGroups:     []string{""},
+					Resources:     []string{"configmaps"},
+					ResourceNames: []string{"cluster-autoscaler-status"},
+					Verbs:         []string{"delete", "get", "update", "create"},
+				},
+			},
+		}
+
+		rolebinding = &rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "gardener.cloud:target:cluster-autoscaler",
+				Namespace: metav1.NamespaceSystem,
+			},
+			Subjects: []rbacv1.Subject{{
+				Kind: rbacv1.ServiceAccountKind,
+				Name: serviceAccountName,
+			}},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: rbacv1.GroupName,
+				Kind:     "Role",
+				Name:     role.Name,
+			},
+		}
 	)
 
 	return registry.AddAllAndSerialize(
 		clusterRole,
 		clusterRoleBinding,
+		role,
+		rolebinding,
 	)
 }

--- a/pkg/operation/botanist/component/clusterautoscaler/cluster_autoscaler.go
+++ b/pkg/operation/botanist/component/clusterautoscaler/cluster_autoscaler.go
@@ -448,6 +448,11 @@ func (c *clusterAutoscaler) computeShootResourcesData(serviceAccountName string)
 					Resources: []string{"jobs", "cronjobs"},
 					Verbs:     []string{"get", "list", "watch"},
 				},
+				{
+					APIGroups: []string{""},
+					Resources: []string{"namespaces"},
+					Verbs:     []string{"get", "list", "watch"},
+				},
 			},
 		}
 

--- a/pkg/operation/botanist/component/clusterautoscaler/cluster_autoscaler_test.go
+++ b/pkg/operation/botanist/component/clusterautoscaler/cluster_autoscaler_test.go
@@ -443,6 +443,14 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
 `
 		clusterRoleBindingYAML = `apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/pkg/operation/botanist/component/clusterautoscaler/cluster_autoscaler_test.go
+++ b/pkg/operation/botanist/component/clusterautoscaler/cluster_autoscaler_test.go
@@ -468,15 +468,22 @@ metadata:
 rules:
 - apiGroups:
   - ""
+  resources:
+  - configmaps
+  verbs:
+  - watch
+  - list
+  - get
+  - create
+- apiGroups:
+  - ""
   resourceNames:
   - cluster-autoscaler-status
   resources:
   - configmaps
   verbs:
   - delete
-  - get
   - update
-  - create
 `
 
 		roleBindingYAML = `apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/operation/botanist/component/clusterautoscaler/cluster_autoscaler_test.go
+++ b/pkg/operation/botanist/component/clusterautoscaler/cluster_autoscaler_test.go
@@ -371,6 +371,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
   - pods
   - services
   - replicationcontrollers
@@ -439,14 +440,6 @@ rules:
   resources:
   - jobs
   - cronjobs
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
   verbs:
   - get
   - list


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind bug

**What this PR does / why we need it**
Adjust permissions for cluster-autoscaler, such that we don't see any error messages anymore and we can make use of `expander: priority`. At the same time, I reduced the scope of permissions for ConfigMaps, as the cluster-autoscaler only needs access to the `kube-system` namespace. 

**Which issue(s) this PR fixes**:
Fixes #6370 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
Fixed a bug that prevented Shoots from being able to use `expander: priority` for cluster-autoscaler
```
