### PR TITLE
Fix injecting custom containerd config imports

### DIFF
--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/containerd/initializer_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/containerd/initializer_test.go
@@ -119,9 +119,9 @@ imports = ["$CUSTOM_CONFIG_FILES"]
 $existing_content
 EOF
 elif ! grep "$CUSTOM_CONFIG_FILES" $FILE >/dev/null ; then
-  existing_imports="$(sed -E 's#imports = \[(.*)\]#\1#g' $FILE)"
+  existing_imports="$(grep -E "^imports" $FILE | sed -E 's#imports = \[(.*)\]#\1#g')"
   [ -z "$existing_imports" ] || existing_imports="$existing_imports, "
-  sed -Ei 's#imports = \[(.*)\]#imports = ['"$existing_imports"' "'"$CUSTOM_CONFIG_FILES"'"]#g' $FILE
+  sed -Ei 's#imports = \[(.*)\]#imports = ['"$existing_imports"'"'"$CUSTOM_CONFIG_FILES"'"]#g' $FILE
 fi
 
 BIN_PATH=/var/bin/containerruntimes

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/containerd/initializer_test.go
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/containerd/initializer_test.go
@@ -113,12 +113,14 @@ CUSTOM_CONFIG_DIR=/etc/containerd/conf.d
 CUSTOM_CONFIG_FILES="$CUSTOM_CONFIG_DIR/*.toml"
 mkdir -p $CUSTOM_CONFIG_DIR
 if ! grep -E "^imports" $FILE >/dev/null ; then
+  # imports directive not present -> add it to the top
   existing_content="$(cat "$FILE")"
   cat <<EOF > $FILE
 imports = ["$CUSTOM_CONFIG_FILES"]
 $existing_content
 EOF
-elif ! grep "$CUSTOM_CONFIG_FILES" $FILE >/dev/null ; then
+elif ! grep -F "$CUSTOM_CONFIG_FILES" $FILE >/dev/null ; then
+  # imports directive present, but does not contain conf.d -> append conf.d to imports
   existing_imports="$(grep -E "^imports" $FILE | sed -E 's#imports = \[(.*)\]#\1#g')"
   [ -z "$existing_imports" ] || existing_imports="$existing_imports, "
   sed -Ei 's#imports = \[(.*)\]#imports = ['"$existing_imports"'"'"$CUSTOM_CONFIG_FILES"'"]#g' $FILE

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/containerd/templates/scripts/init.tpl.sh
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/containerd/templates/scripts/init.tpl.sh
@@ -16,12 +16,14 @@ CUSTOM_CONFIG_DIR=/etc/containerd/conf.d
 CUSTOM_CONFIG_FILES="$CUSTOM_CONFIG_DIR/*.toml"
 mkdir -p $CUSTOM_CONFIG_DIR
 if ! grep -E "^imports" $FILE >/dev/null ; then
+  # imports directive not present -> add it to the top
   existing_content="$(cat "$FILE")"
   cat <<EOF > $FILE
 imports = ["$CUSTOM_CONFIG_FILES"]
 $existing_content
 EOF
-elif ! grep "$CUSTOM_CONFIG_FILES" $FILE >/dev/null ; then
+elif ! grep -F "$CUSTOM_CONFIG_FILES" $FILE >/dev/null ; then
+  # imports directive present, but does not contain conf.d -> append conf.d to imports
   existing_imports="$(grep -E "^imports" $FILE | sed -E 's#imports = \[(.*)\]#\1#g')"
   [ -z "$existing_imports" ] || existing_imports="$existing_imports, "
   sed -Ei 's#imports = \[(.*)\]#imports = ['"$existing_imports"'"'"$CUSTOM_CONFIG_FILES"'"]#g' $FILE

--- a/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/containerd/templates/scripts/init.tpl.sh
+++ b/pkg/operation/botanist/component/extensions/operatingsystemconfig/original/components/containerd/templates/scripts/init.tpl.sh
@@ -22,9 +22,9 @@ imports = ["$CUSTOM_CONFIG_FILES"]
 $existing_content
 EOF
 elif ! grep "$CUSTOM_CONFIG_FILES" $FILE >/dev/null ; then
-  existing_imports="$(sed -E 's#imports = \[(.*)\]#\1#g' $FILE)"
+  existing_imports="$(grep -E "^imports" $FILE | sed -E 's#imports = \[(.*)\]#\1#g')"
   [ -z "$existing_imports" ] || existing_imports="$existing_imports, "
-  sed -Ei 's#imports = \[(.*)\]#imports = ['"$existing_imports"' "'"$CUSTOM_CONFIG_FILES"'"]#g' $FILE
+  sed -Ei 's#imports = \[(.*)\]#imports = ['"$existing_imports"'"'"$CUSTOM_CONFIG_FILES"'"]#g' $FILE
 fi
 
 BIN_PATH={{ .binaryPath }}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area operating-system
/kind bug

**What this PR does / why we need it**:

On operating systems with no containerd config, the default containerd config is written to `/etc/containerd/config.toml` which contains `imports = []`.
For cases with the `imports` directive already present, our injection of `/etc/containerd/conf.d/*` did not work properly and failed with the following error:
```
Sep 29 09:59:39 shoot--dev--hcloud-shoot-worker-s254h-hel1-dc2-97dd9-vfndf systemd[1]: Starting Containerd initializer...
Sep 29 09:59:39 shoot--dev--hcloud-shoot-worker-s254h-hel1-dc2-97dd9-vfndf init-containerd[6705]: sed: -e expression #1, char 53: unterminated `s' command
```

This PR fixes this bug.

Co-Authored-By @JensAc 

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

The script was working for provider-local, as the containerd config present in the machine image doesn't contain the `imports` directive.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix user
A bug has been fixed that caused custom containerd config from `/etc/containerd/conf.d` not to be loaded.
```
