### PR TITLE
Prevent confusing error messages about outdated cloud configs on nodes during rolling updates

### DIFF
--- a/pkg/operation/botanist/operatingsystemconfig.go
+++ b/pkg/operation/botanist/operatingsystemconfig.go
@@ -251,6 +251,7 @@ func (b *Botanist) generateCloudConfigExecutorResourcesForWorker(
 	if err != nil {
 		return "", nil, err
 	}
+
 	var (
 		registry   = managedresources.NewRegistry(kubernetes.ShootScheme, kubernetes.ShootCodec, kubernetes.ShootSerializer)
 		secretName = operatingsystemconfig.Key(worker.Name, kubernetesVersion, worker.CRI)

--- a/pkg/operation/botanist/worker.go
+++ b/pkg/operation/botanist/worker.go
@@ -124,8 +124,7 @@ func CloudConfigUpdatedForAllWorkerPools(
 	for _, worker := range workers {
 		secretMeta, ok := workerPoolToCloudConfigSecretMeta[worker.Name]
 		if !ok {
-			// This is to ensure backwards-compatibility to not break existing clusters which don't have a secret
-			// checksum label yet.
+			result = multierror.Append(result, fmt.Errorf("missing cloud config secret metadata for worker pool %q", worker.Name))
 			continue
 		}
 

--- a/pkg/operation/botanist/worker.go
+++ b/pkg/operation/botanist/worker.go
@@ -22,6 +22,8 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig/downloader"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/worker"
@@ -30,6 +32,7 @@ import (
 	"github.com/gardener/gardener/pkg/utils/retry"
 	"github.com/gardener/gardener/pkg/utils/secrets"
 
+	"github.com/Masterminds/semver"
 	"github.com/hashicorp/go-multierror"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -129,11 +132,12 @@ func CloudConfigUpdatedForAllWorkerPools(
 		}
 
 		var (
+			secretOSCKey   = secretMeta.Name
 			secretChecksum = secretMeta.Annotations[downloader.AnnotationKeyChecksum]
 		)
 
 		for _, node := range workerPoolToNodes[worker.Name] {
-			nodeWillBeDeleted, err := nodeToBeDeleted(node)
+			nodeWillBeDeleted, err := nodeToBeDeleted(node, secretOSCKey)
 			if err != nil {
 				result = multierror.Append(result, fmt.Errorf("failed checking whether node %q will be deleted: %w", node.Name, err))
 				continue
@@ -152,8 +156,11 @@ func CloudConfigUpdatedForAllWorkerPools(
 	return result
 }
 
-func nodeToBeDeleted(node corev1.Node) (bool, error) {
-	return nodeTaintedForNoSchedule(node), nil
+func nodeToBeDeleted(node corev1.Node, secretOSCKey string) (bool, error) {
+	if nodeTaintedForNoSchedule(node) {
+		return true, nil
+	}
+	return nodeOSCKeyDifferentFromSecretOSCKey(node, secretOSCKey)
 }
 
 func nodeTaintedForNoSchedule(node corev1.Node) bool {
@@ -168,6 +175,20 @@ func nodeTaintedForNoSchedule(node corev1.Node) bool {
 	}
 
 	return false
+}
+
+func nodeOSCKeyDifferentFromSecretOSCKey(node corev1.Node, secretOSCKey string) (bool, error) {
+	kubernetesVersion, err := semver.NewVersion(node.Labels[v1beta1constants.LabelWorkerKubernetesVersion])
+	if err != nil {
+		return false, fmt.Errorf("failed parsing Kubernetes version to semver for node %q: %w", node.Name, err)
+	}
+
+	var criConfig *gardencorev1beta1.CRI
+	if v, ok := node.Labels[extensionsv1alpha1.CRINameWorkerLabel]; ok {
+		criConfig = &gardencorev1beta1.CRI{Name: gardencorev1beta1.CRIName(v)}
+	}
+
+	return operatingsystemconfig.Key(node.Labels[v1beta1constants.LabelWorkerPool], kubernetesVersion, criConfig) != secretOSCKey, nil
 }
 
 // exposed for testing

--- a/pkg/operation/botanist/worker_test.go
+++ b/pkg/operation/botanist/worker_test.go
@@ -267,11 +267,11 @@ var _ = Describe("Worker", func() {
 			Expect(CloudConfigUpdatedForAllWorkerPools(workers, workerPoolToNodes, workerPoolToCloudConfigSecretMeta)).To(matcher)
 		},
 
-		Entry("secret checksum missing",
+		Entry("secret meta missing",
 			[]gardencorev1beta1.Worker{{Name: "pool1"}},
 			nil,
 			nil,
-			BeNil(),
+			MatchError(ContainSubstring("missing cloud config secret metadata")),
 		),
 		Entry("annotation outdated",
 			[]gardencorev1beta1.Worker{{Name: "pool1"}},

--- a/pkg/operation/botanist/worker_test.go
+++ b/pkg/operation/botanist/worker_test.go
@@ -281,7 +281,7 @@ var _ = Describe("Worker", func() {
 		),
 		Entry("skip node in deletion",
 			[]gardencorev1beta1.Worker{{Name: "pool1"}},
-			map[string][]corev1.Node{"pool1": {{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{"checksum/cloud-config-data": "outdated"}}, Spec: corev1.NodeSpec{Taints: []corev1.Taint{{Key: MCMPreferNoScheduleKey, Effect: corev1.TaintEffectPreferNoSchedule}}}}}},
+			map[string][]corev1.Node{"pool1": {{ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{"checksum/cloud-config-data": "outdated"}}, Spec: corev1.NodeSpec{Taints: []corev1.Taint{{Key: "deployment.machine.sapcloud.io/prefer-no-schedule", Effect: corev1.TaintEffectPreferNoSchedule}}}}}},
 			map[string]string{"pool1": "foo"},
 			BeNil(),
 		),

--- a/pkg/operation/care/checker.go
+++ b/pkg/operation/care/checker.go
@@ -25,13 +25,13 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/operation/botanist"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 
 	"github.com/Masterminds/semver"
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
-	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -445,7 +445,7 @@ func (b *HealthChecker) CheckClusterNodes(
 		return nil, err
 	}
 
-	workerPoolToSecretChecksum, err := botanist.WorkerPoolToCloudConfigSecretChecksumMap(ctx, shootClient)
+	workerPoolToCloudConfigSecretMeta, err := botanist.WorkerPoolToCloudConfigSecretMetaMap(ctx, shootClient)
 	if err != nil {
 		return nil, err
 	}
@@ -468,7 +468,7 @@ func (b *HealthChecker) CheckClusterNodes(
 		}
 	}
 
-	if err := botanist.CloudConfigUpdatedForAllWorkerPools(workers, workerPoolToNodes, workerPoolToSecretChecksum); err != nil {
+	if err := botanist.CloudConfigUpdatedForAllWorkerPools(workers, workerPoolToNodes, workerPoolToCloudConfigSecretMeta); err != nil {
 		c := b.FailedCondition(condition, "CloudConfigOutdated", err.Error())
 		return &c, nil
 	}

--- a/pkg/operation/care/health_check_test.go
+++ b/pkg/operation/care/health_check_test.go
@@ -23,15 +23,14 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
-	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig/downloader"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor"
 	"github.com/gardener/gardener/pkg/operation/care"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
 	"github.com/Masterminds/semver"
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
-	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -541,9 +540,17 @@ var _ = Describe("health check", func() {
 			cloudConfigSecretChecksum1 = "foo"
 			cloudConfigSecretChecksum2 = "foo"
 			nodeName                   = "node1"
-			cloudConfigSecretChecksums = map[string]string{
-				workerPoolName1: cloudConfigSecretChecksum1,
-				workerPoolName2: cloudConfigSecretChecksum2,
+			cloudConfigSecretMeta      = map[string]metav1.ObjectMeta{
+				workerPoolName1: {
+					Name:        "cloud-config-cpu-worker-1-c63c0",
+					Labels:      map[string]string{"worker.gardener.cloud/pool": workerPoolName1},
+					Annotations: map[string]string{"checksum/data-script": cloudConfigSecretChecksum1},
+				},
+				workerPoolName2: {
+					Name:        "bar",
+					Labels:      map[string]string{"worker.gardener.cloud/pool": workerPoolName2},
+					Annotations: map[string]string{"checksum/data-script": cloudConfigSecretChecksum2},
+				},
 			}
 		)
 
@@ -557,19 +564,16 @@ var _ = Describe("health check", func() {
 		})
 
 		DescribeTable("#CheckClusterNodes",
-			func(nodes []corev1.Node, workerPools []gardencorev1beta1.Worker, cloudConfigSecretChecksums map[string]string, conditionMatcher types.GomegaMatcher) {
+			func(nodes []corev1.Node, workerPools []gardencorev1beta1.Worker, cloudConfigSecretMeta map[string]metav1.ObjectMeta, conditionMatcher types.GomegaMatcher) {
 				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&corev1.NodeList{})).DoAndReturn(func(_ context.Context, list *corev1.NodeList, _ ...client.ListOption) error {
 					*list = corev1.NodeList{Items: nodes}
 					return nil
 				})
 				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&corev1.SecretList{}), gomock.AssignableToTypeOf(client.MatchingLabels{})).DoAndReturn(func(_ context.Context, list *corev1.SecretList, _ ...client.ListOption) error {
 					*list = corev1.SecretList{}
-					for pool, checksum := range cloudConfigSecretChecksums {
+					for _, meta := range cloudConfigSecretMeta {
 						list.Items = append(list.Items, corev1.Secret{
-							ObjectMeta: metav1.ObjectMeta{
-								Labels:      map[string]string{v1beta1constants.LabelWorkerPool: pool},
-								Annotations: map[string]string{downloader.AnnotationKeyChecksum: checksum},
-							},
+							ObjectMeta: meta,
 						})
 					}
 					return nil
@@ -583,7 +587,7 @@ var _ = Describe("health check", func() {
 			},
 			Entry("all healthy",
 				[]corev1.Node{
-					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1}, nil, kubernetesVersion.Original()),
+					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": "1.24.0"}, nil, kubernetesVersion.Original()),
 				},
 				[]gardencorev1beta1.Worker{
 					{
@@ -592,11 +596,11 @@ var _ = Describe("health check", func() {
 						Minimum: 1,
 					},
 				},
-				cloudConfigSecretChecksums,
+				cloudConfigSecretMeta,
 				BeNil()),
 			Entry("node not healthy",
 				[]corev1.Node{
-					newNode(nodeName, false, labels.Set{"worker.gardener.cloud/pool": workerPoolName1}, nil, kubernetesVersion.Original()),
+					newNode(nodeName, false, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": "1.24.0"}, nil, kubernetesVersion.Original()),
 				},
 				[]gardencorev1beta1.Worker{
 					{
@@ -605,14 +609,14 @@ var _ = Describe("health check", func() {
 						Minimum: 1,
 					},
 				},
-				cloudConfigSecretChecksums,
+				cloudConfigSecretMeta,
 				PointTo(beConditionWithStatusAndMsg(gardencorev1beta1.ConditionFalse, "NodeUnhealthy", fmt.Sprintf("Node %q in worker group %q is unhealthy", nodeName, workerPoolName1)))),
 			Entry("node not healthy with error codes",
 				[]corev1.Node{
 					{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:   nodeName,
-							Labels: labels.Set{"worker.gardener.cloud/pool": workerPoolName1},
+							Labels: labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": "1.24.0"},
 						},
 						Status: corev1.NodeStatus{
 							Conditions: []corev1.NodeCondition{
@@ -636,11 +640,11 @@ var _ = Describe("health check", func() {
 						Minimum: 1,
 					},
 				},
-				cloudConfigSecretChecksums,
+				cloudConfigSecretMeta,
 				PointTo(beConditionWithStatusAndCodes(gardencorev1beta1.ConditionFalse, gardencorev1beta1.ErrorConfigurationProblem))),
 			Entry("not enough nodes in worker pool",
 				[]corev1.Node{
-					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1}, nil, kubernetesVersion.Original()),
+					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": "1.24.0"}, nil, kubernetesVersion.Original()),
 				},
 				[]gardencorev1beta1.Worker{
 					{
@@ -654,11 +658,11 @@ var _ = Describe("health check", func() {
 						Minimum: 1,
 					},
 				},
-				cloudConfigSecretChecksums,
+				cloudConfigSecretMeta,
 				PointTo(beConditionWithStatusAndMsg(gardencorev1beta1.ConditionFalse, "MissingNodes", fmt.Sprintf("Not enough worker nodes registered in worker pool %q to meet minimum desired machine count. (%d/%d).", workerPoolName2, 0, 1)))),
 			Entry("not enough nodes in worker pool",
 				[]corev1.Node{
-					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1}, nil, kubernetesVersion.Original()),
+					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": "1.24.0"}, nil, kubernetesVersion.Original()),
 				},
 				[]gardencorev1beta1.Worker{
 					{
@@ -672,11 +676,11 @@ var _ = Describe("health check", func() {
 						Minimum: 1,
 					},
 				},
-				cloudConfigSecretChecksums,
+				cloudConfigSecretMeta,
 				PointTo(beConditionWithStatusAndMsg(gardencorev1beta1.ConditionFalse, "MissingNodes", fmt.Sprintf("Not enough worker nodes registered in worker pool %q to meet minimum desired machine count. (%d/%d).", workerPoolName2, 0, 1)))),
 			Entry("too old Kubernetes patch version",
 				[]corev1.Node{
-					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1}, nil, "v1.19.2"),
+					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": "1.24.0"}, nil, "v1.19.2"),
 				},
 				[]gardencorev1beta1.Worker{
 					{
@@ -685,11 +689,11 @@ var _ = Describe("health check", func() {
 						Minimum: 1,
 					},
 				},
-				cloudConfigSecretChecksums,
+				cloudConfigSecretMeta,
 				PointTo(beConditionWithStatusAndMsg(gardencorev1beta1.ConditionFalse, "KubeletVersionMismatch", fmt.Sprintf("The kubelet version for node %q (v1.19.2) does not match the desired Kubernetes version (v%s)", nodeName, kubernetesVersion.Original())))),
 			Entry("same Kubernetes patch version",
 				[]corev1.Node{
-					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1}, nil, "v1.19.3"),
+					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": "1.24.0"}, nil, "v1.19.3"),
 				},
 				[]gardencorev1beta1.Worker{
 					{
@@ -698,11 +702,11 @@ var _ = Describe("health check", func() {
 						Minimum: 1,
 					},
 				},
-				cloudConfigSecretChecksums,
+				cloudConfigSecretMeta,
 				BeNil()),
 			Entry("too old Kubernetes patch version with pool version overwrite",
 				[]corev1.Node{
-					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1}, nil, "v1.18.2"),
+					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": "1.24.0"}, nil, "v1.18.2"),
 				},
 				[]gardencorev1beta1.Worker{
 					{
@@ -714,11 +718,11 @@ var _ = Describe("health check", func() {
 						},
 					},
 				},
-				cloudConfigSecretChecksums,
+				cloudConfigSecretMeta,
 				PointTo(beConditionWithStatusAndMsg(gardencorev1beta1.ConditionFalse, "KubeletVersionMismatch", fmt.Sprintf("The kubelet version for node %q (v1.18.2) does not match the desired Kubernetes version (v1.18.3)", nodeName)))),
 			Entry("different Kubernetes minor version (all healthy)",
 				[]corev1.Node{
-					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1}, nil, "v1.18.2"),
+					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": "1.24.0"}, nil, "v1.18.2"),
 				},
 				[]gardencorev1beta1.Worker{
 					{
@@ -727,11 +731,11 @@ var _ = Describe("health check", func() {
 						Minimum: 1,
 					},
 				},
-				cloudConfigSecretChecksums,
+				cloudConfigSecretMeta,
 				BeNil()),
 			Entry("missing cloud-config secret checksum for a worker pool",
 				[]corev1.Node{
-					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1}, nil, "v1.18.2"),
+					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": "1.24.0"}, nil, "v1.18.2"),
 				},
 				[]gardencorev1beta1.Worker{
 					{
@@ -744,7 +748,7 @@ var _ = Describe("health check", func() {
 				PointTo(beConditionWithStatusAndMsg(gardencorev1beta1.ConditionFalse, "CloudConfigOutdated", fmt.Sprintf("missing cloud config secret metadata for worker pool %q", workerPoolName1)))),
 			Entry("no cloud-config node checksum for a worker pool",
 				[]corev1.Node{
-					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1}, nil, "v1.18.2"),
+					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": "1.24.0"}, nil, "v1.18.2"),
 				},
 				[]gardencorev1beta1.Worker{
 					{
@@ -753,11 +757,11 @@ var _ = Describe("health check", func() {
 						Minimum: 1,
 					},
 				},
-				cloudConfigSecretChecksums,
+				cloudConfigSecretMeta,
 				BeNil()),
 			Entry("outdated cloud-config secret checksum for a worker pool",
 				[]corev1.Node{
-					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1}, map[string]string{executor.AnnotationKeyChecksum: "outdated"}, "v1.18.2"),
+					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1, "worker.gardener.cloud/kubernetes-version": "1.24.0"}, map[string]string{executor.AnnotationKeyChecksum: "outdated"}, "v1.18.2"),
 				},
 				[]gardencorev1beta1.Worker{
 					{
@@ -766,8 +770,12 @@ var _ = Describe("health check", func() {
 						Minimum: 1,
 					},
 				},
-				map[string]string{
-					workerPoolName1: cloudConfigSecretChecksum1,
+				map[string]metav1.ObjectMeta{
+					workerPoolName1: {
+						Name:        "cloud-config-cpu-worker-1-c63c0",
+						Annotations: map[string]string{"checksum/data-script": cloudConfigSecretChecksum1},
+						Labels:      map[string]string{"worker.gardener.cloud/pool": workerPoolName1},
+					},
 				},
 				PointTo(beConditionWithStatusAndMsg(gardencorev1beta1.ConditionFalse, "CloudConfigOutdated", fmt.Sprintf("the last successfully applied cloud config on node %q is outdated", nodeName)))),
 		)

--- a/pkg/operation/care/health_check_test.go
+++ b/pkg/operation/care/health_check_test.go
@@ -741,7 +741,7 @@ var _ = Describe("health check", func() {
 					},
 				},
 				nil,
-				BeNil()),
+				PointTo(beConditionWithStatusAndMsg(gardencorev1beta1.ConditionFalse, "CloudConfigOutdated", fmt.Sprintf("missing cloud config secret metadata for worker pool %q", workerPoolName1)))),
 			Entry("no cloud-config node checksum for a worker pool",
 				[]corev1.Node{
 					newNode(nodeName, true, labels.Set{"worker.gardener.cloud/pool": workerPoolName1}, nil, "v1.18.2"),


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind bug

**What this PR does / why we need it**:
When the OSC key of a worker pool changes (e.g. when the Kubernetes version is upgraded) then a rolling update of the nodes is triggered.

Earlier, existing nodes (waiting for their removal (which can take some time)) were still considered by https://github.com/gardener/gardener/blob/c44dddf1439a0cbde65c7e9a8b54708b55656129/pkg/operation/botanist/worker.go#L119-L144
Hence, this health check failed and complained that the cloud config is outdated. However, this is actually the desired behaviour since old nodes/to-be-deleted nodes are not supposed to update their cloud config.

With this change, we will consider nodes whose OSC key does not match the OSC key of their cloud config secret as 'to-be-deleted soon'. Consequently, the health check is skipped for them, preventing the misleading error messages.

**Which issue(s) this PR fixes**:
Fixes #6483

**Special notes for your reviewer**:
bcf43a76eba4944a18b3abf0e330a800c417a0ef drops backwards-compatibility/migration code - the Secret checksum label was added with https://github.com/gardener/gardener/pull/3396 in v1.16.0. With this PR the `CloudConfigUpdatedForAllWorkerPools` no longer tolerates a missing checksum label on the Secret.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug has been fixed which caused the `EveryNodeReady` condition on `Shoot`s to become `False` and complaining about outdated cloud configs on nodes during rolling updates.
```
