### PR TITLE
Collect filesystem metrics for the /run tmpfs mount point

### DIFF
--- a/charts/seed-bootstrap/values.yaml
+++ b/charts/seed-bootstrap/values.yaml
@@ -132,7 +132,10 @@ allowedMetrics:
   - node_boot_time_seconds
   - node_cpu_seconds_total
   - node_filesystem_avail_bytes
+  - node_filesystem_files
+  - node_filesystem_files_free
   - node_filesystem_free_bytes
+  - node_filesystem_readonly
   - node_filesystem_size_bytes
   - node_load1
   - node_load5

--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/node-exporter.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/node-exporter.rules.yaml
@@ -79,3 +79,13 @@ groups:
 
   - record: shoot:kube_node_info:count
     expr: count(kube_node_info{type="shoot"})
+
+  # This recording rule creates a series for nodes with less than 5% free inodes on a not read only mount point.
+  # The series exists only if there are less than 5% free inodes,
+  # to keep the cardinality of these federated metrics manageable.
+  # Otherwise we would get a series for each node in each shoot in the federating Prometheus.
+  - record: shoot:node_filesystem_files_free:percent
+    expr: |
+      sum by (node, mountpoint)
+        (node_filesystem_files_free / node_filesystem_files * 100 < 5
+         and node_filesystem_readonly == 0)

--- a/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
@@ -90,7 +90,10 @@ allowedMetrics:
   - node_disk_read_bytes_total
   - node_disk_written_bytes_total
   - node_filesystem_avail_bytes
+  - node_filesystem_files
+  - node_filesystem_files_free
   - node_filesystem_free_bytes
+  - node_filesystem_readonly
   - node_filesystem_size_bytes
   - node_load1
   - node_load15

--- a/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/node-exporter/templates/node-exporter.yaml
@@ -83,7 +83,7 @@ spec:
         - --collector.diskstats
         - --collector.filefd
         - --collector.filesystem
-        - --collector.filesystem.mount-points-exclude=^/.+$
+        - --collector.filesystem.mount-points-exclude=^/(run|var)/.+$|^/(boot|dev|sys|usr)($|/.+$)
         - --collector.loadavg
         - --collector.meminfo
         - --collector.uname


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

Collect filesystem metrics for the `/run` tmpfs mount point

Previously, the filesystem metrics

// See https://github.com/prometheus/node_exporter/blob/68a6c78c0d1fd7359fa15d30b607b322eb512a8d/collector/filesystem_common.go#L134-L149

```
node_filesystem_files      Filesystem total file nodes.
node_filesystem_files_free Filesystem total free file nodes.
node_filesystem_readonly   Filesystem read-only status.
```

were only kept for the root `/` mount point.

With this change, they are kept for

```
mountpoint="/"
mountpoint="/run"
mountpoint="/tmp"
```

but are still discarded for the numerous workload related mount points,
that are not so relevant from the system component monitoring perspective.
e.g.


```
/var/lib/kubelet/pods/c585a9ce-04ad-4484-b61e-6dec922993c6/volumes/kubernetes.io~secret/kubeconfig
/run/containerd/io.containerd.runtime.v2.task/k8s.io/6335e3a8d7cb5542205cac258f3098fd7cebc454f765a6db9120670e2adc0e66/rootfs
```

Excluding these mount points helps to keep the cardinality of these metrics
low.

The new metrics are also allow listed so that they are persisted in prometheus.

A recording rule is added so that these metrics are federated by the aggregate-prometheus
in the garden namespace from all shoot control plane prometheus instances.

**Which issue(s) this PR fixes**:
Fixes #

These metrics can help to detect the issue when the `/run` tmpfs mount
runs out of inodes due to numerous empty directories "systemd-coredump"
in `/run/systemd/propagate` and hence e.g. containerd can not start new
containers.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The node-exporter is configured to collect filesystem metrics for the /run mount point.
```
