### PR TITLE
Move `IsPSPDisabled` helper function to v1beta1/helper

### DIFF
--- a/extensions/pkg/util/shoot.go
+++ b/extensions/pkg/util/shoot.go
@@ -19,9 +19,6 @@ import (
 
 	"github.com/Masterminds/semver"
 	"k8s.io/apimachinery/pkg/version"
-	"k8s.io/utils/pointer"
-
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 )
 
 // VersionMajorMinor extracts and returns the major and the minor part of the given version (input must be a semantic version).
@@ -44,16 +41,4 @@ func VersionInfo(vs string) (*version.Info, error) {
 		Minor:      fmt.Sprintf("%d", v.Minor()),
 		GitVersion: fmt.Sprintf("v%d.%d.%d", v.Major(), v.Minor(), v.Patch()),
 	}, nil
-}
-
-// IsPSPDisabled returns true if the PodSecurityPolicy plugin is explicitly disabled in the ShootSpec
-func IsPSPDisabled(shoot *gardencorev1beta1.Shoot) bool {
-	if shoot.Spec.Kubernetes.KubeAPIServer != nil {
-		for _, plugin := range shoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins {
-			if plugin.Name == "PodSecurityPolicy" && pointer.BoolDeref(plugin.Disabled, false) {
-				return true
-			}
-		}
-	}
-	return false
 }

--- a/extensions/pkg/util/shoot_test.go
+++ b/extensions/pkg/util/shoot_test.go
@@ -20,10 +20,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/version"
-	"k8s.io/utils/pointer"
 
 	"github.com/gardener/gardener/extensions/pkg/util"
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 )
 
 var _ = Describe("Shoot", func() {
@@ -71,50 +69,6 @@ var _ = Describe("Shoot", func() {
 
 			Expect(v).To(Equal(expectedVersionInfo))
 			Expect(err).NotTo(HaveOccurred())
-		})
-	})
-
-	Describe("#IsPSPDisabled", func() {
-		var shoot = &gardencorev1beta1.Shoot{
-			Spec: gardencorev1beta1.ShootSpec{
-				Kubernetes: gardencorev1beta1.Kubernetes{
-					KubeAPIServer: &gardencorev1beta1.KubeAPIServerConfig{},
-				},
-			},
-		}
-
-		It("should return true if PodSecurityPolicy admissionPlugin is disabled", func() {
-			shoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins = []gardencorev1beta1.AdmissionPlugin{
-				{
-					Name:     "PodSecurityPolicy",
-					Disabled: pointer.Bool(true),
-				},
-			}
-			Expect(util.IsPSPDisabled(shoot)).To(BeTrue())
-		})
-
-		It("should return false if PodSecurityPolicy admissionPlugin is not disabled", func() {
-			shoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins = []gardencorev1beta1.AdmissionPlugin{
-				{
-					Name: "PodSecurityPolicy",
-				},
-			}
-			Expect(util.IsPSPDisabled(shoot)).To(BeFalse())
-		})
-
-		It("should return false if PodSecurityPolicy admissionPlugin is not specified in the shootSpec", func() {
-			shoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins = []gardencorev1beta1.AdmissionPlugin{
-				{
-					Name: "NamespaceLifecycle",
-				},
-			}
-			Expect(util.IsPSPDisabled(shoot)).To(BeFalse())
-		})
-
-		It("should return false if KubeAPIServerConfig is nil", func() {
-			shoot.Spec.Kubernetes.KubeAPIServer = nil
-
-			Expect(util.IsPSPDisabled(shoot)).To(BeFalse())
 		})
 	})
 })

--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -1319,3 +1319,15 @@ func MutateShootETCDEncryptionKeyRotation(shoot *gardencorev1beta1.Shoot, f func
 
 	f(shoot.Status.Credentials.Rotation.ETCDEncryptionKey)
 }
+
+// IsPSPDisabled returns true if the PodSecurityPolicy plugin is explicitly disabled in the ShootSpec
+func IsPSPDisabled(shoot *gardencorev1beta1.Shoot) bool {
+	if shoot.Spec.Kubernetes.KubeAPIServer != nil {
+		for _, plugin := range shoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins {
+			if plugin.Name == "PodSecurityPolicy" && pointer.BoolDeref(plugin.Disabled, false) {
+				return true
+			}
+		}
+	}
+	return false
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/kind enhancement

**What this PR does / why we need it**:
A helper function for checking whether PSP admission plugin is disabled was introduced with #6403 in `extensions/pkg/util`. I missed that we need it in https://github.com/gardener/gardener/pull/6409 as well, To prevent duplication, this function is moved to v1beta1/helper.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @acumino 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
