### PR TITLE
Skip problematic webhook check for Gardener-managed webhooks

### DIFF
--- a/pkg/operation/care/constraints.go
+++ b/pkg/operation/care/constraints.go
@@ -24,6 +24,7 @@ import (
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/operation"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/resourcemanager"
 	"github.com/gardener/gardener/pkg/operation/botanist/matchers"
@@ -252,6 +253,10 @@ func (c *Constraint) CheckForProblematicWebhooks(ctx context.Context) (gardencor
 	}
 
 	for _, webhookConfig := range validatingWebhookConfigs {
+		if strings.Contains(webhookConfig.Annotations[resourcesv1alpha1.OriginAnnotation], c.shoot.SeedNamespace) {
+			continue
+		}
+
 		for _, w := range webhookConfig.Webhooks {
 			if IsProblematicWebhook(w.FailurePolicy, w.ObjectSelector, w.NamespaceSelector, w.Rules, w.TimeoutSeconds) {
 				msg := buildProblematicWebhookMessage("ValidatingWebhookConfiguration", webhookConfig.Name, w.Name, w.FailurePolicy, w.TimeoutSeconds)
@@ -278,6 +283,10 @@ func (c *Constraint) CheckForProblematicWebhooks(ctx context.Context) (gardencor
 	}
 
 	for _, webhookConfig := range mutatingWebhookConfigs {
+		if strings.Contains(webhookConfig.Annotations[resourcesv1alpha1.OriginAnnotation], c.shoot.SeedNamespace) {
+			continue
+		}
+
 		for _, w := range webhookConfig.Webhooks {
 			if IsProblematicWebhook(w.FailurePolicy, w.ObjectSelector, w.NamespaceSelector, w.Rules, w.TimeoutSeconds) {
 				msg := buildProblematicWebhookMessage("MutatingWebhookConfiguration", webhookConfig.Name, w.Name, w.FailurePolicy, w.TimeoutSeconds)

--- a/pkg/operation/care/constraints.go
+++ b/pkg/operation/care/constraints.go
@@ -254,10 +254,6 @@ func (c *Constraint) CheckForProblematicWebhooks(ctx context.Context) (gardencor
 	}
 
 	for _, webhookConfig := range validatingWebhookConfigs {
-		if strings.Contains(webhookConfig.Annotations[resourcesv1alpha1.OriginAnnotation], c.shoot.SeedNamespace) {
-			continue
-		}
-
 		for _, w := range webhookConfig.Webhooks {
 			if IsProblematicWebhook(w.FailurePolicy, w.ObjectSelector, w.NamespaceSelector, w.Rules, w.TimeoutSeconds) {
 				msg := buildProblematicWebhookMessage("ValidatingWebhookConfiguration", webhookConfig.Name, w.Name, w.FailurePolicy, w.TimeoutSeconds)
@@ -284,10 +280,6 @@ func (c *Constraint) CheckForProblematicWebhooks(ctx context.Context) (gardencor
 	}
 
 	for _, webhookConfig := range mutatingWebhookConfigs {
-		if strings.Contains(webhookConfig.Annotations[resourcesv1alpha1.OriginAnnotation], c.shoot.SeedNamespace) {
-			continue
-		}
-
 		for _, w := range webhookConfig.Webhooks {
 			if IsProblematicWebhook(w.FailurePolicy, w.ObjectSelector, w.NamespaceSelector, w.Rules, w.TimeoutSeconds) {
 				msg := buildProblematicWebhookMessage("MutatingWebhookConfiguration", webhookConfig.Name, w.Name, w.FailurePolicy, w.TimeoutSeconds)

--- a/pkg/provider-local/webhook/node/add.go
+++ b/pkg/provider-local/webhook/node/add.go
@@ -50,7 +50,7 @@ func AddToManagerWithOptions(mgr manager.Manager, _ AddOptions, name, target str
 	var (
 		provider      = local.Type
 		types         = []extensionswebhook.Type{{Obj: &corev1.Node{}, Subresource: pointer.String("status")}}
-		failurePolicy = admissionregistrationv1.Fail
+		failurePolicy = admissionregistrationv1.Ignore
 	)
 
 	logger = logger.WithValues("provider", provider)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity dev-productivity
/kind enhancement

**What this PR does / why we need it**:
- Gardener-managed webhooks are no longer considered by the shoot care controller when it comes to find problematic webhooks.
- The `node-shoot` webhook was using `Fail` failure policy, but `Ignore` is good enough and is more relaxed which is fine for the local setup.

**Which issue(s) this PR fixes**:
Fixes #6562 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Gardener-managed webhooks are no longer considered by the shoot care controller when it comes to finding problematic webhooks.
```
