### PR TITLE
Prevent panic in gardenlet when shoot namespace doesn't have required project label

### DIFF
--- a/pkg/gardenlet/controller/shoot/shoot_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control.go
@@ -242,6 +242,10 @@ func (r *shootReconciler) Reconcile(ctx context.Context, request reconcile.Reque
 		return reconcile.Result{}, err
 	}
 
+	if project == nil {
+		return reconcile.Result{}, fmt.Errorf("cannot find Project for namespace '%s'", shoot.Namespace)
+	}
+
 	cloudProfile := &gardencorev1beta1.CloudProfile{}
 	if err := gardenClient.Client().Get(ctx, kutil.Key(shoot.Spec.CloudProfileName), cloudProfile); err != nil {
 		return reconcile.Result{}, err

--- a/pkg/operation/garden/garden.go
+++ b/pkg/operation/garden/garden.go
@@ -55,6 +55,9 @@ func (b *Builder) WithProject(project *gardencorev1beta1.Project) *Builder {
 func (b *Builder) WithProjectFrom(reader client.Reader, namespace string) *Builder {
 	b.projectFunc = func(ctx context.Context) (*gardencorev1beta1.Project, error) {
 		project, _, err := gutil.ProjectAndNamespaceFromReader(ctx, reader, namespace)
+		if err != nil {
+			return nil, err
+		}
 		if project == nil {
 			return nil, fmt.Errorf("cannot find Project for namespace '%s'", namespace)
 		}

--- a/pkg/operation/garden/garden.go
+++ b/pkg/operation/garden/garden.go
@@ -55,6 +55,10 @@ func (b *Builder) WithProject(project *gardencorev1beta1.Project) *Builder {
 func (b *Builder) WithProjectFrom(reader client.Reader, namespace string) *Builder {
 	b.projectFunc = func(ctx context.Context) (*gardencorev1beta1.Project, error) {
 		project, _, err := gutil.ProjectAndNamespaceFromReader(ctx, reader, namespace)
+		if project == nil {
+			return nil, fmt.Errorf("cannot find Project for namespace '%s'", namespace)
+		}
+
 		return project, err
 	}
 	return b


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
Before #4040 we used `ProjectForNamespaceFromReader ` which returns an `error` if the project is not found but with #4040 we switched it to  `ProjectAndNamespaceFromReader` which if the project is not found doesn't return an error and the project is set to nil. Which causes panic in gardenlet because it tries to fetch the project name from nil value.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/6286

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug causing `gardenlet` to panic in case of shoot using namespace which doesn't have the required project label is fixed.
```
