### PR TITLE
Remove readiness/liveness probes and metrics requests from apiserver-proxy access log.

### DIFF
--- a/charts/shoot-core/components/charts/apiserver-proxy/templates/_helpers.tpl
+++ b/charts/shoot-core/components/charts/apiserver-proxy/templates/_helpers.tpl
@@ -12,7 +12,26 @@ envoy.yaml: |-
           overload:
             global_downstream_max_connections: 10000
   admin:
-    access_log_path: /dev/stdout
+    access_log:
+    - name: envoy.access_loggers.stdout
+      # Remove spammy readiness/liveness probes and metrics requests from access log
+      filter:
+        and_filter:
+          filters:
+          - header_filter:
+              header:
+                name: :Path
+                string_match:
+                  exact: /ready
+                invert_match: true
+          - header_filter:
+              header:
+                name: :Path
+                string_match:
+                  exact: /stats/prometheus
+                invert_match: true
+      typed_config:
+        "@type": type.googleapis.com/envoy.extensions.access_loggers.stream.v3.StdoutAccessLog
     address:
       pipe:
         # The admin interface should not be exposed as a TCP address.


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Remove readiness/liveness probes and metrics requests from apiserver-proxy access log.

The readiness/liveness probes in conjunction with the regular metrics requests spam
the access log of the apiserver-proxy to the point that it is hard to find the actual
workload requests. This change simply removes the readiness/liveness probes and
metrics requests from the access log so that the actual access log can focus on the
forwarded workload requests.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Access log of api-server proxy now only shows forwarded requests, but ignores readiness/liveness probes and metrics requests.
```
