### PR TITLE
Use PriorityClass for terraformer

### DIFF
--- a/docs/development/priority-classes.md
+++ b/docs/development/priority-classes.md
@@ -39,14 +39,13 @@ The listed well-known `PriorityClasses` follow this rough concept:
 
 ## `PriorityClasses` for Shoot Control Plane Components
 
-| Name                  | Priority  | Associated Components (Examples)                                                                                                                                        |
-|-----------------------|-----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `gardener-system-500` | 999998500 | `etcd-events`, `etcd-main`, `kube-apiserver`                                                                                                                            |
-| `gardener-system-400` | 999998400 | `gardener-resource-manager`                                                                                                                                             |
-| `gardener-system-300` | 999998300 | `cloud-controller-manager`, `cluster-autoscaler`, `csi-driver-controller`, `kube-controller-manager`, `kube-scheduler`, `machine-controller-manager`, `vpn-seed-server` |
-| `gardener-system-200` | 999998200 | `csi-snapshot-controller`, `csi-snapshot-validation`, `cert-controller-manager`, `shoot-dns-service`, `vpa-admission-controller`, `vpa-recommender`, `vpa-updater`      |
-| `gardener-system-100` | 999998100 | `alertmanager`, `grafana-operators`, `grafana-users`, `kube-state-metrics`, `prometheus`, `loki`, `event-logger`                                                        |
-
+| Name                  | Priority  | Associated Components (Examples)                                                                                                                                                      |
+|-----------------------|-----------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `gardener-system-500` | 999998500 | `etcd-events`, `etcd-main`, `kube-apiserver`                                                                                                                                          |
+| `gardener-system-400` | 999998400 | `gardener-resource-manager`                                                                                                                                                           |
+| `gardener-system-300` | 999998300 | `cloud-controller-manager`, `cluster-autoscaler`, `csi-driver-controller`, `kube-controller-manager`, `kube-scheduler`, `machine-controller-manager`, `terraformer, `vpn-seed-server` |
+| `gardener-system-200` | 999998200 | `csi-snapshot-controller`, `csi-snapshot-validation`, `cert-controller-manager`, `shoot-dns-service`, `vpa-admission-controller`, `vpa-recommender`, `vpa-updater`                    |
+| `gardener-system-100` | 999998100 | `alertmanager`, `grafana-operators`, `grafana-users`, `kube-state-metrics`, `prometheus`, `loki`, `event-logger`                                                                      |
 
 There is also a legacy `PriorityClass` called `gardener-shoot-controlplane` with value `100`.
 This `PriorityClass` is deprecated and will be removed in a future release.

--- a/extensions/pkg/terraformer/terraformer.go
+++ b/extensions/pkg/terraformer/terraformer.go
@@ -388,6 +388,7 @@ func (t *terraformer) deployTerraformerPod(ctx context.Context, generateName, co
 				Env:                    t.envVars,
 				TerminationMessagePath: "/terraform-termination-log",
 			}},
+			PriorityClassName:             v1beta1constants.PriorityClassNameShootControlPlane300,
 			RestartPolicy:                 corev1.RestartPolicyNever,
 			ServiceAccountName:            name,
 			TerminationGracePeriodSeconds: pointer.Int64(t.terminationGracePeriodSeconds),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area robustness
/kind enhancement

**What this PR does / why we need it**:

Use well-known PriorityClass for `terraformer` pods in extensions library.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/5634

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other dependency
`terraformer` pods now use `PriorityClass` `gardener-system-300`.
```
