### PR TITLE
Updating CRD for DNSEntries to allow specifying routing policy

### DIFF
--- a/pkg/operation/botanist/component/extensions/crds/templates/crd-dnsentry.tpl.yaml
+++ b/pkg/operation/botanist/component/extensions/crds/templates/crd-dnsentry.tpl.yaml
@@ -54,6 +54,21 @@ spec:
           name: ZONE
           priority: 2000
           type: string
+        - description: routing policy type
+          jsonPath: .status.routingPolicy.type
+          name: POLICY_TYPE
+          priority: 2000
+          type: string
+        - description: routing policy set identifier
+          jsonPath: .status.routingPolicy.setIdentifier
+          name: POLICY_SETID
+          priority: 2000
+          type: string
+        - description: routing policy parameters
+          jsonPath: .status.routingPolicy.parameters
+          name: POLICY_PARAMS
+          priority: 2000
+          type: string
         - description: message describing the reason for the state
           jsonPath: .status.message
           name: MESSAGE
@@ -95,6 +110,26 @@ spec:
                   required:
                     - name
                   type: object
+                routingPolicy:
+                  description: optional routing policy
+                  properties:
+                    parameters:
+                      additionalProperties:
+                        type: string
+                      description: Policy specific parameters
+                      type: object
+                    setIdentifier:
+                      description: SetIdentifier is the identifier of the record set
+                      type: string
+                    type:
+                      description: Policy is the policy type. Allowed values are provider
+                        dependent, e.g. `weighted`
+                      type: string
+                  required:
+                    - parameters
+                    - setIdentifier
+                    - type
+                  type: object
                 targets:
                   description: target records (CNAME or A records), either text or targets must be specified
                   items:
@@ -130,6 +165,26 @@ spec:
                 providerType:
                   description: provider type used for the entry
                   type: string
+                routingPolicy:
+                  description: effective routing policy
+                  properties:
+                    parameters:
+                      additionalProperties:
+                        type: string
+                      description: Policy specific parameters
+                      type: object
+                    setIdentifier:
+                      description: SetIdentifier is the identifier of the record set
+                      type: string
+                    type:
+                      description: Policy is the policy type. Allowed values are provider
+                        dependent, e.g. `weighted`
+                      type: string
+                  required:
+                    - parameters
+                    - setIdentifier
+                    - type
+                  type: object
                 state:
                   description: entry state
                   type: string


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
The dns-controller-manager will support weighted routing policy with the next release.
The `CustomResourceDefinition` for `dnsentries.dns.gardener.cloud` are still managed by the Gardenlet on the seeds, so it needs to be updated.

**Special notes for your reviewer**:
See PR https://github.com/gardener/external-dns-management/pull/270

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Updating CRD for `DNSEntries` to allow specifying routing policy
```
