### PR TITLE
Fix alerting rule for unreachable API server

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules-tests/apiserver-connectivity-check.rules.test.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules-tests/apiserver-connectivity-check.rules.test.yaml
@@ -7,7 +7,7 @@ tests:
 - interval: 30s
   input_series:
   # ApiServerUnreachableViaKubernetesService
-  - series: 'probe_success{job="blackbox-exporter-k8s-service-check"}'
+  - series: 'absent(probe_success{job="blackbox-exporter-k8s-service-check"} == 1)'
     values: '0+0x30'
   alert_rule_test:
   - eval_time: 15m

--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/apiserver-connectivity-check.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/apiserver-connectivity-check.rules.yaml
@@ -2,7 +2,7 @@ groups:
 - name: apiserver-connectivity-check.rules
   rules:
   - alert: ApiServerUnreachableViaKubernetesService
-    expr: probe_success{job="blackbox-exporter-k8s-service-check"} != 1
+    expr: absent(probe_success{job="blackbox-exporter-k8s-service-check"} == 1)
     for: 15m
     labels:
       service: apiserver-connectivity-check


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
If the API Server is down, this alert did not previously fire. `probe_success` wouldn't fail (return 0), it would just return an empty query result.

**Special notes for your reviewer**:
/cc @istvanballok 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fix alerting rule for unreachable API server
```
