### PR TITLE
Improve the ApiServerUnreachableViaKubernetesService alert

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules-tests/apiserver-connectivity-check.rules.test.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules-tests/apiserver-connectivity-check.rules.test.yaml
@@ -4,21 +4,48 @@ rule_files:
 evaluation_interval: 30s
 
 tests:
-- interval: 30s
+- name: ApiServerUnreachableViaKubernetesService, probe_success is 0
+  interval: 30s
   input_series:
-  # ApiServerUnreachableViaKubernetesService
-  - series: 'probe_success{job="blackbox-exporter-k8s-service-check"}'
+  - series: probe_success{job="blackbox-exporter-k8s-service-check",
+                          instance="https://kubernetes.default.svc.cluster.local/healthz"}
     values: '0+0x30'
   alert_rule_test:
   - eval_time: 15m
     alertname: ApiServerUnreachableViaKubernetesService
     exp_alerts:
     - exp_labels:
+        instance: https://kubernetes.default.svc.cluster.local/healthz
+        job: blackbox-exporter-k8s-service-check
         service: apiserver-connectivity-check
         severity: critical
         type: shoot
         visibility: all
-        job: blackbox-exporter-k8s-service-check
       exp_annotations:
         summary: Api server unreachable via the kubernetes service.
-        description: The Api server has been unreachable for 3 minutes via the kubernetes service in the shoot.
+        description: The Api server has been unreachable for 15 minutes via the kubernetes service in the shoot.
+
+- name: ApiServerUnreachableViaKubernetesService,
+    probe_success is first ok then the scrape fails and the series becomes eventually stale after 5 minutes.
+    The alert is expected to fire 15 minutes after the series became stale.
+    The job and instance labels are expected to be retained so that the "absent" alerts and the
+    explicit == 0 alerts can carry the same label set.
+  interval: 30s
+  input_series:
+  - series: probe_success{job="blackbox-exporter-k8s-service-check",
+                          instance="https://kubernetes.default.svc.cluster.local/healthz"}
+    values: '1 1 _x10 stale'
+  alert_rule_test:
+  - eval_time: 21m
+    alertname: ApiServerUnreachableViaKubernetesService
+    exp_alerts:
+    - exp_labels:
+        instance: https://kubernetes.default.svc.cluster.local/healthz
+        job: blackbox-exporter-k8s-service-check
+        service: apiserver-connectivity-check
+        severity: critical
+        type: shoot
+        visibility: all
+      exp_annotations:
+        summary: Api server unreachable via the kubernetes service.
+        description: The Api server has been unreachable for 15 minutes via the kubernetes service in the shoot.

--- a/charts/seed-monitoring/charts/core/charts/prometheus/rules/apiserver-connectivity-check.rules.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/rules/apiserver-connectivity-check.rules.yaml
@@ -2,7 +2,11 @@ groups:
 - name: apiserver-connectivity-check.rules
   rules:
   - alert: ApiServerUnreachableViaKubernetesService
-    expr: probe_success{job="blackbox-exporter-k8s-service-check"} != 1
+    expr: |
+      probe_success{job="blackbox-exporter-k8s-service-check"} == 0
+      or
+      absent(probe_success{job="blackbox-exporter-k8s-service-check",
+                           instance="https://kubernetes.default.svc.cluster.local/healthz"})
     for: 15m
     labels:
       service: apiserver-connectivity-check
@@ -11,7 +15,7 @@ groups:
       visibility: all
     annotations:
       summary: Api server unreachable via the kubernetes service.
-      description: The Api server has been unreachable for 3 minutes via the kubernetes service in the shoot.
+      description: The Api server has been unreachable for 15 minutes via the kubernetes service in the shoot.
   - record: shoot:availability
     expr: probe_success{job="blackbox-exporter-k8s-service-check"} == bool 1
     labels:

--- a/docs/monitoring/operator_alerts.md
+++ b/docs/monitoring/operator_alerts.md
@@ -1,7 +1,7 @@
 # Operator Alerts
 |Alertname|Severity|Type|Description|
 |---|---|---|---|
-|ApiServerUnreachableViaKubernetesService|critical|shoot|`The Api server has been unreachable for 3 minutes via the kubernetes service in the shoot.`|
+|ApiServerUnreachableViaKubernetesService|critical|shoot|`The Api server has been unreachable for 15 minutes via the kubernetes service in the shoot.`|
 |KubeletTooManyOpenFileDescriptorsSeed|critical|seed|`Seed-kubelet ({{ $labels.kubernetes_io_hostname }}) is using {{ $value }}% of the available file/socket descriptors. Kubelet could be under heavy load.`|
 |KubePersistentVolumeUsageCritical|critical|seed|`The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} is only {{ printf "%0.2f" $value }}% free.`|
 |KubePersistentVolumeFullInFourDays|warning|seed|`Based on recent sampling, the PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} is expected to fill up within four days. Currently {{ printf "%0.2f" $value }}% is available.`|

--- a/docs/monitoring/user_alerts.md
+++ b/docs/monitoring/user_alerts.md
@@ -1,7 +1,7 @@
 # User Alerts
 |Alertname|Severity|Type|Description|
 |---|---|---|---|
-|ApiServerUnreachableViaKubernetesService|critical|shoot|`The Api server has been unreachable for 3 minutes via the kubernetes service in the shoot.`|
+|ApiServerUnreachableViaKubernetesService|critical|shoot|`The Api server has been unreachable for 15 minutes via the kubernetes service in the shoot.`|
 |KubeKubeletNodeDown|warning|shoot|`The kubelet {{ $labels.instance }} has been unavailable/unreachable for more than 1 hour. Workloads on the affected node may not be schedulable.`|
 |KubeletTooManyOpenFileDescriptorsShoot|warning|shoot|`Shoot-kubelet ({{ $labels.kubernetes_io_hostname }}) is using {{ $value }}% of the available file/socket descriptors. Kubelet could be under heavy load.`|
 |KubeletTooManyOpenFileDescriptorsShoot|critical|shoot|`Shoot-kubelet ({{ $labels.kubernetes_io_hostname }}) is using {{ $value }}% of the available file/socket descriptors. Kubelet could be under heavy load.`|


### PR DESCRIPTION

**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

Improve the ApiServerUnreachableViaKubernetesService alert

The prometheus in the shoot control plane namespace running in the seed
scrapes the blackbox-exporter that runs in the shoot cluster's kube-system
namespace.

The blackbox exporter tries to connect to the kubernetes api server
that runs in the control plane via the cluster internal service:
`kubernetes.default.svc.cluster.local`.

See the blue path on the diagram here:
https://gardener.cloud/docs/gardener/monitoring/connectivity/

The prometheus instance in the control plane can not reach the
blackbox-exporter in the shoot cluster directly, it uses
the kubernetes api server as a proxy (which uses the VPN connection
between the seed and shoot clusters to talk to the pod in the shoot
cluster).

See https://github.com/gardener/gardener/blob/a4506ca6ae52b9b312814f2449f28e2f5cde8c42/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml#L371-L404

The probe_success metric is 1 if the scrape was successful, i.e. if the
proxied connection to the blackbox-exporter and the connection from the
blackbox-exporter back to the kubernetes api server all work.

The probe_success metric is 0 if the proxied connection to the
blackbox-exporter works, but the blackbox-exporter can not reach the
kubernetes api server. This could happen if there is a network issue
in the shoot cluster but actually the kubernetes api server is working.

If the kubernetes api server is not working at all, than the proxied
connection will not work either and the scrape itself fails, meaning that
the probe_success series will be "absent" and become eventually stale.

For testing purposes, this error condition can be triggered by scaling
the kubernetes api server deployment in the control plane to 0.

  k scale deployment kube-apiserver --replicas=0

We'd expect that the ApiServerUnreachableViaKubernetesService alert
would fire in this case, but it doesn't. The promql expression
  `probe_success{job="blackbox-exporter-k8s-service-check"} != 1`
explicitly filters for a value that does not equal to 1,
and in this case the time series does not exist so the alert
will not fire.

One approach to improve this would be to use
  `absent(probe_success{job="blackbox-exporter-k8s-service-check"} == 1)`
but in that case the job and instance labels of the alert would be
missing, because the absent() function carries over the labels of the
instant-vector selector only if there is no function call or binary
operator involved.

See https://prometheus.io/docs/prometheus/latest/querying/functions/#absent

The slightly more complicated expression in this commit checks for either
explicit failure (== 0) or for the absence of the time series.
This way the job and instance labels (that need to be duplicated
unfortunately) are carried over by absent() to the alert, so
that the alert carries these labels in both failure cases.

Regarding the unit tests, please refer to the documentation first:
https://prometheus.io/docs/prometheus/latest/configuration/unit_testing_rules/#unit-testing-for-rules

The existing test with '0+0x30' checked the case that the probe_success
series had 0 values.

The newly added test case '1 1 _x10 stale' checks the new scenario when
the kubernetes api server crashes:
the probe success has a value 1 in the beginning (i.e. the connectivity
check is working),
then the scrape fails and eventually (after 5 minutes) the time series
becomes stale.
We expect an ApiServerUnreachableViaKubernetesService alert in this case.

Regarding staleness, see
https://prometheus.io/docs/prometheus/latest/querying/basics/#staleness
https://promcon.io/2017-munich/slides/staleness-in-prometheus-2-0.pdf


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/cc @rickardsjp 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Improve the ApiServerUnreachableViaKubernetesService alert
```
