### PR TITLE
Revert "[ci:component:github.com/gardener/apiserver-proxy:v0.6.0->v0.7.0]"

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -320,8 +320,8 @@ images:
 - name: apiserver-proxy-sidecar
   sourceRepository: github.com/gardener/apiserver-proxy
   repository: eu.gcr.io/gardener-project/gardener/apiserver-proxy
-  tag: "v0.7.0"
+  tag: "v0.6.0"
 - name: apiserver-proxy-pod-webhook
   sourceRepository: github.com/gardener/apiserver-proxy
   repository: eu.gcr.io/gardener-project/gardener/apiserver-proxy-pod-webhook
-  tag: "v0.7.0"
+  tag: "v0.6.0"


### PR DESCRIPTION
Reverts gardener/gardener#6698

It seems after https://github.com/gardener/gardener/pull/6705 or https://github.com/gardener/gardener/pull/6698 we see failing e2e tests, for example:
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/6690/pull-gardener-e2e-kind/1572182869307035648
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/6677/pull-gardener-e2e-kind/1572184348826800128

We can revert this PR for now while we investigate the issue, since we would like to go ahead with the v1.56 release this week.