### PR TITLE
Reduce the size of the grafana dashboards configmap

### DIFF
--- a/charts/seed-bootstrap/templates/grafana/_helpers.tpl
+++ b/charts/seed-bootstrap/templates/grafana/_helpers.tpl
@@ -60,15 +60,19 @@ datasources.yaml: |-
 grafana-datasources-{{ include "grafana.datasources.data" . | sha256sum | trunc 8 }}
 {{- end }}
 
+{{- define "grafana.toCompactedJson" -}}
+{{ . | fromJson | toJson}}
+{{- end }}
+
 {{- define "grafana.dashboards.data" -}}
 {{ range $name, $bytes := .Files.Glob "dashboards/**.json" }}
 {{ base $name }}: |-
-{{ toString $bytes | indent 4}}
+{{ toString $bytes | include "grafana.toCompactedJson" | indent 2}}
 {{ end }}
 {{ if .Values.istio.enabled }}
 {{ range $name, $bytes := .Files.Glob "dashboards/istio/**.json" }}
 {{ base $name }}: |-
-{{ toString $bytes | indent 4}}
+{{ toString $bytes | include "grafana.toCompactedJson" | indent 2}}
 {{ end }}
 {{- end }}
 {{- end -}}

--- a/charts/seed-monitoring/charts/grafana/templates/_helpers.tpl
+++ b/charts/seed-monitoring/charts/grafana/templates/_helpers.tpl
@@ -51,34 +51,38 @@ datasources.yaml: |-
 grafana-{{ .Values.role }}-datasources-{{ include "grafana.datasources.data" . | sha256sum | trunc 8 }}
 {{- end }}
 
+{{- define "grafana.toCompactedJson" -}}
+{{ . | fromJson | toJson}}
+{{- end }}
+
 {{- define "grafana.dashboards.data" -}}
 {{- if .Values.sni.enabled }}
 {{ range $name, $bytes := .Files.Glob "dashboards/operators/istio/**.json" }}
 {{ base $name }}: |-
-{{ toString $bytes | indent 2 }}
+{{ toString $bytes | include "grafana.toCompactedJson" | indent 2 }}
 {{- end }}
 {{- end }}
 {{- if .Values.nodeLocalDNS.enabled }}
 {{ range $name, $bytes := .Files.Glob "dashboards/dns/**.json" }}
 {{ base $name }}: |-
-{{ toString $bytes | indent 2 }}
+{{ toString $bytes | include "grafana.toCompactedJson" | indent 2 }}
 {{- end }}
 {{- end }}
 {{ if eq .Values.role "users" }}
 {{ range $name, $bytes := .Files.Glob "dashboards/owners/**.json" }}
 {{ if not (and (eq $name "dashboards/owners/shoot-vpa-dashboard.json") (eq $.Values.vpaEnabled false)) }}
 {{ base $name }}: |-
-{{ toString $bytes | indent 2 }}
+{{ toString $bytes | include "grafana.toCompactedJson" | indent 2 }}
 {{ end }}
 {{ end }}
 {{ else }}
 {{ range $name, $bytes := .Files.Glob "dashboards/owners/**.json" }}
 {{ base $name }}: |-
-{{ toString $bytes | indent 2 }}
+{{ toString $bytes | include "grafana.toCompactedJson" | indent 2 }}
 {{ end }}
 {{ range $name, $bytes := .Files.Glob "dashboards/operators/**.json" }}
 {{ base $name }}: |-
-{{ toString $bytes | indent 2 }}
+{{ toString $bytes | include "grafana.toCompactedJson" | indent 2 }}
 {{ end }}
 {{ end }}
 {{- if .Values.extensions.dashboards }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

Reduce the size of the grafana dashboards configmap

All the grafana dashboards are collected in a single configmap, and in
some configurations we reached the 1MB size limit of configmaps.

As a short term mitigation, at least for the non-extension dashboards,
we use the "compact" (like jq -c) JSON representation instead of the
currently used pretty printed representation, which could save about
50% of the size.

We considered other short term approaches:
- use the compact json representation in github or remove the leading whitespace in each line.
  - This approach would make github code reviews for dashboards more difficult / impossible.

and the mid term approach, that we'll implement later with GEP-19:
- use a single configmap per dashboard

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/cc @rickardsjp 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The gardener grafana dashboards are serialized with the "compact" JSON representation into the configmap to avoid reaching the configmap size limit.
```
