### PR TITLE
Change automated reviewer assignment by prow

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -4,7 +4,6 @@ aliases:
   gardener-reviewers:
   - acumino
   - ary1992
-  - BeckerMax
   - ialidzhikov
   - kris94
   - oliver-goetz
@@ -13,22 +12,12 @@ aliases:
   - shafeeqes
   - timebertt
   - timuthy
-  - abdasgupta
-  - danielfoehrKn
-  - DockToFuture
-  - istvanballok
-  - Kristian-ZH
-  - petersutter
-  - ScheererJ
-  - shreyas-s-rao
-  - vlvasilev
-  - voelzmo
-  - wyb1
   gardener-approvers:
   - acumino
   - ary1992
   - ialidzhikov
   - kris94
+  - oliver-goetz
   - plkokanov
   - rfranzke
   - shafeeqes


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR removes people who are not part of the gardener-core team from group of reviewers, that they are not assigned automatically as reviewers by blunderbuss anymore.
These people have been added to the new [gardener-collaborators](https://github.com/orgs/gardener/teams/gardener-collaborators) group, that they are still able to `/lgtm` PRs. 

**Special notes for your reviewer**:
Escalated privileges for @oliver-goetz 😅 

/hold
Hold until https://github.com/gardener/ci-infra/pull/327 is merged, that prow considers github collaborators for `gardener/gardener`

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
