### PR TITLE
Only validate shoot.worker.machine.architecture if field is not nil

### DIFF
--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -1272,7 +1272,7 @@ func ValidateWorker(worker core.Worker, kubernetesVersion string, fldPath *field
 	}
 
 	if worker.Machine.Architecture != nil {
-		allErrs = append(allErrs, ValidateArchitecture(worker.Machine.Architecture, fldPath.Child("architecture"))...)
+		allErrs = append(allErrs, ValidateArchitecture(worker.Machine.Architecture, fldPath.Child("machine", "architecture"))...)
 	}
 
 	return allErrs

--- a/pkg/apis/core/validation/shoot.go
+++ b/pkg/apis/core/validation/shoot.go
@@ -1271,7 +1271,9 @@ func ValidateWorker(worker core.Worker, kubernetesVersion string, fldPath *field
 		allErrs = append(allErrs, ValidateCRI(worker.CRI, kubernetesVersion, fldPath.Child("cri"))...)
 	}
 
-	allErrs = append(allErrs, ValidateArchitecture(worker.Machine.Architecture, fldPath.Child("architecture"))...)
+	if worker.Machine.Architecture != nil {
+		allErrs = append(allErrs, ValidateArchitecture(worker.Machine.Architecture, fldPath.Child("architecture"))...)
+	}
 
 	return allErrs
 }

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -4163,6 +4163,17 @@ var _ = Describe("Shoot Validation Tests", func() {
 					"Field": Equal("machine.image.version"),
 				}))),
 			),
+			Entry("nil machine architecture",
+				core.Machine{
+					Type: "large",
+					Image: &core.ShootMachineImage{
+						Name:    "image-name",
+						Version: "1.0.0",
+					},
+					Architecture: nil,
+				},
+				BeEmpty(),
+			),
 		)
 
 		DescribeTable("reject when maxUnavailable and maxSurge are invalid",


### PR DESCRIPTION
**How to categorize this PR?**

/area robustness
/kind bug

**What this PR does / why we need it**:

There is a potential panic due to a nil pointer exception.

**Release note**:
```bugfix operator
Prevent potential nil pointer exception in gardener-apiserver if  Shoot's `.spec.worker.machine.architecture` is set to nil. The issue could only occur if the version skew of Gardener is not respected and minor version is skipped during the Gardener update.
```

Signed-off-by: Felix Breuer <fbreuer@pm.me>