### PR TITLE
Fix etcd readiness check

### DIFF
--- a/pkg/operation/botanist/component/etcd/waiter.go
+++ b/pkg/operation/botanist/component/etcd/waiter.go
@@ -79,6 +79,10 @@ func CheckEtcdObject(obj client.Object) error {
 		return fmt.Errorf("observed generation outdated (%d/%d)", *observedGeneration, generation)
 	}
 
+	if etcd.Status.Replicas != etcd.Status.UpdatedReplicas {
+		return fmt.Errorf("update is being rolled out, only %d/%d replicas are up-to-date", etcd.Status.UpdatedReplicas, etcd.Status.Replicas)
+	}
+
 	if op, ok := etcd.Annotations[v1beta1constants.GardenerOperation]; ok {
 		return fmt.Errorf("gardener operation %q is not yet picked up by etcd-druid", op)
 	}

--- a/pkg/operation/botanist/component/etcd/waiter_test.go
+++ b/pkg/operation/botanist/component/etcd/waiter_test.go
@@ -195,8 +195,8 @@ var _ = Describe("#CheckEtcdObject", func() {
 		obj = &druidv1alpha1.Etcd{}
 	})
 
-	It("should return error for non-dns object", func() {
-		Expect(CheckEtcdObject(&corev1.ConfigMap{}))
+	It("should return error for non-etcd object", func() {
+		Expect(CheckEtcdObject(&corev1.ConfigMap{})).NotTo(Succeed())
 	})
 
 	It("should return error if reconciliation failed", func() {
@@ -242,10 +242,20 @@ var _ = Describe("#CheckEtcdObject", func() {
 		Expect(CheckEtcdObject(obj)).To(MatchError("is not ready yet"))
 	})
 
+	It("should return error if status.replicas != status.updatedReplicas", func() {
+		obj.SetGeneration(1)
+		obj.Status.ObservedGeneration = pointer.Int64(1)
+		obj.Status.Replicas = 3
+		obj.Status.UpdatedReplicas = 2
+		Expect(CheckEtcdObject(obj)).To(MatchError("update is being rolled out, only 2/3 replicas are up-to-date"))
+	})
+
 	It("should not return error if object is ready", func() {
 		obj.SetGeneration(1)
 		obj.Status.ObservedGeneration = pointer.Int64(1)
 		obj.Status.Ready = pointer.Bool(true)
+		obj.Status.Replicas = 3
+		obj.Status.UpdatedReplicas = 3
 		Expect(CheckEtcdObject(obj)).To(Succeed())
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
This PR enhances the readiness check for `etcd` resources. It is performed when Gardenlet waits for Etcd-Druid to successfully finish its reconciliation. As written in https://github.com/gardener/gardener/issues/6419#issuecomment-1201281436, the definition for `etcd.status.ready` has become ambiguous since multi-node etcd.

Unexpectedly, `etcd.status.ready` can be `true` while an update is still being rolled out and thus makes Gardenlet to proceed with the shoot reconcile/delete flow in some occasions. 

**Which issue(s) this PR fixes**:
Fixes #6419

**Special notes for your reviewer**:
The bug was found in the scope of #6419 which explains the situation in more detail. **Please note, that the bug itself is only relevant in combination with HA shoot clusters, i.e. those which have a multi-node etcd in their control plane**.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed for HA shoots and their underlying etcd clusters. In some occasions, Gardenlet didn't wait for changes to be completely rolled out to etcd. Especially in combination with the CA-rotation feature this could cause the cluster being stuck in an unrecoverable state.
```
