### PR TITLE
Extend ConditionBuilder interface with a WithClock(...) function

### DIFF
--- a/pkg/apis/.import-restrictions
+++ b/pkg/apis/.import-restrictions
@@ -4,6 +4,7 @@ rules:
   - k8s.io/apimachinery
   - k8s.io/api
   - k8s.io/klog
+  - k8s.io/utils/clock
   - k8s.io/utils/pointer
 - selectorRegexp: github[.]com/gardener
   allowedPrefixes:

--- a/pkg/apis/core/v1beta1/helper/condition_builder.go
+++ b/pkg/apis/core/v1beta1/helper/condition_builder.go
@@ -21,6 +21,7 @@ import (
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/clock"
 )
 
 // ConditionBuilder build a Condition.
@@ -30,6 +31,9 @@ type ConditionBuilder interface {
 	WithReason(reason string) ConditionBuilder
 	WithMessage(message string) ConditionBuilder
 	WithCodes(codes ...gardencorev1beta1.ErrorCode) ConditionBuilder
+	WithClock(clock clock.Clock) ConditionBuilder
+	// Deprecated: Use WithClock(...) instead.
+	// TODO(oliver-goetz): Remove in a future release.
 	WithNowFunc(now func() metav1.Time) ConditionBuilder
 	Build() (new gardencorev1beta1.Condition, updated bool)
 }
@@ -43,6 +47,7 @@ type defaultConditionBuilder struct {
 	message       *string
 	codes         []gardencorev1beta1.ErrorCode
 	nowFunc       func() metav1.Time
+	clock         clock.Clock
 }
 
 // NewConditionBuilder returns a ConditionBuilder for a specific condition.
@@ -53,7 +58,7 @@ func NewConditionBuilder(conditionType gardencorev1beta1.ConditionType) (Conditi
 
 	return &defaultConditionBuilder{
 		conditionType: conditionType,
-		nowFunc:       metav1.Now,
+		clock:         clock.RealClock{},
 	}, nil
 }
 
@@ -90,8 +95,17 @@ func (b *defaultConditionBuilder) WithCodes(codes ...gardencorev1beta1.ErrorCode
 	return b
 }
 
+// WithClock sets a `clock.Clock` which is used for getting the current time
+func (b *defaultConditionBuilder) WithClock(clock clock.Clock) ConditionBuilder {
+	b.clock = clock
+	b.nowFunc = nil
+
+	return b
+}
+
 // WithNowFunc sets the function used for getting the current time.
-// Should only be used for tests.
+// Deprecated: Use WithClock(...) instead.
+// TODO(oliver-goetz): Remove in a future release.
 func (b *defaultConditionBuilder) WithNowFunc(now func() metav1.Time) ConditionBuilder {
 	b.nowFunc = now
 	return b
@@ -104,9 +118,14 @@ func (b *defaultConditionBuilder) WithNowFunc(now func() metav1.Time) ConditionB
 // - The error codes will not be transferred from the old to the new condition
 func (b *defaultConditionBuilder) Build() (new gardencorev1beta1.Condition, updated bool) {
 	var (
-		now       = b.nowFunc()
+		now       = metav1.Time{Time: b.clock.Now()}
 		emptyTime = metav1.Time{}
 	)
+
+	// TODO(oliver-goetz): Delete when removing `WithNowFunc`
+	if b.nowFunc != nil {
+		now = b.nowFunc()
+	}
 
 	new = *b.old.DeepCopy()
 

--- a/pkg/apis/core/v1beta1/helper/condition_builder.go
+++ b/pkg/apis/core/v1beta1/helper/condition_builder.go
@@ -32,9 +32,6 @@ type ConditionBuilder interface {
 	WithMessage(message string) ConditionBuilder
 	WithCodes(codes ...gardencorev1beta1.ErrorCode) ConditionBuilder
 	WithClock(clock clock.Clock) ConditionBuilder
-	// Deprecated: Use WithClock(...) instead.
-	// TODO(oliver-goetz): Remove in a future release.
-	WithNowFunc(now func() metav1.Time) ConditionBuilder
 	Build() (new gardencorev1beta1.Condition, updated bool)
 }
 
@@ -46,7 +43,6 @@ type defaultConditionBuilder struct {
 	reason        *string
 	message       *string
 	codes         []gardencorev1beta1.ErrorCode
-	nowFunc       func() metav1.Time
 	clock         clock.Clock
 }
 
@@ -98,16 +94,7 @@ func (b *defaultConditionBuilder) WithCodes(codes ...gardencorev1beta1.ErrorCode
 // WithClock sets a `clock.Clock` which is used for getting the current time
 func (b *defaultConditionBuilder) WithClock(clock clock.Clock) ConditionBuilder {
 	b.clock = clock
-	b.nowFunc = nil
 
-	return b
-}
-
-// WithNowFunc sets the function used for getting the current time.
-// Deprecated: Use WithClock(...) instead.
-// TODO(oliver-goetz): Remove in a future release.
-func (b *defaultConditionBuilder) WithNowFunc(now func() metav1.Time) ConditionBuilder {
-	b.nowFunc = now
 	return b
 }
 
@@ -121,11 +108,6 @@ func (b *defaultConditionBuilder) Build() (new gardencorev1beta1.Condition, upda
 		now       = metav1.Time{Time: b.clock.Now()}
 		emptyTime = metav1.Time{}
 	)
-
-	// TODO(oliver-goetz): Delete when removing `WithNowFunc`
-	if b.nowFunc != nil {
-		now = b.nowFunc()
-	}
 
 	new = *b.old.DeepCopy()
 

--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -36,9 +36,11 @@ import (
 )
 
 // Clock defines the clock for the helper functions
+// Deprecated: Use ...WithClock(...) functions instead.
 var Clock clock.Clock = clock.RealClock{}
 
 // InitCondition initializes a new Condition with an Unknown status.
+// Deprecated: Use InitConditionWithClock(...) instead.
 func InitCondition(conditionType gardencorev1beta1.ConditionType) gardencorev1beta1.Condition {
 	return InitConditionWithClock(Clock, conditionType)
 }
@@ -70,6 +72,7 @@ func GetCondition(conditions []gardencorev1beta1.Condition, conditionType garden
 
 // GetOrInitCondition tries to retrieve the condition with the given condition type from the given conditions.
 // If the condition could not be found, it returns an initialized condition of the given type.
+// Deprecated: Use GetOrInitConditionWithClock(...) instead.
 func GetOrInitCondition(conditions []gardencorev1beta1.Condition, conditionType gardencorev1beta1.ConditionType) gardencorev1beta1.Condition {
 	return GetOrInitConditionWithClock(Clock, conditions, conditionType)
 }
@@ -84,6 +87,7 @@ func GetOrInitConditionWithClock(clock clock.Clock, conditions []gardencorev1bet
 }
 
 // UpdatedCondition updates the properties of one specific condition.
+// Deprecated: Use UpdatedConditionWithClock(...) instead.
 func UpdatedCondition(condition gardencorev1beta1.Condition, status gardencorev1beta1.ConditionStatus, reason, message string, codes ...gardencorev1beta1.ErrorCode) gardencorev1beta1.Condition {
 	return UpdatedConditionWithClock(Clock, condition, status, reason, message, codes...)
 }
@@ -105,6 +109,7 @@ func UpdatedConditionWithClock(clock clock.Clock, condition gardencorev1beta1.Co
 }
 
 // UpdatedConditionUnknownError updates the condition to 'Unknown' status and the message of the given error.
+// Deprecated: Use UpdatedConditionUnknownErrorWithClock(...) instead.
 func UpdatedConditionUnknownError(condition gardencorev1beta1.Condition, err error, codes ...gardencorev1beta1.ErrorCode) gardencorev1beta1.Condition {
 	return UpdatedConditionUnknownErrorWithClock(Clock, condition, err, codes...)
 }
@@ -115,6 +120,7 @@ func UpdatedConditionUnknownErrorWithClock(clock clock.Clock, condition gardenco
 }
 
 // UpdatedConditionUnknownErrorMessage updates the condition with 'Unknown' status and the given message.
+// Deprecated: Use UpdatedConditionUnknownErrorMessageWithClock(...) instead.
 func UpdatedConditionUnknownErrorMessage(condition gardencorev1beta1.Condition, message string, codes ...gardencorev1beta1.ErrorCode) gardencorev1beta1.Condition {
 	return UpdatedConditionUnknownErrorMessageWithClock(Clock, condition, message, codes...)
 }

--- a/pkg/apis/core/v1beta1/helper/helper.go
+++ b/pkg/apis/core/v1beta1/helper/helper.go
@@ -31,15 +31,21 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/clock"
 	"k8s.io/utils/pointer"
 )
 
-// Now determines the current metav1.Time.
-var Now = metav1.Now
+// Clock defines the clock for the helper functions
+var Clock clock.Clock = clock.RealClock{}
 
 // InitCondition initializes a new Condition with an Unknown status.
 func InitCondition(conditionType gardencorev1beta1.ConditionType) gardencorev1beta1.Condition {
-	now := Now()
+	return InitConditionWithClock(Clock, conditionType)
+}
+
+// InitConditionWithClock initializes a new Condition with an Unknown status. It allows passing a custom clock for testing.
+func InitConditionWithClock(clock clock.Clock, conditionType gardencorev1beta1.ConditionType) gardencorev1beta1.Condition {
+	now := metav1.Time{Time: clock.Now()}
 	return gardencorev1beta1.Condition{
 		Type:               conditionType,
 		Status:             gardencorev1beta1.ConditionUnknown,
@@ -65,19 +71,30 @@ func GetCondition(conditions []gardencorev1beta1.Condition, conditionType garden
 // GetOrInitCondition tries to retrieve the condition with the given condition type from the given conditions.
 // If the condition could not be found, it returns an initialized condition of the given type.
 func GetOrInitCondition(conditions []gardencorev1beta1.Condition, conditionType gardencorev1beta1.ConditionType) gardencorev1beta1.Condition {
+	return GetOrInitConditionWithClock(Clock, conditions, conditionType)
+}
+
+// GetOrInitConditionWithClock tries to retrieve the condition with the given condition type from the given conditions.
+// If the condition could not be found, it returns an initialized condition of the given type. It allows passing a custom clock for testing.
+func GetOrInitConditionWithClock(clock clock.Clock, conditions []gardencorev1beta1.Condition, conditionType gardencorev1beta1.ConditionType) gardencorev1beta1.Condition {
 	if condition := GetCondition(conditions, conditionType); condition != nil {
 		return *condition
 	}
-	return InitCondition(conditionType)
+	return InitConditionWithClock(clock, conditionType)
 }
 
 // UpdatedCondition updates the properties of one specific condition.
 func UpdatedCondition(condition gardencorev1beta1.Condition, status gardencorev1beta1.ConditionStatus, reason, message string, codes ...gardencorev1beta1.ErrorCode) gardencorev1beta1.Condition {
+	return UpdatedConditionWithClock(Clock, condition, status, reason, message, codes...)
+}
+
+// UpdatedConditionWithClock updates the properties of one specific condition. It allows passing a custom clock for testing.
+func UpdatedConditionWithClock(clock clock.Clock, condition gardencorev1beta1.Condition, status gardencorev1beta1.ConditionStatus, reason, message string, codes ...gardencorev1beta1.ErrorCode) gardencorev1beta1.Condition {
 	builder, err := NewConditionBuilder(condition.Type)
 	utilruntime.Must(err)
 	newCondition, _ := builder.
 		WithOldCondition(condition).
-		WithNowFunc(Now).
+		WithClock(clock).
 		WithStatus(status).
 		WithReason(reason).
 		WithMessage(message).
@@ -89,12 +106,22 @@ func UpdatedCondition(condition gardencorev1beta1.Condition, status gardencorev1
 
 // UpdatedConditionUnknownError updates the condition to 'Unknown' status and the message of the given error.
 func UpdatedConditionUnknownError(condition gardencorev1beta1.Condition, err error, codes ...gardencorev1beta1.ErrorCode) gardencorev1beta1.Condition {
-	return UpdatedConditionUnknownErrorMessage(condition, err.Error(), codes...)
+	return UpdatedConditionUnknownErrorWithClock(Clock, condition, err, codes...)
+}
+
+// UpdatedConditionUnknownErrorWithClock updates the condition to 'Unknown' status and the message of the given error. It allows passing a custom clock for testing.
+func UpdatedConditionUnknownErrorWithClock(clock clock.Clock, condition gardencorev1beta1.Condition, err error, codes ...gardencorev1beta1.ErrorCode) gardencorev1beta1.Condition {
+	return UpdatedConditionUnknownErrorMessageWithClock(clock, condition, err.Error(), codes...)
 }
 
 // UpdatedConditionUnknownErrorMessage updates the condition with 'Unknown' status and the given message.
 func UpdatedConditionUnknownErrorMessage(condition gardencorev1beta1.Condition, message string, codes ...gardencorev1beta1.ErrorCode) gardencorev1beta1.Condition {
-	return UpdatedCondition(condition, gardencorev1beta1.ConditionUnknown, gardencorev1beta1.ConditionCheckError, message, codes...)
+	return UpdatedConditionUnknownErrorMessageWithClock(Clock, condition, message, codes...)
+}
+
+// UpdatedConditionUnknownErrorMessageWithClock updates the condition with 'Unknown' status and the given message. It allows passing a custom clock for testing.
+func UpdatedConditionUnknownErrorMessageWithClock(clock clock.Clock, condition gardencorev1beta1.Condition, message string, codes ...gardencorev1beta1.ErrorCode) gardencorev1beta1.Condition {
+	return UpdatedConditionWithClock(clock, condition, gardencorev1beta1.ConditionUnknown, gardencorev1beta1.ConditionCheckError, message, codes...)
 }
 
 // MergeConditions merges the given <oldConditions> with the <newConditions>. Existing conditions are superseded by

--- a/pkg/apis/core/v1beta1/helper/helper_test.go
+++ b/pkg/apis/core/v1beta1/helper/helper_test.go
@@ -23,6 +23,7 @@ import (
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	. "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
+	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
@@ -255,9 +256,9 @@ var _ = Describe("helper", func() {
 			})
 
 			It("should return a new, initialized condition", func() {
-				tmp := Clock
-				Clock = testclock.NewFakeClock(time.Now().Round(time.Second))
-				defer func() { Clock = tmp }()
+				DeferCleanup(test.WithVars(
+					&Clock, testclock.NewFakeClock(time.Now().Round(time.Second)),
+				))
 
 				Expect(GetOrInitCondition(nil, "foo")).To(Equal(InitCondition("foo")))
 			})

--- a/pkg/apis/core/v1beta1/helper/helper_test.go
+++ b/pkg/apis/core/v1beta1/helper/helper_test.go
@@ -30,6 +30,7 @@ import (
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	testclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/pointer"
 )
 
@@ -254,11 +255,9 @@ var _ = Describe("helper", func() {
 			})
 
 			It("should return a new, initialized condition", func() {
-				tmp := Now
-				Now = func() metav1.Time {
-					return metav1.NewTime(time.Unix(0, 0))
-				}
-				defer func() { Now = tmp }()
+				tmp := Clock
+				Clock = testclock.NewFakeClock(time.Now().Round(time.Second))
+				defer func() { Clock = tmp }()
 
 				Expect(GetOrInitCondition(nil, "foo")).To(Equal(InitCondition("foo")))
 			})

--- a/pkg/controllermanager/controller/seed/backupbucketscheck/reconciler.go
+++ b/pkg/controllermanager/controller/seed/backupbucketscheck/reconciler.go
@@ -58,7 +58,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		return reconcile.Result{}, err
 	}
 
-	conditionBackupBucketsReady := gardencorev1beta1helper.GetOrInitCondition(seed.Status.Conditions, gardencorev1beta1.SeedBackupBucketsReady)
+	conditionBackupBucketsReady := gardencorev1beta1helper.GetOrInitConditionWithClock(r.Clock, seed.Status.Conditions, gardencorev1beta1.SeedBackupBucketsReady)
 
 	var (
 		bbCount                int
@@ -88,7 +88,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		}
 
 	case bbCount > 0:
-		if updateErr := utils.PatchSeedCondition(ctx, log, r.Client.Status(), seed, gardencorev1beta1helper.UpdatedCondition(conditionBackupBucketsReady,
+		if updateErr := utils.PatchSeedCondition(ctx, log, r.Client.Status(), seed, gardencorev1beta1helper.UpdatedConditionWithClock(r.Clock, conditionBackupBucketsReady,
 			gardencorev1beta1.ConditionTrue, "BackupBucketsAvailable", "Backup Buckets are available.")); updateErr != nil {
 			return reconcile.Result{}, updateErr
 		}

--- a/pkg/controllermanager/controller/seed/extensionscheck/reconciler.go
+++ b/pkg/controllermanager/controller/seed/extensionscheck/reconciler.go
@@ -118,7 +118,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 		}
 	}
 
-	condition := helper.GetOrInitCondition(seed.Status.Conditions, gardencorev1beta1.SeedExtensionsReady)
+	condition := helper.GetOrInitConditionWithClock(r.Clock, seed.Status.Conditions, gardencorev1beta1.SeedExtensionsReady)
 	extensionsReadyThreshold := utils.GetThresholdForCondition(r.Config.ConditionThresholds, gardencorev1beta1.SeedExtensionsReady)
 
 	switch {
@@ -131,7 +131,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, request reconcile.Request) (
 	case len(progressing) != 0:
 		condition = utils.SetToProgressingOrFalse(r.Clock, extensionsReadyThreshold, condition, "SomeExtensionsProgressing", fmt.Sprintf("Some extensions are progressing: %+v", progressing))
 	default:
-		condition = helper.UpdatedCondition(condition, gardencorev1beta1.ConditionTrue, "AllExtensionsReady", "All extensions installed into the seed cluster are ready and healthy.")
+		condition = helper.UpdatedConditionWithClock(r.Clock, condition, gardencorev1beta1.ConditionTrue, "AllExtensionsReady", "All extensions installed into the seed cluster are ready and healthy.")
 	}
 
 	if err := utils.PatchSeedCondition(ctx, log, r.Client.Status(), seed, condition); err != nil {

--- a/pkg/controllermanager/controller/seed/utils/utils.go
+++ b/pkg/controllermanager/controller/seed/utils/utils.go
@@ -72,22 +72,22 @@ func setToProgressingIfWithinThreshold(
 	switch condition.Status {
 	case gardencorev1beta1.ConditionTrue:
 		if conditionThreshold == 0 {
-			return gardencorev1beta1helper.UpdatedCondition(condition, eventualConditionStatus, reason, message, codes...)
+			return gardencorev1beta1helper.UpdatedConditionWithClock(clock, condition, eventualConditionStatus, reason, message, codes...)
 		}
-		return gardencorev1beta1helper.UpdatedCondition(condition, gardencorev1beta1.ConditionProgressing, reason, message, codes...)
+		return gardencorev1beta1helper.UpdatedConditionWithClock(clock, condition, gardencorev1beta1.ConditionProgressing, reason, message, codes...)
 
 	case gardencorev1beta1.ConditionProgressing:
 		if conditionThreshold == 0 {
-			return gardencorev1beta1helper.UpdatedCondition(condition, eventualConditionStatus, reason, message, codes...)
+			return gardencorev1beta1helper.UpdatedConditionWithClock(clock, condition, eventualConditionStatus, reason, message, codes...)
 		}
 
 		if delta := clock.Now().UTC().Sub(condition.LastTransitionTime.Time.UTC()); delta <= conditionThreshold {
-			return gardencorev1beta1helper.UpdatedCondition(condition, gardencorev1beta1.ConditionProgressing, reason, message, codes...)
+			return gardencorev1beta1helper.UpdatedConditionWithClock(clock, condition, gardencorev1beta1.ConditionProgressing, reason, message, codes...)
 		}
-		return gardencorev1beta1helper.UpdatedCondition(condition, eventualConditionStatus, reason, message, codes...)
+		return gardencorev1beta1helper.UpdatedConditionWithClock(clock, condition, eventualConditionStatus, reason, message, codes...)
 	}
 
-	return gardencorev1beta1helper.UpdatedCondition(condition, eventualConditionStatus, reason, message, codes...)
+	return gardencorev1beta1helper.UpdatedConditionWithClock(clock, condition, eventualConditionStatus, reason, message, codes...)
 }
 
 // PatchSeedCondition patches the seed conditions in case they need to be updated.

--- a/pkg/controllermanager/controller/seed/utils/utils_test.go
+++ b/pkg/controllermanager/controller/seed/utils/utils_test.go
@@ -19,11 +19,9 @@ import (
 	"time"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
-	gardencorev1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	"github.com/gardener/gardener/pkg/client/kubernetes"
 	"github.com/gardener/gardener/pkg/controllermanager/apis/config"
 	. "github.com/gardener/gardener/pkg/controllermanager/controller/seed/utils"
-	"github.com/gardener/gardener/pkg/utils/test"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
@@ -59,10 +57,6 @@ var _ = Describe("Utils", func() {
 		BeforeEach(func() {
 			fakeClock = &testing.FakeClock{}
 			condition = gardencorev1beta1.Condition{Type: conditionType}
-
-			DeferCleanup(test.WithVars(
-				&gardencorev1beta1helper.Clock, fakeClock,
-			))
 		})
 
 		tests := func(

--- a/pkg/controllermanager/controller/seed/utils/utils_test.go
+++ b/pkg/controllermanager/controller/seed/utils/utils_test.go
@@ -61,7 +61,7 @@ var _ = Describe("Utils", func() {
 			condition = gardencorev1beta1.Condition{Type: conditionType}
 
 			DeferCleanup(test.WithVars(
-				&gardencorev1beta1helper.Now, func() metav1.Time { return metav1.Time{Time: fakeClock.Now()} },
+				&gardencorev1beta1helper.Clock, fakeClock,
 			))
 		})
 

--- a/pkg/gardenlet/controller/seed/seed.go
+++ b/pkg/gardenlet/controller/seed/seed.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
@@ -93,7 +94,7 @@ func NewSeedController(
 		log: log,
 
 		reconciler:      newReconciler(gardenCluster.GetClient(), seedClientSet, gardenCluster.GetEventRecorderFor(reconcilerName+"-controller"), imageVector, componentImageVectors, identity, gardenletClientCertificateExpirationTime, config),
-		leaseReconciler: NewLeaseReconciler(gardenCluster.GetClient(), seedClientSet, healthManager, metav1.Now, config),
+		leaseReconciler: NewLeaseReconciler(gardenCluster.GetClient(), seedClientSet, healthManager, clock.RealClock{}, config),
 		careReconciler:  NewCareReconciler(gardenCluster.GetClient(), seedClientSet.Client(), *config.Controllers.SeedCare),
 
 		seedQueue:      workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "seed"),

--- a/pkg/operation/care/health_check_test.go
+++ b/pkg/operation/care/health_check_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gardener/gardener/pkg/operation/botanist/component/extensions/operatingsystemconfig/executor"
 	"github.com/gardener/gardener/pkg/operation/care"
 	kutil "github.com/gardener/gardener/pkg/utils/kubernetes"
+	"github.com/gardener/gardener/pkg/utils/test"
 
 	"github.com/Masterminds/semver"
 	druidv1alpha1 "github.com/gardener/etcd-druid/api/v1alpha1"
@@ -946,14 +947,10 @@ var _ = Describe("health check", func() {
 	DescribeTable("#FailedCondition",
 		func(thresholds map[gardencorev1beta1.ConditionType]time.Duration, lastOperation *gardencorev1beta1.LastOperation, transitionTime metav1.Time, now time.Time, condition gardencorev1beta1.Condition, reason, message string, expected types.GomegaMatcher) {
 			checker := care.NewHealthChecker(thresholds, nil, lastOperation, kubernetesVersion, gardenerVersion)
-			tmp1, tmp2 := care.Now, gardencorev1beta1helper.Clock
-			defer func() {
-				care.Now, gardencorev1beta1helper.Clock = tmp1, tmp2
-			}()
-			care.Now, gardencorev1beta1helper.Clock = func() time.Time {
-				return now
-			}, testclock.NewFakeClock(transitionTime.Time)
-
+			DeferCleanup(test.WithVars(
+				&gardencorev1beta1helper.Clock, testclock.NewFakeClock(transitionTime.Time),
+				&care.Now, func() time.Time { return now },
+			))
 			Expect(checker.FailedCondition(condition, reason, message)).To(expected)
 		},
 		Entry("true condition with threshold",

--- a/test/integration/controllermanager/seed/backupbucketscheck/backupbucketscheck_suite_test.go
+++ b/test/integration/controllermanager/seed/backupbucketscheck/backupbucketscheck_suite_test.go
@@ -117,7 +117,7 @@ var _ = BeforeSuite(func() {
 	// This is required so that the BackupsBucketReady condition is created with appropriate lastUpdateTimestamp and
 	// lastTransitionTimestamp.
 	DeferCleanup(test.WithVars(
-		&gardencorev1beta1helper.Now, func() metav1.Time { return metav1.Time{Time: fakeClock.Now()} },
+		&gardencorev1beta1helper.Clock, fakeClock,
 	))
 
 	By("registering controller")

--- a/test/integration/controllermanager/seed/extensionscheck/extensionscheck_suite_test.go
+++ b/test/integration/controllermanager/seed/extensionscheck/extensionscheck_suite_test.go
@@ -122,7 +122,7 @@ var _ = BeforeSuite(func() {
 	// lastTransitionTimestamp.
 	fakeClock = testclock.NewFakeClock(time.Now())
 	DeferCleanup(test.WithVars(
-		&gardencorev1beta1helper.Now, func() metav1.Time { return metav1.Time{Time: fakeClock.Now()} },
+		&gardencorev1beta1helper.Clock, fakeClock,
 	))
 
 	By("registering controller")


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement|

**What this PR does / why we need it**:
This PR extends `ConditionBuilder` interface with a `WithClock(...)` function as suggested in the linked issue.
Additionally, new `...WithClock(...)` condition helper function are introduced. In the final step, those functions replace the existing helper functions, wherever a `clock` is available.

**Which issue(s) this PR fixes**:
Fixes #6689 

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
ConditionBuilder interface is extended by a `WithClock(...)` function.
`...WithClock(...)` condition helper functions are introduced.
`WithNowFunc(...)` function is removed from ConditionBuilder interface.
```