### PR TITLE
Clean up no longer needed `ginkgo.Skip` statement from the cluster-autoscaler integration tests

### DIFF
--- a/test/testmachinery/shoots/operations/clusterautoscaler.go
+++ b/test/testmachinery/shoots/operations/clusterautoscaler.go
@@ -159,10 +159,6 @@ var _ = ginkgo.Describe("Shoot clusterautoscaler testing", func() {
 		origClusterAutoscalerConfig = shoot.Spec.Kubernetes.ClusterAutoscaler.DeepCopy()
 		origWorkers = shoot.Spec.Provider.Workers
 
-		if shoot.Spec.Provider.Type != "aws" && shoot.Spec.Provider.Type != "azure" {
-			ginkgo.Skip("not applicable")
-		}
-
 		// Create a dedicated worker-pool for cluster autoscaler.
 		testWorkerPool := origWorkers[0]
 		testWorkerPool.Name = testWorkerPoolName


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area testing
/kind enhancement

**What this PR does / why we need it**:
Scale from/to zero should now work all providers - see https://github.com/gardener/autoscaler/issues/27

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
The cluster-autoscaler's scale from/to zero integration test is no longer skipped on providers other than `aws` and `azure`.
```
