### PR TITLE
gardener-apiserver: Enforce the CloudProfile's `.spec.seedSelector` when validating the scheduling constraints of a Shoot

### DIFF
--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -1310,6 +1310,185 @@ var _ = Describe("validator", func() {
 						Expect(err).ToNot(HaveOccurred())
 					})
 				})
+
+				Context("cloud profile's seed selector", func() {
+					It("should reject shoot creation on seed when the cloud profile's seed selector is invalid", func() {
+						cloudProfile.Spec.SeedSelector = &core.SeedSelector{
+							LabelSelector: metav1.LabelSelector{
+								MatchExpressions: []metav1.LabelSelectorRequirement{
+									{Key: "domain", Operator: "invalid-operator", Values: []string{"foo"}},
+								},
+							},
+						}
+
+						Expect(coreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&project)).To(Succeed())
+						Expect(coreInformerFactory.Core().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
+						Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+						Expect(coreInformerFactory.Core().InternalVersion().SecretBindings().Informer().GetStore().Add(&secretBinding)).To(Succeed())
+
+						attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+						err := admissionHandler.Admit(ctx, attrs, nil)
+
+						Expect(err).To(HaveOccurred())
+						Expect(err.Error()).To(ContainSubstring("label selector conversion failed"))
+					})
+
+					It("should allow shoot creation on seed that matches the cloud profile's seed selector", func() {
+						cloudProfile.Spec.SeedSelector = &core.SeedSelector{
+							LabelSelector: metav1.LabelSelector{
+								MatchLabels: map[string]string{"domain": "foo"},
+							},
+						}
+						seed.Labels = map[string]string{"domain": "foo"}
+
+						Expect(coreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&project)).To(Succeed())
+						Expect(coreInformerFactory.Core().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
+						Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+						Expect(coreInformerFactory.Core().InternalVersion().SecretBindings().Informer().GetStore().Add(&secretBinding)).To(Succeed())
+
+						attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+						err := admissionHandler.Admit(ctx, attrs, nil)
+
+						Expect(err).NotTo(HaveOccurred())
+					})
+
+					It("should reject shoot creation on seed that does not match the cloud profile's seed selector", func() {
+						cloudProfile.Spec.SeedSelector = &core.SeedSelector{
+							LabelSelector: metav1.LabelSelector{
+								MatchLabels: map[string]string{"domain": "foo"},
+							},
+						}
+						seed.Labels = nil
+
+						Expect(coreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&project)).To(Succeed())
+						Expect(coreInformerFactory.Core().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
+						Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+						Expect(coreInformerFactory.Core().InternalVersion().SecretBindings().Informer().GetStore().Add(&secretBinding)).To(Succeed())
+
+						attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+						err := admissionHandler.Admit(ctx, attrs, nil)
+
+						Expect(err).To(HaveOccurred())
+						Expect(err.Error()).To(ContainSubstring("cannot schedule shoot '%s' on seed '%s' because the seed selector of cloud profile '%s' is not matching the labels of the seed", shoot.Name, seed.Name, cloudProfile.Name))
+					})
+
+					It("should allow shoot creation on seed that matches one of the provider types in the cloud profile's seed selector", func() {
+						cloudProfile.Spec.SeedSelector = &core.SeedSelector{
+							ProviderTypes: []string{"foo", "bar", "baz"},
+						}
+						seed.Spec.Provider = core.SeedProvider{
+							Type: "baz",
+						}
+
+						Expect(coreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&project)).To(Succeed())
+						Expect(coreInformerFactory.Core().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
+						Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+						Expect(coreInformerFactory.Core().InternalVersion().SecretBindings().Informer().GetStore().Add(&secretBinding)).To(Succeed())
+
+						attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+						err := admissionHandler.Admit(ctx, attrs, nil)
+
+						Expect(err).NotTo(HaveOccurred())
+					})
+
+					It("should reject shoot creation on seed that does not match none of the provider types in the cloud profile's seed selector", func() {
+						cloudProfile.Spec.SeedSelector = &core.SeedSelector{
+							ProviderTypes: []string{"foo", "bar"},
+						}
+						seed.Spec.Provider = core.SeedProvider{
+							Type: "baz",
+						}
+
+						Expect(coreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&project)).To(Succeed())
+						Expect(coreInformerFactory.Core().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
+						Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+						Expect(coreInformerFactory.Core().InternalVersion().SecretBindings().Informer().GetStore().Add(&secretBinding)).To(Succeed())
+
+						attrs := admission.NewAttributesRecord(&shoot, nil, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "", admission.Create, &metav1.CreateOptions{}, false, userInfo)
+						err := admissionHandler.Admit(ctx, attrs, nil)
+
+						Expect(err).To(HaveOccurred())
+						Expect(err.Error()).To(ContainSubstring("cannot schedule shoot '%s' on seed '%s' because none of the provider types in the seed selector of cloud profile '%s' is matching the provider type of the seed", shoot.Name, seed.Name, cloudProfile.Name))
+					})
+
+					It("should allow seedName update to seed that matches the cloud profile's seed selector (w/ shoots/binding subresource)", func() {
+						cloudProfile.Spec.SeedSelector = &core.SeedSelector{
+							LabelSelector: metav1.LabelSelector{
+								MatchLabels: map[string]string{"domain": "foo"},
+							},
+						}
+						seed.Labels = map[string]string{"domain": "foo"}
+
+						Expect(coreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&project)).To(Succeed())
+						Expect(coreInformerFactory.Core().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
+						Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+						Expect(coreInformerFactory.Core().InternalVersion().SecretBindings().Informer().GetStore().Add(&secretBinding)).To(Succeed())
+
+						attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "binding", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
+						err := admissionHandler.Admit(ctx, attrs, nil)
+
+						Expect(err).NotTo(HaveOccurred())
+					})
+
+					It("should reject seedName update to seed that does not match the cloud profile's seed selector (w/ shoots/binding subresource)", func() {
+						cloudProfile.Spec.SeedSelector = &core.SeedSelector{
+							LabelSelector: metav1.LabelSelector{
+								MatchLabels: map[string]string{"domain": "foo"},
+							},
+						}
+						seed.Labels = nil
+
+						Expect(coreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&project)).To(Succeed())
+						Expect(coreInformerFactory.Core().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
+						Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+						Expect(coreInformerFactory.Core().InternalVersion().SecretBindings().Informer().GetStore().Add(&secretBinding)).To(Succeed())
+
+						attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "binding", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
+						err := admissionHandler.Admit(ctx, attrs, nil)
+
+						Expect(err).To(HaveOccurred())
+						Expect(err.Error()).To(ContainSubstring("cannot schedule shoot '%s' on seed '%s' because the seed selector of cloud profile '%s' is not matching the labels of the seed", shoot.Name, seed.Name, cloudProfile.Name))
+					})
+
+					It("should allow seedName update to seed that matches one of the provider types in the cloud profile's seed selector (w/ shoots/binding subresource)", func() {
+						cloudProfile.Spec.SeedSelector = &core.SeedSelector{
+							LabelSelector: metav1.LabelSelector{
+								MatchLabels: map[string]string{"domain": "foo"},
+							},
+						}
+						seed.Labels = map[string]string{"domain": "foo"}
+
+						Expect(coreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&project)).To(Succeed())
+						Expect(coreInformerFactory.Core().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
+						Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+						Expect(coreInformerFactory.Core().InternalVersion().SecretBindings().Informer().GetStore().Add(&secretBinding)).To(Succeed())
+
+						attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "binding", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
+						err := admissionHandler.Admit(ctx, attrs, nil)
+
+						Expect(err).NotTo(HaveOccurred())
+					})
+
+					It("should reject seedName update to seed that does not match none of the provider types in the cloud profile's seed selector (w/ shoots/binding subresource)", func() {
+						cloudProfile.Spec.SeedSelector = &core.SeedSelector{
+							ProviderTypes: []string{"foo", "bar"},
+						}
+						seed.Spec.Provider = core.SeedProvider{
+							Type: "baz",
+						}
+
+						Expect(coreInformerFactory.Core().InternalVersion().Projects().Informer().GetStore().Add(&project)).To(Succeed())
+						Expect(coreInformerFactory.Core().InternalVersion().CloudProfiles().Informer().GetStore().Add(&cloudProfile)).To(Succeed())
+						Expect(coreInformerFactory.Core().InternalVersion().Seeds().Informer().GetStore().Add(&seed)).To(Succeed())
+						Expect(coreInformerFactory.Core().InternalVersion().SecretBindings().Informer().GetStore().Add(&secretBinding)).To(Succeed())
+
+						attrs := admission.NewAttributesRecord(&shoot, oldShoot, core.Kind("Shoot").WithVersion("version"), shoot.Namespace, shoot.Name, core.Resource("shoots").WithVersion("version"), "binding", admission.Update, &metav1.UpdateOptions{}, false, userInfo)
+						err := admissionHandler.Admit(ctx, attrs, nil)
+
+						Expect(err).To(HaveOccurred())
+						Expect(err.Error()).To(ContainSubstring("cannot schedule shoot '%s' on seed '%s' because none of the provider types in the seed selector of cloud profile '%s' is matching the provider type of the seed", shoot.Name, seed.Name, cloudProfile.Name))
+					})
+				})
 			})
 
 			Context("networking settings checks", func() {

--- a/plugin/pkg/shoot/validator/admission_test.go
+++ b/plugin/pkg/shoot/validator/admission_test.go
@@ -1391,7 +1391,7 @@ var _ = Describe("validator", func() {
 						Expect(err).NotTo(HaveOccurred())
 					})
 
-					It("should reject shoot creation on seed that does not match none of the provider types in the cloud profile's seed selector", func() {
+					It("should reject shoot creation on seed that does not match any of the provider types in the cloud profile's seed selector", func() {
 						cloudProfile.Spec.SeedSelector = &core.SeedSelector{
 							ProviderTypes: []string{"foo", "bar"},
 						}
@@ -1411,7 +1411,7 @@ var _ = Describe("validator", func() {
 						Expect(err.Error()).To(ContainSubstring("cannot schedule shoot '%s' on seed '%s' because none of the provider types in the seed selector of cloud profile '%s' is matching the provider type of the seed", shoot.Name, seed.Name, cloudProfile.Name))
 					})
 
-					It("should allow seedName update to seed that matches the cloud profile's seed selector (w/ shoots/binding subresource)", func() {
+					It("should allow updating the seedName to seed that matches the cloud profile's seed selector (w/ shoots/binding subresource)", func() {
 						cloudProfile.Spec.SeedSelector = &core.SeedSelector{
 							LabelSelector: metav1.LabelSelector{
 								MatchLabels: map[string]string{"domain": "foo"},
@@ -1430,7 +1430,7 @@ var _ = Describe("validator", func() {
 						Expect(err).NotTo(HaveOccurred())
 					})
 
-					It("should reject seedName update to seed that does not match the cloud profile's seed selector (w/ shoots/binding subresource)", func() {
+					It("should reject updating the seedName to seed that does not match the cloud profile's seed selector (w/ shoots/binding subresource)", func() {
 						cloudProfile.Spec.SeedSelector = &core.SeedSelector{
 							LabelSelector: metav1.LabelSelector{
 								MatchLabels: map[string]string{"domain": "foo"},
@@ -1450,7 +1450,7 @@ var _ = Describe("validator", func() {
 						Expect(err.Error()).To(ContainSubstring("cannot schedule shoot '%s' on seed '%s' because the seed selector of cloud profile '%s' is not matching the labels of the seed", shoot.Name, seed.Name, cloudProfile.Name))
 					})
 
-					It("should allow seedName update to seed that matches one of the provider types in the cloud profile's seed selector (w/ shoots/binding subresource)", func() {
+					It("should allow updating the seedName to seed that matches one of the provider types in the cloud profile's seed selector (w/ shoots/binding subresource)", func() {
 						cloudProfile.Spec.SeedSelector = &core.SeedSelector{
 							LabelSelector: metav1.LabelSelector{
 								MatchLabels: map[string]string{"domain": "foo"},
@@ -1469,7 +1469,7 @@ var _ = Describe("validator", func() {
 						Expect(err).NotTo(HaveOccurred())
 					})
 
-					It("should reject seedName update to seed that does not match none of the provider types in the cloud profile's seed selector (w/ shoots/binding subresource)", func() {
+					It("should reject updating the seedName to seed that does not match any of the provider types in the cloud profile's seed selector (w/ shoots/binding subresource)", func() {
 						cloudProfile.Spec.SeedSelector = &core.SeedSelector{
 							ProviderTypes: []string{"foo", "bar"},
 						}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area quality
/kind bug

**What this PR does / why we need it**:
This PR modifies the `ShootValidator` admission plugin to validate that the CloudProfile's `.spec.seedSelector` is matching the Seed. The validation is performed when Shoot's seedName is set or updated.

**Which issue(s) this PR fixes**:
Fixes #6654

**Special notes for your reviewer**:
Currently the `ShootValidator` and `ShootBinding` admission plugins duplicate similar code for validating scheduling constraints. @plkokanov shared that it is not required to add the new validation to the `ShootBinding` plugin as `ShootValidator` is already invoked for a binding subresource update

https://github.com/gardener/gardener/blob/3749db49b33e32e2d73c63213f0ea8c94dfba18e/plugin/pkg/shoot/validator/admission.go#L190-L195

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
gardener-apiserver now validates that the CloudProfile's `.spec.seedSelector` is matching Shoot's Seed when the `.spec.seedName` field of the Shoot is set or modified.
```
