### PR TITLE
Add `gomegacheck` linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -22,6 +22,7 @@ linters:
   enable:
   - revive
   - logcheck
+  - gomegacheck
 
 issues:
   exclude-use-default: false
@@ -51,3 +52,7 @@ linters-settings:
       path: hack/tools/bin/logcheck.so
       description: Check structured logging calls to logr.Logger instances
       original-url: github.com/gardener/gardener/hack/tools/logcheck
+    gomegacheck:
+      path: hack/tools/bin/gomegacheck.so
+      description: Check test assertions using gomega
+      original-url: github.com/gardener/gardener/hack/tools/gomegacheck

--- a/Makefile
+++ b/Makefile
@@ -190,7 +190,7 @@ check-generate:
 	@hack/check-generate.sh $(REPO_ROOT)
 
 .PHONY: check
-check: $(GOIMPORTS) $(GOLANGCI_LINT) $(HELM) $(IMPORT_BOSS) $(LOGCHECK)
+check: $(GOIMPORTS) $(GOLANGCI_LINT) $(HELM) $(IMPORT_BOSS) $(LOGCHECK) $(GOMEGACHECK)
 	@hack/check.sh --golangci-lint-config=./.golangci.yaml ./cmd/... ./extensions/... ./pkg/... ./plugin/... ./test/...
 	@hack/check-imports.sh ./charts/... ./cmd/... ./extensions/... ./pkg/... ./plugin/... ./test/... ./third_party/...
 

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ TOOLS_DIR := hack/tools
 include hack/tools.mk
 
 LOGCHECK_DIR := $(TOOLS_DIR)/logcheck
+GOMEGACHECK_DIR := $(TOOLS_DIR)/gomegacheck
 
 #########################################
 # Rules for local development scenarios #
@@ -176,6 +177,7 @@ revendor:
 	@GO111MODULE=on go mod tidy
 	@GO111MODULE=on go mod vendor
 	@cd $(LOGCHECK_DIR); go mod tidy
+	@cd $(GOMEGACHECK_DIR); go mod tidy
 
 .PHONY: clean
 clean:
@@ -194,6 +196,11 @@ check: $(GOIMPORTS) $(GOLANGCI_LINT) $(HELM) $(IMPORT_BOSS) $(LOGCHECK)
 	@cd $(LOGCHECK_DIR); $(abspath $(GOLANGCI_LINT)) run -c $(REPO_ROOT)/.golangci.yaml --timeout 10m ./...
 	@cd $(LOGCHECK_DIR); go vet ./...
 	@cd $(LOGCHECK_DIR); $(abspath $(GOIMPORTS)) -l .
+
+	@echo "> Check $(GOMEGACHECK_DIR)"
+	@cd $(GOMEGACHECK_DIR); $(abspath $(GOLANGCI_LINT)) run -c $(REPO_ROOT)/.golangci.yaml --timeout 10m ./...
+	@cd $(GOMEGACHECK_DIR); go vet ./...
+	@cd $(GOMEGACHECK_DIR); $(abspath $(GOIMPORTS)) -l .
 
 	@hack/check-charts.sh ./charts
 
@@ -215,11 +222,13 @@ generate-sequential: $(CONTROLLER_GEN) $(GEN_CRD_API_REFERENCE_DOCS) $(GOIMPORTS
 format: $(GOIMPORTS)
 	@./hack/format.sh ./cmd ./extensions ./pkg ./plugin ./test ./hack
 	@cd $(LOGCHECK_DIR); $(abspath $(GOIMPORTS)) -l -w .
+	@cd $(GOMEGACHECK_DIR); $(abspath $(GOIMPORTS)) -l -w .
 
 .PHONY: test
 test: $(REPORT_COLLECTOR) $(PROMTOOL)
 	@./hack/test.sh ./cmd/... ./extensions/pkg/... ./pkg/... ./plugin/...
 	@cd $(LOGCHECK_DIR); go test -race -timeout=2m ./... | grep -v 'no test files'
+	@cd $(GOMEGACHECK_DIR); go test -race -timeout=2m ./... | grep -v 'no test files'
 
 .PHONY: test-integration
 test-integration: $(REPORT_COLLECTOR) $(SETUP_ENVTEST)

--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,8 @@ ifneq ($(strip $(shell git status --porcelain 2>/dev/null)),)
 	EFFECTIVE_VERSION := $(EFFECTIVE_VERSION)-dirty
 endif
 
+SHELL=/bin/bash -o pipefail
+
 #########################################
 # Tools                                 #
 #########################################

--- a/extensions/pkg/webhook/certificates/certificates_test.go
+++ b/extensions/pkg/webhook/certificates/certificates_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Certificates", func() {
 				caCert, err := utils.DecodeCertificate(caCertPEM)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(caCert.Subject.CommonName).To(Equal(providerName))
-				Expect(time.Until(caCert.NotAfter)).To(And(BeNumerically(">", 29*24*time.Hour)), BeNumerically("<", 30*24*time.Hour))
+				Expect(time.Until(caCert.NotAfter)).To(And(BeNumerically(">", 9*365*24*time.Hour)))
 
 				By("validating generated server certificate")
 				serverCertPEM, err := os.ReadFile(filepath.Join(certDir, "tls.crt"))

--- a/hack/tools.mk
+++ b/hack/tools.mk
@@ -23,8 +23,8 @@ ifeq ($(strip $(shell go list -m)),github.com/gardener/gardener)
 TOOLS_PKG_PATH             := ./hack/tools
 else
 # dependency on github.com/gardener/gardener/hack/tools is optional and only needed if other projects want to reuse
-# install-promtool.sh or logcheck. If they don't use it and the project doesn't depend on the package, silence the error
-# to minimize confusion.
+# install-promtool.sh, logcheck, or gomegacheck. If they don't use it and the project doesn't depend on the package,
+# silence the error to minimize confusion.
 TOOLS_PKG_PATH             := $(shell go list -tags tools -f '{{ .Dir }}' github.com/gardener/gardener/hack/tools 2>/dev/null)
 endif
 
@@ -35,6 +35,7 @@ GEN_CRD_API_REFERENCE_DOCS := $(TOOLS_BIN_DIR)/gen-crd-api-reference-docs
 GINKGO                     := $(TOOLS_BIN_DIR)/ginkgo
 GOIMPORTS                  := $(TOOLS_BIN_DIR)/goimports
 GOLANGCI_LINT              := $(TOOLS_BIN_DIR)/golangci-lint
+GOMEGACHECK                := $(TOOLS_BIN_DIR)/gomegacheck.so # plugin binary
 GO_TO_PROTOBUF             := $(TOOLS_BIN_DIR)/go-to-protobuf
 HELM                       := $(TOOLS_BIN_DIR)/helm
 IMPORT_BOSS                := $(TOOLS_BIN_DIR)/import-boss
@@ -131,6 +132,14 @@ $(LOGCHECK): $(TOOLS_PKG_PATH)/logcheck/go.* $(shell find $(TOOLS_PKG_PATH)/logc
 else
 $(LOGCHECK): go.mod
 	CGO_ENABLED=1 go build -o $(LOGCHECK) -buildmode=plugin github.com/gardener/gardener/hack/tools/logcheck/plugin
+endif
+
+ifeq ($(strip $(shell go list -m)),github.com/gardener/gardener)
+$(GOMEGACHECK): $(TOOLS_PKG_PATH)/gomegacheck/go.* $(shell find $(TOOLS_PKG_PATH)/gomegacheck -type f -name '*.go')
+	cd $(TOOLS_PKG_PATH)/gomegacheck; CGO_ENABLED=1 go build -o $(abspath $(GOMEGACHECK)) -buildmode=plugin ./plugin
+else
+$(GOMEGACHECK): go.mod
+	CGO_ENABLED=1 go build -o $(GOMEGACHECK) -buildmode=plugin github.com/gardener/gardener/hack/tools/gomegacheck/plugin
 endif
 
 $(MOCKGEN): go.mod

--- a/hack/tools/gomegacheck/README.md
+++ b/hack/tools/gomegacheck/README.md
@@ -1,0 +1,77 @@
+# `gomegacheck` tool
+
+## Description and Motivation
+
+This directory contains a tool for checking test assertions using [gomega](https://github.com/onsi/gomega).
+
+It checks that `Expect`, `Eventually`, `Consistently` and friends have a corresponding `Should`, `ShouldNot` (or similar) call.
+It's easy to forget `.Should(Succeed())` for these assertions, see [onsi/gomega#561](https://github.com/onsi/gomega/issues/561).
+Forgetting these calls is a dangerous trap, as it basically makes the test code itself erroneous.
+The tool also checks that only a single `GomegaMatcher` is passed to `Should` and friends.
+
+As we have seen this happening in a lot of tests in our project, we have added a tool to prevent such programmer-level errors.
+
+You can also check out our [testing guideline](../../../docs/development/testing.md).
+
+## Implementation Details
+
+The tool is implemented using the [`golang.org/x/tools/go/analysis`](https://pkg.go.dev/golang.org/x/tools/go/analysis) package, which is a "linter framework" used by `go vet` and `golangci-lint` as well.
+If you are looking for a better understanding of how the tool is implemented, you can take a look at [this tutorial](https://disaev.me/p/writing-useful-go-analysis-linter/) on writing custom linters, which explains all the fundamental building blocks.
+
+## Installation und Usage
+
+There are two options for installing and using the `gomegacheck` tool:
+
+- standalone binary: simple, but limited
+- [`golangci-lint`](https://golangci-lint.run/) plugin (recommended): specific build requirements, but comes with caching, nice output, and flexible configuration options (e.g., excludes and `//nolint` comments) out of the box
+
+### Standalone Binary
+
+Install the tool with:
+
+```bash
+go install github.com/gardener/gardener/hack/tools/gomegacheck
+```
+
+Use it with:
+```bash
+gomegacheck package [package...]
+```
+
+### [`golangci-lint`](https://golangci-lint.run/) Plugin (Recommended)
+
+[`golangci-lint`](https://golangci-lint.run/) features a mechanism for loading [custom linters](https://golangci-lint.run/contributing/new-linters/#how-to-add-a-private-linter-to-golangci-lint) using Go's plugin library.
+
+Build the plugin with:
+
+```bash
+CGO_ENABLED=1 go build -o gomegacheck.so -buildmode=plugin github.com/gardener/gardener/hack/tools/gomegacheck/plugin
+```
+
+> ⚠️ Both the `golangci-lint` binary and the `gomegacheck` plugin have to be built with `CGO_ENABLED=1` for the plugin mechanism to work. See [golangci/golangci-lint#1276](https://github.com/golangci/golangci-lint/issues/1276#issuecomment-665903858) for more details.
+> This means, you can't use released binaries from GitHub or Homebrew for example, but have to build the binary yourself.
+
+Load the plugin by adding the following to your `.golangci.yaml` configuration file:
+
+```yaml
+linters-settings:
+  custom:
+    gomegacheck:
+      path: hack/tools/bin/gomegacheck.so
+      description: Check test assertions using gomega
+      original-url: github.com/gardener/gardener/hack/tools/gomegacheck
+```
+
+> ℹ️ In order for the plugin mechanism to work, all versions of plugin dependencies that overlap with `golangci-lint` must be set to the same version. You can see the versions by running `go version -m golangci-lint`.
+
+Now, `gomegacheck` is executed along with all other linters:
+
+```bash
+golangci-lint run ./...
+```
+
+This repository is configured to run `gomegacheck` as a `golangci-lint` plugin along with all other linters on:
+
+```bash
+make check
+```

--- a/hack/tools/gomegacheck/go.mod
+++ b/hack/tools/gomegacheck/go.mod
@@ -1,0 +1,15 @@
+module github.com/gardener/gardener/hack/tools/gomegacheck
+
+go 1.18
+
+// This is a separate go module to decouple the gardener codebase and production binaries from dependencies that are
+// only needed to build the gomegacheck tool
+// this has to be kept in sync with the used golangci-lint version
+// use go version -m golanci-lint to detect the dependency versions
+require golang.org/x/tools v0.1.10
+
+require (
+	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 // indirect
+	golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+)

--- a/hack/tools/gomegacheck/go.sum
+++ b/hack/tools/gomegacheck/go.sum
@@ -1,0 +1,8 @@
+golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 h1:kQgndtyPBW/JIYERgdxfwMYh3AVStj88WQTlNDi2a+o=
+golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3/go.mod h1:3p9vT2HGsQu2K1YbXdKPJLVgG5VJdoTa1poYQBtP1AY=
+golang.org/x/sys v0.0.0-20211019181941-9d821ace8654 h1:id054HUawV2/6IGm2IV8KZQjqtwAOo2CYlOToYqa0d0=
+golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/tools v0.1.10 h1:QjFRCZxdOhBJ/UNgnBZLbNV13DlbnK0quyivTnXJM20=
+golang.org/x/tools v0.1.10/go.mod h1:Uh6Zz+xoGYZom868N8YTex3t7RhtHDBrE8Gzo9bV56E=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
+golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/hack/tools/gomegacheck/main.go
+++ b/hack/tools/gomegacheck/main.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"golang.org/x/tools/go/analysis/singlechecker"
+
+	"github.com/gardener/gardener/hack/tools/gomegacheck/pkg/gomegacheck"
+)
+
+func main() {
+	// make a callable binary with a single check out of Analyzer
+	singlechecker.Main(gomegacheck.Analyzer)
+}

--- a/hack/tools/gomegacheck/pkg/gomegacheck/gomegacheck.go
+++ b/hack/tools/gomegacheck/pkg/gomegacheck/gomegacheck.go
@@ -1,0 +1,212 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gomegacheck
+
+import (
+	"fmt"
+	"go/ast"
+	"go/types"
+	"strings"
+
+	"golang.org/x/tools/go/analysis"
+	"golang.org/x/tools/go/analysis/passes/inspect"
+	"golang.org/x/tools/go/ast/inspector"
+	"golang.org/x/tools/go/types/typeutil"
+)
+
+// Analyzer is the gomegacheck analyzer.
+var Analyzer = &analysis.Analyzer{
+	Name:     "gomegacheck",
+	Doc:      "check test assertions using gomega",
+	Run:      run,
+	Requires: []*analysis.Analyzer{inspect.Analyzer},
+}
+
+var (
+	assertionCalls = []string{
+		"Should",
+		"ShouldNot",
+		"To",
+		"ToNot",
+		"NotTo",
+	}
+	asyncAssertionCalls = []string{
+		"Should",
+		"ShouldNot",
+	}
+	expectedAssertionCalls map[string]struct{}
+)
+
+func init() {
+	expectedAssertionCalls = make(map[string]struct{}, len(assertionCalls))
+	for _, a := range assertionCalls {
+		expectedAssertionCalls[a] = struct{}{}
+	}
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	// collect all dependencies of the inspected package by traversing the package import tree
+	// then find the gomega package
+	gomegaPkg := findPackage(pass, "github.com/onsi/gomega")
+	if gomegaPkg == nil {
+		// github.com/onsi/gomega not imported, there are no assertions to check
+		return nil, nil
+	}
+	typesPkg := findPackage(pass, "github.com/onsi/gomega/types")
+	if typesPkg == nil {
+		return nil, fmt.Errorf("gomega imported but not gomega/types, this should not happen")
+	}
+
+	// find the gomega assertion types in order to identify assertions
+	assertionTypes, err := findGomegaAssertionTypes(gomegaPkg)
+	if err != nil {
+		return nil, err
+	}
+
+	// find the gomega matcher type in order to identify matchers
+	matcherType, err := findType(typesPkg, "GomegaMatcher")
+	if err != nil {
+		return nil, err
+	}
+
+	// get a pre-filled *inspector.Inspector, that we requested in Analyzer.Requires
+	insp := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+
+	// filter AST nodes for call expressions (we are only interested in function calls to logr.Logger instances)
+	nodeFilter := []ast.Node{
+		(*ast.CallExpr)(nil),
+		(*ast.ReturnStmt)(nil),
+	}
+
+	for _, assertionType := range assertionTypes {
+		insp.Nodes(nodeFilter, func(node ast.Node, push bool) bool {
+			if !push {
+				return false
+			}
+
+			switch e := node.(type) {
+			case *ast.CallExpr:
+				return checkCallExpr(pass, e, assertionType, matcherType)
+			case *ast.ReturnStmt:
+				// returning an assertion should be fine generally (e.g. helper funcs)
+				// don't traverse further down
+				return false
+			}
+			return true
+		})
+	}
+
+	return nil, nil
+}
+
+func findPackage(pass *analysis.Pass, name string) *types.Package {
+	for _, pkg := range typeutil.Dependencies(pass.Pkg) {
+		if pkg.Path() == name {
+			return pkg
+		}
+	}
+	return nil
+}
+
+func findGomegaAssertionTypes(pkg *types.Package) ([]*types.Named, error) {
+	assertionType, err := findType(pkg, "Assertion")
+	if err != nil {
+		return nil, err
+	}
+	asyncAssertionType, err := findType(pkg, "AsyncAssertion")
+	if err != nil {
+		return nil, err
+	}
+	return []*types.Named{assertionType, asyncAssertionType}, nil
+}
+
+func findType(pkg *types.Package, name string) (*types.Named, error) {
+	obj := pkg.Scope().Lookup(name)
+	if obj == nil {
+		return nil, fmt.Errorf("couldn't find %s.%s type", pkg.Name(), name)
+	}
+	typ, ok := obj.Type().(*types.Named)
+	if !ok {
+		return nil, fmt.Errorf("expected *types.Named, got %T", obj.Type())
+	}
+	return typ, nil
+}
+
+func checkCallExpr(pass *analysis.Pass, callExpr *ast.CallExpr, assertionType *types.Named, matcherType types.Type) bool {
+	var assertionExpr ast.Expr
+
+	if isAssertion(pass, callExpr, assertionType) {
+		assertionExpr = callExpr
+	} else if recv, sel, ok := isCallToAssertion(pass, callExpr, assertionType); ok {
+		if _, found := expectedAssertionCalls[sel]; found {
+			checkCallToAssertion(pass, callExpr, matcherType)
+
+			// this assertion is correctly handled, don't traverse further down
+			return false
+		}
+
+		// this is a call to an assertion but not to one of the expected methods
+		assertionExpr = recv
+	} else {
+		// this call does not return an assertion and is not a call to an assertion itself,
+		// traverse further down
+		return true
+	}
+
+	// if we reach here, there was no call to Should and friends up the AST
+	missingCalls := assertionCalls
+	typ := assertionType.Obj().Name()
+	if typ == "AsyncAssertion" {
+		missingCalls = asyncAssertionCalls
+	}
+
+	pass.Reportf(assertionExpr.End(), "gomega.%s is missing a call to one of %s", typ, strings.Join(missingCalls, ", "))
+	return false
+}
+
+func checkCallToAssertion(pass *analysis.Pass, callExpr *ast.CallExpr, matcherType types.Type) {
+	for i, arg := range callExpr.Args {
+		if i == 0 {
+			continue
+		}
+
+		typesAndInfo, ok := pass.TypesInfo.Types[arg]
+		if !ok {
+			continue
+		}
+
+		if types.AssignableTo(typesAndInfo.Type, matcherType) {
+			pass.ReportRangef(arg, "GomegaMatcher passed to optionalDescription param, you can only pass one matcher to each assertion")
+		}
+	}
+}
+
+func isCallToAssertion(pass *analysis.Pass, callExpr *ast.CallExpr, assertionType types.Type) (ast.Expr, string, bool) {
+	selExpr, ok := callExpr.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return nil, "", false
+	}
+
+	return selExpr.X, selExpr.Sel.Name, isAssertion(pass, selExpr.X, assertionType)
+}
+
+func isAssertion(pass *analysis.Pass, expr ast.Expr, assertionType types.Type) bool {
+	typeAndInfo, ok := pass.TypesInfo.Types[expr]
+	if !ok {
+		return false
+	}
+
+	return types.AssignableTo(typeAndInfo.Type, assertionType)
+}

--- a/hack/tools/gomegacheck/pkg/gomegacheck/gomegacheck_test.go
+++ b/hack/tools/gomegacheck/pkg/gomegacheck/gomegacheck_test.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gomegacheck_test
+
+import (
+	"testing"
+
+	"golang.org/x/tools/go/analysis/analysistest"
+
+	. "github.com/gardener/gardener/hack/tools/gomegacheck/pkg/gomegacheck"
+)
+
+func TestGomegacheck(t *testing.T) {
+	for _, test := range []string{
+		"use-gomega",
+		"no-gomega",
+	} {
+		t.Run(test, func(t *testing.T) {
+			analysistest.Run(t, analysistest.TestData(), Analyzer, test)
+		})
+	}
+}

--- a/hack/tools/gomegacheck/pkg/gomegacheck/testdata/src/README.md
+++ b/hack/tools/gomegacheck/pkg/gomegacheck/testdata/src/README.md
@@ -1,0 +1,12 @@
+# gomegacheck testdata
+
+This directory contains go source files for testing the `gomegacheck` tool using [golang.org/x/tools/go/analysis/analysistest](https://pkg.go.dev/golang.org/x/tools/go/analysis/analysistest).
+
+Parts of the following paths are symlinks to the respective `vendor` files:
+
+```
+./github.com/onsi/gomega
+```
+
+This is done because `analysistest` expects test file dependencies to be placed in `testdata/src` as well under their package import paths.
+Symlinks are used in order to test the `gomegacheck` tool against the currently used dependency versions of the main module. This prevents inconsistencies between the tool test files and the actually linted source files.

--- a/hack/tools/gomegacheck/pkg/gomegacheck/testdata/src/github.com/onsi/gomega/gomega_dsl.go
+++ b/hack/tools/gomegacheck/pkg/gomegacheck/testdata/src/github.com/onsi/gomega/gomega_dsl.go
@@ -1,0 +1,1 @@
+../../../../../../../../../../vendor/github.com/onsi/gomega/gomega_dsl.go

--- a/hack/tools/gomegacheck/pkg/gomegacheck/testdata/src/github.com/onsi/gomega/internal
+++ b/hack/tools/gomegacheck/pkg/gomegacheck/testdata/src/github.com/onsi/gomega/internal
@@ -1,0 +1,1 @@
+../../../../../../../../../../vendor/github.com/onsi/gomega/internal

--- a/hack/tools/gomegacheck/pkg/gomegacheck/testdata/src/github.com/onsi/gomega/types
+++ b/hack/tools/gomegacheck/pkg/gomegacheck/testdata/src/github.com/onsi/gomega/types
@@ -1,0 +1,1 @@
+../../../../../../../../../../vendor/github.com/onsi/gomega/types

--- a/hack/tools/gomegacheck/pkg/gomegacheck/testdata/src/no-gomega/no_gomega_test.go
+++ b/hack/tools/gomegacheck/pkg/gomegacheck/testdata/src/no-gomega/no_gomega_test.go
@@ -1,0 +1,26 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This is a test file for executing unit tests for gomegacheck using golang.org/x/tools/go/analysis/analysistest.
+// This package doesn't import gomega, so there is no need to check any test assertions. There should be no errors.
+
+package no_gomega_test
+
+import (
+	"testing"
+)
+
+func TestFoo(t *testing.T) {
+	t.Log("this test does not use gomega")
+}

--- a/hack/tools/gomegacheck/pkg/gomegacheck/testdata/src/use-gomega/use_gomega_test.go
+++ b/hack/tools/gomegacheck/pkg/gomegacheck/testdata/src/use-gomega/use_gomega_test.go
@@ -1,0 +1,203 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This is a test file for executing unit tests for gomegacheck using golang.org/x/tools/go/analysis/analysistest.
+
+package use_gomega_test
+
+import (
+	"time"
+
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+)
+
+func expect() {
+	gomega.Expect("foo").To(Match())
+	gomega.Expect("foo").Should(Match())
+	gomega.Expect("foo").NotTo(Match())
+	gomega.Expect("foo").ToNot(Match())
+	gomega.Expect("foo").ShouldNot(Match())
+	gomega.Expect("foo").WithOffset(1).To(Match())
+	gomega.Expect("foo").WithOffset(1).Should(Match())
+	gomega.Expect("foo").WithOffset(1).NotTo(Match())
+	gomega.Expect("foo").WithOffset(1).ToNot(Match())
+	gomega.Expect("foo").WithOffset(1).ShouldNot(Match())
+
+	gomega.Expect("foo")               // want `gomega.Assertion is missing a call to one of Should, ShouldNot, To, ToNot, NotTo`
+	gomega.Expect("foo").WithOffset(1) // want `gomega.Assertion is missing a call to one of Should, ShouldNot, To, ToNot, NotTo`
+
+	gomega.Expect("foo").To(Match(), Match())               // want `GomegaMatcher passed to optionalDescription param, you can only pass one matcher to each assertion`
+	gomega.Expect("foo").Should(Match(), Match())           // want `GomegaMatcher passed to optionalDescription param, you can only pass one matcher to each assertion`
+	gomega.Expect("foo").NotTo(Match(), Match())            // want `GomegaMatcher passed to optionalDescription param, you can only pass one matcher to each assertion`
+	gomega.Expect("foo").ToNot(Match(), Match())            // want `GomegaMatcher passed to optionalDescription param, you can only pass one matcher to each assertion`
+	gomega.Expect("foo").ShouldNot(Match(), Match())        // want `GomegaMatcher passed to optionalDescription param, you can only pass one matcher to each assertion`
+	gomega.Expect("foo").WithOffset(1).To(Match(), Match()) // want `GomegaMatcher passed to optionalDescription param, you can only pass one matcher to each assertion`
+}
+
+func expectWithOffset() {
+	gomega.ExpectWithOffset(1, "foo").To(Match())
+	gomega.ExpectWithOffset(1, "foo").Should(Match())
+	gomega.ExpectWithOffset(1, "foo").NotTo(Match())
+	gomega.ExpectWithOffset(1, "foo").ToNot(Match())
+	gomega.ExpectWithOffset(1, "foo").ShouldNot(Match())
+	gomega.ExpectWithOffset(1, "foo").WithOffset(1).To(Match())
+	gomega.ExpectWithOffset(1, "foo").WithOffset(1).Should(Match())
+	gomega.ExpectWithOffset(1, "foo").WithOffset(1).NotTo(Match())
+	gomega.ExpectWithOffset(1, "foo").WithOffset(1).ToNot(Match())
+	gomega.ExpectWithOffset(1, "foo").WithOffset(1).ShouldNot(Match())
+
+	gomega.ExpectWithOffset(1, "foo")               // want `gomega.Assertion is missing a call to one of Should, ShouldNot, To, ToNot, NotTo`
+	gomega.ExpectWithOffset(1, "foo").WithOffset(1) // want `gomega.Assertion is missing a call to one of Should, ShouldNot, To, ToNot, NotTo`
+}
+
+func omega() {
+	gomega.Ω("foo").To(Match())
+	gomega.Ω("foo").Should(Match())
+	gomega.Ω("foo").NotTo(Match())
+	gomega.Ω("foo").ToNot(Match())
+	gomega.Ω("foo").ShouldNot(Match())
+	gomega.Ω("foo").WithOffset(1).To(Match())
+	gomega.Ω("foo").WithOffset(1).Should(Match())
+	gomega.Ω("foo").WithOffset(1).NotTo(Match())
+	gomega.Ω("foo").WithOffset(1).ToNot(Match())
+	gomega.Ω("foo").WithOffset(1).ShouldNot(Match())
+
+	gomega.Ω("foo")               // want `gomega.Assertion is missing a call to one of Should, ShouldNot, To, ToNot, NotTo`
+	gomega.Ω("foo").WithOffset(1) // want `gomega.Assertion is missing a call to one of Should, ShouldNot, To, ToNot, NotTo`
+}
+
+func eventually() {
+	c := make(chan bool)
+
+	gomega.Eventually(c).Should(Match())
+	gomega.Eventually(c).ShouldNot(Match())
+	gomega.Eventually(c).WithOffset(1).Should(Match())
+	gomega.Eventually(c).WithOffset(1).ShouldNot(Match())
+	gomega.Eventually(c).WithTimeout(time.Second).Should(Match())
+	gomega.Eventually(c).WithTimeout(time.Second).ShouldNot(Match())
+	gomega.Eventually(c).WithPolling(time.Second).Should(Match())
+	gomega.Eventually(c).WithPolling(time.Second).ShouldNot(Match())
+
+	gomega.Eventually(c)                          // want `gomega.AsyncAssertion is missing a call to one of Should, ShouldNot`
+	gomega.Eventually(c).WithOffset(1)            // want `gomega.AsyncAssertion is missing a call to one of Should, ShouldNot`
+	gomega.Eventually(c).WithTimeout(time.Second) // want `gomega.AsyncAssertion is missing a call to one of Should, ShouldNot`
+	gomega.Eventually(c).WithPolling(time.Second) // want `gomega.AsyncAssertion is missing a call to one of Should, ShouldNot`
+}
+
+func consistently() {
+	c := make(chan bool)
+
+	gomega.Consistently(c).Should(Match())
+	gomega.Consistently(c).ShouldNot(Match())
+	gomega.Consistently(c).WithOffset(1).Should(Match())
+	gomega.Consistently(c).WithOffset(1).ShouldNot(Match())
+	gomega.Consistently(c).WithTimeout(time.Second).Should(Match())
+	gomega.Consistently(c).WithTimeout(time.Second).ShouldNot(Match())
+	gomega.Consistently(c).WithPolling(time.Second).Should(Match())
+	gomega.Consistently(c).WithPolling(time.Second).ShouldNot(Match())
+
+	gomega.Consistently(c)                          // want `gomega.AsyncAssertion is missing a call to one of Should, ShouldNot`
+	gomega.Consistently(c).WithOffset(1)            // want `gomega.AsyncAssertion is missing a call to one of Should, ShouldNot`
+	gomega.Consistently(c).WithTimeout(time.Second) // want `gomega.AsyncAssertion is missing a call to one of Should, ShouldNot`
+	gomega.Consistently(c).WithPolling(time.Second) // want `gomega.AsyncAssertion is missing a call to one of Should, ShouldNot`
+}
+
+func assertionInAsync() {
+	gomega.Eventually(func(g gomega.Gomega) {
+		g.Expect("foo").To(Match())
+	}).Should(Match())
+	gomega.Eventually(func(g gomega.Gomega) {
+		g.Expect("foo").Should(Match())
+	}).Should(Match())
+	gomega.Eventually(func(g gomega.Gomega) {
+		g.Expect("foo").NotTo(Match())
+	}).Should(Match())
+	gomega.Eventually(func(g gomega.Gomega) {
+		g.Expect("foo").ToNot(Match())
+	}).Should(Match())
+	gomega.Eventually(func(g gomega.Gomega) {
+		g.Expect("foo").ShouldNot(Match())
+	}).Should(Match())
+	gomega.Eventually(func(g gomega.Gomega) {
+		g.Expect("foo").WithOffset(1).To(Match())
+	}).Should(Match())
+	gomega.Eventually(func(g gomega.Gomega) {
+		g.Expect("foo").WithOffset(1).Should(Match())
+	}).Should(Match())
+	gomega.Eventually(func(g gomega.Gomega) {
+		g.Expect("foo").WithOffset(1).NotTo(Match())
+	}).Should(Match())
+	gomega.Eventually(func(g gomega.Gomega) {
+		g.Expect("foo").WithOffset(1).ToNot(Match())
+	}).Should(Match())
+	gomega.Eventually(func(g gomega.Gomega) {
+		g.Expect("foo").WithOffset(1).ShouldNot(Match())
+	}).Should(Match())
+
+	gomega.Eventually(func(g gomega.Gomega) {
+		g.Expect("foo") // want `gomega.Assertion is missing a call to one of Should, ShouldNot, To, ToNot, NotTo`
+	}).Should(Match())
+	gomega.Eventually(func(g gomega.Gomega) {
+		g.Expect("foo").WithOffset(1) // want `gomega.Assertion is missing a call to one of Should, ShouldNot, To, ToNot, NotTo`
+	}).Should(Match())
+}
+
+// returning Assertion/AsyncAssertion should not yield an error.
+
+func helper(actual interface{}) gomega.Assertion {
+	return gomega.Expect(actual).WithOffset(1)
+}
+
+func helperAsync(actual interface{}) gomega.AsyncAssertion {
+	return gomega.Eventually(actual).WithOffset(1)
+}
+
+// calling helpers should however yield an error
+
+func callingHelper() {
+	helper("foo").To(Match())
+	helper("foo").Should(Match())
+	helper("foo").NotTo(Match())
+	helper("foo").ToNot(Match())
+	helper("foo").ShouldNot(Match())
+	helper("foo").WithOffset(1).To(Match())
+	helper("foo").WithOffset(1).Should(Match())
+	helper("foo").WithOffset(1).NotTo(Match())
+	helper("foo").WithOffset(1).ToNot(Match())
+	helper("foo").WithOffset(1).ShouldNot(Match())
+
+	helper("foo")               // want `gomega.Assertion is missing a call to one of Should, ShouldNot, To, ToNot, NotTo`
+	helper("foo").WithOffset(1) // want `gomega.Assertion is missing a call to one of Should, ShouldNot, To, ToNot, NotTo`
+}
+
+func callingHelperAsync() {
+	helperAsync("foo").Should(Match())
+	helperAsync("foo").ShouldNot(Match())
+	helperAsync("foo").WithOffset(1).Should(Match())
+	helperAsync("foo").WithOffset(1).ShouldNot(Match())
+
+	helperAsync("foo")               // want `gomega.AsyncAssertion is missing a call to one of Should, ShouldNot`
+	helperAsync("foo").WithOffset(1) // want `gomega.AsyncAssertion is missing a call to one of Should, ShouldNot`
+}
+
+func Match() types.GomegaMatcher {
+	return dummyMatcher{}
+}
+
+type dummyMatcher struct{}
+
+func (m dummyMatcher) Match(actual interface{}) (success bool, err error)        { return true, nil }
+func (m dummyMatcher) FailureMessage(actual interface{}) (message string)        { return "fail" }
+func (m dummyMatcher) NegatedFailureMessage(actual interface{}) (message string) { return "whatever" }

--- a/hack/tools/gomegacheck/plugin/golangci_lint.go
+++ b/hack/tools/gomegacheck/plugin/golangci_lint.go
@@ -1,0 +1,33 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"github.com/gardener/gardener/hack/tools/gomegacheck/pkg/gomegacheck"
+
+	"golang.org/x/tools/go/analysis"
+)
+
+// AnalyzerPlugin is the golangci-lint plugin.
+var AnalyzerPlugin analyzerPlugin //nolint:deadcode,unused
+
+// analyzerPlugin implements the golangci-lint AnalyzerPlugin interface.
+// see https://golangci-lint.run/contributing/new-linters/#how-to-add-a-private-linter-to-golangci-lint
+type analyzerPlugin struct{}
+
+// GetAnalyzers returns the gomegacheck analyzer.
+func (*analyzerPlugin) GetAnalyzers() []*analysis.Analyzer {
+	return []*analysis.Analyzer{gomegacheck.Analyzer}
+}

--- a/pkg/controllermanager/controller/exposureclass/reconciler_test.go
+++ b/pkg/controllermanager/controller/exposureclass/reconciler_test.go
@@ -82,7 +82,7 @@ var _ = Describe("Controller", func() {
 
 		It("should ensure the finalizer", func() {
 			result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: exposureClassName}})
-			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(exposureClass), exposureClass))
+			Expect(fakeClient.Get(ctx, client.ObjectKeyFromObject(exposureClass), exposureClass)).To(Succeed())
 			Expect(result).To(Equal(reconcile.Result{}))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(exposureClass.GetFinalizers()).Should(ConsistOf(finalizerName))

--- a/pkg/gardenlet/controller/extensions/shootstate_control_test.go
+++ b/pkg/gardenlet/controller/extensions/shootstate_control_test.go
@@ -114,7 +114,7 @@ var _ = Describe("ShootState Control", func() {
 		}
 
 		secretObj = &corev1.Secret{}
-		Expect(json.Unmarshal(secretDataJSON, secretObj))
+		Expect(json.Unmarshal(secretDataJSON, secretObj)).To(Succeed())
 
 		stateResources = []gardencorev1alpha1.ResourceData{
 			{

--- a/pkg/gardenlet/controller/seed/seed_extension_control_test.go
+++ b/pkg/gardenlet/controller/seed/seed_extension_control_test.go
@@ -152,7 +152,7 @@ var _ = Describe("ExtensionCheckReconciler", func() {
 				LastUpdateTime:     metav1.NewTime(now.Add(-time.Minute)),
 			}
 			seed.Status.Conditions = []gardencorev1beta1.Condition{existingCondition}
-			Expect(c.Status().Update(ctx, seed))
+			Expect(c.Status().Update(ctx, seed)).To(Succeed())
 
 			Expect(reconciler.Reconcile(ctx, request)).To(Equal(reconcile.Result{}))
 		})

--- a/pkg/operation/botanist/component/coredns/coredns_test.go
+++ b/pkg/operation/botanist/component/coredns/coredns_test.go
@@ -816,7 +816,7 @@ status: {}
 							},
 						},
 					},
-				}))
+				})).To(Succeed())
 
 				Expect(component.Wait(ctx)).To(MatchError(ContainSubstring("is not healthy")))
 			})
@@ -843,7 +843,7 @@ status: {}
 							},
 						},
 					},
-				}))
+				})).To(Succeed())
 
 				Expect(component.Wait(ctx)).To(Succeed())
 			})

--- a/pkg/operation/botanist/component/dependencywatchdog/bootstrap_test.go
+++ b/pkg/operation/botanist/component/dependencywatchdog/bootstrap_test.go
@@ -521,7 +521,7 @@ status: {}
 							},
 						},
 					},
-				}))
+				})).To(Succeed())
 
 				Expect(dwd.Wait(ctx)).To(MatchError(ContainSubstring("is not healthy")))
 			})
@@ -548,7 +548,7 @@ status: {}
 							},
 						},
 					},
-				}))
+				})).To(Succeed())
 
 				Expect(dwd.Wait(ctx)).To(Succeed())
 			})

--- a/pkg/operation/botanist/component/hvpa/hvpa_test.go
+++ b/pkg/operation/botanist/component/hvpa/hvpa_test.go
@@ -363,7 +363,7 @@ var _ = Describe("HVPA", func() {
 							},
 						},
 					},
-				}))
+				})).To(Succeed())
 
 				Expect(component.Wait(ctx)).To(MatchError(ContainSubstring("is not healthy")))
 			})
@@ -390,7 +390,7 @@ var _ = Describe("HVPA", func() {
 							},
 						},
 					},
-				}))
+				})).To(Succeed())
 
 				Expect(component.Wait(ctx)).To(Succeed())
 			})

--- a/pkg/operation/botanist/component/istio/istiod_test.go
+++ b/pkg/operation/botanist/component/istio/istiod_test.go
@@ -2162,7 +2162,7 @@ spec:
 							},
 						},
 					},
-				}))
+				})).To(Succeed())
 
 				Expect(istiod.Wait(ctx)).To(MatchError(ContainSubstring("is not healthy")))
 			})
@@ -2189,7 +2189,7 @@ spec:
 							},
 						},
 					},
-				}))
+				})).To(Succeed())
 
 				Expect(istiod.Wait(ctx)).To(Succeed())
 			})

--- a/pkg/operation/botanist/component/kubeproxy/kube_proxy_test.go
+++ b/pkg/operation/botanist/component/kubeproxy/kube_proxy_test.go
@@ -1000,7 +1000,7 @@ status: {}
 							},
 						},
 					},
-				}))
+				})).To(Succeed())
 
 				for _, pool := range values.WorkerPools {
 					By(pool.Name)
@@ -1024,7 +1024,7 @@ status: {}
 								},
 							},
 						},
-					}))
+					})).To(Succeed())
 				}
 
 				Expect(component.Wait(ctx)).To(MatchError(ContainSubstring("is not healthy")))
@@ -1052,7 +1052,7 @@ status: {}
 							},
 						},
 					},
-				}))
+				})).To(Succeed())
 
 				for _, pool := range values.WorkerPools {
 					By(pool.Name)
@@ -1076,7 +1076,7 @@ status: {}
 								},
 							},
 						},
-					}))
+					})).To(Succeed())
 				}
 
 				Expect(component.Wait(ctx)).To(MatchError(ContainSubstring("is not healthy")))
@@ -1104,7 +1104,7 @@ status: {}
 							},
 						},
 					},
-				}))
+				})).To(Succeed())
 
 				for _, pool := range values.WorkerPools {
 					By(pool.Name)
@@ -1128,7 +1128,7 @@ status: {}
 								},
 							},
 						},
-					}))
+					})).To(Succeed())
 				}
 
 				Expect(component.Wait(ctx)).To(Succeed())
@@ -1156,7 +1156,7 @@ status: {}
 							},
 						},
 					},
-				}))
+				})).To(Succeed())
 
 				undesiredPool := WorkerPool{Name: "foo", KubernetesVersion: "bar"}
 				Expect(c.Create(ctx, &resourcesv1alpha1.ManagedResource{
@@ -1178,7 +1178,7 @@ status: {}
 							},
 						},
 					},
-				}))
+				})).To(Succeed())
 
 				for _, pool := range values.WorkerPools {
 					By(pool.Name)
@@ -1202,7 +1202,7 @@ status: {}
 								},
 							},
 						},
-					}))
+					})).To(Succeed())
 				}
 
 				Expect(component.Wait(ctx)).To(Succeed())

--- a/pkg/operation/botanist/component/kubestatemetrics/kube_state_metrics_test.go
+++ b/pkg/operation/botanist/component/kubestatemetrics/kube_state_metrics_test.go
@@ -676,7 +676,7 @@ var _ = Describe("KubeStateMetrics", func() {
 								},
 							},
 						},
-					}))
+					})).To(Succeed())
 
 					Expect(ksm.Wait(ctx)).To(MatchError(ContainSubstring("is not healthy")))
 				})
@@ -703,7 +703,7 @@ var _ = Describe("KubeStateMetrics", func() {
 								},
 							},
 						},
-					}))
+					})).To(Succeed())
 
 					Expect(ksm.Wait(ctx)).To(Succeed())
 				})

--- a/pkg/operation/botanist/component/namespaces/namespaces_test.go
+++ b/pkg/operation/botanist/component/namespaces/namespaces_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	"github.com/gardener/gardener/pkg/operation/botanist/component"
@@ -29,7 +30,6 @@ import (
 	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 
-	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -223,7 +223,7 @@ status: {}
 							},
 						},
 					},
-				}))
+				})).To(Succeed())
 
 				Expect(namespaces.Wait(ctx)).To(MatchError(ContainSubstring("is not healthy")))
 			})
@@ -250,7 +250,7 @@ status: {}
 							},
 						},
 					},
-				}))
+				})).To(Succeed())
 
 				Expect(namespaces.Wait(ctx)).To(Succeed())
 			})

--- a/pkg/operation/botanist/component/nginxingress/nginxingress_test.go
+++ b/pkg/operation/botanist/component/nginxingress/nginxingress_test.go
@@ -697,7 +697,7 @@ status: {}
 							},
 						},
 					},
-				}))
+				})).To(Succeed())
 				Expect(nginxIngress.Wait(ctx)).To(MatchError(ContainSubstring("is not healthy")))
 			})
 
@@ -723,7 +723,7 @@ status: {}
 							},
 						},
 					},
-				}))
+				})).To(Succeed())
 				Expect(nginxIngress.Wait(ctx)).To(Succeed())
 			})
 		})

--- a/pkg/operation/botanist/component/nodelocaldns/nodelocaldns_test.go
+++ b/pkg/operation/botanist/component/nodelocaldns/nodelocaldns_test.go
@@ -982,7 +982,7 @@ ip6.arpa:53 {
 							},
 						},
 					},
-				}))
+				})).To(Succeed())
 
 				Expect(component.Wait(ctx)).To(MatchError(ContainSubstring("is not healthy")))
 			})
@@ -1009,7 +1009,7 @@ ip6.arpa:53 {
 							},
 						},
 					},
-				}))
+				})).To(Succeed())
 
 				Expect(component.Wait(ctx)).To(Succeed())
 			})

--- a/pkg/operation/botanist/component/nodeproblemdetector/node_problem_detector_test.go
+++ b/pkg/operation/botanist/component/nodeproblemdetector/node_problem_detector_test.go
@@ -470,7 +470,7 @@ status: {}
 							},
 						},
 					},
-				}))
+				})).To(Succeed())
 
 				Expect(component.Wait(ctx)).To(MatchError(ContainSubstring("is not healthy")))
 			})
@@ -497,7 +497,7 @@ status: {}
 							},
 						},
 					},
-				}))
+				})).To(Succeed())
 
 				Expect(component.Wait(ctx)).To(Succeed())
 			})

--- a/pkg/operation/botanist/component/seedsystem/seedsystem_test.go
+++ b/pkg/operation/botanist/component/seedsystem/seedsystem_test.go
@@ -210,7 +210,7 @@ status: {}
 							},
 						},
 					},
-				}))
+				})).To(Succeed())
 
 				Expect(component.Wait(ctx)).To(MatchError(ContainSubstring("is not healthy")))
 			})
@@ -237,7 +237,7 @@ status: {}
 							},
 						},
 					},
-				}))
+				})).To(Succeed())
 
 				Expect(component.Wait(ctx)).To(Succeed())
 			})

--- a/pkg/operation/botanist/component/shootsystem/shootsystem_test.go
+++ b/pkg/operation/botanist/component/shootsystem/shootsystem_test.go
@@ -372,7 +372,7 @@ metadata:
 							},
 						},
 					},
-				}))
+				})).To(Succeed())
 
 				Expect(component.Wait(ctx)).To(MatchError(ContainSubstring("is not healthy")))
 			})
@@ -399,7 +399,7 @@ metadata:
 							},
 						},
 					},
-				}))
+				})).To(Succeed())
 
 				Expect(component.Wait(ctx)).To(Succeed())
 			})

--- a/pkg/operation/botanist/component/vpa/vpa_test.go
+++ b/pkg/operation/botanist/component/vpa/vpa_test.go
@@ -2006,7 +2006,7 @@ var _ = Describe("VPA", func() {
 								},
 							},
 						},
-					}))
+					})).To(Succeed())
 
 					Expect(vpa.Wait(ctx)).To(MatchError(ContainSubstring("is not healthy")))
 				})
@@ -2033,7 +2033,7 @@ var _ = Describe("VPA", func() {
 								},
 							},
 						},
-					}))
+					})).To(Succeed())
 
 					Expect(vpa.Wait(ctx)).To(Succeed())
 				})

--- a/pkg/operation/botanist/component/vpnshoot/vpnshoot_test.go
+++ b/pkg/operation/botanist/component/vpnshoot/vpnshoot_test.go
@@ -775,7 +775,7 @@ status:
 							},
 						},
 					},
-				}))
+				})).To(Succeed())
 				Expect(vpnShoot.Wait(ctx)).To(MatchError(ContainSubstring("is not healthy")))
 			})
 
@@ -801,7 +801,7 @@ status:
 							},
 						},
 					},
-				}))
+				})).To(Succeed())
 				Expect(vpnShoot.Wait(ctx)).To(Succeed())
 			})
 		})

--- a/pkg/operation/botanist/secrets_test.go
+++ b/pkg/operation/botanist/secrets_test.go
@@ -351,7 +351,7 @@ var _ = Describe("Secrets", func() {
 				Expect(sa3.Secrets).To(ConsistOf(corev1.ObjectReference{Name: "sa3secret1"}))
 
 				sa1Secret := &corev1.Secret{}
-				Expect(fakeShootClient.Get(ctx, kutil.Key(sa1.Namespace, "sa1-token"+suffix), sa1Secret))
+				Expect(fakeShootClient.Get(ctx, kutil.Key(sa1.Namespace, "sa1-token"+suffix), sa1Secret)).To(Succeed())
 				verifyCreatedSATokenSecret(sa1Secret, sa1.Name)
 			})
 		})

--- a/pkg/utils/kubernetes/client/client_test.go
+++ b/pkg/utils/kubernetes/client/client_test.go
@@ -669,7 +669,7 @@ var _ = Describe("Cleaner", func() {
 					ensurer.EXPECT().EnsureGone(ctx, c, &cm1),
 				)
 
-				Expect(o.CleanAndEnsureGone(ctx, c, &cm1))
+				Expect(o.CleanAndEnsureGone(ctx, c, &cm1)).To(Succeed())
 			})
 		})
 	})

--- a/test/integration/resourcemanager/health/health_test.go
+++ b/test/integration/resourcemanager/health/health_test.go
@@ -74,10 +74,10 @@ var _ = Describe("Health controller tests", func() {
 			Consistently(func(g Gomega) []gardencorev1beta1.Condition {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 				return managedResource.Status.Conditions
-			}).ShouldNot(
-				containCondition(ofType(resourcesv1alpha1.ResourcesHealthy)),
-				containCondition(ofType(resourcesv1alpha1.ResourcesProgressing)),
-			)
+			}).Should(And(
+				Not(containCondition(ofType(resourcesv1alpha1.ResourcesHealthy))),
+				Not(containCondition(ofType(resourcesv1alpha1.ResourcesProgressing))),
+			))
 		})
 
 		It("checks ManagedResource again if it is responsible now", func() {
@@ -89,10 +89,10 @@ var _ = Describe("Health controller tests", func() {
 			Eventually(func(g Gomega) []gardencorev1beta1.Condition {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 				return managedResource.Status.Conditions
-			}).Should(
+			}).Should(And(
 				containCondition(ofType(resourcesv1alpha1.ResourcesHealthy), withStatus(gardencorev1beta1.ConditionTrue)),
 				containCondition(ofType(resourcesv1alpha1.ResourcesProgressing), withStatus(gardencorev1beta1.ConditionFalse)),
-			)
+			))
 		})
 	})
 
@@ -112,10 +112,10 @@ var _ = Describe("Health controller tests", func() {
 			Consistently(func(g Gomega) []gardencorev1beta1.Condition {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 				return managedResource.Status.Conditions
-			}).ShouldNot(
-				containCondition(ofType(resourcesv1alpha1.ResourcesHealthy)),
-				containCondition(ofType(resourcesv1alpha1.ResourcesProgressing)),
-			)
+			}).Should(And(
+				Not(containCondition(ofType(resourcesv1alpha1.ResourcesHealthy))),
+				Not(containCondition(ofType(resourcesv1alpha1.ResourcesProgressing))),
+			))
 		})
 
 		It("checks ManagedResource again if it is no longer ignored", func() {
@@ -127,10 +127,10 @@ var _ = Describe("Health controller tests", func() {
 			Eventually(func(g Gomega) []gardencorev1beta1.Condition {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 				return managedResource.Status.Conditions
-			}).Should(
+			}).Should(And(
 				containCondition(ofType(resourcesv1alpha1.ResourcesHealthy), withStatus(gardencorev1beta1.ConditionTrue)),
 				containCondition(ofType(resourcesv1alpha1.ResourcesProgressing), withStatus(gardencorev1beta1.ConditionFalse)),
-			)
+			))
 		})
 	})
 
@@ -139,10 +139,10 @@ var _ = Describe("Health controller tests", func() {
 			Consistently(func(g Gomega) []gardencorev1beta1.Condition {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 				return managedResource.Status.Conditions
-			}).ShouldNot(
-				containCondition(ofType(resourcesv1alpha1.ResourcesHealthy)),
-				containCondition(ofType(resourcesv1alpha1.ResourcesProgressing)),
-			)
+			}).Should(And(
+				Not(containCondition(ofType(resourcesv1alpha1.ResourcesHealthy))),
+				Not(containCondition(ofType(resourcesv1alpha1.ResourcesProgressing))),
+			))
 		})
 
 		It("does not touch ManagedResource if it is still being applied", func() {
@@ -153,10 +153,10 @@ var _ = Describe("Health controller tests", func() {
 			Consistently(func(g Gomega) []gardencorev1beta1.Condition {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 				return managedResource.Status.Conditions
-			}).ShouldNot(
-				containCondition(ofType(resourcesv1alpha1.ResourcesHealthy)),
-				containCondition(ofType(resourcesv1alpha1.ResourcesProgressing)),
-			)
+			}).Should(And(
+				Not(containCondition(ofType(resourcesv1alpha1.ResourcesHealthy))),
+				Not(containCondition(ofType(resourcesv1alpha1.ResourcesProgressing))),
+			))
 		})
 
 		It("does not touch ManagedResource if it failed to be applied", func() {
@@ -167,10 +167,10 @@ var _ = Describe("Health controller tests", func() {
 			Consistently(func(g Gomega) []gardencorev1beta1.Condition {
 				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(managedResource), managedResource)).To(Succeed())
 				return managedResource.Status.Conditions
-			}).ShouldNot(
-				containCondition(ofType(resourcesv1alpha1.ResourcesHealthy)),
-				containCondition(ofType(resourcesv1alpha1.ResourcesProgressing)),
-			)
+			}).Should(And(
+				Not(containCondition(ofType(resourcesv1alpha1.ResourcesHealthy))),
+				Not(containCondition(ofType(resourcesv1alpha1.ResourcesProgressing))),
+			))
 		})
 	})
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity testing
/kind enhancement

**What this PR does / why we need it**:

Add a new linter called `gomegacheck`, that verifies that 
- developers don't forget to call `Should` or similar on `Expect`, `Eventually` and friends
- only a single matcher is passed to `Should` and similar

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/6016
Follow-up after https://github.com/gardener/gardener/pull/6245 and https://github.com/onsi/gomega/issues/561

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
A new `gomegacheck` linter is now executed on `make check`. Find out more in the [docs](https://github.com/gardener/gardener/blob/master/hack/tools/gomegacheck/README.md).
```
