### PR TITLE
Cleanup special owners handling for testmachinery

### DIFF
--- a/.test-defs/OWNERS
+++ b/.test-defs/OWNERS
@@ -1,6 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-reviewers:
-- testmachinery-maintainers
-approvers:
-- testmachinery-maintainers

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -23,6 +23,3 @@ aliases:
   - shafeeqes
   - timebertt
   - timuthy
-  testmachinery-maintainers:
-  - dguendisch
-  - hendrikKahl

--- a/test/testmachinery/OWNERS
+++ b/test/testmachinery/OWNERS
@@ -1,6 +1,0 @@
-# See the OWNERS docs at https://go.k8s.io/owners
-
-reviewers:
-- testmachinery-maintainers
-approvers:
-- testmachinery-maintainers


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/kind cleanup

**What this PR does / why we need it**:

Follow-up on https://github.com/gardener/gardener/pull/6405.

@dguendisch @hendrikKahl are also part of the [gardener-collaborators](https://github.com/orgs/gardener/teams/gardener-collaborators) groups now, so they can `lgtm` PRs just like all other collaborators.
With this PR we follow the same approach for all contributor areas and clean up historical ownership.