### PR TITLE
[GEP-20] Minor changes to GEP to include HA setup for additional shoot control plane components

### DIFF
--- a/docs/proposals/20-ha-control-planes.md
+++ b/docs/proposals/20-ha-control-planes.md
@@ -376,7 +376,7 @@ Following shoot control plane components are currently setup with a single repli
 * Kube Scheduler
 * Machine Controller Manager (MCM)
 
-A mutating webhoook in the **Gardener Resource Manager** can be used to set the replicas for the above components.
+> NOTE: MCM and CCM are components deployed by provider extensions. HA specific configuration should be configured there.
 
 Additionally [Affinity and anti-affinity](#scheduling-control-plane-components) rules must be configured.
 

--- a/docs/proposals/20-ha-control-planes.md
+++ b/docs/proposals/20-ha-control-planes.md
@@ -1,6 +1,6 @@
 ---
 title:  Highly Available Shoot Control Planes
-gep-number: 0020
+gep-number: "20"
 creation-date: 2022-07-07
 status: implementable
 authors:
@@ -46,6 +46,7 @@ reviewers:
     - [Kube Apiserver](#kube-apiserver)
     - [Gardener Resource Manager](#gardener-resource-manager)
     - [Etcd](#etcd)
+    - [Other critical components having single replica](#other-critical-components-having-single-replica)
       - [Gardener `etcd` component changes](#gardener-etcd-component-changes)
   - [Handling Outages](#handling-outages)
     - [Node failures](#node-failures)
@@ -354,6 +355,18 @@ The Gardener Resource Manager is already set up with `spec.replicas: 3` today. O
 
 In contrast to other components, it's not trivial to run multiple replicas for `etcd` because different rules and considerations apply to form a quorum-based cluster [ref](https://etcd.io/docs/v3.4/op-guide/clustering/).
 Most of the complexity (e.g. cluster bootstrap, scale-up) is already outsourced to [Etcd-Druid](https://github.com/gardener/etcd-druid) and efforts have been made to support may use-cases already (see [gardener/etcd-druid#107](https://github.com/gardener/etcd-druid/issues/107) and [Multi-Node etcd GEP](https://github.com/gardener/etcd-druid/blob/master/docs/proposals/multi-node/README.md)). Please note, that especially for `etcd` an `active-passive` alternative was evaluated [here](#etcd-active-passive-options). Due to the complexity and implementation effort it was decided to proceed with the `active-active` built-in support, but to keep this as a reference in case we'll see blockers in the future.
+
+### Other critical components having single replica
+
+Following shoot control plane components are currently setup with a single replica and are planned to run with a minimum of 2 replicas:
+
+* Cluster Autoscaler (if enabled)
+* Cloud Controller Manager
+* Kube Controller Manager
+* Kube Scheduler
+* Machine Controller Manager
+
+Additionally [Affinity and anti-affinity](#scheduling-control-plane-components) rules must be configured.
 
 #### Gardener `etcd` component changes
 

--- a/docs/proposals/20-ha-control-planes.md
+++ b/docs/proposals/20-ha-control-planes.md
@@ -375,8 +375,9 @@ Following shoot control plane components are currently setup with a single repli
 * Kube Controller Manager (KCM)
 * Kube Scheduler
 * Machine Controller Manager (MCM)
+* CSI driver controller
 
-> NOTE: MCM and CCM are components deployed by provider extensions. HA specific configuration should be configured there.
+> NOTE: MCM, CCM and CSI driver controller are components deployed by provider extensions. HA specific configuration should be configured there.
 
 Additionally [Affinity and anti-affinity](#scheduling-control-plane-components) rules must be configured.
 

--- a/docs/proposals/20-ha-control-planes.md
+++ b/docs/proposals/20-ha-control-planes.md
@@ -371,10 +371,12 @@ The groundwork for this was already done by [gardener/gardener#5741](https://git
 Following shoot control plane components are currently setup with a single replica and are planned to run with a minimum of 2 replicas:
 
 * Cluster Autoscaler (if enabled)
-* Cloud Controller Manager
-* Kube Controller Manager
+* Cloud Controller Manager (CCM)
+* Kube Controller Manager (KCM)
 * Kube Scheduler
-* Machine Controller Manager
+* Machine Controller Manager (MCM)
+
+> NOTE: MCM and CCM are components deployed by provider extensions. HA specific configuration should be configured there.
 
 Additionally [Affinity and anti-affinity](#scheduling-control-plane-components) rules must be configured.
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind discussion

**What this PR does / why we need it**:
It corrects the GEP header with the correct GEP number and adds a new section to also propose increasing replica count for additional shoot control plane components as the current recovery mechanism is insufficient to provide availability for these critical components.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
