### PR TITLE
Provider local updates

### DIFF
--- a/example/provider-local/garden/base/kustomization.yaml
+++ b/example/provider-local/garden/base/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
 - project.yaml
 - secret-backup.yaml
 - secretbinding.yaml
-- https://raw.githubusercontent.com/gardener/gardener-extension-networking-calico/v1.23.0/example/controller-registration.yaml
+- https://raw.githubusercontent.com/gardener/gardener-extension-networking-calico/v1.26.0/example/controller-registration.yaml
 
 patchesStrategicMerge:
 - patch-controller-registrations.yaml

--- a/pkg/provider-local/imagevector/images.yaml
+++ b/pkg/provider-local/imagevector/images.yaml
@@ -2,7 +2,7 @@ images:
 - name: machine-controller-manager
   sourceRepository: github.com/gardener/machine-controller-manager
   repository: eu.gcr.io/gardener-project/gardener/machine-controller-manager
-  tag: "v0.45.0"
+  tag: "v0.46.1"
 - name: machine-controller-manager-provider-local
   sourceRepository: github.com/gardener/machine-controller-manager-provider-local
   repository: ghcr.io/gardener/machine-controller-manager-provider-local


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR updates the MCM as well as the Calico extension version used by the `local` provider. Both contain support for ARM64 🥳.

**Which issue(s) this PR fixes**:
Fixes partially #6258 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
The `machine-controller-manager` version deployed by `provider-local` has been updated to `v0.46.1`.
```
```other developer
The `networking-calico` version deployed by `provider-local` has been updated to `v1.26.0`.
```
