### PR TITLE
Show actual db size in KAS dashboard

### DIFF
--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/apiserver-overview.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/apiserver-overview.json
@@ -2101,7 +2101,7 @@
         "current": false,
         "max": false,
         "min": false,
-        "show": false,
+        "show": true,
         "total": false,
         "values": false
       },
@@ -2122,9 +2122,9 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(etcd_db_total_size_in_bytes{job=~\"$apiserver\"})",
+          "expr": "topk(1, etcd_db_total_size_in_bytes{job=~\"$apiserver\"}) by (endpoint)",
           "interval": "",
-          "legendFormat": "Size",
+          "legendFormat": "{{endpoint}}",
           "refId": "A"
         }
       ],

--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/apiserver-overview.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/apiserver-overview.json
@@ -2101,7 +2101,7 @@
         "current": false,
         "max": false,
         "min": false,
-        "show": true,
+        "show": false,
         "total": false,
         "values": false
       },
@@ -2122,7 +2122,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "topk(1, etcd_db_total_size_in_bytes{job=~\"$apiserver\"}) by (endpoint)",
+          "expr": "max(etcd_db_total_size_in_bytes{job=~\"$apiserver\"}) by (endpoint)",
           "interval": "",
           "legendFormat": "{{endpoint}}",
           "refId": "A"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
Earlier the etcd db size shown in the `API Server` dashboard was the sum of all Kube-Apiserver pods for `etcd-main` and `etcd-events` which distorts the actual db size.

```
sum(etcd_db_total_size_in_bytes{job=~"$apiserver"})
```

**Special notes for your reviewer**:
/cc @dguendisch 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `API Server` dashboard in Grafana now shows the actual DB size per instance (`etcd-main`, `etcd-events`). Earlier those values were summed up and distorted if more than one kube-apiserver replica existed in the control plane.
```
