### PR TITLE
Use /usr/bin/env bash in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ ifneq ($(strip $(shell git status --porcelain 2>/dev/null)),)
 	EFFECTIVE_VERSION := $(EFFECTIVE_VERSION)-dirty
 endif
 
-SHELL=/bin/bash -o pipefail
+SHELL=/usr/bin/env bash -o pipefail
 
 #########################################
 # Tools                                 #


### PR DESCRIPTION
This will avoid problems on NixOS and should also work on other
platforms.

Signed-off-by: Jens Schneider <schneider@23technologies.cloud>