### PR TITLE
Improve the listing of cloud-config Secret by specifying a namespace

### DIFF
--- a/pkg/operation/botanist/worker.go
+++ b/pkg/operation/botanist/worker.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -97,7 +98,7 @@ func WorkerPoolToNodesMap(ctx context.Context, shootClient client.Client) (map[s
 // the cloud-config script stored inside the secret's data.
 func WorkerPoolToCloudConfigSecretChecksumMap(ctx context.Context, shootClient client.Client) (map[string]string, error) {
 	secretList := &corev1.SecretList{}
-	if err := shootClient.List(ctx, secretList, client.MatchingLabels{v1beta1constants.GardenRole: v1beta1constants.GardenRoleCloudConfig}); err != nil {
+	if err := shootClient.List(ctx, secretList, client.InNamespace(metav1.NamespaceSystem), client.MatchingLabels{v1beta1constants.GardenRole: v1beta1constants.GardenRoleCloudConfig}); err != nil {
 		return nil, err
 	}
 

--- a/pkg/operation/care/health_check_test.go
+++ b/pkg/operation/care/health_check_test.go
@@ -562,7 +562,11 @@ var _ = Describe("health check", func() {
 					*list = corev1.NodeList{Items: nodes}
 					return nil
 				})
-				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&corev1.SecretList{}), gomock.AssignableToTypeOf(client.MatchingLabels{})).DoAndReturn(func(_ context.Context, list *corev1.SecretList, _ ...client.ListOption) error {
+				cloudConfigSecretListOptions := []client.ListOption{
+					client.InNamespace(metav1.NamespaceSystem),
+					client.MatchingLabels{"gardener.cloud/role": "cloud-config"},
+				}
+				c.EXPECT().List(ctx, gomock.AssignableToTypeOf(&corev1.SecretList{}), cloudConfigSecretListOptions).DoAndReturn(func(_ context.Context, list *corev1.SecretList, _ ...client.ListOption) error {
 					*list = corev1.SecretList{}
 					for pool, checksum := range cloudConfigSecretChecksums {
 						list.Items = append(list.Items, corev1.Secret{


### PR DESCRIPTION
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
The cloud-config Secrets in the Shoot are always in the `kube-system` namespace. We could improve the listing of these Secrets by specifying the namespace (and not listing all Secrets in the cluster).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
