### PR TITLE
Deflakes `SeedExtensionsCheck` controller integration test

### DIFF
--- a/test/integration/controllermanager/seed/extensionscheck/extensionscheck_suite_test.go
+++ b/test/integration/controllermanager/seed/extensionscheck/extensionscheck_suite_test.go
@@ -112,7 +112,8 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	fakeClock = testclock.NewFakeClock(time.Now())
-	//This is required so that the ExtensionsReady condition is created with appropriate lastUpdateTimestamp and lastTransitionTimestamp.
+	// This is required so that the ExtensionsReady condition is created with appropriate lastUpdateTimestamp and
+	// lastTransitionTimestamp.
 	DeferCleanup(test.WithVars(
 		&gardencorev1beta1helper.Now, func() metav1.Time { return metav1.Time{Time: fakeClock.Now()} },
 	))

--- a/test/integration/controllermanager/seed/extensionscheck/extensionscheck_suite_test.go
+++ b/test/integration/controllermanager/seed/extensionscheck/extensionscheck_suite_test.go
@@ -17,22 +17,29 @@ package extensionscheck_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
 	"github.com/gardener/gardener/pkg/controllermanager/controller/seed"
 	"github.com/gardener/gardener/pkg/controllerutils/mapper"
 	gardenerenvtest "github.com/gardener/gardener/pkg/envtest"
 	"github.com/gardener/gardener/pkg/logger"
+	"github.com/gardener/gardener/pkg/utils"
+	"github.com/gardener/gardener/pkg/utils/test"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/client-go/rest"
 	testclock "k8s.io/utils/clock/testing"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -50,6 +57,8 @@ func TestSeedExtensionsCheck(t *testing.T) {
 const testID = "extensionscheck-controller-test"
 
 var (
+	testRunID = testID + "-" + utils.ComputeSHA256Hex([]byte(uuid.NewUUID()))[:8]
+
 	ctx = context.Background()
 	log logr.Logger
 
@@ -89,11 +98,26 @@ var _ = BeforeSuite(func() {
 	mgr, err := manager.New(restConfig, manager.Options{
 		Scheme:             kubernetes.GardenScheme,
 		MetricsBindAddress: "0",
+		NewCache: cache.BuilderWithOptions(cache.Options{
+			SelectorsByObject: map[client.Object]cache.ObjectSelector{
+				&gardencorev1beta1.ControllerInstallation{}: {
+					Label: labels.SelectorFromSet(labels.Set{testID: testRunID}),
+				},
+				&gardencorev1beta1.Seed{}: {
+					Label: labels.SelectorFromSet(labels.Set{testID: testRunID}),
+				},
+			},
+		}),
 	})
 	Expect(err).NotTo(HaveOccurred())
 
+	fakeClock = testclock.NewFakeClock(time.Now())
+	//This is required so that the ExtensionsReady condition is created with appropriate lastUpdateTimestamp and lastTransitionTimestamp.
+	DeferCleanup(test.WithVars(
+		&gardencorev1beta1helper.Now, func() metav1.Time { return metav1.Time{Time: fakeClock.Now()} },
+	))
+
 	By("registering controller")
-	fakeClock = &testclock.FakeClock{}
 	Expect(addSeedExtensionsCheckControllerToManager(mgr)).To(Succeed())
 
 	By("starting manager")

--- a/test/integration/controllermanager/seed/extensionscheck/extensionscheck_test.go
+++ b/test/integration/controllermanager/seed/extensionscheck/extensionscheck_test.go
@@ -27,13 +27,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
-	"github.com/gardener/gardener/pkg/utils/test"
 )
 
 const (
 	conditionThreshold = 1 * time.Second
-	syncPeriod         = 1 * time.Millisecond
+	syncPeriod         = 100 * time.Millisecond
 )
 
 var _ = Describe("Seed ExtensionsCheck controller tests", func() {
@@ -48,6 +46,7 @@ var _ = Describe("Seed ExtensionsCheck controller tests", func() {
 		seed = &gardencorev1beta1.Seed{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: testID + "-",
+				Labels:       map[string]string{testID: testRunID},
 			},
 			Spec: gardencorev1beta1.SeedSpec{
 				Provider: gardencorev1beta1.SeedProvider{
@@ -84,6 +83,7 @@ var _ = Describe("Seed ExtensionsCheck controller tests", func() {
 		ci1 = &gardencorev1beta1.ControllerInstallation{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "foo-1-",
+				Labels:       map[string]string{testID: testRunID},
 			},
 			Spec: gardencorev1beta1.ControllerInstallationSpec{
 				SeedRef: corev1.ObjectReference{
@@ -100,11 +100,6 @@ var _ = Describe("Seed ExtensionsCheck controller tests", func() {
 
 		ci2 = ci1.DeepCopy()
 		ci2.SetGenerateName("foo-2-")
-
-		//This is required so that the ExtensionsReady condition is created with appropriate lastUpdateTimestamp and lastTransitionTimestamp.
-		DeferCleanup(test.WithVars(
-			&gardencorev1beta1helper.Now, func() metav1.Time { return metav1.Time{Time: fakeClock.Now()} },
-		))
 
 		for _, controllerInstallation := range []*gardencorev1beta1.ControllerInstallation{ci1, ci2} {
 			Expect(testClient.Create(ctx, controllerInstallation)).To(Succeed())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
This PR deflakes the SeedExtensionsCheck controller integration test. 
The test was using cluster scoped resources, so the PR adds the described trick in the [testing documentation](https://github.com/gardener/gardener/blob/master/docs/development/testing.md#writing-integration-tests) to use a label selector generated for each test run for all objects in the manager's cache, and also label the appropriate resources with it.

Additionally, the SeedExtensionsCheck `Reconcile()` function will no longer return errors and will only rely on the sync period to be requeued, similar to what is done by the SeedCare reconciler.

**Which issue(s) this PR fixes**:
Fixes #6600

**Special notes for your reviewer**:

/cc @timebertt 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
