### PR TITLE
Enhance resource-manager health controller

### DIFF
--- a/pkg/resourcemanager/controller/health/add.go
+++ b/pkg/resourcemanager/controller/health/add.go
@@ -88,12 +88,12 @@ func AddToManagerWithOptions(mgr manager.Manager, conf ControllerConfig) error {
 
 	if conf.TargetCacheDisabled {
 		// if the target cache is disable, we don't want to start additional informers
-		healthReconciler.EnsureWatchForGVK = func(gvk schema.GroupVersionKind, obj client.Object) error {
+		healthReconciler.ensureWatchForGVK = func(gvk schema.GroupVersionKind, obj client.Object) error {
 			return nil
 		}
 	} else {
 		watchedObjectGVKs := sync.Map{}
-		healthReconciler.EnsureWatchForGVK = func(gvk schema.GroupVersionKind, obj client.Object) error {
+		healthReconciler.ensureWatchForGVK = func(gvk schema.GroupVersionKind, obj client.Object) error {
 			// check if we have already added watch for GVK
 			// if not, store GVK in map
 			if _, ok := watchedObjectGVKs.LoadOrStore(gvk, nil); ok {
@@ -265,7 +265,7 @@ func HealthStatusChanged(log logr.Logger) predicate.Predicate {
 			checked, oldErr := CheckHealth(e.ObjectOld)
 			if !checked {
 				if oldErr != nil {
-					log.Error(oldErr, "Error determining health status of object", "object", e.ObjectOld)
+					log.Error(oldErr, "Error determining health status of old object", "object", e.ObjectOld)
 				}
 				return false
 			}
@@ -274,7 +274,7 @@ func HealthStatusChanged(log logr.Logger) predicate.Predicate {
 			checked, newErr := CheckHealth(e.ObjectNew)
 			if !checked {
 				if newErr != nil {
-					log.Error(newErr, "Error determining health status of object", "object", e.ObjectNew)
+					log.Error(newErr, "Error determining health status of new object", "object", e.ObjectNew)
 				}
 				return false
 			}

--- a/pkg/resourcemanager/controller/health/add.go
+++ b/pkg/resourcemanager/controller/health/add.go
@@ -116,7 +116,7 @@ func AddToManagerWithOptions(mgr manager.Manager, conf ControllerConfig) error {
 			healthLogger.Info("Adding new watch for GroupVersionKind", "groupVersionKind", gvk, "metadataOnly", metadataOnly)
 
 			if err := healthController.Watch(
-				&source.Kind{Type: watchedObj},
+				source.NewKindWithCache(watchedObj, conf.TargetCluster.GetCache()),
 				handler.EnqueueRequestsFromMapFunc(mapToOriginManagedResource(healthLogger, conf.ClusterID)),
 				HealthStatusChanged(healthLogger),
 			); err != nil {
@@ -154,13 +154,13 @@ func AddToManagerWithOptions(mgr manager.Manager, conf ControllerConfig) error {
 		// If we want to have immediate updates for managed resources in Shoots in the future as well, we could consider
 		// adding labels to managed resources and watch them explicitly.
 		b.Watches(
-			&source.Kind{Type: &appsv1.Deployment{}}, handler.EnqueueRequestsFromMapFunc(mapToOriginManagedResource(log, conf.ClusterID)),
+			source.NewKindWithCache(&appsv1.Deployment{}, conf.TargetCluster.GetCache()), handler.EnqueueRequestsFromMapFunc(mapToOriginManagedResource(log, conf.ClusterID)),
 			builder.WithPredicates(progressingStatusChanged),
 		).Watches(
-			&source.Kind{Type: &appsv1.StatefulSet{}}, handler.EnqueueRequestsFromMapFunc(mapToOriginManagedResource(log, conf.ClusterID)),
+			source.NewKindWithCache(&appsv1.StatefulSet{}, conf.TargetCluster.GetCache()), handler.EnqueueRequestsFromMapFunc(mapToOriginManagedResource(log, conf.ClusterID)),
 			builder.WithPredicates(progressingStatusChanged),
 		).Watches(
-			&source.Kind{Type: &appsv1.DaemonSet{}}, handler.EnqueueRequestsFromMapFunc(mapToOriginManagedResource(log, conf.ClusterID)),
+			source.NewKindWithCache(&appsv1.DaemonSet{}, conf.TargetCluster.GetCache()), handler.EnqueueRequestsFromMapFunc(mapToOriginManagedResource(log, conf.ClusterID)),
 			builder.WithPredicates(progressingStatusChanged),
 		)
 	}

--- a/pkg/resourcemanager/controller/health/add.go
+++ b/pkg/resourcemanager/controller/health/add.go
@@ -253,14 +253,6 @@ func HealthStatusChanged(log logr.Logger) predicate.Predicate {
 				return true
 			}
 
-			// ignore metadata-only update events
-			if _, ok := e.ObjectOld.(*metav1.PartialObjectMetadata); ok {
-				return false
-			}
-			if _, ok := e.ObjectNew.(*metav1.PartialObjectMetadata); ok {
-				return false
-			}
-
 			var oldHealthy, newHealthy bool
 			checked, oldErr := CheckHealth(e.ObjectOld)
 			if !checked {

--- a/pkg/resourcemanager/controller/health/add_test.go
+++ b/pkg/resourcemanager/controller/health/add_test.go
@@ -1,0 +1,179 @@
+// Copyright (c) 2022 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package health_test
+
+import (
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	logzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
+	predicate2 "sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	"github.com/gardener/gardener/pkg/logger"
+	. "github.com/gardener/gardener/pkg/resourcemanager/controller/health"
+)
+
+var _ = Describe("HealthStatusChanged", func() {
+	var (
+		log       logr.Logger
+		predicate predicate2.Predicate
+	)
+
+	BeforeEach(func() {
+		log = logger.MustNewZapLogger(logger.DebugLevel, logger.FormatJSON, logzap.WriteTo(GinkgoWriter))
+		predicate = HealthStatusChanged(log)
+	})
+
+	Context("metadata-only events", func() {
+		var (
+			obj *metav1.PartialObjectMetadata
+		)
+
+		BeforeEach(func() {
+			obj = &metav1.PartialObjectMetadata{}
+			obj.SetGroupVersionKind(appsv1.SchemeGroupVersion.WithKind("Deployment"))
+			obj.SetResourceVersion("1")
+		})
+
+		It("should return true for Create", func() {
+			Expect(predicate.Create(event.CreateEvent{Object: obj})).To(BeTrue())
+		})
+
+		It("should return true for Delete", func() {
+			Expect(predicate.Delete(event.DeleteEvent{Object: obj})).To(BeTrue())
+		})
+
+		It("should return true for cache resyncs", func() {
+			objOld := obj.DeepCopy()
+			Expect(predicate.Update(event.UpdateEvent{ObjectOld: objOld, ObjectNew: obj})).To(BeTrue())
+		})
+
+		It("should ignore Update", func() {
+			objOld := obj.DeepCopy()
+			obj.SetResourceVersion("2")
+			Expect(predicate.Update(event.UpdateEvent{ObjectOld: objOld, ObjectNew: obj})).To(BeFalse())
+		})
+
+		It("should ignore Generic", func() {
+			Expect(predicate.Generic(event.GenericEvent{Object: obj})).To(BeFalse())
+		})
+	})
+
+	Context("typed events", func() {
+		var (
+			healthy, unhealthy *appsv1.Deployment
+		)
+
+		BeforeEach(func() {
+			healthy = &appsv1.Deployment{
+				Status: appsv1.DeploymentStatus{Conditions: []appsv1.DeploymentCondition{{
+					Type:   appsv1.DeploymentAvailable,
+					Status: corev1.ConditionTrue,
+				}}},
+			}
+			healthy.SetResourceVersion("1")
+			unhealthy = &appsv1.Deployment{
+				Status: appsv1.DeploymentStatus{Conditions: []appsv1.DeploymentCondition{{
+					Type:   appsv1.DeploymentAvailable,
+					Status: corev1.ConditionFalse,
+				}}},
+			}
+			unhealthy.SetResourceVersion("1")
+		})
+
+		It("should return true for Create", func() {
+			Expect(predicate.Create(event.CreateEvent{Object: healthy})).To(BeTrue())
+			Expect(predicate.Create(event.CreateEvent{Object: unhealthy})).To(BeTrue())
+		})
+
+		It("should return false for Create if object is skipped", func() {
+			metav1.SetMetaDataAnnotation(&healthy.ObjectMeta, "resources.gardener.cloud/skip-health-check", "true")
+			metav1.SetMetaDataAnnotation(&unhealthy.ObjectMeta, "resources.gardener.cloud/skip-health-check", "true")
+
+			Expect(predicate.Create(event.CreateEvent{Object: healthy})).To(BeFalse())
+			Expect(predicate.Create(event.CreateEvent{Object: unhealthy})).To(BeFalse())
+		})
+
+		It("should return true for Delete", func() {
+			Expect(predicate.Delete(event.DeleteEvent{Object: healthy})).To(BeTrue())
+			Expect(predicate.Delete(event.DeleteEvent{Object: unhealthy})).To(BeTrue())
+		})
+
+		It("should return false for Delete if object is skipped", func() {
+			metav1.SetMetaDataAnnotation(&healthy.ObjectMeta, "resources.gardener.cloud/skip-health-check", "true")
+			metav1.SetMetaDataAnnotation(&unhealthy.ObjectMeta, "resources.gardener.cloud/skip-health-check", "true")
+
+			Expect(predicate.Delete(event.DeleteEvent{Object: healthy})).To(BeFalse())
+			Expect(predicate.Delete(event.DeleteEvent{Object: unhealthy})).To(BeFalse())
+		})
+
+		It("should return true for cache resyncs", func() {
+			healthyOld := healthy.DeepCopy()
+			unhealthyOld := unhealthy.DeepCopy()
+
+			Expect(predicate.Update(event.UpdateEvent{ObjectOld: healthyOld, ObjectNew: healthy})).To(BeTrue())
+			Expect(predicate.Update(event.UpdateEvent{ObjectOld: unhealthyOld, ObjectNew: unhealthy})).To(BeTrue())
+		})
+
+		It("should return true for Update, if the health status has changed", func() {
+			healthyOld := healthy.DeepCopy()
+			healthyOld.SetResourceVersion("2")
+			unhealthyOld := unhealthy.DeepCopy()
+			unhealthyOld.SetResourceVersion("2")
+
+			Expect(predicate.Update(event.UpdateEvent{ObjectOld: healthyOld, ObjectNew: unhealthy})).To(BeTrue())
+			Expect(predicate.Update(event.UpdateEvent{ObjectOld: unhealthyOld, ObjectNew: healthy})).To(BeTrue())
+		})
+
+		It("should ignore Update, if the health status has not changed", func() {
+			healthyOld := healthy.DeepCopy()
+			healthyOld.SetResourceVersion("2")
+			unhealthyOld := unhealthy.DeepCopy()
+			unhealthyOld.SetResourceVersion("2")
+
+			Expect(predicate.Update(event.UpdateEvent{ObjectOld: healthyOld, ObjectNew: healthy})).To(BeFalse())
+			Expect(predicate.Update(event.UpdateEvent{ObjectOld: unhealthyOld, ObjectNew: unhealthy})).To(BeFalse())
+		})
+
+		It("should ignore Generic", func() {
+			Expect(predicate.Generic(event.GenericEvent{Object: healthy})).To(BeFalse())
+			Expect(predicate.Generic(event.GenericEvent{Object: unhealthy})).To(BeFalse())
+		})
+	})
+
+	It("should ignore Update if old GVK cannot be determined", func() {
+		obj := &unstructured.Unstructured{}
+		obj.SetGroupVersionKind(appsv1.SchemeGroupVersion.WithKind("Deployment"))
+		objOld := obj.DeepCopy()
+		obj.SetResourceVersion("2")
+		objOld.SetGroupVersionKind(schema.GroupVersionKind{})
+		Expect(predicate.Update(event.UpdateEvent{ObjectOld: objOld, ObjectNew: obj})).To(BeFalse())
+	})
+
+	It("should ignore Update if new GVK cannot be determined", func() {
+		obj := &unstructured.Unstructured{}
+		obj.SetGroupVersionKind(appsv1.SchemeGroupVersion.WithKind("Deployment"))
+		objOld := obj.DeepCopy()
+		obj.SetResourceVersion("2")
+		obj.SetGroupVersionKind(schema.GroupVersionKind{})
+		Expect(predicate.Update(event.UpdateEvent{ObjectOld: objOld, ObjectNew: obj})).To(BeFalse())
+	})
+})

--- a/pkg/resourcemanager/controller/health/add_test.go
+++ b/pkg/resourcemanager/controller/health/add_test.go
@@ -21,8 +21,6 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	logzap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 	predicate2 "sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -157,23 +155,5 @@ var _ = Describe("HealthStatusChanged", func() {
 			Expect(predicate.Generic(event.GenericEvent{Object: healthy})).To(BeFalse())
 			Expect(predicate.Generic(event.GenericEvent{Object: unhealthy})).To(BeFalse())
 		})
-	})
-
-	It("should ignore Update if old GVK cannot be determined", func() {
-		obj := &unstructured.Unstructured{}
-		obj.SetGroupVersionKind(appsv1.SchemeGroupVersion.WithKind("Deployment"))
-		objOld := obj.DeepCopy()
-		obj.SetResourceVersion("2")
-		objOld.SetGroupVersionKind(schema.GroupVersionKind{})
-		Expect(predicate.Update(event.UpdateEvent{ObjectOld: objOld, ObjectNew: obj})).To(BeFalse())
-	})
-
-	It("should ignore Update if new GVK cannot be determined", func() {
-		obj := &unstructured.Unstructured{}
-		obj.SetGroupVersionKind(appsv1.SchemeGroupVersion.WithKind("Deployment"))
-		objOld := obj.DeepCopy()
-		obj.SetResourceVersion("2")
-		obj.SetGroupVersionKind(schema.GroupVersionKind{})
-		Expect(predicate.Update(event.UpdateEvent{ObjectOld: objOld, ObjectNew: obj})).To(BeFalse())
 	})
 })

--- a/pkg/resourcemanager/controller/health/health_checker.go
+++ b/pkg/resourcemanager/controller/health/health_checker.go
@@ -16,7 +16,6 @@ package health
 
 import (
 	"context"
-	"fmt"
 
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
 	"github.com/gardener/gardener/pkg/utils/kubernetes"
@@ -30,110 +29,64 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 )
 
-// healthCheckScheme is a dedicated healthCheckScheme for CheckHealth which contains all API types, that can be checked
-// by CheckHealth. Needed for converting unstructured objects to structured objects.
+// healthCheckScheme is a dedicated scheme for CheckHealth containing the apiextensions types for converting
+// CustomResourceDefinitions from v1beta1 and v1.
 var healthCheckScheme *runtime.Scheme
 
 func init() {
 	healthCheckScheme = runtime.NewScheme()
-	utilruntime.Must(kubernetesscheme.AddToScheme(healthCheckScheme))
 	apiextensionsinstall.Install(healthCheckScheme)
 }
 
 // CheckHealth checks whether the given object is healthy.
 // It returns a bool indicating whether the object was actually checked and an error if any health check failed.
 func CheckHealth(obj client.Object) (bool, error) {
-	// We must not rely on TypeMeta to be set in objects as decoder clears apiVersion and kind fields, see
-	// https://github.com/kubernetes/kubernetes/issues/80609 and https://github.com/gardener/gardener/issues/5357#issuecomment-1040150204.
-	// Instead of using GetObjectKind(), we use a scheme to figure out the GroupVersionKind which works for both typed
-	// and unstructured objects.
-	gvk, err := apiutil.GVKForObject(obj, healthCheckScheme)
-	if err != nil {
-		if runtime.IsNotRegisteredError(err) {
-			// types that this function runs health checks on must be registered in healthCheckScheme
-			// if the healthCheckScheme doesn't recognize it the object, skip the check as we don't have a health check for it
-			return false, nil
-		}
-		return false, fmt.Errorf("failed to determine GVK of object: %w", err)
-	}
-
 	if obj.GetAnnotations()[resourcesv1alpha1.SkipHealthCheck] == "true" {
 		return false, nil
 	}
 
 	// Note: we can't do client-side conversions from one version to another, because conversion code is not exported
-	// to k8s.io/api (apiextensions API is an exception). The only conversion we can do, is from unstructured objects to
-	// typed objects in the same version. This is what most of the following healthCheckScheme.Convert calls do.
-	switch gvk.GroupKind() {
-	case apiextensionsv1.SchemeGroupVersion.WithKind("CustomResourceDefinition").GroupKind():
-		crdObj := obj
-		if gvk.Version == apiextensionsv1beta1.SchemeGroupVersion.Version {
-			// Convert to internal version first if v1beta1 because converter cannot convert from external -> external version.
-			crd := &apiextensions.CustomResourceDefinition{}
-			if err := healthCheckScheme.Convert(crdObj, crd, nil); err != nil {
-				return false, err
-			}
-			crdObj = crd
+	// to k8s.io/api (apiextensions API is an exception). Hence, we only perform health checks for objects in well-known
+	// and supported API versions (except CustomResourceDefinitions for backward-compatibility).
+	// As we don't use unstructured objects in the health controller we don't need to convert to typed objects anymore and
+	// can use the typed objects directly.
+
+	// When adding new types for dedicated health checks here, make sure that they are registered in the scheme for the
+	// target cluster client, see pkg/resourcemanager/cmd/target.go
+	switch o := obj.(type) {
+	case *apiextensionsv1.CustomResourceDefinition:
+		return true, health.CheckCustomResourceDefinition(o)
+	case *apiextensionsv1beta1.CustomResourceDefinition:
+		// convert to v1 via internal version because converter cannot convert from external -> external version.
+		crdInternal := &apiextensions.CustomResourceDefinition{}
+		if err := healthCheckScheme.Convert(o, crdInternal, nil); err != nil {
+			return false, err
 		}
+
 		crd := &apiextensionsv1.CustomResourceDefinition{}
-		if err := healthCheckScheme.Convert(crdObj, crd, nil); err != nil {
+		if err := healthCheckScheme.Convert(crdInternal, crd, nil); err != nil {
 			return false, err
 		}
 		return true, health.CheckCustomResourceDefinition(crd)
-	case appsv1.SchemeGroupVersion.WithKind("DaemonSet").GroupKind():
-		ds := &appsv1.DaemonSet{}
-		if err := healthCheckScheme.Convert(obj, ds, nil); err != nil {
-			return false, err
-		}
-		return true, health.CheckDaemonSet(ds)
-	case appsv1.SchemeGroupVersion.WithKind("Deployment").GroupKind():
-		deploy := &appsv1.Deployment{}
-		if err := healthCheckScheme.Convert(obj, deploy, nil); err != nil {
-			return false, err
-		}
-		return true, health.CheckDeployment(deploy)
-	case batchv1.SchemeGroupVersion.WithKind("Job").GroupKind():
-		job := &batchv1.Job{}
-		if err := healthCheckScheme.Convert(obj, job, nil); err != nil {
-			return false, err
-		}
-		return true, health.CheckJob(job)
-	case corev1.SchemeGroupVersion.WithKind("Pod").GroupKind():
-		pod := &corev1.Pod{}
-		if err := healthCheckScheme.Convert(obj, pod, nil); err != nil {
-			return false, err
-		}
-		return true, health.CheckPod(pod)
-	case appsv1.SchemeGroupVersion.WithKind("ReplicaSet").GroupKind():
-		rs := &appsv1.ReplicaSet{}
-		if err := healthCheckScheme.Convert(obj, rs, nil); err != nil {
-			return false, err
-		}
-		return true, health.CheckReplicaSet(rs)
-	case corev1.SchemeGroupVersion.WithKind("ReplicationController").GroupKind():
-		rc := &corev1.ReplicationController{}
-		if err := healthCheckScheme.Convert(obj, rc, nil); err != nil {
-			return false, err
-		}
-		return true, health.CheckReplicationController(rc)
-	case corev1.SchemeGroupVersion.WithKind("Service").GroupKind():
-		service := &corev1.Service{}
-		if err := healthCheckScheme.Convert(obj, service, nil); err != nil {
-			return false, err
-		}
-		return true, health.CheckService(service)
-	case appsv1.SchemeGroupVersion.WithKind("StatefulSet").GroupKind():
-		statefulSet := &appsv1.StatefulSet{}
-		if err := healthCheckScheme.Convert(obj, statefulSet, nil); err != nil {
-			return false, err
-		}
-		return true, health.CheckStatefulSet(statefulSet)
+	case *appsv1.DaemonSet:
+		return true, health.CheckDaemonSet(o)
+	case *appsv1.Deployment:
+		return true, health.CheckDeployment(o)
+	case *batchv1.Job:
+		return true, health.CheckJob(o)
+	case *corev1.Pod:
+		return true, health.CheckPod(o)
+	case *appsv1.ReplicaSet:
+		return true, health.CheckReplicaSet(o)
+	case *corev1.ReplicationController:
+		return true, health.CheckReplicationController(o)
+	case *corev1.Service:
+		return true, health.CheckService(o)
+	case *appsv1.StatefulSet:
+		return true, health.CheckStatefulSet(o)
 	}
 
 	return false, nil

--- a/pkg/resourcemanager/controller/health/health_reconciler.go
+++ b/pkg/resourcemanager/controller/health/health_reconciler.go
@@ -43,9 +43,9 @@ type reconciler struct {
 	classFilter  *resourcemanagerpredicate.ClassFilter
 	syncPeriod   time.Duration
 
-	// EnsureWatchForGVK ensures that the controller is watching the given object to reconcile corresponding
+	// ensureWatchForGVK ensures that the controller is watching the given object to reconcile corresponding
 	// ManagedResources on health status changes.
-	EnsureWatchForGVK func(gvk schema.GroupVersionKind, obj client.Object) error
+	ensureWatchForGVK func(gvk schema.GroupVersionKind, obj client.Object) error
 }
 
 // InjectClient injects a client into the reconciler.
@@ -124,7 +124,7 @@ func (r *reconciler) executeHealthChecks(ctx context.Context, log logr.Logger, m
 		}
 
 		// ensure watch is started for object
-		if err := r.EnsureWatchForGVK(objectGVK, obj); err != nil {
+		if err := r.ensureWatchForGVK(objectGVK, obj); err != nil {
 			return ctrl.Result{}, err
 		}
 

--- a/pkg/resourcemanager/controller/health/health_reconciler.go
+++ b/pkg/resourcemanager/controller/health/health_reconciler.go
@@ -19,29 +19,33 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/go-logr/logr"
+	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	v1beta1helper "github.com/gardener/gardener/pkg/apis/core/v1beta1/helper"
 	resourcesv1alpha1 "github.com/gardener/gardener/pkg/apis/resources/v1alpha1"
-	"github.com/gardener/gardener/pkg/resourcemanager/predicate"
-
-	"github.com/go-logr/logr"
-	apiequality "k8s.io/apimachinery/pkg/api/equality"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	resourcemanagerpredicate "github.com/gardener/gardener/pkg/resourcemanager/predicate"
 )
 
 type reconciler struct {
 	client       client.Client
 	targetClient client.Client
 	targetScheme *runtime.Scheme
-	classFilter  *predicate.ClassFilter
+	classFilter  *resourcemanagerpredicate.ClassFilter
 	syncPeriod   time.Duration
+
+	// EnsureWatchForGVK ensures that the controller is watching the given object to reconcile corresponding
+	// ManagedResources on health status changes.
+	EnsureWatchForGVK func(gvk schema.GroupVersionKind, obj client.Object) error
 }
 
 // InjectClient injects a client into the reconciler.
@@ -105,19 +109,24 @@ func (r *reconciler) executeHealthChecks(ctx context.Context, log logr.Logger, m
 	var (
 		conditionResourcesHealthy = v1beta1helper.GetOrInitCondition(mr.Status.Conditions, resourcesv1alpha1.ResourcesHealthy)
 		oldCondition              = conditionResourcesHealthy.DeepCopy()
-		resourcesObjectReferences = mr.Status.Resources
 	)
 
-	for _, ref := range resourcesObjectReferences {
+	for _, ref := range mr.Status.Resources {
 		var (
+			objectGVK = ref.GroupVersionKind()
 			objectKey = client.ObjectKey{Namespace: ref.Namespace, Name: ref.Name}
-			objectLog = log.WithValues("object", objectKey, "objectGVK", ref.GroupVersionKind())
+			objectLog = log.WithValues("object", objectKey, "objectGVK", objectGVK)
 		)
 
 		obj, err := newObjectForReference(objectLog, r.targetScheme, ref)
 		if err != nil {
 			log.Error(err, "Failed to construct new object for reference. This should never happen, ignoring")
 			return ctrl.Result{}, nil
+		}
+
+		// ensure watch is started for object
+		if err := r.EnsureWatchForGVK(objectGVK, obj); err != nil {
+			return ctrl.Result{}, err
 		}
 
 		if err := r.targetClient.Get(healthCheckCtx, objectKey, obj); err != nil {
@@ -143,20 +152,28 @@ func (r *reconciler) executeHealthChecks(ctx context.Context, log logr.Logger, m
 
 		}
 
-		if checked, err := CheckHealth(healthCheckCtx, r.targetClient, obj); err != nil {
+		if checked, err := CheckHealth(obj); err != nil {
 			var (
 				reason  = ref.Kind + "Unhealthy"
 				message = fmt.Sprintf("%s %q is unhealthy: %v", ref.Kind, objectKey.String(), err)
 			)
 
-			if !checked {
-				// there was an error executing the health check (which is different than a failed health check)
+			if checked {
+				// consult object's events for more information if sensible
+				additionalMessage, err := FetchAdditionalFailureMessage(ctx, r.targetClient, obj)
+				if err != nil {
+					objectLog.Error(err, "Failed to read events for more information about unhealthy object")
+				} else if additionalMessage != "" {
+					message += "\n\n" + additionalMessage
+				}
+
+				objectLog.Info("Finished ManagedResource health checks", "status", "unhealthy", "reason", reason, "message", message)
+			} else {
+				// there was an error executing the health check (which is different from a failed health check)
 				// handle it separately and log it prominently
 				reason = "HealthCheckError"
 				message = fmt.Sprintf("Error executing health check for %s %q: %v", ref.Kind, objectKey.String(), err)
 				objectLog.Error(err, "Error executing health check for object")
-			} else {
-				objectLog.Info("Finished ManagedResource health checks", "status", "unhealthy", "reason", reason, "message", message)
 			}
 
 			conditionResourcesHealthy = v1beta1helper.UpdatedCondition(conditionResourcesHealthy, gardencorev1beta1.ConditionFalse, reason, message)

--- a/pkg/utils/kubernetes/health/service_test.go
+++ b/pkg/utils/kubernetes/health/service_test.go
@@ -15,50 +15,20 @@
 package health_test
 
 import (
-	"context"
-	"fmt"
-
-	mockclient "github.com/gardener/gardener/pkg/mock/controller-runtime/client"
 	"github.com/gardener/gardener/pkg/utils/kubernetes/health"
 
-	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	kubernetesscheme "k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("Service", func() {
 	Describe("#CheckService", func() {
-		var (
-			ctrl    *gomock.Controller
-			message = "foo"
-		)
-		BeforeEach(func() {
-			ctrl = gomock.NewController(GinkgoT())
-		})
-		AfterEach(func() {
-			ctrl.Finish()
-		})
-
 		DescribeTable("services",
 			func(service *corev1.Service, matcher types.GomegaMatcher) {
-				scheme := kubernetesscheme.Scheme
-				c := mockclient.NewMockClient(ctrl)
-				c.EXPECT().Scheme().Return(kubernetesscheme.Scheme).AnyTimes()
-
-				c.EXPECT().List(gomock.Any(), gomock.AssignableToTypeOf(&corev1.EventList{}), gomock.Any()).DoAndReturn(
-					func(_ context.Context, list *corev1.EventList, _ ...client.ListOption) error {
-						list.Items = []corev1.Event{
-							{Message: message},
-						}
-						return nil
-					},
-				).MaxTimes(1)
-				err := health.CheckService(context.Background(), scheme, c, service)
+				err := health.CheckService(service)
 				Expect(err).To(matcher)
 			},
 			Entry("no LoadBalancer service", &corev1.Service{
@@ -77,7 +47,7 @@ var _ = Describe("Service", func() {
 			Entry("LoadBalancer w/o ingress status", &corev1.Service{
 				TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Service"},
 				Spec:     corev1.ServiceSpec{Type: corev1.ServiceTypeLoadBalancer},
-			}, MatchError(fmt.Sprintf("service is missing ingress status\n\n-> Events:\n*  reported <unknown> ago: %s", message))),
+			}, MatchError("service is missing ingress status")),
 		)
 	})
 })


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area ops-productivity scalability
/kind enhancement

**What this PR does / why we need it**:

Enhance resource-manager health controller in several ways:
- use watches for managed resource and execute the health checks as soon as the health status of some managed resource changes
- eliminate use of unstructured objects and only use typed or metadata-only objects to make full use of the target cluster cache
- fix the progressing controller watches (they were wrongly using the source cluster cache – which was only working by coincidence)
- make health controller logs less noisy

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

The best part is, that resource-manager reconciles `ManagedResources` as soon as their health status changes to false. 
Hence, if you delete some managed resource or break its health, it gets reconciled back immediately now 🚀 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
The `ManagedResource` health status for objects on the seed cluster is now updated immediately on health status changes (switched from periodic checks to proper watching).
```
