### PR TITLE
Fixes `make gardener-down` failing at deletion of `garden` `Project`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -316,7 +316,7 @@ gardener-down: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	$(KUBECTL) delete seed local2 --ignore-not-found --wait --timeout 5m
 	$(SKAFFOLD) delete -m provider-local,gardenlet
 	$(KUBECTL) delete validatingwebhookconfiguration/validate-namespace-deletion --ignore-not-found
-	$(KUBECTL) annotate project local confirmation.gardener.cloud/deletion=true
+	$(KUBECTL) annotate project local garden confirmation.gardener.cloud/deletion=true
 	$(SKAFFOLD) delete -m local-env
 	$(SKAFFOLD) delete -m etcd,controlplane
 	@# workaround for https://github.com/gardener/gardener/issues/5164

--- a/hack/ci-e2e-kind-migration.sh
+++ b/hack/ci-e2e-kind-migration.sh
@@ -32,6 +32,7 @@ trap "
     export_events_for_kind 'gardener-local'; export_events_for_shoots )
   ( export KUBECONFIG=$PWD/example/gardener-local/kind2/kubeconfig; export_logs 'gardener-local2';
     export_events_for_kind 'gardener-local2' )
+  ( make kind-down; make kind2-down )
 " EXIT
 
 make gardener-up
@@ -40,5 +41,6 @@ make gardenlet-kind2-up
 # run test
 make test-e2e-local-migration
 
+# test teardown
 make gardener-down
 make gardenlet-kind2-down

--- a/hack/ci-e2e-kind-migration.sh
+++ b/hack/ci-e2e-kind-migration.sh
@@ -39,3 +39,6 @@ make gardenlet-kind2-up
 
 # run test
 make test-e2e-local-migration
+
+make gardener-down
+make gardenlet-kind2-down

--- a/hack/ci-e2e-kind.sh
+++ b/hack/ci-e2e-kind.sh
@@ -35,3 +35,5 @@ make gardener-up
 
 # run test
 make test-e2e-local
+
+make gardener-down

--- a/hack/ci-e2e-kind.sh
+++ b/hack/ci-e2e-kind.sh
@@ -29,6 +29,7 @@ make kind-up
 trap "
   ( export KUBECONFIG=$PWD/example/gardener-local/kind/kubeconfig; export_logs 'gardener-local';
     export_events_for_kind 'gardener-local'; export_events_for_shoots )
+  ( make kind-down )
 " EXIT
 
 make gardener-up
@@ -36,4 +37,5 @@ make gardener-up
 # run test
 make test-e2e-local
 
+# test teardown
 make gardener-down


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
This pr fixes an issue that would cause `make gardener-down` to fail when trying to delete the `garden` project. Additionally, `make gardener-down` and `make gardenlet-kind2-down` are added to the e2e test scripts so that they also get tested.

**Which issue(s) this PR fixes**:
Fixes #6656 

**Special notes for your reviewer**:
Instead of adding a `confirmation.gardener.cloud/deletion=true` annotation to the `Project` definition directly [here](https://github.com/gardener/gardener/blob/203027d0526b2bf3ebcf1a08d6ac69e9c15a0a66/example/provider-local/garden/base/project.yaml#L2-L7), I added it to the `Makefile` as I saw that that is what we already do for the `local` project.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Fixed an issue that caused `make gardener-down` to fail when deleting the `garden` `Project`.
```
```feature developer
The e2e tests do now also tear down the Gardener environment, effectively verifying whether the `Seed` deletion works as expected.
```
