### PR TITLE
Promote the `SecretBindingProviderValidation` feature gate to GA

### DIFF
--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -1216,7 +1216,7 @@ SecretBindingProvider
 <td>
 <em>(Optional)</em>
 <p>Provider defines the provider type of the SecretBinding.
-This field is immutable when the SecretBindingProviderValidation feature gate is enabled.</p>
+This field is immutable.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -33,8 +33,6 @@ The following tables are a summary of the feature gates that you can set on diff
 | ReversedVPN                                  | `false` | `Alpha` | `1.22` | `1.41` |
 | ReversedVPN                                  | `true`  | `Beta`  | `1.42` |        |
 | CopyEtcdBackupsDuringControlPlaneMigration   | `false` | `Alpha` | `1.37` |        |
-| SecretBindingProviderValidation              | `false` | `Alpha` | `1.38` | `1.50` |
-| SecretBindingProviderValidation              | `true`  | `Beta`  | `1.51` |        |
 | ForceRestore                                 | `false` | `Alpha` | `1.39` |        |
 | ShootCARotation                              | `false` | `Alpha` | `1.42` | `1.50` |
 | ShootCARotation                              | `true`  | `Beta`  | `1.51` |        |
@@ -95,6 +93,10 @@ The following tables are a summary of the feature gates that you can set on diff
 | DisableDNSProviderManagement                 | `false` | `Alpha`   | `1.41` | `1.49` |
 | DisableDNSProviderManagement                 | `true`  | `Beta`    | `1.50` | `1.51` |
 | DisableDNSProviderManagement                 | `true`  | `GA`      | `1.52` |        |
+| SecretBindingProviderValidation              | `false` | `Alpha`   | `1.38` | `1.50` |
+| SecretBindingProviderValidation              | `true`  | `Beta`    | `1.51` | `1.52` |
+| SecretBindingProviderValidation              | `true`  | `GA`      | `1.53` |        |
+
 
 ## Using a feature
 

--- a/docs/deployment/secret_binding_provider_controller.md
+++ b/docs/deployment/secret_binding_provider_controller.md
@@ -26,3 +26,4 @@ A Gardener landscape operator can follow the following steps:
 - Gardener v1.38: The SecretBinding resource has a new optional field `.provider.type`. The SecretBinding provider controller is disabled by default. The `SecretBindingProviderValidation` feature gate of Gardener API server is disabled by default.
 - Gardener v1.42: The SecretBinding provider controller is enabled by default.
 - Gardener v1.51: The `SecretBindingProviderValidation` feature gate of Gardener API server is enabled by default and the SecretBinding provider controller is disabled by default.
+- Gardener v1.53: The `SecretBindingProviderValidation` feature gate of Gardener API server is unconditionally enabled (can no longer be disabled).

--- a/pkg/apis/core/types_secretbinding.go
+++ b/pkg/apis/core/types_secretbinding.go
@@ -34,7 +34,7 @@ type SecretBinding struct {
 	// This field is immutable.
 	Quotas []corev1.ObjectReference
 	// Provider defines the provider type of the SecretBinding.
-	// This field is immutable when the SecretBindingProviderValidation feature gate is enabled.
+	// This field is immutable.
 	Provider *SecretBindingProvider
 }
 

--- a/pkg/apis/core/v1alpha1/generated.proto
+++ b/pkg/apis/core/v1alpha1/generated.proto
@@ -1839,7 +1839,7 @@ message SecretBinding {
   repeated k8s.io.api.core.v1.ObjectReference quotas = 3;
 
   // Provider defines the provider type of the SecretBinding.
-  // This field is immutable when the SecretBindingProviderValidation feature gate is enabled.
+  // This field is immutable.
   // +optional
   optional SecretBindingProvider provider = 4;
 }

--- a/pkg/apis/core/v1alpha1/types_secretbinding.go
+++ b/pkg/apis/core/v1alpha1/types_secretbinding.go
@@ -36,7 +36,7 @@ type SecretBinding struct {
 	// +optional
 	Quotas []corev1.ObjectReference `json:"quotas,omitempty" protobuf:"bytes,3,rep,name=quotas"`
 	// Provider defines the provider type of the SecretBinding.
-	// This field is immutable when the SecretBindingProviderValidation feature gate is enabled.
+	// This field is immutable.
 	// +optional
 	Provider *SecretBindingProvider `json:"provider,omitempty" protobuf:"bytes,4,opt,name=provider"`
 }

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -1752,7 +1752,7 @@ message SecretBinding {
   repeated k8s.io.api.core.v1.ObjectReference quotas = 3;
 
   // Provider defines the provider type of the SecretBinding.
-  // This field is immutable when the SecretBindingProviderValidation feature gate is enabled.
+  // This field is immutable.
   // +optional
   optional SecretBindingProvider provider = 4;
 }

--- a/pkg/apis/core/v1beta1/types_secretbinding.go
+++ b/pkg/apis/core/v1beta1/types_secretbinding.go
@@ -36,7 +36,7 @@ type SecretBinding struct {
 	// +optional
 	Quotas []corev1.ObjectReference `json:"quotas,omitempty" protobuf:"bytes,3,rep,name=quotas"`
 	// Provider defines the provider type of the SecretBinding.
-	// This field is immutable when the SecretBindingProviderValidation feature gate is enabled.
+	// This field is immutable.
 	// +optional
 	Provider *SecretBindingProvider `json:"provider,omitempty" protobuf:"bytes,4,opt,name=provider"`
 }

--- a/pkg/apis/core/validation/secretbinding.go
+++ b/pkg/apis/core/validation/secretbinding.go
@@ -16,12 +16,10 @@ package validation
 
 import (
 	"github.com/gardener/gardener/pkg/apis/core"
-	"github.com/gardener/gardener/pkg/features"
 
 	corev1 "k8s.io/api/core/v1"
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 )
 
 // ValidateSecretBinding validates a SecretBinding object.
@@ -44,7 +42,7 @@ func ValidateSecretBindingUpdate(newBinding, oldBinding *core.SecretBinding) fie
 	allErrs = append(allErrs, apivalidation.ValidateObjectMetaUpdate(&newBinding.ObjectMeta, &oldBinding.ObjectMeta, field.NewPath("metadata"))...)
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newBinding.SecretRef, oldBinding.SecretRef, field.NewPath("secretRef"))...)
 	allErrs = append(allErrs, apivalidation.ValidateImmutableField(newBinding.Quotas, oldBinding.Quotas, field.NewPath("quotas"))...)
-	if utilfeature.DefaultFeatureGate.Enabled(features.SecretBindingProviderValidation) && oldBinding.Provider != nil {
+	if oldBinding.Provider != nil {
 		allErrs = append(allErrs, apivalidation.ValidateImmutableField(newBinding.Provider, oldBinding.Provider, field.NewPath("provider"))...)
 	}
 	allErrs = append(allErrs, ValidateSecretBinding(newBinding)...)
@@ -60,10 +58,7 @@ func ValidateSecretBindingProvider(provider *core.SecretBindingProvider) field.E
 	)
 
 	if provider == nil {
-		if utilfeature.DefaultFeatureGate.Enabled(features.SecretBindingProviderValidation) {
-			allErrs = append(allErrs, field.Required(fldPath, "must specify a provider"))
-		}
-
+		allErrs = append(allErrs, field.Required(fldPath, "must specify a provider"))
 		return allErrs
 	}
 

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -86,6 +86,7 @@ const (
 	// owner: @ialidzhikov
 	// alpha: v1.38.0
 	// beta: v1.51.0
+	// GA: v1.53.0
 	SecretBindingProviderValidation featuregate.Feature = "SecretBindingProviderValidation"
 
 	// ForceRestore enables forcing the shoot's restoration to the destination seed during control plane migration
@@ -134,7 +135,7 @@ var allFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	SeedKubeScheduler:  {Default: false, PreRelease: featuregate.Alpha},
 	ReversedVPN:        {Default: true, PreRelease: featuregate.Beta},
 	CopyEtcdBackupsDuringControlPlaneMigration: {Default: false, PreRelease: featuregate.Alpha},
-	SecretBindingProviderValidation:            {Default: true, PreRelease: featuregate.Beta},
+	SecretBindingProviderValidation:            {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	ForceRestore:                               {Default: false, PreRelease: featuregate.Alpha},
 	DisableDNSProviderManagement:               {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	ShootCARotation:                            {Default: true, PreRelease: featuregate.Beta},

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -5840,7 +5840,7 @@ func schema_pkg_apis_core_v1alpha1_SecretBinding(ref common.ReferenceCallback) c
 					},
 					"provider": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Provider defines the provider type of the SecretBinding. This field is immutable when the SecretBindingProviderValidation feature gate is enabled.",
+							Description: "Provider defines the provider type of the SecretBinding. This field is immutable.",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1alpha1.SecretBindingProvider"),
 						},
 					},
@@ -13051,7 +13051,7 @@ func schema_pkg_apis_core_v1beta1_SecretBinding(ref common.ReferenceCallback) co
 					},
 					"provider": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Provider defines the provider type of the SecretBinding. This field is immutable when the SecretBindingProviderValidation feature gate is enabled.",
+							Description: "Provider defines the provider type of the SecretBinding. This field is immutable.",
 							Ref:         ref("github.com/gardener/gardener/pkg/apis/core/v1beta1.SecretBindingProvider"),
 						},
 					},

--- a/plugin/pkg/shoot/validator/admission.go
+++ b/plugin/pkg/shoot/validator/admission.go
@@ -32,7 +32,6 @@ import (
 	corelisters "github.com/gardener/gardener/pkg/client/core/listers/core/internalversion"
 	corev1alpha1listers "github.com/gardener/gardener/pkg/client/core/listers/core/v1alpha1"
 	"github.com/gardener/gardener/pkg/controllerutils"
-	"github.com/gardener/gardener/pkg/features"
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	cidrvalidation "github.com/gardener/gardener/pkg/utils/validation/cidr"
 	admissionutils "github.com/gardener/gardener/plugin/pkg/utils"
@@ -48,7 +47,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/admission"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/utils/pointer"
 	"k8s.io/utils/strings/slices"
 )
@@ -241,7 +239,7 @@ func (v *ValidateShoot) Admit(ctx context.Context, a admission.Attributes, o adm
 	}
 
 	var secretBinding *core.SecretBinding
-	if utilfeature.DefaultFeatureGate.Enabled(features.SecretBindingProviderValidation) {
+	if a.GetOperation() == admission.Create {
 		secretBinding, err = v.secretBindingLister.SecretBindings(shoot.Namespace).Get(shoot.Spec.SecretBindingName)
 		if err != nil {
 			return apierrors.NewInternalError(fmt.Errorf("could not find referenced secret binding: %+v", err.Error()))
@@ -607,7 +605,7 @@ func (c *validationContext) validateProvider(a admission.Attributes) field.Error
 		return allErrs
 	}
 
-	if a.GetOperation() == admission.Create && utilfeature.DefaultFeatureGate.Enabled(features.SecretBindingProviderValidation) {
+	if a.GetOperation() == admission.Create {
 		if !helper.SecretBindingHasType(c.secretBinding, c.shoot.Spec.Provider.Type) {
 			var secretBindingProviderType string
 			if c.secretBinding.Provider != nil {

--- a/plugin/pkg/shoot/validator/validator_suite_test.go
+++ b/plugin/pkg/shoot/validator/validator_suite_test.go
@@ -19,12 +19,9 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-
-	"github.com/gardener/gardener/pkg/apiserver/features"
 )
 
 func TestValidator(t *testing.T) {
-	features.RegisterFeatureGates()
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Admission ShootValidator Suite")
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind enhancement

**What this PR does / why we need it**:
Promote the `SecretBindingProviderValidation` feature gate to GA and lock to default (`true)`.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/4888

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The `SecretBindingProviderValidation` feature gate of `gardener-apiserver` is promoted to GA and is now unconditionally enabled.
```
