### PR TITLE
Deflake `TokenInvalidator` integration test suite

### DIFF
--- a/pkg/resourcemanager/controller/tokeninvalidator/add.go
+++ b/pkg/resourcemanager/controller/tokeninvalidator/add.go
@@ -15,8 +15,6 @@
 package tokeninvalidator
 
 import (
-	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
-
 	"github.com/spf13/pflag"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -29,8 +27,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/ratelimiter"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 )
 
 // ControllerName is the name of the controller.
@@ -48,6 +49,7 @@ type ControllerOptions struct {
 type ControllerConfig struct {
 	MaxConcurrentWorkers int
 	TargetCluster        cluster.Cluster
+	RateLimiter          ratelimiter.RateLimiter
 }
 
 // AddToManagerWithOptions adds the controller to a Manager with the given config.
@@ -61,6 +63,7 @@ func AddToManagerWithOptions(mgr manager.Manager, conf ControllerConfig) error {
 			MaxConcurrentReconciles: conf.MaxConcurrentWorkers,
 			Reconciler:              NewReconciler(conf.TargetCluster.GetClient(), conf.TargetCluster.GetAPIReader()),
 			RecoverPanic:            true,
+			RateLimiter:             conf.RateLimiter,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity testing
/kind enhancement

**What this PR does / why we need it**:
Earlier, the token-invalidator controller might have requeued too often which causes some exponential backoff by the underlying rate limiter. Hence, when the `Pod` is deleted, the controller might still be in the backoff for too long until the timeout for the `Consistently` hits:

```
• [FAILED] [10.031 seconds]
TokenInvalidator tests
/Users/root/go/src/github.com/gardener/gardener/test/integration/resourcemanager/tokeninvalidator/tokeninvalidator_test.go:33
  [It] should wait with invalidation until the pods using the static token are deleted
  /Users/root/go/src/github.com/gardener/gardener/test/integration/resourcemanager/tokeninvalidator/tokeninvalidator_test.go:139

  Begin Captured GinkgoWriter Output >>
    STEP: Create Pod 09/20/22 14:06:43.353
    STEP: Create Secret and ServiceAccount with AutomountServiceAccountToken=false 09/20/22 14:06:43.358
    STEP: Ensure token is not getting invalidated yet 09/20/22 14:06:43.364
    {"level":"debug","ts":"2022-09-20T14:06:43.367+0200","logger":"controller-runtime.webhook.webhooks","msg":"received request","webhook":"/webhooks/invalidate-service-account-token-secret","UID":"277aba60-6a8f-45f8-8515-176c12d82df3","kind":"/v1, Kind=Secret","resource":{"group":"","version":"v1","resource":"secrets"}}
    {"level":"debug","ts":"2022-09-20T14:06:43.367+0200","logger":"controller-runtime.webhook.webhooks","msg":"wrote response","webhook":"/webhooks/invalidate-service-account-token-secret","code":200,"reason":"","UID":"277aba60-6a8f-45f8-8515-176c12d82df3","allowed":true}
    {"level":"info","ts":"2022-09-20T14:06:43.372+0200","msg":"Requeueing since there is still at least one pod mounting secret","controller":"token-invalidator","object":{"name":"test-5b79f3ab","namespace":"tokeninvalidator-controller-test-95b0c6c4"},"namespace":"tokeninvalidator-controller-test-95b0c6c4","name":"test-5b79f3ab","reconcileID":"5ce32a6d-d027-41ba-865a-6d5ad465a35b","pod":{"namespace":"tokeninvalidator-controller-test-95b0c6c4","name":"foo"}}
    {"level":"info","ts":"2022-09-20T14:06:43.374+0200","msg":"Requeueing since there is still at least one pod mounting secret","controller":"token-invalidator","object":{"name":"test-5b79f3ab","namespace":"tokeninvalidator-controller-test-95b0c6c4"},"namespace":"tokeninvalidator-controller-test-95b0c6c4","name":"test-5b79f3ab","reconcileID":"c891be31-3133-4ad0-98d3-416419c79b7b","pod":{"namespace":"tokeninvalidator-controller-test-95b0c6c4","name":"foo"}}
    {"level":"info","ts":"2022-09-20T14:06:43.380+0200","msg":"Requeueing since there is still at least one pod mounting secret","controller":"token-invalidator","object":{"name":"test-5b79f3ab","namespace":"tokeninvalidator-controller-test-95b0c6c4"},"namespace":"tokeninvalidator-controller-test-95b0c6c4","name":"test-5b79f3ab","reconcileID":"b8f9db96-5ab1-4289-b507-5feabf5e3e9d","pod":{"namespace":"tokeninvalidator-controller-test-95b0c6c4","name":"foo"}}
    {"level":"info","ts":"2022-09-20T14:06:43.403+0200","msg":"Requeueing since there is still at least one pod mounting secret","controller":"token-invalidator","object":{"name":"test-5b79f3ab","namespace":"tokeninvalidator-controller-test-95b0c6c4"},"namespace":"tokeninvalidator-controller-test-95b0c6c4","name":"test-5b79f3ab","reconcileID":"d4cea27e-4111-4ce9-807d-51cd1b38fb1e","pod":{"namespace":"tokeninvalidator-controller-test-95b0c6c4","name":"foo"}}
    {"level":"info","ts":"2022-09-20T14:06:43.446+0200","msg":"Requeueing since there is still at least one pod mounting secret","controller":"token-invalidator","object":{"name":"test-5b79f3ab","namespace":"tokeninvalidator-controller-test-95b0c6c4"},"namespace":"tokeninvalidator-controller-test-95b0c6c4","name":"test-5b79f3ab","reconcileID":"38a6beff-1831-47cd-be1b-093ba9495815","pod":{"namespace":"tokeninvalidator-controller-test-95b0c6c4","name":"foo"}}
    {"level":"info","ts":"2022-09-20T14:06:43.530+0200","msg":"Requeueing since there is still at least one pod mounting secret","controller":"token-invalidator","object":{"name":"test-5b79f3ab","namespace":"tokeninvalidator-controller-test-95b0c6c4"},"namespace":"tokeninvalidator-controller-test-95b0c6c4","name":"test-5b79f3ab","reconcileID":"6608e248-731f-49b7-9002-1fd7644dfe6a","pod":{"namespace":"tokeninvalidator-controller-test-95b0c6c4","name":"foo"}}
    {"level":"info","ts":"2022-09-20T14:06:43.693+0200","msg":"Requeueing since there is still at least one pod mounting secret","controller":"token-invalidator","object":{"name":"test-5b79f3ab","namespace":"tokeninvalidator-controller-test-95b0c6c4"},"namespace":"tokeninvalidator-controller-test-95b0c6c4","name":"test-5b79f3ab","reconcileID":"72998933-e237-4cd2-9807-283fefe4beb0","pod":{"namespace":"tokeninvalidator-controller-test-95b0c6c4","name":"foo"}}
    {"level":"info","ts":"2022-09-20T14:06:44.016+0200","msg":"Requeueing since there is still at least one pod mounting secret","controller":"token-invalidator","object":{"name":"test-5b79f3ab","namespace":"tokeninvalidator-controller-test-95b0c6c4"},"namespace":"tokeninvalidator-controller-test-95b0c6c4","name":"test-5b79f3ab","reconcileID":"bfc543cd-b5dc-48ef-a2d8-6245b375ca11","pod":{"namespace":"tokeninvalidator-controller-test-95b0c6c4","name":"foo"}}
    {"level":"info","ts":"2022-09-20T14:06:44.661+0200","msg":"Requeueing since there is still at least one pod mounting secret","controller":"token-invalidator","object":{"name":"test-5b79f3ab","namespace":"tokeninvalidator-controller-test-95b0c6c4"},"namespace":"tokeninvalidator-controller-test-95b0c6c4","name":"test-5b79f3ab","reconcileID":"46dbbdb0-2f38-4076-9f53-9296d733afac","pod":{"namespace":"tokeninvalidator-controller-test-95b0c6c4","name":"foo"}}
    {"level":"info","ts":"2022-09-20T14:06:45.949+0200","msg":"Requeueing since there is still at least one pod mounting secret","controller":"token-invalidator","object":{"name":"test-5b79f3ab","namespace":"tokeninvalidator-controller-test-95b0c6c4"},"namespace":"tokeninvalidator-controller-test-95b0c6c4","name":"test-5b79f3ab","reconcileID":"dc979f55-32af-4519-8a01-2d237c2e7f16","pod":{"namespace":"tokeninvalidator-controller-test-95b0c6c4","name":"foo"}}
    STEP: Delete Pod 09/20/22 14:06:48.365
    STEP: Ensure token is now getting invalidated 09/20/22 14:06:48.372
    {"level":"info","ts":"2022-09-20T14:06:48.512+0200","msg":"Requeueing since there is still at least one pod mounting secret","controller":"token-invalidator","object":{"name":"test-5b79f3ab","namespace":"tokeninvalidator-controller-test-95b0c6c4"},"namespace":"tokeninvalidator-controller-test-95b0c6c4","name":"test-5b79f3ab","reconcileID":"719c1522-963b-4db6-bbd2-c884f5aea9a7","pod":{"namespace":"tokeninvalidator-controller-test-95b0c6c4","name":"foo"}}
  << End Captured GinkgoWriter Output

  Timed out after 5.001s.
  Expected
      <bool>: false
  to be true
  In [It] at: /Users/root/go/src/github.com/gardener/gardener/test/integration/resourcemanager/tokeninvalidator/tokeninvalidator_test.go:177
```

Hence, let's follow the approach from https://github.com/gardener/gardener/blob/master/docs/development/testing.md#writing-integration-tests here:

> use a custom rate limiter for controllers in integration tests: [example test](https://github.com/gardener/gardener/blob/3dd6b111d677eb4bceadaa8fc469877097660577/test/integration/controllermanager/exposureclass/exposureclass_suite_test.go#L130-L131)
this can be used for limiting exponential backoff to shorten wait times
otherwise, if using the default rate limiter, exponential backoff might exceed the timeout of Eventually calls and cause flakes

**Which issue(s) this PR fixes**:
Fixes #6710

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
