### PR TITLE
Delay the cleanup of the `loki` PriorityClass

### DIFF
--- a/pkg/gardenlet/controller/seed/seed_control.go
+++ b/pkg/gardenlet/controller/seed/seed_control.go
@@ -421,9 +421,10 @@ func deleteBackupBucketInGarden(ctx context.Context, k8sGardenClient client.Clie
 	return client.IgnoreNotFound(k8sGardenClient.Delete(ctx, backupBucket))
 }
 
-// CleanupLegacyPriorityClasses deletes reversed-vpn-auth-server, fluent-bit and loki priority classes
+// CleanupLegacyPriorityClasses deletes reversed-vpn-auth-server and fluent-bit priority classes.
 func CleanupLegacyPriorityClasses(ctx context.Context, seedClient client.Client) error {
-	for _, name := range []string{"reversed-vpn-auth-server", "fluent-bit", "loki"} {
+	// TODO(ialidzhikov): Clean up the loki PriorityClass as well in a future release.
+	for _, name := range []string{"reversed-vpn-auth-server", "fluent-bit"} {
 		priorityClass := &schedulingv1.PriorityClass{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: name,

--- a/pkg/gardenlet/controller/seed/seed_control_test.go
+++ b/pkg/gardenlet/controller/seed/seed_control_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Seed Control", func() {
 
 		Context("when there are legacy priority classes in the cluster", func() {
 			BeforeEach(func() {
-				pcNames := []string{"reversed-vpn-auth-server", "fluent-bit", "loki", "random"}
+				pcNames := []string{"reversed-vpn-auth-server", "fluent-bit", "random"}
 				for _, name := range pcNames {
 					pc := &schedulingv1.PriorityClass{
 						ObjectMeta: v1.ObjectMeta{


### PR DESCRIPTION
/area control-plane
/kind bug
/kind regression

**What this PR does / why we need it**:
With the rollout of v1.53.1 we see that lokis get unheathy with reason:
```
$ k -n shoot--mle--playground describe sts loki

Events:
  Type     Reason        Age                From                    Message
  ----     ------        ----               ----                    -------
  Warning  FailedCreate  10m (x48 over 8h)  statefulset-controller  create Pod loki-0 in StatefulSet loki failed error: pods "loki-0" is forbidden: no PriorityClass with name loki was found
```

The reason for this is that https://github.com/gardener/gardener/pull/6257 introduces https://github.com/gardener/gardener/blob/982b6193dd55112969e344c1ed8bdf626a1c07e0/pkg/gardenlet/controller/seed/seed_control.go#L424-L438 which deletes the `loki` PriorityClass on Seed reconciliation. The problem with this is that the `loki` PriorityClass is also used by the lokis in the Shoot control planes. If a loki Pod has to be recreated before the Shoot is reconciled in the next maintenance window, then KCM will fail to create a new loki Pod with the above error.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue causing the loki PriorityClass to be deleted too early when there are still loki StatefulSets that reference it is now mitigated.
```
