### PR TITLE
Add the container_oom_events_total metric

### DIFF
--- a/charts/seed-bootstrap/charts/monitoring/values.yaml
+++ b/charts/seed-bootstrap/charts/monitoring/values.yaml
@@ -25,8 +25,8 @@ prometheus:
 allowedMetrics:
   cadvisor:
   - container_cpu_cfs_periods_total
-  - container_cpu_cfs_throttled_seconds_total
   - container_cpu_cfs_throttled_periods_total
+  - container_cpu_cfs_throttled_seconds_total
   - container_cpu_usage_seconds_total
   - container_fs_inodes_total
   - container_fs_limit_bytes

--- a/charts/seed-bootstrap/charts/monitoring/values.yaml
+++ b/charts/seed-bootstrap/charts/monitoring/values.yaml
@@ -35,3 +35,4 @@ allowedMetrics:
   - container_memory_working_set_bytes
   - container_network_receive_bytes_total
   - container_network_transmit_bytes_total
+  - container_oom_events_total

--- a/charts/seed-bootstrap/values.yaml
+++ b/charts/seed-bootstrap/values.yaml
@@ -111,14 +111,14 @@ allowedMetrics:
 
   cAdvisor:
   - container_cpu_cfs_periods_total
-  - container_cpu_cfs_throttled_seconds_total
   - container_cpu_cfs_throttled_periods_total
+  - container_cpu_cfs_throttled_seconds_total
   - container_cpu_usage_seconds_total
-  - container_fs_reads_bytes_total
-  - container_fs_writes_bytes_total
   - container_fs_inodes_total
   - container_fs_limit_bytes
+  - container_fs_reads_bytes_total
   - container_fs_usage_bytes
+  - container_fs_writes_bytes_total
   - container_last_seen
   - container_memory_working_set_bytes
   - container_network_receive_bytes_total

--- a/charts/seed-bootstrap/values.yaml
+++ b/charts/seed-bootstrap/values.yaml
@@ -123,6 +123,7 @@ allowedMetrics:
   - container_memory_working_set_bytes
   - container_network_receive_bytes_total
   - container_network_transmit_bytes_total
+  - container_oom_events_total
 
   kubelet:
   - kubelet_volume_stats_available_bytes

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-pods-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-pods-dashboard.json
@@ -155,6 +155,11 @@
         {
           "alias": "/Requests|Limits/",
           "dashes": true
+        },
+        {
+          "$$hashKey": "object:81",
+          "alias": "/OOM/",
+          "yaxis": 2
         }
       ],
       "spaceLength": 10,
@@ -190,6 +195,16 @@
           "intervalFactor": 1,
           "legendFormat": "Limits ({{pod}})",
           "refId": "B"
+        },
+        {
+          "exemplar": true,
+          "expr": "sum(rate(container_oom_events_total{pod=~\"$pod\", container=~\"$container\"}[$__rate_interval])) by (pod)",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "OOM Events ({{pod}})",
+          "refId": "D"
         }
       ],
       "thresholds": [],
@@ -225,7 +240,7 @@
           "label": null,
           "logBase": 1,
           "max": null,
-          "min": null,
+          "min": "0",
           "show": true
         }
       ],


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

The `container_oom_events_total` metric is allow listed and added to the Kubernetes Pods dashboard

**Which issue(s) this PR fixes**:
Fixes #4738

**Special notes for your reviewer**:

/cc @danielfoehrKn, @rickardsjp 

A short command to trigger an OOM event in a container for testing this feature: `tail /dev/zero`

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The container_oom_events_total metric is allow listed and added to the Kubernetes Pods dashboard
```
