### PR TITLE
Add liveness probe for VPA components

### DIFF
--- a/pkg/operation/botanist/component/vpa/admissioncontroller.go
+++ b/pkg/operation/botanist/component/vpa/admissioncontroller.go
@@ -208,6 +208,7 @@ func (v *vpa) reconcileAdmissionControllerDeployment(deployment *appsv1.Deployme
 						fmt.Sprintf("--port=%d", admissionControllerPort),
 						"--register-webhook=false",
 					},
+					LivenessProbe: newDefaultLivenessProbe(),
 					Resources: corev1.ResourceRequirements{
 						Requests: corev1.ResourceList{
 							corev1.ResourceCPU:    resource.MustParse("30m"),
@@ -217,9 +218,15 @@ func (v *vpa) reconcileAdmissionControllerDeployment(deployment *appsv1.Deployme
 							corev1.ResourceMemory: resource.MustParse("3Gi"),
 						},
 					},
-					Ports: []corev1.ContainerPort{{
-						ContainerPort: admissionControllerPort,
-					}},
+					Ports: []corev1.ContainerPort{
+						{
+							Name:          metricsPortName,
+							ContainerPort: 8944,
+						},
+						{
+							ContainerPort: admissionControllerPort,
+						},
+					},
 					VolumeMounts: []corev1.VolumeMount{{
 						Name:      volumeNameCertificates,
 						MountPath: volumeMountPathCertificates,

--- a/pkg/operation/botanist/component/vpa/recommender.go
+++ b/pkg/operation/botanist/component/vpa/recommender.go
@@ -175,13 +175,14 @@ func (v *vpa) reconcileRecommenderDeployment(deployment *appsv1.Deployment, serv
 						"--kube-api-qps=100",
 						"--kube-api-burst=120",
 					},
+					LivenessProbe: newDefaultLivenessProbe(),
 					Ports: []corev1.ContainerPort{
 						{
 							Name:          "server",
 							ContainerPort: recommenderPortServer,
 						},
 						{
-							Name:          "metrics",
+							Name:          metricsPortName,
 							ContainerPort: recommenderPortMetrics,
 						},
 					},

--- a/pkg/operation/botanist/component/vpa/updater.go
+++ b/pkg/operation/botanist/component/vpa/updater.go
@@ -160,13 +160,14 @@ func (v *vpa) reconcileUpdaterDeployment(deployment *appsv1.Deployment, serviceA
 						"--stderrthreshold=info",
 						"--v=2",
 					},
+					LivenessProbe: newDefaultLivenessProbe(),
 					Ports: []corev1.ContainerPort{
 						{
 							Name:          "server",
 							ContainerPort: updaterPortServer,
 						},
 						{
-							Name:          "metrics",
+							Name:          metricsPortName,
 							ContainerPort: updaterPortMetrics,
 						},
 					},


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area auto-scaling
/kind enhancement

**What this PR does / why we need it**:
Adds liveness probe for VPA components. In the past, we have seen multiple situations where a VPA component got stuck, not providing target workloads with recommendations/updates. This change leverages the existing k8s liveness infrastructure to remediate such situations. 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
VPA components do now have a liveness probe defined.
```
