### PR TITLE
Make sure the `default-scheduler` is present even when bin-packing is enabled

### DIFF
--- a/pkg/operation/botanist/component/kubescheduler/kube_scheduler.go
+++ b/pkg/operation/botanist/component/kubescheduler/kube_scheduler.go
@@ -82,6 +82,7 @@ leaderElection:
   leaderElect: true
 {{- if eq .profile "bin-packing" }}
 profiles:
+- schedulerName: ` + corev1.DefaultSchedulerName + `
 {{- if or (eq .apiVersion "kubescheduler.config.k8s.io/v1alpha2") (eq .apiVersion "kubescheduler.config.k8s.io/v1beta1") }}
 - schedulerName: ` + BinPackingSchedulerName + `
   plugins:

--- a/pkg/operation/botanist/component/kubescheduler/kube_scheduler_test.go
+++ b/pkg/operation/botanist/component/kubescheduler/kube_scheduler_test.go
@@ -683,6 +683,7 @@ leaderElection:
   leaderElect: true
 {{- if eq .profile "bin-packing" }}
 profiles:
+- schedulerName: default-scheduler
 {{- if or (eq .apiVersion "kubescheduler.config.k8s.io/v1alpha2") (eq .apiVersion "kubescheduler.config.k8s.io/v1beta1") }}
 - schedulerName: bin-packing-scheduler
   plugins:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
Currently for bin-packing enabled Shoots we observe the following issue. There are some Pods that fail to be scheduled and stay in `Pending`.

```
$ k -n kube-system get po blackbox-exporter-78dff9b57f-bntc2
NAME                                                 READY   STATUS    RESTARTS   AGE
blackbox-exporter-78dff9b57f-bntc2                   0/1     Pending   0          100m
```

The reason for this is that the schedulerName of the Pod is `default-scheduler`:
```
$ k -n kube-system get po blackbox-exporter-78dff9b57f-bntc2 -o yaml | grep schedulerName
  schedulerName: default-scheduler
```
(When bin-packing is enabled we don't specify explicitly in the `default-scheduler` - it is no longer known to the kube-scheduler)

Hence, the Pod was not mutated by the `pod-scheduler-name.resources.gardener.cloud` webhook.

The reason for this is that the kube-apiserver failed to call the  webhook (or the webhook failed to respond):
```
W0901 06:04:12.551320       1 dispatcher.go:176] Failed calling webhook, failing open pod-scheduler-name.resources.gardener.cloud: failed calling webhook "pod-scheduler-name.resources.gardener.cloud": failed to call webhook: Post "https://gardener-resource-manager.shoot--foo--bar:443/webhooks/default-pod-scheduler-name?timeout=10s": dial tcp 10.243.12.146:443: connect: connection refused
E0901 06:04:12.551354       1 dispatcher.go:180] failed calling webhook "pod-scheduler-name.resources.gardener.cloud": failed to call webhook: Post "https://gardener-resource-manager.shoot--foo--bar:443/webhooks/default-pod-scheduler-name?timeout=10s": dial tcp 10.243.12.146:443: connect: connection refused
W0901 06:04:12.583348       1 dispatcher.go:176] Failed calling webhook, failing open pod-scheduler-name.resources.gardener.cloud: failed calling webhook "pod-scheduler-name.resources.gardener.cloud": failed to call webhook: Post "https://gardener-resource-manager.shoot--foo--bar:443/webhooks/default-pod-scheduler-name?timeout=10s": dial tcp 10.243.12.146:443: connect: connection refused
E0901 06:04:12.583380       1 dispatcher.go:180] failed calling webhook "pod-scheduler-name.resources.gardener.cloud": failed to call webhook: Post "https://gardener-resource-manager.shoot--foo--bar:443/webhooks/default-pod-scheduler-name?timeout=10s": dial tcp 10.243.12.146:443: connect: connection refused
```

The `pod-scheduler-name.resources.gardener.cloud` webhook runs with `failurePolicy: Ignore` and that's why in such cases a Pod can "by-pass" the webhook and request the `default-scheduler` (defaulted by kube-apiserver).

There are 2 possible ways to tackle the issue:
1. Add the `default-scheduler` to the kube-scheduler explicitly when the bin-packing is enabled. This would mean if there is something wrong with the webhook and request to it fail, the Pods will be scheduled by the `default scheduler`.
2. Change the webhook's `failurePolicy` to `Fail` and do not allow Pods to be scheduled when the requests to the webhook fail.

I picked approach 1. as it seems more reasonable to do not block the scheduling. Anyways failed requests to the webhook should be rather a rare case. This is also how I think GKE handle the webhook and kube-scheduler for their `optimize-utilization` autoscaling profile - they run the webhook with `failurePolicy: Ignore` and the `default-scheduler` seems to be present in the kube-scheduler component config. 

**Which issue(s) this PR fixes**:
See above.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
3. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
An issue that could potentially cause Pod to fail to be scheduled when the `bin-packing` scheduling profile is used is now fixed. When the kube-apiserver fails to call the `pod-scheduler-name.resources.gardener.cloud` webhook the corresponding Pod will be scheduled according to the `default-scheduler`.
```
