### PR TITLE
Improve the logging in the control plane migration integration test

### DIFF
--- a/test/framework/shootmigrationtest.go
+++ b/test/framework/shootmigrationtest.go
@@ -386,10 +386,11 @@ func (t *ShootMigrationTest) CheckObjectsTimestamp(ctx context.Context, mrExclud
 					}
 
 					creationTimestamp := obj.GetCreationTimestamp()
-					log = log.WithValues("objectKind", obj.GetKind(), "objectNamespace", obj.GetNamespace(), "objectName", obj.GetName(), "creationTimestamp", creationTimestamp)
-					log.Info("Found object")
+					objectLog := log.WithValues("objectKind", obj.GetKind(), "objectNamespace", obj.GetNamespace(), "objectName", obj.GetName(), "creationTimestamp", creationTimestamp)
+
+					objectLog.Info("Found object")
 					if t.MigrationTime.Before(&creationTimestamp) {
-						log.Info("Object is created after shoot migration", "migrationTime", t.MigrationTime)
+						objectLog.Info("Object is created after shoot migration", "migrationTime", t.MigrationTime)
 						return fmt.Errorf("object: %s %s/%s Created At: %s is created after the Shoot migration %s", obj.GetKind(), obj.GetNamespace(), obj.GetName(), creationTimestamp, t.MigrationTime)
 					}
 				}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind bug

**What this PR does / why we need it**:
Currently the logging in https://github.com/gardener/gardener/blob/6f93f5e461c377aac583a7364a90b3dd2f65111e/test/framework/shootmigrationtest.go#L392 aggregates all object keys from previous iterations:

```
{"level":"info","ts":"2022-09-19T16:49:10.379Z","logger":"test","msg":"Object is created after shoot migration","managedResource":"shoot--it--tmhdd-1et-mgr/extension-controlplane-shoot","objectKind":"ServiceAccount","objectNamespace":"kube-system","objectName":"csi-driver-node","creationTimestamp":"2022-09-19 16:23:47 +0000 UTC","objectKind":"ValidatingWebhookConfiguration","objectNamespace":"","objectName":"csi-snapshot-validation","creationTimestamp":"2022-09-19 16:23:47 +0000 UTC","objectKind":"DaemonSet","objectNamespace":"kube-system","objectName":"csi-driver-node","creationTimestamp":"2022-09-19 16:23:47 +0000 UTC","objectKind":"VerticalPodAutoscaler","objectNamespace":"kube-system","objectName":"csi-driver-node","creationTimestamp":"2022-09-19 16:25:49 +0000 UTC","objectKind":"PodSecurityPolicy","objectNamespace":"","objectName":"extensions.gardener.cloud.provider-aws.csi-driver-node","creationTimestamp":"2022-09-19 16:23:47 +0000 UTC","objectKind":"ClusterRole","objectNamespace":"","objectName":"extensions.gardener.cloud:provider-aws:aws-custom-route-controller","creationTimestamp":"2022-09-19 16:43:41 +0000 UTC","migrationTime":"2022-09-19 16:36:35.450222171 +0000 UTC m=+32.146907016"}
```

which makes impossible to find you for which object the log was for.

To prevent summing all the object values from the for loop in the same logger, this PR uses a dedicated object logger for each iteration/object.

**Which issue(s) this PR fixes**:
Noticed when looking into https://github.com/gardener/gardener/issues/6703

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
