### PR TITLE
controller-manager: Prevent nil pointer dereference when `.controllers.certificateSigningRequest` is not specified

### DIFF
--- a/pkg/controllermanager/apis/config/v1alpha1/defaults.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/defaults.go
@@ -39,6 +39,10 @@ func SetDefaults_ControllerManagerConfiguration(obj *ControllerManagerConfigurat
 		obj.Controllers.Bastion.MaxLifetime = &metav1.Duration{Duration: 24 * time.Hour}
 	}
 
+	if obj.Controllers.CertificateSigningRequest == nil {
+		obj.Controllers.CertificateSigningRequest = &CertificateSigningRequestControllerConfiguration{}
+	}
+
 	if obj.Controllers.CloudProfile == nil {
 		obj.Controllers.CloudProfile = &CloudProfileControllerConfiguration{}
 	}

--- a/pkg/controllermanager/apis/config/v1alpha1/defaults_test.go
+++ b/pkg/controllermanager/apis/config/v1alpha1/defaults_test.go
@@ -44,6 +44,8 @@ var _ = Describe("Defaults", func() {
 			Expect(obj.Controllers.Bastion.ConcurrentSyncs).To(PointTo(Equal(5)))
 			Expect(obj.Controllers.Bastion.MaxLifetime).To(PointTo(Equal(metav1.Duration{Duration: 24 * time.Hour})))
 
+			Expect(obj.Controllers.CertificateSigningRequest).NotTo(BeNil())
+
 			Expect(obj.Controllers.CloudProfile).NotTo(BeNil())
 			Expect(obj.Controllers.CloudProfile.ConcurrentSyncs).NotTo(BeNil())
 			Expect(obj.Controllers.CloudProfile.ConcurrentSyncs).To(PointTo(Equal(5)))


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
After https://github.com/gardener/gardener/pull/6620 starting GCM with component config that does not specify `.controllers.certificateSigningRequest` panics with nil pointer dereference at https://github.com/gardener/gardener/blob/b57c3d05a894d425e4d18d7397f3fbd480be5d62/pkg/controllermanager/controller/add.go#L56

<details>

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x2502165]

goroutine 1 [running]:
github.com/gardener/gardener/pkg/controllermanager/controller.AddControllersToManager({0x2cc34a0, 0xc000592d00}, 0xc000348480)
	/go/src/github.com/gardener/gardener/pkg/controllermanager/controller/add.go:56 +0x1e5
github.com/gardener/gardener/cmd/gardener-controller-manager/app.run({0x2cb72f0, 0xc0005be900}, {{0x2cb9bc8?, 0xc00037b3e0?}, 0x24?}, 0xc000348480)
	/go/src/github.com/gardener/gardener/cmd/gardener-controller-manager/app/app.go:177 +0xb2e
github.com/gardener/gardener/cmd/gardener-controller-manager/app.NewCommand.func1(0xc0001fe780, {0xc00053aea0?, 0x1?, 0x1?})
	/go/src/github.com/gardener/gardener/cmd/gardener-controller-manager/app/app.go:85 +0x3a5
github.com/spf13/cobra.(*Command).execute(0xc0001fe780, {0xc000052050, 0x1, 0x1})
	/go/src/github.com/gardener/gardener/vendor/github.com/spf13/cobra/command.go:856 +0x67c
github.com/spf13/cobra.(*Command).ExecuteC(0xc0001fe780)
	/go/src/github.com/gardener/gardener/vendor/github.com/spf13/cobra/command.go:974 +0x3bd
github.com/spf13/cobra.(*Command).Execute(...)
	/go/src/github.com/gardener/gardener/vendor/github.com/spf13/cobra/command.go:902
github.com/spf13/cobra.(*Command).ExecuteContext(...)
	/go/src/github.com/gardener/gardener/vendor/github.com/spf13/cobra/command.go:895
main.main()
	/go/src/github.com/gardener/gardener/cmd/gardener-controller-manager/main.go:32 +0x71
exit status 2
```

</details>

**Which issue(s) this PR fixes**:
See above.

**Special notes for your reviewer**:
This PR adds corresponding defaults when `.controllers.certificateSigningRequest` is nil. The rest of the defaulting for `CertificateSigningRequestControllerConfiguration` is handled by the `SetDefaults_CertificateSigningRequestControllerConfiguration` func.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
