### PR TITLE
Fix containerd-monitoring script to not kill containerd-shims

### DIFF
--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/containerd/component_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/containerd/component_test.go
@@ -107,15 +107,30 @@ set -o nounset
 set -o pipefail
 
 function containerd_monitoring {
-  echo "ContainerD monitor has started !"
+  echo "containerd monitor has started !"
   while [ 1 ]; do
-    if ! timeout 60 ctr c list > /dev/null; then
-      echo "ContainerD daemon failed!"
-      pkill containerd
-      sleep 30
-    else
+    start_timestamp=$(date +%s)
+    until ctr c list > /dev/null; do
+      CONTAINERD_PID=$(systemctl show --property MainPID containerd --value)
+
+      if [ $CONTAINERD_PID -eq 0 ]; then
+          echo "Connection to containerd socket failed (process not started), retrying in $SLEEP_SECONDS seconds..."
+          break
+      fi
+
+      now=$(date +%s)
+      time_elapsed="$(($now-$start_timestamp))"
+
+      if [ $time_elapsed -gt 60 ]; then
+        echo "containerd daemon unreachable for more than 60s. Sending SIGTERM to PID $CONTAINERD_PID"
+        kill -n 15 $CONTAINERD_PID
+        sleep 20
+        break 2
+      fi
+      echo "Connection to containerd socket failed, retrying in $SLEEP_SECONDS seconds..."
       sleep $SLEEP_SECONDS
-    fi
+    done
+    sleep $SLEEP_SECONDS
   done
 }
 

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/containerd/templates/scripts/health-monitor.tpl.sh
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/containerd/templates/scripts/health-monitor.tpl.sh
@@ -3,15 +3,30 @@ set -o nounset
 set -o pipefail
 
 function containerd_monitoring {
-  echo "ContainerD monitor has started !"
+  echo "containerd monitor has started !"
   while [ 1 ]; do
-    if ! timeout 60 ctr c list > /dev/null; then
-      echo "ContainerD daemon failed!"
-      pkill containerd
-      sleep 30
-    else
+    start_timestamp=$(date +%s)
+    until ctr c list > /dev/null; do
+      CONTAINERD_PID=$(systemctl show --property MainPID containerd --value)
+
+      if [ $CONTAINERD_PID -eq 0 ]; then
+          echo "Connection to containerd socket failed (process not started), retrying in $SLEEP_SECONDS seconds..."
+          break
+      fi
+
+      now=$(date +%s)
+      time_elapsed="$(($now-$start_timestamp))"
+
+      if [ $time_elapsed -gt 60 ]; then
+        echo "containerd daemon unreachable for more than 60s. Sending SIGTERM to PID $CONTAINERD_PID"
+        kill -n 15 $CONTAINERD_PID
+        sleep 20
+        break 2
+      fi
+      echo "Connection to containerd socket failed, retrying in $SLEEP_SECONDS seconds..."
       sleep $SLEEP_SECONDS
-    fi
+    done
+    sleep $SLEEP_SECONDS
   done
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area os
/kind bug

**What this PR does / why we need it**:

- Prevents the containerd-monitoring script from sending SIGTERM signals to the containerd-shims in case the containerd daemon is not reachable
   - the containerd daemon currently cannot recover when shim processes are not reachable anymore.
   - user workload (unless they do not write to STDOUT) receive a SIGPIPE error and terminate
- wait 60 seconds before sending the signal (the previously used `timeout` utility does not work as expected, as the `ctr` process returns within <10s due to an internal timeout connecting to the containerd socket)

**Which issue(s) this PR fixes**:
Fixes #6666

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
A bug has been fixed that can lead to containerd-shims getting SIGTERM signals by the containerd monitoring script.
```
