### PR TITLE
Revert "[ci:component:github.com/gardener/etcd-druid:v0.10.0->v0.11.1]"

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -30,7 +30,7 @@ images:
 - name: etcd-druid
   sourceRepository: github.com/gardener/etcd-druid
   repository: eu.gcr.io/gardener-project/gardener/etcd-druid
-  tag: "v0.11.1"
+  tag: "v0.10.0"
 - name: dependency-watchdog
   sourceRepository: github.com/gardener/dependency-watchdog
   repository: eu.gcr.io/gardener-project/gardener/dependency-watchdog

--- a/pkg/operation/botanist/component/etcd/bootstrap.go
+++ b/pkg/operation/botanist/component/etcd/bootstrap.go
@@ -108,7 +108,7 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 				{
 					APIGroups: []string{corev1.GroupName},
 					Resources: []string{"pods"},
-					Verbs:     []string{"get", "list", "watch", "delete"},
+					Verbs:     []string{"list", "watch", "delete"},
 				},
 				{
 					APIGroups: []string{corev1.GroupName},
@@ -318,7 +318,7 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 }
 
 func getDruidDeployCommands(gardenletConf *config.GardenletConfiguration) []string {
-	command := []string{"" + "/etcd-druid"}
+	command := []string{"" + "/bin/etcd-druid"}
 	command = append(command, "--enable-leader-election=true")
 	command = append(command, "--ignore-operation-annotation=false")
 	command = append(command, "--disable-etcd-serviceaccount-automount=true")

--- a/pkg/operation/botanist/component/etcd/bootstrap_test.go
+++ b/pkg/operation/botanist/component/etcd/bootstrap_test.go
@@ -116,7 +116,6 @@ rules:
   resources:
   - pods
   verbs:
-  - get
   - list
   - watch
   - delete
@@ -338,7 +337,7 @@ spec:
     spec:
       containers:
       - command:
-        - /etcd-druid
+        - /bin/etcd-druid
         - --enable-leader-election=true
         - --ignore-operation-annotation=false
         - --disable-etcd-serviceaccount-automount=true
@@ -389,7 +388,7 @@ spec:
     spec:
       containers:
       - command:
-        - /etcd-druid
+        - /bin/etcd-druid
         - --enable-leader-election=true
         - --ignore-operation-annotation=false
         - --disable-etcd-serviceaccount-automount=true


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind regression

**What this PR does / why we need it**:
This reverts commit b9fafe8fb7b6944a58a906374056d2121a32fbbc because of failures in multi-node etcd handling:
- https://prow.gardener.cloud/view/gs/gardener-prow/logs/ci-gardener-e2e-kind/1552014312258670592
- https://prow.gardener.cloud/view/gs/gardener-prow/logs/ci-gardener-e2e-kind/1552135109547659264

**Special notes for your reviewer**:
/cc @acumino
