### PR TITLE
Evaluate etcd's `BackupReady` condition 

### DIFF
--- a/example/seed-crds/10-crd-druid.gardener.cloud_etcds.yaml
+++ b/example/seed-crds/10-crd-druid.gardener.cloud_etcds.yaml
@@ -1715,7 +1715,7 @@ spec:
                 format: int64
                 type: integer
               ready:
-                description: Ready represents the readiness of the etcd resource.
+                description: Ready is `true` if all etcd replicas are ready.
                 type: boolean
               readyReplicas:
                 description: ReadyReplicas is the count of replicas being ready in

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/bronze1man/yaml2json v0.0.0-20211227013850-8972abeaea25
 	github.com/coreos/go-systemd/v22 v22.3.2
 	github.com/gardener/dependency-watchdog v0.7.0
-	github.com/gardener/etcd-druid v0.9.0
+	github.com/gardener/etcd-druid v0.12.3
 	github.com/gardener/hvpa-controller/api v0.5.0
 	github.com/gardener/machine-controller-manager v0.45.0
 	github.com/ghodss/yaml v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -206,8 +206,8 @@ github.com/gardener/dependency-watchdog v0.7.0 h1:54Hy9XxQrP8j0bpzJo9k5tJ3Nd/snR
 github.com/gardener/dependency-watchdog v0.7.0/go.mod h1:OxGZPFb0z8/dTVsk0dCIgcF+q9JhXvfVIdzpYOkcnl8=
 github.com/gardener/etcd-druid v0.1.12/go.mod h1:yZrUQY9clD8/ZXK+MmEq8OS1TaKJeipV0u4kHHrwWeY=
 github.com/gardener/etcd-druid v0.3.0/go.mod h1:uxZjZ57gIgpX554vGp495g2i8DByoS3OkVtiqsxtbwk=
-github.com/gardener/etcd-druid v0.9.0 h1:nQWqmPpT5LhURPTADQ/93x7AiCCe7ruJ9DQnYU/IJ0w=
-github.com/gardener/etcd-druid v0.9.0/go.mod h1:EJF6z4Ghv2FGUe1UzZWOEF1MxCA186fxvjBO44oSJX4=
+github.com/gardener/etcd-druid v0.12.3 h1:FBpsEe+FrBwJ1a2VhaPlXjZsfIAcHGSsF5DvDOcDnbM=
+github.com/gardener/etcd-druid v0.12.3/go.mod h1:EJF6z4Ghv2FGUe1UzZWOEF1MxCA186fxvjBO44oSJX4=
 github.com/gardener/external-dns-management v0.7.3/go.mod h1:Y3om11E865x4aQ7cmcHjknb8RMgCO153huRb/SvP+9o=
 github.com/gardener/external-dns-management v0.7.7/go.mod h1:egCe/FPOsUbXA4WV0ne3h7nAD/nLT09hNt/FQQXK+ec=
 github.com/gardener/gardener v1.1.2/go.mod h1:CP9I0tCDVXTLPkJv/jUtXVUh948kSNKEGUg0haLz9gk=

--- a/pkg/utils/kubernetes/health/etcd.go
+++ b/pkg/utils/kubernetes/health/etcd.go
@@ -32,12 +32,10 @@ func CheckEtcd(etcd *druidv1alpha1.Etcd) error {
 		if cond.Type != druidv1alpha1.ConditionTypeBackupReady {
 			continue
 		}
+
+		// TODO(timuthy): Check for cond.Status != druidv1alpha1.ConditionTrue as soon as https://github.com/gardener/etcd-druid/issues/413 is resolved.
 		if cond.Status == druidv1alpha1.ConditionFalse {
-			errStr := fmt.Sprintf("backup for etcd %q is reported as unready", etcd.Name)
-			if cond.Message != "" {
-				errStr += fmt.Sprintf(": %s", cond.Message)
-			}
-			return fmt.Errorf(errStr)
+			return fmt.Errorf("backup for etcd %q is reported as unready: %s", etcd.Name, cond.Message)
 		}
 	}
 

--- a/pkg/utils/kubernetes/health/etcd_test.go
+++ b/pkg/utils/kubernetes/health/etcd_test.go
@@ -21,16 +21,54 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
 )
 
 var _ = Describe("Etcd", func() {
-	DescribeTable("#CheckEtcd",
+	DescribeTable("Ready field",
 		func(etcd *druidv1alpha1.Etcd, matcher types.GomegaMatcher) {
 			Expect(health.CheckEtcd(etcd)).To(matcher)
 		},
 		Entry("nil", &druidv1alpha1.Etcd{}, MatchError(ContainSubstring("is not ready yet"))),
 		Entry("false", &druidv1alpha1.Etcd{Status: druidv1alpha1.EtcdStatus{Ready: pointer.Bool(false)}}, MatchError(ContainSubstring("is not ready yet"))),
 		Entry("true", &druidv1alpha1.Etcd{Status: druidv1alpha1.EtcdStatus{Ready: pointer.Bool(true)}}, BeNil()),
+	)
+
+	DescribeTable("Backup condition",
+		func(backupReady *bool, matcher types.GomegaMatcher) {
+			etcd := &druidv1alpha1.Etcd{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "etcd-foo",
+				},
+				Status: druidv1alpha1.EtcdStatus{
+					Ready: pointer.Bool(true),
+				},
+			}
+
+			if backupReady != nil {
+				var (
+					message string
+					status  = druidv1alpha1.ConditionTrue
+				)
+				if !*backupReady {
+					message = "backup bucket is not accessible"
+					status = druidv1alpha1.ConditionFalse
+				}
+
+				etcd.Status.Conditions = []druidv1alpha1.Condition{
+					{
+						Type:    druidv1alpha1.ConditionTypeBackupReady,
+						Status:  status,
+						Message: message,
+					},
+				}
+			}
+
+			Expect(health.CheckEtcd(etcd)).To(matcher)
+		},
+		Entry("no condition", nil, BeNil()),
+		Entry("backup not ready", pointer.Bool(false), MatchError(ContainSubstring("backup for etcd \"etcd-foo\" is reported as unready"))),
+		Entry("backup ready", pointer.Bool(true), BeNil()),
 	)
 })

--- a/vendor/github.com/gardener/etcd-druid/api/v1alpha1/etcd_types.go
+++ b/vendor/github.com/gardener/etcd-druid/api/v1alpha1/etcd_types.go
@@ -417,7 +417,7 @@ type EtcdStatus struct {
 	// ReadyReplicas is the count of replicas being ready in the etcd cluster.
 	// +optional
 	ReadyReplicas int32 `json:"readyReplicas,omitempty"`
-	// Ready represents the readiness of the etcd resource.
+	// Ready is `true` if all etcd replicas are ready.
 	// +optional
 	Ready *bool `json:"ready,omitempty"`
 	// UpdatedReplicas is the count of updated replicas in the etcd cluster.

--- a/vendor/github.com/gardener/etcd-druid/pkg/utils/miscellaneous.go
+++ b/vendor/github.com/gardener/etcd-druid/pkg/utils/miscellaneous.go
@@ -50,26 +50,23 @@ const (
 )
 
 const (
-	s3    = "S3"
-	abs   = "ABS"
-	gcs   = "GCS"
-	oss   = "OSS"
-	swift = "Swift"
+	// S3 is a constant for the AWS and S3 compliant storage provider.
+	S3 = "S3"
+	// ABS is a constant for the Azure storage provider.
+	ABS = "ABS"
+	// GCS is a constant for the Google storage provider.
+	GCS = "GCS"
+	// OSS is a constant for the Alicloud storage provider.
+	OSS = "OSS"
+	// Swift is a constant for the OpenStack storage provider.
+	Swift = "Swift"
+	// Local is a constant for the Local storage provider.
 	Local = "Local"
-	ecs   = "ECS"
-	ocs   = "OCS"
+	// ECS is a constant for the EMC storage provider.
+	ECS = "ECS"
+	// OSC is a constant for the OpenShift storage provider.
+	OCS = "OCS"
 )
-
-// ValueExists returns true or false, depending on whether the given string <value>
-// is part of the given []string list <list>.
-func ValueExists(value string, list []string) bool {
-	for _, v := range list {
-		if v == value {
-			return true
-		}
-	}
-	return false
-}
 
 // MergeMaps takes two maps <a>, <b> and merges them. If <b> defines a value with a key
 // already existing in the <a> map, the <a> value for that key will be overwritten.
@@ -211,20 +208,20 @@ func StorageProviderFromInfraProvider(infra *druidv1alpha1.StorageProvider) (str
 	}
 
 	switch *infra {
-	case aws, s3:
-		return s3, nil
-	case azure, abs:
-		return abs, nil
-	case alicloud, oss:
-		return oss, nil
-	case openstack, swift:
-		return swift, nil
-	case gcp, gcs:
-		return gcs, nil
-	case dell, ecs:
-		return ecs, nil
-	case openshift, ocs:
-		return ocs, nil
+	case aws, S3:
+		return S3, nil
+	case azure, ABS:
+		return ABS, nil
+	case alicloud, OSS:
+		return OSS, nil
+	case openstack, Swift:
+		return Swift, nil
+	case gcp, GCS:
+		return GCS, nil
+	case dell, ECS:
+		return ECS, nil
+	case openshift, OCS:
+		return OCS, nil
 	case Local, druidv1alpha1.StorageProvider(strings.ToLower(Local)):
 		return Local, nil
 	default:
@@ -252,7 +249,7 @@ func isContainerInCrashLoopBackOff(containerState v1.ContainerState) bool {
 // Max returns the larger of x or y.
 func Max(x, y int) int {
 	if y > x {
-		return x
+		return y
 	}
 	return x
 }

--- a/vendor/github.com/gardener/etcd-druid/pkg/utils/names.go
+++ b/vendor/github.com/gardener/etcd-druid/pkg/utils/names.go
@@ -54,3 +54,13 @@ func GetJobName(etcd *druidv1alpha1.Etcd) string {
 func GetOrdinalPodName(etcd *druidv1alpha1.Etcd, order int) string {
 	return fmt.Sprintf("%s-%d", etcd.Name, order)
 }
+
+// GetDeltaSnapshotLeaseName returns the name of the delta snapshot lease based on the given `etcd` object.
+func GetDeltaSnapshotLeaseName(etcd *druidv1alpha1.Etcd) string {
+	return fmt.Sprintf("%s-delta-snap", etcd.Name)
+}
+
+// GetFullSnapshotLeaseName returns the name of the full snapshot lease based on the given `etcd` object.
+func GetFullSnapshotLeaseName(etcd *druidv1alpha1.Etcd) string {
+	return fmt.Sprintf("%s-full-snap", etcd.Name)
+}

--- a/vendor/github.com/gardener/etcd-druid/pkg/utils/statefulset.go
+++ b/vendor/github.com/gardener/etcd-druid/pkg/utils/statefulset.go
@@ -1,0 +1,37 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+// CheckStatefulSet checks whether the given StatefulSet is healthy.
+// A StatefulSet is considered healthy if its controller observed its current revision,
+// it is not in an update (i.e. UpdateRevision is empty) and if its current replicas are equal to
+// desired replicas specified in ETCD specs.
+func CheckStatefulSet(etcdReplicas int32, statefulSet *appsv1.StatefulSet) error {
+	if statefulSet.Status.ObservedGeneration < statefulSet.Generation {
+		return fmt.Errorf("observed generation outdated (%d/%d)", statefulSet.Status.ObservedGeneration, statefulSet.Generation)
+	}
+
+	if statefulSet.Status.ReadyReplicas < etcdReplicas {
+		return fmt.Errorf("not enough ready replicas (%d/%d)", statefulSet.Status.ReadyReplicas, etcdReplicas)
+	}
+
+	return nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -79,7 +79,7 @@ github.com/fsnotify/fsnotify
 ## explicit; go 1.13
 github.com/gardener/dependency-watchdog/pkg/restarter/api
 github.com/gardener/dependency-watchdog/pkg/scaler/api
-# github.com/gardener/etcd-druid v0.9.0
+# github.com/gardener/etcd-druid v0.12.3
 ## explicit; go 1.17
 github.com/gardener/etcd-druid/api/v1alpha1
 github.com/gardener/etcd-druid/api/validation


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
This PR makes the `etcd` check consider the `BackupReady` condition.

**Which issue(s) this PR fixes**:
Fixes #6317

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Gardener now evaluates the `BackupReady` condition of `etcd` resources when calculating the health of shoot control planes. In case of non-functioning backups, the state is reported in the `ControlPlaneHealthy` of the affected shoot.
```
