### PR TITLE
Execute workaround for kube-proxy issue only for K8s < 1.25 Shoots

### DIFF
--- a/pkg/operation/botanist/component/kubeproxy/resources/cleanup.sh
+++ b/pkg/operation/botanist/component/kubeproxy/resources/cleanup.sh
@@ -6,10 +6,13 @@ if [ -z "${OLD_KUBE_PROXY_MODE}" ] || [ "${OLD_KUBE_PROXY_MODE}" = "${KUBE_PROXY
   exit 0
 fi
 
-# Workaround kube-proxy bug when switching from ipvs to iptables mode
-if iptables -t filter -L KUBE-NODE-PORT; then
-  echo "KUBE-NODE-PORT chain exists, flushing it..."
-  iptables -t filter -F KUBE-NODE-PORT
+# Workaround kube-proxy bug (https://github.com/kubernetes/kubernetes/issues/109286) when switching from ipvs to iptables mode.
+# The fix (https://github.com/kubernetes/kubernetes/pull/109288) is present in 1.25+.
+if [ "${EXECUTE_WORKAROUND_FOR_K8S_ISSUE_109286}" = "true" ]; then
+  if iptables -t filter -L KUBE-NODE-PORT; then
+    echo "KUBE-NODE-PORT chain exists, flushing it..."
+    iptables -t filter -F KUBE-NODE-PORT
+  fi
 fi
 
 /usr/local/bin/kube-proxy --v=2 --cleanup --config=/var/lib/kube-proxy-config/config.yaml --proxy-mode="${OLD_KUBE_PROXY_MODE}"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:
To fix https://github.com/gardener/gardener/issues/4599 (or https://github.com/kubernetes/kubernetes/issues/109286) we added the following workaround in https://github.com/gardener/gardener/pull/5739. But @ScheererJ also fixed the issue in K8s (kube-proxy >= 1.25) with https://github.com/kubernetes/kubernetes/pull/109288.
Hence, we can stop executing the workaround for K8s >= 1.25 Shoots (worker pools).
This PR aims adds more details about the workaround in the corresponding comment and introduces version check - the motivation for this is to drop the workaround code when one day we drop support for K8s 1.25 Shoots (worker pools).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Workaround for https://issues.k8s.io/109286 is now only executed for < 1.25 Shoots. In K8s 1.25+ the issue is fixed with https://github.com/kubernetes/kubernetes/pull/109288 and we no longer need to execute the workaround.
```
