### PR TITLE
Improve validations on `shoots/binding` update

### DIFF
--- a/docs/usage/control_plane_migration.md
+++ b/docs/usage/control_plane_migration.md
@@ -31,6 +31,5 @@ For controlplane migration, operators with necessary RBAC can use the [`shoots/b
 ```
 export NAMESPACE=my-namespace
 export SHOOT_NAME=my-shoot
-export SERVER=cluster-server-address
-curl -k --cert <path>/<to>/client.crt --key <path>/<to>/client.key -XPATCH -H "Accept: application/json" -H "Content-Type: application/merge-patch+json" --data '{"spec":{"seedName":"<destination-seed>"}}' https://${SERVER}/apis/core.gardener.cloud/v1beta1/namespaces/${NAMESPACE}/shoots/${SHOOT_NAME}/binding | jq -r ".spec.seedName"
+kubectl -n ${NAMESPACE} get shoot ${SHOOT_NAME} -o json | jq '.spec.seedName = "<target-seed>"' | kubectl replace --raw /apis/core.gardener.cloud/v1beta1/namespaces/${NAMESPACE}/shoots/${SHOOT_NAME}/binding -f -
 ```

--- a/docs/usage/control_plane_migration.md
+++ b/docs/usage/control_plane_migration.md
@@ -31,5 +31,5 @@ For controlplane migration, operators with necessary RBAC can use the [`shoots/b
 ```
 export NAMESPACE=my-namespace
 export SHOOT_NAME=my-shoot
-kubectl -n ${NAMESPACE} get shoot ${SHOOT_NAME} -o json | jq '.spec.seedName = "<target-seed>"' | kubectl replace --raw /apis/core.gardener.cloud/v1beta1/namespaces/${NAMESPACE}/shoots/${SHOOT_NAME}/binding -f -
+kubectl -n ${NAMESPACE} get shoot ${SHOOT_NAME} -o json | jq '.spec.seedName = "<destination-seed>"' | kubectl replace --raw /apis/core.gardener.cloud/v1beta1/namespaces/${NAMESPACE}/shoots/${SHOOT_NAME}/binding -f - | jq -r '.spec.seedName'
 ```

--- a/plugin/pkg/shoot/binding/admission.go
+++ b/plugin/pkg/shoot/binding/admission.go
@@ -160,6 +160,10 @@ func (b *Binding) Validate(ctx context.Context, a admission.Attributes, o admiss
 		return apierrors.NewInternalError(errors.New("could not convert resource into Shoot object"))
 	}
 
+	if shoot.DeletionTimestamp != nil {
+		return admission.NewForbidden(a, fmt.Errorf("shoot %s is being deleted, cannot be assigned to a seed", shoot.Name))
+	}
+
 	if oldShoot.Spec.SeedName != nil {
 		if shoot.Spec.SeedName == nil {
 			return admission.NewForbidden(a, fmt.Errorf("spec.seedName cannot be set to nil"))

--- a/plugin/pkg/shoot/dns/admission.go
+++ b/plugin/pkg/shoot/dns/admission.go
@@ -141,6 +141,8 @@ func (d *DNS) Admit(ctx context.Context, a admission.Attributes, o admission.Obj
 		return nil
 	}
 	// Ignore updates to all subresources, except for binding
+	// Binding subresource is required because there are fields being set in the shoot
+	// when it is scheduled and we want this plugin to be triggered.
 	if a.GetSubresource() != "" && a.GetSubresource() != "binding" {
 		return nil
 	}

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -178,8 +178,8 @@ func (v *ValidateShoot) Admit(ctx context.Context, a admission.Attributes, o adm
 		return nil
 	}
 
-	// Ignore updates to shoot status or other subresources
-	if a.GetSubresource() != "" {
+	// Ignore updates to all subresources, except for binding
+	if a.GetSubresource() != "" && a.GetSubresource() != "binding" {
 		return nil
 	}
 
@@ -217,7 +217,7 @@ func (v *ValidateShoot) Admit(ctx context.Context, a admission.Attributes, o adm
 			return nil
 		}
 
-		if !reflect.DeepEqual(shoot.Spec.SeedName, oldShoot.Spec.SeedName) {
+		if a.GetSubresource() != "binding" && !reflect.DeepEqual(shoot.Spec.SeedName, oldShoot.Spec.SeedName) {
 			return admission.NewForbidden(a, fmt.Errorf("spec.seedName cannot be changed by patching the shoot, Please use the shoots/binding subresource"))
 		}
 	}

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -179,6 +179,8 @@ func (v *ValidateShoot) Admit(ctx context.Context, a admission.Attributes, o adm
 	}
 
 	// Ignore updates to all subresources, except for binding
+	// Binding subresource is required because there are fields being set in the shoot
+	// when it is scheduled and we want this plugin to be triggered.
 	if a.GetSubresource() != "" && a.GetSubresource() != "binding" {
 		return nil
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:

- After #6208, It is possible to change specs of shoot other than seedName as well, and there is no validation on this change. This PR improves the shoot validator plugin to act on `shoots/binding` subresource as well.
- Updates to binding are rejected when shoot is getting deleted.
- Documentation on updating binding is also improved.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @plkokanov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
