### PR TITLE
Persist additional disk storage metrics in Prometheus

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/values.yaml
@@ -89,6 +89,12 @@ allowedMetrics:
   - node_cpu_seconds_total
   - node_disk_read_bytes_total
   - node_disk_written_bytes_total
+  - node_disk_io_time_weighted_seconds_total
+  - node_disk_io_time_seconds_total
+  - node_disk_write_time_seconds_total
+  - node_disk_writes_completed_total
+  - node_disk_read_time_seconds_total
+  - node_disk_reads_completed_total
   - node_filesystem_avail_bytes
   - node_filesystem_files
   - node_filesystem_files_free


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement 

**What this PR does / why we need it**:
Persist additional metrics to monitor disk device performance contention/saturation
See https://github.tools.sap/kubernetes/landscape-issues/issues/56

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Persist additional metrics to monitor disk device performance contention/saturation
```
