### PR TITLE
Fix bug in resourcemanager that the ignore annotation does not handle all possible truthy values

### DIFF
--- a/docs/concepts/resource-manager.md
+++ b/docs/concepts/resource-manager.md
@@ -449,7 +449,7 @@ users:
     token: ""
 ```
 
-then the `.users[0].user.token` field of the kubeconfig will be updated accordingly. 
+then the `.users[0].user.token` field of the kubeconfig will be updated accordingly.
 
 The controller also adds an annotation to the `Secret` to keep track when to renew the token before it expires.
 By default, the tokens are issued to expire after 12 hours. The expiration time can be set with the following annotation:
@@ -468,7 +468,7 @@ token-requestor.resources.gardener.cloud/target-secret-namespace: "bar"
 ```
 
 Overall, the TokenRequestor controller provides credentials with limited lifetime (JWT tokens) used by Shoot control plane components running in the Seed
-to talk to the Shoot API Server. 
+to talk to the Shoot API Server.
 Please see the graphic below:
 
 ![image](images/resource-manager-projected-token-controlplane-to-shoot-apiserver.jpg)

--- a/pkg/resourcemanager/controller/health/add.go
+++ b/pkg/resourcemanager/controller/health/add.go
@@ -16,6 +16,7 @@ package health
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -220,5 +221,10 @@ var progressingStatusChanged = predicate.Funcs{
 }
 
 func isIgnored(obj client.Object) bool {
-	return obj.GetAnnotations()[resourcesv1alpha1.Ignore] == "true"
+	value, ok := obj.GetAnnotations()[resourcesv1alpha1.Ignore]
+	if !ok {
+		return false
+	}
+	truthy, _ := strconv.ParseBool(value)
+	return truthy
 }

--- a/pkg/resourcemanager/predicate/ignore.go
+++ b/pkg/resourcemanager/predicate/ignore.go
@@ -15,6 +15,8 @@
 package predicate
 
 import (
+	"strconv"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -69,5 +71,10 @@ func GotMarkedAsIgnored() predicate.Predicate {
 }
 
 func isIgnored(obj client.Object) bool {
-	return obj.GetAnnotations()[resourcesv1alpha1.Ignore] == "true"
+	value, ok := obj.GetAnnotations()[resourcesv1alpha1.Ignore]
+	if !ok {
+		return false
+	}
+	truthy, _ := strconv.ParseBool(value)
+	return truthy
 }

--- a/pkg/resourcemanager/predicate/ignore_test.go
+++ b/pkg/resourcemanager/predicate/ignore_test.go
@@ -59,7 +59,7 @@ var _ = Describe("ignore", func() {
 			})
 
 			It("should not match because ignore annotation is present", func() {
-				metav1.SetMetaDataAnnotation(&managedResource.ObjectMeta, "resources.gardener.cloud/ignore", "true")
+				metav1.SetMetaDataAnnotation(&managedResource.ObjectMeta, "resources.gardener.cloud/ignore", "TRUE")
 
 				Expect(predicate.Update(event.UpdateEvent{ObjectNew: managedResource})).To(BeFalse())
 			})
@@ -71,7 +71,7 @@ var _ = Describe("ignore", func() {
 			})
 
 			It("should not match because ignore annotation is present", func() {
-				metav1.SetMetaDataAnnotation(&managedResource.ObjectMeta, "resources.gardener.cloud/ignore", "true")
+				metav1.SetMetaDataAnnotation(&managedResource.ObjectMeta, "resources.gardener.cloud/ignore", "T")
 
 				Expect(predicate.Delete(event.DeleteEvent{Object: managedResource})).To(BeFalse())
 			})
@@ -83,7 +83,7 @@ var _ = Describe("ignore", func() {
 			})
 
 			It("should not match because ignore annotation is present", func() {
-				metav1.SetMetaDataAnnotation(&managedResource.ObjectMeta, "resources.gardener.cloud/ignore", "true")
+				metav1.SetMetaDataAnnotation(&managedResource.ObjectMeta, "resources.gardener.cloud/ignore", "1")
 
 				Expect(predicate.Generic(event.GenericEvent{Object: managedResource})).To(BeFalse())
 			})
@@ -107,7 +107,7 @@ var _ = Describe("ignore", func() {
 					old := managedResource.DeepCopy()
 
 					if oldIgnored {
-						metav1.SetMetaDataAnnotation(&old.ObjectMeta, "resources.gardener.cloud/ignore", "true")
+						metav1.SetMetaDataAnnotation(&old.ObjectMeta, "resources.gardener.cloud/ignore", "True")
 					}
 					if newIgnored {
 						metav1.SetMetaDataAnnotation(&managedResource.ObjectMeta, "resources.gardener.cloud/ignore", "true")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
Fix bug in resourcemanager that the ignore annotation does not handle all possible truthy values as described in https://github.com/gardener/gardener/blob/v1.54.0/docs/concepts/resource-manager.md#ignoring-updates

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
A bug in resourcemanager that not all truthy values were considered for the `resources.gardener.cloud/ignore` annotation value is fixed.
```
