### PR TITLE
[ci:component:github.com/gardener/etcd-druid:v0.10.0->v0.11.1]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -30,7 +30,7 @@ images:
 - name: etcd-druid
   sourceRepository: github.com/gardener/etcd-druid
   repository: eu.gcr.io/gardener-project/gardener/etcd-druid
-  tag: "v0.10.0"
+  tag: "v0.11.1"
 - name: dependency-watchdog
   sourceRepository: github.com/gardener/dependency-watchdog
   repository: eu.gcr.io/gardener-project/gardener/dependency-watchdog

--- a/pkg/operation/botanist/component/etcd/bootstrap.go
+++ b/pkg/operation/botanist/component/etcd/bootstrap.go
@@ -318,7 +318,7 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 }
 
 func getDruidDeployCommands(gardenletConf *config.GardenletConfiguration) []string {
-	command := []string{"" + "/bin/etcd-druid"}
+	command := []string{"" + "/etcd-druid"}
 	command = append(command, "--enable-leader-election=true")
 	command = append(command, "--ignore-operation-annotation=false")
 	command = append(command, "--disable-etcd-serviceaccount-automount=true")

--- a/pkg/operation/botanist/component/etcd/bootstrap.go
+++ b/pkg/operation/botanist/component/etcd/bootstrap.go
@@ -108,7 +108,7 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 				{
 					APIGroups: []string{corev1.GroupName},
 					Resources: []string{"pods"},
-					Verbs:     []string{"list", "watch", "delete"},
+					Verbs:     []string{"get", "list", "watch", "delete"},
 				},
 				{
 					APIGroups: []string{corev1.GroupName},

--- a/pkg/operation/botanist/component/etcd/bootstrap_test.go
+++ b/pkg/operation/botanist/component/etcd/bootstrap_test.go
@@ -337,7 +337,7 @@ spec:
     spec:
       containers:
       - command:
-        - /bin/etcd-druid
+        - /etcd-druid
         - --enable-leader-election=true
         - --ignore-operation-annotation=false
         - --disable-etcd-serviceaccount-automount=true
@@ -388,7 +388,7 @@ spec:
     spec:
       containers:
       - command:
-        - /bin/etcd-druid
+        - /etcd-druid
         - --enable-leader-election=true
         - --ignore-operation-annotation=false
         - --disable-etcd-serviceaccount-automount=true

--- a/pkg/operation/botanist/component/etcd/bootstrap_test.go
+++ b/pkg/operation/botanist/component/etcd/bootstrap_test.go
@@ -116,6 +116,7 @@ rules:
   resources:
   - pods
   verbs:
+  - get
   - list
   - watch
   - delete


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->

/area control-plane
/kind enhancement

**What this PR does / why we need it**:
Upgrade etcd-druid image from `v0.10.0` to `v0.11.1`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
``` other operator github.com/gardener/etcd-druid #357 @ishan16696
livenessProbe of etcd container has been updated to `ETCDCTL_API=3 etcdctl get foo --consistency=s` making the consistency `serializable`.
```
``` other operator github.com/gardener/etcd-druid #357 @ishan16696
failureThreshold has been updated to `5` for both livenessProbe and readinessProbe of etcd.
```
``` other operator github.com/gardener/etcd-druid #360 @dimityrmirchev
The `etcd-druid` now uses `distroless` instead of `alpine` as a base image.
```
``` other operator github.com/gardener/etcd-druid #366 @aaronfern
`etcd-druid` will now also add statefulset permissions to the etcd role
```
``` other operator github.com/gardener/etcd-druid #367 @timuthy
Published docker images for Etcd-Druid are now multi-arch ready. They support `linux/amd64` and `linux/arm64`.
```
``` other operator github.com/gardener/etcd-druid #271 @aaronfern
Added a new condition `BackupReady` to the etcd status
```
``` noteworthy operator github.com/gardener/etcd-backup-restore #499 @timuthy
Published docker images for Etcd-Backup-Restore are now multi-arch ready. They support `linux/amd64` and `linux/arm64`.
```
``` noteworthy operator github.com/gardener/etcd-backup-restore #499 @timuthy
The Etcd-Backup-Restore image has been updated to `Alpine 3.15.4`.
```
``` action developer github.com/gardener/etcd-backup-restore #403 @aaronfern
Added new package `membergarbagecollector` to remove superfluous members from the ETCD cluster. Due to this, etcd-backup-restore now needs permissions to list `pods` and `statefulsets`.
```
``` improvement operator github.com/gardener/etcd-backup-restore #403 @aaronfern
Added new package `membergarbagecollector` to remove superfluous members from the ETCD cluster.
```
``` noteworthy operator github.com/gardener/etcd-backup-restore #487 @aaronfern
Etcd can now scale up itself from a single member cluster to a multi member cluster
```
``` other operator github.com/gardener/etcd-custom-image #19 @timuthy
Published docker images for Etcd-Custom-Image are now multi-arch ready. They support linux/amd64 and linux/arm64.
```
``` other operator github.com/gardener/etcd-druid #372 @aaronfern
Added pod permission in etcd_role that now enable `etcd-backup-restore` to get/list/watch pods
```
``` improvement operator github.com/gardener/etcd-backup-restore #504 @aaronfern
Fixed a bug where etcd calls related to multi node operation were used in single node operation
```
``` bugfix operator github.com/gardener/etcd-backup-restore #501 @ishan16696
Temp fix: skip the single member restoration if data-dir found to be invalid.
```
``` bugfix operator github.com/gardener/etcd-backup-restore #501 @ishan16696
Fixed a bug in Scaleup feature in func: `IsMemberInCluster()` which can cause Scaleup feature to get fail.
```
``` improvement operator github.com/gardener/etcd-backup-restore #505 @ishan16696
Assigned the correct Peer address to the Etcd after it restores from backup-bucket.
```
``` improvement operator github.com/gardener/etcd-backup-restore #506 @aaronfern
No attempt is made to update member Peer URL when trying to promote a member
```
