### PR TITLE
Use `Fail` policy for shoot webhook in `provider-local`

### DIFF
--- a/extensions/pkg/webhook/shoot/shoot.go
+++ b/extensions/pkg/webhook/shoot/shoot.go
@@ -17,6 +17,7 @@ package shoot
 import (
 	"fmt"
 
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -43,6 +44,8 @@ type Args struct {
 	Mutator extensionswebhook.Mutator
 	// MutatorWithShootClient is a mutator to be used by the admission handler. It needs the shoot client.
 	MutatorWithShootClient extensionswebhook.MutatorWithShootClient
+	// FailurePolicy is the failure policy for the webhook (defaults to Ignore).
+	FailurePolicy *admissionregistrationv1.FailurePolicyType
 }
 
 // New creates a new webhook with the shoot as target cluster.
@@ -56,11 +59,12 @@ func New(mgr manager.Manager, args Args) (*extensionswebhook.Webhook, error) {
 	}
 
 	wh := &extensionswebhook.Webhook{
-		Name:     WebhookName,
-		Types:    args.Types,
-		Path:     WebhookName,
-		Target:   extensionswebhook.TargetShoot,
-		Selector: namespaceSelector,
+		Name:          WebhookName,
+		Types:         args.Types,
+		Path:          WebhookName,
+		Target:        extensionswebhook.TargetShoot,
+		Selector:      namespaceSelector,
+		FailurePolicy: args.FailurePolicy,
 	}
 
 	switch {

--- a/pkg/provider-local/webhook/shoot/add.go
+++ b/pkg/provider-local/webhook/shoot/add.go
@@ -18,6 +18,7 @@ import (
 	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
 	"github.com/gardener/gardener/extensions/pkg/webhook/shoot"
 
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -34,12 +35,15 @@ var (
 type AddOptions struct{}
 
 // AddToManagerWithOptions creates a webhook with the given options and adds it to the manager.
-func AddToManagerWithOptions(mgr manager.Manager, opts AddOptions) (*extensionswebhook.Webhook, error) {
+func AddToManagerWithOptions(mgr manager.Manager, _ AddOptions) (*extensionswebhook.Webhook, error) {
 	logger.Info("Adding webhook to manager")
 
+	failurePolicy := admissionregistrationv1.Fail
+
 	return shoot.New(mgr, shoot.Args{
-		Types:   []extensionswebhook.Type{{Obj: &corev1.ConfigMap{}}},
-		Mutator: NewMutator(),
+		Types:         []extensionswebhook.Type{{Obj: &corev1.ConfigMap{}}},
+		Mutator:       NewMutator(),
+		FailurePolicy: &failurePolicy,
 	})
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind flake

**What this PR does / why we need it**:
This deflakes random e2e shoot creation failures because of a race condition with the shoot webhook.
See for example https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/6667/pull-gardener-e2e-kind/1569575199974625280:

```
{"level":"info","ts":"2022-09-13T06:53:33.408Z","logger":"test","msg":"Last Operation","shoot":"garden-local/e2e-wake-up","lastOperation":"&LastOperation{Description:Shoot cluster has been successfully reconciled.,LastUpdateTime:2022-09-13 06:48:23 +0000 UTC,Progress:100,State:Succeeded,Type:Create,}"}
{"level":"info","ts":"2022-09-13T06:54:03.413Z","logger":"test","msg":"Shoot not yet created","shoot":"garden-local/e2e-wake-up","reason":"condition type SystemComponentsHealthy is not true yet, had message error during apply of object \"v1/ConfigMap/kube-system/kube-proxy-config-d0aca43a\": ConfigMap \"kube-proxy-config-d0aca43a\" is invalid: data: Forbidden: field is immutable when `immutable` is set with reason ApplyFailed"}
```

The `Shoot` got created successfully, however the `kube-proxy` configuration could not be patched. Since it's an immutable `ConfigMap`, it will never succeed again in case the webhook server misses the request on creation.

The `failurePolicy` for shoot webhooks is defaulted to `Ignore` here: https://github.com/gardener/gardener/blob/85a13f1103cdc5e3a8ddbd835c87bf444bc7bb49/extensions/pkg/webhook/registration.go#L97-L98

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
