### PR TITLE
Do not run node-local-dns/node-cache in privileged mode

### DIFF
--- a/pkg/operation/botanist/component/nodelocaldns/nodelocaldns.go
+++ b/pkg/operation/botanist/component/nodelocaldns/nodelocaldns.go
@@ -156,6 +156,9 @@ func (c *nodeLocalDNS) computeResourcesData() (map[string][]byte, error) {
 				},
 			},
 			Spec: policyv1beta1.PodSecurityPolicySpec{
+				AllowedCapabilities: []corev1.Capability{
+					"NET_ADMIN",
+				},
 				AllowedHostPaths: []policyv1beta1.AllowedHostPath{
 					{
 						PathPrefix: "/run/xtables.lock",
@@ -179,7 +182,7 @@ func (c *nodeLocalDNS) computeResourcesData() (map[string][]byte, error) {
 						Max: prometheusErrorPort,
 					},
 				},
-				Privileged: true,
+				Privileged: false,
 				RunAsUser: policyv1beta1.RunAsUserStrategyOptions{
 					Rule: policyv1beta1.RunAsUserStrategyRunAsAny,
 				},
@@ -402,7 +405,9 @@ ip6.arpa:53 {
 									serviceName,
 								},
 								SecurityContext: &corev1.SecurityContext{
-									Privileged: pointer.Bool(true),
+									Capabilities: &corev1.Capabilities{
+										Add: []corev1.Capability{"NET_ADMIN"},
+									},
 								},
 								Ports: []corev1.ContainerPort{
 									{

--- a/pkg/operation/botanist/component/nodelocaldns/nodelocaldns_test.go
+++ b/pkg/operation/botanist/component/nodelocaldns/nodelocaldns_test.go
@@ -110,6 +110,8 @@ metadata:
     app: node-local-dns
   name: gardener.kube-system.node-local-dns
 spec:
+  allowedCapabilities:
+  - NET_ADMIN
   allowedHostPaths:
   - pathPrefix: /run/xtables.lock
   fsGroup:
@@ -122,7 +124,6 @@ spec:
     min: 9253
   - max: 9353
     min: 9353
-  privileged: true
   runAsUser:
     rule: RunAsAny
   seLinux:
@@ -344,7 +345,9 @@ status:
 											"kube-dns-upstream",
 										},
 										SecurityContext: &corev1.SecurityContext{
-											Privileged: pointer.Bool(true),
+											Capabilities: &corev1.Capabilities{
+												Add: []corev1.Capability{"NET_ADMIN"},
+											},
 										},
 										Ports: []corev1.ContainerPort{
 											{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security
/kind enhancement

**What this PR does / why we need it**:
According to my testing the node-local-dns DaemonSet is running fine in non-privileged mode with the `NET_ADMIN` capability.
To keep the upstream chart in sync, I also created https://github.com/kubernetes/kubernetes/pull/111694.

Ref https://kubernetes.slack.com/archives/C09QYUH5W/p1638291963228800

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener-security/standard-compliance/issues/3

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The node-local-dns/node-cache container no longer runs in privileged mode.
```
