### PR TITLE
Improve log values in webhook remediator

### DIFF
--- a/docs/development/logging.md
+++ b/docs/development/logging.md
@@ -138,6 +138,8 @@ results in
 
 The logger is injected by controller-runtime's `Controller` implementation and our `controllerutils.CreateWorker` alike (if a logger is passed using `controllerutils.WithLogger`). The logger returned by `logf.FromContext` is never `nil`. If the context doesn't carry a logger, it falls back to the global logger (`logf.Log`), which might discard logs if not configured, but is also never `nil`.
 
+> ⚠️ Make sure that you don't overwrite the `name` or `namespace` value keys for such loggers, otherwise you will lose information about the reconciled object.
+
 The controller implementation (controller-runtime / `CreateWorker`) itself takes care of logging the error returned by reconcilers.
 Hence, don't log an error that you are returning.
 Generally, functions should not return an error, if they already logged it, because that means the error is already handled and not an error anymore.

--- a/pkg/operation/care/webhook_remediation.go
+++ b/pkg/operation/care/webhook_remediation.go
@@ -217,8 +217,8 @@ func newRemediator(log logr.Logger, webhookConfigKind, webhookConfigName, webhoo
 	return remediator{
 		log: log.WithValues(
 			"kind", webhookConfigKind,
-			"name", webhookConfigName,
-			"webhook", webhookName,
+			"webhookConfigName", webhookConfigName,
+			"webhookName", webhookName,
 		),
 		webhookConfigKind: webhookConfigKind,
 		webhookConfigName: webhookConfigName,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR improves the log values of the webhook remediator part of shoot care controller in gardenlet.
The `name` value already exists in the logger passed down to the remediator, so earlier we were overriding this value and losing information.
Now, the value keys should be more appropriate.

**Special notes for your reviewer**:
/cc @StenlyTU 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
