### PR TITLE
Deflake pod-zone-affinity integration test

### DIFF
--- a/test/integration/resourcemanager/podzoneaffinity/podzoneaffinity_test.go
+++ b/test/integration/resourcemanager/podzoneaffinity/podzoneaffinity_test.go
@@ -23,7 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var _ = Describe("PodSchedulerName tests", func() {
+var _ = Describe("PodZoneAffinity tests", func() {
 	var pod *corev1.Pod
 
 	BeforeEach(func() {
@@ -50,14 +50,12 @@ var _ = Describe("PodSchedulerName tests", func() {
 	Context("when namespace has zone enforcement label", func() {
 		BeforeEach(func() {
 			patch := client.MergeFrom(testNamespace.DeepCopy())
-			testNamespace.Labels = map[string]string{
-				"control-plane.shoot.gardener.cloud/enforce-zone": "",
-			}
+			testNamespace.Labels["control-plane.shoot.gardener.cloud/enforce-zone"] = ""
 			Expect(testClient.Patch(ctx, testNamespace, patch)).To(Succeed())
 
 			DeferCleanup(func() {
 				patch := client.MergeFrom(testNamespace.DeepCopy())
-				testNamespace.Labels = nil
+				delete(testNamespace.Labels, "control-plane.shoot.gardener.cloud/enforce-zone")
 				Expect(testClient.Patch(ctx, testNamespace, patch)).To(Succeed())
 			})
 		})
@@ -81,14 +79,12 @@ var _ = Describe("PodSchedulerName tests", func() {
 	Context("when namespace has zone enforcement label with value", func() {
 		BeforeEach(func() {
 			patch := client.MergeFrom(testNamespace.DeepCopy())
-			testNamespace.Labels = map[string]string{
-				"control-plane.shoot.gardener.cloud/enforce-zone": "zone-a",
-			}
+			testNamespace.Labels["control-plane.shoot.gardener.cloud/enforce-zone"] = "zone-a"
 			Expect(testClient.Patch(ctx, testNamespace, patch)).To(Succeed())
 
 			DeferCleanup(func() {
 				patch := client.MergeFrom(testNamespace.DeepCopy())
-				testNamespace.Labels = nil
+				delete(testNamespace.Labels, "control-plane.shoot.gardener.cloud/enforce-zone")
 				Expect(testClient.Patch(ctx, testNamespace, patch)).To(Succeed())
 			})
 		})


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
This PR fixes flaky integration tests for pod-zone-affinity, reported in #6648.

**Which issue(s) this PR fixes**:
Fixes #6648

**Special notes for your reviewer**:
The main issue was that `BeforeEach` steps removed the test-id label (`corev1.LabelMetadataName`) that was used in the `MutatingWebhookConfiguration` as a namespace selector. However, after iterating over the tests again I decided to improve additional points, in sum:
- Only add and remove `control-plane.shoot.gardener.cloud/enforce-zone` label -> solves above depicted problem
- Remove namespace name label selector from `MutatingWebhookConfiguration` since we already use another label selector which is sufficient. Also, the `corev1.LabelMetadataName` caused problems when `stress` testing.
- Disable client cache for `Namespace` resources, so that modifications in `BeforeEach` are immediately seed by the manager client.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
