### PR TITLE
[ci:component:github.com/gardener/vpa-exporter:0.1.5->0.3.0]

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -282,7 +282,7 @@ images:
 - name: vpa-exporter
   sourceRepository: github.com/gardener/vpa-exporter
   repository: eu.gcr.io/gardener-project/gardener/vpa-exporter
-  tag: "0.1.5"
+  tag: "0.3.0"
 
 # HVPA
 - name: hvpa-controller

--- a/pkg/operation/botanist/component/vpa/exporter.go
+++ b/pkg/operation/botanist/component/vpa/exporter.go
@@ -128,7 +128,7 @@ func (v *vpa) reconcileExporterDeployment(deployment *appsv1.Deployment, service
 					Image:           v.values.Exporter.Image,
 					ImagePullPolicy: corev1.PullIfNotPresent,
 					Command: []string{
-						"/usr/local/bin/vpa-exporter",
+						"/vpa-exporter",
 						fmt.Sprintf("--port=%d", exporterPortMetrics),
 					},
 					Ports: []corev1.ContainerPort{{

--- a/pkg/operation/botanist/component/vpa/vpa_test.go
+++ b/pkg/operation/botanist/component/vpa/vpa_test.go
@@ -277,7 +277,7 @@ var _ = Describe("VPA", func() {
 							Image:           imageExporter,
 							ImagePullPolicy: corev1.PullIfNotPresent,
 							Command: []string{
-								"/usr/local/bin/vpa-exporter",
+								"/vpa-exporter",
 								"--port=9570",
 							},
 							Ports: []corev1.ContainerPort{{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

Update the vpa-exporter image from 0.1.5 to 0.3.0.
The path to the executable file is adjusted as well.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/cc @wyb1

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Update vpa-exporter:0.1.5->0.3.0
Add `targetName` and `targetKind` labels
Added unit-tests and added a check for no targetRef.
Updated alpine image.
Added a new metric to export new VPA recommendations provided via an annotation.
Published docker images for VPA-Exporter are now multi-arch ready. They support `linux/amd64` and `linux/arm64`.
The `vpa-exporter` container now uses `distroless` instead of `alpine` as a base image.
```
