### PR TITLE
Alert on /run tmpfs almost out of inodes

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/node-exporter.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/node-exporter.rules.yaml
@@ -65,18 +65,11 @@ groups:
       description: Root filesystem device on instance {{ $labels.instance }} is almost full.
       summary: Node's root filesystem is almost full
 
-  # alert if the /run filesystem is almost out of inodes
-  - alert: NodeFilesystemAlmostOutOfFiles
-    expr: node_filesystem_files_free{mountpoint="/run"} / node_filesystem_files{mountpoint="/run"} * 100 < 5 and node_filesystem_readonly{mountpoint="/run"} == 0
-    for: 1h
-    labels:
-      service: node-exporter
-      severity: warning
-      type: shoot
-      visibility: all
-    annotations:
-      summary: Filesystem has less than 5% inodes left.
-      description: Filesystem on {{ $labels.device }} mounted at {{ $labels.mountpoint }} on node {{ $labels.node }} has only {{ printf "%.2f" $value }}% available inodes left.
+  # Nodes with less than 5% free inodes on some (not read only) mount points
+  # The series exists only if there are less than 5% free inodes,
+  # to keep the cardinality of these federated metrics manageable (otherwise the total number of nodes in all the shoots)
+  - record: shoot:node_filesystem_files_free:percent
+    expr: sum(node_filesystem_files_free / node_filesystem_files * 100 < 5 and node_filesystem_readonly == 0) by (node)
 
   - alert: VMConntrackTableFull
     for: 1h

--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/node-exporter.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/node-exporter.rules.yaml
@@ -65,6 +65,19 @@ groups:
       description: Root filesystem device on instance {{ $labels.instance }} is almost full.
       summary: Node's root filesystem is almost full
 
+  # alert if the /run filesystem is almost out of inodes
+  - alert: NodeFilesystemAlmostOutOfFiles
+    expr: node_filesystem_files_free{mountpoint="/run"} / node_filesystem_files{mountpoint="/run"} * 100 < 5 and node_filesystem_readonly{mountpoint="/run"} == 0
+    for: 1h
+    labels:
+      service: node-exporter
+      severity: warning
+      type: shoot
+      visibility: owner
+    annotations:
+      summary: Filesystem has less than 5% inodes left.
+      description: Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available inodes left
+
   - alert: VMConntrackTableFull
     for: 1h
     expr: instance:conntrack_entries_usage:percent > 90

--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/node-exporter.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/node-exporter.rules.yaml
@@ -73,7 +73,7 @@ groups:
       service: node-exporter
       severity: warning
       type: shoot
-      visibility: owner
+      visibility: all
     annotations:
       summary: Filesystem has less than 5% inodes left.
       description: Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available inodes left

--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/node-exporter.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/node-exporter.rules.yaml
@@ -76,7 +76,7 @@ groups:
       visibility: all
     annotations:
       summary: Filesystem has less than 5% inodes left.
-      description: Filesystem on {{ $labels.device }} at {{ $labels.instance }} has only {{ printf "%.2f" $value }}% available inodes left
+      description: Filesystem on {{ $labels.device }} mounted at {{ $labels.mountpoint }} on node {{ $labels.node }} has only {{ printf "%.2f" $value }}% available inodes left.
 
   - alert: VMConntrackTableFull
     for: 1h


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
Add a Prometheus alert to alert on high inode usage on the `/run` filesystem

**Which issue(s) this PR fixes**:
Fixes https://github.tools.sap/kubernetes/landscape-issues/issues/62

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Alert rule for /run filesystem almost out of inodes condition
```
