### PR TITLE
Fix the network metrics for clusters with containerd

### DIFF
--- a/charts/seed-bootstrap/templates/prometheus/config.yaml
+++ b/charts/seed-bootstrap/templates/prometheus/config.yaml
@@ -56,9 +56,18 @@ data:
         # The system container POD is used for networking
         regex: POD;({{ without .Values.allowedMetrics.cAdvisor "container_network_receive_bytes_total" "container_network_transmit_bytes_total" | join "|" }})
         action: drop
-      - source_labels: [ container ]
-        regex: ^$
+      - source_labels: [ __name__, container, interface, id ]
+        regex: container_network.+;;(eth0;/.+|(ens.+|tunl0|eth0);/)|.+;.+;.*;.*
+        action: keep
+      - source_labels: [ __name__, container, interface ]
+        regex: container_network.+;POD;(.{5,}|tun0|en.+)
         action: drop
+      - source_labels: [ __name__, id ]
+        regex: container_network.+;/
+        target_label: host_network
+        replacement: "true"
+      - regex: ^id$
+        action: labeldrop
       # drop terraform pods
       - source_labels: [ pod ]
         regex: ^.+\.tf-pod.+$

--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
@@ -171,6 +171,10 @@ data:
       - source_labels: [ __name__, container, interface ]
         regex: container_network.+;POD;(.{5,}|tun0|en.+)
         action: drop
+      - source_labels: [ __name__, id ]
+        regex: container_network.+;/
+        target_label: host_network
+        replacement: "true"
       - regex: ^id$
         action: labeldrop
 

--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
@@ -165,8 +165,8 @@ data:
         # The system container POD is used for networking
         regex: POD;({{ without .Values.allowedMetrics.cAdvisor "container_network_receive_bytes_total" "container_network_transmit_bytes_total" | join "|" }})
         action: drop
-      - source_labels: [ __name__, container, interface ]
-        regex: container_network.+;;eth0|.+;.+;.*
+      - source_labels: [ __name__, container, interface, id ]
+        regex: container_network.+;;(eth0;/.+|(ens.+|tunl0|eth0);/)|.+;.+;.*;.*
         action: keep
       - regex: ^id$
         action: labeldrop

--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
@@ -165,8 +165,8 @@ data:
         # The system container POD is used for networking
         regex: POD;({{ without .Values.allowedMetrics.cAdvisor "container_network_receive_bytes_total" "container_network_transmit_bytes_total" | join "|" }})
         action: drop
-      - source_labels: [ container ]
-        regex: .+
+      - source_labels: [ __name__, container ]
+        regex: container_network.+;|.+;.+
         action: keep
       - regex: ^id$
         action: labeldrop

--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
@@ -168,6 +168,9 @@ data:
       - source_labels: [ __name__, container, interface, id ]
         regex: container_network.+;;(eth0;/.+|(ens.+|tunl0|eth0);/)|.+;.+;.*;.*
         action: keep
+      - source_labels: [ __name__, container, interface ]
+        regex: container_network.+;POD;(.{5,}|tun0|en.+)
+        action: drop
       - regex: ^id$
         action: labeldrop
 

--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
@@ -166,8 +166,8 @@ data:
         regex: POD;({{ without .Values.allowedMetrics.cAdvisor "container_network_receive_bytes_total" "container_network_transmit_bytes_total" | join "|" }})
         action: drop
       - source_labels: [ container ]
-        regex: ^$
-        action: drop
+        regex: .+
+        action: keep
       - regex: ^id$
         action: labeldrop
 

--- a/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
+++ b/charts/seed-monitoring/charts/core/charts/prometheus/templates/config.yaml
@@ -165,8 +165,8 @@ data:
         # The system container POD is used for networking
         regex: POD;({{ without .Values.allowedMetrics.cAdvisor "container_network_receive_bytes_total" "container_network_transmit_bytes_total" | join "|" }})
         action: drop
-      - source_labels: [ __name__, container ]
-        regex: container_network.+;|.+;.+
+      - source_labels: [ __name__, container, interface ]
+        regex: container_network.+;;eth0|.+;.+;.*
         action: keep
       - regex: ^id$
         action: labeldrop

--- a/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-pods-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/operators/kubernetes-pods-dashboard.json
@@ -396,11 +396,104 @@
       }
     },
     {
+      "datasource": null,
+      "description": "If host_network is true, the pod will not have network I/O metrics.\n\nNote: For pods that use the host network, we cannot collect meaningful network metrics, because the host network includes network traffic from the system services and other pods. Therefore, this dashboard only shows the network traffic for pods which are not in the host network namespace.\n",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": null,
+            "filterable": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "pod"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 156
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 4,
+        "x": 0,
+        "y": 16
+      },
+      "id": 10,
+      "options": {
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "7.5.16",
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "max(kube_pod_info{pod=~\"$pod\"}) by(pod, host_network)",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Host Network",
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "pod",
+                "host_network"
+              ]
+            }
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {
+              "host_network": 1,
+              "pod": 0
+            },
+            "renameByName": {}
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
       "aliasColors": {},
       "bars": false,
       "dashLength": 10,
       "dashes": false,
       "datasource": "prometheus",
+      "description": "Note: For pods that use the host network, we cannot collect meaningful network metrics, because the host network includes network traffic from the system services and other pods. Therefore, this dashboard only shows the network traffic for pods which are not in the host network namespace.",
       "editable": true,
       "error": false,
       "fieldConfig": {
@@ -414,8 +507,8 @@
       "grid": {},
       "gridPos": {
         "h": 7,
-        "w": 24,
-        "x": 0,
+        "w": 20,
+        "x": 4,
         "y": 16
       },
       "hiddenSeries": false,

--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/node-details-dashboard.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/node-details-dashboard.json
@@ -528,22 +528,22 @@
       "targets": [
         {
           "exemplar": true,
-          "expr": "sum(rate(container_network_receive_bytes_total{kubernetes_io_hostname=~\"^$Node$\",type=\"shoot\"}[$__rate_interval]))",
+          "expr": "sum(rate(container_network_receive_bytes_total{kubernetes_io_hostname=~\"^$Node$\",type=\"shoot\",host_network=\"true\"}[$__rate_interval])) by (interface)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "Received",
+          "legendFormat": "Received {{interface}}",
           "metric": "network",
           "refId": "A",
           "step": 10
         },
         {
           "exemplar": true,
-          "expr": "- sum (rate(container_network_transmit_bytes_total{kubernetes_io_hostname=~\"^$Node$\",type=\"shoot\"}[$__rate_interval]))",
+          "expr": "- sum (rate(container_network_transmit_bytes_total{kubernetes_io_hostname=~\"^$Node$\",type=\"shoot\",host_network=\"true\"}[$__rate_interval])) by (interface)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
-          "legendFormat": "Sent",
+          "legendFormat": "Sent {{interface}}",
           "metric": "network",
           "refId": "B",
           "step": 10


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind bug

**What this PR does / why we need it**:

Fix the network metrics for clusters with containerd

The network metrics

```
# HELP container_network_receive_bytes_total Cumulative count of bytes received
# HELP container_network_transmit_bytes_total Cumulative count of bytes transmitted
```

are exposed by the `/metrics/cadvisor` endpoint of the kubelet. They can be accessed via:

```
kubectl proxy
curl -s http://localhost:8001/api/v1/nodes/<node>/proxy/metrics/cadvisor
```

It turns out that the exposed metrics differ depending on the underlying container runtime: docker or containerd.

The prometheus scrape job "cadvisor" uses *metric relabeling* rules to keep only the "relevant" metrics; the cadvisor that is embedded in the kubelet exposes many metrics, most of which were considered to be not so valuable some time ago. 

The network metrics are not container specific but rather specific to the pod level: all the containers of a pod share the same network namespace (by definition) and hence the network metrics show the network traffic together for all the containers of a pod. Consequently, the `container` label is not so meaningful for the network metrics.

It turns out that the cadvisor that is compiled into the kubelet sets a different value for the `container` label depending on the underlying container runtime: it is the dummy value `POD` for docker and an empty string for containerd.

Unfortunately the existing metric relabeling rules depended on the value of the `container` label and in the end they resulted in dropping the network metrics for containerd based clusters.

This PR fixes this issue: the network metrics are properly kept in Prometheus also for containerd based clusters.

This PR also includes tightly related improvements for docker based clusters: previously, all the network metrics were kept for all the pods. Unfortunately the network metrics are not meaningful for pods that use the host network, because they contain the host network's network metrics which is not specific to the pod and also have a significant cardinality: they contain the bridge network devices for each regular pod. Now these metrics are not kept in Prometheus any more. In larger clusters with many pods, they contributed significantly to the overall cardinality of the data that is stored in Prometheus.

Furthermore this PR fixes the node level network metrics (query) as well: it did not show any data for containerd based clusters and showed bogus data for docker based clusters.

**Which issue(s) this PR fixes**:
Fixes #2800 

**Special notes for your reviewer**:

Please check the commit messages for more details.

/cc @rickardsjp @wyb1 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Fix the network metrics for clusters with containerd.
The "Kubernetes Pods" dashboard's "Network I/O" panel showed no data for clusters with containerd. Now it correctly shows the network metrics (sent and received bytes/s) for pods that are not in the host network namespace, also for clusters with containerd. For pods in the host network namespace no network metrics are shown because by definition the host network namespace's network stats include all the pods and system services and hence are not meaningful in the context of a specific pod. This explanation is as also included on the dashboard to avoid confusion due to missing data.
The "Node Details" dashboard's "Network I/O Pressure" panel showed incorrect readings for clusters with docker and no data for clusters with containerd. Both aspects are fixed.
```
