### PR TITLE
Fix time format from PR #6150

### DIFF
--- a/charts/seed-bootstrap/charts/fluent-bit/templates/_helpers.tpl
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/_helpers.tpl
@@ -216,23 +216,23 @@ parsers.conf: |-
   [PARSER]
       Name        lokiParser
       Format      regex
-      Regex       ^level=(?<severity>\w+)\s+ts=(?<time>\d{4}-\d{2}-\d{2}[Tt].*[zZ])\s+caller=(?<source>[^\s]*+)\s+(?<log>.*)$
+      Regex       ^level=(?<severity>\w+)\s+ts=(?<time>\d{4}-\d{2}-\d{2}[Tt]{1}\d{2}:\d{2}:\d{2}\.\d+\S+?)\S*?\s+caller=(?<source>.*?)\s+(?<log>.*)$
       Time_Key    time
-      Time_Format %Y-%m-%dT%H:%M:%S%Z
+      Time_Format %Y-%m-%dT%H:%M:%S.%L%z
 
   [PARSER]
       Name        prometheusParser
       Format      regex
-      Regex       ^ts=(?<time>\d{4}-\d{2}-\d{2}[Tt].*[zZ])\s+caller=(?<source>[^\s]*+)\s+level=(?<severity>\w+).*\s+msg=(?<log>.*)$
+      Regex       ^ts=(?<time>\d{4}-\d{2}-\d{2}[Tt]{1}\d{2}:\d{2}:\d{2}\.\d+\S+)\s+caller=(?<source>.+?)\s+level=(?<severity>\w+)\s+(?<log>.*)$
       Time_Key    time
-      Time_Format %Y-%m-%dT%H:%M:%S%Z
+      Time_Format %Y-%m-%dT%H:%M:%S.%L%z
 
   [PARSER]
       Name        lokiCuratorParser
       Format      regex
-      Regex       ^level=(?<severity>\w+)\s+caller=(?<source>[^\s]*+)\s+ts=(?<time>\d{4}-\d{2}-\d{2}[Tt].*[zZ])\s+(?<log>.*)$
+      Regex       ^level=(?<severity>\w+)\s+caller=(?<source>.*?)\s+ts=(?<time>\d{4}-\d{2}-\d{2}[Tt]{1}\d{2}:\d{2}:\d{2}\.\d+\S+?)\S*?\s+(?<log>.*)$
       Time_Key    time
-      Time_Format %Y-%m-%dT%H:%M:%S%Z
+      Time_Format %Y-%m-%dT%H:%M:%S.%L%z
 
   [PARSER]
       Name        extensionsParser

--- a/pkg/operation/botanist/component/vpnseedserver/logging.go
+++ b/pkg/operation/botanist/component/vpnseedserver/logging.go
@@ -31,7 +31,7 @@ const (
     Format      regex
     Regex       ^(?<time>\d{4}-\d{2}-\d{2}\s+[^\s]+)\s+(?<log>.*)$
     Time_Key    time
-    Time_Format %m%d %H:%M:%S.%L
+    Time_Format %Y-%m-%d %H:%M:%S
 `
 	loggingFilterVpnSeedServer = `[FILTER]
     Name                parser
@@ -45,9 +45,9 @@ const (
 	loggingParserEnvoyProxy     = `[PARSER]
     Name        ` + loggingParserNameEnvoyProxy + `
     Format      regex
-    Regex       ^\[(?<time>\d{4}-\d{2}-\d{2}T[^"]*)]\s+(?<log>.*)$
+    Regex       ^\[(?<time>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+\S+?)]\s+(?<log>.*)$
     Time_Key    time
-    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Format %Y-%m-%dT%H:%M:%S.%L%z
 `
 	loggingFilterEnvoyProxy = `[FILTER]
     Name                parser

--- a/pkg/operation/botanist/component/vpnseedserver/logging_test.go
+++ b/pkg/operation/botanist/component/vpnseedserver/logging_test.go
@@ -32,14 +32,14 @@ var _ = Describe("Logging", func() {
     Format      regex
     Regex       ^(?<time>\d{4}-\d{2}-\d{2}\s+[^\s]+)\s+(?<log>.*)$
     Time_Key    time
-    Time_Format %m%d %H:%M:%S.%L
+    Time_Format %Y-%m-%d %H:%M:%S
 
 [PARSER]
     Name        vpnSeedServerEnvoyProxyParser
     Format      regex
-    Regex       ^\[(?<time>\d{4}-\d{2}-\d{2}T[^"]*)]\s+(?<log>.*)$
+    Regex       ^\[(?<time>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+\S+?)]\s+(?<log>.*)$
     Time_Key    time
-    Time_Format %Y-%m-%dT%H:%M:%S%z
+    Time_Format %Y-%m-%dT%H:%M:%S.%L%z
 `))
 
 			Expect(loggingConfig.Filters).To(Equal(`[FILTER]


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind bug

**What this PR does / why we need it**:
The time format of some of the parsers from #6250 does not describe the milliseconds, aka time after the dot `.\d{0,9}Z`. According to the [fluent-bit documentation](https://docs.fluentbit.io/manual/pipeline/parsers/configuring-parser) the parsers are using [strptime(3)](https://linux.die.net/man/3/strptime) to parse the time. The documentation lack such examples.
```
[2022/07/22 12:55:56] [ warn] [parser:lokiParser] invalid time format %Y-%m-%dT%H:%M:%S%Z for '2022-07-22T12:55:56.23057524Z'
[2022/07/22 12:54:58] [ warn] [parser:prometheusParser] invalid time format %Y-%m-%dT%H:%M:%S%Z for '2022-07-22T12:54:58.210Z'
[2022/07/22 12:47:39] [ warn] [parser:vpnSeedServerEnvoyProxyParser] invalid time format %Y-%m-%dT%H:%M:%S%z for '2022-07-22T12:47:18.485Z'
```
I used a python [script](https://www.geeksforgeeks.org/python-validate-string-date-format/) (which uses `strptime`) to verify the time format.
According to this [StackOverflow question](https://stackoverflow.com/questions/698223/how-can-i-parse-a-time-string-containing-milliseconds-in-it-with-python) the milliseconds can be handled via `.%f`. This is true only for the python script and was rejected from the `fluent-bit` code.
In the end, `.%L%z` form the [issue](https://github.com/fluent/fluent-bit/issues/703) did the job.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The Loki, Prometheus, and the VPN seed server envoy proxy parsers parse timezone and milliseconds from the timestamp.
```
