### PR TITLE
Streamline `gardener-seed-admission-controller` entrypoint

### DIFF
--- a/cmd/gardener-seed-admission-controller/app/gardener_seed_admission_controller.go
+++ b/cmd/gardener-seed-admission-controller/app/gardener_seed_admission_controller.go
@@ -76,55 +76,6 @@ func NewSeedAdmissionControllerCommand() *cobra.Command {
 	return cmd
 }
 
-// Options has all the context and parameters needed to run gardener-seed-admission-controller.
-type Options struct {
-	// BindAddress is the address the HTTP server should bind to.
-	BindAddress string
-	// Port is the port that should be opened by the HTTP server.
-	Port int
-	// ServerCertDir is the path to server TLS cert and key.
-	ServerCertDir string
-	// MetricsBindAddress is the TCP address that the controller should bind to
-	// for serving prometheus metrics.
-	// It can be set to "0" to disable the metrics serving.
-	MetricsBindAddress string
-	// HealthBindAddress is the TCP address that the controller should bind to for serving health probes.
-	HealthBindAddress string
-	// EnableProfiling enables profiling via web interface host:port/debug/pprof/.
-	EnableProfiling bool
-	// EnableContentionProfiling enables lock contention profiling, if
-	// enableProfiling is true.
-	EnableContentionProfiling bool
-}
-
-// AddFlags adds gardener-seed-admission-controller's flags to the specified FlagSet.
-func (o *Options) AddFlags(fs *pflag.FlagSet) {
-	fs.StringVar(&o.BindAddress, "bind-address", "0.0.0.0", "Address to bind to")
-	fs.IntVar(&o.Port, "port", 9443, "Webhook server port")
-	fs.StringVar(&o.ServerCertDir, "tls-cert-dir", "", "Directory with server TLS certificate and key (must contain a tls.crt and tls.key file)")
-	fs.StringVar(&o.MetricsBindAddress, "metrics-bind-address", ":8080", "Bind address for the metrics server")
-	fs.StringVar(&o.HealthBindAddress, "health-bind-address", ":8081", "Bind address for the health server")
-	fs.BoolVar(&o.EnableProfiling, "profiling", false, "Enable profiling via web interface host:port/debug/pprof/")
-	fs.BoolVar(&o.EnableContentionProfiling, "contention-profiling", false, "Enable lock contention profiling, if profiling is enabled")
-}
-
-// validate validates all the required options.
-func (o *Options) validate() error {
-	if len(o.BindAddress) == 0 {
-		return fmt.Errorf("missing bind address")
-	}
-
-	if o.Port == 0 {
-		return fmt.Errorf("missing port")
-	}
-
-	if len(o.ServerCertDir) == 0 {
-		return fmt.Errorf("missing server tls cert path")
-	}
-
-	return nil
-}
-
 // Run runs gardener-seed-admission-controller using the specified options.
 func (o *Options) Run(ctx context.Context) error {
 	log.Info("Getting rest config")

--- a/cmd/gardener-seed-admission-controller/app/gardener_seed_admission_controller.go
+++ b/cmd/gardener-seed-admission-controller/app/gardener_seed_admission_controller.go
@@ -29,15 +29,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
-	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/controllerutils/routes"
 	gardenerhealthz "github.com/gardener/gardener/pkg/healthz"
-	"github.com/gardener/gardener/pkg/seedadmissioncontroller/webhooks/admission/extensioncrds"
-	"github.com/gardener/gardener/pkg/seedadmissioncontroller/webhooks/admission/extensionresources"
-	"github.com/gardener/gardener/pkg/seedadmissioncontroller/webhooks/admission/podschedulername"
 )
 
 // Name is a const for the name of this component.
@@ -177,14 +172,6 @@ func (o *Options) Run(ctx context.Context) error {
 	if err := mgr.AddReadyzCheck("webhook-server", server.StartedChecker()); err != nil {
 		return err
 	}
-
-	webhookLogger := log.WithName("webhook")
-
-	if err := extensionresources.AddWebhooks(mgr); err != nil {
-		return err
-	}
-	server.Register(extensioncrds.WebhookPath, &webhook.Admission{Handler: extensioncrds.New(webhookLogger.WithName(extensioncrds.HandlerName)), RecoverPanic: true})
-	server.Register(podschedulername.WebhookPath, &webhook.Admission{Handler: admission.HandlerFunc(podschedulername.DefaultShootControlPlanePodsSchedulerName), RecoverPanic: true})
 
 	log.Info("Starting manager")
 	return mgr.Start(ctx)

--- a/cmd/gardener-seed-admission-controller/app/options.go
+++ b/cmd/gardener-seed-admission-controller/app/options.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"fmt"
+
+	"github.com/spf13/pflag"
+)
+
+type options struct {
+	// bindAddress is the address the HTTP server should bind to.
+	bindAddress string
+	// port is the port that should be opened by the HTTP server.
+	port int
+	// serverCertDir is the path to server TLS cert and key.
+	serverCertDir string
+	// metricsBindAddress is the TCP address that the controller should bind to for serving prometheus metrics.
+	// It can be set to "0" to disable the metrics serving.
+	metricsBindAddress string
+	// healthBindAddress is the TCP address that the controller should bind to for serving health probes.
+	healthBindAddress string
+	// enableProfiling enables profiling via web interface host:port/debug/pprof/.
+	enableProfiling bool
+	// enableContentionProfiling enables lock contention profiling, if enableProfiling is true.
+	enableContentionProfiling bool
+}
+
+func (o *options) addFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&o.bindAddress, "bind-address", "0.0.0.0", "Address to bind to")
+	fs.IntVar(&o.port, "port", 9443, "Webhook server port")
+	fs.StringVar(&o.serverCertDir, "tls-cert-dir", "", "Directory with server TLS certificate and key (must contain a tls.crt and tls.key file)")
+	fs.StringVar(&o.metricsBindAddress, "metrics-bind-address", ":8080", "Bind address for the metrics server")
+	fs.StringVar(&o.healthBindAddress, "health-bind-address", ":8081", "Bind address for the health server")
+	fs.BoolVar(&o.enableProfiling, "profiling", false, "Enable profiling via web interface host:port/debug/pprof/")
+	fs.BoolVar(&o.enableContentionProfiling, "contention-profiling", false, "Enable lock contention profiling, if profiling is enabled")
+}
+
+func (o *options) complete() error {
+	return nil
+}
+
+func (o *options) validate() error {
+	if len(o.bindAddress) == 0 {
+		return fmt.Errorf("missing bind address")
+	}
+
+	if o.port == 0 {
+		return fmt.Errorf("missing port")
+	}
+
+	if len(o.serverCertDir) == 0 {
+		return fmt.Errorf("missing server tls cert path")
+	}
+
+	return nil
+}

--- a/cmd/gardener-seed-admission-controller/main.go
+++ b/cmd/gardener-seed-admission-controller/main.go
@@ -18,21 +18,16 @@ import (
 	"fmt"
 	"os"
 
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
-
 	"github.com/gardener/gardener/cmd/gardener-seed-admission-controller/app"
 	"github.com/gardener/gardener/cmd/utils"
-	"github.com/gardener/gardener/pkg/logger"
+
+	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
 )
 
 func main() {
 	utils.DeduplicateWarnings()
 
-	logf.SetLogger(logger.MustNewZapLogger(logger.InfoLevel, logger.FormatJSON))
-
-	ctx := signals.SetupSignalHandler()
-	if err := app.NewSeedAdmissionControllerCommand().ExecuteContext(ctx); err != nil {
+	if err := app.NewCommand().ExecuteContext(signals.SetupSignalHandler()); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}

--- a/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller.go
+++ b/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller.go
@@ -292,7 +292,8 @@ func (g *gardenerSeedAdmissionController) Deploy(ctx context.Context) error {
 										Port:   intstr.FromInt(healthPort),
 									},
 								},
-								InitialDelaySeconds: 5,
+								InitialDelaySeconds: 15,
+								TimeoutSeconds:      5,
 							},
 							ReadinessProbe: &corev1.Probe{
 								ProbeHandler: corev1.ProbeHandler{
@@ -303,6 +304,7 @@ func (g *gardenerSeedAdmissionController) Deploy(ctx context.Context) error {
 									},
 								},
 								InitialDelaySeconds: 10,
+								TimeoutSeconds:      5,
 							},
 							VolumeMounts: []corev1.VolumeMount{{
 								Name:      volumeName,

--- a/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller_test.go
+++ b/pkg/operation/botanist/component/seedadmissioncontroller/seedadmissioncontroller_test.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver"
+
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
@@ -169,7 +170,8 @@ spec:
             path: /healthz
             port: 8081
             scheme: HTTP
-          initialDelaySeconds: 5
+          initialDelaySeconds: 15
+          timeoutSeconds: 5
         name: gardener-seed-admission-controller
         ports:
         - containerPort: 8080
@@ -182,6 +184,7 @@ spec:
             port: 8081
             scheme: HTTP
           initialDelaySeconds: 10
+          timeoutSeconds: 5
         resources:
           limits:
             memory: 100Mi

--- a/pkg/seedadmissioncontroller/webhooks/add.go
+++ b/pkg/seedadmissioncontroller/webhooks/add.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhooks
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"github.com/gardener/gardener/pkg/seedadmissioncontroller/webhooks/admission/extensioncrds"
+	"github.com/gardener/gardener/pkg/seedadmissioncontroller/webhooks/admission/extensionresources"
+	"github.com/gardener/gardener/pkg/seedadmissioncontroller/webhooks/admission/podschedulername"
+)
+
+// AddWebhookHandlersToManager adds all webhook handlers to the given manager.
+func AddWebhookHandlersToManager(mgr manager.Manager) error {
+	var (
+		log    = mgr.GetLogger().WithName("webhook")
+		server = mgr.GetWebhookServer()
+	)
+
+	if err := extensionresources.AddWebhooks(mgr); err != nil {
+		return err
+	}
+
+	server.Register(extensioncrds.WebhookPath, &webhook.Admission{Handler: extensioncrds.New(log.WithName(extensioncrds.HandlerName)), RecoverPanic: true})
+	server.Register(podschedulername.WebhookPath, &webhook.Admission{Handler: admission.HandlerFunc(podschedulername.DefaultShootControlPlanePodsSchedulerName), RecoverPanic: true})
+
+	return nil
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR streamlines the main entrypoint of the `gardener-seed-admission-controller` so that it is in line with all other components which have been refactored to native controller-runtime functionality. Similar to #6706.

**Which issue(s) this PR fixes**:
Part of #4251 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
NONE
```
