### PR TITLE
Switch default backend to `eu.gcr.io/gardener-project/gardener/ingress-default-backend:0.11.0`

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -46,9 +46,9 @@ images:
   tag: "v1.3.0"
   targetVersion: ">= 1.22"
 - name: ingress-default-backend
-  sourceRepository: https://github.com/kubernetes/ingress-gce
-  repository: k8s.gcr.io/defaultbackend-amd64
-  tag: "1.5"
+  sourceRepository: github.com/gardener/ingress-default-backend
+  repository: eu.gcr.io/gardener-project/gardener/ingress-default-backend
+  tag: "0.11.0"
 
 # Seed controlplane
 #   hyperkube is used for kubectl + kubelet binaries on the worker nodes

--- a/charts/shoot-addons/charts/nginx-ingress/templates/default-backend-deployment.yaml
+++ b/charts/shoot-addons/charts/nginx-ingress/templates/default-backend-deployment.yaml
@@ -54,7 +54,7 @@ spec:
           {{- end }}
           livenessProbe:
             httpGet:
-              path: /healthz
+              path: /healthy
               port: 8080
               scheme: HTTP
             initialDelaySeconds: 30

--- a/pkg/operation/botanist/component/nginxingress/nginxingress.go
+++ b/pkg/operation/botanist/component/nginxingress/nginxingress.go
@@ -378,7 +378,7 @@ func (n *nginxIngress) computeResourcesData() (map[string][]byte, error) {
 							LivenessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
 									HTTPGet: &corev1.HTTPGetAction{
-										Path:   "/healthz",
+										Path:   "/healthy",
 										Port:   intstr.FromInt(int(containerPortBackend)),
 										Scheme: corev1.URISchemeHTTP,
 									},

--- a/pkg/operation/botanist/component/nginxingress/nginxingress_test.go
+++ b/pkg/operation/botanist/component/nginxingress/nginxingress_test.go
@@ -409,7 +409,7 @@ spec:
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
-            path: /healthz
+            path: /healthy
             port: 8080
             scheme: HTTP
           initialDelaySeconds: 30


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:
This PR switch default backend from `k8s.gcr.io/defaultbackend-amd64:1.5` to `eu.gcr.io/gardener-project/gardener/ingress-default-backend:0.11.0`. This is required because upstream doesn't publish multi-arch images. We will switch back to the upstream image once multi-arch image is available.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/backlog/issues/19

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The ingress default backend has been switched to `eu.gcr.io/gardener-project/gardener/ingress-default-backend:0.11.0`.
```
