### PR TITLE
Set ldflags in skaffold builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -312,6 +312,9 @@ export SKAFFOLD_BUILD_CONCURRENCY = 0
 # use static label for skaffold to prevent rolling all gardener components on every `skaffold` invocation
 gardener-up gardener-down gardenlet-kind2-up gardenlet-kind2-down: export SKAFFOLD_LABEL = skaffold.dev/run-id=gardener-local
 
+# set ldflags for skaffold
+gardener-up gardenlet-kind2-up: export LD_FLAGS = $(shell $(REPO_ROOT)/hack/get-build-ld-flags.sh)
+
 gardener-up: $(SKAFFOLD) $(HELM) $(KUBECTL)
 	SKAFFOLD_DEFAULT_REPO=localhost:5001 SKAFFOLD_PUSH=true $(SKAFFOLD) run
 

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -24,15 +24,23 @@ build:
   - image: eu.gcr.io/gardener-project/gardener/apiserver
     ko:
       main: ./cmd/gardener-apiserver
+      ldflags:
+        - "{{.LD_FLAGS}}"
   - image: eu.gcr.io/gardener-project/gardener/controller-manager
     ko:
       main: ./cmd/gardener-controller-manager
+      ldflags:
+        - "{{.LD_FLAGS}}"
   - image: eu.gcr.io/gardener-project/gardener/scheduler
     ko:
       main: ./cmd/gardener-scheduler
+      ldflags:
+        - "{{.LD_FLAGS}}"
   - image: eu.gcr.io/gardener-project/gardener/admission-controller
     ko:
       main: ./cmd/gardener-admission-controller
+      ldflags:
+        - "{{.LD_FLAGS}}"
 deploy:
   helm:
     releases:
@@ -66,6 +74,8 @@ build:
   - image: eu.gcr.io/gardener-project/gardener/extensions/provider-local
     ko:
       main: ./cmd/gardener-extension-provider-local
+      ldflags:
+        - "{{.LD_FLAGS}}"
 deploy:
   helm:
     releases:
@@ -124,11 +134,8 @@ build:
   - image: eu.gcr.io/gardener-project/gardener/gardenlet
     ko:
       main: ./cmd/gardenlet
-      # inject dummy version into ko builds just to satisfy semver format, otherwise shoot reconciliation will fail with
-      # "Invalid Semantic Version"
       ldflags:
-      - -X k8s.io/component-base/version/verflag.programName=Gardener
-      - -X k8s.io/component-base/version.gitVersion=v0.0.0-dev
+        - "{{.LD_FLAGS}}"
   - image: eu.gcr.io/gardener-project/gardener/resource-manager
     ko:
       main: ./cmd/gardener-resource-manager


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR sets our common `ldflags` in skaffold builds too.
As a result, seeds and shoots will report a meaningful Gardener version in the gardener-local setup.
Follow up to [this discussion](https://github.com/gardener/gardener/pull/6678#issuecomment-1250955707).

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
