### PR TITLE
Export all events of kind and shoot clusters to `ARTIFACTS` directory in CI

### DIFF
--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -90,10 +90,23 @@ Hence, if you want to access the shoot cluster, you have to run the following co
 ```bash
 cat <<EOF | sudo tee -a /etc/hosts
 
-# Manually created to access local Gardener shoot clusters with names 'local' or 'e2e-default' in the 'garden-local' namespace.
+# Manually created to access local Gardener shoot clusters.
 # TODO: Remove this again when the shoot cluster access is no longer required.
 127.0.0.1 api.local.local.external.local.gardener.cloud
 127.0.0.1 api.local.local.internal.local.gardener.cloud
+
+127.0.0.1 api.e2e-managedseed.garden.external.local.gardener.cloud
+127.0.0.1 api.e2e-managedseed.garden.internal.local.gardener.cloud
+127.0.0.1 api.e2e-hibernated.local.external.local.gardener.cloud
+127.0.0.1 api.e2e-hibernated.local.internal.local.gardener.cloud
+127.0.0.1 api.e2e-unpriv.local.external.local.gardener.cloud
+127.0.0.1 api.e2e-unpriv.local.internal.local.gardener.cloud
+127.0.0.1 api.e2e-wake-up.local.external.local.gardener.cloud
+127.0.0.1 api.e2e-wake-up.local.internal.local.gardener.cloud
+127.0.0.1 api.e2e-migrate.local.external.local.gardener.cloud
+127.0.0.1 api.e2e-migrate.local.internal.local.gardener.cloud
+127.0.0.1 api.e2e-rotate.local.external.local.gardener.cloud
+127.0.0.1 api.e2e-rotate.local.internal.local.gardener.cloud
 127.0.0.1 api.e2e-default.local.external.local.gardener.cloud
 127.0.0.1 api.e2e-default.local.internal.local.gardener.cloud
 EOF

--- a/hack/ci-e2e-kind-migration.sh
+++ b/hack/ci-e2e-kind-migration.sh
@@ -28,10 +28,10 @@ make kind2-up
 
 # export all container logs and events after test execution
 trap "
-  KUBECONFIG=$PWD/example/gardener-local/kind/kubeconfig export_logs    'gardener-local'
-  KUBECONFIG=$PWD/example/gardener-local/kind/kubeconfig export_events  'gardener-local'
-  KUBECONFIG=$PWD/example/gardener-local/kind2/kubeconfig export_logs   'gardener-local2'
-  KUBECONFIG=$PWD/example/gardener-local/kind2/kubeconfig export_events 'gardener-local2'
+  ( export KUBECONFIG=$PWD/example/gardener-local/kind/kubeconfig; export_logs 'gardener-local';
+    export_events_for_kind 'gardener-local'; export_events_for_shoots )
+  ( export KUBECONFIG=$PWD/example/gardener-local/kind2/kubeconfig; export_logs 'gardener-local2';
+    export_events_for_kind 'gardener-local2' )
 " EXIT
 
 make gardener-up

--- a/hack/ci-e2e-kind-migration.sh
+++ b/hack/ci-e2e-kind-migration.sh
@@ -26,8 +26,13 @@ clamp_mss_to_pmtu
 make kind-up
 make kind2-up
 
-# dump all container logs after test execution
-trap "KUBECONFIG=$PWD/example/gardener-local/kind/kubeconfig dump_logs 'gardener-local'; KUBECONFIG=$PWD/example/gardener-local/kind2/kubeconfig dump_logs 'gardener-local2'" EXIT
+# export all container logs and events after test execution
+trap "
+  KUBECONFIG=$PWD/example/gardener-local/kind/kubeconfig export_logs    'gardener-local'
+  KUBECONFIG=$PWD/example/gardener-local/kind/kubeconfig export_events  'gardener-local'
+  KUBECONFIG=$PWD/example/gardener-local/kind2/kubeconfig export_logs   'gardener-local2'
+  KUBECONFIG=$PWD/example/gardener-local/kind2/kubeconfig export_events 'gardener-local2'
+" EXIT
 
 make gardener-up
 make gardenlet-kind2-up

--- a/hack/ci-e2e-kind.sh
+++ b/hack/ci-e2e-kind.sh
@@ -27,8 +27,8 @@ make kind-up
 
 # export all container logs and events after test execution
 trap "
-  KUBECONFIG=$PWD/example/gardener-local/kind/kubeconfig export_logs   'gardener-local'
-  KUBECONFIG=$PWD/example/gardener-local/kind/kubeconfig export_events 'gardener-local'
+  ( export KUBECONFIG=$PWD/example/gardener-local/kind/kubeconfig; export_logs 'gardener-local';
+    export_events_for_kind 'gardener-local'; export_events_for_shoots )
 " EXIT
 
 make gardener-up

--- a/hack/ci-e2e-kind.sh
+++ b/hack/ci-e2e-kind.sh
@@ -25,8 +25,11 @@ clamp_mss_to_pmtu
 # test setup
 make kind-up
 
-# dump all container logs after test execution
-trap "KUBECONFIG=$PWD/example/gardener-local/kind/kubeconfig dump_logs 'gardener-local'" EXIT
+# export all container logs and events after test execution
+trap "
+  KUBECONFIG=$PWD/example/gardener-local/kind/kubeconfig export_logs   'gardener-local'
+  KUBECONFIG=$PWD/example/gardener-local/kind/kubeconfig export_events 'gardener-local'
+" EXIT
 
 make gardener-up
 

--- a/hack/test-e2e-local.sh
+++ b/hack/test-e2e-local.sh
@@ -16,6 +16,16 @@ export GOMEGA_DEFAULT_CONSISTENTLY_POLLING_INTERVAL=200ms
 
 ginkgo_flags=
 
+shoot_names=(
+  e2e-managedseed.garden
+  e2e-hibernated.local
+  e2e-unpriv.local
+  e2e-wake-up.local
+  e2e-migrate.local
+  e2e-rotate.local
+  e2e-default.local
+)
+
 # If running in prow, we want to generate a machine-readable output file under the location specified via $ARTIFACTS.
 # This will add a JUnit view above the build log that shows an overview over successful and failed test cases.
 if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ]; then
@@ -23,15 +33,17 @@ if [ -n "${CI:-}" -a -n "${ARTIFACTS:-}" ]; then
   ginkgo_flags="--output-dir=$ARTIFACTS --junit-report=junit.xml"
 
   # make shoot domains accessible to test
-  for shoot in e2e-default e2e-rotate ; do
-    printf "\n127.0.0.1 api.%s.local.external.local.gardener.cloud\n127.0.0.1 api.%s.local.internal.local.gardener.cloud\n" $shoot $shoot >>/etc/hosts
+  for shoot in "${shoot_names[@]}" ; do
+    printf "\n127.0.0.1 api.%s.external.local.gardener.cloud\n127.0.0.1 api.%s.internal.local.gardener.cloud\n" $shoot $shoot >>/etc/hosts
   done
   printf "\n127.0.0.1 gu-local--e2e-rotate.ingress.local.seed.local.gardener.cloud\n" >>/etc/hosts
   printf "\n127.0.0.1 api.e2e-managedseed.garden.external.local.gardener.cloud\n127.0.0.1 api.e2e-managedseed.garden.internal.local.gardener.cloud\n" >>/etc/hosts
 else
-  if ! grep -q "127.0.0.1 api.e2e-default.local.external.local.gardener.cloud" /etc/hosts; then
-    printf "To access the shoot cluster and running e2e tests, you have to extend your /etc/hosts file.\nPlease refer https://github.com/gardener/gardener/blob/master/docs/deployment/getting_started_locally.md#accessing-the-shoot-cluster"
-  fi
+  for shoot in "${shoot_names[@]}" ; do
+    if ! grep -q "$(printf "\n127.0.0.1 api.%s.external.local.gardener.cloud\n127.0.0.1 api.%s.internal.local.gardener.cloud\n" $shoot $shoot)" /etc/hosts; then
+      printf "To access shoot clusters and run e2e tests, you have to extend your /etc/hosts file.\nPlease refer to https://github.com/gardener/gardener/blob/master/docs/deployment/getting_started_locally.md#accessing-the-shoot-cluster\n"
+    fi
+  done
 fi
 
 for ((i = 2; i <= "$#"; i++)); do

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -24,10 +24,10 @@ import (
 )
 
 // DefaultShoot returns a Shoot object with default values for the e2e tests.
-func DefaultShoot(generateName string) *gardencorev1beta1.Shoot {
+func DefaultShoot(name string) *gardencorev1beta1.Shoot {
 	return &gardencorev1beta1.Shoot{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: generateName,
+			Name: name,
 			Annotations: map[string]string{
 				v1beta1constants.AnnotationShootInfrastructureCleanupWaitPeriodSeconds: "0",
 				v1beta1constants.AnnotationShootCloudConfigExecutionMaxDelaySeconds:    "0",

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -15,13 +15,24 @@
 package e2e
 
 import (
+	"os"
+
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/test/framework"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/pointer"
 )
+
+// DefaultGardenConfig returns a GardenerConfig framework object with default values for the e2e tests.
+func DefaultGardenConfig(projectNamespace string) *framework.GardenerConfig {
+	return &framework.GardenerConfig{
+		ProjectNamespace:   projectNamespace,
+		GardenerKubeconfig: os.Getenv("KUBECONFIG"),
+	}
+}
 
 // DefaultShoot returns a Shoot object with default values for the e2e tests.
 func DefaultShoot(name string) *gardencorev1beta1.Shoot {

--- a/test/e2e/common.go
+++ b/test/e2e/common.go
@@ -29,6 +29,9 @@ import (
 // DefaultGardenConfig returns a GardenerConfig framework object with default values for the e2e tests.
 func DefaultGardenConfig(projectNamespace string) *framework.GardenerConfig {
 	return &framework.GardenerConfig{
+		CommonConfig: &framework.CommonConfig{
+			DisableStateDump: true,
+		},
 		ProjectNamespace:   projectNamespace,
 		GardenerKubeconfig: os.Getenv("KUBECONFIG"),
 	}

--- a/test/e2e/managedseed/create_rotate_delete.go
+++ b/test/e2e/managedseed/create_rotate_delete.go
@@ -55,11 +55,9 @@ var _ = Describe("ManagedSeed Tests", Label("ManagedSeed", "default"), func() {
 		GardenerConfig: &framework.GardenerConfig{
 			ProjectNamespace:   "garden",
 			GardenerKubeconfig: os.Getenv("KUBECONFIG"),
-			SkipAccessingShoot: true,
 		},
 	})
-	f.Shoot = e2e.DefaultShoot("")
-	f.Shoot.Name = "e2e-managedseed"
+	f.Shoot = e2e.DefaultShoot("e2e-managedseed")
 
 	It("Create Shoot, Create ManagedSeed, Delete ManagedSeed, Delete Shoot", func() {
 		By("Create Shoot")

--- a/test/e2e/managedseed/create_rotate_delete.go
+++ b/test/e2e/managedseed/create_rotate_delete.go
@@ -17,7 +17,6 @@ package managedseed
 import (
 	"context"
 	"fmt"
-	"os"
 	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
@@ -52,10 +51,7 @@ var _ = Describe("ManagedSeed Tests", Label("ManagedSeed", "default"), func() {
 	})
 
 	f := framework.NewShootCreationFramework(&framework.ShootCreationConfig{
-		GardenerConfig: &framework.GardenerConfig{
-			ProjectNamespace:   "garden",
-			GardenerKubeconfig: os.Getenv("KUBECONFIG"),
-		},
+		GardenerConfig: e2e.DefaultGardenConfig("garden"),
 	})
 	f.Shoot = e2e.DefaultShoot("e2e-managedseed")
 

--- a/test/e2e/shoot/common.go
+++ b/test/e2e/shoot/common.go
@@ -43,6 +43,5 @@ func defaultGardenConfig() *framework.GardenerConfig {
 	return &framework.GardenerConfig{
 		ProjectNamespace:   projectNamespace,
 		GardenerKubeconfig: os.Getenv("KUBECONFIG"),
-		SkipAccessingShoot: true,
 	}
 }

--- a/test/e2e/shoot/common.go
+++ b/test/e2e/shoot/common.go
@@ -16,8 +16,8 @@ package shoot
 
 import (
 	"context"
-	"os"
 
+	"github.com/gardener/gardener/test/e2e"
 	"github.com/gardener/gardener/test/framework"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -31,17 +31,8 @@ var _ = BeforeEach(func() {
 	parentCtx = context.Background()
 })
 
-const projectNamespace = "garden-local"
-
 func defaultShootCreationFramework() *framework.ShootCreationFramework {
 	return framework.NewShootCreationFramework(&framework.ShootCreationConfig{
-		GardenerConfig: defaultGardenConfig(),
+		GardenerConfig: e2e.DefaultGardenConfig("garden-local"),
 	})
-}
-
-func defaultGardenConfig() *framework.GardenerConfig {
-	return &framework.GardenerConfig{
-		ProjectNamespace:   projectNamespace,
-		GardenerKubeconfig: os.Getenv("KUBECONFIG"),
-	}
 }

--- a/test/e2e/shoot/create_and_delete_hibernated.go
+++ b/test/e2e/shoot/create_and_delete_hibernated.go
@@ -28,7 +28,7 @@ import (
 
 var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 	f := defaultShootCreationFramework()
-	f.Shoot = e2e.DefaultShoot("hibernated-")
+	f.Shoot = e2e.DefaultShoot("e2e-hibernated")
 	f.Shoot.Spec.Hibernation = &gardencorev1beta1.Hibernation{
 		Enabled: pointer.Bool(true),
 	}

--- a/test/e2e/shoot/create_and_delete_unprivileged.go
+++ b/test/e2e/shoot/create_and_delete_unprivileged.go
@@ -27,7 +27,7 @@ import (
 
 var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 	f := defaultShootCreationFramework()
-	f.Shoot = e2e.DefaultShoot("unpriv-")
+	f.Shoot = e2e.DefaultShoot("e2e-unpriv")
 	f.Shoot.Spec.Kubernetes.AllowPrivilegedContainers = pointer.Bool(false)
 
 	It("Create and Delete Unprivileged Shoot", Label("unprivileged"), func() {

--- a/test/e2e/shoot/create_hibernate_wakeup_delete.go
+++ b/test/e2e/shoot/create_hibernate_wakeup_delete.go
@@ -26,7 +26,7 @@ import (
 
 var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 	f := defaultShootCreationFramework()
-	f.Shoot = e2e.DefaultShoot("wake-up-")
+	f.Shoot = e2e.DefaultShoot("e2e-wake-up")
 
 	It("Create, Hibernate, Wake up and Delete Shoot", func() {
 		By("Create Shoot")

--- a/test/e2e/shoot/create_migrate_delete.go
+++ b/test/e2e/shoot/create_migrate_delete.go
@@ -29,7 +29,7 @@ import (
 
 var _ = Describe("Shoot Tests", Label("Shoot", "control-plane-migration"), func() {
 	f := defaultShootCreationFramework()
-	f.Shoot = e2e.DefaultShoot("migrate-")
+	f.Shoot = e2e.DefaultShoot("e2e-migrate")
 	// Assign seedName so that shoot does not get scheduled to the seed that will be used as target.
 	f.Shoot.Spec.SeedName = pointer.String("local")
 

--- a/test/e2e/shoot/create_rotate_delete.go
+++ b/test/e2e/shoot/create_rotate_delete.go
@@ -31,8 +31,7 @@ import (
 
 var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 	f := defaultShootCreationFramework()
-	f.Shoot = e2e.DefaultShoot("")
-	f.Shoot.Name = "e2e-rotate"
+	f.Shoot = e2e.DefaultShoot("e2e-rotate")
 	f.Shoot.Annotations = utils.MergeStringMaps(f.Shoot.Annotations, map[string]string{
 		// Use a single zone HA control plane because we don't know if there is a multi-AZ seed available.
 		v1beta1constants.ShootAlphaControlPlaneHighAvailability: v1beta1constants.ShootAlphaControlPlaneHighAvailabilitySingleZone,

--- a/test/e2e/shoot/create_update_delete.go
+++ b/test/e2e/shoot/create_update_delete.go
@@ -32,8 +32,7 @@ import (
 
 var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 	f := defaultShootCreationFramework()
-	f.Shoot = e2e.DefaultShoot("")
-	f.Shoot.Name = "e2e-default"
+	f.Shoot = e2e.DefaultShoot("e2e-default")
 
 	// explicitly use one version below the latest supported minor version so that Kubernetes version update test can be
 	// performed


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity testing
/kind enhancement

**What this PR does / why we need it**:
Export all events of kind and shoot clusters to `ARTIFACTS` directory in CI and disable the state dump of the TestMachinery framework. This makes it easier to search and navigate while debugging. It also improves the output of the CI jobs.

**Which issue(s) this PR fixes**:
Part of #6016

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
