### PR TITLE
Deflake more integration tests

### DIFF
--- a/pkg/controllermanager/controller/controllerdeployment/add.go
+++ b/pkg/controllermanager/controller/controllerdeployment/add.go
@@ -15,8 +15,9 @@
 package controllerdeployment
 
 import (
-	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	"k8s.io/utils/pointer"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -44,6 +45,7 @@ func (r *Reconciler) AddToManager(mgr manager.Manager) error {
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: pointer.IntDeref(r.Config.ConcurrentSyncs, 0),
 			RecoverPanic:            true,
+			RateLimiter:             r.RateLimiter,
 		}).
 		Complete(r)
 }

--- a/pkg/controllermanager/controller/controllerdeployment/reconciler.go
+++ b/pkg/controllermanager/controller/controllerdeployment/reconciler.go
@@ -22,6 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/ratelimiter"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -34,6 +35,9 @@ import (
 type Reconciler struct {
 	Client client.Client
 	Config config.ControllerDeploymentControllerConfiguration
+
+	// RateLimiter allows limiting exponential backoff for testing purposes
+	RateLimiter ratelimiter.RateLimiter
 }
 
 // Reconcile performs the main reconciliation logic.

--- a/pkg/controllermanager/controller/exposureclass/add.go
+++ b/pkg/controllermanager/controller/exposureclass/add.go
@@ -15,8 +15,9 @@
 package exposureclass
 
 import (
-	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 	"k8s.io/utils/pointer"
+
+	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
 
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -42,6 +43,7 @@ func (r *Reconciler) AddToManager(mgr manager.Manager) error {
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: pointer.IntDeref(r.Config.ConcurrentSyncs, 0),
 			RecoverPanic:            true,
+			RateLimiter:             r.RateLimiter,
 		}).
 		Complete(r)
 }

--- a/pkg/controllermanager/controller/exposureclass/reconciler.go
+++ b/pkg/controllermanager/controller/exposureclass/reconciler.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/ratelimiter"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	gardencorev1alpha1 "github.com/gardener/gardener/pkg/apis/core/v1alpha1"
@@ -40,6 +41,9 @@ type Reconciler struct {
 	Client   client.Client
 	Config   config.ExposureClassControllerConfiguration
 	Recorder record.EventRecorder
+
+	// RateLimiter allows limiting exponential backoff for testing purposes
+	RateLimiter ratelimiter.RateLimiter
 }
 
 // Reconcile performs the main reconciliation logic.

--- a/test/integration/controllermanager/controllerdeployment/controllerdeployment_test.go
+++ b/test/integration/controllermanager/controllerdeployment/controllerdeployment_test.go
@@ -34,6 +34,7 @@ var _ = Describe("ControllerDeployment controller tests", func() {
 		controllerDeployment = &gardencorev1beta1.ControllerDeployment{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: testID + "-",
+				Labels:       map[string]string{testID: testRunID},
 			},
 			Type: "helm",
 		}
@@ -41,6 +42,7 @@ var _ = Describe("ControllerDeployment controller tests", func() {
 		controllerRegistration = &gardencorev1beta1.ControllerRegistration{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: testID + "-",
+				Labels:       map[string]string{testID: testRunID},
 			},
 		}
 	})

--- a/test/integration/controllermanager/exposureclass/exposureclass_suite_test.go
+++ b/test/integration/controllermanager/exposureclass/exposureclass_suite_test.go
@@ -18,6 +18,9 @@ import (
 	"context"
 	"testing"
 
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
 	exposureclasscontroller "github.com/gardener/gardener/pkg/controllermanager/controller/exposureclass"
@@ -55,6 +58,7 @@ var (
 	testClient client.Client
 
 	testNamespace *corev1.Namespace
+	testRunID     string
 )
 
 var _ = BeforeSuite(func() {
@@ -91,6 +95,7 @@ var _ = BeforeSuite(func() {
 	}
 	Expect(testClient.Create(ctx, testNamespace)).To(Succeed())
 	log.Info("Created Namespace for test", "namespaceName", testNamespace.Name)
+	testRunID = testNamespace.Name
 
 	DeferCleanup(func() {
 		By("deleting test namespace")
@@ -102,6 +107,11 @@ var _ = BeforeSuite(func() {
 		Scheme:             kubernetes.GardenScheme,
 		MetricsBindAddress: "0",
 		Namespace:          testNamespace.Name,
+		NewCache: cache.BuilderWithOptions(cache.Options{
+			DefaultSelector: cache.ObjectSelector{
+				Label: labels.SelectorFromSet(labels.Set{testID: testRunID}),
+			},
+		}),
 	})
 	Expect(err).NotTo(HaveOccurred())
 

--- a/test/integration/controllermanager/exposureclass/exposureclass_test.go
+++ b/test/integration/controllermanager/exposureclass/exposureclass_test.go
@@ -55,7 +55,6 @@ var _ = Describe("ExposureClass controller test", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: testID + "-",
 				Namespace:    testNamespace.Name,
-				Labels:       map[string]string{testID: testRunID},
 			},
 			Spec: gardencorev1beta1.ShootSpec{
 				CloudProfileName:  "test-cloudprofile",
@@ -84,6 +83,12 @@ var _ = Describe("ExposureClass controller test", func() {
 		log.Info("Created ExposureClass for test", "exposureClass", client.ObjectKeyFromObject(exposureClass))
 
 		DeferCleanup(func() {
+			if shoot != nil {
+				// delete the shoot first, otherwise exposureclass will not be released
+				By("Delete Shoot")
+				Expect(testClient.Delete(ctx, shoot)).To(Or(Succeed(), BeNotFoundError()))
+			}
+
 			By("Delete ExposureClass")
 			Expect(testClient.Delete(ctx, exposureClass)).To(Or(Succeed(), BeNotFoundError()))
 			Eventually(func() error {
@@ -98,10 +103,13 @@ var _ = Describe("ExposureClass controller test", func() {
 			Expect(testClient.Create(ctx, shoot)).To(Succeed())
 			log.Info("Created Shoot for test", "shoot", client.ObjectKeyFromObject(shoot))
 
-			DeferCleanup(func() {
-				By("Delete Shoot")
-				Expect(testClient.Delete(ctx, shoot)).To(Or(Succeed(), BeNotFoundError()))
-			})
+			By("Wait until manager has observed shoot")
+			// Use the manager's cache to ensure it has observed the shoot.
+			// Otherwise, the controller might clean up the ExposureClass too early because it thinks all referencing shoots
+			// are gone. Similar to https://github.com/gardener/gardener/issues/6486
+			Eventually(func() error {
+				return mgrClient.Get(ctx, client.ObjectKeyFromObject(shoot), &gardencorev1beta1.Shoot{})
+			}).Should(Succeed())
 		}
 	})
 

--- a/test/integration/controllermanager/exposureclass/exposureclass_test.go
+++ b/test/integration/controllermanager/exposureclass/exposureclass_test.go
@@ -37,6 +37,7 @@ var _ = Describe("ExposureClass controller test", func() {
 		exposureClass = &gardencorev1alpha1.ExposureClass{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: testID + "-",
+				Labels:       map[string]string{testID: testRunID},
 			},
 			Handler: "test-exposure-class-handler-name",
 			Scheduling: &gardencorev1alpha1.ExposureClassScheduling{
@@ -54,6 +55,7 @@ var _ = Describe("ExposureClass controller test", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: testID + "-",
 				Namespace:    testNamespace.Name,
+				Labels:       map[string]string{testID: testRunID},
 			},
 			Spec: gardencorev1beta1.ShootSpec{
 				CloudProfileName:  "test-cloudprofile",

--- a/test/integration/controllermanager/shoot/maintenance/maintenance_test.go
+++ b/test/integration/controllermanager/shoot/maintenance/maintenance_test.go
@@ -439,9 +439,8 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 
 			Expect(kutil.SetAnnotationAndUpdate(ctx, testClient, shoot, v1beta1constants.GardenerOperation, v1beta1constants.ShootOperationMaintain)).To(Succeed())
 
-			Eventually(func() string {
-				err := testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)
-				Expect(err).NotTo(HaveOccurred())
+			Eventually(func(g Gomega) string {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
 				return *shoot.Spec.Provider.Workers[0].Kubernetes.Version
 			}).Should(Equal(testKubernetesVersionHighestPatchLowMinor.Version))
 		})
@@ -455,9 +454,8 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 
 			Expect(kutil.SetAnnotationAndUpdate(ctx, testClient, shoot, v1beta1constants.GardenerOperation, v1beta1constants.ShootOperationMaintain)).To(Succeed())
 
-			Eventually(func() string {
-				err := testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)
-				Expect(err).NotTo(HaveOccurred())
+			Eventually(func(g Gomega) string {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
 				return *shoot.Spec.Provider.Workers[0].Kubernetes.Version
 			}).Should(Equal(testKubernetesVersionHighestPatchLowMinor.Version))
 		})
@@ -476,9 +474,8 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 			Expect(kutil.SetAnnotationAndUpdate(ctx, testClient, shoot, v1beta1constants.GardenerOperation, v1beta1constants.ShootOperationMaintain)).To(Succeed())
 
 			// expect worker pool to have updated to latest patch version of next minor version
-			Eventually(func() string {
-				err := testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)
-				Expect(err).NotTo(HaveOccurred())
+			Eventually(func(g Gomega) string {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
 				return *shoot.Spec.Provider.Workers[0].Kubernetes.Version
 			}).Should(Equal(testKubernetesVersionHighestPatchConsecutiveMinor.Version))
 		})
@@ -497,9 +494,8 @@ var _ = Describe("Shoot Maintenance controller tests", func() {
 			Expect(kutil.SetAnnotationAndUpdate(ctx, testClient, shoot, v1beta1constants.GardenerOperation, v1beta1constants.ShootOperationMaintain)).To(Succeed())
 
 			// expect worker pool to have updated to latest patch version of next minor version
-			Eventually(func() string {
-				err := testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)
-				Expect(err).NotTo(HaveOccurred())
+			Eventually(func(g Gomega) string {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
 				return *shoot.Spec.Provider.Workers[0].Kubernetes.Version
 			}).Should(Equal(testKubernetesVersionLowPatchConsecutiveMinor.Version))
 		})

--- a/test/integration/extensions/webhook/cloudprovider/cloudprovider_test.go
+++ b/test/integration/extensions/webhook/cloudprovider/cloudprovider_test.go
@@ -69,9 +69,8 @@ var _ = Describe("CloudProvider tests", func() {
 		It("should not mutate the secret because matching labels are not present", func() {
 			By("create Secret")
 			Eventually(func(g Gomega) {
-				Expect(testClient.Create(ctx, secret)).To(Succeed())
-
-				Expect(secret.Data).To(Equal(originalData))
+				g.Expect(testClient.Create(ctx, secret)).To(Succeed())
+				g.Expect(secret.Data).To(Equal(originalData))
 			}).Should(Succeed())
 		})
 
@@ -82,9 +81,8 @@ var _ = Describe("CloudProvider tests", func() {
 
 			By("create Secret")
 			Eventually(func(g Gomega) {
-				Expect(testClient.Create(ctx, secret)).To(Succeed())
-
-				Expect(secret.Data).To(Equal(map[string][]byte{
+				g.Expect(testClient.Create(ctx, secret)).To(Succeed())
+				g.Expect(secret.Data).To(Equal(map[string][]byte{
 					"clientID":     []byte("foo"),
 					"clientSecret": []byte("bar"),
 				}))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:

Deflake more integration tests
- `ExposureClass` controller
- `ControllerDeployment` controller
- `cloudprovider` webhook

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/6496