### PR TITLE
Don't deploy `PSP`s when `PodSecurityPolicy` plugin is disabled

### DIFF
--- a/charts/shoot-addons/charts/kubernetes-dashboard/templates/deployment-dashboard.yaml
+++ b/charts/shoot-addons/charts/kubernetes-dashboard/templates/deployment-dashboard.yaml
@@ -33,6 +33,9 @@ spec:
         readOnlyRootFilesystem: true
         runAsUser: 1001
         runAsGroup: 2001
+        fsGroup: 1
+        supplementalGroups:
+        - 1
       containers:
       - name: kubernetes-dashboard
         image: {{ index .Values.images "kubernetes-dashboard" }}

--- a/charts/shoot-addons/charts/kubernetes-dashboard/templates/deployment-metrics-scraper.yaml
+++ b/charts/shoot-addons/charts/kubernetes-dashboard/templates/deployment-metrics-scraper.yaml
@@ -46,11 +46,14 @@ spec:
           readOnlyRootFilesystem: true
           runAsUser: 1001
           runAsGroup: 2001
-      {{- if semverCompare "> 1.22.x" .Capabilities.KubeVersion.GitVersion }}
       securityContext:
+        {{- if semverCompare "> 1.22.x" .Capabilities.KubeVersion.GitVersion }}
         seccompProfile:
           type: RuntimeDefault
-      {{- end }}
+        {{- end }}
+        fsGroup: 1
+        supplementalGroups:
+        - 1
       serviceAccountName: kubernetes-dashboard
       nodeSelector:
         kubernetes.io/os: linux

--- a/charts/shoot-addons/charts/nginx-ingress/templates/default-backend-deployment.yaml
+++ b/charts/shoot-addons/charts/nginx-ingress/templates/default-backend-deployment.yaml
@@ -38,6 +38,8 @@ spec:
       securityContext:
         runAsUser: 65534
         fsGroup: 65534
+        supplementalGroups:
+        - 1
       containers:
         - name: {{ template "nginx-ingress.name" . }}-{{ .Values.defaultBackend.name }}
           image: {{ index .Values.images "ingress-default-backend" }}

--- a/charts/shoot-addons/charts/nginx-ingress/templates/psp/nginx-ingress-rolebinding-privileged.yaml
+++ b/charts/shoot-addons/charts/nginx-ingress/templates/psp/nginx-ingress-rolebinding-privileged.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.global.pspDisabled }}
 apiVersion: {{ include "rbacversion" . }}
 kind: RoleBinding
 metadata:
@@ -13,3 +14,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ template "nginx-ingress.fullname" . }}
   namespace: kube-system
+{{- end }}

--- a/charts/shoot-addons/values.yaml
+++ b/charts/shoot-addons/values.yaml
@@ -1,5 +1,6 @@
 global:
   vpaEnabled: false
+  pspDisabled: false
 kubernetes-dashboard:
   enabled: false
   images:

--- a/charts/shoot-core/components/charts/apiserver-proxy/templates/psp/apiserver-proxy-clusterrole.yaml
+++ b/charts/shoot-core/components/charts/apiserver-proxy/templates/psp/apiserver-proxy-clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.global.pspDisabled }}
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
 metadata:
@@ -15,3 +16,4 @@ rules:
   - podsecuritypolicies
   verbs:
   - use
+{{- end }}

--- a/charts/shoot-core/components/charts/apiserver-proxy/templates/psp/apiserver-proxy-psp.yaml
+++ b/charts/shoot-core/components/charts/apiserver-proxy/templates/psp/apiserver-proxy-psp.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.global.pspDisabled }}
 apiVersion: {{ include "podsecuritypolicyversion" .}}
 kind: PodSecurityPolicy
 metadata:
@@ -30,3 +31,4 @@ spec:
   fsGroup:
     rule: 'RunAsAny'
   readOnlyRootFilesystem: false
+{{- end }}

--- a/charts/shoot-core/components/charts/apiserver-proxy/templates/psp/apiserver-proxy-rolebinding.yaml
+++ b/charts/shoot-core/components/charts/apiserver-proxy/templates/psp/apiserver-proxy-rolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.global.pspDisabled }}
 apiVersion: {{ include "rbacversion" . }}
 kind: RoleBinding
 metadata:
@@ -16,3 +17,4 @@ subjects:
 - kind: ServiceAccount
   name: apiserver-proxy
   namespace: kube-system
+{{- end }}

--- a/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/deployment.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/deployment.yaml
@@ -46,6 +46,8 @@ spec:
       securityContext:
         runAsUser: 65534
         fsGroup: 65534
+        supplementalGroups:
+        - 1
       containers:
       - name: blackbox-exporter
         image: {{ index .Values.images "blackbox-exporter" }}

--- a/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/psp/node-exporter-clusterrole.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/psp/node-exporter-clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.global.pspDisabled }}
 apiVersion: {{ include "rbacversion" . }}
 kind: ClusterRole
 metadata:
@@ -12,3 +13,4 @@ rules:
   - podsecuritypolicies
   verbs:
   - use
+{{- end }}

--- a/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/psp/node-exporter-psp.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/psp/node-exporter-psp.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.global.pspDisabled }}
 apiVersion: {{ include "podsecuritypolicyversion" .}}
 kind: PodSecurityPolicy
 metadata:
@@ -24,3 +25,4 @@ spec:
   fsGroup:
     rule: 'RunAsAny'
   readOnlyRootFilesystem: false
+{{- end }}

--- a/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/psp/node-exporter-rolebinding.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/psp/node-exporter-rolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.global.pspDisabled }}
 apiVersion: {{ include "rbacversion" . }}
 kind: RoleBinding
 metadata:
@@ -13,3 +14,4 @@ subjects:
 - kind: ServiceAccount
   name: node-exporter
   namespace: kube-system
+{{- end }}

--- a/charts/shoot-core/components/values.yaml
+++ b/charts/shoot-core/components/values.yaml
@@ -2,6 +2,7 @@ global:
   kubernetesVersion: 1.20.1
   podNetwork: 100.96.0.0/11
   vpaEnabled: false
+  pspDisabled: false
 apiserver-proxy:
   enabled: false
   images:

--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -1320,7 +1320,7 @@ func MutateShootETCDEncryptionKeyRotation(shoot *gardencorev1beta1.Shoot, f func
 	f(shoot.Status.Credentials.Rotation.ETCDEncryptionKey)
 }
 
-// IsPSPDisabled returns true if the PodSecurityPolicy plugin is explicitly disabled in the ShootSpec.
+// IsPSPDisabled returns true if the PodSecurityPolicy plugin is explicitly disabled in the ShootSpec or the cluster version is >= 1.25.
 func IsPSPDisabled(shoot *gardencorev1beta1.Shoot) bool {
 	if versionutils.ConstraintK8sGreaterEqual125.Check(semver.MustParse(shoot.Spec.Kubernetes.Version)) {
 		return true

--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -22,6 +22,7 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/utils/version"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
 
 	"github.com/Masterminds/semver"
@@ -1320,8 +1321,12 @@ func MutateShootETCDEncryptionKeyRotation(shoot *gardencorev1beta1.Shoot, f func
 	f(shoot.Status.Credentials.Rotation.ETCDEncryptionKey)
 }
 
-// IsPSPDisabled returns true if the PodSecurityPolicy plugin is explicitly disabled in the ShootSpec
+// IsPSPDisabled returns true if the PodSecurityPolicy plugin is explicitly disabled in the ShootSpec.
 func IsPSPDisabled(shoot *gardencorev1beta1.Shoot) bool {
+	if version.ConstraintK8sGreaterEqual125.Check(semver.MustParse(shoot.Spec.Kubernetes.Version)) {
+		return true
+	}
+
 	if shoot.Spec.Kubernetes.KubeAPIServer != nil {
 		for _, plugin := range shoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins {
 			if plugin.Name == "PodSecurityPolicy" && pointer.BoolDeref(plugin.Disabled, false) {

--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -22,7 +22,6 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
-	"github.com/gardener/gardener/pkg/utils/version"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
 
 	"github.com/Masterminds/semver"
@@ -1323,7 +1322,7 @@ func MutateShootETCDEncryptionKeyRotation(shoot *gardencorev1beta1.Shoot, f func
 
 // IsPSPDisabled returns true if the PodSecurityPolicy plugin is explicitly disabled in the ShootSpec.
 func IsPSPDisabled(shoot *gardencorev1beta1.Shoot) bool {
-	if version.ConstraintK8sGreaterEqual125.Check(semver.MustParse(shoot.Spec.Kubernetes.Version)) {
+	if versionutils.ConstraintK8sGreaterEqual125.Check(semver.MustParse(shoot.Spec.Kubernetes.Version)) {
 		return true
 	}
 

--- a/pkg/apis/core/v1beta1/helper/helper_test.go
+++ b/pkg/apis/core/v1beta1/helper/helper_test.go
@@ -2339,15 +2339,15 @@ var _ = Describe("helper", func() {
 			shoot = &gardencorev1beta1.Shoot{
 				Spec: gardencorev1beta1.ShootSpec{
 					Kubernetes: gardencorev1beta1.Kubernetes{
-						Version:       "1.24",
+						Version:       "1.24.0",
 						KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{},
 					},
 				},
 			}
 		})
 
-		It("should return true if Kubernetes version >=1.25", func() {
-			shoot.Spec.Kubernetes.Version = "1.25"
+		It("should return true if Kubernetes version >= 1.25", func() {
+			shoot.Spec.Kubernetes.Version = "1.25.0"
 
 			Expect(IsPSPDisabled(shoot)).To(BeTrue())
 		})

--- a/pkg/apis/core/v1beta1/helper/helper_test.go
+++ b/pkg/apis/core/v1beta1/helper/helper_test.go
@@ -2333,13 +2333,24 @@ var _ = Describe("helper", func() {
 	)
 
 	Describe("#IsPSPDisabled", func() {
-		var shoot = &gardencorev1beta1.Shoot{
-			Spec: gardencorev1beta1.ShootSpec{
-				Kubernetes: gardencorev1beta1.Kubernetes{
-					KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{},
+		var shoot *gardencorev1beta1.Shoot
+
+		BeforeEach(func() {
+			shoot = &gardencorev1beta1.Shoot{
+				Spec: gardencorev1beta1.ShootSpec{
+					Kubernetes: gardencorev1beta1.Kubernetes{
+						Version:       "1.24",
+						KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{},
+					},
 				},
-			},
-		}
+			}
+		})
+
+		It("should return true if Kubernetes version >=1.25", func() {
+			shoot.Spec.Kubernetes.Version = "1.25"
+
+			Expect(IsPSPDisabled(shoot)).To(BeTrue())
+		})
 
 		It("should return true if PodSecurityPolicy admissionPlugin is disabled", func() {
 			shoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins = []gardencorev1beta1.AdmissionPlugin{
@@ -2348,6 +2359,7 @@ var _ = Describe("helper", func() {
 					Disabled: pointer.Bool(true),
 				},
 			}
+
 			Expect(IsPSPDisabled(shoot)).To(BeTrue())
 		})
 
@@ -2357,6 +2369,7 @@ var _ = Describe("helper", func() {
 					Name: "PodSecurityPolicy",
 				},
 			}
+
 			Expect(IsPSPDisabled(shoot)).To(BeFalse())
 		})
 
@@ -2366,6 +2379,7 @@ var _ = Describe("helper", func() {
 					Name: "NamespaceLifecycle",
 				},
 			}
+
 			Expect(IsPSPDisabled(shoot)).To(BeFalse())
 		})
 

--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -256,7 +256,8 @@ func (b *Botanist) generateCoreAddonsChart(ctx context.Context) (*chartrenderer.
 // creates a ManagedResource CRD that references the rendered manifests and creates it.
 func (b *Botanist) generateOptionalAddonsChart(_ context.Context) (*chartrenderer.RenderedChart, error) {
 	global := map[string]interface{}{
-		"vpaEnabled": b.Shoot.WantsVerticalPodAutoscaler,
+		"vpaEnabled":  b.Shoot.WantsVerticalPodAutoscaler,
+		"pspDisabled": b.Shoot.PSPDisabled,
 	}
 
 	kubernetesDashboardConfig, err := b.GenerateKubernetesDashboardConfig()

--- a/pkg/operation/botanist/addons.go
+++ b/pkg/operation/botanist/addons.go
@@ -190,6 +190,7 @@ func (b *Botanist) generateCoreAddonsChart(ctx context.Context) (*chartrenderer.
 			"kubernetesVersion": b.Shoot.GetInfo().Spec.Kubernetes.Version,
 			"podNetwork":        b.Shoot.Networks.Pods.String(),
 			"vpaEnabled":        b.Shoot.WantsVerticalPodAutoscaler,
+			"pspDisabled":       b.Shoot.PSPDisabled,
 		}
 
 		podSecurityPolicies = map[string]interface{}{
@@ -242,7 +243,7 @@ func (b *Botanist) generateCoreAddonsChart(ctx context.Context) (*chartrenderer.
 			"blackbox-exporter": blackboxExporter,
 		}, b.Operation.IsShootMonitoringEnabled()),
 		"network-policies":        networkPolicyConfig,
-		"podsecuritypolicies":     common.GenerateAddonConfig(podSecurityPolicies, true),
+		"podsecuritypolicies":     common.GenerateAddonConfig(podSecurityPolicies, !b.Shoot.PSPDisabled),
 		"shoot-info":              common.GenerateAddonConfig(nil, true),
 		"vertical-pod-autoscaler": common.GenerateAddonConfig(nil, b.Shoot.WantsVerticalPodAutoscaler),
 		"cluster-identity":        map[string]interface{}{"clusterIdentity": b.Shoot.GetInfo().Status.ClusterIdentity},

--- a/pkg/operation/botanist/component/coredns/coredns.go
+++ b/pkg/operation/botanist/component/coredns/coredns.go
@@ -428,8 +428,10 @@ import custom/*.server
 						NodeSelector:       map[string]string{v1beta1constants.LabelWorkerPoolSystemComponents: "true"},
 						DNSPolicy:          corev1.DNSDefault,
 						SecurityContext: &corev1.PodSecurityContext{
-							RunAsNonRoot: pointer.Bool(true),
-							RunAsUser:    pointer.Int64(65534),
+							RunAsNonRoot:       pointer.Bool(true),
+							RunAsUser:          pointer.Int64(65534),
+							FSGroup:            pointer.Int64(1),
+							SupplementalGroups: []int64{1},
 						},
 						Tolerations: []corev1.Toleration{{
 							Key:      "CriticalAddonsOnly",

--- a/pkg/operation/botanist/component/coredns/coredns_test.go
+++ b/pkg/operation/botanist/component/coredns/coredns_test.go
@@ -360,8 +360,11 @@ spec:
         worker.gardener.cloud/system-components: "true"
       priorityClassName: system-cluster-critical
       securityContext:
+        fsGroup: 1
         runAsNonRoot: true
         runAsUser: 65534
+        supplementalGroups:
+        - 1
       serviceAccountName: coredns
       tolerations:
       - key: CriticalAddonsOnly

--- a/pkg/operation/botanist/component/kubeproxy/kube_proxy.go
+++ b/pkg/operation/botanist/component/kubeproxy/kube_proxy.go
@@ -102,6 +102,8 @@ type Values struct {
 	VPAEnabled bool
 	// WorkerPools is a list of worker pools for which the kube-proxy DaemonSets should be deployed.
 	WorkerPools []WorkerPool
+	// PSPDisabled marks whether the PodSecurityPolicy admission plugin is disabled.
+	PSPDisabled bool
 }
 
 // WorkerPool contains configuration for the kube-proxy deployment for this specific worker pool.

--- a/pkg/operation/botanist/component/kubeproxy/kube_proxy_test.go
+++ b/pkg/operation/botanist/component/kubeproxy/kube_proxy_test.go
@@ -405,7 +405,6 @@ rules:
   verbs:
   - use
 `
-
 			roleBindingPSPYAML = `apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -423,7 +422,6 @@ subjects:
   name: kube-proxy
   namespace: kube-system
 `
-
 			daemonSetNameFor = func(pool WorkerPool) string {
 				return "kube-proxy-" + pool.Name + "-v" + pool.KubernetesVersion
 			}
@@ -658,98 +656,115 @@ status: {}
 			}
 		)
 
-		It("should successfully deploy all resources", func() {
-			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceCentral), managedResourceCentral)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: resourcesv1alpha1.SchemeGroupVersion.Group, Resource: "managedresources"}, managedResourceCentral.Name)))
-			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretCentral), managedResourceSecretCentral)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: corev1.SchemeGroupVersion.Group, Resource: "secrets"}, managedResourceSecretCentral.Name)))
+		Context("ClusterVersion", func() {
+			JustBeforeEach(func() {
+				Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceCentral), managedResourceCentral)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: resourcesv1alpha1.SchemeGroupVersion.Group, Resource: "managedresources"}, managedResourceCentral.Name)))
+				Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretCentral), managedResourceSecretCentral)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: corev1.SchemeGroupVersion.Group, Resource: "secrets"}, managedResourceSecretCentral.Name)))
 
-			for _, pool := range values.WorkerPools {
-				By(pool.Name)
+				for _, pool := range values.WorkerPools {
+					By(pool.Name)
 
-				managedResource := managedResourceForPool(pool)
-				managedResourceSecret := managedResourceSecretForPool(pool)
+					managedResource := managedResourceForPool(pool)
+					managedResourceSecret := managedResourceSecretForPool(pool)
 
-				Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: resourcesv1alpha1.SchemeGroupVersion.Group, Resource: "managedresources"}, managedResource.Name)))
-				Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), managedResourceSecret)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: corev1.SchemeGroupVersion.Group, Resource: "secrets"}, managedResourceSecret.Name)))
-			}
+					Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: resourcesv1alpha1.SchemeGroupVersion.Group, Resource: "managedresources"}, managedResource.Name)))
+					Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), managedResourceSecret)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: corev1.SchemeGroupVersion.Group, Resource: "secrets"}, managedResourceSecret.Name)))
+				}
 
-			Expect(component.Deploy(ctx)).To(Succeed())
+				Expect(component.Deploy(ctx)).To(Succeed())
 
-			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceCentral), managedResourceCentral)).To(Succeed())
-			Expect(managedResourceCentral).To(DeepEqual(&resourcesv1alpha1.ManagedResource{
-				TypeMeta: metav1.TypeMeta{
-					APIVersion: resourcesv1alpha1.SchemeGroupVersion.String(),
-					Kind:       "ManagedResource",
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name:            managedResourceCentral.Name,
-					Namespace:       managedResourceCentral.Namespace,
-					ResourceVersion: "1",
-					Labels: map[string]string{
-						"origin":    "gardener",
-						"component": "kube-proxy",
-					},
-				},
-				Spec: resourcesv1alpha1.ManagedResourceSpec{
-					InjectLabels: map[string]string{"shoot.gardener.cloud/no-cleanup": "true"},
-					SecretRefs: []corev1.LocalObjectReference{{
-						Name: managedResourceSecretCentral.Name,
-					}},
-					KeepObjects: pointer.Bool(false),
-				},
-			}))
-
-			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretCentral), managedResourceSecretCentral)).To(Succeed())
-			Expect(managedResourceSecretCentral.Type).To(Equal(corev1.SecretTypeOpaque))
-			Expect(managedResourceSecretCentral.Data).To(HaveLen(10))
-			Expect(string(managedResourceSecretCentral.Data["serviceaccount__kube-system__kube-proxy.yaml"])).To(Equal(serviceAccountYAML))
-			Expect(string(managedResourceSecretCentral.Data["clusterrolebinding____gardener.cloud_target_node-proxier.yaml"])).To(Equal(clusterRoleBindingYAML))
-			Expect(string(managedResourceSecretCentral.Data["service__kube-system__kube-proxy.yaml"])).To(Equal(serviceYAML))
-			Expect(string(managedResourceSecretCentral.Data["secret__kube-system__"+secretName+".yaml"])).To(Equal(secretYAML))
-			Expect(string(managedResourceSecretCentral.Data["configmap__kube-system__"+configMapNameFor(values.IPVSEnabled)+".yaml"])).To(Equal(configMapYAMLFor(values.IPVSEnabled)))
-			Expect(string(managedResourceSecretCentral.Data["configmap__kube-system__"+configMapConntrackFixScriptName+".yaml"])).To(Equal(configMapConntrackFixScriptYAML))
-			Expect(string(managedResourceSecretCentral.Data["configmap__kube-system__"+configMapCleanupScriptName+".yaml"])).To(Equal(configMapCleanupScriptYAML))
-			Expect(string(managedResourceSecretCentral.Data["podsecuritypolicy____gardener.kube-system.kube-proxy.yaml"])).To(Equal(podSecurityPolicyYAML))
-			Expect(string(managedResourceSecretCentral.Data["clusterrole____gardener.cloud_psp_kube-system_kube-proxy.yaml"])).To(Equal(clusterRolePSPYAML))
-			Expect(string(managedResourceSecretCentral.Data["rolebinding__kube-system__gardener.cloud_psp_kube-proxy.yaml"])).To(Equal(roleBindingPSPYAML))
-
-			for _, pool := range values.WorkerPools {
-				By(pool.Name)
-
-				managedResource := managedResourceForPool(pool)
-				managedResourceSecret := managedResourceSecretForPool(pool)
-
-				Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
-				Expect(managedResource).To(DeepEqual(&resourcesv1alpha1.ManagedResource{
+				Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceCentral), managedResourceCentral)).To(Succeed())
+				Expect(managedResourceCentral).To(DeepEqual(&resourcesv1alpha1.ManagedResource{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: resourcesv1alpha1.SchemeGroupVersion.String(),
 						Kind:       "ManagedResource",
 					},
 					ObjectMeta: metav1.ObjectMeta{
-						Name:            managedResource.Name,
-						Namespace:       managedResource.Namespace,
+						Name:            managedResourceCentral.Name,
+						Namespace:       managedResourceCentral.Namespace,
 						ResourceVersion: "1",
 						Labels: map[string]string{
-							"origin":             "gardener",
-							"component":          "kube-proxy",
-							"role":               "pool",
-							"pool-name":          pool.Name,
-							"kubernetes-version": pool.KubernetesVersion,
+							"origin":    "gardener",
+							"component": "kube-proxy",
 						},
 					},
 					Spec: resourcesv1alpha1.ManagedResourceSpec{
 						InjectLabels: map[string]string{"shoot.gardener.cloud/no-cleanup": "true"},
 						SecretRefs: []corev1.LocalObjectReference{{
-							Name: managedResourceSecret.Name,
+							Name: managedResourceSecretCentral.Name,
 						}},
 						KeepObjects: pointer.Bool(false),
 					},
 				}))
 
-				Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), managedResourceSecret)).To(Succeed())
-				Expect(managedResourceSecret.Type).To(Equal(corev1.SecretTypeOpaque))
-				Expect(managedResourceSecret.Data).To(HaveLen(1))
-				Expect(string(managedResourceSecret.Data["daemonset__kube-system__"+daemonSetNameFor(pool)+".yaml"])).To(Equal(daemonSetYAMLFor(pool, values.IPVSEnabled, values.VPAEnabled)))
-			}
+				Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretCentral), managedResourceSecretCentral)).To(Succeed())
+				Expect(managedResourceSecretCentral.Type).To(Equal(corev1.SecretTypeOpaque))
+				Expect(managedResourceSecretCentral.Data).To(HaveLen(10))
+				Expect(string(managedResourceSecretCentral.Data["serviceaccount__kube-system__kube-proxy.yaml"])).To(Equal(serviceAccountYAML))
+				Expect(string(managedResourceSecretCentral.Data["clusterrolebinding____gardener.cloud_target_node-proxier.yaml"])).To(Equal(clusterRoleBindingYAML))
+				Expect(string(managedResourceSecretCentral.Data["service__kube-system__kube-proxy.yaml"])).To(Equal(serviceYAML))
+				Expect(string(managedResourceSecretCentral.Data["secret__kube-system__"+secretName+".yaml"])).To(Equal(secretYAML))
+				Expect(string(managedResourceSecretCentral.Data["configmap__kube-system__"+configMapNameFor(values.IPVSEnabled)+".yaml"])).To(Equal(configMapYAMLFor(values.IPVSEnabled)))
+				Expect(string(managedResourceSecretCentral.Data["configmap__kube-system__"+configMapConntrackFixScriptName+".yaml"])).To(Equal(configMapConntrackFixScriptYAML))
+				Expect(string(managedResourceSecretCentral.Data["configmap__kube-system__"+configMapCleanupScriptName+".yaml"])).To(Equal(configMapCleanupScriptYAML))
+
+				for _, pool := range values.WorkerPools {
+					By(pool.Name)
+
+					managedResource := managedResourceForPool(pool)
+					managedResourceSecret := managedResourceSecretForPool(pool)
+
+					Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
+					Expect(managedResource).To(DeepEqual(&resourcesv1alpha1.ManagedResource{
+						TypeMeta: metav1.TypeMeta{
+							APIVersion: resourcesv1alpha1.SchemeGroupVersion.String(),
+							Kind:       "ManagedResource",
+						},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:            managedResource.Name,
+							Namespace:       managedResource.Namespace,
+							ResourceVersion: "1",
+							Labels: map[string]string{
+								"origin":             "gardener",
+								"component":          "kube-proxy",
+								"role":               "pool",
+								"pool-name":          pool.Name,
+								"kubernetes-version": pool.KubernetesVersion,
+							},
+						},
+						Spec: resourcesv1alpha1.ManagedResourceSpec{
+							InjectLabels: map[string]string{"shoot.gardener.cloud/no-cleanup": "true"},
+							SecretRefs: []corev1.LocalObjectReference{{
+								Name: managedResourceSecret.Name,
+							}},
+							KeepObjects: pointer.Bool(false),
+						},
+					}))
+
+					Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), managedResourceSecret)).To(Succeed())
+					Expect(managedResourceSecret.Type).To(Equal(corev1.SecretTypeOpaque))
+					Expect(managedResourceSecret.Data).To(HaveLen(1))
+					Expect(string(managedResourceSecret.Data["daemonset__kube-system__"+daemonSetNameFor(pool)+".yaml"])).To(Equal(daemonSetYAMLFor(pool, values.IPVSEnabled, values.VPAEnabled)))
+				}
+
+				It("should deploy all the resources successfully when PSP is not disabled", func() {
+					BeforeEach(func() {
+						values.PSPDisabled = false
+						component = New(c, namespace, values)
+					})
+					Expect(string(managedResourceSecretCentral.Data["podsecuritypolicy____gardener.kube-system.kube-proxy.yaml"])).To(Equal(podSecurityPolicyYAML))
+					Expect(string(managedResourceSecretCentral.Data["clusterrole____gardener.cloud_psp_kube-system_kube-proxy.yaml"])).To(Equal(clusterRolePSPYAML))
+					Expect(string(managedResourceSecretCentral.Data["rolebinding__kube-system__gardener.cloud_psp_kube-proxy.yaml"])).To(Equal(roleBindingPSPYAML))
+				})
+
+				It("should deploy all the resources successfully when PSP is disabled", func() {
+					BeforeEach(func() {
+						values.PSPDisabled = true
+						component = New(c, namespace, values)
+					})
+					Expect(string(managedResourceSecretCentral.Data["rolebinding__kube-system__gardener.cloud_psp_kube-proxy.yaml"])).To(Equal(roleBindingPSPYAML))
+				})
+			})
 		})
 
 		It("should successfully deploy the expected config when IPVS is disabled", func() {

--- a/pkg/operation/botanist/component/kubeproxy/kube_proxy_test.go
+++ b/pkg/operation/botanist/component/kubeproxy/kube_proxy_test.go
@@ -656,7 +656,7 @@ status: {}
 			}
 		)
 
-		Context("ClusterVersion", func() {
+		Context("IPVS Enabled", func() {
 			JustBeforeEach(func() {
 				Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceCentral), managedResourceCentral)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: resourcesv1alpha1.SchemeGroupVersion.Group, Resource: "managedresources"}, managedResourceCentral.Name)))
 				Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecretCentral), managedResourceSecretCentral)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: corev1.SchemeGroupVersion.Group, Resource: "secrets"}, managedResourceSecretCentral.Name)))

--- a/pkg/operation/botanist/component/kubeproxy/resources.go
+++ b/pkg/operation/botanist/component/kubeproxy/resources.go
@@ -180,6 +180,23 @@ func (k *kubeProxy) computeCentralResourcesData() (map[string][]byte, error) {
 			Data: map[string]string{dataKeyCleanupScript: cleanupScript},
 		}
 
+		podSecurityPolicy *policyv1beta1.PodSecurityPolicy
+		clusterRolePSP    *rbacv1.ClusterRole
+		roleBindingPSP    *rbacv1.RoleBinding
+	)
+
+	utilruntime.Must(kutil.MakeUnique(secret))
+	utilruntime.Must(kutil.MakeUnique(configMap))
+	utilruntime.Must(kutil.MakeUnique(configMapConntrackFixScript))
+	utilruntime.Must(kutil.MakeUnique(configMapCleanupScript))
+
+	k.serviceAccount = serviceAccount
+	k.secret = secret
+	k.configMap = configMap
+	k.configMapCleanupScript = configMapCleanupScript
+	k.configMapConntrackFixScript = configMapConntrackFixScript
+
+	if !k.values.PSPDisabled {
 		podSecurityPolicy = &policyv1beta1.PodSecurityPolicy{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "gardener.kube-system.kube-proxy",
@@ -255,18 +272,7 @@ func (k *kubeProxy) computeCentralResourcesData() (map[string][]byte, error) {
 				Namespace: serviceAccount.Namespace,
 			}},
 		}
-	)
-
-	utilruntime.Must(kutil.MakeUnique(secret))
-	utilruntime.Must(kutil.MakeUnique(configMap))
-	utilruntime.Must(kutil.MakeUnique(configMapConntrackFixScript))
-	utilruntime.Must(kutil.MakeUnique(configMapCleanupScript))
-
-	k.serviceAccount = serviceAccount
-	k.secret = secret
-	k.configMap = configMap
-	k.configMapCleanupScript = configMapCleanupScript
-	k.configMapConntrackFixScript = configMapConntrackFixScript
+	}
 
 	return registry.AddAllAndSerialize(
 		serviceAccount,

--- a/pkg/operation/botanist/component/metricsserver/metrics_server.go
+++ b/pkg/operation/botanist/component/metricsserver/metrics_server.go
@@ -291,8 +291,9 @@ func (m *metricsServer) computeResourcesData(serverSecret, caSecret *corev1.Secr
 							v1beta1constants.LabelWorkerPoolSystemComponents: "true",
 						},
 						SecurityContext: &corev1.PodSecurityContext{
-							RunAsUser: pointer.Int64(65534),
-							FSGroup:   pointer.Int64(65534),
+							RunAsUser:          pointer.Int64(65534),
+							FSGroup:            pointer.Int64(65534),
+							SupplementalGroups: []int64{1},
 						},
 						DNSPolicy:          corev1.DNSDefault, // make sure to not use the coredns for DNS resolution.
 						ServiceAccountName: serviceAccount.Name,

--- a/pkg/operation/botanist/component/metricsserver/metrics_server_test.go
+++ b/pkg/operation/botanist/component/metricsserver/metrics_server_test.go
@@ -274,6 +274,8 @@ spec:
       securityContext:
         fsGroup: 65534
         runAsUser: 65534
+        supplementalGroups:
+        - 1
       serviceAccountName: metrics-server
       tolerations:
       - key: CriticalAddonsOnly

--- a/pkg/operation/botanist/component/nodelocaldns/nodelocaldns_test.go
+++ b/pkg/operation/botanist/component/nodelocaldns/nodelocaldns_test.go
@@ -75,7 +75,8 @@ var _ = Describe("NodeLocalDNS", func() {
 	BeforeEach(func() {
 		c = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
 		values = Values{
-			Image: image,
+			Image:       image,
+			PSPDisabled: true,
 		}
 
 		managedResource = &resourcesv1alpha1.ManagedResource{
@@ -566,10 +567,9 @@ ip6.arpa:53 {
 						values.ForceTcpToClusterDNS = true
 						values.ForceTcpToUpstreamDNS = true
 					})
-					Context("w/o VPA, PSP is not disabled", func() {
+					Context("w/o VPA", func() {
 						BeforeEach(func() {
 							values.VPAEnabled = false
-							values.PSPDisabled = false
 						})
 
 						It("should succesfully deploy all resources", func() {
@@ -579,16 +579,12 @@ ip6.arpa:53 {
 							daemonset := daemonSetYAMLFor()
 							utilruntime.Must(references.InjectAnnotations(daemonset))
 							Expect(daemonset).To(DeepEqual(managedResourceDaemonset))
-							Expect(string(managedResourceSecret.Data["rolebinding__kube-system__gardener.cloud_psp_node-local-dns.yaml"])).To(Equal(roleBindingPSPYAML))
-							Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_psp_kube-system_node-local-dns.yaml"])).To(Equal(clusterRoleYAML))
-							Expect(string(managedResourceSecret.Data["podsecuritypolicy____gardener.kube-system.node-local-dns.yaml"])).To(Equal(podSecurityPolicyYAML))
 						})
 					})
 
-					Context("w/ VPA, PSP is disabled", func() {
+					Context("w/ VPA", func() {
 						BeforeEach(func() {
 							values.VPAEnabled = true
-							values.PSPDisabled = true
 						})
 
 						It("should succesfully deploy all resources", func() {
@@ -607,9 +603,8 @@ ip6.arpa:53 {
 						values.ForceTcpToClusterDNS = true
 						values.ForceTcpToUpstreamDNS = false
 					})
-					Context("w/o VPA, PSP is disabled", func() {
+					Context("w/o VPA", func() {
 						BeforeEach(func() {
-							values.PSPDisabled = true
 							values.VPAEnabled = false
 						})
 
@@ -623,10 +618,9 @@ ip6.arpa:53 {
 						})
 					})
 
-					Context("w/ VPA, PSP is not disabled", func() {
+					Context("w/ VPA", func() {
 						BeforeEach(func() {
 							values.VPAEnabled = true
-							values.PSPDisabled = false
 						})
 
 						It("should succesfully deploy all resources", func() {
@@ -637,9 +631,6 @@ ip6.arpa:53 {
 							daemonset := daemonSetYAMLFor()
 							utilruntime.Must(references.InjectAnnotations(daemonset))
 							Expect(daemonset).To(DeepEqual(managedResourceDaemonset))
-							Expect(string(managedResourceSecret.Data["rolebinding__kube-system__gardener.cloud_psp_node-local-dns.yaml"])).To(Equal(roleBindingPSPYAML))
-							Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_psp_kube-system_node-local-dns.yaml"])).To(Equal(clusterRoleYAML))
-							Expect(string(managedResourceSecret.Data["podsecuritypolicy____gardener.kube-system.node-local-dns.yaml"])).To(Equal(podSecurityPolicyYAML))
 						})
 					})
 				})
@@ -648,10 +639,9 @@ ip6.arpa:53 {
 						values.ForceTcpToClusterDNS = false
 						values.ForceTcpToUpstreamDNS = true
 					})
-					Context("w/o VPA, PSP is not disabled", func() {
+					Context("w/o VPA", func() {
 						BeforeEach(func() {
 							values.VPAEnabled = false
-							values.PSPDisabled = false
 						})
 
 						It("should succesfully deploy all resources", func() {
@@ -661,16 +651,12 @@ ip6.arpa:53 {
 							daemonset := daemonSetYAMLFor()
 							utilruntime.Must(references.InjectAnnotations(daemonset))
 							Expect(daemonset).To(DeepEqual(managedResourceDaemonset))
-							Expect(string(managedResourceSecret.Data["rolebinding__kube-system__gardener.cloud_psp_node-local-dns.yaml"])).To(Equal(roleBindingPSPYAML))
-							Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_psp_kube-system_node-local-dns.yaml"])).To(Equal(clusterRoleYAML))
-							Expect(string(managedResourceSecret.Data["podsecuritypolicy____gardener.kube-system.node-local-dns.yaml"])).To(Equal(podSecurityPolicyYAML))
 						})
 					})
 
-					Context("w/ VPA, PSP is disabled", func() {
+					Context("w/ VPA", func() {
 						BeforeEach(func() {
 							values.VPAEnabled = true
-							values.PSPDisabled = true
 						})
 
 						It("should succesfully deploy all resources", func() {
@@ -689,10 +675,9 @@ ip6.arpa:53 {
 						values.ForceTcpToClusterDNS = false
 						values.ForceTcpToUpstreamDNS = false
 					})
-					Context("w/o VPA, PSP is not disabled", func() {
+					Context("w/o VPA", func() {
 						BeforeEach(func() {
 							values.VPAEnabled = false
-							values.PSPDisabled = false
 						})
 
 						It("should succesfully deploy all resources", func() {
@@ -702,16 +687,12 @@ ip6.arpa:53 {
 							daemonset := daemonSetYAMLFor()
 							utilruntime.Must(references.InjectAnnotations(daemonset))
 							Expect(daemonset).To(DeepEqual(managedResourceDaemonset))
-							Expect(string(managedResourceSecret.Data["rolebinding__kube-system__gardener.cloud_psp_node-local-dns.yaml"])).To(Equal(roleBindingPSPYAML))
-							Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_psp_kube-system_node-local-dns.yaml"])).To(Equal(clusterRoleYAML))
-							Expect(string(managedResourceSecret.Data["podsecuritypolicy____gardener.kube-system.node-local-dns.yaml"])).To(Equal(podSecurityPolicyYAML))
 						})
 					})
 
-					Context("w/ VPA, PSP is disabled", func() {
+					Context("w/ VPA", func() {
 						BeforeEach(func() {
 							values.VPAEnabled = true
-							values.PSPDisabled = true
 						})
 
 						It("should succesfully deploy all resources", func() {
@@ -794,10 +775,9 @@ ip6.arpa:53 {
 						values.ForceTcpToClusterDNS = true
 						values.ForceTcpToUpstreamDNS = true
 					})
-					Context("w/o VPA, PSP is not disabled", func() {
+					Context("w/o VPA", func() {
 						BeforeEach(func() {
 							values.VPAEnabled = false
-							values.PSPDisabled = false
 						})
 
 						It("should succesfully deploy all resources", func() {
@@ -807,16 +787,12 @@ ip6.arpa:53 {
 							daemonset := daemonSetYAMLFor()
 							utilruntime.Must(references.InjectAnnotations(daemonset))
 							Expect(daemonset).To(DeepEqual(managedResourceDaemonset))
-							Expect(string(managedResourceSecret.Data["rolebinding__kube-system__gardener.cloud_psp_node-local-dns.yaml"])).To(Equal(roleBindingPSPYAML))
-							Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_psp_kube-system_node-local-dns.yaml"])).To(Equal(clusterRoleYAML))
-							Expect(string(managedResourceSecret.Data["podsecuritypolicy____gardener.kube-system.node-local-dns.yaml"])).To(Equal(podSecurityPolicyYAML))
 						})
 					})
 
-					Context("w/ VPA, PSP is disabled", func() {
+					Context("w/ VPA", func() {
 						BeforeEach(func() {
 							values.VPAEnabled = true
-							values.PSPDisabled = true
 						})
 
 						It("should succesfully deploy all resources", func() {
@@ -836,10 +812,9 @@ ip6.arpa:53 {
 						values.ForceTcpToClusterDNS = true
 						values.ForceTcpToUpstreamDNS = false
 					})
-					Context("w/o VPA, PSP is disabled", func() {
+					Context("w/o VPA", func() {
 						BeforeEach(func() {
 							values.VPAEnabled = false
-							values.PSPDisabled = true
 						})
 
 						It("should succesfully deploy all resources", func() {
@@ -852,10 +827,9 @@ ip6.arpa:53 {
 						})
 					})
 
-					Context("w/ VPA, PSP is not disabled", func() {
+					Context("w/ VPA", func() {
 						BeforeEach(func() {
 							values.VPAEnabled = true
-							values.PSPDisabled = false
 						})
 
 						It("should succesfully deploy all resources", func() {
@@ -866,9 +840,6 @@ ip6.arpa:53 {
 							daemonset := daemonSetYAMLFor()
 							utilruntime.Must(references.InjectAnnotations(daemonset))
 							Expect(daemonset).To(DeepEqual(managedResourceDaemonset))
-							Expect(string(managedResourceSecret.Data["rolebinding__kube-system__gardener.cloud_psp_node-local-dns.yaml"])).To(Equal(roleBindingPSPYAML))
-							Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_psp_kube-system_node-local-dns.yaml"])).To(Equal(clusterRoleYAML))
-							Expect(string(managedResourceSecret.Data["podsecuritypolicy____gardener.kube-system.node-local-dns.yaml"])).To(Equal(podSecurityPolicyYAML))
 						})
 					})
 				})
@@ -877,10 +848,9 @@ ip6.arpa:53 {
 						values.ForceTcpToClusterDNS = false
 						values.ForceTcpToUpstreamDNS = true
 					})
-					Context("w/o VPA, PSP is not disabled", func() {
+					Context("w/o VPA", func() {
 						BeforeEach(func() {
 							values.VPAEnabled = false
-							values.PSPDisabled = false
 						})
 
 						It("should succesfully deploy all resources", func() {
@@ -890,16 +860,12 @@ ip6.arpa:53 {
 							daemonset := daemonSetYAMLFor()
 							utilruntime.Must(references.InjectAnnotations(daemonset))
 							Expect(daemonset).To(DeepEqual(managedResourceDaemonset))
-							Expect(string(managedResourceSecret.Data["rolebinding__kube-system__gardener.cloud_psp_node-local-dns.yaml"])).To(Equal(roleBindingPSPYAML))
-							Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_psp_kube-system_node-local-dns.yaml"])).To(Equal(clusterRoleYAML))
-							Expect(string(managedResourceSecret.Data["podsecuritypolicy____gardener.kube-system.node-local-dns.yaml"])).To(Equal(podSecurityPolicyYAML))
 						})
 					})
 
-					Context("w/ VPA, PSP is disabled", func() {
+					Context("w/ VPA", func() {
 						BeforeEach(func() {
 							values.VPAEnabled = true
-							values.PSPDisabled = true
 						})
 
 						It("should succesfully deploy all resources", func() {
@@ -918,10 +884,9 @@ ip6.arpa:53 {
 						values.ForceTcpToClusterDNS = false
 						values.ForceTcpToUpstreamDNS = false
 					})
-					Context("w/o VPA, PSP is disabled", func() {
+					Context("w/o VPA", func() {
 						BeforeEach(func() {
 							values.VPAEnabled = false
-							values.PSPDisabled = true
 						})
 
 						It("should succesfully deploy all resources", func() {
@@ -934,9 +899,8 @@ ip6.arpa:53 {
 						})
 					})
 
-					Context("w/ VPA, PSP is not disabled", func() {
+					Context("w/ VPA", func() {
 						BeforeEach(func() {
-							values.PSPDisabled = false
 							values.VPAEnabled = true
 						})
 
@@ -948,11 +912,105 @@ ip6.arpa:53 {
 							daemonset := daemonSetYAMLFor()
 							utilruntime.Must(references.InjectAnnotations(daemonset))
 							Expect(daemonset).To(DeepEqual(managedResourceDaemonset))
-							Expect(string(managedResourceSecret.Data["rolebinding__kube-system__gardener.cloud_psp_node-local-dns.yaml"])).To(Equal(roleBindingPSPYAML))
-							Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_psp_kube-system_node-local-dns.yaml"])).To(Equal(clusterRoleYAML))
-							Expect(string(managedResourceSecret.Data["podsecuritypolicy____gardener.kube-system.node-local-dns.yaml"])).To(Equal(podSecurityPolicyYAML))
 						})
 					})
+				})
+			})
+		})
+
+		Context("PodSecurityPolicy", func() {
+			BeforeEach(func() {
+				values.ClusterDNS = "1.2.3.4"
+				values.DNSServer = ""
+				values.ForceTcpToClusterDNS = true
+				values.ForceTcpToUpstreamDNS = true
+				values.VPAEnabled = true
+			})
+
+			JustBeforeEach(func() {
+				configMapData := map[string]string{
+					"Corefile": `cluster.local:53 {
+    errors
+    cache {
+            success 9984 30
+            denial 9984 5
+    }
+    reload
+    loop
+    bind ` + bindIP(values) + `
+    forward . ` + values.ClusterDNS + ` {
+            ` + forceTcpToClusterDNS(values) + `
+    }
+    prometheus :` + strconv.Itoa(prometheusPort) + `
+    health ` + ipvsAddress + `:` + strconv.Itoa(livenessProbePort) + `
+    }
+in-addr.arpa:53 {
+    errors
+    cache 30
+    reload
+    loop
+    bind ` + bindIP(values) + `
+    forward . ` + values.ClusterDNS + ` {
+            ` + forceTcpToClusterDNS(values) + `
+    }
+    prometheus :` + strconv.Itoa(prometheusPort) + `
+    }
+ip6.arpa:53 {
+    errors
+    cache 30
+    reload
+    loop
+    bind ` + bindIP(values) + `
+    forward . ` + values.ClusterDNS + ` {
+            ` + forceTcpToClusterDNS(values) + `
+    }
+    prometheus :` + strconv.Itoa(prometheusPort) + `
+    }
+.:53 {
+    errors
+    cache 30
+    reload
+    loop
+    bind ` + bindIP(values) + `
+    forward . __PILLAR__UPSTREAM__SERVERS__ {
+            ` + forceTcpToUpstreamDNS(values) + `
+    }
+    prometheus :` + strconv.Itoa(prometheusPort) + `
+    }
+`,
+				}
+				configMapHash = utils.ComputeConfigMapChecksum(configMapData)[:8]
+
+				Expect(string(managedResourceSecret.Data["configmap__kube-system__node-local-dns-"+configMapHash+".yaml"])).To(Equal(configMapYAMLFor()))
+				Expect(string(managedResourceSecret.Data["verticalpodautoscaler__kube-system__node-local-dns.yaml"])).To(Equal(vpaYAML))
+				managedResourceDaemonset, _, err := kubernetes.ShootCodec.UniversalDecoder().Decode(managedResourceSecret.Data["daemonset__kube-system__node-local-dns.yaml"], nil, &appsv1.DaemonSet{})
+				Expect(err).ToNot(HaveOccurred())
+				daemonset := daemonSetYAMLFor()
+				utilruntime.Must(references.InjectAnnotations(daemonset))
+				Expect(daemonset).To(DeepEqual(managedResourceDaemonset))
+			})
+
+			Context("PSP is not disabled", func() {
+				BeforeEach(func() {
+					values.PSPDisabled = false
+				})
+
+				It("should succesfully deploy all resources", func() {
+					Expect(managedResourceSecret.Data).To(HaveLen(8))
+					Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_psp_kube-system_node-local-dns.yaml"])).To(Equal(clusterRoleYAML))
+					Expect(string(managedResourceSecret.Data["rolebinding__kube-system__gardener.cloud_psp_node-local-dns.yaml"])).To(Equal(roleBindingPSPYAML))
+					Expect(string(managedResourceSecret.Data["podsecuritypolicy____gardener.kube-system.node-local-dns.yaml"])).To(Equal(podSecurityPolicyYAML))
+
+				})
+			})
+
+			Context("PSP is disabled", func() {
+				BeforeEach(func() {
+					values.PSPDisabled = true
+				})
+
+				It("should succesfully deploy all resources", func() {
+					Expect(managedResourceSecret.Data).To(HaveLen(5))
 				})
 			})
 		})

--- a/pkg/operation/botanist/component/nodelocaldns/nodelocaldns_test.go
+++ b/pkg/operation/botanist/component/nodelocaldns/nodelocaldns_test.go
@@ -154,7 +154,7 @@ rules:
   verbs:
   - use
 `
-			roleBindingYAML = `apiVersion: rbac.authorization.k8s.io/v1
+			roleBindingPSPYAML = `apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   annotations:
@@ -497,9 +497,6 @@ status: {}
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), managedResourceSecret)).To(Succeed())
 			Expect(managedResourceSecret.Type).To(Equal(corev1.SecretTypeOpaque))
 			Expect(string(managedResourceSecret.Data["serviceaccount__kube-system__node-local-dns.yaml"])).To(Equal(serviceAccountYAML))
-			Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_psp_kube-system_node-local-dns.yaml"])).To(Equal(clusterRoleYAML))
-			Expect(string(managedResourceSecret.Data["rolebinding__kube-system__gardener.cloud_psp_node-local-dns.yaml"])).To(Equal(roleBindingYAML))
-			Expect(string(managedResourceSecret.Data["podsecuritypolicy____gardener.kube-system.node-local-dns.yaml"])).To(Equal(podSecurityPolicyYAML))
 			Expect(string(managedResourceSecret.Data["service__kube-system__kube-dns-upstream.yaml"])).To(Equal(serviceYAML))
 		})
 
@@ -569,9 +566,10 @@ ip6.arpa:53 {
 						values.ForceTcpToClusterDNS = true
 						values.ForceTcpToUpstreamDNS = true
 					})
-					Context("w/o VPA", func() {
+					Context("w/o VPA, PSP is not disabled", func() {
 						BeforeEach(func() {
 							values.VPAEnabled = false
+							values.PSPDisabled = false
 						})
 
 						It("should succesfully deploy all resources", func() {
@@ -581,13 +579,16 @@ ip6.arpa:53 {
 							daemonset := daemonSetYAMLFor()
 							utilruntime.Must(references.InjectAnnotations(daemonset))
 							Expect(daemonset).To(DeepEqual(managedResourceDaemonset))
-
+							Expect(string(managedResourceSecret.Data["rolebinding__kube-system__gardener.cloud_psp_node-local-dns.yaml"])).To(Equal(roleBindingPSPYAML))
+							Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_psp_kube-system_node-local-dns.yaml"])).To(Equal(clusterRoleYAML))
+							Expect(string(managedResourceSecret.Data["podsecuritypolicy____gardener.kube-system.node-local-dns.yaml"])).To(Equal(podSecurityPolicyYAML))
 						})
 					})
 
-					Context("w/ VPA", func() {
+					Context("w/ VPA, PSP is disabled", func() {
 						BeforeEach(func() {
 							values.VPAEnabled = true
+							values.PSPDisabled = true
 						})
 
 						It("should succesfully deploy all resources", func() {
@@ -606,8 +607,9 @@ ip6.arpa:53 {
 						values.ForceTcpToClusterDNS = true
 						values.ForceTcpToUpstreamDNS = false
 					})
-					Context("w/o VPA", func() {
+					Context("w/o VPA, PSP is disabled", func() {
 						BeforeEach(func() {
+							values.PSPDisabled = true
 							values.VPAEnabled = false
 						})
 
@@ -621,9 +623,10 @@ ip6.arpa:53 {
 						})
 					})
 
-					Context("w/ VPA", func() {
+					Context("w/ VPA, PSP is not disabled", func() {
 						BeforeEach(func() {
 							values.VPAEnabled = true
+							values.PSPDisabled = false
 						})
 
 						It("should succesfully deploy all resources", func() {
@@ -634,6 +637,9 @@ ip6.arpa:53 {
 							daemonset := daemonSetYAMLFor()
 							utilruntime.Must(references.InjectAnnotations(daemonset))
 							Expect(daemonset).To(DeepEqual(managedResourceDaemonset))
+							Expect(string(managedResourceSecret.Data["rolebinding__kube-system__gardener.cloud_psp_node-local-dns.yaml"])).To(Equal(roleBindingPSPYAML))
+							Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_psp_kube-system_node-local-dns.yaml"])).To(Equal(clusterRoleYAML))
+							Expect(string(managedResourceSecret.Data["podsecuritypolicy____gardener.kube-system.node-local-dns.yaml"])).To(Equal(podSecurityPolicyYAML))
 						})
 					})
 				})
@@ -642,9 +648,10 @@ ip6.arpa:53 {
 						values.ForceTcpToClusterDNS = false
 						values.ForceTcpToUpstreamDNS = true
 					})
-					Context("w/o VPA", func() {
+					Context("w/o VPA, PSP is not disabled", func() {
 						BeforeEach(func() {
 							values.VPAEnabled = false
+							values.PSPDisabled = false
 						})
 
 						It("should succesfully deploy all resources", func() {
@@ -654,12 +661,16 @@ ip6.arpa:53 {
 							daemonset := daemonSetYAMLFor()
 							utilruntime.Must(references.InjectAnnotations(daemonset))
 							Expect(daemonset).To(DeepEqual(managedResourceDaemonset))
+							Expect(string(managedResourceSecret.Data["rolebinding__kube-system__gardener.cloud_psp_node-local-dns.yaml"])).To(Equal(roleBindingPSPYAML))
+							Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_psp_kube-system_node-local-dns.yaml"])).To(Equal(clusterRoleYAML))
+							Expect(string(managedResourceSecret.Data["podsecuritypolicy____gardener.kube-system.node-local-dns.yaml"])).To(Equal(podSecurityPolicyYAML))
 						})
 					})
 
-					Context("w/ VPA", func() {
+					Context("w/ VPA, PSP is disabled", func() {
 						BeforeEach(func() {
 							values.VPAEnabled = true
+							values.PSPDisabled = true
 						})
 
 						It("should succesfully deploy all resources", func() {
@@ -678,9 +689,10 @@ ip6.arpa:53 {
 						values.ForceTcpToClusterDNS = false
 						values.ForceTcpToUpstreamDNS = false
 					})
-					Context("w/o VPA", func() {
+					Context("w/o VPA, PSP is not disabled", func() {
 						BeforeEach(func() {
 							values.VPAEnabled = false
+							values.PSPDisabled = false
 						})
 
 						It("should succesfully deploy all resources", func() {
@@ -690,12 +702,16 @@ ip6.arpa:53 {
 							daemonset := daemonSetYAMLFor()
 							utilruntime.Must(references.InjectAnnotations(daemonset))
 							Expect(daemonset).To(DeepEqual(managedResourceDaemonset))
+							Expect(string(managedResourceSecret.Data["rolebinding__kube-system__gardener.cloud_psp_node-local-dns.yaml"])).To(Equal(roleBindingPSPYAML))
+							Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_psp_kube-system_node-local-dns.yaml"])).To(Equal(clusterRoleYAML))
+							Expect(string(managedResourceSecret.Data["podsecuritypolicy____gardener.kube-system.node-local-dns.yaml"])).To(Equal(podSecurityPolicyYAML))
 						})
 					})
 
-					Context("w/ VPA", func() {
+					Context("w/ VPA, PSP is disabled", func() {
 						BeforeEach(func() {
 							values.VPAEnabled = true
+							values.PSPDisabled = true
 						})
 
 						It("should succesfully deploy all resources", func() {
@@ -778,9 +794,10 @@ ip6.arpa:53 {
 						values.ForceTcpToClusterDNS = true
 						values.ForceTcpToUpstreamDNS = true
 					})
-					Context("w/o VPA", func() {
+					Context("w/o VPA, PSP is not disabled", func() {
 						BeforeEach(func() {
 							values.VPAEnabled = false
+							values.PSPDisabled = false
 						})
 
 						It("should succesfully deploy all resources", func() {
@@ -790,12 +807,16 @@ ip6.arpa:53 {
 							daemonset := daemonSetYAMLFor()
 							utilruntime.Must(references.InjectAnnotations(daemonset))
 							Expect(daemonset).To(DeepEqual(managedResourceDaemonset))
+							Expect(string(managedResourceSecret.Data["rolebinding__kube-system__gardener.cloud_psp_node-local-dns.yaml"])).To(Equal(roleBindingPSPYAML))
+							Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_psp_kube-system_node-local-dns.yaml"])).To(Equal(clusterRoleYAML))
+							Expect(string(managedResourceSecret.Data["podsecuritypolicy____gardener.kube-system.node-local-dns.yaml"])).To(Equal(podSecurityPolicyYAML))
 						})
 					})
 
-					Context("w/ VPA", func() {
+					Context("w/ VPA, PSP is disabled", func() {
 						BeforeEach(func() {
 							values.VPAEnabled = true
+							values.PSPDisabled = true
 						})
 
 						It("should succesfully deploy all resources", func() {
@@ -815,9 +836,10 @@ ip6.arpa:53 {
 						values.ForceTcpToClusterDNS = true
 						values.ForceTcpToUpstreamDNS = false
 					})
-					Context("w/o VPA", func() {
+					Context("w/o VPA, PSP is disabled", func() {
 						BeforeEach(func() {
 							values.VPAEnabled = false
+							values.PSPDisabled = true
 						})
 
 						It("should succesfully deploy all resources", func() {
@@ -830,9 +852,10 @@ ip6.arpa:53 {
 						})
 					})
 
-					Context("w/ VPA", func() {
+					Context("w/ VPA, PSP is not disabled", func() {
 						BeforeEach(func() {
 							values.VPAEnabled = true
+							values.PSPDisabled = false
 						})
 
 						It("should succesfully deploy all resources", func() {
@@ -843,6 +866,9 @@ ip6.arpa:53 {
 							daemonset := daemonSetYAMLFor()
 							utilruntime.Must(references.InjectAnnotations(daemonset))
 							Expect(daemonset).To(DeepEqual(managedResourceDaemonset))
+							Expect(string(managedResourceSecret.Data["rolebinding__kube-system__gardener.cloud_psp_node-local-dns.yaml"])).To(Equal(roleBindingPSPYAML))
+							Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_psp_kube-system_node-local-dns.yaml"])).To(Equal(clusterRoleYAML))
+							Expect(string(managedResourceSecret.Data["podsecuritypolicy____gardener.kube-system.node-local-dns.yaml"])).To(Equal(podSecurityPolicyYAML))
 						})
 					})
 				})
@@ -851,9 +877,10 @@ ip6.arpa:53 {
 						values.ForceTcpToClusterDNS = false
 						values.ForceTcpToUpstreamDNS = true
 					})
-					Context("w/o VPA", func() {
+					Context("w/o VPA, PSP is not disabled", func() {
 						BeforeEach(func() {
 							values.VPAEnabled = false
+							values.PSPDisabled = false
 						})
 
 						It("should succesfully deploy all resources", func() {
@@ -863,12 +890,16 @@ ip6.arpa:53 {
 							daemonset := daemonSetYAMLFor()
 							utilruntime.Must(references.InjectAnnotations(daemonset))
 							Expect(daemonset).To(DeepEqual(managedResourceDaemonset))
+							Expect(string(managedResourceSecret.Data["rolebinding__kube-system__gardener.cloud_psp_node-local-dns.yaml"])).To(Equal(roleBindingPSPYAML))
+							Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_psp_kube-system_node-local-dns.yaml"])).To(Equal(clusterRoleYAML))
+							Expect(string(managedResourceSecret.Data["podsecuritypolicy____gardener.kube-system.node-local-dns.yaml"])).To(Equal(podSecurityPolicyYAML))
 						})
 					})
 
-					Context("w/ VPA", func() {
+					Context("w/ VPA, PSP is disabled", func() {
 						BeforeEach(func() {
 							values.VPAEnabled = true
+							values.PSPDisabled = true
 						})
 
 						It("should succesfully deploy all resources", func() {
@@ -887,9 +918,10 @@ ip6.arpa:53 {
 						values.ForceTcpToClusterDNS = false
 						values.ForceTcpToUpstreamDNS = false
 					})
-					Context("w/o VPA", func() {
+					Context("w/o VPA, PSP is disabled", func() {
 						BeforeEach(func() {
 							values.VPAEnabled = false
+							values.PSPDisabled = true
 						})
 
 						It("should succesfully deploy all resources", func() {
@@ -902,8 +934,9 @@ ip6.arpa:53 {
 						})
 					})
 
-					Context("w/ VPA", func() {
+					Context("w/ VPA, PSP is not disabled", func() {
 						BeforeEach(func() {
+							values.PSPDisabled = false
 							values.VPAEnabled = true
 						})
 
@@ -915,6 +948,9 @@ ip6.arpa:53 {
 							daemonset := daemonSetYAMLFor()
 							utilruntime.Must(references.InjectAnnotations(daemonset))
 							Expect(daemonset).To(DeepEqual(managedResourceDaemonset))
+							Expect(string(managedResourceSecret.Data["rolebinding__kube-system__gardener.cloud_psp_node-local-dns.yaml"])).To(Equal(roleBindingPSPYAML))
+							Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_psp_kube-system_node-local-dns.yaml"])).To(Equal(clusterRoleYAML))
+							Expect(string(managedResourceSecret.Data["podsecuritypolicy____gardener.kube-system.node-local-dns.yaml"])).To(Equal(podSecurityPolicyYAML))
 						})
 					})
 				})

--- a/pkg/operation/botanist/component/nodeproblemdetector/node_problem_detector_test.go
+++ b/pkg/operation/botanist/component/nodeproblemdetector/node_problem_detector_test.go
@@ -64,7 +64,6 @@ var _ = Describe("NodeProblemDetector", func() {
 			VPAEnabled: false,
 		}
 		component = New(c, namespace, values)
-
 		managedResource = &resourcesv1alpha1.ManagedResource{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      managedResourceName,
@@ -148,7 +147,7 @@ metadata:
   labels:
     app.kubernetes.io/instance: shoot-core
     app.kubernetes.io/name: node-problem-detector
-  name: node-problem-detector-psp
+  name: gardener.cloud:psp:kube-system:node-problem-detector
 rules:
 - apiGroups:
   - extensions
@@ -169,11 +168,11 @@ metadata:
   labels:
     app.kubernetes.io/instance: shoot-core
     app.kubernetes.io/name: node-problem-detector
-  name: node-problem-detector-psp
+  name: gardener.cloud:psp:node-problem-detector
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: node-problem-detector-psp
+  name: gardener.cloud:psp:kube-system:node-problem-detector
 subjects:
 - kind: ServiceAccount
   name: node-problem-detector
@@ -350,6 +349,7 @@ status: {}
 		)
 
 		JustBeforeEach(func() {
+			component = New(c, namespace, values)
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: resourcesv1alpha1.SchemeGroupVersion.Group, Resource: "managedresources"}, managedResource.Name)))
 			Expect(c.Get(ctx, client.ObjectKeyFromObject(managedResourceSecret), managedResourceSecret)).To(MatchError(apierrors.NewNotFound(schema.GroupResource{Group: corev1.SchemeGroupVersion.Group, Resource: "secrets"}, managedResourceSecret.Name)))
 			Expect(component.Deploy(ctx)).To(Succeed())
@@ -379,32 +379,62 @@ status: {}
 			Expect(string(managedResourceSecret.Data["serviceaccount__kube-system__node-problem-detector.yaml"])).To(Equal(serviceAccountYAML))
 			Expect(string(managedResourceSecret.Data["clusterrole____node-problem-detector.yaml"])).To(Equal(clusterRoleYAML))
 			Expect(string(managedResourceSecret.Data["clusterrolebinding____node-problem-detector.yaml"])).To(Equal(clusterRoleBindingYAML))
-			Expect(string(managedResourceSecret.Data["clusterrole____node-problem-detector-psp.yaml"])).To(Equal(clusterRolePSPYAML))
-			Expect(string(managedResourceSecret.Data["clusterrolebinding____node-problem-detector-psp.yaml"])).To(Equal(clusterRoleBindingPSPYAML))
-			Expect(string(managedResourceSecret.Data["podsecuritypolicy____node-problem-detector.yaml"])).To(Equal(podSecurityPolicyYAML))
 		})
 
 		Context("w/o apiserver host, w/o vpaEnables", func() {
-			It("should successfully deploy all resources", func() {
-				Expect(string(managedResourceSecret.Data["daemonset__kube-system__node-problem-detector.yaml"])).To(Equal(daemonsetYAMLFor("", false)))
+			Context("PSP is disabled", func() {
+				BeforeEach(func() {
+					values.PSPDisabled = true
+				})
+				It("should successfully deploy all resources", func() {
+					Expect(string(managedResourceSecret.Data["daemonset__kube-system__node-problem-detector.yaml"])).To(Equal(daemonsetYAMLFor("", false)))
+				})
+			})
+
+			Context("PSP is not disabled", func() {
+				BeforeEach(func() {
+					values.PSPDisabled = false
+				})
+				It("should successfully deploy all resources", func() {
+					Expect(string(managedResourceSecret.Data["daemonset__kube-system__node-problem-detector.yaml"])).To(Equal(daemonsetYAMLFor("", false)))
+					Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_psp_node-problem-detector.yaml"])).To(Equal(clusterRoleBindingPSPYAML))
+					Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_psp_kube-system_node-problem-detector.yaml"])).To(Equal(clusterRolePSPYAML))
+					Expect(string(managedResourceSecret.Data["podsecuritypolicy____node-problem-detector.yaml"])).To(Equal(podSecurityPolicyYAML))
+				})
 			})
 		})
 
-		Context("w/ apiserver host,w/ vpaEnables", func() {
+		Context("w/ apiserver host,w/ vpaEnabled", func() {
 			var (
 				apiserverHost = "apiserver.host"
 				vpaEnabled    = true
 			)
-
 			BeforeEach(func() {
 				values.APIServerHost = &apiserverHost
 				values.VPAEnabled = vpaEnabled
-				component = New(c, namespace, values)
 			})
 
-			It("should successfully deploy all resources", func() {
-				Expect(string(managedResourceSecret.Data["verticalpodautoscaler__kube-system__node-problem-detector.yaml"])).To(Equal(vpaYAML))
-				Expect(string(managedResourceSecret.Data["daemonset__kube-system__node-problem-detector.yaml"])).To(Equal(daemonsetYAMLFor(apiserverHost, vpaEnabled)))
+			Context("PSP is disabled", func() {
+				BeforeEach(func() {
+					values.PSPDisabled = true
+				})
+				It("should successfully deploy all resources", func() {
+					Expect(string(managedResourceSecret.Data["verticalpodautoscaler__kube-system__node-problem-detector.yaml"])).To(Equal(vpaYAML))
+					Expect(string(managedResourceSecret.Data["daemonset__kube-system__node-problem-detector.yaml"])).To(Equal(daemonsetYAMLFor(apiserverHost, vpaEnabled)))
+				})
+			})
+
+			Context("PSP is not disabled", func() {
+				BeforeEach(func() {
+					values.PSPDisabled = false
+				})
+				It("should successfully deploy all resources", func() {
+					Expect(string(managedResourceSecret.Data["verticalpodautoscaler__kube-system__node-problem-detector.yaml"])).To(Equal(vpaYAML))
+					Expect(string(managedResourceSecret.Data["daemonset__kube-system__node-problem-detector.yaml"])).To(Equal(daemonsetYAMLFor(apiserverHost, vpaEnabled)))
+					Expect(string(managedResourceSecret.Data["clusterrolebinding____gardener.cloud_psp_node-problem-detector.yaml"])).To(Equal(clusterRoleBindingPSPYAML))
+					Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_psp_kube-system_node-problem-detector.yaml"])).To(Equal(clusterRolePSPYAML))
+					Expect(string(managedResourceSecret.Data["podsecuritypolicy____node-problem-detector.yaml"])).To(Equal(podSecurityPolicyYAML))
+				})
 			})
 		})
 	})

--- a/pkg/operation/botanist/component/nodeproblemdetector/node_problem_detector_test.go
+++ b/pkg/operation/botanist/component/nodeproblemdetector/node_problem_detector_test.go
@@ -381,7 +381,7 @@ status: {}
 			Expect(string(managedResourceSecret.Data["clusterrolebinding____node-problem-detector.yaml"])).To(Equal(clusterRoleBindingYAML))
 		})
 
-		Context("w/o apiserver host, w/o vpaEnables", func() {
+		Context("w/o apiserver host, w/o vpaEnabled", func() {
 			Context("PSP is disabled", func() {
 				BeforeEach(func() {
 					values.PSPDisabled = true

--- a/pkg/operation/botanist/component/vpnshoot/vpnshoot_test.go
+++ b/pkg/operation/botanist/component/vpnshoot/vpnshoot_test.go
@@ -612,9 +612,6 @@ status:
 
 			Expect(string(managedResourceSecret.Data["networkpolicy__kube-system__gardener.cloud--allow-vpn.yaml"])).To(Equal(networkPolicyYAML))
 			Expect(string(managedResourceSecret.Data["serviceaccount__kube-system__vpn-shoot.yaml"])).To(Equal(serviceAccountYAML))
-			Expect(string(managedResourceSecret.Data["podsecuritypolicy____gardener.kube-system.vpn-shoot.yaml"])).To(Equal(podSecurityPolicyYAML))
-			Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_psp_kube-system_vpn-shoot.yaml"])).To(Equal(clusterRolePSPYAML))
-			Expect(string(managedResourceSecret.Data["rolebinding__kube-system__gardener.cloud_psp_vpn-shoot.yaml"])).To(Equal(roleBindingPSPYAML))
 
 			if !values.ReversedVPN.Enabled {
 				Expect(string(managedResourceSecret.Data["secret__kube-system__"+secretNameTLSAuthLegacyVPN+".yaml"])).To(Equal(secretTLSAuthYAML))
@@ -634,11 +631,11 @@ status:
 				Expect(string(managedResourceSecret.Data["secret__kube-system__"+secretNameDHTest+".yaml"])).To(Equal(secretDHYAML))
 			})
 
-			Context("w/o VPA", func() {
+			Context("w/o VPA, PSP is disabled", func() {
 				BeforeEach(func() {
 					values.VPAEnabled = false
+					values.PSPDisabled = true
 				})
-
 				It("should successfully deploy all resources", func() {
 					secretNameClient := expectVPNShootSecret(managedResourceSecret.Data, values.ReversedVPN.Enabled)
 					secretNameCA := expectCASecret(managedResourceSecret.Data)
@@ -649,9 +646,10 @@ status:
 				})
 			})
 
-			Context("w/ VPA", func() {
+			Context("w/ VPA, PSP is not disabled", func() {
 				BeforeEach(func() {
 					values.VPAEnabled = true
+					values.PSPDisabled = false
 				})
 
 				It("should successfully deploy all resources", func() {
@@ -663,6 +661,9 @@ status:
 					deployment := &appsv1.Deployment{}
 					Expect(runtime.DecodeInto(newCodec(), managedResourceSecret.Data["deployment__kube-system__vpn-shoot.yaml"], deployment)).To(Succeed())
 					Expect(deployment).To(Equal(deploymentFor(secretNameCA, secretNameClient, secretNameTLSAuthLegacyVPN, values.ReversedVPN.Enabled, values.VPAEnabled)))
+					Expect(string(managedResourceSecret.Data["rolebinding__kube-system__gardener.cloud_psp_vpn-shoot.yaml"])).To(Equal(roleBindingPSPYAML))
+					Expect(string(managedResourceSecret.Data["podsecuritypolicy____gardener.kube-system.vpn-shoot.yaml"])).To(Equal(podSecurityPolicyYAML))
+					Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_psp_kube-system_vpn-shoot.yaml"])).To(Equal(clusterRolePSPYAML))
 				})
 			})
 		})
@@ -672,9 +673,10 @@ status:
 				values.ReversedVPN.Enabled = true
 			})
 
-			Context("w/o VPA", func() {
+			Context("w/o VPA, PSP is not disabled", func() {
 				BeforeEach(func() {
 					values.VPAEnabled = false
+					values.PSPDisabled = false
 				})
 
 				It("should successfully deploy all resources", func() {
@@ -687,12 +689,16 @@ status:
 					deployment := &appsv1.Deployment{}
 					Expect(runtime.DecodeInto(newCodec(), managedResourceSecret.Data["deployment__kube-system__vpn-shoot.yaml"], deployment)).To(Succeed())
 					Expect(deployment).To(Equal(deploymentFor(secretNameCA, secretNameClient, secretNameTLSAuth, values.ReversedVPN.Enabled, values.VPAEnabled)))
+					Expect(string(managedResourceSecret.Data["rolebinding__kube-system__gardener.cloud_psp_vpn-shoot.yaml"])).To(Equal(roleBindingPSPYAML))
+					Expect(string(managedResourceSecret.Data["podsecuritypolicy____gardener.kube-system.vpn-shoot.yaml"])).To(Equal(podSecurityPolicyYAML))
+					Expect(string(managedResourceSecret.Data["clusterrole____gardener.cloud_psp_kube-system_vpn-shoot.yaml"])).To(Equal(clusterRolePSPYAML))
 				})
 			})
 
-			Context("w/ VPA", func() {
+			Context("w/ VPA, PSP is disabled", func() {
 				BeforeEach(func() {
 					values.VPAEnabled = true
+					values.PSPDisabled = true
 				})
 
 				It("should successfully deploy all resources", func() {

--- a/pkg/operation/botanist/kubeproxy.go
+++ b/pkg/operation/botanist/kubeproxy.go
@@ -54,6 +54,7 @@ func (b *Botanist) DefaultKubeProxy() (kubeproxy.Interface, error) {
 			ImageAlpine:    imageAlpine.String(),
 			PodNetworkCIDR: pointer.String(b.Shoot.Networks.Pods.String()),
 			VPAEnabled:     b.Shoot.WantsVerticalPodAutoscaler,
+			PSPDisabled:    b.Shoot.PSPDisabled,
 		},
 	), nil
 }

--- a/pkg/operation/botanist/nodelocaldns.go
+++ b/pkg/operation/botanist/nodelocaldns.go
@@ -56,6 +56,7 @@ func (b *Botanist) DefaultNodeLocalDNS() (nodelocaldns.Interface, error) {
 			ForceTcpToUpstreamDNS: v1beta1helper.IsTCPEnforcedForNodeLocalDNSToUpstreamDNS(b.Shoot.GetInfo().Spec.SystemComponents, b.Shoot.GetInfo().Annotations),
 			ClusterDNS:            clusterDNS,
 			DNSServer:             dnsServer,
+			PSPDisabled:           b.Shoot.PSPDisabled,
 		},
 	), nil
 }

--- a/pkg/operation/botanist/nodeproblemdetector.go
+++ b/pkg/operation/botanist/nodeproblemdetector.go
@@ -31,8 +31,9 @@ func (b *Botanist) DefaultNodeProblemDetector() (component.DeployWaiter, error) 
 	}
 
 	values := nodeproblemdetector.Values{
-		Image:      image.String(),
-		VPAEnabled: b.Shoot.WantsVerticalPodAutoscaler,
+		Image:       image.String(),
+		VPAEnabled:  b.Shoot.WantsVerticalPodAutoscaler,
+		PSPDisabled: b.Shoot.PSPDisabled,
 	}
 
 	if b.APIServerSNIEnabled() {

--- a/pkg/operation/botanist/vpnshoot.go
+++ b/pkg/operation/botanist/vpnshoot.go
@@ -62,6 +62,7 @@ func (b *Botanist) DefaultVPNShoot() (vpnshoot.Interface, error) {
 			ServiceCIDR: b.Shoot.Networks.Services.String(),
 			NodeCIDR:    nodeNetworkCIDR,
 		},
+		PSPDisabled: b.Shoot.PSPDisabled,
 	}
 
 	return vpnshoot.New(

--- a/pkg/operation/shoot/shoot.go
+++ b/pkg/operation/shoot/shoot.go
@@ -262,6 +262,8 @@ func (b *Builder) Build(ctx context.Context, c client.Reader) (*Shoot, error) {
 	shoot.NodeLocalDNSEnabled = helper.IsNodeLocalDNSEnabled(shoot.GetInfo().Spec.SystemComponents, shoot.GetInfo().Annotations)
 	shoot.Purpose = gardencorev1beta1helper.GetPurpose(shootObject)
 
+	shoot.PSPDisabled = gardencorev1beta1helper.IsPSPDisabled(shoot.GetInfo())
+
 	backupEntryName, err := gutil.GenerateBackupEntryName(shootObject.Status.TechnicalID, shootObject.UID)
 	if err != nil {
 		return nil, err

--- a/pkg/operation/shoot/types.go
+++ b/pkg/operation/shoot/types.go
@@ -89,6 +89,7 @@ type Shoot struct {
 	HibernationEnabled                  bool
 	ReversedVPNEnabled                  bool
 	NodeLocalDNSEnabled                 bool
+	PSPDisabled                         bool
 	Networks                            *Networks
 	ExposureClass                       *gardencorev1alpha1.ExposureClass
 	BackupEntryName                     string

--- a/pkg/utils/version/version.go
+++ b/pkg/utils/version/version.go
@@ -59,6 +59,8 @@ var (
 	ConstraintK8sEqual124 *semver.Constraints
 	// ConstraintK8sLess124 is a version constraint for versions < 1.24.
 	ConstraintK8sLess124 *semver.Constraints
+	// ConstraintK8sGreaterEqual125 is a version constraint for versions >= 1.25.
+	ConstraintK8sGreaterEqual125 *semver.Constraints
 )
 
 func init() {
@@ -99,6 +101,8 @@ func init() {
 	ConstraintK8sEqual124, err = semver.NewConstraint("1.24.x")
 	utilruntime.Must(err)
 	ConstraintK8sLess124, err = semver.NewConstraint("< 1.24")
+	utilruntime.Must(err)
+	ConstraintK8sGreaterEqual125, err = semver.NewConstraint(">= 1.25")
 	utilruntime.Must(err)
 }
 

--- a/test/framework/applications/guestbooktest.go
+++ b/test/framework/applications/guestbooktest.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/pkg/utils/retry"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
@@ -141,7 +142,7 @@ func (t *GuestBookTest) DeployGuestBookApp(ctx context.Context) {
 			"enabled": false,
 		},
 		"podSecurityPolicy": map[string]interface{}{
-			"create": true,
+			"create": !gardencorev1beta1helper.IsPSPDisabled(shoot),
 		},
 		"rbac": map[string]interface{}{
 			"create": true,

--- a/test/framework/k8s_utils.go
+++ b/test/framework/k8s_utils.go
@@ -472,9 +472,6 @@ func DeployRootPod(ctx context.Context, c client.Client, namespace string, noden
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      fmt.Sprintf("rootpod-%s", id),
 			Namespace: namespace,
-			Annotations: map[string]string{
-				"kubernetes.io/psp": "gardener.privileged",
-			},
 		},
 		Spec: corev1.PodSpec{
 			Containers: []corev1.Container{

--- a/test/testmachinery/shoots/applications/networking.go
+++ b/test/testmachinery/shoots/applications/networking.go
@@ -32,6 +32,7 @@ import (
 	"io"
 	"time"
 
+	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/test/framework"
 	"github.com/gardener/gardener/test/framework/resources/templates"
 
@@ -66,7 +67,9 @@ var _ = ginkgo.Describe("Shoot network testing", func() {
 		}
 		ginkgo.By("Deploy the net test daemon set")
 		framework.ExpectNoError(f.RenderAndDeployTemplate(ctx, f.ShootClient, "network-nginx-serviceaccount.yaml.tpl", templateParams))
-		framework.ExpectNoError(f.RenderAndDeployTemplate(ctx, f.ShootClient, "network-nginx-rolebinding-privileged.yaml.tpl", templateParams))
+		if !gardencorev1beta1helper.IsPSPDisabled(f.Shoot) {
+			framework.ExpectNoError(f.RenderAndDeployTemplate(ctx, f.ShootClient, "network-nginx-rolebinding-privileged.yaml.tpl", templateParams))
+		}
 		framework.ExpectNoError(f.RenderAndDeployTemplate(ctx, f.ShootClient, templates.NginxDaemonSetName, templateParams))
 
 		err := f.WaitUntilDaemonSetIsRunning(ctx, f.ShootClient.Client(), name, f.Namespace)

--- a/test/testmachinery/shoots/logging/seed_logging_stack.go
+++ b/test/testmachinery/shoots/logging/seed_logging_stack.go
@@ -21,6 +21,7 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	versionutils "github.com/gardener/gardener/pkg/utils/version"
@@ -190,7 +191,9 @@ var _ = ginkgo.Describe("Seed logging testing", func() {
 		framework.ExpectNoError(create(ctx, f.ShootClient.Client(), fluentBitPriorityClass))
 		framework.ExpectNoError(create(ctx, f.ShootClient.Client(), fluentBitClusterRole))
 		framework.ExpectNoError(create(ctx, f.ShootClient.Client(), fluentBitClusterRoleBinding))
-		framework.ExpectNoError(f.RenderAndDeployTemplate(ctx, f.ShootClient, "fluent-bit-psp-clusterrolebinding.yaml", nil))
+		if !gardencorev1beta1helper.IsPSPDisabled(f.Shoot) {
+			framework.ExpectNoError(f.RenderAndDeployTemplate(ctx, f.ShootClient, "fluent-bit-psp-clusterrolebinding.yaml", nil))
+		}
 
 		ginkgo.By("Deploy the fluent-bit DaemonSet")
 		framework.ExpectNoError(create(ctx, f.ShootClient.Client(), fluentBitConfMap))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:
The `PSP`s for gardener components and the corresponding `clusterRole`s and `clusterRoleBinding`s are not deployed if the `PodSecurityPolicy` admission plugin is disabled in the `Shoot` spec. In such cases, setting `allowPrivilegedContainers=true` won't have any effect (which won't disrupt anything since the admission controller is not present anymore). There will be further PRs to adapt this field to use the new `PodSecurity` admission controller.

Note: As of now, it's not possible to disable the plugin, since all the extensions have to be adapted.

**Which issue(s) this PR fixes**:
Part of #5250 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
