### PR TITLE
Adapt blackbox exporter resource requests to VPA recommendations

### DIFF
--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/prometheus.yaml
@@ -148,8 +148,8 @@ spec:
           protocol: TCP
         resources:
           requests:
-            cpu: 5m
-            memory: 35Mi
+            cpu: 10m
+            memory: 25Mi
           limits:
             memory: 128Mi
         volumeMounts:

--- a/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/deployment.yaml
+++ b/charts/shoot-core/components/charts/monitoring/charts/blackbox-exporter/templates/deployment.yaml
@@ -62,9 +62,9 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 5Mi
+            memory: 25Mi
           limits:
-            memory: 150Mi
+            memory: 128Mi
         ports:
         - containerPort: 9115
           protocol: TCP


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

Adapt blackbox exporter resource requests to VPA recommendations

Motivation: we observed that soon after a shoot cluster is woken up
from hibernation (or after it was created), the blackbox exporter deployment is rolled by
the VPA updater:

   Pod was evicted by VPA Updater to apply resource recommendation.

The resource requests and limits of the 2 blackbox exporters are aligned
as well.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/cc @rickardsjp 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Adapt blackbox exporter resource requests to VPA recommendations
```
