### PR TITLE
Enforce PSP admission plugin disablement before upgrading the shoot cluster to `v1.25`

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -65,7 +65,7 @@
 * [Troubleshooting guide](usage/trouble_shooting_guide.md)
 * [Trusted TLS certificate for shoot control planes](usage/trusted-tls-for-control-planes.md)
 * [Controlling the Kubernetes versions for specific worker pools](usage/worker_pool_k8s_versions.md)
-* [Migrating to PodSecurity admission controller](usage/pod-security.md)
+* [Migrating from `PodSecurityPolicy`s to PodSecurity admission controller](usage/pod-security.md)
 
 ## [API Reference](api-reference/README.md)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -65,6 +65,7 @@
 * [Troubleshooting guide](usage/trouble_shooting_guide.md)
 * [Trusted TLS certificate for shoot control planes](usage/trusted-tls-for-control-planes.md)
 * [Controlling the Kubernetes versions for specific worker pools](usage/worker_pool_k8s_versions.md)
+* [Migrating to PodSecurity admission controller](usage/pod-security.md)
 
 ## [API Reference](api-reference/README.md)
 

--- a/docs/concepts/controller-manager.md
+++ b/docs/concepts/controller-manager.md
@@ -229,7 +229,7 @@ This loop also watches the `Seed` object and adds finalizers to it at creation. 
 
 ### [ControllerDeployment](../../pkg/controllermanager/controller/controllerdeployment)
 
-Extentions are registered in garden cluster via `ControllerRegistration` and deployment of respective extentions are specified via `ControllerDeployment`. For more info refer [here](../extensions/controllerregistration.md).
+Extensions are registered in garden cluster via `ControllerRegistration` and deployment of respective extensions are specified via `ControllerDeployment`. For more info refer [here](../extensions/controllerregistration.md).
 
 This controller ensures that `ControllerDeployment` in-use always exists until the last `ControllerRegistration` referencing them gets deleted. The controller adds a finalizer which is only released when there is no `ControllerRegistration` referencing the `ControllerDeployment` anymore.
 

--- a/docs/proposals/10-shoot-additional-container-runtimes.md
+++ b/docs/proposals/10-shoot-additional-container-runtimes.md
@@ -108,7 +108,7 @@ Each extension will need to address the following concern:
             apiVersion: extensions.gardener.cloud/v1alpha1
             kind: ContainerRuntime
             metadata:
-              name: kata-containers-runtime-extention
+              name: kata-containers-runtime-extension
               namespace: shoot--foo--bar
             spec:
               type: kata-containers

--- a/docs/usage/pod-security.md
+++ b/docs/usage/pod-security.md
@@ -1,0 +1,17 @@
+# Migrating to PodSecurity
+
+Kubernetes has deprecated `PodSecurityPolicy`s in v1.21 and it will be removed in v1.25. With v1.23, a new feature called [`PodSecurity`](https://kubernetes.io/docs/concepts/security/pod-security-admission/) was promoted to beta. From `v1.25` onwards, there will be no API serving `PodSecurityPolicy`, so you have to cleanup all the existing PSPs before upgrading their cluster. Detailed migration steps are described [here](https://kubernetes.io/docs/tasks/configure-pod-container/migrate-from-psp/).
+
+After migration, you should disable the `PodSecurityPolicy` admission plugin. For this you have to add: 
+```
+admissionPlugins:
+- name: PodSecurityPolicy
+  disabled: true
+```
+in `kubernetes.kubeAPIServer.AdmissionPlugins` field in the shoot spec. Please refer the example shoot manifest [here](../../example/90-shoot.yaml).
+
+Only if this field is set, the cluster can be upgraded to kubernetes `v1.25`.
+
+Note: You should disable the admission plugin and wait till Gardener finish at least one shoot reconciliation before upgrading to `v1.25`. This is to make sure all the `PodSecurityPolicy` related resources deployed by Gardener are cleaned up.
+
+It is strongly recommended that you do this migration in v1.23+ (where the new `PodSecurity` was promoted to `beta`), for smoother migration with enough soak time for the changes.

--- a/docs/usage/pod-security.md
+++ b/docs/usage/pod-security.md
@@ -1,15 +1,15 @@
-# Migrating to PodSecurity
+# Migrating From `PodSecurityPolicy`s To PodSecurity Admission Controller
 
-Kubernetes has deprecated `PodSecurityPolicy`s in v1.21 and it will be removed in v1.25. With v1.23, a new feature called [`PodSecurity`](https://kubernetes.io/docs/concepts/security/pod-security-admission/) was promoted to beta. From `v1.25` onwards, there will be no API serving `PodSecurityPolicy`, so you have to cleanup all the existing PSPs before upgrading their cluster. Detailed migration steps are described [here](https://kubernetes.io/docs/tasks/configure-pod-container/migrate-from-psp/).
+Kubernetes has deprecated the `PodSecurityPolicy` API in v1.21 and it will be removed in v1.25. With v1.23, a new feature called [`PodSecurity`](https://kubernetes.io/docs/concepts/security/pod-security-admission/) was promoted to beta. From `v1.25` onwards, there will be no API serving `PodSecurityPolicy`s, so you have to cleanup all the existing PSPs before upgrading your cluster. Detailed migration steps are described [here](https://kubernetes.io/docs/tasks/configure-pod-container/migrate-from-psp/).
 
-After migration, you should disable the `PodSecurityPolicy` admission plugin. For this you have to add: 
-```
+After migration, you should disable the `PodSecurityPolicy` admission plugin. To do so, you have to add: 
+```yaml
 admissionPlugins:
 - name: PodSecurityPolicy
   disabled: true
 ```
-in `kubernetes.kubeAPIServer.AdmissionPlugins` field in the shoot spec. Please refer the example shoot manifest [here](../../example/90-shoot.yaml).
+in `spec.kubernetes.kubeAPIServer.admissionPlugins` field in the `Shoot` resource. Please refer the example `Shoot` manifest [here](../../example/90-shoot.yaml).
 
-Only if this field is set, the cluster can be upgraded to kubernetes `v1.25`.
+Only if the `PodSecurityPolicy` admission plugin is disabled the cluster can be upgraded to `v1.25`.
 
-<strong>Note:</strong> You should disable the admission plugin and wait till Gardener finish at least one shoot reconciliation before upgrading to `v1.25`. This is to make sure all the `PodSecurityPolicy` related resources deployed by Gardener are cleaned up.
+> :warning: You should disable the admission plugin and wait until Gardener finish at least one `Shoot` reconciliation before upgrading to `v1.25`. This is to make sure all the `PodSecurityPolicy` related resources deployed by Gardener are cleaned up.

--- a/docs/usage/pod-security.md
+++ b/docs/usage/pod-security.md
@@ -12,6 +12,4 @@ in `kubernetes.kubeAPIServer.AdmissionPlugins` field in the shoot spec. Please r
 
 Only if this field is set, the cluster can be upgraded to kubernetes `v1.25`.
 
-Note: You should disable the admission plugin and wait till Gardener finish at least one shoot reconciliation before upgrading to `v1.25`. This is to make sure all the `PodSecurityPolicy` related resources deployed by Gardener are cleaned up.
-
-It is strongly recommended that you do this migration in v1.23+ (where the new `PodSecurity` was promoted to `beta`), for smoother migration with enough soak time for the changes.
+<strong>Note:</strong> You should disable the admission plugin and wait till Gardener finish at least one shoot reconciliation before upgrading to `v1.25`. This is to make sure all the `PodSecurityPolicy` related resources deployed by Gardener are cleaned up.

--- a/pkg/api/core/shoot/warnings.go
+++ b/pkg/api/core/shoot/warnings.go
@@ -19,10 +19,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/Masterminds/semver"
 	"github.com/gardener/gardener/pkg/apis/core"
 	"github.com/gardener/gardener/pkg/features"
-	versionutils "github.com/gardener/gardener/pkg/utils/version"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilfeature "k8s.io/apiserver/pkg/util/feature"
@@ -44,14 +42,6 @@ func GetWarnings(_ context.Context, shoot, oldShoot *core.Shoot, credentialsRota
 	if oldShoot != nil {
 		warnings = append(warnings, getWarningsForDueCredentialsRotations(shoot, credentialsRotationInterval)...)
 		warnings = append(warnings, getWarningsForIncompleteCredentialsRotation(shoot, credentialsRotationInterval)...)
-
-		if versionutils.ConstraintK8sLess125.Check(semver.MustParse(shoot.Spec.Kubernetes.Version)) &&
-			versionutils.ConstraintK8sGreaterEqual123.Check(semver.MustParse(shoot.Spec.Kubernetes.Version)) {
-			warning := getWarningsForPSPAdmissionPlugin(shoot)
-			if warning != "" {
-				warnings = append(warnings, warning)
-			}
-		}
 	}
 
 	return warnings
@@ -154,21 +144,4 @@ func isOldEnough(t time.Time, threshold time.Duration) bool {
 
 func completionWarning(credentials string, recommendedCompletionInterval time.Duration) string {
 	return fmt.Sprintf("the %s rotation was initiated more than %s ago and should be completed", credentials, recommendedCompletionInterval)
-}
-
-func getWarningsForPSPAdmissionPlugin(shoot *core.Shoot) string {
-	pspDisabled := false
-	if shoot.Spec.Kubernetes.KubeAPIServer != nil {
-		for _, plugin := range shoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins {
-			if plugin.Name == "PodSecurityPolicy" && pointer.BoolDeref(plugin.Disabled, false) {
-				pspDisabled = true
-			}
-		}
-	}
-
-	if !pspDisabled {
-		return "you should consider migrating to PodSecurity, see https://github.com/gardener/gardener/blob/master/docs/usage/pod-security.md#migrating-to-podsecurity for details"
-	}
-
-	return ""
 }

--- a/pkg/api/core/shoot/warnings_test.go
+++ b/pkg/api/core/shoot/warnings_test.go
@@ -43,6 +43,7 @@ var _ = Describe("Warnings", func() {
 			shoot = &core.Shoot{
 				Spec: core.ShootSpec{
 					Kubernetes: core.Kubernetes{
+						Version:                     "1.22.11",
 						EnableStaticTokenKubeconfig: pointer.Bool(false),
 					},
 				},
@@ -278,5 +279,50 @@ var _ = Describe("Warnings", func() {
 				),
 			)
 		})
+
+		Context("PodSecurityPolicy", func() {
+			BeforeEach(func() {
+				shoot.CreationTimestamp = metav1.Now()
+			})
+
+			It("should return a warning when the PodSecurity admission plugin is not disabled for shoots >= 1.23 and < 1.25", func() {
+				shoot.Spec.Kubernetes.Version = "1.24.2"
+
+				warnings := GetWarnings(ctx, shoot, shoot, credentialsRotationInterval)
+				Expect(warnings).To(ContainElement(
+					ContainSubstring("you should consider migrating to PodSecurity, see https://github.com/gardener/gardener/blob/master/docs/usage/pod-security.md#migrating-to-podsecurity for details"),
+				))
+			})
+
+			It("should not return a warning when the PodSecurity admission plugin is disabled for shoots >= 1.23 and < 1.25", func() {
+				shoot.Spec.Kubernetes.Version = "1.24.2"
+				shoot.Spec.Kubernetes.KubeAPIServer = &core.KubeAPIServerConfig{
+					AdmissionPlugins: []core.AdmissionPlugin{
+						{
+							Name:     "PodSecurityPolicy",
+							Disabled: pointer.Bool(true),
+						},
+					},
+				}
+
+				warnings := GetWarnings(ctx, shoot, shoot, credentialsRotationInterval)
+				Expect(warnings).To(BeEmpty())
+			})
+
+			It("should not return a warning when the PodSecurity admission plugin is not disabled for shoots < 1.23", func() {
+				shoot.Spec.Kubernetes.Version = "1.22.11"
+
+				warnings := GetWarnings(ctx, shoot, shoot, credentialsRotationInterval)
+				Expect(warnings).To(BeEmpty())
+			})
+
+			It("should not return a warning when the PodSecurity admission plugin is not disabled for shoots >= 1.25", func() {
+				shoot.Spec.Kubernetes.Version = "1.25.0"
+
+				warnings := GetWarnings(ctx, shoot, shoot, credentialsRotationInterval)
+				Expect(warnings).To(BeEmpty())
+			})
+		})
+
 	})
 })

--- a/pkg/api/core/shoot/warnings_test.go
+++ b/pkg/api/core/shoot/warnings_test.go
@@ -279,50 +279,5 @@ var _ = Describe("Warnings", func() {
 				),
 			)
 		})
-
-		Context("PodSecurityPolicy", func() {
-			BeforeEach(func() {
-				shoot.CreationTimestamp = metav1.Now()
-			})
-
-			It("should return a warning when the PodSecurity admission plugin is not disabled for shoots >= 1.23 and < 1.25", func() {
-				shoot.Spec.Kubernetes.Version = "1.24.2"
-
-				warnings := GetWarnings(ctx, shoot, shoot, credentialsRotationInterval)
-				Expect(warnings).To(ContainElement(
-					ContainSubstring("you should consider migrating to PodSecurity, see https://github.com/gardener/gardener/blob/master/docs/usage/pod-security.md#migrating-to-podsecurity for details"),
-				))
-			})
-
-			It("should not return a warning when the PodSecurity admission plugin is disabled for shoots >= 1.23 and < 1.25", func() {
-				shoot.Spec.Kubernetes.Version = "1.24.2"
-				shoot.Spec.Kubernetes.KubeAPIServer = &core.KubeAPIServerConfig{
-					AdmissionPlugins: []core.AdmissionPlugin{
-						{
-							Name:     "PodSecurityPolicy",
-							Disabled: pointer.Bool(true),
-						},
-					},
-				}
-
-				warnings := GetWarnings(ctx, shoot, shoot, credentialsRotationInterval)
-				Expect(warnings).To(BeEmpty())
-			})
-
-			It("should not return a warning when the PodSecurity admission plugin is not disabled for shoots < 1.23", func() {
-				shoot.Spec.Kubernetes.Version = "1.22.11"
-
-				warnings := GetWarnings(ctx, shoot, shoot, credentialsRotationInterval)
-				Expect(warnings).To(BeEmpty())
-			})
-
-			It("should not return a warning when the PodSecurity admission plugin is not disabled for shoots >= 1.25", func() {
-				shoot.Spec.Kubernetes.Version = "1.25.0"
-
-				warnings := GetWarnings(ctx, shoot, shoot, credentialsRotationInterval)
-				Expect(warnings).To(BeEmpty())
-			})
-		})
-
 	})
 })

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -279,7 +279,7 @@ func ValidateShootSpecUpdate(newSpec, oldSpec *core.ShootSpec, newObjectMeta met
 		pspDisabledInNewSpec := isPSPDisabled(newSpec.Kubernetes.KubeAPIServer)
 		pspDisabledInOldSpec := isPSPDisabled(oldSpec.Kubernetes.KubeAPIServer)
 		if !pspDisabledInNewSpec || !pspDisabledInOldSpec {
-			allErrs = append(allErrs, field.Forbidden(fldPath.Child("kubernetes").Child("version"), fmt.Sprintf("admission plugin: %q should be disabled for kubernetes version >=1.25, Refer [Migrating to PodSecurity](https://github.com/gardener/gardener/blob/master/docs/usage/pod-security.md#migrating-to-podsecurity)", "PodSecurityPolicy")))
+			allErrs = append(allErrs, field.Forbidden(fldPath.Child("kubernetes").Child("version"), `admission plugin "PodSecurityPolicy" should be disabled for Kubernetes versions >=1.25, please check https://github.com/gardener/gardener/blob/master/docs/usage/pod-security.md#migrating-to-podsecurity`))
 		}
 	}
 

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -272,7 +272,9 @@ func ValidateShootSpecUpdate(newSpec, oldSpec *core.ShootSpec, newObjectMeta met
 	allErrs = append(allErrs, validateDNSUpdate(newSpec.DNS, oldSpec.DNS, newSpec.SeedName != nil, fldPath.Child("dns"))...)
 	allErrs = append(allErrs, validateKubernetesVersionUpdate(newSpec.Kubernetes.Version, oldSpec.Kubernetes.Version, fldPath.Child("kubernetes", "version"))...)
 
-	if len(newSpec.Kubernetes.Version) != 0 && versionutils.ConstraintK8sGreaterEqual125.Check(semver.MustParse(newSpec.Kubernetes.Version)) {
+	if len(newSpec.Kubernetes.Version) != 0 && len(oldSpec.Kubernetes.Version) != 0 &&
+		versionutils.ConstraintK8sGreaterEqual125.Check(semver.MustParse(newSpec.Kubernetes.Version)) &&
+		versionutils.ConstraintK8sLess125.Check(semver.MustParse(oldSpec.Kubernetes.Version)) {
 		if err := validatePSPAdmissionPlugin(newSpec.Kubernetes.KubeAPIServer, fldPath.Child("kubernetes")); err != nil {
 			allErrs = append(allErrs, err)
 		}

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -985,7 +985,7 @@ func validatePSPAdmissionPlugin(kubeAPIServerConfig *core.KubeAPIServerConfig, f
 			}
 		}
 	}
-	return field.Forbidden(fldPath.Child("version"), fmt.Sprintf("admission plugin: %q should be disabled for kubernetes version >=1.25, Refer [docs]", "PodSecurityPolicy"))
+	return field.Forbidden(fldPath.Child("version"), fmt.Sprintf("admission plugin: %q should be disabled for kubernetes version >=1.25, Refer [Migrating to PodSecurity](https://github.com/gardener/gardener/blob/master/docs/usage/pod-security.md#migrating-to-podsecurity)", "PodSecurityPolicy"))
 }
 
 func validateKubeControllerManager(kcm *core.KubeControllerManagerConfig, version string, fldPath *field.Path) field.ErrorList {

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -2245,75 +2245,111 @@ var _ = Describe("Shoot Validation Tests", func() {
 			})
 		})
 
-		It("should require a kubernetes version", func() {
-			shoot.Spec.Kubernetes.Version = ""
+		Context("Kubernetes Version", func() {
+			It("should require a kubernetes version", func() {
+				shoot.Spec.Kubernetes.Version = ""
 
-			errorList := ValidateShoot(shoot)
+				errorList := ValidateShoot(shoot)
 
-			Expect(errorList).To(HaveLen(1))
-			Expect(*errorList[0]).To(MatchFields(IgnoreExtras, Fields{
-				"Type":  Equal(field.ErrorTypeRequired),
-				"Field": Equal("spec.kubernetes.version"),
-			}))
-		})
+				Expect(errorList).To(HaveLen(1))
+				Expect(*errorList[0]).To(MatchFields(IgnoreExtras, Fields{
+					"Type":  Equal(field.ErrorTypeRequired),
+					"Field": Equal("spec.kubernetes.version"),
+				}))
+			})
 
-		It("should forbid removing the kubernetes version", func() {
-			newShoot := prepareShootForUpdate(shoot)
-			newShoot.Spec.Kubernetes.Version = ""
+			It("should forbid removing the kubernetes version", func() {
+				newShoot := prepareShootForUpdate(shoot)
+				newShoot.Spec.Kubernetes.Version = ""
 
-			Expect(ValidateShootUpdate(newShoot, shoot)).To(ConsistOf(
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":   Equal(field.ErrorTypeInvalid),
-					"Field":  Equal("spec.kubernetes.version"),
-					"Detail": Equal("cannot validate kubernetes version upgrade because it is unset"),
-				})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":   Equal(field.ErrorTypeInvalid),
-					"Field":  Equal("spec.provider.workers[0].kubernetes.version"),
-					"Detail": Equal("cannot validate kubernetes version upgrade because it is unset"),
-				})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":   Equal(field.ErrorTypeRequired),
-					"Field":  Equal("spec.kubernetes.version"),
-					"Detail": Equal("kubernetes version must not be empty"),
-				})),
-			))
-		})
+				Expect(ValidateShootUpdate(newShoot, shoot)).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeInvalid),
+						"Field":  Equal("spec.kubernetes.version"),
+						"Detail": Equal("cannot validate kubernetes version upgrade because it is unset"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeInvalid),
+						"Field":  Equal("spec.provider.workers[0].kubernetes.version"),
+						"Detail": Equal("cannot validate kubernetes version upgrade because it is unset"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeRequired),
+						"Field":  Equal("spec.kubernetes.version"),
+						"Detail": Equal("kubernetes version must not be empty"),
+					})),
+				))
+			})
 
-		It("should forbid kubernetes version downgrades", func() {
-			newShoot := prepareShootForUpdate(shoot)
-			newShoot.Spec.Kubernetes.Version = "1.7.2"
+			It("should forbid kubernetes version downgrades", func() {
+				newShoot := prepareShootForUpdate(shoot)
+				newShoot.Spec.Kubernetes.Version = "1.7.2"
 
-			Expect(ValidateShootUpdate(newShoot, shoot)).To(ConsistOf(
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":   Equal(field.ErrorTypeForbidden),
-					"Field":  Equal("spec.kubernetes.version"),
-					"Detail": Equal("kubernetes version downgrade is not supported"),
-				})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":   Equal(field.ErrorTypeForbidden),
-					"Field":  Equal("spec.provider.workers[0].kubernetes.version"),
-					"Detail": Equal("kubernetes version downgrade is not supported"),
-				})),
-			))
-		})
+				Expect(ValidateShootUpdate(newShoot, shoot)).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeForbidden),
+						"Field":  Equal("spec.kubernetes.version"),
+						"Detail": Equal("kubernetes version downgrade is not supported"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeForbidden),
+						"Field":  Equal("spec.provider.workers[0].kubernetes.version"),
+						"Detail": Equal("kubernetes version downgrade is not supported"),
+					})),
+				))
+			})
 
-		It("should forbid kubernetes version upgrades skipping a minor version", func() {
-			newShoot := prepareShootForUpdate(shoot)
-			newShoot.Spec.Kubernetes.Version = "1.22.1"
+			It("should forbid kubernetes version upgrades skipping a minor version", func() {
+				newShoot := prepareShootForUpdate(shoot)
+				newShoot.Spec.Kubernetes.Version = "1.22.1"
 
-			Expect(ValidateShootUpdate(newShoot, shoot)).To(ConsistOf(
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":   Equal(field.ErrorTypeForbidden),
-					"Field":  Equal("spec.kubernetes.version"),
-					"Detail": Equal("kubernetes version upgrade cannot skip a minor version"),
-				})),
-				PointTo(MatchFields(IgnoreExtras, Fields{
-					"Type":   Equal(field.ErrorTypeForbidden),
-					"Field":  Equal("spec.provider.workers[0].kubernetes.version"),
-					"Detail": Equal("kubernetes version upgrade cannot skip a minor version"),
-				})),
-			))
+				Expect(ValidateShootUpdate(newShoot, shoot)).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeForbidden),
+						"Field":  Equal("spec.kubernetes.version"),
+						"Detail": Equal("kubernetes version upgrade cannot skip a minor version"),
+					})),
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeForbidden),
+						"Field":  Equal("spec.provider.workers[0].kubernetes.version"),
+						"Detail": Equal("kubernetes version upgrade cannot skip a minor version"),
+					})),
+				))
+			})
+
+			It("should forbid upgrading to v1.25 if PodSecurityPolicy admission plugin is not disabled", func() {
+				shoot.Spec.Kubernetes.Version = "1.24.0"
+				newShoot := prepareShootForUpdate(shoot)
+				newShoot.Spec.Kubernetes.Version = "1.25.0"
+
+				Expect(ValidateShootUpdate(newShoot, shoot)).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeForbidden),
+						"Field":  Equal("spec.kubernetes.version"),
+						"Detail": ContainSubstring("admission plugin: %q should be disabled for kubernetes version >=1.25", "PodSecurityPolicy"),
+					})),
+				))
+			})
+
+			It("should allow upgrading to v1.25 if PodSecurityPolicy admission plugin is disabled", func() {
+				shoot.Spec.Kubernetes.Version = "1.24.0"
+				newShoot := prepareShootForUpdate(shoot)
+				newShoot.Spec.Kubernetes.Version = "1.25.0"
+				newShoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins = []core.AdmissionPlugin{
+					{
+						Name:     "PodSecurityPolicy",
+						Disabled: pointer.Bool(true),
+					},
+				}
+
+				Expect(ValidateShootUpdate(newShoot, shoot)).To(BeEmpty())
+			})
+
+			It("should allow creating a new shoot with v1.25 even if PodSecurityPolicy admission plugin is not disabled", func() {
+				shoot.Spec.Kubernetes.Version = "1.25.0"
+
+				Expect(ValidateShoot(shoot)).To(BeEmpty())
+			})
 		})
 
 		Context("worker pool kubernetes version", func() {

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -2333,11 +2333,19 @@ var _ = Describe("Shoot Validation Tests", func() {
 
 			// TODO(shafeeqes): Add "should allow upgrading to v1.25 if PodSecurityPolicy admission plugin is disabled"
 			// once this plugin is removed from requiredPlugins
-
 			It("should allow creating a new shoot with v1.25 even if PodSecurityPolicy admission plugin is not disabled", func() {
 				shoot.Spec.Kubernetes.Version = "1.25.0"
 
 				Expect(ValidateShoot(shoot)).To(BeEmpty())
+			})
+
+			It("should allow updating specs of a shoot with v1.25 even if PodSecurityPolicy admission plugin is not explicitly disabled", func() {
+				shoot.Spec.Kubernetes.Version = "1.25.0"
+				newShoot := prepareShootForUpdate(shoot)
+				newShoot.Spec.Kubernetes.Version = "1.25.0"
+				newShoot.Spec.Provider.Workers[0].Maximum = 5
+
+				Expect(ValidateShootUpdate(newShoot, shoot)).To(BeEmpty())
 			})
 		})
 

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -2331,19 +2331,8 @@ var _ = Describe("Shoot Validation Tests", func() {
 				))
 			})
 
-			It("should allow upgrading to v1.25 if PodSecurityPolicy admission plugin is disabled", func() {
-				shoot.Spec.Kubernetes.Version = "1.24.0"
-				newShoot := prepareShootForUpdate(shoot)
-				newShoot.Spec.Kubernetes.Version = "1.25.0"
-				newShoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins = []core.AdmissionPlugin{
-					{
-						Name:     "PodSecurityPolicy",
-						Disabled: pointer.Bool(true),
-					},
-				}
-
-				Expect(ValidateShootUpdate(newShoot, shoot)).To(BeEmpty())
-			})
+			// TODO(shafeeqes): Add "should allow upgrading to v1.25 if PodSecurityPolicy admission plugin is disabled"
+			// once this plugin is removed from requiredPlugins
 
 			It("should allow creating a new shoot with v1.25 even if PodSecurityPolicy admission plugin is not disabled", func() {
 				shoot.Spec.Kubernetes.Version = "1.25.0"

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -2326,7 +2326,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 					PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":   Equal(field.ErrorTypeForbidden),
 						"Field":  Equal("spec.kubernetes.version"),
-						"Detail": ContainSubstring("admission plugin: %q should be disabled for kubernetes version >=1.25", "PodSecurityPolicy"),
+						"Detail": ContainSubstring("admission plugin \"PodSecurityPolicy\" should be disabled for Kubernetes versions >=1.25, please check https://github.com/gardener/gardener/blob/master/docs/usage/pod-security.md#migrating-from-podsecuritypolicys-to-podsecurity-admission-controller"),
 					})),
 				))
 			})

--- a/pkg/operation/botanist/component/kubeapiserver/configmaps.go
+++ b/pkg/operation/botanist/component/kubeapiserver/configmaps.go
@@ -51,7 +51,7 @@ func (k *kubeAPIServer) reconcileConfigMapAdmission(ctx context.Context, configM
 	configMap.Data = map[string]string{}
 
 	admissionConfig := &apiserverv1alpha1.AdmissionConfiguration{}
-	for _, plugin := range k.values.AdmissionPlugins {
+	for _, plugin := range k.values.EnabledAdmissionPlugins {
 		if plugin.Config == nil {
 			continue
 		}

--- a/pkg/operation/botanist/component/kubeapiserver/deployment.go
+++ b/pkg/operation/botanist/component/kubeapiserver/deployment.go
@@ -597,7 +597,7 @@ func (k *kubeAPIServer) computeKubeAPIServerCommand() []string {
 func (k *kubeAPIServer) admissionPluginNames() []string {
 	var out []string
 
-	for _, plugin := range k.values.AdmissionPlugins {
+	for _, plugin := range k.values.EnabledAdmissionPlugins {
 		out = append(out, plugin.Name)
 	}
 

--- a/pkg/operation/botanist/component/kubeapiserver/deployment.go
+++ b/pkg/operation/botanist/component/kubeapiserver/deployment.go
@@ -486,6 +486,7 @@ func (k *kubeAPIServer) computeKubeAPIServerCommand() []string {
 
 	out = append(out, "/usr/local/bin/kube-apiserver")
 	out = append(out, "--enable-admission-plugins="+strings.Join(k.admissionPluginNames(), ","))
+	out = append(out, "--disable-admission-plugins="+strings.Join(k.disabledAdmissionPluginNames(), ","))
 	out = append(out, fmt.Sprintf("--admission-control-config-file=%s/%s", volumeMountPathAdmissionConfiguration, configMapAdmissionDataKey))
 	out = append(out, "--allow-privileged=true")
 	out = append(out, "--anonymous-auth="+strconv.FormatBool(k.values.AnonymousAuthenticationEnabled))
@@ -597,6 +598,16 @@ func (k *kubeAPIServer) admissionPluginNames() []string {
 	var out []string
 
 	for _, plugin := range k.values.AdmissionPlugins {
+		out = append(out, plugin.Name)
+	}
+
+	return out
+}
+
+func (k *kubeAPIServer) disabledAdmissionPluginNames() []string {
+	var out []string
+
+	for _, plugin := range k.values.DisabledAdmissionPlugins {
 		out = append(out, plugin.Name)
 	}
 

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
@@ -118,8 +118,8 @@ type Interface interface {
 
 // Values contains configuration values for the kube-apiserver resources.
 type Values struct {
-	// AdmissionPlugins is the list of admission plugins with configuration for the kube-apiserver.
-	AdmissionPlugins []gardencorev1beta1.AdmissionPlugin
+	// EnabledAdmissionPlugins is the list of admission plugins that should be enabled with configuration for the kube-apiserver.
+	EnabledAdmissionPlugins []gardencorev1beta1.AdmissionPlugin
 	// DisabledAdmissionPlugins is the list of admission plugins that should be disabled for the kube-apiserver.
 	DisabledAdmissionPlugins []gardencorev1beta1.AdmissionPlugin
 	// AnonymousAuthenticationEnabled states whether anonymous authentication is enabled.

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver.go
@@ -120,6 +120,8 @@ type Interface interface {
 type Values struct {
 	// AdmissionPlugins is the list of admission plugins with configuration for the kube-apiserver.
 	AdmissionPlugins []gardencorev1beta1.AdmissionPlugin
+	// DisabledAdmissionPlugins is the list of admission plugins that should be disabled for the kube-apiserver.
+	DisabledAdmissionPlugins []gardencorev1beta1.AdmissionPlugin
 	// AnonymousAuthenticationEnabled states whether anonymous authentication is enabled.
 	AnonymousAuthenticationEnabled bool
 	// APIAudiences are identifiers of the API. The service account token authenticator will validate that tokens used

--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
@@ -1258,7 +1258,7 @@ plugins: null
 						{Name: "Baz", Config: &runtime.RawExtension{Raw: []byte("some-config-for-baz")}},
 					}
 
-					kapi = New(kubernetesInterface, namespace, sm, Values{AdmissionPlugins: admissionPlugins, Version: version})
+					kapi = New(kubernetesInterface, namespace, sm, Values{EnabledAdmissionPlugins: admissionPlugins, Version: version})
 
 					configMapAdmission = &corev1.ConfigMap{
 						ObjectMeta: metav1.ObjectMeta{Name: "kube-apiserver-admission-config", Namespace: namespace},
@@ -1858,11 +1858,11 @@ rules:
 					Expect(c.Create(ctx, legacySecret)).To(Succeed())
 
 					kapi = New(kubernetesInterface, namespace, sm, Values{
-						AdmissionPlugins: admissionPlugins,
-						Autoscaling:      AutoscalingConfig{APIServerResources: apiServerResources},
-						EventTTL:         &metav1.Duration{Duration: eventTTL},
-						ExternalHostname: externalHostname,
-						Images:           images,
+						EnabledAdmissionPlugins: admissionPlugins,
+						Autoscaling:             AutoscalingConfig{APIServerResources: apiServerResources},
+						EventTTL:                &metav1.Duration{Duration: eventTTL},
+						ExternalHostname:        externalHostname,
+						Images:                  images,
 						ServiceAccount: ServiceAccountConfig{
 							Issuer:                serviceAccountIssuer,
 							AcceptedIssuers:       acceptedIssuers,

--- a/pkg/operation/botanist/kubeapiserver.go
+++ b/pkg/operation/botanist/kubeapiserver.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"net"
 
-	"github.com/Masterminds/semver"
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	gardencorev1alpha1helper "github.com/gardener/gardener/pkg/apis/core/v1alpha1/helper"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -36,7 +35,6 @@ import (
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	secretutils "github.com/gardener/gardener/pkg/utils/secrets"
-	versionutils "github.com/gardener/gardener/pkg/utils/version"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -56,8 +54,7 @@ func (b *Botanist) DefaultKubeAPIServer(ctx context.Context) (kubeapiserver.Inte
 	}
 
 	var (
-		apiServerConfig   = b.Shoot.GetInfo().Spec.Kubernetes.KubeAPIServer
-		kubernetesVersion = b.Shoot.GetInfo().Spec.Kubernetes.Version
+		apiServerConfig = b.Shoot.GetInfo().Spec.Kubernetes.KubeAPIServer
 
 		enabledAdmissionPlugins  = kutil.GetAdmissionPluginsForVersion(b.Shoot.GetInfo().Spec.Kubernetes.Version)
 		disabledAdmissionPlugins []gardencorev1beta1.AdmissionPlugin
@@ -73,7 +70,7 @@ func (b *Botanist) DefaultKubeAPIServer(ctx context.Context) (kubeapiserver.Inte
 
 	if apiServerConfig != nil {
 		enabledAdmissionPlugins = b.computeKubeAPIServerAdmissionPlugins(enabledAdmissionPlugins, apiServerConfig.AdmissionPlugins)
-		disabledAdmissionPlugins = b.computeDisabledKubeAPIServerAdmissionPlugins(apiServerConfig.AdmissionPlugins, kubernetesVersion)
+		disabledAdmissionPlugins = b.computeDisabledKubeAPIServerAdmissionPlugins(apiServerConfig.AdmissionPlugins)
 
 		if apiServerConfig.APIAudiences != nil {
 			apiAudiences = apiServerConfig.APIAudiences
@@ -156,13 +153,10 @@ func (b *Botanist) computeKubeAPIServerAdmissionPlugins(defaultPlugins, configur
 	return admissionPlugins
 }
 
-func (b *Botanist) computeDisabledKubeAPIServerAdmissionPlugins(configuredPlugins []gardencorev1beta1.AdmissionPlugin, kubernetesVersion string) []gardencorev1beta1.AdmissionPlugin {
+func (b *Botanist) computeDisabledKubeAPIServerAdmissionPlugins(configuredPlugins []gardencorev1beta1.AdmissionPlugin) []gardencorev1beta1.AdmissionPlugin {
 	var disabledAdmissionPlugins []gardencorev1beta1.AdmissionPlugin
 	for _, plugin := range configuredPlugins {
 		if pointer.BoolDeref(plugin.Disabled, false) {
-			if versionutils.ConstraintK8sGreaterEqual125.Check(semver.MustParse(kubernetesVersion)) && plugin.Name == "PodSecurityPolicy" {
-				continue
-			}
 			disabledAdmissionPlugins = append(disabledAdmissionPlugins, plugin)
 		}
 	}

--- a/pkg/operation/botanist/kubeapiserver.go
+++ b/pkg/operation/botanist/kubeapiserver.go
@@ -59,7 +59,7 @@ func (b *Botanist) DefaultKubeAPIServer(ctx context.Context) (kubeapiserver.Inte
 		apiServerConfig   = b.Shoot.GetInfo().Spec.Kubernetes.KubeAPIServer
 		kubernetesVersion = b.Shoot.GetInfo().Spec.Kubernetes.Version
 
-		admissionPlugins         = kutil.GetAdmissionPluginsForVersion(b.Shoot.GetInfo().Spec.Kubernetes.Version)
+		enabledAdmissionPlugins  = kutil.GetAdmissionPluginsForVersion(b.Shoot.GetInfo().Spec.Kubernetes.Version)
 		disabledAdmissionPlugins []gardencorev1beta1.AdmissionPlugin
 		apiAudiences             = []string{"kubernetes", "gardener"}
 		auditConfig              *kubeapiserver.AuditConfig
@@ -72,7 +72,7 @@ func (b *Botanist) DefaultKubeAPIServer(ctx context.Context) (kubeapiserver.Inte
 	)
 
 	if apiServerConfig != nil {
-		admissionPlugins = b.computeKubeAPIServerAdmissionPlugins(admissionPlugins, apiServerConfig.AdmissionPlugins)
+		enabledAdmissionPlugins = b.computeKubeAPIServerAdmissionPlugins(enabledAdmissionPlugins, apiServerConfig.AdmissionPlugins)
 		disabledAdmissionPlugins = b.computeDisabledKubeAPIServerAdmissionPlugins(apiServerConfig.AdmissionPlugins, kubernetesVersion)
 
 		if apiServerConfig.APIAudiences != nil {
@@ -103,7 +103,7 @@ func (b *Botanist) DefaultKubeAPIServer(ctx context.Context) (kubeapiserver.Inte
 		b.Shoot.SeedNamespace,
 		b.SecretsManager,
 		kubeapiserver.Values{
-			AdmissionPlugins:               admissionPlugins,
+			EnabledAdmissionPlugins:        enabledAdmissionPlugins,
 			DisabledAdmissionPlugins:       disabledAdmissionPlugins,
 			AnonymousAuthenticationEnabled: gardencorev1beta1helper.ShootWantsAnonymousAuthentication(b.Shoot.GetInfo().Spec.Kubernetes.KubeAPIServer),
 			APIAudiences:                   apiAudiences,

--- a/pkg/operation/botanist/kubeapiserver_test.go
+++ b/pkg/operation/botanist/kubeapiserver_test.go
@@ -283,7 +283,7 @@ var _ = Describe("KubeAPIServer", func() {
 
 					kubeAPIServer, err := botanist.DefaultKubeAPIServer(ctx)
 					Expect(err).NotTo(HaveOccurred())
-					Expect(kubeAPIServer.GetValues().AdmissionPlugins).To(Equal(expectedPlugins))
+					Expect(kubeAPIServer.GetValues().EnabledAdmissionPlugins).To(Equal(expectedPlugins))
 				},
 
 				Entry("only default plugins",

--- a/pkg/operation/botanist/kubeapiserver_test.go
+++ b/pkg/operation/botanist/kubeapiserver_test.go
@@ -460,38 +460,6 @@ var _ = Describe("KubeAPIServer", func() {
 					Expect(err).NotTo(HaveOccurred())
 					Expect(kubeAPIServer.GetValues().DisabledAdmissionPlugins).To(Equal(expectedDisabledPlugins))
 				})
-
-				Context("kubernetes version >= 1.25", func() {
-					BeforeEach(func() {
-						shootCopy.Spec.Kubernetes.Version = "1.25.0"
-					})
-
-					It("should skip adding PodSecurityPolicy to the list of disabled admission plugins if kubernetes version >= 1.25", func() {
-						shootCopy.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins = []gardencorev1beta1.AdmissionPlugin{
-							{Name: "Priority"},
-							{Name: "NamespaceLifecycle", Config: &runtime.RawExtension{Raw: []byte("namespace-lifecycle-config")}, Disabled: pointer.Bool(true)},
-							{Name: "LimitRanger"},
-							{Name: "PodSecurityPolicy", Disabled: pointer.Bool(true)},
-							{Name: "ServiceAccount"},
-							{Name: "NodeRestriction"},
-							{Name: "DefaultStorageClass", Disabled: pointer.Bool(true)},
-							{Name: "DefaultTolerationSeconds"},
-							{Name: "ResourceQuota"},
-							{Name: "foo", Config: &runtime.RawExtension{Raw: []byte("foo-config")}, Disabled: pointer.Bool(true)},
-						}
-
-						expectedDisabledPlugins := []gardencorev1beta1.AdmissionPlugin{
-							{Name: "NamespaceLifecycle", Config: &runtime.RawExtension{Raw: []byte("namespace-lifecycle-config")}, Disabled: pointer.Bool(true)},
-							{Name: "DefaultStorageClass", Disabled: pointer.Bool(true)},
-							{Name: "foo", Config: &runtime.RawExtension{Raw: []byte("foo-config")}, Disabled: pointer.Bool(true)},
-						}
-
-						botanist.Shoot.SetInfo(shootCopy)
-						kubeAPIServer, err := botanist.DefaultKubeAPIServer(ctx)
-						Expect(err).NotTo(HaveOccurred())
-						Expect(kubeAPIServer.GetValues().DisabledAdmissionPlugins).To(Equal(expectedDisabledPlugins))
-					})
-				})
 			})
 		})
 

--- a/pkg/operation/botanist/kubeapiserver_test.go
+++ b/pkg/operation/botanist/kubeapiserver_test.go
@@ -460,6 +460,38 @@ var _ = Describe("KubeAPIServer", func() {
 					Expect(err).NotTo(HaveOccurred())
 					Expect(kubeAPIServer.GetValues().DisabledAdmissionPlugins).To(Equal(expectedDisabledPlugins))
 				})
+
+				Context("kubernetes version >= 1.25", func() {
+					BeforeEach(func() {
+						shootCopy.Spec.Kubernetes.Version = "1.25.0"
+					})
+
+					It("should skip adding PodSecurityPolicy to the list of disabled admission plugins if kubernetes version >= 1.25", func() {
+						shootCopy.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins = []gardencorev1beta1.AdmissionPlugin{
+							{Name: "Priority"},
+							{Name: "NamespaceLifecycle", Config: &runtime.RawExtension{Raw: []byte("namespace-lifecycle-config")}, Disabled: pointer.Bool(true)},
+							{Name: "LimitRanger"},
+							{Name: "PodSecurityPolicy", Disabled: pointer.Bool(true)},
+							{Name: "ServiceAccount"},
+							{Name: "NodeRestriction"},
+							{Name: "DefaultStorageClass", Disabled: pointer.Bool(true)},
+							{Name: "DefaultTolerationSeconds"},
+							{Name: "ResourceQuota"},
+							{Name: "foo", Config: &runtime.RawExtension{Raw: []byte("foo-config")}, Disabled: pointer.Bool(true)},
+						}
+
+						expectedDisabledPlugins := []gardencorev1beta1.AdmissionPlugin{
+							{Name: "NamespaceLifecycle", Config: &runtime.RawExtension{Raw: []byte("namespace-lifecycle-config")}, Disabled: pointer.Bool(true)},
+							{Name: "DefaultStorageClass", Disabled: pointer.Bool(true)},
+							{Name: "foo", Config: &runtime.RawExtension{Raw: []byte("foo-config")}, Disabled: pointer.Bool(true)},
+						}
+
+						botanist.Shoot.SetInfo(shootCopy)
+						kubeAPIServer, err := botanist.DefaultKubeAPIServer(ctx)
+						Expect(err).NotTo(HaveOccurred())
+						Expect(kubeAPIServer.GetValues().DisabledAdmissionPlugins).To(Equal(expectedDisabledPlugins))
+					})
+				})
 			})
 		})
 

--- a/pkg/registry/core/shoot/strategy_test.go
+++ b/pkg/registry/core/shoot/strategy_test.go
@@ -471,6 +471,30 @@ var _ = Describe("Strategy", func() {
 					))
 				})
 			})
+
+			Context("k8s version < 1.25", func() {
+				BeforeEach(func() {
+					shoot.Spec.Kubernetes.Version = "1.24.0"
+				})
+				It("should not cleanup PodSecurityPolicy from the admission plugins list", func() {
+					shootregistry.NewStrategy(0).Canonicalize(shoot)
+
+					Expect(shoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins).To(ContainElements(
+						core.AdmissionPlugin{
+							Name:   "NodeRestriction",
+							Config: &runtime.RawExtension{Raw: []byte("bar")},
+						},
+						core.AdmissionPlugin{
+							Name:   "PodSecurity",
+							Config: &runtime.RawExtension{Raw: []byte("foo")},
+						},
+						core.AdmissionPlugin{
+							Name:     "PodSecurityPolicy",
+							Disabled: pointer.Bool(true),
+						},
+					))
+				})
+			})
 		})
 	})
 })

--- a/pkg/utils/version/version.go
+++ b/pkg/utils/version/version.go
@@ -61,6 +61,8 @@ var (
 	ConstraintK8sLess124 *semver.Constraints
 	// ConstraintK8sGreaterEqual125 is a version constraint for versions >= 1.25.
 	ConstraintK8sGreaterEqual125 *semver.Constraints
+	// ConstraintK8sLess125 is a version constraint for versions < 1.25.
+	ConstraintK8sLess125 *semver.Constraints
 )
 
 func init() {
@@ -103,6 +105,8 @@ func init() {
 	ConstraintK8sLess124, err = semver.NewConstraint("< 1.24")
 	utilruntime.Must(err)
 	ConstraintK8sGreaterEqual125, err = semver.NewConstraint(">= 1.25")
+	utilruntime.Must(err)
+	ConstraintK8sLess125, err = semver.NewConstraint("< 1.25")
 	utilruntime.Must(err)
 }
 

--- a/test/integration/extensions/webhook/cloudprovider/ensurer.go
+++ b/test/integration/extensions/webhook/cloudprovider/ensurer.go
@@ -47,7 +47,7 @@ func (e *ensurer) InjectScheme(_ *runtime.Scheme) error {
 	return nil
 }
 
-// EnsureCloudProviderSecret isimplemented on extention side which mutates the cloudprovider secret. contain
+// EnsureCloudProviderSecret is implemented on extension side which mutates the cloudprovider secret. contain
 // For testing purpose we are mutating the cloudprovider secret's data to check whether this
 // function is called in webhook.
 func (e *ensurer) EnsureCloudProviderSecret(ctx context.Context, _ gcontext.GardenContext, new, _ *corev1.Secret) error {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:
This PR adds a validation to check whether `PodSecurityPolicy` admission plugin is disabled before upgrading the shoot cluster to kubernetes version `v1.25`. This is to make sure the PSPs are cleaned up because there'll be no API serving this resource from v1.25 onwards.

It also adds the disabled admission plugins via `--disable-admission-plugins` for the kube-apiserver which was missed in https://github.com/gardener/gardener/pull/6403. 
Reason: Earlier we were only passing the plugins which we want to be enabled and just removing the unwanted plugin from this list won't work since kubernetes enables some plugins by default. We need to do it explicitly via the disable flag.

~Also we add a warning to consider the migration in v1.23+ clusters.~
Can't be currently done because it's not possible to disable the plugin yet.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/5250

**Special notes for your reviewer**:
Since now, k8s `v1.25` is not supported, I tested by changing constraints to v1.24 and upgrading from v1.23.6 to v1.24
```
$ k patch shoot -n garden-local local -p '{"spec": {"kubernetes": {"version": "1.24.0"}}}'
The Shoot "local" is invalid: spec.kubernetes.version: Forbidden: admission plugin: "PodSecurityPolicy" should be disabled for kubernetes version >=1.25, Refer [Migrating to PodSecurity](https://github.com/gardener/gardener/blob/master/docs/usage/pod-security.md#migrating-to-podsecurity)
```
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
`PodSecurityPolicy` admission plugin should be disabled before upgrading the shoot cluster to kubernetes `v1.25`. Please refer [Migrating to PodSecurity](https://github.com/gardener/gardener/blob/master/docs/usage/pod-security.md#migrating-to-podsecurity).
```
