### PR TITLE
Use `Eventually`/`Consistently` in all integration tests

### DIFF
--- a/test/framework/resources/templates/pod-anti-affinity-deployment.yaml.tpl
+++ b/test/framework/resources/templates/pod-anti-affinity-deployment.yaml.tpl
@@ -39,7 +39,7 @@ spec:
 {{- end }}
       containers:
       - name: pause-container
-        image: gcr.io/google_containers/pause-amd64:3.1
+        image: k8s.gcr.io/pause:3.7
         imagePullPolicy: IfNotPresent
         securityContext:
           runAsUser: 1001

--- a/test/integration/controllermanager/shoot/maintenance/utils_test.go
+++ b/test/integration/controllermanager/shoot/maintenance/utils_test.go
@@ -32,7 +32,6 @@ import (
 // This is better than wait.Poll* because it respects gomega's environment variables for globally configuring the
 // polling intervals and timeouts. This allows to easily make integration tests more robust in CI environments.
 // see https://onsi.github.io/gomega/#modifying-default-intervals
-// TODO: use this helper in all test cases instead of polling like in the other helper functions.
 func waitForShootToBeMaintained(shoot *gardencorev1beta1.Shoot) {
 	By("waiting for shoot to be maintained")
 	Eventually(func(g Gomega) bool {

--- a/test/integration/extensions/controller/backupbucket/backupbucket_test.go
+++ b/test/integration/extensions/controller/backupbucket/backupbucket_test.go
@@ -233,7 +233,7 @@ func runTest(c client.Client, ignoreOperationAnnotation bool) {
 	Consistently(func() string {
 		Expect(c.Get(ctx, backupBucketObjectKey, backupBucket)).To(Succeed())
 		return backupBucket.ResourceVersion
-	}, 2, 0.1).Should(Equal(resourceVersion))
+	}).Should(Equal(resourceVersion))
 
 	By("verify backupbucket (nothing should have changed)")
 	backupBucket = &extensionsv1alpha1.BackupBucket{}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind technical-debt

**What this PR does / why we need it**:
This PR removes the remaining usages of "wait until" or "retry until" functions in integration tests.

**Which issue(s) this PR fixes**:
Fixes https://github.com/gardener/gardener/issues/6397

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
