### PR TITLE
Promote `SeedChange` and `CopyEtcdBackupsDuringControlPlaneMigration` feature gates to beta

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -33,7 +33,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | SeedKubeScheduler                            | `false` | `Alpha` | `1.15` |        |
 | ReversedVPN                                  | `false` | `Alpha` | `1.22` | `1.41` |
 | ReversedVPN                                  | `true`  | `Beta`  | `1.42` |        |
-| CopyEtcdBackupsDuringControlPlaneMigration   | `false` | `Alpha` | `1.37` |        |
+| CopyEtcdBackupsDuringControlPlaneMigration   | `false` | `Alpha` | `1.37` | `1.52` |
+| CopyEtcdBackupsDuringControlPlaneMigration   | `true`  | `Beta`  | `1.53` |        |
 | ForceRestore                                 | `false` | `Alpha` | `1.39` |        |
 | ShootCARotation                              | `false` | `Alpha` | `1.42` | `1.50` |
 | ShootCARotation                              | `true`  | `Beta`  | `1.51` |        |

--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -28,7 +28,8 @@ The following tables are a summary of the feature gates that you can set on diff
 | APIServerSNI                                 | `false` | `Alpha` | `1.7`  | `1.18` |
 | APIServerSNI                                 | `true`  | `Beta`  | `1.19` |        |
 | APIServerSNI (deprecated)                    | `true`  | `Beta`  | `1.48` |        |
-| SeedChange                                   | `false` | `Alpha` | `1.12` |        |
+| SeedChange                                   | `false` | `Alpha` | `1.12` | `1.52` |
+| SeedChange                                   | `true`  | `Beta`  | `1.53` |        |
 | SeedKubeScheduler                            | `false` | `Alpha` | `1.15` |        |
 | ReversedVPN                                  | `false` | `Alpha` | `1.22` | `1.41` |
 | ReversedVPN                                  | `true`  | `Beta`  | `1.42` |        |

--- a/docs/usage/control_plane_migration.md
+++ b/docs/usage/control_plane_migration.md
@@ -2,7 +2,7 @@
 
 ## Preconditions
 
-To be able to use this feature you need to enable the feature gate `SeedChange` in your `gardener-apiserver` by adding the following command flag: `--feature-gates=SeedChange=true`.
+To be able to use this feature, the `SeedChange` feature gate has to be enabled on your `gardener-apiserver`.
 
 Also, the involved Seeds need to have enabled BackupBuckets.
 

--- a/docs/usage/control_plane_migration.md
+++ b/docs/usage/control_plane_migration.md
@@ -22,7 +22,7 @@ If the `Shoot` has different `.spec.seedName` and `.status.seedName` a process i
 
 If the process is successful, we update the status of the `Shoot` by setting the `.status.seedName` to the null value. That way, a restoration is triggered in the `Destination Seed` and `.status.lastOperation` is changed to `Restore`. The control plane migration is completed when the `Restore` operation has completed successfully.
 
-By default the shoot's etcd backups will continue to be uploaded to the `BackupBucket` of the `Source Seed` after control plane migration has finished. If you want the etcd backups to instead be uploaded to the `BackupBucket` of the `Destination Seed`, you have to enable the `CopyEtcdBackupsDuringControlPlaneMigration` feature gate on the `gardenlet` by adding the following command flag: `--feature-gates=CopyEtcdBackupsDuringControlPlaneMigration=true`. Note that this will also move the existing etcd backups to the `BackupBucket` of the `Destination Seed` during the control plane migration process.
+When the `CopyEtcdBackupsDuringControlPlaneMigration` feature gate is enabled on the `gardenlet`, the etcd backups will be copied over to the `BackupBucket` of the `Destination Seed` during control plane migration and any future backups will be uploaded there. Otherwise, backups will continue to be uploaded to the `BackupBucket` of the `Source Seed`,
 
 ## Triggering the migration
 

--- a/example/20-componentconfig-gardenlet.yaml
+++ b/example/20-componentconfig-gardenlet.yaml
@@ -119,7 +119,7 @@ featureGates:
   APIServerSNI: true
   SeedKubeScheduler: false
   ReversedVPN: true
-  CopyEtcdBackupsDuringControlPlaneMigration: false
+  CopyEtcdBackupsDuringControlPlaneMigration: true
   ForceRestore: false
   ShootCARotation: true
   ShootSARotation: true

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -58,8 +58,9 @@ const (
 
 	// SeedChange enables updating the `spec.seedName` field during shoot validation from a non-empty value
 	// in order to trigger shoot control plane migration.
-	// owner: @stoyanr
+	// owner: @stoyanr @plkokanov
 	// alpha: v1.12.0
+	// beta: v1.53.0
 	SeedChange featuregate.Feature = "SeedChange"
 
 	// SeedKubeScheduler adds an additional kube-scheduler in seed clusters where the feature is enabled.
@@ -131,7 +132,7 @@ var allFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	HVPAForShootedSeed: {Default: false, PreRelease: featuregate.Alpha},
 	ManagedIstio:       {Default: true, PreRelease: featuregate.Beta},
 	APIServerSNI:       {Default: true, PreRelease: featuregate.Beta},
-	SeedChange:         {Default: false, PreRelease: featuregate.Alpha},
+	SeedChange:         {Default: true, PreRelease: featuregate.Beta},
 	SeedKubeScheduler:  {Default: false, PreRelease: featuregate.Alpha},
 	ReversedVPN:        {Default: true, PreRelease: featuregate.Beta},
 	CopyEtcdBackupsDuringControlPlaneMigration: {Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -78,6 +78,7 @@ const (
 	// to the object store of the destination seed during control plane migration.
 	// owner: @plkokanov
 	// alpha: v1.37.0
+	// beta: v1.53.0
 	CopyEtcdBackupsDuringControlPlaneMigration featuregate.Feature = "CopyEtcdBackupsDuringControlPlaneMigration"
 
 	// SecretBindingProviderValidation enables validations on Gardener API server that:
@@ -135,7 +136,7 @@ var allFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	SeedChange:         {Default: true, PreRelease: featuregate.Beta},
 	SeedKubeScheduler:  {Default: false, PreRelease: featuregate.Alpha},
 	ReversedVPN:        {Default: true, PreRelease: featuregate.Beta},
-	CopyEtcdBackupsDuringControlPlaneMigration: {Default: false, PreRelease: featuregate.Alpha},
+	CopyEtcdBackupsDuringControlPlaneMigration: {Default: true, PreRelease: featuregate.Beta},
 	SecretBindingProviderValidation:            {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	ForceRestore:                               {Default: false, PreRelease: featuregate.Alpha},
 	DisableDNSProviderManagement:               {Default: true, PreRelease: featuregate.GA, LockToDefault: true},

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -58,7 +58,7 @@ const (
 
 	// SeedChange enables updating the `spec.seedName` field during shoot validation from a non-empty value
 	// in order to trigger shoot control plane migration.
-	// owner: @stoyanr @plkokanov
+	// owner: @plkokanov
 	// alpha: v1.12.0
 	// beta: v1.53.0
 	SeedChange featuregate.Feature = "SeedChange"

--- a/plugin/pkg/shoot/binding/admission_test.go
+++ b/plugin/pkg/shoot/binding/admission_test.go
@@ -169,6 +169,7 @@ var _ = Describe("Shoot Binding Validator", func() {
 			})
 
 			It("should reject update of binding when shoot.spec.seedName is not nil and SeedChange feature gate is disabled", func() {
+				defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.SeedChange, false)()
 				shoot.Spec.SeedName = pointer.String(newSeed.Name)
 
 				attrs := admission.NewAttributesRecord(shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoot").WithVersion("version"), "binding", admission.Update, &metav1.UpdateOptions{}, false, nil)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane-migration
/kind enhancement

**What this PR does / why we need it**:
Promotes `SeedChange` and `CopyEtcdBackupsDuringControlPlaneMigration` feature gates to beta as they have been enabled in our tests for quite some time and are also tested with the e2e control plane migration tests that get executed on PRs.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `SeedChange` and `CopyEtcdBackupsDuringControlPlaneMigration` feature gates have been promoted to beta and are now enabled by default. 
```
