### PR TITLE
Restore node labels for kube state metrics

### DIFF
--- a/pkg/operation/botanist/component/kubestatemetrics/kube_state_metrics_test.go
+++ b/pkg/operation/botanist/component/kubestatemetrics/kube_state_metrics_test.go
@@ -236,6 +236,7 @@ var _ = Describe("KubeStateMetrics", func() {
 					"--port=8080",
 					"--telemetry-port=8081",
 					"--resources=deployments,pods,statefulsets,nodes,horizontalpodautoscalers,persistentvolumeclaims,replicasets",
+					"--metric-labels-allowlist=nodes=[*]",
 				}
 				serviceAccountName = "kube-state-metrics"
 			}
@@ -261,6 +262,7 @@ var _ = Describe("KubeStateMetrics", func() {
 					"--resources=daemonsets,deployments,nodes,pods,statefulsets,verticalpodautoscalers,replicasets",
 					"--namespaces=kube-system",
 					"--kubeconfig=/var/run/secrets/gardener.cloud/shoot/generic-kubeconfig/kubeconfig",
+					"--metric-labels-allowlist=nodes=[*]",
 				}
 				automountServiceAccountToken = pointer.Bool(false)
 				volumeMounts = []corev1.VolumeMount{{

--- a/pkg/operation/botanist/component/kubestatemetrics/resources.go
+++ b/pkg/operation/botanist/component/kubestatemetrics/resources.go
@@ -204,6 +204,7 @@ func (k *kubeStateMetrics) reconcileDeployment(
 		})
 		args = append(args,
 			"--resources=deployments,pods,statefulsets,nodes,horizontalpodautoscalers,persistentvolumeclaims,replicasets",
+			"--metric-labels-allowlist=nodes=[*]",
 		)
 	}
 
@@ -218,6 +219,7 @@ func (k *kubeStateMetrics) reconcileDeployment(
 			"--resources=daemonsets,deployments,nodes,pods,statefulsets,verticalpodautoscalers,replicasets",
 			"--namespaces="+metav1.NamespaceSystem,
 			"--kubeconfig="+gutil.PathGenericKubeconfig,
+			"--metric-labels-allowlist=nodes=[*]",
 		)
 	}
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
In upgrading kube-state-metrics to 2.5.0 from 1.9.7 in https://github.com/gardener/gardener/pull/6224, kubernetes metrics
labels were made optional. They now need to be allow-listed in ksm's
launch arguments.
Now we allow-list all of kubernetes' node labels to achieve the same result
as before.

**Which issue(s) this PR fixes**:
Fix worker group dropdown in "Node/Worker Pool Overview" dashboard.

**Special notes for your reviewer**:
/cc @istvanballok

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix worker group dropdown in "Node/Worker Pool Overview" dashboard.
```
