### PR TITLE
fix(dnsrecord): reconcile dnsrecords when changing their spec

### DIFF
--- a/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord.go
+++ b/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord.go
@@ -144,7 +144,7 @@ func (c *dnsRecord) deploy(ctx context.Context, operation string) (extensionsv1a
 	}
 
 	mutateFn := func() error {
-		if c.values.AnnotateOperation {
+		if c.values.AnnotateOperation || c.valuesDontMatchDNSRecord() {
 			metav1.SetMetaDataAnnotation(&c.dnsRecord.ObjectMeta, v1beta1constants.GardenerOperation, operation)
 		}
 		metav1.SetMetaDataAnnotation(&c.dnsRecord.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())

--- a/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord_test.go
+++ b/pkg/operation/botanist/component/extensions/dnsrecord/dnsrecord_test.go
@@ -364,9 +364,6 @@ var _ = Describe("DNSRecord", func() {
 				Expect(dnsRecord.Deploy(ctx)).To(Succeed())
 
 				deployedDNS := &extensionsv1alpha1.DNSRecord{}
-				err = c.Get(ctx, client.ObjectKey{Name: name, Namespace: namespace}, deployedDNS)
-				Expect(err).NotTo(HaveOccurred())
-
 				dnsRecord.SetValues([]string{address, "8.8.8.8", "1.1.1.1"})
 				Expect(dnsRecord.Deploy(ctx)).To(Succeed())
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind bug

**What this PR does / why we need it**:
Since https://github.com/gardener/gardener/pull/5531, the DNSRecord is only annotated with gardener.cloud/operation=reconcile if the shoot.gardener.cloud/tasks annotation contains deployDNSRecord*. This in turn is only done during maintenance in order to limit the number of API calls made to the DNS provider.

If the DNSRecord object is not annotated with gardener.cloud/operation=reconcile, the DNSRecord controller will not act on it, even if the spec has changed.

**Which issue(s) this PR fixes**:
Fixes #6463 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fixed a bug where the Shoot reconciliation could get stuck due to `DNSRecords` not being reconciled.
```
