### PR TITLE
Keep traffic from istio ingress gateway to the target pods in the same zone if possible.

### DIFF
--- a/pkg/operation/botanist/component/kubeapiserverexposure/kube_apiserver_sni.go
+++ b/pkg/operation/botanist/component/kubeapiserverexposure/kube_apiserver_sni.go
@@ -31,9 +31,11 @@ import (
 
 	"github.com/Masterminds/sprig"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 	istioapinetworkingv1beta1 "istio.io/api/networking/v1beta1"
 	istionetworkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	istionetworkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -130,6 +132,16 @@ func (s *sni) Deploy(ctx context.Context) error {
 							Interval: &durationpb.Duration{Seconds: 75},
 						},
 					},
+				},
+				LoadBalancer: &istioapinetworkingv1beta1.LoadBalancerSettings{
+					LocalityLbSetting: &istioapinetworkingv1beta1.LocalityLoadBalancerSetting{
+						Enabled:          &wrapperspb.BoolValue{Value: true},
+						FailoverPriority: []string{corev1.LabelTopologyZone},
+					},
+				},
+				// OutlierDetection is required for locality settings to take effect
+				OutlierDetection: &istioapinetworkingv1beta1.OutlierDetection{
+					MinHealthPercent: 0,
 				},
 				Tls: &istioapinetworkingv1beta1.ClientTLSSettings{
 					Mode: istioapinetworkingv1beta1.ClientTLSSettings_DISABLE,

--- a/pkg/operation/botanist/component/kubeapiserverexposure/kube_apiserver_sni_test.go
+++ b/pkg/operation/botanist/component/kubeapiserverexposure/kube_apiserver_sni_test.go
@@ -30,6 +30,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 	istioapinetworkingv1beta1 "istio.io/api/networking/v1beta1"
 	istionetworkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	istionetworkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
@@ -108,6 +109,15 @@ var _ = Describe("#SNI", func() {
 								Interval: &durationpb.Duration{Seconds: 75},
 							},
 						},
+					},
+					LoadBalancer: &istioapinetworkingv1beta1.LoadBalancerSettings{
+						LocalityLbSetting: &istioapinetworkingv1beta1.LocalityLoadBalancerSetting{
+							Enabled:          &wrapperspb.BoolValue{Value: true},
+							FailoverPriority: []string{"topology.kubernetes.io/zone"},
+						},
+					},
+					OutlierDetection: &istioapinetworkingv1beta1.OutlierDetection{
+						MinHealthPercent: 0,
 					},
 					Tls: &istioapinetworkingv1beta1.ClientTLSSettings{
 						Mode: istioapinetworkingv1beta1.ClientTLSSettings_DISABLE,

--- a/pkg/operation/botanist/component/test/istiocomponent.go
+++ b/pkg/operation/botanist/component/test/istiocomponent.go
@@ -18,6 +18,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 	istioapimetav1alpha1 "istio.io/api/meta/v1alpha1"
 	istioapinetworkingv1beta1 "istio.io/api/networking/v1beta1"
 )
@@ -30,7 +31,11 @@ func CmpOptsForDestinationRule() cmp.Option {
 		istioapinetworkingv1beta1.ConnectionPoolSettings{},
 		istioapinetworkingv1beta1.ConnectionPoolSettings_TCPSettings{},
 		istioapinetworkingv1beta1.ConnectionPoolSettings_TCPSettings_TcpKeepalive{},
+		istioapinetworkingv1beta1.LoadBalancerSettings{},
+		istioapinetworkingv1beta1.LocalityLoadBalancerSetting{},
+		istioapinetworkingv1beta1.OutlierDetection{},
 		durationpb.Duration{},
+		wrapperspb.BoolValue{},
 		istioapinetworkingv1beta1.ClientTLSSettings{},
 		istioapimetav1alpha1.IstioStatus{},
 	)

--- a/pkg/operation/botanist/component/vpnauthzserver/external_authz_server.go
+++ b/pkg/operation/botanist/component/vpnauthzserver/external_authz_server.go
@@ -25,6 +25,7 @@ import (
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
 
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 	istionetworkingv1beta1 "istio.io/api/networking/v1beta1"
 	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -161,6 +162,16 @@ func (a *authzServer) Deploy(ctx context.Context) error {
 							},
 						},
 					},
+				},
+				LoadBalancer: &istionetworkingv1beta1.LoadBalancerSettings{
+					LocalityLbSetting: &istionetworkingv1beta1.LocalityLoadBalancerSetting{
+						Enabled:          &wrapperspb.BoolValue{Value: true},
+						FailoverPriority: []string{corev1.LabelTopologyZone},
+					},
+				},
+				// OutlierDetection is required for locality settings to take effect
+				OutlierDetection: &istionetworkingv1beta1.OutlierDetection{
+					MinHealthPercent: 0,
 				},
 				Tls: &istionetworkingv1beta1.ClientTLSSettings{
 					Mode: istionetworkingv1beta1.ClientTLSSettings_DISABLE,

--- a/pkg/operation/botanist/component/vpnauthzserver/external_authz_server_test.go
+++ b/pkg/operation/botanist/component/vpnauthzserver/external_authz_server_test.go
@@ -28,6 +28,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 	istioapinetworkingv1beta1 "istio.io/api/networking/v1beta1"
 	istionetworkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	istionetworkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
@@ -194,6 +195,15 @@ var _ = Describe("ExtAuthzServer", func() {
 								},
 							},
 						},
+					},
+					LoadBalancer: &istioapinetworkingv1beta1.LoadBalancerSettings{
+						LocalityLbSetting: &istioapinetworkingv1beta1.LocalityLoadBalancerSetting{
+							Enabled:          &wrapperspb.BoolValue{Value: true},
+							FailoverPriority: []string{"topology.kubernetes.io/zone"},
+						},
+					},
+					OutlierDetection: &istioapinetworkingv1beta1.OutlierDetection{
+						MinHealthPercent: 0,
 					},
 					Tls: &istioapinetworkingv1beta1.ClientTLSSettings{
 						Mode: istioapinetworkingv1beta1.ClientTLSSettings_DISABLE,

--- a/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server.go
+++ b/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server.go
@@ -30,6 +30,7 @@ import (
 	secretsmanager "github.com/gardener/gardener/pkg/utils/secrets/manager"
 
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 	istionetworkingv1beta1 "istio.io/api/networking/v1beta1"
 	networkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
@@ -583,6 +584,16 @@ func (v *vpnSeedServer) Deploy(ctx context.Context) error {
 							},
 						},
 					},
+				},
+				LoadBalancer: &istionetworkingv1beta1.LoadBalancerSettings{
+					LocalityLbSetting: &istionetworkingv1beta1.LocalityLoadBalancerSetting{
+						Enabled:          &wrapperspb.BoolValue{Value: true},
+						FailoverPriority: []string{corev1.LabelTopologyZone},
+					},
+				},
+				// OutlierDetection is required for locality settings to take effect
+				OutlierDetection: &istionetworkingv1beta1.OutlierDetection{
+					MinHealthPercent: 0,
 				},
 				Tls: &istionetworkingv1beta1.ClientTLSSettings{
 					Mode: istionetworkingv1beta1.ClientTLSSettings_DISABLE,

--- a/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server_test.go
+++ b/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server_test.go
@@ -33,6 +33,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"google.golang.org/protobuf/types/known/durationpb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 	istionetworkingv1beta1 "istio.io/api/networking/v1beta1"
 	networkingv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
 	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
@@ -527,6 +528,15 @@ admin:
 								},
 							},
 						},
+					},
+					LoadBalancer: &istionetworkingv1beta1.LoadBalancerSettings{
+						LocalityLbSetting: &istionetworkingv1beta1.LocalityLoadBalancerSetting{
+							Enabled:          &wrapperspb.BoolValue{Value: true},
+							FailoverPriority: []string{"topology.kubernetes.io/zone"},
+						},
+					},
+					OutlierDetection: &istionetworkingv1beta1.OutlierDetection{
+						MinHealthPercent: 0,
 					},
 					Tls: &istionetworkingv1beta1.ClientTLSSettings{
 						Mode: istionetworkingv1beta1.ClientTLSSettings_DISABLE,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area networking
/area cost
/area high-availability
/kind enhancement

**What this PR does / why we need it**:
Keep traffic from istio ingress gateway to the target pods in the same zone if possible.

Supporting multiple availability zones has a number of benefits in terms of potential availability. However, it also can have some downsides, especially with regards to additional latency and potential cost increase. As availability zones have some spatial distance between them there is some automatic latency added to traffic moving between zones. In addition to that, there might be a cost involved in sending data between zones.
These are the main reasons why it may be beneficial to keep traffic within an availability zone if possible, i.e. if there are ready backend available within the zone. Even though this might have positive impact with regards to reduced latency and costs, it is important to note that this can also caused imbalance in terms of the request distribution, e.g. backends in a zone without an istio ingress gateway might receive hardly any traffic as long as the other backends can handle the load.
This change configures the istio ingress gateway to prioritize backends in the same zone higher as those in different zones. In case no backend is available in the current zone the request is routed to any of the other backends. It is necessary to activate the outlier detection. Without it, istio will not honour the fail-over priorities.
This change explicitly does not take care about scheduling workload in particular zones.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The istio ingress gateway prefers backends within the same availability zone to reduce cross-zonal traffic.
```
