### PR TITLE
Remove `PodSecurityPolicy` from requiredPlugins and add a user-facing warning to consider migration

### DIFF
--- a/docs/api-reference/core.md
+++ b/docs/api-reference/core.md
@@ -5671,7 +5671,7 @@ LastOperationType
 </em>
 </td>
 <td>
-<p>Type of the last operation, one of Create, Reconcile, Delete.</p>
+<p>Type of the last operation, one of Create, Reconcile, Delete, Migrate, Restore.</p>
 </td>
 </tr>
 </tbody>

--- a/docs/usage/pod-security.md
+++ b/docs/usage/pod-security.md
@@ -64,3 +64,5 @@ For proper functioning of Gardener, `kube-system` namespace will also be automat
 ## `.spec.kubernetes.allowPrivilegedContainers` in the Shoot spec
 
 If this field is set to `true` then all authenticated users can use the "gardener.privileged" `PodSecurityPolicy`, allowing full unrestricted access to Pod features. However, the `PodSecurityPolicy` admission plugin is removed in Kubernetes `v1.25` and `PodSecurity` has taken its place as its successor. Therefore, this field doesn't have any relevance in versions `>= v1.25` anymore. If you need to set a default pod admission level for your cluster, follow [this documentation](#admission-configuration-for-the-podsecurity-admission-plugin).
+
+> Note: You should remove this field from the `Shoot` spec for `v1.24` clusters after migrating to the new `PodSecurity` admission controller, before upgrading your cluster to `v1.25`.

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_backupbuckets.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_backupbuckets.yaml
@@ -194,7 +194,7 @@ spec:
                     type: string
                   type:
                     description: Type of the last operation, one of Create, Reconcile,
-                      Delete.
+                      Delete, Migrate, Restore.
                     type: string
                 required:
                 - description

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_backupentries.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_backupentries.yaml
@@ -195,7 +195,7 @@ spec:
                     type: string
                   type:
                     description: Type of the last operation, one of Create, Reconcile,
-                      Delete.
+                      Delete, Migrate, Restore.
                     type: string
                 required:
                 - description

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_bastions.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_bastions.yaml
@@ -239,7 +239,7 @@ spec:
                     type: string
                   type:
                     description: Type of the last operation, one of Create, Reconcile,
-                      Delete.
+                      Delete, Migrate, Restore.
                     type: string
                 required:
                 - description

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_containerruntimes.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_containerruntimes.yaml
@@ -222,7 +222,7 @@ spec:
                     type: string
                   type:
                     description: Type of the last operation, one of Create, Reconcile,
-                      Delete.
+                      Delete, Migrate, Restore.
                     type: string
                 required:
                 - description

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_controlplanes.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_controlplanes.yaml
@@ -190,7 +190,7 @@ spec:
                     type: string
                   type:
                     description: Type of the last operation, one of Create, Reconcile,
-                      Delete.
+                      Delete, Migrate, Restore.
                     type: string
                 required:
                 - description

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_dnsrecords.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_dnsrecords.yaml
@@ -209,7 +209,7 @@ spec:
                     type: string
                   type:
                     description: Type of the last operation, one of Create, Reconcile,
-                      Delete.
+                      Delete, Migrate, Restore.
                     type: string
                 required:
                 - description

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_extensions.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_extensions.yaml
@@ -156,7 +156,7 @@ spec:
                     type: string
                   type:
                     description: Type of the last operation, one of Create, Reconcile,
-                      Delete.
+                      Delete, Migrate, Restore.
                     type: string
                 required:
                 - description

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_infrastructures.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_infrastructures.yaml
@@ -186,7 +186,7 @@ spec:
                     type: string
                   type:
                     description: Type of the last operation, one of Create, Reconcile,
-                      Delete.
+                      Delete, Migrate, Restore.
                     type: string
                 required:
                 - description

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_networks.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_networks.yaml
@@ -172,7 +172,7 @@ spec:
                     type: string
                   type:
                     description: Type of the last operation, one of Create, Reconcile,
-                      Delete.
+                      Delete, Migrate, Restore.
                     type: string
                 required:
                 - description

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
@@ -319,7 +319,7 @@ spec:
                     type: string
                   type:
                     description: Type of the last operation, one of Create, Reconcile,
-                      Delete.
+                      Delete, Migrate, Restore.
                     type: string
                 required:
                 - description

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_workers.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_workers.yaml
@@ -413,7 +413,7 @@ spec:
                     type: string
                   type:
                     description: Type of the last operation, one of Create, Reconcile,
-                      Delete.
+                      Delete, Migrate, Restore.
                     type: string
                 required:
                 - description

--- a/pkg/api/core/shoot/warnings.go
+++ b/pkg/api/core/shoot/warnings.go
@@ -147,18 +147,13 @@ func completionWarning(credentials string, recommendedCompletionInterval time.Du
 }
 
 func getWarningsForPSPAdmissionPlugin(shoot *core.Shoot) string {
-	pspDisabled := false
 	if shoot.Spec.Kubernetes.KubeAPIServer != nil {
 		for _, plugin := range shoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins {
 			if plugin.Name == "PodSecurityPolicy" && pointer.BoolDeref(plugin.Disabled, false) {
-				pspDisabled = true
+				return ""
 			}
 		}
 	}
 
-	if !pspDisabled {
-		return "you should consider migrating to PodSecurity, see https://github.com/gardener/gardener/blob/master/docs/usage/pod-security.md#migrating-from-podsecuritypolicys-to-podsecurity-admission-controller for details"
-	}
-
-	return ""
+	return "you should consider migrating to PodSecurity, see https://github.com/gardener/gardener/blob/master/docs/usage/pod-security.md#migrating-from-podsecuritypolicys-to-podsecurity-admission-controller for details"
 }

--- a/pkg/api/core/shoot/warnings.go
+++ b/pkg/api/core/shoot/warnings.go
@@ -19,7 +19,9 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/Masterminds/semver"
 	"github.com/gardener/gardener/pkg/apis/core"
+	versionutils "github.com/gardener/gardener/pkg/utils/version"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
@@ -40,6 +42,14 @@ func GetWarnings(_ context.Context, shoot, oldShoot *core.Shoot, credentialsRota
 	if oldShoot != nil {
 		warnings = append(warnings, getWarningsForDueCredentialsRotations(shoot, credentialsRotationInterval)...)
 		warnings = append(warnings, getWarningsForIncompleteCredentialsRotation(shoot, credentialsRotationInterval)...)
+
+		if versionutils.ConstraintK8sLess125.Check(semver.MustParse(shoot.Spec.Kubernetes.Version)) &&
+			versionutils.ConstraintK8sGreaterEqual123.Check(semver.MustParse(shoot.Spec.Kubernetes.Version)) {
+			warning := getWarningsForPSPAdmissionPlugin(shoot)
+			if warning != "" {
+				warnings = append(warnings, warning)
+			}
+		}
 	}
 
 	return warnings
@@ -134,4 +144,21 @@ func isOldEnough(t time.Time, threshold time.Duration) bool {
 
 func completionWarning(credentials string, recommendedCompletionInterval time.Duration) string {
 	return fmt.Sprintf("the %s rotation was initiated more than %s ago and should be completed", credentials, recommendedCompletionInterval)
+}
+
+func getWarningsForPSPAdmissionPlugin(shoot *core.Shoot) string {
+	pspDisabled := false
+	if shoot.Spec.Kubernetes.KubeAPIServer != nil {
+		for _, plugin := range shoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins {
+			if plugin.Name == "PodSecurityPolicy" && pointer.BoolDeref(plugin.Disabled, false) {
+				pspDisabled = true
+			}
+		}
+	}
+
+	if !pspDisabled {
+		return "you should consider migrating to PodSecurity, see https://github.com/gardener/gardener/blob/master/docs/usage/pod-security.md#migrating-from-podsecuritypolicys-to-podsecurity-admission-controller for details"
+	}
+
+	return ""
 }

--- a/pkg/apis/core/types_common.go
+++ b/pkg/apis/core/types_common.go
@@ -111,7 +111,7 @@ type LastOperation struct {
 	Progress int32
 	// Status of the last operation, one of Aborted, Processing, Succeeded, Error, Failed.
 	State LastOperationState
-	// Type of the last operation, one of Create, Reconcile, Delete.
+	// Type of the last operation, one of Create, Reconcile, Delete, Migrate, Restore.
 	Type LastOperationType
 }
 

--- a/pkg/apis/core/v1alpha1/generated.proto
+++ b/pkg/apis/core/v1alpha1/generated.proto
@@ -1298,7 +1298,7 @@ message LastOperation {
   // Status of the last operation, one of Aborted, Processing, Succeeded, Error, Failed.
   optional string state = 4;
 
-  // Type of the last operation, one of Create, Reconcile, Delete.
+  // Type of the last operation, one of Create, Reconcile, Delete, Migrate, Restore.
   optional string type = 5;
 }
 

--- a/pkg/apis/core/v1alpha1/types_common.go
+++ b/pkg/apis/core/v1alpha1/types_common.go
@@ -111,7 +111,7 @@ type LastOperation struct {
 	Progress int32 `json:"progress" protobuf:"varint,3,opt,name=progress"`
 	// Status of the last operation, one of Aborted, Processing, Succeeded, Error, Failed.
 	State LastOperationState `json:"state" protobuf:"bytes,4,opt,name=state,casttype=LastOperationState"`
-	// Type of the last operation, one of Create, Reconcile, Delete.
+	// Type of the last operation, one of Create, Reconcile, Delete, Migrate, Restore.
 	Type LastOperationType `json:"type" protobuf:"bytes,5,opt,name=type,casttype=LastOperationType"`
 }
 

--- a/pkg/apis/core/v1beta1/defaults.go
+++ b/pkg/apis/core/v1beta1/defaults.go
@@ -145,7 +145,7 @@ func SetDefaults_SeedSettingDependencyWatchdog(obj *SeedSettingDependencyWatchdo
 func SetDefaults_Shoot(obj *Shoot) {
 	// Errors are ignored here because we cannot do anything meaningful with them - variables will default to `false`.
 	k8sLess125, _ := versionutils.CheckVersionMeetsConstraint(obj.Spec.Kubernetes.Version, "< 1.25")
-	if obj.Spec.Kubernetes.AllowPrivilegedContainers == nil && k8sLess125 {
+	if obj.Spec.Kubernetes.AllowPrivilegedContainers == nil && k8sLess125 && !isPSPDisabled(obj) {
 		obj.Spec.Kubernetes.AllowPrivilegedContainers = pointer.Bool(true)
 	}
 	if obj.Spec.Kubernetes.KubeAPIServer == nil {
@@ -483,4 +483,15 @@ func addTolerations(tolerations *[]Toleration, additionalTolerations ...Tolerati
 		}
 		*tolerations = append(*tolerations, toleration)
 	}
+}
+
+func isPSPDisabled(shoot *Shoot) bool {
+	if shoot.Spec.Kubernetes.KubeAPIServer != nil {
+		for _, plugin := range shoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins {
+			if plugin.Name == "PodSecurityPolicy" && pointer.BoolDeref(plugin.Disabled, false) {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/pkg/apis/core/v1beta1/generated.proto
+++ b/pkg/apis/core/v1beta1/generated.proto
@@ -1219,7 +1219,7 @@ message LastOperation {
   // Status of the last operation, one of Aborted, Processing, Succeeded, Error, Failed.
   optional string state = 4;
 
-  // Type of the last operation, one of Create, Reconcile, Delete.
+  // Type of the last operation, one of Create, Reconcile, Delete, Migrate, Restore.
   optional string type = 5;
 }
 

--- a/pkg/apis/core/v1beta1/types_common.go
+++ b/pkg/apis/core/v1beta1/types_common.go
@@ -111,7 +111,7 @@ type LastOperation struct {
 	Progress int32 `json:"progress" protobuf:"varint,3,opt,name=progress"`
 	// Status of the last operation, one of Aborted, Processing, Succeeded, Error, Failed.
 	State LastOperationState `json:"state" protobuf:"bytes,4,opt,name=state,casttype=LastOperationState"`
-	// Type of the last operation, one of Create, Reconcile, Delete.
+	// Type of the last operation, one of Create, Reconcile, Delete, Migrate, Restore.
 	Type LastOperationType `json:"type" protobuf:"bytes,5,opt,name=type,casttype=LastOperationType"`
 }
 

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -2551,22 +2551,40 @@ var _ = Describe("Shoot Validation Tests", func() {
 				))
 			})
 
-			It("should not allow upgrading to v1.25 if PodSecurityPolicy admission plugin is already disabled in the Shoot spec", func() {
+			It("should not allow upgrading to v1.25 if PodSecurityPolicy admission plugin is disabled in the Shoot spec but the Shoot hasn't reconciled succesfully", func() {
 				shoot.Spec.Kubernetes.Version = "1.24.0"
-				newShoot := prepareShootForUpdate(shoot)
-				newShoot.Spec.Kubernetes.Version = "1.25.0"
 				shoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins = []core.AdmissionPlugin{
 					{
 						Name:     "PodSecurityPolicy",
 						Disabled: pointer.Bool(true),
 					},
 				}
-				newShoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins = []core.AdmissionPlugin{
+				newShoot := prepareShootForUpdate(shoot)
+				newShoot.Spec.Kubernetes.Version = "1.25.0"
+
+				Expect(ValidateShootUpdate(newShoot, shoot)).To(ConsistOf(
+					PointTo(MatchFields(IgnoreExtras, Fields{
+						"Type":   Equal(field.ErrorTypeForbidden),
+						"Field":  Equal("spec.kubernetes.version"),
+						"Detail": ContainSubstring("Shoot should have been reconciled successfully before upgrading to v1.25"),
+					})),
+				))
+			})
+
+			It("should allow upgrading to v1.25 if PodSecurityPolicy admission plugin is disabled in the Shoot spec and the Shoot has reconciled succesfully", func() {
+				shoot.Spec.Kubernetes.Version = "1.24.0"
+				shoot.Status.LastOperation = &core.LastOperation{
+					Type:  core.LastOperationTypeReconcile,
+					State: core.LastOperationStateSucceeded,
+				}
+				shoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins = []core.AdmissionPlugin{
 					{
 						Name:     "PodSecurityPolicy",
 						Disabled: pointer.Bool(true),
 					},
 				}
+				newShoot := prepareShootForUpdate(shoot)
+				newShoot.Spec.Kubernetes.Version = "1.25.0"
 
 				Expect(ValidateShootUpdate(newShoot, shoot)).To(BeEmpty())
 			})

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -2462,7 +2462,7 @@ var _ = Describe("Shoot Validation Tests", func() {
 				newShoot := prepareShootForUpdate(shoot)
 				newShoot.Spec.Kubernetes.Version = ""
 
-				Expect(ValidateShootUpdate(newShoot, shoot)).To(ConsistOf(
+				Expect(ValidateShootUpdate(newShoot, shoot)).To(ContainElements(
 					PointTo(MatchFields(IgnoreExtras, Fields{
 						"Type":   Equal(field.ErrorTypeInvalid),
 						"Field":  Equal("spec.kubernetes.version"),
@@ -2558,6 +2558,10 @@ var _ = Describe("Shoot Validation Tests", func() {
 						Name:     "PodSecurityPolicy",
 						Disabled: pointer.Bool(true),
 					},
+				}
+				shoot.Status.LastOperation = &core.LastOperation{
+					Type:  core.LastOperationTypeReconcile,
+					State: core.LastOperationStateFailed,
 				}
 				newShoot := prepareShootForUpdate(shoot)
 				newShoot.Spec.Kubernetes.Version = "1.25.0"

--- a/pkg/apis/core/validation/utils.go
+++ b/pkg/apis/core/validation/utils.go
@@ -129,3 +129,22 @@ func ValidateFailureToleranceTypeValue(value core.FailureToleranceType, fldPath 
 
 	return allErrs
 }
+
+// shootReconciliationSuccessful checks if a shoot is successfully reconciled.
+// In case it is not, it also returns a descriptive message stating the reason.
+func shootReconciliationSuccessful(shoot *core.Shoot) (bool, string) {
+	if shoot.Generation != shoot.Status.ObservedGeneration {
+		return false, "shoot generation did not equal observed generation"
+	}
+	if len(shoot.Status.Conditions) == 0 && shoot.Status.LastOperation == nil {
+		return false, "no conditions and last operation present yet"
+	}
+
+	if shoot.Status.LastOperation != nil &&
+		shoot.Status.LastOperation.Type == core.LastOperationTypeReconcile &&
+		shoot.Status.LastOperation.State == core.LastOperationStateSucceeded {
+		return true, ""
+	}
+
+	return false, "shoot doesn't have Reconcile state: succeeded"
+}

--- a/pkg/apis/core/validation/utils.go
+++ b/pkg/apis/core/validation/utils.go
@@ -137,21 +137,18 @@ func shootReconciliationSuccessful(shoot *core.Shoot) (bool, string) {
 	if shoot.Generation != shoot.Status.ObservedGeneration {
 		return false, "shoot generation did not equal observed generation"
 	}
-	if len(shoot.Status.Conditions) == 0 && shoot.Status.LastOperation == nil {
-		return false, "no conditions and last operation present yet"
+	if shoot.Status.LastOperation == nil {
+		return false, "no last operation present yet"
 	}
 
-	if shoot.Status.LastOperation != nil {
-		lastOperationType := shoot.Status.LastOperation.Type
-		if lastOperationType == core.LastOperationTypeCreate ||
-			lastOperationType == core.LastOperationTypeReconcile ||
-			lastOperationType == core.LastOperationTypeRestore ||
-			lastOperationType == core.LastOperationTypeMigrate {
-			if shoot.Status.LastOperation.State != core.LastOperationStateSucceeded {
-				return false, fmt.Sprintf("last operation type was %s but state was not succeeded", lastOperationType)
-			}
+	if shoot.Status.LastOperation.Type == core.LastOperationTypeCreate ||
+		shoot.Status.LastOperation.Type == core.LastOperationTypeReconcile {
+		if shoot.Status.LastOperation.State == core.LastOperationStateSucceeded {
+			return true, ""
+		} else {
+			return false, fmt.Sprintf("last operation type was %s but state was not succeeded", shoot.Status.LastOperation.Type)
 		}
 	}
 
-	return true, ""
+	return false, fmt.Sprintf("last operation was %s, not Reconcile", shoot.Status.LastOperation.Type)
 }

--- a/pkg/apis/core/validation/utils.go
+++ b/pkg/apis/core/validation/utils.go
@@ -140,11 +140,17 @@ func shootReconciliationSuccessful(shoot *core.Shoot) (bool, string) {
 		return false, "no conditions and last operation present yet"
 	}
 
-	if shoot.Status.LastOperation != nil &&
-		shoot.Status.LastOperation.Type == core.LastOperationTypeReconcile &&
-		shoot.Status.LastOperation.State == core.LastOperationStateSucceeded {
-		return true, ""
+	if shoot.Status.LastOperation != nil {
+		if shoot.Status.LastOperation.Type == core.LastOperationTypeCreate ||
+			shoot.Status.LastOperation.Type == core.LastOperationTypeReconcile ||
+			shoot.Status.LastOperation.Type == core.LastOperationTypeRestore {
+			if shoot.Status.LastOperation.State != core.LastOperationStateSucceeded {
+				return false, "last operation type was create, reconcile or restore but state was not succeeded"
+			}
+		} else if shoot.Status.LastOperation.Type == core.LastOperationTypeMigrate {
+			return false, "last operation type was migrate, the migration process is not finished yet"
+		}
 	}
 
-	return false, "shoot doesn't have Reconcile state: succeeded"
+	return true, ""
 }

--- a/pkg/apis/core/validation/utils.go
+++ b/pkg/apis/core/validation/utils.go
@@ -15,6 +15,7 @@
 package validation
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 
@@ -141,14 +142,14 @@ func shootReconciliationSuccessful(shoot *core.Shoot) (bool, string) {
 	}
 
 	if shoot.Status.LastOperation != nil {
-		if shoot.Status.LastOperation.Type == core.LastOperationTypeCreate ||
-			shoot.Status.LastOperation.Type == core.LastOperationTypeReconcile ||
-			shoot.Status.LastOperation.Type == core.LastOperationTypeRestore {
+		lastOperationType := shoot.Status.LastOperation.Type
+		if lastOperationType == core.LastOperationTypeCreate ||
+			lastOperationType == core.LastOperationTypeReconcile ||
+			lastOperationType == core.LastOperationTypeRestore ||
+			lastOperationType == core.LastOperationTypeMigrate {
 			if shoot.Status.LastOperation.State != core.LastOperationStateSucceeded {
-				return false, "last operation type was create, reconcile or restore but state was not succeeded"
+				return false, fmt.Sprintf("last operation type was %s but state was not succeeded", lastOperationType)
 			}
-		} else if shoot.Status.LastOperation.Type == core.LastOperationTypeMigrate {
-			return false, "last operation type was migrate, the migration process is not finished yet"
 		}
 	}
 

--- a/pkg/openapi/openapi_generated.go
+++ b/pkg/openapi/openapi_generated.go
@@ -4198,7 +4198,7 @@ func schema_pkg_apis_core_v1alpha1_LastOperation(ref common.ReferenceCallback) c
 					},
 					"type": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Type of the last operation, one of Create, Reconcile, Delete.",
+							Description: "Type of the last operation, one of Create, Reconcile, Delete, Migrate, Restore.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",
@@ -11328,7 +11328,7 @@ func schema_pkg_apis_core_v1beta1_LastOperation(ref common.ReferenceCallback) co
 					},
 					"type": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Type of the last operation, one of Create, Reconcile, Delete.",
+							Description: "Type of the last operation, one of Create, Reconcile, Delete, Migrate, Restore.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",

--- a/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_backupbuckets.yaml
+++ b/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_backupbuckets.yaml
@@ -196,7 +196,7 @@ spec:
                     type: string
                   type:
                     description: Type of the last operation, one of Create, Reconcile,
-                      Delete.
+                      Delete, Migrate, Restore.
                     type: string
                 required:
                 - description

--- a/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_backupentries.yaml
+++ b/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_backupentries.yaml
@@ -197,7 +197,7 @@ spec:
                     type: string
                   type:
                     description: Type of the last operation, one of Create, Reconcile,
-                      Delete.
+                      Delete, Migrate, Restore.
                     type: string
                 required:
                 - description

--- a/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_bastions.yaml
+++ b/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_bastions.yaml
@@ -241,7 +241,7 @@ spec:
                     type: string
                   type:
                     description: Type of the last operation, one of Create, Reconcile,
-                      Delete.
+                      Delete, Migrate, Restore.
                     type: string
                 required:
                 - description

--- a/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_containerruntimes.yaml
+++ b/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_containerruntimes.yaml
@@ -224,7 +224,7 @@ spec:
                     type: string
                   type:
                     description: Type of the last operation, one of Create, Reconcile,
-                      Delete.
+                      Delete, Migrate, Restore.
                     type: string
                 required:
                 - description

--- a/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_controlplanes.yaml
+++ b/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_controlplanes.yaml
@@ -192,7 +192,7 @@ spec:
                     type: string
                   type:
                     description: Type of the last operation, one of Create, Reconcile,
-                      Delete.
+                      Delete, Migrate, Restore.
                     type: string
                 required:
                 - description

--- a/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_dnsrecords.yaml
+++ b/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_dnsrecords.yaml
@@ -211,7 +211,7 @@ spec:
                     type: string
                   type:
                     description: Type of the last operation, one of Create, Reconcile,
-                      Delete.
+                      Delete, Migrate, Restore.
                     type: string
                 required:
                 - description

--- a/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_extensions.yaml
+++ b/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_extensions.yaml
@@ -158,7 +158,7 @@ spec:
                     type: string
                   type:
                     description: Type of the last operation, one of Create, Reconcile,
-                      Delete.
+                      Delete, Migrate, Restore.
                     type: string
                 required:
                 - description

--- a/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_infrastructures.yaml
+++ b/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_infrastructures.yaml
@@ -188,7 +188,7 @@ spec:
                     type: string
                   type:
                     description: Type of the last operation, one of Create, Reconcile,
-                      Delete.
+                      Delete, Migrate, Restore.
                     type: string
                 required:
                 - description

--- a/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_networks.yaml
+++ b/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_networks.yaml
@@ -174,7 +174,7 @@ spec:
                     type: string
                   type:
                     description: Type of the last operation, one of Create, Reconcile,
-                      Delete.
+                      Delete, Migrate, Restore.
                     type: string
                 required:
                 - description

--- a/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
+++ b/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
@@ -321,7 +321,7 @@ spec:
                     type: string
                   type:
                     description: Type of the last operation, one of Create, Reconcile,
-                      Delete.
+                      Delete, Migrate, Restore.
                     type: string
                 required:
                 - description

--- a/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_workers.yaml
+++ b/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_workers.yaml
@@ -415,7 +415,7 @@ spec:
                     type: string
                   type:
                     description: Type of the last operation, one of Create, Reconcile,
-                      Delete.
+                      Delete, Migrate, Restore.
                     type: string
                 required:
                 - description

--- a/pkg/operation/botanist/coredns.go
+++ b/pkg/operation/botanist/coredns.go
@@ -28,7 +28,6 @@ import (
 	"github.com/gardener/gardener/pkg/utils/images"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 
-	"github.com/Masterminds/semver"
 	appsv1 "k8s.io/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/pointer"
@@ -51,7 +50,7 @@ func (b *Botanist) DefaultCoreDNS() (coredns.Interface, error) {
 		PodNetworkCIDR:                  b.Shoot.Networks.Pods.String(),
 		NodeNetworkCIDR:                 b.Shoot.GetInfo().Spec.Networking.Nodes,
 		AutoscalingMode:                 gardencorev1beta1.CoreDNSAutoscalingModeHorizontal,
-		KubernetesVersion:               semver.MustParse(b.Shoot.GetInfo().Spec.Kubernetes.Version),
+		KubernetesVersion:               b.Shoot.KubernetesVersion,
 		SearchPathRewritesEnabled:       gardencorev1beta1helper.IsCoreDNSRewritingEnabled(gardenletfeatures.FeatureGate.Enabled(features.CoreDNSQueryRewriting), b.Shoot.GetInfo().GetAnnotations()),
 		SearchPathRewriteCommonSuffixes: getCommonSuffixesForRewriting(b.Shoot.GetInfo().Spec.SystemComponents),
 	}

--- a/pkg/operation/botanist/metricsserver.go
+++ b/pkg/operation/botanist/metricsserver.go
@@ -20,7 +20,6 @@ import (
 	"github.com/gardener/gardener/pkg/utils/images"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 
-	"github.com/Masterminds/semver"
 	"k8s.io/utils/pointer"
 )
 
@@ -40,7 +39,7 @@ func (b *Botanist) DefaultMetricsServer() (component.DeployWaiter, error) {
 		Image:             image.String(),
 		VPAEnabled:        b.Shoot.WantsVerticalPodAutoscaler,
 		KubeAPIServerHost: kubeAPIServerHost,
-		KubernetesVersion: semver.MustParse(b.Shoot.GetInfo().Spec.Kubernetes.Version),
+		KubernetesVersion: b.Shoot.KubernetesVersion,
 	}
 
 	return metricsserver.New(

--- a/pkg/operation/botanist/nodelocaldns.go
+++ b/pkg/operation/botanist/nodelocaldns.go
@@ -24,7 +24,6 @@ import (
 	"github.com/gardener/gardener/pkg/utils/images"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 
-	"github.com/Masterminds/semver"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -58,7 +57,7 @@ func (b *Botanist) DefaultNodeLocalDNS() (nodelocaldns.Interface, error) {
 			ClusterDNS:            clusterDNS,
 			DNSServer:             dnsServer,
 			PSPDisabled:           b.Shoot.PSPDisabled,
-			KubernetesVersion:     semver.MustParse(b.Shoot.GetInfo().Spec.Kubernetes.Version),
+			KubernetesVersion:     b.Shoot.KubernetesVersion,
 		},
 	), nil
 }

--- a/pkg/operation/botanist/nodeproblemdetector.go
+++ b/pkg/operation/botanist/nodeproblemdetector.go
@@ -20,7 +20,6 @@ import (
 	"github.com/gardener/gardener/pkg/utils/images"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
 
-	"github.com/Masterminds/semver"
 	"k8s.io/utils/pointer"
 )
 
@@ -35,7 +34,7 @@ func (b *Botanist) DefaultNodeProblemDetector() (component.DeployWaiter, error) 
 		Image:             image.String(),
 		VPAEnabled:        b.Shoot.WantsVerticalPodAutoscaler,
 		PSPDisabled:       b.Shoot.PSPDisabled,
-		KubernetesVersion: semver.MustParse(b.Shoot.GetInfo().Spec.Kubernetes.Version),
+		KubernetesVersion: b.Shoot.KubernetesVersion,
 	}
 
 	if b.APIServerSNIEnabled() {

--- a/pkg/operation/botanist/resource_manager.go
+++ b/pkg/operation/botanist/resource_manager.go
@@ -61,6 +61,11 @@ func (b *Botanist) DefaultResourceManager() (resourcemanager.Interface, error) {
 	}
 	image = &imagevector.Image{Repository: repository, Tag: &tag}
 
+	version, err := semver.NewVersion(b.SeedClientSet.Version())
+	if err != nil {
+		return nil, err
+	}
+
 	cfg := resourcemanager.Values{
 		AlwaysUpdate:                         pointer.Bool(true),
 		ClusterIdentity:                      b.Seed.GetInfo().Status.ClusterIdentity,
@@ -76,7 +81,7 @@ func (b *Botanist) DefaultResourceManager() (resourcemanager.Interface, error) {
 		SyncPeriod:                           pointer.Duration(time.Minute),
 		TargetDiffersFromSourceCluster:       true,
 		TargetDisableCache:                   pointer.Bool(true),
-		Version:                              semver.MustParse(b.SeedClientSet.Version()),
+		Version:                              version,
 		WatchedNamespace:                     pointer.String(b.Shoot.SeedNamespace),
 		VPA: &resourcemanager.VPAConfig{
 			MinAllowed: corev1.ResourceList{

--- a/pkg/operation/botanist/vpnshoot.go
+++ b/pkg/operation/botanist/vpnshoot.go
@@ -21,8 +21,6 @@ import (
 	"github.com/gardener/gardener/pkg/operation/botanist/component/vpnshoot"
 	"github.com/gardener/gardener/pkg/utils/images"
 	"github.com/gardener/gardener/pkg/utils/imagevector"
-
-	"github.com/Masterminds/semver"
 )
 
 // DefaultVPNShoot returns a deployer for the VPNShoot
@@ -65,7 +63,7 @@ func (b *Botanist) DefaultVPNShoot() (vpnshoot.Interface, error) {
 			NodeCIDR:    nodeNetworkCIDR,
 		},
 		PSPDisabled:       b.Shoot.PSPDisabled,
-		KubernetesVersion: semver.MustParse(b.Shoot.GetInfo().Spec.Kubernetes.Version),
+		KubernetesVersion: b.Shoot.KubernetesVersion,
 	}
 
 	return vpnshoot.New(

--- a/pkg/utils/validation/admissionplugins/admissionplugins.go
+++ b/pkg/utils/validation/admissionplugins/admissionplugins.go
@@ -62,7 +62,7 @@ var admissionPluginsVersionRanges = map[string]*AdmissionPluginVersionRange{
 	"PodNodeSelector":                      {},
 	"PodPreset":                            {RemovedInVersion: "1.20"},
 	"PodSecurity":                          {AddedInVersion: "1.22", Required: true},
-	"PodSecurityPolicy":                    {RemovedInVersion: "1.25", Required: true},
+	"PodSecurityPolicy":                    {RemovedInVersion: "1.25"},
 	"PodTolerationRestriction":             {},
 	"Priority":                             {Required: true},
 	"ResourceQuota":                        {},
@@ -135,7 +135,7 @@ func ValidateAdmissionPlugins(admissionPlugins []core.AdmissionPlugin, version s
 		supported, err := IsAdmissionPluginSupported(plugin.Name, version)
 		if err != nil {
 			allErrs = append(allErrs, field.Invalid(idxPath.Child("name"), plugin.Name, err.Error()))
-		} else if !supported {
+		} else if !supported && !pointer.BoolDeref(plugin.Disabled, false) {
 			allErrs = append(allErrs, field.Forbidden(idxPath.Child("name"), fmt.Sprintf("admission plugin %q is not supported in Kubernetes version %s", plugin.Name, version)))
 		} else {
 			if admissionPluginsVersionRanges[plugin.Name].Forbidden {

--- a/test/e2e/shoot/create_update_delete.go
+++ b/test/e2e/shoot/create_update_delete.go
@@ -36,7 +36,14 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 
 	// explicitly use one version below the latest supported minor version so that Kubernetes version update test can be
 	// performed
-	f.Shoot.Spec.Kubernetes.Version = "1.23.6"
+	f.Shoot.Spec.Kubernetes.Version = "1.24.0"
+
+	// Testing without this setting and expecting the test to fail. will uncomment this and push afterwards.
+	// // Disable PodSecurityPolicy in the Shoot spec
+	// f.Shoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins = append(f.Shoot.Spec.Kubernetes.KubeAPIServer.AdmissionPlugins, gardencorev1beta1.AdmissionPlugin{
+	// 	Name:     "PodSecurityPolicy",
+	// 	Disabled: pointer.Bool(true),
+	// })
 
 	// create two additional worker pools which explicitly specify the kubernetes version
 	pool1 := f.Shoot.Spec.Provider.Workers[0]
@@ -44,7 +51,7 @@ var _ = Describe("Shoot Tests", Label("Shoot", "default"), func() {
 	pool2.Name += "2"
 	pool2.Kubernetes = &gardencorev1beta1.WorkerKubernetes{Version: &f.Shoot.Spec.Kubernetes.Version}
 	pool3.Name += "3"
-	pool3.Kubernetes = &gardencorev1beta1.WorkerKubernetes{Version: pointer.String("1.22.0")}
+	pool3.Kubernetes = &gardencorev1beta1.WorkerKubernetes{Version: pointer.String("1.23.6")}
 	f.Shoot.Spec.Provider.Workers = append(f.Shoot.Spec.Provider.Workers, *pool2, *pool3)
 
 	It("Create, Update, Delete", Label("simple"), func() {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area usability control-plane testing
/kind enhancement

**What this PR does / why we need it**:
This PR adds a user-faced warning for shoots >= v1.23 and < v1.25, to consider migrating from `PodSecurityPolicy` to `PodSecurity` admission controller.
This PR also removes the `PodSecurityPolicy` from the required plugins.
The e2e tests for create-update-delete shoot is also enhanced.

**Which issue(s) this PR fixes**:
Part of #5250 

**Special notes for your reviewer**:
~/hold until https://github.com/gardener/gardener-extension-provider-openstack/pull/485 is released.~

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
It is now possible to disable `PodSecurityPolicy` admission plugin, please make sure you have updated the extensions to a version which supports this change.
```
