### PR TITLE
Integrate etcd-druid v0.12

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -30,7 +30,7 @@ images:
 - name: etcd-druid
   sourceRepository: github.com/gardener/etcd-druid
   repository: eu.gcr.io/gardener-project/gardener/etcd-druid
-  tag: "v0.10.0"
+  tag: "v0.12.0"
 - name: dependency-watchdog
   sourceRepository: github.com/gardener/dependency-watchdog
   repository: eu.gcr.io/gardener-project/gardener/dependency-watchdog

--- a/pkg/operation/botanist/component/etcd/bootstrap.go
+++ b/pkg/operation/botanist/component/etcd/bootstrap.go
@@ -319,7 +319,7 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 }
 
 func getDruidDeployCommands(gardenletConf *config.GardenletConfiguration) []string {
-	command := []string{"" + "/bin/etcd-druid"}
+	command := []string{"" + "/etcd-druid"}
 	command = append(command, "--enable-leader-election=true")
 	command = append(command, "--ignore-operation-annotation=false")
 	command = append(command, "--disable-etcd-serviceaccount-automount=true")

--- a/pkg/operation/botanist/component/etcd/bootstrap.go
+++ b/pkg/operation/botanist/component/etcd/bootstrap.go
@@ -319,7 +319,7 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 }
 
 func getDruidDeployCommands(gardenletConf *config.GardenletConfiguration) []string {
-	command := []string{"" + "/etcd-druid"}
+	command := []string{"/etcd-druid"}
 	command = append(command, "--enable-leader-election=true")
 	command = append(command, "--ignore-operation-annotation=false")
 	command = append(command, "--disable-etcd-serviceaccount-automount=true")

--- a/pkg/operation/botanist/component/etcd/bootstrap.go
+++ b/pkg/operation/botanist/component/etcd/bootstrap.go
@@ -108,7 +108,7 @@ func (b *bootstrapper) Deploy(ctx context.Context) error {
 				{
 					APIGroups: []string{corev1.GroupName},
 					Resources: []string{"pods"},
-					Verbs:     []string{"list", "watch", "delete"},
+					Verbs:     []string{"get", "list", "watch", "delete"},
 				},
 				{
 					APIGroups: []string{corev1.GroupName},

--- a/pkg/operation/botanist/component/etcd/bootstrap_test.go
+++ b/pkg/operation/botanist/component/etcd/bootstrap_test.go
@@ -338,7 +338,7 @@ spec:
     spec:
       containers:
       - command:
-        - /bin/etcd-druid
+        - /etcd-druid
         - --enable-leader-election=true
         - --ignore-operation-annotation=false
         - --disable-etcd-serviceaccount-automount=true
@@ -390,7 +390,7 @@ spec:
     spec:
       containers:
       - command:
-        - /bin/etcd-druid
+        - /etcd-druid
         - --enable-leader-election=true
         - --ignore-operation-annotation=false
         - --disable-etcd-serviceaccount-automount=true

--- a/pkg/operation/botanist/component/etcd/bootstrap_test.go
+++ b/pkg/operation/botanist/component/etcd/bootstrap_test.go
@@ -116,6 +116,7 @@ rules:
   resources:
   - pods
   verbs:
+  - get
   - list
   - watch
   - delete

--- a/pkg/operation/botanist/component/etcd/etcd.go
+++ b/pkg/operation/botanist/component/etcd/etcd.go
@@ -471,7 +471,7 @@ func (e *etcd) Deploy(ctx context.Context) error {
 		}
 		e.etcd.Spec.Replicas = replicas
 		e.etcd.Spec.SchedulingConstraints = schedulingConstraints
-		e.etcd.Spec.PriorityClassName = pointer.String(v1beta1constants.PriorityClassNameShootControlPlane)
+		e.etcd.Spec.PriorityClassName = pointer.String(v1beta1constants.PriorityClassNameShootControlPlane500)
 		e.etcd.Spec.Annotations = annotations
 		e.etcd.Spec.Labels = utils.MergeStringMaps(e.getRoleLabels(), e.getDeprecatedRoleLabels(), map[string]string{
 			v1beta1constants.LabelApp:                            LabelAppValue,

--- a/pkg/operation/botanist/component/etcd/etcd_test.go
+++ b/pkg/operation/botanist/component/etcd/etcd_test.go
@@ -313,7 +313,7 @@ var _ = Describe("Etcd", func() {
 				},
 				Spec: druidv1alpha1.EtcdSpec{
 					Replicas:          replicas,
-					PriorityClassName: pointer.String("gardener-shoot-controlplane"),
+					PriorityClassName: pointer.String("gardener-system-500"),
 					Labels: map[string]string{
 						"gardener.cloud/role":              "controlplane",
 						"garden.sapcloud.io/role":          "controlplane",

--- a/test/e2e/shoot/create_rotate_delete.go
+++ b/test/e2e/shoot/create_rotate_delete.go
@@ -24,15 +24,19 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/utils"
 	"github.com/gardener/gardener/test/e2e"
 	"github.com/gardener/gardener/test/e2e/shoot/internal/rotation"
 )
 
-// TODO(timuthy): enable rotation for HA shoots as soon as data consistency issue in multi-node etcd is solved.
 var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 	f := defaultShootCreationFramework()
 	f.Shoot = e2e.DefaultShoot("")
 	f.Shoot.Name = "e2e-rotate"
+	f.Shoot.Annotations = utils.MergeStringMaps(f.Shoot.Annotations, map[string]string{
+		// Use a single zone HA control plane because we don't know if there is a multi-AZ seed available.
+		v1beta1constants.ShootAlphaControlPlaneHighAvailability: v1beta1constants.ShootAlphaControlPlaneHighAvailabilitySingleZone,
+	})
 
 	It("Create Shoot, Rotate Credentials and Delete Shoot", Label("credentials-rotation"), func() {
 		ctx, cancel := context.WithTimeout(parentCtx, 20*time.Minute)

--- a/test/e2e/shoot/internal/rotation/certificate_authorities.go
+++ b/test/e2e/shoot/internal/rotation/certificate_authorities.go
@@ -54,6 +54,7 @@ var allGardenletCAs = []string{
 	caCluster,
 	caClient,
 	caETCD,
+	caETCDPeer,
 	caFrontProxy,
 	caKubelet,
 	caMetricsServer,
@@ -64,6 +65,7 @@ const (
 	caCluster       = "ca"
 	caClient        = "ca-client"
 	caETCD          = "ca-etcd"
+	caETCDPeer      = "ca-etcd-peer"
 	caFrontProxy    = "ca-front-proxy"
 	caKubelet       = "ca-kubelet"
 	caMetricsServer = "ca-metrics-server"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/component etcd-druid
/area backup
/kind enhancement

**What this PR does / why we need it**:
This PR enhances pod permissions for etcd-druid and uses single-zone HA shoot for e2e rotation tests. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->

``` feature operator
Enhance pod permissions for etcd-druid.
```

``` feature developer
Use single-zone HA shoot for e2e rotation tests.
```

``` other operator
Use priority class `gardener-system-500` for etcd, as per https://github.com/gardener/gardener/issues/5634.
```

``` improvement operator github.com/gardener/etcd-backup-restore #504 @aaronfern
Fixed a bug where etcd calls related to multi node operation were used in single node operation
```

``` improvement operator github.com/gardener/etcd-backup-restore #505 @ishan16696
Assigned the correct Peer address to the Etcd after it restores from backup-bucket.
```

``` improvement operator github.com/gardener/etcd-backup-restore #506 @aaronfern
No attempt is made to update member Peer URL when trying to promote a member
```

``` improvement operator github.com/gardener/etcd-backup-restore #510 @timuthy
An issue has been fixed that caused the `Backup-Restore` component to connect to the wrong etcd cluster for initializing and member-add procedures.
```

``` bugfix operator github.com/gardener/etcd-druid #388 @timuthy
A bug has been fixed that caused the `etcd-backup-restore` side-car to connect to the etcd cluster via the `peer-service` URL. The side-car is supposed to use the `client-service` instead since it a) exposes client port `2379` and b)  redirects traffic only to members which are ready to service traffic.
```

``` other operator github.com/gardener/etcd-druid #389 @timuthy
The definition of the `etcd.status.ready` field was defined more precisely due to changed semantics of multi-node etcd clusters. `etcd.status.ready` is `true` whenever all underlying etcd replicas are ready. Please note, that the implementation for this check was not changed.
```

``` improvement operator github.com/gardener/etcd-backup-restore #513 @timuthy
A new flag `--service-endpoints` has been added to the `etcdbrctl server` command. These (Kubernetes) service URLs ensure that `etcd-backup-restore` only connects to etcd member which are ready to server traffic. Especially the `MemberAdd` and `Init` steps require this.
```

``` breaking operator github.com/gardener/etcd-backup-restore #493 @ishan16696
Dropping the feature of passing storage container credentials through ENV for the following storage provider: S3, Swift, OCS, ABS, OSS. Please switch to pass the storage container credentials through volume file mount.
```

``` noteworthy user github.com/gardener/etcd-backup-restore #509 @ishan16696
For multi-node etcd: Added a feature of single member etcd restoration in case of data/data-dir of etcd member found to be corrupted or invalid.
```

``` bugfix operator github.com/gardener/etcd-druid #396 @timuthy
An issue has been fixed that caused the `liveness` and `readiness` probes of `etcd` to always succeed even though an error was reported. This prevented defective etcd pods from being restarted automatically and caused unready candidates being considered as ready to serve traffic via the `etcd service`.
```

``` bugfix operator github.com/gardener/etcd-druid #396 @timuthy
A `startup` probe has been added to `etcd` to allow 2 minutes of initialization time before checking for etcd liveness.
```

``` feature developer github.com/gardener/etcd-druid #396 @timuthy
Add support for running envtest on M1 Macbooks.
```

``` other operator github.com/gardener/etcd-druid #397 @aaronfern
Fixed an issue in the release job needed to add the correct image version `config/default/manager_image_patch.yaml`.
```

``` other operator github.com/gardener/etcd-druid #271 @aaronfern
Added a new condition `BackupReady` to the etcd status
```

``` other operator github.com/gardener/etcd-druid #357 @ishan16696
livenessProbe of etcd container has been updated to `ETCDCTL_API=3 etcdctl get foo --consistency=s` making the consistency `serializable`.
```

``` other operator github.com/gardener/etcd-druid #357 @ishan16696
failureThreshold has been updated to `5` for both livenessProbe and readinessProbe of etcd.
```

``` other operator github.com/gardener/etcd-druid #360 @dimityrmirchev
The `etcd-druid` now uses `distroless` instead of `alpine` as a base image.
```

``` breaking operator github.com/gardener/etcd-druid #360 @dimityrmirchev
The entrypoint for `etcd-druid` in its container image has been modified.
```

``` feature developer github.com/gardener/etcd-druid #365 @abdasgupta
Deploying the etcd StatefulSet through a Helm chart has been abandoned. A codified version (component concept) is now used for this purpose.
```

``` breaking operator github.com/gardener/etcd-druid #365 @abdasgupta
`etcd` Statefulsets are not claimed anymore based on labels. Instead, the statefulsets are fetched using Name and Namespace combination. Thus, `etcd.spec.selector` does not have an effect on statefulsets anymore.
```

``` other operator github.com/gardener/etcd-druid #366 @aaronfern
`etcd-druid` will now also add statefulset permissions to the etcd role
```

``` other operator github.com/gardener/etcd-druid #367 @timuthy
Published docker images for Etcd-Druid are now multi-arch ready. They support `linux/amd64` and `linux/arm64`.
```

``` noteworthy operator github.com/gardener/etcd-backup-restore #499 @timuthy
Published docker images for Etcd-Backup-Restore are now multi-arch ready. They support `linux/amd64` and `linux/arm64`.
```

``` noteworthy operator github.com/gardener/etcd-backup-restore #499 @timuthy
The Etcd-Backup-Restore image has been updated to `Alpine 3.15.4`.
```

``` action developer github.com/gardener/etcd-backup-restore #403 @aaronfern
Added new package `membergarbagecollector` to remove superfluous members from the ETCD cluster. Due to this, etcd-backup-restore now needs permissions to list `pods` and `statefulsets`.
```

``` noteworthy operator github.com/gardener/etcd-backup-restore #487 @aaronfern
Etcd can now scale up itself from a single member cluster to a multi member cluster
```

``` other operator github.com/gardener/etcd-custom-image #19 @timuthy
Published docker images for Etcd-Custom-Image are now multi-arch ready. They support linux/amd64 and linux/arm64.
```

``` other operator github.com/gardener/etcd-druid #372 @aaronfern
Added pod permission in etcd_role that now enable `etcd-backup-restore` to get/list/watch pods
```

``` other operator github.com/gardener/etcd-druid #375 @timuthy
Etcd-Druid's Golang version has been update to `1.18.4.`.
```

``` other operator github.com/gardener/etcd-druid #377 @timuthy
The correct image version has been set in `config/default/manager_image_patch.yaml` to match the current release.
```