### PR TITLE
Project admins can no longer modify serviceaccounts

### DIFF
--- a/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
+++ b/charts/gardener/controlplane/charts/application/templates/rbac-user.yaml
@@ -303,7 +303,6 @@ rules:
   resources:
   - secrets
   - configmaps
-  - serviceaccounts # TODO(dimityrmirchev): Remove create/delete/modify permissions for serviceaccounts in a future release
   verbs:
   - create
   - delete
@@ -318,6 +317,7 @@ rules:
   resources:
   - events
   - resourcequotas
+  - serviceaccounts
   verbs:
   - get
   - list


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area user-management
/kind cleanup

**What this PR does / why we need it**:
This is a cleanup after https://github.com/gardener/gardener/pull/5971

This PR removes the create/modify/delete permissions for `serviceaccounts` for project members with the `admin` role. In order to manage `serviceaccounts` one should use the `serviceaccountmanager` role.

cc @donistz 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```breaking user
The create/modify/delete permissions for `ServiceAccount`s assigned to `Project` members with the `admin` role are now removed. Read permissions are preserved. In order to fully manage `ServiceAccount`s in the project namespace, use the `serviceaccountmanager` role. Please find more information [here](https://gardener.cloud/docs/gardener/usage/project_namespace_access/).
```
