### PR TITLE
Validate seed network configuration on gardenlet startup.

### DIFF
--- a/cmd/gardenlet/app/gardenlet.go
+++ b/cmd/gardenlet/app/gardenlet.go
@@ -630,22 +630,19 @@ func checkSeedConfig(ctx context.Context, seedClient client.Client, seedConfig *
 		return nil
 	}
 
-	podNetwork := shootInfo.Data["podNetwork"]
-	if podNetwork != seedConfig.Spec.Networks.Pods {
+	if podNetwork := shootInfo.Data["podNetwork"]; podNetwork != seedConfig.Spec.Networks.Pods {
 		return fmt.Errorf("incorrect pod network specified in seed configuration (cluster=%q vs. config=%q)", podNetwork, seedConfig.Spec.Networks.Pods)
 	}
 
-	serviceNetwork := shootInfo.Data["serviceNetwork"]
-	if serviceNetwork != seedConfig.Spec.Networks.Services {
+	if serviceNetwork := shootInfo.Data["serviceNetwork"]; serviceNetwork != seedConfig.Spec.Networks.Services {
 		return fmt.Errorf("incorrect service network specified in seed configuration (cluster=%q vs. config=%q)", serviceNetwork, seedConfig.Spec.Networks.Services)
 	}
 
-	nodeNetwork, exists := shootInfo.Data["nodeNetwork"]
 	// Be graceful in case the (optional) node network is only available on one side
-	if seedConfig.Spec.Networks.Nodes != nil && exists {
-		if nodeNetwork != *seedConfig.Spec.Networks.Nodes {
-			return fmt.Errorf("incorrect node network specified in seed configuration (cluster=%q vs. config=%q)", nodeNetwork, *seedConfig.Spec.Networks.Nodes)
-		}
+	if nodeNetwork, exists := shootInfo.Data["nodeNetwork"]; exists &&
+		seedConfig.Spec.Networks.Nodes != nil &&
+		*seedConfig.Spec.Networks.Nodes != nodeNetwork {
+		return fmt.Errorf("incorrect node network specified in seed configuration (cluster=%q vs. config=%q)", nodeNetwork, *seedConfig.Spec.Networks.Nodes)
 	}
 
 	return nil

--- a/cmd/gardenlet/app/gardenlet.go
+++ b/cmd/gardenlet/app/gardenlet.go
@@ -61,6 +61,7 @@ import (
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
 	eventsv1 "k8s.io/api/events/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -71,6 +72,7 @@ import (
 	"k8s.io/component-base/version/verflag"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -274,6 +276,11 @@ func NewGardenlet(ctx context.Context, cfg *config.GardenletConfiguration) (*Gar
 		kubernetes.WithDisabledCachedClient(),
 	)
 	if err != nil {
+		return nil, err
+	}
+
+	// Check whether seed configuration fits to the reality in the cluster
+	if err = checkSeedConfig(ctx, seedClientForBootstrap.Client(), cfg.SeedConfig); err != nil {
 		return nil, err
 	}
 
@@ -607,4 +614,39 @@ func extractID(line string) string {
 	id = strings.TrimPrefix(id, "docker-")
 
 	return id
+}
+
+func checkSeedConfig(ctx context.Context, seedClient client.Client, seedConfig *config.SeedConfig) error {
+	if seedConfig == nil {
+		// Nothing to check
+		return nil
+	}
+
+	shootInfo := &corev1.ConfigMap{}
+	if err := seedClient.Get(ctx, kutil.Key(metav1.NamespaceSystem, v1beta1constants.ConfigMapNameShootInfo), shootInfo); client.IgnoreNotFound(err) != nil {
+		return err
+	} else if apierrors.IsNotFound(err) {
+		// Seed cluster does not seem to be managed by Gardener
+		return nil
+	}
+
+	podNetwork := shootInfo.Data["podNetwork"]
+	if podNetwork != seedConfig.Spec.Networks.Pods {
+		return fmt.Errorf("incorrect pod network specified in seed configuration (cluster=%q vs. config=%q)", podNetwork, seedConfig.Spec.Networks.Pods)
+	}
+
+	serviceNetwork := shootInfo.Data["serviceNetwork"]
+	if serviceNetwork != seedConfig.Spec.Networks.Services {
+		return fmt.Errorf("incorrect service network specified in seed configuration (cluster=%q vs. config=%q)", serviceNetwork, seedConfig.Spec.Networks.Services)
+	}
+
+	nodeNetwork, exists := shootInfo.Data["nodeNetwork"]
+	// Be graceful in case the (optional) node network is only available on one side
+	if seedConfig.Spec.Networks.Nodes != nil && exists {
+		if nodeNetwork != *seedConfig.Spec.Networks.Nodes {
+			return fmt.Errorf("incorrect node network specified in seed configuration (cluster=%q vs. config=%q)", nodeNetwork, *seedConfig.Spec.Networks.Nodes)
+		}
+	}
+
+	return nil
 }

--- a/cmd/gardenlet/app/gardenlet.go
+++ b/cmd/gardenlet/app/gardenlet.go
@@ -280,7 +280,7 @@ func NewGardenlet(ctx context.Context, cfg *config.GardenletConfiguration) (*Gar
 	}
 
 	// Check whether seed configuration fits to the reality in the cluster
-	if err = checkSeedConfig(ctx, seedClientForBootstrap.Client(), cfg.SeedConfig); err != nil {
+	if err = CheckSeedConfig(ctx, seedClientForBootstrap.Client(), cfg.SeedConfig); err != nil {
 		return nil, err
 	}
 
@@ -616,7 +616,8 @@ func extractID(line string) string {
 	return id
 }
 
-func checkSeedConfig(ctx context.Context, seedClient client.Client, seedConfig *config.SeedConfig) error {
+// CheckSeedConfig validates the networking configuration of the seed configuration against the actual cluster
+func CheckSeedConfig(ctx context.Context, seedClient client.Client, seedConfig *config.SeedConfig) error {
 	if seedConfig == nil {
 		// Nothing to check
 		return nil

--- a/cmd/gardenlet/app/gardenlet_suite_test.go
+++ b/cmd/gardenlet/app/gardenlet_suite_test.go
@@ -23,5 +23,5 @@ import (
 
 func TestGardenlet(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Gardenlet Suite")
+	RunSpecs(t, "Command Gardenlet App Suite")
 }

--- a/cmd/gardenlet/app/gardenlet_suite_test.go
+++ b/cmd/gardenlet/app/gardenlet_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestGardenlet(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Gardenlet Suite")
+}

--- a/cmd/gardenlet/app/gardenlet_test.go
+++ b/cmd/gardenlet/app/gardenlet_test.go
@@ -27,7 +27,6 @@ import (
 	gomegatypes "github.com/onsi/gomega/types"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -123,13 +122,3 @@ var _ = Describe("Gardenlet", func() {
 		)
 	})
 })
-
-func clientGet(result runtime.Object) interface{} {
-	return func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
-		switch obj.(type) {
-		case *corev1.ConfigMap:
-			*obj.(*corev1.ConfigMap) = *result.(*corev1.ConfigMap)
-		}
-		return nil
-	}
-}

--- a/cmd/gardenlet/app/gardenlet_test.go
+++ b/cmd/gardenlet/app/gardenlet_test.go
@@ -1,0 +1,138 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app_test
+
+import (
+	"context"
+
+	. "github.com/gardener/gardener/cmd/gardenlet/app"
+	"github.com/gardener/gardener/pkg/apis/core"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
+	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	gomegatypes "github.com/onsi/gomega/types"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Gardenlet", func() {
+	Describe("#CheckSeedConfig", func() {
+		var (
+			ctx    = context.TODO()
+			ctrl   *gomock.Controller
+			client *mockclient.MockClient
+
+			podCIDR     = "10.0.0.0/8"
+			serviceCIDR = "192.168.0.0/16"
+			nodeCIDR    = "172.16.0.0/12"
+			otherCIDR   = "1.1.0.0/22"
+
+			shootInfoWithNodes = &corev1.ConfigMap{
+				Data: map[string]string{
+					"podNetwork":     podCIDR,
+					"serviceNetwork": serviceCIDR,
+					"nodeNetwork":    nodeCIDR,
+				},
+			}
+			shootInfoWithIncorrectNodes = &corev1.ConfigMap{
+				Data: map[string]string{
+					"podNetwork":     podCIDR,
+					"serviceNetwork": serviceCIDR,
+					"nodeNetwork":    otherCIDR,
+				},
+			}
+			shootInfoWithoutNodes = &corev1.ConfigMap{
+				Data: map[string]string{
+					"podNetwork":     podCIDR,
+					"serviceNetwork": serviceCIDR,
+				},
+			}
+		)
+
+		BeforeEach(func() {
+			ctrl = gomock.NewController(GinkgoT())
+			client = mockclient.NewMockClient(ctrl)
+		})
+
+		DescribeTable("validate seed network configuration",
+			func(seedConfig *config.SeedConfig, shootInfo *corev1.ConfigMap, secretRetrievalExpected bool, matcher gomegatypes.GomegaMatcher) {
+				if secretRetrievalExpected {
+					client.EXPECT().Get(ctx, kutil.Key(metav1.NamespaceSystem, v1beta1constants.ConfigMapNameShootInfo), &corev1.ConfigMap{}).DoAndReturn(clientGet(shootInfo))
+				}
+				Expect(CheckSeedConfig(ctx, client, seedConfig)).To(matcher)
+			},
+			Entry("no seed configuration", nil, shootInfoWithNodes, false, BeNil()),
+			Entry("correct seed configuration with nodes", &config.SeedConfig{SeedTemplate: core.SeedTemplate{Spec: core.SeedSpec{Networks: core.SeedNetworks{
+				Nodes:    &nodeCIDR,
+				Pods:     podCIDR,
+				Services: serviceCIDR,
+			}}}}, shootInfoWithNodes, true, BeNil()),
+			Entry("correct seed configuration without nodes", &config.SeedConfig{SeedTemplate: core.SeedTemplate{Spec: core.SeedSpec{Networks: core.SeedNetworks{
+				Pods:     podCIDR,
+				Services: serviceCIDR,
+			}}}}, shootInfoWithoutNodes, true, BeNil()),
+			Entry("correct seed configuration with nodes but no nodes in shoot-info", &config.SeedConfig{SeedTemplate: core.SeedTemplate{Spec: core.SeedSpec{Networks: core.SeedNetworks{
+				Nodes:    &nodeCIDR,
+				Pods:     podCIDR,
+				Services: serviceCIDR,
+			}}}}, shootInfoWithoutNodes, true, BeNil()),
+			Entry("correct seed configuration without nodes but nodes in shoot-info", &config.SeedConfig{SeedTemplate: core.SeedTemplate{Spec: core.SeedSpec{Networks: core.SeedNetworks{
+				Pods:     podCIDR,
+				Services: serviceCIDR,
+			}}}}, shootInfoWithNodes, true, BeNil()),
+			Entry("correct seed configuration incorrect nodes but no nodes in shoot-info", &config.SeedConfig{SeedTemplate: core.SeedTemplate{Spec: core.SeedSpec{Networks: core.SeedNetworks{
+				Nodes:    &otherCIDR,
+				Pods:     podCIDR,
+				Services: serviceCIDR,
+			}}}}, shootInfoWithoutNodes, true, BeNil()),
+			Entry("correct seed configuration without nodes but incorrect nodes in shoot-info", &config.SeedConfig{SeedTemplate: core.SeedTemplate{Spec: core.SeedSpec{Networks: core.SeedNetworks{
+				Pods:     podCIDR,
+				Services: serviceCIDR,
+			}}}}, shootInfoWithIncorrectNodes, true, BeNil()),
+			Entry("incorrect node cidr", &config.SeedConfig{SeedTemplate: core.SeedTemplate{Spec: core.SeedSpec{Networks: core.SeedNetworks{
+				Nodes:    &otherCIDR,
+				Pods:     podCIDR,
+				Services: serviceCIDR,
+			}}}}, shootInfoWithNodes, true, HaveOccurred()),
+			Entry("incorrect pod cidr", &config.SeedConfig{SeedTemplate: core.SeedTemplate{Spec: core.SeedSpec{Networks: core.SeedNetworks{
+				Nodes:    &nodeCIDR,
+				Pods:     otherCIDR,
+				Services: serviceCIDR,
+			}}}}, shootInfoWithNodes, true, HaveOccurred()),
+			Entry("incorrect service cidr", &config.SeedConfig{SeedTemplate: core.SeedTemplate{Spec: core.SeedSpec{Networks: core.SeedNetworks{
+				Nodes:    &nodeCIDR,
+				Pods:     podCIDR,
+				Services: otherCIDR,
+			}}}}, shootInfoWithNodes, true, HaveOccurred()),
+		)
+	})
+})
+
+func clientGet(result runtime.Object) interface{} {
+	return func(ctx context.Context, key client.ObjectKey, obj runtime.Object) error {
+		switch obj.(type) {
+		case *corev1.ConfigMap:
+			*obj.(*corev1.ConfigMap) = *result.(*corev1.ConfigMap)
+		}
+		return nil
+	}
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Validate seed network configuration on gardenlet startup.

In case the seed specification does not fit to the actual seed cluster configuration
the result may be hard to find issues, e.g. in the network policies. Therefore, this
change introduces a validation during the gardenlet startup to compare the seed
specification with the reality in the seed cluster.
For now, this only works in case the seed cluster is managed itself by Gardener as
it uses the shoot-info config map. Other clusters are always accepted.

**Which issue(s) this PR fixes**:
Fixes #6548.

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Gardenlet now checks that the seed network configuration conforms to the reality in the seed cluster in case the seed is a shoot itself.
```

/invite @rfranzke @timebertt 