### PR TITLE
Add `Progressing` condition type to `ControllerInstallations` and check it when computing the `ExtensionsReady` condition

### DIFF
--- a/pkg/apis/core/types_controllerinstallation.go
+++ b/pkg/apis/core/types_controllerinstallation.go
@@ -72,6 +72,8 @@ const (
 	ControllerInstallationHealthy ConditionType = "Healthy"
 	// ControllerInstallationInstalled is a condition type for indicating whether the controller has been installed.
 	ControllerInstallationInstalled ConditionType = "Installed"
+	// ControllerInstallationProgressing is a condition type for indicating whether the controller is progressing.
+	ControllerInstallationProgressing ConditionType = "Progressing"
 	// ControllerInstallationValid is a condition type for indicating whether the installation request is valid.
 	ControllerInstallationValid ConditionType = "Valid"
 	// ControllerInstallationRequired is a condition type for indicating that the respective extension controller is

--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -158,8 +158,9 @@ func IsResourceSupported(resources []gardencorev1beta1.ControllerResource, resou
 // installed.
 func IsControllerInstallationSuccessful(controllerInstallation gardencorev1beta1.ControllerInstallation) bool {
 	var (
-		installed bool
-		healthy   bool
+		installed      bool
+		healthy        bool
+		notProgressing bool
 	)
 
 	for _, condition := range controllerInstallation.Status.Conditions {
@@ -169,9 +170,12 @@ func IsControllerInstallationSuccessful(controllerInstallation gardencorev1beta1
 		if condition.Type == gardencorev1beta1.ControllerInstallationHealthy && condition.Status == gardencorev1beta1.ConditionTrue {
 			healthy = true
 		}
+		if condition.Type == gardencorev1beta1.ControllerInstallationProgressing && condition.Status == gardencorev1beta1.ConditionFalse {
+			notProgressing = true
+		}
 	}
 
-	return installed && healthy
+	return installed && healthy && notProgressing
 }
 
 // IsControllerInstallationRequired returns true if a ControllerInstallation has been marked as "required".

--- a/pkg/apis/core/v1beta1/helper/helper_test.go
+++ b/pkg/apis/core/v1beta1/helper/helper_test.go
@@ -323,6 +323,10 @@ var _ = Describe("helper", func() {
 						Type:   gardencorev1beta1.ControllerInstallationHealthy,
 						Status: gardencorev1beta1.ConditionTrue,
 					},
+					{
+						Type:   gardencorev1beta1.ControllerInstallationProgressing,
+						Status: gardencorev1beta1.ConditionFalse,
+					},
 				},
 				true,
 			),
@@ -347,11 +351,24 @@ var _ = Describe("helper", func() {
 			Entry("expect false",
 				[]gardencorev1beta1.Condition{
 					{
+						Type:   gardencorev1beta1.ControllerInstallationProgressing,
+						Status: gardencorev1beta1.ConditionTrue,
+					},
+				},
+				false,
+			),
+			Entry("expect false",
+				[]gardencorev1beta1.Condition{
+					{
 						Type:   gardencorev1beta1.ControllerInstallationInstalled,
 						Status: gardencorev1beta1.ConditionTrue,
 					},
 					{
 						Type:   gardencorev1beta1.ControllerInstallationHealthy,
+						Status: gardencorev1beta1.ConditionFalse,
+					},
+					{
+						Type:   gardencorev1beta1.ControllerInstallationProgressing,
 						Status: gardencorev1beta1.ConditionFalse,
 					},
 				},
@@ -365,6 +382,27 @@ var _ = Describe("helper", func() {
 					},
 					{
 						Type:   gardencorev1beta1.ControllerInstallationHealthy,
+						Status: gardencorev1beta1.ConditionTrue,
+					},
+					{
+						Type:   gardencorev1beta1.ControllerInstallationProgressing,
+						Status: gardencorev1beta1.ConditionFalse,
+					},
+				},
+				false,
+			),
+			Entry("expect false",
+				[]gardencorev1beta1.Condition{
+					{
+						Type:   gardencorev1beta1.ControllerInstallationInstalled,
+						Status: gardencorev1beta1.ConditionTrue,
+					},
+					{
+						Type:   gardencorev1beta1.ControllerInstallationHealthy,
+						Status: gardencorev1beta1.ConditionTrue,
+					},
+					{
+						Type:   gardencorev1beta1.ControllerInstallationProgressing,
 						Status: gardencorev1beta1.ConditionTrue,
 					},
 				},

--- a/pkg/apis/core/v1beta1/types_controllerinstallation.go
+++ b/pkg/apis/core/v1beta1/types_controllerinstallation.go
@@ -77,6 +77,8 @@ const (
 	ControllerInstallationHealthy ConditionType = "Healthy"
 	// ControllerInstallationInstalled is a condition type for indicating whether the controller has been installed.
 	ControllerInstallationInstalled ConditionType = "Installed"
+	// ControllerInstallationProgressing is a condition type for indicating whether the controller is progressing.
+	ControllerInstallationProgressing ConditionType = "Progressing"
 	// ControllerInstallationValid is a condition type for indicating whether the installation request is valid.
 	ControllerInstallationValid ConditionType = "Valid"
 	// ControllerInstallationRequired is a condition type for indicating that the respective extension controller is

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation.go
@@ -77,6 +77,11 @@ func NewController(
 		return nil, err
 	}
 
+	seedClient, err := clientMap.GetClient(ctx, keys.ForSeedWithName(config.SeedConfig.Name))
+	if err != nil {
+		return nil, err
+	}
+
 	controllerInstallationInformer, err := gardenClient.Cache().GetInformer(ctx, &gardencorev1beta1.ControllerInstallation{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to get ControllerInstallation Informer: %w", err)
@@ -86,7 +91,7 @@ func NewController(
 		log: log,
 
 		reconciler:     newReconciler(clientMap, identity, gardenNamespace, gardenClusterIdentity),
-		careReconciler: newCareReconciler(clientMap, config.Controllers.ControllerInstallationCare),
+		careReconciler: NewCareReconciler(gardenClient.Client(), seedClient.Client(), *config.Controllers.ControllerInstallationCare),
 
 		controllerInstallationQueue:     workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "controllerinstallation"),
 		controllerInstallationCareQueue: workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "controllerinstallation-care"),

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation_care_control_test.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation_care_control_test.go
@@ -1,0 +1,233 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllerinstallation_test
+
+import (
+	"context"
+	"time"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
+	. "github.com/gardener/gardener/pkg/gardenlet/controller/controllerinstallation"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	gomegatypes "github.com/onsi/gomega/types"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	controllerInstallationName = "foo"
+	gardenNamespace            = "garden"
+	syncPeriodDuration         = time.Second
+)
+
+var _ = Describe("ControllerInstallation Care Control", func() {
+	var (
+		ctx context.Context
+
+		gardenClient client.Client
+		seedClient   client.Client
+
+		controllerInstallation *gardencorev1beta1.ControllerInstallation
+		request                reconcile.Request
+
+		reconciler reconcile.Reconciler
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+
+		controllerInstallation = &gardencorev1beta1.ControllerInstallation{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: controllerInstallationName,
+			},
+			Spec: gardencorev1beta1.ControllerInstallationSpec{
+				SeedRef: corev1.ObjectReference{
+					Name: "foo-seed",
+				},
+			},
+		}
+
+		request = reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name: controllerInstallationName,
+			},
+		}
+
+		gardenClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.GardenScheme).Build()
+		seedClient = fakeclient.NewClientBuilder().WithScheme(kubernetes.SeedScheme).Build()
+
+		reconciler = NewCareReconciler(gardenClient, seedClient, config.ControllerInstallationCareControllerConfiguration{
+			SyncPeriod: &metav1.Duration{Duration: syncPeriodDuration},
+		})
+	})
+
+	Context("when care operation does not get executed", func() {
+		It("should not return error during reconciliation if ControllerInstallation resource is missing", func() {
+			result, err := reconciler.Reconcile(ctx, request)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{}))
+		})
+
+		It("should not return error during reconciliation if ControllerInstallation resource has deletionTimestamp", func() {
+			now := metav1.Now()
+			controllerInstallation.DeletionTimestamp = &now
+
+			Expect(gardenClient.Create(ctx, controllerInstallation)).To(Succeed())
+
+			result, err := reconciler.Reconcile(ctx, request)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{}))
+		})
+	})
+
+	Context("when care operation gets executed", func() {
+		JustBeforeEach(func() {
+			Expect(gardenClient.Create(ctx, controllerInstallation)).To(Succeed())
+		})
+
+		It("should set conditions to Unknown if managed resource does not exist yet", func() {
+			result, err := reconciler.Reconcile(ctx, request)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{
+				RequeueAfter: syncPeriodDuration,
+			}))
+
+			Expect(gardenClient.Get(ctx, client.ObjectKeyFromObject(controllerInstallation), controllerInstallation)).To(Succeed())
+			Expect(controllerInstallation.Status.Conditions).To(consistOfConditionsInUnknownStatus("SeedReadError", "Failed to get ManagedResource"))
+		})
+
+		DescribeTable("should set correct conditions when managed resource exists", func(managedResource *resourcesv1alpha1.ManagedResource, matchExpectedConditions gomegatypes.GomegaMatcher) {
+			Expect(seedClient.Create(ctx, managedResource)).To(Succeed())
+
+			result, err := reconciler.Reconcile(ctx, request)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal(reconcile.Result{
+				RequeueAfter: syncPeriodDuration,
+			}))
+
+			Expect(gardenClient.Get(ctx, client.ObjectKeyFromObject(controllerInstallation), controllerInstallation)).To(Succeed())
+			Expect(controllerInstallation.Status.Conditions).To(matchExpectedConditions)
+		},
+			Entry("managed resource conditions are not set",
+				managedResource(nil),
+				ConsistOf(
+					conditionWithStatusAndReason(gardencorev1beta1.ConditionFalse, "InstallationPending"),
+					conditionWithStatusAndReason(gardencorev1beta1.ConditionFalse, "ControllerNotHealthy"),
+					conditionWithStatusAndReason(gardencorev1beta1.ConditionTrue, "ControllerNotRolledOut"),
+				),
+			),
+			Entry("managed resource is not healthy",
+				notHealthyManagedResource(),
+				ConsistOf(
+					conditionWithStatusAndReason(gardencorev1beta1.ConditionFalse, "InstallationPending"),
+					conditionWithStatusAndReason(gardencorev1beta1.ConditionFalse, "ControllerNotHealthy"),
+					conditionWithStatusAndReason(gardencorev1beta1.ConditionTrue, "ControllerNotRolledOut"),
+				),
+			),
+			Entry("managed resource is healthy",
+				healthyManagedResource(),
+				ConsistOf(
+					conditionWithStatusAndReason(gardencorev1beta1.ConditionTrue, "InstallationSuccessful"),
+					conditionWithStatusAndReason(gardencorev1beta1.ConditionTrue, "ControllerHealthy"),
+					conditionWithStatusAndReason(gardencorev1beta1.ConditionFalse, "ControllerRolledOut"),
+				),
+			),
+		)
+	})
+})
+
+func consistOfConditionsInUnknownStatus(reason, message string) gomegatypes.GomegaMatcher {
+	return ConsistOf(
+		conditionWithStatusReasonAndMesssage(gardencorev1beta1.ConditionUnknown, reason, message),
+		conditionWithStatusReasonAndMesssage(gardencorev1beta1.ConditionUnknown, reason, message),
+		conditionWithStatusReasonAndMesssage(gardencorev1beta1.ConditionUnknown, reason, message),
+	)
+}
+
+func conditionWithStatusAndReason(status gardencorev1beta1.ConditionStatus, reason string) gomegatypes.GomegaMatcher {
+	return conditionWithStatusReasonAndMesssage(status, reason, "")
+}
+
+func conditionWithStatusReasonAndMesssage(status gardencorev1beta1.ConditionStatus, reason, message string) gomegatypes.GomegaMatcher {
+	return MatchFields(IgnoreExtras, Fields{
+		"Status":  Equal(status),
+		"Reason":  Equal(reason),
+		"Message": ContainSubstring(message),
+	})
+}
+
+func healthyManagedResource() *resourcesv1alpha1.ManagedResource {
+	return managedResource(
+		[]gardencorev1beta1.Condition{
+			{
+				Type:   resourcesv1alpha1.ResourcesApplied,
+				Status: gardencorev1beta1.ConditionTrue,
+			},
+			{
+				Type:   resourcesv1alpha1.ResourcesHealthy,
+				Status: gardencorev1beta1.ConditionTrue,
+			},
+			{
+				Type:   resourcesv1alpha1.ResourcesProgressing,
+				Status: gardencorev1beta1.ConditionFalse,
+			},
+		})
+}
+
+func notHealthyManagedResource() *resourcesv1alpha1.ManagedResource {
+	return managedResource(
+		[]gardencorev1beta1.Condition{
+			{
+				Type:    resourcesv1alpha1.ResourcesApplied,
+				Reason:  "NotApplied",
+				Message: "Resources are not applied",
+				Status:  gardencorev1beta1.ConditionFalse,
+			},
+			{
+				Type:    resourcesv1alpha1.ResourcesHealthy,
+				Reason:  "NotHealthy",
+				Message: "Resources are not healthy",
+				Status:  gardencorev1beta1.ConditionFalse,
+			},
+			{
+				Type:    resourcesv1alpha1.ResourcesProgressing,
+				Reason:  "ResourcesProgressing",
+				Message: "Resources are progressing",
+				Status:  gardencorev1beta1.ConditionTrue,
+			},
+		})
+}
+
+func managedResource(conditions []gardencorev1beta1.Condition) *resourcesv1alpha1.ManagedResource {
+	return &resourcesv1alpha1.ManagedResource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      controllerInstallationName,
+			Namespace: gardenNamespace,
+		},
+		Status: resourcesv1alpha1.ManagedResourceStatus{
+			Conditions: conditions,
+		},
+	}
+}

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation_care_control_test.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation_care_control_test.go
@@ -133,25 +133,25 @@ var _ = Describe("ControllerInstallation Care Control", func() {
 			Entry("managed resource conditions are not set",
 				managedResource(nil),
 				ConsistOf(
-					conditionWithStatusAndReason(gardencorev1beta1.ConditionFalse, "InstallationPending"),
-					conditionWithStatusAndReason(gardencorev1beta1.ConditionFalse, "ControllerNotHealthy"),
-					conditionWithStatusAndReason(gardencorev1beta1.ConditionTrue, "ControllerNotRolledOut"),
+					conditionWithTypeStatusAndReason(gardencorev1beta1.ControllerInstallationInstalled, gardencorev1beta1.ConditionFalse, "InstallationPending"),
+					conditionWithTypeStatusAndReason(gardencorev1beta1.ControllerInstallationHealthy, gardencorev1beta1.ConditionFalse, "ControllerNotHealthy"),
+					conditionWithTypeStatusAndReason(gardencorev1beta1.ControllerInstallationProgressing, gardencorev1beta1.ConditionTrue, "ControllerNotRolledOut"),
 				),
 			),
 			Entry("managed resource is not healthy",
 				notHealthyManagedResource(),
 				ConsistOf(
-					conditionWithStatusAndReason(gardencorev1beta1.ConditionFalse, "InstallationPending"),
-					conditionWithStatusAndReason(gardencorev1beta1.ConditionFalse, "ControllerNotHealthy"),
-					conditionWithStatusAndReason(gardencorev1beta1.ConditionTrue, "ControllerNotRolledOut"),
+					conditionWithTypeStatusAndReason(gardencorev1beta1.ControllerInstallationInstalled, gardencorev1beta1.ConditionFalse, "InstallationPending"),
+					conditionWithTypeStatusAndReason(gardencorev1beta1.ControllerInstallationHealthy, gardencorev1beta1.ConditionFalse, "ControllerNotHealthy"),
+					conditionWithTypeStatusAndReason(gardencorev1beta1.ControllerInstallationProgressing, gardencorev1beta1.ConditionTrue, "ControllerNotRolledOut"),
 				),
 			),
 			Entry("managed resource is healthy",
 				healthyManagedResource(),
 				ConsistOf(
-					conditionWithStatusAndReason(gardencorev1beta1.ConditionTrue, "InstallationSuccessful"),
-					conditionWithStatusAndReason(gardencorev1beta1.ConditionTrue, "ControllerHealthy"),
-					conditionWithStatusAndReason(gardencorev1beta1.ConditionFalse, "ControllerRolledOut"),
+					conditionWithTypeStatusAndReason(gardencorev1beta1.ControllerInstallationInstalled, gardencorev1beta1.ConditionTrue, "InstallationSuccessful"),
+					conditionWithTypeStatusAndReason(gardencorev1beta1.ControllerInstallationHealthy, gardencorev1beta1.ConditionTrue, "ControllerHealthy"),
+					conditionWithTypeStatusAndReason(gardencorev1beta1.ControllerInstallationProgressing, gardencorev1beta1.ConditionFalse, "ControllerRolledOut"),
 				),
 			),
 		)
@@ -160,18 +160,19 @@ var _ = Describe("ControllerInstallation Care Control", func() {
 
 func consistOfConditionsInUnknownStatus(reason, message string) gomegatypes.GomegaMatcher {
 	return ConsistOf(
-		conditionWithStatusReasonAndMesssage(gardencorev1beta1.ConditionUnknown, reason, message),
-		conditionWithStatusReasonAndMesssage(gardencorev1beta1.ConditionUnknown, reason, message),
-		conditionWithStatusReasonAndMesssage(gardencorev1beta1.ConditionUnknown, reason, message),
+		conditionWithTypeStatusReasonAndMesssage(gardencorev1beta1.ControllerInstallationInstalled, gardencorev1beta1.ConditionUnknown, reason, message),
+		conditionWithTypeStatusReasonAndMesssage(gardencorev1beta1.ControllerInstallationHealthy, gardencorev1beta1.ConditionUnknown, reason, message),
+		conditionWithTypeStatusReasonAndMesssage(gardencorev1beta1.ControllerInstallationProgressing, gardencorev1beta1.ConditionUnknown, reason, message),
 	)
 }
 
-func conditionWithStatusAndReason(status gardencorev1beta1.ConditionStatus, reason string) gomegatypes.GomegaMatcher {
-	return conditionWithStatusReasonAndMesssage(status, reason, "")
+func conditionWithTypeStatusAndReason(condType gardencorev1beta1.ConditionType, status gardencorev1beta1.ConditionStatus, reason string) gomegatypes.GomegaMatcher {
+	return conditionWithTypeStatusReasonAndMesssage(condType, status, reason, "")
 }
 
-func conditionWithStatusReasonAndMesssage(status gardencorev1beta1.ConditionStatus, reason, message string) gomegatypes.GomegaMatcher {
+func conditionWithTypeStatusReasonAndMesssage(condType gardencorev1beta1.ConditionType, status gardencorev1beta1.ConditionStatus, reason, message string) gomegatypes.GomegaMatcher {
 	return MatchFields(IgnoreExtras, Fields{
+		"Type":    Equal(condType),
 		"Status":  Equal(status),
 		"Reason":  Equal(reason),
 		"Message": ContainSubstring(message),

--- a/pkg/gardenlet/controller/controllerinstallation/controllerinstallation_suite_test.go
+++ b/pkg/gardenlet/controller/controllerinstallation/controllerinstallation_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllerinstallation_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestControllerInstallation(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ControllerInstallation Controller Suite")
+}

--- a/pkg/registry/core/controllerinstallation/storage/tableconvertor.go
+++ b/pkg/registry/core/controllerinstallation/storage/tableconvertor.go
@@ -43,6 +43,7 @@ func newTableConvertor() rest.TableConvertor {
 			{Name: "Valid", Type: "string", Format: "name", Description: swaggerMetadataDescriptions["Valid"]},
 			{Name: "Installed", Type: "string", Format: "name", Description: swaggerMetadataDescriptions["installed"]},
 			{Name: "Healthy", Type: "string", Format: "name", Description: swaggerMetadataDescriptions["healthy"]},
+			{Name: "Progressing", Type: "string", Format: "name", Description: swaggerMetadataDescriptions["progressing"]},
 			{Name: "Age", Type: "date", Description: swaggerMetadataDescriptions["creationTimestamp"]},
 		},
 	}
@@ -86,6 +87,11 @@ func (c *convertor) ConvertToTable(ctx context.Context, o runtime.Object, tableO
 			cells = append(cells, "<unknown>")
 		}
 		if cond := helper.GetCondition(obj.Status.Conditions, core.ControllerInstallationHealthy); cond != nil {
+			cells = append(cells, cond.Status)
+		} else {
+			cells = append(cells, "<unknown>")
+		}
+		if cond := helper.GetCondition(obj.Status.Conditions, core.ControllerInstallationProgressing); cond != nil {
 			cells = append(cells, cond.Status)
 		} else {
 			cells = append(cells, "<unknown>")

--- a/pkg/utils/kubernetes/health/managedresource.go
+++ b/pkg/utils/kubernetes/health/managedresource.go
@@ -65,3 +65,17 @@ func CheckManagedResourceHealthy(mr *resourcesv1alpha1.ManagedResource) error {
 
 	return nil
 }
+
+// CheckManagedResourceProgressing checks if the condition ResourcesProgressing of a ManagedResource is False.
+func CheckManagedResourceProgressing(mr *resourcesv1alpha1.ManagedResource) error {
+	status := mr.Status
+	conditionProgressing := v1beta1helper.GetCondition(status.Conditions, resourcesv1alpha1.ResourcesProgressing)
+
+	if conditionProgressing == nil {
+		return fmt.Errorf("condition %s for managed resource %s/%s has not been reported yet", resourcesv1alpha1.ResourcesProgressing, mr.GetNamespace(), mr.GetName())
+	} else if conditionProgressing.Status != gardencorev1beta1.ConditionFalse {
+		return fmt.Errorf("condition %s of managed resource %s/%s is %s: %s", resourcesv1alpha1.ResourcesProgressing, mr.GetNamespace(), mr.GetName(), conditionProgressing.Status, conditionProgressing.Message)
+	}
+
+	return nil
+}

--- a/pkg/utils/kubernetes/health/managedresource_test.go
+++ b/pkg/utils/kubernetes/health/managedresource_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 var _ = Describe("Managedresource", func() {
-	Context("CheckManagedResource", func() {
+	Context("#CheckManagedResource", func() {
 		DescribeTable("managedresource",
 			func(mr resourcesv1alpha1.ManagedResource, matcher types.GomegaMatcher) {
 				err := health.CheckManagedResource(&mr)
@@ -122,7 +122,7 @@ var _ = Describe("Managedresource", func() {
 		)
 	})
 
-	Context("CheckManagedResourceApplied", func() {
+	Context("#CheckManagedResourceApplied", func() {
 		DescribeTable("managedresource",
 			func(mr resourcesv1alpha1.ManagedResource, matcher types.GomegaMatcher) {
 				err := health.CheckManagedResourceApplied(&mr)
@@ -177,7 +177,7 @@ var _ = Describe("Managedresource", func() {
 		)
 	})
 
-	Context("CheckManagedResourceHealthy", func() {
+	Context("#CheckManagedResourceHealthy", func() {
 		DescribeTable("managedresource",
 			func(mr resourcesv1alpha1.ManagedResource, matcher types.GomegaMatcher) {
 				err := health.CheckManagedResourceHealthy(&mr)
@@ -222,6 +222,46 @@ var _ = Describe("Managedresource", func() {
 			}, HaveOccurred()),
 			Entry("no status", resourcesv1alpha1.ManagedResource{
 				ObjectMeta: metav1.ObjectMeta{Generation: 2},
+			}, HaveOccurred()),
+		)
+	})
+
+	Context("#CheckManagedResourceProgressing", func() {
+		DescribeTable("managedresource",
+			func(mr resourcesv1alpha1.ManagedResource, matcher types.GomegaMatcher) {
+				err := health.CheckManagedResourceProgressing(&mr)
+				Expect(err).To(matcher)
+			},
+			Entry("progressing condition not false", resourcesv1alpha1.ManagedResource{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Status: resourcesv1alpha1.ManagedResourceStatus{
+					ObservedGeneration: 1,
+					Conditions: []gardencorev1beta1.Condition{
+						{
+							Type:   resourcesv1alpha1.ResourcesProgressing,
+							Status: gardencorev1beta1.ConditionTrue,
+						},
+					},
+				},
+			}, HaveOccurred()),
+			Entry("progressing condition false", resourcesv1alpha1.ManagedResource{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Status: resourcesv1alpha1.ManagedResourceStatus{
+					ObservedGeneration: 1,
+					Conditions: []gardencorev1beta1.Condition{
+						{
+							Type:   resourcesv1alpha1.ResourcesProgressing,
+							Status: gardencorev1beta1.ConditionFalse,
+						},
+					},
+				},
+			}, Not(HaveOccurred())),
+			Entry("no progressing condition", resourcesv1alpha1.ManagedResource{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Status: resourcesv1alpha1.ManagedResourceStatus{
+					ObservedGeneration: 1,
+					Conditions:         []gardencorev1beta1.Condition{},
+				},
 			}, HaveOccurred()),
 		)
 	})

--- a/test/integration/gardenlet/controllerinstallation/care/care_suite_test.go
+++ b/test/integration/gardenlet/controllerinstallation/care/care_suite_test.go
@@ -1,0 +1,161 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package care_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+	"github.com/gardener/gardener/pkg/client/kubernetes"
+	gardenerenvtest "github.com/gardener/gardener/pkg/envtest"
+	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
+	"github.com/gardener/gardener/pkg/gardenlet/controller/controllerinstallation"
+	"github.com/gardener/gardener/pkg/logger"
+	"github.com/gardener/gardener/pkg/utils/test"
+	. "github.com/gardener/gardener/pkg/utils/test/matchers"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+func TestControllerInstallationCare(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ControllerInstallationCare Controller Integration Test Suite")
+}
+
+const (
+	testID     = "controllerinstallation-care-controller-test"
+	syncPeriod = 100 * time.Millisecond
+)
+
+var (
+	ctx = context.Background()
+	log logr.Logger
+
+	restConfig *rest.Config
+	testEnv    *gardenerenvtest.GardenerTestEnvironment
+	testClient client.Client
+
+	gardenNamespace *corev1.Namespace
+)
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, zap.WriteTo(GinkgoWriter)))
+	log = logf.Log.WithName(testID)
+
+	By("starting test environment")
+	testEnv = &gardenerenvtest.GardenerTestEnvironment{
+		Environment: &envtest.Environment{
+			CRDInstallOptions: envtest.CRDInstallOptions{
+				Paths: []string{filepath.Join("..", "..", "..", "..", "..", "example", "resource-manager", "10-crd-resources.gardener.cloud_managedresources.yaml")},
+			},
+			ErrorIfCRDPathMissing: true,
+		},
+		GardenerAPIServer: &gardenerenvtest.GardenerAPIServer{
+			Args: []string{"--disable-admission-plugins=DeletionConfirmation,ResourceReferenceManager,ExtensionValidator"},
+		},
+	}
+
+	var err error
+	restConfig, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(restConfig).NotTo(BeNil())
+
+	DeferCleanup(func() {
+		By("stopping test environment")
+		Expect(testEnv.Stop()).To(Succeed())
+	})
+
+	scheme := kubernetes.GardenScheme
+	Expect(resourcesv1alpha1.AddToScheme(scheme)).To(Succeed())
+
+	By("creating testClient")
+	testClient, err = client.New(restConfig, client.Options{Scheme: kubernetes.GardenScheme})
+	Expect(err).NotTo(HaveOccurred())
+
+	By("creating garden namespace for test")
+	gardenNamespace = &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "garden-",
+		},
+	}
+
+	Expect(testClient.Create(ctx, gardenNamespace)).To(Succeed())
+	log.Info("Created Namespace for test", "namespaceName", gardenNamespace.Name)
+
+	DeferCleanup(func() {
+		By("deleting test namespace")
+		Expect(testClient.Delete(ctx, gardenNamespace)).To(Or(Succeed(), BeNotFoundError()))
+	})
+
+	DeferCleanup(test.WithVars(
+		&controllerinstallation.ManagedResourcesNamespace, gardenNamespace.Name,
+	))
+
+	By("setup manager")
+	mgr, err := manager.New(restConfig, manager.Options{
+		Scheme:             kubernetes.GardenScheme,
+		MetricsBindAddress: "0",
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	By("registering controller")
+	Expect(addControllerInstallationCareControllerToManager(mgr)).To(Succeed())
+
+	By("starting manager")
+	mgrContext, mgrCancel := context.WithCancel(ctx)
+
+	go func() {
+		defer GinkgoRecover()
+		Expect(mgr.Start(mgrContext)).To(Succeed())
+	}()
+
+	DeferCleanup(func() {
+		By("stopping manager")
+		mgrCancel()
+	})
+})
+
+func addControllerInstallationCareControllerToManager(mgr manager.Manager) error {
+	c, err := controller.New("controllerinstallation-care-controller", mgr, controller.Options{
+		Reconciler: controllerinstallation.NewCareReconciler(testClient, testClient, config.ControllerInstallationCareControllerConfiguration{
+			SyncPeriod: &metav1.Duration{Duration: syncPeriod},
+		}),
+	})
+	if err != nil {
+		return err
+	}
+
+	return c.Watch(
+		&source.Kind{Type: &gardencorev1beta1.ControllerInstallation{}},
+		&handler.EnqueueRequestForObject{},
+	)
+}

--- a/test/integration/gardenlet/controllerinstallation/care/care_test.go
+++ b/test/integration/gardenlet/controllerinstallation/care/care_test.go
@@ -1,0 +1,194 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package care_test
+
+import (
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gstruct"
+	gomegatypes "github.com/onsi/gomega/types"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("ControllerInstallationCare controller tests", func() {
+	var controllerInstallation *gardencorev1beta1.ControllerInstallation
+
+	BeforeEach(func() {
+		By("Create ControllerInstallation")
+		controllerInstallation = &gardencorev1beta1.ControllerInstallation{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "foo-",
+			},
+			Spec: gardencorev1beta1.ControllerInstallationSpec{
+				SeedRef: corev1.ObjectReference{
+					Name: "foo-seed",
+				},
+				RegistrationRef: corev1.ObjectReference{
+					Name: "foo-registration",
+				},
+				DeploymentRef: &corev1.ObjectReference{
+					Name: "foo-deployment",
+				},
+			},
+		}
+		Expect(testClient.Create(ctx, controllerInstallation)).To(Succeed())
+		log.Info("Created controllerinstallation for test", "controllerinstallation", client.ObjectKeyFromObject(controllerInstallation))
+
+		DeferCleanup(func() {
+			By("Delete ControllerInstallation")
+			Expect(testClient.Delete(ctx, controllerInstallation)).To(Succeed())
+		})
+	})
+
+	Context("when ManagedResources for the ControllerInstallation does not exist", func() {
+		It("should set conditions to Unknown", func() {
+			Eventually(func(g Gomega) {
+				g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(controllerInstallation), controllerInstallation)).To(Succeed())
+				g.Expect(controllerInstallation.Status.Conditions).To(ConsistOf(
+					And(ofType(gardencorev1beta1.ControllerInstallationInstalled), withStatus(gardencorev1beta1.ConditionUnknown), withReason("SeedReadError"), withMessageSubstrings("Failed to get ManagedResource", "not found")),
+					And(ofType(gardencorev1beta1.ControllerInstallationHealthy), withStatus(gardencorev1beta1.ConditionUnknown), withReason("SeedReadError"), withMessageSubstrings("Failed to get ManagedResource", "not found")),
+					And(ofType(gardencorev1beta1.ControllerInstallationProgressing), withStatus(gardencorev1beta1.ConditionUnknown), withReason("SeedReadError"), withMessageSubstrings("Failed to get ManagedResource", "not found")),
+				))
+			}).Should(Succeed())
+		})
+	})
+
+	Context("when ManagedResource for the ControllerInstallation exists", func() {
+		var managedResource *resourcesv1alpha1.ManagedResource
+
+		BeforeEach(func() {
+			By("Create ManagedResource")
+			managedResource = &resourcesv1alpha1.ManagedResource{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       controllerInstallation.Name,
+					Namespace:  gardenNamespace.Name,
+					Generation: 1,
+				},
+				Spec: resourcesv1alpha1.ManagedResourceSpec{
+					SecretRefs: []corev1.LocalObjectReference{{
+						Name: "foo-secret",
+					}},
+				},
+			}
+			Expect(testClient.Create(ctx, managedResource)).To(Succeed())
+			log.Info("Created managedresource for test", "managedresource", client.ObjectKeyFromObject(managedResource))
+
+			DeferCleanup(func() {
+				By("Delete ManagedResource")
+				Expect(testClient.Delete(ctx, managedResource)).To(Succeed())
+			})
+		})
+
+		Context("when generation of ManagedResource is outdated", func() {
+			It("shout set Installed condition to False with generation outdated error", func() {
+				Eventually(func(g Gomega) {
+					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(controllerInstallation), controllerInstallation)).To(Succeed())
+					g.Expect(controllerInstallation.Status.Conditions).To(containCondition(ofType(gardencorev1beta1.ControllerInstallationInstalled), withStatus(gardencorev1beta1.ConditionFalse), withReason("InstallationPending"), withMessageSubstrings("observed generation of managed resource", "outdated (0/1)")))
+				}).Should(Succeed())
+			})
+		})
+
+		Context("when generation of ManagedResource is up to date", func() {
+			BeforeEach(func() {
+				managedResource.Status.ObservedGeneration = managedResource.Generation
+				Expect(testClient.Status().Update(ctx, managedResource)).To(Succeed())
+			})
+
+			It("should set conditions to failed when ManagedResource conditions do not exist yet", func() {
+				Eventually(func(g Gomega) {
+					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(controllerInstallation), controllerInstallation)).To(Succeed())
+					g.Expect(controllerInstallation.Status.Conditions).To(ConsistOf(
+						And(ofType(gardencorev1beta1.ControllerInstallationInstalled), withStatus(gardencorev1beta1.ConditionFalse), withReason("InstallationPending"), withMessageSubstrings("condition", "has not been reported")),
+						And(ofType(gardencorev1beta1.ControllerInstallationHealthy), withStatus(gardencorev1beta1.ConditionFalse), withReason("ControllerNotHealthy"), withMessageSubstrings("condition", "has not been reported")),
+						And(ofType(gardencorev1beta1.ControllerInstallationProgressing), withStatus(gardencorev1beta1.ConditionTrue), withReason("ControllerNotRolledOut"), withMessageSubstrings("condition", "has not been reported")),
+					))
+				}).Should(Succeed())
+			})
+
+			It("should set conditions to failed when conditions of ManagedResource are not successful yet", func() {
+				managedResource.Status.Conditions = []gardencorev1beta1.Condition{
+					{Type: resourcesv1alpha1.ResourcesApplied, Status: gardencorev1beta1.ConditionFalse, LastTransitionTime: metav1.Now(), LastUpdateTime: metav1.Now()},
+					{Type: resourcesv1alpha1.ResourcesHealthy, Status: gardencorev1beta1.ConditionFalse, LastTransitionTime: metav1.Now(), LastUpdateTime: metav1.Now()},
+					{Type: resourcesv1alpha1.ResourcesProgressing, Status: gardencorev1beta1.ConditionTrue, LastTransitionTime: metav1.Now(), LastUpdateTime: metav1.Now()},
+				}
+				Expect(testClient.Status().Update(ctx, managedResource)).To(Succeed())
+
+				Eventually(func(g Gomega) {
+					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(controllerInstallation), controllerInstallation)).To(Succeed())
+					g.Expect(controllerInstallation.Status.Conditions).To(ConsistOf(
+						And(ofType(gardencorev1beta1.ControllerInstallationInstalled), withStatus(gardencorev1beta1.ConditionFalse), withReason("InstallationPending")),
+						And(ofType(gardencorev1beta1.ControllerInstallationHealthy), withStatus(gardencorev1beta1.ConditionFalse), withReason("ControllerNotHealthy")),
+						And(ofType(gardencorev1beta1.ControllerInstallationProgressing), withStatus(gardencorev1beta1.ConditionTrue), withReason("ControllerNotRolledOut")),
+					))
+				}).Should(Succeed())
+			})
+
+			It("should set conditions to successful when conditions of ManagedResource become successful", func() {
+				managedResource.Status.Conditions = []gardencorev1beta1.Condition{
+					{Type: resourcesv1alpha1.ResourcesApplied, Status: gardencorev1beta1.ConditionTrue, LastTransitionTime: metav1.Now(), LastUpdateTime: metav1.Now()},
+					{Type: resourcesv1alpha1.ResourcesHealthy, Status: gardencorev1beta1.ConditionTrue, LastTransitionTime: metav1.Now(), LastUpdateTime: metav1.Now()},
+					{Type: resourcesv1alpha1.ResourcesProgressing, Status: gardencorev1beta1.ConditionFalse, LastTransitionTime: metav1.Now(), LastUpdateTime: metav1.Now()},
+				}
+				Expect(testClient.Status().Update(ctx, managedResource)).To(Succeed())
+
+				Eventually(func(g Gomega) {
+					g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(controllerInstallation), controllerInstallation)).To(Succeed())
+					g.Expect(controllerInstallation.Status.Conditions).To(ConsistOf(
+						And(ofType(gardencorev1beta1.ControllerInstallationInstalled), withStatus(gardencorev1beta1.ConditionTrue), withReason("InstallationSuccessful")),
+						And(ofType(gardencorev1beta1.ControllerInstallationHealthy), withStatus(gardencorev1beta1.ConditionTrue), withReason("ControllerHealthy")),
+						And(ofType(gardencorev1beta1.ControllerInstallationProgressing), withStatus(gardencorev1beta1.ConditionFalse), withReason("ControllerRolledOut")),
+					))
+				}).Should(Succeed())
+			})
+		})
+	})
+})
+
+func containCondition(matchers ...gomegatypes.GomegaMatcher) gomegatypes.GomegaMatcher {
+	return ContainElement(And(matchers...))
+}
+
+func ofType(conditionType gardencorev1beta1.ConditionType) gomegatypes.GomegaMatcher {
+	return gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+		"Type": Equal(conditionType),
+	})
+}
+
+func withStatus(status gardencorev1beta1.ConditionStatus) gomegatypes.GomegaMatcher {
+	return gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+		"Status": Equal(status),
+	})
+}
+
+func withReason(reason string) gomegatypes.GomegaMatcher {
+	return gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+		"Reason": Equal(reason),
+	})
+}
+
+func withMessageSubstrings(messages ...string) gomegatypes.GomegaMatcher {
+	var substringMatchers = make([]gomegatypes.GomegaMatcher, 0, len(messages))
+	for _, message := range messages {
+		substringMatchers = append(substringMatchers, ContainSubstring(message))
+	}
+	return gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+		"Message": SatisfyAll(substringMatchers...),
+	})
+}

--- a/test/integration/gardenlet/controllerinstallation/care/care_test.go
+++ b/test/integration/gardenlet/controllerinstallation/care/care_test.go
@@ -35,6 +35,7 @@ var _ = Describe("ControllerInstallationCare controller tests", func() {
 		controllerInstallation = &gardencorev1beta1.ControllerInstallation{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "foo-",
+				Labels:       map[string]string{testID: testRunID},
 			},
 			Spec: gardencorev1beta1.ControllerInstallationSpec{
 				SeedRef: corev1.ObjectReference{

--- a/test/integration/gardenlet/shoot/secret/secret_suite_test.go
+++ b/test/integration/gardenlet/shoot/secret/secret_suite_test.go
@@ -99,10 +99,6 @@ var _ = BeforeSuite(func() {
 	testClient, err = client.New(restConfig, client.Options{Scheme: kubernetes.GardenScheme})
 	Expect(err).NotTo(HaveOccurred())
 
-	By("creating test client")
-	testClient, err = client.New(restConfig, client.Options{Scheme: kubernetes.GardenScheme})
-	Expect(err).NotTo(HaveOccurred())
-
 	By("creating project namespace")
 	testNamespace = &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR adds a `Progressing` type condition to `ControllerInstallations`, similar to the already existing `Installed` and `Healthy` condition which correspond to the `Applied` and `Healthy` conditions of `ManagedResources` that are created for each `ControllerInstallation`. The `Progressing` condition will be updated based on the `ManagedResource`'s `ResourcesProgressing` condition.
This new `Progressing` condition is now also checked when maintaining the `ExtensionsReady` condition of `Seeds` so that we are sure that a shoot is reconciled only after the `Seed`'s extensions have been completely updated/rolled out. When the `Progressing` condition is not `False`, the `ExtensionsReady` condition will be evaluated to `False` 

**Which issue(s) this PR fixes**:
Part of #4722 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Added condition with type `Progressing` to the `ControllerInstallation` resource, which is maintained based on the `ResourcesProgressing` condition of the `ManagedResource` created for the `ControllerInstallation`
```
```other operator
When the `ExtensionsReady` condition is evaluated, the `ControllerInstallations` `Progressing` condition is now also taken into account. When the `Progressing` condition is not `False`, the `ExtensionsReady` condition will be evaluated to `False` 
```
