### PR TITLE
Improve the Node/Worker Pool Overview dashboard

### DIFF
--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/node-pool-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/node-pool-dashboard.json
@@ -46,7 +46,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(sum(rate(node_cpu_seconds_total{mode!=\"idle\"}[$__rate_interval])) by (node) + on (node) group_right sum(kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}) by (label_worker_gardener_cloud_pool, node) - 1) by (label_worker_gardener_cloud_pool)",
+          "expr": "avg by (label_worker_gardener_cloud_pool) (\n    sum by (node) (rate(node_cpu_seconds_total{mode!~\"idle|iowait|steal\"}[$__rate_interval]))\n  + on (node) group_right ()\n    sum by (label_worker_gardener_cloud_pool, node) (\n      0 * kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}\n    )\n)",
           "format": "time_series",
           "intervalFactor": 2,
           "legendFormat": "{{label_worker_gardener_cloud_pool}}",
@@ -132,7 +132,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(sum(node_memory_Active_bytes) by (node) + on (node) group_right sum(kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}) by (label_worker_gardener_cloud_pool, node) - 1) by (label_worker_gardener_cloud_pool)",
+          "expr": "avg by (label_worker_gardener_cloud_pool) (\n    sum by (node) (node_memory_Active_bytes)\n  + on (node) group_right ()\n    sum by (label_worker_gardener_cloud_pool, node) (\n      0 * kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}\n    )\n)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{label_worker_gardener_cloud_pool}}",
@@ -218,7 +218,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "count(sum(kube_node_info) by (node) + on (node) group_right sum(kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}) by (label_worker_gardener_cloud_pool, node))",
+          "expr": "count(kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"})",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "nodes",
@@ -306,7 +306,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(sum(kube_pod_info{type=\"shoot\"}) by (node) + on (node) group_right sum(kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}) by (label_worker_gardener_cloud_pool, node)) by (label_worker_gardener_cloud_pool)",
+          "expr": "avg by (label_worker_gardener_cloud_pool) (\n    count by (node) (kube_pod_info{type=\"shoot\"})\n  + on (node) group_right ()\n    sum by (label_worker_gardener_cloud_pool, node) (\n      0 * kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}\n    )\n)",
           "format": "time_series",
           "intervalFactor": 1,
           "legendFormat": "{{label_worker_gardener_cloud_pool}}",
@@ -553,7 +553,7 @@
       ],
       "targets": [
         {
-          "expr": "sum(rate(node_cpu_seconds_total{mode!=\"idle\"}[$__rate_interval])) by (node) + on (node) group_right sum(kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}) by (label_worker_gardener_cloud_pool, node) - 1",
+          "expr": "  sum by (node) (rate(node_cpu_seconds_total{mode!~\"idle|iowait|steal\"}[$__rate_interval]))\n+ on (node) group_right ()\n  sum by (label_worker_gardener_cloud_pool, node) (\n    0 * kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}\n  )",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
@@ -561,21 +561,21 @@
           "refId": "B"
         },
         {
-          "expr": "sum(kube_node_status_allocatable{resource=\"cpu\", unit=\"core\"}) by (node) + on (node) group_right sum(kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}) by (label_worker_gardener_cloud_pool, node) - 1",
+          "expr": "  sum by (node) (kube_node_status_allocatable{resource=\"cpu\",unit=\"core\"})\n+ on (node) group_right ()\n  sum by (label_worker_gardener_cloud_pool, node) (\n    0 * kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}\n  )",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
           "refId": "C"
         },
         {
-          "expr": "(sum(kube_node_status_allocatable{resource=\"cpu\", unit=\"core\"}) by (node) - sum(rate(node_cpu_seconds_total{mode!=\"idle\"}[$__rate_interval])) by (node)) + on (node) group_right sum(kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}) by (label_worker_gardener_cloud_pool, node) - 1",
+          "expr": "  (\n      sum by (node) (kube_node_status_allocatable{resource=\"cpu\",unit=\"core\"})\n    -\n      sum by (node) (rate(node_cpu_seconds_total{mode!~\"idle|iowait|steal\"}[$__rate_interval]))\n  )\n+ on (node) group_right ()\n  sum by (label_worker_gardener_cloud_pool, node) (\n    0 * kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}\n  )",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
           "refId": "D"
         },
         {
-          "expr": "sum(node_memory_Active_bytes) by (node) + on (node) group_right sum(kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}) by (label_worker_gardener_cloud_pool, node) - 1",
+          "expr": "  sum by (node) (node_memory_Active_bytes)\n+ on (node) group_right ()\n  sum by (label_worker_gardener_cloud_pool, node) (\n    0 * kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}\n  )",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
@@ -583,21 +583,21 @@
           "refId": "E"
         },
         {
-          "expr": "sum(kube_node_status_allocatable{resource=\"memory\", unit=\"byte\"}) by (node) + on (node) group_right sum(kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}) by (label_worker_gardener_cloud_pool, node) - 1",
+          "expr": "  sum by (node) (kube_node_status_allocatable{resource=\"memory\",unit=\"byte\"})\n+ on (node) group_right ()\n  sum by (label_worker_gardener_cloud_pool, node) (\n    0 * kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}\n  )",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
           "refId": "F"
         },
         {
-          "expr": "(sum(kube_node_status_allocatable{resource=\"memory\", unit=\"byte\"}) by (node) - sum(node_memory_Active_bytes) by (node)) + on (node) group_right sum(kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}) by (label_worker_gardener_cloud_pool, node) - 1",
+          "expr": "  (\n      sum by (node) (kube_node_status_allocatable{resource=\"memory\",unit=\"byte\"})\n    -\n      sum by (node) (node_memory_Active_bytes)\n  )\n+ on (node) group_right ()\n  sum by (label_worker_gardener_cloud_pool, node) (\n    0 * kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}\n  )",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
           "refId": "G"
         },
         {
-          "expr": "sum(kube_pod_info{type=\"shoot\"}) by (node) + on (node) group_right sum(kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}) by (label_worker_gardener_cloud_pool, node)",
+          "expr": "  count by (node) (kube_pod_info{type=\"shoot\"})\n+ on (node) group_right ()\n  sum by (label_worker_gardener_cloud_pool, node) (\n    0 * kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}\n  )",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
@@ -669,7 +669,7 @@
           "targets": [
             {
               "exemplar": true,
-              "expr": "sum(node_nf_conntrack_stat_insert_failed) by (node)",
+              "expr": "sum(rate(node_nf_conntrack_stat_insert_failed[$__rate_interval])) by (node)",
               "interval": "",
               "legendFormat": "{{node}}",
               "refId": "A"
@@ -696,7 +696,7 @@
           "yaxes": [
             {
               "$$hashKey": "object:115",
-              "decimals": 0,
+              "decimals": null,
               "format": "short",
               "label": null,
               "logBase": 1,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

Improve the Node/Worker Pool Overview dashboard

The query of the panel
"Average # of Pods on each Node in Worker Group(s) $worker_group"
was incorrect: it was off by 1.

The new query uses count instead of sum because actually we want to
count the pods.

When the 2 vectors are merged with the + operator to enrich the series
with the worker group label, we should add 0 instead of 1 to avoid
manipulating the result.

Note that we used the new Prometheus feature to format this query:

```
avg by (label_worker_gardener_cloud_pool) (
    count by (node) (kube_pod_info{type="shoot"})
  + on (node) group_right ()
    sum by (label_worker_gardener_cloud_pool, node) (
      0 * kube_node_labels{label_worker_gardener_cloud_pool=~"etcd.+"}
    )
)
```

The query of the panel
"Number of Nodes in Worker Group(s) $worker_group"
could be simplified.

The query of the panel
"Average Memory Usage of Nodes in Worker Group(s) $worker_group"
was slightly improved.

The query of the panel
"Average CPU Usage of Nodes in Worker Group(s) $worker_group"
was improved to exclude the iowait and steal CPU times.

The "Failed Connection Tracking Inserts" panel was missing the
rate function for the counter metric.

The queries of the "Overview of all nodes" table were also formatted
and improved in a similar way.


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/cc @rickardsjp 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Improve the Node/Worker Pool Overview dashboard
```
