### PR TITLE
Deflake bastion controller integration test

### DIFF
--- a/test/integration/controllermanager/bastion/bastion_suite_test.go
+++ b/test/integration/controllermanager/bastion/bastion_suite_test.go
@@ -60,6 +60,7 @@ var (
 	restConfig     *rest.Config
 	testEnv        *gardenerenvtest.GardenerTestEnvironment
 	testClient     client.Client
+	mgrClient      client.Reader
 	testCoreClient *gardenversionedcoreclientset.Clientset
 	logBuffer      *gbytes.Buffer
 
@@ -122,6 +123,7 @@ var _ = BeforeSuite(func() {
 		Namespace:          testNamespace.Name,
 	})
 	Expect(err).NotTo(HaveOccurred())
+	mgrClient = mgr.GetClient()
 
 	By("setting up field indexes")
 	Expect(indexer.AddBastionShootName(ctx, mgr.GetFieldIndexer())).To(Succeed())

--- a/test/integration/controllermanager/bastion/bastion_test.go
+++ b/test/integration/controllermanager/bastion/bastion_test.go
@@ -108,6 +108,15 @@ var _ = Describe("Bastion controller tests", func() {
 				By("Delete Shoot")
 				Expect(client.IgnoreNotFound(testClient.Delete(ctx, shoot))).To(Succeed())
 			})
+
+			By("Wait until manager has observed shoot")
+			// Use the manager's cache to ensure it has observed the shoot.
+			// Otherwise, the controller might clean up the bastion too early because it thinks the target shoot is gone.
+			// This should not happen in reality, so make sure to stabilize the test and keep the controller simple.
+			// see https://github.com/gardener/gardener/issues/6486
+			Eventually(func() error {
+				return mgrClient.Get(ctx, client.ObjectKeyFromObject(shoot), &gardencorev1beta1.Shoot{})
+			}).Should(Succeed())
 		}
 
 		By("Create Bastion")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind flake

**What this PR does / why we need it**:

Implement option a) from https://github.com/gardener/gardener/issues/6486#issuecomment-1214837042.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/6486

**Special notes for your reviewer**:

With https://github.com/gardener/gardener/pull/6497, I was able to reproduce the flake.

Before this PR:
```
$ source ./hack/test-integration.env
$ export USE_EXISTING_GARDENER=true
$ stress -ignore "unable to grab random port" -p 128 ./test/integration/controllermanager/bastion/bastion.test
...
3m50s: 1032 runs so far, 6 failures (0.58%)
```

With this PR:
```
$ source ./hack/test-integration.env
$ export USE_EXISTING_GARDENER=true
$ stress -ignore "unable to grab random port" -p 128 ./test/integration/controllermanager/bastion/bastion.test
...
4m10s: 1080 runs so far, 0 failures
```
