### PR TITLE
Fix to-dns network policy in garden namespace for node-local-dns if non-ip based policy engine is used.

### DIFF
--- a/pkg/operation/botanist/component/networkpolicies/global.go
+++ b/pkg/operation/botanist/component/networkpolicies/global.go
@@ -19,6 +19,7 @@ import (
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	"github.com/gardener/gardener/pkg/operation/botanist/component/coredns"
+	"github.com/gardener/gardener/pkg/operation/botanist/component/nodelocaldns"
 
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -225,20 +226,36 @@ func getGlobalNetworkPolicyTransformers(values GlobalValues) []networkPolicyTran
 							},
 						},
 						Egress: []networkingv1.NetworkPolicyEgressRule{{
-							To: []networkingv1.NetworkPolicyPeer{{
-								NamespaceSelector: &metav1.LabelSelector{
-									MatchLabels: map[string]string{
-										v1beta1constants.LabelRole: metav1.NamespaceSystem,
+							To: []networkingv1.NetworkPolicyPeer{
+								{
+									NamespaceSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											v1beta1constants.LabelRole: metav1.NamespaceSystem,
+										},
+									},
+									PodSelector: &metav1.LabelSelector{
+										MatchExpressions: []metav1.LabelSelectorRequirement{{
+											Key:      coredns.LabelKey,
+											Operator: metav1.LabelSelectorOpIn,
+											Values:   []string{coredns.LabelValue},
+										}},
 									},
 								},
-								PodSelector: &metav1.LabelSelector{
-									MatchExpressions: []metav1.LabelSelectorRequirement{{
-										Key:      coredns.LabelKey,
-										Operator: metav1.LabelSelectorOpIn,
-										Values:   []string{coredns.LabelValue},
-									}},
+								{
+									NamespaceSelector: &metav1.LabelSelector{
+										MatchLabels: map[string]string{
+											v1beta1constants.LabelRole: metav1.NamespaceSystem,
+										},
+									},
+									PodSelector: &metav1.LabelSelector{
+										MatchExpressions: []metav1.LabelSelectorRequirement{{
+											Key:      coredns.LabelKey,
+											Operator: metav1.LabelSelectorOpIn,
+											Values:   []string{nodelocaldns.LabelValue},
+										}},
+									},
 								},
-							}},
+							},
 							Ports: []networkingv1.NetworkPolicyPort{
 								{Protocol: protocolPtr(corev1.ProtocolUDP), Port: intStrPtr(coredns.PortServiceServer)},
 								{Protocol: protocolPtr(corev1.ProtocolTCP), Port: intStrPtr(coredns.PortServiceServer)},

--- a/pkg/operation/botanist/component/networkpolicies/global_test.go
+++ b/pkg/operation/botanist/component/networkpolicies/global_test.go
@@ -176,20 +176,36 @@ func constructNPAllowToDNS(namespace string, dnsServerAddress, nodeLocalIPVSAddr
 					MatchLabels: map[string]string{"networking.gardener.cloud/to-dns": "allowed"},
 				},
 				Egress: []networkingv1.NetworkPolicyEgressRule{{
-					To: []networkingv1.NetworkPolicyPeer{{
-						NamespaceSelector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{
-								"role": "kube-system",
+					To: []networkingv1.NetworkPolicyPeer{
+						{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"role": "kube-system",
+								},
+							},
+							PodSelector: &metav1.LabelSelector{
+								MatchExpressions: []metav1.LabelSelectorRequirement{{
+									Key:      "k8s-app",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"kube-dns"},
+								}},
 							},
 						},
-						PodSelector: &metav1.LabelSelector{
-							MatchExpressions: []metav1.LabelSelectorRequirement{{
-								Key:      "k8s-app",
-								Operator: metav1.LabelSelectorOpIn,
-								Values:   []string{"kube-dns"},
-							}},
+						{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{
+									"role": "kube-system",
+								},
+							},
+							PodSelector: &metav1.LabelSelector{
+								MatchExpressions: []metav1.LabelSelectorRequirement{{
+									Key:      "k8s-app",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"node-local-dns"},
+								}},
+							},
 						},
-					}},
+					},
 					Ports: []networkingv1.NetworkPolicyPort{
 						{Protocol: &protocolUDP, Port: &port53},
 						{Protocol: &protocolTCP, Port: &port53},

--- a/pkg/operation/botanist/component/nodelocaldns/nodelocaldns.go
+++ b/pkg/operation/botanist/component/nodelocaldns/nodelocaldns.go
@@ -50,8 +50,9 @@ const (
 	// ManagedResourceName is the name of the ManagedResource containing the resource specifications.
 	ManagedResourceName = "shoot-core-node-local-dns"
 
-	labelKey   = "k8s-app"
-	labelValue = "node-local-dns"
+	labelKey = "k8s-app"
+	// LabelValue is the value of a label used for the identification of node-local-dns pods.
+	LabelValue = "node-local-dns"
 	// portServiceServer is the service port used for the DNS server.
 	portServiceServer = 53
 	// portServer is the target port used for the DNS server.
@@ -249,7 +250,7 @@ ip6.arpa:53 {
 				Name:      "node-local-dns",
 				Namespace: metav1.NamespaceSystem,
 				Labels: map[string]string{
-					labelKey:                        labelValue,
+					labelKey:                        LabelValue,
 					v1beta1constants.GardenRole:     v1beta1constants.GardenRoleSystemComponent,
 					managedresources.LabelKeyOrigin: managedresources.LabelValueGardener,
 				},
@@ -262,13 +263,13 @@ ip6.arpa:53 {
 				},
 				Selector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
-						labelKey: labelValue,
+						labelKey: LabelValue,
 					},
 				},
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{
-							labelKey:                                 labelValue,
+							labelKey:                                 LabelValue,
 							v1beta1constants.LabelNetworkPolicyToDNS: "allowed",
 						},
 						Annotations: map[string]string{
@@ -474,7 +475,7 @@ ip6.arpa:53 {
 					v1beta1constants.AnnotationSeccompDefaultProfile:  v1beta1constants.AnnotationSeccompAllowedProfilesRuntimeDefaultValue,
 				},
 				Labels: map[string]string{
-					v1beta1constants.LabelApp: labelValue,
+					v1beta1constants.LabelApp: LabelValue,
 				},
 			},
 			Spec: policyv1beta1.PodSecurityPolicySpec{
@@ -527,7 +528,7 @@ ip6.arpa:53 {
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "gardener.cloud:psp:kube-system:node-local-dns",
 				Labels: map[string]string{
-					v1beta1constants.LabelApp: labelValue,
+					v1beta1constants.LabelApp: LabelValue,
 				},
 			},
 			Rules: []rbacv1.PolicyRule{
@@ -545,7 +546,7 @@ ip6.arpa:53 {
 				Name:      "gardener.cloud:psp:node-local-dns",
 				Namespace: metav1.NamespaceSystem,
 				Labels: map[string]string{
-					v1beta1constants.LabelApp: labelValue,
+					v1beta1constants.LabelApp: LabelValue,
 				},
 				Annotations: map[string]string{resourcesv1alpha1.DeleteOnInvalidUpdate: "true"},
 			},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/kind enhancement

**What this PR does / why we need it**:
Fix to-dns network policy in garden namespace for node-local-dns if non-ip based policy engine is used.

Network policies are enforced by different means depending on the CNI. Some rely
on IPs, others work mostly on pod identities and ignore IPs mostly. (Calico falls
into the first category. Cilium is an example for the second category.)
To allow Seeds to run in both environments even with node-local-dns being enabled
the to-dns network policy must allow connections to the pod and its IP. The former
was missing here.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:
There is an analogous `to-dns` network policy in the shoot's `kube-system` namespace, which already included this block. The network policy is differently structured, though.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Operation of a seed using cilium as networking provider and node-local-dns is now working.
```
