### PR TITLE
Revert "Use HA shoot for e2e rotation test"

### DIFF
--- a/test/e2e/shoot/create_rotate_delete.go
+++ b/test/e2e/shoot/create_rotate_delete.go
@@ -24,19 +24,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/test/e2e"
 	"github.com/gardener/gardener/test/e2e/shoot/internal/rotation"
 )
 
+// TODO(timuthy): enable rotation for HA shoots as soon as data consistency issue in multi-node etcd is solved.
 var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 	f := defaultShootCreationFramework()
 	f.Shoot = e2e.DefaultShoot("")
 	f.Shoot.Name = "e2e-rotate"
-	f.Shoot.Annotations = utils.MergeStringMaps(f.Shoot.Annotations, map[string]string{
-		// Use a single zone HA control plane because we don't know if there is a multi-AZ seed available.
-		v1beta1constants.ShootAlphaControlPlaneHighAvailability: v1beta1constants.ShootAlphaControlPlaneHighAvailabilitySingleZone,
-	})
 
 	It("Create Shoot, Rotate Credentials and Delete Shoot", Label("credentials-rotation"), func() {
 		ctx, cancel := context.WithTimeout(parentCtx, 20*time.Minute)

--- a/test/e2e/shoot/internal/rotation/certificate_authorities.go
+++ b/test/e2e/shoot/internal/rotation/certificate_authorities.go
@@ -54,7 +54,6 @@ var allGardenletCAs = []string{
 	caCluster,
 	caClient,
 	caETCD,
-	caETCDPeer,
 	caFrontProxy,
 	caKubelet,
 	caMetricsServer,
@@ -65,7 +64,6 @@ const (
 	caCluster       = "ca"
 	caClient        = "ca-client"
 	caETCD          = "ca-etcd"
-	caETCDPeer      = "ca-etcd-peer"
 	caFrontProxy    = "ca-front-proxy"
 	caKubelet       = "ca-kubelet"
 	caMetricsServer = "ca-metrics-server"


### PR DESCRIPTION
Reverts gardener/gardener#6395 due to flaky behaviour, see

- https://prow.gardener.cloud/view/gs/gardener-prow/logs/ci-gardener-e2e-kind/1552014312258670592
- https://prow.gardener.cloud/view/gs/gardener-prow/logs/ci-gardener-e2e-kind/1552135109547659264

See also https://testgrid.k8s.io/gardener-gardener#ci-gardener-e2e-kind, before merging this PR the test was quite stable.