### PR TITLE
Remove warning in vpn-shoot by setting the correct file permissions on tls key.

### DIFF
--- a/pkg/operation/botanist/component/vpnshoot/vpnshoot.go
+++ b/pkg/operation/botanist/component/vpnshoot/vpnshoot.go
@@ -649,7 +649,7 @@ func (v *vpnShoot) getVolumes(secretCA, secret, secretTLSAuth, secretDH *corev1.
 			Name: volumeName,
 			VolumeSource: corev1.VolumeSource{
 				Projected: &corev1.ProjectedVolumeSource{
-					DefaultMode: pointer.Int32(420),
+					DefaultMode: pointer.Int32(0400),
 					Sources: []corev1.VolumeProjection{
 						{
 							Secret: &corev1.SecretProjection{

--- a/pkg/operation/botanist/component/vpnshoot/vpnshoot_test.go
+++ b/pkg/operation/botanist/component/vpnshoot/vpnshoot_test.go
@@ -328,7 +328,7 @@ status: {}
 							Name: "vpn-shoot",
 							VolumeSource: corev1.VolumeSource{
 								Projected: &corev1.ProjectedVolumeSource{
-									DefaultMode: pointer.Int32(420),
+									DefaultMode: pointer.Int32(0400),
 									Sources: []corev1.VolumeProjection{
 										{
 											Secret: &corev1.SecretProjection{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind cleanup

**What this PR does / why we need it**:
Remove warning in vpn-shoot by setting the correct file permissions on tls key.

OpenVPN complains if the private key is group/other accessible, which it should
not be. This change sets the permissions properly and thereby silences the
warning.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:
A similar change is not possible (easily) on the `vpn-seed-server` side as the secret is used by openvpn and envoy proxy, but the latter one is not running as root.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
A warning in vpn-shoot about the private key being group/other accessible is now addressed.
```
