### PR TITLE
Dump logs of shoot machine pods in e2e tests

### DIFF
--- a/hack/ci-common.sh
+++ b/hack/ci-common.sh
@@ -18,7 +18,30 @@ set -o errexit
 
 dump_logs() {
   cluster_name=${1}
+  echo "> Collecting logs of kind cluster '${cluster_name}'"
   kind export logs "${ARTIFACTS:-}" --name "${cluster_name}" || true
+
+  # dump logs from shoot machine pods (similar to `kind export logs`)
+  while IFS= read -r namespace; do
+    while IFS= read -r node; do
+      echo "> Collecting logs of shoot cluster '$namespace', node '$node'"
+      node_dir="${ARTIFACTS:-}/$namespace/$node"
+      mkdir -p "$node_dir"
+
+      # general stuff
+      kubectl -n "$namespace" exec "$node" -- crictl images > "$node_dir/images.log" || true
+      kubectl -n "$namespace" get pod "$node" --show-managed-fields -oyaml > "$node_dir/pod.yaml" || true
+
+      # systemd units
+      for unit in cloud-config-downloader kubelet containerd ; do
+        kubectl -n "$namespace" exec "$node" -- journalctl --no-pager -u $unit.service > "$node_dir/$unit.log" || true
+      done
+      kubectl -n "$namespace" exec "$node" -- journalctl --no-pager > "$node_dir/journal.log" || true
+
+      # container logs
+      kubectl cp "$namespace/$node":/var/log "$node_dir" || true
+    done < <(kubectl -n "$namespace" get po -l app=machine -oname | cut -d/ -f2)
+  done < <(kubectl get ns -l gardener.cloud/role=shoot -oname | cut -d/ -f2)
 }
 
 clamp_mss_to_pmtu() {

--- a/hack/ci-e2e-kind-migration.sh
+++ b/hack/ci-e2e-kind-migration.sh
@@ -27,9 +27,8 @@ make kind-up
 make kind2-up
 
 # dump all container logs after test execution
-trap  "dump_logs 'gardener-local'; dump_logs 'gardener-local2'" EXIT
+trap "KUBECONFIG=$PWD/example/gardener-local/kind/kubeconfig dump_logs 'gardener-local'; KUBECONFIG=$PWD/example/gardener-local/kind2/kubeconfig dump_logs 'gardener-local2'" EXIT
 
-export KUBECONFIG=$PWD/gardener-local/kind/kubeconfig
 make gardener-up
 make gardenlet-kind2-up
 

--- a/hack/ci-e2e-kind.sh
+++ b/hack/ci-e2e-kind.sh
@@ -26,9 +26,8 @@ clamp_mss_to_pmtu
 make kind-up
 
 # dump all container logs after test execution
-trap "dump_logs 'gardener-local'" EXIT
+trap "KUBECONFIG=$PWD/example/gardener-local/kind/kubeconfig dump_logs 'gardener-local'" EXIT
 
-export KUBECONFIG=$PWD/example/provider-local/base/kubeconfig
 make gardener-up
 
 # run test

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -156,7 +156,8 @@ deploy:
               echo "Wait until seed gets created by gardenlet"
               sleep 2
             done
-            kubectl wait --for=condition=gardenletready --for=condition=extensionsready --for=condition=bootstrapped seed local --timeout=5m
+            kubectl wait --for=condition=gardenletready --for=condition=extensionsready --for=condition=bootstrapped \
+              --for=condition=seedsystemcomponentshealthy --for=condition=backupbucketsready seed local --timeout=5m
     releases:
     - name: gardener-gardenlet
       chartPath: charts/gardener/gardenlet


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity testing
/kind enhancement

**What this PR does / why we need it**:

Similar to `kind export logs`, we now export the logs of all shoot machine pods (systemd units + containers) for simplifying debugging of failing e2e tests.

Here are two example failures for demoing how the shoot logs are exported:
- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/6581/pull-gardener-e2e-kind/1563082230614462464
- https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/6581/pull-gardener-e2e-kind-migration/1563094578158899200

Shoot logs are available via the artifacts browser in a shoot-specific directory.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/6016

