### PR TITLE
Use multi-arch node-problem-detector image

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -161,8 +161,8 @@ images:
   tag: "1.22.5"
 - name: node-problem-detector
   sourceRepository: github.com/kubernetes/node-problem-detector
-  repository: k8s.gcr.io/node-problem-detector/node-problem-detector
-  tag: "v0.8.7"
+  repository: eu.gcr.io/gardener-project/3rd/node-problem-detector
+  tag: "v0.8.10-gardener.1"
 
 # Shoot optional addons
 - name: kubernetes-dashboard

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -160,7 +160,7 @@ images:
   repository: k8s.gcr.io/dns/k8s-dns-node-cache
   tag: "1.22.5"
 - name: node-problem-detector
-  sourceRepository: github.com/kubernetes/node-problem-detector
+  sourceRepository: github.com/gardener/node-problem-detector
   repository: eu.gcr.io/gardener-project/3rd/node-problem-detector
   tag: "v0.8.10-gardener.1"
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind enhancement

**What this PR does / why we need it**:
Until the NPD community release multi-arch image we will use NPD image built on our side.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/backlog/issues/19

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`node-problem-detector` image is updated from `k8s.gcr.io/node-problem-detector/node-problem-detector:v0.8.7` to `eu.gcr.io/gardener-project/3rd/node-problem-detector:v0.8.10-gardener.1`.
```
