### PR TITLE
[GEP-20] Configure high-availability settings for `gardener-resource-manager`

### DIFF
--- a/pkg/operation/botanist/kubeapiserver.go
+++ b/pkg/operation/botanist/kubeapiserver.go
@@ -134,8 +134,6 @@ func (b *Botanist) DefaultKubeAPIServer(ctx context.Context) (kubeapiserver.Inte
 		watchCacheSizes = apiServerConfig.WatchCacheSizes
 	}
 
-	failureToleranceType := b.GetFailureToleranceType()
-
 	return kubeapiserver.New(
 		b.K8sSeedClient,
 		b.Shoot.SeedNamespace,
@@ -163,7 +161,7 @@ func (b *Botanist) DefaultKubeAPIServer(ctx context.Context) (kubeapiserver.Inte
 				NodeNetworkCIDR:    b.Shoot.GetInfo().Spec.Networking.Nodes,
 			},
 			WatchCacheSizes:      watchCacheSizes,
-			FailureToleranceType: failureToleranceType,
+			FailureToleranceType: b.GetFailureToleranceType(),
 		},
 	), nil
 }

--- a/pkg/operation/botanist/resource_manager.go
+++ b/pkg/operation/botanist/resource_manager.go
@@ -81,7 +81,8 @@ func (b *Botanist) DefaultResourceManager() (resourcemanager.Interface, error) {
 				corev1.ResourceMemory: resource.MustParse("30Mi"),
 			},
 		},
-		SchedulingProfile: v1beta1helper.ShootSchedulingProfile(b.Shoot.GetInfo()),
+		SchedulingProfile:    v1beta1helper.ShootSchedulingProfile(b.Shoot.GetInfo()),
+		FailureToleranceType: b.GetFailureToleranceType(),
 	}
 
 	return resourcemanager.New(

--- a/pkg/utils/checksums.go
+++ b/pkg/utils/checksums.go
@@ -50,7 +50,7 @@ func ComputeConfigMapChecksum(data map[string]string) string {
 	return computeChecksum(out)
 }
 
-// ComputeChecksum computes a SHA256 checksum for the give map.
+// ComputeChecksum computes a SHA256 checksum for the given data.
 func ComputeChecksum(data interface{}) string {
 	jsonString, err := json.Marshal(data)
 	if err != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area high-availability
/area control-plane
/kind enhancement

**What this PR does / why we need it**:
This PR adds Pod [Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) to the `gardener-resource-manager` of shoot control-planes and replaces the formerly used `podAntiAffinity`.

**Which issue(s) this PR fixes**:
Fixes parts of #6529

**Special notes for your reviewer**:
Since the [Pod Topology Webook](https://github.com/gardener/gardener/tree/master/pkg/resourcemanager/webhook/podtopologyspreadconstraints) is not applied to GRM itself, we need to workaround the rolling update issue https://github.com/kubernetes/kubernetes/issues/98215 directly in the deployment procedure.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `gardener-resource-manager` deployment was changed from pod anti-affinity to [Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/). Non-HA shoot clusters will still have the `gardener-resource-manager` pods being scheduled on different nodes on a best-effort basis. For HA clusters, the Topology Spread Constraints make sure that a distribution across nodes (single-zone) and zones (multi-zonal) is guaranteed, in order to tolerate failures in these domains.
```
