### PR TITLE
Improve network I/O metric relabeling and refine dashboard

### DIFF
--- a/charts/seed-bootstrap/templates/prometheus/config.yaml
+++ b/charts/seed-bootstrap/templates/prometheus/config.yaml
@@ -56,9 +56,16 @@ data:
         # The system container POD is used for networking
         regex: POD;({{ without .Values.allowedMetrics.cAdvisor "container_network_receive_bytes_total" "container_network_transmit_bytes_total" | join "|" }})
         action: drop
-      - source_labels: [ container ]
-        regex: ^$
+      - source_labels: [ __name__, container, interface, id ]
+        regex: container_network.+;;(eth0;/.+|(ens.+|tunl0|eth0);/)|.+;.+;.*;.*
+        action: keep
+      - source_labels: [ __name__, container, interface ]
+        regex: container_network.+;POD;(.{5,}|tun0|en.+)
         action: drop
+      - source_labels: [ __name__, id ]
+        regex: container_network.+;/
+        target_label: host_network
+        replacement: "true"
       # drop terraform pods
       - source_labels: [ pod ]
         regex: ^.+\.tf-pod.+$

--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
@@ -165,9 +165,16 @@ data:
         # The system container POD is used for networking
         regex: POD;({{ without .Values.allowedMetrics.cAdvisor "container_network_receive_bytes_total" "container_network_transmit_bytes_total" | join "|" }})
         action: drop
-      - source_labels: [ container ]
-        regex: ^$
+      - source_labels: [ __name__, container, interface, id ]
+        regex: container_network.+;;(eth0;/.+|(ens.+|tunl0|eth0);/)|.+;.+;.*;.*
+        action: keep
+      - source_labels: [ __name__, container, interface ]
+        regex: container_network.+;POD;(.{5,}|tun0|en.+)
         action: drop
+      - source_labels: [ __name__, id ]
+        regex: container_network.+;/
+        target_label: host_network
+        replacement: "true"
       - regex: ^id$
         action: labeldrop
 

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-pods-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-pods-dashboard.json
@@ -396,11 +396,104 @@
       }
     },
     {
+      "datasource": null,
+      "description": "If host_network is true, the pod will not have network I/O metrics.\n\nNote: For pods that use the host network, we cannot collect meaningful network metrics, because the host network includes network traffic from the system services and other pods. Therefore, this dashboard only shows the network traffic for pods which are not in the host network namespace.\n",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": null,
+            "filterable": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "pod"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 156
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 0,
+        "y": 16
+      },
+      "id": 10,
+      "options": {
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "7.5.16",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "max(kube_pod_info{pod=~\"$pod\"}) by(pod, host_network)",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Host Network",
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "pod",
+                "host_network"
+              ]
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {
+              "host_network": 1,
+              "pod": 0
+            },
+            "renameByName": {}
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
+      "description": "Note: For pods that use the host network, we cannot collect meaningful network metrics, because the host network includes network traffic from the system services and other pods. Therefore, this dashboard only shows the network traffic for pods which are not in the host network namespace.",
       "editable": true,
       "error": false,
       "fieldConfig": {

--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/node-details-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/node-details-dashboard.json
@@ -528,22 +528,22 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(rate(container_network_receive_bytes_total{kubernetes_io_hostname=~\"^$Node$\",type=\"shoot\"}[$__rate_interval]))",
+          "expr": "sum(rate(container_network_receive_bytes_total{kubernetes_io_hostname=~\"^$Node$\",type=\"shoot\",host_network=\"true\"}[$__rate_interval])) by (interface)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "Received",
+          "legendFormat": "Received {{interface}}",
           "metric": "network",
           "refId": "A",
           "step": 10
         },
         {
           "exemplar": true,
-          "expr": "- sum (rate(container_network_transmit_bytes_total{kubernetes_io_hostname=~\"^$Node$\",type=\"shoot\"}[$__rate_interval]))",
+          "expr": "- sum (rate(container_network_transmit_bytes_total{kubernetes_io_hostname=~\"^$Node$\",type=\"shoot\",host_network=\"true\"}[$__rate_interval])) by (interface)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "Sent",
+          "legendFormat": "Sent {{interface}}",
           "metric": "network",
           "refId": "B",
           "step": 10


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
Enhance containerd network I/O metrics.
Add a table next to the network I/O panel that shows whether a pod is in the host network namespace. This is important because if pods are in the host network namespace, we cannot collect meaningful metrics. The host network includes traffic from system services and other pods.

**Which issue(s) this PR fixes**:
Fixes an issue with the network I/O dashboard in clusters using containerd

**Special notes for your reviewer**:
/cc @istvanballok @wyb1 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Improve network I/O metric relabeling and refine dashboard
```
