### PR TITLE
Configure static asset dependencies for `ko`

### DIFF
--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -76,6 +76,9 @@ build:
       main: ./cmd/gardener-extension-provider-local
       ldflags:
         - "{{.LD_FLAGS}}"
+      dependencies:
+        paths:
+        - pkg/provider-local/imagevector
 deploy:
   helm:
     releases:
@@ -136,6 +139,10 @@ build:
       main: ./cmd/gardenlet
       ldflags:
         - "{{.LD_FLAGS}}"
+      dependencies:
+        paths:
+        - charts
+        - pkg/operation/botanist/component
   - image: eu.gcr.io/gardener-project/gardener/resource-manager
     ko:
       main: ./cmd/gardener-resource-manager


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind enhancement

**What this PR does / why we need it**:
Static assets as well as embedded files should be maintained as dependencies for Skaffold, so that every time such a file changes the image is re-built accordingly when running `gardener-up`.

See https://github.com/GoogleContainerTools/skaffold/issues/7836.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Changes in static and embedded files, e.g. files in `charts`, are now considered when running `gardener-up`. This results in a new CRI image (typically `gardenlet` or `provider-local`) that is deployed to the local garden cluster.
```
