### PR TITLE
Reload kube-apiserver variable on dashboard time change

### DIFF
--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/apiserver-request-duration-and-response-size.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/apiserver-request-duration-and-response-size.json
@@ -17,7 +17,7 @@
   "gnetId": null,
   "graphTooltip": 1,
   "id": 34,
-  "iteration": 1644251281045,
+  "iteration": 1658937508680,
   "links": [],
   "panels": [
     {
@@ -160,7 +160,7 @@
       },
       "pluginVersion": "7.5.11",
       "repeatDirection": "h",
-      "repeatIteration": 1644251281045,
+      "repeatIteration": 1658937508680,
       "repeatPanelId": 6,
       "reverseYBuckets": false,
       "scopedVars": {
@@ -245,7 +245,7 @@
       },
       "pluginVersion": "7.5.11",
       "repeatDirection": "h",
-      "repeatIteration": 1644251281045,
+      "repeatIteration": 1658937508680,
       "repeatPanelId": 6,
       "reverseYBuckets": false,
       "scopedVars": {
@@ -330,7 +330,7 @@
       },
       "pluginVersion": "7.5.11",
       "repeatDirection": "h",
-      "repeatIteration": 1644251281045,
+      "repeatIteration": 1658937508680,
       "repeatPanelId": 6,
       "reverseYBuckets": false,
       "scopedVars": {
@@ -519,7 +519,7 @@
         "show": true
       },
       "pluginVersion": "7.5.11",
-      "repeatIteration": 1644251281045,
+      "repeatIteration": 1658937508680,
       "repeatPanelId": 20,
       "reverseYBuckets": false,
       "scopedVars": {
@@ -603,7 +603,7 @@
         "show": true
       },
       "pluginVersion": "7.5.11",
-      "repeatIteration": 1644251281045,
+      "repeatIteration": 1658937508680,
       "repeatPanelId": 20,
       "reverseYBuckets": false,
       "scopedVars": {
@@ -687,7 +687,7 @@
         "show": true
       },
       "pluginVersion": "7.5.11",
-      "repeatIteration": 1644251281045,
+      "repeatIteration": 1658937508680,
       "repeatPanelId": 20,
       "reverseYBuckets": false,
       "scopedVars": {
@@ -770,7 +770,7 @@
           "query": "label_values(apiserver_audit_event_total,pod)",
           "refId": "StandardVariableQuery"
         },
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
         "sort": 1,
@@ -784,6 +784,7 @@
         "allValue": ".+",
         "current": {
           "selected": true,
+          "tags": [],
           "text": [
             "pods"
           ],
@@ -824,5 +825,6 @@
   "timepicker": {},
   "timezone": "utc",
   "title": "API Server Request Duration and Response Size",
-  "uid": "apiserver-request-duration-and-response"
+  "uid": "apiserver-request-duration-and-response",
+  "version": 1
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:
The dashboard is build around a variable that selects the respective kube-apiserver pod names on dashboard load only.
Hence if you select a different timeframe (then with potentially other podnames), the dashboard will not display anything.
Hence the variable must be load on time refresh instead.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/invite @wyb1 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
