### PR TITLE
Migration to PodSecurity (1)

### DIFF
--- a/charts/shoot-core/components/charts/apiserver-proxy/templates/psp/apiserver-proxy-clusterrole.yaml
+++ b/charts/shoot-core/components/charts/apiserver-proxy/templates/psp/apiserver-proxy-clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if semverCompare "< 1.23-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
 metadata:
@@ -15,3 +16,4 @@ rules:
   - podsecuritypolicies
   verbs:
   - use
+{{- end }}

--- a/charts/shoot-core/components/charts/apiserver-proxy/templates/psp/apiserver-proxy-psp.yaml
+++ b/charts/shoot-core/components/charts/apiserver-proxy/templates/psp/apiserver-proxy-psp.yaml
@@ -1,3 +1,4 @@
+{{- if semverCompare "< 1.23-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: {{ include "podsecuritypolicyversion" .}}
 kind: PodSecurityPolicy
 metadata:
@@ -30,3 +31,4 @@ spec:
   fsGroup:
     rule: 'RunAsAny'
   readOnlyRootFilesystem: false
+{{- end }}

--- a/charts/shoot-core/components/charts/apiserver-proxy/templates/psp/apiserver-proxy-rolebinding.yaml
+++ b/charts/shoot-core/components/charts/apiserver-proxy/templates/psp/apiserver-proxy-rolebinding.yaml
@@ -11,7 +11,11 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
+  {{- if semverCompare "< 1.23-0" .Capabilities.KubeVersion.GitVersion }}
   name: gardener.cloud:psp:kube-system:apiserver-proxy
+  {{- else }}
+  name: gardener.cloud:psp:privileged
+  {{- end }}
 subjects:
 - kind: ServiceAccount
   name: apiserver-proxy

--- a/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/psp/node-exporter-clusterrole.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/psp/node-exporter-clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if semverCompare "< 1.23-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
 metadata:
@@ -12,3 +13,4 @@ rules:
   - podsecuritypolicies
   verbs:
   - use
+{{- end }}

--- a/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/psp/node-exporter-psp.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/psp/node-exporter-psp.yaml
@@ -1,3 +1,4 @@
+{{- if semverCompare "< 1.23-0" .Capabilities.KubeVersion.GitVersion }}
 apiVersion: {{ include "podsecuritypolicyversion" .}}
 kind: PodSecurityPolicy
 metadata:
@@ -24,3 +25,4 @@ spec:
   fsGroup:
     rule: 'RunAsAny'
   readOnlyRootFilesystem: false
+{{- end }}

--- a/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/psp/node-exporter-rolebinding.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/psp/node-exporter-rolebinding.yaml
@@ -8,7 +8,11 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
+  {{- if semverCompare "< 1.23-0" .Capabilities.KubeVersion.GitVersion }}
   name: gardener.cloud:psp:kube-system:node-exporter
+  {{- else }}
+  name: gardener.cloud:psp:privileged
+  {{- end }}
 subjects:
 - kind: ServiceAccount
   name: node-exporter

--- a/pkg/operation/botanist/component/kubeproxy/kube_proxy.go
+++ b/pkg/operation/botanist/component/kubeproxy/kube_proxy.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gardener/gardener/pkg/utils/flow"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 
+	"github.com/Masterminds/semver"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -102,6 +103,8 @@ type Values struct {
 	VPAEnabled bool
 	// WorkerPools is a list of worker pools for which the kube-proxy DaemonSets should be deployed.
 	WorkerPools []WorkerPool
+	// Version is the Kubernetes version of the cluster
+	Version *semver.Version
 }
 
 // WorkerPool contains configuration for the kube-proxy deployment for this specific worker pool.

--- a/pkg/operation/botanist/component/kubeproxy/kube_proxy_test.go
+++ b/pkg/operation/botanist/component/kubeproxy/kube_proxy_test.go
@@ -28,7 +28,9 @@ import (
 	retryfake "github.com/gardener/gardener/pkg/utils/retry/fake"
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	"github.com/gardener/gardener/pkg/utils/version"
 
+	"github.com/Masterminds/semver"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -88,6 +90,7 @@ var _ = Describe("KubeProxy", func() {
 
 	BeforeEach(func() {
 		c = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+		k8sversion, _ := semver.NewVersion("1.24")
 		values = Values{
 			IPVSEnabled: true,
 			FeatureGates: map[string]bool{
@@ -101,6 +104,7 @@ var _ = Describe("KubeProxy", func() {
 				{Name: "pool1", KubernetesVersion: "1.20.13", Image: "some-image:some-tag1"},
 				{Name: "pool2", KubernetesVersion: "1.21.4", Image: "some-image:some-tag2"},
 			},
+			Version: k8sversion,
 		}
 		component = New(c, namespace, values)
 
@@ -401,7 +405,12 @@ rules:
   - use
 `
 
-			roleBindingPSPYAML = `apiVersion: rbac.authorization.k8s.io/v1
+			roleBindingPSPYAMLFor = func(k8sVersion *semver.Version) string {
+				roleRefName := "gardener.cloud:psp:privileged"
+				if version.ConstraintK8sLess123.Check(k8sVersion) {
+					roleRefName = "gardener.cloud:psp:kube-system:kube-proxy"
+				}
+				out := `apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   annotations:
@@ -412,12 +421,14 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: gardener.cloud:psp:kube-system:kube-proxy
+  name: ` + roleRefName + `
 subjects:
 - kind: ServiceAccount
   name: kube-proxy
   namespace: kube-system
 `
+				return out
+			}
 
 			daemonSetNameFor = func(pool WorkerPool) string {
 				return "kube-proxy-" + pool.Name + "-v" + pool.KubernetesVersion
@@ -648,98 +659,115 @@ status: {}
 			}
 		)
 
-		It("should successfully deploy all resources", func() {
-			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceCentral), managedResourceCentral)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: resourcesv1alpha1.SchemeGroupVersion.Group, Resource: "managedresources"}, managedResourceCentral.Name)))
-			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretCentral), managedResourceSecretCentral)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: corev1.SchemeGroupVersion.Group, Resource: "secrets"}, managedResourceSecretCentral.Name)))
+		Context("ClusterVersion", func() {
+			JustBeforeEach(func() {
+				Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceCentral), managedResourceCentral)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: resourcesv1alpha1.SchemeGroupVersion.Group, Resource: "managedresources"}, managedResourceCentral.Name)))
+				Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretCentral), managedResourceSecretCentral)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: corev1.SchemeGroupVersion.Group, Resource: "secrets"}, managedResourceSecretCentral.Name)))
 
-			for _, pool := range values.WorkerPools {
-				By(pool.Name)
+				for _, pool := range values.WorkerPools {
+					By(pool.Name)
 
-				managedResource := managedResourceForPool(pool)
-				managedResourceSecret := managedResourceSecretForPool(pool)
+					managedResource := managedResourceForPool(pool)
+					managedResourceSecret := managedResourceSecretForPool(pool)
 
-				Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: resourcesv1alpha1.SchemeGroupVersion.Group, Resource: "managedresources"}, managedResource.Name)))
-				Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), managedResourceSecret)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: corev1.SchemeGroupVersion.Group, Resource: "secrets"}, managedResourceSecret.Name)))
-			}
+					Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: resourcesv1alpha1.SchemeGroupVersion.Group, Resource: "managedresources"}, managedResource.Name)))
+					Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), managedResourceSecret)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: corev1.SchemeGroupVersion.Group, Resource: "secrets"}, managedResourceSecret.Name)))
+				}
 
-			Expect(component.Deploy(ctx)).To(Succeed())
+				Expect(component.Deploy(ctx)).To(Succeed())
 
-			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceCentral), managedResourceCentral)).To(Succeed())
-			Expect(managedResourceCentral).To(DeepEqual(&resourcesv1alpha1.ManagedResource{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: resourcesv1alpha1.SchemeGroupVersion.String(),
-					Kind:       "ManagedResource",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:            managedResourceCentral.Name,
-					Namespace:       managedResourceCentral.Namespace,
-					ResourceVersion: "1",
-					Labels: map[string]string{
-						"origin":    "gardener",
-						"component": "kube-proxy",
-					},
-				},
-				Spec: resourcesv1alpha1.ManagedResourceSpec{
-					InjectLabels: map[string]string{"shoot.gardener.cloud/no-cleanup": "true"},
-					SecretRefs: []corev1.LocalObjectReference{{
-						Name: managedResourceSecretCentral.Name,
-					}},
-					KeepObjects: pointer.Bool(false),
-				},
-			}))
-
-			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretCentral), managedResourceSecretCentral)).To(Succeed())
-			Expect(managedResourceSecretCentral.Type).To(Equal(corev1.SecretTypeOpaque))
-			Expect(managedResourceSecretCentral.Data).To(HaveLen(10))
-			Expect(string(managedResourceSecretCentral.Data["serviceaccount__kube-system__kube-proxy.yaml"])).To(Equal(serviceAccountYAML))
-			Expect(string(managedResourceSecretCentral.Data["clusterrolebinding____gardener.cloud_target_node-proxier.yaml"])).To(Equal(clusterRoleBindingYAML))
-			Expect(string(managedResourceSecretCentral.Data["service__kube-system__kube-proxy.yaml"])).To(Equal(serviceYAML))
-			Expect(string(managedResourceSecretCentral.Data["secret__kube-system__"+secretName+".yaml"])).To(Equal(secretYAML))
-			Expect(string(managedResourceSecretCentral.Data["configmap__kube-system__"+configMapNameFor(values.IPVSEnabled)+".yaml"])).To(Equal(configMapYAMLFor(values.IPVSEnabled)))
-			Expect(string(managedResourceSecretCentral.Data["configmap__kube-system__"+configMapConntrackFixScriptName+".yaml"])).To(Equal(configMapConntrackFixScriptYAML))
-			Expect(string(managedResourceSecretCentral.Data["configmap__kube-system__"+configMapCleanupScriptName+".yaml"])).To(Equal(configMapCleanupScriptYAML))
-			Expect(string(managedResourceSecretCentral.Data["podsecuritypolicy____gardener.kube-system.kube-proxy.yaml"])).To(Equal(podSecurityPolicyYAML))
-			Expect(string(managedResourceSecretCentral.Data["clusterrole____gardener.cloud_psp_kube-system_kube-proxy.yaml"])).To(Equal(clusterRolePSPYAML))
-			Expect(string(managedResourceSecretCentral.Data["rolebinding__kube-system__gardener.cloud_psp_kube-proxy.yaml"])).To(Equal(roleBindingPSPYAML))
-
-			for _, pool := range values.WorkerPools {
-				By(pool.Name)
-
-				managedResource := managedResourceForPool(pool)
-				managedResourceSecret := managedResourceSecretForPool(pool)
-
-				Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
-				Expect(managedResource).To(DeepEqual(&resourcesv1alpha1.ManagedResource{
+				Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceCentral), managedResourceCentral)).To(Succeed())
+				Expect(managedResourceCentral).To(DeepEqual(&resourcesv1alpha1.ManagedResource{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: resourcesv1alpha1.SchemeGroupVersion.String(),
 						Kind:       "ManagedResource",
 					},
 					ObjectMeta: metav1.ObjectMeta{
-						Name:            managedResource.Name,
-						Namespace:       managedResource.Namespace,
+						Name:            managedResourceCentral.Name,
+						Namespace:       managedResourceCentral.Namespace,
 						ResourceVersion: "1",
 						Labels: map[string]string{
-							"origin":             "gardener",
-							"component":          "kube-proxy",
-							"role":               "pool",
-							"pool-name":          pool.Name,
-							"kubernetes-version": pool.KubernetesVersion,
+							"origin":    "gardener",
+							"component": "kube-proxy",
 						},
 					},
 					Spec: resourcesv1alpha1.ManagedResourceSpec{
 						InjectLabels: map[string]string{"shoot.gardener.cloud/no-cleanup": "true"},
 						SecretRefs: []corev1.LocalObjectReference{{
-							Name: managedResourceSecret.Name,
+							Name: managedResourceSecretCentral.Name,
 						}},
 						KeepObjects: pointer.Bool(false),
 					},
 				}))
 
-				Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), managedResourceSecret)).To(Succeed())
-				Expect(managedResourceSecret.Type).To(Equal(corev1.SecretTypeOpaque))
-				Expect(managedResourceSecret.Data).To(HaveLen(1))
-				Expect(string(managedResourceSecret.Data["daemonset__kube-system__"+daemonSetNameFor(pool)+".yaml"])).To(Equal(daemonSetYAMLFor(pool, values.IPVSEnabled, values.VPAEnabled)))
-			}
+				Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretCentral), managedResourceSecretCentral)).To(Succeed())
+				Expect(managedResourceSecretCentral.Type).To(Equal(corev1.SecretTypeOpaque))
+				Expect(managedResourceSecretCentral.Data).To(HaveLen(10))
+				Expect(string(managedResourceSecretCentral.Data["serviceaccount__kube-system__kube-proxy.yaml"])).To(Equal(serviceAccountYAML))
+				Expect(string(managedResourceSecretCentral.Data["clusterrolebinding____gardener.cloud_target_node-proxier.yaml"])).To(Equal(clusterRoleBindingYAML))
+				Expect(string(managedResourceSecretCentral.Data["service__kube-system__kube-proxy.yaml"])).To(Equal(serviceYAML))
+				Expect(string(managedResourceSecretCentral.Data["secret__kube-system__"+secretName+".yaml"])).To(Equal(secretYAML))
+				Expect(string(managedResourceSecretCentral.Data["configmap__kube-system__"+configMapNameFor(values.IPVSEnabled)+".yaml"])).To(Equal(configMapYAMLFor(values.IPVSEnabled)))
+				Expect(string(managedResourceSecretCentral.Data["configmap__kube-system__"+configMapConntrackFixScriptName+".yaml"])).To(Equal(configMapConntrackFixScriptYAML))
+				Expect(string(managedResourceSecretCentral.Data["configmap__kube-system__"+configMapCleanupScriptName+".yaml"])).To(Equal(configMapCleanupScriptYAML))
+
+				for _, pool := range values.WorkerPools {
+					By(pool.Name)
+
+					managedResource := managedResourceForPool(pool)
+					managedResourceSecret := managedResourceSecretForPool(pool)
+
+					Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
+					Expect(managedResource).To(DeepEqual(&resourcesv1alpha1.ManagedResource{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: resourcesv1alpha1.SchemeGroupVersion.String(),
+							Kind:       "ManagedResource",
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:            managedResource.Name,
+							Namespace:       managedResource.Namespace,
+							ResourceVersion: "1",
+							Labels: map[string]string{
+								"origin":             "gardener",
+								"component":          "kube-proxy",
+								"role":               "pool",
+								"pool-name":          pool.Name,
+								"kubernetes-version": pool.KubernetesVersion,
+							},
+						},
+						Spec: resourcesv1alpha1.ManagedResourceSpec{
+							InjectLabels: map[string]string{"shoot.gardener.cloud/no-cleanup": "true"},
+							SecretRefs: []corev1.LocalObjectReference{{
+								Name: managedResourceSecret.Name,
+							}},
+							KeepObjects: pointer.Bool(false),
+						},
+					}))
+
+					Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), managedResourceSecret)).To(Succeed())
+					Expect(managedResourceSecret.Type).To(Equal(corev1.SecretTypeOpaque))
+					Expect(managedResourceSecret.Data).To(HaveLen(1))
+					Expect(string(managedResourceSecret.Data["daemonset__kube-system__"+daemonSetNameFor(pool)+".yaml"])).To(Equal(daemonSetYAMLFor(pool, values.IPVSEnabled, values.VPAEnabled)))
+				}
+
+				It("should deploy all the resources successfully for cluster version <1.23", func() {
+					BeforeEach(func() {
+						values.Version, _ = semver.NewVersion("1.22")
+						component = New(c, namespace, values)
+					})
+					Expect(string(managedResourceSecretCentral.Data["podsecuritypolicy____gardener.kube-system.kube-proxy.yaml"])).To(Equal(podSecurityPolicyYAML))
+					Expect(string(managedResourceSecretCentral.Data["clusterrole____gardener.cloud_psp_kube-system_kube-proxy.yaml"])).To(Equal(clusterRolePSPYAML))
+					Expect(string(managedResourceSecretCentral.Data["rolebinding__kube-system__gardener.cloud_psp_kube-proxy.yaml"])).To(Equal(roleBindingPSPYAMLFor(values.Version)))
+				})
+
+				It("should deploy all the resources successfully for cluster version >=1.23", func() {
+					BeforeEach(func() {
+						values.Version, _ = semver.NewVersion("1.24")
+						component = New(c, namespace, values)
+					})
+					Expect(string(managedResourceSecretCentral.Data["rolebinding__kube-system__gardener.cloud_psp_kube-proxy.yaml"])).To(Equal(roleBindingPSPYAMLFor(values.Version)))
+				})
+			})
 		})
 
 		It("should successfully deploy the expected config when IPVS is disabled", func() {

--- a/pkg/operation/botanist/component/nodelocaldns/nodelocaldns_test.go
+++ b/pkg/operation/botanist/component/nodelocaldns/nodelocaldns_test.go
@@ -507,10 +507,6 @@ status: {}
 			Expect(string(managedResourceSecret.Data["serviceaccount__kube-system__node-local-dns.yaml"])).To(Equal(serviceAccountYAML))
 			Expect(string(managedResourceSecret.Data["service__kube-system__kube-dns-upstream.yaml"])).To(Equal(serviceYAML))
 			Expect(string(managedResourceSecret.Data["rolebinding__kube-system__gardener.cloud_psp_node-local-dns.yaml"])).To(Equal(roleBindingPSPYAMLFor(values.Version)))
-			if version.ConstraintK8sLess123.Check(values.Version) {
-				Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_psp_kube-system_node-local-dns.yaml"])).To(Equal(clusterRoleYAML))
-				Expect(string(managedResourceSecret.Data["podsecuritypolicy____gardener.kube-system.node-local-dns.yaml"])).To(Equal(podSecurityPolicyYAML))
-			}
 		})
 
 		Context("NodeLocalDNS with ipvsEnabled not enabled", func() {
@@ -592,6 +588,8 @@ ip6.arpa:53 {
 							daemonset := daemonSetYAMLFor()
 							utilruntime.Must(references.InjectAnnotations(daemonset))
 							Expect(daemonset).To(DeepEqual(managedResourceDaemonset))
+							Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_psp_kube-system_node-local-dns.yaml"])).To(Equal(clusterRoleYAML))
+							Expect(string(managedResourceSecret.Data["podsecuritypolicy____gardener.kube-system.node-local-dns.yaml"])).To(Equal(podSecurityPolicyYAML))
 						})
 					})
 
@@ -645,6 +643,8 @@ ip6.arpa:53 {
 							daemonset := daemonSetYAMLFor()
 							utilruntime.Must(references.InjectAnnotations(daemonset))
 							Expect(daemonset).To(DeepEqual(managedResourceDaemonset))
+							Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_psp_kube-system_node-local-dns.yaml"])).To(Equal(clusterRoleYAML))
+							Expect(string(managedResourceSecret.Data["podsecuritypolicy____gardener.kube-system.node-local-dns.yaml"])).To(Equal(podSecurityPolicyYAML))
 						})
 					})
 				})
@@ -666,6 +666,8 @@ ip6.arpa:53 {
 							daemonset := daemonSetYAMLFor()
 							utilruntime.Must(references.InjectAnnotations(daemonset))
 							Expect(daemonset).To(DeepEqual(managedResourceDaemonset))
+							Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_psp_kube-system_node-local-dns.yaml"])).To(Equal(clusterRoleYAML))
+							Expect(string(managedResourceSecret.Data["podsecuritypolicy____gardener.kube-system.node-local-dns.yaml"])).To(Equal(podSecurityPolicyYAML))
 						})
 					})
 
@@ -719,6 +721,8 @@ ip6.arpa:53 {
 							daemonset := daemonSetYAMLFor()
 							utilruntime.Must(references.InjectAnnotations(daemonset))
 							Expect(daemonset).To(DeepEqual(managedResourceDaemonset))
+							Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_psp_kube-system_node-local-dns.yaml"])).To(Equal(clusterRoleYAML))
+							Expect(string(managedResourceSecret.Data["podsecuritypolicy____gardener.kube-system.node-local-dns.yaml"])).To(Equal(podSecurityPolicyYAML))
 						})
 					})
 				})
@@ -804,6 +808,8 @@ ip6.arpa:53 {
 							daemonset := daemonSetYAMLFor()
 							utilruntime.Must(references.InjectAnnotations(daemonset))
 							Expect(daemonset).To(DeepEqual(managedResourceDaemonset))
+							Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_psp_kube-system_node-local-dns.yaml"])).To(Equal(clusterRoleYAML))
+							Expect(string(managedResourceSecret.Data["podsecuritypolicy____gardener.kube-system.node-local-dns.yaml"])).To(Equal(podSecurityPolicyYAML))
 						})
 					})
 
@@ -858,6 +864,8 @@ ip6.arpa:53 {
 							daemonset := daemonSetYAMLFor()
 							utilruntime.Must(references.InjectAnnotations(daemonset))
 							Expect(daemonset).To(DeepEqual(managedResourceDaemonset))
+							Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_psp_kube-system_node-local-dns.yaml"])).To(Equal(clusterRoleYAML))
+							Expect(string(managedResourceSecret.Data["podsecuritypolicy____gardener.kube-system.node-local-dns.yaml"])).To(Equal(podSecurityPolicyYAML))
 						})
 					})
 				})
@@ -879,6 +887,8 @@ ip6.arpa:53 {
 							daemonset := daemonSetYAMLFor()
 							utilruntime.Must(references.InjectAnnotations(daemonset))
 							Expect(daemonset).To(DeepEqual(managedResourceDaemonset))
+							Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_psp_kube-system_node-local-dns.yaml"])).To(Equal(clusterRoleYAML))
+							Expect(string(managedResourceSecret.Data["podsecuritypolicy____gardener.kube-system.node-local-dns.yaml"])).To(Equal(podSecurityPolicyYAML))
 						})
 					})
 
@@ -932,6 +942,8 @@ ip6.arpa:53 {
 							daemonset := daemonSetYAMLFor()
 							utilruntime.Must(references.InjectAnnotations(daemonset))
 							Expect(daemonset).To(DeepEqual(managedResourceDaemonset))
+							Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_psp_kube-system_node-local-dns.yaml"])).To(Equal(clusterRoleYAML))
+							Expect(string(managedResourceSecret.Data["podsecuritypolicy____gardener.kube-system.node-local-dns.yaml"])).To(Equal(podSecurityPolicyYAML))
 						})
 					})
 				})

--- a/pkg/operation/botanist/component/nodeproblemdetector/node_problem_detector.go
+++ b/pkg/operation/botanist/component/nodeproblemdetector/node_problem_detector.go
@@ -24,7 +24,9 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
 	"github.com/gardener/gardener/pkg/utils/managedresources"
+	"github.com/gardener/gardener/pkg/utils/version"
 
+	"github.com/Masterminds/semver"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -46,8 +48,8 @@ const (
 	daemonSetName                          = "node-problem-detector"
 	clusterRoleName                        = "node-problem-detector"
 	clusterRoleBindingName                 = "node-problem-detector"
-	clusterRolePSPName                     = "node-problem-detector-psp"
-	clusterRoleBindingPSPName              = "node-problem-detector-psp"
+	clusterRolePSPName                     = "gardener.cloud:psp:kube-system:node-problem-detector"
+	clusterRoleBindingPSPName              = "gardener.cloud:psp:node-problem-detector"
 	vpaName                                = "node-problem-detector"
 	daemonSetTerminationGracePeriodSeconds = 30
 	daemonSetPrometheusPort                = 20257
@@ -64,6 +66,8 @@ type Values struct {
 	Image string
 	// VPAEnabled marks whether VerticalPodAutoscaler is enabled for the shoot.
 	VPAEnabled bool
+	// Version is the Kubernetes version of the cluster
+	Version *semver.Version
 }
 
 // New creates a new instance of DeployWaiter for node-problem-detector.
@@ -169,81 +173,6 @@ func (c *nodeProblemDetector) computeResourcesData() (map[string][]byte, error) 
 				Name:      serviceAccount.Name,
 				Namespace: serviceAccount.Namespace,
 			}},
-		}
-
-		clusterRolePSP = &rbacv1.ClusterRole{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   clusterRolePSPName,
-				Labels: getLabels(),
-			},
-			Rules: []rbacv1.PolicyRule{
-				{
-					APIGroups:     []string{"extensions", "policy"},
-					Resources:     []string{"podsecuritypolicies"},
-					Verbs:         []string{"use"},
-					ResourceNames: []string{"node-problem-detector"},
-				},
-			},
-		}
-
-		clusterRoleBindingPSP = &rbacv1.ClusterRoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:        clusterRoleBindingPSPName,
-				Annotations: map[string]string{resourcesv1alpha1.DeleteOnInvalidUpdate: "true"},
-				Labels:      getLabels(),
-			},
-			RoleRef: rbacv1.RoleRef{
-				APIGroup: rbacv1.GroupName,
-				Kind:     "ClusterRole",
-				Name:     clusterRolePSP.Name,
-			},
-			Subjects: []rbacv1.Subject{{
-				Kind:      rbacv1.ServiceAccountKind,
-				Name:      serviceAccount.Name,
-				Namespace: serviceAccount.Namespace,
-			}},
-		}
-
-		podSecurityPolicy = &policyv1beta1.PodSecurityPolicy{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:   podSecurityPolicyName,
-				Labels: getLabels(),
-			},
-			Spec: policyv1beta1.PodSecurityPolicySpec{
-				Privileged:               true,
-				AllowPrivilegeEscalation: pointer.Bool(true),
-				AllowedCapabilities: []corev1.Capability{
-					corev1.Capability(policyv1beta1.All),
-				},
-				Volumes: []policyv1beta1.FSType{
-					policyv1beta1.ConfigMap,
-					policyv1beta1.EmptyDir,
-					policyv1beta1.Projected,
-					policyv1beta1.Secret,
-					policyv1beta1.DownwardAPI,
-					policyv1beta1.HostPath,
-				},
-				HostNetwork: false,
-				HostIPC:     false,
-				HostPID:     false,
-				AllowedHostPaths: []policyv1beta1.AllowedHostPath{
-					{PathPrefix: "/etc/localtime"},
-					{PathPrefix: "/var/log"},
-					{PathPrefix: "/dev/kmsg"},
-				},
-				RunAsUser: policyv1beta1.RunAsUserStrategyOptions{
-					Rule: policyv1beta1.RunAsUserStrategyRunAsAny,
-				},
-				SELinux: policyv1beta1.SELinuxStrategyOptions{
-					Rule: policyv1beta1.SELinuxStrategyRunAsAny,
-				},
-				SupplementalGroups: policyv1beta1.SupplementalGroupsStrategyOptions{
-					Rule: policyv1beta1.SupplementalGroupsStrategyRunAsAny,
-				},
-				FSGroup: policyv1beta1.FSGroupStrategyOptions{
-					Rule: policyv1beta1.FSGroupStrategyRunAsAny,
-				},
-			},
 		}
 
 		daemonSet = &appsv1.DaemonSet{
@@ -382,8 +311,91 @@ func (c *nodeProblemDetector) computeResourcesData() (map[string][]byte, error) 
 				},
 			},
 		}
-		vpa *vpaautoscalingv1.VerticalPodAutoscaler
+
+		vpa               *vpaautoscalingv1.VerticalPodAutoscaler
+		podSecurityPolicy *policyv1beta1.PodSecurityPolicy
+		clusterRolePSP    *rbacv1.ClusterRole
+		roleRefName       = "gardener.cloud:psp:privileged"
 	)
+
+	if version.ConstraintK8sLess123.Check(c.values.Version) {
+		podSecurityPolicy = &policyv1beta1.PodSecurityPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   podSecurityPolicyName,
+				Labels: getLabels(),
+			},
+			Spec: policyv1beta1.PodSecurityPolicySpec{
+				Privileged:               true,
+				AllowPrivilegeEscalation: pointer.Bool(true),
+				AllowedCapabilities: []corev1.Capability{
+					corev1.Capability(policyv1beta1.All),
+				},
+				Volumes: []policyv1beta1.FSType{
+					policyv1beta1.ConfigMap,
+					policyv1beta1.EmptyDir,
+					policyv1beta1.Projected,
+					policyv1beta1.Secret,
+					policyv1beta1.DownwardAPI,
+					policyv1beta1.HostPath,
+				},
+				HostNetwork: false,
+				HostIPC:     false,
+				HostPID:     false,
+				AllowedHostPaths: []policyv1beta1.AllowedHostPath{
+					{PathPrefix: "/etc/localtime"},
+					{PathPrefix: "/var/log"},
+					{PathPrefix: "/dev/kmsg"},
+				},
+				RunAsUser: policyv1beta1.RunAsUserStrategyOptions{
+					Rule: policyv1beta1.RunAsUserStrategyRunAsAny,
+				},
+				SELinux: policyv1beta1.SELinuxStrategyOptions{
+					Rule: policyv1beta1.SELinuxStrategyRunAsAny,
+				},
+				SupplementalGroups: policyv1beta1.SupplementalGroupsStrategyOptions{
+					Rule: policyv1beta1.SupplementalGroupsStrategyRunAsAny,
+				},
+				FSGroup: policyv1beta1.FSGroupStrategyOptions{
+					Rule: policyv1beta1.FSGroupStrategyRunAsAny,
+				},
+			},
+		}
+
+		clusterRolePSP = &rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:   clusterRolePSPName,
+				Labels: getLabels(),
+			},
+			Rules: []rbacv1.PolicyRule{
+				{
+					APIGroups:     []string{"extensions", "policy"},
+					Resources:     []string{"podsecuritypolicies"},
+					Verbs:         []string{"use"},
+					ResourceNames: []string{podSecurityPolicy.Name},
+				},
+			},
+		}
+
+		roleRefName = clusterRolePSP.Name
+	}
+
+	var clusterRoleBindingPSP = &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        clusterRoleBindingPSPName,
+			Annotations: map[string]string{resourcesv1alpha1.DeleteOnInvalidUpdate: "true"},
+			Labels:      getLabels(),
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     roleRefName,
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind:      rbacv1.ServiceAccountKind,
+			Name:      serviceAccount.Name,
+			Namespace: serviceAccount.Namespace,
+		}},
+	}
 
 	if c.values.VPAEnabled {
 		updateMode := vpaautoscalingv1.UpdateModeAuto

--- a/pkg/operation/botanist/component/nodeproblemdetector/node_problem_detector_test.go
+++ b/pkg/operation/botanist/component/nodeproblemdetector/node_problem_detector_test.go
@@ -389,10 +389,6 @@ status: {}
 			Expect(string(managedResourceSecret.Data["clusterrole____node-problem-detector.yaml"])).To(Equal(clusterRoleYAML))
 			Expect(string(managedResourceSecret.Data["clusterrolebinding____node-problem-detector.yaml"])).To(Equal(clusterRoleBindingYAML))
 			Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_psp_node-problem-detector.yaml"])).To(Equal(clusterRoleBindingPSPYAMLFor(values.Version)))
-			if version.ConstraintK8sLess123.Check(values.Version) {
-				Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_psp_kube-system_node-problem-detector.yaml"])).To(Equal(clusterRolePSPYAML))
-				Expect(string(managedResourceSecret.Data["podsecuritypolicy____node-problem-detector.yaml"])).To(Equal(podSecurityPolicyYAML))
-			}
 		})
 
 		Context("w/o apiserver host, w/o vpaEnables", func() {
@@ -402,6 +398,8 @@ status: {}
 				})
 				It("should successfully deploy all resources", func() {
 					Expect(string(managedResourceSecret.Data["daemonset__kube-system__node-problem-detector.yaml"])).To(Equal(daemonsetYAMLFor("", false)))
+					Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_psp_kube-system_node-problem-detector.yaml"])).To(Equal(clusterRolePSPYAML))
+					Expect(string(managedResourceSecret.Data["podsecuritypolicy____node-problem-detector.yaml"])).To(Equal(podSecurityPolicyYAML))
 				})
 			})
 
@@ -432,6 +430,8 @@ status: {}
 				It("should successfully deploy all resources", func() {
 					Expect(string(managedResourceSecret.Data["verticalpodautoscaler__kube-system__node-problem-detector.yaml"])).To(Equal(vpaYAML))
 					Expect(string(managedResourceSecret.Data["daemonset__kube-system__node-problem-detector.yaml"])).To(Equal(daemonsetYAMLFor(apiserverHost, vpaEnabled)))
+					Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_psp_kube-system_node-problem-detector.yaml"])).To(Equal(clusterRolePSPYAML))
+					Expect(string(managedResourceSecret.Data["podsecuritypolicy____node-problem-detector.yaml"])).To(Equal(podSecurityPolicyYAML))
 				})
 			})
 

--- a/pkg/operation/botanist/component/vpnshoot/vpnshoot.go
+++ b/pkg/operation/botanist/component/vpnshoot/vpnshoot.go
@@ -31,7 +31,9 @@ import (
 	"github.com/gardener/gardener/pkg/utils/managedresources"
 	secretutils "github.com/gardener/gardener/pkg/utils/secrets"
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
+	"github.com/gardener/gardener/pkg/utils/version"
 
+	"github.com/Masterminds/semver"
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -114,6 +116,8 @@ type Values struct {
 	ReversedVPN ReversedVPNValues
 	// Network contains the configuration values for the network.
 	Network NetworkValues
+	// Version is the Kubernetes version of the cluster
+	Version *semver.Version
 }
 
 // New creates a new instance of DeployWaiter for vpnshoot
@@ -362,75 +366,6 @@ func (v *vpnShoot) computeResourcesData(secretCAVPN, secretVPNShoot *corev1.Secr
 			},
 		}
 
-		podSecurityPolicy = &policyv1beta1.PodSecurityPolicy{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "gardener.kube-system.vpn-shoot",
-			},
-			Spec: policyv1beta1.PodSecurityPolicySpec{
-				Privileged: true,
-				Volumes: []policyv1beta1.FSType{
-					"secret",
-					"emptyDir",
-					"projected",
-					"hostPath",
-				},
-				AllowedCapabilities: []corev1.Capability{
-					"NET_ADMIN",
-				},
-				AllowedHostPaths: []policyv1beta1.AllowedHostPath{
-					{
-						PathPrefix: volumeMountPathDevNetTun,
-					},
-				},
-				RunAsUser: policyv1beta1.RunAsUserStrategyOptions{
-					Rule: policyv1beta1.RunAsUserStrategyRunAsAny,
-				},
-				SELinux: policyv1beta1.SELinuxStrategyOptions{
-					Rule: policyv1beta1.SELinuxStrategyRunAsAny,
-				},
-				SupplementalGroups: policyv1beta1.SupplementalGroupsStrategyOptions{
-					Rule: policyv1beta1.SupplementalGroupsStrategyRunAsAny,
-				},
-				FSGroup: policyv1beta1.FSGroupStrategyOptions{
-					Rule: policyv1beta1.FSGroupStrategyRunAsAny,
-				},
-			},
-		}
-
-		clusterRolePSP = &rbacv1.ClusterRole{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "gardener.cloud:psp:kube-system:vpn-shoot",
-			},
-			Rules: []rbacv1.PolicyRule{
-				{
-					APIGroups:     []string{"policy", "extensions"},
-					ResourceNames: []string{podSecurityPolicy.Name},
-					Resources:     []string{"podsecuritypolicies"},
-					Verbs:         []string{"use"},
-				},
-			},
-		}
-
-		roleBindingPSP = &rbacv1.RoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "gardener.cloud:psp:vpn-shoot",
-				Namespace: metav1.NamespaceSystem,
-				Annotations: map[string]string{
-					resourcesv1alpha1.DeleteOnInvalidUpdate: "true",
-				},
-			},
-			RoleRef: rbacv1.RoleRef{
-				APIGroup: rbacv1.GroupName,
-				Kind:     "ClusterRole",
-				Name:     clusterRolePSP.Name,
-			},
-			Subjects: []rbacv1.Subject{{
-				Kind:      rbacv1.ServiceAccountKind,
-				Name:      serviceAccount.Name,
-				Namespace: serviceAccount.Namespace,
-			}},
-		}
-
 		deployment = &appsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      deploymentName,
@@ -501,8 +436,85 @@ func (v *vpnShoot) computeResourcesData(secretCAVPN, secretVPNShoot *corev1.Secr
 				},
 			},
 		}
+
+		podSecurityPolicy *policyv1beta1.PodSecurityPolicy
+		clusterRolePSP    *rbacv1.ClusterRole
+		roleRefName       = "gardener.cloud:psp:privileged"
 	)
 	utilruntime.Must(references.InjectAnnotations(deployment))
+
+	if version.ConstraintK8sLess123.Check(v.values.Version) {
+		podSecurityPolicy = &policyv1beta1.PodSecurityPolicy{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "gardener.kube-system.vpn-shoot",
+			},
+			Spec: policyv1beta1.PodSecurityPolicySpec{
+				Privileged: true,
+				Volumes: []policyv1beta1.FSType{
+					"secret",
+					"emptyDir",
+					"projected",
+					"hostPath",
+				},
+				AllowedCapabilities: []corev1.Capability{
+					"NET_ADMIN",
+				},
+				AllowedHostPaths: []policyv1beta1.AllowedHostPath{
+					{
+						PathPrefix: volumeMountPathDevNetTun,
+					},
+				},
+				RunAsUser: policyv1beta1.RunAsUserStrategyOptions{
+					Rule: policyv1beta1.RunAsUserStrategyRunAsAny,
+				},
+				SELinux: policyv1beta1.SELinuxStrategyOptions{
+					Rule: policyv1beta1.SELinuxStrategyRunAsAny,
+				},
+				SupplementalGroups: policyv1beta1.SupplementalGroupsStrategyOptions{
+					Rule: policyv1beta1.SupplementalGroupsStrategyRunAsAny,
+				},
+				FSGroup: policyv1beta1.FSGroupStrategyOptions{
+					Rule: policyv1beta1.FSGroupStrategyRunAsAny,
+				},
+			},
+		}
+
+		clusterRolePSP = &rbacv1.ClusterRole{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "gardener.cloud:psp:kube-system:vpn-shoot",
+			},
+			Rules: []rbacv1.PolicyRule{
+				{
+					APIGroups:     []string{"policy", "extensions"},
+					ResourceNames: []string{podSecurityPolicy.Name},
+					Resources:     []string{"podsecuritypolicies"},
+					Verbs:         []string{"use"},
+				},
+			},
+		}
+
+		roleRefName = clusterRolePSP.Name
+	}
+
+	var roleBindingPSP = &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "gardener.cloud:psp:vpn-shoot",
+			Namespace: metav1.NamespaceSystem,
+			Annotations: map[string]string{
+				resourcesv1alpha1.DeleteOnInvalidUpdate: "true",
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName,
+			Kind:     "ClusterRole",
+			Name:     roleRefName,
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind:      rbacv1.ServiceAccountKind,
+			Name:      serviceAccount.Name,
+			Namespace: serviceAccount.Namespace,
+		}},
+	}
 
 	if v.values.VPAEnabled {
 		vpaUpdateMode := vpaautoscalingv1.UpdateModeAuto

--- a/pkg/operation/botanist/component/vpnshoot/vpnshoot_test.go
+++ b/pkg/operation/botanist/component/vpnshoot/vpnshoot_test.go
@@ -629,11 +629,6 @@ status:
 			if !values.ReversedVPN.Enabled {
 				Expect(string(managedResourceSecret.Data["secret__kube-system__"+secretNameTLSAuthLegacyVPN+".yaml"])).To(Equal(secretTLSAuthYAML))
 			}
-
-			if version.ConstraintK8sLess123.Check(values.Version) {
-				Expect(string(managedResourceSecret.Data["podsecuritypolicy____gardener.kube-system.vpn-shoot.yaml"])).To(Equal(podSecurityPolicyYAML))
-				Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_psp_kube-system_vpn-shoot.yaml"])).To(Equal(clusterRolePSPYAML))
-			}
 		})
 
 		Context("VPNShoot with ReversedVPN not enabled", func() {
@@ -678,6 +673,8 @@ status:
 					deployment := &appsv1.Deployment{}
 					Expect(runtime.DecodeInto(newCodec(), managedResourceSecret.Data["deployment__kube-system__vpn-shoot.yaml"], deployment)).To(Succeed())
 					Expect(deployment).To(Equal(deploymentFor(secretNameCA, secretNameClient, secretNameTLSAuthLegacyVPN, values.ReversedVPN.Enabled, values.VPAEnabled)))
+					Expect(string(managedResourceSecret.Data["podsecuritypolicy____gardener.kube-system.vpn-shoot.yaml"])).To(Equal(podSecurityPolicyYAML))
+					Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_psp_kube-system_vpn-shoot.yaml"])).To(Equal(clusterRolePSPYAML))
 				})
 			})
 		})
@@ -723,6 +720,8 @@ status:
 					deployment := &appsv1.Deployment{}
 					Expect(runtime.DecodeInto(newCodec(), managedResourceSecret.Data["deployment__kube-system__vpn-shoot.yaml"], deployment)).To(Succeed())
 					Expect(deployment).To(Equal(deploymentFor(secretNameCA, secretNameClient, secretNameTLSAuth, values.ReversedVPN.Enabled, values.VPAEnabled)))
+					Expect(string(managedResourceSecret.Data["podsecuritypolicy____gardener.kube-system.vpn-shoot.yaml"])).To(Equal(podSecurityPolicyYAML))
+					Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_psp_kube-system_vpn-shoot.yaml"])).To(Equal(clusterRolePSPYAML))
 				})
 			})
 		})

--- a/pkg/operation/botanist/kubeproxy.go
+++ b/pkg/operation/botanist/kubeproxy.go
@@ -54,6 +54,7 @@ func (b *Botanist) DefaultKubeProxy() (kubeproxy.Interface, error) {
 			ImageAlpine:    imageAlpine.String(),
 			PodNetworkCIDR: pointer.String(b.Shoot.Networks.Pods.String()),
 			VPAEnabled:     b.Shoot.WantsVerticalPodAutoscaler,
+			Version:        b.Shoot.KubernetesVersion,
 		},
 	), nil
 }

--- a/pkg/operation/botanist/nodelocaldns.go
+++ b/pkg/operation/botanist/nodelocaldns.go
@@ -56,6 +56,7 @@ func (b *Botanist) DefaultNodeLocalDNS() (nodelocaldns.Interface, error) {
 			ForceTcpToUpstreamDNS: v1beta1helper.IsTCPEnforcedForNodeLocalDNSToUpstreamDNS(b.Shoot.GetInfo().Spec.SystemComponents, b.Shoot.GetInfo().Annotations),
 			ClusterDNS:            clusterDNS,
 			DNSServer:             dnsServer,
+			Version:               b.Shoot.KubernetesVersion,
 		},
 	), nil
 }

--- a/pkg/operation/botanist/nodeproblemdetector.go
+++ b/pkg/operation/botanist/nodeproblemdetector.go
@@ -33,6 +33,7 @@ func (b *Botanist) DefaultNodeProblemDetector() (component.DeployWaiter, error) 
 	values := nodeproblemdetector.Values{
 		Image:      image.String(),
 		VPAEnabled: b.Shoot.WantsVerticalPodAutoscaler,
+		Version:    b.Shoot.KubernetesVersion,
 	}
 
 	if b.APIServerSNIEnabled() {

--- a/pkg/operation/botanist/vpnshoot.go
+++ b/pkg/operation/botanist/vpnshoot.go
@@ -62,6 +62,7 @@ func (b *Botanist) DefaultVPNShoot() (vpnshoot.Interface, error) {
 			ServiceCIDR: b.Shoot.Networks.Services.String(),
 			NodeCIDR:    nodeNetworkCIDR,
 		},
+		Version: b.Shoot.KubernetesVersion,
 	}
 
 	return vpnshoot.New(

--- a/pkg/utils/version/version.go
+++ b/pkg/utils/version/version.go
@@ -55,6 +55,8 @@ var (
 	ConstraintK8sEqual123 *semver.Constraints
 	// ConstraintK8sGreaterEqual123 is a version constraint for versions >= 1.23.
 	ConstraintK8sGreaterEqual123 *semver.Constraints
+	// ConstraintK8sLess123 is a version constraint for versions < 1.23.
+	ConstraintK8sLess123 *semver.Constraints
 	// ConstraintK8sEqual124 is a version constraint for versions == 1.24.
 	ConstraintK8sEqual124 *semver.Constraints
 	// ConstraintK8sLess124 is a version constraint for versions < 1.24.
@@ -93,6 +95,8 @@ func init() {
 	ConstraintK8sGreaterEqual122, err = semver.NewConstraint(">= 1.22")
 	utilruntime.Must(err)
 	ConstraintK8sEqual123, err = semver.NewConstraint("1.23.x")
+	utilruntime.Must(err)
+	ConstraintK8sLess123, err = semver.NewConstraint("< 1.23")
 	utilruntime.Must(err)
 	ConstraintK8sGreaterEqual123, err = semver.NewConstraint(">= 1.23")
 	utilruntime.Must(err)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:
This PR is the first step towards migrating to `PodSecurity` from `PodSecurityPolicy`.
This PR adapts the components currently using dedicated PSPs to use `gardener.privileged` PSP, as explained in https://kubernetes.io/docs/tasks/configure-pod-container/migrate-from-psp/#bypass-psp
None of these components have mutating fields in the PodSpec,(except `node-exporter` for MustRunAsNonRoot field, but runAsNonRoot is already set to true in the template podSpec in the daemonset) so we don't need to make any changes in that regard.
All these changes are done for only clusters with k8s `v1.23+`.
And GCM garbage collects the old resources automatically.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/5250

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Individual PSPs for components are removed for clusters with v1.23+, they all now use `gardener.privileged` PSP. This will also be removed in the future versions, once gardener moves to the new `PodSecurity` admission controller.
```
