### PR TITLE
Scrape logs from pods in the shoot kube-system which have the resources.gardener.cloud/managed-by:gardener label:value

### DIFF
--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/promtail/config_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/promtail/config_test.go
@@ -202,10 +202,16 @@ scrape_configs:
     source_labels:
     - __meta_kubernetes_pod_label_gardener_cloud_role
     - __meta_kubernetes_pod_label_origin
+    - __meta_kubernetes_pod_label_resources_gardener_cloud_managed_by
   - action: replace
     regex: '.+'
     replacement: "gardener"
     source_labels: ['__meta_kubernetes_pod_label_gardener_cloud_role']
+    target_label: __meta_kubernetes_pod_label_origin
+  - action: replace
+    regex: 'gardener'
+    replacement: "gardener"
+    source_labels: ['__meta_kubernetes_pod_label_resources_gardener_cloud_managed_by']
     target_label: __meta_kubernetes_pod_label_origin
   - action: keep
     regex: 'gardener'

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/promtail/templates/promtail-config.tpl.yaml
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/promtail/templates/promtail-config.tpl.yaml
@@ -89,10 +89,16 @@ scrape_configs:
     source_labels:
     - __meta_kubernetes_pod_label_gardener_cloud_role
     - __meta_kubernetes_pod_label_origin
+    - __meta_kubernetes_pod_label_resources_gardener_cloud_managed_by
   - action: replace
     regex: '.+'
     replacement: "gardener"
     source_labels: ['__meta_kubernetes_pod_label_gardener_cloud_role']
+    target_label: __meta_kubernetes_pod_label_origin
+  - action: replace
+    regex: 'gardener'
+    replacement: "gardener"
+    source_labels: ['__meta_kubernetes_pod_label_resources_gardener_cloud_managed_by']
     target_label: __meta_kubernetes_pod_label_origin
   - action: keep
     regex: 'gardener'


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
With this PR the logs of pods in the shoot's `kube-system` namespace which got the `resources.gardener.cloud/managed-by:gardener` `label:value` will be scraped from `Promtail` and stored in Loki. Thus, for example, the logs from `csi-driver-node` pods that have neither `gardener.cloud/role` nor `origin` labels will be scraped and stored, too. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Logs from pods managed by `garden-resource-manager` will be scraped and stored in the shoot's Loki.
```
