### PR TITLE
Cleanup old priority class and related migration code 

### DIFF
--- a/pkg/apis/core/v1beta1/constants/types_constants.go
+++ b/pkg/apis/core/v1beta1/constants/types_constants.go
@@ -757,7 +757,4 @@ const (
 	// PriorityClassNameShootControlPlane100 is the name of a PriorityClass for Shoot control plane components.
 	// Please consider the documentation in https://github.com/gardener/gardener/blob/master/docs/development/priority-classes.md
 	PriorityClassNameShootControlPlane100 = "gardener-system-100"
-	// PriorityClassNameShootControlPlane is the name of a PriorityClass for Shoot control plane components.
-	// Deprecated: this PriorityClass will be removed in a future version, use the fine-granular PriorityClasses above instead.
-	PriorityClassNameShootControlPlane = "gardener-shoot-controlplane"
 )

--- a/pkg/gardenlet/controller/factory.go
+++ b/pkg/gardenlet/controller/factory.go
@@ -41,10 +41,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	schedulingv1 "k8s.io/api/scheduling/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/cluster"
 )
 
@@ -94,11 +91,6 @@ func (f *LegacyControllerFactory) Start(ctx context.Context) error {
 	identity, err := determineIdentity()
 	if err != nil {
 		return err
-	}
-
-	// TODO(acumino): Remove in a future release.
-	if err := client.IgnoreNotFound(f.SeedCluster.GetClient().Delete(ctx, &schedulingv1.PriorityClass{ObjectMeta: metav1.ObjectMeta{Name: "gardener-system-critical-migration"}})); err != nil {
-		return fmt.Errorf("unable to delete Gardenlet's old PriorityClass: %w", err)
 	}
 
 	backupBucketController, err := backupbucketcontroller.NewBackupBucketController(ctx, log, f.GardenCluster, f.SeedCluster, f.Config)

--- a/pkg/operation/botanist/component/seedsystem/seedsystem.go
+++ b/pkg/operation/botanist/component/seedsystem/seedsystem.go
@@ -176,8 +176,6 @@ var gardenletManagedPriorityClasses = []struct {
 	{v1beta1constants.PriorityClassNameShootControlPlane300, 999998300, "PriorityClass for Shoot control plane components"},
 	{v1beta1constants.PriorityClassNameShootControlPlane200, 999998200, "PriorityClass for Shoot control plane components"},
 	{v1beta1constants.PriorityClassNameShootControlPlane100, 999998100, "PriorityClass for Shoot control plane components"},
-	// TODO: remove this in a future release once all components have been migrated to the other fine-granular PriorityClasses.
-	{v1beta1constants.PriorityClassNameShootControlPlane, 100, "DEPRECATED PriorityClass for Shoot control plane components"},
 }
 
 func addPriorityClasses(registry *managedresources.Registry) error {

--- a/pkg/operation/botanist/component/seedsystem/seedsystem_test.go
+++ b/pkg/operation/botanist/component/seedsystem/seedsystem_test.go
@@ -275,7 +275,6 @@ func expectPriorityClasses(data map[string][]byte) {
 		{"gardener-system-300", 999998300, "PriorityClass for Shoot control plane components"},
 		{"gardener-system-200", 999998200, "PriorityClass for Shoot control plane components"},
 		{"gardener-system-100", 999998100, "PriorityClass for Shoot control plane components"},
-		{"gardener-shoot-controlplane", 100, "DEPRECATED PriorityClass for Shoot control plane components"},
 	}
 
 	for _, pc := range expected {

--- a/pkg/operation/botanist/component/seedsystem/seedsystem_test.go
+++ b/pkg/operation/botanist/component/seedsystem/seedsystem_test.go
@@ -151,7 +151,7 @@ status: {}
 		})
 
 		It("should successfully deploy the resources", func() {
-			Expect(managedResourceSecret.Data).To(HaveLen(12))
+			Expect(managedResourceSecret.Data).To(HaveLen(11))
 			Expect(string(managedResourceSecret.Data["deployment__"+namespace+"__reserve-excess-capacity.yaml"])).To(Equal(deploymentYAML))
 			expectPriorityClasses(managedResourceSecret.Data)
 		})

--- a/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server.go
+++ b/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server.go
@@ -338,7 +338,7 @@ func (v *vpnSeedServer) Deploy(ctx context.Context) error {
 				},
 				Spec: corev1.PodSpec{
 					AutomountServiceAccountToken: pointer.Bool(false),
-					PriorityClassName:            v1beta1constants.PriorityClassNameShootControlPlane,
+					PriorityClassName:            v1beta1constants.PriorityClassNameShootControlPlane300,
 					DNSPolicy:                    corev1.DNSDefault, // make sure to not use the coredns for DNS resolution.
 					Containers: []corev1.Container{
 						{

--- a/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server_test.go
+++ b/pkg/operation/botanist/component/vpnseedserver/vpn_seed_server_test.go
@@ -285,7 +285,7 @@ admin:
 						},
 						Spec: corev1.PodSpec{
 							AutomountServiceAccountToken: pointer.Bool(false),
-							PriorityClassName:            v1beta1constants.PriorityClassNameShootControlPlane,
+							PriorityClassName:            v1beta1constants.PriorityClassNameShootControlPlane300,
 							DNSPolicy:                    corev1.DNSDefault, // make sure to not use the coredns for DNS resolution.
 							Containers: []corev1.Container{
 								{


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/kind cleanup

**What this PR does / why we need it**:
This PR cleanup priority class `gardener-shoot-controlplane` and related migration code.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/5634

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
