### PR TITLE
Add panels for cpu/memory utilization per worker pool(s)

### DIFF
--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/node-details-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/node-details-dashboard.json
@@ -110,7 +110,7 @@
       "pluginVersion": "7.5.16",
       "targets": [
         {
-          "expr": "sum(rate(node_cpu_seconds_total{mode!=\"idle\", node=~\"$Node\"}[$__rate_interval])) / sum(kube_node_status_capacity{resource=\"cpu\", unit=\"core\", node=~\"$Node\"}) * 100",
+          "expr": "sum(rate(node_cpu_seconds_total{mode=~\"system|user|irq|softirq\", node=~\"$Node\"}[$__rate_interval])) / sum(kube_node_status_capacity{resource=\"cpu\", unit=\"core\", node=~\"$Node\"}) * 100",
           "format": "time_series",
           "instant": true,
           "intervalFactor": 1,
@@ -264,7 +264,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(rate(node_cpu_seconds_total{mode!=\"idle\", node=~\"$Node\"}[$__rate_interval]))",
+          "expr": "sum(rate(node_cpu_seconds_total{mode=~\"system|user|irq|softirq\", node=~\"$Node\"}[$__rate_interval]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -280,7 +280,7 @@
         },
         {
           "exemplar": true,
-          "expr": "sum(kube_node_status_capacity{resource=\"cpu\", unit=\"core\", node=~\"$Node\"}) - sum(rate(node_cpu_seconds_total{mode!=\"idle\", node=~\"$Node\"}[$__rate_interval]))",
+          "expr": "sum(kube_node_status_capacity{resource=\"cpu\", unit=\"core\", node=~\"$Node\"}) - sum(rate(node_cpu_seconds_total{mode=~\"system|user|irq|softirq\", node=~\"$Node\"}[$__rate_interval]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,

--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/node-pool-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/node-pool-dashboard.json
@@ -68,7 +68,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "avg by (label_worker_gardener_cloud_pool) (\n    sum by (node) (rate(node_cpu_seconds_total{mode!~\"idle|iowait|steal\"}[$__rate_interval]))\n  + on (node) group_right ()\n    sum by (label_worker_gardener_cloud_pool, node) (\n      0 * kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}\n    )\n)",
+          "expr": "avg by (label_worker_gardener_cloud_pool) (\n    sum by (node) (rate(node_cpu_seconds_total{mode=~\"system|user|irq|softirq\"}[$__rate_interval]))\n  + on (node) group_right ()\n    sum by (label_worker_gardener_cloud_pool, node) (\n      0 * kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}\n    )\n)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -264,7 +264,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "avg by (label_worker_gardener_cloud_pool) (\nsum by (node) (rate(node_cpu_seconds_total{mode!~\"idle|iowait|steal\"}[5m])) / sum by (node) (kube_node_status_capacity{resource=\"cpu\", unit=\"core\"}) * 100\n+ on (node) group_right ()\n  sum by (label_worker_gardener_cloud_pool, node) (\n    0 * kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}\n  )\n)",
+          "expr": "avg by (label_worker_gardener_cloud_pool) (\n        sum by (node) (rate(node_cpu_seconds_total{mode=~\"system|user|irq|softirq\"}[$__rate_interval]))\n      /\n        sum by (node) (kube_node_status_capacity{resource=\"cpu\",unit=\"core\"})\n    *\n      100\n  + on (node) group_right ()\n    sum by (label_worker_gardener_cloud_pool, node) (\n      0 * kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}\n    )\n)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{label_worker_gardener_cloud_pool}}",
@@ -362,7 +362,7 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "avg by (label_worker_gardener_cloud_pool) (\nsum by (node) ((node_memory_MemTotal_bytes{} - node_memory_MemAvailable_bytes{}) / node_memory_MemTotal_bytes{}) * 100\n+ on (node) group_right ()\n  sum by (label_worker_gardener_cloud_pool, node) (\n    0 * kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}\n  )\n)",
+          "expr": "avg by (label_worker_gardener_cloud_pool) (\n      sum by (node) (\n        (node_memory_MemTotal_bytes - node_memory_MemAvailable_bytes) / node_memory_MemTotal_bytes\n      )\n    *\n      100\n  + on (node) group_right ()\n    sum by (label_worker_gardener_cloud_pool, node) (\n      0 * kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}\n    )\n)",
           "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{label_worker_gardener_cloud_pool}}",
@@ -822,7 +822,7 @@
       ],
       "targets": [
         {
-          "expr": "  sum by (node) (rate(node_cpu_seconds_total{mode!~\"idle|iowait|steal\"}[$__rate_interval]))\n+ on (node) group_right ()\n  sum by (label_worker_gardener_cloud_pool, node) (\n    0 * kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}\n  )",
+          "expr": "  sum by (node) (rate(node_cpu_seconds_total{mode=~\"system|user|irq|softirq\"}[$__rate_interval]))\n+ on (node) group_right ()\n  sum by (label_worker_gardener_cloud_pool, node) (\n    0 * kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}\n  )",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,
@@ -837,7 +837,7 @@
           "refId": "C"
         },
         {
-          "expr": "  (\n      sum by (node) (kube_node_status_allocatable{resource=\"cpu\",unit=\"core\"})\n    -\n      sum by (node) (rate(node_cpu_seconds_total{mode!~\"idle|iowait|steal\"}[$__rate_interval]))\n  )\n+ on (node) group_right ()\n  sum by (label_worker_gardener_cloud_pool, node) (\n    0 * kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}\n  )",
+          "expr": "  (\n      sum by (node) (kube_node_status_allocatable{resource=\"cpu\",unit=\"core\"})\n    -\n      sum by (node) (rate(node_cpu_seconds_total{mode=~\"system|user|irq|softirq\"}[$__rate_interval]))\n  )\n+ on (node) group_right ()\n  sum by (label_worker_gardener_cloud_pool, node) (\n    0 * kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}\n  )",
           "format": "table",
           "instant": true,
           "intervalFactor": 1,

--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/node-pool-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/node-pool-dashboard.json
@@ -1,12 +1,22 @@
-
 {
   "annotations": {
-    "list": []
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
   },
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1560432099527,
+  "id": 29,
+  "iteration": 1662037380383,
   "links": [],
   "panels": [
     {
@@ -14,14 +24,21 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "description": "Shows the average CPU usage of all nodes in the selected worker group(s).",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 12,
         "x": 0,
         "y": 0
       },
+      "hiddenSeries": false,
       "id": 8,
       "legend": {
         "avg": false,
@@ -36,7 +53,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "7.5.16",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -46,8 +67,10 @@
       "steppedLine": false,
       "targets": [
         {
+          "exemplar": true,
           "expr": "avg by (label_worker_gardener_cloud_pool) (\n    sum by (node) (rate(node_cpu_seconds_total{mode!~\"idle|iowait|steal\"}[$__rate_interval]))\n  + on (node) group_right ()\n    sum by (label_worker_gardener_cloud_pool, node) (\n      0 * kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}\n    )\n)",
           "format": "time_series",
+          "interval": "",
           "intervalFactor": 2,
           "legendFormat": "{{label_worker_gardener_cloud_pool}}",
           "refId": "A"
@@ -73,6 +96,7 @@
       },
       "yaxes": [
         {
+          "$$hashKey": "object:1495",
           "format": "short",
           "label": "Cores",
           "logBase": 1,
@@ -81,6 +105,7 @@
           "show": true
         },
         {
+          "$$hashKey": "object:1496",
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -99,14 +124,21 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "description": "Shows the memory usage of all nodes in the selected worker group(s).",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 12,
         "x": 12,
         "y": 0
       },
+      "hiddenSeries": false,
       "id": 10,
       "legend": {
         "alignAsTable": false,
@@ -122,7 +154,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "7.5.16",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -185,15 +221,218 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
-      "decimals": 0,
-      "description": "Shows the number of nodes of selected worker groups in the cluster over time.",
+      "datasource": null,
+      "description": "Shows the average CPU utilization of all nodes in the selected worker group(s).",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
-        "h": 7,
+        "h": 8,
         "w": 12,
         "x": 0,
         "y": 7
       },
+      "hiddenSeries": false,
+      "id": 18,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.16",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "avg by (label_worker_gardener_cloud_pool) (\nsum by (node) (rate(node_cpu_seconds_total{mode!~\"idle|iowait|steal\"}[5m])) / sum by (node) (kube_node_status_capacity{resource=\"cpu\", unit=\"core\"}) * 100\n+ on (node) group_right ()\n  sum by (label_worker_gardener_cloud_pool, node) (\n    0 * kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}\n  )\n)",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{label_worker_gardener_cloud_pool}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Average CPU Utilization of Nodes in Worker Group(s) $worker_group",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1443",
+          "format": "short",
+          "label": "Percentile",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1444",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "Shows the average memory utilization of all nodes in the selected worker group(s).",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 7
+      },
+      "hiddenSeries": false,
+      "id": 20,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.16",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "avg by (label_worker_gardener_cloud_pool) (\nsum by (node) ((node_memory_MemTotal_bytes{} - node_memory_MemAvailable_bytes{}) / node_memory_MemTotal_bytes{}) * 100\n+ on (node) group_right ()\n  sum by (label_worker_gardener_cloud_pool, node) (\n    0 * kube_node_labels{label_worker_gardener_cloud_pool=~\"$worker_group\"}\n  )\n)",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{label_worker_gardener_cloud_pool}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Average Memory Utilization of Nodes in Worker Group(s) $worker_group",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:1707",
+          "format": "short",
+          "label": "Percentile",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:1708",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": 0,
+      "description": "Shows the number of nodes of selected worker groups in the cluster over time.",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 12,
+        "x": 0,
+        "y": 15
+      },
+      "hiddenSeries": false,
       "id": 6,
       "legend": {
         "avg": false,
@@ -208,7 +447,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "7.5.16",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -272,15 +515,22 @@
       "bars": false,
       "dashLength": 10,
       "dashes": false,
+      "datasource": null,
       "decimals": 1,
       "description": "Shows the average number of pods running on each node of the selected worker group(s).",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "fill": 0,
+      "fillGradient": 0,
       "gridPos": {
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 7
+        "y": 15
       },
+      "hiddenSeries": false,
       "id": 12,
       "legend": {
         "alignAsTable": false,
@@ -296,7 +546,11 @@
       "linewidth": 1,
       "links": [],
       "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
       "percentage": false,
+      "pluginVersion": "7.5.16",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -357,19 +611,23 @@
     },
     {
       "columns": [],
+      "datasource": null,
       "description": "Shows an overview of all nodes in the shoot cluster.",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "fontSize": "100%",
       "gridPos": {
         "h": 10,
         "w": 24,
         "x": 0,
-        "y": 14
+        "y": 22
       },
       "id": 4,
       "links": [
         {
-          "includeVars": false,
-          "type": "dashboard"
+          "url": "/"
         }
       ],
       "pageSize": null,
@@ -382,12 +640,14 @@
       "styles": [
         {
           "alias": "Time",
+          "align": "auto",
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
           "pattern": "Time",
           "type": "hidden"
         },
         {
           "alias": "",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -404,6 +664,7 @@
         },
         {
           "alias": "CPU Usage",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -420,6 +681,7 @@
         },
         {
           "alias": "Allocatable CPU",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -436,6 +698,7 @@
         },
         {
           "alias": "Idle CPU",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -452,6 +715,7 @@
         },
         {
           "alias": "Memory Usage",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -468,6 +732,7 @@
         },
         {
           "alias": "Allocatable Memory",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -484,6 +749,7 @@
         },
         {
           "alias": "Unused Memory",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -500,6 +766,7 @@
         },
         {
           "alias": "Pods",
+          "align": "auto",
           "colorMode": "cell",
           "colors": [
             "rgba(50, 172, 45, 0.97)",
@@ -519,6 +786,7 @@
         },
         {
           "alias": "Node",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -536,6 +804,7 @@
         },
         {
           "alias": "Worker Group",
+          "align": "auto",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -608,7 +877,7 @@
       "timeShift": null,
       "title": "Overview of all Nodes",
       "transform": "table",
-      "type": "table"
+      "type": "table-old"
     },
     {
       "collapsed": true,
@@ -617,7 +886,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 24
+        "y": 32
       },
       "id": 16,
       "panels": [
@@ -725,7 +994,7 @@
     }
   ],
   "refresh": "1m",
-  "schemaVersion": 18,
+  "schemaVersion": 27,
   "style": "dark",
   "tags": [
     "workload",
@@ -736,20 +1005,29 @@
       {
         "allValue": null,
         "current": {
-          "text": "All",
+          "selected": true,
+          "tags": [],
+          "text": [
+            "All"
+          ],
           "value": [
             "$__all"
           ]
         },
         "datasource": "prometheus",
         "definition": "label_values(kube_node_labels, label_worker_gardener_cloud_pool)",
+        "description": null,
+        "error": null,
         "hide": 0,
         "includeAll": true,
         "label": "Worker Group",
         "multi": true,
         "name": "worker_group",
         "options": [],
-        "query": "label_values(kube_node_labels, label_worker_gardener_cloud_pool)",
+        "query": {
+          "query": "label_values(kube_node_labels, label_worker_gardener_cloud_pool)",
+          "refId": "prometheus-worker_group-Variable-Query"
+        },
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:
This PR adds 2 panels for cpu/memory utilization per worker pool(s) to the `Node/Worker Pool Overview` dashboard. Currently the cpu/memory utilization data is present in the `Node Details` dashboard. However it can be useful to have on per worker pool base as well to better monitoring the utilization for the cluster.

![Screenshot 2022-09-02 at 14 25 20](https://user-images.githubusercontent.com/9372594/188129493-d06b9c3c-d03f-4d60-af3c-7ffafa075166.png)


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
