### PR TITLE
Configurable log level/format for gardener admission controller

### DIFF
--- a/charts/gardener/controlplane/charts/runtime/templates/admission-controller/configmap-componentconfig.yaml
+++ b/charts/gardener/controlplane/charts/runtime/templates/admission-controller/configmap-componentconfig.yaml
@@ -30,6 +30,8 @@ data:
       {{- if .Values.global.admission.kubeconfig }}
       kubeconfig: /etc/gardener-admission-controller/kubeconfig/kubeconfig
       {{- end }}
+    logLevel: {{ .Values.global.admission.config.logLevel | default "info" }}
+    logFormat: {{ .Values.global.admission.config.logFormat | default "json" }}
     server:
       https:
         bindAddress: {{ required ".Values.global.admission.config.server.https.bindAddress is required" .Values.global.admission.config.server.https.bindAddress }}

--- a/charts/gardener/controlplane/values.yaml
+++ b/charts/gardener/controlplane/values.yaml
@@ -287,6 +287,8 @@ global:
        # contentType: application/json
         qps: 100
         burst: 130
+      logLevel: info
+      logFormat: json
       server:
         https:
           bindAddress: 0.0.0.0

--- a/cmd/gardener-admission-controller/app/gardener_admission_controller.go
+++ b/cmd/gardener-admission-controller/app/gardener_admission_controller.go
@@ -116,7 +116,10 @@ func (o *options) validate() error {
 }
 
 func (o *options) run(ctx context.Context) error {
-	logf.SetLogger(logger.MustNewZapLogger(o.config.LogLevel, o.config.LogFormat))
+	log, err := logger.NewZapLogger(o.config.LogLevel, o.config.LogFormat)
+	if err != nil {
+		return fmt.Errorf("error instantiating zap logger: %w", err)
+	}
 
 	log.Info("Starting Gardener admission controller", "version", version.Get())
 

--- a/cmd/gardener-admission-controller/app/gardener_admission_controller.go
+++ b/cmd/gardener-admission-controller/app/gardener_admission_controller.go
@@ -34,6 +34,7 @@ import (
 	seedauthorizergraph "github.com/gardener/gardener/pkg/admissioncontroller/webhooks/auth/seed/graph"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	gardenerhealthz "github.com/gardener/gardener/pkg/healthz"
+	"github.com/gardener/gardener/pkg/logger"
 	"github.com/gardener/gardener/pkg/server/routes"
 
 	"github.com/spf13/cobra"
@@ -115,6 +116,8 @@ func (o *options) validate() error {
 }
 
 func (o *options) run(ctx context.Context) error {
+	logf.SetLogger(logger.MustNewZapLogger(o.config.LogLevel, o.config.LogFormat))
+
 	log.Info("Starting Gardener admission controller", "version", version.Get())
 
 	log.Info("Getting rest config")
@@ -222,7 +225,6 @@ func NewGardenerAdmissionControllerCommand() *cobra.Command {
 				return err
 			}
 
-			log.Info("Starting "+Name, "version", version.Get())
 			cmd.Flags().VisitAll(func(flag *pflag.Flag) {
 				log.Info(fmt.Sprintf("FLAG: --%s=%s", flag.Name, flag.Value)) //nolint:logcheck
 			})

--- a/cmd/gardener-admission-controller/main.go
+++ b/cmd/gardener-admission-controller/main.go
@@ -20,16 +20,12 @@ import (
 
 	"github.com/gardener/gardener/cmd/gardener-admission-controller/app"
 	"github.com/gardener/gardener/cmd/utils"
-	"github.com/gardener/gardener/pkg/logger"
 
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 )
 
 func main() {
 	utils.DeduplicateWarnings()
-
-	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON))
 
 	ctx := signals.SetupSignalHandler()
 	if err := app.NewGardenerAdmissionControllerCommand().ExecuteContext(ctx); err != nil {

--- a/example/20-componentconfig-gardener-admission-controller.yaml
+++ b/example/20-componentconfig-gardener-admission-controller.yaml
@@ -4,6 +4,8 @@ kind: AdmissionControllerConfiguration
 gardenClientConnection:
   qps: 100
   burst: 130
+logLevel: info
+logFormat: json
 server:
   https:
     bindAddress: 0.0.0.0
@@ -28,8 +30,6 @@ server:
       apiGroup: rbac.authorization.k8s.io
     operationMode: block
   enableDebugHandlers: true
-logLevel: info
-logFormat: json
 debugging:
   enableProfiling: false
   enableContentionProfiling: false

--- a/example/20-componentconfig-gardener-admission-controller.yaml
+++ b/example/20-componentconfig-gardener-admission-controller.yaml
@@ -28,6 +28,8 @@ server:
       apiGroup: rbac.authorization.k8s.io
     operationMode: block
   enableDebugHandlers: true
+logLevel: info
+logFormat: json
 debugging:
   enableProfiling: false
   enableContentionProfiling: false

--- a/pkg/admissioncontroller/apis/config/types.go
+++ b/pkg/admissioncontroller/apis/config/types.go
@@ -30,8 +30,10 @@ type AdmissionControllerConfiguration struct {
 	// when communicating with the garden apiserver.
 	GardenClientConnection componentbaseconfig.ClientConnectionConfiguration
 	// LogLevel is the level/severity for the logs. Must be one of [info,debug,error].
+	// Defaults to "info".
 	LogLevel string
 	// LogFormat is the format for the logs. Must be one of [json,text].
+	// Defaults to "json".
 	LogFormat string
 	// Server defines the configuration of the HTTP server.
 	Server ServerConfiguration

--- a/pkg/admissioncontroller/apis/config/types.go
+++ b/pkg/admissioncontroller/apis/config/types.go
@@ -31,6 +31,8 @@ type AdmissionControllerConfiguration struct {
 	GardenClientConnection componentbaseconfig.ClientConnectionConfiguration
 	// LogLevel is the level/severity for the logs. Must be one of [info,debug,error].
 	LogLevel string
+	// LogFormat is the format for the logs. Must be one of [json,text].
+	LogFormat string
 	// Server defines the configuration of the HTTP server.
 	Server ServerConfiguration
 	// Debugging holds configuration for Debugging related features.

--- a/pkg/admissioncontroller/apis/config/v1alpha1/defaults.go
+++ b/pkg/admissioncontroller/apis/config/v1alpha1/defaults.go
@@ -29,6 +29,9 @@ func SetDefaults_AdmissionControllerConfiguration(obj *AdmissionControllerConfig
 	if len(obj.LogLevel) == 0 {
 		obj.LogLevel = "info"
 	}
+	if len(obj.LogFormat) == 0 {
+		obj.LogFormat = "json"
+	}
 	if len(obj.Server.HTTPS.BindAddress) == 0 {
 		obj.Server.HTTPS.BindAddress = "0.0.0.0"
 	}

--- a/pkg/admissioncontroller/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/admissioncontroller/apis/config/v1alpha1/defaults_test.go
@@ -36,6 +36,7 @@ var _ = Describe("Defaults", func() {
 				SetObjectDefaults_AdmissionControllerConfiguration(obj)
 
 				Expect(obj.LogLevel).To(Equal("info"))
+				Expect(obj.LogFormat).To(Equal("json"))
 				Expect(obj.Server.HTTPS.BindAddress).To(Equal("0.0.0.0"))
 				Expect(obj.Server.HTTPS.Port).To(Equal(2721))
 				Expect(obj.Server.ResourceAdmissionConfiguration).To(Equal(&ResourceAdmissionConfiguration{}))

--- a/pkg/admissioncontroller/apis/config/v1alpha1/types.go
+++ b/pkg/admissioncontroller/apis/config/v1alpha1/types.go
@@ -31,6 +31,8 @@ type AdmissionControllerConfiguration struct {
 	GardenClientConnection componentbaseconfigv1alpha1.ClientConnectionConfiguration `json:"gardenClientConnection"`
 	// LogLevel is the level/severity for the logs. Must be one of [info,debug,error].
 	LogLevel string `json:"logLevel"`
+	// LogFormat is the format for the logs. Must be one of [json,text].
+	LogFormat string `json:"logFormat"`
 	// Server defines the configuration of the HTTP server.
 	Server ServerConfiguration `json:"server"`
 	// Debugging holds configuration for Debugging related features.

--- a/pkg/admissioncontroller/apis/config/v1alpha1/types.go
+++ b/pkg/admissioncontroller/apis/config/v1alpha1/types.go
@@ -30,8 +30,10 @@ type AdmissionControllerConfiguration struct {
 	// when communicating with the garden apiserver.
 	GardenClientConnection componentbaseconfigv1alpha1.ClientConnectionConfiguration `json:"gardenClientConnection"`
 	// LogLevel is the level/severity for the logs. Must be one of [info,debug,error].
+	// Defaults to "info".
 	LogLevel string `json:"logLevel"`
 	// LogFormat is the format for the logs. Must be one of [json,text].
+	// Defaults to "json".
 	LogFormat string `json:"logFormat"`
 	// Server defines the configuration of the HTTP server.
 	Server ServerConfiguration `json:"server"`

--- a/pkg/admissioncontroller/apis/config/v1alpha1/zz_generated.conversion.go
+++ b/pkg/admissioncontroller/apis/config/v1alpha1/zz_generated.conversion.go
@@ -117,6 +117,7 @@ func autoConvert_v1alpha1_AdmissionControllerConfiguration_To_config_AdmissionCo
 		return err
 	}
 	out.LogLevel = in.LogLevel
+	out.LogFormat = in.LogFormat
 	if err := Convert_v1alpha1_ServerConfiguration_To_config_ServerConfiguration(&in.Server, &out.Server, s); err != nil {
 		return err
 	}
@@ -142,6 +143,7 @@ func autoConvert_config_AdmissionControllerConfiguration_To_v1alpha1_AdmissionCo
 		return err
 	}
 	out.LogLevel = in.LogLevel
+	out.LogFormat = in.LogFormat
 	if err := Convert_config_ServerConfiguration_To_v1alpha1_ServerConfiguration(&in.Server, &out.Server, s); err != nil {
 		return err
 	}

--- a/pkg/admissioncontroller/apis/config/validation/admissioncontrollerconfiguration.go
+++ b/pkg/admissioncontroller/apis/config/validation/admissioncontrollerconfiguration.go
@@ -16,6 +16,7 @@ package validation
 
 import (
 	apisconfig "github.com/gardener/gardener/pkg/admissioncontroller/apis/config"
+	"github.com/gardener/gardener/pkg/logger"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -26,6 +27,13 @@ import (
 // ValidateAdmissionControllerConfiguration validates the given `AdmissionControllerConfiguration`.
 func ValidateAdmissionControllerConfiguration(config *apisconfig.AdmissionControllerConfiguration) field.ErrorList {
 	allErrs := field.ErrorList{}
+
+	if !sets.NewString(logger.AllLogLevels...).Has(config.LogLevel) {
+		allErrs = append(allErrs, field.NotSupported(field.NewPath("logLevel"), config.LogLevel, logger.AllLogLevels))
+	}
+	if !sets.NewString(logger.AllLogFormats...).Has(config.LogFormat) {
+		allErrs = append(allErrs, field.NotSupported(field.NewPath("logFormat"), config.LogFormat, logger.AllLogFormats))
+	}
 
 	serverPath := field.NewPath("server")
 	if config.Server.ResourceAdmissionConfiguration != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
This PR adds Configurable log level/format for the gardener admission controller.
New command line flags are introduced to achieve it - `--log-level=<debug/info/error>` and `log-format=<json/text>`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:
Part of #5191
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
gardener-admission-controller's log level and log format can be now configured.
```
