### PR TITLE
Configure the number of parallel E2E tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,7 @@ ACTIVATE_SEEDAUTHORIZER                    := false
 SEED_NAME                                  := ""
 DEV_SETUP_WITH_WEBHOOKS                    := false
 KIND_ENV                                   := "skaffold"
+PARALLEL_E2E_TESTS                         := 5
 
 ifneq ($(strip $(shell git status --porcelain 2>/dev/null)),)
 	EFFECTIVE_VERSION := $(EFFECTIVE_VERSION)-dirty
@@ -353,14 +354,13 @@ tear-down-kind2-env: $(KUBECTL)
 	$(KUBECTL) delete -k $(REPO_ROOT)/example/provider-local/seed-kind2/local
 
 test-e2e-local-simple: $(GINKGO)
-	./hack/test-e2e-local.sh --label-filter "Shoot && simple"
+	./hack/test-e2e-local.sh --procs=$(PARALLEL_E2E_TESTS) --label-filter "Shoot && simple"
 
 test-e2e-local-migration: $(GINKGO)
-	./hack/test-e2e-local.sh --label-filter "Shoot && control-plane-migration"
+	./hack/test-e2e-local.sh --procs=$(PARALLEL_E2E_TESTS) --label-filter "Shoot && control-plane-migration"
 
 test-e2e-local: $(GINKGO)
-	@# run at maximum 5 tests in parallel for now until we have better experience of how much load a single prow pod can take
-	./hack/test-e2e-local.sh --procs=5 --label-filter="default"
+	./hack/test-e2e-local.sh --procs=$(PARALLEL_E2E_TESTS) --label-filter="default"
 
 ci-e2e-kind: $(KIND) $(YQ)
 	./hack/ci-e2e-kind.sh

--- a/hack/ci-e2e-kind.sh
+++ b/hack/ci-e2e-kind.sh
@@ -35,7 +35,7 @@ trap "
 make gardener-up
 
 # run test
-make test-e2e-local
+make test-e2e-local PARALLEL_E2E_TESTS=10
 
 # test teardown
 make gardener-down


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR introduces the parameter `PARALLEL_E2E_TESTS` in our `Makefile` to define the number of e2e tests which are carried out in parallel. Default value is `5`.
The setting allows us to configure the tests for bigger and smaller test machines.

For our prow configuration the number is increased to 10 because the cluster is running with 32 CPU nodes now.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
The number of e2e tests carried out in parallel is configurable now.
```
