### PR TITLE
Fix the monitoring configuration tracking the count of ETCD objects to use correct metric for k8s >= 1.21

### DIFF
--- a/pkg/operation/botanist/component/etcd/etcd.go
+++ b/pkg/operation/botanist/component/etcd/etcd.go
@@ -138,7 +138,7 @@ func New(
 	storageCapacity string,
 	defragmentationSchedule *string,
 	caRotationPhase gardencorev1beta1.ShootCredentialsRotationPhase,
-	k8sGTE121 bool,
+	k8sVersion string,
 ) Interface {
 	name := "etcd-" + role
 	log = log.WithValues("etcd", client.ObjectKey{Namespace: namespace, Name: name})
@@ -173,7 +173,7 @@ func New(
 		nodeSpread:              nodeSpread,
 		zoneSpread:              zoneSpread,
 		caRotationPhase:         caRotationPhase,
-		k8sGTE121:               k8sGTE121,
+		k8sVersion:              k8sVersion,
 
 		etcd: &druidv1alpha1.Etcd{
 			ObjectMeta: metav1.ObjectMeta{
@@ -197,7 +197,7 @@ type etcd struct {
 	defragmentationSchedule *string
 	nodeSpread              bool
 	zoneSpread              bool
-	k8sGTE121               bool
+	k8sVersion              string
 
 	etcd *druidv1alpha1.Etcd
 

--- a/pkg/operation/botanist/component/etcd/etcd.go
+++ b/pkg/operation/botanist/component/etcd/etcd.go
@@ -138,6 +138,7 @@ func New(
 	storageCapacity string,
 	defragmentationSchedule *string,
 	caRotationPhase gardencorev1beta1.ShootCredentialsRotationPhase,
+	k8sGTE121 bool,
 ) Interface {
 	name := "etcd-" + role
 	log = log.WithValues("etcd", client.ObjectKey{Namespace: namespace, Name: name})
@@ -172,6 +173,7 @@ func New(
 		nodeSpread:              nodeSpread,
 		zoneSpread:              zoneSpread,
 		caRotationPhase:         caRotationPhase,
+		k8sGTE121:               k8sGTE121,
 
 		etcd: &druidv1alpha1.Etcd{
 			ObjectMeta: metav1.ObjectMeta{
@@ -195,6 +197,7 @@ type etcd struct {
 	defragmentationSchedule *string
 	nodeSpread              bool
 	zoneSpread              bool
+	k8sGTE121               bool
 
 	etcd *druidv1alpha1.Etcd
 

--- a/pkg/operation/botanist/component/etcd/etcd_test.go
+++ b/pkg/operation/botanist/component/etcd/etcd_test.go
@@ -662,7 +662,7 @@ var _ = Describe("Etcd", func() {
 
 		By("creating secrets managed outside of this package for whose secretsmanager.Get() will be called")
 		Expect(fakeClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "ca-etcd", Namespace: testNamespace}})).To(Succeed())
-		etcd = New(c, log, testNamespace, sm, testRole, class, annotations, replicas, storageCapacity, &defragmentationSchedule, "")
+		etcd = New(c, log, testNamespace, sm, testRole, class, annotations, replicas, storageCapacity, &defragmentationSchedule, "", false)
 	})
 
 	AfterEach(func() {
@@ -824,7 +824,7 @@ var _ = Describe("Etcd", func() {
 				existingReplicas int32 = 245
 			)
 
-			etcd = New(c, log, testNamespace, sm, testRole, class, annotations, nil, storageCapacity, &defragmentationSchedule, "")
+			etcd = New(c, log, testNamespace, sm, testRole, class, annotations, nil, storageCapacity, &defragmentationSchedule, "", false)
 			setHVPAConfig()
 
 			gomock.InOrder(
@@ -884,7 +884,7 @@ var _ = Describe("Etcd", func() {
 				existingReplicas int32 = 245
 			)
 
-			etcd = New(c, log, testNamespace, sm, testRole, class, annotations, nil, storageCapacity, &defragmentationSchedule, "")
+			etcd = New(c, log, testNamespace, sm, testRole, class, annotations, nil, storageCapacity, &defragmentationSchedule, "", false)
 			setHVPAConfig()
 
 			gomock.InOrder(
@@ -1111,7 +1111,7 @@ var _ = Describe("Etcd", func() {
 
 				replicas = pointer.Int32Ptr(1)
 
-				etcd = New(c, log, testNamespace, sm, testRole, class, annotations, replicas, storageCapacity, &defragmentationSchedule, "")
+				etcd = New(c, log, testNamespace, sm, testRole, class, annotations, replicas, storageCapacity, &defragmentationSchedule, "", false)
 				newSetHVPAConfigFunc(updateMode)()
 
 				gomock.InOrder(
@@ -1322,7 +1322,7 @@ var _ = Describe("Etcd", func() {
 			})
 
 			JustBeforeEach(func() {
-				etcd = New(c, log, testNamespace, sm, testRole, class, zoneAnnotations, replicas, storageCapacity, &defragmentationSchedule, rotationPhase)
+				etcd = New(c, log, testNamespace, sm, testRole, class, zoneAnnotations, replicas, storageCapacity, &defragmentationSchedule, rotationPhase, false)
 			})
 
 			Context("when CA rotation phase is in `Preparing` state", func() {
@@ -1784,7 +1784,7 @@ var _ = Describe("Etcd", func() {
 		})
 
 		JustBeforeEach(func() {
-			etcd = New(c, log, testNamespace, sm, testRole, class, zoneAnnotations, replicas, storageCapacity, &defragmentationSchedule, "")
+			etcd = New(c, log, testNamespace, sm, testRole, class, zoneAnnotations, replicas, storageCapacity, &defragmentationSchedule, "", false)
 		})
 
 		Context("when HA control-plane is not requested", func() {

--- a/pkg/operation/botanist/component/etcd/etcd_test.go
+++ b/pkg/operation/botanist/component/etcd/etcd_test.go
@@ -662,7 +662,7 @@ var _ = Describe("Etcd", func() {
 
 		By("creating secrets managed outside of this package for whose secretsmanager.Get() will be called")
 		Expect(fakeClient.Create(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "ca-etcd", Namespace: testNamespace}})).To(Succeed())
-		etcd = New(c, log, testNamespace, sm, testRole, class, annotations, replicas, storageCapacity, &defragmentationSchedule, "", false)
+		etcd = New(c, log, testNamespace, sm, testRole, class, annotations, replicas, storageCapacity, &defragmentationSchedule, "", "1.20.1")
 	})
 
 	AfterEach(func() {
@@ -824,7 +824,7 @@ var _ = Describe("Etcd", func() {
 				existingReplicas int32 = 245
 			)
 
-			etcd = New(c, log, testNamespace, sm, testRole, class, annotations, nil, storageCapacity, &defragmentationSchedule, "", false)
+			etcd = New(c, log, testNamespace, sm, testRole, class, annotations, nil, storageCapacity, &defragmentationSchedule, "", "1.20.1")
 			setHVPAConfig()
 
 			gomock.InOrder(
@@ -884,7 +884,7 @@ var _ = Describe("Etcd", func() {
 				existingReplicas int32 = 245
 			)
 
-			etcd = New(c, log, testNamespace, sm, testRole, class, annotations, nil, storageCapacity, &defragmentationSchedule, "", false)
+			etcd = New(c, log, testNamespace, sm, testRole, class, annotations, nil, storageCapacity, &defragmentationSchedule, "", "1.20.1")
 			setHVPAConfig()
 
 			gomock.InOrder(
@@ -1111,7 +1111,7 @@ var _ = Describe("Etcd", func() {
 
 				replicas = pointer.Int32Ptr(1)
 
-				etcd = New(c, log, testNamespace, sm, testRole, class, annotations, replicas, storageCapacity, &defragmentationSchedule, "", false)
+				etcd = New(c, log, testNamespace, sm, testRole, class, annotations, replicas, storageCapacity, &defragmentationSchedule, "", "1.20.1")
 				newSetHVPAConfigFunc(updateMode)()
 
 				gomock.InOrder(
@@ -1322,7 +1322,7 @@ var _ = Describe("Etcd", func() {
 			})
 
 			JustBeforeEach(func() {
-				etcd = New(c, log, testNamespace, sm, testRole, class, zoneAnnotations, replicas, storageCapacity, &defragmentationSchedule, rotationPhase, false)
+				etcd = New(c, log, testNamespace, sm, testRole, class, zoneAnnotations, replicas, storageCapacity, &defragmentationSchedule, rotationPhase, "1.20.1")
 			})
 
 			Context("when CA rotation phase is in `Preparing` state", func() {
@@ -1784,7 +1784,7 @@ var _ = Describe("Etcd", func() {
 		})
 
 		JustBeforeEach(func() {
-			etcd = New(c, log, testNamespace, sm, testRole, class, zoneAnnotations, replicas, storageCapacity, &defragmentationSchedule, "", false)
+			etcd = New(c, log, testNamespace, sm, testRole, class, zoneAnnotations, replicas, storageCapacity, &defragmentationSchedule, "", "1.20.1")
 		})
 
 		Context("when HA control-plane is not requested", func() {

--- a/pkg/operation/botanist/component/etcd/monitoring.go
+++ b/pkg/operation/botanist/component/etcd/monitoring.go
@@ -21,6 +21,7 @@ import (
 	"text/template"
 
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	versionutils "github.com/gardener/gardener/pkg/utils/version"
 
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
@@ -363,13 +364,19 @@ func (e *etcd) ScrapeConfigs() ([]string, error) {
 // AlertingRules returns the alerting rules for AlertManager.
 func (e *etcd) AlertingRules() (map[string]string, error) {
 	var alertingRules bytes.Buffer
+
+	k8sGTE121, err := versionutils.CompareVersions(e.k8sVersion, ">=", "1.21")
+	if err != nil {
+		return nil, err
+	}
+
 	if err := monitoringAlertingRulesTemplate.Execute(&alertingRules, map[string]interface{}{
 		"role":           e.role,
 		"Role":           strings.Title(e.role),
 		"class":          e.class,
 		"classImportant": ClassImportant,
 		"backupEnabled":  e.backupConfig != nil,
-		"k8sGTE121":      e.k8sGTE121,
+		"k8sGTE121":      k8sGTE121,
 	}); err != nil {
 		return nil, err
 	}

--- a/pkg/operation/botanist/component/etcd/monitoring.go
+++ b/pkg/operation/botanist/component/etcd/monitoring.go
@@ -151,8 +151,13 @@ const (
       description: Etcd3 {{ .role }} DB size has crossed its current practical limit of 8GB. Etcd quota must be increased to allow updates.
       summary: Etcd3 {{ .role }} DB size has crossed its current practical limit.
 
+  {{- if .k8sGTE121 }}
+  - record: shoot:apiserver_storage_objects:sum_by_resource
+    expr: max(apiserver_storage_objects) by (resource)
+  {{- else }}
   - record: shoot:etcd_object_counts:sum_by_resource
     expr: max(etcd_object_counts) by (resource)
+  {{- end }}
 
   {{- if .backupEnabled }}
   # etcd backup failure alerts
@@ -364,6 +369,7 @@ func (e *etcd) AlertingRules() (map[string]string, error) {
 		"class":          e.class,
 		"classImportant": ClassImportant,
 		"backupEnabled":  e.backupConfig != nil,
+		"k8sGTE121":      e.k8sGTE121,
 	}); err != nil {
 		return nil, err
 	}

--- a/pkg/operation/botanist/component/etcd/monitoring_test.go
+++ b/pkg/operation/botanist/component/etcd/monitoring_test.go
@@ -28,7 +28,7 @@ import (
 var _ = Describe("Monitoring", func() {
 	Describe("#ScrapeConfig", func() {
 		It("should successfully test the scrape configuration", func() {
-			etcd := New(nil, logr.Discard(), testNamespace, nil, testRole, ClassNormal, nil, nil, "", nil, "", false)
+			etcd := New(nil, logr.Discard(), testNamespace, nil, testRole, ClassNormal, nil, nil, "", nil, "", "1.20.1")
 			test.ScrapeConfigs(etcd, expectedScrapeConfigEtcd, expectedScrapeConfigBackupRestore)
 		})
 	})
@@ -36,7 +36,7 @@ var _ = Describe("Monitoring", func() {
 	Describe("#AlertingRules", func() {
 		Context("w/o backup", func() {
 			It("should successfully test the alerting rules (normal)", func() {
-				etcd := New(nil, logr.Discard(), testNamespace, nil, testRole, ClassNormal, nil, nil, "", nil, "", false)
+				etcd := New(nil, logr.Discard(), testNamespace, nil, testRole, ClassNormal, nil, nil, "", nil, "", "1.20.1")
 				test.AlertingRulesWithPromtool(
 					etcd,
 					map[string]string{fmt.Sprintf("kube-etcd3-%s.rules.yaml", testRole): expectedAlertingRulesNormalWithoutBackup},
@@ -45,7 +45,7 @@ var _ = Describe("Monitoring", func() {
 			})
 
 			It("should successfully test the alerting rules (important)", func() {
-				etcd := New(nil, logr.Discard(), testNamespace, nil, testRole, ClassImportant, nil, nil, "", nil, "", false)
+				etcd := New(nil, logr.Discard(), testNamespace, nil, testRole, ClassImportant, nil, nil, "", nil, "", "1.20.1")
 				test.AlertingRulesWithPromtool(
 					etcd,
 					map[string]string{fmt.Sprintf("kube-etcd3-%s.rules.yaml", testRole): expectedAlertingRulesImportantWithoutBackup},
@@ -54,7 +54,7 @@ var _ = Describe("Monitoring", func() {
 			})
 
 			It("should successfully test the alerting rules for k8s >= 1.21 (normal)", func() {
-				etcd := New(nil, logr.Discard(), testNamespace, nil, testRole, ClassNormal, nil, nil, "", nil, "", true)
+				etcd := New(nil, logr.Discard(), testNamespace, nil, testRole, ClassNormal, nil, nil, "", nil, "", "1.21.1")
 				test.AlertingRulesWithPromtool(
 					etcd,
 					map[string]string{fmt.Sprintf("kube-etcd3-%s.rules.yaml", testRole): expectedAlertingRulesNormalK8SGTE121},
@@ -65,7 +65,7 @@ var _ = Describe("Monitoring", func() {
 
 		Context("w/ backup", func() {
 			It("should successfully test the alerting rules (normal)", func() {
-				etcd := New(nil, logr.Discard(), testNamespace, nil, testRole, ClassNormal, nil, nil, "", nil, "", false)
+				etcd := New(nil, logr.Discard(), testNamespace, nil, testRole, ClassNormal, nil, nil, "", nil, "", "1.20.1")
 				etcd.SetBackupConfig(&BackupConfig{})
 				test.AlertingRulesWithPromtool(
 					etcd,
@@ -75,7 +75,7 @@ var _ = Describe("Monitoring", func() {
 			})
 
 			It("should successfully test the alerting rules (important)", func() {
-				etcd := New(nil, logr.Discard(), testNamespace, nil, testRole, ClassImportant, nil, nil, "", nil, "", false)
+				etcd := New(nil, logr.Discard(), testNamespace, nil, testRole, ClassImportant, nil, nil, "", nil, "", "1.20.1")
 				etcd.SetBackupConfig(&BackupConfig{})
 				test.AlertingRulesWithPromtool(
 					etcd,

--- a/pkg/operation/botanist/component/etcd/monitoring_test.go
+++ b/pkg/operation/botanist/component/etcd/monitoring_test.go
@@ -28,7 +28,7 @@ import (
 var _ = Describe("Monitoring", func() {
 	Describe("#ScrapeConfig", func() {
 		It("should successfully test the scrape configuration", func() {
-			etcd := New(nil, logr.Discard(), testNamespace, nil, testRole, ClassNormal, nil, nil, "", nil, "")
+			etcd := New(nil, logr.Discard(), testNamespace, nil, testRole, ClassNormal, nil, nil, "", nil, "", false)
 			test.ScrapeConfigs(etcd, expectedScrapeConfigEtcd, expectedScrapeConfigBackupRestore)
 		})
 	})
@@ -36,7 +36,7 @@ var _ = Describe("Monitoring", func() {
 	Describe("#AlertingRules", func() {
 		Context("w/o backup", func() {
 			It("should successfully test the alerting rules (normal)", func() {
-				etcd := New(nil, logr.Discard(), testNamespace, nil, testRole, ClassNormal, nil, nil, "", nil, "")
+				etcd := New(nil, logr.Discard(), testNamespace, nil, testRole, ClassNormal, nil, nil, "", nil, "", false)
 				test.AlertingRulesWithPromtool(
 					etcd,
 					map[string]string{fmt.Sprintf("kube-etcd3-%s.rules.yaml", testRole): expectedAlertingRulesNormalWithoutBackup},
@@ -45,18 +45,27 @@ var _ = Describe("Monitoring", func() {
 			})
 
 			It("should successfully test the alerting rules (important)", func() {
-				etcd := New(nil, logr.Discard(), testNamespace, nil, testRole, ClassImportant, nil, nil, "", nil, "")
+				etcd := New(nil, logr.Discard(), testNamespace, nil, testRole, ClassImportant, nil, nil, "", nil, "", false)
 				test.AlertingRulesWithPromtool(
 					etcd,
 					map[string]string{fmt.Sprintf("kube-etcd3-%s.rules.yaml", testRole): expectedAlertingRulesImportantWithoutBackup},
 					filepath.Join("testdata", "monitoring_alertingrules_important_without_backup.yaml"),
 				)
 			})
+
+			It("should successfully test the alerting rules for k8s >= 1.21 (normal)", func() {
+				etcd := New(nil, logr.Discard(), testNamespace, nil, testRole, ClassNormal, nil, nil, "", nil, "", true)
+				test.AlertingRulesWithPromtool(
+					etcd,
+					map[string]string{fmt.Sprintf("kube-etcd3-%s.rules.yaml", testRole): expectedAlertingRulesNormalK8SGTE121},
+					filepath.Join("testdata", "monitoring_alertingrules_normal_without_backup.yaml"),
+				)
+			})
 		})
 
 		Context("w/ backup", func() {
 			It("should successfully test the alerting rules (normal)", func() {
-				etcd := New(nil, logr.Discard(), testNamespace, nil, testRole, ClassNormal, nil, nil, "", nil, "")
+				etcd := New(nil, logr.Discard(), testNamespace, nil, testRole, ClassNormal, nil, nil, "", nil, "", false)
 				etcd.SetBackupConfig(&BackupConfig{})
 				test.AlertingRulesWithPromtool(
 					etcd,
@@ -66,7 +75,7 @@ var _ = Describe("Monitoring", func() {
 			})
 
 			It("should successfully test the alerting rules (important)", func() {
-				etcd := New(nil, logr.Discard(), testNamespace, nil, testRole, ClassImportant, nil, nil, "", nil, "")
+				etcd := New(nil, logr.Discard(), testNamespace, nil, testRole, ClassImportant, nil, nil, "", nil, "", false)
 				etcd.SetBackupConfig(&BackupConfig{})
 				test.AlertingRulesWithPromtool(
 					etcd,
@@ -250,9 +259,14 @@ metric_relabel_configs:
     annotations:
       description: Etcd3 ` + testRole + ` DB size has crossed its current practical limit of 8GB. Etcd quota must be increased to allow updates.
       summary: Etcd3 ` + testRole + ` DB size has crossed its current practical limit.
+`
 
-  - record: shoot:etcd_object_counts:sum_by_resource
+	alertingRulesEtcdObject = `  - record: shoot:etcd_object_counts:sum_by_resource
     expr: max(etcd_object_counts) by (resource)
+`
+
+	alertingRulesApiserverObjects = `  - record: shoot:apiserver_storage_objects:sum_by_resource
+    expr: max(apiserver_storage_objects) by (resource)
 `
 
 	alertingRulesBackup = `  # etcd backup failure alerts
@@ -305,8 +319,9 @@ metric_relabel_configs:
       summary: Etcd backup restore ` + testRole + ` process down or snapshotter failed with error
 `
 
-	expectedAlertingRulesNormalWithoutBackup    = alertingRulesNormal + alertingRulesDefault
-	expectedAlertingRulesImportantWithoutBackup = alertingRulesImportant + alertingRulesDefault
-	expectedAlertingRulesNormalWithBackup       = alertingRulesNormal + alertingRulesDefault + alertingRulesBackup
-	expectedAlertingRulesImportantWithBackup    = alertingRulesImportant + alertingRulesDefault + alertingRulesBackup
+	expectedAlertingRulesNormalWithoutBackup    = alertingRulesNormal + alertingRulesDefault + alertingRulesEtcdObject
+	expectedAlertingRulesImportantWithoutBackup = alertingRulesImportant + alertingRulesDefault + alertingRulesEtcdObject
+	expectedAlertingRulesNormalK8SGTE121        = alertingRulesNormal + alertingRulesDefault + alertingRulesApiserverObjects
+	expectedAlertingRulesNormalWithBackup       = alertingRulesNormal + alertingRulesDefault + alertingRulesEtcdObject + alertingRulesBackup
+	expectedAlertingRulesImportantWithBackup    = alertingRulesImportant + alertingRulesDefault + alertingRulesEtcdObject + alertingRulesBackup
 )

--- a/pkg/operation/botanist/component/etcd/waiter_test.go
+++ b/pkg/operation/botanist/component/etcd/waiter_test.go
@@ -88,7 +88,7 @@ var _ = Describe("#Wait", func() {
 			&retry.UntilTimeout, waiter.UntilTimeout,
 		)
 
-		etcd = New(c, log, testNamespace, sm, testRole, ClassNormal, nil, pointer.Int32Ptr(1), "12Gi", pointer.String("abcd"), "", false)
+		etcd = New(c, log, testNamespace, sm, testRole, ClassNormal, nil, pointer.Int32Ptr(1), "12Gi", pointer.String("abcd"), "", "1.20.1")
 		etcd.SetHVPAConfig(&HVPAConfig{
 			Enabled: true,
 			MaintenanceTimeWindow: gardencorev1beta1.MaintenanceTimeWindow{

--- a/pkg/operation/botanist/component/etcd/waiter_test.go
+++ b/pkg/operation/botanist/component/etcd/waiter_test.go
@@ -88,7 +88,7 @@ var _ = Describe("#Wait", func() {
 			&retry.UntilTimeout, waiter.UntilTimeout,
 		)
 
-		etcd = New(c, log, testNamespace, sm, testRole, ClassNormal, nil, pointer.Int32Ptr(1), "12Gi", pointer.String("abcd"), "")
+		etcd = New(c, log, testNamespace, sm, testRole, ClassNormal, nil, pointer.Int32Ptr(1), "12Gi", pointer.String("abcd"), "", false)
 		etcd.SetHVPAConfig(&HVPAConfig{
 			Enabled: true,
 			MaintenanceTimeWindow: gardencorev1beta1.MaintenanceTimeWindow{

--- a/pkg/operation/botanist/etcd.go
+++ b/pkg/operation/botanist/etcd.go
@@ -33,7 +33,6 @@ import (
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/timewindow"
-	versionutils "github.com/gardener/gardener/pkg/utils/version"
 
 	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -57,11 +56,6 @@ func (b *Botanist) DefaultEtcd(role string, class etcd.Class) (etcd.Interface, e
 		replicas = pointer.Int32(getReplicas(b.Shoot.GetInfo()))
 	}
 
-	k8sGTE121, err := versionutils.CompareVersions(b.ShootVersion(), ">=", "1.21")
-	if err != nil {
-		return nil, err
-	}
-
 	e := NewEtcd(
 		b.K8sSeedClient.Client(),
 		b.Logger,
@@ -74,7 +68,7 @@ func (b *Botanist) DefaultEtcd(role string, class etcd.Class) (etcd.Interface, e
 		b.Seed.GetValidVolumeSize("10Gi"),
 		&defragmentationSchedule,
 		gardencorev1beta1helper.GetShootCARotationPhase(b.Shoot.GetInfo().Status.Credentials),
-		k8sGTE121,
+		b.ShootVersion(),
 	)
 
 	hvpaEnabled := gardenletfeatures.FeatureGate.Enabled(features.HVPA)

--- a/pkg/operation/botanist/etcd.go
+++ b/pkg/operation/botanist/etcd.go
@@ -33,6 +33,7 @@ import (
 	gutil "github.com/gardener/gardener/pkg/utils/gardener"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/timewindow"
+	versionutils "github.com/gardener/gardener/pkg/utils/version"
 
 	hvpav1alpha1 "github.com/gardener/hvpa-controller/api/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -56,6 +57,11 @@ func (b *Botanist) DefaultEtcd(role string, class etcd.Class) (etcd.Interface, e
 		replicas = pointer.Int32(getReplicas(b.Shoot.GetInfo()))
 	}
 
+	k8sGTE121, err := versionutils.CompareVersions(b.ShootVersion(), ">=", "1.21")
+	if err != nil {
+		return nil, err
+	}
+
 	e := NewEtcd(
 		b.K8sSeedClient.Client(),
 		b.Logger,
@@ -68,6 +74,7 @@ func (b *Botanist) DefaultEtcd(role string, class etcd.Class) (etcd.Interface, e
 		b.Seed.GetValidVolumeSize("10Gi"),
 		&defragmentationSchedule,
 		gardencorev1beta1helper.GetShootCARotationPhase(b.Shoot.GetInfo().Status.Credentials),
+		k8sGTE121,
 	)
 
 	hvpaEnabled := gardenletfeatures.FeatureGate.Enabled(features.HVPA)

--- a/pkg/operation/botanist/etcd_test.go
+++ b/pkg/operation/botanist/etcd_test.go
@@ -509,7 +509,7 @@ func (v *newEtcdValidator) NewEtcd(
 	storageCapacity string,
 	defragmentationSchedule *string,
 	_ gardencorev1beta1.ShootCredentialsRotationPhase,
-	_ bool,
+	_ string,
 ) etcd.Interface {
 	Expect(client).To(v.expectedClient)
 	Expect(log).To(v.expectedLogger)

--- a/pkg/operation/botanist/etcd_test.go
+++ b/pkg/operation/botanist/etcd_test.go
@@ -107,6 +107,9 @@ var _ = Describe("Etcd", func() {
 			botanist.Seed.SetInfo(&gardencorev1beta1.Seed{})
 			botanist.Shoot.SetInfo(&gardencorev1beta1.Shoot{
 				Spec: gardencorev1beta1.ShootSpec{
+					Kubernetes: gardencorev1beta1.Kubernetes{
+						Version: "1.20.2",
+					},
 					Maintenance: &gardencorev1beta1.Maintenance{
 						TimeWindow: &maintenanceTimeWindow,
 					},
@@ -506,6 +509,7 @@ func (v *newEtcdValidator) NewEtcd(
 	storageCapacity string,
 	defragmentationSchedule *string,
 	_ gardencorev1beta1.ShootCredentialsRotationPhase,
+	_ bool,
 ) etcd.Interface {
 	Expect(client).To(v.expectedClient)
 	Expect(log).To(v.expectedLogger)


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:
Fix the monitoring configuration tracking the count of ETCD objects to use correct metric for k8s >= 1.21
Follow-up on https://github.com/gardener/gardener/pull/6390#issuecomment-1227325779

cc @istvanballok @wyb1 @Sallyan 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug in the monitoring configuration that was scraping the deprecated metric `etcd_object_counts` even for k8s >= 1.21 has been fixed.
```
