### PR TITLE
Upgrade logging components to v0.44.0

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -240,7 +240,7 @@ images:
 - name: fluent-bit-plugin-installer
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/fluent-bit-to-loki
-  tag: "v0.43.0"
+  tag: "v0.44.0"
 - name: loki
   sourceRepository: github.com/grafana/loki
   repository: grafana/loki
@@ -248,7 +248,7 @@ images:
 - name: loki-curator
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/loki-curator
-  tag: "v0.43.0"
+  tag: "v0.44.0"
 - name: kube-rbac-proxy
   sourceRepository: github.com/brancz/kube-rbac-proxy
   repository: quay.io/brancz/kube-rbac-proxy
@@ -260,11 +260,11 @@ images:
 - name: telegraf
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/telegraf-iptables
-  tag: "v0.43.0"
+  tag: "v0.44.0"
 - name: event-logger
   sourceRepository: github.com/gardener/logging
   repository: eu.gcr.io/gardener-project/gardener/event-logger
-  tag: "v0.43.0"
+  tag: "v0.44.0"
 
 # VPA
 - name: vpa-admission-controller

--- a/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-daemonset.yaml
+++ b/charts/seed-bootstrap/charts/fluent-bit/templates/fluent-bit-daemonset.yaml
@@ -32,7 +32,6 @@ spec:
         - cp
         - /source/plugins/.
         - /plugins
-        - -fr
         volumeMounts:
         - name: plugins
           mountPath: "/plugins"


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area logging
/kind enhancement

**What this PR does / why we need it**:
With this PR the logging components which are supported by `Gardener` are bumped to v0.44.0 version.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```bugfix operator github.com/gardener/logging #153 @vlvasilev
Fix sending on a closed channel in the `fluent-bit's` plugin `SortedClient` when closing it before the last batch is sent. 
```
```other developer github.com/gardener/logging #154 @vlvasilev
Remove the alpine image used as a carrier for the `fluent-bit-to-loki` plugin.
```