### PR TITLE
Deflake ExtensionsCheck test and BackupBucketsCheck test

### DIFF
--- a/pkg/controllermanager/controller/seed/utils/utils.go
+++ b/pkg/controllermanager/controller/seed/utils/utils.go
@@ -99,7 +99,11 @@ func PatchSeedCondition(ctx context.Context, log logr.Logger, c client.StatusWri
 		return nil
 	}
 
-	log.Info("Patching condition", "conditionType", condition.Type, "conditionStatus", condition.Status)
 	seed.Status.Conditions = conditions
-	return c.Patch(ctx, seed, patch)
+	if err := c.Patch(ctx, seed, patch); err != nil {
+		return err
+	}
+
+	log.Info("Successfully patched condition", "conditionType", condition.Type, "conditionStatus", condition.Status)
+	return nil
 }


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind flake

**What this PR does / why we need it**:
Deflakes the seed ExtensionsCheck and BackupBucketsCheck controllers integration tests.

I think that the reason for the latest flake https://prow.gardener.cloud/view/gs/gardener-prow/pr-logs/pull/gardener_gardener/6705/pull-gardener-integration/1572124710328602624 is that the check whether the `ExtensionReady` condition is `True` gets evaluated too fast after the creation of the 2nd `ControllerInstallation` [here](https://github.com/gardener/gardener/blob/24dc519d70c664bb64ebe46808320ae9595d3cfc/test/integration/controllermanager/seed/extensionscheck/extensionscheck_test.go#L109-L113). That can happen because after creating and updating the conditions of the 1st `ControllerInstallation` the `ExtensionsReady` condition will be set to `True`. Then when the 2nd `ControllerInstallation` is created, the condition is set to `Progressing` and when the 2nd `ControllerInstallation` is updated with successful conditions, the `ExtensionsReady` condition is set to `True` again. However, the test can miss the transition from `True` -> `Progressing` -> `True` and only notice the first `True` condition, which then leads to incorrect expects during the rest of the tests.
However, during local testing I could not reproduce the flake reported in the issue.

I've restructured the tests and the logging, a bit so that hopefully if a flake happens again it is more clear why it is happening.

Theoretically there is one more flake that can happen because of this check here: https://github.com/gardener/gardener/blob/24dc519d70c664bb64ebe46808320ae9595d3cfc/pkg/controllermanager/controller/seed/utils/utils.go#L84-L85
Because the clock [here](https://github.com/gardener/gardener/blob/24dc519d70c664bb64ebe46808320ae9595d3cfc/test/integration/controllermanager/seed/extensionscheck/extensionscheck_test.go#L153-L154) can be stepped after line 84, but before line 85, thus the current condition could still be evaluated to `Progressing` as it will be within the threshold, but then its timestamp will be updated as part of the `UpdatedCondition()` call. 

This PR 
**Which issue(s) this PR fixes**:
Fixes #6679

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
4. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
