### PR TITLE
Revert "Do not run kube-proxy/cleanup in privileged mode"

### DIFF
--- a/pkg/operation/botanist/component/kubeproxy/kube_proxy_test.go
+++ b/pkg/operation/botanist/component/kubeproxy/kube_proxy_test.go
@@ -566,9 +566,7 @@ spec:
         name: cleanup
         resources: {}
         securityContext:
-          capabilities:
-            add:
-            - NET_ADMIN
+          privileged: true
         volumeMounts:
         - mountPath: /script
           name: kube-proxy-cleanup-script

--- a/pkg/operation/botanist/component/kubeproxy/resources.go
+++ b/pkg/operation/botanist/component/kubeproxy/resources.go
@@ -347,9 +347,7 @@ func (k *kubeProxy) computePoolResourcesData(pool WorkerPool) (map[string][]byte
 								},
 							},
 							SecurityContext: &corev1.SecurityContext{
-								Capabilities: &corev1.Capabilities{
-									Add: []corev1.Capability{"NET_ADMIN"},
-								},
+								Privileged: pointer.Bool(true),
 							},
 							VolumeMounts: []corev1.VolumeMount{
 								{


### PR DESCRIPTION


**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind bug

**What this PR does / why we need it**:
This reverts commit fc9de555d6bce14b1d3fdcf3b5a8d6ce0388117a.

After https://github.com/gardener/gardener/pull/6476 I noticed the following error when switching the kube-proxy mode (while testing some other changes):
```
$ k -n kube-system logs kube-proxy-cpu-worker-v1.20.15-5prt7 cleanup
...
I0822 13:41:05.358412      26 iptables.go:351] running ip6tables-save [-t nat]
E0822 13:41:05.361246      26 proxier.go:439] Failed to execute iptables-save for nat: exit status 1
I0822 13:41:05.361270      26 iptables.go:351] running ip6tables-save [-t filter]
E0822 13:41:05.364014      26 proxier.go:476] Failed to execute iptables-save for filter: exit status 1
...
F0822 13:41:05.722184      26 server.go:495] encountered an error while tearing down rules
```

I see that in a non-privileged container `ip6tables-save -t nat`

```
# ip6tables-save -t nat
ip6tables-save v1.8.5 (legacy): Cannot initialize: Permission denied (you must be root)
```

while it succeeds in privileged one.

Maybe while testing #6476 I didn't notice the above error because there was nothing to cleanup or the error happens with particular kube-proxy versions or with particular CRI (docker/containerd). Anyways, as currently there are no plans to run kube-proxy in non-provileged mode (due to the many sysctls it does internally), we can leave the cleanup init container in privileged mode.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
