### PR TITLE
Promote `Shoot{C,S}ARotation` feature gates to GA

### DIFF
--- a/docs/deployment/feature_gates.md
+++ b/docs/deployment/feature_gates.md
@@ -35,10 +35,6 @@ The following tables are a summary of the feature gates that you can set on diff
 | CopyEtcdBackupsDuringControlPlaneMigration   | `false` | `Alpha` | `1.37` | `1.52` |
 | CopyEtcdBackupsDuringControlPlaneMigration   | `true`  | `Beta`  | `1.53` |        |
 | ForceRestore                                 | `false` | `Alpha` | `1.39` |        |
-| ShootCARotation                              | `false` | `Alpha` | `1.42` | `1.50` |
-| ShootCARotation                              | `true`  | `Beta`  | `1.51` |        |
-| ShootSARotation                              | `false` | `Alpha` | `1.48` | `1.50` |
-| ShootSARotation                              | `true`  | `Beta`  | `1.51` |        |
 | HAControlPlanes                              | `false` | `Alpha` | `1.49` |        |
 | DefaultSeccompProfile                        | `false` | `Alpha` | `1.54` |        |
 | CoreDNSQueryRewriting                        | `false` | `Alpha` | `1.55` |        |
@@ -102,6 +98,12 @@ The following tables are a summary of the feature gates that you can set on diff
 | SecretBindingProviderValidation              |         | `Removed`    | `1.55` |        |
 | SeedKubeScheduler                            | `false` | `Alpha`      | `1.15` | `1.54` |
 | SeedKubeScheduler                            | `false` | `Deprecated` | `1.55` |        |
+| ShootCARotation                              | `false` | `Alpha`      | `1.42` | `1.50` |
+| ShootCARotation                              | `true`  | `Beta`       | `1.51` | `1.56` |
+| ShootCARotation                              | `true`  | `GA`         | `1.57` |        |
+| ShootSARotation                              | `false` | `Alpha`      | `1.48` | `1.50` |
+| ShootSARotation                              | `true`  | `Beta`       | `1.51` | `1.56` |
+| ShootSARotation                              | `true`  | `GA`         | `1.57` |        |
 
 ## Using a feature
 

--- a/pkg/api/core/shoot/warnings.go
+++ b/pkg/api/core/shoot/warnings.go
@@ -20,10 +20,8 @@ import (
 	"time"
 
 	"github.com/gardener/gardener/pkg/apis/core"
-	"github.com/gardener/gardener/pkg/features"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/utils/pointer"
 )
 
@@ -61,10 +59,8 @@ func getWarningsForDueCredentialsRotations(shoot *core.Shoot, credentialsRotatio
 		warnings []string
 	)
 
-	if utilfeature.DefaultFeatureGate.Enabled(features.ShootCARotation) {
-		if rotation.CertificateAuthorities == nil || initiationDue(rotation.CertificateAuthorities.LastInitiationTime, credentialsRotationInterval) {
-			warnings = append(warnings, "you should consider rotating the certificate authorities, see https://github.com/gardener/gardener/blob/master/docs/usage/shoot_credentials_rotation.md#certificate-authorities for details")
-		}
+	if rotation.CertificateAuthorities == nil || initiationDue(rotation.CertificateAuthorities.LastInitiationTime, credentialsRotationInterval) {
+		warnings = append(warnings, "you should consider rotating the certificate authorities, see https://github.com/gardener/gardener/blob/master/docs/usage/shoot_credentials_rotation.md#certificate-authorities for details")
 	}
 
 	if rotation.ETCDEncryptionKey == nil || initiationDue(rotation.ETCDEncryptionKey.LastInitiationTime, credentialsRotationInterval) {
@@ -81,10 +77,8 @@ func getWarningsForDueCredentialsRotations(shoot *core.Shoot, credentialsRotatio
 		warnings = append(warnings, "you should consider rotating the observability passwords, see https://github.com/gardener/gardener/blob/master/docs/usage/shoot_credentials_rotation.md#observability-passwords-for-grafana for details")
 	}
 
-	if utilfeature.DefaultFeatureGate.Enabled(features.ShootSARotation) {
-		if rotation.ServiceAccountKey == nil || initiationDue(rotation.ServiceAccountKey.LastInitiationTime, credentialsRotationInterval) {
-			warnings = append(warnings, "you should consider rotating the ServiceAccount token signing key, see https://github.com/gardener/gardener/blob/master/docs/usage/shoot_credentials_rotation.md#serviceaccount-token-signing-key for details")
-		}
+	if rotation.ServiceAccountKey == nil || initiationDue(rotation.ServiceAccountKey.LastInitiationTime, credentialsRotationInterval) {
+		warnings = append(warnings, "you should consider rotating the ServiceAccount token signing key, see https://github.com/gardener/gardener/blob/master/docs/usage/shoot_credentials_rotation.md#serviceaccount-token-signing-key for details")
 	}
 
 	if rotation.SSHKeypair == nil || initiationDue(rotation.SSHKeypair.LastInitiationTime, credentialsRotationInterval) {
@@ -107,18 +101,14 @@ func getWarningsForIncompleteCredentialsRotation(shoot *core.Shoot, credentialsR
 
 	// Only consider credentials for which completion must be triggered explicitly by the user. Credentials which are
 	// rotated in "one phase" are excluded.
-	if utilfeature.DefaultFeatureGate.Enabled(features.ShootCARotation) {
-		if rotation.CertificateAuthorities != nil && completionDue(rotation.CertificateAuthorities.LastInitiationTime, rotation.CertificateAuthorities.LastCompletionTime, recommendedCompletionInterval) {
-			warnings = append(warnings, completionWarning("certificate authorities", recommendedCompletionInterval))
-		}
+	if rotation.CertificateAuthorities != nil && completionDue(rotation.CertificateAuthorities.LastInitiationTime, rotation.CertificateAuthorities.LastCompletionTime, recommendedCompletionInterval) {
+		warnings = append(warnings, completionWarning("certificate authorities", recommendedCompletionInterval))
 	}
 	if rotation.ETCDEncryptionKey != nil && completionDue(rotation.ETCDEncryptionKey.LastInitiationTime, rotation.ETCDEncryptionKey.LastCompletionTime, recommendedCompletionInterval) {
 		warnings = append(warnings, completionWarning("ETCD encryption key", recommendedCompletionInterval))
 	}
-	if utilfeature.DefaultFeatureGate.Enabled(features.ShootSARotation) {
-		if rotation.ServiceAccountKey != nil && completionDue(rotation.ServiceAccountKey.LastInitiationTime, rotation.ServiceAccountKey.LastCompletionTime, recommendedCompletionInterval) {
-			warnings = append(warnings, completionWarning("ServiceAccount token signing key", recommendedCompletionInterval))
-		}
+	if rotation.ServiceAccountKey != nil && completionDue(rotation.ServiceAccountKey.LastInitiationTime, rotation.ServiceAccountKey.LastCompletionTime, recommendedCompletionInterval) {
+		warnings = append(warnings, completionWarning("ServiceAccount token signing key", recommendedCompletionInterval))
 	}
 
 	return warnings

--- a/pkg/api/core/shoot/warnings_test.go
+++ b/pkg/api/core/shoot/warnings_test.go
@@ -20,14 +20,11 @@ import (
 
 	. "github.com/gardener/gardener/pkg/api/core/shoot"
 	"github.com/gardener/gardener/pkg/apis/core"
-	"github.com/gardener/gardener/pkg/features"
-	"github.com/gardener/gardener/pkg/utils/test"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	gomegatypes "github.com/onsi/gomega/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/utils/pointer"
 )
 
@@ -84,9 +81,6 @@ var _ = Describe("Warnings", func() {
 
 			DescribeTable("warnings for specific credentials rotations",
 				func(matcher gomegatypes.GomegaMatcher, mutateShoot func(*core.Shoot), mutateRotation func(rotation *core.ShootCredentialsRotation)) {
-					defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.ShootCARotation, true)()
-					defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.ShootSARotation, true)()
-
 					if mutateShoot != nil {
 						mutateShoot(shoot)
 					}

--- a/pkg/apis/core/validation/shoot_test.go
+++ b/pkg/apis/core/validation/shoot_test.go
@@ -34,14 +34,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	utilfeature "k8s.io/apiserver/pkg/util/feature"
 	"k8s.io/utils/pointer"
 
 	"github.com/gardener/gardener/pkg/apis/core"
 	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
 	. "github.com/gardener/gardener/pkg/apis/core/validation"
-	"github.com/gardener/gardener/pkg/features"
-	"github.com/gardener/gardener/pkg/utils/test"
 	. "github.com/gardener/gardener/pkg/utils/test/matchers"
 )
 
@@ -2820,9 +2817,6 @@ var _ = Describe("Shoot Validation Tests", func() {
 
 			DescribeTable("starting rotation of all credentials",
 				func(allowed bool, status core.ShootStatus) {
-					defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.ShootCARotation, true)()
-					defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.ShootSARotation, true)()
-
 					metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "gardener.cloud/operation", "rotate-credentials-start")
 					shoot.Status = status
 
@@ -3024,9 +3018,6 @@ var _ = Describe("Shoot Validation Tests", func() {
 
 			DescribeTable("completing rotation of all credentials",
 				func(allowed bool, status core.ShootStatus) {
-					defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.ShootCARotation, true)()
-					defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.ShootSARotation, true)()
-
 					metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "maintenance.gardener.cloud/operation", "rotate-credentials-complete")
 					shoot.Status = status
 
@@ -3223,17 +3214,8 @@ var _ = Describe("Shoot Validation Tests", func() {
 				}),
 			)
 
-			It("should do nothing if the ShootCARotation feature gate is disabled and the start operation is set", func() {
-				defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.ShootCARotation, false)()
-
-				metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "gardener.cloud/operation", "rotate-ca-start")
-
-				Expect(ValidateShoot(shoot)).To(BeEmpty())
-			})
-
 			DescribeTable("starting CA rotation",
 				func(allowed bool, status core.ShootStatus) {
-					defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.ShootCARotation, true)()
 					metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "maintenance.gardener.cloud/operation", "rotate-ca-start")
 					shoot.Status = status
 
@@ -3339,7 +3321,6 @@ var _ = Describe("Shoot Validation Tests", func() {
 
 			DescribeTable("completing CA rotation",
 				func(allowed bool, status core.ShootStatus) {
-					defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.ShootCARotation, true)()
 					metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "gardener.cloud/operation", "rotate-ca-complete")
 					shoot.Status = status
 
@@ -3404,17 +3385,8 @@ var _ = Describe("Shoot Validation Tests", func() {
 				}),
 			)
 
-			It("should do nothing if the ShootSARotation feature gate is disabled and the start operation is set", func() {
-				defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.ShootSARotation, false)()
-
-				metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "gardener.cloud/operation", "rotate-serviceaccount-key-start")
-
-				Expect(ValidateShoot(shoot)).To(BeEmpty())
-			})
-
 			DescribeTable("starting service account key rotation",
 				func(allowed bool, status core.ShootStatus) {
-					defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.ShootSARotation, true)()
 					metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "gardener.cloud/operation", "rotate-serviceaccount-key-start")
 					shoot.Status = status
 
@@ -3520,7 +3492,6 @@ var _ = Describe("Shoot Validation Tests", func() {
 
 			DescribeTable("completing service account key rotation",
 				func(allowed bool, status core.ShootStatus) {
-					defer test.WithFeatureGate(utilfeature.DefaultFeatureGate, features.ShootSARotation, true)()
 					metav1.SetMetaDataAnnotation(&shoot.ObjectMeta, "maintenance.gardener.cloud/operation", "rotate-serviceaccount-key-complete")
 					shoot.Status = status
 

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -107,12 +107,14 @@ const (
 	// owner: @rfranzke
 	// alpha: v1.42.0
 	// beta: v1.51.0
+	// GA: v1.57.0
 	ShootCARotation featuregate.Feature = "ShootCARotation"
 
 	// ShootSARotation enables the automated rotation of the shoot service account signing key.
 	// owner: @rfranzke
 	// alpha: v1.48.0
 	// beta: v1.51.0
+	// GA: v1.57.0
 	ShootSARotation featuregate.Feature = "ShootSARotation"
 
 	// HAControlPlanes allows shoot control planes to be run in high availability mode.
@@ -143,8 +145,8 @@ var allFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	CopyEtcdBackupsDuringControlPlaneMigration: {Default: true, PreRelease: featuregate.Beta},
 	ForceRestore:                 {Default: false, PreRelease: featuregate.Alpha},
 	DisableDNSProviderManagement: {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
-	ShootCARotation:              {Default: true, PreRelease: featuregate.Beta},
-	ShootSARotation:              {Default: true, PreRelease: featuregate.Beta},
+	ShootCARotation:              {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
+	ShootSARotation:              {Default: true, PreRelease: featuregate.GA, LockToDefault: true},
 	HAControlPlanes:              {Default: false, PreRelease: featuregate.Alpha},
 	DefaultSeccompProfile:        {Default: false, PreRelease: featuregate.Alpha},
 	CoreDNSQueryRewriting:        {Default: false, PreRelease: featuregate.Alpha},

--- a/pkg/features/features.go
+++ b/pkg/features/features.go
@@ -87,7 +87,7 @@ const (
 	// ForceRestore enables forcing the shoot's restoration to the destination seed during control plane migration
 	// if the preparation for migration in the source seed is not finished after a certain grace period
 	// and is considered unlikely to succeed ("bad case" scenario).
-	// owner: @stoyanr
+	// owner: @plkokanov
 	// alpha: v1.39.0
 	ForceRestore featuregate.Feature = "ForceRestore"
 
@@ -137,8 +137,8 @@ const (
 var allFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	HVPA:               {Default: false, PreRelease: featuregate.Alpha},
 	HVPAForShootedSeed: {Default: false, PreRelease: featuregate.Alpha},
-	ManagedIstio:       {Default: true, PreRelease: featuregate.Beta},
-	APIServerSNI:       {Default: true, PreRelease: featuregate.Beta},
+	ManagedIstio:       {Default: true, PreRelease: featuregate.Deprecated},
+	APIServerSNI:       {Default: true, PreRelease: featuregate.Deprecated},
 	SeedChange:         {Default: true, PreRelease: featuregate.Beta},
 	SeedKubeScheduler:  {Default: false, PreRelease: featuregate.Deprecated},
 	ReversedVPN:        {Default: true, PreRelease: featuregate.Beta},

--- a/pkg/gardenlet/controller/shoot/shoot_control.go
+++ b/pkg/gardenlet/controller/shoot/shoot_control.go
@@ -31,9 +31,7 @@ import (
 	"github.com/gardener/gardener/pkg/client/kubernetes/clientmap"
 	"github.com/gardener/gardener/pkg/controllerutils"
 	gardenerextensions "github.com/gardener/gardener/pkg/extensions"
-	"github.com/gardener/gardener/pkg/features"
 	"github.com/gardener/gardener/pkg/gardenlet/apis/config"
-	gardenletfeatures "github.com/gardener/gardener/pkg/gardenlet/features"
 	"github.com/gardener/gardener/pkg/operation"
 	botanistpkg "github.com/gardener/gardener/pkg/operation/botanist"
 	"github.com/gardener/gardener/pkg/operation/garden"
@@ -726,24 +724,16 @@ func (r *shootReconciler) updateShootStatusOperationStart(ctx context.Context, s
 	switch shoot.Annotations[v1beta1constants.GardenerOperation] {
 	case v1beta1constants.ShootOperationRotateCredentialsStart:
 		mustRemoveOperationAnnotation = true
-		if gardenletfeatures.FeatureGate.Enabled(features.ShootCARotation) {
-			startRotationCA(shoot, &now)
-		}
-		if gardenletfeatures.FeatureGate.Enabled(features.ShootSARotation) {
-			startRotationServiceAccountKey(shoot, &now)
-		}
+		startRotationCA(shoot, &now)
+		startRotationServiceAccountKey(shoot, &now)
 		startRotationKubeconfig(shoot, &now)
 		startRotationSSHKeypair(shoot, &now)
 		startRotationObservability(shoot, &now)
 		startRotationETCDEncryptionKey(shoot, &now)
 	case v1beta1constants.ShootOperationRotateCredentialsComplete:
 		mustRemoveOperationAnnotation = true
-		if gardenletfeatures.FeatureGate.Enabled(features.ShootCARotation) {
-			completeRotationCA(shoot)
-		}
-		if gardenletfeatures.FeatureGate.Enabled(features.ShootSARotation) {
-			completeRotationServiceAccountKey(shoot)
-		}
+		completeRotationCA(shoot)
+		completeRotationServiceAccountKey(shoot)
 		completeRotationETCDEncryptionKey(shoot)
 
 	case v1beta1constants.ShootOperationRotateCAStart:


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area security open-source
/kind enhancement

**What this PR does / why we need it**:
Promote `Shoot{C,S}ARotation` feature gates to GA (promoted to beta with #6252).

**Which issue(s) this PR fixes**:
Part of #3292

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking operator
The `ShootCARotation` and `ShootSARotation` feature gates have been promoted to beta and are now enabled by default. Make sure that all provider extensions registered to your system support these features before upgrading to this Gardener version.
```
