### PR TITLE
Keep custom `etcd` annotations

### DIFF
--- a/pkg/operation/botanist/component/etcd/etcd.go
+++ b/pkg/operation/botanist/component/etcd/etcd.go
@@ -448,10 +448,9 @@ func (e *etcd) Deploy(ctx context.Context) error {
 	}
 
 	if _, err := controllerutils.GetAndCreateOrMergePatch(ctx, e.client, e.etcd, func() error {
-		e.etcd.Annotations = map[string]string{
-			v1beta1constants.GardenerOperation: v1beta1constants.GardenerOperationReconcile,
-			v1beta1constants.GardenerTimestamp: TimeNow().UTC().String(),
-		}
+		metav1.SetMetaDataAnnotation(&e.etcd.ObjectMeta, v1beta1constants.GardenerOperation, v1beta1constants.GardenerOperationReconcile)
+		metav1.SetMetaDataAnnotation(&e.etcd.ObjectMeta, v1beta1constants.GardenerTimestamp, TimeNow().UTC().String())
+
 		e.etcd.Labels = map[string]string{
 			v1beta1constants.LabelRole:  e.role,
 			v1beta1constants.GardenRole: v1beta1constants.GardenRoleControlPlane,


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area control-plane
/area ops-productivity
/kind enhancement

**What this PR does / why we need it**:
This PR prevents the `etcd` deployment step from entirely overwriting the `annotations` section. Etcd-Druid plans to introduce custom annotations, e.g. for temporary skipping reconciliations, which will help operators to recover an `etcd` cluster in case existing automatons reached a dead end.

**Special notes for your reviewer**:
/cc @abdasgupta @ishan16696 @aaronfern 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator
Gardener will now keep any custom annotations that were put to `Etcd` resources in the seed cluster. This can help if operators need to manually restore an ETCD cluster in exceptional cases.
```
