### PR TITLE
[GEP-20] Fix getting namespace in Zone-Affinity webhook

### DIFF
--- a/pkg/resourcemanager/webhook/podtopologyspreadconstraints/handler.go
+++ b/pkg/resourcemanager/webhook/podtopologyspreadconstraints/handler.go
@@ -100,7 +100,7 @@ func (h *handler) Handle(_ context.Context, req admission.Request) admission.Res
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
 
-	log := h.logger.WithValues("pod", kutil.ObjectKeyForCreateWebhooks(pod))
+	log := h.logger.WithValues("pod", kutil.ObjectKeyForCreateWebhooks(pod, req))
 	log.Info("Mutating topology spread constraint label selector")
 	return admission.PatchResponseFromRaw(req.Object.Raw, marshaledPod)
 }

--- a/pkg/resourcemanager/webhook/podzoneaffinity/handler.go
+++ b/pkg/resourcemanager/webhook/podzoneaffinity/handler.go
@@ -74,7 +74,7 @@ func (h *handler) Handle(ctx context.Context, req admission.Request) admission.R
 		return admission.Errored(http.StatusUnprocessableEntity, err)
 	}
 
-	log := h.logger.WithValues("pod", kutil.ObjectKeyForCreateWebhooks(pod))
+	log := h.logger.WithValues("pod", kutil.ObjectKeyForCreateWebhooks(pod, req))
 
 	// Check conflicting and add required pod affinity terms.
 	handlePodAffinity(log, pod)

--- a/pkg/resourcemanager/webhook/podzoneaffinity/handler.go
+++ b/pkg/resourcemanager/webhook/podzoneaffinity/handler.go
@@ -80,7 +80,7 @@ func (h *handler) Handle(ctx context.Context, req admission.Request) admission.R
 	handlePodAffinity(log, pod)
 
 	// If the concrete zone is already determined by Gardener, let the pod be scheduled only to nodes in that zone.
-	if err := handleNodeAffinity(ctx, h.client, log, pod); err != nil {
+	if err := handleNodeAffinity(ctx, h.client, log, pod, req.Namespace); err != nil {
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
 
@@ -155,8 +155,8 @@ func filterAffinityTerms(log logr.Logger, terms []corev1.PodAffinityTerm, matchF
 	return filteredAffinityTerms
 }
 
-func handleNodeAffinity(ctx context.Context, cl client.Client, log logr.Logger, pod *corev1.Pod) error {
-	nodeSelector, err := getZoneSpecificNodeSelector(ctx, cl, pod.Namespace)
+func handleNodeAffinity(ctx context.Context, cl client.Client, log logr.Logger, pod *corev1.Pod, namespace string) error {
+	nodeSelector, err := getZoneSpecificNodeSelector(ctx, cl, namespace)
 	if err != nil {
 		return err
 	}

--- a/pkg/resourcemanager/webhook/podzoneaffinity/handler.go
+++ b/pkg/resourcemanager/webhook/podzoneaffinity/handler.go
@@ -74,7 +74,7 @@ func (h *handler) Handle(ctx context.Context, req admission.Request) admission.R
 		return admission.Errored(http.StatusUnprocessableEntity, err)
 	}
 
-	log := h.logger.WithValues("pod", client.ObjectKeyFromObject(pod))
+	log := h.logger.WithValues("pod", kutil.ObjectKeyForCreateWebhooks(pod))
 
 	// Check conflicting and add required pod affinity terms.
 	handlePodAffinity(log, pod)

--- a/pkg/resourcemanager/webhook/podzoneaffinity/handler_test.go
+++ b/pkg/resourcemanager/webhook/podzoneaffinity/handler_test.go
@@ -62,10 +62,13 @@ var _ = Describe("Handler", func() {
 		Expect(err).NotTo(HaveOccurred())
 		encoder = &json.Serializer{}
 
+		namespace = "shoot--foo--bar"
+
 		request = admission.Request{
 			AdmissionRequest: admissionv1.AdmissionRequest{
 				Kind:      metav1.GroupVersionKind{Group: "", Kind: "Pod", Version: "v1"},
 				Operation: admissionv1.Create,
+				Namespace: namespace,
 			},
 		}
 
@@ -76,8 +79,6 @@ var _ = Describe("Handler", func() {
 		handler = NewHandler(log)
 		Expect(admission.InjectDecoderInto(decoder, handler)).To(BeTrue())
 		Expect(inject.ClientInto(fakeClient, handler)).To(BeTrue())
-
-		namespace = "shoot--foo--bar"
 
 		pod = &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/resourcemanager/webhook/projectedtokenmount/handler.go
+++ b/pkg/resourcemanager/webhook/projectedtokenmount/handler.go
@@ -64,7 +64,7 @@ func (h *handler) Handle(ctx context.Context, req admission.Request) admission.R
 		return admission.Errored(http.StatusUnprocessableEntity, err)
 	}
 
-	log := h.logger.WithValues("pod", kutil.ObjectKeyForCreateWebhooks(pod))
+	log := h.logger.WithValues("pod", kutil.ObjectKeyForCreateWebhooks(pod, req))
 
 	if len(pod.Spec.ServiceAccountName) == 0 || pod.Spec.ServiceAccountName == "default" {
 		log.Info("Pod's service account name is empty or defaulted, nothing to be done", "serviceAccountName", pod.Spec.ServiceAccountName)

--- a/pkg/resourcemanager/webhook/seccompprofile/handler.go
+++ b/pkg/resourcemanager/webhook/seccompprofile/handler.go
@@ -82,7 +82,7 @@ func (h *Handler) Handle(_ context.Context, req admission.Request) admission.Res
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
 
-	log := h.logger.WithValues("pod", kutil.ObjectKeyForCreateWebhooks(pod))
+	log := h.logger.WithValues("pod", kutil.ObjectKeyForCreateWebhooks(pod, req))
 	log.Info("Mutating pod with default seccomp profile")
 	return admission.PatchResponseFromRaw(req.Object.Raw, marshaledPod)
 }

--- a/pkg/resourcemanager/webhook/tokeninvalidator/handler.go
+++ b/pkg/resourcemanager/webhook/tokeninvalidator/handler.go
@@ -50,7 +50,7 @@ func (w *tokenInvalidator) Handle(_ context.Context, req admission.Request) admi
 		return admission.Errored(http.StatusUnprocessableEntity, err)
 	}
 
-	log := w.logger.WithValues("secret", kutil.ObjectKeyForCreateWebhooks(secret))
+	log := w.logger.WithValues("secret", kutil.ObjectKeyForCreateWebhooks(secret, req))
 
 	if secret.Data == nil {
 		log.Info("Secret's data is nil, nothing to be done")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area high-availability
/area control-plane
/kind bug

**What this PR does / why we need it**:
This PR fixes an issue in the Zone Affinity webhook. Earlier it used the namespace information from the incoming pod object which is not always set, esp. for Kubernetes <= 1.24 ([ref](https://github.com/kubernetes/kubernetes/pull/94637)).

**Special notes for your reviewer**:
Credits to @ashwani2k who noticed and reported the issue.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
