### PR TITLE
[release-v1.52] Revert "Adapt gardenlet to use priority class gardener-system-critical (#6235)"

### DIFF
--- a/charts/gardener/gardenlet/charts/runtime/templates/deployment.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/deployment.yaml
@@ -63,7 +63,7 @@ spec:
 {{ toYaml .Values.global.gardenlet.podLabels | indent 8 }}
         {{- end }}
     spec:
-      priorityClassName: gardener-system-critical
+      priorityClassName: gardenlet
       {{- if not .Values.global.gardenlet.config.seedClientConnection.kubeconfig }}
       serviceAccountName: {{ required ".Values.global.gardenlet.serviceAccountName is required" .Values.global.gardenlet.serviceAccountName }}
       {{- else }}

--- a/charts/gardener/gardenlet/charts/runtime/templates/priorityclass.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/priorityclass.yaml
@@ -1,9 +1,7 @@
 apiVersion: {{ include "priorityclassversion" . }}
 kind: PriorityClass
 metadata:
-  name: gardener-system-critical
-  annotations:
-    resources.gardener.cloud/mode: Ignore # TODO(kris94) remove in future release
-value: 999998950
+  name: gardenlet
+value: 1000000000
 globalDefault: false
-description: "This class is used to ensure that the gardenlet and some seed system components has a high priority and is not preempted in favor of other pods."
+description: "This class is used to ensure that the gardenlet has a high priority and is not preempted in favor of other pods."

--- a/pkg/gardenlet/controller/factory.go
+++ b/pkg/gardenlet/controller/factory.go
@@ -49,7 +49,6 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	schedulingv1 "k8s.io/api/scheduling/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/runtime"
@@ -133,10 +132,6 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 	seedClient, err := f.clientMap.GetClient(ctx, keys.ForSeedWithName(f.cfg.SeedConfig.Name))
 	if err != nil {
 		return fmt.Errorf("failed to get seed client: %w", err)
-	}
-
-	if err := client.IgnoreNotFound(seedClient.Client().Delete(ctx, &schedulingv1.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: "gardenlet"}})); err != nil {
-		return fmt.Errorf("unable to delete Gardenlet's old PriorityClass: %w", err)
 	}
 
 	backupBucketController, err := backupbucketcontroller.NewBackupBucketController(ctx, log, f.clientMap, f.cfg, f.recorder)

--- a/pkg/gardenlet/controller/managedseed/charttest/charttest.go
+++ b/pkg/gardenlet/controller/managedseed/charttest/charttest.go
@@ -95,13 +95,13 @@ func ValidateGardenletChartPriorityClass(ctx context.Context, c client.Client) {
 		priorityClass,
 	)).ToNot(HaveOccurred())
 	Expect(priorityClass.GlobalDefault).To(Equal(false))
-	Expect(priorityClass.Value).To(Equal(int32(999998950)))
+	Expect(priorityClass.Value).To(Equal(int32(1000000000)))
 }
 
 func getEmptyPriorityClass() *schedulingv1.PriorityClass {
 	return &schedulingv1.PriorityClass{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "gardener-system-critical",
+			Name: "gardenlet",
 		},
 	}
 }
@@ -953,7 +953,7 @@ func ComputeExpectedGardenletDeploymentSpec(
 				Labels: expectedLabels,
 			},
 			Spec: corev1.PodSpec{
-				PriorityClassName:  "gardener-system-critical",
+				PriorityClassName:  "gardenlet",
 				ServiceAccountName: "gardenlet",
 				Containers: []corev1.Container{
 					{

--- a/pkg/operation/botanist/component/seedsystem/seedsystem.go
+++ b/pkg/operation/botanist/component/seedsystem/seedsystem.go
@@ -166,6 +166,7 @@ var gardenletManagedPriorityClasses = []struct {
 	value       int32
 	description string
 }{
+	{v1beta1constants.PriorityClassNameSeedSystemCritical, 999998950, "PriorityClass for Seed system components"},
 	{v1beta1constants.PriorityClassNameSeedSystem900, 999998900, "PriorityClass for Seed system components"},
 	{v1beta1constants.PriorityClassNameSeedSystem800, 999998800, "PriorityClass for Seed system components"},
 	{v1beta1constants.PriorityClassNameSeedSystem700, 999998700, "PriorityClass for Seed system components"},

--- a/pkg/operation/botanist/component/seedsystem/seedsystem_test.go
+++ b/pkg/operation/botanist/component/seedsystem/seedsystem_test.go
@@ -151,7 +151,7 @@ status: {}
 		})
 
 		It("should successfully deploy the resources", func() {
-			Expect(managedResourceSecret.Data).To(HaveLen(12))
+			Expect(managedResourceSecret.Data).To(HaveLen(13))
 			Expect(string(managedResourceSecret.Data["deployment__"+namespace+"__reserve-excess-capacity.yaml"])).To(Equal(deploymentYAML))
 			expectPriorityClasses(managedResourceSecret.Data)
 		})
@@ -265,6 +265,7 @@ func expectPriorityClasses(data map[string][]byte) {
 		value       int32
 		description string
 	}{
+		{"gardener-system-critical", 999998950, "PriorityClass for Seed system components"},
 		{"gardener-system-900", 999998900, "PriorityClass for Seed system components"},
 		{"gardener-system-800", 999998800, "PriorityClass for Seed system components"},
 		{"gardener-system-700", 999998700, "PriorityClass for Seed system components"},


### PR DESCRIPTION
/kind bug

Cherry-pick of https://github.com/gardener/gardener/pull/6432

```bugfix operator
A bug causing `gardenlet` helm chart deployment to fail is fixed.
```
