### PR TITLE
Integration test for cloudprovider extension webhook

### DIFF
--- a/extensions/pkg/webhook/certificates/certificates.go
+++ b/extensions/pkg/webhook/certificates/certificates.go
@@ -77,7 +77,7 @@ func getWebhookServerCertConfig(name, namespace, providerName, mode, url string)
 
 	switch mode {
 	case webhook.ModeURL:
-		if addr := net.ParseIP(url); addr != nil {
+		if addr := net.ParseIP(serverName); addr != nil {
 			ipAddresses = []net.IP{addr}
 		} else {
 			dnsNames = []string{serverName}

--- a/test/integration/extensions/webhook/cloudprovider/cloudprovider_suite_test.go
+++ b/test/integration/extensions/webhook/cloudprovider/cloudprovider_suite_test.go
@@ -1,0 +1,160 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudprovider_test
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	"github.com/gardener/gardener/extensions/pkg/webhook/cloudprovider"
+	webhookcmd "github.com/gardener/gardener/extensions/pkg/webhook/cmd"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/logger"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+	testcloudprovider "github.com/gardener/gardener/test/integration/extensions/webhook/cloudprovider"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+func TestWebhookCloudProvider(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Extensions Webhook CloudProvider Integration Test Suite")
+}
+
+const testID = "extensions-webhook-cloudprovider-test"
+
+var (
+	ctx = context.TODO()
+	log logr.Logger
+
+	restConfig *rest.Config
+	testEnv    *envtest.Environment
+	testClient client.Client
+
+	testNamespace *corev1.Namespace
+	providerName  = "test-provider"
+)
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)))
+	log = logf.Log.WithName(testID)
+
+	By("starting test environment")
+	testEnv = &envtest.Environment{
+		CRDInstallOptions: envtest.CRDInstallOptions{
+			Paths: []string{
+				filepath.Join("..", "..", "..", "..", "..", "example", "seed-crds", "10-crd-extensions.gardener.cloud_clusters.yaml"),
+			},
+		},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	var err error
+	restConfig, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(restConfig).NotTo(BeNil())
+
+	DeferCleanup(func() {
+		By("stopping test environment")
+		Expect(testEnv.Stop()).To(Succeed())
+	})
+
+	By("creating test client")
+	testClient, err = client.New(restConfig, client.Options{Scheme: kubernetes.SeedScheme})
+	Expect(err).NotTo(HaveOccurred())
+
+	By("creating test namespace")
+	testNamespace = &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			// create dedicated namespace for each test run, so that we can run multiple tests concurrently for stress tests
+			GenerateName: testID + "-",
+			Labels: map[string]string{
+				v1beta1constants.LabelShootProvider: providerName,
+			},
+		},
+	}
+	Expect(testClient.Create(ctx, testNamespace)).To(Succeed())
+	log.Info("Created Namespace for test", "namespaceName", testNamespace.Name)
+
+	DeferCleanup(func() {
+		By("deleting test namespace")
+		Expect(testClient.Delete(ctx, testNamespace)).To(Or(Succeed(), BeNotFoundError()))
+	})
+
+	By("setup manager")
+	mgr, err := manager.New(restConfig, manager.Options{
+		Port:               testEnv.WebhookInstallOptions.LocalServingPort,
+		Host:               testEnv.WebhookInstallOptions.LocalServingHost,
+		CertDir:            testEnv.WebhookInstallOptions.LocalServingCertDir,
+		Scheme:             kubernetes.SeedScheme,
+		MetricsBindAddress: "0",
+		Namespace:          testNamespace.Name,
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	By("registering webhook")
+	Expect(addTestWebhookToManager(mgr, false)).To(Succeed())
+
+	By("starting manager")
+	mgrContext, mgrCancel := context.WithCancel(ctx)
+
+	go func() {
+		defer GinkgoRecover()
+		Expect(mgr.Start(mgrContext)).To(Succeed())
+	}()
+
+	DeferCleanup(func() {
+		By("stopping manager")
+		mgrCancel()
+	})
+})
+
+func addTestWebhookToManager(mgr manager.Manager, enableObjectSelector bool) error {
+	switchOptions := webhookcmd.NewSwitchOptions(
+		webhookcmd.Switch("cloudprovider", func(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
+			return cloudprovider.New(mgr, cloudprovider.Args{
+				Provider:             providerName,
+				Mutator:              cloudprovider.NewMutator(log, testcloudprovider.NewEnsurer(log)),
+				EnableObjectSelector: enableObjectSelector,
+			})
+		}),
+	)
+
+	addToManagerOptions := webhookcmd.NewAddToManagerOptions(providerName, "", nil, &webhookcmd.ServerOptions{
+		Mode: extensionswebhook.ModeURL,
+		URL:  fmt.Sprintf("%s:%d", testEnv.WebhookInstallOptions.LocalServingHost, testEnv.WebhookInstallOptions.LocalServingPort),
+	}, switchOptions)
+
+	if err := addToManagerOptions.Complete(); err != nil {
+		return err
+	}
+
+	_, err := addToManagerOptions.Completed().AddToManager(ctx, mgr)
+	return err
+}

--- a/test/integration/extensions/webhook/cloudprovider/cloudprovider_test.go
+++ b/test/integration/extensions/webhook/cloudprovider/cloudprovider_test.go
@@ -1,0 +1,106 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudprovider_test
+
+import (
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("", func() {
+	var (
+		cluster *extensionsv1alpha1.Cluster
+		secret  *corev1.Secret
+
+		originalData = map[string][]byte{
+			"clientID": []byte("test"),
+		}
+	)
+	BeforeEach(func() {
+		cluster = &extensionsv1alpha1.Cluster{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: testNamespace.Name,
+			},
+			Spec: extensionsv1alpha1.ClusterSpec{
+				CloudProfile: runtime.RawExtension{Raw: []byte("{}")},
+				Seed:         runtime.RawExtension{Raw: []byte("{}")},
+				Shoot:        runtime.RawExtension{Raw: []byte("{}")},
+			},
+		}
+
+		secret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      v1beta1constants.SecretNameCloudProvider,
+				Namespace: testNamespace.Name,
+			},
+			Data: originalData,
+		}
+	})
+
+	JustBeforeEach(func() {
+		By("Create Cluster")
+		Expect(testClient.Create(ctx, cluster)).To(Succeed())
+		log.Info("Created Cluster for test", "cluster", client.ObjectKeyFromObject(cluster))
+
+		DeferCleanup(func() {
+			By("deleting Cluster")
+			Expect(client.IgnoreNotFound(testClient.Delete(ctx, cluster))).To(Succeed())
+		})
+	})
+
+	Context("secret name is not cloudprovider", func() {
+		BeforeEach(func() {
+			secret.Name = "test-secret"
+			Expect(testClient.Create(ctx, secret)).To(Succeed())
+
+			DeferCleanup(func() {
+				By("deleting Secret")
+				Expect(client.IgnoreNotFound(testClient.Delete(ctx, secret))).To(Succeed())
+			})
+		})
+
+		It("should not mutate the secret", func() {
+			Expect(secret.Data).To(Equal(originalData))
+		})
+	})
+
+	Context("secretname is cloudprofile", func() {
+		BeforeEach(func() {
+			DeferCleanup(func() {
+				By("delete Secret")
+				Expect(client.IgnoreNotFound(testClient.Delete(ctx, secret))).To(Succeed())
+			})
+		})
+
+		It("should mutate secret", func() {
+			By("create Secret")
+			Eventually(func(g Gomega) {
+				Expect(testClient.Create(ctx, secret)).To(Succeed())
+
+				Expect(secret.Data).To(Equal(map[string][]byte{
+					"clientID":     []byte("foo"),
+					"clientSecret": []byte("bar"),
+				}))
+			}).Should(Succeed())
+		})
+	})
+})

--- a/test/integration/extensions/webhook/cloudprovider/ensurer.go
+++ b/test/integration/extensions/webhook/cloudprovider/ensurer.go
@@ -35,12 +35,10 @@ func NewEnsurer(logger logr.Logger) cloudprovider.Ensurer {
 
 type ensurer struct {
 	logger logr.Logger
-	client client.Client
 }
 
 // InjectClient injects the given client into the ensurer.
-func (e *ensurer) InjectClient(client client.Client) error {
-	e.client = client
+func (e *ensurer) InjectClient(_ client.Client) error {
 	return nil
 }
 

--- a/test/integration/extensions/webhook/cloudprovider/ensurer.go
+++ b/test/integration/extensions/webhook/cloudprovider/ensurer.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cloudprovider
+
+import (
+	"context"
+
+	"github.com/gardener/gardener/extensions/pkg/webhook/cloudprovider"
+	gcontext "github.com/gardener/gardener/extensions/pkg/webhook/context"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// NewEnsurer creates cloudprovider ensurer.
+func NewEnsurer(logger logr.Logger) cloudprovider.Ensurer {
+	return &ensurer{
+		logger: logger,
+	}
+}
+
+type ensurer struct {
+	logger logr.Logger
+	client client.Client
+}
+
+// InjectClient injects the given client into the ensurer.
+func (e *ensurer) InjectClient(client client.Client) error {
+	e.client = client
+	return nil
+}
+
+// InjectScheme injects the given scheme into the decoder of the ensurer.
+func (e *ensurer) InjectScheme(_ *runtime.Scheme) error {
+	return nil
+}
+
+// EnsureCloudProviderSecret isimplemented on extention side which mutates the cloudprovider secret. contain
+// For testing purpose we are mutating the cloudprovider secret's data to check whether this
+// function is called in webhook.
+func (e *ensurer) EnsureCloudProviderSecret(ctx context.Context, _ gcontext.GardenContext, new, _ *corev1.Secret) error {
+	e.logger.Info("Mutate cloudprovider secret", "namespace", new.Namespace, "name", new.Name)
+	new.Data["clientID"] = []byte(`foo`)
+	new.Data["clientSecret"] = []byte(`bar`)
+
+	return nil
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity robustness quality testing
/kind enhancement

**What this PR does / why we need it**:
This PR will add an integration test for the [`cloudprovider`](https://github.com/gardener/gardener/tree/master/extensions/pkg/webhook/cloudprovider) extension webhook.

A minor bug was found at : https://github.com/gardener/gardener/blob/8146f211ee37c98d334cefd204d8d5f19448ce27/extensions/pkg/webhook/certificates/certificates.go#L80 

`parseIP` should be called with `serverName` which will include only IP part without the port number. It has been also fixed in this PR.
Thanks to @timebertt for noticing the bug.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/2751

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
