### PR TITLE
Deflake Shoot Maintenance controller integration test

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -170,7 +170,7 @@ images:
   repository: registry.k8s.io/dns/k8s-dns-node-cache
   tag: "1.22.8"
 - name: node-problem-detector
-  sourceRepository: github.com/gardener/node-problem-detector
+  sourceRepository: github.com/kubernetes/node-problem-detector
   repository: registry.k8s.io/node-problem-detector/node-problem-detector
   tag: "v0.8.12"
 

--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -526,13 +526,13 @@ func SeedUsesNginxIngressController(seed *gardencorev1beta1.Seed) bool {
 // DetermineMachineImageForName finds the cloud specific machine images in the <cloudProfile> for the given <name> and
 // region. In case it does not find the machine image with the <name>, it returns false. Otherwise, true and the
 // cloud-specific machine image will be returned.
-func DetermineMachineImageForName(cloudProfile *gardencorev1beta1.CloudProfile, name string) (bool, gardencorev1beta1.MachineImage, error) {
+func DetermineMachineImageForName(cloudProfile *gardencorev1beta1.CloudProfile, name string) (bool, gardencorev1beta1.MachineImage) {
 	for _, image := range cloudProfile.Spec.MachineImages {
 		if strings.EqualFold(image.Name, name) {
-			return true, image, nil
+			return true, image
 		}
 	}
-	return false, gardencorev1beta1.MachineImage{}, nil
+	return false, gardencorev1beta1.MachineImage{}
 }
 
 // FindMachineImageVersion finds the machine image version in the <cloudProfile> for the given <name> and <version>.

--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -535,6 +535,22 @@ func DetermineMachineImageForName(cloudProfile *gardencorev1beta1.CloudProfile, 
 	return false, gardencorev1beta1.MachineImage{}, nil
 }
 
+// FindMachineImageVersion finds the machine image version in the <cloudProfile> for the given <name> and <version>.
+// In case no machine image version can be found with the given <name> or <version>, false is being returned.
+func FindMachineImageVersion(cloudProfile *gardencorev1beta1.CloudProfile, name, version string) (bool, gardencorev1beta1.MachineImageVersion) {
+	for _, image := range cloudProfile.Spec.MachineImages {
+		if image.Name == name {
+			for _, imageVersion := range image.Versions {
+				if imageVersion.Version == version {
+					return true, imageVersion
+				}
+			}
+		}
+	}
+
+	return false, gardencorev1beta1.MachineImageVersion{}
+}
+
 // ShootMachineImageVersionExists checks if the shoot machine image (name, version) exists in the machine image constraint and returns true if yes and the index in the versions slice
 func ShootMachineImageVersionExists(constraint gardencorev1beta1.MachineImage, image gardencorev1beta1.ShootMachineImage) (bool, int) {
 	if constraint.Name != image.Name {

--- a/pkg/controllermanager/apis/config/validation/validation.go
+++ b/pkg/controllermanager/apis/config/validation/validation.go
@@ -35,7 +35,7 @@ func ValidateControllerManagerConfiguration(conf *config.ControllerManagerConfig
 
 	if conf.LogFormat != "" {
 		if !sets.NewString(logger.AllLogFormats...).Has(conf.LogFormat) {
-			allErrs = append(allErrs, field.NotSupported(field.NewPath("logFormat"), conf.LogLevel, logger.AllLogFormats))
+			allErrs = append(allErrs, field.NotSupported(field.NewPath("logFormat"), conf.LogFormat, logger.AllLogFormats))
 		}
 	}
 

--- a/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
+++ b/pkg/controllermanager/controller/shoot/maintenance/reconciler.go
@@ -427,10 +427,7 @@ func isWorkerCRPartOfCloudProfileVersionCRs(wanted gardencorev1beta1.ContainerRu
 }
 
 func determineMachineImage(cloudProfile *gardencorev1beta1.CloudProfile, shootMachineImage *gardencorev1beta1.ShootMachineImage) (gardencorev1beta1.MachineImage, error) {
-	machineImagesFound, machineImageFromCloudProfile, err := gardencorev1beta1helper.DetermineMachineImageForName(cloudProfile, shootMachineImage.Name)
-	if err != nil {
-		return gardencorev1beta1.MachineImage{}, fmt.Errorf("failure while determining the default machine image in the CloudProfile: %s", err.Error())
-	}
+	machineImagesFound, machineImageFromCloudProfile := gardencorev1beta1helper.DetermineMachineImageForName(cloudProfile, shootMachineImage.Name)
 	if !machineImagesFound {
 		return gardencorev1beta1.MachineImage{}, fmt.Errorf("failure while determining the default machine image in the CloudProfile: no machineImage with name %q (specified in shoot) could be found in the cloudProfile %q", shootMachineImage.Name, cloudProfile.Name)
 	}

--- a/test/integration/controllermanager/shoot/maintenance/maintenance_suite_test.go
+++ b/test/integration/controllermanager/shoot/maintenance/maintenance_suite_test.go
@@ -54,6 +54,7 @@ var (
 	restConfig *rest.Config
 	testEnv    *gardenerenvtest.GardenerTestEnvironment
 	testClient client.Client
+	mgrClient  client.Reader
 
 	testNamespace *corev1.Namespace
 )
@@ -107,6 +108,7 @@ var _ = BeforeSuite(func() {
 		Namespace:          testNamespace.Name,
 	})
 	Expect(err).NotTo(HaveOccurred())
+	mgrClient = mgr.GetClient()
 
 	By("registering controller")
 	Expect((&maintenance.Reconciler{

--- a/test/integration/controllermanager/shoot/maintenance/utils_test.go
+++ b/test/integration/controllermanager/shoot/maintenance/utils_test.go
@@ -35,14 +35,14 @@ import (
 // see https://onsi.github.io/gomega/#modifying-default-intervals
 func waitForShootToBeMaintained(shoot *gardencorev1beta1.Shoot) {
 	By("waiting for shoot to be maintained")
-	Eventually(func(g Gomega) bool {
+	EventuallyWithOffset(1, func(g Gomega) bool {
 		g.Expect(testClient.Get(ctx, client.ObjectKeyFromObject(shoot), shoot)).To(Succeed())
 		return shoot.ObjectMeta.Annotations[v1beta1constants.GardenerOperation] == v1beta1constants.ShootOperationMaintain
 	}).Should(BeFalse())
 }
 
 func waitMachineImageVersionToBeExpiredInCloudProfile(cloudProfileName, imageName, imageVersion string, expirationDate *metav1.Time) {
-	Eventually(func(g Gomega) {
+	EventuallyWithOffset(1, func(g Gomega) {
 		cloudProfile := &gardencorev1beta1.CloudProfile{}
 		g.Expect(mgrClient.Get(ctx, client.ObjectKey{Name: cloudProfileName}, cloudProfile)).To(Succeed())
 
@@ -55,7 +55,7 @@ func waitMachineImageVersionToBeExpiredInCloudProfile(cloudProfileName, imageNam
 }
 
 func waitKubernetesVersionToBeExpiredInCloudProfile(cloudProfileName, k8sVersion string, expirationDate *metav1.Time) {
-	Eventually(func(g Gomega) {
+	EventuallyWithOffset(1, func(g Gomega) {
 		cloudProfile := &gardencorev1beta1.CloudProfile{}
 		g.Expect(mgrClient.Get(ctx, client.ObjectKey{Name: cloudProfileName}, cloudProfile)).To(Succeed())
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
See #6659

**Which issue(s) this PR fixes**:
Fixes #6659

On the yesterdays HEAD (203027d0526b2bf3ebcf1a08d6ac69e9c15a0a66):
```
$ stress -p 32 ./test/integration/controllermanager/shoot/maintenance/maintenance.test -ginkgo.progress
...
10m20s: 422 runs so far, 19 failures (4.50%)
```

With this PR:
```
$ stress -p 32 ./test/integration/controllermanager/shoot/maintenance/maintenance.test -ginkgo.progress
...
21m20s: 873 runs so far, 0 failures
```

**Special notes for your reviewer**:
The PR also includes 2 cleanup small commits that are not directly related to the deflaking but I decided to add them as this PR as it does not make sense to create a new PR for such small changes.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
