### PR TITLE
Use priority class `gardener-system-critical`

### DIFF
--- a/charts/gardener/gardenlet/charts/runtime/templates/deployment.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/deployment.yaml
@@ -63,7 +63,7 @@ spec:
 {{ toYaml .Values.global.gardenlet.podLabels | indent 8 }}
         {{- end }}
     spec:
-      priorityClassName: gardener-system-critical-migration
+      priorityClassName: gardener-system-critical
       {{- if not .Values.global.gardenlet.config.seedClientConnection.kubeconfig }}
       serviceAccountName: {{ required ".Values.global.gardenlet.serviceAccountName is required" .Values.global.gardenlet.serviceAccountName }}
       {{- else }}

--- a/charts/gardener/gardenlet/charts/runtime/templates/priorityclass.yaml
+++ b/charts/gardener/gardenlet/charts/runtime/templates/priorityclass.yaml
@@ -1,7 +1,7 @@
 apiVersion: {{ include "priorityclassversion" . }}
 kind: PriorityClass
 metadata:
-  name: gardener-system-critical-migration
+  name: gardener-system-critical
 value: 999998950
 globalDefault: false
 description: "This class is used to ensure that the gardenlet and some seed system components has a high priority and is not preempted in favor of other pods."

--- a/pkg/gardenlet/controller/factory.go
+++ b/pkg/gardenlet/controller/factory.go
@@ -135,7 +135,7 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to get seed client: %w", err)
 	}
 
-	// TODO: Remove in a future release.
+	// TODO(acumino): Remove in a future release.
 	if err := client.IgnoreNotFound(seedClient.Client().Delete(ctx, &schedulingv1.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: "gardener-system-critical-migration"}})); err != nil {
 		return fmt.Errorf("unable to delete Gardenlet's old PriorityClass: %w", err)
 	}

--- a/pkg/gardenlet/controller/factory.go
+++ b/pkg/gardenlet/controller/factory.go
@@ -135,7 +135,8 @@ func (f *GardenletControllerFactory) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to get seed client: %w", err)
 	}
 
-	if err := client.IgnoreNotFound(seedClient.Client().Delete(ctx, &schedulingv1.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: "gardenlet"}})); err != nil {
+	// TODO: Remove in a future release.
+	if err := client.IgnoreNotFound(seedClient.Client().Delete(ctx, &schedulingv1.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: "gardener-system-critical-migration"}})); err != nil {
 		return fmt.Errorf("unable to delete Gardenlet's old PriorityClass: %w", err)
 	}
 

--- a/pkg/gardenlet/controller/managedseed/charttest/charttest.go
+++ b/pkg/gardenlet/controller/managedseed/charttest/charttest.go
@@ -101,7 +101,7 @@ func ValidateGardenletChartPriorityClass(ctx context.Context, c client.Client) {
 func getEmptyPriorityClass() *schedulingv1.PriorityClass {
 	return &schedulingv1.PriorityClass{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "gardener-system-critical-migration",
+			Name: gardencorev1beta1constants.PriorityClassNameSeedSystemCritical,
 		},
 	}
 }
@@ -956,7 +956,7 @@ func ComputeExpectedGardenletDeploymentSpec(
 				Labels: expectedLabels,
 			},
 			Spec: corev1.PodSpec{
-				PriorityClassName:  "gardener-system-critical-migration",
+				PriorityClassName:  gardencorev1beta1constants.PriorityClassNameSeedSystemCritical,
 				ServiceAccountName: "gardenlet",
 				Containers: []corev1.Container{
 					{

--- a/pkg/operation/botanist/component/istio/charts/istio/istio-ingress/templates/deployment.yaml
+++ b/pkg/operation/botanist/component/istio/charts/istio/istio-ingress/templates/deployment.yaml
@@ -201,7 +201,7 @@ spec:
               path: istio-token
               expirationSeconds: 43200
               audience: istio-ca
-      priorityClassName: gardener-system-critical-migration
+      priorityClassName: gardener-system-critical
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/pkg/operation/botanist/component/istio/charts/istio/istio-istiod/templates/deployment.yaml
+++ b/pkg/operation/botanist/component/istio/charts/istio/istio-istiod/templates/deployment.yaml
@@ -147,7 +147,7 @@ spec:
       - name: config-volume
         configMap:
           name: istio
-      priorityClassName: gardener-system-critical-migration
+      priorityClassName: gardener-system-critical
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/pkg/operation/botanist/component/istio/istiod_test.go
+++ b/pkg/operation/botanist/component/istio/istiod_test.go
@@ -841,7 +841,7 @@ spec:
       - name: config-volume
         configMap:
           name: istio
-      priorityClassName: gardener-system-critical-migration
+      priorityClassName: gardener-system-critical
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -1882,7 +1882,7 @@ spec:
               path: istio-token
               expirationSeconds: 43200
               audience: istio-ca
-      priorityClassName: gardener-system-critical-migration
+      priorityClassName: gardener-system-critical
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/pkg/operation/botanist/component/resourcemanager/resource_manager.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager.go
@@ -455,7 +455,7 @@ func (r *resourceManager) ensureDeployment(ctx context.Context) error {
 		return err
 	}
 
-	priorityClassName := "gardener-system-critical-migration"
+	priorityClassName := v1beta1constants.PriorityClassNameSeedSystemCritical
 	if r.values.TargetDiffersFromSourceCluster {
 		priorityClassName = v1beta1constants.PriorityClassNameShootControlPlane400
 	}

--- a/pkg/operation/botanist/component/resourcemanager/resource_manager_test.go
+++ b/pkg/operation/botanist/component/resourcemanager/resource_manager_test.go
@@ -358,7 +358,7 @@ var _ = Describe("ResourceManager", func() {
 			return cmd
 		}
 		deploymentFor = func(kubernetesVersion *semver.Version, watchedNamespace *string, targetKubeconfig *string, targetClusterDiffersFromSourceCluster bool) *appsv1.Deployment {
-			priorityClassName := "gardener-system-critical-migration"
+			priorityClassName := v1beta1constants.PriorityClassNameSeedSystemCritical
 			if targetClusterDiffersFromSourceCluster {
 				priorityClassName = v1beta1constants.PriorityClassNameShootControlPlane400
 			}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
This PR removes priority class `gardener-system-critical-migration` introduced in https://github.com/gardener/gardener/pull/6510 and uses `gardener-system-critical` priority class for all the components which are supposed to use `gardener-system-critical` priority class as described in https://github.com/gardener/gardener/issues/5634.

**Which issue(s) this PR fixes**:
Fixes Part of https://github.com/gardener/gardener/issues/5634

**Special notes for your reviewer**:
/cc @ialidzhikov 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
