### PR TITLE
Fix nodes CIDR in local `Seed` specification

### DIFF
--- a/cmd/gardener-extension-provider-local/app/options.go
+++ b/cmd/gardener-extension-provider-local/app/options.go
@@ -38,6 +38,7 @@ import (
 	controlplanewebhook "github.com/gardener/gardener/pkg/provider-local/webhook/controlplane"
 	controlplaneexposurewebhook "github.com/gardener/gardener/pkg/provider-local/webhook/controlplaneexposure"
 	dnsconfigwebhook "github.com/gardener/gardener/pkg/provider-local/webhook/dnsconfig"
+	networkpolicywebhook "github.com/gardener/gardener/pkg/provider-local/webhook/networkpolicy"
 	nodewebhook "github.com/gardener/gardener/pkg/provider-local/webhook/node"
 	shootwebhook "github.com/gardener/gardener/pkg/provider-local/webhook/shoot"
 )
@@ -65,6 +66,7 @@ func WebhookSwitchOptions() *webhookcmd.SwitchOptions {
 		webhookcmd.Switch(extensioncontrolplanewebhook.WebhookName, controlplanewebhook.AddToManager),
 		webhookcmd.Switch(extensionshootwebhook.WebhookName, shootwebhook.AddToManager),
 		webhookcmd.Switch(dnsconfigwebhook.WebhookName, dnsconfigwebhook.AddToManager),
+		webhookcmd.Switch(networkpolicywebhook.WebhookName, networkpolicywebhook.AddToManager),
 		webhookcmd.Switch(nodewebhook.WebhookName, nodewebhook.AddToManager),
 		webhookcmd.Switch(nodewebhook.WebhookNameShoot, nodewebhook.AddShootWebhookToManager),
 	)

--- a/example/gardener-local/gardenlet/values.yaml
+++ b/example/gardener-local/gardenlet/values.yaml
@@ -80,7 +80,7 @@ global:
             name: seed-local
             namespace: garden
           networks:
-            nodes: 172.19.0.0/16
+            nodes: 172.18.0.0/16
             # Those CIDRs must match those specified in the kind Cluster configuration.
             pods: 10.1.0.0/16
             services: 10.2.0.0/16

--- a/example/provider-local/seed-kind/local/seed.yaml
+++ b/example/provider-local/seed-kind/local/seed.yaml
@@ -26,7 +26,7 @@ spec:
     name: seed-local
     namespace: garden
   networks:
-    nodes: 172.19.0.0/16
+    nodes: 172.18.0.0/16
     pods: 10.1.0.0/16
     services: 10.2.0.0/16
     shootDefaults:

--- a/pkg/provider-local/webhook/networkpolicy/add.go
+++ b/pkg/provider-local/webhook/networkpolicy/add.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package networkpolicy
+
+import (
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	extensionswebhook "github.com/gardener/gardener/extensions/pkg/webhook"
+	v1beta1constants "github.com/gardener/gardener/pkg/apis/core/v1beta1/constants"
+	"github.com/gardener/gardener/pkg/provider-local/local"
+)
+
+// WebhookName is the name of the networkpolicy webhook.
+const WebhookName = "networkpolicy"
+
+var (
+	logger = log.Log.WithName("local-networkpolicy-webhook")
+
+	// DefaultAddOptions are the default AddOptions for AddToManager.
+	DefaultAddOptions = AddOptions{}
+)
+
+// AddOptions are options to apply when adding the local exposure webhook to the manager.
+type AddOptions struct{}
+
+// AddToManagerWithOptions creates a webhook with the given options and adds it to the manager.
+func AddToManagerWithOptions(mgr manager.Manager, _ AddOptions) (*extensionswebhook.Webhook, error) {
+	logger.Info("Adding webhook to manager")
+
+	var (
+		name     = "networkpolicy"
+		provider = local.Type
+		types    = []extensionswebhook.Type{{Obj: &networkingv1.NetworkPolicy{}}}
+	)
+
+	logger = logger.WithValues("provider", provider)
+
+	handler, err := extensionswebhook.NewBuilder(mgr, logger).WithMutator(&mutator{}, types...).Build()
+	if err != nil {
+		return nil, err
+	}
+
+	logger.Info("Creating webhook", "name", name)
+
+	return &extensionswebhook.Webhook{
+		Name:     name,
+		Provider: provider,
+		Types:    types,
+		Target:   extensionswebhook.TargetSeed,
+		Path:     name,
+		Webhook:  &admission.Webhook{Handler: handler, RecoverPanic: true},
+		Selector: &metav1.LabelSelector{MatchExpressions: []metav1.LabelSelectorRequirement{
+			{Key: v1beta1constants.LabelSeedProvider, Operator: metav1.LabelSelectorOpIn, Values: []string{provider}},
+		}},
+	}, nil
+}
+
+// AddToManager creates a webhook with the default options and adds it to the manager.
+func AddToManager(mgr manager.Manager) (*extensionswebhook.Webhook, error) {
+	return AddToManagerWithOptions(
+		mgr,
+		DefaultAddOptions,
+	)
+}

--- a/pkg/provider-local/webhook/networkpolicy/mutator.go
+++ b/pkg/provider-local/webhook/networkpolicy/mutator.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2021 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package networkpolicy
+
+import (
+	"context"
+	"fmt"
+
+	networkingv1 "k8s.io/api/networking/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	extensionscontroller "github.com/gardener/gardener/extensions/pkg/controller"
+)
+
+type mutator struct {
+	client client.Client
+}
+
+func (m *mutator) InjectClient(client client.Client) error {
+	m.client = client
+	return nil
+}
+
+func (m *mutator) Mutate(ctx context.Context, newObj, _ client.Object) error {
+	if newObj.GetName() != "allow-to-private-networks" {
+		return nil
+	}
+
+	networkPolicy, ok := newObj.(*networkingv1.NetworkPolicy)
+	if !ok {
+		return fmt.Errorf("unexpected object, got %T wanted *networkingv1.NetworkPolicy", newObj)
+	}
+
+	cluster, err := extensionscontroller.GetCluster(ctx, m.client, networkPolicy.Namespace)
+	if err != nil {
+		return err
+	}
+
+	if cluster.Seed.Spec.Networks.Nodes == nil {
+		return nil
+	}
+
+	for i, egress := range networkPolicy.Spec.Egress {
+		for j, to := range egress.To {
+			if to.IPBlock == nil {
+				continue
+			}
+
+			for k, except := range to.IPBlock.Except {
+				if except == *cluster.Seed.Spec.Networks.Nodes {
+					networkPolicy.Spec.Egress[i].To[j].IPBlock.Except = append(networkPolicy.Spec.Egress[i].To[j].IPBlock.Except[:k], networkPolicy.Spec.Egress[i].To[j].IPBlock.Except[k+1:]...)
+				}
+			}
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
**How to categorize this PR?**
<!--
Please select area, kind, and priority for this pull request. This helps the community categorizing it.
Replace below TODOs or exchange the existing identifiers with those that fit best in your opinion.
If multiple identifiers make sense you can also state the commands multiple times, e.g.
  /area control-plane
  /area auto-scaling
  ...

"/area" identifiers:     audit-logging|auto-scaling|backup|certification|control-plane-migration|control-plane|cost|delivery|dev-productivity|disaster-recovery|documentation|high-availability|logging|metering|monitoring|networking|open-source|ops-productivity|os|performance|quality|robustness|scalability|security|storage|testing|usability|user-management
"/kind" identifiers:     api-change|bug|cleanup|discussion|enhancement|epic|impediment|poc|post-mortem|question|regression|task|technical-debt|test

For Gardener Enhancement Proposals (GEPs), please check the following [documentation](https://github.com/gardener/gardener/tree/master/docs/proposals/README.md) before submitting this pull request.
-->
/area dev-productivity
/kind bug

**What this PR does / why we need it**:
This PR fixes the nodes CIDR in the local `Seed` specification (it's actually `172.18.0.0/16` instead of `172.19.0.0/16`).
With this change, we have to allow access to pods in the seed cluster's host network from pods in the shoot control plane namespaces. This is needed because machine pods want to talk to the registry pods to pull images.
By default, Gardener deploys a `NetworkPolicy` which explicitly blocks such traffic.
Previously, this was only working by accident because the nodes CIDR was wrong.

**Which issue(s) this PR fixes**:
Fixes #6777

**Special notes for your reviewer**:
Thanks to @ScheererJ for the joint analysis!

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
