### PR TITLE
Add a panel "Response Size Rate" to the API Server dashboard

### DIFF
--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/apiserver-overview.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/apiserver-overview.json
@@ -89,7 +89,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.10",
+      "pluginVersion": "7.5.16",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -196,7 +196,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.10",
+      "pluginVersion": "7.5.16",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -296,7 +296,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.10",
+      "pluginVersion": "7.5.16",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -395,7 +395,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.10",
+      "pluginVersion": "7.5.16",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -504,7 +504,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.10",
+      "pluginVersion": "7.5.16",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -599,7 +599,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.10",
+      "pluginVersion": "7.5.16",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -708,7 +708,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.10",
+      "pluginVersion": "7.5.16",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -807,7 +807,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.10",
+      "pluginVersion": "7.5.16",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -932,7 +932,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.10",
+      "pluginVersion": "7.5.16",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1044,7 +1044,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.10",
+      "pluginVersion": "7.5.16",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1158,7 +1158,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.10",
+      "pluginVersion": "7.5.16",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1264,7 +1264,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.10",
+      "pluginVersion": "7.5.16",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1375,7 +1375,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.10",
+      "pluginVersion": "7.5.16",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1488,7 +1488,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.10",
+      "pluginVersion": "7.5.16",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1601,7 +1601,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.10",
+      "pluginVersion": "7.5.16",
       "pointradius": 5,
       "points": false,
       "renderer": "flot",
@@ -1701,7 +1701,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.10",
+      "pluginVersion": "7.5.16",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1796,7 +1796,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.10",
+      "pluginVersion": "7.5.16",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -1904,7 +1904,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.10",
+      "pluginVersion": "7.5.16",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2003,7 +2003,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.10",
+      "pluginVersion": "7.5.16",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2112,7 +2112,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.10",
+      "pluginVersion": "7.5.16",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2211,7 +2211,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.10",
+      "pluginVersion": "7.5.16",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2310,7 +2310,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.10",
+      "pluginVersion": "7.5.16",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2409,7 +2409,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.10",
+      "pluginVersion": "7.5.16",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2517,7 +2517,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.10",
+      "pluginVersion": "7.5.16",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2634,7 +2634,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.10",
+      "pluginVersion": "7.5.16",
       "pointradius": 0.5,
       "points": false,
       "renderer": "flot",
@@ -2735,7 +2735,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.10",
+      "pluginVersion": "7.5.16",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2842,7 +2842,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.10",
+      "pluginVersion": "7.5.16",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -2942,7 +2942,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.10",
+      "pluginVersion": "7.5.16",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -3043,7 +3043,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.10",
+      "pluginVersion": "7.5.16",
       "pointradius": 0.5,
       "points": false,
       "renderer": "flot",
@@ -3145,7 +3145,7 @@
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "7.5.10",
+      "pluginVersion": "7.5.16",
       "pointradius": 0.5,
       "points": false,
       "renderer": "flot",
@@ -3217,7 +3217,7 @@
       {
         "allValue": ".*",
         "current": {
-          "selected": true,
+          "selected": false,
           "text": [
             "All"
           ],
@@ -3382,13 +3382,9 @@
       {
         "allValue": null,
         "current": {
-          "selected": true,
-          "text": [
-            "0.99"
-          ],
-          "value": [
-            "0.99"
-          ]
+          "selected": false,
+          "text": "0.99",
+          "value": "0.99"
         },
         "datasource": null,
         "definition": "label_values(apiserver_latency_seconds:quantile, quantile)",

--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/apiserver-overview.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/apiserver-overview.json
@@ -2063,13 +2063,117 @@
       }
     },
     {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "description": "This panel shows the rate of response sizes by resource and verb.\n\nOutstandingly high values could give a hint for shoot operators on where\nto start on the journey of reducing the load on the API servers,\nby making sure to use WATCH requests instead of periodic LIST and\nGET requests in the various controllers.\n\nHigh values for WATCH requests could hint at reducing the rate of change for the specific resource.",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 84
+      },
+      "hiddenSeries": false,
+      "id": 98,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sort": "avg",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "alertThreshold": true
+      },
+      "percentage": false,
+      "pluginVersion": "7.5.16",
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "exemplar": true,
+          "expr": "sum(rate(apiserver_response_sizes_sum{pod=~\"$apiserver\",verb=~\"$verb\"}[$__rate_interval])) by(resource, verb) > 0",
+          "interval": "",
+          "legendFormat": "{{resource}} {{verb}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Response Size Rate Per Resource and Verb",
+      "tooltip": {
+        "shared": false,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:884",
+          "format": "binBps",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:885",
+          "format": "short",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
       "collapsed": false,
       "datasource": null,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 84
+        "y": 92
       },
       "id": 85,
       "panels": [],
@@ -2092,7 +2196,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 85
+        "y": 93
       },
       "hiddenSeries": false,
       "id": 80,
@@ -2187,7 +2291,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 85
+        "y": 93
       },
       "hiddenSeries": false,
       "id": 81,
@@ -2286,7 +2390,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 91
+        "y": 99
       },
       "hiddenSeries": false,
       "id": 77,
@@ -2385,7 +2489,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 91
+        "y": 99
       },
       "hiddenSeries": false,
       "id": 78,
@@ -2484,7 +2588,7 @@
         "h": 6,
         "w": 24,
         "x": 0,
-        "y": 97
+        "y": 105
       },
       "hiddenSeries": false,
       "id": 82,
@@ -2585,7 +2689,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 103
+        "y": 111
       },
       "id": 61,
       "panels": [],
@@ -2610,7 +2714,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 104
+        "y": 112
       },
       "hiddenSeries": false,
       "id": 55,
@@ -2711,7 +2815,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 104
+        "y": 112
       },
       "hiddenSeries": false,
       "id": 76,
@@ -2811,7 +2915,7 @@
         "h": 7,
         "w": 12,
         "x": 0,
-        "y": 112
+        "y": 120
       },
       "hiddenSeries": false,
       "id": 57,
@@ -2918,7 +3022,7 @@
         "h": 7,
         "w": 12,
         "x": 12,
-        "y": 112
+        "y": 120
       },
       "hiddenSeries": false,
       "id": 59,
@@ -3019,7 +3123,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 119
+        "y": 127
       },
       "hiddenSeries": false,
       "id": 83,
@@ -3121,7 +3225,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 119
+        "y": 127
       },
       "hiddenSeries": false,
       "id": 86,

--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/apiserver-overview.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/apiserver-overview.json
@@ -99,7 +99,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(.9,sum(rate(apiserver_admission_controller_admission_duration_seconds_bucket{job=~\"$apiserver\",operation=~\"$operation\"}[$__rate_interval])) by(le,name))",
+          "expr": "histogram_quantile(.9,sum(rate(apiserver_admission_controller_admission_duration_seconds_bucket{pod=~\"$apiserver\",operation=~\"$operation\"}[$__rate_interval])) by(le,name))",
           "interval": "",
           "legendFormat": "{{name}}",
           "refId": "A"
@@ -206,7 +206,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.90,sum(rate(apiserver_admission_webhook_admission_duration_seconds_bucket{job=~\"$apiserver\",operation=~\"$operation\"}[$__rate_interval])) by(le,name))",
+          "expr": "histogram_quantile(0.90,sum(rate(apiserver_admission_webhook_admission_duration_seconds_bucket{pod=~\"$apiserver\",operation=~\"$operation\"}[$__rate_interval])) by(le,name))",
           "interval": "",
           "legendFormat": "{{name}}",
           "refId": "A"
@@ -306,7 +306,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.90,sum(rate(apiserver_admission_step_admission_duration_seconds_bucket{job=~\"$apiserver\",operation=~\"$operation\"}[$__rate_interval])) by(le,type))",
+          "expr": "histogram_quantile(0.90,sum(rate(apiserver_admission_step_admission_duration_seconds_bucket{pod=~\"$apiserver\",operation=~\"$operation\"}[$__rate_interval])) by(le,type))",
           "interval": "",
           "legendFormat": "{{type}}",
           "refId": "A"
@@ -405,7 +405,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(apiserver_admission_webhook_rejection_count{job=~\"$apiserver\",operation=~\"$operation\"}[$__rate_interval])) by (name,error_type)",
+          "expr": "sum(rate(apiserver_admission_webhook_rejection_count{pod=~\"$apiserver\",operation=~\"$operation\"}[$__rate_interval])) by (name,error_type)",
           "interval": "",
           "legendFormat": "{{name}} ({{error_type}})",
           "refId": "A"
@@ -514,7 +514,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(apiserver_audit_event_total{job=~\"$apiserver\"}[$__rate_interval]))",
+          "expr": "sum(rate(apiserver_audit_event_total{pod=~\"$apiserver\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "Events",
           "refId": "A"
@@ -609,7 +609,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(apiserver_audit_requests_rejected_total{job=~\"$apiserver\"}[$__rate_interval]))",
+          "expr": "sum(rate(apiserver_audit_requests_rejected_total{pod=~\"$apiserver\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "Events",
           "refId": "A"
@@ -718,7 +718,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(authenticated_user_requests{job=~\"$apiserver\"}[$__rate_interval]))",
+          "expr": "sum(rate(authenticated_user_requests{pod=~\"$apiserver\"}[$__rate_interval]))",
           "interval": "",
           "legendFormat": "Requests",
           "refId": "A"
@@ -817,7 +817,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(authentication_attempts{job=~\"$apiserver\"}[$__rate_interval])) by(result)",
+          "expr": "sum(rate(authentication_attempts{pod=~\"$apiserver\"}[$__rate_interval])) by(result)",
           "interval": "",
           "legendFormat": "{{result}}",
           "refId": "A"
@@ -942,7 +942,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(apiserver_request_total{job=~\"$apiserver\"}[$__rate_interval]))",
+          "expr": "sum(rate(apiserver_request_total{pod=~\"$apiserver\"}[$__rate_interval]))",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1055,7 +1055,7 @@
       "targets": [
         {
           "exemplar": false,
-          "expr": "max by(verb, quantile) (apiserver_latency_seconds:quantile{job=~\"$apiserver\", verb=~\"$verb\",quantile=~\"$quantile\",subresource!~\"log|portforward|exec|proxy\"})",
+          "expr": "max by(verb, quantile) (apiserver_latency_seconds:quantile{pod=~\"$apiserver\", verb=~\"$verb\",quantile=~\"$quantile\",subresource!~\"log|portforward|exec|proxy\"})",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 2,
@@ -1168,7 +1168,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(apiserver_request_total{job=~\"$apiserver\"}[$__rate_interval])) by(verb)",
+          "expr": "sum(rate(apiserver_request_total{pod=~\"$apiserver\"}[$__rate_interval])) by(verb)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -1274,7 +1274,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "avg(rate(apiserver_request_total{job=~\"$apiserver\",verb=~\"$verb\"}[$__rate_interval])) by (verb)",
+          "expr": "avg(rate(apiserver_request_total{pod=~\"$apiserver\",verb=~\"$verb\"}[$__rate_interval])) by (verb)",
           "format": "time_series",
           "interval": "",
           "intervalFactor": 1,
@@ -1385,7 +1385,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(apiserver_request_total{job=~\"$apiserver\",scope!=\"\"}[$__rate_interval])) by(scope)",
+          "expr": "sum(rate(apiserver_request_total{pod=~\"$apiserver\",scope!=\"\"}[$__rate_interval])) by(scope)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -1498,7 +1498,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(apiserver_request_total{job=~\"$apiserver\"}[$__rate_interval])) by(resource)",
+          "expr": "sum(rate(apiserver_request_total{pod=~\"$apiserver\"}[$__rate_interval])) by(resource)",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -1806,7 +1806,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(max_over_time(apiserver_current_inqueue_requests{job=~\"$apiserver\"}[1m])) by (request_kind)",
+          "expr": "sum(max_over_time(apiserver_current_inqueue_requests{pod=~\"$apiserver\"}[1m])) by (request_kind)",
           "interval": "",
           "legendFormat": "{{request_kind}}",
           "refId": "A"
@@ -1914,7 +1914,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.90,sum(rate(apiserver_response_sizes_bucket{job=~\"$apiserver\",verb=~\"$verb\"}[$__rate_interval])) by(le,resource,subresource))",
+          "expr": "histogram_quantile(0.90,sum(rate(apiserver_response_sizes_bucket{pod=~\"$apiserver\",verb=~\"$verb\"}[$__rate_interval])) by(le,resource,subresource))",
           "interval": "",
           "legendFormat": "{{resource}}{{subresource}}",
           "refId": "A"
@@ -2013,7 +2013,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(apiserver_request_terminations_total{job=~\"$apiserver\",verb=~\"$verb\"}[$__rate_interval])) by (resource,subresource,code)",
+          "expr": "sum(rate(apiserver_request_terminations_total{pod=~\"$apiserver\",verb=~\"$verb\"}[$__rate_interval])) by (resource,subresource,code)",
           "interval": "",
           "legendFormat": "{{ resource }}{{subresource}} ({{code}})",
           "refId": "A"
@@ -2122,7 +2122,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(etcd_db_total_size_in_bytes{job=~\"$apiserver\"}) by (endpoint)",
+          "expr": "max(etcd_db_total_size_in_bytes{pod=~\"$apiserver\"}) by (endpoint)",
           "interval": "",
           "legendFormat": "{{endpoint}}",
           "refId": "A"
@@ -2221,7 +2221,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "max(etcd_object_counts{job=~\"$apiserver\"}) by (resource) or max(apiserver_storage_objects{job=~\"$apiserver\"}) by (resource)",
+          "expr": "max(etcd_object_counts{pod=~\"$apiserver\"}) by (resource) or max(apiserver_storage_objects{pod=~\"$apiserver\"}) by (resource)",
           "interval": "",
           "legendFormat": "{{resource}}",
           "refId": "A"
@@ -2320,7 +2320,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.90,sum(rate(apiserver_storage_transformation_duration_seconds_bucket{job=~\"$apiserver\"}[$__rate_interval])) by(le,transformation_type))",
+          "expr": "histogram_quantile(0.90,sum(rate(apiserver_storage_transformation_duration_seconds_bucket{pod=~\"$apiserver\"}[$__rate_interval])) by(le,transformation_type))",
           "interval": "",
           "legendFormat": "{{transformation_type}}",
           "refId": "A"
@@ -2419,7 +2419,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(apiserver_storage_transformation_operations_total{job=~\"$apiserver\"}[$__rate_interval])) by (transformation_type,transformer_prefix)",
+          "expr": "sum(rate(apiserver_storage_transformation_operations_total{pod=~\"$apiserver\"}[$__rate_interval])) by (transformation_type,transformer_prefix)",
           "interval": "",
           "legendFormat": "{{transformation_type}},{{transformer_prefix}}",
           "refId": "A"
@@ -2527,7 +2527,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(.9,sum(rate(etcd_request_duration_seconds_bucket{job=~\"$apiserver\"}[$__rate_interval])) by(le,type))",
+          "expr": "histogram_quantile(.9,sum(rate(etcd_request_duration_seconds_bucket{pod=~\"$apiserver\"}[$__rate_interval])) by(le,type))",
           "hide": false,
           "interval": "",
           "intervalFactor": 1,
@@ -2644,7 +2644,7 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "sum(apiserver_registered_watchers{job=~\"$apiserver\"})by(kind)",
+          "expr": "sum(apiserver_registered_watchers{pod=~\"$apiserver\"})by(kind)",
           "interval": "",
           "legendFormat": "{{kind}}",
           "refId": "A"
@@ -2745,7 +2745,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(apiserver_init_events_total{job=~\"$apiserver\"}[$__rate_interval])) by(resource)",
+          "expr": "sum(rate(apiserver_init_events_total{pod=~\"$apiserver\"}[$__rate_interval])) by(resource)",
           "interval": "",
           "legendFormat": "{{resource}}",
           "refId": "A"
@@ -2852,7 +2852,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "histogram_quantile(0.90,sum(rate(apiserver_watch_events_sizes_bucket{job=~\"$apiserver\"}[$__rate_interval])) by(le,kind))",
+          "expr": "histogram_quantile(0.90,sum(rate(apiserver_watch_events_sizes_bucket{pod=~\"$apiserver\"}[$__rate_interval])) by(le,kind))",
           "interval": "",
           "legendFormat": "{{kind}}",
           "refId": "A"
@@ -2952,7 +2952,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(rate(apiserver_watch_events_total{job=~\"$apiserver\"}[$__rate_interval])) by(kind)",
+          "expr": "sum(rate(apiserver_watch_events_total{pod=~\"$apiserver\"}[$__rate_interval])) by(kind)",
           "interval": "",
           "legendFormat": "{{kind}}",
           "refId": "A"
@@ -3053,7 +3053,7 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "sum(increase(watch_cache_capacity_increase_total{job=~\"$apiserver\"}[$__rate_interval])) by (resource)",
+          "expr": "sum(increase(watch_cache_capacity_increase_total{pod=~\"$apiserver\"}[$__rate_interval])) by (resource)",
           "interval": "",
           "legendFormat": "{{resource}}",
           "refId": "A"
@@ -3155,7 +3155,7 @@
       "steppedLine": true,
       "targets": [
         {
-          "expr": "sum(increase(watch_cache_capacity_decrease_total{job=~\"$apiserver\"}[$__rate_interval])) by (resource)",
+          "expr": "sum(increase(watch_cache_capacity_decrease_total{pod=~\"$apiserver\"}[$__rate_interval])) by (resource)",
           "interval": "",
           "legendFormat": "{{resource}}",
           "refId": "A"
@@ -3218,15 +3218,11 @@
         "allValue": ".*",
         "current": {
           "selected": false,
-          "text": [
-            "All"
-          ],
-          "value": [
-            "$__all"
-          ]
+          "text": "All",
+          "value": "$__all"
         },
         "datasource": "prometheus",
-        "definition": "label_values(apiserver_request_total,job)",
+        "definition": "label_values(apiserver_request_total,pod)",
         "description": null,
         "error": null,
         "hide": 0,
@@ -3236,7 +3232,7 @@
         "name": "apiserver",
         "options": [],
         "query": {
-          "query": "label_values(apiserver_request_total,job)",
+          "query": "label_values(apiserver_request_total,pod)",
           "refId": "StandardVariableQuery"
         },
         "refresh": 1,

--- a/charts/seed-monitoring/charts/grafana/dashboards/owners/apiserver-overview.json
+++ b/charts/seed-monitoring/charts/grafana/dashboards/owners/apiserver-overview.json
@@ -1711,7 +1711,7 @@
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(max_over_time(apiserver_current_inflight_requests{job=~\"kube-apiserver\"}[1m])) by (request_kind)",
+          "expr": "sum(max_over_time(apiserver_current_inflight_requests{pod=~\"$apiserver\"}[1m])) by (request_kind)",
           "interval": "",
           "legendFormat": "{{request_kind}}",
           "refId": "A"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

Add a panel "Response Size Rate" to the API Server dashboard

This panel shows the rate of response sizes by resource and verb.

Outstandingly high values could give a hint for shoot operators on where
to start on the journey of reducing the load on the API servers,
by making sure to use WATCH requests instead of periodic LIST and
GET requests in the various controllers.

High values for WATCH requests could hint at reducing the rate of change
for the specific resource.

Note that in Kubernetes 1.22, it seems that the response size (alpha) metrics are not reported for WATCH requests, but with 1.23 (the metrics were graduated), even WATCH requests are covered.

Example screenshots:
<img width="300" alt="image" src="https://user-images.githubusercontent.com/23032437/189936232-fb45443e-37b1-4f97-bf01-ca854d71be99.png">
<img width="300" alt="image" src="https://user-images.githubusercontent.com/23032437/189936348-eece2535-8e88-445e-85e6-3f46c620282a.png">

This PR also fixes the "API Server" variable of the dashboard.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

/cc @wyb1 @rickardsjp 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add a panel "Response Size Rate" to the API Server dashboard
```
