### PR TITLE
Deflake `Shoot` credentials rotation e2e test

### DIFF
--- a/pkg/provider-local/webhook/node/add.go
+++ b/pkg/provider-local/webhook/node/add.go
@@ -44,13 +44,21 @@ var (
 type AddOptions struct{}
 
 // AddToManagerWithOptions creates a webhook with the given options and adds it to the manager.
-func AddToManagerWithOptions(mgr manager.Manager, _ AddOptions, name, target string) (*extensionswebhook.Webhook, error) {
+func AddToManagerWithOptions(
+	mgr manager.Manager,
+	_ AddOptions,
+	name string,
+	target string,
+	failurePolicy admissionregistrationv1.FailurePolicyType,
+) (
+	*extensionswebhook.Webhook,
+	error,
+) {
 	logger.Info("Adding webhook to manager")
 
 	var (
-		provider      = local.Type
-		types         = []extensionswebhook.Type{{Obj: &corev1.Node{}, Subresource: pointer.String("status")}}
-		failurePolicy = admissionregistrationv1.Ignore
+		provider = local.Type
+		types    = []extensionswebhook.Type{{Obj: &corev1.Node{}, Subresource: pointer.String("status")}}
 	)
 
 	logger = logger.WithValues("provider", provider)
@@ -70,16 +78,28 @@ func AddToManagerWithOptions(mgr manager.Manager, _ AddOptions, name, target str
 		Path:           name,
 		Webhook:        &admission.Webhook{Handler: handler},
 		FailurePolicy:  &failurePolicy,
-		TimeoutSeconds: pointer.Int32(1),
+		TimeoutSeconds: pointer.Int32(5),
 	}, nil
 }
 
 // AddToManager creates a webhook with the default options and adds it to the manager.
 func AddToManager(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
-	return AddToManagerWithOptions(mgr, DefaultAddOptions, WebhookName, extensionswebhook.TargetSeed)
+	return AddToManagerWithOptions(
+		mgr,
+		DefaultAddOptions,
+		WebhookName,
+		extensionswebhook.TargetSeed,
+		admissionregistrationv1.Fail,
+	)
 }
 
 // AddShootWebhookToManager creates a shoot webhook with the default options and adds it to the manager.
 func AddShootWebhookToManager(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
-	return AddToManagerWithOptions(mgr, DefaultAddOptions, WebhookNameShoot, extensionswebhook.TargetShoot)
+	return AddToManagerWithOptions(
+		mgr,
+		DefaultAddOptions,
+		WebhookNameShoot,
+		extensionswebhook.TargetShoot,
+		admissionregistrationv1.Ignore,
+	)
 }

--- a/test/e2e/shoot/internal/rotation/observability.go
+++ b/test/e2e/shoot/internal/rotation/observability.go
@@ -57,8 +57,8 @@ func (v *ObservabilityVerifier) Before(ctx context.Context) {
 	By("Using old credentials to access observability endpoint")
 	Eventually(func(g Gomega) {
 		response, err := v.accessEndpoint(ctx, v.observabilityEndpoint, v.oldKeypairData["username"], v.oldKeypairData["password"])
-		Expect(err).NotTo(HaveOccurred())
-		Expect(response.StatusCode).To(Equal(http.StatusOK))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(response.StatusCode).To(Equal(http.StatusOK))
 	}).Should(Succeed())
 }
 
@@ -92,8 +92,8 @@ func (v *ObservabilityVerifier) AfterPrepared(ctx context.Context) {
 	By("Using new credentials to access observability endpoint")
 	Eventually(func(g Gomega) {
 		response, err := v.accessEndpoint(ctx, v.observabilityEndpoint, secret.Data["username"], secret.Data["password"])
-		Expect(err).NotTo(HaveOccurred())
-		Expect(response.StatusCode).To(Equal(http.StatusOK))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(response.StatusCode).To(Equal(http.StatusOK))
 	}).Should(Succeed())
 }
 

--- a/test/e2e/shoot/internal/rotation/observability.go
+++ b/test/e2e/shoot/internal/rotation/observability.go
@@ -75,8 +75,8 @@ func (v *ObservabilityVerifier) AfterPrepared(ctx context.Context) {
 	By("Using old credentials to access observability endpoint")
 	Consistently(func(g Gomega) {
 		response, err := v.accessEndpoint(ctx, v.observabilityEndpoint, v.oldKeypairData["username"], v.oldKeypairData["password"])
-		Expect(err).NotTo(HaveOccurred())
-		Expect(response.StatusCode).To(Equal(http.StatusUnauthorized))
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(response.StatusCode).To(Equal(http.StatusUnauthorized))
 	}).Should(Succeed())
 
 	By("Verifying new observability secret")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
This PR sets the `failurePolicy` of the `node` webhook of `provider-local` in seeds to `Fail` again. This was changed with https://github.com/gardener/gardener/pull/6573 since the webhook is also used in shoots, however it caused issues with our e2e tests (see #6623).

For shoots, it's not critical to change the node resource capacity with this webhook, however for seeds it is so that we can ensure that all seed system components as well as shoot control plane components can be scheduled and are not unnecessarily preempted/re-scheduled.

**Which issue(s) this PR fixes**:
Fixes #6623

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
