### PR TITLE
Improve the K8s version checks in the nginx-ingress component to consider versions with suffixes

### DIFF
--- a/pkg/operation/seed/nginxingress.go
+++ b/pkg/operation/seed/nginxingress.go
@@ -62,7 +62,7 @@ func defaultNginxIngress(c client.Client, imageVector imagevector.ImageVector, k
 	values := nginxingress.Values{
 		ImageController:     imageController.String(),
 		ImageDefaultBackend: imageDefaultBackend.String(),
-		KubernetesVersion:   kubernetesVersion,
+		KubernetesVersion:   kubernetesVersion.String(),
 		IngressClass:        ingressClass,
 		ConfigData:          config,
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
Currently against `v1.22.12-gke.300` GKE Seed cluster the nginx-ingress fails with:
```
$ k -n garden get po nginx-ingress-controller-598d78445b-58gv4
NAME                                        READY   STATUS             RESTARTS          AGE
nginx-ingress-controller-598d78445b-58gv4   0/1     CrashLoopBackOff   137 (4m31s ago)   11h

$ k -n garden logs nginx-ingress-controller-598d78445b-58gv4
exec /usr/bin/dumb-init: operation not permitted
```

The `v1.22.12-gke.300` creates troubles for the semver module:
```golang
version.ConstraintK8sGreaterEqual122.Check(semver.MustParse("v1.22.12-gke.300")) // evaluates wrongly to "false"

version.ConstraintK8sGreaterEqual122.Check(semver.MustParse("v1.22.12")) // evaluates as expected to "true"
```

To fix this issue this PR switches from the semver library to the helper funcs in `pkg/util/version` that internally "normalize" the version before doing the constraint check.

The same issue also explained in https://github.com/gardener/gardener/blob/f15aa0f45ffab0bab67e47cd16b9df2632505a30/pkg/operation/seed/nginxingress.go#L144-L150

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing the Seed nginx-ingress to fail on 1.22 GKE Seed cluster (or any 1.22 Seed cluster with K8s version that has a suffix - for example `v1.22.12-gke.300`) is now fixed.
```
