### PR TITLE
Use debug log level in all tests

### DIFF
--- a/docs/development/logging.md
+++ b/docs/development/logging.md
@@ -228,7 +228,7 @@ See [Dave Cheney's post](https://dave.cheney.net/2015/11/05/lets-talk-about-logg
 - Pass `zap.WriteTo(GinkgoWriter)` in tests where you want to see the logs on test failure but not on success, for example:
 
   ```go
-  logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)))
+  logf.SetLogger(logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)))
   log := logf.Log.WithName("test")
   ```
 

--- a/extensions/pkg/controller/status_test.go
+++ b/extensions/pkg/controller/status_test.go
@@ -19,13 +19,14 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/go-logr/logr"
+
 	. "github.com/gardener/gardener/extensions/pkg/controller"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	"github.com/gardener/gardener/pkg/logger"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
-	"github.com/go-logr/logr"
 
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
@@ -54,7 +55,7 @@ var _ = Describe("Status", func() {
 
 	BeforeEach(func() {
 		ctrl = gomock.NewController(GinkgoT())
-		log = logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON, logzap.WriteTo(GinkgoWriter))
+		log = logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, logzap.WriteTo(GinkgoWriter))
 		c = mockclient.NewMockClient(ctrl)
 
 		statusUpdater = NewStatusUpdater()

--- a/extensions/pkg/terraformer/state_test.go
+++ b/extensions/pkg/terraformer/state_test.go
@@ -40,7 +40,7 @@ var _ = Describe("terraformer", func() {
 
 	BeforeEach(func() {
 		ctx = context.Background()
-		log = logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON, logzap.WriteTo(GinkgoWriter))
+		log = logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, logzap.WriteTo(GinkgoWriter))
 	})
 
 	Describe("#IsStateEmpty", func() {

--- a/extensions/pkg/terraformer/terraform_test.go
+++ b/extensions/pkg/terraformer/terraform_test.go
@@ -77,7 +77,7 @@ var _ = Describe("terraformer", func() {
 
 		ctx = context.Background()
 
-		log = logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON, logzap.WriteTo(GinkgoWriter))
+		log = logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, logzap.WriteTo(GinkgoWriter))
 	})
 
 	AfterEach(func() {

--- a/pkg/admissioncontroller/webhooks/admission/auditpolicy/admission_test.go
+++ b/pkg/admissioncontroller/webhooks/admission/auditpolicy/admission_test.go
@@ -161,7 +161,7 @@ rules:
 	)
 
 	BeforeEach(func() {
-		log = logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON, logzap.WriteTo(GinkgoWriter))
+		log = logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, logzap.WriteTo(GinkgoWriter))
 		testEncoder = &jsonserializer.Serializer{}
 
 		ctrl = gomock.NewController(GinkgoT())

--- a/pkg/admissioncontroller/webhooks/admission/internaldomainsecret/admission_test.go
+++ b/pkg/admissioncontroller/webhooks/admission/internaldomainsecret/admission_test.go
@@ -73,7 +73,7 @@ var _ = Describe("handler", func() {
 	)
 
 	BeforeEach(func() {
-		log = logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON, logzap.WriteTo(GinkgoWriter))
+		log = logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, logzap.WriteTo(GinkgoWriter))
 
 		ctrl = gomock.NewController(GinkgoT())
 		mockReader = mockclient.NewMockReader(ctrl)

--- a/pkg/admissioncontroller/webhooks/admission/kubeconfigsecret/admission_test.go
+++ b/pkg/admissioncontroller/webhooks/admission/kubeconfigsecret/admission_test.go
@@ -154,7 +154,7 @@ users:
 	)
 
 	BeforeEach(func() {
-		log = logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON, logzap.WriteTo(GinkgoWriter))
+		log = logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, logzap.WriteTo(GinkgoWriter))
 
 		var err error
 		decoder, err = admission.NewDecoder(kubernetes.GardenScheme)

--- a/pkg/admissioncontroller/webhooks/admission/namespacedeletion/admission_test.go
+++ b/pkg/admissioncontroller/webhooks/admission/namespacedeletion/admission_test.go
@@ -65,7 +65,7 @@ var _ = Describe("handler", func() {
 	)
 
 	BeforeEach(func() {
-		log = logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON, logzap.WriteTo(GinkgoWriter))
+		log = logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, logzap.WriteTo(GinkgoWriter))
 
 		ctrl = gomock.NewController(GinkgoT())
 		mockCache = mockcache.NewMockCache(ctrl)

--- a/pkg/admissioncontroller/webhooks/admission/resourcesize/admission_test.go
+++ b/pkg/admissioncontroller/webhooks/admission/resourcesize/admission_test.go
@@ -217,7 +217,7 @@ var _ = Describe("handler", func() {
 
 	BeforeEach(func() {
 		logBuffer = gbytes.NewBuffer()
-		log = logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON, logzap.WriteTo(io.MultiWriter(GinkgoWriter, logBuffer)), logzap.Level(zapcore.Level(0)))
+		log = logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, logzap.WriteTo(io.MultiWriter(GinkgoWriter, logBuffer)), logzap.Level(zapcore.Level(0)))
 
 		var err error
 		decoder, err = admission.NewDecoder(kubernetes.GardenScheme)

--- a/pkg/admissioncontroller/webhooks/admission/seedrestriction/admission_test.go
+++ b/pkg/admissioncontroller/webhooks/admission/seedrestriction/admission_test.go
@@ -88,7 +88,7 @@ var _ = Describe("handler", func() {
 		decoder, err = admission.NewDecoder(kubernetes.GardenScheme)
 		Expect(err).NotTo(HaveOccurred())
 
-		log = logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON, logzap.WriteTo(GinkgoWriter))
+		log = logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, logzap.WriteTo(GinkgoWriter))
 		request = admission.Request{}
 		encoder = &json.Serializer{}
 

--- a/pkg/admissioncontroller/webhooks/auth/seed/authorizer_test.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/authorizer_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Seed", func() {
 		ctx = context.Background()
 		ctrl = gomock.NewController(GinkgoT())
 
-		log = logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON, logzap.WriteTo(GinkgoWriter))
+		log = logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, logzap.WriteTo(GinkgoWriter))
 		graph = mockgraph.NewMockInterface(ctrl)
 		authorizer = NewAuthorizer(log, graph)
 

--- a/pkg/admissioncontroller/webhooks/auth/seed/graph/graph_test.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/graph/graph_test.go
@@ -150,7 +150,7 @@ var _ = Describe("graph", func() {
 			},
 		}
 
-		log = logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON, logzap.WriteTo(GinkgoWriter))
+		log = logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, logzap.WriteTo(GinkgoWriter))
 		graph = New(log, fakeClient)
 		Expect(graph.Setup(ctx, fakeInformers)).To(Succeed())
 

--- a/pkg/admissioncontroller/webhooks/auth/seed/handler_test.go
+++ b/pkg/admissioncontroller/webhooks/auth/seed/handler_test.go
@@ -36,7 +36,7 @@ import (
 
 var _ = Describe("Handler", func() {
 	var (
-		log = logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON, logzap.WriteTo(GinkgoWriter), logzap.Level(zapcore.Level(0)))
+		log = logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, logzap.WriteTo(GinkgoWriter), logzap.Level(zapcore.Level(0)))
 
 		handler      http.HandlerFunc
 		respRecorder *httptest.ResponseRecorder

--- a/pkg/resourcemanager/webhook/projectedtokenmount/handler_test.go
+++ b/pkg/resourcemanager/webhook/projectedtokenmount/handler_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Handler", func() {
 	)
 
 	BeforeEach(func() {
-		log = logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON, logzap.WriteTo(GinkgoWriter))
+		log = logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, logzap.WriteTo(GinkgoWriter))
 
 		decoder, err = admission.NewDecoder(kubernetesscheme.Scheme)
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/resourcemanager/webhook/tokeninvalidator/handler_test.go
+++ b/pkg/resourcemanager/webhook/tokeninvalidator/handler_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Handler", func() {
 	)
 
 	BeforeEach(func() {
-		log = logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON, logzap.WriteTo(GinkgoWriter))
+		log = logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, logzap.WriteTo(GinkgoWriter))
 
 		decoder, err = admission.NewDecoder(kubernetesscheme.Scheme)
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/seedadmissioncontroller/webhooks/admission/extensioncrds/admission_test.go
+++ b/pkg/seedadmissioncontroller/webhooks/admission/extensioncrds/admission_test.go
@@ -63,7 +63,7 @@ var _ = Describe("handler", func() {
 		)
 
 		BeforeEach(func() {
-			log = logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON, logzap.WriteTo(GinkgoWriter))
+			log = logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, logzap.WriteTo(GinkgoWriter))
 
 			ctrl = gomock.NewController(GinkgoT())
 			c = mockclient.NewMockClient(ctrl)

--- a/test/framework/framework_test.go
+++ b/test/framework/framework_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Framework tests", func() {
 
 		It("Should download chart artifacts", func() {
 			f = &framework.CommonFramework{
-				Logger:       logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)),
+				Logger:       logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)),
 				ResourcesDir: "./resources",
 				ChartDir:     "./resources/charts",
 			}

--- a/test/integration/controllermanager/shoot/hibernation/hibernation_suite_test.go
+++ b/test/integration/controllermanager/shoot/hibernation/hibernation_suite_test.go
@@ -48,7 +48,7 @@ var (
 )
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)).WithName("test"))
+	logf.SetLogger(logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)).WithName("test"))
 
 	By("starting test environment")
 	testEnv = &envtest.GardenerTestEnvironment{

--- a/test/integration/controllermanager/shoot/maintenance/maintenance_suite_test.go
+++ b/test/integration/controllermanager/shoot/maintenance/maintenance_suite_test.go
@@ -54,7 +54,7 @@ var (
 )
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)))
+	logf.SetLogger(logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)))
 	log = logf.Log.WithName("test")
 
 	By("starting test environment")

--- a/test/integration/controllermanager/shoot/retry/retry_suite_test.go
+++ b/test/integration/controllermanager/shoot/retry/retry_suite_test.go
@@ -47,7 +47,7 @@ var (
 )
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)).WithName("test"))
+	logf.SetLogger(logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)).WithName("test"))
 
 	By("starting test environment")
 	testEnv = &envtest.GardenerTestEnvironment{

--- a/test/integration/envtest/envtest_suite_test.go
+++ b/test/integration/envtest/envtest_suite_test.go
@@ -46,7 +46,7 @@ var (
 )
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)).WithName("test"))
+	logf.SetLogger(logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)).WithName("test"))
 
 	By("starting test environment")
 	testEnv = &envtest.GardenerTestEnvironment{}

--- a/test/integration/extensions/controller/backupbucket/backupbucket_suite_test.go
+++ b/test/integration/extensions/controller/backupbucket/backupbucket_suite_test.go
@@ -45,7 +45,7 @@ var (
 )
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)))
+	logf.SetLogger(logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)))
 	log = logf.Log.WithName("backupbucket-test")
 
 	By("starting test environment")

--- a/test/integration/extensions/webhook/certificates/certificates_suite_test.go
+++ b/test/integration/extensions/webhook/certificates/certificates_suite_test.go
@@ -46,7 +46,7 @@ var (
 )
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)).WithName("test"))
+	logf.SetLogger(logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)).WithName("test"))
 
 	By("starting test environment")
 	testEnv = &envtest.Environment{

--- a/test/integration/gardenlet/shoot/secret/secret_suite_test.go
+++ b/test/integration/gardenlet/shoot/secret/secret_suite_test.go
@@ -56,7 +56,7 @@ var (
 )
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)).WithName("test"))
+	logf.SetLogger(logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)).WithName("test"))
 
 	By("starting test environment")
 	testEnv = &gardenerenvtest.GardenerTestEnvironment{

--- a/test/integration/resourcemanager/garbagecollector/garbagecollector_suite_test.go
+++ b/test/integration/resourcemanager/garbagecollector/garbagecollector_suite_test.go
@@ -55,7 +55,7 @@ var (
 )
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)))
+	logf.SetLogger(logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)))
 	log = logf.Log.WithName("test")
 
 	By("starting test environment")

--- a/test/integration/resourcemanager/health/health_suite_test.go
+++ b/test/integration/resourcemanager/health/health_suite_test.go
@@ -59,7 +59,7 @@ var (
 )
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)))
+	logf.SetLogger(logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)))
 	log = logf.Log.WithName("test")
 
 	By("starting test environment")

--- a/test/integration/resourcemanager/managedresource/resource_suite_test.go
+++ b/test/integration/resourcemanager/managedresource/resource_suite_test.go
@@ -62,7 +62,7 @@ var (
 )
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)))
+	logf.SetLogger(logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)))
 	log = logf.Log.WithName("test")
 
 	By("starting test environment")

--- a/test/integration/resourcemanager/podschedulername/podschedulername_suite_test.go
+++ b/test/integration/resourcemanager/podschedulername/podschedulername_suite_test.go
@@ -51,7 +51,7 @@ var (
 )
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)).WithName("test"))
+	logf.SetLogger(logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)).WithName("test"))
 
 	By("starting test environment")
 	testEnv = &envtest.Environment{

--- a/test/integration/resourcemanager/rootcapublisher/publisher_suite_test.go
+++ b/test/integration/resourcemanager/rootcapublisher/publisher_suite_test.go
@@ -54,7 +54,7 @@ var (
 )
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)).WithName("test"))
+	logf.SetLogger(logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)).WithName("test"))
 
 	By("starting test environment")
 	var err error

--- a/test/integration/resourcemanager/secret/secret_suite_test.go
+++ b/test/integration/resourcemanager/secret/secret_suite_test.go
@@ -61,7 +61,7 @@ var (
 )
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)))
+	logf.SetLogger(logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)))
 	log = logf.Log.WithName("secret-test")
 
 	By("starting test environment")

--- a/test/integration/resourcemanager/tokeninvalidator/tokeninvalidator_suite_test.go
+++ b/test/integration/resourcemanager/tokeninvalidator/tokeninvalidator_suite_test.go
@@ -54,7 +54,7 @@ var (
 )
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)).WithName("test"))
+	logf.SetLogger(logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)).WithName("test"))
 
 	By("starting test environment")
 	testEnv = &envtest.Environment{

--- a/test/integration/resourcemanager/tokenrequestor/tokenrequestor_suite_test.go
+++ b/test/integration/resourcemanager/tokenrequestor/tokenrequestor_suite_test.go
@@ -50,7 +50,7 @@ var (
 )
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)).WithName("test"))
+	logf.SetLogger(logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)).WithName("test"))
 
 	By("starting test environment")
 	testEnv = &envtest.Environment{}

--- a/test/integration/scheduler/scheduler_suite_test.go
+++ b/test/integration/scheduler/scheduler_suite_test.go
@@ -60,7 +60,7 @@ var (
 )
 
 var _ = BeforeSuite(func() {
-	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)).WithName("test"))
+	logf.SetLogger(logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)).WithName("test"))
 
 	By("starting test environment")
 	testEnv = &envtest.GardenerTestEnvironment{

--- a/test/integration/seedadmissioncontroller/seedadmission_suite_test.go
+++ b/test/integration/seedadmissioncontroller/seedadmission_suite_test.go
@@ -62,7 +62,7 @@ var _ = BeforeSuite(func() {
 	utils.DeduplicateWarnings()
 	ctx, ctxCancel = context.WithCancel(context.Background())
 
-	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)))
+	logf.SetLogger(logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)))
 	log = logf.Log.WithName("test")
 
 	By("starting test environment")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

Switch all unit and integration tests to debug log level.
Usually, you don't see the logs of tests (success case).
However, if there are failures and you see the logs, you will want to get as many details as possible for debugging.

part of https://github.com/gardener/gardener/issues/4251