### PR TITLE
[GEP-20] Add Topology Spread Constraints for Kube-Apiserver

### DIFF
--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
@@ -1711,19 +1711,14 @@ rules:
 			It("should have the expected pod settings", func() {
 				deployAndRead()
 
-				Expect(deployment.Spec.Template.Spec.Affinity).To(Equal(&corev1.Affinity{
-					PodAntiAffinity: &corev1.PodAntiAffinity{
-						PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{{
-							Weight: 1,
-							PodAffinityTerm: corev1.PodAffinityTerm{
-								TopologyKey: "kubernetes.io/hostname",
-								LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
-									"app":  "kubernetes",
-									"role": "apiserver",
-								}},
-							},
-						}},
-					},
+				Expect(deployment.Spec.Template.Spec.TopologySpreadConstraints).To(ConsistOf(corev1.TopologySpreadConstraint{
+					TopologyKey:       "kubernetes.io/hostname",
+					MaxSkew:           1,
+					WhenUnsatisfiable: corev1.DoNotSchedule,
+					LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+						"app":  "kubernetes",
+						"role": "apiserver",
+					}},
 				}))
 				Expect(deployment.Spec.Template.Spec.PriorityClassName).To(Equal("gardener-system-500"))
 				Expect(deployment.Spec.Template.Spec.AutomountServiceAccountToken).To(PointTo(BeFalse()))
@@ -1733,27 +1728,63 @@ rules:
 				Expect(deployment.Spec.Template.Spec.TerminationGracePeriodSeconds).To(PointTo(Equal(int64(30))))
 			})
 
-			It("should have pod anti affinity for zone", func() {
+			It("should have topology spread constraint for zone", func() {
 				v := values
 				failureToleranceType := gardencorev1beta1.FailureToleranceTypeZone
 				v.FailureToleranceType = &failureToleranceType
 				kapi = New(kubernetesInterface, namespace, sm, v)
 				deployAndRead()
 
-				Expect(deployment.Spec.Template.Spec.Affinity).To(Equal(&corev1.Affinity{
-					PodAntiAffinity: &corev1.PodAntiAffinity{
-						PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{{
-							Weight: 1,
-							PodAffinityTerm: corev1.PodAffinityTerm{
-								TopologyKey: "topology.kubernetes.io/zone",
-								LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
-									"app":  "kubernetes",
-									"role": "apiserver",
-								}},
-							},
+				Expect(deployment.Spec.Template.Spec.TopologySpreadConstraints).To(ConsistOf(
+					corev1.TopologySpreadConstraint{
+						TopologyKey:       "topology.kubernetes.io/zone",
+						MaxSkew:           1,
+						WhenUnsatisfiable: corev1.DoNotSchedule,
+						LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+							"app":  "kubernetes",
+							"role": "apiserver",
 						}},
 					},
-				}))
+					corev1.TopologySpreadConstraint{
+						TopologyKey:       "kubernetes.io/hostname",
+						MaxSkew:           1,
+						WhenUnsatisfiable: corev1.DoNotSchedule,
+						LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+							"app":  "kubernetes",
+							"role": "apiserver",
+						}},
+					},
+				))
+			})
+
+			It("should have topology spread constraint for zone and adapted maxSkew", func() {
+				v := values
+				failureToleranceType := gardencorev1beta1.FailureToleranceTypeZone
+				v.FailureToleranceType = &failureToleranceType
+				v.Autoscaling.MaxReplicas = 6
+				kapi = New(kubernetesInterface, namespace, sm, v)
+				deployAndRead()
+
+				Expect(deployment.Spec.Template.Spec.TopologySpreadConstraints).To(ConsistOf(
+					corev1.TopologySpreadConstraint{
+						TopologyKey:       "topology.kubernetes.io/zone",
+						MaxSkew:           2,
+						WhenUnsatisfiable: corev1.DoNotSchedule,
+						LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+							"app":  "kubernetes",
+							"role": "apiserver",
+						}},
+					},
+					corev1.TopologySpreadConstraint{
+						TopologyKey:       "kubernetes.io/hostname",
+						MaxSkew:           1,
+						WhenUnsatisfiable: corev1.DoNotSchedule,
+						LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
+							"app":  "kubernetes",
+							"role": "apiserver",
+						}},
+					},
+				))
 			})
 
 			It("should have no init containers when reversed vpn is enabled", func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area high-availability
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
This PR adds Pod [Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) to the Kube-Apiserver of shoot control-planes and replaces the formerly used `podAntiAffinity`.

**Which issue(s) this PR fixes**:
Fixes parts of #6529

**Special notes for your reviewer**:
/cc @unmarshall @shreyas-s-rao 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `kube-apiserver` deployment was changed from pod anti-affinity to [Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/). Non-HA shoot clusters will still have the `kube-apiserver` pods being scheduled on different nodes on a best-effort basis. For HA clusters, the Topology Spread Constraints make sure that a distribution across nodes (single-zone) and zones (multi-zonal) is guaranteed, in order to tolerate failures in these domains.
```
