### PR TITLE
Use `kube-state-metrics` v2.5.0 for seed version >=1.20

### DIFF
--- a/pkg/operation/seed/components.go
+++ b/pkg/operation/seed/components.go
@@ -83,8 +83,8 @@ func defaultEtcdDruid(
 	return etcd.NewBootstrapper(c, v1beta1constants.GardenNamespace, conf, image.String(), imageVectorOverwrite), nil
 }
 
-func defaultKubeStateMetrics(c client.Client, imageVector imagevector.ImageVector) (component.DeployWaiter, error) {
-	image, err := imageVector.FindImage(images.ImageNameKubeStateMetrics)
+func defaultKubeStateMetrics(c client.Client, imageVector imagevector.ImageVector, seedVersion string) (component.DeployWaiter, error) {
+	image, err := imageVector.FindImage(images.ImageNameKubeStateMetrics, imagevector.TargetVersion(seedVersion))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operation/seed/seed.go
+++ b/pkg/operation/seed/seed.go
@@ -908,7 +908,7 @@ func runCreateSeedFlow(
 	if err != nil {
 		return err
 	}
-	kubeStateMetrics, err := defaultKubeStateMetrics(seedClient, imageVector)
+	kubeStateMetrics, err := defaultKubeStateMetrics(seedClient, imageVector, kubernetesVersion.String())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring control-plane
/kind enhancement

**What this PR does / why we need it**:
https://github.com/gardener/gardener/pull/6224 PR upgraded kube-state-metrics version to v2.5.0 for shoot of Kubernetes version >=1.20, but not the same for seed. This PR adapts changes in seed control-flow to use kube-state-metrics image based on seed Kubernetes version.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
