### PR TITLE
Update cluster-proportional-autoscaler image

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -289,7 +289,7 @@ images:
 - name: cluster-proportional-autoscaler
   sourceRepository: https://github.com/kubernetes-sigs/cluster-proportional-autoscaler
   repository: k8s.gcr.io/cpa/cluster-proportional-autoscaler
-  tag: "1.8.5"
+  tag: "1.8.6"
 
 # Istio
 - name: istio-proxy


### PR DESCRIPTION
/area networking
/kind enhancement

**What this PR does / why we need it**:
Same as https://github.com/gardener/gardener-extension-networking-calico/pull/206

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The following image is updated:
- k8s.gcr.io/cpa/cluster-proportional-autoscaler: v1.8.5 -> v1.8.6
```
