### PR TITLE
Updated gardenlet image to use `scratch` based image

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -170,12 +170,35 @@ RUN --mount=type=cache,target=/root/.cache/go-build \
     -ldflags="$(cat /tmp/build-flags)" \
     -o /gardenlet ./cmd/gardenlet
 
-FROM base AS gardenlet
+FROM base AS dependencies-gardenlet
 
-RUN apk add --update openvpn
+RUN apk add --update openvpn tzdata
 
-COPY charts /charts
+WORKDIR /volume
+
+RUN mkdir -p ./lib ./usr/sbin ./usr/share ./usr/lib ./tmp ./etc \
+    && cp -d /lib/ld-musl-* ./lib \
+    && cp -d /lib/libcrypto.so.* ./usr/lib \
+    && cp -d /lib/libssl.so.* ./usr/lib \
+    && cp -d /usr/lib/liblzo2.so.* ./usr/lib \
+    && cp -d /usr/sbin/openvpn ./usr/sbin \
+    && cp -r /usr/share/zoneinfo ./usr/share/zoneinfo \
+    # nonroot user
+    && echo 'nonroot:x:65532:65532:nonroot,,,:/home/nonroot:/sbin/nologin' > ./etc/passwd \
+    && echo 'nonroot:x:65532:nonroot' > ./etc/group \
+    && mkdir -p ./home/nonroot \
+    && chown 65532:65532 ./home/nonroot \
+    && chown 65532:65532 ./tmp
+
+FROM scratch AS gardenlet
+
 COPY --from=builder-gardenlet /gardenlet /gardenlet
+COPY --from=dependencies-gardenlet /volume /
+COPY charts /charts
+
+USER nonroot
+WORKDIR /
+
 ENTRYPOINT ["/gardenlet"]
 
 ############# extension-provider-local #############

--- a/cmd/gardenlet/main.go
+++ b/cmd/gardenlet/main.go
@@ -28,7 +28,7 @@ func main() {
 	utils.DeduplicateWarnings()
 	features.RegisterFeatureGates()
 
-	if err := exec.Command("which", "openvpn").Run(); err != nil {
+	if err := exec.Command("openvpn", "--version").Run(); err != nil {
 		panic("openvpn is not installed or not executable. cannot start gardenlet.")
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source security
/kind enhancement

**What this PR does / why we need it**:
This PR changes the gardenlet image to use `scratch` as base image. It also changes the default user that is executing the binaries from root to a nonroot user. This will help reduce the attack surface of the image.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
* changed `which openvpn` to `openvpn --version` since `which` command no longer exists in `gardenlet` image

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
`gardenlet` is now using `scratch` instead of `alpine` as a base image.
```
