### PR TITLE
Add networkpolicies for istio-ingress

### DIFF
--- a/pkg/operation/botanist/component/istio/charts/istio/istio-ingress/templates/networkpolicies.yaml
+++ b/pkg/operation/botanist/component/istio/charts/istio/istio-ingress/templates/networkpolicies.yaml
@@ -1,0 +1,153 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  annotations:
+    gardener.cloud/description: Disables all Egress traffic from
+      this namespace.
+  name: deny-all-egress
+  namespace: {{ .Release.Namespace }}
+spec:
+  podSelector: {}
+  policyTypes:
+  - Egress
+
+---
+
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: to-shoot-apiserver
+  namespace: {{ .Release.Namespace }}
+spec:
+  egress:
+  - ports:
+    - port: 443
+      protocol: TCP
+    to:
+    - namespaceSelector: {}
+    - podSelector:
+        matchLabels:
+          app: kubernetes
+          gardener.cloud/role: controlplane
+          role: apiserver
+  podSelector:
+    matchLabels:
+      app: istio-ingressgateway
+  policyTypes:
+  - Egress
+
+---
+
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: to-shoot-vpnserver
+  namespace: {{ .Release.Namespace }}
+spec:
+  egress:
+  - ports:
+    - port: 1194
+      protocol: TCP
+    to:
+    - namespaceSelector: {}
+    - podSelector:
+        matchLabels:
+          app: vpn-seed-server
+          gardener.cloud/role: controlplane
+  podSelector:
+    matchLabels:
+      app: istio-ingressgateway
+  policyTypes:
+  - Egress
+
+---
+
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: to-vpn-auth-server
+  namespace: {{ .Release.Namespace }}
+spec:
+  egress:
+  - ports:
+    - port: 9001
+      protocol: TCP
+    to:
+    - namespaceSelector:
+        matchLabels:
+          role: garden
+    - podSelector:
+        matchLabels:
+          app: reversed-vpn-auth-server
+  podSelector:
+    matchLabels:
+      app: istio-ingressgateway
+  policyTypes:
+  - Egress
+
+---
+
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-to-dns
+  namespace:  {{ .Release.Namespace }}
+
+spec:
+  egress:
+  - ports:
+    - port: 8053
+      protocol: UDP
+    - port: 8053
+      protocol: TCP
+    to:
+    - podSelector:
+        matchExpressions:
+        - key: k8s-app
+          operator: In
+          values:
+          - kube-dns
+  - ports:
+    - port: 53
+      protocol: UDP
+    - port: 53
+      protocol: TCP
+    to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+    - podSelector:
+        matchExpressions:
+        - key: k8s-app
+          operator: In
+          values:
+          - node-local-dns
+  podSelector:
+    matchLabels:
+      app: istio-ingressgateway
+  policyTypes:
+  - Egress
+
+---
+
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: to-istio-pilot
+  namespace:  {{ .Release.Namespace }}
+spec:
+  egress:
+  - ports:
+    - port: 15012
+      protocol: TCP
+    to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: istio-system
+    - podSelector:
+        matchLabels:
+          app: istiod
+  podSelector:
+    matchLabels:
+      app: istio-ingressgateway
+  policyTypes:
+  - Egress


### PR DESCRIPTION
**How to categorize this PR?**

/area networking
/kind enhancement

**What this PR does / why we need it**:
Provide strict network policies for the istio-ingressgateway so that it can only establish network connectivity to the endpoints that it is configured to reach inside the cluster.
This is a second line of defence in case of a bug or misconfiguration in the instio-ingressgateway.

**Which issue(s) this PR fixes**:
None

**Special notes for your reviewer**:

**Release note**:

```other operator
Deploy network policies to namespace istio-ingress to only allow egress traffic to configured endpoints inside the cluster.
```
