### PR TITLE
Fix flaky scheduler integration test

### DIFF
--- a/test/integration/controllermanager/bastion/bastion_suite_test.go
+++ b/test/integration/controllermanager/bastion/bastion_suite_test.go
@@ -78,7 +78,7 @@ var _ = BeforeSuite(func() {
 	testEnv = &gardenerenvtest.GardenerTestEnvironment{
 		GardenerAPIServer: &gardenerenvtest.GardenerAPIServer{
 			Args: []string{
-				"--disable-admission-plugins=Bastion,ResourceReferenceManager,ExtensionValidator,ShootBinding,ShootDNS,ShootQuotaValidator,ShootTolerationRestriction,ShootValidator",
+				"--disable-admission-plugins=Bastion,DeletionConfirmation,ResourceReferenceManager,ExtensionValidator,ShootBinding,ShootDNS,ShootQuotaValidator,ShootTolerationRestriction,ShootValidator",
 				"--feature-gates=SeedChange=true",
 			},
 		},

--- a/test/integration/controllermanager/bastion/bastion_test.go
+++ b/test/integration/controllermanager/bastion/bastion_test.go
@@ -22,7 +22,6 @@ import (
 	operationsv1alpha1 "github.com/gardener/gardener/pkg/apis/operations/v1alpha1"
 	bastionstrategy "github.com/gardener/gardener/pkg/registry/operations/bastion"
 	"github.com/gardener/gardener/pkg/utils"
-	"github.com/gardener/gardener/pkg/utils/gardener"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 
@@ -107,7 +106,6 @@ var _ = Describe("Bastion controller tests", func() {
 
 			DeferCleanup(func() {
 				By("Delete Shoot")
-				Expect(client.IgnoreNotFound(gardener.ConfirmDeletion(ctx, testClient, shoot))).To(Succeed())
 				Expect(client.IgnoreNotFound(testClient.Delete(ctx, shoot))).To(Succeed())
 			})
 		}
@@ -150,7 +148,6 @@ var _ = Describe("Bastion controller tests", func() {
 			})
 
 			By("Mark Shoot for deletion")
-			Expect(gardener.ConfirmDeletion(ctx, testClient, shoot)).To(Succeed())
 			Expect(testClient.Delete(ctx, shoot)).To(Succeed())
 		})
 

--- a/test/integration/scheduler/shoot/scheduler_test.go
+++ b/test/integration/scheduler/shoot/scheduler_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/scheduler/apis/config"
 	shootcontroller "github.com/gardener/gardener/pkg/scheduler/controller/shoot"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
 var _ = Describe("Scheduler tests", func() {
@@ -277,6 +278,9 @@ func createShoot(providerType, cloudProfile, region string, dnsDomain *string) *
 	DeferCleanup(func() {
 		By("deleting Shoot")
 		Expect(client.IgnoreNotFound(testClient.Delete(ctx, shoot))).To(Succeed())
+		Eventually(func() error {
+			return testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)
+		}).Should(BeNotFoundError())
 	})
 	return shoot
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
Scheduler integration test was flaking:
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/6458/pull-gardener-integration/1556191533948997632
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/6413/pull-gardener-integration/1552640511913758720
with 
```
Message: "seeds.core.gardener.cloud \"scheduler-test-wxtb5\" is forbidden: cannot delete seed scheduler-test-wxtb5 since it is still used by shoot(s)"
```

This PR adds these changes:
- Wait till the `shoot` gets deleted in the scheduler integration test
- Drop explicit `ConfirmDeletion` call in bastion integration test in favour of disabling `DeletionConfirmation` plugin

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
/cc @timebertt 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
