### PR TITLE
Remote local setup

### DIFF
--- a/docs/deployment/content/remote-local-setup.yaml
+++ b/docs/deployment/content/remote-local-setup.yaml
@@ -1,0 +1,86 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: remote-local-setup
+  labels: {component: remote-local-setup}
+spec:
+  selector:
+    matchLabels: {component: remote-local-setup}
+  strategy: {type: Recreate}
+  template:
+    metadata:
+      labels: {component: remote-local-setup}
+    spec:
+      terminationGracePeriodSeconds: 1
+      containers:
+      - name: dev
+        image: docker:20.10-dind
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -ex
+          cd
+          apk add bash bash-completion curl fzf g++ git jq less lsof make mandoc mc procps tmux tmux-doc yq vim
+          apk add --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main mount
+          echo golang            && curl -sLO "https://go.dev/dl/$(curl -sL https://golang.org/VERSION?m=text).linux-amd64.tar.gz" && tar -C /usr/local -xzf go1.*.linux-amd64.tar.gz
+          echo helm              && curl -sLO "https://get.helm.sh/helm-$(curl -sL https://api.github.com/repos/helm/helm/releases/latest | jq .tag_name -r)-linux-amd64.tar.gz" && tar -xzf helm-*-linux-amd64.tar.gz && mv linux-amd64/helm /usr/local/bin/helm
+          echo kind              && curl -sL  "https://kind.sigs.k8s.io/dl/$(curl -sL https://api.github.com/repos/kubernetes-sigs/kind/releases/latest | jq .tag_name -r)/kind-linux-amd64" -o /usr/local/bin/kind && chmod +x /usr/local/bin/kind
+          echo kns               && curl -sL  "https://raw.githubusercontent.com/blendle/kns/master/bin/kns" -o /usr/local/bin/kns && chmod +x /usr/local/bin/kns
+          echo ktx               && curl -sL  "https://raw.githubusercontent.com/blendle/kns/master/bin/ktx" -o /usr/local/bin/ktx && chmod +x /usr/local/bin/ktx
+          echo kube-ps1          && curl -sL  "https://raw.githubusercontent.com/jonmosco/kube-ps1/master/kube-ps1.sh" -o ~/.kube-ps1.sh
+          echo kubectl           && curl -sL  "https://dl.k8s.io/release/$(curl -sL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
+          echo tmux-completion   && curl -sL  "https://raw.githubusercontent.com/imomaliev/tmux-bash-completion/master/completions/tmux" -o /usr/share/bash-completion/completions/tmux
+          echo docker-completion && curl -sL  "https://raw.githubusercontent.com/docker/docker-ce/master/components/cli/contrib/completion/bash/docker" -o /usr/share/bash-completion/completions/docker
+          bash -c "echo api.{e2e-managedseed.garden,{local,e2e-{hibernated,unpriv,wake-up,migrate,rotate,default}}.local}.{internal,external}.local.gardener.cloud \
+                   | sed 's/ /\n/g' | sed 's/^/127.0.0.1 /' | sort >> /etc/hosts"
+          echo 'source ~/.bashrc' > ~/.bash_profile
+          cat > ~/.bashrc <<"EOF"
+            export PATH=$PATH:/usr/local/go/bin
+            export KUBECONFIG=~/gardener/example/gardener-local/kind/kubeconfig:/tmp/kubeconfig-shoot-local.yaml
+            source <(kubectl completion bash)
+            alias k=kubectl
+            complete -o default -F __start_kubectl k
+            source ~/.kube-ps1.sh
+            export PS1='[\w $(printf "$(kube_ps1)")]\$ '
+            cd ~/gardener
+          EOF
+          cat > ~/.tmux.conf <<"EOF"
+            set -g mouse on
+            set -g mode-keys vi
+            set -g default-shell /bin/bash
+            set -g pane-border-status top
+            set -g pane-border-format " #{pane_index} #{pane_title} - #{pane_current_command} "
+          EOF
+          git clone -q https://github.com/gardener/gardener.git
+          dockerd-entrypoint.sh &
+          until docker ps >/dev/null 2>&1; do sleep 1; done
+          tmux new -d -s gardener -n gardener
+          tmux select-pane -T top
+          tmux send top Enter; sleep 1; tmux send 1; sleep 1; tmux send C; sleep 1; tmux send i; sleep 1; tmux send t; sleep 1; tmux send V; sleep 1; tmux send s; sleep 1; tmux send 5 Enter
+          tmux split-window \; select-pane -T kind     ; sleep 1; tmux send "make kind-up"                                       \; select-layout even-vertical
+          tmux split-window \; select-pane -T gardener ; sleep 1; tmux send "make gardener-up"                                   \; select-layout even-vertical
+          tmux split-window \; select-pane -T shoot    ; sleep 1; tmux send "kubectl apply -f example/provider-local/shoot.yaml" \; select-layout even-vertical
+          tmux split-window \; select-pane -T config   ; sleep 1; tmux send "kubectl -n garden-local get secret local.kubeconfig -o jsonpath={.data.kubeconfig} | base64 -d > /tmp/kubeconfig-shoot-local.yaml" \; select-layout even-vertical
+          tmux split-window \; select-pane -T config   ; sleep 1; tmux send "make test-e2e-local-simple" \; select-layout even-vertical
+          read
+        stdin: true
+        resources:
+          requests: {cpu: 8, memory: 8G}
+          limits:   {cpu: 8, memory: 8G}
+        securityContext:
+          privileged: true
+        volumeMounts:
+        # Without bind mounting `/sys/fs/cgroup` the shoot worker node fails currently; all the other components work fine
+        # Due to bind mounting `/sys/fs/cgroup` from the host, the docker container in this dind pod (i.e. the KinD cluster) uses a top level cgroup and hence is not constrained by the resource limits of this pod
+        # These host cgroups might leak, but it is probably not an issue e.g. due to hibernating the hosting Gardener dev k8s cluster so that the nodes are recreated regularly anyway
+        # To avoid conflicts on the top level docker cgroup, one dev pod per node is recommended
+        # See
+        # https://github.com/kubernetes-sigs/kind/issues/303
+        # https://github.com/kubernetes/test-infra/blob/dcf27e157932c3e8680be4ae6cb8a4e2c7acf8cf/config/prow/config.yaml#L978-L988
+        # https://github.com/gardener/ci-infra/blob/dff565bced0f386dd1acb0743beb3831dae6c10d/config/prow/config.yaml#L288-L298
+        - {name: cgroup,  mountPath: /sys/fs/cgroup}
+        - {name: modules, mountPath: /lib/modules, readOnly: true}
+      volumes:
+      - {name: cgroup,  hostPath: {type: Directory, path: /sys/fs/cgroup}}
+      - {name: modules, hostPath: {type: Directory, path: /lib/modules}}

--- a/docs/deployment/getting_started_locally.md
+++ b/docs/deployment/getting_started_locally.md
@@ -180,6 +180,38 @@ make kind2-down
 make kind-down
 ```
 
+## Remote local setup
+
+Just like Prow is executing the KinD based integration tests in a K8s pod, it is
+possible to interactively run this KinD based Gardener development environment
+aka "local setup" in a "remote" K8s pod.
+
+```shell
+k apply -f docs/deployment/content/remote-local-setup.yaml
+k exec -it deployment/remote-local-setup -- sh
+
+tmux -u a
+```
+
+### Caveats
+
+Please refer to the [TMUX documentation](https://github.com/tmux/tmux/wiki) for
+working effectively inside the remote-local-setup pod.
+
+To access Grafana, Prometheus or other components in a browser, two port forwards are needed:
+
+The port forward from the laptop to the pod:
+
+```shell
+k port-forward deployment/remote-local-setup 3000
+```
+
+The port forward in the remote-local-setup pod to the respective component:
+
+```shell
+k port-forward -n shoot--local--local deployment/grafana-operators 3000
+```
+
 ## Further reading
 
 This setup makes use of the local provider extension. You can read more about it in [this document](../extensions/provider-local.md).

--- a/docs/development/content/remote-local-setup.yaml
+++ b/docs/development/content/remote-local-setup.yaml
@@ -1,0 +1,104 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: remote-local-setup
+  labels: {component: remote-local-setup}
+spec:
+  selector:
+    matchLabels: {component: remote-local-setup}
+  strategy: {type: Recreate}
+  template:
+    metadata:
+      labels: {component: remote-local-setup}
+    spec:
+      terminationGracePeriodSeconds: 1
+      containers:
+      - name: dev
+        image: docker:20.10-dind
+        command:
+        - /bin/sh
+        - -c
+        - |
+          set -ex
+          cd
+          apk add bash bash-completion curl fzf git jq less lsof make mandoc mc procps tmux tmux-doc yq vim
+          apk add --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main mount
+          echo golang            && curl -sLO "https://go.dev/dl/$(curl -sL https://golang.org/VERSION?m=text).linux-amd64.tar.gz" && tar -C /usr/local -xzf go1.*.linux-amd64.tar.gz
+          echo helm              && curl -sLO "https://get.helm.sh/helm-$(curl -sL https://api.github.com/repos/helm/helm/releases/latest | jq .tag_name -r)-linux-amd64.tar.gz" && tar -xzf helm-*-linux-amd64.tar.gz && mv linux-amd64/helm /usr/local/bin/helm
+          echo kind              && curl -sL  "https://kind.sigs.k8s.io/dl/$(curl -sL https://api.github.com/repos/kubernetes-sigs/kind/releases/latest | jq .tag_name -r)/kind-linux-amd64" -o /usr/local/bin/kind && chmod +x /usr/local/bin/kind
+          echo kns               && curl -sL  "https://raw.githubusercontent.com/blendle/kns/master/bin/kns" -o /usr/local/bin/kns && chmod +x /usr/local/bin/kns
+          echo ktx               && curl -sL  "https://raw.githubusercontent.com/blendle/kns/master/bin/ktx" -o /usr/local/bin/ktx && chmod +x /usr/local/bin/ktx
+          echo kube-ps1          && curl -sL  "https://raw.githubusercontent.com/jonmosco/kube-ps1/master/kube-ps1.sh" -o ~/.kube-ps1.sh
+          echo kubectl           && curl -sL  "https://dl.k8s.io/release/$(curl -sL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl" -o /usr/local/bin/kubectl && chmod +x /usr/local/bin/kubectl
+          echo tmux-completion   && curl -sL  "https://raw.githubusercontent.com/imomaliev/tmux-bash-completion/master/completions/tmux" -o /usr/share/bash-completion/completions/tmux
+          echo docker-completion && curl -sL  "https://raw.githubusercontent.com/docker/docker-ce/master/components/cli/contrib/completion/bash/docker" -o /usr/share/bash-completion/completions/docker
+          echo '127.0.0.1 api.local.local.external.local.gardener.cloud' >> /etc/hosts
+          echo 'source ~/.bashrc' > ~/.bash_profile
+          cat > ~/.bashrc <<"EOF"
+            export PATH=$PATH:/usr/local/go/bin
+            export KUBECONFIG=~/gardener/example/gardener-local/kind/kubeconfig:/tmp/kubeconfig-shoot-local.yaml
+            source <(kubectl completion bash)
+            alias k=kubectl
+            complete -o default -F __start_kubectl k
+            source ~/.kube-ps1.sh
+            export PS1='[\w $(printf "$(kube_ps1)")]\$ '
+            cd ~/gardener
+          EOF
+          cat > ~/.tmux.conf <<"EOF"
+            set -g mouse on
+            set -g mode-keys vi
+            set -g default-shell /bin/bash
+            set -g pane-border-status top
+            set -g pane-border-format " #{pane_index} #{pane_title} - #{pane_current_command} "
+          EOF
+          git clone -q https://github.com/gardener/gardener.git
+          cd gardener
+          # TODO 'host.docker.internal' can not be resolved on docker for Linux (https://github.com/docker/for-linux/issues/264, https://stackoverflow.com/questions/48546124/what-is-linux-equivalent-of-host-docker-internal)
+          #      maybe there is a better way than using the IP address of the docker0 device: 172.17.0.1
+          #      ip addr show docker0 | awk '/inet .* docker0/{print substr($2,0, index($2,"/")-1)}'
+          git grep -l host.docker.internal | xargs sed -i 's/host.docker.internal/172.17.0.1/'
+          dockerd-entrypoint.sh &
+          until docker ps >/dev/null 2>&1; do sleep 1; done
+          tmux new -d -s gardener -n gardener1
+          tmux select-pane -T top
+          tmux send top Enter; sleep 1; tmux send 1; sleep 1; tmux send C; sleep 1; tmux send i; sleep 1; tmux send t; sleep 1; tmux send V; sleep 1; tmux send s; sleep 1; tmux send 5 Enter
+          function step {
+            tmux split-window \; select-pane -T "$1"
+            sleep 1
+            tmux send "$2"
+            tmux select-layout even-vertical
+          }
+          step kind            "make kind-up   KIND_ENV=local"
+          step dev-setup       "make dev-setup"
+          step gapi            "kubectl wait --for=condition=ready pod -l run=etcd -n garden                  && make start-apiserver"
+          step gac             "kubectl wait --for=condition=available apiservice v1beta1.core.gardener.cloud && make start-admission-controller"
+          step dev-setup-hooks "make dev-setup DEV_SETUP_WITH_WEBHOOKS=true"
+          tmux new-window -n gardener2
+          tmux select-pane -T "gcm"; sleep 1; tmux send "make start-controller-manager"
+          step local           "make register-local-env"
+          step gardenlet       "make start-gardenlet SEED_NAME=local"
+          # TODO avoid workarounds
+          step local           'KUBECONFIG=${KUBECONFIG%:*} USER=root make start-extension-provider-local'
+          step shoot           "kubectl apply -f example/provider-local/shoot.yaml"
+          step shoot           "kubectl -n garden-local get secret local.kubeconfig -o jsonpath={.data.kubeconfig} | base64 -d > /tmp/kubeconfig-shoot-local.yaml"
+          read
+        stdin: true
+        resources:
+          requests: {cpu: 8, memory: 8G}
+          limits:   {cpu: 8, memory: 8G}
+        securityContext:
+          privileged: true
+        volumeMounts:
+        # Without bind mounting `/sys/fs/cgroup` the shoot worker node fails currently; all the other components work fine
+        # Due to bind mounting `/sys/fs/cgroup` from the host, the docker container in this dind pod (i.e. the KinD cluster) uses a top level cgroup and hence is not constrained by the resource limits of this pod
+        # These host cgroups might leak, but it is probably not an issue e.g. due to hibernating the hosting Gardener dev k8s cluster so that the nodes are recreated regularly anyway
+        # To avoid conflicts on the top level docker cgroup, one dev pod per node is recommended
+        # See
+        # https://github.com/kubernetes-sigs/kind/issues/303
+        # https://github.com/kubernetes/test-infra/blob/dcf27e157932c3e8680be4ae6cb8a4e2c7acf8cf/config/prow/config.yaml#L978-L988
+        # https://github.com/gardener/ci-infra/blob/dff565bced0f386dd1acb0743beb3831dae6c10d/config/prow/config.yaml#L288-L298
+        - {name: cgroup,  mountPath: /sys/fs/cgroup}
+        - {name: modules, mountPath: /lib/modules, readOnly: true}
+      volumes:
+      - {name: cgroup,  hostPath: {type: Directory, path: /sys/fs/cgroup}}
+      - {name: modules, hostPath: {type: Directory, path: /lib/modules}}

--- a/docs/development/getting_started_locally.md
+++ b/docs/development/getting_started_locally.md
@@ -199,6 +199,38 @@ make tear-down-local-env
 make kind-down
 ```
 
+## Remote local setup
+
+Just like Prow is executing the KinD based integration tests in a K8s pod, it is
+possible to interactively run this KinD based Gardener development environment
+aka "local setup" in a "remote" K8s pod.
+
+```shell
+k apply -f docs/development/content/remote-local-setup.yaml
+k exec -it deployment/remote-local-setup -- sh
+
+tmux -u a
+```
+
+### Caveats
+
+Please refer to the [TMUX documentation](https://github.com/tmux/tmux/wiki) for
+working effectively inside the remote-local-setup pod.
+
+To access Grafana, Prometheus or other components in a browser, two port forwards are needed:
+
+The port forward from the laptop to the pod:
+
+```shell
+k port-forward deployment/remote-local-setup 3000
+```
+
+The port forward in the remote-local-setup pod to the respective component:
+
+```shell
+k port-forward -n shoot--local--local deployment/grafana-operators 3000
+```
+
 ## Further reading
 
 This setup makes use of the local provider extension. You can read more about it in [this document](../extensions/provider-local.md).


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:

Document how to run the "local setup" in a "remote" pod.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

cc @rfranzke, @wyb1, @rickardsjp 

<img width="300" alt="image" src="https://user-images.githubusercontent.com/23032437/191929978-d0aed5ed-5ed4-4744-8c31-7c2461c3bc69.png">

<img width="300" alt="image" src="https://user-images.githubusercontent.com/23032437/191930278-279b5e42-3b4c-4604-b093-065ef839ecbd.png">

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature developer
There is a new variant for running the local setup remotely. This can be helpful if your workstation does only have limited resources available (CPUs, memory). Please refer to [this](https://github.com/gardener/gardener/blob/master/docs/development/getting_started_locally.md#remote-local-setup) or [this](https://github.com/gardener/gardener/blob/master/docs/deployment/getting_started_locally.md#remote-local-setup) document.
```
