### PR TITLE
Update `redis` test image to multi arch image

### DIFF
--- a/test/framework/applications/guestbooktest.go
+++ b/test/framework/applications/guestbooktest.go
@@ -134,8 +134,8 @@ func (t *GuestBookTest) DeployGuestBookApp(ctx context.Context) {
 	chartOverrides := map[string]interface{}{
 		"image": map[string]interface{}{
 			"registry":   "eu.gcr.io",
-			"repository": "gardener-project/3rd/bitnami/redis",
-			"tag":        "5.0.7-debian-9-r12",
+			"repository": "gardener-project/3rd/redis",
+			"tag":        "5.0.8",
 		},
 		"cluster": map[string]interface{}{
 			"enabled": false,
@@ -145,6 +145,9 @@ func (t *GuestBookTest) DeployGuestBookApp(ctx context.Context) {
 		},
 		"rbac": map[string]interface{}{
 			"create": true,
+		},
+		"master": map[string]interface{}{
+			"command": "redis-server",
 		},
 	}
 	if shoot.Spec.Provider.Type == "alicloud" {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area delivery
/kind enhancement

**What this PR does / why we need it**:
This PR updates the `bitnami/redis` test images from `bitnami/redis` to `redis` and adapts the required changes for it. Also, the new `redis` image is multi-arch.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/backlog/issues/19

**Special notes for your reviewer**:
/cc @ialidzhikov I have tested the guestbook test locally and it works fine.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
