### PR TITLE
Disables owner checks for clustered ETCD

### DIFF
--- a/pkg/operation/botanist/etcd.go
+++ b/pkg/operation/botanist/etcd.go
@@ -121,7 +121,10 @@ func (b *Botanist) DeployEtcd(ctx context.Context) error {
 			LeaderElection:       backupLeaderElection,
 		})
 
-		if gardencorev1beta1helper.SeedSettingOwnerChecksEnabled(b.Seed.GetInfo().Spec.Settings) {
+		// Owner checks are only enabled if the `etcd-main` resource is deployed with 1 replica.
+		// They must not be used for clustered etcd. Ref: https://github.com/gardener/gardener/issues/6302
+		if gardencorev1beta1helper.SeedSettingOwnerChecksEnabled(b.Seed.GetInfo().Spec.Settings) &&
+			getReplicas(b.Shoot.GetInfo()) == 1 {
 			b.Shoot.Components.ControlPlane.EtcdMain.SetOwnerCheckConfig(&etcd.OwnerCheckConfig{
 				Name: gutil.GetOwnerDomain(b.Shoot.InternalClusterDomain),
 				ID:   *b.Seed.GetInfo().Status.ClusterIdentity,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area high-availability
/area control-plane-migration
/kind enhancement

**What this PR does / why we need it**:
This PR disables owner checks (initially added by https://github.com/gardener/etcd-backup-restore/pull/383) for the `etcd-main` `Etcd` resource when the desired replicas are greater than 1. Replicas greater than 1 basically means that the `HAControlPlanes` feature gate is enabled and the shoot is annotated with `alpha.control-plane.shoot.gardener.cloud/high-availability`, and therefore the etcds for the shoot will be started as a cluster.

**Which issue(s) this PR fixes**:
Part of #6302 

**Special notes for your reviewer**:
/cc @ishan16696 @timuthy @unmarshall 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Owner checks (which are used by the `backup-restore` sidecar to determine whether the owner domain name resolves to the specified owner ID and if not, take a final full snapshot and disable the cluster), will no longer be enabled by `gardenlet`, if the `HAControlPlanes` feature gate is enabled, the `Shoot` is annotated with `alpha.control-plane.shoot.gardener.cloud/high-availability` and the `Shoot`'s ETCDs are started as a cluster (with more than 1 replica).
```
