### PR TITLE
[WIP] Etcd-Druid v0.11.3 Upgrade

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -30,7 +30,7 @@ images:
 - name: etcd-druid
   sourceRepository: github.com/gardener/etcd-druid
   repository: eu.gcr.io/gardener-project/gardener/etcd-druid
-  tag: "v0.11.1"
+  tag: "v0.11.3-dev-c12a22c25db6c1d8efbe318571e36b8fdb4a1940"
 - name: dependency-watchdog
   sourceRepository: github.com/gardener/dependency-watchdog
   repository: eu.gcr.io/gardener-project/gardener/dependency-watchdog

--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -30,7 +30,7 @@ images:
 - name: etcd-druid
   sourceRepository: github.com/gardener/etcd-druid
   repository: eu.gcr.io/gardener-project/gardener/etcd-druid
-  tag: "v0.10.0"
+  tag: "v0.11.1"
 - name: dependency-watchdog
   sourceRepository: github.com/gardener/dependency-watchdog
   repository: eu.gcr.io/gardener-project/gardener/dependency-watchdog

--- a/pkg/operation/botanist/component/etcd/bootstrap.go
+++ b/pkg/operation/botanist/component/etcd/bootstrap.go
@@ -108,7 +108,7 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 				{
 					APIGroups: []string{corev1.GroupName},
 					Resources: []string{"pods"},
-					Verbs:     []string{"list", "watch", "delete"},
+					Verbs:     []string{"get", "list", "watch", "delete"},
 				},
 				{
 					APIGroups: []string{corev1.GroupName},
@@ -318,7 +318,7 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 }
 
 func getDruidDeployCommands(gardenletConf *config.GardenletConfiguration) []string {
-	command := []string{"" + "/bin/etcd-druid"}
+	command := []string{"" + "/etcd-druid"}
 	command = append(command, "--enable-leader-election=true")
 	command = append(command, "--ignore-operation-annotation=false")
 	command = append(command, "--disable-etcd-serviceaccount-automount=true")

--- a/pkg/operation/botanist/component/etcd/bootstrap_test.go
+++ b/pkg/operation/botanist/component/etcd/bootstrap_test.go
@@ -116,6 +116,7 @@ rules:
   resources:
   - pods
   verbs:
+  - get
   - list
   - watch
   - delete
@@ -337,7 +338,7 @@ spec:
     spec:
       containers:
       - command:
-        - /bin/etcd-druid
+        - /etcd-druid
         - --enable-leader-election=true
         - --ignore-operation-annotation=false
         - --disable-etcd-serviceaccount-automount=true
@@ -388,7 +389,7 @@ spec:
     spec:
       containers:
       - command:
-        - /bin/etcd-druid
+        - /etcd-druid
         - --enable-leader-election=true
         - --ignore-operation-annotation=false
         - --disable-etcd-serviceaccount-automount=true

--- a/pkg/operation/botanist/component/etcd/waiter.go
+++ b/pkg/operation/botanist/component/etcd/waiter.go
@@ -79,6 +79,10 @@ func CheckEtcdObject(obj client.Object) error {
 		return fmt.Errorf("observed generation outdated (%d/%d)", *observedGeneration, generation)
 	}
 
+	if etcd.Status.Replicas != etcd.Status.UpdatedReplicas {
+		return fmt.Errorf("update is being rolled out, only %d/%d replicas are up-to-date", etcd.Status.Replicas, etcd.Status.UpdatedReplicas)
+	}
+
 	if op, ok := etcd.Annotations[v1beta1constants.GardenerOperation]; ok {
 		return fmt.Errorf("gardener operation %q is not yet picked up by etcd-druid", op)
 	}

--- a/test/e2e/shoot/create_rotate_delete.go
+++ b/test/e2e/shoot/create_rotate_delete.go
@@ -24,15 +24,19 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/test/e2e"
 	"github.com/gardener/gardener/test/e2e/shoot/internal/rotation"
 )
 
-// TODO(timuthy): enable rotation for HA shoots as soon as data consistency issue in multi-node etcd is solved.
 var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 	f := defaultShootCreationFramework()
 	f.Shoot = e2e.DefaultShoot("")
 	f.Shoot.Name = "e2e-rotate"
+	f.Shoot.Annotations = utils.MergeStringMaps(f.Shoot.Annotations, map[string]string{
+		// Use a single zone HA control plane because we don't know if there is a multi-AZ seed available.
+		v1beta1constants.ShootAlphaControlPlaneHighAvailability: v1beta1constants.ShootAlphaControlPlaneHighAvailabilitySingleZone,
+	})
 
 	It("Create Shoot, Rotate Credentials and Delete Shoot", Label("credentials-rotation"), func() {
 		ctx, cancel := context.WithTimeout(parentCtx, 20*time.Minute)

--- a/test/e2e/shoot/internal/rotation/certificate_authorities.go
+++ b/test/e2e/shoot/internal/rotation/certificate_authorities.go
@@ -54,6 +54,7 @@ var allGardenletCAs = []string{
 	caCluster,
 	caClient,
 	caETCD,
+	caETCDPeer,
 	caFrontProxy,
 	caKubelet,
 	caMetricsServer,
@@ -64,6 +65,7 @@ const (
 	caCluster       = "ca"
 	caClient        = "ca-client"
 	caETCD          = "ca-etcd"
+	caETCDPeer      = "ca-etcd-peer"
 	caFrontProxy    = "ca-front-proxy"
 	caKubelet       = "ca-kubelet"
 	caMetricsServer = "ca-metrics-server"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
This PR is a preparation for the Etcd-Druid v0.11.3 upgrade. It's only purpose is to let the e2e tests run to verify the release. Lately we were not able to reproduce issues with a local e2e test runs.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
