### PR TITLE
Migrate gardenlet priority-class

### DIFF
--- a/charts/gardener/gardenlet/charts/runtime/templates/deployment.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/deployment.yaml
@@ -63,7 +63,7 @@ spec:
 {{ toYaml .Values.global.gardenlet.podLabels | indent 8 }}
         {{- end }}
     spec:
-      priorityClassName: gardener-system-critical-mig
+      priorityClassName: gardener-system-critical-migration
       {{- if not .Values.global.gardenlet.config.seedClientConnection.kubeconfig }}
       serviceAccountName: {{ required ".Values.global.gardenlet.serviceAccountName is required" .Values.global.gardenlet.serviceAccountName }}
       {{- else }}

--- a/charts/gardener/gardenlet/charts/runtime/templates/deployment.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/deployment.yaml
@@ -63,7 +63,7 @@ spec:
 {{ toYaml .Values.global.gardenlet.podLabels | indent 8 }}
         {{- end }}
     spec:
-      priorityClassName: gardenlet
+      priorityClassName: gardener-system-critical-mig
       {{- if not .Values.global.gardenlet.config.seedClientConnection.kubeconfig }}
       serviceAccountName: {{ required ".Values.global.gardenlet.serviceAccountName is required" .Values.global.gardenlet.serviceAccountName }}
       {{- else }}

--- a/charts/gardener/gardenlet/charts/runtime/templates/priorityclass.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/priorityclass.yaml
@@ -1,7 +1,7 @@
 apiVersion: {{ include "priorityclassversion" . }}
 kind: PriorityClass
 metadata:
-  name: gardenlet
-value: 1000000000
+  name: gardener-system-critical-mig
+value: 999998950
 globalDefault: false
-description: "This class is used to ensure that the gardenlet has a high priority and is not preempted in favor of other pods."
+description: "This class is used to ensure that the gardenlet and some seed system components has a high priority and is not preempted in favor of other pods."

--- a/charts/gardener/gardenlet/charts/runtime/templates/priorityclass.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/priorityclass.yaml
@@ -1,7 +1,7 @@
 apiVersion: {{ include "priorityclassversion" . }}
 kind: PriorityClass
 metadata:
-  name: gardener-system-critical-mig
+  name: gardener-system-critical-migration
 value: 999998950
 globalDefault: false
 description: "This class is used to ensure that the gardenlet and some seed system components has a high priority and is not preempted in favor of other pods."

--- a/pkg/gardenlet/controller/managedseed/charttest/charttest.go
+++ b/pkg/gardenlet/controller/managedseed/charttest/charttest.go
@@ -95,13 +95,13 @@ func ValidateGardenletChartPriorityClass(ctx context.Context, c client.Client) {
 		priorityClass,
 	)).ToNot(HaveOccurred())
 	Expect(priorityClass.GlobalDefault).To(Equal(false))
-	Expect(priorityClass.Value).To(Equal(int32(1000000000)))
+	Expect(priorityClass.Value).To(Equal(int32(999998950)))
 }
 
 func getEmptyPriorityClass() *schedulingv1.PriorityClass {
 	return &schedulingv1.PriorityClass{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "gardenlet",
+			Name: "gardener-system-critical-mig",
 		},
 	}
 }
@@ -956,7 +956,7 @@ func ComputeExpectedGardenletDeploymentSpec(
 				Labels: expectedLabels,
 			},
 			Spec: corev1.PodSpec{
-				PriorityClassName:  "gardenlet",
+				PriorityClassName:  "gardener-system-critical-mig",
 				ServiceAccountName: "gardenlet",
 				Containers: []corev1.Container{
 					{

--- a/pkg/gardenlet/controller/managedseed/charttest/charttest.go
+++ b/pkg/gardenlet/controller/managedseed/charttest/charttest.go
@@ -101,7 +101,7 @@ func ValidateGardenletChartPriorityClass(ctx context.Context, c client.Client) {
 func getEmptyPriorityClass() *schedulingv1.PriorityClass {
 	return &schedulingv1.PriorityClass{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "gardener-system-critical-mig",
+			Name: "gardener-system-critical-migration",
 		},
 	}
 }
@@ -956,7 +956,7 @@ func ComputeExpectedGardenletDeploymentSpec(
 				Labels: expectedLabels,
 			},
 			Spec: corev1.PodSpec{
-				PriorityClassName:  "gardener-system-critical-mig",
+				PriorityClassName:  "gardener-system-critical-migration",
 				ServiceAccountName: "gardenlet",
 				Containers: []corev1.Container{
 					{

--- a/pkg/operation/botanist/component/istio/charts/istio/istio-ingress/templates/deployment.yaml
+++ b/pkg/operation/botanist/component/istio/charts/istio/istio-ingress/templates/deployment.yaml
@@ -201,7 +201,7 @@ spec:
               path: istio-token
               expirationSeconds: 43200
               audience: istio-ca
-      priorityClassName: gardener-system-critical-mig
+      priorityClassName: gardener-system-critical-migration
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/pkg/operation/botanist/component/istio/charts/istio/istio-ingress/templates/deployment.yaml
+++ b/pkg/operation/botanist/component/istio/charts/istio/istio-ingress/templates/deployment.yaml
@@ -201,7 +201,7 @@ spec:
               path: istio-token
               expirationSeconds: 43200
               audience: istio-ca
-      priorityClassName: gardener-system-critical
+      priorityClassName: gardener-system-critical-mig
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/pkg/operation/botanist/component/istio/charts/istio/istio-istiod/templates/deployment.yaml
+++ b/pkg/operation/botanist/component/istio/charts/istio/istio-istiod/templates/deployment.yaml
@@ -147,7 +147,7 @@ spec:
       - name: config-volume
         configMap:
           name: istio
-      priorityClassName: gardener-system-critical
+      priorityClassName: gardener-system-critical-mig
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/pkg/operation/botanist/component/istio/charts/istio/istio-istiod/templates/deployment.yaml
+++ b/pkg/operation/botanist/component/istio/charts/istio/istio-istiod/templates/deployment.yaml
@@ -147,7 +147,7 @@ spec:
       - name: config-volume
         configMap:
           name: istio
-      priorityClassName: gardener-system-critical-mig
+      priorityClassName: gardener-system-critical-migration
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/pkg/operation/botanist/component/istio/istiod_test.go
+++ b/pkg/operation/botanist/component/istio/istiod_test.go
@@ -841,7 +841,7 @@ spec:
       - name: config-volume
         configMap:
           name: istio
-      priorityClassName: gardener-system-critical
+      priorityClassName: gardener-system-critical-mig
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -1882,7 +1882,7 @@ spec:
               path: istio-token
               expirationSeconds: 43200
               audience: istio-ca
-      priorityClassName: gardener-system-critical
+      priorityClassName: gardener-system-critical-mig
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/pkg/operation/botanist/component/istio/istiod_test.go
+++ b/pkg/operation/botanist/component/istio/istiod_test.go
@@ -841,7 +841,7 @@ spec:
       - name: config-volume
         configMap:
           name: istio
-      priorityClassName: gardener-system-critical-mig
+      priorityClassName: gardener-system-critical-migration
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -1882,7 +1882,7 @@ spec:
               path: istio-token
               expirationSeconds: 43200
               audience: istio-ca
-      priorityClassName: gardener-system-critical-mig
+      priorityClassName: gardener-system-critical-migration
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/pkg/operation/botanist/component/resourcemanager/resource_manager.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager.go
@@ -455,6 +455,11 @@ func (r *resourceManager) ensureDeployment(ctx context.Context) error {
 		return err
 	}
 
+	priorityClassName := "gardener-system-critical-mig"
+	if r.values.TargetDiffersFromSourceCluster {
+		priorityClassName = v1beta1constants.PriorityClassNameShootControlPlane400
+	}
+
 	_, err = controllerutils.GetAndCreateOrMergePatch(ctx, r.client, deployment, func() error {
 		deployment.Labels = r.getLabels()
 
@@ -482,6 +487,7 @@ func (r *resourceManager) ensureDeployment(ctx context.Context) error {
 						},
 					},
 				},
+				PriorityClassName: priorityClassName,
 				SecurityContext: &corev1.PodSecurityContext{
 					// Workaround for https://github.com/kubernetes/kubernetes/issues/82573
 					// Fixed with https://github.com/kubernetes/kubernetes/pull/89193 starting with Kubernetes 1.19

--- a/pkg/operation/botanist/component/resourcemanager/resource_manager.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager.go
@@ -455,7 +455,7 @@ func (r *resourceManager) ensureDeployment(ctx context.Context) error {
 		return err
 	}
 
-	priorityClassName := "gardener-system-critical-mig"
+	priorityClassName := "gardener-system-critical-migration"
 	if r.values.TargetDiffersFromSourceCluster {
 		priorityClassName = v1beta1constants.PriorityClassNameShootControlPlane400
 	}

--- a/pkg/operation/botanist/component/resourcemanager/resource_manager_test.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager_test.go
@@ -358,7 +358,7 @@ var _ = Describe("ResourceManager", func() {
 			return cmd
 		}
 		deploymentFor = func(kubernetesVersion *semver.Version, watchedNamespace *string, targetKubeconfig *string, targetClusterDiffersFromSourceCluster bool) *appsv1.Deployment {
-			priorityClassName := "gardener-system-critical-mig"
+			priorityClassName := "gardener-system-critical-migration"
 			if targetClusterDiffersFromSourceCluster {
 				priorityClassName = v1beta1constants.PriorityClassNameShootControlPlane400
 			}

--- a/pkg/operation/botanist/component/seedsystem/seedsystem.go
+++ b/pkg/operation/botanist/component/seedsystem/seedsystem.go
@@ -166,7 +166,6 @@ var gardenletManagedPriorityClasses = []struct {
 	value       int32
 	description string
 }{
-	{v1beta1constants.PriorityClassNameSeedSystemCritical, 999998950, "PriorityClass for Seed system components"},
 	{v1beta1constants.PriorityClassNameSeedSystem900, 999998900, "PriorityClass for Seed system components"},
 	{v1beta1constants.PriorityClassNameSeedSystem800, 999998800, "PriorityClass for Seed system components"},
 	{v1beta1constants.PriorityClassNameSeedSystem700, 999998700, "PriorityClass for Seed system components"},

--- a/pkg/operation/botanist/component/seedsystem/seedsystem_test.go
+++ b/pkg/operation/botanist/component/seedsystem/seedsystem_test.go
@@ -151,7 +151,7 @@ status: {}
 		})
 
 		It("should successfully deploy the resources", func() {
-			Expect(managedResourceSecret.Data).To(HaveLen(13))
+			Expect(managedResourceSecret.Data).To(HaveLen(12))
 			Expect(string(managedResourceSecret.Data["deployment__"+namespace+"__reserve-excess-capacity.yaml"])).To(Equal(deploymentYAML))
 			expectPriorityClasses(managedResourceSecret.Data)
 		})
@@ -265,7 +265,6 @@ func expectPriorityClasses(data map[string][]byte) {
 		value       int32
 		description string
 	}{
-		{"gardener-system-critical", 999998950, "PriorityClass for Seed system components"},
 		{"gardener-system-900", 999998900, "PriorityClass for Seed system components"},
 		{"gardener-system-800", 999998800, "PriorityClass for Seed system components"},
 		{"gardener-system-700", 999998700, "PriorityClass for Seed system components"},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
This PR removes `gardenlet` priority class and `gardener-system-critical` and uses `gardener-system-critical-migration` priority class for all the components which are supposed to use `gardener-system-critical` priority class as described in #5634. This is the first step to migrate `gardenlet` priority class to `gardener-system-critical`. 
Once `gardenlet` priority class is cleaned and GRM garbage collect  `gardener-system-critical` priority class, in the next release we can switch `gardener-system-critical-migration` priority class to `gardener-system-critical`.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/5634

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
