### PR TITLE
Deflake ExposureClass controller integration test

### DIFF
--- a/test/integration/controllermanager/exposureclass/exposureclass_suite_test.go
+++ b/test/integration/controllermanager/exposureclass/exposureclass_suite_test.go
@@ -72,7 +72,7 @@ var _ = BeforeSuite(func() {
 	By("starting test environment")
 	testEnv = &gardenerenvtest.GardenerTestEnvironment{
 		GardenerAPIServer: &gardenerenvtest.GardenerAPIServer{
-			Args: []string{"--disable-admission-plugins=DeletionConfirmation,ResourceReferenceManager,ExtensionValidator,ShootBinding,ShootDNS,ShootQuotaValidator,ShootTolerationRestriction,ShootValidator"},
+			Args: []string{"--disable-admission-plugins=DeletionConfirmation,ResourceReferenceManager,ExtensionValidator,ShootBinding,ShootDNS,ShootExposureClass,ShootQuotaValidator,ShootTolerationRestriction,ShootValidator"},
 		},
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:

Addresses https://github.com/gardener/gardener/issues/6496#issuecomment-1222467733

```
stress -ignore "(unable to grab random port)" -p 64 ./test/integration/controllermanager/exposureclass/exposureclass.test
before
4m30s: 1562 runs so far, 57 failures (3.65%)
after
4m15s: 1539 runs so far, 0 failures
```

**Which issue(s) this PR fixes**:
Follow-up on https://github.com/gardener/gardener/pull/6527
Fixes https://github.com/gardener/gardener/issues/6496

