### PR TITLE
[GEP-20] Zone pinning for shoots on multi-zonal seeds 📌 

### DIFF
--- a/cmd/gardener-resource-manager/app/app.go
+++ b/cmd/gardener-resource-manager/app/app.go
@@ -31,6 +31,7 @@ import (
 	tokenrequestorcontroller "github.com/gardener/gardener/pkg/resourcemanager/controller/tokenrequestor"
 	resourcemanagerhealthz "github.com/gardener/gardener/pkg/resourcemanager/healthz"
 	podschedulernamewebhook "github.com/gardener/gardener/pkg/resourcemanager/webhook/podschedulername"
+	"github.com/gardener/gardener/pkg/resourcemanager/webhook/podzoneaffinity"
 	projectedtokenmountwebhook "github.com/gardener/gardener/pkg/resourcemanager/webhook/projectedtokenmount"
 	seccompprofilewebhook "github.com/gardener/gardener/pkg/resourcemanager/webhook/seccompprofile"
 	tokeninvalidatorwebhook "github.com/gardener/gardener/pkg/resourcemanager/webhook/tokeninvalidator"
@@ -64,6 +65,7 @@ func NewResourceManagerCommand() *cobra.Command {
 		rootCAControllerOpts           = &rootcacontroller.ControllerOptions{}
 		projectedTokenMountWebhookOpts = &projectedtokenmountwebhook.WebhookOptions{}
 		podSchedulerNameWebhookOpts    = &podschedulernamewebhook.WebhookOptions{}
+		podZoneAffinityWebhookOpts     = &podzoneaffinity.WebhookOptions{}
 		seccompProfileWebhookOpts      = &seccompprofilewebhook.WebhookOptions{}
 
 		cmd = &cobra.Command{
@@ -93,6 +95,7 @@ func NewResourceManagerCommand() *cobra.Command {
 					rootCAControllerOpts,
 					projectedTokenMountWebhookOpts,
 					podSchedulerNameWebhookOpts,
+					podZoneAffinityWebhookOpts,
 					seccompProfileWebhookOpts,
 				); err != nil {
 					return err
@@ -170,8 +173,15 @@ func NewResourceManagerCommand() *cobra.Command {
 				); err != nil {
 					return err
 				}
+
 				if podSchedulerNameWebhookOpts.Completed().Enabled {
 					if err := podschedulernamewebhook.AddToManager(mgr); err != nil {
+						return err
+					}
+				}
+
+				if podZoneAffinityWebhookOpts.Completed().Enabled {
+					if err := podzoneaffinity.AddToManager(mgr); err != nil {
 						return err
 					}
 				}
@@ -226,6 +236,7 @@ func NewResourceManagerCommand() *cobra.Command {
 		rootCAControllerOpts,
 		projectedTokenMountWebhookOpts,
 		podSchedulerNameWebhookOpts,
+		podZoneAffinityWebhookOpts,
 		seccompProfileWebhookOpts,
 	)
 	verflag.AddFlags(cmd.Flags())

--- a/docs/concepts/resource-manager.md
+++ b/docs/concepts/resource-manager.md
@@ -522,18 +522,18 @@ Please find an overview below for pods deployed in the Shoot cluster:
 
 ### Pod Zone Affinity
 
-When this webhook is activated and namespaces are annotated with `shoot.gardener.cloud/zone-pinning` then it automatically adds a [pod affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity):
+When this webhook is activated and namespaces are annotated with `control-plane.shoot.gardener.cloud/enforce-zone` then it automatically adds a [pod affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity) to all `Pod`s created in these namespaces:
 
 ```
 spec:
   affinity:
     podAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
-      - LabelSelector: {}
-        TopologyKey: topology.kubernetes.io/zone
+      - labelSelector: {}
+        topologyKey: topology.kubernetes.io/zone
 ```
 
-In addition, if the annotation key `shoot.gardener.cloud/zone-pinning` has a value `<zone-value>`, i.e. zone assigned, this information is added as part of a node affinity.
+In addition, if the annotation key `control-plane.shoot.gardener.cloud/enforce-zone` has a value `<zone-value>`, i.e. zone assigned, this information is added as part of a node affinity.
 
 ```
 spec:

--- a/docs/concepts/resource-manager.md
+++ b/docs/concepts/resource-manager.md
@@ -519,3 +519,37 @@ Hence, it is served from the Seed GRM and each Shoot GRM.
 Please find an overview below for pods deployed in the Shoot cluster:
 
 ![image](images/resource-manager-projected-token-shoot-to-shoot-apiserver.jpg)
+
+### Pod Zone Affinity
+
+When this webhook is activated and namespaces are annotated with `shoot.gardener.cloud/zone-pinning` then it automatically adds a [pod affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity):
+
+```
+spec:
+  affinity:
+    podAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - LabelSelector: {}
+        TopologyKey: topology.kubernetes.io/zone
+```
+
+In addition, if the annotation key `shoot.gardener.cloud/zone-pinning` has a value `<zone-value>`, i.e. zone assigned, this information is added as part of a node affinity.
+
+```
+spec:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+          - matchExpressions:
+            - key: topology.kubernetes.io/zone
+              operator: In
+              values:
+              - <zone-value>
+```
+
+Those terms let pods within a namespace being scheduled to nodes residing in the very same zone which is either randomly picked, or to a very specific zone.
+In addition, the webhook removes any (anti-)affinities with `topology.kubernetes.io/zone` because they potentially contradict the above shown configuration.
+Gardener uses this webhook to schedule control-plane pods within a single zone on a multi-zonal seed (seed with worker nodes across zones).
+The goal is to reduce cross zonal network traffic within the seed with this approach.
+

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -256,9 +256,9 @@ const (
 	// GardenRoleExposureClassHandler is the value of the GardenRole key indicating type 'exposureclass-handler'.
 	GardenRoleExposureClassHandler = "exposureclass-handler"
 
-	// ShootZonePinning is an annotation key which is used to pin or schedule all control-plane pods
+	// ShootControlPlaneEnforceZone is an annotation key which is used to pin or schedule all control-plane pods
 	// to the very same availability zone.
-	ShootZonePinning = "shoot.gardener.cloud/zone-pinning"
+	ShootControlPlaneEnforceZone = "control-plane.shoot.gardener.cloud/enforce-zone"
 	// ShootUID is an annotation key for the shoot namespace in the seed cluster,
 	// which value will be the value of `shoot.status.uid`
 	ShootUID = "shoot.gardener.cloud/uid"

--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -256,6 +256,9 @@ const (
 	// GardenRoleExposureClassHandler is the value of the GardenRole key indicating type 'exposureclass-handler'.
 	GardenRoleExposureClassHandler = "exposureclass-handler"
 
+	// ShootZonePinning is an annotation key which is used to pin or schedule all control-plane pods
+	// to the very same availability zone.
+	ShootZonePinning = "shoot.gardener.cloud/zone-pinning"
 	// ShootUID is an annotation key for the shoot namespace in the seed cluster,
 	// which value will be the value of `shoot.status.uid`
 	ShootUID = "shoot.gardener.cloud/uid"

--- a/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control_reconcile.go
@@ -281,6 +281,11 @@ func (r *shootReconciler) runReconcileShootFlow(ctx context.Context, o *operatio
 			Fn:           flow.TaskFn(botanist.WaitUntilEtcdsReady).SkipIf(o.Shoot.HibernationEnabled),
 			Dependencies: flow.NewTaskIDs(deployETCD),
 		})
+		_ = g.Add(flow.Task{
+			Name:         "Adding zone information to Shoot namespace",
+			Fn:           flow.TaskFn(botanist.AddZoneInformationToSeedNamespace).SkipIf(o.Shoot.HibernationEnabled),
+			Dependencies: flow.NewTaskIDs(waitUntilEtcdReady),
+		})
 		deployControlPlane = g.Add(flow.Task{
 			Name:         "Deploying shoot control plane components",
 			Fn:           flow.TaskFn(botanist.DeployControlPlane).RetryUntilTimeout(defaultInterval, defaultTimeout),

--- a/pkg/operation/botanist/component/resourcemanager/resource_manager.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager.go
@@ -1107,7 +1107,7 @@ func GetPodZoneAffinityMutatingWebhook(secretServerCA *corev1.Secret, buildClien
 		NamespaceSelector: &metav1.LabelSelector{
 			MatchExpressions: []metav1.LabelSelectorRequirement{
 				{
-					Key:      v1beta1constants.ShootZonePinning,
+					Key:      v1beta1constants.ShootControlPlaneEnforceZone,
 					Operator: metav1.LabelSelectorOpExists,
 				},
 			},

--- a/pkg/operation/botanist/component/resourcemanager/resource_manager_test.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager_test.go
@@ -304,6 +304,7 @@ var _ = Describe("ResourceManager", func() {
 			},
 			SchedulingProfile:            &binPackingSchedulingProfile,
 			DefaultSeccompProfileEnabled: true,
+			PodZoneAffinityEnabled:       true,
 		}
 		resourceManager = New(c, deployNamespace, sm, image, cfg)
 		resourceManager.SetSecrets(secrets)
@@ -353,6 +354,7 @@ var _ = Describe("ResourceManager", func() {
 				"--pod-scheduler-name-webhook-enabled=true",
 				fmt.Sprintf("--pod-scheduler-name-webhook-scheduler=%v", "bin-packing-scheduler"),
 			)
+			cmd = append(cmd, "--pod-zone-affinity-webhook-enabled=true")
 			cmd = append(cmd, "--seccomp-profile-webhook-enabled=true")
 
 			return cmd
@@ -759,6 +761,36 @@ var _ = Describe("ResourceManager", func() {
 							Name:      "gardener-resource-manager",
 							Namespace: deployNamespace,
 							Path:      pointer.String("/webhooks/seccomp-profile"),
+						},
+					},
+					AdmissionReviewVersions: []string{"v1beta1", "v1"},
+					FailurePolicy:           &failurePolicy,
+					MatchPolicy:             &matchPolicy,
+					SideEffects:             &sideEffect,
+					TimeoutSeconds:          pointer.Int32(10),
+				},
+				{
+					Name: "pod-zone-affinity.resources.gardener.cloud",
+					Rules: []admissionregistrationv1.RuleWithOperations{{
+						Rule: admissionregistrationv1.Rule{
+							APIGroups:   []string{""},
+							APIVersions: []string{"v1"},
+							Resources:   []string{"pods"},
+						},
+						Operations: []admissionregistrationv1.OperationType{"CREATE"},
+					}},
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchExpressions: []metav1.LabelSelectorRequirement{{
+							Key:      "shoot.gardener.cloud/zone-pinning",
+							Operator: metav1.LabelSelectorOpExists,
+						}},
+					},
+					ObjectSelector: &metav1.LabelSelector{},
+					ClientConfig: admissionregistrationv1.WebhookClientConfig{
+						Service: &admissionregistrationv1.ServiceReference{
+							Name:      "gardener-resource-manager",
+							Namespace: deployNamespace,
+							Path:      pointer.String("/webhooks/pod-zone-affinity"),
 						},
 					},
 					AdmissionReviewVersions: []string{"v1beta1", "v1"},

--- a/pkg/operation/botanist/component/resourcemanager/resource_manager_test.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager_test.go
@@ -781,7 +781,7 @@ var _ = Describe("ResourceManager", func() {
 					}},
 					NamespaceSelector: &metav1.LabelSelector{
 						MatchExpressions: []metav1.LabelSelectorRequirement{{
-							Key:      "shoot.gardener.cloud/zone-pinning",
+							Key:      "control-plane.shoot.gardener.cloud/enforce-zone",
 							Operator: metav1.LabelSelectorOpExists,
 						}},
 					},

--- a/pkg/operation/botanist/namespaces.go
+++ b/pkg/operation/botanist/namespaces.go
@@ -79,9 +79,10 @@ func (b *Botanist) DeploySeedNamespace(ctx context.Context) error {
 
 		// Label namespace to pin all control-plane pods of a shoot cluster to one zone
 		// if the seed has workers across different availability zones.
+		zone := namespace.Labels[v1beta1constants.ShootControlPlaneEnforceZone]
 		delete(namespace.Labels, v1beta1constants.ShootControlPlaneEnforceZone)
-		if zonePinningRequired(b.Shoot.GetInfo(), b.Seed.GetInfo()) && !metav1.HasLabel(namespace.ObjectMeta, v1beta1constants.ShootControlPlaneEnforceZone) {
-			metav1.SetMetaDataLabel(&namespace.ObjectMeta, v1beta1constants.ShootControlPlaneEnforceZone, "")
+		if zonePinningRequired(b.Shoot.GetInfo(), b.Seed.GetInfo()) {
+			metav1.SetMetaDataLabel(&namespace.ObjectMeta, v1beta1constants.ShootControlPlaneEnforceZone, zone)
 		}
 
 		return nil

--- a/pkg/operation/botanist/namespaces.go
+++ b/pkg/operation/botanist/namespaces.go
@@ -147,14 +147,13 @@ func (b *Botanist) AddZoneInformationToSeedNamespace(ctx context.Context) error 
 		return fmt.Errorf("zone information cannot be extracted because node %q does not contain any zone information", node.Name)
 	}
 
-	namespace := b.SeedNamespaceObject.DeepCopy()
-	metav1.SetMetaDataLabel(&namespace.ObjectMeta, v1beta1constants.ShootControlPlaneEnforceZone, zone)
+	patch := client.MergeFrom(b.SeedNamespaceObject.DeepCopy())
+	metav1.SetMetaDataLabel(&b.SeedNamespaceObject.ObjectMeta, v1beta1constants.ShootControlPlaneEnforceZone, zone)
 
-	if err := b.K8sSeedClient.Client().Patch(ctx, namespace, client.MergeFrom(b.SeedNamespaceObject)); err != nil {
+	if err := b.K8sSeedClient.Client().Patch(ctx, b.SeedNamespaceObject, patch); err != nil {
 		return err
 	}
 
-	b.SeedNamespaceObject = namespace
 	return nil
 }
 

--- a/pkg/operation/seed/components.go
+++ b/pkg/operation/seed/components.go
@@ -149,6 +149,7 @@ func defaultGardenerResourceManager(c client.Client, seedClientVersion string, i
 			},
 		},
 		DefaultSeccompProfileEnabled: gardenletfeatures.FeatureGate.Enabled(features.DefaultSeccompProfile),
+		PodZoneAffinityEnabled:       true,
 	}), nil
 }
 

--- a/pkg/operation/seed/components.go
+++ b/pkg/operation/seed/components.go
@@ -149,7 +149,7 @@ func defaultGardenerResourceManager(c client.Client, seedClientVersion string, i
 			},
 		},
 		DefaultSeccompProfileEnabled: gardenletfeatures.FeatureGate.Enabled(features.DefaultSeccompProfile),
-		PodZoneAffinityEnabled:       true,
+		PodZoneAffinityEnabled:       gardenletfeatures.FeatureGate.Enabled(features.HAControlPlanes),
 	}), nil
 }
 

--- a/pkg/resourcemanager/webhook/podschedulername/podschedulername_suite_test.go
+++ b/pkg/resourcemanager/webhook/podschedulername/podschedulername_suite_test.go
@@ -23,5 +23,5 @@ import (
 
 func TestPodSchedulerName(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Webhook PodZoneAffinity Suite")
+	RunSpecs(t, "Webhook PodSchedulerName Suite")
 }

--- a/pkg/resourcemanager/webhook/podzoneaffinity/add.go
+++ b/pkg/resourcemanager/webhook/podzoneaffinity/add.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package podzoneaffinity
+
+import (
+	"github.com/spf13/pflag"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+const (
+	// WebhookPath is the path at which the handler should be registered.
+	WebhookPath = "/webhooks/pod-zone-affinity"
+)
+
+var defaultWebhookConfig WebhookConfig
+
+// WebhookOptions are options for adding the webhook to a Manager.
+type WebhookOptions struct {
+	enabled bool
+}
+
+// WebhookConfig is the completed configuration for the webhook.
+type WebhookConfig struct {
+	Enabled bool
+}
+
+// AddToManagerWithOptions adds the webhook to a Manager with the given config.
+func AddToManagerWithOptions(mgr manager.Manager, conf WebhookConfig) error {
+	server := mgr.GetWebhookServer()
+	server.Register(WebhookPath, &webhook.Admission{
+		Handler: NewHandler(),
+	})
+	return nil
+}
+
+// AddToManager adds the webhook to a Manager using the default config.
+func AddToManager(mgr manager.Manager) error {
+	return AddToManagerWithOptions(mgr, defaultWebhookConfig)
+}
+
+// AddFlags adds the needed command line flags to the given FlagSet.
+func (o *WebhookOptions) AddFlags(fs *pflag.FlagSet) {
+	fs.BoolVar(&o.enabled, "pod-zone-affinity-webhook-enabled", false, "enables the pod zone affinity webhook")
+}
+
+// Complete completes the given command line flags and set the defaultWebhookConfig accordingly.
+func (o *WebhookOptions) Complete() error {
+	defaultWebhookConfig = WebhookConfig{
+		Enabled: o.enabled,
+	}
+	return nil
+}
+
+// Completed returns the completed WebhookConfig.
+func (o *WebhookOptions) Completed() *WebhookConfig {
+	return &defaultWebhookConfig
+}

--- a/pkg/resourcemanager/webhook/podzoneaffinity/add.go
+++ b/pkg/resourcemanager/webhook/podzoneaffinity/add.go
@@ -21,6 +21,8 @@ import (
 )
 
 const (
+	// HandlerName is the name of the webhook handler.
+	HandlerName = "pod-zone-affinity"
 	// WebhookPath is the path at which the handler should be registered.
 	WebhookPath = "/webhooks/pod-zone-affinity"
 )
@@ -38,10 +40,10 @@ type WebhookConfig struct {
 }
 
 // AddToManagerWithOptions adds the webhook to a Manager with the given config.
-func AddToManagerWithOptions(mgr manager.Manager, conf WebhookConfig) error {
+func AddToManagerWithOptions(mgr manager.Manager, _ WebhookConfig) error {
 	server := mgr.GetWebhookServer()
 	server.Register(WebhookPath, &webhook.Admission{
-		Handler: NewHandler(),
+		Handler: NewHandler(mgr.GetLogger().WithName("webhook").WithName(HandlerName)),
 	})
 	return nil
 }

--- a/pkg/resourcemanager/webhook/podzoneaffinity/handler.go
+++ b/pkg/resourcemanager/webhook/podzoneaffinity/handler.go
@@ -1,0 +1,224 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package podzoneaffinity
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	gardencorev1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+var podGVK = metav1.GroupVersionKind{Group: "", Kind: "Pod", Version: "v1"}
+
+type handler struct {
+	client  client.Client
+	decoder *admission.Decoder
+}
+
+// NewHandler returns a new handler.
+func NewHandler() admission.Handler {
+	return &handler{}
+}
+
+func (h *handler) InjectClient(cl client.Client) error {
+	h.client = cl
+	return nil
+}
+
+func (h *handler) InjectDecoder(d *admission.Decoder) error {
+	h.decoder = d
+	return nil
+}
+
+func (h *handler) Handle(ctx context.Context, req admission.Request) admission.Response {
+	if req.Operation != admissionv1.Create {
+		return admission.Allowed("only 'create' operation is handled")
+	}
+
+	if req.Kind != podGVK {
+		return admission.Allowed("resource is not corev1.Pod")
+	}
+
+	if req.SubResource != "" {
+		return admission.Allowed("subresources on pods are not supported")
+	}
+
+	pod := &corev1.Pod{}
+	if err := h.decoder.Decode(req, pod); err != nil {
+		return admission.Errored(http.StatusUnprocessableEntity, err)
+	}
+
+	// Check conflicting and add required pod affinity terms.
+	handlePodAffinity(pod)
+
+	// If the concrete zone is already determined by Gardener, let the pod be scheduled only to nodes in that zone.
+	if err := handleNodeAffinity(ctx, h.client, pod); err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	marshaledPod, err := json.Marshal(pod)
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	return admission.PatchResponseFromRaw(req.Object.Raw, marshaledPod)
+}
+
+func handlePodAffinity(pod *corev1.Pod) {
+	affinityTerm := corev1.PodAffinityTerm{
+		// Use empty label selector to match any pods in the shoot control plane namespace.
+		LabelSelector: &metav1.LabelSelector{},
+		TopologyKey:   corev1.LabelTopologyZone,
+	}
+
+	// First remove potentially conflicting pod anti affinity terms that would forbid scheduling into a single zone.
+	removeConflictingPodAntiAffinityTerms(pod, affinityTerm)
+
+	// Handle required affinity to let the pod be scheduled to a specific zone.
+	handleZonePodAffinityTerm(pod, affinityTerm)
+}
+
+func removeConflictingPodAntiAffinityTerms(pod *corev1.Pod, affinityTerm corev1.PodAffinityTerm) {
+	if pod.Spec.Affinity == nil || pod.Spec.Affinity.PodAntiAffinity == nil {
+		return
+	}
+
+	// Remove pod anti-affinity rules with zone topology key.
+	remainingAntiAffinityTerms := make([]corev1.PodAffinityTerm, 0, len(pod.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution))
+	for _, term := range pod.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution {
+		if equality.Semantic.DeepEqual(term, affinityTerm) {
+			continue
+		}
+		remainingAntiAffinityTerms = append(remainingAntiAffinityTerms, term)
+	}
+	pod.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution = remainingAntiAffinityTerms
+}
+
+func handleZonePodAffinityTerm(pod *corev1.Pod, affinityTerm corev1.PodAffinityTerm) {
+	if pod.Spec.Affinity == nil {
+		pod.Spec.Affinity = &corev1.Affinity{}
+	}
+	if pod.Spec.Affinity.PodAffinity == nil {
+		pod.Spec.Affinity.PodAffinity = &corev1.PodAffinity{}
+	}
+
+	var (
+		zoneTermExisting      bool
+		filteredAffinityTerms = make([]corev1.PodAffinityTerm, 0, len(pod.Spec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution))
+	)
+
+	for _, term := range pod.Spec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution {
+		if equality.Semantic.DeepEqual(term, affinityTerm) {
+			zoneTermExisting = true
+		}
+
+		// If there is another affinity configured on zones, we assume that this will be conflicting.
+		if term.TopologyKey == corev1.LabelTopologyZone && !zoneTermExisting {
+			continue
+		}
+
+		filteredAffinityTerms = append(filteredAffinityTerms, term)
+	}
+
+	pod.Spec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution = filteredAffinityTerms
+
+	// Add pod affinity for zone if not already available.
+	if !zoneTermExisting {
+		pod.Spec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution = append(pod.Spec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution, affinityTerm)
+	}
+}
+
+func handleNodeAffinity(ctx context.Context, cl client.Client, pod *corev1.Pod) error {
+	nodeSelector, err := getZoneSpecificNodeSelector(ctx, cl, pod.Namespace)
+	if err != nil {
+		return err
+	}
+
+	if nodeSelector == nil {
+		return nil
+	}
+
+	if pod.Spec.Affinity.NodeAffinity == nil {
+		pod.Spec.Affinity.NodeAffinity = &corev1.NodeAffinity{}
+	}
+
+	if pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+		pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = &corev1.NodeSelector{}
+	}
+
+	var (
+		zoneTermExisting          bool
+		filteredAntiAffinityTerms = make([]corev1.NodeSelectorTerm, 0, len(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms))
+	)
+
+	for _, term := range pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms {
+		// Check if node affinity already exists.
+		if equality.Semantic.DeepEqual(term, nodeSelector) {
+			zoneTermExisting = true
+		}
+
+		// Check conflicting affinity terms.
+		for _, expr := range term.MatchExpressions {
+			if expr.Key == corev1.LabelTopologyZone && !zoneTermExisting {
+				continue
+			}
+			filteredAntiAffinityTerms = append(filteredAntiAffinityTerms, term)
+		}
+	}
+
+	pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = filteredAntiAffinityTerms
+
+	// Add node affinity for zone if not already available.
+	if !zoneTermExisting {
+		pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = append(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms, *nodeSelector)
+	}
+
+	return nil
+}
+
+func getZoneSpecificNodeSelector(ctx context.Context, cl client.Client, namespace string) (*corev1.NodeSelectorTerm, error) {
+	namespaceObj := &corev1.Namespace{}
+	if err := cl.Get(ctx, kutil.Key(namespace), namespaceObj); err != nil {
+		return nil, err
+	}
+
+	// Check if scheduling to a specific zone is required.
+	var nodeSelector *corev1.NodeSelectorTerm
+	zone := namespaceObj.Labels[gardencorev1beta1constants.ShootZonePinning]
+	if zone != "" {
+		nodeSelector = &corev1.NodeSelectorTerm{
+			MatchExpressions: []corev1.NodeSelectorRequirement{
+				{
+					Key:      corev1.LabelTopologyZone,
+					Operator: corev1.NodeSelectorOpIn,
+					Values: []string{
+						zone,
+					},
+				},
+			},
+		}
+	}
+
+	return nodeSelector, nil
+}

--- a/pkg/resourcemanager/webhook/podzoneaffinity/handler_test.go
+++ b/pkg/resourcemanager/webhook/podzoneaffinity/handler_test.go
@@ -1,0 +1,499 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package podzoneaffinity_test
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	. "github.com/gardener/gardener/pkg/resourcemanager/webhook/podzoneaffinity"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gomodules.xyz/jsonpatch/v2"
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+var _ = Describe("Handler", func() {
+	var (
+		ctx        = context.Background()
+		fakeClient client.Client
+		encoder    runtime.Encoder
+
+		request   admission.Request
+		pod       *corev1.Pod
+		namespace string
+
+		patchType admissionv1.PatchType
+
+		handler admission.Handler
+	)
+
+	BeforeEach(func() {
+		fakeClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+
+		decoder, err := admission.NewDecoder(kubernetesscheme.Scheme)
+		Expect(err).NotTo(HaveOccurred())
+		encoder = &json.Serializer{}
+
+		request = admission.Request{
+			AdmissionRequest: admissionv1.AdmissionRequest{
+				Kind:      metav1.GroupVersionKind{Group: "", Kind: "Pod", Version: "v1"},
+				Operation: admissionv1.Create,
+			},
+		}
+
+		patchType = admissionv1.PatchTypeJSONPatch
+
+		handler = NewHandler()
+		Expect(admission.InjectDecoderInto(decoder, handler)).To(BeTrue())
+		Expect(inject.ClientInto(fakeClient, handler)).To(BeTrue())
+
+		namespace = "shoot--foo--bar"
+
+		pod = &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pod-0",
+				Namespace: namespace,
+			},
+			Spec: corev1.PodSpec{},
+		}
+
+		Expect(fakeClient.Create(ctx, &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: namespace,
+			},
+		})).To(Succeed())
+	})
+
+	Describe("#Handle", func() {
+		It("should allow when operation is not 'create'", func() {
+			request.Operation = admissionv1.Update
+
+			response := handler.Handle(ctx, request)
+
+			Expect(response).To(Equal(admission.Response{
+				AdmissionResponse: admissionv1.AdmissionResponse{
+					Allowed: true,
+					Result: &metav1.Status{
+						Reason: "only 'create' operation is handled",
+						Code:   http.StatusOK,
+					},
+				},
+			}))
+		})
+
+		It("should allow when resource is not corev1.Pod", func() {
+			request.Kind = metav1.GroupVersionKind{Group: "", Kind: "ConfigMap", Version: "v1"}
+
+			response := handler.Handle(ctx, request)
+
+			Expect(response).To(Equal(admission.Response{
+				AdmissionResponse: admissionv1.AdmissionResponse{
+					Allowed: true,
+					Result: &metav1.Status{
+						Reason: "resource is not corev1.Pod",
+						Code:   http.StatusOK,
+					},
+				},
+			}))
+		})
+
+		It("should allow when subresource is specified", func() {
+			request.SubResource = "status"
+
+			response := handler.Handle(ctx, request)
+
+			Expect(response).To(Equal(admission.Response{
+				AdmissionResponse: admissionv1.AdmissionResponse{
+					Allowed: true,
+					Result: &metav1.Status{
+						Reason: "subresources on pods are not supported",
+						Code:   http.StatusOK,
+					},
+				},
+			}))
+		})
+
+		It("should return an error because the pod cannot be decoded", func() {
+			request.Object.Raw = []byte(`{]`)
+
+			Expect(handler.Handle(ctx, request)).To(Equal(admission.Response{
+				AdmissionResponse: admissionv1.AdmissionResponse{
+					Allowed: false,
+					Result: &metav1.Status{
+						Code:    int32(http.StatusUnprocessableEntity),
+						Message: "couldn't get version/kind; json parse error: invalid character ']' looking for beginning of object key string",
+					},
+				},
+			}))
+		})
+
+		It("should add the zone pod affinity if affinity is not set", func() {
+			pod.Spec.Affinity = nil
+			objData, err := runtime.Encode(encoder, pod)
+			Expect(err).NotTo(HaveOccurred())
+			request.Object.Raw = objData
+
+			response := handler.Handle(ctx, request)
+
+			Expect(response).To(Equal(admission.Response{
+				AdmissionResponse: admissionv1.AdmissionResponse{
+					Allowed:   true,
+					PatchType: &patchType,
+				},
+				Patches: []jsonpatch.Operation{
+					{
+						Operation: "add",
+						Path:      "/spec/affinity",
+						Value: map[string]interface{}{
+							"podAffinity": map[string]interface{}{
+								"requiredDuringSchedulingIgnoredDuringExecution": []interface{}{
+									map[string]interface{}{
+										"labelSelector": map[string]interface{}{},
+										"topologyKey":   "topology.kubernetes.io/zone",
+									},
+								},
+							},
+						},
+					},
+				},
+			}))
+		})
+
+		It("should add the zone pod affinity for a specific zone if affinity is not set", func() {
+			zone := "zone-a"
+
+			Expect(fakeClient.Update(ctx, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: namespace,
+					Labels: map[string]string{
+						"shoot.gardener.cloud/zone-pinning": zone,
+					},
+				},
+			})).To(Succeed())
+
+			pod.Spec.Affinity = nil
+			objData, err := runtime.Encode(encoder, pod)
+			Expect(err).NotTo(HaveOccurred())
+			request.Object.Raw = objData
+
+			response := handler.Handle(ctx, request)
+
+			Expect(response.Patches).To(ConsistOf([]jsonpatch.Operation{
+				{
+					Operation: "add",
+					Path:      "/spec/affinity",
+					Value: map[string]interface{}{
+						"nodeAffinity": map[string]interface{}{
+							"requiredDuringSchedulingIgnoredDuringExecution": map[string]interface{}{
+								"nodeSelectorTerms": []interface{}{
+									map[string]interface{}{
+										"matchExpressions": []interface{}{
+											map[string]interface{}{
+												"key":      "topology.kubernetes.io/zone",
+												"operator": "In",
+												"values": []interface{}{
+													zone,
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+						"podAffinity": map[string]interface{}{
+							"requiredDuringSchedulingIgnoredDuringExecution": []interface{}{
+								map[string]interface{}{
+									"labelSelector": map[string]interface{}{},
+									"topologyKey":   "topology.kubernetes.io/zone",
+								},
+							},
+						},
+					},
+				},
+			}))
+
+			Expect(response.AdmissionResponse).To(Equal(admissionv1.AdmissionResponse{
+				Allowed:   true,
+				PatchType: &patchType,
+			}))
+		})
+
+		It("should add the zone pod affinity if another pod affinity is set", func() {
+			pod.Spec.Affinity = &corev1.Affinity{
+				PodAffinity: &corev1.PodAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+						{
+							TopologyKey: "kubernetes.io/hostname",
+						},
+					},
+				},
+			}
+			objData, err := runtime.Encode(encoder, pod)
+			Expect(err).NotTo(HaveOccurred())
+			request.Object.Raw = objData
+
+			response := handler.Handle(ctx, request)
+
+			Expect(response).To(Equal(admission.Response{
+				AdmissionResponse: admissionv1.AdmissionResponse{
+					Allowed:   true,
+					PatchType: &patchType,
+				},
+				Patches: []jsonpatch.Operation{
+					{
+						Operation: "add",
+						Path:      "/spec/affinity/podAffinity/requiredDuringSchedulingIgnoredDuringExecution/1",
+						Value: map[string]interface{}{
+							"labelSelector": map[string]interface{}{},
+							"topologyKey":   "topology.kubernetes.io/zone",
+						},
+					},
+				},
+			}))
+		})
+
+		It("should add the zone pod affinity for a specific zone if another node affinity is set", func() {
+			zone := "zone-a"
+
+			Expect(fakeClient.Update(ctx, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: namespace,
+					Labels: map[string]string{
+						"shoot.gardener.cloud/zone-pinning": zone,
+					},
+				},
+			})).To(Succeed())
+
+			pod.Spec.Affinity = &corev1.Affinity{
+				NodeAffinity: &corev1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{
+							{
+								MatchExpressions: []corev1.NodeSelectorRequirement{
+									{
+										Key:      "kubernetes.io/hostname",
+										Operator: corev1.NodeSelectorOpNotIn,
+										Values:   []string{"foo", "bar"},
+									},
+								},
+							},
+						},
+					},
+				},
+				PodAffinity: &corev1.PodAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+						{
+							TopologyKey:   "topology.kubernetes.io/zone",
+							LabelSelector: &metav1.LabelSelector{},
+						},
+					},
+				},
+			}
+			objData, err := runtime.Encode(encoder, pod)
+			Expect(err).NotTo(HaveOccurred())
+			request.Object.Raw = objData
+
+			response := handler.Handle(ctx, request)
+
+			Expect(response).To(Equal(admission.Response{
+				AdmissionResponse: admissionv1.AdmissionResponse{
+					Allowed:   true,
+					PatchType: &patchType,
+				},
+				Patches: []jsonpatch.Operation{
+					{
+						Operation: "add",
+						Path:      "/spec/affinity/nodeAffinity/requiredDuringSchedulingIgnoredDuringExecution/nodeSelectorTerms/1",
+						Value: map[string]interface{}{
+							"matchExpressions": []interface{}{
+								map[string]interface{}{
+									"key":      "topology.kubernetes.io/zone",
+									"operator": "In",
+									"values": []interface{}{
+										zone,
+									},
+								},
+							},
+						},
+					},
+				},
+			}))
+
+			Expect(response.AdmissionResponse).To(Equal(admissionv1.AdmissionResponse{
+				Allowed:   true,
+				PatchType: &patchType,
+			}))
+		})
+
+		It("should not change anything as required affinities are set", func() {
+			zone := "zone-a"
+
+			Expect(fakeClient.Update(ctx, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: namespace,
+					Labels: map[string]string{
+						"shoot.gardener.cloud/zone-pinning": zone,
+					},
+				},
+			})).To(Succeed())
+
+			pod.Spec.Affinity = &corev1.Affinity{
+				NodeAffinity: &corev1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{
+							{
+								MatchExpressions: []corev1.NodeSelectorRequirement{
+									{
+										Key:      "topology.kubernetes.io/zone",
+										Operator: corev1.NodeSelectorOpIn,
+										Values:   []string{zone},
+									},
+								},
+							},
+						},
+					},
+				},
+				PodAffinity: &corev1.PodAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+						{
+							TopologyKey:   "topology.kubernetes.io/zone",
+							LabelSelector: &metav1.LabelSelector{},
+						},
+					},
+				},
+			}
+			objData, err := runtime.Encode(encoder, pod)
+			Expect(err).NotTo(HaveOccurred())
+			request.Object.Raw = objData
+
+			response := handler.Handle(ctx, request)
+
+			Expect(response.AdmissionResponse).To(Equal(admissionv1.AdmissionResponse{
+				Allowed:   true,
+				PatchType: nil,
+				Patch:     nil,
+			}))
+		})
+
+		It("should remove a conflicting terms", func() {
+			zone := "zone-a"
+
+			Expect(fakeClient.Update(ctx, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: namespace,
+					Labels: map[string]string{
+						"shoot.gardener.cloud/zone-pinning": zone,
+					},
+				},
+			})).To(Succeed())
+
+			pod.Spec.Affinity = &corev1.Affinity{
+				NodeAffinity: &corev1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{
+							{
+								MatchExpressions: []corev1.NodeSelectorRequirement{
+									{
+										Key: "topology.kubernetes.io/zone",
+									},
+								},
+							},
+						},
+					},
+				},
+				PodAffinity: &corev1.PodAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+						{
+							TopologyKey: "topology.kubernetes.io/zone",
+							Namespaces: []string{
+								"default",
+							},
+						},
+					},
+				},
+				PodAntiAffinity: &corev1.PodAntiAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+						{
+							TopologyKey:   "topology.kubernetes.io/zone",
+							LabelSelector: &metav1.LabelSelector{},
+						},
+						{
+							TopologyKey: "kubernetes.io/hostname",
+						},
+					},
+				},
+			}
+			objData, err := runtime.Encode(encoder, pod)
+			Expect(err).NotTo(HaveOccurred())
+			request.Object.Raw = objData
+
+			response := handler.Handle(ctx, request)
+
+			Expect(response.AdmissionResponse).To(Equal(admissionv1.AdmissionResponse{
+				Allowed:   true,
+				PatchType: &patchType,
+			}))
+
+			Expect(response.Patches).To(ConsistOf([]jsonpatch.Operation{
+				{
+					Operation: "replace",
+					Path:      "/spec/affinity/nodeAffinity/requiredDuringSchedulingIgnoredDuringExecution/nodeSelectorTerms/0/matchExpressions/0/operator",
+					Value:     "In",
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/affinity/nodeAffinity/requiredDuringSchedulingIgnoredDuringExecution/nodeSelectorTerms/0/matchExpressions/0/values",
+					Value:     []interface{}{"zone-a"},
+				},
+				{
+					Operation: "add",
+					Path:      "/spec/affinity/podAffinity/requiredDuringSchedulingIgnoredDuringExecution/0/labelSelector",
+					Value:     map[string]interface{}{},
+				},
+				{
+					Operation: "remove",
+					Path:      "/spec/affinity/podAffinity/requiredDuringSchedulingIgnoredDuringExecution/0/namespaces",
+					Value:     nil,
+				},
+				{
+					Operation: "remove",
+					Path:      "/spec/affinity/podAntiAffinity/requiredDuringSchedulingIgnoredDuringExecution/1",
+					Value:     nil,
+				},
+				{
+					Operation: "replace",
+					Path:      "/spec/affinity/podAntiAffinity/requiredDuringSchedulingIgnoredDuringExecution/0/topologyKey",
+					Value:     "kubernetes.io/hostname",
+				},
+				{
+					Operation: "remove",
+					Path:      "/spec/affinity/podAntiAffinity/requiredDuringSchedulingIgnoredDuringExecution/0/labelSelector",
+					Value:     nil,
+				},
+			}))
+		})
+	})
+})

--- a/pkg/resourcemanager/webhook/podzoneaffinity/handler_test.go
+++ b/pkg/resourcemanager/webhook/podzoneaffinity/handler_test.go
@@ -19,7 +19,10 @@ import (
 	"net/http"
 
 	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/logger"
 	. "github.com/gardener/gardener/pkg/resourcemanager/webhook/podzoneaffinity"
+
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"gomodules.xyz/jsonpatch/v2"
@@ -31,6 +34,7 @@ import (
 	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	logzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/runtime/inject"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
@@ -40,6 +44,7 @@ var _ = Describe("Handler", func() {
 		ctx        = context.Background()
 		fakeClient client.Client
 		encoder    runtime.Encoder
+		log        logr.Logger
 
 		request   admission.Request
 		pod       *corev1.Pod
@@ -66,7 +71,9 @@ var _ = Describe("Handler", func() {
 
 		patchType = admissionv1.PatchTypeJSONPatch
 
-		handler = NewHandler()
+		log = logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, logzap.WriteTo(GinkgoWriter))
+
+		handler = NewHandler(log)
 		Expect(admission.InjectDecoderInto(decoder, handler)).To(BeTrue())
 		Expect(inject.ClientInto(fakeClient, handler)).To(BeTrue())
 
@@ -189,7 +196,7 @@ var _ = Describe("Handler", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: namespace,
 					Labels: map[string]string{
-						"shoot.gardener.cloud/zone-pinning": zone,
+						"control-plane.shoot.gardener.cloud/enforce-zone": zone,
 					},
 				},
 			})).To(Succeed())
@@ -282,7 +289,7 @@ var _ = Describe("Handler", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: namespace,
 					Labels: map[string]string{
-						"shoot.gardener.cloud/zone-pinning": zone,
+						"control-plane.shoot.gardener.cloud/enforce-zone": zone,
 					},
 				},
 			})).To(Succeed())
@@ -355,7 +362,7 @@ var _ = Describe("Handler", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: namespace,
 					Labels: map[string]string{
-						"shoot.gardener.cloud/zone-pinning": zone,
+						"control-plane.shoot.gardener.cloud/enforce-zone": zone,
 					},
 				},
 			})).To(Succeed())
@@ -405,7 +412,7 @@ var _ = Describe("Handler", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: namespace,
 					Labels: map[string]string{
-						"shoot.gardener.cloud/zone-pinning": zone,
+						"control-plane.shoot.gardener.cloud/enforce-zone": zone,
 					},
 				},
 			})).To(Succeed())

--- a/pkg/resourcemanager/webhook/podzoneaffinity/podzoneaffinity_suite_test.go
+++ b/pkg/resourcemanager/webhook/podzoneaffinity/podzoneaffinity_suite_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package podschedulername_test
+package podzoneaffinity_test
 
 import (
 	"testing"
@@ -21,7 +21,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestPodSchedulerName(t *testing.T) {
+func TestPodZoneAffinity(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Webhook PodZoneAffinity Suite")
 }

--- a/test/integration/resourcemanager/podschedulername/podschedulername_test.go
+++ b/test/integration/resourcemanager/podschedulername/podschedulername_test.go
@@ -23,9 +23,7 @@ import (
 )
 
 var _ = Describe("PodSchedulerName tests", func() {
-	var (
-		pod *corev1.Pod
-	)
+	var pod *corev1.Pod
 
 	BeforeEach(func() {
 		pod = &corev1.Pod{
@@ -52,29 +50,23 @@ var _ = Describe("PodSchedulerName tests", func() {
 		pod.Spec.SchedulerName = "bar-scheduler"
 		Expect(testClient.Create(ctx, pod)).To(Succeed())
 
-		Consistently(func() string {
-			Expect(testClient.Get(ctx, client.ObjectKeyFromObject(pod), pod)).To(Succeed())
-			return pod.Spec.SchedulerName
-		}).Should(Equal("bar-scheduler"))
+		Expect(testClient.Get(ctx, client.ObjectKeyFromObject(pod), pod)).To(Succeed())
+		Expect(pod.Spec.SchedulerName).To(Equal("bar-scheduler"))
 	})
 
 	It("should patch the scheduler name when the pod scheduler is not specified", func() {
 		pod.Spec.SchedulerName = ""
 		Expect(testClient.Create(ctx, pod)).To(Succeed())
 
-		Consistently(func() string {
-			Expect(testClient.Get(ctx, client.ObjectKeyFromObject(pod), pod)).To(Succeed())
-			return pod.Spec.SchedulerName
-		}).Should(Equal("bin-packing-scheduler"))
+		Expect(testClient.Get(ctx, client.ObjectKeyFromObject(pod), pod)).To(Succeed())
+		Expect(pod.Spec.SchedulerName).To(Equal("bin-packing-scheduler"))
 	})
 
 	It("should patch the scheduler name when the pod scheduler is 'default-scheduler'", func() {
 		pod.Spec.SchedulerName = corev1.DefaultSchedulerName
 		Expect(testClient.Create(ctx, pod)).To(Succeed())
 
-		Consistently(func() string {
-			Expect(testClient.Get(ctx, client.ObjectKeyFromObject(pod), pod)).To(Succeed())
-			return pod.Spec.SchedulerName
-		}).Should(Equal("bin-packing-scheduler"))
+		Expect(testClient.Get(ctx, client.ObjectKeyFromObject(pod), pod)).To(Succeed())
+		Expect(pod.Spec.SchedulerName).To(Equal("bin-packing-scheduler"))
 	})
 })

--- a/test/integration/resourcemanager/podzoneaffinity/podzoneaffinity_suite_test.go
+++ b/test/integration/resourcemanager/podzoneaffinity/podzoneaffinity_suite_test.go
@@ -1,0 +1,167 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package podzoneaffinity_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/gardener/gardener/pkg/logger"
+	"github.com/gardener/gardener/pkg/operation/botanist/component/resourcemanager"
+	"github.com/gardener/gardener/pkg/resourcemanager/webhook/podzoneaffinity"
+	"github.com/gardener/gardener/pkg/utils"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+func TestPodPodZoneAffinity(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "PodZoneAffinity Integration Test Suite")
+}
+
+const testID = "podzoneaffinity-webhook-test"
+
+var (
+	ctx = context.Background()
+	log logr.Logger
+
+	restConfig *rest.Config
+	testEnv    *envtest.Environment
+	testClient client.Client
+
+	testNamespace *corev1.Namespace
+)
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)))
+	log = logf.Log.WithName(testID)
+
+	// determine a unique namespace name to add a corresponding namespaceSelector to the webhook config
+	testNamespaceName := testID + "-" + utils.ComputeSHA256Hex([]byte(uuid.NewUUID()))[:8]
+
+	By("starting test environment")
+	testEnv = &envtest.Environment{
+		WebhookInstallOptions: envtest.WebhookInstallOptions{
+			MutatingWebhooks: getMutatingWebhookConfigurations(testNamespaceName),
+		},
+	}
+
+	var err error
+	restConfig, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(restConfig).NotTo(BeNil())
+
+	DeferCleanup(func() {
+		By("stopping test environment")
+		Expect(testEnv.Stop()).To(Succeed())
+	})
+
+	By("creating test client")
+	testClient, err = client.New(restConfig, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+
+	By("creating test namespace")
+	testNamespace = &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			// create dedicated namespace for each test run, so that we can run multiple tests concurrently for stress tests
+			Name: testNamespaceName,
+		},
+	}
+	Expect(testClient.Create(ctx, testNamespace)).To(Succeed())
+	log.Info("Created Namespace for test", "namespaceName", testNamespace.Name)
+
+	DeferCleanup(func() {
+		By("deleting test namespace")
+		Expect(testClient.Delete(ctx, testNamespace)).To(Or(Succeed(), BeNotFoundError()))
+	})
+
+	By("setting up manager")
+	mgr, err := manager.New(restConfig, manager.Options{
+		Port:               testEnv.WebhookInstallOptions.LocalServingPort,
+		Host:               testEnv.WebhookInstallOptions.LocalServingHost,
+		CertDir:            testEnv.WebhookInstallOptions.LocalServingCertDir,
+		MetricsBindAddress: "0",
+		Namespace:          testNamespace.Name,
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	By("registering webhook")
+	Expect(podzoneaffinity.AddToManager(mgr)).To(Succeed())
+
+	By("starting manager")
+	mgrContext, mgrCancel := context.WithCancel(ctx)
+
+	go func() {
+		defer GinkgoRecover()
+		Expect(mgr.Start(mgrContext)).To(Succeed())
+	}()
+
+	// Wait for the webhook server to start
+	Eventually(func() error {
+		checker := mgr.GetWebhookServer().StartedChecker()
+		return checker(&http.Request{})
+	}).Should(BeNil())
+
+	DeferCleanup(func() {
+		By("stopping manager")
+		mgrCancel()
+	})
+})
+
+func getMutatingWebhookConfigurations(namespace string) []*admissionregistrationv1.MutatingWebhookConfiguration {
+	webhookConfig := []*admissionregistrationv1.MutatingWebhookConfiguration{
+		{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: admissionregistrationv1.SchemeGroupVersion.String(),
+				Kind:       "MutatingWebhookConfiguration",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "gardener-resource-manager",
+			},
+			Webhooks: []admissionregistrationv1.MutatingWebhook{
+				resourcemanager.GetPodZoneAffinityMutatingWebhook(nil, func(_ *corev1.Secret, path string) admissionregistrationv1.WebhookClientConfig {
+					return admissionregistrationv1.WebhookClientConfig{
+						Service: &admissionregistrationv1.ServiceReference{
+							Path: &path,
+						},
+					}
+				}),
+			},
+		},
+	}
+
+	webhookConfig[0].Webhooks[0].NamespaceSelector.MatchExpressions = append(webhookConfig[0].Webhooks[0].NamespaceSelector.MatchExpressions, metav1.LabelSelectorRequirement{
+		Key:      corev1.LabelMetadataName,
+		Operator: metav1.LabelSelectorOpIn,
+		Values:   []string{namespace},
+	})
+
+	return webhookConfig
+}

--- a/test/integration/resourcemanager/podzoneaffinity/podzoneaffinity_test.go
+++ b/test/integration/resourcemanager/podzoneaffinity/podzoneaffinity_test.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package podzoneaffinity_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("PodSchedulerName tests", func() {
+	var (
+		pod *corev1.Pod
+	)
+
+	BeforeEach(func() {
+		pod = &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "test-",
+				Namespace:    testNamespace.Name,
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "foo-container",
+						Image: "foo",
+					},
+				},
+			},
+		}
+		DeferCleanup(func() {
+			Expect(testClient.Delete(ctx, pod)).To(Succeed())
+		})
+	})
+
+	Context("when namespace has zone enforcement label", func() {
+		BeforeEach(func() {
+			testNamespace.Labels = map[string]string{
+				"control-plane.shoot.gardener.cloud/enforce-zone": "",
+			}
+			Expect(testClient.Update(ctx, testNamespace)).To(Succeed())
+			DeferCleanup(func() {
+				testNamespace.Labels = nil
+				Expect(testClient.Update(ctx, testNamespace)).To(Succeed())
+			})
+		})
+
+		It("should add podAffinity", func() {
+			Expect(testClient.Create(ctx, pod)).To(Succeed())
+
+			Consistently(func() ([]corev1.PodAffinityTerm, error) {
+				Expect(testClient.Get(ctx, client.ObjectKeyFromObject(pod), pod)).To(Succeed())
+				if pod.Spec.Affinity == nil {
+					return nil, fmt.Errorf("affininty is nil")
+				}
+				if pod.Spec.Affinity.PodAffinity == nil {
+					return nil, fmt.Errorf("podAffinity is nil")
+				}
+				return pod.Spec.Affinity.PodAffinity.RequiredDuringSchedulingIgnoredDuringExecution, nil
+			}).Should(ConsistOf(MatchFields(IgnoreExtras, Fields{
+				"TopologyKey": Equal(corev1.LabelTopologyZone),
+				"LabelSelector": PointTo(MatchFields(IgnoreExtras, Fields{
+					"MatchLabels":      BeNil(),
+					"MatchExpressions": BeNil(),
+				})),
+			})))
+		})
+	})
+
+	Context("when namespace has zone enforcement label with value", func() {
+		BeforeEach(func() {
+			testNamespace.Labels = map[string]string{
+				"control-plane.shoot.gardener.cloud/enforce-zone": "zone-a",
+			}
+			Expect(testClient.Update(ctx, testNamespace)).To(Succeed())
+			DeferCleanup(func() {
+				testNamespace.Labels = nil
+				Expect(testClient.Update(ctx, testNamespace)).To(Succeed())
+			})
+		})
+
+		It("should add nodeAffinity", func() {
+			Expect(testClient.Create(ctx, pod)).To(Succeed())
+
+			Consistently(func() ([]corev1.NodeSelectorRequirement, error) {
+				Expect(testClient.Get(ctx, client.ObjectKeyFromObject(pod), pod)).To(Succeed())
+				if pod.Spec.Affinity == nil {
+					return nil, fmt.Errorf("affininty is nil")
+				}
+				if pod.Spec.Affinity.NodeAffinity == nil {
+					return nil, fmt.Errorf("nodeAffinity is nil")
+				}
+				if pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+					return nil, fmt.Errorf("requiredDuringSchedulingIgnoredDuringExecution is nil")
+				}
+				Expect(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms).To(HaveLen(1))
+				return pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions, nil
+			}).Should(ConsistOf(MatchFields(IgnoreExtras, Fields{
+				"Key":      Equal(corev1.LabelTopologyZone),
+				"Operator": Equal(corev1.NodeSelectorOpIn),
+				"Values":   ConsistOf(Equal("zone-a")),
+			})))
+		})
+	})
+
+	Context("when namespace hasn't zone enforcement label", func() {
+		It("should not add podAffinity", func() {
+			Expect(testClient.Create(ctx, pod)).To(Succeed())
+
+			Consistently(func() *corev1.Affinity {
+				Expect(testClient.Get(ctx, client.ObjectKeyFromObject(pod), pod)).To(Succeed())
+				return pod.Spec.Affinity
+			}).Should(BeNil())
+		})
+	})
+})

--- a/test/integration/resourcemanager/tokeninvalidator/tokeninvalidator_test.go
+++ b/test/integration/resourcemanager/tokeninvalidator/tokeninvalidator_test.go
@@ -39,14 +39,14 @@ var _ = Describe("TokenInvalidator tests", func() {
 		serviceAccount *corev1.ServiceAccount
 		secret         *corev1.Secret
 
-		verifyNotInvalidated = func() bool {
-			Expect(testClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
+		verifyNotInvalidated = func(g Gomega) bool {
+			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
 			return secret.Labels["token-invalidator.resources.gardener.cloud/consider"] == "" &&
 				(secret.Data["token"] == nil || bytes.Equal(secret.Data["token"], validToken))
 		}
 
-		verifyInvalidated = func() bool {
-			Expect(testClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
+		verifyInvalidated = func(g Gomega) bool {
+			g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(secret), secret)).To(Succeed())
 			return secret.Labels["token-invalidator.resources.gardener.cloud/consider"] == "true" &&
 				!bytes.Equal(secret.Data["token"], validToken)
 		}
@@ -164,7 +164,7 @@ var _ = Describe("TokenInvalidator tests", func() {
 		Expect(testClient.Create(ctx, serviceAccount)).To(Succeed())
 		Expect(testClient.Create(ctx, secret)).To(Succeed())
 
-		Consistently(verifyNotInvalidated()).Should(BeTrue())
+		Consistently(verifyNotInvalidated).Should(BeTrue())
 
 		Expect(testClient.Delete(ctx, pod)).To(Succeed())
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area high-availability
/kind enhancement

**What this PR does / why we need it**:
This PR adds the zone pinning requirement discussed by GEP-20, [ref](https://github.com/gardener/gardener/blob/master/docs/proposals/20-ha-control-planes.md#zone-pinning).

In essence it does the following:
- Gardenlet labels namespaces which belong to `non-HA` or `single-zonal` shoots if it's responsible for a `multi-zonal` seed (seed which has worker across availability zones).
- A `pod-zone-affinity` webhook in GRM adds a zone-aware affinity term for such control-plane pods so that those will be scheduled into a single zone only.
- After `etcd` was deployed successfully, it's assumed that at least one stateful pod was scheduled. Gardenlet then extracts the zone information from that pod/node.
- From that moment on, pods' affinity configurations is enhanced by a `nodeAffinity` to "pin" pods to a specific zone. It is especially important to schedule pods to the original zone when shoots are being woken up from hibernation.

**Which issue(s) this PR fixes**:
Fixes partially #6529

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
Gardener has been being prepared for more shoot HA use-cases and thus some assumption about currently running landscapes are required: If you use a `multi-zonal` labelled seed and scheduled non-HA shoots onto it, this release of Gardener will potentially cause scheduling conflicts to the control-plane pods as it will try to locate all pods into a single zone only. Pods that can't be re-scheduled (mainly because of volume dependencies) will remain in `Pending` state.
```
```feature operator
Gardener is prepared to run non-HA and single-zonal shoots on multi-zonal seeds. In such a setup, control-plane pods of the mentioned shoots are scheduled into a single availability zone only to avoid any extra cross zonal traffic that would usually involve higher latency and cost. **PLEASE NOTE**: The `StorageClass` in seeds used for control-plane components must have `volumeBindingMode: WaitForFirstConsumer` to let the zone-pinning work properly.
```
