### PR TITLE
update logging components from 0.42.0 to 0.43.0

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -240,7 +240,7 @@ images:
 - name: fluent-bit-plugin-installer
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/fluent-bit-to-loki
-  tag: "v0.42.0"
+  tag: "v0.43.0"
 - name: loki
   sourceRepository: github.com/grafana/loki
   repository: grafana/loki
@@ -248,7 +248,7 @@ images:
 - name: loki-curator
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/loki-curator
-  tag: "v0.42.0"
+  tag: "v0.43.0"
 - name: kube-rbac-proxy
   sourceRepository: github.com/brancz/kube-rbac-proxy
   repository: quay.io/brancz/kube-rbac-proxy
@@ -260,11 +260,11 @@ images:
 - name: telegraf
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/telegraf-iptables
-  tag: "v0.42.0"
+  tag: "v0.43.0"
 - name: event-logger
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/event-logger
-  tag: "v0.42.0"
+  tag: "v0.43.0"
 
 # VPA
 - name: vpa-admission-controller

--- a/charts/seed-bootstrap/charts/fluent-bit/templates/_fluent-bit-config.tpl
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/_fluent-bit-config.tpl
@@ -106,7 +106,7 @@
       Match kubernetes.*
       Url http://loki.garden.svc:3100/loki/api/v1/push
       LogLevel info
-      BatchWait 40s
+      BatchWait 60s
       BatchSize 30720
       Labels {origin="seed"}
       LineFormat json
@@ -137,9 +137,9 @@
       SendDeletedClustersLogsToDefaultClient true
       CleanExpiredClientsPeriod 1h
       ControllerSyncTimeout 120s
-      PreservedLabels origin,namespace_name
       NumberOfBatchIDs 5
       TenantID operator
+      PreservedLabels origin,namespace_name,pod_name
 
   [Output]
       Name gardenerloki

--- a/pkg/operation/botanist/component/logging/eventlogger/event_logger.go
+++ b/pkg/operation/botanist/component/logging/eventlogger/event_logger.go
@@ -378,9 +378,9 @@ func (l *eventLogger) emptyVPA() *vpaautoscalingv1.VerticalPodAutoscaler {
 func (l *eventLogger) computeCommand() []string {
 	return []string{
 		"./event-logger",
-		"--seed-event-namespace=" + l.namespace,
+		"--seed-event-namespaces=" + l.namespace,
 		"--shoot-kubeconfig=" + gutil.PathGenericKubeconfig,
-		"--shoot-event-namespace=" + metav1.NamespaceSystem,
+		"--shoot-event-namespaces=" + metav1.NamespaceSystem + "," + metav1.NamespaceDefault,
 	}
 }
 

--- a/pkg/operation/botanist/component/logging/eventlogger/event_logger_test.go
+++ b/pkg/operation/botanist/component/logging/eventlogger/event_logger_test.go
@@ -417,9 +417,9 @@ var _ = Describe("EventLogger", func() {
 									ImagePullPolicy: corev1.PullIfNotPresent,
 									Command: []string{
 										"./event-logger",
-										"--seed-event-namespace=" + namespace,
+										"--seed-event-namespaces=" + namespace,
 										"--shoot-kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig",
-										"--shoot-event-namespace=kube-system",
+										"--shoot-event-namespaces=kube-system,default",
 									},
 									Resources: corev1.ResourceRequirements{
 										Requests: corev1.ResourceList{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
This PR updates the logging components from version v0.42.0 to v.043.0 and adapts the gardener for the new features:
- scrapes events from the shoot default namepsace.
- pack the shoot's log before being sent to the central Loki when the shoot is in the creation or deletion state.
- remove the `__gardener_multitenant_id__` label when logs are sent to the central Loki.
- the name of the batch ID label can be changed via the `fluent-bit-to-loki` plugin configuration.
Also, fix a race condition in the multitenant client which could be a fix for #4747

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
``` other operator github.com/gardener/logging #138 @vlvasilev
All split logs between shoot and central Loki are packed before being sent to the central Loki.
```

``` feature operator github.com/gardener/logging #142 @vlvasilev
The event-logger watches events of multiple namespaces specified by `--seed-event-namespaces` and `--shoot-event-namespaces` like comma-separated values.
The flags `--seed-event-namespace` and `--shoot-event-namespace` are dropped.
```

``` bugfix operator github.com/gardener/logging #144 @vlvasilev
Remove race condition in the multitenant client when labels set is not cloned.
```

``` other operator github.com/gardener/logging #147 @vlvasilev
Remove the `__gardener_multitenant_id__` label when it is not needed
```

``` other operator github.com/gardener/logging #148 @vlvasilev
The name of the batch ID label can be set via `IdLabelName` from the plugin configuration.
```
