### PR TITLE
fix: overview of all nodes dashboard

### DIFF
--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/node-pool-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/node-pool-dashboard.json
@@ -568,7 +568,7 @@
           "refId": "C"
         },
         {
-          "expr": "(sum(kube_node_status_allocatable{resource=\"cpu\", unit=\"core\") by (node) - sum(rate(node_cpu_seconds_total{mode!=\"idle\"}[$__rate_interval])) by (node)) + on (node) group_right sum(kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}) by (label_worker_gardener_cloud_pool, node) - 1",
+          "expr": "(sum(kube_node_status_allocatable{resource=\"cpu\", unit=\"core\"}) by (node) - sum(rate(node_cpu_seconds_total{mode!=\"idle\"}[$__rate_interval])) by (node)) + on (node) group_right sum(kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}) by (label_worker_gardener_cloud_pool, node) - 1",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,


### PR DESCRIPTION
**How to categorize this PR?**

/area monitoring
/kind bug

**What this PR does / why we need it**:
In grafana dashboard `Node/Worker Pool Overview`, panel `Overview of all Nodes` shows error: 
```
"invalid parameter \"query\": 1:62: parse error: unexpected character inside braces: ')'"
```
<img width="815" alt="Screen Shot 2022-07-27 at 20 22 01" src="https://user-images.githubusercontent.com/50126000/181245569-debac1c8-793f-41b2-8062-6821ba4cc859.png">

Checked the queries of this panel, query D is like below: 
```
(sum(kube_node_status_allocatable{resource="cpu", unit="core") by (node) - sum(rate(node_cpu_seconds_total{mode!="idle"}[$__rate_interval])) by (node)) + on (node) group_right sum(kube_node_labels{label_worker_gardener_cloud_pool=~"$worker_group"}) by (label_worker_gardener_cloud_pool, node) - 1
```
it missed the right curly brace in `sum(kube_node_status_allocatable{resource="cpu", unit="core") by (node)`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing a panel in the `Node/Worker Pool Overview` dashboard to fail to load due to invalid query is now fixed.
```
