### PR TITLE
[GEP-20] Use relaxed Topology Spread Constraint for non-HA shoots

### DIFF
--- a/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/kube_apiserver_test.go
@@ -1714,7 +1714,7 @@ rules:
 				Expect(deployment.Spec.Template.Spec.TopologySpreadConstraints).To(ConsistOf(corev1.TopologySpreadConstraint{
 					TopologyKey:       "kubernetes.io/hostname",
 					MaxSkew:           1,
-					WhenUnsatisfiable: corev1.DoNotSchedule,
+					WhenUnsatisfiable: corev1.ScheduleAnyway,
 					LabelSelector: &metav1.LabelSelector{MatchLabels: map[string]string{
 						"app":  "kubernetes",
 						"role": "apiserver",

--- a/pkg/utils/kubernetes/kubernetes.go
+++ b/pkg/utils/kubernetes/kubernetes.go
@@ -23,6 +23,8 @@ import (
 	"strings"
 	"time"
 
+	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
+	"github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/utils/retry"
 
@@ -672,4 +674,36 @@ func ObjectKeyForCreateWebhooks(obj client.Object) client.ObjectKey {
 	}
 
 	return client.ObjectKey{Namespace: namespace, Name: name}
+}
+
+// GetTopologySpreadConstraints returns the required topology spread constraints based
+// on the passed `failureToleranceType`.
+func GetTopologySpreadConstraints(failureToleranceType *gardencorev1beta1.FailureToleranceType, maxReplicas int32, labelSelector metav1.LabelSelector) []corev1.TopologySpreadConstraint {
+	const criticalMaxReplicaCount = 6
+
+	constraints := []corev1.TopologySpreadConstraint{
+		{
+			TopologyKey:       corev1.LabelHostname,
+			MaxSkew:           1,
+			WhenUnsatisfiable: corev1.DoNotSchedule,
+			LabelSelector:     &labelSelector,
+		},
+	}
+
+	if helper.IsFailureToleranceTypeZone(failureToleranceType) {
+		maxSkew := int32(1)
+		// Increase maxSkew if there can be >= 6 replicas, see https://github.com/kubernetes/kubernetes/issues/109364.
+		if maxReplicas >= criticalMaxReplicaCount {
+			maxSkew = 2
+		}
+
+		constraints = append(constraints, corev1.TopologySpreadConstraint{
+			TopologyKey:       corev1.LabelTopologyZone,
+			MaxSkew:           maxSkew,
+			WhenUnsatisfiable: corev1.DoNotSchedule,
+			LabelSelector:     &labelSelector,
+		})
+	}
+
+	return constraints
 }

--- a/pkg/utils/kubernetes/kubernetes.go
+++ b/pkg/utils/kubernetes/kubernetes.go
@@ -681,11 +681,17 @@ func ObjectKeyForCreateWebhooks(obj client.Object) client.ObjectKey {
 func GetTopologySpreadConstraints(failureToleranceType *gardencorev1beta1.FailureToleranceType, maxReplicas int32, labelSelector metav1.LabelSelector) []corev1.TopologySpreadConstraint {
 	const criticalMaxReplicaCount = 6
 
+	whenUnsatisfiable := corev1.DoNotSchedule
+	if failureToleranceType == nil {
+		// Spread should be a best-effort only if no HA is configured.
+		whenUnsatisfiable = corev1.ScheduleAnyway
+	}
+
 	constraints := []corev1.TopologySpreadConstraint{
 		{
 			TopologyKey:       corev1.LabelHostname,
 			MaxSkew:           1,
-			WhenUnsatisfiable: corev1.DoNotSchedule,
+			WhenUnsatisfiable: whenUnsatisfiable,
 			LabelSelector:     &labelSelector,
 		},
 	}

--- a/pkg/utils/kubernetes/kubernetes_test.go
+++ b/pkg/utils/kubernetes/kubernetes_test.go
@@ -1586,7 +1586,7 @@ var _ = Describe("kubernetes", func() {
 				Expect(constraints).To(ConsistOf(corev1.TopologySpreadConstraint{
 					MaxSkew:           1,
 					TopologyKey:       "kubernetes.io/hostname",
-					WhenUnsatisfiable: "DoNotSchedule",
+					WhenUnsatisfiable: "ScheduleAnyway",
 					LabelSelector:     &labelSelector,
 				}))
 			})

--- a/pkg/utils/kubernetes/kubernetes_test.go
+++ b/pkg/utils/kubernetes/kubernetes_test.go
@@ -1561,4 +1561,99 @@ var _ = Describe("kubernetes", func() {
 		Entry("object w/ namespace with generateName", &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "bar", GenerateName: "foo"}}, client.ObjectKey{Namespace: "bar", Name: "foo"}),
 		Entry("object w/ namespace with name", &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "bar", Name: "foo"}}, client.ObjectKey{Namespace: "bar", Name: "foo"}),
 	)
+
+	Describe("#GetTopologySpreadConstraints", func() {
+		var (
+			labelSelector metav1.LabelSelector
+			toleranceType *gardencorev1beta1.FailureToleranceType
+		)
+
+		BeforeEach(func() {
+			labelSelector = metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"foo": "bar",
+				},
+			}
+		})
+
+		Context("when HA is not configured", func() {
+			BeforeEach(func() {
+				toleranceType = nil
+			})
+
+			It("should return constraint on node level", func() {
+				constraints := GetTopologySpreadConstraints(nil, 1, labelSelector)
+				Expect(constraints).To(ConsistOf(corev1.TopologySpreadConstraint{
+					MaxSkew:           1,
+					TopologyKey:       "kubernetes.io/hostname",
+					WhenUnsatisfiable: "DoNotSchedule",
+					LabelSelector:     &labelSelector,
+				}))
+			})
+		})
+
+		Context("when HA is configured", func() {
+			Context("with node tolerance", func() {
+				BeforeEach(func() {
+					nodeTolerance := gardencorev1beta1.FailureToleranceTypeNode
+					toleranceType = &nodeTolerance
+				})
+
+				It("should return constraint on node level", func() {
+					constraints := GetTopologySpreadConstraints(toleranceType, 1, labelSelector)
+					Expect(constraints).To(ConsistOf(corev1.TopologySpreadConstraint{
+						MaxSkew:           1,
+						TopologyKey:       "kubernetes.io/hostname",
+						WhenUnsatisfiable: "DoNotSchedule",
+						LabelSelector:     &labelSelector,
+					}))
+				})
+			})
+
+			Context("with zone tolerance", func() {
+				BeforeEach(func() {
+					nodeTolerance := gardencorev1beta1.FailureToleranceTypeZone
+					toleranceType = &nodeTolerance
+				})
+
+				It("should return constraint on node and zone level", func() {
+					constraints := GetTopologySpreadConstraints(toleranceType, 1, labelSelector)
+					Expect(constraints).To(ConsistOf(
+						corev1.TopologySpreadConstraint{
+							MaxSkew:           1,
+							TopologyKey:       "topology.kubernetes.io/zone",
+							WhenUnsatisfiable: "DoNotSchedule",
+							LabelSelector:     &labelSelector,
+						},
+						corev1.TopologySpreadConstraint{
+							MaxSkew:           1,
+							TopologyKey:       "kubernetes.io/hostname",
+							WhenUnsatisfiable: "DoNotSchedule",
+							LabelSelector:     &labelSelector,
+						},
+					))
+				})
+
+				Context("when max replicas required higher maxSkew", func() {
+					It("should return constraint on node and zone level", func() {
+						constraints := GetTopologySpreadConstraints(toleranceType, 6, labelSelector)
+						Expect(constraints).To(ConsistOf(
+							corev1.TopologySpreadConstraint{
+								MaxSkew:           2,
+								TopologyKey:       "topology.kubernetes.io/zone",
+								WhenUnsatisfiable: "DoNotSchedule",
+								LabelSelector:     &labelSelector,
+							},
+							corev1.TopologySpreadConstraint{
+								MaxSkew:           1,
+								TopologyKey:       "kubernetes.io/hostname",
+								WhenUnsatisfiable: "DoNotSchedule",
+								LabelSelector:     &labelSelector,
+							},
+						))
+					})
+				})
+			})
+		})
+	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
In https://github.com/gardener/gardener/pull/6674 we switched from Pod Anti-Affinity to Topology Spread Constraint.
The constraints are always set to `WhenUnsatisfiable: corev1.DoNotSchedule` which does not correspond to what Gardener used earlier with `PreferredDuringSchedulingIgnoredDuringExecution` for non-HA shoots. Hence, we should only define the spread constraint on a best effort basis, i.e. `corev1.ScheduleAnyway`.

**Special notes for your reviewer**:
The Topology Spread Constraints configuration has been generalized and extracted to a utility function to make it re-usable in other components.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
