### PR TITLE
Switch health check port of node local dns to a less often used port.

### DIFF
--- a/pkg/operation/botanist/component/nodelocaldns/nodelocaldns.go
+++ b/pkg/operation/botanist/component/nodelocaldns/nodelocaldns.go
@@ -61,7 +61,7 @@ const (
 
 	domain            = gardencorev1beta1.DefaultDomain
 	serviceName       = "kube-dns-upstream"
-	livenessProbePort = 8080
+	livenessProbePort = 8099
 	configDataKey     = "Corefile"
 )
 
@@ -314,6 +314,8 @@ ip6.arpa:53 {
 									"/etc/Corefile",
 									"-upstreamsvc",
 									serviceName,
+									"-health-port",
+									strconv.Itoa(livenessProbePort),
 								},
 								SecurityContext: &corev1.SecurityContext{
 									Capabilities: &corev1.Capabilities{

--- a/pkg/operation/botanist/component/nodelocaldns/nodelocaldns_test.go
+++ b/pkg/operation/botanist/component/nodelocaldns/nodelocaldns_test.go
@@ -68,7 +68,7 @@ var _ = Describe("NodeLocalDNS", func() {
 		prometheusPort      = 9253
 		prometheusErrorPort = 9353
 		prometheusScrape    = true
-		livenessProbePort   = 8080
+		livenessProbePort   = 8099
 		configMapHash       string
 	)
 
@@ -344,6 +344,8 @@ status:
 											"/etc/Corefile",
 											"-upstreamsvc",
 											"kube-dns-upstream",
+											"-health-port",
+											"8099",
 										},
 										SecurityContext: &corev1.SecurityContext{
 											Capabilities: &corev1.Capabilities{


### PR DESCRIPTION
Switch health check port of node local dns to a less often used port.

Per default, node local dns uses port 8080 for its health check. As node local dns
binds the port on the node level it might conflict with other node wide services
or pods running in the host network. As port 8080 is sometimes used for http like
services it seems to provoke conflicts if node local dns uses this port for health
checks.
This change simply moves the node local dns health check port to a different, less
utilized port.

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Switch health check port of node local dns to a less often used port.

Per default, node local dns uses port 8080 for its health check. As node local dns
binds the port on the node level it might conflict with other node wide services
or pods running in the host network. As port 8080 is sometimes used for http like
services it seems to provoke conflicts if node local dns uses this port for health
checks.
This change simply moves the node local dns health check port to a different, less
utilized port.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Node-local-dns health check does not longer use port 8080 of the host, but uses port 8099 instead.
```
