### PR TITLE
Upgrade `sigs.k8s.io/controller-tools` to `v0.10.0`

### DIFF
--- a/example/resource-manager/10-crd-resources.gardener.cloud_managedresources.yaml
+++ b/example/resource-manager/10-crd-resources.gardener.cloud_managedresources.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: managedresources.resources.gardener.cloud
 spec:

--- a/example/seed-crds/10-crd-autoscaling.k8s.io_hvpas.yaml
+++ b/example/seed-crds/10-crd-autoscaling.k8s.io_hvpas.yaml
@@ -4,7 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     api-approved.kubernetes.io: unapproved, temporarily squatting
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: hvpas.autoscaling.k8s.io
 spec:

--- a/example/seed-crds/10-crd-druid.gardener.cloud_etcdcopybackupstasks.yaml
+++ b/example/seed-crds/10-crd-druid.gardener.cloud_etcdcopybackupstasks.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: etcdcopybackupstasks.druid.gardener.cloud
 spec:

--- a/example/seed-crds/10-crd-druid.gardener.cloud_etcds.yaml
+++ b/example/seed-crds/10-crd-druid.gardener.cloud_etcds.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: etcds.druid.gardener.cloud
 spec:

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_backupbuckets.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_backupbuckets.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: backupbuckets.extensions.gardener.cloud
 spec:

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_backupentries.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_backupentries.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: backupentries.extensions.gardener.cloud
 spec:

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_bastions.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_bastions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: bastions.extensions.gardener.cloud
 spec:

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_clusters.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_clusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: clusters.extensions.gardener.cloud
 spec:

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_containerruntimes.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_containerruntimes.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: containerruntimes.extensions.gardener.cloud
 spec:

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_controlplanes.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_controlplanes.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: controlplanes.extensions.gardener.cloud
 spec:

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_dnsrecords.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_dnsrecords.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: dnsrecords.extensions.gardener.cloud
 spec:

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_extensions.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_extensions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: extensions.extensions.gardener.cloud
 spec:

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_infrastructures.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_infrastructures.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: infrastructures.extensions.gardener.cloud
 spec:

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_networks.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_networks.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: networks.extensions.gardener.cloud
 spec:

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: operatingsystemconfigs.extensions.gardener.cloud
 spec:

--- a/example/seed-crds/10-crd-extensions.gardener.cloud_workers.yaml
+++ b/example/seed-crds/10-crd-extensions.gardener.cloud_workers.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: workers.extensions.gardener.cloud
 spec:

--- a/example/seed-crds/10-crd-resources.gardener.cloud_managedresources.yaml
+++ b/example/seed-crds/10-crd-resources.gardener.cloud_managedresources.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: managedresources.resources.gardener.cloud
 spec:

--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed
 	sigs.k8s.io/controller-runtime v0.13.0
 	sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20220706173534-cd0058ad295c // v0.12.3
-	sigs.k8s.io/controller-tools v0.9.2
+	sigs.k8s.io/controller-tools v0.10.0
 	sigs.k8s.io/yaml v1.3.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1391,8 +1391,8 @@ sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20220706173534-cd0058a
 sigs.k8s.io/controller-runtime/tools/setup-envtest v0.0.0-20220706173534-cd0058ad295c/go.mod h1:nLkMD2WB4Jcix1qfVuJeOF4j5y/VfyeOIlTxG5Wj9co=
 sigs.k8s.io/controller-tools v0.2.4/go.mod h1:m/ztfQNocGYBgTTCmFdnK94uVvgxeZeE3LtJvd/jIzA=
 sigs.k8s.io/controller-tools v0.4.0/go.mod h1:G9rHdZMVlBDocIxGkK3jHLWqcTMNvveypYJwrvYKjWU=
-sigs.k8s.io/controller-tools v0.9.2 h1:AkTE3QAdz9LS4iD3EJvHyYxBkg/g9fTbgiYsrcsFCcM=
-sigs.k8s.io/controller-tools v0.9.2/go.mod h1:NUkn8FTV3Sad3wWpSK7dt/145qfuQ8CKJV6j4jHC5rM=
+sigs.k8s.io/controller-tools v0.10.0 h1:0L5DTDTFB67jm9DkfrONgTGmfc/zYow0ZaHyppizU2U=
+sigs.k8s.io/controller-tools v0.10.0/go.mod h1:uvr0EW6IsprfB0jpQq6evtKy+hHyHCXNfdWI5ONPx94=
 sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 h1:iXTIw73aPyC+oRdyqqvVJuloN1p0AC/kzH07hu3NE+k=
 sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
 sigs.k8s.io/kind v0.7.0/go.mod h1:An/AbWHT6pA/Lm0Og8j3ukGhfJP3RiVN/IBU6Lo3zl8=

--- a/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_backupbuckets.yaml
+++ b/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_backupbuckets.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     gardener.cloud/deletion-protected: "true"
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: backupbuckets.extensions.gardener.cloud
 spec:

--- a/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_backupentries.yaml
+++ b/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_backupentries.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     gardener.cloud/deletion-protected: "true"
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: backupentries.extensions.gardener.cloud
 spec:

--- a/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_bastions.yaml
+++ b/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_bastions.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     gardener.cloud/deletion-protected: "true"
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: bastions.extensions.gardener.cloud
 spec:

--- a/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_clusters.yaml
+++ b/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_clusters.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: clusters.extensions.gardener.cloud
 spec:

--- a/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_containerruntimes.yaml
+++ b/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_containerruntimes.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     gardener.cloud/deletion-protected: "true"
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: containerruntimes.extensions.gardener.cloud
 spec:

--- a/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_controlplanes.yaml
+++ b/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_controlplanes.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     gardener.cloud/deletion-protected: "true"
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: controlplanes.extensions.gardener.cloud
 spec:

--- a/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_dnsrecords.yaml
+++ b/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_dnsrecords.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     gardener.cloud/deletion-protected: "true"
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: dnsrecords.extensions.gardener.cloud
 spec:

--- a/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_extensions.yaml
+++ b/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_extensions.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     gardener.cloud/deletion-protected: "true"
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: extensions.extensions.gardener.cloud
 spec:

--- a/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_infrastructures.yaml
+++ b/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_infrastructures.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     gardener.cloud/deletion-protected: "true"
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: infrastructures.extensions.gardener.cloud
 spec:

--- a/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_networks.yaml
+++ b/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_networks.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     gardener.cloud/deletion-protected: "true"
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: networks.extensions.gardener.cloud
 spec:

--- a/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
+++ b/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_operatingsystemconfigs.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     gardener.cloud/deletion-protected: "true"
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: operatingsystemconfigs.extensions.gardener.cloud
 spec:

--- a/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_workers.yaml
+++ b/pkg/operation/botanist/component/extensions/crds/templates/crd-extensions.gardener.cloud_workers.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     gardener.cloud/deletion-protected: "true"
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: workers.extensions.gardener.cloud
 spec:

--- a/pkg/operation/botanist/component/extensions/crds/templates/crd-resources.gardener.cloud_managedresources.yaml
+++ b/pkg/operation/botanist/component/extensions/crds/templates/crd-resources.gardener.cloud_managedresources.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     gardener.cloud/deletion-protected: "true"
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: managedresources.resources.gardener.cloud
 spec:

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1598,8 +1598,8 @@ sigs.k8s.io/controller-runtime/tools/setup-envtest/remote
 sigs.k8s.io/controller-runtime/tools/setup-envtest/store
 sigs.k8s.io/controller-runtime/tools/setup-envtest/versions
 sigs.k8s.io/controller-runtime/tools/setup-envtest/workflows
-# sigs.k8s.io/controller-tools v0.9.2
-## explicit; go 1.17
+# sigs.k8s.io/controller-tools v0.10.0
+## explicit; go 1.19
 sigs.k8s.io/controller-tools/cmd/controller-gen
 sigs.k8s.io/controller-tools/pkg/crd
 sigs.k8s.io/controller-tools/pkg/crd/markers

--- a/vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go
+++ b/vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/vendor/sigs.k8s.io/controller-tools/pkg/crd/doc.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/crd/doc.go
@@ -17,14 +17,14 @@ limitations under the License.
 // Package crd contains utilities for generating CustomResourceDefinitions and
 // their corresponding OpenAPI validation schemata.
 //
-// Markers
+// # Markers
 //
 // Markers live under the markers subpackage.  Two types of markers exist:
 // those that modify schema generation (for validation), and those that modify
 // the rest of the CRD.  See the subpackage for more information and all
 // supported markers.
 //
-// Collecting Types and Generating CRDs
+// # Collecting Types and Generating CRDs
 //
 // The Parser is the entrypoint for collecting the information required to
 // generate CRDs.  Like loader and collector, its methods are idemptotent, not
@@ -40,13 +40,13 @@ limitations under the License.
 // Errors are generally attached directly to the relevant Package with
 // AddError.
 //
-// Known Packages
+// # Known Packages
 //
 // There are a few types from Kubernetes that have special meaning, but don't
 // have validation markers attached.  Those specific types have overrides
 // listed in KnownPackages that can be added as overrides to any parser.
 //
-// Flattening
+// # Flattening
 //
 // Once schemata are generated, they can be used directly by external tooling
 // (like JSONSchema validators), but must first be "flattened" to not contain

--- a/vendor/sigs.k8s.io/controller-tools/pkg/crd/flatten.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/crd/flatten.go
@@ -143,6 +143,8 @@ func flattenAllOfInto(dst *apiext.JSONSchemaProps, src apiext.JSONSchemaProps, e
 				dstProps.Schema = &apiext.JSONSchemaProps{}
 			}
 			flattenAllOfInto(dstProps.Schema, *srcProps.Schema, errRec)
+		case "XPreserveUnknownFields":
+			dstField.Set(srcField)
 		case "XMapType":
 			dstField.Set(srcField)
 		// NB(directxman12): no need to explicitly handle nullable -- false is considered to be the zero value

--- a/vendor/sigs.k8s.io/controller-tools/pkg/crd/known_types.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/crd/known_types.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -74,7 +74,8 @@ var KnownPackages = map[string]PackageOverride{
 	"k8s.io/apimachinery/pkg/runtime": func(p *Parser, pkg *loader.Package) {
 		p.Schemata[TypeIdent{Name: "RawExtension", Package: pkg}] = apiext.JSONSchemaProps{
 			// TODO(directxman12): regexp validation for this (or get kube to support it as a format value)
-			Type: "object",
+			Type:                   "object",
+			XPreserveUnknownFields: boolPtr(true),
 		}
 		p.AddPackage(pkg) // get the rest of the types
 	},

--- a/vendor/sigs.k8s.io/controller-tools/pkg/crd/markers/doc.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/crd/markers/doc.go
@@ -19,7 +19,7 @@ limitations under the License.
 //
 // All markers related to CRD generation live in AllDefinitions.
 //
-// Validation Markers
+// # Validation Markers
 //
 // Validation markers have values that implement ApplyToSchema
 // (crd.SchemaMarker).  Any marker implementing this will automatically
@@ -31,7 +31,7 @@ limitations under the License.
 // All validation markers start with "+kubebuilder:validation", and
 // have the same name as their type name.
 //
-// CRD Markers
+// # CRD Markers
 //
 // Markers that modify anything in the CRD itself *except* for the schema
 // implement ApplyToCRD (crd.CRDMarker).  They are expected to detect whether
@@ -39,7 +39,7 @@ limitations under the License.
 // them), or to the root-level CRD for legacy cases.  They are applied *after*
 // the rest of the CRD is computed.
 //
-// Misc
+// # Misc
 //
 // This package also defines the "+groupName" and "+versionName" package-level
 // markers, for defining package<->group-version mappings.

--- a/vendor/sigs.k8s.io/controller-tools/pkg/crd/markers/topology.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/crd/markers/topology.go
@@ -55,15 +55,15 @@ func init() {
 //
 // Possible data-structure types of a list are:
 //
-// - "map": it needs to have a key field, which will be used to build an
-//   associative list. A typical example is a the pod container list,
-//   which is indexed by the container name.
+//   - "map": it needs to have a key field, which will be used to build an
+//     associative list. A typical example is a the pod container list,
+//     which is indexed by the container name.
 //
-// - "set": Fields need to be "scalar", and there can be only one
-//   occurrence of each.
+//   - "set": Fields need to be "scalar", and there can be only one
+//     occurrence of each.
 //
-// - "atomic": All the fields in the list are treated as a single value,
-//   are typically manipulated together by the same actor.
+//   - "atomic": All the fields in the list are treated as a single value,
+//     are typically manipulated together by the same actor.
 type ListType string
 
 // +controllertools:marker:generateHelp:category="CRD processing"
@@ -83,12 +83,12 @@ type ListMapKey string
 //
 // Possible values:
 //
-// - "granular": items in the map are independent of each other,
-//   and can be manipulated by different actors.
-//   This is the default behavior.
+//   - "granular": items in the map are independent of each other,
+//     and can be manipulated by different actors.
+//     This is the default behavior.
 //
-// - "atomic": all fields are treated as one unit.
-//   Any changes have to replace the entire map.
+//   - "atomic": all fields are treated as one unit.
+//     Any changes have to replace the entire map.
 type MapType string
 
 // +controllertools:marker:generateHelp:category="CRD processing"
@@ -99,12 +99,12 @@ type MapType string
 //
 // Possible values:
 //
-// - "granular": fields in the struct are independent of each other,
-//   and can be manipulated by different actors.
-//   This is the default behavior.
+//   - "granular": fields in the struct are independent of each other,
+//     and can be manipulated by different actors.
+//     This is the default behavior.
 //
-// - "atomic": all fields are treated as one unit.
-//   Any changes have to replace the entire struct.
+//   - "atomic": all fields are treated as one unit.
+//     Any changes have to replace the entire struct.
 type StructType string
 
 func (l ListType) ApplyToSchema(schema *apiext.JSONSchemaProps) error {

--- a/vendor/sigs.k8s.io/controller-tools/pkg/crd/spec.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/crd/spec.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,

--- a/vendor/sigs.k8s.io/controller-tools/pkg/genall/doc.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/genall/doc.go
@@ -17,14 +17,14 @@ limitations under the License.
 // Package genall defines entrypoints for generation tools to hook into and
 // share the same set of parsing, typechecking, and marker information.
 //
-// Generators
+// # Generators
 //
 // Each Generator knows how to register its markers into a central Registry,
 // and then how to generate output using a Collector and some root packages.
 // Each generator can be considered to be the output type of a marker, for easy
 // command line parsing.
 //
-// Output and Input
+// # Output and Input
 //
 // Generators output artifacts via an OutputRule.  OutputRules know how to
 // write output for different package-associated (code) files, as well as
@@ -40,7 +40,7 @@ limitations under the License.
 // InputRule defines custom input loading, but its shared across all
 // Generators.  There's currently only a filesystem implementation.
 //
-// Runtime and Context
+// # Runtime and Context
 //
 // Runtime maps together Generators, and constructs "contexts" which provide
 // the common collector and roots, plus the output rule for that generator, and
@@ -50,7 +50,7 @@ limitations under the License.
 // skipping type-checking errors (since those are commonly caused by the
 // partial type-checking of loader.TypeChecker).
 //
-// Options
+// # Options
 //
 // The FromOptions (and associated helpers) function makes it easy to use generators
 // and output rules as markers that can be parsed from the command line, producing

--- a/vendor/sigs.k8s.io/controller-tools/pkg/genall/help/pretty/doc.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/genall/help/pretty/doc.go
@@ -17,13 +17,13 @@ limitations under the License.
 // Package pretty contains utilities for formatting terminal help output,
 // and a use of those to display marker help.
 //
-// Terminal Output
+// # Terminal Output
 //
 // The Span interface and Table struct allow you to construct tables with
 // colored formatting, without causing ANSI formatting characters to mess up width
 // calculations.
 //
-// Marker Help
+// # Marker Help
 //
 // The MarkersSummary prints a summary table for marker help, while the MarkersDetails
 // prints out more detailed information, with explainations of the individual marker fields.

--- a/vendor/sigs.k8s.io/controller-tools/pkg/genall/options.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/genall/options.go
@@ -30,6 +30,8 @@ var (
 // +controllertools:marker:generateHelp:category=""
 
 // InputPaths represents paths and go-style path patterns to use as package roots.
+//
+// Multiple paths can be specified using "{path1, path2, path3}".
 type InputPaths []string
 
 // RegisterOptionsMarkers registers "mandatory" options markers for FromOptions into the given registry.

--- a/vendor/sigs.k8s.io/controller-tools/pkg/genall/zz_generated.markerhelp.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/genall/zz_generated.markerhelp.go
@@ -29,8 +29,8 @@ func (InputPaths) Help() *markers.DefinitionHelp {
 	return &markers.DefinitionHelp{
 		Category: "",
 		DetailedHelp: markers.DetailedHelp{
-			Summary: "represents paths and go-style path patterns to use as package roots.",
-			Details: "",
+			Summary: "represents paths and go-style path patterns to use as package roots. ",
+			Details: "Multiple paths can be specified using \"{path1, path2, path3}\".",
 		},
 		FieldHelp: map[string]markers.DetailedHelp{},
 	}

--- a/vendor/sigs.k8s.io/controller-tools/pkg/loader/doc.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/loader/doc.go
@@ -22,7 +22,7 @@ limitations under the License.
 // Because it uses go/packages, it's modules-aware, and works in both modules-
 // and non-modules environments.
 //
-// Loading
+// # Loading
 //
 // The main entrypoint for loading is LoadRoots, which traverse the package
 // graph starting at the given patterns (file, package, path, or ...-wildcard,
@@ -33,7 +33,7 @@ limitations under the License.
 // Packages are suitable for comparison, as each unique package only ever has
 // one *Package object returned.
 //
-// Syntax and TypeChecking
+// # Syntax and TypeChecking
 //
 // ASTs and type-checking information can be loaded with NeedSyntax and
 // NeedTypesInfo, respectively.  Both are idempotent -- repeated calls will
@@ -41,14 +41,14 @@ limitations under the License.
 // check the current package -- if you want to type-check imports as well,
 // you'll need to type-check them first.
 //
-// Reference Pruning and Recursive Checking
+// # Reference Pruning and Recursive Checking
 //
 // In order to type-check using only the packages you care about, you can use a
 // TypeChecker.  TypeChecker will visit each top-level type declaration,
 // collect (optionally filtered) references, and type-check references
 // packages.
 //
-// Errors
+// # Errors
 //
 // Errors can be added to each package.  Use ErrFromNode to create an error
 // from an AST node.  Errors can then be printed (complete with file and

--- a/vendor/sigs.k8s.io/controller-tools/pkg/loader/loader.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/loader/loader.go
@@ -338,34 +338,34 @@ func LoadRoots(roots ...string) ([]*Package, error) {
 // supports roots that are filesystem paths. For more information, please
 // refer to the high-level outline of this function's logic:
 //
-//     1. If no roots are provided then load the working directory and return
-//        early.
+//  1. If no roots are provided then load the working directory and return
+//     early.
 //
-//     2. Otherwise sort the provided roots into two, distinct buckets:
+//  2. Otherwise sort the provided roots into two, distinct buckets:
 //
-//            a. package/module names
-//            b. filesystem paths
+//     a. package/module names
+//     b. filesystem paths
 //
-//        A filesystem path is distinguished from a Go package/module name by
-//        the same rules as followed by the "go" command. At a high level, a
-//        root is a filesystem path IFF it meets ANY of the following criteria:
+//     A filesystem path is distinguished from a Go package/module name by
+//     the same rules as followed by the "go" command. At a high level, a
+//     root is a filesystem path IFF it meets ANY of the following criteria:
 //
-//            * is absolute
-//            * begins with .
-//            * begins with ..
+//     * is absolute
+//     * begins with .
+//     * begins with ..
 //
-//        For more information please refer to the output of the command
-//        "go help packages".
+//     For more information please refer to the output of the command
+//     "go help packages".
 //
-//     3. Load the package/module roots as a single call to packages.Load. If
-//        there are no filesystem path roots then return early.
+//  3. Load the package/module roots as a single call to packages.Load. If
+//     there are no filesystem path roots then return early.
 //
-//     4. For filesystem path roots ending with "...", check to see if its
-//        descendants include any nested, Go modules. If so, add the directory
-//        that contains the nested Go module to the filesystem path roots.
+//  4. For filesystem path roots ending with "...", check to see if its
+//     descendants include any nested, Go modules. If so, add the directory
+//     that contains the nested Go module to the filesystem path roots.
 //
-//     5. Load the filesystem path roots and return the load packages for the
-//        package/module roots AND the filesystem path roots.
+//  5. Load the filesystem path roots and return the load packages for the
+//     package/module roots AND the filesystem path roots.
 func LoadRootsWithConfig(cfg *packages.Config, roots ...string) ([]*Package, error) {
 	l := &loader{
 		cfg:      cfg,

--- a/vendor/sigs.k8s.io/controller-tools/pkg/markers/collect.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/markers/collect.go
@@ -65,13 +65,13 @@ func (c *Collector) init() {
 //
 // - it's in the Godoc for that AST node
 //
-// - it's in the closest non-godoc comment group above that node,
-//   *and* that node is a type or field node, *and* [it's either
-//   registered as type-level *or* it's not registered as being
-//   package-level]
+//   - it's in the closest non-godoc comment group above that node,
+//     *and* that node is a type or field node, *and* [it's either
+//     registered as type-level *or* it's not registered as being
+//     package-level]
 //
-// - it's not in the Godoc of a node, doesn't meet the above criteria, and
-//   isn't in a struct definition (in which case it's package-level)
+//   - it's not in the Godoc of a node, doesn't meet the above criteria, and
+//     isn't in a struct definition (in which case it's package-level)
 func (c *Collector) MarkersInPackage(pkg *loader.Package) (map[ast.Node]MarkerValues, error) {
 	c.mu.Lock()
 	c.init()

--- a/vendor/sigs.k8s.io/controller-tools/pkg/markers/doc.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/markers/doc.go
@@ -19,7 +19,7 @@ limitations under the License.
 // avoid confusing with struct tags).  Parsed result (output) values take the
 // form of Go values, much like the "encoding/json" package.
 //
-// Definitions and Parsing
+// # Definitions and Parsing
 //
 // Markers are defined as structured Definitions which can be used to
 // consistently parse marker comments.  A Definition contains an concrete
@@ -29,20 +29,20 @@ limitations under the License.
 //
 // Markers take the general form
 //
-//  +path:to:marker=val
+//	+path:to:marker=val
 //
-//  +path:to:marker:arg1=val,arg2=val2
+//	+path:to:marker:arg1=val,arg2=val2
 //
-//  +path:to:marker
+//	+path:to:marker
 //
 // Arguments may be ints, bools, strings, and slices.  Ints and bool take their
 // standard form from Go.  Strings may take any of their standard forms, or any
 // sequence of unquoted characters up until a `,` or `;` is encountered.  Lists
 // take either of the following forms:
 //
-//  val;val;val
+//	val;val;val
 //
-//  {val, val, val}
+//	{val, val, val}
 //
 // Note that the first form will not properly parse nested slices, but is
 // generally convenient and is the form used in many existing markers.
@@ -61,7 +61,7 @@ limitations under the License.
 // non-optional fields aren't mentioned, an error will be raised unless
 // `Strict` is set to false.
 //
-// Registries and Lookup
+// # Registries and Lookup
 //
 // Definitions can be added to registries to facilitate lookups.  Each
 // definition is marked as either describing a type, struct field, or package
@@ -69,7 +69,7 @@ limitations under the License.
 // long as each describes a different construct (type, field, or package).
 // Definitions can then be looked up by passing unparsed markers.
 //
-// Collection and Extraction
+// # Collection and Extraction
 //
 // Markers can be collected from a loader.Package using a Collector.  The
 // Collector will read from a given Registry, collecting comments that look
@@ -85,7 +85,7 @@ limitations under the License.
 // Like loader.Package, Collector's methods are idempotent and will not
 // reperform work.
 //
-// Traversal
+// # Traversal
 //
 // EachType function iterates over each type in a Package, providing
 // conveniently structured type and field information with marker values
@@ -93,14 +93,14 @@ limitations under the License.
 //
 // PackageMarkers can be used to fetch just package-level markers.
 //
-// Help
+// # Help
 //
 // Help can be defined for each marker using the DefinitionHelp struct.  It's
 // mostly intended to be generated off of godocs using cmd/helpgen, which takes
 // the first line as summary (removing the type/field name), and considers the
 // rest as details.  It looks for the
 //
-//   +controllertools:generateHelp[:category=<string>]
+//	+controllertools:generateHelp[:category=<string>]
 //
 // marker to start generation.
 //

--- a/vendor/sigs.k8s.io/controller-tools/pkg/markers/reg.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/markers/reg.go
@@ -52,7 +52,8 @@ func (r *Registry) init() {
 
 // Define defines a new marker with the given name, target, and output type.
 // It's a shortcut around
-//  r.Register(MakeDefinition(name, target, obj))
+//
+//	r.Register(MakeDefinition(name, target, obj))
 func (r *Registry) Define(name string, target TargetType, obj interface{}) error {
 	def, err := MakeDefinition(name, target, obj)
 	if err != nil {

--- a/vendor/sigs.k8s.io/controller-tools/pkg/markers/zip.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/markers/zip.go
@@ -149,11 +149,11 @@ type TypeCallback func(info *TypeInfo)
 // EachType collects all markers, then calls the given callback for each type declaration in a package.
 // Each individual spec is considered separate, so
 //
-//  type (
-//      Foo string
-//      Bar int
-//      Baz struct{}
-//  )
+//	type (
+//	    Foo string
+//	    Bar int
+//	    Baz struct{}
+//	)
 //
 // yields three calls to the callback.
 func EachType(col *Collector, pkg *loader.Package, cb TypeCallback) error {

--- a/vendor/sigs.k8s.io/controller-tools/pkg/rbac/parser.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/rbac/parser.go
@@ -19,7 +19,7 @@ limitations under the License.
 //
 // The markers take the form:
 //
-//  +kubebuilder:rbac:groups=<groups>,resources=<resources>,resourceNames=<resource names>,verbs=<verbs>,urls=<non resource urls>
+//	+kubebuilder:rbac:groups=<groups>,resources=<resources>,resourceNames=<resource names>,verbs=<verbs>,urls=<non resource urls>
 package rbac
 
 import (

--- a/vendor/sigs.k8s.io/controller-tools/pkg/schemapatcher/gen.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/schemapatcher/gen.go
@@ -358,11 +358,15 @@ func crdsFromDirectory(ctx *genall.GenerationContext, dir string) (map[schema.Gr
 		if err := kyaml.Unmarshal(rawContent, &typeMeta); err != nil {
 			continue
 		}
+
+		if typeMeta.APIVersion == "" || typeMeta.Kind != "CustomResourceDefinition" {
+			// If there's no API version this file probably isn't a CRD.
+			// Likewise we don't need to care if the Kind isn't CustomResourceDefinition.
+			continue
+		}
+
 		if !isSupportedAPIExtGroupVer(typeMeta.APIVersion) {
 			return nil, fmt.Errorf("load %q: apiVersion %q not supported", filepath.Join(dir, fileInfo.Name()), typeMeta.APIVersion)
-		}
-		if typeMeta.Kind != "CustomResourceDefinition" {
-			continue
 		}
 
 		// collect the group-kind and versions from the actual structured form

--- a/vendor/sigs.k8s.io/controller-tools/pkg/version/version.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/version/version.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -36,10 +36,10 @@ func Version() string {
 //
 // - "Version: v0.2.1" when the program has been compiled with:
 //
-//   $ go get github.com/controller-tools/cmd/controller-gen@v0.2.1
+//	$ go get github.com/controller-tools/cmd/controller-gen@v0.2.1
 //
-//   Note: go modules requires the usage of semver compatible tags starting with
-//        'v' to have nice human-readable versions.
+//	Note: go modules requires the usage of semver compatible tags starting with
+//	     'v' to have nice human-readable versions.
 //
 // - "Version: (devel)" when the program is compiled from a local git checkout.
 //

--- a/vendor/sigs.k8s.io/controller-tools/pkg/webhook/zz_generated.markerhelp.go
+++ b/vendor/sigs.k8s.io/controller-tools/pkg/webhook/zz_generated.markerhelp.go
@@ -81,6 +81,10 @@ func (Config) Help() *markers.DefinitionHelp {
 				Summary: "is an ordered list of preferred `AdmissionReview` versions the Webhook expects.",
 				Details: "",
 			},
+			"ReinvocationPolicy": {
+				Summary: "allows mutating webhooks to request reinvocation after other mutations ",
+				Details: "To allow mutating admission plugins to observe changes made by other plugins, built-in mutating admission plugins are re-run if a mutating webhook modifies an object, and mutating webhooks can specify a reinvocationPolicy to control whether they are reinvoked as well.",
+			},
 		},
 	}
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area open-source
/kind enhancement

**What this PR does / why we need it**:
Upgrade dependencies
 - sigs.k8s.io/controller-tools to v0.10.0


**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The following dependency is updated:
- sigs.k8s.io/controller-tools: v0.9.2 -> v0.10.0
```
