### PR TITLE
Add new Prometheus alert `ApiserverRequestsFailureRate` for API Server failure rate

### DIFF
--- a/pkg/operation/botanist/component/kubeapiserver/monitoring.go
+++ b/pkg/operation/botanist/component/kubeapiserver/monitoring.go
@@ -184,6 +184,17 @@ const (
 
   - record: shoot:kube_apiserver:sum_by_pod
     expr: sum(up{job="` + monitoringPrometheusJobName + `"}) by (pod)
+
+  - alert: ApiserverRequestsFailureRate10mins
+    expr: max(sum by(instance,resource,verb) (rate(` + monitoringMetricApiserverRequestTotal + `{code=~"5.."}[10m])) / sum by(instance,resource,verb) (rate(` + monitoringMetricApiserverRequestTotal + `[10m]))) * 100
+    for: 30m
+    labels:
+      severity: warning
+      type: seed
+      visibility: owner
+    annotations:
+      description: The Apiserver requests failure rate exceed 0.3%.
+      summary: Kubernetes API server failure rate is high
 `
 )
 

--- a/pkg/operation/botanist/component/kubeapiserver/monitoring.go
+++ b/pkg/operation/botanist/component/kubeapiserver/monitoring.go
@@ -185,15 +185,16 @@ const (
   - record: shoot:kube_apiserver:sum_by_pod
     expr: sum(up{job="` + monitoringPrometheusJobName + `"}) by (pod)
   ### API failure rate ###
-  - alert: ApiserverRequestsFailureRate10mins
-    expr: max(sum by(instance,resource,verb) (rate(` + monitoringMetricApiserverRequestTotal + `{code=~"5.."}[10m])) / sum by(instance,resource,verb) (rate(` + monitoringMetricApiserverRequestTotal + `[10m]))) * 100
+  - alert: ApiserverRequestsFailureRate
+    expr: max(sum by(instance,resource,verb) (rate(` + monitoringMetricApiserverRequestTotal + `{code=~"5.."}[10m])) / sum by(instance,resource,verb) (rate(` + monitoringMetricApiserverRequestTotal + `[10m]))) * 100 > 10
     for: 30m
     labels:
+      service: ` + v1beta1constants.DeploymentNameKubeAPIServer + `
       severity: warning
       type: seed
-      visibility: owner
+      visibility: operator
     annotations:
-      description: The Apiserver requests failure rate exceed 0.3%.
+      description: The API Server requests failure rate exceeds 10%.
       summary: Kubernetes API server failure rate is high
 `
 )

--- a/pkg/operation/botanist/component/kubeapiserver/monitoring.go
+++ b/pkg/operation/botanist/component/kubeapiserver/monitoring.go
@@ -184,7 +184,7 @@ const (
 
   - record: shoot:kube_apiserver:sum_by_pod
     expr: sum(up{job="` + monitoringPrometheusJobName + `"}) by (pod)
-
+  ### API failure rate ###
   - alert: ApiserverRequestsFailureRate10mins
     expr: max(sum by(instance,resource,verb) (rate(` + monitoringMetricApiserverRequestTotal + `{code=~"5.."}[10m])) / sum by(instance,resource,verb) (rate(` + monitoringMetricApiserverRequestTotal + `[10m]))) * 100
     for: 30m

--- a/pkg/operation/botanist/component/kubeapiserver/monitoring_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/monitoring_test.go
@@ -191,5 +191,16 @@ metric_relabel_configs:
 
   - record: shoot:kube_apiserver:sum_by_pod
     expr: sum(up{job="kube-apiserver"}) by (pod)
+  ### API failure rate ###
+  - alert: ApiserverRequestsFailureRate10mins
+    expr: max(sum by(instance,resource,verb) (rate(apiserver_request_total{code=~"5.."}[10m])) / sum by(instance,resource,verb) (rate(apiserver_request_total[10m]))) * 100
+    for: 30m
+    labels:
+      severity: warning
+      type: seed
+      visibility: owner
+    annotations:
+      description: The Apiserver requests failure rate exceed 0.3%.
+      summary: Kubernetes API server failure rate is high
 `
 )

--- a/pkg/operation/botanist/component/kubeapiserver/monitoring_test.go
+++ b/pkg/operation/botanist/component/kubeapiserver/monitoring_test.go
@@ -192,15 +192,16 @@ metric_relabel_configs:
   - record: shoot:kube_apiserver:sum_by_pod
     expr: sum(up{job="kube-apiserver"}) by (pod)
   ### API failure rate ###
-  - alert: ApiserverRequestsFailureRate10mins
-    expr: max(sum by(instance,resource,verb) (rate(apiserver_request_total{code=~"5.."}[10m])) / sum by(instance,resource,verb) (rate(apiserver_request_total[10m]))) * 100
+  - alert: ApiserverRequestsFailureRate
+    expr: max(sum by(instance,resource,verb) (rate(apiserver_request_total{code=~"5.."}[10m])) / sum by(instance,resource,verb) (rate(apiserver_request_total[10m]))) * 100 > 10
     for: 30m
     labels:
+      service: kube-apiserver
       severity: warning
       type: seed
-      visibility: owner
+      visibility: operator
     annotations:
-      description: The Apiserver requests failure rate exceed 0.3%.
+      description: The API Server requests failure rate exceeds 10%.
       summary: Kubernetes API server failure rate is high
 `
 )

--- a/pkg/operation/botanist/component/kubeapiserver/testdata/monitoring_alertingrules.yaml
+++ b/pkg/operation/botanist/component/kubeapiserver/testdata/monitoring_alertingrules.yaml
@@ -30,6 +30,11 @@ tests:
     values: '1+1x31'
   - series: 'apiserver_audit_event_total{job="kube-apiserver"}'
     values: '0+30x31'
+  # ApiserverRequestsFailureRate
+  - series: 'apiserver_request_total{job="kube-apiserver", instance="instance", verb="POST", resource="services", code="500"}'
+    values: '1+10x60'
+  - series: 'apiserver_request_total{job="kube-apiserver", instance="instance", verb="POST", resource="services"}'
+    values: '1+30x60'
   alert_rule_test:
   - eval_time: 5m
     alertname: ApiServerNotReachable
@@ -101,3 +106,14 @@ tests:
       exp_annotations:
         description: 'The API servers cumulative failure rate in logging audit events is greater than 2%.'
         summary: 'The kubernetes API server has too many failed attempts to log audit events'
+  - eval_time: 31m
+    alertname: ApiserverRequestsFailureRate
+    exp_alerts:
+    - exp_labels:
+        service: kube-apiserver
+        severity: warning
+        type: seed
+        visibility: operator
+      exp_annotations:
+        description: 'The API Server requests failure rate exceeds 10%.'
+        summary: 'Kubernetes API server failure rate is high'


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area monitoring
/kind enhancement

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Add api server failure rate high alert to control plane

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Add new Prometheus alert `ApiserverRequestsFailureRate` for API Server failure rate. 
```
