### PR TITLE
Adds validation of k8s admission plugins

### DIFF
--- a/docs/development/new-kubernetes-version.md
+++ b/docs/development/new-kubernetes-version.md
@@ -58,9 +58,17 @@ Run the [`.ci/check-and-release`](https://github.com/gardener/hyperkube/blob/mas
   - To maintain this list for new Kubernetes versions, run `hack/compare-k8s-feature-gates.sh <old-version> <new-version>` (e.g. `hack/compare-k8s-feature-gates.sh v1.22 v1.23`).
   - It will present 3 lists of feature gates: those added and those removed in `<new-version>` compared to `<old-version>` and feature gates that got locked to default in `<new-version>`.
   - Add all added feature gates to the map with `<new-version>` as `AddedInVersion` and no `RemovedInVersion`.
-  - For any removed feature gates, add `<new-version>` as RemovedInVersion to the already existing feature gate in the map.
+  - For any removed feature gates, add `<new-version>` as `RemovedInVersion` to the already existing feature gate in the map.
   - For feature gates locked to default, add `<new-version>` as `LockedToDefaultInVersion` to the already existing feature gate in the map.
   - See [this](https://github.com/gardener/gardener/pull/5255/commits/97923b0604300ff805def8eae981ed388d5e4a83) example commit.
+- Maintain the Kubernetes `kube-apiserver` admission plugins used for validation of `Shoot` resources:
+  - The admission plugins are maintained in [this](https://github.com/gardener/gardener/blob/master/pkg/utils/validation/admissionplugins/admissionplugins.go) file.
+  - To maintain this list for new Kubernetes versions, run `hack/compare-k8s-admission-plugins.sh <old-version> <new-version>` (e.g. `hack/compare-k8s-admission-plugins.sh 1.24 1.25`).
+  - It will present 2 lists of admission plugins: those added and those removed in `<new-version>` compared to `<old-version>`.
+  - Add all added admission plugins to the `admissionPluginsVersionRanges` map with `<new-version>` as `AddedInVersion` and no `RemovedInVersion`.
+  - For any removed admission plugins, add `<new-version>` as `RemovedInVersion` to the already existing admission plugin in the map.
+  - Flag any admission plugins that are required (plugins that must not be disabled in the `Shoot` spec) by setting the `Required` boolean variable to true for the admission plugin in the map.
+  - Flag any admission plugins that are forbidden by setting the `Forbidden` boolean variable to true for the admission plugin in the map.
 - Maintain the `ServiceAccount` names for the controllers part of `kube-controller-manager`:
   - The names are maintained in [this](https://github.com/gardener/gardener/blob/master/pkg/operation/botanist/component/shootsystem/shootsystem.go) file.
   - To maintain this list for new Kubernetes versions, run `hack/compare-k8s-controllers.sh <old-version> <new-version>` (e.g. `hack/compare-k8s-controllers.sh 1.22 1.23`).

--- a/hack/compare-k8s-admission-plugins.sh
+++ b/hack/compare-k8s-admission-plugins.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+usage() {
+  echo "Usage:"
+  echo "> compare-k8s-admission-plugins.sh [ -h | <old version> <new version> ]"
+  echo
+  echo ">> For example: compare-k8s-admission-plugins.sh 1.22 1.23"
+
+  exit 0
+}
+
+if [ "$1" == "-h" ] || [ "$#" -ne 2 ]; then
+  usage
+fi
+
+versions=("$1" "$2")
+
+options_plugins="pkg/kubeapiserver/options/plugins.go"
+server_plugins="staging/src/k8s.io/apiserver/pkg/server/plugins.go"
+
+out_dir=$(mktemp -d)
+function cleanup_output {
+    rm -rf "$out_dir"
+}
+trap cleanup_output EXIT
+
+for version in "${versions[@]}"; do
+  rm -f "${out_dir}/admissionplugins-${version}.txt" "${out_dir}/admissionplugins-${version}.txt"
+  touch "${out_dir}/admissionplugins-${version}.txt" "${out_dir}/admissionplugins-${version}.txt"
+
+  { wget -q -O - "https://raw.githubusercontent.com/kubernetes/kubernetes/release-${version}/${options_plugins}" || echo; } > "${out_dir}/options_plugins.go"
+  { wget -q -O - "https://raw.githubusercontent.com/kubernetes/kubernetes/release-${version}/${server_plugins}" || echo; } > "${out_dir}/server_plugins.go"
+  awk '/var AllOrderedPlugins = \[\]string\{/,/\}/' "${out_dir}/options_plugins.go" > "${out_dir}/ordered_admission_plugins.txt"
+  grep  '\.Register' "${out_dir}/options_plugins.go" | awk '{print $1}' | { grep -Eo '^[a-z]\w+' || true; } > "${out_dir}/plugin_packages.txt"
+  grep  '\.Register' "${out_dir}/server_plugins.go" | awk '{print $1}' | { grep -Eo '^[a-z]\w+' || true; } >> "${out_dir}/plugin_packages.txt"
+  while read plugin_package; do
+    grep -E "\s+${plugin_package}\..*,.*" "${out_dir}/ordered_admission_plugins.txt" | { grep -Eo '//\s*[a-z|A-Z]\w+' | tr -d '//' | tr -d ' ' || true; }  >> "${out_dir}/admissionplugins-${version}.txt"
+  done < "${out_dir}/plugin_packages.txt"
+
+  sort -u -o "${out_dir}/admissionplugins-${version}.txt" "${out_dir}/admissionplugins-${version}.txt"
+done
+
+echo "Admission plugins added in $2 compared to $1:"
+diff "${out_dir}/admissionplugins-$1.txt" "${out_dir}/admissionplugins-$2.txt" | grep '>' | awk '{print $2}'
+echo
+echo "Admission plugins removed in $2 compared to $1:"
+diff "${out_dir}/admissionplugins-$1.txt" "${out_dir}/admissionplugins-$2.txt" | grep '<' | awk '{print $2}'
+echo

--- a/pkg/utils/validation/admissionplugins/admissionplugins.go
+++ b/pkg/utils/validation/admissionplugins/admissionplugins.go
@@ -1,0 +1,151 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package admissionplugins
+
+import (
+	"fmt"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/pointer"
+
+	"github.com/gardener/gardener/pkg/apis/core"
+	utilsversion "github.com/gardener/gardener/pkg/utils/version"
+)
+
+// admissionPluginsVersionRanges contains the version ranges for all Kubernetes admission plugins.
+// Extracted from https://raw.githubusercontent.com/kubernetes/kubernetes/release-${version}/pkg/kubeapiserver/options/plugins.go
+// and https://raw.githubusercontent.com/kubernetes/kubernetes/release-${version}/staging/src/k8s.io/apiserver/pkg/server/plugins.go.
+// To maintain this list for each new Kubernetes version:
+//   - Run hack/compare-k8s-admission-plugins.sh <old-version> <new-version> (e.g. 'hack/compare-k8s-admission-plugins.sh 1.22 1.23').
+//     It will present 2 lists of admission plugins: those added and those removed in <new-version> compared to <old-version> and
+//   - Add all added admission plugins to the map with <new-version> as AddedInVersion and no RemovedInVersion.
+//   - For any removed admission plugin, add <new-version> as RemovedInVersion to the already existing admission plugin in the map.
+
+var admissionPluginsVersionRanges = map[string]*AdmissionPluginVersionRange{
+	"AlwaysAdmit":                          {},
+	"AlwaysDeny":                           {},
+	"AlwaysPullImages":                     {},
+	"CertificateApproval":                  {AddedInVersion: "1.18"},
+	"CertificateSigning":                   {AddedInVersion: "1.18"},
+	"CertificateSubjectRestriction":        {AddedInVersion: "1.18"},
+	"DefaultIngressClass":                  {AddedInVersion: "1.18"},
+	"DefaultStorageClass":                  {},
+	"DefaultTolerationSeconds":             {},
+	"DenyEscalatingExec":                   {RemovedInVersion: "1.21"},
+	"DenyExecOnPrivileged":                 {RemovedInVersion: "1.21"},
+	"DenyServiceExternalIPs":               {AddedInVersion: "1.21"},
+	"EventRateLimit":                       {},
+	"ExtendedResourceToleration":           {},
+	"ImagePolicyWebhook":                   {},
+	"LimitPodHardAntiAffinityTopology":     {},
+	"LimitRanger":                          {},
+	"MutatingAdmissionWebhook":             {Required: true},
+	"NamespaceAutoProvision":               {},
+	"NamespaceExists":                      {},
+	"NamespaceLifecycle":                   {Required: true},
+	"NodeRestriction":                      {Required: true},
+	"OwnerReferencesPermissionEnforcement": {},
+	"PersistentVolumeClaimResize":          {},
+	"PersistentVolumeLabel":                {},
+	"PodNodeSelector":                      {},
+	"PodPreset":                            {RemovedInVersion: "1.20"},
+	"PodSecurity":                          {AddedInVersion: "1.22", Required: true},
+	"PodSecurityPolicy":                    {RemovedInVersion: "1.25", Required: true},
+	"PodTolerationRestriction":             {},
+	"Priority":                             {Required: true},
+	"ResourceQuota":                        {},
+	"RuntimeClass":                         {},
+	"SecurityContextDeny":                  {Forbidden: true},
+	"ServiceAccount":                       {},
+	"StorageObjectInUseProtection":         {Required: true},
+	"TaintNodesByCondition":                {},
+	"ValidatingAdmissionWebhook":           {Required: true},
+}
+
+// IsAdmissionPluginSupported returns true if the given admission plugin is supported for the given Kubernetes version.
+// An admission plugin is only supported if it's a known admission plugin and its version range contains the given Kubernetes version.
+func IsAdmissionPluginSupported(plugin, version string) (bool, error) {
+	vr := admissionPluginsVersionRanges[plugin]
+	if vr == nil {
+		return false, fmt.Errorf("unknown admission plugin %q", plugin)
+	}
+	return vr.Contains(version)
+}
+
+// AdmissionPluginVersionRange represents a version range of type [AddedInVersion, RemovedInVersion).
+type AdmissionPluginVersionRange struct {
+	Forbidden        bool
+	Required         bool
+	AddedInVersion   string
+	RemovedInVersion string
+}
+
+// Contains returns true if the range contains the given version, false otherwise.
+// The range contains the given version only if it's greater or equal than AddedInVersion (always true if AddedInVersion is empty),
+// and less than RemovedInVersion (always true if RemovedInVersion is empty).
+func (r *AdmissionPluginVersionRange) Contains(version string) (bool, error) {
+	var constraint string
+	switch {
+	case r.AddedInVersion != "" && r.RemovedInVersion == "":
+		constraint = fmt.Sprintf(">= %s", r.AddedInVersion)
+	case r.AddedInVersion == "" && r.RemovedInVersion != "":
+		constraint = fmt.Sprintf("< %s", r.RemovedInVersion)
+	case r.AddedInVersion != "" && r.RemovedInVersion != "":
+		constraint = fmt.Sprintf(">= %s, < %s", r.AddedInVersion, r.RemovedInVersion)
+	default:
+		constraint = "*"
+	}
+	return utilsversion.CheckVersionMeetsConstraint(version, constraint)
+}
+
+func getAllForbiddenPlugins() []string {
+	var allForbiddenPlugins []string
+	for name, vr := range admissionPluginsVersionRanges {
+		if vr.Forbidden {
+			allForbiddenPlugins = append(allForbiddenPlugins, name)
+		}
+	}
+	return allForbiddenPlugins
+}
+
+// ValidateAdmissionPlugins validates the given Kubernetes admission plugins against the given Kubernetes version.
+func ValidateAdmissionPlugins(admissionPlugins []core.AdmissionPlugin, version string, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+
+	for i, plugin := range admissionPlugins {
+		idxPath := fldPath.Index(i)
+
+		if len(plugin.Name) == 0 {
+			allErrs = append(allErrs, field.Required(idxPath.Child("name"), "must provide a name"))
+			return allErrs
+		}
+
+		supported, err := IsAdmissionPluginSupported(plugin.Name, version)
+		if err != nil {
+			allErrs = append(allErrs, field.Invalid(idxPath.Child("name"), plugin.Name, err.Error()))
+		} else if !supported {
+			allErrs = append(allErrs, field.Forbidden(idxPath.Child("name"), fmt.Sprintf("admission plugin %q is not supported in Kubernetes version %s", plugin.Name, version)))
+		} else {
+			if admissionPluginsVersionRanges[plugin.Name].Forbidden {
+				allErrs = append(allErrs, field.Forbidden(idxPath.Child("name"), fmt.Sprintf("forbidden admission plugin was specified - do not use plugins from the following list: %+v", getAllForbiddenPlugins())))
+			}
+			if pointer.BoolDeref(plugin.Disabled, false) && admissionPluginsVersionRanges[plugin.Name].Required {
+				allErrs = append(allErrs, field.Forbidden(idxPath, fmt.Sprintf("admission plugin %q cannot be disabled", plugin.Name)))
+			}
+		}
+	}
+
+	return allErrs
+}

--- a/pkg/utils/validation/admissionplugins/admissionplugins_suite_test.go
+++ b/pkg/utils/validation/admissionplugins/admissionplugins_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package admissionplugins_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestAdmissionPlugins(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "AdmissionPlugin Validation Suite")
+}

--- a/pkg/utils/validation/admissionplugins/admissionplugins_test.go
+++ b/pkg/utils/validation/admissionplugins/admissionplugins_test.go
@@ -1,0 +1,113 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package admissionplugins_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
+	gomegatypes "github.com/onsi/gomega/types"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/pointer"
+
+	"github.com/gardener/gardener/pkg/apis/core"
+	. "github.com/gardener/gardener/pkg/utils/validation/admissionplugins"
+)
+
+var _ = Describe("admissionplugins", func() {
+	DescribeTable("#IsAdmissionPluginSupported",
+		func(admissionPluginName, version string, supported, success bool) {
+			result, err := IsAdmissionPluginSupported(admissionPluginName, version)
+			if success {
+				Expect(err).To(Not(HaveOccurred()))
+				Expect(result).To(Equal(supported))
+			} else {
+				Expect(err).To(HaveOccurred())
+			}
+		},
+	)
+
+	Describe("AdmissionPluginVersionRange", func() {
+		DescribeTable("#Contains",
+			func(vr AdmissionPluginVersionRange, version string, contains, success bool) {
+				result, err := vr.Contains(version)
+				if success {
+					Expect(err).To(Not(HaveOccurred()))
+					Expect(result).To(Equal(contains))
+				} else {
+					Expect(err).To(HaveOccurred())
+				}
+			},
+
+			Entry("[,) contains 1.2.3", AdmissionPluginVersionRange{}, "1.2.3", true, true),
+			Entry("[,) contains 0.1.2", AdmissionPluginVersionRange{}, "0.1.2", true, true),
+			Entry("[,) contains 1.3.5", AdmissionPluginVersionRange{}, "1.3.5", true, true),
+			Entry("[,) fails with foo", AdmissionPluginVersionRange{}, "foo", false, false),
+
+			Entry("[, 1.3) contains 1.2.3", AdmissionPluginVersionRange{RemovedInVersion: "1.3"}, "1.2.3", true, true),
+			Entry("[, 1.3) contains 0.1.2", AdmissionPluginVersionRange{RemovedInVersion: "1.3"}, "0.1.2", true, true),
+			Entry("[, 1.3) doesn't contain 1.3.5", AdmissionPluginVersionRange{RemovedInVersion: "1.3"}, "1.3.5", false, true),
+			Entry("[, 1.3) fails with foo", AdmissionPluginVersionRange{RemovedInVersion: "1.3"}, "foo", false, false),
+
+			Entry("[1.0, ) contains 1.2.3", AdmissionPluginVersionRange{AddedInVersion: "1.0"}, "1.2.3", true, true),
+			Entry("[1.0, ) doesn't contain 0.1.2", AdmissionPluginVersionRange{AddedInVersion: "1.0"}, "0.1.2", false, true),
+			Entry("[1.0, ) contains 1.3.5", AdmissionPluginVersionRange{AddedInVersion: "1.0"}, "1.3.5", true, true),
+			Entry("[1.0, ) fails with foo", AdmissionPluginVersionRange{AddedInVersion: "1.0"}, "foo", false, false),
+
+			Entry("[1.0, 1.3) contains 1.2.3", AdmissionPluginVersionRange{AddedInVersion: "1.0", RemovedInVersion: "1.3"}, "1.2.3", true, true),
+			Entry("[1.0, 1.3) doesn't contain 0.1.2", AdmissionPluginVersionRange{AddedInVersion: "1.0", RemovedInVersion: "1.3"}, "0.1.2", false, true),
+			Entry("[1.0, 1.3) doesn't contain 1.3.5", AdmissionPluginVersionRange{AddedInVersion: "1.0", RemovedInVersion: "1.3"}, "1.3.5", false, true),
+			Entry("[1.0, 1.3) fails with foo", AdmissionPluginVersionRange{AddedInVersion: "1.0", RemovedInVersion: "1.3"}, "foo", false, false),
+		)
+	})
+
+	Describe("#ValidateAdmissionPlugins", func() {
+		DescribeTable("validate admission plugins",
+			func(plugins []core.AdmissionPlugin, version string, matcher gomegatypes.GomegaMatcher) {
+				errList := ValidateAdmissionPlugins(plugins, version, field.NewPath("admissionPlugins"))
+				Expect(errList).To(matcher)
+			},
+			Entry("empty list", nil, "1.18.14", BeEmpty()),
+			Entry("supported admission plugin", []core.AdmissionPlugin{{Name: "AlwaysAdmit"}}, "1.18.14", BeEmpty()),
+			Entry("unsupported admission plugin", []core.AdmissionPlugin{{Name: "DenyEscalatingExec"}}, "1.22.16", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(field.ErrorTypeForbidden),
+				"Field":  Equal(field.NewPath("admissionPlugins[0].name").String()),
+				"Detail": Equal("admission plugin \"DenyEscalatingExec\" is not supported in Kubernetes version 1.22.16"),
+			})))),
+			Entry("admission plugin without name", []core.AdmissionPlugin{{}}, "1.18.14", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(field.ErrorTypeRequired),
+				"Field":  Equal(field.NewPath("admissionPlugins[0].name").String()),
+				"Detail": Equal("must provide a name"),
+			})))),
+			Entry("unknown admission plugin", []core.AdmissionPlugin{{Name: "Foo"}}, "1.18.14", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":     Equal(field.ErrorTypeInvalid),
+				"Field":    Equal(field.NewPath("admissionPlugins[0].name").String()),
+				"BadValue": Equal("Foo"),
+				"Detail":   Equal("unknown admission plugin \"Foo\""),
+			})))),
+			Entry("disabling non-required admission plugin", []core.AdmissionPlugin{{Name: "AlwaysAdmit", Disabled: pointer.Bool(true)}}, "1.18.14", BeEmpty()),
+			Entry("disabling required admission plugin", []core.AdmissionPlugin{{Name: "MutatingAdmissionWebhook", Disabled: pointer.Bool(true)}}, "1.18.14", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(field.ErrorTypeForbidden),
+				"Field":  Equal(field.NewPath("admissionPlugins[0]").String()),
+				"Detail": Equal("admission plugin \"MutatingAdmissionWebhook\" cannot be disabled"),
+			})))),
+			Entry("adding forbidden admission plugin", []core.AdmissionPlugin{{Name: "SecurityContextDeny"}}, "1.18.4", ConsistOf(PointTo(MatchFields(IgnoreExtras, Fields{
+				"Type":   Equal(field.ErrorTypeForbidden),
+				"Field":  Equal(field.NewPath("admissionPlugins[0].name").String()),
+				"Detail": Equal("forbidden admission plugin was specified - do not use plugins from the following list: [SecurityContextDeny]"),
+			})))),
+		)
+	})
+})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
Adds validation of Kubernetes admission plugins. The admission plugins and the versions in which they were added/removed will be maintained by first executing a hack script - `compare-k8s-admission-plugins.sh <old-version> <new-version>` which returns 2 lists of admission plugins. The first one specifies which ones were added in the new version and the second one - which ones were removed in the new version. The lists can then be used to edit  the `admissionPluginsVersionRanges`  map in `pkg/utils/validation/admissionplugins/admissionplugins.go`.
The lists are computed from `https://raw.githubusercontent.com/kubernetes/kubernetes/release-<release>/pkg/kubeapiserver/options/plugins.go` by using only the registered plugins specified in this method: https://github.com/kubernetes/kubernetes/blob/bcea98234f0fdc5ce4e976758977eec72b13bfd4/pkg/kubeapiserver/options/plugins.go#L107 and then getting their names from comments in https://github.com/kubernetes/kubernetes/blob/bcea98234f0fdc5ce4e976758977eec72b13bfd4/pkg/kubeapiserver/options/plugins.go#L64

Basically it works similar to #4149

**Which issue(s) this PR fixes**:
Fixes #6559

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Kubernetes admission plugins that can be specified in `shoot.kubernetes.apiServer.admissionPlugins` are now validated aginst the kubernetes version of the shoot cluster.
```
