### PR TITLE
Deflakes ExtensionsCheck and BackupBucketsCheck controllers integration tests

### DIFF
--- a/test/integration/controllermanager/seed/backupbucketscheck/backupbucketscheck_suite_test.go
+++ b/test/integration/controllermanager/seed/backupbucketscheck/backupbucketscheck_suite_test.go
@@ -62,6 +62,7 @@ var (
 	restConfig *rest.Config
 	testEnv    *gardenerenvtest.GardenerTestEnvironment
 	testClient client.Client
+	mgrClient  client.Client
 
 	fakeClock *testclock.FakeClock
 )
@@ -107,6 +108,7 @@ var _ = BeforeSuite(func() {
 		}),
 	})
 	Expect(err).NotTo(HaveOccurred())
+	mgrClient = mgr.GetClient()
 
 	By("setting up field indexes")
 	Expect(indexer.AddBackupBucketSeedName(ctx, mgr.GetFieldIndexer())).To(Succeed())

--- a/test/integration/controllermanager/seed/backupbucketscheck/backupbucketscheck_test.go
+++ b/test/integration/controllermanager/seed/backupbucketscheck/backupbucketscheck_test.go
@@ -131,6 +131,18 @@ var _ = Describe("Seed BackupBucketsCheck controller tests", func() {
 				g.Expect(seed.Status.Conditions).To(ContainCondition(OfType(gardencorev1beta1.SeedBackupBucketsReady), WithStatus(gardencorev1beta1.ConditionProgressing), WithReason(reason)))
 			}).Should(Succeed())
 
+			By("Wait until manager has observed Progressing condition")
+			// Use the manager's cached client to be sure that it has observed that the BackupBucketsReady condition
+			// has been set to Progressing. Otherwise, it is possible that during the reconciliation which happens
+			// after stepping the fake clock, an outdated Seed object with its BackupBucketsReady condition set to
+			// True is retrieved by the cached client. This will cause the reconciliation to set the condition to
+			// Progressing again with a new timestamp. After that the condition will never change because the
+			// fake clock is not stepped anymore.
+			Eventually(func(g Gomega) {
+				g.Expect(mgrClient.Get(ctx, client.ObjectKeyFromObject(seed), seed)).To(Succeed())
+				g.Expect(seed.Status.Conditions).To(ContainCondition(OfType(gardencorev1beta1.SeedBackupBucketsReady), WithStatus(gardencorev1beta1.ConditionProgressing), WithReason(reason)))
+			}).Should(Succeed())
+
 			By("Step clock")
 			fakeClock.Step(conditionThreshold + 1*time.Second)
 

--- a/test/integration/controllermanager/seed/extensionscheck/extensionscheck_suite_test.go
+++ b/test/integration/controllermanager/seed/extensionscheck/extensionscheck_suite_test.go
@@ -67,6 +67,7 @@ var (
 	restConfig *rest.Config
 	testEnv    *gardenerenvtest.GardenerTestEnvironment
 	testClient client.Client
+	mgrClient  client.Client
 
 	fakeClock *testclock.FakeClock
 )
@@ -112,6 +113,7 @@ var _ = BeforeSuite(func() {
 		}),
 	})
 	Expect(err).NotTo(HaveOccurred())
+	mgrClient = mgr.GetClient()
 
 	By("setting up field indexes")
 	Expect(indexer.AddControllerInstallationSeedRefName(ctx, mgr.GetFieldIndexer())).To(Succeed())


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
Deflakes the seed ExtensionsCheck controller integration test and also aligns the seed BackupBucketsCheck controller integration test as there's a chance that it was affected by the same flake.

The reason for the flake is the cached client that is used in the reconciler. The `ExtensionsReady` condition is set to `Progressing` in this `Eventually` call: 
https://github.com/gardener/gardener/blob/8a7d7b08f54a005be62c6bbfca50f91bb15246cf/test/integration/controllermanager/seed/extensionscheck/extensionscheck_test.go#L135-L139

However, subsequent reconciliations might still read an outdated seed object, which still has a `True` `ExtensionsReady` condition. This can lead to a case where the clock is stepped, after that a reconciliation occurs that reads the condition with status `True` and accordingly sets it to `Progressing` with the new timestamp retrieved from the clock. The condition will then remain `Progressing` forever as the clock is not stepped anymore.

With this change we make sure that the cached client has observed the changed condition state before stepping the clock.

**Which issue(s) this PR fixes**:
Fixes #6679

**Special notes for your reviewer**:
Before this change:
```
$ stress -ignore "unable to grab random port" -p 16 ./test/integration/controllermanager/seed/extensionscheck/extensionscheck.test 
12m30s: 1576 runs so far, 4 failures (0.25%)
```
After the change:
```
$ stress -ignore "unable to grab random port" -p 16 ./test/integration/controllermanager/seed/extensionscheck/extensionscheck.test 
33m15s: 4230 runs so far, 0 failures
```

I also added some temporary logs to make sure that this was the reason for the flake:
```diff
--- a/pkg/controllermanager/controller/seed/extensionscheck/reconciler.go
+++ b/pkg/controllermanager/controller/seed/extensionscheck/reconciler.go
@@ -121,6 +121,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
        condition := helper.GetOrInitCondition(seed.Status.Conditions, gardencorev1beta1.SeedExtensionsReady)
        extensionsReadyThreshold := utils.GetThresholdForCondition(r.Config.ConditionThresholds, gardencorev1beta1.SeedExtensionsReady)
 
+       log.Info("Processing condition", "condition", condition)
        switch {
        case len(notValid) != 0:
                condition = utils.SetToProgressingOrFalse(r.Clock, extensionsReadyThreshold, condition, "NotAllExtensionsValid", fmt.Sprintf("Some extensions are not valid: %+v", notValid))
```
Which produced the following:
```
    [1mSTEP:[0m Patch conditions to False of foo-1-frs7k [38;5;243m09/17/22 21:46:08.893[0m
    [1mSTEP:[0m Wait until condition is Progressing [38;5;243m09/17/22 21:46:09.026[0m
    {"level":"info","ts":"2022-09-17T21:46:09.028+0300","msg":"Processing condition","controller":"seed-extensions-check","object":{"name":"extensionscheck-controller-test-88csb"},"namespace":"","name":"extensionscheck-controller-test-88csb","reconcileID":"5aaaebd0-0442-42e9-83b8-b5342604c6e3","condition":{"type":"ExtensionsReady","status":"True","lastTransitionTime":"2022-09-17T18:51:59Z","lastUpdateTime":"2022-09-17T18:51:59Z","reason":"AllExtensionsReady","message":"All extensions installed into the seed cluster are ready and healthy."}}
    {"level":"info","ts":"2022-09-17T21:46:09.028+0300","msg":"Patching condition","controller":"seed-extensions-check","object":{"name":"extensionscheck-controller-test-88csb"},"namespace":"","name":"extensionscheck-controller-test-88csb","reconcileID":"5aaaebd0-0442-42e9-83b8-b5342604c6e3","conditionType":"ExtensionsReady","conditionStatus":"Progressing"}
    [1mSTEP:[0m Step clock [38;5;243m09/17/22 21:46:09.251[0m
    [1mSTEP:[0m Wait until condition is False [38;5;243m09/17/22 21:46:09.251[0m
    {"level":"info","ts":"2022-09-17T21:46:09.251+0300","msg":"Processing condition","controller":"seed-extensions-check","object":{"name":"extensionscheck-controller-test-88csb"},"namespace":"","name":"extensionscheck-controller-test-88csb","reconcileID":"b757a233-cc6f-4486-805f-c08635120f99","condition":{"type":"ExtensionsReady","status":"True","lastTransitionTime":"2022-09-17T18:51:59Z","lastUpdateTime":"2022-09-17T18:51:59Z","reason":"AllExtensionsReady","message":"All extensions installed into the seed cluster are ready and healthy."}}
    {"level":"info","ts":"2022-09-17T21:46:09.251+0300","msg":"Patching condition","controller":"seed-extensions-check","object":{"name":"extensionscheck-controller-test-88csb"},"namespace":"","name":"extensionscheck-controller-test-88csb","reconcileID":"b757a233-cc6f-4486-805f-c08635120f99","conditionType":"ExtensionsReady","conditionStatus":"Progressing"}
    {"level":"info","ts":"2022-09-17T21:46:09.752+0300","msg":"Processing condition","controller":"seed-extensions-check","object":{"name":"extensionscheck-controller-test-88csb"},"namespace":"","name":"extensionscheck-controller-test-88csb","reconcileID":"d46bb98f-8389-4ea6-928b-16ee8242c6e5","condition":{"type":"ExtensionsReady","status":"Progressing","lastTransitionTime":"2022-09-17T18:53:59Z","lastUpdateTime":"2022-09-17T18:53:59Z","reason":"SomeExtensionsProgressing","message":"Some extensions are progressing: map[foo-1-frs7k:]"}}
    {"level":"info","ts":"2022-09-17T21:46:10.252+0300","msg":"Processing condition","controller":"seed-extensions-check","object":{"name":"extensionscheck-controller-test-88csb"},"namespace":"","name":"extensionscheck-controller-test-88csb","reconcileID":"3a878fbd-b6fe-4027-b9c3-0169daea154f","condition":{"type":"ExtensionsReady","status":"Progressing","lastTransitionTime":"2022-09-17T18:53:59Z","lastUpdateTime":"2022-09-17T18:53:59Z","reason":"SomeExtensionsProgressing","message":"Some extensions are progressing: map[foo-1-frs7k:]"}}
    {"level":"info","ts":"2022-09-17T21:46:10.752+0300","msg":"Processing condition","controller":"seed-extensions-check","object":{"name":"extensionscheck-controller-test-88csb"},"namespace":"","name":"extensionscheck-controller-test-88csb","reconcileID":"81c41d4c-dd8a-49a0-850d-007e8fd27c3f","condition":{"type":"ExtensionsReady","status":"Progressing","lastTransitionTime":"2022-09-17T18:53:59Z","lastUpdateTime":"2022-09-17T18:53:59Z","reason":"SomeExtensionsProgressing","message":"Some extensions are progressing: map[foo-1-frs7k:]"}}
```

It's visible that the condition is patched to `Progressing`, but on the next reconciliation it is read as `True`.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
