### PR TITLE
Revert "[ci:component:github.com/gardener/vpn2:0.10.0->0.11.1]"

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -104,7 +104,7 @@ images:
 - name: vpn-seed-server
   sourceRepository: github.com/gardener/vpn2
   repository: eu.gcr.io/gardener-project/gardener/vpn-seed-server
-  tag: "0.11.1"
+  tag: "0.10.0"
 
 # Monitoring
 - name: alertmanager
@@ -160,7 +160,7 @@ images:
 - name: vpn-shoot-client
   sourceRepository: github.com/gardener/vpn2
   repository: eu.gcr.io/gardener-project/gardener/vpn-shoot-client
-  tag: "0.11.1"
+  tag: "0.10.0"
 - name: coredns
   sourceRepository: github.com/coredns/coredns
   repository: coredns/coredns


### PR DESCRIPTION
Reverts gardener/gardener#6705

It seems after https://github.com/gardener/gardener/pull/6705 or https://github.com/gardener/gardener/pull/6698 we see failing e2e tests, for example:
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/6690/pull-gardener-e2e-kind/1572182869307035648
https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/6677/pull-gardener-e2e-kind/1572184348826800128

We can revert this PR for now while we investigate the issue, since we would like to go ahead with the v1.56 release this week.