### PR TITLE
Adjust metrics-server memory resource requests when VPA is enabled

### DIFF
--- a/pkg/operation/botanist/component/metricsserver/metrics_server.go
+++ b/pkg/operation/botanist/component/metricsserver/metrics_server.go
@@ -395,6 +395,11 @@ func (m *metricsServer) computeResourcesData(serverSecret, caSecret *corev1.Secr
 	}
 
 	if m.values.VPAEnabled {
+		deployment.Spec.Template.Spec.Containers[0].Resources.Requests = corev1.ResourceList{
+			corev1.ResourceCPU:    resource.MustParse("50m"),
+			corev1.ResourceMemory: resource.MustParse("60Mi"),
+		}
+
 		vpaUpdateMode := vpaautoscalingv1.UpdateModeAuto
 		controlledValues := vpaautoscalingv1.ContainerControlledValuesRequestsOnly
 		vpa = &vpaautoscalingv1.VerticalPodAutoscaler{
@@ -417,7 +422,7 @@ func (m *metricsServer) computeResourcesData(serverSecret, caSecret *corev1.Secr
 							ContainerName: vpaautoscalingv1.DefaultContainerResourcePolicy,
 							MinAllowed: corev1.ResourceList{
 								corev1.ResourceCPU:    resource.MustParse("50m"),
-								corev1.ResourceMemory: resource.MustParse("150Mi"),
+								corev1.ResourceMemory: resource.MustParse("60Mi"),
 							},
 							ControlledValues: &controlledValues,
 						},

--- a/pkg/operation/botanist/component/metricsserver/metrics_server_test.go
+++ b/pkg/operation/botanist/component/metricsserver/metrics_server_test.go
@@ -100,7 +100,7 @@ spec:
       controlledValues: RequestsOnly
       minAllowed:
         cpu: 50m
-        memory: 150Mi
+        memory: 60Mi
   targetRef:
     apiVersion: apps/v1
     kind: Deployment
@@ -187,7 +187,12 @@ metadata:
   namespace: kube-system
 `
 
-		deploymentYAMLFor = func(secretName string, withHostEnv bool) string {
+		deploymentYAMLFor = func(secretName string, withHostEnv, vpaEnabled bool) string {
+			memoryRequests := "150Mi"
+			if vpaEnabled {
+				memoryRequests = "60Mi"
+			}
+
 			out := `apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -266,7 +271,7 @@ spec:
             memory: 1Gi
           requests:
             cpu: 50m
-            memory: 150Mi
+            memory: ` + memoryRequests + `
         volumeMounts:
         - mountPath: /srv/metrics-server/tls
           name: metrics-server
@@ -379,7 +384,7 @@ status: {}
 				}
 			}
 
-			Expect(string(managedResourceSecret.Data["deployment__kube-system__metrics-server.yaml"])).To(Equal(deploymentYAMLFor(secretName, false)))
+			Expect(string(managedResourceSecret.Data["deployment__kube-system__metrics-server.yaml"])).To(Equal(deploymentYAMLFor(secretName, false, false)))
 
 			secret := &corev1.Secret{}
 			Expect(runtime.DecodeInto(newCodec(), managedResourceSecret.Data["secret__kube-system__"+secretName+".yaml"], secret)).To(Succeed())
@@ -439,7 +444,7 @@ status: {}
 				}
 			}
 
-			Expect(string(managedResourceSecret.Data["deployment__kube-system__metrics-server.yaml"])).To(Equal(deploymentYAMLFor(secretName, true)))
+			Expect(string(managedResourceSecret.Data["deployment__kube-system__metrics-server.yaml"])).To(Equal(deploymentYAMLFor(secretName, true, true)))
 
 			secret := &corev1.Secret{}
 			Expect(runtime.DecodeInto(newCodec(), managedResourceSecret.Data["secret__kube-system__"+secretName+".yaml"], secret)).To(Succeed())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area scalability
/kind enhancement

**What this PR does / why we need it**:
Adjust the `metrics-server` initial memory resource requests and corresponding memory `minAllowed` values to 60Mi when VPA is enabled. This will avoid redundant memory reservation as value of 150Mi is enough for ~4000 containers and most of the clusters have much less containers.
**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
